### PR TITLE
ci(multiarch): fix multi-arch container publish (list-property quoting + project-local RIDs)

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -104,43 +104,46 @@ jobs:
       # rebuilt by the release path / runbook §1, NOT on every main merge.
       # CIRun=true → continuous version 3.0.0-ci.<build> baked in; image tagged <sha> + moving `main`.
       #
-      # MULTI-ARCH: we drop `-r linux-x64` and instead set RuntimeIdentifiers + ContainerRuntimeIdentifiers
-      # to "linux-x64;linux-arm64". With no single RID set, the SDK (>= 8.0.405; we're on .NET 10)
+      # MULTI-ARCH: we drop `-r linux-x64` and instead set ContainerRuntimeIdentifiers to
+      # "linux-x64;linux-arm64". With no single RID set, the SDK (>= 8.0.405; we're on .NET 10)
       # publishes per-RID and combines the results into an OCI Image Index (manifest list) — so one tag
       # serves both x86 cloud nodes AND Apple-silicon (arm64) local k3s, which can then pull-and-self-
       # update natively from ACR instead of hand-building locally. ContainerRuntimeIdentifiers MUST be a
-      # subset of RuntimeIdentifiers (we set them equal). No Docker is needed: pushing the index straight
-      # to a remote registry (ContainerRegistry set) is fully Docker-free.
+      # subset of RuntimeIdentifiers — that subset requirement is why <RuntimeIdentifiers>linux-x64;linux-arm64
+      # </RuntimeIdentifiers> is declared INSIDE Memex.Portal.Distributed.csproj (project-local), NOT as a
+      # global `-p:RuntimeIdentifiers` here: a global `-p:` propagates to every ProjectReference and makes
+      # ~6 referenced libraries fail `NETSDK1083: RuntimeIdentifier 'linux-x64;linux-arm64' is not recognized`.
+      # No Docker is needed: pushing the index straight to a remote registry (ContainerRegistry set) is Docker-free.
       # 🚨 PREREQUISITE: memex-portal-ai-base:latest in ACR must itself be MULTI-ARCH, else the arm64 leg
       # has no base layer and this step fails. base-image-acr.yml (workflow_dispatch) builds it multi-arch
       # (buildx → ACR); operators doing the first multi-arch roll run that once (see LocalColimaMac.md).
-      # 🚨 The ;-separated property LISTS are %3B-escaped, NOT raw `;`: a raw `;` in a `-p:Foo=a;b` arg is
-      # parsed by MSBuild's command-line property splitter as the START OF A NEW PROPERTY (`b`), which it
-      # then rejects — `MSBUILD : error MSB1006: Property is not valid. Switch: linux-arm64`. `%3B` is the
-      # MSBuild escape for a literal semicolon inside a value. Applies to RuntimeIdentifiers,
-      # ContainerRuntimeIdentifiers AND ContainerImageTags (every `-p:` whose value is a `;`-list).
+      # 🚨 List-valued `-p:` props are wrapped '"a;b"' — single-quoted DOUBLE-quotes around a REAL `;`, NOT
+      # `%3B`. `%3B` is an MSBuild-ESCAPED (literal) semicolon, so `-p:ContainerRuntimeIdentifiers=a%3Bb` is a
+      # SINGLE RID value "a;b" that NEVER splits into a list — the SDK then builds ONE image with the bogus RID
+      # "linux-x64;linux-arm64" and fails (OutputPath MSB4115 / NETSDK1083). The '"…"' form (the SDK's own
+      # documented Bash escaping) keeps the value one CLI switch while letting MSBuild split the real `;` into a
+      # 2-item list. Applies to ContainerRuntimeIdentifiers AND ContainerImageTags (every `-p:` whose value is a `;`-list).
       - name: Build + push portal-ai
         run: >
           dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
-          -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
-          -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"
+          -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:CIRun=true
           -p:ContainerRegistry=${{ env.ACR }}
           -p:ContainerRepository=memex-portal-ai
-          -p:ContainerImageTags="${{ steps.vars.outputs.version }}%3B${{ steps.vars.outputs.sha }}%3Bmain"
+          -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"'
           -p:ContainerBaseImage=${{ env.ACR }}/memex-portal-ai-base:latest
       # migration — lean image on the standard (already multi-arch) aspnet base; same multi-arch publish.
+      # <RuntimeIdentifiers> lives in Memex.Database.Migration.csproj (project-local, same reason as above).
       - name: Build + push migration
         run: >
           dotnet publish memex/aspire/Memex.Database.Migration/Memex.Database.Migration.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
-          -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
-          -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"
+          -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:CIRun=true
           -p:ContainerRegistry=${{ env.ACR }}
           -p:ContainerRepository=memex-migration
-          -p:ContainerImageTags="${{ steps.vars.outputs.version }}%3B${{ steps.vars.outputs.sha }}%3Bmain"
+          -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"'
 
   # ───────────────────────────────── DEPLOY ──────────────────────────────────
   # One leg per environment (namespace) on the shared private cluster. Each leg points the

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -66,23 +66,28 @@ jobs:
             -t "$BASE:$VERSION" -t "$BASE:latest" \
             --push deploy/base-images/portal-ai
 
