### PR TITLE
fix(serialization): make short-name $type round-trip — green main after #136

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/Serialization.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Serialization.md
@@ -145,6 +145,16 @@ hub.WithTypes(typeof(Story), typeof(Task), typeof(Comment))
 
 A missing registration does not throw on write — the discriminator is simply absent, and the object deserializes as `JsonElement` or `object` instead of the expected CLR type. Register early; diagnose by inspecting stored JSON for a missing `$type`.
 
+### The `$type` discriminator is the SHORT name — register the type on BOTH ends
+
+The `$type` discriminator defaults to the **short** type name (`StackControl`, `LayoutStackSkin`), **not** the namespace-qualified full name (`MeshWeaver.Layout.StackControl`). A short name is **only** resolvable through the type registry — there is no `Type.GetType("StackControl")` reflection fallback the way there is for a full name. Two consequences, both non-negotiable:
+
+1. **Every control, skin, and content type must be registered on BOTH the sending hub and the receiving hub.** The sender writes `"$type":"StackControl"`; the receiver can only turn that back into a `StackControl` if its own registry maps `StackControl → typeof(StackControl)`. A type registered on the sender but missing on the receiver comes back as an untyped `JsonElement` — every `Content is StackControl` soft-cast fails, the value "renders empty", and reactive waits time out (this is the class of bug behind the untyped-`JsonElement` sync-hub storms). For layout, both ends call `AddLayoutTypes()`, whose reflection sweep registers every `IUiControl` / `Skin` / `StreamMessage` — so controls and skins are covered automatically; **any non-control record you nest inside control state must be added explicitly** (see the `WithTypes(...)` list of `LayoutAreaDefinition`, `PivotConfiguration`, … in `AddLayoutTypes`).
+
+2. **Never resolve a discriminator with `Type.GetType` (reflection) instead of the registry.** Reflection only ever worked because the old discriminator was a full name; it silently masked types that were never registered on the receiver. With short names it returns `null` and the value is dropped. The registry is the single source of truth — resolution flows through `ITypeRegistry.TryGetType` (which also resolves legacy full names via an alias) or, for polymorphic members, through the hub's `PolymorphicTypeInfoResolver` (whose derived-type discriminators are the same registry short names). A custom `JsonConverter` that resolves a `$type` by hand (e.g. `SkinListConverter`) **must** go through the registry / resolver, never bare `Type.GetType` — otherwise short-named elements are silently skipped.
+
+> Backward compatibility: the registry keeps an alias from each type's full name to its definition, so JSON persisted with a legacy `"$type":"MeshWeaver.Layout.StackControl"` still deserializes. New writes always emit the short name.
+
 ### Use typed query helpers
 
 The extension methods filter by `$type` and project directly to `T`, avoiding manual casting:

--- a/src/MeshWeaver.Layout/Serialization/OptionConverter.cs
+++ b/src/MeshWeaver.Layout/Serialization/OptionConverter.cs
@@ -53,11 +53,16 @@ public class OptionConverter : JsonConverter<Option>
         // Parse the type name to determine the concrete Option<T> type
         Type? concreteType = null;
 
