### PR TITLE
test(clients): headless render tests for the React Native leaf pack

### DIFF
--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -74,7 +74,7 @@ jobs:
       - run: npm test # vitest: envelope round-trip + in-memory Connect/Deliver correlation & demux
 
   react-native:
-    name: "RN connector (typecheck)"
+    name: "RN connector (typecheck + test)"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -93,9 +93,11 @@ jobs:
       - name: Install + generate grpc-web client
         working-directory: clients/grpc-web
         run: npm install --no-audit --no-fund && npm run gen
-      # Targeted install (RN types only) — the pack typechecks against @meshweaver/react/core via tsconfig path.
-      - run: npm install --no-save --no-audit --no-fund react-native@0.76.5 react@18.3.1 @types/react@18.3.12 typescript@5.6.3
+      # Targeted install: typecheck needs RN types; the render test needs vitest + react-test-renderer
+      # (react-native itself is mocked in the test — see vitest.config.ts).
+      - run: npm install --no-save --no-audit --no-fund react-native@0.76.5 react@18.3.1 react-test-renderer@18.3.1 @types/react@18.3.12 @types/react-test-renderer@18.3.0 vitest@2.1.9 typescript@5.6.3
       - run: npx tsc --noEmit
+      - run: npx vitest run # headless render of the sample area through the RN leaf pack
 
   portal:
     name: "Portal example (build)"

