### PR TITLE
fix(orleans): bound grain keep-alive — a hung AI stream can't wedge the grain forever (#147)

### DIFF
--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -96,7 +96,31 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
             _ =>
             {
                 if (Volatile.Read(ref _activeOperations) > 0)
-                    DelayDeactivation(TimeSpan.FromMinutes(10));
+                {
+                    if (LongRunningOperationCapExceeded(
+                            Volatile.Read(ref _longRunningStartedTicks),
+                            DateTime.UtcNow.Ticks,
+                            MaxLongRunningOperationDuration.Ticks))
+                    {
+                        // #147: a long-running operation (typically a hung AI stream with no timeout) has
+                        // been active past the cap. STOP re-arming DelayDeactivation — let Orleans
+                        // idle-collect the grain so deactivation fires executionCts.Cancel()
+                        // (RegisterForDisposal) and cancels the stuck call, instead of pinning the grain
+                        // in memory forever (1376-message backlog, recovery only via pod restart).
+                        logger.LogWarning(
+                            "Grain {GrainId}: a long-running operation has been active for over {Max} " +
+                            "(active={Count}) — no longer extending grain lifetime and requesting " +
+                            "deactivation so executionCts.Cancel() can cancel the stuck operation (#147).",
+                            this.GetPrimaryKeyString(), MaxLongRunningOperationDuration,
+                            Volatile.Read(ref _activeOperations));
+                        // Request deactivation NOW rather than waiting out the last DelayDeactivation
+                        // window + CollectionAgeLimit. On deactivation OnDeactivateAsync disposes the hub,
+                        // RegisterForDisposal fires executionCts.Cancel(), and the hung AI call is torn down.
+                        DeactivateOnIdle();
+                    }
+                    else
+                        DelayDeactivation(TimeSpan.FromMinutes(10));
+                }
                 return Task.CompletedTask;
             },
             new GrainTimerCreationOptions
@@ -299,6 +323,24 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
 
     private IGrainTimer? _keepAliveTimer;
     private int _activeOperations;
+    // Wall-clock ticks when the CURRENT run of long-running operations began (0 = none active). Bounds
+    // how long the keep-alive may extend: a hung AI stream (no timeout — #147) would otherwise hold
+    // _activeOperations > 0 and re-arm DelayDeactivation every minute FOREVER, pinning the grain in memory
+    // with no recovery short of a pod restart. Set on the 0→1 transition, cleared on →0.
+    private long _longRunningStartedTicks;
+    // Generous upper bound on a single run of long-running operations. Legit rounds — including nested
+    // delegation trees where a parent holds its slot while a sub-thread works — complete well within this;
+    // only a genuinely-hung endpoint exceeds it. Past this the keep-alive STOPS extending, Orleans
+    // idle-collects the grain, and executionCts.Cancel() (RegisterForDisposal) cancels the stuck AI call.
+    private static readonly TimeSpan MaxLongRunningOperationDuration = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Pure decision for the keep-alive timer (unit-testable without an Orleans cluster/clock): a
+    /// long-running-operation RUN whose start is known has exceeded the cap. <paramref name="startedTicks"/>
+    /// == 0 means no run is active (or the clock was cleared) — never expired. See #147.
+    /// </summary>
+    internal static bool LongRunningOperationCapExceeded(long startedTicks, long nowTicks, long maxDurationTicks)
+        => startedTicks != 0 && nowTicks - startedTicks > maxDurationTicks;
 
     /// <summary>
     /// Starts a long-running operation scope.
