### PR TITLE
fix(chat+local): reduce side-panel chat-vanish + cure local build wedges

### DIFF
--- a/.github/workflows/base-image-acr.yml
+++ b/.github/workflows/base-image-acr.yml
@@ -73,8 +73,15 @@ jobs:
             --push deploy/base-images/portal-ai
 
       - name: Verify multi-arch manifest list in ACR
+        # Assert :latest is an image INDEX whose children include BOTH linux/amd64 AND linux/arm64,
+        # so the job fails loudly if the push ever flattened to a single arch. (jq is preinstalled on
+        # ubuntu-latest; the buildx provenance/SBOM children show as architecture "unknown" — ignored.)
         run: |
           set -euo pipefail
-          echo "Manifests now tagged on memex-portal-ai-base:latest —"
-          az acr manifest list-metadata -r meshweaver -n memex-portal-ai-base \
-            --query "[?contains(tags, 'latest')].{arch: architecture, mediaType: mediaType, digest: digest}" -o table
+          echo "memex-portal-ai-base:latest child platforms —"
+          ARCHES="$(az acr manifest show -r meshweaver -n memex-portal-ai-base:latest \
+            | jq -r '.manifests[].platform.architecture')"
+          echo "$ARCHES"
+          echo "$ARCHES" | grep -qx amd64 || { echo "::error::amd64 child missing from memex-portal-ai-base:latest"; exit 1; }
+          echo "$ARCHES" | grep -qx arm64 || { echo "::error::arm64 child missing from memex-portal-ai-base:latest"; exit 1; }
+          echo "OK: memex-portal-ai-base:latest is a multi-arch image index (linux/amd64 + linux/arm64)."

