### PR TITLE
fix(build): chain memex/Directory.Build.props to root (CI versioning + warnings gate)

### DIFF
--- a/memex/Directory.Build.props
+++ b/memex/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -27,7 +27,7 @@ namespace Memex.Portal.Shared.Api;
 /// </para>
 ///
 /// <para>
-/// <b>Auth</b>: gated by the existing <see cref="McpAuthenticationExtensions.PolicyName"/>
+/// <b>Auth</b>: gated by the existing <c>McpAuthenticationExtensions.PolicyName</c>
 /// policy — same <c>Authorization: Bearer mw_…</c> token format as <c>/mcp</c>, validated
 /// by <c>ApiTokenAuthenticationHandler</c>.
 /// </para>

--- a/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
@@ -250,7 +250,7 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
     /// <summary>
     /// Reactive load of the user's role names from AccessAssignment nodes via the
     /// canonical synced query (<c>workspace.GetQuery</c>). Same machinery as
-    /// <see cref="FindUserByEmail"/> — bypasses RLS, dedupes, gates on Initial,
+    /// <c>FindUserByEmail</c> — bypasses RLS, dedupes, gates on Initial,
     /// includes static providers. Bearer auth uses this via
     /// <see cref="UserRoleResolver.LoadDbRolesAsync"/> to enrich principals with
     /// DB-resolved roles rather than only the roles stamped on the API token at

--- a/memex/Memex.Portal.Shared/Authentication/UserRoleResolver.cs
+++ b/memex/Memex.Portal.Shared/Authentication/UserRoleResolver.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Memex.Portal.Shared.Authentication;
 
 /// <summary>
-/// Thin façade over <see cref="OnboardingMiddleware.LoadUserRoles"/> so callers
+/// Thin façade over <c>OnboardingMiddleware.LoadUserRoles</c> so callers
 /// outside this assembly can resolve a user's AccessAssignment-derived roles in
 /// one call.
 ///

--- a/memex/Memex.Portal.Shared/Models/ModelProviderService.cs
+++ b/memex/Memex.Portal.Shared/Models/ModelProviderService.cs
@@ -26,10 +26,10 @@ namespace Memex.Portal.Shared.Models;
 /// 🚨 Reactive end-to-end. No <c>async</c>, no <c>await</c>, no
 /// <c>FromAsync</c>. Reads go through <c>workspace.GetQuery</c> (synced) or
 /// <c>workspace.GetMeshNodeStream</c> (live single-node) per
-/// <see cref="MeshWeaver.Documentation.Data.Architecture.SyncedMeshNodeQueries">SyncedMeshNodeQueries</see>.
+/// <c>SyncedMeshNodeQueries</c>.
 /// Writes go through <see cref="IMeshService.CreateNode"/> /
 /// <see cref="IMeshService.DeleteNode"/> and
-/// <see cref="MeshNodeStreamExtensions.Update"/> on the workspace remote
+/// <c>MeshNodeStreamExtensions.Update</c> on the workspace remote
 /// stream.
 /// </para>
 ///
