### PR TITLE
ci: multi-arch portal-ai base in ACR + escape `;` in RID/tag property lists

### DIFF
--- a/.github/workflows/base-image-acr.yml
+++ b/.github/workflows/base-image-acr.yml
@@ -1,0 +1,80 @@
+name: Rebuild portal-ai base image (ACR, multi-arch)
+
+# Operator runbook: (re)bake the ONE hand-authored base image into ACR, MULTI-ARCH.
+#
+#   memex-portal-ai-base = aspnet + node20 + @anthropic-ai/claude-code + @github/copilot
+#
+# Why a dedicated workflow_dispatch (and NOT part of main-cd): the base changes rarely (it is the
+# slow apt + npm layer), so main-cd does NOT rebuild it per merge — main-cd layers the published
+# portal app ON TOP of whatever `memex-portal-ai-base:latest` already sits in ACR. That tag MUST be
+# a multi-arch manifest LIST (linux/amd64 + linux/arm64): the amd64 child feeds the x86 cloud nodes,
+# the arm64 child feeds Apple-silicon local k3s AND is the base layer main-cd's arm64 portal leg
+# pulls. A single-arch base ⇒ main-cd's arm64 publish has no base layer ⇒ it fails. This workflow is
+# how an operator bakes/refreshes that multi-arch base.
+#
+# No local Docker needed: buildx runs on the GitHub runner; setup-qemu-action emulates the arm64
+# RUN steps on the amd64 runner; `buildx --push` writes the manifest list straight to ACR in one shot
+# (@anthropic-ai/claude-code is pure JS / arch-independent; @github/copilot resolves its matching
+# per-platform optional-dep binary inside each platform's emulated build). This mirrors the GHCR base
+# build in release-images.yml — same buildx step, pushed to ACR (meshweaver.azurecr.io) instead.
+#
+# Auth: OIDC federated login (no stored secret). The federated credential is scoped to
+# ref:refs/heads/main, so dispatch this on the `main` ref: `gh workflow run base-image-acr.yml --ref main`.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write   # OIDC federated login to Azure (no stored client secret)
+
+env:
+  ACR: meshweaver.azurecr.io
+
+jobs:
+  base:
+    name: "Build + push multi-arch base to ACR"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      # buildx + QEMU: emulate the linux/arm64 RUN steps (apt/node/npm) of the base Dockerfile on this
+      # amd64 runner; buildx assembles + pushes the manifest list.
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Ensure Azure CLI
+        # GitHub's ubuntu-latest no longer ships the Azure CLI on PATH for azure/login@v2
+        # ("Unable to locate executable file: az"). Install it if missing (idempotent).
+        run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      # Authenticate the local Docker config to ACR (writes an identity token into ~/.docker/config.json);
+      # buildx reads that config to push to meshweaver.azurecr.io.
+      - name: ACR login
+        run: az acr login --name meshweaver
+
+      # `--push` writes the multi-arch OCI image index (manifest list) directly to ACR. We tag :latest
+      # (what main-cd's ContainerBaseImage references) AND git-<short-sha> (matches the existing ACR tag
+      # convention, for traceability of which commit's Dockerfile baked this base).
+      - name: Build + push portal-ai base image (multi-arch) to ACR
+        run: |
+          set -euo pipefail
+          BASE="$ACR/memex-portal-ai-base"
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            -t "$BASE:latest" -t "$BASE:git-$SHORT_SHA" \
+            --push deploy/base-images/portal-ai
+
+      - name: Verify multi-arch manifest list in ACR
+        run: |
+          set -euo pipefail
+          echo "Manifests now tagged on memex-portal-ai-base:latest —"
+          az acr manifest list-metadata -r meshweaver -n memex-portal-ai-base \
+            --query "[?contains(tags, 'latest')].{arch: architecture, mediaType: mediaType, digest: digest}" -o table

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -112,30 +112,35 @@ jobs:
       # subset of RuntimeIdentifiers (we set them equal). No Docker is needed: pushing the index straight
       # to a remote registry (ContainerRegistry set) is fully Docker-free.
       # 🚨 PREREQUISITE: memex-portal-ai-base:latest in ACR must itself be MULTI-ARCH, else the arm64 leg
-      # has no base layer and this step fails. release-images.yml builds it multi-arch (buildx); operators
-      # doing the first multi-arch roll must rebuild the base multi-arch once (see LocalColimaMac.md).
+      # has no base layer and this step fails. base-image-acr.yml (workflow_dispatch) builds it multi-arch
+      # (buildx → ACR); operators doing the first multi-arch roll run that once (see LocalColimaMac.md).
+      # 🚨 The ;-separated property LISTS are %3B-escaped, NOT raw `;`: a raw `;` in a `-p:Foo=a;b` arg is
+      # parsed by MSBuild's command-line property splitter as the START OF A NEW PROPERTY (`b`), which it
+      # then rejects — `MSBUILD : error MSB1006: Property is not valid. Switch: linux-arm64`. `%3B` is the
+      # MSBuild escape for a literal semicolon inside a value. Applies to RuntimeIdentifiers,
+      # ContainerRuntimeIdentifiers AND ContainerImageTags (every `-p:` whose value is a `;`-list).
       - name: Build + push portal-ai
         run: >
           dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
-          -p:RuntimeIdentifiers="linux-x64;linux-arm64"
-          -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"
+          -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
+          -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"
           -p:CIRun=true
           -p:ContainerRegistry=${{ env.ACR }}
           -p:ContainerRepository=memex-portal-ai