-      # MULTI-ARCH (steps 2-4): drop `-r linux-x64`; set RuntimeIdentifiers + ContainerRuntimeIdentifiers
-      # to "linux-x64;linux-arm64". With no single RID, the SDK (>= 8.0.405; we're on .NET 10) publishes
-      # per-RID and combines them into an OCI Image Index (manifest list) — one tag, both architectures.
-      # ContainerRuntimeIdentifiers MUST be a subset of RuntimeIdentifiers (we set them equal). The arm64
-      # leg pulls the arm64 layer from the multi-arch base built above.
+      # MULTI-ARCH (steps 2-4): drop `-r linux-x64`; set ContainerRuntimeIdentifiers to "linux-x64;linux-arm64".
+      # With no single RID, the SDK (>= 8.0.405; we're on .NET 10) publishes per-RID and combines them into an
+      # OCI Image Index (manifest list) — one tag, both architectures. ContainerRuntimeIdentifiers MUST be a
+      # subset of RuntimeIdentifiers — that subset requirement is why <RuntimeIdentifiers>linux-x64;linux-arm64
+      # </RuntimeIdentifiers> is declared INSIDE the csprojs (project-local), NOT as a global `-p:RuntimeIdentifiers`
+      # (a global `-p:` propagates to every ProjectReference → ~6 libs fail `NETSDK1083: RuntimeIdentifier
+      # 'linux-x64;linux-arm64' is not recognized`). The arm64 leg pulls the arm64 layer from the multi-arch base above.
+      # 🚨 List-valued `-p:` props use REAL `;` kept as ONE CLI switch, NOT `%3B`: `%3B` is an MSBuild-ESCAPED
+      # (literal) semicolon, so a%3Bb is a SINGLE bogus RID "a;b" that never splits → build fails. Static lists use
+      # '"a;b"' (single-quoted double-quotes); lists containing a bash var ($VERSION) use "\"$VERSION;latest\"" so
+      # bash expands the var while MSBuild still gets the value as one switch with a splittable real `;`.
 
       # 2. portal-ai app image (SDK container build, layered on the multi-arch base; CLIs baked in).
       - name: Build + push portal-ai
         run: >
           dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
-          -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
-          -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"
+          -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:Version=$VERSION
           -p:ContainerRegistry=ghcr.io
           -p:ContainerRepository=$IMAGE_NS/memex-portal-ai
-          -p:ContainerImageTags="$VERSION%3Blatest"
+          -p:ContainerImageTags="\"$VERSION;latest\""
           -p:ContainerBaseImage=ghcr.io/$IMAGE_NS/memex-portal-ai-base:$VERSION
 
       # 3. lean portal app image (default — already multi-arch — SDK aspnet base, no co-hosted CLIs).
@@ -90,24 +95,22 @@ jobs:
         run: >
           dotnet publish memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
-          -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
-          -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"
+          -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:Version=$VERSION
           -p:ContainerRegistry=ghcr.io
           -p:ContainerRepository=$IMAGE_NS/memex-portal
-          -p:ContainerImageTags="$VERSION%3Blatest"
+          -p:ContainerImageTags="\"$VERSION;latest\""
 
       # 4. db-migration image (SDK container build, default — already multi-arch — base).
       - name: Build + push migration
         run: >
           dotnet publish memex/aspire/Memex.Database.Migration/Memex.Database.Migration.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
-          -p:RuntimeIdentifiers="linux-x64%3Blinux-arm64"
-          -p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"
+          -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:Version=$VERSION
           -p:ContainerRegistry=ghcr.io
           -p:ContainerRepository=$IMAGE_NS/memex-migration
-          -p:ContainerImageTags="$VERSION%3Blatest"
+          -p:ContainerImageTags="\"$VERSION;latest\""
 
       # 5. Mirror the released (clean-version) images into ACR (meshweaver.azurecr.io). The continuous
       #    channel ships to ACR (main-cd.yml); mirroring the official release there too means an

--- a/memex/aspire/Memex.Database.Migration/Memex.Database.Migration.csproj
+++ b/memex/aspire/Memex.Database.Migration/Memex.Database.Migration.csproj
@@ -3,6 +3,14 @@
     <ProjectGuid>{a1b2c3d4-e5f6-7890-abcd-ef1234567890}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Multi-arch container publish: declare the RID set HERE (project-local), NOT as a global
+         `-p:RuntimeIdentifiers=` on the CLI. The container publish (`-t:PublishContainer
+         -p:ContainerRuntimeIdentifiers=linux-x64;linux-arm64`) requires RuntimeIdentifiers to be
+         declared so the SDK drives a per-RID inner build and assembles an OCI image index. A global
+         `-p:RuntimeIdentifiers` would propagate to every ProjectReference and make the libraries fail
+         `NETSDK1083: RuntimeIdentifier 'linux-x64;linux-arm64' is not recognized`; a project-local
+         property does not propagate, so the libraries are built per-RID with a single valid RID. -->
+    <RuntimeIdentifiers>linux-x64;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+++ b/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
@@ -6,6 +6,14 @@
     <PublishProfile>DefaultContainer</PublishProfile>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
     <RequiresAspNetWebAssets>true</RequiresAspNetWebAssets>
