### PR TITLE
fix(build): stable AssemblyVersion — cures the migration binding crash (#143)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -99,10 +99,19 @@
          is the Graph MVID now, not this string, so a stable local value is safe. -->
     <InformationalVersion Condition="'$(CIRun)' == 'true'">$(Version)+build.$([System.DateTime]::UtcNow.Ticks)</InformationalVersion>
     <InformationalVersion Condition="'$(CIRun)' != 'true'">$(Version)</InformationalVersion>
-    <!-- AssemblyVersion + FileVersion = 3.0.0.<build> (numeric only — the -rc1 label is not
-         allowed here); changes every build for MSBuild's CopyToOutputDirectory heuristic (else
-         test bins hold stale framework DLLs and re-runs exercise old code). -->
-    <AssemblyVersion>$(_VersionNumeric).$(_BuildNumber)</AssemblyVersion>
+    <!-- 🔴 AssemblyVersion is STABLE (3.0.0.0) — it is the RUNTIME ASSEMBLY-BINDING identity, so it
+         MUST be identical across every assembly in a coherent build. `_BuildNumber` is
+         seconds-since-midnight/2 evaluated PER PROJECT at MSBuild time, so a time-based
+         AssemblyVersion drifts a few seconds (→ a different number) between projects built in the
+         same run. That made `Memex.Database.Migration` reference `MeshWeaver.Documentation,
+         Version=3.0.0.280` while the packaged DLL had a different `3.0.0.<other>` → FileNotFoundException
+         at startup → the migration CrashLoopBackOff'd, the schema stuck at v39, and Space creation
+         failed (issue #143). Binding identity must not depend on wall-clock time.
+         FileVersion KEEPS the per-build number — that (plus build timestamps) drives MSBuild's
+         CopyToOutputDirectory heuristic so test bins don't hold stale framework DLLs; it does NOT
+         participate in assembly binding, so it can vary freely. NodeType ABI identity uses the Graph
+         MVID and the self-updater keys on the image tag (ci.N) — neither uses AssemblyVersion. -->
+    <AssemblyVersion>$(_VersionNumeric).0</AssemblyVersion>
     <FileVersion>$(_VersionNumeric).$(_BuildNumber)</FileVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes #143.

## Symptom

Space creation fails on prod: *"database schema issue on the backend (sync_behavior column missing)"*. The `memex-migration` container CrashLoopBackOffs on startup:

```
Current DB version: 39
System.IO.FileNotFoundException: Could not load file or assembly
'MeshWeaver.Documentation, Version=3.0.0.280' — the system cannot find the file.
```

So the schema never advances past **v39**, the `sync_behavior` migration (PR #119) never applies, and Space creation fails. (The portals on the same `ci.122` build run fine — only the *migration* image hit it.)

## Root cause

`Directory.Build.props` set `AssemblyVersion = $(_VersionNumeric).$(_BuildNumber)`, where `_BuildNumber` is **seconds-since-midnight ÷ 2**, evaluated **per project at MSBuild time**. `AssemblyVersion` is the **runtime assembly-binding identity** — it must be identical across every assembly in a coherent build. A time-based value drifts a few seconds between projects built in the same CI run, so `Memex.Database.Migration` was compiled against `MeshWeaver.Documentation` **v3.0.0.280** while the packaged DLL carried a different `3.0.0.<other>` → binding fails → crash before applying v40.

## Fix

- `AssemblyVersion` → **stable** `$(_VersionNumeric).0` (`3.0.0.0`).
- `FileVersion` keeps the per-build number (drives MSBuild's copy heuristic; does **not** participate in binding).

Safe against everything documented in that file: the self-updater keys on the **image tag** (`ci.N`), NodeType ABI identity uses the **Graph MVID** — neither uses `AssemblyVersion`. And it only ever bit CI: **local builds already set `_BuildNumber=0`**, so `AssemblyVersion` was already `3.0.0.0` locally — this makes CI match the already-correct local behavior.

## Validation

`dotnet build memex/aspire/Memex.Database.Migration -c Release -p:CIRun=true` succeeds, and the generated AssemblyInfo for **both** the migration and `MeshWeaver.Documentation` now reads `AssemblyVersion("3.0.0.0")` (previously they drifted). After merge → CD rebuilds → the migration runs → v40 (`sync_behavior`) applies → Space creation works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)