### PR TITLE
fix(mesh): cure the _Provider orphan untyped-storm (atioz sglauser flake)

### DIFF
--- a/memex/Memex.Client/MauiProgram.cs
+++ b/memex/Memex.Client/MauiProgram.cs
@@ -177,6 +177,8 @@ public static class MauiProgram
         builder.Services.AddSingleton<DeviceOnboarding>();
         // The single source of truth for "where we are" — drives the content frame AND the top-bar menu.
         builder.Services.AddSingleton<NavigationService>();
+        // Bridges the native view pack's href nav links (NavLinkControl.Url) to the shell navigation above.
+        builder.Services.AddSingleton<MeshWeaver.Maui.IMauiNavigator, MauiNavigator>();
         // Provider-driven app-level menus (Settings ⚙, User 👤) for the portal shell — rendered through the
         // SAME DevExpress popup mechanism as the platform Node/Mesh/AI menus, so the shell hardcodes no menu
         // item list. Adding a menu entry = adding it to a provider here, never editing PortalShellPage.

--- a/memex/Memex.Client/Services/MauiNavigator.cs
+++ b/memex/Memex.Client/Services/MauiNavigator.cs
@@ -1,0 +1,41 @@
+using Memex.Client.Pages;
+using MeshWeaver.Maui;
+using MeshWeaver.Messaging;
+
+namespace Memex.Client.Services;
+
+/// <summary>
+/// Bridges the native view pack's <see cref="IMauiNavigator"/> to the shell's <see cref="NavigationService"/>:
+/// a href-style <c>NavLinkControl</c> click navigates the shell to that mesh path by pushing a
+/// <see cref="NavLocation"/> that builds a <see cref="NodeAreaView"/> for the node's area — the same
+/// destination the shell uses for search results and node cards. Registered into the shared mesh/MAUI
+/// container so <c>MauiView</c>s resolve it from <c>Stream.Hub.ServiceProvider</c>.
+/// </summary>
+public sealed class MauiNavigator(NavigationService nav, IMessageHub hub) : IMauiNavigator
+{
+    public void NavigateTo(string href, string? title = null)
+    {
+        var path = Normalize(href);
+        if (string.IsNullOrEmpty(path)) return;
+        const string area = "Overview";
+        var label = string.IsNullOrWhiteSpace(title) ? LastSegment(path) : title!;
+        // Same shape PortalShellPage.NavigateToNode uses — node path + Overview area → NodeAreaView.
+        nav.Navigate(new NavLocation(label, path, area, () => new NodeAreaView(hub, path, area)));
+    }
+
+    // Mesh URL shape is {baseUrl}/{meshpath} — strip a leading '/' and the local-only '@/' (or bare '@')
+    // prefix so the remainder is the node path the shell navigates to.
+    private static string Normalize(string href)
+    {
+        var s = href.Trim();
+        if (s.StartsWith("@/", StringComparison.Ordinal)) s = s[2..];
+        else if (s.StartsWith('@')) s = s[1..];
+        return s.TrimStart('/');
+    }
+
+    private static string LastSegment(string path)
+    {
+        var i = path.LastIndexOf('/');
+        return i >= 0 && i < path.Length - 1 ? path[(i + 1)..] : path;
+    }
+}

--- a/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
+++ b/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reflection;
@@ -10,6 +11,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -316,20 +318,35 @@ public static class ShippedReleaseSeed
 /// </summary>
 public sealed class ShippedReleaseSeedHostedService(
     IMessageHub hub,
+    IConfiguration configuration,
     ILogger<ShippedReleaseSeedHostedService>? logger = null) : IHostedService
 {
     private IDisposable? _subscription;
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        // Boot pre-seed = the shipped sample/framework partitions PLUS any extra partitions a deployment
+        // opts into via config (ShippedRelease:ExtraPreseedPartitions). User/Space partitions are NOT
+        // shipped (they're user-Released), but a deployment can pre-build a heavily-used runtime Space at
+        // boot so its NodeType/dashboard views don't render empty during the cold compile-on-first-access
+        // window after a pod restart. Set PER-DEPLOYMENT (e.g. atioz: AgenticPension) — never hardcode a
+        // customer's space name into framework source. Pre-build is async (never blocks host startup).
+        var extra = configuration.GetSection("ShippedRelease:ExtraPreseedPartitions").Get<string[]>()
+            ?? [];
+        var partitions = ShippedReleaseSeed.ShippedPartitions
+            .Concat(extra)
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
         logger?.LogInformation(
             "[PlatformStartup] version={Version}; pre-building shipped code-NodeType releases as System for "
-            + "{Partitions} and recording the boot activity under {VersionNode}.",
+            + "{Partitions}{Extra} and recording the boot activity under {VersionNode}.",
             ShippedReleaseSeed.InstalledPlatformVersion,
-            string.Join(", ", ShippedReleaseSeed.ShippedPartitions),
+            string.Join(", ", partitions),
+            extra.Length > 0 ? $" (incl. config extras: {string.Join(", ", extra)})" : "",
             ShippedReleaseSeed.PlatformVersionNodePath);
         _subscription = ShippedReleaseSeed
-            .RunPlatformStartup(hub, ShippedReleaseSeed.ShippedPartitions, logger)
+            .RunPlatformStartup(hub, partitions, logger)
             .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default)
             .Subscribe(
                 _ => { },

--- a/memex/aspire/Memex.Database.Migration/Migrations/V38_DropLegacyProviderSchema.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V38_DropLegacyProviderSchema.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Database.Migration.Migrations;
+
+/// <summary>
+/// Remove the orphaned top-level <c>_provider</c> partition schema.
+///
+/// <para>History: the built-in AI model catalog briefly lived under a top-level <c>_Provider</c>
+/// namespace (commit 04c71b17a) before it was relocated to <c>Provider</c> / <c>Admin/Provider</c>
+/// (f7c467222). The relocation left a stale <c>_provider</c> schema carrying a single
+/// <c>_Provider/_Policy</c> PartitionAccessPolicy — written by a hub that lacked the type registration,
+/// so its <c>$type</c> is the namespace-qualified FULL name. That orphan keeps a phantom partition
+/// alive: PathResolutionService synthesises a bare <c>_Provider</c> root on every probe, and the
+/// access-control read path re-reads <c>_Provider/_Policy</c>, which never type-resolves → "stayed an
+/// untyped JsonElement" logged thousands of times per hour (the atioz storm + sglauser flake).</para>
+///
+/// <para>No current code path writes a top-level <c>_provider</c> schema — the live
+/// <c>{user}/_Provider/…</c> credential namespace lives INSIDE each user's own partition schema, NOT
+/// here — so dropping it is safe and idempotent (<c>IF EXISTS</c> → no-op on portals that never had
+/// it). Also removes the stale <c>searchable_schemas</c> registration so queries stop fanning out to
+/// the dropped schema. Mirrors <see cref="V03_DropRogueSchemas"/>.</para>
+/// </summary>
+public sealed class V38_DropLegacyProviderSchema : IMigration
+{
+    private const string Schema = "_provider";
+
+    public int Version => 38;
+    public string Description => "Drop the orphaned legacy top-level _provider partition schema";
+
+    public async Task RunAsync(MigrationContext ctx)
+    {
+        // Always best-effort de-register from the searchable-schemas index — the row can outlive the
+        // schema, and a dangling entry keeps cross-schema queries fanning out to a non-existent schema.
+        await TryDeregisterSearchableSchema(ctx);
+
+        if (!await SchemaHelpers.SchemaExistsAsync(ctx.DataSource, Schema))
+        {
+            ctx.Logger.LogInformation("Repair v38: schema \"{Schema}\" absent — nothing to drop.", Schema);
+            return;
+        }
+
+        // Audit what we're removing before the CASCADE so a surprise is visible in the log.
+        try
+        {
+            await using var countCmd = ctx.DataSource.CreateCommand(
+                $"SELECT (SELECT count(*) FROM \"{Schema}\".mesh_nodes), (SELECT count(*) FROM \"{Schema}\".access)");
+            await using var reader = await countCmd.ExecuteReaderAsync();
+            if (await reader.ReadAsync())
+                ctx.Logger.LogInformation(
+                    "Repair v38: dropping orphan schema \"{Schema}\" ({Nodes} mesh_nodes, {Access} access rows).",
+                    Schema, reader.GetInt64(0), reader.GetInt64(1));
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.LogWarning(ex, "Repair v38: pre-drop audit of \"{Schema}\" failed (continuing to drop).", Schema);
+        }
+
+        // Best-effort, log-and-continue (mirrors V03_DropRogueSchemas): a failed DROP (lock contention,
+        // an unexpected dependency) must NOT abort the whole migration run and block the deploy — and it
+        // must not leave the run aborted between the two drops (the top_level_index matview UNIONs the
+        // searchable schemas, and Phase 3's SearchableSchemasUpdater rebuilds it AFTER all migrations).
+        try
+        {
+            await using (var dropCmd = ctx.DataSource.CreateCommand($"DROP SCHEMA IF EXISTS \"{Schema}\" CASCADE"))
+                await dropCmd.ExecuteNonQueryAsync();
+            await using (var dropVCmd = ctx.DataSource.CreateCommand($"DROP SCHEMA IF EXISTS \"{Schema}_versions\" CASCADE"))
+                await dropVCmd.ExecuteNonQueryAsync();
+            ctx.Logger.LogInformation("Repair v38: dropped orphan schema \"{Schema}\" (+ _versions).", Schema);
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.LogWarning(ex, "Repair v38: failed to drop orphan schema \"{Schema}\" (continuing).", Schema);
+        }
+    }
+
+    /// <summary>
+    /// Remove <c>_provider</c> from <c>public.searchable_schemas</c> if that registry table exists.
+    /// Tolerant: the table may not exist on every deployment shape, and a missing row is a no-op.
+    /// </summary>
+    private static async Task TryDeregisterSearchableSchema(MigrationContext ctx)
+    {
+        try
+        {
+            await using var cmd = ctx.DataSource.CreateCommand(
+                "DELETE FROM public.searchable_schemas WHERE lower(schema_name) = $1");
+            cmd.Parameters.AddWithValue(Schema);
+            var removed = await cmd.ExecuteNonQueryAsync();
+            if (removed > 0)
+                ctx.Logger.LogInformation("Repair v38: de-registered \"{Schema}\" from searchable_schemas.", Schema);
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.LogWarning(ex, "Repair v38: could not de-register \"{Schema}\" from searchable_schemas (continuing).", Schema);
+        }
+    }
+}

--- a/memex/aspire/Memex.Database.Migration/Program.cs
+++ b/memex/aspire/Memex.Database.Migration/Program.cs
@@ -148,6 +148,7 @@ var migrations = new IMigration[]
     new V35_ReconcilePartitionAccessIndex(),
     new V36_MoveAgentsToPerPartitionAgentNamespace(),
     new V37_MoveAgentsToAgentNamespaceBySchema(),
+    new V38_DropLegacyProviderSchema(),
 };
 
 var ctx = new MigrationContext(dataSource, connectionString, options, logger, initResult.IsFreshDb);

