### PR TITLE
feat(self-update): CI-green update gate + pull-based deploy + local-only test guard

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -145,47 +145,15 @@ jobs:
           -p:ContainerRepository=memex-migration
           -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"'
 
-  # ───────────────────────────────── DEPLOY ──────────────────────────────────
-  # One leg per environment (namespace) on the shared private cluster. Each leg points the
-  # deployment at the freshly-pushed SHA tag and restarts — the documented code-update flow
-  # (kubectl set image + rollout restart + rollout status), NOT deploy.sh (env setup).
-  # fail-fast:false so one environment failing doesn't abort the rollout to the others.
-  deploy:
-    name: "Deploy ${{ matrix.ns }}"
-    needs: images
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        ns: [memex, atioz, memex-cloud]
-    # Map each namespace to a GitHub Environment so prod (memex-cloud) CAN be given a required-
-    # reviewer / wait-timer protection rule later without touching this file. No rule = auto-deploy.
-    environment: ${{ matrix.ns }}
-    steps:
-      - name: Ensure Azure CLI
-        # GitHub's ubuntu-latest no longer ships the Azure CLI on PATH for azure/login@v2
-        # ("Unable to locate executable file: az"). Install it if missing (idempotent).
-        run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-      - name: Azure login (OIDC)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      # Private cluster → kubectl ONLY via `az aks command invoke`. $NS/$TAG are expanded by the
-      # runner shell here, so the resolved namespace + tag are baked into the command string the
-      # cluster runs. migration + portal are set + restarted together (matches AGENTS.md); we then
-      # WAIT on the portal rollout so an unhealthy image fails this job loudly instead of going green.
-      - name: Roll out to ${{ matrix.ns }}
-        env:
-          NS: ${{ matrix.ns }}
-          TAG: ${{ needs.images.outputs.tag }}
-        run: |
-          set -euo pipefail
-          az aks command invoke -g "$AKS_RG" -n "$AKS_CLUSTER" --command "
-            kubectl -n $NS set image deployment/memex-portal-deployment memex-portal=$ACR/memex-portal-ai:$TAG;
-            kubectl -n $NS set image deployment/memex-migration-deployment memex-migration=$ACR/memex-migration:$TAG;
-            kubectl -n $NS rollout restart deployment/memex-migration-deployment deployment/memex-portal-deployment;
-            kubectl -n $NS rollout status deployment/memex-portal-deployment --timeout=300s
-          "
+  # ─────────────────────────────── NO DEPLOY JOB ─────────────────────────────
+  # Deployment is PULL-BASED, not push. CI's job ends at "publish the image to ACR" (the `images`
+  # job above). Each installation — memex / atioz / memex-cloud AND every external install in the
+  # world that prod knows nothing about — runs the in-portal self-updater
+  # (memex/Memex.Portal.Shared/SelfUpdate): it polls ACR with its OWN workload identity, and, per its
+  # own Admin/UpdatePolicy (Continuous/Stable/None + the CI-green gate), patches its OWN portal +
+  # migration Deployments via its OWN in-cluster ServiceAccount token. So CI needs NO cluster
+  # credentials — which is also why the old `az aks command invoke` deploy job was deleted: it
+  # required a central service principal with per-cluster Azure RBAC (the `commandResults/read`
+  # authorization failure on 2026-06-29), a model that cannot scale to installs prod doesn't manage.
+  # See SelfUpdate.md / DEPLOY-RUNBOOK.md for enabling self-update on an environment (the SA + RBAC are
+  # in the Helm chart; set selfUpdate.azureClientId and grant the UAMI AcrPull).

