### PR TITLE
fix(messaging): disposal watchdog must tear down children — cures the heartbeat-leak wedge

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -167,7 +167,14 @@ public static class MeshExtensions
             if (callback != null)
             {
                 var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.GrainKeepAlive");
-                logger?.LogInformation("HeartBeat: keeping grain alive for {Hub} (callback on {Parent})",
+                // Debug, NOT Information: this fires for EVERY sync-stream keep-alive heartbeat on EVERY
+                // open stream, every heartbeat interval — the single highest-volume log line on a busy
+                // portal (≈half of all log lines + ~11% of CPU under load, measured via dotnet-trace on
+                // the wedged e2e portal: ConsoleLoggerProcessor.ProcessLogQueue). At Information it ships
+                // to Loki on every tick and bleeds ingest budget for zero diagnostic value (a grain
+                // staying alive is the expected steady state). Keep it at Debug for when a deactivation
+                // is actually being investigated.
+                logger?.LogDebug("HeartBeat: keeping grain alive for {Hub} (callback on {Parent})",
                     hub.Address, current.Address);
                 callback.KeepAlive();
                 break;

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1368,13 +1368,52 @@ public sealed class MessageHub : IMessageHub
                         return;
                     logger.LogError(
                         "DISPOSAL DEADLOCK DETECTED: Hub {Address} did not complete shutdown within {Timeout}. " +
-                        "RunLevel={RunLevel}. Force-completing disposal to prevent hang.",
+                        "RunLevel={RunLevel}. Force-tearing-down children + disposables to prevent a heartbeat/stream leak.",
                         Address, DisposalWatchdogTimeout, RunLevel);
+                    // 🚨 The watchdog fires because the reactive shutdown state machine
+                    // (Quiescing → DisposeHostedHubs → ShutDown) never advanced — the posted
+                    // ShutdownRequest was starved on a wedged/flooded action block (RunLevel stays
+                    // Started). DisposeImpl + hostedHubs.Dispose run ONLY inside that state machine's
+                    // ShutDown/DisposeHostedHubs phases, so a watchdog that merely SignalDisposal
+                    // Completed() would unblock the caller while LEAKING every hosted sync-stream hub
+                    // and its Observable.Interval heartbeat timer — they keep heart-beating forever.
+                    // That accumulation IS the portal wedge (236+ orphaned heartbeats → 2 cores →
+                    // /healthz timeout). So force the teardown here too: dispose the hosted hubs (stops
+                    // their heartbeats) and this hub's own subscriptions. Both are thread-safe and
+                    // idempotent (HostedHubsCollection.Dispose is lock+CAS guarded; DisposeImpl nulls
+                    // its reactive actions under lock and disposes an idempotent CompositeDisposable),
+                    // so the normal ShutDown phase running later is a harmless no-op.
+                    ForceTeardownAfterWatchdog();
                     SignalDisposalCompleted();
                 },
                 // disposalCompleted faulting (SignalDisposalFaulted) propagates through TakeUntil;
                 // the watchdog is no longer needed — swallow so it isn't an unobserved error.
                 _ => { });
+    }
+
+    /// <summary>
+    /// Best-effort teardown invoked by the disposal watchdog when the reactive shutdown state machine
+    /// wedged (the ShutdownRequest never got a turn). Runs OFF the action block, so it touches only
+    /// thread-safe, idempotent surfaces: <see cref="HostedHubsCollection.Dispose"/> (lock+CAS) to stop
+    /// every hosted sync-stream hub's keep-alive heartbeat, and <see cref="DisposeImpl"/> for this hub's
+    /// own registered subscriptions. Each step is independently guarded so one fault can't strand the
+    /// other. <c>messageService.Dispose()</c> is deliberately NOT called here — it may block on the
+    /// wedged turn; abandoning one wedged turn-task is far cheaper than leaking all the heartbeats.
+    /// </summary>
+    private void ForceTeardownAfterWatchdog()
+    {
+        try { hostedHubs.Dispose(); }
+        catch (Exception ex)
+        {
+            TryLog(LogLevel.Warning, "[DISPOSE-WATCHDOG] {Address}: hosted-hub force-dispose faulted: {Type}: {Message}",
+                Address, ex.GetType().Name, ex.Message);
+        }
+        try { DisposeImpl(); }
+        catch (Exception ex)
+        {
+            TryLog(LogLevel.Warning, "[DISPOSE-WATCHDOG] {Address}: DisposeImpl force faulted: {Type}: {Message}",
+                Address, ex.GetType().Name, ex.Message);
+        }
     }
 
     private void DisposeImpl()

--- a/test/MeshWeaver.Messaging.Hub.Test/MessageHubTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/MessageHubTest.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using MeshWeaver.Fixture;
 using Xunit;
 
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 namespace MeshWeaver.Messaging.Hub.Test;
@@ -305,6 +306,66 @@ public class MessageHubTest(ITestOutputHelper output) : HubTestBase(output)
             "the aggregate watermark shed the excess sheddable traffic");
         victim.StormBreaker.TripCount.Should().Be(0,
             "the per-key breaker must NOT be what saved the hub — this isolates the aggregate path");