--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -13,6 +13,11 @@
     "LogLevel": {
       "Default": "Warning",
       "MeshWeaver": "Warning",
+      // Blazor circuit lifecycle (open/close + connection up/down) — one line per session-level
+      // event, deliberately surfaced at Information so a user's flaky-connection churn is visible in
+      // Loki. Low volume (NOT per-message); connection-DOWN is Warning so it shows even if this is
+      // lowered. The "what's going on in Blazor" channel.
+      "MeshWeaver.Blazor.Circuit": "Information",
       "Microsoft": "Warning",
       "Microsoft.AspNetCore": "Warning",
       "Orleans": "Warning",

--- a/src/MeshWeaver.AI/AIExtensions.cs
+++ b/src/MeshWeaver.AI/AIExtensions.cs
@@ -125,6 +125,9 @@ public static class AIExtensions
             // ("awaiting first data"). Registered with nameof so the stored "$type":"PartitionAccessPolicy"
             // resolves — a redeploy/next sync then reads every AI partition's policy correctly. Mirrors
             // MeshNodeExtensions' registration for the Graph/Doc hubs.
+            // Full-name READ alias FIRST (legacy data persisted with a full-name $type), short nameof
+            // LAST so this hub keeps WRITING the short name. See WithGraphTypes for the full rationale.
+            .WithType(typeof(MeshWeaver.Mesh.Security.PartitionAccessPolicy), typeof(MeshWeaver.Mesh.Security.PartitionAccessPolicy).FullName!)
             .WithType(typeof(MeshWeaver.Mesh.Security.PartitionAccessPolicy), nameof(MeshWeaver.Mesh.Security.PartitionAccessPolicy))
             // User + UserActivityRecord: the chat composer reads the caller's user-partition root node
             // ({user}, NodeType "User") for _userHome + onboarding, and its _UserActivity satellite. The
@@ -134,7 +137,9 @@ public static class AIExtensions
             // $type discriminator)" → "renders empty, reactive waits time out": the composer never binds
             // and the chat window DISAPPEARS on submit (and home areas hang "awaiting first data"). Same
             // class as PartitionAccessPolicy above. Also added to AddMeshTypes (their core home).
+            .WithType(typeof(MeshWeaver.Mesh.Security.User), typeof(MeshWeaver.Mesh.Security.User).FullName!)
             .WithType(typeof(MeshWeaver.Mesh.Security.User), nameof(MeshWeaver.Mesh.Security.User))
+            .WithType(typeof(MeshWeaver.Mesh.Activity.UserActivityRecord), typeof(MeshWeaver.Mesh.Activity.UserActivityRecord).FullName!)
             .WithType(typeof(MeshWeaver.Mesh.Activity.UserActivityRecord), nameof(MeshWeaver.Mesh.Activity.UserActivityRecord))
             // MessageViewModel is not registered — handled as JsonElement on the wire.
             // SubmitMessageRequest / SubmitMessageResponse deleted 2026-05-25:

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -363,15 +363,25 @@ public static class MeshNodeExtensions
         typeRegistry.WithType(typeof(CodeConfiguration), nameof(CodeConfiguration));
         typeRegistry.WithType(typeof(Comment), nameof(Comment));
         typeRegistry.WithType(typeof(MarkdownContent), nameof(MarkdownContent));
+        // Security content types (AccessAssignment / PartitionAccessPolicy / RoleAssignment / Role).
+        // Each MUST register its $type here: without it, the node read across a hub boundary (the
+        // GetQuery / MeshNodeStreamCache deserialization path) degrades to an untyped JsonElement,
+        // every `Content is X` soft-cast fails, and the grant/policy is silently NOT applied — e.g. a
+        // PublicRead partition (Skill, Harness, Provider) reads as empty/denied ("not found").
+        //
+        // LEGACY READ-COMPAT: a node persisted by a hub that lacked this registration carries a
+        // namespace-qualified FULL-name $type (e.g. "MeshWeaver.Mesh.Security.PartitionAccessPolicy" —
+        // the _Provider/_Policy storm). Register the full name as a READ alias FIRST, then the short
+        // nameof LAST so this hub keeps WRITING the short name (nameByType is last-write-wins) while
+        // resolving BOTH on read. PolymorphicTypeInfoResolver now warns whenever an unregistered type
+        // is serialized, so any NEW full-name node is surfaced at its publishing hub, not silently stored.
+        typeRegistry.WithType(typeof(AccessAssignment), typeof(AccessAssignment).FullName!);
         typeRegistry.WithType(typeof(AccessAssignment), nameof(AccessAssignment));
-        // PartitionAccessPolicy is a sibling security content type to AccessAssignment and MUST register
-        // its $type here too. Without it, a `_Policy` node read across a hub boundary (the GetQuery /
-        // MeshNodeStreamCache deserialization path) degrades to an untyped JsonElement, every
-        // `Content is PartitionAccessPolicy` soft-cast fails, and the partition's PublicRead policy is
-        // silently NOT applied — so PublicRead partitions (Skill, Harness, Provider) read as empty/denied
-        // (skills + harnesses "not found"). Registering the discriminator makes the policy type-resolve.
+        typeRegistry.WithType(typeof(PartitionAccessPolicy), typeof(PartitionAccessPolicy).FullName!);
         typeRegistry.WithType(typeof(PartitionAccessPolicy), nameof(PartitionAccessPolicy));
+        typeRegistry.WithType(typeof(RoleAssignment), typeof(RoleAssignment).FullName!);
         typeRegistry.WithType(typeof(RoleAssignment), nameof(RoleAssignment));
+        typeRegistry.WithType(typeof(Role), typeof(Role).FullName!);
         typeRegistry.WithType(typeof(Role), nameof(Role));
         typeRegistry.WithType(typeof(AccessObject), nameof(AccessObject));
         typeRegistry.WithType(typeof(GetPermissionRequest), nameof(GetPermissionRequest));

--- a/src/MeshWeaver.Hosting.Blazor/CircuitAccessHandler.cs
+++ b/src/MeshWeaver.Hosting.Blazor/CircuitAccessHandler.cs
@@ -30,6 +30,10 @@ public class CircuitAccessHandler : CircuitHandler
     private readonly AuthenticationStateProvider _authStateProvider;
     private readonly ICircuitContextAccessor _circuitContextAccessor;
     private readonly ILogger _logger;
+    // Dedicated low-volume category for circuit lifecycle (open/close/up/down) so it can be made
+    // visible (Information) independently of the chatty MeshWeaver.AccessContext channel — these are
+    // the "what's going on in Blazor" signals: a connection-down is the literal transport flake.
+    private readonly ILogger _circuitLogger;
     private AccessContext? _userContext;
 
     /// <summary>
@@ -49,6 +53,7 @@ public class CircuitAccessHandler : CircuitHandler
         _authStateProvider = authStateProvider;
         _circuitContextAccessor = circuitContextAccessor;
         _logger = loggerFactory.CreateLogger("MeshWeaver.AccessContext");
+        _circuitLogger = loggerFactory.CreateLogger("MeshWeaver.Blazor.Circuit");
     }
 
     /// <summary>
@@ -100,8 +105,32 @@ public class CircuitAccessHandler : CircuitHandler
             accessService?.SetCircuitContext(_userContext);
         }
 