--- a/deploy/aks/SELF-UPDATE.md
+++ b/deploy/aks/SELF-UPDATE.md
@@ -1,0 +1,72 @@
+# Pull-based self-update (the deploy model)
+
+Deployment is **pull, not push**. CI's responsibility ends at *publishing the image to ACR*
+(`.github/workflows/main-cd.yml` → the `images` job). There is **no deploy job** and CI holds **no
+cluster credentials**. Each installation updates *itself*:
+
+```
+merge to main ─▶ "Build and Test" (green) ─▶ images job builds+pushes  meshweaver.azurecr.io/memex-portal-ai:<version>
+                                                                              │
+        ┌─────────────────────────────────────────────────────────────────────┼──────────────── … every install in the world
+        ▼                                   ▼                                   ▼
+   memex install                       atioz install                      external install
+   SelfUpdateHostedService polls ACR (its OWN workload identity) every 6h, per its OWN Admin/UpdatePolicy,
+   and PATCHes its OWN portal+migration Deployments via its OWN in-cluster ServiceAccount token.
+```
+
+**Why** — prod must not know about the (potentially many) installs, and a central CI service principal
+with per-cluster Azure RBAC cannot scale to clusters prod doesn't manage. (It was also the concrete
+break on 2026-06-29: the CD SP lacked `Microsoft.ContainerService/managedClusters/commandResults/read`,
+so every `az aks command invoke` deploy leg failed.) Pull-based removes that failure class entirely.
+
+Code: `memex/Memex.Portal.Shared/SelfUpdate/` — `SelfUpdateHostedService` (poller), `AcrTagLister`
+(ACR via AAD→ACR token exchange), `VersionSelect` (which tag), `KubernetesDeploymentUpdater` (in-cluster
+PATCH). Wired by `AddSelfUpdate()` in `MemexConfiguration.cs`.
+
+## Update policy (Admin → Platform updates)
+
+`Admin/UpdatePolicy` (`UpdatePolicyContent`), editable in the **Platform updates** settings tab:
+
+| Field | Meaning |
+|---|---|
+| **Update strategy** | `Continuous` (newest build incl. `-ci.N`, default) · `Stable` (clean releases only) · `None` (manual) |
+| **Only update to CI-verified (green) builds** | default **on**. The `images` job publishes ONLY when "Build and Test" is green, so every published tag is green by construction; this flag stays correct if an unverified **edge** channel is added (it excludes `-edge.N` tags). Off = also accept edge builds. |
+
+## Enabling self-update on an AKS environment
+
+Most of it is already in the chart (`deploy/helm/templates/memex-portal/`): the `memex-portal-sa`
+ServiceAccount, a namespaced Role/RoleBinding granting `get,patch` on the portal+migration Deployments,
+`serviceAccountName: memex-portal-sa` on the Deployment, and the conditional workload-identity
+annotation/label/env. The gaps are operational:
+
+1. **Azure (once):** ensure the portal UAMI + per-namespace federated credentials exist
+   (`deploy/aks/infra/modules/portal-identity.bicep`, default-on via `main.bicep`), and grant it
+   **AcrPull** on the registry (cross-RG, out-of-band — see `DEPLOY-RUNBOOK.md`):
+   ```bash
+   PORTAL_MI=$(az identity show -g memex-aks-rg -n memexaks-portal-mi --query principalId -o tsv)
+   az role assignment create --assignee-object-id "$PORTAL_MI" --assignee-principal-type ServicePrincipal \
+     --role AcrPull --scope "$(az acr show -n meshweaver --query id -o tsv)"
+   ```
+2. **Set `selfUpdate.azureClientId`** to the UAMI client id in each env's (git-ignored) values overlay,
+   then **`helm upgrade`** the env. This both wires workload identity AND (for envs whose live
+   Deployment predates the chart's SA — e.g. **atioz**, currently on the `default` SA) creates the SA +
+   RBAC and sets `serviceAccountName`. Manual fallback without re-helm:
+   ```bash
+   kubectl -n <ns> apply -f <SA + Role + RoleBinding from the chart>
+   kubectl -n <ns> patch deployment memex-portal-deployment --type=merge -p \
+     '{"spec":{"template":{"metadata":{"labels":{"azure.workload.identity/use":"true"}},"spec":{"serviceAccountName":"memex-portal-sa"}}}}'
+   ```
+3. **Verify:** the portal logs `[SelfUpdate] starting … canPatch=True`, and a newer ACR tag triggers
+   `[SelfUpdate] applying update <tag>`. A `403` on PATCH = missing RBAC (step 2); a token/ACR error =
+   missing workload identity or AcrPull (steps 1–2).
+
+> ⚠️ The chart's migration is a **Job**, but the updater/RBAC target `memex-migration-deployment`. Live
+> AKS clusters still have that Deployment (scaled to 0), so the migration PATCH is a harmless no-op
+> there; a chart-only env logs a 404 and skips it.
+
+## Follow-up: the "edge" (any / unverified) channel
+
+`RequireCiGreen = false` only does something once an **edge channel** publishes images on *every* build
+(not just green), tagged with an `edge` SemVer label (e.g. `3.0.0-edge.<run>`). Add a workflow that
+builds+pushes on `push: main` (independent of the test gate) to those tags; `VersionSelect.IsEdge` already
+recognizes and (in green-only mode) skips them.

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -64,20 +64,20 @@ public sealed class SelfUpdateHostedService : IHostedService
             // a maybe-absent node (NotFound storm).
             .EnsureExists(_hub, accessService, _options.DefaultPolicy, _logger)
             .SelectMany(_ => workspace.GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
-                .Select(node => UpdatePolicyNodeType.Parse(node, jsonOptions).Policy)
-                .DistinctUntilChanged()                               // <-- only re-switch on a REAL policy change
-                .StartWith(_options.DefaultPolicy))
+                .Select(node => UpdatePolicyNodeType.Parse(node, jsonOptions))
+                .DistinctUntilChanged(c => (c.Policy, c.RequireCiGreen)) // <-- re-switch only on a REAL policy change
+                .StartWith(new UpdatePolicyContent { Policy = _options.DefaultPolicy }))
             // The policy re-drives the poller via Switch. With DistinctUntilChanged the timer is only
             // re-subscribed when the admin ACTUALLY changes the policy (human-rare) — not a storm.
