### PR TITLE
fix(build): add missing ToolCallVisibility.cs — main build broken since #136

### DIFF
--- a/src/MeshWeaver.Layout/ToolCallVisibility.cs
+++ b/src/MeshWeaver.Layout/ToolCallVisibility.cs
@@ -1,0 +1,99 @@
+namespace MeshWeaver.Layout;
+
+/// <summary>
+/// Decides which of a message's <see cref="ToolCallEntry"/> entries the chat
+/// tool-calls section shows up front and which collapse into a "show all"
+/// control. Keeps the bubble compact while a round fans out across many tools.
+///
+/// <para>The window is filled, in order:</para>
+/// <list type="number">
+///   <item><description><b>Running</b> first (a delegation actively streaming its sub-thread).</description></item>
+///   <item><description><b>Pending</b> next (dispatched, result not back yet).</description></item>
+///   <item><description><b>Completed</b> backfill — when fewer than <see cref="DefaultVisibleCap"/>
+///     are active, the most-recently-finished calls fill the remaining slots so the window stays full.</description></item>
+/// </list>
+///
+/// <para>A just-finished call also <b>lingers</b> in the window for
+/// <see cref="CompletedLinger"/> even when the active set already fills the cap,
+/// so a completion flashes its ✓ before dropping into the collapsed remainder.</para>
+///
+/// <para>Pure + deterministic (the caller passes <c>nowUtc</c>) so it unit-tests
+/// without a clock and renders identically server-side and in the circuit.</para>
+/// </summary>
+public static class ToolCallVisibility
+{
+    /// <summary>Maximum number of <i>active</i> (running + pending) entries kept in the visible window.</summary>
+    public const int DefaultVisibleCap = 5;
+
+    /// <summary>How long a freshly-completed call stays in the visible window before it may collapse.</summary>
+    public static readonly TimeSpan CompletedLinger = TimeSpan.FromSeconds(5);
+
+    /// <summary>Actively executing — only a delegation streaming its sub-thread carries this status.</summary>
+    public static bool IsRunning(ToolCallEntry call) => call.Status == ToolCallStatus.Streaming;
+
+    /// <summary>
+    /// Dispatched but no result yet. <see cref="ToolCallEntry.Status"/> defaults to
+    /// <see cref="ToolCallStatus.Success"/> via the record initializer even before the result lands,
+    /// so "pending" is "default status, result still null" — a terminal Failed/Cancelled counts as completed.
+    /// </summary>
+    public static bool IsPending(ToolCallEntry call) =>
+        call.Status == ToolCallStatus.Success && call.Result is null;
+
+    /// <summary>Settled — has a result, or reached a terminal Failed/Cancelled status.</summary>
+    public static bool IsCompleted(ToolCallEntry call) => !IsRunning(call) && !IsPending(call);
+
+    /// <summary>A completed call within the <see cref="CompletedLinger"/> window of <paramref name="nowUtc"/>.</summary>
+    public static bool IsFreshlyCompleted(ToolCallEntry call, DateTime nowUtc) =>
+        IsCompleted(call) && nowUtc - call.Timestamp < CompletedLinger;
+
+    /// <summary>The split of a tool-call list into the visible window and the collapsed remainder.</summary>
+    /// <param name="Visible">Entries shown up front (running → pending → completed backfill / lingering).</param>
+    /// <param name="Hidden">Entries folded into the "show all" control.</param>
+    /// <param name="RunningCount">Total running across the whole list.</param>
+    /// <param name="PendingCount">Total pending across the whole list.</param>
+    /// <param name="CompletedCount">Total completed across the whole list.</param>
+    public sealed record View(
+        IReadOnlyList<ToolCallEntry> Visible,
+        IReadOnlyList<ToolCallEntry> Hidden,
+        int RunningCount,
+        int PendingCount,
+        int CompletedCount)
+    {
+        /// <summary>True when there is a collapsed remainder worth a "show all" control.</summary>
+        public bool HasHidden => Hidden.Count > 0;
+    }
+
+    /// <summary>
+    /// Partitions <paramref name="calls"/> into the visible window and the collapsed remainder.
+    /// </summary>
+    /// <param name="calls">The message's tool calls (null/empty yields an empty view).</param>
+    /// <param name="nowUtc">Reference time for the linger window — pass <c>DateTime.UtcNow</c>.</param>
+    /// <param name="cap">Active-window size (defaults to <see cref="DefaultVisibleCap"/>).</param>
+    public static View Partition(IReadOnlyList<ToolCallEntry>? calls, DateTime nowUtc, int cap = DefaultVisibleCap)
+    {
+        if (calls is null || calls.Count == 0)
+            return new View([], [], 0, 0, 0);
+
+        var running = calls.Where(IsRunning).ToList();
+        var pending = calls.Where(IsPending).ToList();
+        // Most-recently-finished first, so backfill and linger surface the newest completions.
+        var completed = calls.Where(IsCompleted).OrderByDescending(c => c.Timestamp).ToList();
+
+        // Active owns the window: running on top, then pending, capped.
+        var active = running.Concat(pending).ToList();
+        var activeShown = active.Take(cap).ToList();
+
+        // Backfill leftover slots with the newest completed ("when fewer than 5, also show closed");
+        // ALSO keep any just-finished call on screen for the linger window even when the cap is full.
+        var slots = Math.Max(0, cap - activeShown.Count);
+        var freshCount = completed.Count(c => IsFreshlyCompleted(c, nowUtc));
+        var completedShown = completed.Take(Math.Max(slots, freshCount)).ToList();
+
+        var visible = activeShown.Concat(completedShown).ToList();
+        var hidden = active.Skip(activeShown.Count)
+            .Concat(completed.Skip(completedShown.Count))
+            .ToList();
+
+        return new View(visible, hidden, running.Count, pending.Count, completed.Count);
+    }
+}