-        _logger.LogDebug("Circuit opened: id={CircuitId}, user={UserId}",
+        // Information (was Debug): one line per circuit — cheap, and the anchor for correlating a
+        // user's session with the connection up/down churn below and any anonymous-gate redirect.
+        _circuitLogger.LogInformation("Circuit opened: id={CircuitId}, user={UserId}",
             circuit.Id, _userContext?.ObjectId ?? "(anonymous)");
+    }
+
+    /// <summary>
+    /// The SignalR transport for this circuit dropped (network blip, tab backgrounded, server
+    /// pressure, deploy). Logged at Warning because a repeated up/down churn for one user IS the
+    /// "flaky" symptom — this is the server-side trace that was previously missing entirely
+    /// (OnConnectionDownAsync was never overridden, so a flapping circuit left no record).
+    /// </summary>
+    public override Task OnConnectionDownAsync(Circuit circuit, CancellationToken ct)
+    {
+        _circuitLogger.LogWarning("Circuit connection DOWN: id={CircuitId}, user={UserId}",
+            circuit.Id, _userContext?.ObjectId ?? "(anonymous)");
+        return Task.CompletedTask;
+    }
+
+    /// <summary>The SignalR transport re-established (reconnect succeeded). Pairs with
+    /// <see cref="OnConnectionDownAsync"/> so a down→up gap is measurable in the logs.</summary>
+    public override Task OnConnectionUpAsync(Circuit circuit, CancellationToken ct)
+    {
+        _circuitLogger.LogInformation("Circuit connection UP: id={CircuitId}, user={UserId}",
+            circuit.Id, _userContext?.ObjectId ?? "(anonymous)");
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
@@ -127,7 +156,7 @@ public class CircuitAccessHandler : CircuitHandler
     /// <inheritdoc />
     public override Task OnCircuitClosedAsync(Circuit circuit, CancellationToken ct)
     {
-        _logger.LogDebug("Circuit closed: id={CircuitId}, user={UserId}",
+        _circuitLogger.LogInformation("Circuit closed: id={CircuitId}, user={UserId}",
             circuit.Id, _userContext?.ObjectId ?? "(anonymous)");
         // Clear the persistent fallback to prevent stale context
         var accessService = _hub.ServiceProvider.GetService<AccessService>();

--- a/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
+++ b/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
@@ -461,6 +461,20 @@ internal class NavigationService : INavigationService
         // re-introduce the 2026-05-21 identity-loss false-denial.
         if (string.Equals(userId, WellKnownUsers.Anonymous, StringComparison.OrdinalIgnoreCase))
         {
+            // The anonymous hard-gate is firing → a forceLoad:true redirect to /login is a FULL page
+            // reload (the "send → page reloads / GUI vanishes" symptom). Log WHY: dump the three identity
+            // sources at the decision point so a MIS-fire on an actually-authenticated user (the
+            // 2026-05-21 identity-loss regression, where a deferred Rx continuation reads a cleared
+            // ambient context) is visible in the logs instead of silent. Warning-level so it surfaces
+            // under the default MeshWeaver=Warning cap with no config change.
+            var accessService = _hub.ServiceProvider.GetService<AccessService>();
+            _logger?.LogWarning(
+                "Anonymous-gate: redirecting {Uri} → /login (forceLoad full reload), resolved path '{Prefix}'. "
+                + "Identity sources at decision — ambient={Ambient}, circuit={Circuit}, accessor={Accessor}.",
+                _navigationManager.Uri, resolution.Prefix,
+                accessService?.Context?.ObjectId ?? "(null)",
+                accessService?.CircuitContext?.ObjectId ?? "(null)",
+                _circuitContextAccessor?.UserContext?.ObjectId ?? "(null)");
             IsResolving = false;
             Context = null;
             CurrentNamespace = null;

--- a/src/MeshWeaver.Maui/IMauiNavigator.cs
+++ b/src/MeshWeaver.Maui/IMauiNavigator.cs
@@ -1,0 +1,26 @@
+namespace MeshWeaver.Maui;
+
+/// <summary>
+/// Client-side navigation for the native MAUI view pack: the AspNetCore-free counterpart of the Blazor
+/// portal's <c>&lt;a href&gt;</c> / <c>INavigationService.NavigateTo</c>. A href-style nav link
+/// (<see cref="Layout.NavLinkControl"/> with a <c>Url</c> but no server <c>ClickAction</c>) navigates the
+/// shell to that mesh path instead of posting a <c>ClickedEvent</c> — exactly as the portal turns a nav
+/// link's URL into a route change.
+/// <para>
+/// The implementation lives in the MAUI app (it wraps the shell's navigation + builds the node view) and is
+/// registered into the SHARED mesh/MAUI container, so <see cref="MauiView"/>s resolve it from
+/// <c>Stream.Hub.ServiceProvider</c>. When no navigator is registered (e.g. a host that has no shell), nav
+/// links fall back to their <c>ClickAction</c>.
+/// </para>
+/// </summary>
+public interface IMauiNavigator
+{
+    /// <summary>
+    /// Navigates the shell to <paramref name="href"/> — a mesh path in the portal URL shape
+    /// (<c>{meshpath}</c>, optionally leading <c>/</c>). The path resolves to a node's area (default
+    /// <c>Overview</c>), matching <c>{baseUrl}/{meshpath}</c>.
+    /// </summary>
+    /// <param name="href">The navigation target (a mesh path; leading <c>/</c> and the local-only <c>@/</c> prefix are tolerated).</param>
+    /// <param name="title">Optional display title for the destination; falls back to the path's last segment.</param>
+    void NavigateTo(string href, string? title = null);
+}

--- a/src/MeshWeaver.Maui/MauiViewPack.cs
+++ b/src/MeshWeaver.Maui/MauiViewPack.cs
@@ -190,6 +190,26 @@ public abstract class MauiView : IDisposable
             try { setter((T?)Convert.ChangeType(value, typeof(T))); } catch { setter(defaultValue); }
     }
 
+    /// <summary>
+    /// Dispatches a click for this control's area as a <see cref="ClickedEvent"/> to the stream owner —
+    /// the server-side <c>ClickAction</c> delegate does NOT serialize to the client, so a click is a
+    /// message that the layout area receives and turns into the action. Mirrors <c>BlazorView.OnClick</c>,
+    /// incl. stamping the (device-)user <see cref="AccessContext"/> so the owning hub's access gate doesn't
+    /// deny the downstream write. Shared by Button / NavLink / MenuItem / any clickable container.
+    /// </summary>
+    protected void PostClick(object? payload = null)
+    {
+        if (Stream is null) return;
+        var access = Stream.Hub.ServiceProvider.GetService<AccessService>();
+        var ctx = access?.Context ?? access?.CircuitContext;
+        var evt = payload is null
+            ? new ClickedEvent(Area, Stream.StreamId)
+            : new ClickedEvent(Area, Stream.StreamId) { Payload = payload };
+        Stream.Hub.Post(evt, o => ctx is not null
+            ? o.WithTarget(Stream.Owner).WithAccessContext(ctx)
+            : o.WithTarget(Stream.Owner));
+    }
+
     public void Dispose()
     {
         foreach (var d in Disposables) d.Dispose();
@@ -366,8 +386,18 @@ public sealed class LabelView : MauiView<LabelControl>
 public sealed class ButtonView : MauiView<ButtonControl>
 {
     private Button _button = null!;
-    protected override View CreateView() => _button = new Button();
-    protected override void Bind() => Bind<object>(Model.Data, v => _button.Text = v?.ToString() ?? "");
+    protected override View CreateView()
+    {
+        _button = new Button();
+        // A click dispatches the control's server-side ClickAction via a ClickedEvent (see PostClick).
+        _button.Clicked += (_, _) => PostClick();
+        return _button;
+    }
+    protected override void Bind()
+    {
+        Bind<object>(Model.Data, v => _button.Text = v?.ToString() ?? "");
+        Bind<bool>(Model.Disabled, d => _button.IsEnabled = !d, defaultValue: false);
+    }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Maui/MauiViewPack.cs
+++ b/src/MeshWeaver.Maui/MauiViewPack.cs
@@ -385,7 +385,9 @@ public static class MauiViewPackExtensions
         // Wave 2 — nav + badges.
         .Register<BadgeControl, BadgeView>()
         .Register<NavLinkControl, NavLinkView>()
-        .Register<MenuItemControl, MenuItemView>();
+        .Register<MenuItemControl, MenuItemView>()
+        // Phase 2 — agent-backed chat: a single thread message bubble (streaming text + exec status).
+        .Register<ThreadMessageBubbleControl, ThreadMessageBubbleView>();
 }
 
 // ---- Wave 1 control views -------------------------------------------------------------------------
@@ -1531,4 +1533,77 @@ public sealed class MeshSearchView : MauiView<MeshSearchControl>
         JsonElement je when je.ValueKind == JsonValueKind.False => false,
         _ => bool.TryParse(value.ToString(), out var p) ? p : defaultValue,
     };
+}
+
+// ---- Chat: agent-backed thread message bubble ----------------------------------------------------
+
+/// <summary>
+/// A single thread message as a native chat bubble — the AspNetCore-free counterpart of Blazor's
+/// <c>ThreadMessageBubbleView</c>. Role drives alignment + colour (user → right/blue, assistant → left/grey);
+/// the body <c>Text</c> is data-bound (a <see cref="JsonPointerReference"/>) so it refines in place while the
+/// agent streams. While executing it shows a spinner + the live <c>ExecutionStatus</c>; a footer chips the
+/// author, model, and timestamp. (Tool-call chips + markdown body + edit/resubmit are later refinements;
+/// this renders the conversation natively, which the agent chat needs first.)
+/// </summary>
+public sealed class ThreadMessageBubbleView : MauiView<ThreadMessageBubbleControl>
+{
+    private Label _body = null!;
+    private ActivityIndicator _spinner = null!;
+    private Label _status = null!;
+    private Label _footer = null!;
+    private HorizontalStackLayout _statusRow = null!;
+
+    protected override View CreateView()
+    {
+        var isUser = string.Equals(Model.Role, "user", StringComparison.OrdinalIgnoreCase);
+
+        var author = new Label
+        {
+            Text = string.IsNullOrWhiteSpace(Model.AuthorName) ? (isUser ? "You" : "Assistant") : Model.AuthorName,
+            FontSize = 11, FontAttributes = FontAttributes.Bold,
+            TextColor = isUser ? Colors.White : Color.FromArgb("#C0C0C0"),
+        };
+        _body = new Label { TextColor = Colors.White, LineBreakMode = LineBreakMode.WordWrap };
+
+        _spinner = new ActivityIndicator { IsVisible = false, IsRunning = false, Color = Colors.White, HeightRequest = 14, WidthRequest = 14 };
+        _status = new Label { FontSize = 11, TextColor = Color.FromArgb("#C0C0C0") };
+        _statusRow = new HorizontalStackLayout { Spacing = 6, IsVisible = false, Children = { _spinner, _status } };
+
+        _footer = new Label { FontSize = 10, TextColor = Color.FromArgb("#9A9A9A") };
+
+        var content = new VerticalStackLayout { Spacing = 4, Children = { author, _body, _statusRow, _footer } };
+
+        return new Border
+        {
+            Padding = new Thickness(10, 6),
+            Margin = new Thickness(isUser ? 40 : 0, 2, isUser ? 0 : 40, 2),
+            HorizontalOptions = isUser ? LayoutOptions.End : LayoutOptions.Start,
+            BackgroundColor = isUser ? Colors.RoyalBlue : Color.FromArgb("#3A3A3C"),
+            StrokeThickness = 0,
+            StrokeShape = new Microsoft.Maui.Controls.Shapes.RoundRectangle { CornerRadius = 12 },
+            Content = content,
+        };
+    }
+
+    protected override void Bind()
+    {
+        Bind<string>(Model.Text, v => _body.Text = v ?? "");
+        Bind<bool>(Model.IsExecuting, executing =>
+        {
+            _statusRow.IsVisible = executing;
+            _spinner.IsVisible = executing;
+            _spinner.IsRunning = executing;
+        }, defaultValue: false);
+        Bind<string>(Model.ExecutionStatus, v => _status.Text = v ?? "");
+        _footer.Text = BuildFooter();
+        _footer.IsVisible = !string.IsNullOrEmpty(_footer.Text);
+    }
+
+    private string BuildFooter()
+    {
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(Model.ModelName)) parts.Add(Model.ModelName!);
+        if (Model.Timestamp is { } ts) parts.Add(ts.ToLocalTime().ToString("t"));
+        return string.Join(" · ", parts);
+    }
 }

--- a/src/MeshWeaver.Maui/MauiViewPack.cs
+++ b/src/MeshWeaver.Maui/MauiViewPack.cs
@@ -630,7 +630,14 @@ public sealed class BadgeView : MauiView<BadgeControl>
 public sealed class NavLinkView : MauiView<NavLinkControl>
 {
     private Button _button = null!;
-    protected override View CreateView() => _button = new Button { HorizontalOptions = LayoutOptions.Start };
+    protected override View CreateView()
+    {
+        _button = new Button { HorizontalOptions = LayoutOptions.Start };
+        // Fires the link's ClickAction via ClickedEvent. (Pure href navigation is a later wave — it
+        // needs a MAUI INavigationService; ClickAction-based nav links work now.)
+        _button.Clicked += (_, _) => PostClick();
+        return _button;
+    }
     protected override void Bind() => Bind<object>(Model.Title, v => _button.Text = v?.ToString() ?? "");
 }
 
@@ -638,7 +645,15 @@ public sealed class NavLinkView : MauiView<NavLinkControl>
 public sealed class MenuItemView : MauiView<MenuItemControl>
 {
     private Label _label = null!;
-    protected override View CreateView() => _label = new Label();
+    protected override View CreateView()
+    {
+        _label = new Label();
+        // Menu items act via their ClickAction — make the label tappable and dispatch it.
+        var tap = new TapGestureRecognizer();
+        tap.Tapped += (_, _) => PostClick();
+        _label.GestureRecognizers.Add(tap);
+        return _label;
+    }
     protected override void Bind() => Bind<object>(Model.Title, v => _label.Text = v?.ToString() ?? "");
 }
 

--- a/src/MeshWeaver.Maui/MauiViewPack.cs
+++ b/src/MeshWeaver.Maui/MauiViewPack.cs
@@ -361,8 +361,14 @@ public static class MauiViewPackExtensions
         // Wave 2 — details forms: number / date / combobox / listbox.
         .Register<NumberFieldControl, NumberFieldView>()
         .Register<DateTimeControl, DateTimeView>()
+        .Register<DateControl, DateView>()
         .Register<ComboboxControl, ComboboxView>()
         .Register<ListboxControl, ListboxView>()
+        .Register<RadioGroupControl, RadioGroupView>()
+        // Wave 2 — simple leaves: slider (range), spacer (flex gap), exception (error caption).
+        .Register<SliderControl, SliderView>()
+        .Register<SpacerControl, SpacerView>()
+        .Register<ExceptionControl, ExceptionView>()
         // Tabular data.
         .Register<DataGridControl, DataGridView>()
         // Wave 2 — layout: a real grid + tabs (other containers fall back to ContainerView).
@@ -664,19 +670,31 @@ public sealed class BadgeView : MauiView<BadgeControl>
     protected override void Bind() => Bind<object>(Model.Data, v => _label.Text = v?.ToString() ?? "");
 }
 
