### PR TITLE
feat(gitsync): git-history browser — commit log, change list, and diffs over the server-side working tree

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -677,6 +677,8 @@ public static class MemexConfiguration
                         .AddGitHubSyncSettingsTab()
                         // Code workspace tab — on-disk working-tree editor (checkout/edit/commit/push).
                         .AddWorkingTreeTab()
+                        // Git history tab — read-only git browser (commit log + changes + diffs) over the same working tree.
+                        .AddGitHistoryTab()
                         // Content Indexing tab — Space nodes, only when the indexing pipeline is active.
                         .AddContentIndexSettingsTab();
                 })

--- a/src/MeshWeaver.GitSync/GitHistoryTab.cs
+++ b/src/MeshWeaver.GitSync/GitHistoryTab.cs
@@ -1,0 +1,335 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Application.Styles;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Layout.DataGrid;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// The "Git history" settings tab — a read-only git browser over the on-disk working tree
+/// (<see cref="GitWorkingTreeService"/>). It renders the commit log of the Space's connected repo,
+/// the files each commit changed, and any uncommitted working-tree changes — and shows a Monaco
+/// side-by-side <see cref="DiffEditorControl"/> for the selected change. This is the same per-user
+/// checkout the co-hosted AI CLIs operate on, so it doubles as a window into what the assistants did.
+///
+/// <para>Sits beside <see cref="WorkingTreeTab"/> (Code workspace, which edits + commits + pushes);
+/// this tab only reads. Following the framework rules: tabular data is rendered with
+/// <see cref="DataGridControl"/> (never hand-built HTML), diffs with <see cref="DiffEditorControl"/>;
+/// every git call is reactive through <see cref="GitWorkingTreeService"/> / <see cref="GitCli"/>
+/// (no <c>async</c>/<c>await</c>/<c>Task</c>); UI state lives only in <c>host</c> data ids.</para>
+/// </summary>
+public static class GitHistoryTab
+{
+    /// <summary>The settings-menu item id for the Git-history tab.</summary>
+    public const string TabId = "GitHistory";
+
+    private const int MaxCommits = 100;
+    private const char Sep = '\x1f'; // diff-selection key delimiter (can't occur in a file path)
+
+    private const string ResultId = "ghResult";          // checkout/refresh status line
+    private const string RefreshId = "ghRefresh";        // bumped → re-query log + working-tree status
+    private const string SelectedCommitId = "ghCommit";  // selected commit hash ("" = none)
+    private const string SelectedChangeId = "ghChange";  // diff selection key ("" = none)
+    private const string CommitRowsId = "ghCommitRows";  // commit-log grid data
+    private const string WtRowsId = "ghWtRows";          // working-tree change grid data
+    private const string CommitFileRowsId = "ghCommitFiles"; // selected-commit change grid data
+
+    /// <summary>Registers the Git-history settings tab provider (shown on any node within a Space).</summary>
+    public static MessageHubConfiguration AddGitHistoryTab(this MessageHubConfiguration config)
+        => config.AddSettingsMenuItems(new SettingsMenuItemProvider(GetTab));
+
+    private static IObservable<IReadOnlyList<SettingsMenuItemDefinition>> GetTab(
+        LayoutAreaHost host, RenderingContext ctx)
+    {
+        IReadOnlyList<SettingsMenuItemDefinition> none = Array.Empty<SettingsMenuItemDefinition>();
+        var tab = new SettingsMenuItemDefinition(
+            Id: TabId,
+            Label: "Git history",
+            ContentBuilder: BuildContent,
+            Group: "Integration",
+            Icon: FluentIcons.History(),
+            GroupIcon: FluentIcons.Document(),
+            Order: 270, // just after the Code-workspace tab (260)
+            RequiredPermission: Permission.None,
+            Keywords: new[] { "git", "commit", "history", "diff", "changes", "log" });
+
+        // Same gate as the Code-workspace tab: visible inside a Space to users who may Update it.
+        var spaceRoot = WorkingTreeTab.SpaceRootPath(host.Hub.Address.ToString());
+        if (string.IsNullOrEmpty(spaceRoot))
+            return Observable.Return(none);
+
+        return host.Workspace.GetMeshNodeStream(spaceRoot)
+            .Select(node => string.Equals(node?.NodeType, GitHubSyncService.SpaceNodeType, StringComparison.Ordinal))
+            .CombineLatest(
+                host.Hub.GetEffectivePermissions(spaceRoot),
+                (isSpace, perms) => isSpace && perms.HasFlag(Permission.Update))
+            .DistinctUntilChanged()
+            .Select(show => show ? (IReadOnlyList<SettingsMenuItemDefinition>)new[] { tab } : none)
+            .Catch<IReadOnlyList<SettingsMenuItemDefinition>, Exception>(_ => Observable.Return(none))
+            .StartWith(none);
+    }
+
+    internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack, MeshNode? node)
+    {
+        var sp = host.Hub.ServiceProvider;
+        var workingTrees = sp.GetRequiredService<GitWorkingTreeService>();
+        var sync = sp.GetRequiredService<GitHubSyncService>();
+        var userId = sp.GetService<AccessService>()?.Context?.ObjectId ?? "";
+        var spacePath = WorkingTreeTab.SpaceRootPath(node?.Path ?? "");
+
+        if (string.IsNullOrEmpty(spacePath))
+            return stack.WithView(Controls.Markdown("Git history is available inside a Space."));
+        if (string.IsNullOrEmpty(userId))
+            return stack.WithView(Controls.Markdown("Sign in to browse git history."));
+
+        // Seed the selection/refresh state once so the sub-views below have a stream to bind to.
+        host.UpdateData(ResultId, "");
+        host.UpdateData(RefreshId, "0");
+        host.UpdateData(SelectedCommitId, "");
+        host.UpdateData(SelectedChangeId, "");
+
+        stack = stack.WithView(Controls.H2("Git history"));
+        stack = stack.WithView(Controls.Markdown(
+            "Browse the commit history of this Space's server-side working tree, see what each commit " +
+            "changed, and inspect uncommitted changes — the same checkout the AI assistants edit."));
+
+        // Everything keys off the Space's connected repo (slug + branch) from the GitHub-Sync config.
+        stack = stack.WithView((h, _) => sync.WatchConfig(spacePath)
+            .Select(cfg => (UiControl?)BuildBrowser(workingTrees, userId, cfg))
+            .StartWith((UiControl?)Controls.Markdown("_Loading repository settings…_")));
+
+        return stack;
+    }
+
+    private static UiControl BuildBrowser(GitWorkingTreeService wt, string userId, GitHubSyncConfig? cfg)
+    {
+        var repoFullName = WorkingTreeTab.RepoFullName(cfg?.RepositoryUrl);
+        if (repoFullName is null)
+            return Controls.Markdown("Connect a GitHub repository in the **GitHub Sync** tab first.");
+
+        var repoSlug = WorkingTreeTab.RepoSlug(repoFullName);
+        var branch = string.IsNullOrWhiteSpace(cfg!.Branch) ? "main" : cfg.Branch;
+
+        var stack = Controls.Stack.WithWidth("100%").WithStyle("gap:12px;");
+
+        // Checkout / pull + refresh toolbar.
+        stack = stack.WithView(Controls.Stack.WithOrientation(Orientation.Horizontal).WithStyle("gap:8px;")
+            .WithView(Controls.Button($"Check out / pull {repoFullName} ({branch})")
+                .WithAppearance(Appearance.Accent)
+                .WithIconStart(FluentIcons.ArrowDownload())
+                .WithClickAction(ctx =>
+                {
+                    ctx.Host.UpdateData(ResultId, $"_Checking out {repoFullName}…_");
+                    wt.Checkout(userId, repoFullName, branch).Subscribe(
+                        tree =>
+                        {
+                            ctx.Host.UpdateData(ResultId, $"Checked out on **{tree.Branch}**.");
+                            ctx.Host.UpdateData(RefreshId, Guid.NewGuid().ToString("N"));
+                        },
+                        ex => ctx.Host.UpdateData(ResultId, $"⚠ {ex.Message}"));
+                    return Task.CompletedTask;
+                }))
+            .WithView(Controls.Button("Refresh")
+                .WithIconStart(FluentIcons.ArrowClockwise())
+                .WithClickAction(ctx =>
+                {
+                    ctx.Host.UpdateData(RefreshId, Guid.NewGuid().ToString("N"));
+                    return Task.CompletedTask;
+                })));
+
+        // Status line.
+        stack = stack.WithView((h, _) => h.Stream.GetDataStream<string>(ResultId)
+            .Select(msg => (UiControl?)(string.IsNullOrEmpty(msg) ? Controls.Stack : Controls.Markdown(msg!)))
+            .StartWith((UiControl?)Controls.Stack));
+
+        // Working-tree (uncommitted) changes.
+        stack = stack.WithView(Controls.H3("Working-tree changes"));
+        stack = stack.WithView((h, _) => h.Stream.GetDataStream<string>(RefreshId)
+            .Select(_ => wt.Status(userId, repoSlug)
+                .Select(s => (UiControl?)BuildWorkingTreeChanges(h, s))
+                .Catch<UiControl?, Exception>(_ => Observable.Return((UiControl?)NotCheckedOut())))
+            .Switch()
+            .StartWith((UiControl?)Controls.Markdown("_…_")));
+
+        // Commit history.
+        stack = stack.WithView(Controls.H3("Commits"));
+        stack = stack.WithView((h, _) => h.Stream.GetDataStream<string>(RefreshId)
+            .Select(_ => wt.Log(userId, repoSlug, MaxCommits)
+                .Select(commits => (UiControl?)BuildCommitLog(h, commits))
+                .Catch<UiControl?, Exception>(_ => Observable.Return((UiControl?)NotCheckedOut())))
+            .Switch()
+            .StartWith((UiControl?)Controls.Markdown("_Loading history…_")));
+
+        // Files changed by the selected commit.
+        stack = stack.WithView((h, _) => h.Stream.GetDataStream<string>(SelectedCommitId)
+            .Select(hash => string.IsNullOrEmpty(hash)
+                ? Observable.Return((UiControl?)Controls.Stack)
+                : wt.CommitChanges(userId, repoSlug, hash!)
+                    .Select(changes => (UiControl?)BuildCommitDetail(h, hash!, changes))
+                    .Catch<UiControl?, Exception>(ex => Observable.Return((UiControl?)Controls.Markdown($"⚠ {ex.Message}"))))
+            .Switch()
+            .StartWith((UiControl?)Controls.Stack));
+
+        // Diff pane for the selected change.
+        stack = stack.WithView((h, _) => h.Stream.GetDataStream<string>(SelectedChangeId)
+            .Select(key => BuildDiff(wt, userId, repoSlug, key))
+            .Switch()
+            .StartWith((UiControl?)SelectAChange()));
+
+        return stack;
+    }
+
+    // ── change / commit lists (DataGrid, never hand-built HTML) ───────────────────────────────
+
+    private static UiControl BuildWorkingTreeChanges(LayoutAreaHost host, WorkingTreeStatus status)
+    {
+        if (status.IsClean)
+            return Controls.Markdown($"On **{status.Branch}** — working tree clean.");
+        var stack = Controls.Stack.WithWidth("100%").WithStyle("gap:6px;");
+        stack = stack.WithView(Controls.Markdown(
+            $"On **{status.Branch}** — {status.Changes.Count} uncommitted change(s):"));
+        stack = stack.WithView(BuildChangeGrid(host, WtRowsId, status.Changes, c => $"W{Sep}{c.Path}"));
+        return stack;
+    }
+
+    private static UiControl BuildCommitDetail(LayoutAreaHost host, string hash, IReadOnlyList<GitFileChange> changes)
+    {
+        var stack = Controls.Stack.WithWidth("100%").WithStyle("gap:6px;");
+        stack = stack.WithView(Controls.Markdown($"**Changed in `{Short(hash)}`** — {changes.Count} file(s):"));
+        if (changes.Count == 0)
+            return stack.WithView(Controls.Markdown("_No file changes._"));
+        stack = stack.WithView(BuildChangeGrid(host, CommitFileRowsId, changes, c => $"C{Sep}{hash}{Sep}{c.Path}"));
+        return stack;
+    }
+
+    private static UiControl BuildCommitLog(LayoutAreaHost host, IReadOnlyList<GitCommit> commits)
+    {
+        if (commits.Count == 0)
+            return Controls.Markdown("_No commits._");
+
+        var rows = commits.Select(c => new CommitRow(c.Hash, c.ShortHash, c.Date, c.Author, c.Subject)).ToList();
+        host.UpdateData(CommitRowsId, rows);
+
+        var grid = new DataGridControl(new JsonPointerReference(LayoutAreaReference.GetDataPointer(CommitRowsId)))
+            .WithColumn(new PropertyColumnControl<string> { Property = "shortHash" }.WithTitle("Commit"))
+            .WithColumn(new PropertyColumnControl<string> { Property = "date" }.WithTitle("Date"))
+            .WithColumn(new PropertyColumnControl<string> { Property = "author" }.WithTitle("Author"))
+            .WithColumn(new PropertyColumnControl<string> { Property = "subject" }.WithTitle("Subject"))
+            .WithClickAction(HandleCommitClick);
+
+        var stack = Controls.Stack.WithWidth("100%").WithStyle("gap:6px;").WithView(grid);
+        if (commits.Count >= MaxCommits)
+            stack = stack.WithView(Controls.Markdown($"_Showing the latest {MaxCommits} commits._"));
+        return stack;
+    }
+
+    private static UiControl BuildChangeGrid(
+        LayoutAreaHost host, string dataId, IReadOnlyList<GitFileChange> changes, Func<GitFileChange, string> keyFor)
+    {
+        var rows = changes.Select(c => new ChangeRow(c.Status, c.Path, keyFor(c))).ToList();
+        host.UpdateData(dataId, rows);
+        return new DataGridControl(new JsonPointerReference(LayoutAreaReference.GetDataPointer(dataId)))
+            .WithColumn(new PropertyColumnControl<string> { Property = "status" }.WithTitle("Status"))
+            .WithColumn(new PropertyColumnControl<string> { Property = "path" }.WithTitle("File"))
+            .WithClickAction(HandleChangeClick);
+    }
+
+    // ── diff pane (DiffEditorControl) ─────────────────────────────────────────────────────────
+
+    private static IObservable<UiControl?> BuildDiff(
+        GitWorkingTreeService wt, string userId, string repoSlug, string? key)
+    {
+        if (string.IsNullOrEmpty(key))
+            return Observable.Return((UiControl?)SelectAChange());
+
+        var parts = key!.Split(Sep);
+        // Working-tree change: HEAD (committed) vs the on-disk working copy.
+        if (parts is ["W", var wtPath])
+            return wt.ShowFile(userId, repoSlug, "HEAD", wtPath).Catch(Observable.Return(""))
+                .CombineLatest(
+                    wt.ReadFile(userId, repoSlug, wtPath).Catch(Observable.Return("")),
+                    (head, work) => (UiControl?)BuildDiffEditor(wtPath, head, work, "HEAD", "Working tree"));
+        // Commit change: the file at the commit's parent vs at the commit itself.
+        if (parts is ["C", var hash, var cPath])
+            return wt.ShowFile(userId, repoSlug, $"{hash}^", cPath).Catch(Observable.Return(""))
+                .CombineLatest(
+                    wt.ShowFile(userId, repoSlug, hash, cPath).Catch(Observable.Return("")),
+                    (before, after) => (UiControl?)BuildDiffEditor(cPath, before, after, $"{Short(hash)}^", Short(hash)));
+
+        return Observable.Return((UiControl?)SelectAChange());
+    }
+
+    private static UiControl BuildDiffEditor(
+        string path, string original, string modified, string originalLabel, string modifiedLabel)
+    {
+        var stack = Controls.Stack.WithWidth("100%").WithStyle("gap:6px;");
+        stack = stack.WithView(Controls.Markdown($"**`{path}`**"));
+        stack = stack.WithView(new DiffEditorControl
+        {
+            OriginalContent = original,
+            ModifiedContent = modified,
+            OriginalLabel = originalLabel,
+            ModifiedLabel = modifiedLabel,
+            Language = WorkingTreeTab.LanguageFor(path),
+            Height = "600px",
+        });
+        return stack;
+    }
+
+    // ── click handlers ────────────────────────────────────────────────────────────────────────
+
+    private static void HandleCommitClick(UiActionContext ctx)
+    {
+        var row = ExtractRow<CommitRow>(ctx);
+        if (row is null || string.IsNullOrEmpty(row.Hash)) return;
+        ctx.Host.UpdateData(SelectedCommitId, row.Hash);
+        ctx.Host.UpdateData(SelectedChangeId, ""); // reset the diff when switching commits
+    }
+
+    private static void HandleChangeClick(UiActionContext ctx)
+    {
+        var row = ExtractRow<ChangeRow>(ctx);
+        if (row is null || string.IsNullOrEmpty(row.Key)) return;
+        ctx.Host.UpdateData(SelectedChangeId, row.Key);
+    }
+
+    /// <summary>
+    /// Reads the clicked DataGrid row as <typeparamref name="T"/>. The row records aren't registered
+    /// in the type registry, so the cross-hub click round-trip may deliver
+    /// <see cref="DataGridCellClick.Item"/> as the concrete record OR as a <see cref="JsonElement"/> —
+    /// handle both by re-reading the JSON through the hub's serializer.
+    /// </summary>
+    private static T? ExtractRow<T>(UiActionContext ctx) where T : class
+    {
+        if (ctx.Payload is not DataGridCellClick { Item: { } item }) return null;
+        if (item is T typed) return typed;
+        var opts = ctx.Hub.JsonSerializerOptions;
+        var json = item is JsonElement je ? je.GetRawText() : JsonSerializer.Serialize(item, opts);
+        return JsonSerializer.Deserialize<T>(json, opts);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────────────────
+
+    // Fresh control per call — a shared instance would reuse a layout-area control Id across areas/emissions.
+    private static UiControl NotCheckedOut() =>
+        Controls.Markdown("_Not checked out yet — use **Check out / pull** above._");
+    private static UiControl SelectAChange() =>
+        Controls.Markdown("_Select a change to view its diff._");
+
+    private static string Short(string hash) => hash.Length > 8 ? hash[..8] : hash;
+
+    /// <summary>The commit-log grid row (camelCase property names match the DataGrid columns).</summary>
+    public sealed record CommitRow(string Hash, string ShortHash, string Date, string Author, string Subject);
+
+    /// <summary>A changed-file grid row; <see cref="Key"/> encodes the diff to show when clicked.</summary>
+    public sealed record ChangeRow(string Status, string Path, string Key);
+}

