### PR TITLE
fix(react): pin the live layout-area protocol (verified against Memex.LocalMesh)

### DIFF
--- a/clients/react/src/live/grpcSource.ts
+++ b/clients/react/src/live/grpcSource.ts
@@ -58,7 +58,11 @@ export class GrpcAreaSource implements AreaSource {
   /** Open the area subscription and fold every change into the tree until the stream ends. */
   async start(): Promise<void> {
     for await (const delivery of this.connection.watch(this.address, this.streamId, "SubscribeRequest", {
-      reference: this.reference,
+      // The sync-stream Reference is a polymorphic WorkspaceReference — it MUST carry its $type
+      // discriminator or the mesh can't deserialize it. Verified against Memex.LocalMesh: a $type-less
+      // reference elicits no subscription; with "LayoutAreaReference" the area streams back. Field casing
+      // is server-insensitive, so the lowercase { area, id, layout } passes through.
+      reference: { $type: "LayoutAreaReference", ...this.reference },
     })) {
       this.applyChange(delivery.message);
     }
@@ -66,11 +70,17 @@ export class GrpcAreaSource implements AreaSource {
 
   private applyChange(message: Record<string, unknown>): void {
     const raw = (message.change ?? message.Change) as Json;
-    const change = typeof raw === "string" ? JSON.parse(raw) : raw;
-    if (change == null) return;
-    const changeType = String(message.changeType ?? message.ChangeType ?? "Patch");
-    // Full (or the enum's 0) replaces the snapshot; everything else is an RFC 7396 merge-patch.
-    this.state = changeType === "Full" || changeType === "0" ? change : mergePatch(this.state, change);
+    const wrapper = typeof raw === "string" ? JSON.parse(raw) : raw;
+    if (wrapper == null) return;
+    // Verified against Memex.LocalMesh: DataChangedEvent.Change wraps the EntityStore JSON as
+    // { Content: "<entitystore json>" }. The EntityStore IS { areas, data } — exactly the tree the
+    // renderer consumes (its $type is ignored). ChangeType 0 = Full (replace); anything else = RFC 7396 patch.
+    const w = wrapper as Record<string, unknown>;
+    const content = w.Content ?? w.content;
+    const store = (typeof content === "string" ? JSON.parse(content) : content ?? wrapper) as Json;
+    if (store == null) return;
+    const changeType = String(message.changeType ?? message.ChangeType ?? "1");
+    this.state = changeType === "Full" || changeType === "0" ? (store as AreaTree) : mergePatch(this.state, store);
     this.notify();
   }
 


### PR DESCRIPTION
## What

`GrpcAreaSource` (the renderer's live data plane) had `WIRE:`-guessed subscribe/change handling. I **verified the real protocol against a running mesh** — the new `Memex.LocalMesh` (monolith runtime + SQLite + gRPC, PR #154) — by subscribing to a Doc area over gRPC-web and capturing exactly what the mesh sends:

- **Reference is polymorphic** — it must carry its `$type`. A `$type`-less reference elicited **no subscription**; `{ $type: "LayoutAreaReference", area }` streams the area back. (Field casing is server-insensitive.)
- **`DataChangedEvent.Change` wraps the EntityStore** as `{ Content: "<store json>" }`; the EntityStore *is* `{ areas, data }` — the exact tree the renderer consumes. The old code treated the wrapper as the tree, so nothing rendered.
- **`ChangeType` `0` = Full** (replace); anything else = RFC 7396 merge-patch.

Captured live (Doc/Architecture, area "Overview"): first a `"Building layout..."` progress store, then a Full store whose `Overview` area is a `StackControl` of `NamedAreaControl` children — the real doc control tree the renderer already knows how to render.

## Verification

react suite green (11 tests), typecheck clean. This turns the client's `WIRE:` guesses into a protocol **verified against a live mesh**, and unblocks the RN/web client rendering real layout areas.

## Depends on / relates to
- **#154** — `Memex.LocalMesh` (the local mesh this was verified against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)