+    <!-- Multi-arch container publish: declare the RID set HERE (project-local), NOT as a global
+         `-p:RuntimeIdentifiers=` on the CLI. The container publish (`-t:PublishContainer
+         -p:ContainerRuntimeIdentifiers=linux-x64;linux-arm64`) requires RuntimeIdentifiers to be
+         declared so the SDK drives a per-RID inner build and assembles an OCI image index. A global
+         `-p:RuntimeIdentifiers` would propagate to every ProjectReference and make the libraries fail
+         `NETSDK1083: RuntimeIdentifier 'linux-x64;linux-arm64' is not recognized`; a project-local
+         property does not propagate, so the libraries are built per-RID with a single valid RID. -->
+    <RuntimeIdentifiers>linux-x64;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -59,11 +67,20 @@
       <_MeshLocalFeedStage>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)meshlocalfeed'))</_MeshLocalFeedStage>
     </PropertyGroup>
     <RemoveDir Directories="$(_MeshLocalFeedStage)" />
+    <!-- 🚨 RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers;..." is load-bearing for the MULTI-ARCH
+         publish. During a multi-RID container publish the SDK runs a per-RID inner build with a concrete
+         global RuntimeIdentifier (linux-x64, then linux-arm64). The <MSBuild> task inherits the parent's
+         global properties, so without RemoveProperties these Pack calls would inherit RuntimeIdentifier=
+         linux-x64 and try to pack the RID-AGNOSTIC BusinessRules/Generator libraries for that RID — which
+         were restored without it → NETSDK1047 "assets file doesn't have a target for 'net10.0/linux-x64'".
+         These are plain (RID-agnostic) NuGet packages; strip the RID so Pack runs RID-agnostic. -->
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\..\src\MeshWeaver.BusinessRules\MeshWeaver.BusinessRules.csproj"
              Targets="Pack"
+             RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers;SelfContained;PublishSelfContained"
              Properties="Configuration=$(Configuration);PackageOutputPath=$(_MeshLocalFeedStage)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\..\src\MeshWeaver.BusinessRules.Generator\MeshWeaver.BusinessRules.Generator.csproj"
              Targets="Pack"
+             RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers;SelfContained;PublishSelfContained"
              Properties="Configuration=$(Configuration);PackageOutputPath=$(_MeshLocalFeedStage)" />
     <!-- Inject via ResolvedFileToPublish, NOT Content. A <Content> item added inside a
          BeforeTargets="ComputeFilesToPublish" hook arrives TOO LATE: the SDK chain


### PR DESCRIPTION
## Problem

The multi-arch (linux/amd64 + linux/arm64) container publish in `main-cd.yml` and `release-images.yml` had **never run green**. It failed with `NETSDK1083: RuntimeIdentifier 'linux-x64;linux-arm64' is not recognized` on ~6 referenced library projects.

## Root cause (three compounding defects)

1. **`%3B` is an MSBuild-*escaped* (literal) semicolon, not a list separator.** `-p:ContainerRuntimeIdentifiers="linux-x64%3Blinux-arm64"` is a **single** RID value `linux-x64;linux-arm64` that never splits into a 2-item list, so the SDK builds one image with that bogus RID → `MSB4115` (OutputPath has a literal `;`) / `NETSDK1083`. The same single bad RID propagated to libraries was the original NETSDK1083.
2. **The global `-p:RuntimeIdentifiers` propagates to every `ProjectReference`**, so the libraries inherited the bad multi-value RID.
3. **`BakeMeshLocalFeed`'s `<MSBuild Targets="Pack">` calls inherited the per-RID `RuntimeIdentifier`** (linux-x64, then linux-arm64) from the inner publish and tried to pack the RID-agnostic `BusinessRules`/`Generator` libs for that RID → `NETSDK1047`. This only surfaces under a per-RID build, which is why multi-arch "never ran green."

## Fix

- Pass list-valued `-p:` props with a **real `;` kept as one CLI switch** (the SDK's documented Bash escaping): `'"linux-x64;linux-arm64"'` for static lists, `"\"$VERSION;latest\""` when the value contains a bash var. Dropped all `%3B`.
- Declare `<RuntimeIdentifiers>linux-x64;linux-arm64</RuntimeIdentifiers>` **project-local** in `Memex.Portal.Distributed.csproj` + `Memex.Database.Migration.csproj` (satisfies the `ContainerRuntimeIdentifiers ⊆ RuntimeIdentifiers` requirement **without** propagating to libraries). Dropped the global `-p:RuntimeIdentifiers` from both workflows.
- Added `RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers;SelfContained;PublishSelfContained"` to the two `BakeMeshLocalFeed` Pack calls so they run RID-agnostic.

## Verification

Published both images to ACR with the fixed invocation (no Docker, Docker-free SDK push). `az acr manifest show` reports **both architectures** for each:

- `memex-portal-ai` → `["amd64","arm64"]`
- `memex-migration` → `["amd64","arm64"]`

(test tags cleaned up afterward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
