### PR TITLE
fix(self-update): use WorkloadIdentityCredential on AKS (not ManagedIdentityCredential)

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/AcrTagLister.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/AcrTagLister.cs
@@ -40,8 +40,15 @@ public sealed class AcrTagLister(SelfUpdateOptions options, ILogger<AcrTagLister
 
     private static TokenCredential CreateCredential()
     {
-        // Mirror SchemaHelpers: pin to AZURE_CLIENT_ID when present (workload/managed identity on
-        // AKS), else fall back to the full DefaultAzureCredential chain for local/dev.
+        // AKS WORKLOAD IDENTITY (the deployed shape): the workload-identity webhook injects
+        // AZURE_FEDERATED_TOKEN_FILE (+ AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_AUTHORITY_HOST). The
+        // portal's UAMI is FEDERATED, not assigned to the node VMSS, so ManagedIdentityCredential (IMDS)
+        // gets NO token — only WorkloadIdentityCredential exchanges the projected service-account token
+        // for an AAD token. Detect WI by the token file and prefer it. Fall back to a VMSS/IMDS
+        // user-assigned MI when only AZURE_CLIENT_ID is set, else the full dev chain (local/non-Azure,
+        // where the AAD acquisition simply fails and the poller logs + skips).
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_FEDERATED_TOKEN_FILE")))
+            return new WorkloadIdentityCredential();
         var clientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
         return string.IsNullOrEmpty(clientId)
             ? new DefaultAzureCredential()


### PR DESCRIPTION
Completes the operational self-update install (follows #110). `AcrTagLister` used `ManagedIdentityCredential` (IMDS) when `AZURE_CLIENT_ID` was set — but the portal's UAMI is **federated** (workload identity), not VMSS-assigned, so IMDS returns no token and **every self-update poll failed** (`[SelfUpdate] check failed`).

Fix: detect AKS workload identity by `AZURE_FEDERATED_TOKEN_FILE` (injected by the WI webhook) and use **`WorkloadIdentityCredential`**, which exchanges the projected SA token for an AAD token. Falls back to user-assigned MI (VMSS/IMDS) when only `AZURE_CLIENT_ID` is set, else the dev chain.

**Verified live on atioz** with the now-provisioned: portal UAMI `memexaks-portal-mi` + AcrPull on `meshweaver`, the `atioz:memex-portal-sa` federated credential, and the `memex-portal-sa` ServiceAccount + get/patch RBAC. The poller authenticates and lists ACR tags with **0 errors** (`canPatch=True`).

Must merge so future images the self-updater rolls to keep the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)