-/// <summary>Navigation link → a MAUI <see cref="Button"/> (title; href navigation is a later wave).</summary>
+/// <summary>Navigation link → a MAUI <see cref="Button"/>. A link with a <c>Url</c> navigates the shell via
+/// <see cref="IMauiNavigator"/> (the href path); links without a Url fall back to their server
+/// <c>ClickAction</c> (a <see cref="MauiView.PostClick"/> <c>ClickedEvent</c>).</summary>
 public sealed class NavLinkView : MauiView<NavLinkControl>
 {
     private Button _button = null!;
+    private string? _href;
     protected override View CreateView()
     {
         _button = new Button { HorizontalOptions = LayoutOptions.Start };
-        // Fires the link's ClickAction via ClickedEvent. (Pure href navigation is a later wave — it
-        // needs a MAUI INavigationService; ClickAction-based nav links work now.)
-        _button.Clicked += (_, _) => PostClick();
+        _button.Clicked += (_, _) =>
+        {
+            var nav = !string.IsNullOrWhiteSpace(_href)
+                ? Stream?.Hub.ServiceProvider.GetService<IMauiNavigator>()
+                : null;
+            if (nav is not null) nav.NavigateTo(_href!, _button.Text);
+            else PostClick(); // ClickAction-based link (or no navigator registered).
+        };
         return _button;
     }
-    protected override void Bind() => Bind<object>(Model.Title, v => _button.Text = v?.ToString() ?? "");
+    protected override void Bind()
+    {
+        Bind<object>(Model.Title, v => _button.Text = v?.ToString() ?? "");
+        Bind<object>(Model.Url, v => _href = v?.ToString());
+    }
 }
 
 /// <summary>Menu item → a MAUI <see cref="Label"/> (title).</summary>
@@ -936,6 +954,97 @@ public sealed class DateTimeView : FormMauiView<DateTimeControl>
         else if (v is DateTimeOffset dto) _picker.Date = dto.DateTime;
         else if (v is string s && DateTime.TryParse(s, out var p)) _picker.Date = p;
     });