--- a/src/MeshWeaver.GitSync/GitWorkingTreeModels.cs
+++ b/src/MeshWeaver.GitSync/GitWorkingTreeModels.cs
@@ -12,6 +12,14 @@ public sealed record WorkingTree(string UserId, string RepoSlug, string Path, st
 /// <param name="Status">The two-char porcelain code (e.g. <c>M</c>, <c>A</c>, <c>D</c>, <c>??</c>).</param>
 public sealed record GitFileChange(string Path, string Status);
 
+/// <summary>One commit in the working tree's history — a row in the git-browser commit log.</summary>
+/// <param name="Hash">The full commit SHA.</param>
+/// <param name="ShortHash">The abbreviated SHA (git's <c>%h</c>).</param>
+/// <param name="Date">The author date, pre-formatted for display (e.g. <c>2026-06-29 14:03</c>).</param>
+/// <param name="Author">The author name.</param>
+/// <param name="Subject">The commit subject (first line of the message).</param>
+public sealed record GitCommit(string Hash, string ShortHash, string Date, string Author, string Subject);
+
 /// <summary>Working-tree status: current branch + whether it is clean + the pending changes.</summary>
 public sealed record WorkingTreeStatus(string Branch, bool IsClean, IReadOnlyList<GitFileChange> Changes);
 

--- a/src/MeshWeaver.GitSync/GitWorkingTreeService.cs
+++ b/src/MeshWeaver.GitSync/GitWorkingTreeService.cs
@@ -160,6 +160,52 @@ public sealed class GitWorkingTreeService(
                 .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
     }
 
+    // ── git browser (read-only history) ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The latest <paramref name="maxCount"/> commits on the working tree's current branch (newest
+    /// first) — the commit log the git browser renders. Fields are unit-separator delimited so a
+    /// subject containing any other character parses cleanly.
+    /// </summary>
+    public IObservable<IReadOnlyList<GitCommit>> Log(string userId, string repoSlug, int maxCount = 100)
+    {
+        var dest = PathFor(userId, repoSlug);
+        return Expect(git.Run(dest,
+        [
+            "log", $"-n{maxCount}", "--date=format:%Y-%m-%d %H:%M",
+            // %H %h %ad %an %s, separated by the 0x1f unit separator (%x1f).
+            "--pretty=format:%H%x1f%h%x1f%ad%x1f%an%x1f%s",
+        ])).Select(ParseLog);
+    }
+
+    /// <summary>
+    /// The files changed by <paramref name="commitHash"/> against its parent (status + repo-relative
+    /// path). <c>--root</c> makes the initial commit list its files as added rather than empty;
+    /// <c>--no-renames</c> keeps every line a simple <c>STATUS\tpath</c> (a rename shows as D + A).
+    /// </summary>
+    public IObservable<IReadOnlyList<GitFileChange>> CommitChanges(string userId, string repoSlug, string commitHash)
+    {
+        var dest = PathFor(userId, repoSlug);
+        return Expect(git.Run(dest,
+            ["diff-tree", "--no-commit-id", "--name-status", "--no-renames", "-r", "--root", commitHash]))
+            .Select(ParseNameStatus);
+    }
+
+    /// <summary>
+    /// The content of <paramref name="relativePath"/> at git revision <paramref name="rev"/> (e.g.
+    /// <c>"HEAD"</c>, a commit hash, or <c>"{hash}^"</c> for a parent) — the two sides a diff needs.
+    /// Returns <c>""</c> when the path did not exist at that revision (an added or deleted file): that
+    /// empty side is a legitimate diff input, not an error, so this does NOT go through <see cref="Expect"/>.
+    /// </summary>
+    public IObservable<string> ShowFile(string userId, string repoSlug, string rev, string relativePath)
+    {
+        if (relativePath.StartsWith('-'))
+            return Observable.Throw<string>(new GitWorkingTreeException($"Invalid path '{relativePath}'."));
+        var dest = PathFor(userId, repoSlug);
+        return git.Run(dest, ["show", $"{rev}:{relativePath}"])
+            .Select(r => r.Ok ? r.StdOut : "");
+    }
+
     // ── internals ─────────────────────────────────────────────────────────────────────────
 
     private IObservable<string> CurrentBranch(string dest) =>
@@ -189,6 +235,34 @@ public sealed class GitWorkingTreeService(
             changes.Add(new GitFileChange(line[3..].Trim(), line[..2].Trim()));
         }
         return new WorkingTreeStatus(branch, changes.Count == 0, changes);
+    }
+
+    /// <summary>The 0x1f unit separator that delimits <c>git log</c> fields (can't occur in commit text).</summary>
+    private const char LogFieldSeparator = '\x1f';
+
+    private static IReadOnlyList<GitCommit> ParseLog(GitCommandResult r)
+    {
+        var commits = new List<GitCommit>();
+        foreach (var line in r.StdOut.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            // count: 5 → the subject keeps everything after the 4th separator even if it held one.
+            var f = line.Split(LogFieldSeparator, 5);
+            if (f.Length < 5) continue;
+            commits.Add(new GitCommit(f[0], f[1], f[2], f[3], f[4]));
+        }
+        return commits;
+    }
+
+    private static IReadOnlyList<GitFileChange> ParseNameStatus(GitCommandResult r)
+    {
+        var changes = new List<GitFileChange>();
+        foreach (var line in r.StdOut.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var tab = line.IndexOf('\t');
+            if (tab < 0) continue;
+            changes.Add(new GitFileChange(line[(tab + 1)..].Trim(), line[..tab].Trim()));
+        }
+        return changes;
     }
 
     /// <summary>The credential-helper config that reads the token from <c>$GW_TOKEN</c> (token never in argv).</summary>