-            .Select(policy => policy == UpdatePolicyKind.None
+            .Select(content => content.Policy == UpdatePolicyKind.None
                 ? Observable.Empty<Unit>()                            // None => never poll
                 : Observable.Interval(_options.PollInterval).StartWith(-1L)
-                    .SelectMany(_ => RunOnce(policy)
+                    .SelectMany(_ => RunOnce(content)
                         .Catch((Exception ex) =>
                         {
                             // wedges-to-zero: a tick error (ACR outage, k8s 403) logs and the poller
                             // keeps ticking. No outer .Retry (that would be a resubscribe storm).
-                            _logger?.LogWarning(ex, "[SelfUpdate] check failed (policy={Policy}).", policy);
+                            _logger?.LogWarning(ex, "[SelfUpdate] check failed (policy={Policy}).", content.Policy);
                             return Observable.Empty<Unit>();
                         })))
             .Switch()
@@ -96,9 +96,9 @@ public sealed class SelfUpdateHostedService : IHostedService
 
     /// <summary>One evaluation: list tags → pick target per policy → gate target &gt; current →
     /// record availability → (if armed) patch the workloads.</summary>
-    private IObservable<Unit> RunOnce(UpdatePolicyKind policy) =>
+    private IObservable<Unit> RunOnce(UpdatePolicyContent policy) =>
         _http.Invoke(ct => _acr.ListTagsAsync(_options.PortalRepository, ct))
-            .Select(tags => VersionSelect.PickTarget(tags, policy))
+            .Select(tags => VersionSelect.PickTarget(tags, policy.Policy, policy.RequireCiGreen))
             .Where(target => !string.IsNullOrEmpty(target)
                           && VersionSelect.IsNewer(target!, ShippedReleaseSeed.InstalledPlatformVersion))
             .SelectMany(target => RecordAvailable(target!)

--- a/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
@@ -40,6 +40,17 @@ public record UpdatePolicyContent
     [Description("Update strategy")]
     public UpdatePolicyKind Policy { get; init; } = UpdatePolicyKind.Continuous;
 
+    /// <summary>
+    /// When <c>true</c> (default) the install only rolls to builds that PASSED CI ("green").
+    /// The continuous-delivery pipeline already publishes an image ONLY when "MeshWeaver Build and
+    /// Test" succeeds, so the verified channel contains green builds exclusively; this flag is the
+    /// forward-looking guard that keeps that guarantee if an "edge" channel (publish-on-every-build,
+    /// tags carrying the <c>edge</c> pre-release label) is ever added — green-only ignores those.
+    /// Set <c>false</c> to also accept unverified edge builds (bleeding-edge / pre-merge testing).
+    /// </summary>
+    [Description("Only update to CI-verified (green) builds")]
+    public bool RequireCiGreen { get; init; } = true;
+
     /// <summary>The newest image tag the poller has found on the registry (for the admin UI /
     /// detect-and-notify). Written by the poller; not user-editable.</summary>
     [Browsable(false)]

--- a/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
@@ -22,7 +22,7 @@ public static class VersionSelect
     /// (<c>!IsPrerelease</c>); <see cref="UpdatePolicyKind.None"/> always returns <c>null</c>.
     /// Returns the ORIGINAL tag string (so the image patch uses the exact registry tag).
     /// </summary>
-    public static string? PickTarget(IEnumerable<string> tags, UpdatePolicyKind policy)
+    public static string? PickTarget(IEnumerable<string> tags, UpdatePolicyKind policy, bool requireCiGreen = true)
     {
         if (policy == UpdatePolicyKind.None)
             return null;
@@ -35,11 +35,24 @@ public static class VersionSelect
         if (policy == UpdatePolicyKind.Stable)
             parsed = parsed.Where(x => !x.ver.IsPrerelease);
 
+        // CI-green gate: the verified channel (continuous delivery, which builds+pushes ONLY when the
+        // test workflow is green) never carries the `edge` pre-release label. An unverified "edge"
+        // channel (publish-on-every-build, e.g. `3.0.0-edge.51`) would. requireCiGreen excludes those,
+        // so the install never auto-rolls to a build that hasn't passed CI. Off => edge builds eligible.
+        if (requireCiGreen)
+            parsed = parsed.Where(x => !IsEdge(x.ver));
+
         return parsed
             .OrderByDescending(x => x.ver)
             .Select(x => x.tag)
             .FirstOrDefault();
     }
+
+    /// <summary>An UNVERIFIED edge/pre-merge build — identified by an <c>edge</c> SemVer pre-release
+    /// label (e.g. <c>3.0.0-edge.51</c>). Verified CD builds use <c>-ci.&lt;n&gt;</c> or a clean release,
+    /// never <c>edge</c>.</summary>
+    private static bool IsEdge(NuGetVersion version) =>
+        version.ReleaseLabels.Any(label => string.Equals(label, "edge", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// True if <paramref name="targetTag"/> is strictly newer than <paramref name="currentVersion"/>.

--- a/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
@@ -53,8 +53,10 @@ public static class UpdatePolicySettingsTab
         stack = stack.WithView(Controls.Markdown(
             "The platform self-updates per the strategy below. **Continuous** rolls to the newest build " +
             "(including build-numbered continuous builds); **Stable** rolls only to clean releases; " +
-            "**None** disables auto-update. On Kubernetes the portal patches its own deployment; elsewhere " +
-            "the latest version is surfaced for a manual update."));
+            "**None** disables auto-update. **Only update to CI-verified (green) builds** (default on) " +
+            "keeps the install on builds that passed CI — turn it off to also accept unverified edge builds. " +
+            "On Kubernetes the portal patches its own deployment; elsewhere the latest version is surfaced " +
+            "for a manual update."));
 
         // Running version (the installed platform version baked into the binary).
         stack = stack.WithView(Controls.Markdown(

--- a/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
+++ b/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
@@ -32,6 +32,22 @@ public class VersionSelectTest
     public void PickTarget_NoParseableTags_ReturnsNull()
         => Assert.Null(VersionSelect.PickTarget(["latest", "main", "garbage"], UpdatePolicyKind.Continuous));
 
+    // CI-green gate: a `-edge.N` build is UNVERIFIED. Default (RequireCiGreen=true) must skip it even
+    // though it is the newest; opting into "any" (RequireCiGreen=false) rolls to it.
+    [Fact]
+    public void GreenOnly_Default_ExcludesEdgeBuilds_EvenWhenNewest()
+        => Assert.Equal("3.0.0-ci.51",
+            VersionSelect.PickTarget(["3.0.0-ci.51", "3.1.0-edge.7"], UpdatePolicyKind.Continuous));
+
+    [Fact]
+    public void Any_RequireCiGreenFalse_IncludesEdgeBuilds()
+        => Assert.Equal("3.1.0-edge.7",
+            VersionSelect.PickTarget(["3.0.0-ci.51", "3.1.0-edge.7"], UpdatePolicyKind.Continuous, requireCiGreen: false));
+
+    [Fact]
+    public void UpdatePolicyContent_DefaultsToRequireCiGreen()
+        => Assert.True(new UpdatePolicyContent().RequireCiGreen, "green-only must be the safe default");
+
     [Theory]
     [InlineData("3.1.0-ci.5", "3.0.0-ci.51", true)]   // higher base wins
     [InlineData("3.0.0-ci.51", "3.0.0-ci.40", true)]  // monotonic ci number

--- a/test/MeshWeaver.Documentation.Test/TestsAreLocalOnlyGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/TestsAreLocalOnlyGuard.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard: unit and integration tests MUST run against LOCAL deployments only — local infra
+/// (Testcontainers, in-memory) and LOCAL/fake LLMs (<c>FakeChatClient</c> / a local Ollama), NEVER a
+/// cloud LLM API or a managed/remote database. This keeps the suite hermetic, deterministic, free, and
+/// offline (and is why the suite is not flaky on network/cost grounds).
+///
+/// <para>The guard targets what actually makes a network call: constructing a REAL cloud-LLM SDK
+/// client, or pointing at a managed/remote database. It deliberately does NOT flag cloud endpoint
+/// STRINGS — those legitimately appear as provider-catalog config data (e.g. a catalog's
+/// <c>DefaultEndpoint</c>) and in URL-construction tests that send through a FAKE handler, neither of
+/// which calls out. Whitelist a genuine exception with a trailing <c>// local-only-guard:allow</c>.</para>
+/// </summary>
+public class TestsAreLocalOnlyGuard
+{
+    // Patterns that mean a test would actually TALK to a cloud LLM (a real provider SDK client) or a
+    // managed/remote DB — none of which exist today (tests use FakeChatClient + Testcontainers). Not
+    // endpoint strings (catalog config) or model names, which are fine. Catches a future regression.
+    private static readonly string[] ForbiddenEndpoints =
+    [
+        // Real cloud-LLM SDK clients / registrations
+        "new OpenAIClient(", "new AzureOpenAIClient(", "new AnthropicClient(", "new MistralClient(",
+        "new CohereClient(", "new GenerativeModel(", "AddOpenAIChatClient", "AddAnthropicChatClient",
+        // Managed / remote databases (tests use Testcontainers, never a hosted DB)
+        ".postgres.database.azure.com", ".rds.amazonaws.com", ".database.windows.net",
+    ];
+
+    private const string AllowMarker = "local-only-guard:allow";
+
+    [Fact]
+    public void NoTestReachesACloudLlmOrRemoteDeployment()
+    {
+        var root = FindRepoRoot();
+        var testDir = Path.Combine(root, "test");
+        Assert.True(Directory.Exists(testDir), $"expected a 'test' directory at the repo root ({root})");
+
+        var offenders = Directory
+            .EnumerateFiles(testDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !IsUnderBinOrObj(f) && !IsThisGuard(f))
+            .SelectMany(f => File.ReadLines(f).Select((line, i) => (file: f, line, no: i + 1)))
+            .Where(x => !x.line.Contains(AllowMarker, StringComparison.Ordinal))
+            .Where(x => ForbiddenEndpoints.Any(e => x.line.Contains(e, StringComparison.OrdinalIgnoreCase)))
+            .Select(x => $"  {Path.GetRelativePath(root, x.file)}:{x.no}: {x.line.Trim()}")
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "Tests must use LOCAL deployments + local/fake LLMs (Testcontainers, FakeChatClient, local Ollama) — "
+            + "never a cloud LLM API or a remote/managed DB. Offending lines:\n" + string.Join("\n", offenders));
+    }
+
+    private static bool IsUnderBinOrObj(string path) =>
+        path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+        || path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+
+    private static bool IsThisGuard(string path) =>
+        Path.GetFileName(path).Equals("TestsAreLocalOnlyGuard.cs", StringComparison.Ordinal);
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+            ?? throw new InvalidOperationException(
+                "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
Follows from the 2026-06-29 atioz CD failure: the central CI service principal lacked `Microsoft.ContainerService/managedClusters/commandResults/read`, so every `az aks command invoke` deploy leg failed. The right model — and the one that scales to many installs prod doesn't manage — is **pull-based** self-update, which MeshWeaver already implements (`memex/Memex.Portal.Shared/SelfUpdate/`).

## What changed

**1. Pull-based deploy (drop the CD push)**
- `main-cd.yml`: removed the `deploy` job (the `az aks command invoke … set image … rollout` legs). CI's job ends at **publish image to ACR** (the `images` job stays). Each install's `SelfUpdateHostedService` polls ACR with its **own** workload identity and patches its **own** Deployments via its **own** in-cluster ServiceAccount token. CI holds **no** cluster credentials → the RBAC failure class is gone, and prod needs zero knowledge of installs.
- Runbook for enabling it per environment (SA/RBAC are already in the Helm chart; set `selfUpdate.azureClientId` + grant the UAMI AcrPull): **`deploy/aks/SELF-UPDATE.md`**.

**2. "Update only to CI-green builds" setting** (your ask)
- New `RequireCiGreen` field on `Admin/UpdatePolicy` (**default on**) — renders as a checkbox in the **Platform updates** settings tab. `VersionSelect` excludes unverified `-edge.N` tags in green-only mode; off accepts them.
- Note: the CD already publishes an image **only** on a green "Build and Test" run, so today every published tag is green by construction. This makes the guarantee explicit and future-proofs an "edge" (publish-on-every-build) channel — documented as a follow-up in the runbook.

**3. Local-only test guard** (your ask)
- `TestsAreLocalOnlyGuard` fails if any test constructs a **real cloud-LLM SDK client** or points at a **managed/remote DB**. Deliberately does NOT flag endpoint *strings* (those are legitimate provider-catalog config / fake-handler URL-construction). Locks in Testcontainers + `FakeChatClient` (the suite is already 100% local).

## Tests
- `VersionSelectTest`: +3 green-only cases (18/18 pass).
- `TestsAreLocalOnlyGuard`: passes (no test reaches a cloud client / remote DB today).

## Operational follow-ups (need cluster + Azure-admin; see runbook)
- Grant the portal UAMI **AcrPull**; set `selfUpdate.azureClientId`; **`helm upgrade`** each env so the live Deployment runs as `memex-portal-sa` (atioz currently on `default` SA → would 403). Until then, the shared portals are on hand-deployed images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)