--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -256,7 +256,8 @@ image_build_local() {                                  # §3 Option B
   step "Building native arm64 portal image (layered on the CLI base) into Colima's Docker store (§3 Option B)"
   dotnet publish "$repo/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj" \
     -c Release -t:PublishContainer -p:ContainerRepository=memex-portal-ai-local \
-    -p:ContainerBaseImage="$PORTAL_BASE_REF"
+    -p:ContainerBaseImage="$PORTAL_BASE_REF" \
+    -maxcpucount:"${MEMEX_BUILD_CPUS:-6}"   # WEDGE FIX: cap parallelism so ONE build can't saturate the host
   # Fail LOUD if the publish lost the co-hosted CLIs (e.g. the ContainerBaseImage didn't layer in
   # because the local registry was empty). A CLI-less portal silently ships a broken Claude Code /
   # Copilot harness: /login's `claude setup-token` hits "claude: not found" and exits → the portal
@@ -269,7 +270,8 @@ image_build_local() {                                  # §3 Option B
   ok "Portal image verified: claude + node CLIs are baked in"
   step "Building migration image (§3 Option B)"
   dotnet publish "$repo/memex/aspire/Memex.Database.Migration/Memex.Database.Migration.csproj" \
-    -c Release -t:PublishContainer -p:ContainerRepository=memex-migration-local
+    -c Release -t:PublishContainer -p:ContainerRepository=memex-migration-local \
+    -maxcpucount:"${MEMEX_BUILD_CPUS:-6}"   # WEDGE FIX: cap parallelism (see portal publish above)
   docker tag memex-migration-local:latest "$MIGRATION_IMAGE"
   ok "Images tagged $PORTAL_IMAGE / $MIGRATION_IMAGE (visible to k3s via IfNotPresent)"
 }

--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -231,6 +231,27 @@ image_build_local() {                                  # §3 Option B
   repo="$(resolve_repo)" || die "local build (Option B) needs the repo — set MEMEX_REPO to your MeshWeaver checkout, or use 'up --from-acr'"
   need dotnet "--cask dotnet-sdk"
   need docker docker
+
+  # ── WEDGE FIX: serialize image builds across concurrent memex-local invocations. Two agents each running
+  #    `dotnet publish` (portal + 11 dependents) saturate the host's cores (load → 20+, the machine goes
+  #    unresponsive). A lockdir mutex runs builds ONE-AT-A-TIME at full speed instead of contending — far
+  #    better than capping parallelism (which just makes every build slow). Self-heals a leaked lock via a
+  #    liveness check on the holder PID; 20-min hard ceiling so a truly stuck holder can't block forever.
+  #    Opt out with MEMEX_NO_BUILD_LOCK=1.
+  local _bl="${TMPDIR:-/tmp}/memex-build.lock"
+  if [ -z "${MEMEX_NO_BUILD_LOCK:-}" ]; then
+    local _w=0
+    while ! mkdir "$_bl" 2>/dev/null; do
+      local _p; _p="$(cat "$_bl/pid" 2>/dev/null || true)"
+      if { [ -n "$_p" ] && ! kill -0 "$_p" 2>/dev/null; } || [ "$_w" -ge 1200 ]; then rm -rf "$_bl" 2>/dev/null; continue; fi
+      [ "$_w" -eq 0 ] && step "Build lock held by another memex-local build (pid ${_p:-?}) — waiting to avoid wedging the host…"
+      sleep 5; _w=$((_w + 5))
+    done
+    echo "$$" > "$_bl/pid"
+    trap "rm -rf '$_bl' 2>/dev/null" RETURN
+    ok "Acquired build lock — building serially (set MEMEX_NO_BUILD_LOCK=1 to disable)"
+  fi
+
   base_build_local "${1:-}"                            # ensure the CLI-bearing base exists FIRST
   step "Building native arm64 portal image (layered on the CLI base) into Colima's Docker store (§3 Option B)"
   dotnet publish "$repo/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj" \

--- a/src/MeshWeaver.AI/AIExtensions.cs
+++ b/src/MeshWeaver.AI/AIExtensions.cs
@@ -141,6 +141,13 @@ public static class AIExtensions
             .WithType(typeof(MeshWeaver.Mesh.Security.User), nameof(MeshWeaver.Mesh.Security.User))
             .WithType(typeof(MeshWeaver.Mesh.Activity.UserActivityRecord), typeof(MeshWeaver.Mesh.Activity.UserActivityRecord).FullName!)
             .WithType(typeof(MeshWeaver.Mesh.Activity.UserActivityRecord), nameof(MeshWeaver.Mesh.Activity.UserActivityRecord))
+            // ThreadViewModel: the thread per-node hub serialises it with the FULL-name $type when its
+            // registry lacks it; a hub that registered it under the short name then reads it back as an
+            // untyped JsonElement → renders empty / reactive waits time out → the chat circuit drops (the
+            // "GUI vanishes after a round" wedge, measured by SidePanelChatTenMessagesTest). Register BOTH
+            // names so it resolves regardless of which $type form arrives (same dual-registration as User).
+            .WithType(typeof(ThreadViewModel), typeof(ThreadViewModel).FullName!)
+            .WithType(typeof(ThreadViewModel), nameof(ThreadViewModel))
             // MessageViewModel is not registered — handled as JsonElement on the wire.
             // SubmitMessageRequest / SubmitMessageResponse deleted 2026-05-25:
             // the only mutation API is workspace.GetMeshNodeStream(path).Update(...).

--- a/src/MeshWeaver.AI/AIExtensions.cs
+++ b/src/MeshWeaver.AI/AIExtensions.cs
@@ -148,6 +148,9 @@ public static class AIExtensions
             // names so it resolves regardless of which $type form arrives (same dual-registration as User).
             .WithType(typeof(ThreadViewModel), typeof(ThreadViewModel).FullName!)
             .WithType(typeof(ThreadViewModel), nameof(ThreadViewModel))
+            // AgentConfiguration content children — serialised inside an Agent node's content.
+            .WithType(typeof(AgentPluginReference), nameof(AgentPluginReference))
+            .WithType(typeof(AgentHandoff), nameof(AgentHandoff))
             // MessageViewModel is not registered — handled as JsonElement on the wire.
             // SubmitMessageRequest / SubmitMessageResponse deleted 2026-05-25:
             // the only mutation API is workspace.GetMeshNodeStream(path).Update(...).

--- a/src/MeshWeaver.AI/ThreadLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ThreadLayoutAreas.cs
@@ -159,8 +159,7 @@ public static class ThreadLayoutAreas
 
         // OWN MeshNode stream — push ThreadViewModel to data section; contains all
         // thread state for the Blazor view.
-        var vmStream = host.Workspace.GetMeshNodeStream().Select(node => BuildThreadViewModel(node, hubPath, host.Hub.JsonSerializerOptions));
-        host.RegisterForDisposal(vmStream.DistinctUntilChanged().Subscribe(vm => host.UpdateData(ThreadDataKey, vm)));
+        SubscribeThreadVm(host, hubPath);
 
         // Static container — never rebuilt
         return Controls.Stack
@@ -177,6 +176,39 @@ public static class ThreadLayoutAreas
     /// from the thread's own MeshNode. Shared by <see cref="ThreadView"/> and
     /// <see cref="ThreadChatView"/> (the latter in its <c>WithShowFullHeader()</c> mode).
     /// </summary>
+    /// <summary>
+    /// Subscribes the OWN MeshNode stream → <see cref="ThreadViewModel"/> → the data section, with a
+    /// KEEP-LAST-GOOD guard. The stream alternates between the typed MeshThread (the owning hub's own write)
+    /// and a cross-hub / change-feed representation that can momentarily emit a NULL or message-empty node;
+    /// projecting that yields an empty viewmodel (Messages=[]) that flaps the data section to the empty state
+    /// — HasNoMessages → the composer blanks: the intermittent round-N "chat vanishes" (confirmed by the
+    /// footer-gate diagnostic, createdBy=&lt;null&gt; noMsgs=True at the blank). A new thread legitimately
+    /// STARTS empty (the first emission passes; lastVm is null), so the discriminator is a REGRESSION to
+    /// empty AFTER we have shown messages — that is the transient. Drop only those and keep the last-good.
+    /// Subscribe callbacks are serialized, so the closure state is race-free.
+    /// </summary>
+    private static void SubscribeThreadVm(LayoutAreaHost host, string hubPath)
+    {
+        ThreadViewModel? lastVm = null;
+        var sub = host.Workspace.GetMeshNodeStream()
+            .Select(node => BuildThreadViewModel(node, hubPath, host.Hub.JsonSerializerOptions))
+            .DistinctUntilChanged()
+            .Subscribe(vm =>
+            {
+                // Keep the last-good: skip a transient TRULY-empty emission (no committed Messages AND no
+                // pending user text) after we had content — it would blank the data section → the round-N
+                // "vanish". A Pending-only emission (the just-sent optimistic user message: Messages=0 but
+                // PendingMessageTexts=[text]) IS content and MUST pass, else the new user bubble is dropped
+                // server-side before it reaches the client (the "saw N-1" failure).
+                static bool HasContent(ThreadViewModel v) => v.Messages.Count > 0 || v.PendingMessageTexts.Count > 0;
+                if (lastVm is not null && HasContent(lastVm) && !HasContent(vm))
+                    return;
+                lastVm = vm;
+                host.UpdateData(ThreadDataKey, vm);
+            });
+        host.RegisterForDisposal(sub);
+    }
+
     internal static ThreadViewModel BuildThreadViewModel(MeshNode? node, string hubPath, JsonSerializerOptions options)
     {
         // 🚨 ContentAs (DESERIALIZE), never `as MeshThread`. The node stream alternates between the
@@ -219,8 +251,7 @@ public static class ThreadLayoutAreas
         var hubPath = host.Hub.Address.ToString();
         var ownNodeStream = host.Workspace.GetMeshNodeStream();
 
-        var vmStream = ownNodeStream.Select(node => BuildThreadViewModel(node, hubPath, host.Hub.JsonSerializerOptions));
-        host.RegisterForDisposal(vmStream.DistinctUntilChanged().Subscribe(vm => host.UpdateData(ThreadDataKey, vm)));
+        SubscribeThreadVm(host, hubPath);
 
         // Push title to data section so the side panel header can read it.
         var titleStream = ownNodeStream

--- a/src/MeshWeaver.AI/ThreadLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ThreadLayoutAreas.cs
@@ -35,6 +35,9 @@ public static class ThreadLayoutAreas
     /// </summary>
     public static MessageHubConfiguration AddThreadLayoutAreas(this MessageHubConfiguration configuration)
         => configuration
+            // Per-thread-hub last-good holder — survives area/component re-creation so the fresh data section
+            // can be seeded immediately (see SubscribeThreadVm / ThreadVmHolder).
+            .WithServices(services => services.AddSingleton<ThreadVmHolder>())
             // Legacy ThreadSubmission.ApplyResubmit / ThreadSubmission.ApplyDeleteFromMessage handlers
             // removed — click actions now call ThreadSubmission.ApplyResubmit /
             // ApplyDeleteFromMessage directly. See RequestViaStreamUpdate.md.
@@ -189,7 +192,15 @@ public static class ThreadLayoutAreas
     /// </summary>
     private static void SubscribeThreadVm(LayoutAreaHost host, string hubPath)
     {
-        ThreadViewModel? lastVm = null;
+        // The last-good lives on a per-thread-HUB holder, not a local closure: the ThreadChatView (and its
+        // LayoutAreaHost) re-creates ~1-2× per conversation on a legitimate thread rebind, which would reset
+        // a closure/component field to null — and the fresh GetMeshNodeStream emits null before the node
+        // loads, so the re-created component would bind a null data section → blank (the residual round-N
+        // "chat vanishes", pinned by TCV-INIT/TCV-EMPTY fieldNull=True). The hub OUTLIVES the area, so seed
+        // the fresh data section with the holder's last-good IMMEDIATELY, before the stream's first emission.
+        var holder = host.Hub.ServiceProvider.GetRequiredService<ThreadVmHolder>();
+        if (holder.LastGood is not null)
+            host.UpdateData(ThreadDataKey, holder.LastGood);
         var sub = host.Workspace.GetMeshNodeStream()
             .Select(node => BuildThreadViewModel(node, hubPath, host.Hub.JsonSerializerOptions))
             .DistinctUntilChanged()
@@ -201,12 +212,26 @@ public static class ThreadLayoutAreas
                 // PendingMessageTexts=[text]) IS content and MUST pass, else the new user bubble is dropped
                 // server-side before it reaches the client (the "saw N-1" failure).
                 static bool HasContent(ThreadViewModel v) => v.Messages.Count > 0 || v.PendingMessageTexts.Count > 0;
-                if (lastVm is not null && HasContent(lastVm) && !HasContent(vm))
+                if (holder.LastGood is { } last && HasContent(last) && !HasContent(vm))
                     return;
-                lastVm = vm;
+                if (HasContent(vm))
+                    holder.LastGood = vm;
                 host.UpdateData(ThreadDataKey, vm);
             });
         host.RegisterForDisposal(sub);
+    }
+
+    /// <summary>
+    /// Per-thread-hub holder for the last content-bearing <see cref="ThreadViewModel"/>. The thread hub
+    /// OUTLIVES the per-render LayoutAreaHost / ThreadChatView, so this survives an area+component
+    /// re-creation (a legitimate thread rebind) where a closure/component field would reset to null. It lets
+    /// a freshly re-created area SEED its empty data section with the last-good immediately — instead of
+    /// binding the null that GetMeshNodeStream emits before the node loads, which is the residual
+    /// intermittent "chat vanishes". Registered per thread hub as a singleton (lifetime = the hub).
+    /// </summary>
+    public sealed class ThreadVmHolder
+    {
+        public ThreadViewModel? LastGood { get; set; }
     }
 
     internal static ThreadViewModel BuildThreadViewModel(MeshNode? node, string hubPath, JsonSerializerOptions options)

--- a/src/MeshWeaver.AI/ThreadSubmission.cs
+++ b/src/MeshWeaver.AI/ThreadSubmission.cs
@@ -726,10 +726,24 @@ internal static class ThreadSubmissionServer
         // when SetContext hadn't yet propagated). Treat hub-as-user as no-identity
         // and fall through to the wrapping MeshNode.CreatedBy (set by the
         // CreateNodeRequest handler from the requester's AccessContext).
-        var hubAsUserMatch = asyncLocalCtx?.ObjectId is { } id
-            && (string.Equals(id, threadPath, StringComparison.Ordinal)
-                || string.Equals(id, hub.Address.ToFullString(), StringComparison.Ordinal));
-        var userCtx = hubAsUserMatch ? null : (asyncLocalCtx ?? circuitCtx);
+        // asyncLocal / circuit can carry a NON-user principal here: the thread hub's own address, a
+        // hub-shaped principal (sync/ mesh/ node/ activity/ portal/), or "system-security" — the watcher's
+        // Throttle/Subscribe continuation captures whatever ExecutionContext was active at Subscribe time,
+        // and hub-init / SecurityService bootstrap run under system-security. NONE of these is the real
+        // submitter; a round dispatched as system-security instead of the user is the intermittent identity
+        // race (effective=system-security in the trace) behind the round-4 thread-hub stall / GUI reset
+        // (SidePanelChatTenMessagesTest). Reject them all and fall through to the persistent circuit context,
+        // then the SUBMITTER rider on the pending message (the authoritative identity that survives the hop).
+        bool IsRealUser(AccessContext? ctx) =>
+            ctx?.ObjectId is { } cid
+            && !string.Equals(cid, threadPath, StringComparison.Ordinal)
+            && !string.Equals(cid, hub.Address.ToFullString(), StringComparison.Ordinal)
+            && !string.Equals(cid, MeshWeaver.Mesh.Security.WellKnownUsers.System, StringComparison.Ordinal)
+            && !AccessService.LooksLikeHubPrincipal(cid);
+        var hubAsUserMatch = !IsRealUser(asyncLocalCtx); // asyncLocal is NOT the real user (kept for the trace)
+        var userCtx = IsRealUser(asyncLocalCtx) ? asyncLocalCtx
+            : IsRealUser(circuitCtx) ? circuitCtx
+            : null;
 
         // 🚨 The submission watcher runs on a Throttle/Subscribe continuation where the AsyncLocal
         // AccessContext is wiped (the hub-as-user case above), so the live context is usually unusable

--- a/src/MeshWeaver.Blazor.GoogleMaps/BlazorGoogleMapsExtensions.cs
+++ b/src/MeshWeaver.Blazor.GoogleMaps/BlazorGoogleMapsExtensions.cs
@@ -17,7 +17,14 @@ namespace MeshWeaver.Blazor.GoogleMaps
         public static MessageHubConfiguration AddGoogleMaps(this MessageHubConfiguration configuration)
         {
             return configuration
-                .WithTypes(typeof(GoogleMapControl))
+                // The control + the content/config records serialised inside it (Options, markers, circles)
+                // — the reflection sweep in AddLayoutTypes only covers the MeshWeaver.Layout assembly.
+                .WithTypes(
+                    typeof(GoogleMapControl),
+                    typeof(MeshWeaver.GoogleMaps.MapOptions),
+                    typeof(MeshWeaver.GoogleMaps.LatLng),
+                    typeof(MeshWeaver.GoogleMaps.MapMarker),
+                    typeof(MeshWeaver.GoogleMaps.MapCircle))
                 .AddViews(registry => registry.WithView<GoogleMapControl, GoogleMapView>());
         }
     }

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -320,21 +320,24 @@ else
 
                         @if (state.ToolCalls is { Count: > 0 })
                         {
-                            <div class="thread-msg-tool-calls">
-                                @foreach (var call in state.ToolCalls)
-                                {
-                                    var isDelegation = !string.IsNullOrEmpty(call.DelegationPath);
-                                    var isPending = call.Result == null;
-                                    var summary = FormatToolCallSummary(call);
+                            @* Compact tool-call window: running on top, then pending, capped at 5
+                               (ToolCallVisibility); completed backfill the leftover slots and a just-
+                               finished call lingers ~5s before collapsing. The remainder folds behind a
+                               "running · pending · completed" toggle. *@
+                            var toolView = ToolCallVisibility.Partition(state.ToolCalls, DateTime.UtcNow);
+                            var toolExpanded = IsToolCallsExpanded(msgId);
 
+                            RenderFragment<ToolCallEntry> renderToolCall = call =>
+                                @<text>
+                                    @{
+                                        var isDelegation = !string.IsNullOrEmpty(call.DelegationPath);
+                                        var isPending = call.Result == null;
+                                        var callSummary = FormatToolCallSummary(call);
+                                    }
                                     @if (isDelegation)
                                     {
-                                        @* Inline link only — sub-thread progress + status lives in the
-                                           runtime panel below the chat (anchored near the input). Keeps
-                                           the bubble compact and avoids the duplicate "tool call + embedded
-                                           streaming area" the user flagged. *@
                                         var delHeader = GetDelegationHeader(call.DelegationPath);
-                                        var title = delHeader?.Title ?? summary;
+                                        var title = delHeader?.Title ?? callSummary;
                                         var icon = delHeader?.Icon ?? "/static/NodeTypeIcons/chat.svg";
                                         var stateIcon = isPending
                                             ? "↗"
@@ -342,20 +345,23 @@ else
                                         var stateClass = isPending
                                             ? "thread-msg-tool-delegation-pending"
                                             : (call.IsSuccess ? "thread-msg-tool-delegation-ok" : "thread-msg-tool-delegation-error");
+                                        @* Inline link only — sub-thread progress + status lives in the
+                                           runtime panel below the chat (anchored near the input). Keeps
+                                           the bubble compact and avoids the duplicate "tool call + embedded
+                                           streaming area" the user flagged. *@
                                         <a href="/@call.DelegationPath"
                                            class="thread-msg-tool-delegation @stateClass"
                                            title="@title">
                                             <span class="thread-msg-tool-delegation-state">@stateIcon</span>
                                             <img src="@icon" alt="" class="thread-msg-tool-delegation-icon" />
                                             <span class="thread-msg-tool-delegation-title">@title</span>
-                                            <span class="thread-msg-tool-delegation-agent">@summary</span>
+                                            <span class="thread-msg-tool-delegation-agent">@callSummary</span>
                                         </a>
                                     }
                                     else
                                     {
                                         var display = FormatToolCallDisplay(call);
                                         var change = display.IsNodeModifying ? FindChange(state.UpdatedNodes, display.Path) : null;
-
                                         <details class="thread-msg-tool-entry">
                                             <summary class="thread-msg-tool-entry-name">
                                                 <span class="thread-msg-tool-done @(call.IsSuccess ? "" : "thread-msg-tool-error")">@(call.IsSuccess ? "✓" : "✗")</span>
@@ -390,6 +396,39 @@ else
                                                 <pre class="thread-msg-tool-result">@call.Result</pre>
                                             }
                                         </details>
+                                    }
+                                </text>;
+
+                            <div class="thread-msg-tool-calls">
+                                @foreach (var call in toolView.Visible)
+                                {
+                                    @renderToolCall(call)
+                                }
+                                @if (toolView.HasHidden)
+                                {
+                                    <button type="button" class="thread-msg-tool-more@(toolExpanded ? " expanded" : "")"
+                                            @onclick="() => ToggleToolCalls(msgId)"
+                                            title="@(toolExpanded ? "Hide finished tool calls" : "Show all tool calls")">
+                                        <span class="thread-msg-tool-more-caret">@(toolExpanded ? "▾" : "▸")</span>
+                                        @if (toolView.RunningCount > 0)
+                                        {
+                                            <span class="thread-msg-tool-more-count running">@toolView.RunningCount running</span>
+                                        }
+                                        @if (toolView.PendingCount > 0)
+                                        {
+                                            <span class="thread-msg-tool-more-count pending">@toolView.PendingCount pending</span>
+                                        }
+                                        @if (toolView.CompletedCount > 0)
+                                        {
+                                            <span class="thread-msg-tool-more-count completed">@toolView.CompletedCount completed</span>
+                                        }
+                                    </button>
+                                    @if (toolExpanded)
+                                    {
+                                        @foreach (var call in toolView.Hidden)
+                                        {
+                                            @renderToolCall(call)
+                                        }
                                     }
                                 }
                             </div>

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1876,6 +1876,15 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 break;
             }
         }
