### PR TITLE
fix: sample orgs invisible in search due to wrong NodeType

### DIFF
--- a/samples/Graph/Data/ACME/index.md
+++ b/samples/Graph/Data/ACME/index.md
@@ -1,5 +1,5 @@
 ---
-NodeType: Organization
+NodeType: Markdown
 Name: ACME
 Category: Task Management
 Description: Project and task management demo showcasing MeshWeaver's collaborative workflows and AI agent integration

--- a/samples/Graph/Data/Cornerstone/index.md
+++ b/samples/Graph/Data/Cornerstone/index.md
@@ -1,5 +1,5 @@
 ---
-NodeType: Organization
+NodeType: Markdown
 Name: Cornerstone
 Category: Insurance
 Description: Reinsurance pricing demo showcasing property risk management, geographic visualization, and Excel data import

--- a/samples/Graph/Data/Northwind/index.md
+++ b/samples/Graph/Data/Northwind/index.md
@@ -1,5 +1,5 @@
 ---
-NodeType: Organization
+NodeType: Markdown
 Name: Northwind
 Category: Analytics
 Description: Gourmet food distribution analytics demonstrating MeshWeaver's data visualization and AI-assisted exploration capabilities


### PR DESCRIPTION
## Summary
- Change `NodeType: Organization` → `NodeType: Markdown` in ACME, Northwind, and Cornerstone `index.md` files
- `Organization` NodeType triggers `OrganizationAccessRule` which fails the read permission check for file-based samples
- `Markdown` NodeType has no custom access rule, matching FutuRe (which already works correctly)

## Test plan
- [ ] Run portal: `dotnet run --project memex/Memex.Portal.Monolith`
- [ ] Search "ACME" in search bar → should show ACME and children
- [ ] Navigate to ACME → should render overview
- [ ] Navigate to ACME/ProductLaunch/TodosByCategory → should render todo board
- [ ] Verify Northwind and Cornerstone also appear in search

Supersedes the `organization-layout-areas` branch (draft PR), which attempted multiple workarounds for this root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)