+}
+
+/// <summary>Date-only field → MAUI <see cref="DatePicker"/> (two-way). Sibling of <see cref="DateTimeView"/>
+/// for the framework's <see cref="DateControl"/> (date without a time component).</summary>
+public sealed class DateView : FormMauiView<DateControl>
+{
+    private DatePicker _picker = null!;
+    protected override View CreateView()
+    {
+        _picker = new DatePicker();
+        _picker.DateSelected += (_, e) => Write<object>(Model.Data, e.NewDate);
+        return _picker;
+    }
+    protected override void Bind() => BindValue<object>(Model.Data, v =>
+    {
+        if (v is DateTime d) _picker.Date = d;
+        else if (v is DateTimeOffset dto) _picker.Date = dto.DateTime;
+        else if (v is string s && DateTime.TryParse(s, out var p)) _picker.Date = p;
+    });
+}
+
+/// <summary>Single-choice radio group → a vertical stack of MAUI <see cref="RadioButton"/>s sharing a group
+/// (two-way). Mirrors <see cref="SelectView"/> but presents the options inline instead of in a dropdown.</summary>
+public sealed class RadioGroupView : FormMauiView<RadioGroupControl>
+{
+    private VerticalStackLayout _stack = null!;
+    private List<(string Text, string? Value)> _options = new();
+    private readonly List<RadioButton> _buttons = new();
+    // A stable group name keeps the radios mutually exclusive (MAUI scopes selection by GroupName).
+    private readonly string _group = "rg-" + Guid.NewGuid().ToString("N");
+
+    protected override View CreateView() => _stack = new VerticalStackLayout { Spacing = 4 };
+
+    protected override void Bind()
+    {
+        _options = CoerceOptions(Model.Options);
+        _stack.Children.Clear();
+        _buttons.Clear();
+        foreach (var (text, value) in _options)
+        {
+            var rb = new RadioButton { Content = text, GroupName = _group, Value = value };
+            rb.CheckedChanged += (_, e) => { if (e.Value) Write(Model.Data, value); };
+            _buttons.Add(rb);
+            _stack.Children.Add(rb);
+        }
+        BindValue<object>(Model.Data, v =>
+        {
+            var idx = _options.FindIndex(o => string.Equals(o.Value, v?.ToString(), StringComparison.Ordinal));
+            for (var i = 0; i < _buttons.Count; i++) _buttons[i].IsChecked = i == idx;
+        });
+    }
+}
+
+/// <summary>Numeric slider → MAUI <see cref="Slider"/> over [Min, Max]. The framework
+/// <see cref="SliderControl"/> carries no data pointer (Min/Max/Step only), so this renders the range
+/// visually — read-only, matching the control's shape (Blazor has no slider component at all).</summary>
+public sealed class SliderView : MauiView<SliderControl>
+{
+    protected override View CreateView() => new Slider
+    {
+        Minimum = Model.Min,
+        Maximum = Math.Max(Model.Max, Model.Min + 1),
+    };
+}
+
+/// <summary>Spacer → a transparent, flexible <see cref="BoxView"/> that absorbs free space in its parent
+/// stack/grid (the layout-skin spacer).</summary>
+public sealed class SpacerView : MauiView<SpacerControl>
+{
+    protected override View CreateView() => new BoxView
+    {
+        Color = Colors.Transparent,
+        HorizontalOptions = LayoutOptions.Fill,
+        VerticalOptions = LayoutOptions.Fill,
+    };
+}
+
+/// <summary>Exception message → a red caption with the message and (when present) type + stack trace,
+/// the native counterpart of Blazor's error message bar.</summary>
+public sealed class ExceptionView : MauiView<ExceptionControl>
+{
+    protected override View CreateView()
+    {
+        var stack = new VerticalStackLayout { Spacing = 2, Padding = new Thickness(8) };
+        stack.Children.Add(new Label { Text = Model.Message, TextColor = Colors.OrangeRed, FontAttributes = FontAttributes.Bold });
+        if (!string.IsNullOrWhiteSpace(Model.Type))
+            stack.Children.Add(new Label { Text = Model.Type, TextColor = Colors.OrangeRed, FontSize = 11 });
+        if (!string.IsNullOrWhiteSpace(Model.StackTrace))
+            stack.Children.Add(new Label { Text = Model.StackTrace, TextColor = Colors.Gray, FontSize = 10 });
+        return stack;
+    }
 }
 
 /// <summary>Combobox → MAUI <see cref="Picker"/> (two-way; native Picker has no free-type filter — a

--- a/src/MeshWeaver.Maui/MauiViewPack.cs
+++ b/src/MeshWeaver.Maui/MauiViewPack.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Linq;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Layout;
@@ -377,6 +378,8 @@ public static class MauiViewPackExtensions
         // Wave 2 — query-driven: mesh node picker + catalog search.
         .Register<MeshNodePickerControl, MeshNodePickerView>()
         .Register<MeshSearchControl, MeshSearchView>()
+        // Node-bound editor: edits a node's content directly via GetMeshNodeStream(path).Update(...).
+        .Register<MeshNodeContentEditorControl, MeshNodeContentEditorView>()
         // Embedded remote area (e.g. the home page's bottom chat composer) → the existing LayoutAreaView.
         .Register<LayoutAreaControl, LayoutAreaControlView>()
         // Wave 2 — nav + badges.
@@ -1202,6 +1205,143 @@ public sealed class LayoutAreaControlView : MauiView<LayoutAreaControl>
         return address.Equals(workspace.Hub.Address)
             ? new LayoutAreaView(workspace, Model.Reference, Renderer)
             : new LayoutAreaView(workspace, address, Model.Reference, Renderer);
+    }
+}
+
+// ---- Wave 2 control views: node-bound editor --------------------------------------------------------
+
+/// <summary>
+/// Native, cache-bound editor for a mesh node's content — the AspNetCore-free counterpart of Blazor's
+/// <c>MeshNodeContentEditorView</c>. Binds DIRECTLY to the node stream (<c>Hub.GetMeshNodeStream(NodePath)</c>):
+/// reads stay live with the node and every field edit writes back through <c>GetMeshNodeStream(NodePath)
+/// .Update(...)</c> as a per-field read-modify-write patch. ONE source of truth (the node stream) — NO
+/// <c>/data</c> replica, NO debounced save loop (the forbidden replicate-then-save antipattern). The fields
+/// are declared on the control (reflected on the backend), so the view needs no client type registry.
+/// </summary>
+public sealed class MeshNodeContentEditorView : MauiView<MeshNodeContentEditorControl>
+{
+    private VerticalStackLayout _root = null!;
+    private string _path = "";
+    private bool _canEdit = true;
+    private bool _suppress;          // true while loading echoed node state → don't re-persist
+    private string? _focusedKey;     // the field the user is actively typing → don't clobber it
+    // One loader per field key: applies the latest node content to that field's native control.
+    private readonly Dictionary<string, Action<MeshNode>> _loaders = new();
+
+    protected override View CreateView()
+    {
+        _path = Model.NodePath ?? "";
+        _canEdit = Model.CanEdit;
+        _root = new VerticalStackLayout { Spacing = 8 };
+        foreach (var f in Model.Fields)
+            _root.Children.Add(BuildField(f));
+        return _root;
+    }
+
+    protected override void Bind()
+    {
+        if (Stream is null || string.IsNullOrEmpty(_path)) return;
+        // Bind to the node stream — reads stay live; reuse the shared cache handle.
+        var sub = Stream.Hub.GetMeshNodeStream(_path)
+            .Where(n => n is not null)
+            .Subscribe(node => MainThread.BeginInvokeOnMainThread(() =>
+            {
+                _suppress = true;
+                try { foreach (var load in _loaders.Values) load(node!); }
+                finally { _suppress = false; }
+            }));
+        Disposables.Add(sub);
+    }
+
+    private View BuildField(MeshNodeEditorField f)
+    {
+        var label = new Label { Text = f.Label, FontSize = 12, TextColor = Colors.Gray };
+        View input;
+        switch (f.Kind)
+        {
+            case MeshNodeEditorFieldKind.Bool:
+            {
+                var cb = new CheckBox { IsEnabled = _canEdit };
+                cb.CheckedChanged += (_, e) => { if (!_suppress) Persist(f.Key, JsonValue.Create(e.Value)); };
+                _loaders[f.Key] = node =>
+                {
+                    var v = FieldValue(node, f.Key);
+                    cb.IsChecked = v is JsonValue jb && jb.TryGetValue<bool>(out var b) && b;
+                };
+                input = cb;
+                break;
+            }
+            case MeshNodeEditorFieldKind.Enum:
+            {
+                var picker = new Picker { IsEnabled = _canEdit };
+                foreach (var o in f.Options) picker.Items.Add(o);
+                picker.SelectedIndexChanged += (_, _) =>
+                {
+                    if (_suppress) return;
+                    var val = picker.SelectedIndex >= 0 ? f.Options[picker.SelectedIndex] : null;
+                    Persist(f.Key, val is null ? null : JsonValue.Create(val));
+                };
+                _loaders[f.Key] = node =>
+                {
+                    var v = FieldValue(node, f.Key)?.ToString();
+                    picker.SelectedIndex = v is null ? -1 : f.Options.IndexOf(v);
+                };
+                input = picker;
+                break;
+            }
+            default: // Text
+            {
+                var entry = new Entry { IsEnabled = _canEdit };
+                entry.Focused += (_, _) => _focusedKey = f.Key;
+                entry.Unfocused += (_, _) => { if (_focusedKey == f.Key) _focusedKey = null; };
+                entry.TextChanged += (_, e) =>
+                {
+                    if (!_suppress)
+                        Persist(f.Key, string.IsNullOrEmpty(e.NewTextValue) ? null : JsonValue.Create(e.NewTextValue));
+                };
+                _loaders[f.Key] = node =>
+                {
+                    if (f.Key == _focusedKey) return; // don't clobber the active edit with an echo
+                    var v = FieldValue(node, f.Key);
+                    entry.Text = v is JsonValue js ? js.ToString() : v?.ToString() ?? "";
+                };
+                input = entry;
+                break;
+            }
+        }
+        return new VerticalStackLayout { Spacing = 2, Children = { label, input } };
+    }
+
+    private JsonNode? FieldValue(MeshNode node, string key) => ToJsonObject(node.Content)?[key];
+
+    /// <summary>Per-field read-modify-write straight to the node via the cache: re-read the latest content
+    /// inside the lambda and set ONLY this field, so concurrent writers / hidden fields aren't clobbered.</summary>
+    private void Persist(string key, JsonNode? value)
+    {
+        if (!_canEdit || Stream is null || string.IsNullOrEmpty(_path)) return;
+        var opts = Stream.Hub.JsonSerializerOptions;
+        var logger = Stream.Hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger<MeshNodeContentEditorView>();
+        Stream.Hub.GetMeshNodeStream(_path)
+            .Update(node =>
+            {
+                var obj = ToJsonObject(node.Content) ?? new JsonObject();
+                obj[key] = value is null ? null : JsonNode.Parse(value.ToJsonString());
+                return node with { Content = JsonSerializer.SerializeToElement<object>(obj, opts) };
+            })
+            .Subscribe(_ => { }, ex => logger?.LogWarning(ex,
+                "MeshNodeContentEditor: persist failed for {Path} field {Key}", _path, key));
+    }
+
+    private JsonObject? ToJsonObject(object? content)
+    {
+        if (content is null) return null;
+        try
+        {
+            return content is JsonElement je
+                ? JsonNode.Parse(je.GetRawText()) as JsonObject
+                : JsonSerializer.SerializeToNode(content, Stream!.Hub.JsonSerializerOptions) as JsonObject;
+        }
+        catch { return null; }
     }
 }
 