--- a/clients/README.md
+++ b/clients/README.md
@@ -32,5 +32,5 @@ Full architecture: `src/MeshWeaver.Documentation/Data/Architecture/ForeignLangua
 
 `.github/workflows/clients.yml` runs on any PR touching `clients/`: `meshweaver` (Python) pytest,
 `@meshweaver/react` typecheck + vitest, `@meshweaver/client` (Node) typecheck, `@meshweaver/client-web`
-typecheck + vitest (buf-generates from the canonical `mesh.proto`), the RN connector typecheck, and the
-portal build. Both gRPC-codegen jobs generate from the one canonical `mesh.proto`.
+typecheck + vitest (buf-generates from the canonical `mesh.proto`), the RN connector typecheck + headless
+render tests, and the portal build. Both gRPC-codegen jobs generate from the one canonical `mesh.proto`.

--- a/clients/react-native/README.md
+++ b/clients/react-native/README.md
@@ -26,6 +26,16 @@ npm run ios                          # expo start --ios  (press i)
 In a monorepo, point Metro at `../react` (Metro `watchFolders` + a `@meshweaver/react` alias), or install
 the published package. `npm run typecheck` checks the pack against the core via a tsconfig path.
 
+## Tests
+
+`npm test` (vitest) renders the sample area through the leaf pack + the shared renderer core **headlessly**
+— react-native is swapped for a lightweight host-component mock (`test/react-native.mock.tsx`), so
+`react-test-renderer` produces a tree we assert on with no native runtime. It proves the pack maps a
+`UiControl` tree to the right native components **and resolves `/data` bindings** — e.g. the `TextField`
+becomes a `<TextInput>` carrying `"Ada Lovelace"`, the `CheckBox` a `<Switch value={true}>`, the `DataGrid`
+its bound rows — the runtime proof that `npm run typecheck` alone can't give. (An on-device render still
+needs `npm run ios`; this is the deterministic, CI-runnable level.)
+
 ## Leaf pack coverage
 
 Stacks/grids/cards/nav/toolbar (skins → `View`), `Label`/`Markdown`/`Html`/`Badge` (`Text`), `Button`

--- a/clients/react-native/package.json
+++ b/clients/react-native/package.json
@@ -8,7 +8,8 @@
     "start": "expo start",
     "ios": "expo start --ios",
     "android": "expo start --android",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "expo": "~52.0.0",
@@ -18,6 +19,9 @@
   },
   "devDependencies": {
     "@types/react": "~18.3.0",
-    "typescript": "^5.6.0"
+    "@types/react-test-renderer": "~18.3.0",
+    "react-test-renderer": "18.3.1",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
   }
 }

--- a/clients/react-native/src/rnPack.test.tsx
+++ b/clients/react-native/src/rnPack.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import TestRenderer, { type ReactTestRendererJSON } from "react-test-renderer";
+import { RegistryProvider, ScopeProvider, RenderArea, StaticAreaSource } from "@meshweaver/react/core";
+import { rnPack } from "./rnPack";
+import { sampleArea } from "./sample";
+
+// Render the sample area through the RN leaf pack + the shared renderer core, headless. Proves the app
+// actually renders a UiControl tree to native components and resolves /data bindings — the runtime proof
+// that "typecheck passes" can't give. react-native is mocked to identifiable host nodes (see vitest.config).
+
+type Json = ReactTestRendererJSON;
+
+function render(): Json {
+  let root!: TestRenderer.ReactTestRenderer;
+  TestRenderer.act(() => {
+    root = TestRenderer.create(
+      <RegistryProvider pack={rnPack}>
+        <ScopeProvider source={new StaticAreaSource(sampleArea)} area="main">
+          <RenderArea areaKey="main" />
+        </ScopeProvider>
+      </RegistryProvider>,
+    );
+  });
+  return root.toJSON() as Json;
+}
+
+// Depth-first walk yielding every node in the rendered tree.
+function* walk(node: Json | Json[] | null): Generator<Json> {
+  if (node == null) return;
+  if (Array.isArray(node)) {
+    for (const n of node) yield* walk(n);
+    return;
+  }
+  yield node;
+  if (node.children) for (const c of node.children) yield* walk(c as Json);
+}
+
+// The visible text under a node (its string children, recursively).
+function textOf(node: Json): string {
+  let out = "";
+  for (const c of node.children ?? []) {
+    if (typeof c === "string") out += c;
+    else if (c && typeof c === "object") out += textOf(c as Json);
+  }
+  return out;
+}
+
+describe("RN leaf pack renders the sample area", () => {
+  const nodes = [...walk(render())];
+  const byType = (t: string) => nodes.filter((n) => n.type === t);
+  const allText = nodes.filter((n) => n.type === "Text").map(textOf);
+
+  it("renders without hitting the Unsupported fallback", () => {
+    expect(nodes.length).toBeGreaterThan(0);
+    expect(allText.some((t) => t.includes("Unsupported"))).toBe(false);
+  });
+
+  it("renders Label/Markdown as <Text> (the header + intro)", () => {
+    expect(allText).toContain("MeshWeaver on React Native");
+    expect(allText.some((t) => t.includes("native leaves"))).toBe(true);
+  });
+
+  it("binds a TextField to /data/name (a <TextInput> carrying the resolved value)", () => {
+    const inputs = byType("TextInput");
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0].props.value).toBe("Ada Lovelace");
+  });
+
+  it("binds a CheckBox to /data/active (a <Switch> reflecting the boolean)", () => {
+    const switches = byType("Switch");
+    expect(switches).toHaveLength(1);
+    expect(switches[0].props.value).toBe(true);
+  });
+
+  it("renders a Button (<Pressable>) with its label", () => {
+    const pressables = byType("Pressable");
+    expect(pressables.length).toBeGreaterThan(0);
+    expect(allText).toContain("Save");
+  });
+
+  it("renders the Badge text", () => {
+    expect(allText).toContain("Green");
+  });
+
+  it("renders the DataGrid: header titles + every bound row cell", () => {
+    expect(allText).toContain("Account"); // column title
+    expect(allText).toContain("Amount");
+    expect(allText).toContain("ACME"); // /data/rows[0].name
+    expect(allText).toContain("124000"); // /data/rows[0].amount
+    expect(allText).toContain("Northwind"); // /data/rows[1].name
+  });
+});

--- a/clients/react-native/test/react-native.mock.tsx
+++ b/clients/react-native/test/react-native.mock.tsx
@@ -1,0 +1,22 @@
+// A minimal react-native stand-in for headless tests. Each primitive renders as a host node named after
+// itself (so react-test-renderer's toJSON tags them by type and carries their props) — enough to assert
+// that the leaf pack maps a UiControl tree to the right native components with the right props/bindings,
+// without a native runtime. This is NOT a device render; it's the deterministic, CI-runnable unit level.
+import React from "react";
+
+const host =
+  (name: string) =>
+  ({ children, ...props }: any) =>
+    React.createElement(name, props, children);
+
+export const View = host("View");
+export const Text = host("Text");
+export const TextInput = host("TextInput");
+export const Switch = host("Switch");
+export const Pressable = host("Pressable");
+export const ScrollView = host("ScrollView");
+export const ActivityIndicator = host("ActivityIndicator");
+export const SafeAreaView = host("SafeAreaView");
+export const StatusBar = host("StatusBar");
+
+export const StyleSheet = { create: <T,>(styles: T): T => styles };

--- a/clients/react-native/vitest.config.ts
+++ b/clients/react-native/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+// Headless render tests for the RN leaf pack. The renderer core is source-aliased (same as tsconfig
+// paths), react-native is swapped for a lightweight host-component mock, and react is deduped so the
+// aliased core and react-test-renderer share ONE react instance (else: invalid hook call).
+export default defineConfig({
+  resolve: {
+    dedupe: ["react", "react-test-renderer"],
+    alias: {
+      "@meshweaver/react/core": fileURLToPath(new URL("../react/src/core.ts", import.meta.url)),
+      "react-native": fileURLToPath(new URL("./test/react-native.mock.tsx", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/src/MeshWeaver.Documentation/Data/Architecture/ForeignLanguageIntegration.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ForeignLanguageIntegration.md
@@ -158,7 +158,7 @@ the binding's pointer (optimistically applied, exactly as the live stream echoes
 | **Web / Vite** | Fluent (shipped) | none | demo + 11 vitest tests, screenshot |
 | **Next.js** | Fluent (shipped) | `"use client"` + Fluent SSR (~10 lines) | guide (`clients/react/docs/nextjs.md`) |
 | **Electron (desktop)** | Fluent (shipped) | a `BrowserWindow` (shipped) | `clients/react/electron/main.cjs` |
-| **React Native / Expo (the MAUI peer)** | **RN pack (shipped)** | Expo project + gRPC-web transport (both **shipped**) | `clients/react-native` (+ `src/live.ts`), typechecks |
+| **React Native / Expo (the MAUI peer)** | **RN pack (shipped)** | Expo project + gRPC-web transport (both **shipped**) | `clients/react-native` (+ `src/live.ts`), typechecks + **7 headless render tests** |
 | **Browser / RN live transport** | n/a (transport) | none | **`@meshweaver/client-web`** (`clients/grpc-web`), typechecks + builds |
 | **Portal example** | Fluent (shipped) | an app shell (shipped) | `clients/portal`, builds, screenshot |
 
@@ -194,7 +194,8 @@ src/MeshWeaver.Documentation/Data/Architecture/ForeignLanguageBridge.md   transp
 
 **Verified here:** the C# transport (in-memory + live Kestrel h2c round-trips), the React renderer
 (pixel-verified web render, 11 vitest tests, 0.9 MB bundle), the RN connector (typechecks against real
-react-native types — proving the core compiles with zero DOM/Fluent runtime), the gRPC-web client
+react-native types AND 7 headless render tests that mount the sample through the RN pack — proving the core
+renders with zero DOM/Fluent runtime and resolves bindings), the gRPC-web client
 (`@meshweaver/client-web` typechecks + builds from the canonical `mesh.proto`, **8 vitest tests** driving the
 real connection against an in-memory Connect+Deliver service — ack, RequestId correlation, streamId demux —
 wired into the RN app's `src/live.ts`), and the portal (builds + rendered). CI typechecks/tests all of it.


### PR DESCRIPTION
## What

The RN app (`clients/react-native`) typechecked in CI but had **zero runtime tests** and had never been rendered — "compiles" isn't "renders". This adds a **headless render test** that mounts the sample area through the RN leaf pack + the shared renderer core.

## How

- `react-test-renderer` renders the tree to JSON; **react-native is swapped for a lightweight host-component mock** (`test/react-native.mock.tsx`), so there's no native runtime — deterministic and CI-runnable.
- `vitest.config.ts` source-aliases the core (as tsconfig paths do), aliases react-native to the mock, and **dedupes react** so the aliased core and react-test-renderer share one react instance.

## What it proves

The pack maps a `UiControl` tree to the right native components **and resolves `/data` bindings**:
- `Label`/`Markdown` → `<Text>` (header + intro)
- `TextField` → `<TextInput value="Ada Lovelace">` (bound to `/data/name`)
- `CheckBox` → `<Switch value={true}>` (bound to `/data/active`)
- `Button` → `<Pressable>` "Save", `Badge` "Green"
- `DataGrid` → column titles + every bound row cell
- no `Unsupported` fallback

7 tests. CI: the RN job now runs `vitest` after `tsc`.

An on-device render still needs `npm run ios`; this is the unit level below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)