@@ -308,7 +350,10 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
     /// </summary>
     private IDisposable BeginLongRunningOperation()
     {
-        Interlocked.Increment(ref _activeOperations);
+        // Stamp the start of the active-operation RUN on the 0→1 transition so the keep-alive timer can
+        // bound it (see MaxLongRunningOperationDuration / #147).
+        if (Interlocked.Increment(ref _activeOperations) == 1)
+            Volatile.Write(ref _longRunningStartedTicks, DateTime.UtcNow.Ticks);
         // DelayDeactivation is thread-safe in Orleans
         DelayDeactivation(TimeSpan.FromMinutes(10));
         logger.LogInformation("Grain {GrainId}: long-running operation started (active={Count})",
@@ -317,6 +362,8 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         return new LongRunningOperationScope(() =>
         {
             var remaining = Interlocked.Decrement(ref _activeOperations);
+            if (remaining == 0)
+                Volatile.Write(ref _longRunningStartedTicks, 0);   // run ended — clear the bound clock
             logger.LogInformation("Grain {GrainId}: long-running operation completed (active={Count})",
                 this.GetPrimaryKeyString(), remaining);
         });

--- a/test/MeshWeaver.Hosting.Orleans.Test/MessageHubGrainKeepAliveTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/MessageHubGrainKeepAliveTest.cs
@@ -1,0 +1,44 @@
+using System;
+using MeshWeaver.Hosting.Orleans;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Pins the bounded grain keep-alive decision (issue #147). A hung long-running operation — an AI stream
+/// with no timeout — must NOT extend the grain lifetime forever: doing so pinned the thread grain in
+/// memory (1376-message backlog, 1h+ wedge, recovery only via pod restart) because the 1-minute keep-alive
+/// timer re-armed <c>DelayDeactivation</c> indefinitely while <c>_activeOperations &gt; 0</c>.
+/// <see cref="MessageHubGrain.LongRunningOperationCapExceeded"/> is the pure predicate the timer uses to
+/// STOP re-arming (and request deactivation) once the active run exceeds the cap, so Orleans idle-collects
+/// the grain and <c>executionCts.Cancel()</c> (RegisterForDisposal) tears down the stuck call.
+/// </summary>
+public class MessageHubGrainKeepAliveTest
+{
+    private static readonly long Max = TimeSpan.FromMinutes(30).Ticks;
+
+    [Fact]
+    public void NoActiveRun_NeverExpires()
+        // startedTicks == 0 means no long-running run is active (or the clock was cleared on →0) — never
+        // capped, even at an arbitrarily-far "now".
+        => Assert.False(MessageHubGrain.LongRunningOperationCapExceeded(
+            startedTicks: 0, nowTicks: TimeSpan.FromHours(10).Ticks, maxDurationTicks: Max));
+
+    [Fact]
+    public void FreshRun_NotExpired()
+        => Assert.False(MessageHubGrain.LongRunningOperationCapExceeded(
+            startedTicks: 1000, nowTicks: 1000 + TimeSpan.FromMinutes(29).Ticks, maxDurationTicks: Max));
+
+    [Fact]
+    public void ExactlyAtCap_NotYetExpired()
+        // Strictly-greater-than boundary — exactly at the cap is not yet expired.
+        => Assert.False(MessageHubGrain.LongRunningOperationCapExceeded(
+            startedTicks: 1000, nowTicks: 1000 + Max, maxDurationTicks: Max));
+
+    [Fact]
+    public void RunPastCap_Expired()
+        // The #147 hung stream: active past 30 min → capped → the timer stops extending and calls
+        // DeactivateOnIdle so the grain can recover.
+        => Assert.True(MessageHubGrain.LongRunningOperationCapExceeded(
+            startedTicks: 1000, nowTicks: 1000 + TimeSpan.FromMinutes(31).Ticks, maxDurationTicks: Max));
+}


### PR DESCRIPTION
Addresses #147 (the permanent-wedge core).

## The wedge

A thread grain wedged **permanently** — `NonReentrancyQueueSize: 1376`, `IdlenessTimeSpan: 01:07:53`, recovery only via pod restart. The round's durable DB state was already terminal, but the grain stayed pinned in memory.

## Root cause

An AI streaming round has **no timeout** (`ThreadExecution` line 1620: *"No time-limit watchdog"*). While it runs it holds `_activeOperations > 0` via `BeginLongRunningOperation`, and the 1-minute keep-alive timer re-arms `DelayDeactivation(10min)` **indefinitely** while that counter is positive. So a hung LLM endpoint pins the grain forever → the grain never idle-collects → `executionCts.Cancel()` (wired on hub disposal via `RegisterForDisposal`) **never fires** → the stuck AI call is never cancelled. A circular dependency with no exit.

## Fix — bound the keep-alive (issue's Fix 1)

- Stamp when the active-operation **run** begins (`0→1`) and clear on `→0`.
- The keep-alive timer stops re-arming `DelayDeactivation` once the run exceeds **`MaxLongRunningOperationDuration` (30 min)** and calls **`DeactivateOnIdle()`**.
- On deactivation → hub disposes → `RegisterForDisposal` fires `executionCts.Cancel()` → the hung call is torn down → the round faults gracefully to the output cell (wedges-to-zero) instead of pinning the grain.
- 30 min is generous: legit rounds — including nested delegation trees where a parent holds its slot while a sub-thread works — complete well within it; only a genuinely-hung endpoint exceeds it.

The cap decision is extracted as the pure, unit-tested **`LongRunningOperationCapExceeded`** (no cluster / no 30-min wall clock needed).

## Test

`MessageHubGrainKeepAliveTest` (4): no active run never expires; fresh run and exactly-at-cap not expired; past-cap expired. `MeshWeaver.Hosting.Orleans` builds clean.

## Follow-ups (tracked on #147, not required to break the wedge)
An **idle-based** streaming timeout (finer than the 30-min backstop) and an **admin/MCP force-deactivate-by-path** for instant recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)