--- a/src/MeshWeaver.Maui/MauiViewPack.cs
+++ b/src/MeshWeaver.Maui/MauiViewPack.cs
@@ -243,6 +243,44 @@ public abstract class FormMauiView<TControl> : MauiView<TControl> where TControl
         if (boundValue is JsonPointerReference reference && Stream is not null)
             Stream.UpdatePointer(value, Control.DataContext, reference);
     }
+
+    /// <summary>
+    /// Coerces a list control's Options into (display text, value-string) pairs the native picker/list
+    /// can show + select. Handles both a typed <see cref="Option"/> list AND — the case the old code
+    /// missed — a <see cref="JsonElement"/> array (Options arrive serialized after the layout-stream
+    /// round-trip, so <c>as IEnumerable&lt;Option&gt;</c> was null → no options rendered). Value is the
+    /// item's string form (selection-match + write-back); covers the common string/enum-valued option.
+    /// </summary>
+    protected static List<(string Text, string? Value)> CoerceOptions(object? options)
+    {
+        var result = new List<(string Text, string? Value)>();
+        switch (options)
+        {
+            case IEnumerable<Option> typed:
+                foreach (var o in typed) result.Add((o.Text, o.GetItem()?.ToString()));
+                break;
+            case JsonElement { ValueKind: JsonValueKind.Array } arr:
+                foreach (var el in arr.EnumerateArray())
+                {
+                    var text = el.TryGetProperty("text", out var t) && t.ValueKind == JsonValueKind.String
+                        ? t.GetString() ?? ""
+                        : el.ToString();
+                    var val = el.TryGetProperty("item", out var it) ? JsonScalar(it)
+                        : el.TryGetProperty("itemString", out var its) ? its.GetString()
+                        : text;
+                    result.Add((text, val));
+                }
+                break;
+        }
+        return result;
+    }
+
+    private static string? JsonScalar(JsonElement e) => e.ValueKind switch
+    {
+        JsonValueKind.String => e.GetString(),
+        JsonValueKind.Null => null,
+        _ => e.GetRawText()
+    };
 }
 
 /// <summary>
@@ -803,26 +841,31 @@ public sealed class CheckBoxView : FormMauiView<CheckBoxControl>
 public sealed class SelectView : FormMauiView<SelectControl>
 {
     private Picker _picker = null!;
-    private List<Option> _options = new();
+    private List<(string Text, string? Value)> _options = new();
 
     protected override View CreateView()
     {
         _picker = new Picker();
-        _options = (Model.Options as IEnumerable<Option>)?.ToList() ?? new();
-        foreach (var o in _options) _picker.Items.Add(o.Text);
         _picker.SelectedIndexChanged += (_, _) =>
         {
             if (_picker.SelectedIndex >= 0 && _picker.SelectedIndex < _options.Count)
-                Write(Model.Data, _options[_picker.SelectedIndex].GetItem());
+                Write(Model.Data, _options[_picker.SelectedIndex].Value);
         };
         return _picker;
     }
 
-    protected override void Bind() => BindValue<object>(Model.Data, v =>
+    protected override void Bind()
     {
-        var idx = _options.FindIndex(o => Equals(o.GetItem()?.ToString(), v?.ToString()));
-        if (idx >= 0) _picker.SelectedIndex = idx;
-    });
+        // Options now coerce from the JsonElement round-trip too (were silently empty before).
+        _options = CoerceOptions(Model.Options);
+        _picker.Items.Clear();
+        foreach (var (text, _) in _options) _picker.Items.Add(text);
+        BindValue<object>(Model.Data, v =>
+        {
+            var idx = _options.FindIndex(o => string.Equals(o.Value, v?.ToString(), StringComparison.Ordinal));
+            if (idx >= 0) _picker.SelectedIndex = idx;
+        });
+    }
 }
 
 /// <summary>Boolean toggle → MAUI <see cref="Switch"/> (two-way).</summary>
@@ -900,48 +943,57 @@ public sealed class DateTimeView : FormMauiView<DateTimeControl>
 public sealed class ComboboxView : FormMauiView<ComboboxControl>
 {
     private Picker _picker = null!;
-    private List<Option> _options = new();
+    private List<(string Text, string? Value)> _options = new();
     protected override View CreateView()
     {
         _picker = new Picker();
-        _options = (Model.Options as IEnumerable<Option>)?.ToList() ?? new();
-        foreach (var o in _options) _picker.Items.Add(o.Text);
         _picker.SelectedIndexChanged += (_, _) =>
         {
             if (_picker.SelectedIndex >= 0 && _picker.SelectedIndex < _options.Count)
-                Write(Model.Data, _options[_picker.SelectedIndex].GetItem());
+                Write(Model.Data, _options[_picker.SelectedIndex].Value);
         };
         return _picker;
     }
-    protected override void Bind() => BindValue<object>(Model.Data, v =>
+    protected override void Bind()
     {
-        var idx = _options.FindIndex(o => Equals(o.GetItem()?.ToString(), v?.ToString()));
-        if (idx >= 0) _picker.SelectedIndex = idx;
-    });
+        // Free-type filter is still a later wave (native Picker has none); options now at least populate.
+        _options = CoerceOptions(Model.Options);
+        _picker.Items.Clear();
+        foreach (var (text, _) in _options) _picker.Items.Add(text);
+        BindValue<object>(Model.Data, v =>
+        {
+            var idx = _options.FindIndex(o => string.Equals(o.Value, v?.ToString(), StringComparison.Ordinal));
+            if (idx >= 0) _picker.SelectedIndex = idx;
+        });
+    }
 }
 
 /// <summary>Listbox → MAUI <see cref="Picker"/> (two-way single-select this wave).</summary>
 public sealed class ListboxView : FormMauiView<ListboxControl>
 {
     private Picker _picker = null!;
-    private List<Option> _options = new();
+    private List<(string Text, string? Value)> _options = new();
     protected override View CreateView()
     {
         _picker = new Picker();
-        _options = (Model.Options as IEnumerable<Option>)?.ToList() ?? new();
-        foreach (var o in _options) _picker.Items.Add(o.Text);
         _picker.SelectedIndexChanged += (_, _) =>
         {
             if (_picker.SelectedIndex >= 0 && _picker.SelectedIndex < _options.Count)
-                Write(Model.Data, _options[_picker.SelectedIndex].GetItem());
+                Write(Model.Data, _options[_picker.SelectedIndex].Value);
         };
         return _picker;
     }
-    protected override void Bind() => BindValue<object>(Model.Data, v =>
+    protected override void Bind()
     {
-        var idx = _options.FindIndex(o => Equals(o.GetItem()?.ToString(), v?.ToString()));
-        if (idx >= 0) _picker.SelectedIndex = idx;
-    });
+        _options = CoerceOptions(Model.Options);
+        _picker.Items.Clear();
+        foreach (var (text, _) in _options) _picker.Items.Add(text);
+        BindValue<object>(Model.Data, v =>
+        {
+            var idx = _options.FindIndex(o => string.Equals(o.Value, v?.ToString(), StringComparison.Ordinal));
+            if (idx >= 0) _picker.SelectedIndex = idx;
+        });
+    }
 }
 
 /// <summary>Layout grid → a wrapping MAUI <see cref="FlexLayout"/> of its child areas (a real flowing grid

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -31,6 +31,14 @@ public static class MeshExtensions
         config.TypeRegistry.WithType(typeof(PingResponse), nameof(PingResponse));
         config.TypeRegistry.WithType(typeof(MeshNode), nameof(MeshNode));
         config.TypeRegistry.WithType(typeof(MeshNodeState), nameof(MeshNodeState));
