### PR TITLE
Minor fixes to UI: focus steal & overlapping elements

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Components/SearchBar.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Components/SearchBar.razor.cs
@@ -3,6 +3,7 @@ using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace MeshWeaver.Blazor.Portal.Components;
 
@@ -23,6 +24,9 @@ public partial class SearchBar : IAsyncDisposable
     [Inject]
     public INavigationService? NavigationService { get; set; }
 
+    [Inject]
+    public required IJSRuntime JSRuntime { get; set; }
+
     private SearchHub? _searchHub;
     private ElementReference inputRef;
     private int _inputKey;
@@ -41,12 +45,17 @@ public partial class SearchBar : IAsyncDisposable
         _searchHub = new SearchHub(Hub);
     }
 
-    public Task OnKeyDownAsync(FluentKeyCodeEventArgs? args)
+    public async Task OnKeyDownAsync(FluentKeyCodeEventArgs? args)
     {
         if (args is not null && args.Key == KeyCode.Slash)
-            _ = inputRef.FocusAsync();
-
-        return Task.CompletedTask;
+        {
+            var isEditing = await JSRuntime.InvokeAsync<bool>(
+                "eval",
+                "(() => { const el = document.activeElement; if (!el) return false; const tag = el.tagName; if (tag === 'TEXTAREA' || (tag === 'INPUT' && /^(text|search|url|email|tel|password)$/i.test(el.type))) return true; if (el.isContentEditable) return true; if (el.closest('.monaco-editor')) return true; return false; })()"
+            );
+            if (!isEditing)
+                _ = inputRef.FocusAsync();
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
@@ -64,7 +64,7 @@
     ::deep.layout>header {
         grid-area: head;
         position: relative;
-        z-index: 200;
+        z-index: 1100;
     }
 
     ::deep.layout>.fluent-appbar {
@@ -283,7 +283,7 @@
     ::deep.layout>header {
         grid-area: head;
         position: relative;
-        z-index: 200;
+        z-index: 1100;
     }
 
     ::deep.layout>.fluent-appbar {

--- a/src/MeshWeaver.Blazor.Portal/SidePanel/SidePanel.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/SidePanel/SidePanel.razor.css
@@ -27,7 +27,7 @@
     background-color: var(--neutral-layer-2);
     flex-shrink: 0;
     position: relative;
-    z-index: 1000;
+    z-index: 10;
     min-height: 48px;
 }
 


### PR DESCRIPTION
### Two fixes for the MeshWeaver UI:

**Main:**
Pressing / or ? anywhere on the page used to jump the cursor into the search bar when you were typing in the AI chat. Now the app checks whether you're already typing somewhere first. If you are, the shortcut is ignored and your cursor stays put. (The problem with the ? seems to concern only US keyboards where / and ? share the same physical key — ? is just Shift+/)

**Other:**
The search dropdown was hidden behind the AI chat's title bar. Raised the header's priority so the dropdown always appears on top, and lowered the chat title bar's priority.
