### PR TITLE
test(ai): include provider-keys in built-in skill assertions (fix red main)

### DIFF
--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("agent", "code", "create-space", "harness", "layout-area", "maui", "model");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("agent", "code", "create-space", "harness", "layout-area", "maui", "model", "provider-keys");
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -29,7 +29,7 @@ public class SkillNodeTypeTest
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
         skills.Should().OnlyContain(n => n.Namespace == SkillNodeType.RootNamespace);
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("agent", "code", "create-space", "harness", "layout-area", "maui", "model");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("agent", "code", "create-space", "harness", "layout-area", "maui", "model", "provider-keys");
 
         var def = (SkillDefinition)skills.Single(n => n.Id == "model").Content!;
         def.Action!.Kind.Should().Be(SkillActionKind.Pick);


### PR DESCRIPTION
main has been **red since #119** — two AI skill tests fail on every build:
- `BuiltInSkillProvider_ShipsStandardSkills_AsPickSkillNodes`
- `SkillStaticRepoSource_Emits_BuiltInSkills_UnderSkillPartition`

#119 added `src/MeshWeaver.AI/Data/Skill/provider-keys.md` (a legitimate built-in skill — proper `nodeType: Skill` frontmatter, same shape as `model.md`) but didn't update the two assertions pinning the exact built-in set:
```
Expected collection {…, "model", "provider-keys"} to equal {…, "model"}.
```
Fix: add `"provider-keys"` to both expected sets — the same one-line maintenance the catalog got for `maui` / `layout-area`. Both tests green locally. Unblocks the CD so the now-self-updating portals can pull new images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)