### PR TITLE
feat(home): restore the "Welcome back" heading to the top of the user home

### DIFF
--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -204,14 +204,17 @@ public static class UserActivityLayoutAreas
     }
 
     /// <summary>
-    /// The default home page shown until the owner authors their own <see cref="User.Body"/> — the chat
-    /// composer on top (start a thread right away), then the home regions embedded as <c>@@("area/…")</c>
-    /// blocks (the same mechanism as the Space welcome's <c>@@("area/Search")</c>), and a small
-    /// "it's configurable" note at the bottom linking to the config guide. This is the single source of
-    /// truth for "the default", shared by the render path and the unit tests.
+    /// The default home page shown until the owner authors their own <see cref="User.Body"/> — a
+    /// "Welcome back" heading on top, then the chat composer (start a thread right away) and the home
+    /// regions embedded as <c>@@("area/…")</c> blocks (the same mechanism as the Space welcome's
+    /// <c>@@("area/Search")</c>), and a small "it's configurable" note at the bottom linking to the
+    /// config guide. This is the single source of truth for "the default", shared by the render path
+    /// and the unit tests.
     /// </summary>
     internal static string UserWelcomeMarkdown(string ownerName) =>
         $$"""
+        ### Welcome back, {{ownerName}}
+
         @@("area/Composer")
 
         @@("area/Pinned")
@@ -220,7 +223,7 @@ public static class UserActivityLayoutAreas
 
         @@("area/Catalog")
 
-        _Welcome back, {{ownerName}} — this home is yours to shape. [It's fully configurable]({{ConfigGuideLink}}): tell the assistant in the chat above what you'd like to see, or edit this page's **Body** directly._
+        _This home is yours to shape. [It's fully configurable]({{ConfigGuideLink}}): tell the assistant in the chat above what you'd like to see, or edit this page's **Body** directly._
         """;
 
     // ── Home region areas ────────────────────────────────────────────────────────────────────────

--- a/test/MeshWeaver.Graph.Test/UserActivityHomeOverrideTest.cs
+++ b/test/MeshWeaver.Graph.Test/UserActivityHomeOverrideTest.cs
@@ -36,25 +36,29 @@ public class UserActivityHomeOverrideTest
     }
 
     [Fact]
-    public void OwnerHome_WelcomeTemplate_EmbedsRegions_ComposerOnTop_TextAtBottom()
+    public void OwnerHome_WelcomeTemplate_HeadingOnTop_ComposerThenRegions_TextAtBottom()
     {
         var md = UserActivityLayoutAreas.UserWelcomeMarkdown("Roland");
 
+        md.Should().Contain("### Welcome back, Roland");
         md.Should().Contain("@@(\"area/Composer\")");
         md.Should().Contain("@@(\"area/Pinned\")");
         md.Should().Contain("@@(\"area/Threads\")");
         md.Should().Contain("@@(\"area/Catalog\")");
 
+        var welcome = md.IndexOf("Welcome back", StringComparison.Ordinal);
         var composer = md.IndexOf("area/Composer", StringComparison.Ordinal);
         var pinned = md.IndexOf("area/Pinned", StringComparison.Ordinal);
         var threads = md.IndexOf("area/Threads", StringComparison.Ordinal);
         var configurable = md.IndexOf("configurable", StringComparison.Ordinal);
 
-        // Chat composer on top — before every region.
-        composer.Should().BeLessThan(pinned, "the chat composer must be at the top of the home page");
+        // The welcome heading is back at the very top — above the chat composer.
+        welcome.Should().BeLessThan(composer, "the welcome heading must be at the top of the home page");
+        // Chat composer above the regions.
+        composer.Should().BeLessThan(pinned, "the chat composer sits above the regions");
         // Regions keep pinned-then-threads order.
         pinned.Should().BeLessThan(threads);
-        // The configurable welcome note sits at the BOTTOM — after the regions.
+        // The configurable note sits at the BOTTOM — after the regions (the only "configurable" text).
         configurable.Should().BeGreaterThan(threads, "the configurable text must be at the bottom of the page");
     }
 


### PR DESCRIPTION
The user home default template (`UserWelcomeMarkdown`) had the greeting only in the bottom "it's configurable" note. This brings the **welcome back as a heading at the top** (above the chat composer) and leaves just the config text at the bottom.

```diff
+     ### Welcome back, {ownerName}
+
      @@("area/Composer")
      @@("area/Pinned")
      @@("area/Threads")
      @@("area/Catalog")

-     _Welcome back, {ownerName} — this home is yours to shape. [It's fully configurable](…): …_
+     _This home is yours to shape. [It's fully configurable](…): …_
```

- `UserWelcomeMarkdown`: add `### Welcome back, {ownerName}` on top; drop the duplicated greeting from the bottom note (+ doc comment).
- `UserActivityHomeOverrideTest`: assert the heading precedes the composer and the config text stays at the bottom.

## Verification
- `Release -warnaserror` build clean (0/0).
- `UserActivityHomeOverrideTest`: 11/11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)