-        // Handle both simple type names and full type names
-        if (typeName.StartsWith("MeshWeaver.Layout.Option`1[") && typeName.EndsWith("]"))
+        // Accept BOTH the short ("Option`1[Int32]") and full ("MeshWeaver.Layout.Option`1[Int32]")
+        // generic forms: the $type discriminator now defaults to the SHORT type name
+        // (TypeRegistry.FormatType, fb2ee677d), so the converter must match the short generic form too,
+        // not only the namespace-qualified one — otherwise Option<T> fails to deserialize.
+        const string optionGenericMarker = "Option`1[";
+        var optionMarkerIndex = typeName.IndexOf(optionGenericMarker, StringComparison.Ordinal);
+        if (optionMarkerIndex >= 0 && typeName.EndsWith("]"))
         {
             // Extract the generic type argument from the type name
-            var genericArg = typeName.Substring("MeshWeaver.Layout.Option`1[".Length);
+            var genericArg = typeName.Substring(optionMarkerIndex + optionGenericMarker.Length);
             genericArg = genericArg.Substring(0, genericArg.Length - 1); // Remove the closing ]
 
             // Map common type names

--- a/src/MeshWeaver.Layout/SkinListConverter.cs
+++ b/src/MeshWeaver.Layout/SkinListConverter.cs
@@ -84,26 +84,46 @@ public class SkinListConverter : JsonConverter<ImmutableList<Skin>>
                     var typeName = typeElement.GetString();
                     if (!string.IsNullOrEmpty(typeName))
                     {
-                        Type? skinType = null;
+                        // Resolve the concrete skin type from its $type discriminator. The discriminator now
+                        // defaults to the SHORT type name (TypeRegistry.FormatType, fb2ee677d), which is
+                        // resolvable ONLY through the type registry — so a skin's type MUST be registered on
+                        // BOTH the sending and receiving hub. Resolution order:
+                        //   1. this converter's registry (short names, and legacy full names via the registry
+                        //      alias) — used by the options-registered instance (LayoutExtensions.AddLayoutTypes);
+                        //   2. Type.GetType — the [JsonConverter]-attribute instance has no registry, but a legacy
+                        //      namespace-qualified FULL name still resolves by reflection;
+                        //   3. STJ's registry-backed polymorphism on the base Skin — the attribute path's
+                        //      short-name case: the hub's PolymorphicTypeInfoResolver keys Skin's derived types
+                        //      by the same short names, so resolution still flows through the registry.
+                        var json = root.GetRawText();
+                        Type? skinType =
+                            _typeRegistry?.TryGetType(typeName, out var typeInfo) == true
+                                ? typeInfo!.Type
+                                : Type.GetType(typeName!);
 
-                        // Try to get type from registry first, then fall back to Type.GetType
-                        if (_typeRegistry?.TryGetType(typeName, out var typeInfo) == true)
+                        Skin? skin = null;
+                        if (skinType != null && typeof(Skin).IsAssignableFrom(skinType))
                         {
-                            skinType = typeInfo!.Type;
+                            skin = (Skin?)JsonSerializer.Deserialize(json, skinType, options);
                         }
                         else
                         {
-                            skinType = Type.GetType(typeName!);
+                            // No registry on this instance and not a full name → resolve the SHORT name through
+                            // the hub's polymorphism resolver. An unregistered skin stays unresolved and is
+                            // skipped (the same graceful degradation as a missing $type — the serialize side
+                            // already warns loudly on unregistered types via WarnUnregisteredSerialization).
+                            try
+                            {
+                                skin = (Skin?)JsonSerializer.Deserialize(json, typeof(Skin), options);
+                            }
+                            catch (NotSupportedException)
+                            {
+                                // Abstract Skin + unrecognized discriminator (unregistered on this hub) → skip.
+                            }
                         }
 
-                        if (skinType != null && typeof(Skin).IsAssignableFrom(skinType))
-                        {
-                            // Deserialize to the specific skin type
-                            var json = root.GetRawText();
-                            var skin = (Skin?)JsonSerializer.Deserialize(json, skinType, options);
-                            if (skin != null)
-                                result.Add(skin);
-                        }
+                        if (skin != null)
+                            result.Add(skin);
                     }
                 }
                 // If no type discriminator or unknown type, skip the item

--- a/src/MeshWeaver.Messaging.Hub/Serialization/TypeRegistry.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/TypeRegistry.cs
@@ -53,6 +53,13 @@ internal class TypeRegistry(ITypeRegistry? parent) : ITypeRegistry
         new(BasicTypes.Select(t => new KeyValuePair<string, TypeDefinition>(t.Name, new TypeDefinition(t, t.Name, null!))));
     private readonly ConcurrentDictionary<Type, string> nameByType =
         new(BasicTypes.Select(t => new KeyValuePair<Type, string>(t, t.Name)));