--- a/src/MeshWeaver.GitSync/WorkingTreeTab.cs
+++ b/src/MeshWeaver.GitSync/WorkingTreeTab.cs
@@ -69,7 +69,7 @@ public static class WorkingTreeTab
             .StartWith(none);
     }
 
-    private static string SpaceRootPath(string? path) =>
+    internal static string SpaceRootPath(string? path) =>
         string.IsNullOrEmpty(path) ? "" : path.Split('/', 2)[0];
 
     internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack, MeshNode? node)
@@ -275,7 +275,7 @@ public static class WorkingTreeTab
     }
 
     /// <summary>Monaco language id from a file extension.</summary>
-    private static string LanguageFor(string path)
+    internal static string LanguageFor(string path)
     {
         var ext = Path.GetExtension(path).ToLowerInvariant();
         return ext switch
@@ -297,7 +297,7 @@ public static class WorkingTreeTab
     }
 
     /// <summary>Parses an <c>owner/repo</c> full name from a GitHub repo URL.</summary>
-    private static string? RepoFullName(string? url)
+    internal static string? RepoFullName(string? url)
     {
         if (string.IsNullOrWhiteSpace(url)) return null;
         var u = url.Trim();
@@ -308,7 +308,7 @@ public static class WorkingTreeTab
         return parts.Length >= 2 ? $"{parts[0]}/{parts[1]}" : null;
     }
 
