### PR TITLE
feat(mesh): Memex.LocalMesh — headless local mesh host (monolith runtime + SQLite + gRPC)

### DIFF
--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -26,6 +26,7 @@
   <Folder Name="/memex/">
     <Project Path="memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj" />
     <Project Path="memex/Memex.Portal.Monolith/Memex.Portal.Monolith.csproj" />
+    <Project Path="memex/Memex.LocalMesh/Memex.LocalMesh.csproj" />
   </Folder>
   <Folder Name="/memex/aspire/">
     <Project Path="memex/aspire/Memex.AppHost/Memex.AppHost.csproj" />

--- a/memex/Memex.LocalMesh/Memex.LocalMesh.csproj
+++ b/memex/Memex.LocalMesh/Memex.LocalMesh.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The in-process (monolith) mesh + SQLite persistence — the same local-first stack the MAUI client
+         runs in-process, here as a headless host so a JS client (React Native / web) can reach it over gRPC. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Sqlite\MeshWeaver.Hosting.Sqlite.csproj" />
+    <!-- The gRPC bridge (bidi Open + gRPC-web Connect/Deliver split) the foreign-language clients use. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Grpc\MeshWeaver.Hosting.Grpc.csproj" />
+    <!-- Node types + content to render: Graph (sample data + node types) and the embedded Documentation. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Documentation\MeshWeaver.Documentation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/memex/Memex.LocalMesh/Program.cs
+++ b/memex/Memex.LocalMesh/Program.cs
@@ -1,0 +1,47 @@
+using MeshWeaver.Documentation;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Grpc;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Sqlite;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+
+// Headless local mesh host: the in-process ("monolith") mesh backed by SQLite, exposed over gRPC. This is
+// the JS-world counterpart of the MAUI client's in-process mesh — MAUI embeds the mesh in the C# app; a
+// React Native / web client is JavaScript, so the mesh runs here as a local sidecar and the client reaches
+// it over the gRPC bridge (bidi Open for Node/.NET, the gRPC-web Connect+Deliver split for browser/RN).
+// NOT the Blazor portal (Memex.Portal.Monolith): no AspNetCore UI, just the mesh + gRPC.
+
+var builder = WebApplication.CreateBuilder(args);
+
+// One cleartext port serving both gRPC transports: HTTP/2 (h2c) for the bidi Open, HTTP/1.1 for gRPC-web.
+// Local sidecar → no TLS; the client points at http://localhost:<port>.
+var port = builder.Configuration.GetValue("Grpc:Port", 5250);
+builder.WebHost.ConfigureKestrel(k =>
+    k.ListenLocalhost(port, l => l.Protocols = HttpProtocols.Http1AndHttp2));
+
+// SQLite file under the OS local-app-data (same shape as the MAUI client's memex-local.db).
+var dbPath = builder.Configuration["Sqlite:Path"]
+    ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Memex", "memex-local.db");
+Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+
+builder.UseMeshWeaver(
+    AddressExtensions.CreateMeshAddress("local"),
+    mesh => mesh
+        .AddPartitionedSqlitePersistence($"Data Source={dbPath}")
+        .AddGraph()          // node types + graph
+        .AddDocumentation()  // the embedded "Doc" partition — real layout areas the client can render
+        .AddGrpcHub()        // py/node stream-routed address types + the gRPC services
+        .UseMonolithMesh()); // in-process single-silo runtime (NOT Orleans)
+
+var app = builder.Build();
+
+app.UseMeshWeaverGrpcWeb();     // browser / React-Native gRPC-web (Connect + Deliver)
+app.MapMeshWeaverGrpc();        // the mesh gRPC service (Open + Connect + Deliver)
+app.MapGet("/", () => Results.Text(
+    $"MeshWeaver local mesh — monolith runtime, SQLite at {dbPath}. gRPC on this endpoint " +
+    $"(http/2 bidi + gRPC-web). Point a client at http://localhost:{port}."));
+
+app.Run();

--- a/memex/Memex.LocalMesh/appsettings.json
+++ b/memex/Memex.LocalMesh/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Grpc": {
+    "Port": 5250
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "MeshWeaver": "Information"
+    }
+  }
+}


### PR DESCRIPTION
## What

You asked for a **new project** — a React Native client **packaged with SQLite + the monolith *mesh*** (not the Monolith *project*), following how MAUI does it. This is the first piece: the **backend**.

`Memex.LocalMesh` is the in-process ("monolith") mesh backed by **SQLite**, exposed over the **gRPC bridge** — the JS-world counterpart of the MAUI client's in-process mesh. MAUI embeds the mesh in the C# app (`UseMonolithMesh` + `AddPartitionedSqlitePersistence`); a React Native / web client is JavaScript, so the mesh runs here as a **local sidecar** and the client reaches it over gRPC.

**Not** the Blazor portal (`Memex.Portal.Monolith`) — no AspNetCore UI, just mesh + gRPC:
- WebApplication + Kestrel on one cleartext port (`Http1AndHttp2`): HTTP/2 for the bidi `Open`, HTTP/1.1 for gRPC-web.
- `UseMeshWeaver(local)` → `AddPartitionedSqlitePersistence(memex-local.db)` → `AddGraph` → `AddDocumentation` (the embedded `Doc` partition = real layout areas to render) → `AddGrpcHub` → `UseMonolithMesh`.
- `UseMeshWeaverGrpcWeb()` + `MapMeshWeaverGrpc()`.

## Verification

**Builds, and runs:**
```
Now listening on: http://localhost:5250
```
Root endpoint reports the SQLite path + gRPC. The .NET solution CI compiles it (it's in the slnx).

```bash
dotnet run --project memex/Memex.LocalMesh   # → gRPC mesh on http://localhost:5250, SQLite persistence
```

## Next (follow-ups)

1. Wire the RN client's **live mode** at `http://localhost:5250` (+ the RN streaming-`fetch` polyfill) so it renders real layout areas from this local SQLite mesh.
2. A **"run both together"** packaging step (the RN app + this sidecar).
3. RLS is off for now (local single-user dev); add it + a device-user identity when auth is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)