+    // Resolution-only aliases (full namespace-qualified names) → definition. Consulted by TryGetType so
+    // a full-name $type discriminator still resolves on the way IN, but deliberately NOT part of the
+    // canonical `typeByName` map that the polymorphic resolver enumerates (PolymorphicTypeInfoResolver
+    // → typeRegistry.Types) — otherwise each type would appear TWICE as a JsonDerivedType (short + full)
+    // and STJ's discriminator emission breaks ("must specify a type discriminator"). One canonical
+    // (short) name per type for OUTPUT; the full name is an INPUT-side alias only.
+    private readonly ConcurrentDictionary<string, TypeDefinition> aliasByName = new();
 
     private readonly KeyFunctionBuilder keyFunctionBuilder = new();
 
@@ -64,8 +71,23 @@ internal class TypeRegistry(ITypeRegistry? parent) : ITypeRegistry
         var typeDefinition = new TypeDefinition(type, typeName, keyFunctionBuilder);
         typeByName[typeName] = typeDefinition;
         nameByType[type] = typeName;
+        IndexFullNameAlias(type, typeDefinition, typeName);
 
         return this;
+    }
+
+    // Resolution alias: index the full (namespace-qualified) name alongside the canonical name, so a
+    // full-name $type discriminator — persisted data, OR a payload written before the short-name $type
+    // default (fb2ee677d) — still RESOLVES on the way IN. The canonical OUTPUT name stays whatever the
+    // caller registered (short by default) via nameByType, so new payloads keep serialising short.
+    // Collision-safe: full names are unique; TryAdd never clobbers an explicit registration that already
+    // owns the key. This is what lets TryGetType("MeshWeaver.Layout.StackControl") and the old full-name
+    // generic forms resolve again after the short-name default (LayoutSerializationTest et al.).
+    private void IndexFullNameAlias(Type type, TypeDefinition definition, string canonicalName)
+    {
+        var fullName = (type.FullName ?? type.Name).Replace('+', '.');
+        if (fullName != canonicalName)
+            aliasByName.TryAdd(fullName, definition);
     }
 
     public KeyFunction? GetKeyFunction(string collection) =>
@@ -81,7 +103,8 @@ internal class TypeRegistry(ITypeRegistry? parent) : ITypeRegistry
 
     public bool TryGetType(string name, out ITypeDefinition? typeDefinition)
     {
-        typeDefinition = typeByName.GetValueOrDefault(name);
+        // Canonical (short) name first, then the full-name resolution alias (input side only).
+        typeDefinition = typeByName.GetValueOrDefault(name) ?? aliasByName.GetValueOrDefault(name);
         if (typeDefinition != null)
             return true;
         // Handle nullable syntax (e.g., "Int32?" -> Nullable<Int32>)
@@ -206,7 +229,9 @@ internal class TypeRegistry(ITypeRegistry? parent) : ITypeRegistry
             return parentTypeName;
 
         typeName = defaultName ?? FormatType(type);
-        typeByName[typeName] = new(type, typeName, keyFunctionBuilder);
+        var definition = new TypeDefinition(type, typeName, keyFunctionBuilder);
+        typeByName[typeName] = definition;
+        IndexFullNameAlias(type, definition, typeName);
         return nameByType[type] = typeName;
     }
 
@@ -231,13 +256,14 @@ internal class TypeRegistry(ITypeRegistry? parent) : ITypeRegistry
             ret = new TypeDefinition(type, typeName, keyFunctionBuilder);
             typeByName[ret.CollectionName] = (TypeDefinition)ret;
             nameByType[type] = ret.CollectionName;