-          -p:ContainerImageTags="${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"
+          -p:ContainerImageTags="${{ steps.vars.outputs.version }}%3B${{ steps.vars.outputs.sha }}%3Bmain"
           -p:ContainerBaseImage=${{ env.ACR }}/memex-portal-ai-base:latest
       # migration — lean image on the standard (already multi-arch) aspnet base; same multi-arch publish.
       - name: Build + push migration
         run: >
           dotnet publish memex/aspire/Memex.Database.Migration/Memex.Database.Migration.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
-          -p:RuntimeIdentifiers="linux-x64;linux-arm64"
-          -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"
+          -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
+          -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"
           -p:CIRun=true
           -p:ContainerRegistry=${{ env.ACR }}
           -p:ContainerRepository=memex-migration
-          -p:ContainerImageTags="${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"
+          -p:ContainerImageTags="${{ steps.vars.outputs.version }}%3B${{ steps.vars.outputs.sha }}%3Bmain"
 
   # ───────────────────────────────── DEPLOY ──────────────────────────────────
   # One leg per environment (namespace) on the shared private cluster. Each leg points the

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -77,12 +77,12 @@ jobs:
         run: >
           dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
-          -p:RuntimeIdentifiers="linux-x64;linux-arm64"
-          -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"
+          -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
+          -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"
           -p:Version=$VERSION
           -p:ContainerRegistry=ghcr.io
           -p:ContainerRepository=$IMAGE_NS/memex-portal-ai
-          -p:ContainerImageTags="$VERSION;latest"
+          -p:ContainerImageTags="$VERSION%3Blatest"
           -p:ContainerBaseImage=ghcr.io/$IMAGE_NS/memex-portal-ai-base:$VERSION
 
       # 3. lean portal app image (default — already multi-arch — SDK aspnet base, no co-hosted CLIs).
@@ -90,24 +90,24 @@ jobs:
         run: >
           dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
-          -p:RuntimeIdentifiers="linux-x64;linux-arm64"
-          -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"
+          -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
+          -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"
           -p:Version=$VERSION
           -p:ContainerRegistry=ghcr.io
           -p:ContainerRepository=$IMAGE_NS/memex-portal
-          -p:ContainerImageTags="$VERSION;latest"
+          -p:ContainerImageTags="$VERSION%3Blatest"
 
       # 4. db-migration image (SDK container build, default — already multi-arch — base).
       - name: Build + push migration
         run: >
           dotnet publish memex/aspire/Memex.Database.Migration/Memex.Database.Migration.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
-          -p:RuntimeIdentifiers="linux-x64;linux-arm64"
-          -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"
+          -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
+          -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"
           -p:Version=$VERSION
           -p:ContainerRegistry=ghcr.io
           -p:ContainerRepository=$IMAGE_NS/memex-migration
-          -p:ContainerImageTags="$VERSION;latest"
+          -p:ContainerImageTags="$VERSION%3Blatest"
 
       # 5. Mirror the released (clean-version) images into ACR (meshweaver.azurecr.io). The continuous
       #    channel ships to ACR (main-cd.yml); mirroring the official release there too means an


### PR DESCRIPTION
## What & why

Makes the `main-cd` auto-deploy work with its multi-arch portal build. Two parts.

### A. Multi-arch `memex-portal-ai-base` in ACR — new `base-image-acr.yml`
`main-cd` layers the published portal app **on top of** `meshweaver.azurecr.io/memex-portal-ai-base:latest`. That base in ACR is currently **amd64-only**, so `main-cd`'s arm64 portal leg has no base layer and fails. The base is only ever built multi-arch by `release-images.yml` → **GHCR** (and that workflow has never run), so ACR never got a multi-arch copy.

New **`base-image-acr.yml`** (`workflow_dispatch`) rebuilds the one hand-authored base image (`aspnet + node20 + @anthropic-ai/claude-code + @github/copilot`) **multi-arch (linux/amd64 + linux/arm64)** straight into ACR via `buildx + setup-qemu + OIDC + az acr login + buildx --push`. Mirrors the GHCR base build in `release-images.yml`; no local Docker needed (buildx runs on the runner, `--push` writes the manifest list directly to ACR).

### B. Escape `;` in MSBuild property lists — `MSB1006` fix
`main-cd`'s build failed `MSBUILD : error MSB1006: Property is not valid. Switch: linux-arm64`. A raw `;` in a `-p:Foo=a;b` argument is parsed by MSBuild's command-line property splitter as the **start of a new property** (`b`), not a value separator. Escape each `;` as `%3B` (MSBuild's literal-semicolon escape).

Verified empirically against a real csproj:
- `-p:RuntimeIdentifiers="linux-x64;linux-arm64"` → `MSB1006 ... Switch: linux-arm64`
- `-p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"` → parses to `linux-x64;linux-arm64`
- `ContainerImageTags` with raw `;` breaks **identically** (`MSB1006 ... Switch: <sha>`) — so it is escaped too; fixing only the RIDs would still fail on the next `;`.

Applied to every `;`-list `-p:` value (RuntimeIdentifiers, ContainerRuntimeIdentifiers, ContainerImageTags) in **both** `main-cd.yml` (portal + migration) and `release-images.yml` (portal-ai + portal + migration).

## Validation plan after merge
1. Dispatch `base-image-acr.yml` on `main`; confirm `az acr manifest list-metadata` shows amd64 **and** arm64 for `memex-portal-ai-base:latest`.
2. Confirm `main-cd` (fired by Build-and-Test on this merge) builds the multi-arch portal and all 3 deploy legs (memex / atioz / memex-cloud) go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)