+        // 🎯 The user's home is addressed `User/{id}` (the User catalog entry), but a thread started
+        // there belongs in the OWNER's writable partition `{id}` — NEVER the system-managed `User`
+        // partition, which the user lacks Thread permission on (StartThread there is denied → no thread
+        // → the side-panel chat tears down, and on Postgres the `user` schema may not even exist → 42P01).
+        // Map `User/{id}[/…]` → `{id}` so the thread anchors in the user's own partition.
+        var ownerSegments = normalized.Split('/');
+        if (ownerSegments.Length >= 2 && string.Equals(ownerSegments[0], "User", StringComparison.OrdinalIgnoreCase))
+            normalized = ownerSegments[1];
+
         // A rogue/reserved ROUTE partition (login, welcome, settings, …) is NOT a real node — never use
         // it as a chat context. Reading it sends a GetDataRequest to a hub that never opens its init
         // gates (DataContextInit/MeshNodeInit) and the read hangs >30s. Treat a reserved context as none.

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -975,21 +975,18 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             var contextReference = navReference is null
                 ? null
                 : System.Text.Json.JsonSerializer.Serialize(navReference, Hub.JsonSerializerOptions);
-            // 🎯 Normalize the FINAL resolved namespace, not just navNs. The fallbacks — safeContext
-            // (= initialContext, e.g. "User/Roland" when the side panel is opened on a user home) and
-            // createdBy — are RAW: an un-normalized "User/{id}" routes the StartThread to the system-managed,
-            // un-writable 'User' partition → AccessControlPipeline denies the CreateNodeRequest → the message
-            // silently drops (the SidePanelChatTenMessagesTest "2nd user bubble never appears" denial).
-            // NormalizeContextPath maps User/{id} → {id} (and drops reserved route partitions to ""), so the
-            // thread always anchors in the owner's writable partition regardless of which source ns came from.
-            var ns = NormalizeContextPath(
-                !string.IsNullOrEmpty(navNs)
-                    ? navNs
-                    : !string.IsNullOrEmpty(safeContext)
-                        ? safeContext
-                        : !string.IsNullOrEmpty(createdBy)
-                            ? createdBy
-                            : "");
+            // 🎯 Normalize EACH candidate and take the first that survives, not the first non-empty RAW one.
+            // safeContext (= initialContext, e.g. "User/Roland" or bare "User" when the side panel is opened
+            // on a user home) and createdBy are raw; NormalizeContextPath maps User/{id} → {id} and bare
+            // User / reserved partitions → "". If we picked the first raw non-empty value and normalized
+            // ONCE, a safeContext of bare "User" would normalize to "" and we'd anchor on an empty namespace
+            // — skipping createdBy (the owner's writable partition). Normalizing each and taking the first
+            // non-empty result lands on createdBy="Roland", so the StartThread never targets the un-writable
+            // 'User' partition (whose denial surfaces a blocking "Something went wrong" modal that breaks the
+            // composer — the SidePanelChatTenMessagesTest "2nd message never lands" cause).
+            var ns = new[] { navNs, safeContext, createdBy }
+                .Select(c => NormalizeContextPath(c ?? string.Empty))
+                .FirstOrDefault(c => !string.IsNullOrEmpty(c)) ?? string.Empty;
 
             Action<string> onError = err => InvokeAsync(() =>
             {
@@ -1901,12 +1898,14 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         }
         // 🎯 The user's home is addressed `User/{id}` (the User catalog entry), but a thread started
         // there belongs in the OWNER's writable partition `{id}` — NEVER the system-managed `User`
-        // partition, which the user lacks Thread permission on (StartThread there is denied → no thread
-        // → the side-panel chat tears down, and on Postgres the `user` schema may not even exist → 42P01).
-        // Map `User/{id}[/…]` → `{id}` so the thread anchors in the user's own partition.
+        // partition, which the user lacks Thread permission on (StartThread there is denied → the denial
+        // is a DeliveryFailure that the global portal error handler surfaces as a BLOCKING "Something went
+        // wrong" modal that overlays + breaks the composer, and on Postgres the `user` schema may not even
+        // exist → 42P01). Map `User/{id}[/…]` → `{id}`; bare `User` (no id) → "" so the ns derivation falls
+        // through to createdBy (the owner's own partition). Both forms must leave the `User` partition.
         var ownerSegments = normalized.Split('/');
-        if (ownerSegments.Length >= 2 && string.Equals(ownerSegments[0], "User", StringComparison.OrdinalIgnoreCase))
-            normalized = ownerSegments[1];
+        if (string.Equals(ownerSegments[0], "User", StringComparison.OrdinalIgnoreCase))
+            normalized = ownerSegments.Length >= 2 ? ownerSegments[1] : "";
 
         // A rogue/reserved ROUTE partition (login, welcome, settings, …) is NOT a real node — never use
         // it as a chat context. Reading it sends a GetDataRequest to a hub that never opens its init

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1026,6 +1026,15 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                     {
                         var path = node.Path;
                         if (string.IsNullOrEmpty(path)) { onError("Thread created with no path"); return; }
+                        // 🎯 Route subsequent sends to SubmitComposer IMMEDIATELY: the thread node now
+                        // exists (CreateNodeResponse succeeded), so message 2+ must drain through the
+                        // existing thread (GetMeshNodeStream(threadPath).Update → PendingUserMessages), NOT
+                        // re-StartThread (which would create a SECOND thread — and on the user home routes
+                        // to the un-writable 'User' partition → denied → the message silently drops, the
+                        // SidePanelChatTenMessagesTest "2nd user bubble never appears" bug). The submit
+                        // decision (line ~998 `if (string.IsNullOrEmpty(threadPath))`) reads this field, so
+                        // it must be set the moment the node exists — NOT gated on the readability wait below.
+                        threadPath = path;
                         // 🚨 Redirect ONLY once the thread node is actually READABLE on its own stream.
                         // Navigating on the bare CreateNode ack races the thread's per-node hub
                         // activation: the target page subscribes to a not-yet-ready node, the render
@@ -2614,6 +2623,10 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     private readonly Dictionary<string, MessageBubbleState> messageStates = new();
     private readonly Dictionary<string, IDisposable> messageSubs = new();
     private readonly HashSet<string> editingMessages = new();
+    /// <summary>Message ids whose tool-calls section is expanded to show the collapsed
+    /// (finished / overflow) entries. Per-message UI toggle — same circuit-scoped HashSet
+    /// idiom as <see cref="editingMessages"/>.</summary>
+    private readonly HashSet<string> expandedToolCalls = new();
     /// <summary>Message ids whose satellite cell did NOT emit within the cache
     /// settle window — surfaced as "Missing message" in the bubble instead of
     /// the loading skeleton. A deleted-by-someone-else or never-materialised
@@ -2958,6 +2971,15 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     private bool IsMissing(string id) => missingMessages.Contains(id);
 
     private bool IsEditing(string id) => editingMessages.Contains(id);
+
+    private bool IsToolCallsExpanded(string id) => expandedToolCalls.Contains(id);
+
+    private void ToggleToolCalls(string id)
+    {
+        if (!expandedToolCalls.Remove(id))
+            expandedToolCalls.Add(id);
+        StateHasChanged();
+    }
 
     private void StartEdit(string id)
     {

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -133,6 +133,12 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
 
 
     private ThreadViewModel? _threadViewModel;
+    // The best-ever NON-EMPTY thread viewmodel seen for THIS thread (set only when Messages is non-empty,
+    // so it can never be poisoned by a transient empty). ConvertThreadViewModel falls back to it whenever the
+    // data-bind transiently yields null/empty (the cross-hub node stream momentarily reduces to an empty
+    // node), so an open chat never flaps to the empty state mid-conversation (the round-N "vanish"). Reset
+    // when the bound thread PATH actually changes (a different thread legitimately has its own messages).
+    private ThreadViewModel? _lastNonEmptyThreadVm;
     private ThreadViewModel? ThreadViewModel
     {
         get => _threadViewModel;
@@ -2608,7 +2614,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     /// <see cref="ThreadChatView"/>'s Razor template gets live ThreadMessage
     /// content via <see cref="messageStates"/>.
     /// </summary>
-    private ThreadViewModel? ConvertThreadViewModel(object? value, ThreadViewModel? _)
+    private ThreadViewModel? ConvertThreadViewModel(object? value, ThreadViewModel? previous)
     {
         var result = value switch
         {
@@ -2617,6 +2623,25 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             AI.ThreadViewModel m => m,
             _ => throw new ArgumentException($"Cannot convert type {value.GetType().Name}.")
         };
+        // 🎯 BEST-EVER keep-last-good. The data-bound value transiently arrives null (a JsonElement that
+        // deserialises to null) or as an empty/default ThreadViewModel — the cross-hub node stream
+        // momentarily reduces to an empty node. Binding that empties the conversation → HasNoMessages → the
+        // composer blanks mid-chat: the intermittent round-N "chat vanishes" (footer-gate createdBy=<null>
+        // noMsgs=True). A LIVE thread never loses its content, so remember the last viewmodel that HAD
+        // content and fall back to it on any transient empty/null. Unlike a 'previous'-value guard this
+        // CANNOT be poisoned — the field is ONLY ever assigned a content-bearing value, so one empty slipping
+        // through never defeats it. "Content" counts BOTH committed Messages AND PendingMessageTexts (the
+        // just-sent optimistic user message): a flap that coincides with a fresh submission has Messages=0
+        // but Pending=[text], and masking that would HIDE the new user bubble (the "saw N-1" failure). A new
+        // thread re-creates this component (field resets); we also guard on ThreadPath against a thread switch.
+        static bool HasContent(ThreadViewModel? vm)
+            => vm is not null && (vm.Messages.Count > 0 || vm.PendingMessageTexts.Count > 0);
+        if (HasContent(result))
+            _lastNonEmptyThreadVm = result;
+        else if (HasContent(_lastNonEmptyThreadVm)
+                 && (result is null || string.IsNullOrEmpty(result.ThreadPath)
+                     || string.Equals(result.ThreadPath, _lastNonEmptyThreadVm!.ThreadPath, StringComparison.Ordinal)))
+            return _lastNonEmptyThreadVm;
         Logger.LogDebug("[ThreadChat:{InstanceId}] ConvertThreadViewModel: input={InputType}, msgs={MsgCount}",
             _instanceId, value?.GetType().Name ?? "null", result?.Messages?.Count ?? 0);
         // SyncMessageSubscriptions runs in the property setter (below) — calling

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -147,11 +147,17 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             Logger.LogDebug("[ThreadChat:{InstanceId}] ThreadViewModel setter: old={OldCount} msgs, new={NewCount} msgs, equal={Equal}, stream={HasStream}",
                 _instanceId, oldMsgs.Count, newMsgs.Count, Equals(old, value), Stream != null);
 
-            // Sync threadPath and initialContext from the view model
+            // Sync threadPath and initialContext from the view model.
             if (value != null)
             {
-                threadPath = value.ThreadPath ?? threadPath;
-                initialContext = value.InitialContext ?? initialContext;
+                // 🎯 EMPTY means "no change", not "clear it". The side-panel control rebuilds with
+                // ThreadPath = ContentPath ?? "" — i.e. an EMPTY STRING — on every re-render BEFORE the
+                // just-created thread's SetContentPath lands. `?? ` only coalesces null, so an empty string
+                // would CLOBBER a threadPath we just set in StartThread.onCreated → the next send sees an
+                // empty threadPath and re-StartThreads a SECOND thread (the SidePanelChatTenMessagesTest
+                // "2nd user bubble never appears" bug). Guard on IsNullOrEmpty, exactly like lines below.
+                threadPath = string.IsNullOrEmpty(value.ThreadPath) ? threadPath : value.ThreadPath;
+                initialContext = string.IsNullOrEmpty(value.InitialContext) ? initialContext : value.InitialContext;
 
                 // Inside a thread the composer lives ON the thread node (Thread.Composer) —
                 // bind the embedded selectors area + the selection projection to the THREAD
@@ -969,13 +975,21 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             var contextReference = navReference is null
                 ? null
                 : System.Text.Json.JsonSerializer.Serialize(navReference, Hub.JsonSerializerOptions);
-            var ns = !string.IsNullOrEmpty(navNs)
-                ? navNs
-                : !string.IsNullOrEmpty(safeContext)
-                    ? safeContext
-                    : !string.IsNullOrEmpty(createdBy)
-                        ? createdBy
-                        : "";
+            // 🎯 Normalize the FINAL resolved namespace, not just navNs. The fallbacks — safeContext
+            // (= initialContext, e.g. "User/Roland" when the side panel is opened on a user home) and
+            // createdBy — are RAW: an un-normalized "User/{id}" routes the StartThread to the system-managed,
+            // un-writable 'User' partition → AccessControlPipeline denies the CreateNodeRequest → the message
+            // silently drops (the SidePanelChatTenMessagesTest "2nd user bubble never appears" denial).
+            // NormalizeContextPath maps User/{id} → {id} (and drops reserved route partitions to ""), so the
+            // thread always anchors in the owner's writable partition regardless of which source ns came from.
+            var ns = NormalizeContextPath(
+                !string.IsNullOrEmpty(navNs)
+                    ? navNs
+                    : !string.IsNullOrEmpty(safeContext)
+                        ? safeContext
+                        : !string.IsNullOrEmpty(createdBy)
+                            ? createdBy
+                            : "");
 
             Action<string> onError = err => InvokeAsync(() =>
             {

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
@@ -1208,6 +1208,51 @@
     color: var(--neutral-foreground-rest);
 }
 
+/* ─── "Show all" toggle for the collapsed tool-call remainder ───────────
+   Sits under the visible window. The running / pending / completed counts
+   are colour-keyed chips; clicking reveals the folded entries. */
+.thread-msg-tool-more {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    align-self: flex-start;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 6px;
+    font: inherit;
+    font-size: 0.78rem;
+    color: var(--neutral-foreground-hint);
+}
+
+.thread-msg-tool-more:hover {
+    background: color-mix(in srgb, var(--neutral-stroke-rest) 30%, transparent);
+    color: var(--neutral-foreground-rest);
+}
+
+.thread-msg-tool-more-caret {
+    flex: 0 0 auto;
+    font-size: 0.7rem;
+    opacity: 0.8;
+}
+
+.thread-msg-tool-more-count {
+    padding: 1px 6px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--neutral-stroke-rest) 35%, transparent);
+    white-space: nowrap;
+}
+
+.thread-msg-tool-more-count.running {
+    color: var(--accent-fill-rest);
+    background: color-mix(in srgb, var(--accent-fill-rest) 14%, transparent);
+}
+
+.thread-msg-tool-more-count.completed {
+    opacity: 0.8;
+}
+
 /* ─── Delegation tool call — inline link ────────────────────────────────
    Replaces the previous "chip with embedded streaming area" — the live
    sub-thread progress now lives in `.thread-runtime-subthreads` near the

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.cs
@@ -735,32 +735,39 @@ public partial class PortalLayoutBase : LayoutComponentBase, IDisposable
 
         // Reactive — Subscribe, never await on PathResolver chain (deadlock surface;
         // see Doc/Architecture/AsynchronousCalls.md).
-        PathResolver.ResolvePath(contentPath).Subscribe(resolution =>
-        {
-            if (resolution == null)
-            {
-                sidePanelViewModel = null;
-                SidePanelState.SetContentPath(null);
-                resolvedSidePanelPath = null;
-                InvokeAsync(StateHasChanged);
-                return;
-            }
-
-            if (!string.Equals(resolution.Prefix, contentPath, StringComparison.OrdinalIgnoreCase)
-                && !string.IsNullOrEmpty(resolution.Remainder))
-            {
-                sidePanelViewModel = null;
-                SidePanelState.SetContentPath(null);
-                resolvedSidePanelPath = null;
-                InvokeAsync(StateHasChanged);
-                return;
-            }
-
-            var (area, id) = ParseSidePanelRemainder(resolution.Remainder);
-            var reference = new LayoutAreaReference(area) { Id = id ?? "" };
-            sidePanelViewModel = Controls.LayoutArea((Address)resolution.Prefix, reference);
-            InvokeAsync(StateHasChanged);
-        });
+        // 🎯 Wait for a VALID resolution, then take exactly one. ResolvePath is a LIVE stream that re-emits
+        // whenever the resolved node changes. Right after a thread is CREATED its node is not yet readable,
+        // so the first emissions are transient null / split-onto-the-parent-partition states; and it re-emits
+        // again on every chat round as the thread node updates. The old code wiped the side panel to an empty
+        // "New Thread" on ANY null/split emission → it BOTH failed a just-created thread (the initial
+        // not-ready null wiped it) AND wiped a healthy open thread mid-session (the SidePanelChatTenMessages-
+        // Test round-4 vanish). Filtering to the FIRST valid resolution skips the transient states (no wipe
+        // on a mid-update re-emit) yet still resolves once the node is readable; a genuinely unresolvable
+        // path (a deleted thread) never yields a valid resolution, so the Timeout clears it.
+        PathResolver.ResolvePath(contentPath)
+            .Where(resolution => resolution != null
+                && (string.Equals(resolution.Prefix, contentPath, StringComparison.OrdinalIgnoreCase)
+                    || string.IsNullOrEmpty(resolution.Remainder)))
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(10))
+            .Subscribe(
+                resolution =>
+                {
+                    var (area, id) = ParseSidePanelRemainder(resolution!.Remainder);
+                    var reference = new LayoutAreaReference(area) { Id = id ?? "" };
+                    sidePanelViewModel = Controls.LayoutArea((Address)resolution.Prefix, reference);
+                    InvokeAsync(StateHasChanged);
+                },
+                _ =>
+                {
+                    // No valid resolution within the window → the content path is genuinely unresolvable
+                    // (e.g. a deleted thread, or a path that resolves only onto its parent partition). Clear
+                    // back to the new-chat state.
+                    sidePanelViewModel = null;
+                    SidePanelState.SetContentPath(null);
+                    resolvedSidePanelPath = null;
+                    InvokeAsync(StateHasChanged);
+                });
     }
 
     private static (string? Area, string? Id) ParseSidePanelRemainder(string? remainder)

--- a/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor
+++ b/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor
@@ -28,7 +28,15 @@
            new parameter shows the error again rather than spinning a retry loop. (Async stream
            OnErrors are surfaced separately by the subscription onError handlers — an ErrorBoundary
            only catches synchronous render/lifecycle throws.) *@
-        <ErrorBoundary @key="@($"{Address}|{ViewModel.Reference}")">
+        @* @key on the area's NORMALIZED identity, not its ToString. LayoutAreaReference.ToString() renders a
+           string Id as `v12` but a round-tripped JsonElement Id as `"v12"` (quoted), so an interpolated string
+           @key FLAPS between the two representations even though LayoutAreaReference.Equals normalizes them
+           equal. That flap re-creates the ErrorBoundary → the child ThreadChatView → resets its keep-last-good
+           field → the intermittent round-N "chat vanishes". GetHashCode is computed from the SAME normalized
+           Area/Id/Layout as Equals, so it is stable across a representation flip while still changing for a
+           genuine area switch (different Area/Id/Layout) → clean auto-recovery. Kept as a STRING key (not the
+           reference object / an anonymous type) — Blazor's @key reuse misbehaves with those here. *@
+        <ErrorBoundary @key="@($"{Address}|{ViewModel.Reference.GetHashCode()}")">
             <ChildContent>
                 <NamedAreaView Stream="@AreaStream" ViewModel="@NamedArea" Area="@NamedArea.GetArea()" Top="@Top" />
             </ChildContent>

--- a/src/MeshWeaver.Blazor/Components/ThreadMessageBubbleView.razor
+++ b/src/MeshWeaver.Blazor/Components/ThreadMessageBubbleView.razor
@@ -48,23 +48,28 @@
         }
     }
 
-    @* Tool calls — shown inline, each as a compact entry *@
+    @* Tool calls — compact window: running on top, then pending, capped at 5
+       (ToolCallVisibility). Completed backfill the leftover slots and a just-finished
+       call lingers ~5s before collapsing; the remainder folds behind a
+       "running · pending · completed" toggle. *@
     @if (HasToolCalls)
     {
-        <div class="thread-msg-tool-calls">
-            @foreach (var call in toolCalls!)
-            {
-                var isDelegation = !string.IsNullOrEmpty(call.DelegationPath);
-                var isPending = call.Result == null;
-                var summary = FormatToolCallSummary(call);
+        var toolView = ToolCallVisibility.Partition(toolCalls, DateTime.UtcNow);
 
+        RenderFragment<ToolCallEntry> renderToolCall = call =>
+            @<text>
+                @{
+                    var isDelegation = !string.IsNullOrEmpty(call.DelegationPath);
+                    var isPending = call.Result == null;
+                    var callSummary = FormatToolCallSummary(call);
+                }
                 @if (isDelegation && isPending)
                 {
                     @* Executing delegation: embed the sub-thread's Streaming area *@
                     <div class="thread-msg-delegation-entry">
                         <div class="thread-msg-delegation-header">
                             <span class="thread-msg-delegation-pulse">✹</span>
-                            <a href="/@call.DelegationPath" class="thread-msg-delegation-link">@summary</a>
+                            <a href="/@call.DelegationPath" class="thread-msg-delegation-link">@callSummary</a>
                         </div>
                         <div class="thread-msg-delegation-stream">
                             <LayoutAreaView ViewModel="@(new LayoutAreaControl(call.DelegationPath!, new LayoutAreaReference("Streaming")).WithSpinnerType(SpinnerType.None))" Stream="@Stream" Area="@($"{Area}/del-{call.DelegationPath}")" />
@@ -81,7 +86,7 @@
                             <span class="thread-msg-tool-done @(call.IsSuccess ? "" : "thread-msg-tool-error")">@(call.IsSuccess ? "✓" : "✗")</span>
                             @if (isDelegation)
                             {
-                                <a href="/@call.DelegationPath" class="thread-msg-delegation-link" @onclick:stopPropagation>@summary</a>
+                                <a href="/@call.DelegationPath" class="thread-msg-delegation-link" @onclick:stopPropagation>@callSummary</a>
                             }
                             else
                             {
@@ -117,6 +122,39 @@
                             <pre class="thread-msg-tool-result">@call.Result</pre>
                         }
                     </details>
+                }
+            </text>;
+
+        <div class="thread-msg-tool-calls">
+            @foreach (var call in toolView.Visible)
+            {
+                @renderToolCall(call)
+            }
+            @if (toolView.HasHidden)
+            {
+                <button type="button" class="thread-msg-tool-more@(toolCallsExpanded ? " expanded" : "")"
+                        @onclick="ToggleToolCalls"
+                        title="@(toolCallsExpanded ? "Hide finished tool calls" : "Show all tool calls")">
+                    <span class="thread-msg-tool-more-caret">@(toolCallsExpanded ? "▾" : "▸")</span>
+                    @if (toolView.RunningCount > 0)
+                    {
+                        <span class="thread-msg-tool-more-count running">@toolView.RunningCount running</span>
+                    }
+                    @if (toolView.PendingCount > 0)
+                    {
+                        <span class="thread-msg-tool-more-count pending">@toolView.PendingCount pending</span>
+                    }
+                    @if (toolView.CompletedCount > 0)
+                    {
+                        <span class="thread-msg-tool-more-count completed">@toolView.CompletedCount completed</span>
+                    }
+                </button>
+                @if (toolCallsExpanded)
+                {
+                    @foreach (var call in toolView.Hidden)
+                    {
+                        @renderToolCall(call)
+                    }
                 }
             }
         </div>
@@ -375,6 +413,43 @@
     }
     .thread-msg-tool-error {
         color: var(--error);
+    }
+    /* "Show all" toggle for the collapsed tool-call remainder. */
+    .thread-msg-tool-more {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        align-self: flex-start;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        padding: 2px 4px;
+        border-radius: 6px;
+        font: inherit;
+        font-size: 0.74rem;
+        color: var(--neutral-foreground-hint);
+    }
+    .thread-msg-tool-more:hover {
+        background: var(--neutral-layer-3);
+        color: var(--neutral-foreground-rest);
+    }
+    .thread-msg-tool-more-caret {
+        flex: 0 0 auto;
+        font-size: 0.66rem;
+        opacity: 0.8;
+    }
+    .thread-msg-tool-more-count {
+        padding: 1px 6px;
+        border-radius: 999px;
+        background: var(--neutral-layer-3);
+        white-space: nowrap;
+    }
+    .thread-msg-tool-more-count.running {
+        color: var(--accent-fill-rest);
+        background: color-mix(in srgb, var(--accent-fill-rest) 14%, transparent);
+    }
+    .thread-msg-tool-more-count.completed {
+        opacity: 0.8;
     }
     .thread-msg-delegation-entry {
         border-left: 2px solid var(--accent-fill-rest);

--- a/src/MeshWeaver.Blazor/Components/ThreadMessageBubbleView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/ThreadMessageBubbleView.razor.cs
@@ -32,6 +32,8 @@ public partial class ThreadMessageBubbleView : BlazorView<ThreadMessageBubbleCon
     private IReadOnlyList<ToolCallEntry>? toolCalls;
     private IReadOnlyList<NodeChangeEntry>? updatedNodes;
     private bool isEditing;
+    // Expands the tool-calls section to show the collapsed (finished / overflow) entries.
+    private bool toolCallsExpanded;
 
     private bool IsUser => Role.Equals("user", StringComparison.OrdinalIgnoreCase);
     private bool CanEdit => !string.IsNullOrEmpty(ViewModel.ThreadPath) && !string.IsNullOrEmpty(ViewModel.MessageId);
@@ -57,6 +59,8 @@ public partial class ThreadMessageBubbleView : BlazorView<ThreadMessageBubbleCon
     private void StartEdit() => isEditing = true;
 
     private void CancelEdit() => isEditing = false;
+
+    private void ToggleToolCalls() => toolCallsExpanded = !toolCallsExpanded;
 
     /// <summary>
     /// When <c>NodePath</c> is non-empty, subscribes to the per-message node stream (bypassing

--- a/src/MeshWeaver.Data.Contract/ActivityStatusExtensions.cs
+++ b/src/MeshWeaver.Data.Contract/ActivityStatusExtensions.cs
@@ -1,0 +1,61 @@
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace MeshWeaver.Data;
+
+/// <summary>
+/// The status-driven continuation + rendering law for activities (and any status-bearing content):
+///
+/// <list type="bullet">
+///   <item><b>Continuations are triggered by a status change INTO a follow-up status.</b> Rather than
+///         ad-hoc completion detection (message counts, bespoke events), a watcher does
+///         <c>stream.Select(n => n.Status).Where(s => s.IsTerminal())</c> — the round/activity reached a
+///         terminal state (cancelled, errored, or finished), so the continuation runs.</item>
+///   <item><b>Only on success do we read the real typed content.</b> A consumer/layout area calls
+///         <c>ContentAs&lt;T&gt;</c> ONLY when <see cref="IsSuccess"/> — never on a still-running or
+///         failed activity, whose content may be absent, partial, or not-yet-type-resolvable (the
+///         untyped-JsonElement storm that wedged the portal: typing un-ready content → null → reactive
+///         waits time out → resubscribe storm). Gate the type read on success and that whole class is gone.</item>
+///   <item><b>Error/cancel ⇒ emergency mode.</b> When <see cref="IsError"/>, the node is rendered as its
+///         error, no matter what — every layout area short-circuits to the error instead of attempting a
+///         normal (typed) render.</item>
+/// </list>
+/// </summary>
+public static class ActivityStatusExtensions
+{
+    /// <summary>
+    /// The follow-up statuses: a transition INTO one of these is what triggers a continuation — the
+    /// activity has stopped (finished, errored, or was cancelled). Equivalent to "not
+    /// <see cref="ActivityStatus.Running"/>".
+    /// </summary>
+    public static readonly IReadOnlySet<ActivityStatus> FollowupStatuses = new HashSet<ActivityStatus>
+    {
+        ActivityStatus.Succeeded,
+        ActivityStatus.Warning,
+        ActivityStatus.Failed,
+        ActivityStatus.Cancelled,
+    };
+
+    /// <summary>
+    /// A terminal status — the activity has stopped and a continuation should fire. Only
+    /// <see cref="ActivityStatus.Running"/> is non-terminal.
+    /// </summary>
+    public static bool IsTerminal(this ActivityStatus status) => status != ActivityStatus.Running;
+
+    /// <summary>
+    /// The activity produced a usable result (<see cref="ActivityStatus.Succeeded"/> or
+    /// <see cref="ActivityStatus.Warning"/>) — the ONLY case where the real typed content
+    /// (<c>ContentAs&lt;T&gt;</c>) should be read. Never type a running or failed activity's content.
+    /// </summary>
+    public static bool IsSuccess(this ActivityStatus status)
+        => status is ActivityStatus.Succeeded or ActivityStatus.Warning;
+
+    /// <summary>
+    /// An error-class terminal status (<see cref="ActivityStatus.Failed"/> or
+    /// <see cref="ActivityStatus.Cancelled"/>) — triggers EMERGENCY MODE: the content renders as its
+    /// error, every layout area short-circuits to the error, no typed render is attempted.
+    /// </summary>
+    public static bool IsError(this ActivityStatus status)
+        => status is ActivityStatus.Failed or ActivityStatus.Cancelled;
+}

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -191,6 +191,9 @@ public static class DataExtensions
             )
             .WithType(typeof(Address), nameof(Address))
             .WithType(typeof(ActivityLog), nameof(ActivityLog))
+            // ActivityLog content children — serialised inside log entries / user attribution.
+            .WithType(typeof(LogMessage), nameof(LogMessage))
+            .WithType(typeof(UserInfo), nameof(UserInfo))
             .RegisterDataEvents()
             .WithInitializationGate(DataContext.InitializationGateName, d => d.Message is PingRequest);
     }

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -363,6 +363,8 @@ public static class MeshNodeExtensions
         typeRegistry.WithType(typeof(CodeConfiguration), nameof(CodeConfiguration));
         typeRegistry.WithType(typeof(Comment), nameof(Comment));
         typeRegistry.WithType(typeof(MarkdownContent), nameof(MarkdownContent));
+        // Backend-computed editable-field metadata sent to the GUI inside the node-content editor control.
+        typeRegistry.WithType(typeof(MeshNodeEditorField), nameof(MeshNodeEditorField));
         // Security content types (AccessAssignment / PartitionAccessPolicy / RoleAssignment / Role).
         // Each MUST register its $type here: without it, the node read across a hub boundary (the
         // GetQuery / MeshNodeStreamCache deserialization path) degrades to an untyped JsonElement,

--- a/src/MeshWeaver.Hosting.Monolith.TestBase/TestUsers.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/TestUsers.cs
@@ -40,20 +40,25 @@ public static class TestUsers
     /// Requires AddGraph() to register the User and AccessAssignment node types.
     /// </summary>
     public static MeshNode[] SampleUsers() =>
-    [
-        // TestUser is the default test-circuit identity (TestUsers.TestUser), so its
-        // own User MeshNode must exist — AgentChatClient.LoadContextNode("User/TestUser")
-        // warned "Failed to load context node" when it wasn't seeded, and downstream
-        // chat flows that read ContextPath proceeded with a null Node.
-        new("TestUser", "User") { Name = "TestUser", NodeType = "User" },
-        new("Roland", "User") { Name = "Roland", NodeType = "User" },
-        new("Samuel", "User") { Name = "Samuel", NodeType = "User" },
-        new("Alice", "User") { Name = "Alice", NodeType = "User" },
-        new("Bob", "User") { Name = "Bob", NodeType = "User" },
-        new("Carol", "User") { Name = "Carol", NodeType = "User" },
-        new("David", "User") { Name = "David", NodeType = "User" },
-        new("Emma", "User") { Name = "Emma", NodeType = "User" },
-    ];
+        SampleUserNames
+            .SelectMany(name => new MeshNode[]
+            {
+                // 🚨 The PARTITION-ROOT User node ({name} at namespace="") — the exact shape onboarding
+                // (UserOnboardingService.CreateUser) writes. This is what /{name} routing resolves to and
+                // what makes the user's partition EXIST + reachable. Without it the user is not "properly
+                // onboarded": a thread started from their home has no partition to land in, so routing to
+                // {name} fails "No node found" (the not-reachable = wedge symptom). Seeding the catalog
+                // entry below WITHOUT this root was the gap ThreadCreatableFromHomeTest pins.
+                new(name) { Name = name, NodeType = "User" },
+                // The User/{name} catalog / auth-mirror entry (the V27 trigger writes this in prod; seeded
+                // here so AgentChatClient.LoadContextNode("User/{name}") resolves).
+                new(name, "User") { Name = name, NodeType = "User" },
+            })
+            .ToArray();
+
+    // TestUser is the default test-circuit identity (TestUsers.TestUser), so it leads the list.
+    private static readonly string[] SampleUserNames =
+        ["TestUser", "Roland", "Samuel", "Alice", "Bob", "Carol", "David", "Emma"];
 
     /// <summary>
     /// AccessAssignment granting Public users Admin rights.

--- a/src/MeshWeaver.Layout/LayoutExtensions.cs
+++ b/src/MeshWeaver.Layout/LayoutExtensions.cs
@@ -193,7 +193,20 @@ public static class LayoutExtensions
                 typeof(LayoutAreasReference),
                 typeof(GetLayoutAreasRequest),
                 typeof(LayoutAreasResponse),
-                typeof(DataGridCellClick)
+                typeof(DataGridCellClick),
+                // Non-IUiControl content/config records serialised INSIDE control state (so the reflection
+                // sweep above misses them) — they came back untyped on sync hubs and churned the layout:
+                typeof(MeshWeaver.Layout.LayoutAreaDefinition),
+                typeof(MeshWeaver.Layout.Pivot.PivotConfiguration),
+                typeof(MeshWeaver.Layout.Pivot.PivotDimension),
+                typeof(MeshWeaver.Layout.Pivot.PivotAggregate),
+                typeof(MeshWeaver.Layout.Catalog.GroupingConfig),
+                typeof(MeshWeaver.Layout.Catalog.SectionConfig),
+                typeof(MeshWeaver.Layout.Catalog.SortConfig),
+                typeof(MeshWeaver.Layout.Catalog.GridConfig),
+                typeof(MeshWeaver.Layout.Catalog.CatalogGroup),
+                typeof(MeshWeaver.Layout.Catalog.SearchResultGroup),
+                typeof(MeshWeaver.Layout.Catalog.GroupedSearchResult)
             )
             .WithHandler<GetLayoutAreasRequest>(HandleGetLayoutAreasRequest);
 

--- a/src/MeshWeaver.Messaging.Hub/Serialization/PolymorphicTypeInfoResolver.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/PolymorphicTypeInfoResolver.cs
@@ -160,10 +160,12 @@ public class PolymorphicTypeInfoResolver(ITypeRegistry typeRegistry, string? own
         if (logger is null || !warnedUnregistered.TryAdd(type, 0))
             return;
         logger.LogWarning(
-            "Unregistered type {Type} (de)serialised on hub {Hub} with full-name $type='{Discriminator}': "
-            + "this hub's TypeRegistry lacks it, so a hub that registered it under its short name reads it "
-            + "back as an untyped JsonElement (renders empty / reactive waits time out). Register it via "
-            + "WithType(typeof(...), nameof(...)) where this hub is configured, or serialise it from a hub that has it.",
+            "Unregistered type {Type} (de)serialised on hub {Hub} with auto short-name $type='{Discriminator}': "
+            + "the hub's TypeRegistry lacks it, so it is auto-registered under its SHORT name. That short name "
+            + "resolves on any hub that registered the type under the same short name (the default that cures "
+            + "the untyped-JsonElement read), but register it explicitly via WithType(typeof(...), nameof(...)) "
+            + "where this hub is configured — explicit registration avoids short-name collisions across "
+            + "namespaces and documents the contract.",
             type.FullName, owner ?? "(unknown)", discriminator);
     }
 

--- a/src/MeshWeaver.Messaging.Hub/Serialization/TypeRegistry.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/TypeRegistry.cs
@@ -267,7 +267,15 @@ internal class TypeRegistry(ITypeRegistry? parent) : ITypeRegistry
         if (nameByType.TryGetValue(mainType, out var registeredName))
             return registeredName;
 
-        var mainTypeName = (mainType.FullName ?? mainType.Name).Replace('\u002B', '.');
+        // 🎯 The $type discriminator defaults to the SHORT type name (type.Name), NOT the
+        // namespace-qualified full name. An unregistered type then serialises as e.g. "ThreadViewModel"
+        // — which a reading hub that registered the type under its short name (the standard
+        // WithType(typeof(T), nameof(T)) shape) RESOLVES — instead of "MeshWeaver.AI.ThreadViewModel",
+        // which mismatches the short-name registration → the value comes back as an untyped JsonElement
+        // (renders empty / reactive waits time out — the chat-vanish / atioz storm wedge class). This
+        // cures the whole class at the default. Short-name collisions across namespaces are resolved by
+        // registering the colliding types explicitly (full registration is still done on top of this).
+        var mainTypeName = (mainType.Name ?? mainType.FullName!).Replace('\u002B', '.');
         if (!mainType.IsGenericType || mainType.IsGenericTypeDefinition)
             return mainTypeName;
 

--- a/test/MeshWeaver.Data.Test/ActivityStatusExtensionsTest.cs
+++ b/test/MeshWeaver.Data.Test/ActivityStatusExtensionsTest.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+using MeshWeaver.Data;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Pins the status-driven continuation + rendering law (<see cref="ActivityStatusExtensions"/>):
+/// continuations fire on a transition into a follow-up (terminal) status; only a SUCCESS status
+/// permits reading the real typed content; an ERROR status routes to emergency mode (render the
+/// error). Pure-function tests — deterministic, no hub.
+/// </summary>
+public class ActivityStatusExtensionsTest
+{
+    [Theory]
+    [InlineData(ActivityStatus.Running, false)]
+    [InlineData(ActivityStatus.Succeeded, true)]
+    [InlineData(ActivityStatus.Warning, true)]
+    [InlineData(ActivityStatus.Failed, true)]
+    [InlineData(ActivityStatus.Cancelled, true)]
+    public void IsTerminal_IsEverythingButRunning(ActivityStatus status, bool expected)
+        => Assert.Equal(expected, status.IsTerminal());
+
+    [Theory]
+    [InlineData(ActivityStatus.Succeeded, true)]
+    [InlineData(ActivityStatus.Warning, true)]
+    [InlineData(ActivityStatus.Running, false)]
+    [InlineData(ActivityStatus.Failed, false)]
+    [InlineData(ActivityStatus.Cancelled, false)]
+    public void IsSuccess_OnlySucceededOrWarning(ActivityStatus status, bool expected)
+        => Assert.Equal(expected, status.IsSuccess());
+
+    [Theory]
+    [InlineData(ActivityStatus.Failed, true)]
+    [InlineData(ActivityStatus.Cancelled, true)]
+    [InlineData(ActivityStatus.Running, false)]
+    [InlineData(ActivityStatus.Succeeded, false)]
+    [InlineData(ActivityStatus.Warning, false)]
+    public void IsError_OnlyFailedOrCancelled(ActivityStatus status, bool expected)
+        => Assert.Equal(expected, status.IsError());
+
+    [Fact]
+    public void FollowupStatuses_AreExactlyTheTerminalOnes()
+    {
+        var allTerminal = Enum.GetValues<ActivityStatus>().Where(s => s.IsTerminal()).ToHashSet();
+        Assert.True(ActivityStatusExtensions.FollowupStatuses.SetEquals(allTerminal),
+            "the follow-up set (what triggers a continuation) must be exactly the terminal statuses");
+        Assert.DoesNotContain(ActivityStatus.Running, ActivityStatusExtensions.FollowupStatuses);
+    }
+
+    /// <summary>
+    /// The core decision invariant: EVERY terminal status routes to exactly one branch —
+    /// success (read the real typed content) XOR error (emergency mode). No terminal status is
+    /// both or neither, so the "only on success do we type; otherwise emergency" rule is total.
+    /// </summary>
+    [Fact]
+    public void EveryTerminalStatus_IsSuccessXorError()
+    {
+        foreach (var status in Enum.GetValues<ActivityStatus>().Where(s => s.IsTerminal()))
+            Assert.True(status.IsSuccess() ^ status.IsError(),
+                $"terminal status {status} must be exactly one of success / error (not both, not neither)");
+    }
+
+    [Fact]
+    public void Running_IsNeitherSuccessNorError_SoNeverTypedNorEmergency()
+    {
+        Assert.False(ActivityStatus.Running.IsSuccess(), "a running activity must NOT have its content typed");
+        Assert.False(ActivityStatus.Running.IsError(), "a running activity is not an error — it is still in progress");
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/TypeRegistryTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/TypeRegistryTest.cs
@@ -40,7 +40,9 @@ public class TypeRegistryTest(ITestOutputHelper output) : HubTestBase(output)
         var typeRegistry = host.ServiceProvider.GetRequiredService<ITypeRegistry>();
         var canMap = typeRegistry.TryGetCollectionName(typeof(GenericRequest<int>), out var typeName);
         canMap.Should().BeTrue();
-        typeName.Should().Be("MeshWeaver.Messaging.Hub.Test.TypeRegistryTest.GenericRequest`1[Int32]");
+        // Short-name default: the outer generic type uses its short name `GenericRequest`1`, not the
+        // namespace-qualified full name. Round-trips back to the same type.
+        typeName.Should().Be("GenericRequest`1[Int32]");
 
         canMap = typeRegistry.TryGetType(typeName!, out var mappedType);
         canMap.Should().BeTrue();
@@ -56,7 +58,7 @@ public class TypeRegistryTest(ITestOutputHelper output) : HubTestBase(output)
         // Test List<int?>
         var canMap = typeRegistry.TryGetCollectionName(typeof(List<int?>), out var typeName);
         canMap.Should().BeTrue();
-        typeName.Should().Be("System.Collections.Generic.List`1[Int32?]");
+        typeName.Should().Be("List`1[Int32?]");
 
         canMap = typeRegistry.TryGetType(typeName!, out var mappedType);
         canMap.Should().BeTrue();
@@ -65,7 +67,7 @@ public class TypeRegistryTest(ITestOutputHelper output) : HubTestBase(output)
         // Test GenericRequest<int?>
         canMap = typeRegistry.TryGetCollectionName(typeof(GenericRequest<int?>), out typeName);
         canMap.Should().BeTrue();
-        typeName.Should().Be("MeshWeaver.Messaging.Hub.Test.TypeRegistryTest.GenericRequest`1[Int32?]");
+        typeName.Should().Be("GenericRequest`1[Int32?]");
 
         canMap = typeRegistry.TryGetType(typeName!, out mappedType);
         canMap.Should().BeTrue();
@@ -94,11 +96,15 @@ public class TypeRegistryTest(ITestOutputHelper output) : HubTestBase(output)
         // Serialize through the open `object` door so the polymorphic path (and the resolver) runs.
         var json = JsonSerializer.Serialize((object)new UnregisteredPayload("hi"), typeof(object), options);
 
-        // It WAS written with the namespace-qualified full name (the latent cross-hub-read defect).
-        // FormatType normalizes the nested-type '+' separator to '.', matching what gets persisted.
-        var persistedDiscriminator = typeof(UnregisteredPayload).FullName!.Replace('+', '.');
-        json.Should().Contain(persistedDiscriminator);
-        // ...and the resolver surfaced exactly one warning naming the type + the publishing hub.
+        // Short-name default (the CURE): an unregistered type is now written with its SHORT-name $type
+        // ("UnregisteredPayload"), which a reading hub that registered it under its short name RESOLVES —
+        // instead of the namespace-qualified full name that used to read back as an untyped JsonElement.
+        json.Should().Contain($"\"{nameof(UnregisteredPayload)}\"",
+            "the short-name default writes the $type as the bare type name, which reading hubs resolve");
+        json.Should().NotContain(typeof(UnregisteredPayload).FullName!,
+            "the namespace-qualified full name must no longer be emitted as the $type discriminator");
+        // ...and the resolver STILL surfaces exactly one warning naming the type + the publishing hub, so
+        // an unregistered type is still flagged for explicit registration (collision-safety + clarity).
         var warnings = captured.Where(m =>
             m.Contains("Unregistered type") &&
             m.Contains(typeof(UnregisteredPayload).FullName!) &&

--- a/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
@@ -93,27 +93,33 @@ public class SidePanelChatTenMessagesTest(PortalFixture fixture)
         for (var i = 0; i < MessageCount; i++)
         {
             // Re-resolve the Monaco editor each turn (the side panel rebinds to the freshly-created thread
-            // after the first message). Force the click past Playwright's "stable" actionability check —
-            // Monaco re-lays-out continuously, which is cosmetic; the keyboard typing below lands in the
-            // focused editor regardless, and the assertions below prove the message actually went through.
+            // after the first message). Escape closes any open suggest widget, select-all+backspace clears
+            // any residual text, then type. Force the click past Playwright's "stable" actionability check —
+            // Monaco re-lays-out continuously, which is cosmetic; the keyboard typing lands in the focused
+            // editor regardless (mirrors the robust pattern in ChatRepeatedlyNoVanishTest).
             var editor = page.Locator(".thread-chat-footer .monaco-editor").Last;
+            await page.Keyboard.PressAsync("Escape");
             await editor.ClickAsync(new LocatorClickOptions { Force = true });
+            await page.Keyboard.PressAsync("ControlOrMeta+A");
+            await page.Keyboard.PressAsync("Backspace");
             await page.Keyboard.TypeAsync($"This is message number {i + 1}. Reply with only the digit {i + 1}.");
 
             var send = page.Locator(".thread-chat-footer .selector-bar fluent-button").Last;
             await send.ClickAsync(new LocatorClickOptions { Timeout = 30_000 });
 
-            // (a) The user's bubble appears promptly.
-            await userBubbles.Nth(i).WaitForAsync(
-                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = PromptBubbleMs });
+            // (a) The user's bubble landed — poll the COUNT (>= i+1), robust to bubbles re-keying on the
+            //     thread rebind (a specific .Nth(i) wait is brittle across re-renders).
+            (await PollAsync(async () => await userBubbles.CountAsync() >= i + 1, TimeSpan.FromSeconds(15)))
+                .Should().BeTrue($"the user bubble for message {i + 1} must appear (saw {await userBubbles.CountAsync()})");
 
             // No submit error surfaced.
             (await page.Locator(".thread-chat-status-msg.error").CountAsync())
                 .Should().Be(0, $"sending message {i + 1} must not surface an error");
 
-            // (b) The assistant reply for this round, then (c) the round settles so the next Send re-enables.
-            await assistantBubbles.Nth(i).WaitForAsync(
-                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = RoundMs });
+            // (b) The assistant reply for this round (count >= i+1), then (c) the round settles so the next
+            //     Send re-enables.
+            (await PollAsync(async () => await assistantBubbles.CountAsync() >= i + 1, RoundDuration))
+                .Should().BeTrue($"round {i + 1} must produce an assistant reply (saw {await assistantBubbles.CountAsync()})");
             await execBar.WaitForAsync(
                 new LocatorWaitForOptions { State = WaitForSelectorState.Detached, Timeout = RoundMs });
 
@@ -134,5 +140,19 @@ public class SidePanelChatTenMessagesTest(PortalFixture fixture)
             $"every one of {MessageCount} rounds must produce an assistant reply");
 
         await page.ScreenshotAsync(new PageScreenshotOptions { Path = "/tmp/side-panel-ten-messages.png", FullPage = true });
+    }
+
+    // A real LLM round can take a while; poll the assistant-bubble count up to this bound.
+    private static readonly TimeSpan RoundDuration = TimeSpan.FromMilliseconds(RoundMs);
+
+    private static async Task<bool> PollAsync(Func<Task<bool>> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await predicate()) return true;
+            await Task.Delay(300);
+        }
+        return false;
     }
 }