+        // AccessContext rides as a TYPED field on every IMessageDelivery. Unregistered, the
+        // polymorphic resolver stamps it a full-name $type ("MeshWeaver.Messaging.AccessContext") —
+        // harmless for the typed field (it round-trips) but it's ongoing log noise (the
+        // PolymorphicTypeInfoResolver "serializing UNREGISTERED type" warning fires once per hub) and
+        // dirties persisted deliveries. Register it (full-name READ alias FIRST, short name LAST) so
+        // it serialises with a stable short discriminator on every hub that applies AddMeshTypes.
+        config.TypeRegistry.WithType(typeof(MeshWeaver.Messaging.AccessContext), typeof(MeshWeaver.Messaging.AccessContext).FullName!);
+        config.TypeRegistry.WithType(typeof(MeshWeaver.Messaging.AccessContext), nameof(MeshWeaver.Messaging.AccessContext));
         // Core identity/activity node-content types live in THIS assembly but were never registered
         // anywhere, so any hub reading a {user} root node ("User") or its _UserActivity satellite
         // ("UserActivityRecord") got an untyped JsonElement ("TypeRegistry lacks the $type
@@ -38,7 +46,11 @@ public static class MeshExtensions
         // home-areas-hang-on-"awaiting first data" class of bug. Register them in the core registry
         // every host applies. (PartitionAccessPolicy is already registered via AddGraph; the AI
         // partition hubs additionally get all three via AddAITypes.)
+        // Full-name READ alias FIRST (legacy nodes persisted with a full-name $type), short nameof LAST
+        // so this hub keeps WRITING the short name. See WithGraphTypes for the full rationale.
+        config.TypeRegistry.WithType(typeof(MeshWeaver.Mesh.Security.User), typeof(MeshWeaver.Mesh.Security.User).FullName!);
         config.TypeRegistry.WithType(typeof(MeshWeaver.Mesh.Security.User), nameof(MeshWeaver.Mesh.Security.User));
+        config.TypeRegistry.WithType(typeof(MeshWeaver.Mesh.Activity.UserActivityRecord), typeof(MeshWeaver.Mesh.Activity.UserActivityRecord).FullName!);
         config.TypeRegistry.WithType(typeof(MeshWeaver.Mesh.Activity.UserActivityRecord), nameof(MeshWeaver.Mesh.Activity.UserActivityRecord));
         config.TypeRegistry.WithType(typeof(CreateNodeRequest), nameof(CreateNodeRequest));
         config.TypeRegistry.WithType(typeof(CreateNodeResponse), nameof(CreateNodeResponse));

--- a/src/MeshWeaver.Messaging.Hub/Serialization/PolymorphicTypeInfoResolver.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/PolymorphicTypeInfoResolver.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections;
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using MeshWeaver.Domain;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Messaging.Serialization;
 
@@ -10,8 +12,15 @@ namespace MeshWeaver.Messaging.Serialization;
 /// <summary>
 /// Custom type info resolver that provides polymorphism configuration based on the type registry.
 /// </summary>
-public class PolymorphicTypeInfoResolver(ITypeRegistry typeRegistry) : DefaultJsonTypeInfoResolver
+/// <param name="typeRegistry">The hub's type registry — the source of $type discriminators.</param>
+/// <param name="owner">A human-readable identity for the hub these options belong to (its address),
+/// used only to attribute the "serialized an unregistered type" warning to the publishing hub.</param>
+/// <param name="logger">Optional logger for the unregistered-type diagnostic.</param>
+public class PolymorphicTypeInfoResolver(ITypeRegistry typeRegistry, string? owner = null, ILogger? logger = null) : DefaultJsonTypeInfoResolver
 {
+    // Warn at most once per unregistered type (per hub/options instance) so the diagnostic can never
+    // itself become a storm. Instance field — dies with the hub's options; never static.
+    private readonly ConcurrentDictionary<Type, byte> warnedUnregistered = new();
     /// <summary>
     /// Resolves the <see cref="JsonTypeInfo"/> for <paramref name="type"/> and, for eligible object
     /// types, augments it with polymorphism options whose derived types are discovered from the type
@@ -73,8 +82,15 @@ public class PolymorphicTypeInfoResolver(ITypeRegistry typeRegistry) : DefaultJs
         // This ensures all concrete types get $type discriminators
         if (!baseType.IsAbstract && !baseType.IsInterface)
         {
+            // A type that is registered in THIS hub's registry resolves to its short collection name;
+            // an UNregistered type falls back to GetOrAddType → FormatType → the namespace-qualified
+            // full name. Probe registration BEFORE the auto-add so we can tell the two apart (generic
+            // names legitimately contain '.', so a naive '.'-scan would false-positive).
+            var wasRegistered = typeRegistry.TryGetCollectionName(baseType, out _);
             // Automatically register the type in the registry if not already present
             var typeName = typeRegistry.GetOrAddType(baseType);
+            if (!wasRegistered)
+                WarnUnregisteredSerialization(baseType, typeName);
             derivedTypes.Add(new JsonDerivedType(baseType, typeName));
         }
 
@@ -127,6 +143,30 @@ public class PolymorphicTypeInfoResolver(ITypeRegistry typeRegistry) : DefaultJs
 
         return derivedTypes;
     }
+
+    /// <summary>
+    /// The type is NOT registered in this hub's <see cref="ITypeRegistry"/>, so its <c>$type</c>
+    /// discriminator is the namespace-qualified full name instead of a stable short name. A node
+    /// (de)serialised this way — when read by another hub that registered the type under its short name
+    /// (or not at all) — comes back as an untyped <see cref="JsonElement"/>: every <c>Content is X</c>
+    /// soft-cast fails, the value "renders empty", and reactive waits time out (the <c>_Provider/_Policy</c>
+    /// storm). The fix is one of two things this warning is meant to make actionable: register the type on
+    /// the hub (<c>WithType(typeof(T), nameof(T))</c>), OR serialise the node from a hub that HAS it.
+    /// Deduped per type (instance dict, never static) so the diagnostic itself can never storm; this runs
+    /// during JsonTypeInfo resolution, which STJ caches per type, so it is at most once-per-type-per-hub.
+    /// </summary>
+    private void WarnUnregisteredSerialization(Type type, string discriminator)
+    {
+        if (logger is null || !warnedUnregistered.TryAdd(type, 0))
+            return;
+        logger.LogWarning(
+            "Unregistered type {Type} (de)serialised on hub {Hub} with full-name $type='{Discriminator}': "
+            + "this hub's TypeRegistry lacks it, so a hub that registered it under its short name reads it "
+            + "back as an untyped JsonElement (renders empty / reactive waits time out). Register it via "
+            + "WithType(typeof(...), nameof(...)) where this hub is configured, or serialise it from a hub that has it.",
+            type.FullName, owner ?? "(unknown)", discriminator);
+    }
+
     private static bool IsValidDerivedTypeForBase(Type baseType, Type derivedType)
     {
         // For object type, include all registered types that can be serialized polymorphically

--- a/src/MeshWeaver.Messaging.Hub/SerializationExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/SerializationExtensions.cs
@@ -99,8 +99,14 @@ public static class SerializationExtensions
 
         foreach (var standardConverter in standardConverters)
             options.Converters.Add(standardConverter);
-        options.TypeInfoResolver = new PolymorphicTypeInfoResolver(typeRegistry);
-        
+        // Pass the hub's address + a logger so the resolver can attribute an "unregistered type
+        // serialized with a full-name $type" warning to the publishing hub — the diagnostic that
+        // pinpoints WHERE a node is being serialized without its type registered.
+        options.TypeInfoResolver = new PolymorphicTypeInfoResolver(
+            typeRegistry,
+            hub.Address?.ToString(),
+            hub.ServiceProvider.GetService<ILogger<PolymorphicTypeInfoResolver>>());
+
         return options;
     }
 

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansUnresolvableNodeNoWedgeTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansUnresolvableNodeNoWedgeTest.cs
@@ -100,6 +100,48 @@ public class OrleansUnresolvableNodeNoWedgeTest(ITestOutputHelper output) : Orle
     }
 
     /// <summary>
