### PR TITLE
fix(self-update): roll to the manifest-list tag, not the per-arch RID image

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using NuGet.Versioning;
 
 namespace Memex.Portal.Shared.SelfUpdate;
@@ -15,6 +16,14 @@ namespace Memex.Portal.Shared.SelfUpdate;
 /// </summary>
 public static class VersionSelect
 {
+    // The multi-arch container build publishes, per version, a manifest-list tag (e.g. 3.0.0-ci.43) PLUS
+    // one image per RID (3.0.0-ci.43-linux-x64, 3.0.0-ci.43-linux-arm64). The RID suffix parses as an extra
+    // SemVer pre-release identifier that sorts ABOVE the clean tag (numeric 43 < alphanumeric 43-linux-x64),
+    // so without this filter PickTarget rolls to the x64-only image — wrong arch on an arm64 node, and never
+    // the intended manifest list. Drop RID-suffixed tags; the manifest list is the canonical deploy tag.
+    private static readonly Regex RuntimeIdentifierSuffix =
+        new(@"-(linux|win|osx)-(x64|x86|arm|arm64)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     /// <summary>
     /// The best tag to roll to under <paramref name="policy"/>, or <c>null</c> when nothing qualifies.
     /// <see cref="UpdatePolicyKind.Continuous"/> considers every parseable tag (incl. build-numbered
@@ -28,6 +37,7 @@ public static class VersionSelect
             return null;
 
         var parsed = tags
+            .Where(t => !RuntimeIdentifierSuffix.IsMatch(t))   // exclude per-RID image tags; keep the manifest list
             .Select(t => (tag: t, ver: NuGetVersion.TryParse(t, out var v) ? v : null))
             .Where(x => x.ver is not null)
             .Select(x => (x.tag, ver: x.ver!));

--- a/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
+++ b/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
@@ -32,6 +32,15 @@ public class VersionSelectTest
     public void PickTarget_NoParseableTags_ReturnsNull()
         => Assert.Null(VersionSelect.PickTarget(["latest", "main", "garbage"], UpdatePolicyKind.Continuous));
 
+    [Fact]
+    public void Continuous_IgnoresPerArchRidTags_PrefersManifestList()
+        // The multi-arch CD pushes the manifest list (3.0.0-ci.43) alongside per-RID image tags whose
+        // suffix parses as an extra pre-release identifier that sorts ABOVE it. The poller must roll to the
+        // manifest list, never the x64-only image (which would be wrong-arch on an arm64 node).
+        => Assert.Equal("3.0.0-ci.43", VersionSelect.PickTarget(
+            ["3.0.0-ci.43", "3.0.0-ci.43-linux-x64", "3.0.0-ci.43-linux-arm64", "main", "main-linux-x64"],
+            UpdatePolicyKind.Continuous));
+
     // CI-green gate: a `-edge.N` build is UNVERIFIED. Default (RequireCiGreen=true) must skip it even
     // though it is the newest; opting into "any" (RequireCiGreen=false) rolls to it.
     [Fact]


### PR DESCRIPTION
**Caught by verifying self-update end-to-end on atioz** (it auto-rolled `1.0.0` → `3.0.0-ci.43` 🎉, but landed on the *wrong tag*).

The multi-arch container build publishes, per version, a manifest-list tag (`3.0.0-ci.43`) **plus** one image per RID (`3.0.0-ci.43-linux-x64`, `3.0.0-ci.43-linux-arm64`). The RID suffix parses as an extra SemVer pre-release identifier that sorts **above** the clean tag (numeric `43` < alphanumeric `43-linux-x64`), so `VersionSelect.PickTarget` preferred the **x64-only** image — wrong-arch on an arm64 node, and never the intended manifest list. It only "worked" on atioz because atioz is amd64.

Fix: `PickTarget` drops RID-suffixed tags (`-(linux|win|osx)-(x64|x86|arm|arm64)$`) before ranking → always rolls to the manifest list. Pinned by `VersionSelectTest.Continuous_IgnoresPerArchRidTags_PrefersManifestList` (19/19 green locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)