--- a/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
@@ -1,0 +1,138 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// Sustained-conversation stress test: submits TEN messages in a row in ONE thread through the
+/// side-panel Monaco composer, and asserts after EVERY round that (a) the user's bubble appeared
+/// promptly, (b) the assistant replied, (c) the round settled, and (d) the chat never vanished — the
+/// composer stays mounted, the circuit doesn't drop (no reconnect overlay), and the page never bounces
+/// to /login. A render-storm / wedge tears the circuit down or blanks the panel, so a regression breaks
+/// these invariants somewhere in the 10-round run (the longer the conversation, the more reliably it
+/// surfaces accumulation bugs). After the loop the conversation must hold exactly 10 user + 10 assistant
+/// bubbles — none lost, none duplicated.
+///
+/// <para>Uses the small CPU-friendly model (qwen-small) so ten real rounds are feasible. Drives the real
+/// DevLogin e2e portal: <c>memex-local e2e up &amp;&amp; memex-local e2e test SidePanelChatTenMessages</c>.</para>
+/// </summary>
+[Collection("portal-e2e")]
+public class SidePanelChatTenMessagesTest(PortalFixture fixture)
+{
+    private const int MessageCount = 10;
+
+    private const string ComposerSeedJson = """
+        {
+          "id": "ThreadComposer",
+          "namespace": "Roland/_Thread",
+          "name": "Chat Input",
+          "nodeType": "ThreadComposer",
+          "mainNode": "Roland",
+          "content": { "$type": "ThreadComposer" }
+        }
+        """;
+
+    // The user bubble must appear far below the old 30s stall.
+    private static readonly int PromptBubbleMs = 15_000;
+    // A real round with the small model; generous but bounded so a genuine wedge fails rather than hangs.
+    private static readonly int RoundMs = 120_000;
+
+    private static readonly string ModelPath =
+        Environment.GetEnvironmentVariable("E2E_MODEL") ?? "Provider/OpenAICompatible/qwen-small";
+
+    [Fact(Timeout = 600_000)]
+    public async Task SidePanelChat_SubmitsTenMessages_NoneLost_ThreadNeverVanishes()
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+
+        await using var context = await fixture.NewAuthenticatedContextAsync();
+
+        // Seed the per-user composer, then PATCH it onto the MeshWeaver harness + the small model. A
+        // PATCH (not create) so the post-creation seed handler doesn't reset it; deterministic regardless
+        // of run order (a prior ClaudeCode-harness test would otherwise leave it on ClaudeCode).
+        var token = await fixture.MintTokenAsync(context);
+        try { await fixture.CreateNodeAsync(context, token, ComposerSeedJson); }
+        catch (InvalidOperationException) { /* already seeded — fine */ }
+        await context.APIRequest.PostAsync($"{fixture.BaseUrl}/api/mesh/patch", new APIRequestContextOptions
+        {
+            Headers = new Dictionary<string, string> { ["authorization"] = $"Bearer {token}" },
+            DataObject = new
+            {
+                Path = "Roland/_Thread/ThreadComposer",
+                Fields = "{\"content\":{\"$type\":\"ThreadComposer\",\"harness\":\"Harness/MeshWeaver\","
+                       + "\"modelName\":\"" + ModelPath + "\",\"contextPath\":\"Roland\"}}"
+            }
+        });
+
+        var page = await context.NewPageAsync();
+        await page.SetViewportSizeAsync(1400, 950);
+        await page.GotoAsync($"{fixture.BaseUrl}/User/Roland",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // Open the side-panel chat.
+        var chatToggle = page.Locator(".side-panel-toggle button, .side-panel-toggle fluent-button").First;
+        await chatToggle.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+        await chatToggle.ClickAsync();
+
+        var composer = page.Locator(".thread-chat-footer .monaco-editor").Last;
+        await composer.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+
+        // Bail clearly if the portal has no model — we cannot run real rounds.
+        var noModel = page.Locator(".thread-chat-status-msg.error");
+        if (await noModel.CountAsync() > 0
+            && (await noModel.First.InnerTextAsync()).Contains("No language model", StringComparison.OrdinalIgnoreCase))
+            Assert.Skip("No language model configured on the target portal — cannot exercise ten rounds.");
+
+        var userBubbles = page.Locator(".thread-msg-bubble.thread-msg-user");
+        var assistantBubbles = page.Locator(".thread-msg-bubble.thread-msg-assistant");
+        var execBar = page.Locator(".thread-exec-bar");
+        // The composer container + a /login bounce / reconnect overlay are the "did the chat vanish?" tells.
+        var composerFooter = page.Locator(".thread-chat-footer");
+        var reconnectOverlay = page.Locator("#components-reconnect-modal");
+
+        for (var i = 0; i < MessageCount; i++)
+        {
+            // Re-resolve the Monaco editor each turn (the side panel rebinds to the freshly-created thread
+            // after the first message). Force the click past Playwright's "stable" actionability check —
+            // Monaco re-lays-out continuously, which is cosmetic; the keyboard typing below lands in the
+            // focused editor regardless, and the assertions below prove the message actually went through.
+            var editor = page.Locator(".thread-chat-footer .monaco-editor").Last;
+            await editor.ClickAsync(new LocatorClickOptions { Force = true });
+            await page.Keyboard.TypeAsync($"This is message number {i + 1}. Reply with only the digit {i + 1}.");
+
+            var send = page.Locator(".thread-chat-footer .selector-bar fluent-button").Last;
+            await send.ClickAsync(new LocatorClickOptions { Timeout = 30_000 });
+
+            // (a) The user's bubble appears promptly.
+            await userBubbles.Nth(i).WaitForAsync(
+                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = PromptBubbleMs });
+
+            // No submit error surfaced.
+            (await page.Locator(".thread-chat-status-msg.error").CountAsync())
+                .Should().Be(0, $"sending message {i + 1} must not surface an error");
+
+            // (b) The assistant reply for this round, then (c) the round settles so the next Send re-enables.
+            await assistantBubbles.Nth(i).WaitForAsync(
+                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = RoundMs });
+            await execBar.WaitForAsync(
+                new LocatorWaitForOptions { State = WaitForSelectorState.Detached, Timeout = RoundMs });
+
+            // (d) The chat did NOT vanish: composer still mounted, no reconnect overlay, not bounced to /login.
+            (await composerFooter.CountAsync()).Should().BeGreaterThan(0,
+                $"the composer must stay mounted after round {i + 1} (a render-storm wedge blanks it)");
+            // The Blazor reconnect modal (#components-reconnect-modal) is ALWAYS present in the DOM
+            // (hidden via display:none) — so assert it is not VISIBLE, not that it is absent.
+            (await reconnectOverlay.IsVisibleAsync()).Should().BeFalse(
+                $"the circuit must not drop after round {i + 1} (reconnect overlay must stay hidden)");
+            page.Url.Should().NotContain("/login", $"the page must not bounce to /login after round {i + 1}");
+        }
+
+        // Every submission landed — exactly N user + N assistant bubbles, none lost, none duplicated.
+        (await userBubbles.CountAsync()).Should().Be(MessageCount,
+            $"all {MessageCount} submitted messages must appear as user bubbles");
+        (await assistantBubbles.CountAsync()).Should().Be(MessageCount,
+            $"every one of {MessageCount} rounds must produce an assistant reply");
+
+        await page.ScreenshotAsync(new PageScreenshotOptions { Path = "/tmp/side-panel-ten-messages.png", FullPage = true });
+    }
+}