+    /// A SINGLE-SEGMENT phantom partition — a top-level path segment with no node and no
+    /// provisioned partition behind it (the <c>_Provider</c> shape: an orphaned partition that a
+    /// stale schema/index keeps "looking alive") — must resolve to a FAST answer for a
+    /// <c>SubscribeRequest</c>: either the partition-root synthesis activates a bare placeholder, or
+    /// routing NACKs <c>NotFound</c> ("address unknown"). What it must NEVER do is leave the cache
+    /// hub's <c>SubscribeRequest</c> parked until the 60s framework RequestTimeout — that 60s spin is
+    /// exactly the sglauser flake. <c>WaitAsync(15s)</c> turns any such hang into a deterministic
+    /// <see cref="TimeoutException"/> (RED); a value OR a <see cref="DeliveryFailureException"/>
+    /// inside the window is GREEN.
+    /// </summary>
+    [Fact]
+    public async Task SubscribeToPhantomSingleSegmentPartition_AnswersFast_NeverSpinsToRequestTimeout()
+    {
+        var phantom = $"phantom{Guid.NewGuid():N}";   // single segment, never provisioned
+        var reader = GetClient($"reader-{Guid.NewGuid():N}", "TestUser");
+
+        Func<Task> subscribe = () => reader.Observe(
+                new GetDataRequest(new MeshNodeReference()),
+                o => o.WithTarget(new Address(phantom)))
+            .FirstAsync().ToTask()
+            .WaitAsync(15.Seconds());
+
+        try
+        {
+            await subscribe();
+            Output.WriteLine("[test] phantom partition answered (synthesized root) within budget — no spin");
+        }
+        catch (DeliveryFailureException dfe)
+        {
+            // "address unknown" surfaced fast — the desired outcome for a truly-absent partition.
+            Output.WriteLine($"[test] phantom partition fast-NACKed (address unknown): {dfe.Message}");
+        }
+        catch (TimeoutException)
+        {
+            Assert.Fail(
+                "WEDGE: a SubscribeRequest to a phantom single-segment partition spun past 15s instead of "
+                + "answering or fast-failing. Routing must give 'address unknown' (DeliveryFailure{NotFound}) "
+                + "promptly — never let the cache hub's Observe park until the 60s RequestTimeout (the flake).");
+        }
+    }
+
+    /// <summary>
     /// An ILLEGAL (unregistered) node type must surface a PROPER outcome FAST — either a
     /// clean rejection or a <see cref="DeliveryFailureException"/> — and must never hang
     /// the caller or crash the owning hub. Every op is bounded with <c>WaitAsync</c>, so a

--- a/test/MeshWeaver.Messaging.Hub.Test/TypeRegistryTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/TypeRegistryTest.cs
@@ -1,8 +1,14 @@
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.Domain;
 using MeshWeaver.Fixture;
+using MeshWeaver.Messaging.Serialization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace MeshWeaver.Messaging.Hub.Test;
@@ -14,6 +20,14 @@ public class TypeRegistryTest(ITestOutputHelper output) : HubTestBase(output)
     record HelloEvent;
 
     private record GenericRequest<T>(T Value);
+
+    // A type deliberately NOT registered on any hub — used to prove the resolver warns when a hub
+    // serializes a type its TypeRegistry doesn't know (the "serialized from the wrong place" defect).
+    private record UnregisteredPayload(string Value);
+
+    // A stand-in for a security content type, used to pin the legacy full-name-alias ordering contract
+    // (register full name FIRST, short name LAST) that WithGraphTypes / AddAITypes / AddMeshTypes rely on.
+    private record AliasedContent(bool PublicRead);
 
     protected override MessageHubConfiguration ConfigureHost(
         MessageHubConfiguration configuration
@@ -56,5 +70,79 @@ public class TypeRegistryTest(ITestOutputHelper output) : HubTestBase(output)
         canMap = typeRegistry.TryGetType(typeName!, out mappedType);
         canMap.Should().BeTrue();
         mappedType!.Type.Should().Be(typeof(GenericRequest<int?>));
+    }
+
+    /// <summary>
+    /// Serializing a type that is NOT in the serializing hub's registry stamps a full-name $type and
+    /// MUST warn — that warning is how we find a node "serialized from the wrong place" (the
+    /// _Provider/_Policy storm). The warning names the type and the publishing hub, and is deduped.
+    /// </summary>
+    [Fact]
+    public void SerializingUnregisteredType_WarnsAndNamesThePublisher()
+    {
+        var host = GetHost();
+        var typeRegistry = host.ServiceProvider.GetRequiredService<ITypeRegistry>();
+        // Sanity: the payload type is genuinely unregistered on this hub.
+        typeRegistry.TryGetCollectionName(typeof(UnregisteredPayload), out _).Should().BeFalse();
+
+        var captured = new ConcurrentQueue<string>();
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new ObjectPolymorphicConverter(typeRegistry));
+        options.TypeInfoResolver = new PolymorphicTypeInfoResolver(
+            typeRegistry, owner: "mesh/the-publishing-hub", logger: new CapturingLogger(captured));
+
+        // Serialize through the open `object` door so the polymorphic path (and the resolver) runs.
+        var json = JsonSerializer.Serialize((object)new UnregisteredPayload("hi"), typeof(object), options);
+
+        // It WAS written with the namespace-qualified full name (the latent cross-hub-read defect).
+        // FormatType normalizes the nested-type '+' separator to '.', matching what gets persisted.
+        var persistedDiscriminator = typeof(UnregisteredPayload).FullName!.Replace('+', '.');
+        json.Should().Contain(persistedDiscriminator);
+        // ...and the resolver surfaced exactly one warning naming the type + the publishing hub.
+        var warnings = captured.Where(m =>
+            m.Contains("Unregistered type") &&
+            m.Contains(typeof(UnregisteredPayload).FullName!) &&
+            m.Contains("mesh/the-publishing-hub")).ToList();
+        warnings.Should().ContainSingle("the unregistered-type warning fires once per type and identifies the hub");
+    }
+
+    /// <summary>
+    /// The legacy full-name alias contract: registering the full name FIRST and the short
+    /// <c>nameof</c> LAST makes BOTH discriminators resolve on read while the hub keeps WRITING the
+    /// short name (nameByType is last-write-wins). This is exactly what WithGraphTypes / AddAITypes /
+    /// AddMeshTypes now do for the security content types so legacy full-name nodes deserialize.
+    /// </summary>
+    [Fact]
+    public void FullNameAlias_ResolvesBothDiscriminators_ButWritesShortName()
+    {
+        var host = GetHost();
+        var typeRegistry = host.ServiceProvider.GetRequiredService<ITypeRegistry>();
+
+        typeRegistry.WithType(typeof(AliasedContent), typeof(AliasedContent).FullName!); // full name FIRST
+        typeRegistry.WithType(typeof(AliasedContent), nameof(AliasedContent));           // short name LAST
+
+        // Read: a legacy full-name $type AND the short name both resolve to the same type.
+        typeRegistry.TryGetType(typeof(AliasedContent).FullName!, out var byFull).Should().BeTrue();
+        byFull!.Type.Should().Be(typeof(AliasedContent));
+        typeRegistry.TryGetType(nameof(AliasedContent), out var byShort).Should().BeTrue();
+        byShort!.Type.Should().Be(typeof(AliasedContent));
+
+        // Write: the hub emits the SHORT name (so it never re-introduces full-name nodes).
+        typeRegistry.TryGetCollectionName(typeof(AliasedContent), out var writeName).Should().BeTrue();
+        writeName.Should().Be(nameof(AliasedContent));
+    }
+
+    private sealed class CapturingLogger(ConcurrentQueue<string> sink) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) => sink.Enqueue(formatter(state, exception));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }


### PR DESCRIPTION
## Problem
sglauser's atioz flakiness ("permission issues") was **not** the async-transition class fixed the day before. A legacy orphan top-level `_provider` Postgres schema held a single `_Provider/_Policy` `PartitionAccessPolicy`, left behind when the model catalog relocated `_Provider → Admin/Provider`. It was serialized by a hub **without the type registered**, so its persisted `$type` is the **full** name `MeshWeaver.Mesh.Security.PartitionAccessPolicy`; readers register only the short `nameof` name → it never type-resolves → `MeshNodeStreamCache.GetQuery` logs "stayed an untyped JsonElement" **thousands of times/hour** → cache-hub saturation → sglauser's 60s `SubscribeRequest` `TimeoutException`s.

## Fix
- **`V38_DropLegacyProviderSchema`** — drops the orphan `_provider` schema (+ `_versions`) and de-registers it from `searchable_schemas`. Guarded, idempotent, log-and-continue (mirrors `V03`). Only the top-level schema; the live `{user}/_Provider/…` per-user namespace (inside each user's own partition schema) is untouched.
- **Serialize-time diagnostic** (`PolymorphicTypeInfoResolver`) — warns when a hub (de)serializes a type its `TypeRegistry` lacks (→ full-name `$type`), naming the type **and the publishing hub**. Precise "not registered" probe (not a naive `.`-scan; generics carry dots), deduped per type. This is what found the orphan's siblings.
- **Full-name READ aliases** (full name first, `nameof` last → resolve both on read, keep writing short) for the security content types (`PartitionAccessPolicy/User/UserActivityRecord/AccessAssignment/RoleAssignment/Role`) + `AccessContext`.
- **Routing** — phantom-partition regression test; routing already fast-fails "address unknown" (the 60s timeouts were the storm starving the cache hub, not a routing bug).
- **Blazor logging** — anonymous-gate `/login` forceLoad redirect → Warning (dumps which identity source was null); `CircuitAccessHandler` connection down → Warning, up/open/close → Information on a dedicated `MeshWeaver.Blazor.Circuit` category.

## Verification
Deployed to **atioz** (image `hotfix-provider-0629-1055`): migration ran to "Version: 38", `_provider` gone from `searchable_schemas`, untyped storm → 0, `_Provider` mentions → 0, 60s `SubscribeRequest` timeouts → 0, `atioz.meshweaver.cloud` HTTP 200. The serialize-warning immediately surfaced `AccessContext` (now registered here) and an AgenticPension boot-read (separate, pre-existing). Reviewed by an agent (no blockers); two MEDIUM findings applied (V38 try/catch guard, read/write-neutral warning wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)