### PR TITLE
fix(self-update): ignore bare git-sha tags — cure the "frozen on ci.122" pin

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
@@ -24,6 +24,17 @@ public static class VersionSelect
     private static readonly Regex RuntimeIdentifierSuffix =
         new(@"-(linux|win|osx)-(x64|x86|arm|arm64)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+    // 🔴 A real platform tag is DOTTED SemVer (3.0.0 / 3.0.0-ci.133). The multi-arch build ALSO pushes a
+    // 7-char git-sha tag per version (e.g. 6943991, 4779b4e) and a bare `main` tag — those are NOT deploy
+    // targets. But NuGetVersion.TryParse accepts a bare number, so an ALL-DIGIT sha like "6943991" parses
+    // as the version 6943991.0.0 and sorts ABOVE every real release (3.x). PickTarget would then pick that
+    // sha and pin the self-updater to whatever release it belongs to — the prod symptom where every portal
+    // froze on ci.122 (whose sha, 6943991, is all digits) and reverted any manual roll to a newer ci.N
+    // (ci.133's sha, 4779b4e, has letters so it never even parsed). Require the MAJOR.MINOR.PATCH dotted
+    // shape that a git-sha / `main` can never have.
+    private static readonly Regex PlatformVersionTag =
+        new(@"^\d+\.\d+\.\d+([-+].*)?$", RegexOptions.Compiled);
+
     /// <summary>
     /// The best tag to roll to under <paramref name="policy"/>, or <c>null</c> when nothing qualifies.
     /// <see cref="UpdatePolicyKind.Continuous"/> considers every parseable tag (incl. build-numbered
@@ -38,6 +49,7 @@ public static class VersionSelect
 
         var parsed = tags
             .Where(t => !RuntimeIdentifierSuffix.IsMatch(t))   // exclude per-RID image tags; keep the manifest list
+            .Where(t => PlatformVersionTag.IsMatch(t))         // exclude bare git-sha / `main` tags (see PlatformVersionTag)
             .Select(t => (tag: t, ver: NuGetVersion.TryParse(t, out var v) ? v : null))
             .Where(x => x.ver is not null)
             .Select(x => (x.tag, ver: x.ver!));

--- a/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
+++ b/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
@@ -41,6 +41,16 @@ public class VersionSelectTest
             ["3.0.0-ci.43", "3.0.0-ci.43-linux-x64", "3.0.0-ci.43-linux-arm64", "main", "main-linux-x64"],
             UpdatePolicyKind.Continuous));
 
+    [Fact]
+    public void Continuous_IgnoresBareGitShaTags_EvenAllDigitOnes()
+        // The CD pushes a 7-char git-sha tag per version alongside the ci.N tag. An ALL-DIGIT sha like
+        // "6943991" NuGet-parses as version 6943991.0.0 and outranks every real 3.x release — the prod bug
+        // that froze every portal on ci.122 (whose sha, 6943991, is all digits) and reverted rolls to a
+        // newer ci.N. Only a real MAJOR.MINOR.PATCH tag may be picked; git-shas (digit- or letter-) are out.
+        => Assert.Equal("3.0.0-ci.133", VersionSelect.PickTarget(
+            ["3.0.0-ci.122", "6943991", "3.0.0-ci.133", "4779b4e", "main"],
+            UpdatePolicyKind.Continuous));
+
     // CI-green gate: a `-edge.N` build is UNVERIFIED. Default (RequireCiGreen=true) must skip it even
     // though it is the newest; opting into "any" (RequireCiGreen=false) rolls to it.
     [Fact]


### PR DESCRIPTION
## Symptom

Every AKS portal (atioz / memex / memex-cloud) was **frozen on `ci.122`** and **reverted any manual roll** to a newer `ci.N` within ~8s — the revert shows on the Deployment as field manager `unknown` (the self-updater's tag-less strategic-merge PATCH).

## Root cause

The multi-arch CD pushes a **7-char git-sha tag** per version next to the `ci.N` tag. `NuGetVersion.TryParse` accepts a bare number, so ci.122's **all-digit** sha **`6943991`** parses as version **`6943991.0.0`** and sorts **above every real `3.x` release**. `VersionSelect.PickTarget` therefore picked `6943991`, and the poller patched every portal + migration Deployment back to `:6943991` — pinning to ci.122. (ci.133's sha `4779b4e` has letters, so it never parsed — which is why the platform could never advance forward either.)

## Fix

Require the `MAJOR.MINOR.PATCH` dotted shape a git-sha / `main` tag can never have (`PlatformVersionTag`) before parsing. git-shas (digit- or letter-) and `main`/`latest` are excluded; the real `ci.N` / release tags are ranked correctly.

## Test

`VersionSelectTest.Continuous_IgnoresBareGitShaTags_EvenAllDigitOnes` — `{3.0.0-ci.122, 6943991, 3.0.0-ci.133, 4779b4e, main}` must pick `3.0.0-ci.133` (was `6943991`). `Memex.Portal.Shared.Test` **20/20**.

Note: to break the chicken-and-egg (the *current* buggy self-updater reverts any roll, including to a fixed image), the immediate unblock is to remove the sole offending `6943991` tag from ACR so the running poller re-picks `ci.133`; this PR makes it permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)