+            IndexFullNameAlias(type, (TypeDefinition)ret, ret.CollectionName);
         }
         return ret;
     }
 
     public ITypeDefinition? GetTypeDefinition(string typeName)
     {
-        var ret = typeByName.GetValueOrDefault(typeName);
+        var ret = typeByName.GetValueOrDefault(typeName) ?? aliasByName.GetValueOrDefault(typeName);
         if (ret != null)
             return ret;
         return parent?.GetTypeDefinition(typeName);

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansMarkdownExportTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansMarkdownExportTest.cs
@@ -246,48 +246,47 @@ public class OrleansMarkdownExportTest(ITestOutputHelper output) : TestBase(outp
     }
 
     /// <summary>
-    /// Negative counterpart: a sub-hub that does NOT register the export types â€” reproduces the
-    /// prod condition before <c>PortalApplication.DefaultPortalConfig</c> was updated. The
-    /// deserialize path used to throw <see cref="NotSupportedException"/> straight into the
-    /// observable and crash the circuit. After the robustness fix in
-    /// <c>LayoutExtensions.GetStream&lt;T&gt;</c>, the exception is caught and logged, and the
-    /// observable yields <c>default(T)</c> so subscribers keep flowing. This test asserts the
-    /// graceful-degradation contract: the stream completes with <c>null</c> rather than tearing
-    /// down the pipeline.
+    /// A sub-hub that does NOT explicitly register the export types still resolves the polymorphic
+    /// <see cref="ExportDocumentControl"/> — because a hosted hub's <c>ITypeRegistry</c> CHAINS to its
+    /// parent's (<c>new TypeRegistry(parent…)</c>; <c>TypeRegistry.Types</c> concats the parent's), and the
+    /// <c>$type</c> discriminator is now the SHORT type name (<c>TypeRegistry.FormatType</c>, fb2ee677d),
+    /// which resolves on ANY hub up the chain that knows the type. This is the both-ends-via-chain contract:
+    /// the type is registered on the SENDER and reachable through the RECEIVER's registry chain.
+    /// <para>This used to assert graceful degradation to <c>null</c>, back when the server emitted a
+    /// namespace-qualified FULL-name <c>$type</c> while the chain registered the SHORT name — a name
+    /// MISMATCH (not a missing registration) that left the type unresolved. The short-name default removed
+    /// that mismatch, so the control now resolves through the chain as intended. The graceful-degradation
+    /// catch in <c>LayoutExtensions.GetStream&lt;T&gt;</c> (NotSupportedException → logged + <c>null</c>
+    /// yield) remains the defensive path for a type that is genuinely absent from the ENTIRE chain.</para>
     /// </summary>
     [Fact(Timeout = 60000)]
-    public async Task SubHub_WithoutExportTypesRegistered_DegradesGracefullyToNull()
+    public async Task SubHub_WithoutExplicitRegistration_ResolvesExportDocumentControlViaRegistryChain()
     {
         using var cts = new CancellationTokenSource(60.Seconds());
-        var parent = GetClient("portal-parent-bare");
+        var parent = GetClient("portal-parent-chain");
 
         var nodePath = await CreateMarkdownNodeAsync(
-            parent, "subhub-bare",
-            "# Hello\n\nSub-hub without export types registered.", cts.Token);
+            parent, "subhub-chain",
+            "# Hello\n\nSub-hub resolving the control through its parent registry chain.", cts.Token);
         Output.WriteLine($"Created Markdown node: {nodePath}");
 
-        // Bare sub-hub â€” no AddMarkdownExportTypes. This is what the portal did before the fix.
-        var subHub = parent.GetHostedHub(new Address("portal", "subhub-bare"),
+        // Sub-hub WITHOUT its own AddMarkdownExportTypes — it must resolve the control through the
+        // parent/mesh registry chain alone.
+        var subHub = parent.GetHostedHub(new Address("portal", "subhub-chain"),
             c => c.AddLayoutClient())!;
 
         var stream = subHub.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
             new Address(nodePath), new LayoutAreaReference(ExportDocumentLayoutArea.PdfArea));
         // Server renders the UiControl under the Area pointer (not empty string).
 
-        // Observe the control stream â€” should NOT throw. An entry arrives but deserialization
-        // fails (caught + logged), yielding null.
-        UiControl? control = null;
-        using var subscription = stream.GetControlStream(ExportDocumentLayoutArea.PdfArea)
-            .Subscribe(v => control = v);
+        var control = await stream.GetControlStream(ExportDocumentLayoutArea.PdfArea)
+            .Timeout(30.Seconds())
+            .FirstAsync(x => x != null);
 
-        // Give the server time to render and the failed decode time to settle.
-        await Task.Delay(5.Seconds(), cts.Token);
-
-        control.Should().BeNull(
-            "without the sub-hub's TypeRegistry knowing ExportDocumentControl, the polymorphic " +
-            "UiControl deserialize throws NotSupportedException internally; the catch in " +
-            "LayoutExtensions.GetStream turns the crash into a logged error + null yield " +
-            "instead of tearing down the observable pipeline.");
+        control.Should().BeOfType<ExportDocumentControl>(
+            "the short-name $type resolves through the sub-hub's parent registry chain even though the " +
+            "sub-hub did not register the export types itself — the both-ends-via-chain contract.");
+        ((ExportDocumentControl)control!).SourcePath.Should().Be(nodePath);
     }
 
     [Fact(Timeout = 60000)]

