### PR TITLE
test: de-flake Submit_ThreeMessages + CodeEditRecompile (CI-load timing)

### DIFF
--- a/test/MeshWeaver.AI.Test/ThreadSubmissionIntegrationTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadSubmissionIntegrationTest.cs
@@ -616,8 +616,10 @@ public class ThreadSubmissionIntegrationTest : AITestBase
             IEnumerable<ChatMessage> messages, ChatOptions? options = null,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            // Long enough for tests to race in a few more submits; short enough to keep CI fast.
-            await Task.Delay(1000, cancellationToken);
+            // Long enough for the mid-round submits to all register even under 2-core CI load —
+            // 1s under-budgeted the runner, so u4 landed after round 1 ended and the batch split
+            // into 3 response cells instead of 2. Still short enough to keep CI fast.
+            await Task.Delay(3000, cancellationToken);
             yield return new ChatResponseUpdate(ChatRole.Assistant, "slow ack");
         }
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
@@ -618,7 +618,7 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
         //    to the trigger so a future click with a newer timestamp is again
         //    dispatchable (the watcher uses strict-greater-than as the gate).
         await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
-            .Should().Within(TimeSpan.FromSeconds(15))
+            .Should().Within(TimeSpan.FromSeconds(30))
             .Match(n => n?.Content is NodeTypeDefinition d
                 && d.LastReleaseRequestHandledAt is { } handled
                 && handled >= triggerAt);


### PR DESCRIPTION
The #121-merge build was green on the deterministic skill regression (that's fixed), but tripped two **pre-existing CI-load flakes** — neither a regression from the recent changes:

- **`Submit_ThreeMessages`** asserts exactly 6 messages / 2 response cells, which needs all three mid-round submits to register before round 1's slow-model window (**1s**) closes. On the 2-core runner u4 landed after round 1 ended → the batch split into 3 cells → fail. Widen the round window **1s→3s** so batching is reliable; the assertion is unchanged (still proves mid-round submits batch into one round).
- **`CodeEditRecompile`** — the post-2nd-compile wait for `LastReleaseRequestHandledAt` was **15s**; the second Roslyn compile + watcher settle is tight under load. Widen **15s→30s** (`WaitForLatestRelease` is already 50s, so the compile itself wasn't the limiter).

Both verified locally (Submit passes with 3s; Monolith test compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)