-    private static string RepoSlug(string repoFullName)
+    internal static string RepoSlug(string repoFullName)
     {
         var slash = repoFullName.LastIndexOf('/');
         return slash >= 0 ? repoFullName[(slash + 1)..] : repoFullName;

--- a/test/MeshWeaver.GitSync.Test/GitHistoryServiceTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHistoryServiceTest.cs
@@ -1,0 +1,125 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.GitSync;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Exercises the git-browser read methods (<see cref="GitWorkingTreeService.Log"/> /
+/// <see cref="GitWorkingTreeService.CommitChanges"/> / <see cref="GitWorkingTreeService.ShowFile"/>)
+/// against a LOCAL bare repo with two commits — no network, real <c>git</c> via <see cref="GitCli"/>.
+/// c1 adds <c>README.md</c>; c2 modifies it and adds <c>docs/new.txt</c>. After the service clones,
+/// it must surface the log newest-first, the per-commit name-status, and file content at any
+/// revision (and <c>""</c> for a path that did not exist at that revision).
+/// </summary>
+public class GitHistoryServiceTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    private readonly string workspaceRoot = Path.Combine(Path.GetTempPath(), "mw-ghist-" + Guid.NewGuid().ToString("N"));
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        base.ConfigureMesh(builder).ConfigureServices(s =>
+        {
+            s.Configure<GitWorkingTreeOptions>(o => o.Root = workspaceRoot);
+            return s;
+        });
+
+    private GitWorkingTreeService WorkingTrees => Mesh.ServiceProvider.GetRequiredService<GitWorkingTreeService>();
+    private GitCli Git => Mesh.ServiceProvider.GetRequiredService<GitCli>();
+
+    [Fact(Timeout = 60000)]
+    public async Task Log_CommitChanges_ShowFile_OverTwoCommits()
+    {
+        var temp = NewTempDir();
+        var bare = Path.Combine(temp, "remote.git");
+        var seed = Path.Combine(temp, "seed");
+
+        await RunGit(temp, "init", "--bare", "-b", "main", bare);
+        await RunGit(temp, "-c", "init.defaultBranch=main", "init", seed);
+
+        // c1: add README.md
+        await File.WriteAllTextAsync(Path.Combine(seed, "README.md"), "# v1\n");
+        await RunGit(seed, "add", "-A");
+        await RunGit(seed, "-c", "user.email=t@t.dev", "-c", "user.name=Test", "commit", "-m", "first commit");
+
+        // c2: modify README.md + add docs/new.txt
+        await File.WriteAllTextAsync(Path.Combine(seed, "README.md"), "# v2\n");
+        Directory.CreateDirectory(Path.Combine(seed, "docs"));
+        await File.WriteAllTextAsync(Path.Combine(seed, "docs", "new.txt"), "hello\n");
+        await RunGit(seed, "add", "-A");
+        await RunGit(seed, "-c", "user.email=t@t.dev", "-c", "user.name=Test", "commit", "-m", "second commit");
+
+        await RunGit(seed, "remote", "add", "origin", bare);
+        await RunGit(seed, "push", "origin", "main");
+
+        // Clone via the service (local path = no auth).
+        await WorkingTrees.CloneOrUpdate(UserId, "demo", bare, "main", token: null).Timeout(60.Seconds()).ToTask();
+
+        // Log: newest commit first, fully populated.
+        var log = await WorkingTrees.Log(UserId, "demo").Timeout(30.Seconds()).ToTask();
+        Assert.True(log.Count >= 2, $"expected >= 2 commits, got {log.Count}");
+        Assert.Equal("second commit", log[0].Subject);
+        Assert.Equal("first commit", log[1].Subject);
+        Assert.All(log, c => Assert.False(string.IsNullOrEmpty(c.Hash)));
+        Assert.All(log, c => Assert.False(string.IsNullOrEmpty(c.ShortHash)));
+        Assert.All(log, c => Assert.Equal("Test", c.Author));
+
+        var head = log[0].Hash;
+
+        // CommitChanges: README modified (M), docs/new.txt added (A).
+        var changes = await WorkingTrees.CommitChanges(UserId, "demo", head).Timeout(30.Seconds()).ToTask();
+        Assert.Contains(changes, c => c.Path == "README.md" && c.Status == "M");
+        Assert.Contains(changes, c => c.Path == "docs/new.txt" && c.Status == "A");
+
+        // ShowFile: content at HEAD vs its parent, and "" for paths absent at the revision.
+        Assert.Equal("# v2", (await WorkingTrees.ShowFile(UserId, "demo", head, "README.md").Timeout(30.Seconds()).ToTask()).Trim());
+        Assert.Equal("# v1", (await WorkingTrees.ShowFile(UserId, "demo", $"{head}^", "README.md").Timeout(30.Seconds()).ToTask()).Trim());
+        Assert.Equal("", await WorkingTrees.ShowFile(UserId, "demo", head, "does/not/exist.txt").Timeout(30.Seconds()).ToTask());
+        // docs/new.txt did not exist at the parent → empty (the "added" side of a diff).
+        Assert.Equal("", await WorkingTrees.ShowFile(UserId, "demo", $"{head}^", "docs/new.txt").Timeout(30.Seconds()).ToTask());
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task WorkingTreeChange_DiffsHeadVsWorkingCopy()
+    {
+        var temp = NewTempDir();
+        var bare = Path.Combine(temp, "remote.git");
+        var seed = Path.Combine(temp, "seed");
+        await RunGit(temp, "init", "--bare", "-b", "main", bare);
+        await RunGit(temp, "-c", "init.defaultBranch=main", "init", seed);
+        await File.WriteAllTextAsync(Path.Combine(seed, "README.md"), "# base\n");
+        await RunGit(seed, "add", "-A");
+        await RunGit(seed, "-c", "user.email=t@t.dev", "-c", "user.name=Test", "commit", "-m", "init");
+        await RunGit(seed, "remote", "add", "origin", bare);
+        await RunGit(seed, "push", "origin", "main");
+
+        await WorkingTrees.CloneOrUpdate(UserId, "demo", bare, "main", token: null).Timeout(60.Seconds()).ToTask();
+
+        // Edit the working copy without committing.
+        await WorkingTrees.WriteFile(UserId, "demo", "README.md", "# edited\n").Timeout(30.Seconds()).ToTask();
+
+        var status = await WorkingTrees.Status(UserId, "demo").Timeout(30.Seconds()).ToTask();
+        Assert.Contains(status.Changes, c => c.Path == "README.md");
+
+        // The diff pane's two sides: HEAD (committed) vs the on-disk working copy.
+        var head = (await WorkingTrees.ShowFile(UserId, "demo", "HEAD", "README.md").Timeout(30.Seconds()).ToTask()).Trim();
+        var work = (await WorkingTrees.ReadFile(UserId, "demo", "README.md").Timeout(30.Seconds()).ToTask()).Trim();
+        Assert.Equal("# base", head);
+        Assert.Equal("# edited", work);
+    }
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-ghist-remote-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private async Task RunGit(string dir, params string[] args)
+    {
+        var r = await Git.Run(dir, args).Timeout(30.Seconds()).ToTask();
+        Assert.True(r.Ok, $"git {string.Join(' ', args)} failed (exit {r.ExitCode}): {r.Message}");
+    }
+}


### PR DESCRIPTION
## What

A read-only **Git history** settings tab beside the Code-workspace tab, backed by the per-user on-disk working tree (`GitWorkingTreeService`) that the co-hosted AI CLIs also operate on. Browse the commit log of a Space's connected repo, see what each commit changed, inspect uncommitted working-tree changes, and view a Monaco side-by-side diff for any file.

## Changes

- **`GitWorkingTreeService`** — `Log` (`git log`), `CommitChanges` (`git diff-tree --name-status`), `ShowFile` (`git show rev:path`; `""` when the path is absent at that revision). All reactive through `GitCli`/`IIoPool`; no `async`/`Task` on the surface.
- **`GitWorkingTreeModels`** — `GitCommit` record (a commit-log row).
- **`GitHistoryTab`** (new) — the tab UI: `DataGrid` for the commit log + change lists, `DiffEditorControl` for diffs (no hand-built HTML), reactive state in host data ids. Clicked-row `Item` is read defensively (typed record or `JsonElement`).
- **`WorkingTreeTab`** — 4 repo/language helpers `private` → `internal` for reuse.
- **`MemexConfiguration`** — register `.AddGitHistoryTab()`.
- **`GitHistoryServiceTest`** (new) — log ordering, per-commit name-status (M/A), file content at a revision, `""` for absent paths, HEAD-vs-working-copy diff — against a local bare repo, no network.

## Verification

- `MeshWeaver.GitSync`, its test project, and `Memex.Portal.Shared` build clean (0 warnings, 0 errors).
- `GitHistoryServiceTest`: 2/2 passed (~1s, no network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)