### PR TITLE
fix(gitsync): harden git-browser service (Copilot review of #114)

### DIFF
--- a/src/MeshWeaver.GitSync/GitWorkingTreeService.cs
+++ b/src/MeshWeaver.GitSync/GitWorkingTreeService.cs
@@ -169,10 +169,13 @@ public sealed class GitWorkingTreeService(
     /// </summary>
     public IObservable<IReadOnlyList<GitCommit>> Log(string userId, string repoSlug, int maxCount = 100)
     {
+        // Clamp: 0/negative makes `git log -n` show nothing or error; an unbounded value would let a
+        // caller pull the whole history into the portal. 1000 is a generous ceiling for a browser.
+        var n = Math.Clamp(maxCount, 1, 1000);
         var dest = PathFor(userId, repoSlug);
         return Expect(git.Run(dest,
         [
-            "log", $"-n{maxCount}", "--date=format:%Y-%m-%d %H:%M",
+            "log", $"-n{n}", "--date=format:%Y-%m-%d %H:%M",
             // %H %h %ad %an %s, separated by the 0x1f unit separator (%x1f).
             "--pretty=format:%H%x1f%h%x1f%ad%x1f%an%x1f%s",
         ])).Select(ParseLog);
@@ -185,6 +188,11 @@ public sealed class GitWorkingTreeService(
     /// </summary>
     public IObservable<IReadOnlyList<GitFileChange>> CommitChanges(string userId, string repoSlug, string commitHash)
     {
+        // A blank hash, or one starting with '-', would be parsed by git as a flag (argument injection)
+        // rather than a revision — reject it before it reaches the CLI.
+        if (string.IsNullOrWhiteSpace(commitHash) || commitHash.StartsWith('-'))
+            return Observable.Throw<IReadOnlyList<GitFileChange>>(
+                new GitWorkingTreeException($"Invalid commit '{commitHash}'."));
         var dest = PathFor(userId, repoSlug);
         return Expect(git.Run(dest,
             ["diff-tree", "--no-commit-id", "--name-status", "--no-renames", "-r", "--root", commitHash]))
@@ -194,17 +202,32 @@ public sealed class GitWorkingTreeService(
     /// <summary>
     /// The content of <paramref name="relativePath"/> at git revision <paramref name="rev"/> (e.g.
     /// <c>"HEAD"</c>, a commit hash, or <c>"{hash}^"</c> for a parent) — the two sides a diff needs.
-    /// Returns <c>""</c> when the path did not exist at that revision (an added or deleted file): that
-    /// empty side is a legitimate diff input, not an error, so this does NOT go through <see cref="Expect"/>.
+    /// <para>Returns <c>""</c> ONLY when the path genuinely did not exist at that revision (an added or
+    /// deleted file — its empty side is a legitimate diff input). Any OTHER git failure (invalid
+    /// revision, repo not checked out, …) is propagated as a <see cref="GitWorkingTreeException"/>
+    /// rather than masked as empty, so a real fault is never silently swallowed.</para>
     /// </summary>
     public IObservable<string> ShowFile(string userId, string repoSlug, string rev, string relativePath)
     {
-        if (relativePath.StartsWith('-'))
-            return Observable.Throw<string>(new GitWorkingTreeException($"Invalid path '{relativePath}'."));
+        // Neither side may start with '-' (git would parse it as a flag — argument injection).
+        if (rev.StartsWith('-') || relativePath.StartsWith('-'))
+            return Observable.Throw<string>(
+                new GitWorkingTreeException($"Invalid revision '{rev}' or path '{relativePath}'."));
         var dest = PathFor(userId, repoSlug);
         return git.Run(dest, ["show", $"{rev}:{relativePath}"])
-            .Select(r => r.Ok ? r.StdOut : "");
+            .SelectMany(r => r.Ok
+                ? Observable.Return(r.StdOut)
+                : IsPathAbsentAtRev(r.StdErr)
+                    ? Observable.Return("")
+                    : Observable.Throw<string>(new GitWorkingTreeException(
+                        $"git show {rev}:{relativePath} failed (exit {r.ExitCode}): {r.Message}")));
     }
+
+    /// <summary>True when <c>git show</c>'s stderr signals the path simply wasn't in that revision
+    /// (vs. a real failure like a bad rev) — the messages git emits for an added/deleted file.</summary>
+    private static bool IsPathAbsentAtRev(string stderr) =>
+        stderr.Contains("does not exist in", StringComparison.Ordinal)
+        || stderr.Contains("exists on disk, but not in", StringComparison.Ordinal);
 
     // ── internals ─────────────────────────────────────────────────────────────────────────
 

--- a/test/MeshWeaver.GitSync.Test/GitHistoryServiceTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHistoryServiceTest.cs
@@ -79,6 +79,22 @@ public class GitHistoryServiceTest(ITestOutputHelper output) : GitHubSyncTestBas
         Assert.Equal("", await WorkingTrees.ShowFile(UserId, "demo", head, "does/not/exist.txt").Timeout(30.Seconds()).ToTask());
         // docs/new.txt did not exist at the parent → empty (the "added" side of a diff).
         Assert.Equal("", await WorkingTrees.ShowFile(UserId, "demo", $"{head}^", "docs/new.txt").Timeout(30.Seconds()).ToTask());
+
+        // Hardening: a GENUINE git failure must PROPAGATE — never be masked as "". Running against a
+        // directory that exists but is NOT a checkout yields "not a git repository", which is a real
+        // fault (distinct from the "path absent at this revision" case that legitimately returns "").
+        Directory.CreateDirectory(WorkingTrees.PathFor(UserId, "notarepo"));
+        await Assert.ThrowsAsync<GitWorkingTreeException>(() => WorkingTrees
+            .ShowFile(UserId, "notarepo", "HEAD", "README.md").FirstAsync().ToTask());
+
+        // Argument-injection guards: a rev/hash/path starting with '-' (or a blank hash) is rejected
+        // before it reaches git, so it can't be parsed as a flag.
+        await Assert.ThrowsAsync<GitWorkingTreeException>(() => WorkingTrees
+            .ShowFile(UserId, "demo", "--upload-pack=x", "README.md").FirstAsync().ToTask());
+        await Assert.ThrowsAsync<GitWorkingTreeException>(() => WorkingTrees
+            .CommitChanges(UserId, "demo", "--output=/tmp/x").FirstAsync().ToTask());
+        await Assert.ThrowsAsync<GitWorkingTreeException>(() => WorkingTrees
+            .CommitChanges(UserId, "demo", "   ").FirstAsync().ToTask());
     }
 
     [Fact(Timeout = 60000)]

--- a/test/MeshWeaver.GitSync.Test/GitHistoryTabTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHistoryTabTest.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// GUI test: the "Git history" settings tab shows on a Space, and selecting it renders its content
+/// pane — <see cref="GitHistoryTab.BuildContent"/> → BuildBrowser. With no repository connected the
+/// browser renders its "connect a repository" guidance; this asserts the tab WIRING (registration +
+/// gate + content composition), not git data (that is covered by <see cref="GitHistoryServiceTest"/>).
+/// </summary>
+public class GitHistoryTabTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    // The base only registers the GitHub-Sync tab; register the Git-history tab too (the portal does
+    // this in MemexConfiguration) so it appears on the Settings page under test.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).ConfigureDefaultNodeHub(c => c.AddGitHistoryTab());
+
+    [Fact(Timeout = 60000)]
+    public async Task GitHistoryTab_ShownOnSpace()
+    {
+        var space = "GhHist" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "History Space");
+
+        var json = await RenderSettings(new Address(space), j => j.GetRawText().Contains("Git history"));
+        Assert.Contains("Git history", json);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task GitHistoryTab_Content_Renders()
+    {
+        var space = "GhHistC" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "History Content Space");
+
+        // Select the Git-history tab so its content pane renders. The H2 title + intro are emitted by
+        // BuildContent up front (independent of repo/checkout state), so asserting the intro proves the
+        // content pane composed and ran.
+        var json = await RenderSettings(
+            new Address(space),
+            new LayoutAreaReference("Settings") { Id = GitHistoryTab.TabId },
+            j => j.GetRawText().Contains("Browse the commit history"));
+
+        Assert.Contains("Git history", json);               // the tab title (H2)
+        Assert.Contains("Browse the commit history", json); // BuildContent's intro pane rendered
+    }
+
+    private Task<string> RenderSettings(Address hostAddress, Func<JsonElement, bool> until)
+        => RenderSettings(hostAddress, new LayoutAreaReference("Settings"), until);
+
+    private async Task<string> RenderSettings(Address hostAddress, LayoutAreaReference reference, Func<JsonElement, bool> until)
+    {
+        var client = GetClient();
+        var stream = client.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(hostAddress, reference);
+        var change = await stream.Should().Within(30.Seconds()).Match(ci => until(ci.Value));
+        return change.Value.GetRawText();
+    }
+}


### PR DESCRIPTION
Follow-up to #114, addressing GitHub Copilot's review.

## Changes (`GitWorkingTreeService`)
- **`Log`** — clamp `maxCount` to `[1,1000]`. `0`/negative makes `git log -n` misbehave; an unbounded value would let a caller pull the whole history into the portal.
- **`CommitChanges`** — reject a blank or `-`-prefixed commit hash (git argument injection).
- **`ShowFile`** — distinguish a path **genuinely absent at a revision** (the legitimate empty side of an added/deleted-file diff → `""`) from a **real git failure** (invalid rev, repo not checked out), which now **propagates** as `GitWorkingTreeException` instead of being silently masked as `""`. Also guards `rev` against a leading `-`. This removes the swallow the repo's no-band-aid rule forbids.

## Tests
- **`GitHistoryServiceTest`** — a genuine error (git run in a non-repo dir) propagates rather than returning `""`; `-`/blank `rev`/`hash` guards reject before reaching git.
- **`GitHistoryTabTest`** (new) — the **Git history** settings tab shows on a Space and its content pane (`BuildContent`) renders; registers `AddGitHistoryTab` in the test mesh exactly as the portal does in `MemexConfiguration`.

## Verification
- `Release -warnaserror` build clean (0 warnings, 0 errors).
- `GitHistory` tests: 4/4 pass (~2s, no network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)