+    }
+
+    /// <summary>
+    /// The portal-wedge root cause (memory <c>wedge-reproduced-local-k3s-e2e-portal</c>): the reactive
+    /// disposal state machine (Quiescing → DisposeHostedHubs → ShutDown) runs <c>DisposeImpl</c> and
+    /// <c>hostedHubs.Dispose()</c> ONLY in its final phases. If the action block is wedged, the posted
+    /// <c>ShutdownRequest</c> is starved (RunLevel stays Started), the state machine never advances, and
+    /// the 8s watchdog used to only signal completion — unblocking the caller while LEAKING every hosted
+    /// sync-stream hub and its <c>Observable.Interval</c> keep-alive heartbeat. Those orphaned heartbeats
+    /// accumulate run-over-run until the portal pegs CPU and <c>/healthz</c> times out. This pins the fix:
+    /// when the watchdog fires it must actually tear the children + subscriptions down. RED before the
+    /// fix (both probes leak → time out); GREEN after.
+    /// </summary>
+    [Fact]
+    public async Task Dispose_WhenActionBlockWedged_WatchdogTearsDownChildrenAndDisposables()
+    {
+        using var blockHandlerEntered = new ManualResetEventSlim(false);
+        using var releaseBlock = new ManualResetEventSlim(false);
+        using var ownDisposed = new ManualResetEventSlim(false);
+        using var childDisposed = new ManualResetEventSlim(false);
+
+        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "wedged-dispose"), c => c
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithHandler<BlockTurnRequest>((_, d) =>
+            {
+                blockHandlerEntered.Set();
+                releaseBlock.Wait(TimeSpan.FromSeconds(30)); // hold the single turn thread → starve ShutdownRequest
+                return d.Processed();
+            }));
+
+        // Stands in for a sync-stream subscription that DisposeImpl tears down.
+        victim.RegisterForDisposal(Disposable.Create(ownDisposed.Set));
+        // Stands in for a hosted sync-stream hub whose keep-alive heartbeat is stopped by hostedHubs.Dispose().
+        var child = victim.GetHostedHub(new Address("child", "1"),
+            cc => cc.WithPostingIdentity(PostingIdentity.System), HostedHubCreation.Always)!;
+        child.RegisterForDisposal(Disposable.Create(childDisposed.Set));
+
+        try
+        {
+            // 1) Wedge the victim's action block so its ShutdownRequest can never get a turn.
+            victim.Post(new BlockTurnRequest(), o => o.WithTarget(victim.Address));
+            blockHandlerEntered.Wait(TimeSpan.FromSeconds(10))
+                .Should().BeTrue("the block handler must occupy the turn thread before we dispose");
+
+            // 2) Dispose — the state machine is starved; only the 8s watchdog can complete it.
+            victim.Dispose();
+
+            // 3) The watchdog (8s) must force the real teardown, not just signal completion.
+            ownDisposed.Wait(TimeSpan.FromSeconds(20))
+                .Should().BeTrue("the watchdog must run DisposeImpl so the hub's own subscriptions don't leak when disposal wedges");
+            childDisposed.Wait(TimeSpan.FromSeconds(20))
+                .Should().BeTrue("the watchdog must dispose hosted hubs so their keep-alive heartbeats don't leak forever");
+        }
+        finally
+        {
+            // Always release the held turn — even if an assertion fails — so the blocking handler
+            // can't pin a thread for 30s and bleed into other tests.
+            releaseBlock.Set();
+        }
+        await Task.Yield();
     }
 
     [Fact]


### PR DESCRIPTION
## The wedge, reproduced and root-caused

Reproduced the recurring portal wedge **live** on the local k3s e2e portal (CPU pegged ~2 cores, `/healthz` readiness-probe timeout — the prod 502 signature) and pinned the root with a `dotnet-trace` CPU sample + a code read.

`MessageHub` disposal is a reactive state machine: **Quiescing → DisposeHostedHubs → ShutDown**. `DisposeImpl()` (this hub's subscriptions) and `hostedHubs.Dispose()` (every hosted sync-stream hub **and its `Observable.Interval` keep-alive heartbeat**) run **only** in that machine's final phases. When the action block is wedged/flooded, the posted `ShutdownRequest` is **starved** (`RunLevel` stays `Started`); the 8s watchdog then only called `SignalDisposalCompleted()` — unblocking the caller (grain deactivation / tests) while **leaking every hosted hub and its heartbeat timer**. Those orphaned heartbeats keep firing forever and accumulate run-over-run until the portal pegs CPU and the liveness probe times out.

CPU trace at the wedge (inclusive): ~12.5% heartbeat/stream message routing, **~11% `ConsoleLoggerProcessor`** (the per-heartbeat `Information` log), rest GC/native churn — all driven by the leaked, never-disposed streams.

The 8s "force-complete" watchdog was therefore a band-aid that **hid a leak**.

## Fix

- **Watchdog now actually tears down** (`ForceTeardownAfterWatchdog`) before signalling: disposes the hosted hubs (stops their heartbeats) and this hub's own subscriptions. Both are **thread-safe + idempotent** (`HostedHubsCollection.Dispose` is lock+CAS; `DisposeImpl` nulls its reactive actions under lock and disposes an idempotent `CompositeDisposable`), so the normal `ShutDown` phase running later is a harmless no-op. `messageService.Dispose()` is deliberately **not** called off-block (it can block on the wedged turn).
- **Per-heartbeat keep-alive log `Information` → `Debug`** (`MeshExtensions.HandleHeartBeat`): it fires per stream per interval — ~half of all log lines + ~11% of CPU under load, zero diagnostic value at steady state, real Loki ingest cost.

## Deterministic repro (RED before, GREEN after)

`Dispose_WhenActionBlockWedged_WatchdogTearsDownChildrenAndDisposables`: wedge a hub's action block with a blocking handler, dispose it, assert the watchdog tears down both a hosted child hub and a registered disposable within the window.

## Tests

`MeshWeaver.Messaging.Hub.Test` **71/71** (incl. the new repro + all existing `Dispose_*` / storm / mesh-root-dispose tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)