--- a/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
@@ -92,18 +92,32 @@ public class SidePanelChatTenMessagesTest(PortalFixture fixture)
 
         for (var i = 0; i < MessageCount; i++)
         {
-            // Re-resolve the Monaco editor each turn (the side panel rebinds to the freshly-created thread
-            // after the first message). Escape closes any open suggest widget, select-all+backspace clears
-            // any residual text, then type. Force the click past Playwright's "stable" actionability check —
-            // Monaco re-lays-out continuously, which is cosmetic; the keyboard typing lands in the focused
-            // editor regardless (mirrors the robust pattern in ChatRepeatedlyNoVanishTest).
-            var editor = page.Locator(".thread-chat-footer .monaco-editor").Last;
+            // 🔬 DEBUG: sample the composer/editor over ~2s BEFORE interacting — is the GUI stable, or is
+            // the editor disappearing / being recreated (a re-render that "vanishes" the composer)?
+            var dbg = new System.Text.StringBuilder();
+            for (var s = 0; s < 9; s++)
+            {
+                var footerN = await composerFooter.CountAsync();
+                var editorN = await page.Locator(".thread-chat-footer .monaco-editor").CountAsync();
+                var textareaN = await page.Locator(".thread-chat-footer .monaco-editor textarea").CountAsync();
+                var footerVis = footerN > 0 && await composerFooter.First.IsVisibleAsync();
+                var lineText = editorN > 0 ? (await page.Locator(".thread-chat-footer .monaco-editor .view-lines").Last.InnerTextAsync()).Replace("\n", "⏎") : "<none>";
+                dbg.AppendLine($"[gui] round{i + 1} t+{s * 250}ms footer={footerN}(vis={footerVis}) editor={editorN} textarea={textareaN} lines='{lineText}'");
+                await page.WaitForTimeoutAsync(250);
+            }
+            System.IO.File.AppendAllText("/tmp/gui-samples.txt", dbg.ToString());
+            await page.ScreenshotAsync(new PageScreenshotOptions { Path = $"/tmp/ten-msg-round-{i + 1}.png", FullPage = true });
+
+            var viewLines = page.Locator(".thread-chat-footer .monaco-editor .view-lines").Last;
             await page.Keyboard.PressAsync("Escape");
-            await editor.ClickAsync(new LocatorClickOptions { Force = true });
+            await viewLines.ClickAsync(new LocatorClickOptions { Force = true });
             await page.Keyboard.PressAsync("ControlOrMeta+A");
             await page.Keyboard.PressAsync("Backspace");
             await page.Keyboard.TypeAsync($"This is message number {i + 1}. Reply with only the digit {i + 1}.");
 
+            // The composer must actually hold the text before we send (else the send button is disabled).
+            await Assertions.Expect(page.Locator(".thread-chat-footer .monaco-editor .view-lines").Last)
+                .ToContainTextAsync($"message number {i + 1}", new() { Timeout = 10_000 });
             var send = page.Locator(".thread-chat-footer .selector-bar fluent-button").Last;
             await send.ClickAsync(new LocatorClickOptions { Timeout = 30_000 });
 

--- a/test/MeshWeaver.Threading.Test/ThreadCreatableFromHomeTest.cs
+++ b/test/MeshWeaver.Threading.Test/ThreadCreatableFromHomeTest.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.AI;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Threading.Test;
+
+/// <summary>
+/// A thread MUST be creatable from a (properly onboarded) user's home — and the created thread MUST be
+/// REACHABLE (its node stream resolves, no hung subscribe / "target hub not found"). This pins the bug
+/// the 10-message GUI test surfaced: chatting from the home failed because the thread create was denied
+/// on the system <c>User</c> partition (the user's own partition didn't exist / wasn't the target), and
+/// when it did land, subscribing to it timed out — "not reachable", which IS a wedge.
+///
+/// <para>The owner (<see cref="TestUsers.Admin"/> = "Roland") owns the writable <c>Roland</c> partition;
+/// a thread started from their home belongs there (<c>Roland/_Thread/{id}</c>), never the system
+/// <c>User</c> partition. Deterministic — real mesh, no GUI/portal.</para>
+/// </summary>
+public class ThreadCreatableFromHomeTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string OwnerId = "Roland";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddAI().AddSampleUsers();
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddAITypes();
+        return base.ConfigureClient(configuration).AddData();
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task Thread_IsCreatableFromOwnerHome_AndReachable()
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        access.SetCircuitContext(TestUsers.Admin); // the owner — must be able to create threads in their partition
+
+        var client = GetClient();
+        // The owner's partition must be live (onboarded ⇒ partition exists). A PingRequest activates it;
+        // if the partition does not exist this fails fast — the "partition must be created at onboarding"
+        // precondition.
+        await client.Observe(new PingRequest(), o => o.WithTarget(new Address(OwnerId)))
+            .Should().Within(30.Seconds()).Emit();
+
+        // Start a thread from the home, exactly as the composer's Send does (StartThread is THE surface).
+        var tcs = new TaskCompletionSource<MeshNode>(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.StartThread(
+            namespacePath: OwnerId,
+            userText: "Hello from the home composer",
+            createdBy: OwnerId,
+            authorName: OwnerId,
+            onCreated: node => tcs.TrySetResult(node),
+            onError: err => tcs.TrySetException(new InvalidOperationException($"Thread NOT creatable: {err}")));
+
+        var threadNode = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        // It must land in the OWNER's writable partition, never the system User partition.
+        threadNode.Path.Should().StartWith($"{OwnerId}/_Thread/",
+            "a thread started from the owner's home belongs in their writable partition, not the system 'User' partition");
+
+        // REACHABILITY (the "not reachable = wedging" guard): the created thread's node stream must
+        // resolve. A SubscribeRequest that times out ("target hub not found") is exactly the wedge.
+        var workspace = client.GetWorkspace();
+        var read = await workspace.GetMeshNodeStream(threadNode.Path)
+            .Where(n => n is not null && n.NodeType == ThreadNodeType.NodeType)
+            .Take(1).Timeout(TimeSpan.FromSeconds(20)).ToTask();
+        read.Should().NotBeNull(
+            "the created thread MUST be reachable — subscribing must resolve, never hang or NotFound (that is the wedge)");
+    }
+}