--- a/test/MeshWeaver.Layout.Test/ControlsSerializationTest.cs
+++ b/test/MeshWeaver.Layout.Test/ControlsSerializationTest.cs
@@ -20,7 +20,7 @@ public class ControlsSerializationTest(ITestOutputHelper output) : HubTestBase(o
 
 
     private const string benchmark =
-        $$$"""{"$type":"MeshWeaver.Layout.HtmlControl","data":"Hello World","moduleName":"{{{ModuleSetup.ModuleName}}}","apiVersion":"{{{ModuleSetup.ApiVersion}}}","skins":[]}""";
+        $$$"""{"$type":"HtmlControl","data":"Hello World","moduleName":"{{{ModuleSetup.ModuleName}}}","apiVersion":"{{{ModuleSetup.ApiVersion}}}","skins":[]}""";
     [HubFact]
     public void BasicSerialization()
     {

--- a/test/MeshWeaver.Layout.Test/LayoutSerializationTest.cs
+++ b/test/MeshWeaver.Layout.Test/LayoutSerializationTest.cs
@@ -25,14 +25,14 @@ public class LayoutSerializationTest(ITestOutputHelper output) : HubTestBase(out
         // Real-world JSON payload with polymorphic layout controls
         var json = """
         {
-            "$type":"MeshWeaver.Layout.StackControl",
+            "$type":"StackControl",
             "skin":{
-                "$type":"MeshWeaver.Layout.LayoutStackSkin",
+                "$type":"LayoutStackSkin",
                 "orientation":"Vertical"
             },
             "areas":[
                 {
-                    "$type":"MeshWeaver.Layout.NamedAreaControl",
+                    "$type":"NamedAreaControl",
                     "area":"Catalog/1",
                     "moduleName":"MeshWeaver.Layout",
                     "apiVersion":"1.0.0",
@@ -40,7 +40,7 @@ public class LayoutSerializationTest(ITestOutputHelper output) : HubTestBase(out
                     "skins":[]
                 },
                 {
-                    "$type":"MeshWeaver.Layout.NamedAreaControl",
+                    "$type":"NamedAreaControl",
                     "area":"Catalog/2",
                     "moduleName":"MeshWeaver.Layout",
                     "apiVersion":"1.0.0",
@@ -48,7 +48,7 @@ public class LayoutSerializationTest(ITestOutputHelper output) : HubTestBase(out
                     "skins":[]
                 },
                 {
-                    "$type":"MeshWeaver.Layout.NamedAreaControl",
+                    "$type":"NamedAreaControl",
                     "area":"Catalog/3",
                     "moduleName":"MeshWeaver.Layout",
                     "apiVersion":"1.0.0",
@@ -56,7 +56,7 @@ public class LayoutSerializationTest(ITestOutputHelper output) : HubTestBase(out
                     "skins":[]
                 },
                 {
-                    "$type":"MeshWeaver.Layout.NamedAreaControl",
+                    "$type":"NamedAreaControl",
                     "area":"Catalog/4",
                     "moduleName":"MeshWeaver.Layout",
                     "apiVersion":"1.0.0",
@@ -64,7 +64,7 @@ public class LayoutSerializationTest(ITestOutputHelper output) : HubTestBase(out
                     "skins":[]
                 },
                 {
-                    "$type":"MeshWeaver.Layout.NamedAreaControl",
+                    "$type":"NamedAreaControl",
                     "area":"Catalog/5",
                     "moduleName":"MeshWeaver.Layout",
                     "apiVersion":"1.0.0",
@@ -72,7 +72,7 @@ public class LayoutSerializationTest(ITestOutputHelper output) : HubTestBase(out
                     "skins":[]
                 },
                 {
-                    "$type":"MeshWeaver.Layout.NamedAreaControl",
+                    "$type":"NamedAreaControl",
                     "area":"Catalog/6",
                     "moduleName":"MeshWeaver.Layout",
                     "apiVersion":"1.0.0",
@@ -141,7 +141,7 @@ public class LayoutSerializationTest(ITestOutputHelper output) : HubTestBase(out
     public void Deserialize()
     {
         var serialized =
-            """{"$type":"MeshWeaver.Layout.StackControl","skin":{"$type":"MeshWeaver.Layout.LayoutStackSkin","orientation":"Vertical"},"areas":[{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/1","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"1","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/2","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"2","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/3","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"3","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/4","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"4","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/5","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"5","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/6","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"6","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/7","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"7","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/8","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"8","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/9","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"9","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/10","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"10","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/11","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"11","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/12","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"12","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/13","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"13","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/14","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"14","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/15","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"15","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/16","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"16","skins":[]},{"$type":"MeshWeaver.Layout.NamedAreaControl","area":"Catalog/17","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"17","skins":[]}],"moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","skins":[{"$type":"MeshWeaver.Layout.LayoutStackSkin","orientation":"Vertical"},{}],"pageTitle":"Articles"}""";
+            """{"$type":"StackControl","skin":{"$type":"LayoutStackSkin","orientation":"Vertical"},"areas":[{"$type":"NamedAreaControl","area":"Catalog/1","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"1","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/2","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"2","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/3","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"3","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/4","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"4","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/5","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"5","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/6","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"6","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/7","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"7","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/8","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"8","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/9","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"9","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/10","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"10","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/11","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"11","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/12","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"12","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/13","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"13","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/14","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"14","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/15","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"15","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/16","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"16","skins":[]},{"$type":"NamedAreaControl","area":"Catalog/17","moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","id":"17","skins":[]}],"moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","skins":[{"$type":"LayoutStackSkin","orientation":"Vertical"},{}],"pageTitle":"Articles"}""";
         var deserialized = JsonSerializer.Deserialize<UiControl>(serialized, GetClient().JsonSerializerOptions);
         deserialized.Should().NotBeNull("Deserialized object should not be null");
     }
@@ -233,7 +233,7 @@ public class LayoutSerializationTest(ITestOutputHelper output) : HubTestBase(out
         deserialized.Should().NotBeNull();
 
         // Second, test that we can handle legacy payloads with empty skin objects
-        var legacyJsonWithEmptySkin = """{"$type":"MeshWeaver.Layout.StackControl","skin":{"$type":"MeshWeaver.Layout.LayoutStackSkin","orientation":"Vertical"},"areas":[],"moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","skins":[{"$type":"MeshWeaver.Layout.LayoutStackSkin","orientation":"Vertical"},{}],"pageTitle":"Articles"}""";
+        var legacyJsonWithEmptySkin = """{"$type":"StackControl","skin":{"$type":"LayoutStackSkin","orientation":"Vertical"},"areas":[],"moduleName":"MeshWeaver.Layout","apiVersion":"1.0.0","skins":[{"$type":"LayoutStackSkin","orientation":"Vertical"},{}],"pageTitle":"Articles"}""";
 
         // This should not throw an exception - empty objects should be handled gracefully
         Action deserializeLegacy = () =>

--- a/test/MeshWeaver.Layout.Test/SkinSerializationTest.cs
+++ b/test/MeshWeaver.Layout.Test/SkinSerializationTest.cs
@@ -87,7 +87,7 @@ public class SkinSerializationTest(ITestOutputHelper output) : HubTestBase(outpu
 
         // Even a skin with default properties should have a $type discriminator
         serialized.Should().Contain("$type");
-        serialized.Should().Contain("MeshWeaver.Layout.LayoutStackSkin");
+        serialized.Should().Contain("LayoutStackSkin");
 
         // Should not contain empty objects
         serialized.Should().NotContain("{}");
@@ -114,7 +114,7 @@ public class SkinSerializationTest(ITestOutputHelper output) : HubTestBase(outpu
 
         // The JSON should contain type discriminators for polymorphic deserialization
         serialized.Should().Contain("$type");
-        serialized.Should().Contain("MeshWeaver.Layout.StackControl");
+        serialized.Should().Contain("StackControl");
 
         // Deserialize explicitly to the base UiControl type
         var deserializedAsBase = JsonSerializer.Deserialize<UiControl>(serialized, client.JsonSerializerOptions);


### PR DESCRIPTION
## Why main is red

#136 changed the `$type` discriminator default from the namespace-qualified **full** name to the **short** type name (`TypeRegistry.FormatType`, fb2ee677d). That's the intended contract, but it broke deserialization paths that still resolved a type by **reflection on its full name** — `MeshWeaver.Layout.Test` (7 failures) and the Orleans markdown-export round-trip. Main "Build and Test" went red → **Continuous Delivery skipped → nothing deployed**.

This is the fix-forward the regression needs (keep short names; make resolution registry-driven, not reflection-driven).

## Changes

- **`TypeRegistry`** — keep a resolution-only **alias** from each type's full name to its definition (`aliasByName`), consulted by `TryGetType` / `GetTypeDefinition`. New writes stay short; JSON persisted with a legacy full-name `$type` still resolves. The alias map is **separate** from `typeByName` so `PolymorphicTypeInfoResolver` (which enumerates `.Types`) never sees a type twice — duplicates break the discriminator (*"must specify a type discriminator"*).
- **`SkinListConverter`** — the `[JsonConverter]` attribute on `UiControl.Skins` forces the **parameterless (registry-less)** converter, which could only resolve a skin via `Type.GetType` (full names only) → short-named skins were silently dropped (0 skins round-tripped). Now resolves the short name through the hub's registry-backed polymorphism resolver; legacy full names still resolve; unregistered skins still skip gracefully.
- **`OptionConverter`** — accept both the short (`Option\`1[Int32]`) and full generic `$type` forms so `Option<T>` deserializes under the short-name default.
- **Tests** — update `Layout.Test` expectations to the **short-name** output; rework the Orleans negative test: a hosted hub's `TypeRegistry` **chains to its parent's**, so the short-name `$type` now resolves through the chain even without explicit sub-hub registration (the **both-ends-via-chain** contract). The old "degrades to null" was an artifact of the full-vs-short name *mismatch* #136 removed; `GetStream`'s catch remains the defensive path for a type absent from the whole chain.
- **Doc** — `Serialization.md`: register controls on **both** sender and receiver; the short `$type` resolves only through the registry, not `Type.GetType` reflection.

## Tests

`Layout.Test` 248/248 · `TypeRegistry` 4/4 · Orleans markdown-export 5/5 · `DocumentationLinkIntegrity` green · full solution build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)