@@ -229,7 +229,7 @@ public class ModelProviderService(IMeshService meshService, IMessageHub hub, ILo
     /// <summary>
     /// Reactive rotate-key. Updates the <c>ApiKey</c> field on the
     /// <c>ModelProvider</c> node via
-    /// <see cref="MeshNodeStreamExtensions.Update"/>. Other fields are
+    /// <c>MeshNodeStreamExtensions.Update</c>. Other fields are
     /// preserved.
     /// </summary>
     public IObservable<bool> RotateKey(string providerNodePath, string? newApiKey)

--- a/memex/Memex.Portal.Shared/Skills/AgentSkillSyncService.cs
+++ b/memex/Memex.Portal.Shared/Skills/AgentSkillSyncService.cs
@@ -42,7 +42,7 @@ public sealed class AgentSkillSyncOptions
 ///
 /// <para><b>Live</b>, not one-shot: the platform skill catalog (the PublicRead <c>Skill</c> namespace) is
 /// observed with a synced query, so <c>AGENTS.md</c> is re-rendered whenever a skill node is added /
-/// changed / removed. The background subscription carries no <see cref="MeshWeaver.Mesh.Security.AccessContext"/>,
+/// changed / removed. The background subscription carries no <c>AccessContext</c>,
 /// so the synced query short-circuits to the System-loaded snapshot (no per-user RLS filter) and sees every
 /// platform skill. The (small, infrequent) file write runs on the <see cref="IoPoolNames.FileSystem"/> I/O
 /// pool so the synced-query emission thread never blocks on disk.</para>

--- a/memex/Memex.Portal.Shared/Teams/TeamsReplySender.cs
+++ b/memex/Memex.Portal.Shared/Teams/TeamsReplySender.cs
@@ -20,7 +20,7 @@ namespace Memex.Portal.Shared.Teams;
 /// <summary>
 /// Delivers agent replies back into Teams. Watches the <see cref="TeamsConversation"/> link nodes; for
 /// each, observes its thread the <b>exact same way the GUI and tests do</b>
-/// (<c>workspace.GetMeshNodeStream(threadPath)</c> → <see cref="MeshThread"/>, wait for
+/// (<c>workspace.GetMeshNodeStream(threadPath)</c> → <c>MeshThread</c>, wait for
 /// <c>!IsExecuting</c> with a new <c>Messages[^1]</c>), reads that response message node at
 /// <c>{threadPath}/{messageId}</c> (<see cref="ThreadMessage"/>, public <c>Text</c>), and posts it via
 /// <see cref="ITeamsClient"/>. Send-once is tracked by <see cref="TeamsConversation.LastDeliveredMessageId"/>

--- a/memex/aspire/Memex.Database.Migration/Migrations/V15_FinalUserSchemaCleanup.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V15_FinalUserSchemaCleanup.cs
@@ -8,7 +8,7 @@ namespace Memex.Database.Migration.Migrations;
 ///
 ///   1. <b>Stale ApiToken duplicates</b> — rows like
 ///      <c>(ns='User/&lt;userid&gt;/ApiToken', id=&lt;hashPrefix&gt;)</c> written by the
-///      pre-fix <see cref="Memex.Portal.Shared.Authentication.ApiTokenService"/>
+///      pre-fix <c>ApiTokenService</c>
 ///      whose post-fix replacements already exist at
 ///      <c>(ns='&lt;userid&gt;/ApiToken', id=&lt;hashPrefix&gt;)</c> in the user partition.
 ///      We move the row into the user partition under the correct namespace; if a

--- a/memex/aspire/Memex.Database.Migration/Migrations/V23_PartitionChangesNotify.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V23_PartitionChangesNotify.cs
@@ -7,9 +7,9 @@ namespace Memex.Database.Migration.Migrations;
 /// an <c>Admin/Partition/*</c> row is inserted, updated, or deleted in
 /// <c>admin.mesh_nodes</c>. The payload is a small JSON document
 /// (<c>{"op":"INSERT","namespace":"acme"}</c>) consumed by
-/// <see cref="MeshWeaver.Hosting.PostgreSql.PgPartitionNotifyListener"/>
+/// <c>PgPartitionNotifyListener</c>
 /// on every silo. Each listener invalidates its
-/// <see cref="MeshWeaver.Hosting.PostgreSql.PgPartitionCache"/> entry for the
+/// <c>PgPartitionCache</c> entry for the
 /// affected namespace so the next access re-probes
 /// <c>information_schema.schemata</c> and picks up the new/dropped state.
 ///

--- a/memex/aspire/Memex.Database.Migration/Migrations/V32_RepairAuthMirrorTriggerAndBackfill.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V32_RepairAuthMirrorTriggerAndBackfill.cs
@@ -16,7 +16,7 @@ namespace Memex.Database.Migration.Migrations;
 /// on a fresh DB. So fresh deployments ended up at <c>db_version=31</c> with no mirror
 /// function, no triggers on any partition, and an empty <c>auth</c> schema — every auth
 /// lookup silently fell back to a cross-partition fan-out. (Confirmed on
-/// <c>memex.systemorph.com</c> 2026-06-02: <c>FUNC=0</c>, triggers <c>NONE</c>, <c>auth=0</c>.)
+/// <c>memex.systemorph.com</c> 2026-06-02: <c>FUNC=0</c>, triggers <c>NONE</c>, <c>auth=0</c>.)</para>
 ///
 /// <para><b>The repair (idempotent).</b>
 /// <list type="number">


### PR DESCRIPTION
**Why self-update's continuous channel never rolled.** `memex/Directory.Build.props` was a bare `<Project>` that didn't import the root, and MSBuild auto-imports only the *nearest* `Directory.Build.props`. So everything under `memex/` — the portal + migration images, i.e. exactly what the self-updater rolls — never got the root's **CI versioning**, security package overrides, or `TreatWarningsAsErrors`. The images were tagged the SDK default **`1.0.0`** instead of `$(PlatformVersion)-ci.$(GITHUB_RUN_NUMBER)`, so the self-updater saw nothing "newer" (every tag was `1.0.0`).

- **Chain to root** (`GetPathOfFileAbove`). Verified: CI build now computes **`3.0.0-ci.<run>`**, release **`3.0.0`**.
- Chaining also turns on `TreatWarningsAsErrors` for `memex/` (it had silently escaped the repo's warnings-as-errors gate — *"that's why we have it"* 🙂), surfacing **12 latent doc-comment issues**, all fixed: 8 unresolvable/ambiguous crefs in `Memex.Portal.Shared`; 1 malformed-XML `<summary>` + 3 cross-assembly crefs in `Database.Migration`. `memex/` builds clean under the gate now.

Completes the self-update chain (with #116): the continuous channel will now publish monotonically-increasing `-ci.N` images for installs to roll to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)