### PR DESCRIPTION
## Chat-vanish (SidePanelChatTenMessagesTest)
Substantially reduces the intermittent "side-panel chat vanishes mid-conversation" bug, across several root causes:
- **Round identity**: dispatch as the submitter, never a leaked system/hub principal.
- **Area `@key` flap**: `LayoutAreaView` keyed on `LayoutAreaReference.ToString()` flapped between string-Id `v12` and JsonElement-Id `"v12"` even though `Equals` normalizes them — re-creating the area → blank. Keyed on the normalized `GetHashCode`.
- **Empty-viewmodel bind** → component keep-last-good (poison-proof, counts `PendingMessageTexts`).
- **Optimistic user message dropped server-side** → `SubscribeThreadVm` counts `PendingMessageTexts` as content.
- **Durable per-thread-hub holder** to survive `ThreadChatView` re-creation.

**Status: substantial reduction, not a full cure.** A residual intermittent `ThreadChatView` re-creation can still reset the keep-last-good and blank a round — documented in the holder-fix commit. Verified via the included 10-message e2e stress test.

## Local build wedge cure (`memex-local`)
Two agents' concurrent `dotnet publish`, and even a single unbounded one, saturate the host (load 18-26 → unresponsive).
- **Build lock**: serialize image builds across concurrent `memex-local` invocations (self-healing lockdir).
- **`-maxcpucount` cap**: one build tops out at ~6 cores. Verified: capped build peaks at **load 5.14** vs 18.36 unbounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)