--- a/test/MeshWeaver.Layout.Test/ToolCallVisibilityTest.cs
+++ b/test/MeshWeaver.Layout.Test/ToolCallVisibilityTest.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Pins the chat tool-calls window logic: the visible set is filled running → pending →
+/// completed-backfill, capped at 5 active, with a 5-second linger that keeps a just-finished
+/// call on screen even when the cap is full. The collapsed remainder + per-bucket counts drive
+/// the "show all" control.
+/// </summary>
+public class ToolCallVisibilityTest
+{
+    private static readonly DateTime Now = new(2026, 6, 29, 12, 0, 0, DateTimeKind.Utc);
+
+    private static ToolCallEntry Running(string name = "delegate_to_agent") =>
+        new() { Name = name, Status = ToolCallStatus.Streaming, Result = "…live…", Timestamp = Now };
+
+    private static ToolCallEntry Pending(string name = "Search") =>
+        // Status defaults to Success via the record initializer; a null Result is the pending tell.
+        new() { Name = name, Result = null, Timestamp = Now };
+
+    private static ToolCallEntry Completed(string name, TimeSpan ago) =>
+        new() { Name = name, Status = ToolCallStatus.Success, Result = "done", Timestamp = Now - ago };
+
+    [Fact]
+    public void Empty_or_null_yields_empty_view()
+    {
+        ToolCallVisibility.Partition(null, Now).Visible.Should().BeEmpty();
+        var view = ToolCallVisibility.Partition([], Now);
+        view.Visible.Should().BeEmpty();
+        view.Hidden.Should().BeEmpty();
+        view.HasHidden.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Classifies_running_pending_completed()
+    {
+        ToolCallVisibility.IsRunning(Running()).Should().BeTrue();
+        ToolCallVisibility.IsPending(Pending()).Should().BeTrue();
+        ToolCallVisibility.IsCompleted(Completed("Get", TimeSpan.Zero)).Should().BeTrue();
+
+        // A terminal failure with no result still counts as completed, not pending.
+        var failed = new ToolCallEntry { Name = "Update", Status = ToolCallStatus.Failed, Result = null, Timestamp = Now };
+        ToolCallVisibility.IsCompleted(failed).Should().BeTrue();
+        ToolCallVisibility.IsPending(failed).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Counts_reflect_whole_list_regardless_of_window()
+    {
+        var calls = new List<ToolCallEntry>
+        {
+            Running(), Running(),
+            Pending(), Pending(), Pending(),
+            Completed("a", TimeSpan.FromMinutes(1)), Completed("b", TimeSpan.FromMinutes(2)),
+        };
+
+        var view = ToolCallVisibility.Partition(calls, Now);
+
+        view.RunningCount.Should().Be(2);
+        view.PendingCount.Should().Be(3);
+        view.CompletedCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Running_sit_above_pending_in_the_window()
+    {
+        var r1 = Running("delegate_to_X");
+        var p1 = Pending("Search");
+        var r2 = Running("delegate_to_Y");
+        // Interleaved input order — the window must still group running before pending.
+        var view = ToolCallVisibility.Partition([p1, r1, r2], Now);
+
+        view.Visible.Take(2).Should().OnlyContain(c => ToolCallVisibility.IsRunning(c));
+        view.Visible[2].Should().BeSameAs(p1);
+    }
+
+    [Fact]
+    public void Caps_active_window_at_five_and_hides_the_rest()
+    {
+        // Seven pending — only five fit the window, two collapse.
+        var calls = Enumerable.Range(0, 7).Select(i => Pending($"t{i}")).ToList();
+
+        var view = ToolCallVisibility.Partition(calls, Now);
+
+        view.Visible.Should().HaveCount(5);
+        view.Hidden.Should().HaveCount(2);
+        view.HasHidden.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Backfills_empty_slots_with_newest_completed()
+    {
+        var calls = new List<ToolCallEntry>
+        {
+            Running(),                                   // 1 active
+            Completed("old", TimeSpan.FromMinutes(10)),
+            Completed("mid", TimeSpan.FromMinutes(5)),
+            Completed("new", TimeSpan.FromMinutes(1)),
+            Completed("newest", TimeSpan.FromSeconds(30)),
+            Completed("ancient", TimeSpan.FromHours(1)),
+        };
+
+        var view = ToolCallVisibility.Partition(calls, Now);
+
+        // 1 active + backfill to fill the 5-slot window with the newest completed.
+        view.Visible.Should().HaveCount(5);
+        var completedVisible = view.Visible.Where(ToolCallVisibility.IsCompleted).Select(c => c.Name).ToList();
+        completedVisible.Should().ContainInOrder("newest", "new", "mid", "old");
+        view.Hidden.Should().ContainSingle().Which.Name.Should().Be("ancient");
+    }
+
+    [Fact]
+    public void Freshly_completed_lingers_in_window_even_when_cap_is_full()
+    {
+        var calls = new List<ToolCallEntry>
+        {
+            Running(), Running(), Running(), Running(), Running(),  // cap full with active
+            Completed("justFinished", TimeSpan.FromSeconds(2)),     // < 5s linger
+            Completed("longDone", TimeSpan.FromMinutes(3)),         // stale
+        };
+
+        var view = ToolCallVisibility.Partition(calls, Now);
+
+        // Window holds the 5 running PLUS the fresh completion (it briefly exceeds the cap)…
+        view.Visible.Should().HaveCount(6);
+        view.Visible.Should().Contain(c => c.Name == "justFinished");
+        // …but the stale completion stays collapsed.
+        view.Hidden.Should().ContainSingle().Which.Name.Should().Be("longDone");
+    }
+
+    [Fact]
+    public void Stale_completion_collapses_once_linger_passes()
+    {
+        var calls = new List<ToolCallEntry>
+        {
+            Running(), Running(), Running(), Running(), Running(),
+            Completed("done", TimeSpan.FromSeconds(6)),  // just past the 5s window
+        };
+
+        var view = ToolCallVisibility.Partition(calls, Now);
+
+        view.Visible.Should().HaveCount(5).And.OnlyContain(c => ToolCallVisibility.IsRunning(c));
+        view.Hidden.Should().ContainSingle().Which.Name.Should().Be("done");
+    }
+}


### PR DESCRIPTION
main has been **build-broken since #136**: it merged the modified `ThreadMessageBubbleView.razor` (calls `ToolCallVisibility.Partition`) but not the new `ToolCallVisibility.cs` — that file was untracked and never `git add`ed. `error CS0103: The name 'ToolCallVisibility' does not exist` → build fails → test shards skipped → **Continuous Delivery skipped → nothing deployed**.

This adds the two un-added files (`ToolCallVisibility.cs` + its test). Verified: `MeshWeaver.Blazor` builds clean.

🚨 This unblocks deployment — once merged + green, CD will roll the environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)