### PR TITLE
project-template-memex-meshweaver

### DIFF
--- a/dist/templates/aspire/Memex.AppHost/Program.cs
+++ b/dist/templates/aspire/Memex.AppHost/Program.cs
@@ -115,12 +115,9 @@ var appInsights = builder.AddAzureApplicationInsights("appinsights")
 // --- Database Migration ---
 var dbMigration = builder
     .AddProject<Projects.Memex_Database_Migration>("db-migration")
+    .WithReference(appInsights)
+    .WaitFor(appInsights)
     .WithEnvironment("Embedding__Model", embeddingModel);
-
-if (!useLocalDb)
-{
-    dbMigration.WithReference(appInsights).WaitFor(appInsights);
-}
 
 // --- Portal (co-hosted Orleans silo + web) ---
 var portal = builder


### PR DESCRIPTION
### Summary

Make the db-migration project always reference Application Insights in the Aspire project template, regardless of deployment mode (remove the conditional `if (!useLocalDb)` guard so db-migration unconditionally gets `.WithReference(appInsights).WaitFor(appInsights)`).

Previously, dbMigration.WithReference(appInsights).WaitFor(appInsights) was gated behind if (!useLocalDb), meaning local dev mode skipped AppInsights for the migration job. This was inconsistent — the appInsights resource is always provisioned and the portal already references it unconditionally in all modes. The conditional provided no actual protection since missing Azure credentials would already surface through the portal.

Run: `dotnet new meshweaver-memex` - this scaffolds a complete 6-project solution with ACME as default sample data