### PR TITLE
fix(chat): composer autocomplete, tool-call collapse, streaming scroll, chip preview modal

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ChatMessageList.razor.js
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ChatMessageList.razor.js
@@ -100,7 +100,7 @@ window.customElements.define('chat-messages', class ChatMessages extends HTMLEle
 
             const elem = this.lastElementChild;
             if (this._isFirstAutoScroll || addedUserMessage || (hasTextUpdates && this._isNearScrollBoundary(300))) {
-                elem.scrollIntoView({ behavior: this._isFirstAutoScroll ? 'instant' : 'smooth' });
+                elem.scrollIntoView({ behavior: this._isFirstAutoScroll ? 'auto' : 'smooth' });
                 this._isFirstAutoScroll = false;
             }
         });

--- a/src/MeshWeaver.Blazor.Portal/Chat/ChatMessageList.razor.js
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ChatMessageList.razor.js
@@ -2,9 +2,12 @@
 // If you don't want that behavior, you can simply not load this module.
 
 window.customElements.define('chat-messages', class ChatMessages extends HTMLElement {
-    static _isFirstAutoScroll = true;
-
     connectedCallback() {
+        // Per-INSTANCE (not static): a static field is shared across every <chat-messages> on the
+        // page, so with two threads open the first scroll in either steals the other's initial
+        // scroll-to-bottom. Each element tracks its own first-scroll flag.
+        this._isFirstAutoScroll = true;
+
         this._observer = new MutationObserver(mutations => this._scheduleAutoScroll(mutations));
         this._observer.observe(this, {
             childList: true,
@@ -17,7 +20,6 @@ window.customElements.define('chat-messages', class ChatMessages extends HTMLEle
         // Track the in-progress state to detect when chat ends
         const inProgressAttr = this.getAttribute('in-progress');
         this._previousInProgressState = inProgressAttr === 'true' || (this.hasAttribute('in-progress') && inProgressAttr !== 'false');
-        console.log('Initial in-progress state:', this._previousInProgressState, 'attr:', inProgressAttr);
     }
 
     disconnectedCallback() {
@@ -34,18 +36,14 @@ window.customElements.define('chat-messages', class ChatMessages extends HTMLEle
             const inProgressAttr = this.getAttribute('in-progress');
             const isInProgress = inProgressAttr === 'true' || (this.hasAttribute('in-progress') && inProgressAttr !== 'false');
 
-            console.log('Auto-scroll check - in-progress attr:', inProgressAttr, 'isInProgress:', isInProgress, 'previous:', this._previousInProgressState);
-
             // Check if chat just ended (in-progress changed from true to false)
             const chatJustEnded = this._previousInProgressState && !isInProgress;
             if (chatJustEnded) {
-                console.log('Chat just ended! Scrolling to bottom');
                 this._previousInProgressState = isInProgress;
                 // Always scroll to bottom when chat ends
                 const elem = this.lastElementChild;
                 if (elem) {
                     elem.scrollIntoView({ behavior: 'smooth' });
-                    console.log('Scrolled to bottom after chat completion');
                 }
                 return;
             }
@@ -55,14 +53,12 @@ window.customElements.define('chat-messages', class ChatMessages extends HTMLEle
                 if (m.type === 'attributes' && m.attributeName === 'in-progress') {
                     const oldValue = m.oldValue;
                     const newValue = this.getAttribute('in-progress');
-                    console.log('in-progress attribute changed from', oldValue, 'to', newValue);
 
                     // Chat ended if it went from having the attribute to not having it, or from 'true' to 'false'
                     const wasInProgress = oldValue === 'true' || (oldValue !== null && oldValue !== 'false');
                     const nowInProgress = newValue === 'true' || (newValue !== null && newValue !== 'false');
 
                     if (wasInProgress && !nowInProgress) {
-                        console.log('Detected chat completion via attribute change');
                         return true;
                     }
                 }
@@ -70,7 +66,6 @@ window.customElements.define('chat-messages', class ChatMessages extends HTMLEle
             });
 
             if (hasInProgressChange) {
-                console.log('Chat completed - scrolling to bottom');
                 const elem = this.lastElementChild;
                 if (elem) {
                     elem.scrollIntoView({ behavior: 'smooth' });
@@ -104,17 +99,19 @@ window.customElements.define('chat-messages', class ChatMessages extends HTMLEle
             });
 
             const elem = this.lastElementChild;
-            if (ChatMessages._isFirstAutoScroll || addedUserMessage || (hasTextUpdates && this._elemIsNearScrollBoundary(elem, 300))) {
-                elem.scrollIntoView({ behavior: ChatMessages._isFirstAutoScroll ? 'instant' : 'smooth' });
-                ChatMessages._isFirstAutoScroll = false;
+            if (this._isFirstAutoScroll || addedUserMessage || (hasTextUpdates && this._isNearScrollBoundary(300))) {
+                elem.scrollIntoView({ behavior: this._isFirstAutoScroll ? 'instant' : 'smooth' });
+                this._isFirstAutoScroll = false;
             }
         });
     }
 
-    _elemIsNearScrollBoundary(elem, threshold) {
-        const maxScrollPos = document.body.scrollHeight - window.innerHeight;
-        const remainingScrollDistance = maxScrollPos - window.scrollY;
-        return remainingScrollDistance < elem.offsetHeight + threshold;
+    _isNearScrollBoundary(threshold) {
+        // Measure against THIS element's own scroll box (the chat container), not the page/body —
+        // window.scrollY / document.body.scrollHeight give the wrong axis when the container, not
+        // <body>, is the scroller.
+        const remainingScrollDistance = this.scrollHeight - this.scrollTop - this.clientHeight;
+        return remainingScrollDistance < threshold;
     }
 });
 

--- a/src/MeshWeaver.Blazor.Portal/Chat/NodePreviewDialog.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/NodePreviewDialog.razor
@@ -1,0 +1,27 @@
+@using MeshWeaver.Data
+@using MeshWeaver.Layout
+@using MeshWeaver.Blazor.Components
+@using Microsoft.FluentUI.AspNetCore.Components
+@implements IDialogContentComponent<string>
+
+@* #131 — modal preview of a referenced node, layered OVER the thread. Renders the node's own
+   default layout area (the same area its full page shows) so the user sees the full context
+   without leaving the conversation. Dismissing the dialog returns to the thread untouched. *@
+<div class="node-preview-dialog-body">
+    @if (viewModel is not null)
+    {
+        <LayoutAreaView ViewModel="@viewModel" Top="true" />
+    }
+</div>
+
+@code {
+    [Parameter] public string Content { get; set; } = null!;
+    [CascadingParameter] public FluentDialog Dialog { get; set; } = null!;
+
+    private LayoutAreaControl? viewModel;
+
+    // The node PATH is its mesh address; a null area reference selects the node's default view —
+    // exactly what ApplicationPage renders for "/{path}" with no area segment.
+    protected override void OnParametersSet()
+        => viewModel = new LayoutAreaControl(Content, new LayoutAreaReference((string?)null));
+}

--- a/src/MeshWeaver.Blazor.Portal/Chat/NodePreviewDialog.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/NodePreviewDialog.razor.css
@@ -1,0 +1,10 @@
+/* #131 node-preview modal body: give the embedded layout area a bounded, scrollable box so a
+   large node view (dashboards, long documents) stays within the dialog instead of overflowing. */
+.node-preview-dialog-body {
+    height: 80vh;
+    max-height: 80vh;
+    min-height: 0;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+}

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -399,6 +399,25 @@ else
                                     }
                                 </text>;
 
+                            @* Wrap the whole round's tool calls in a collapsible group so a long
+                               tool-call history collapses to a single summary line once complete and
+                               stops pushing the assistant's reply off-screen. Open while any call runs,
+                               or when the cell has no assistant text (tool-only — the user needs to see
+                               what was done); collapsed once complete with a reply present. *@
+                            var anyPending = state.ToolCalls.Any(c => c.Result is null);
+                            var failCount = state.ToolCalls.Count(c => !c.IsSuccess && c.Result is not null);
+                            var anyFailed = failCount > 0;
+                            var groupHasText = !string.IsNullOrWhiteSpace(state.Text);
+                            var groupOpen = anyPending || !groupHasText;
+                            var groupIcon = anyPending ? "↗" : (anyFailed ? "✗" : "✓");
+                            var groupLabel = anyFailed
+                                ? $"{state.ToolCalls.Count} tool calls ({failCount} failed)"
+                                : $"{state.ToolCalls.Count} tool calls";
+                            <details class="thread-msg-tool-group" open="@groupOpen">
+                            <summary class="thread-msg-tool-group-summary">
+                                <span class="thread-msg-tool-done @(anyFailed ? "thread-msg-tool-error" : "")">@groupIcon</span>
+                                @groupLabel
+                            </summary>
                             <div class="thread-msg-tool-calls">
                                 @foreach (var call in toolView.Visible)
                                 {
@@ -432,6 +451,7 @@ else
                                     }
                                 }
                             </div>
+                            </details>
                         }
                     }
                     </div>

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -16,6 +16,7 @@ using MeshWeaver.Messaging;
 using MeshWeaver.Reactive;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Configuration;
+using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -61,6 +62,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
 {
     [Inject] private INavigationService NavigationService { get; set; } = null!;
     [Inject] private SidePanelStateService SidePanelState { get; set; } = null!;
+    [Inject] private IDialogService DialogService { get; set; } = null!;
     [Inject] private IMeshService MeshQuery { get; set; } = null!;
     [Inject] private IChatCompletionOrchestrator CompletionOrchestrator { get; set; } = null!;
     [Inject] private IConfiguration Configuration { get; set; } = null!;
@@ -204,13 +206,10 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                     submissionHandler.OnResponseAppeared();
                     isCancelling = false;
                 }
-                // Force re-render and auto-scroll to bottom
-                InvokeAsync(async () =>
-                {
-                    StateHasChanged();
-                    await Task.Yield(); // Let render complete
-                    await ScrollToBottomAsync();
-                });
+                // Re-render. Auto-scroll is handled entirely by the JS MutationObserver attached in
+                // OnAfterRenderAsync (#128) — it fires post-paint on every DOM mutation, including
+                // streamed text, so no Task.Yield timing guess or explicit scroll call is needed here.
+                InvokeAsync(StateHasChanged);
             }
         }
     }
@@ -228,6 +227,9 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     // Input state
     private MonacoEditorView? monacoEditor;
     private ElementReference messagesContainer;
+    // #128 auto-scroll: the JS module + the per-container handle it returns (disposed on teardown).
+    private IJSObjectReference? _scrollModule;
+    private IJSObjectReference? _scrollHandle;
     private string? MessageText;
     private readonly bool isCreatingThread;
     private bool isCancelling;
@@ -1527,6 +1529,25 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
+
+        // #128 auto-scroll: attach the MutationObserver-based stick-to-bottom module to the message
+        // container once it exists. HideEmptyState omits the container (compact/dashboard mode), so
+        // guard on the module not yet being attached rather than firstRender alone — the container may
+        // first appear on a later render when a thread loads.
+        if (_scrollHandle is null && !_isDisposed && !ViewModel.HideEmptyState)
+        {
+            try
+            {
+                _scrollModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.js");
+                _scrollHandle = await _scrollModule.InvokeAsync<IJSObjectReference>("attach", messagesContainer);
+            }
+            catch (Exception ex) when (!_isDisposed)
+            {
+                Logger.LogDebug(ex, "[ThreadChat:{InstanceId}] Failed to attach auto-scroll module", _instanceId);
+            }
+        }
+
         if (_focusPickerOnRender && pendingPicker is not null)
         {
             _focusPickerOnRender = false;
@@ -1838,19 +1859,6 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         }
     }
 
-    private async Task ScrollToBottomAsync()
-    {
-        try
-        {
-            await JSRuntime.InvokeVoidAsync("eval",
-                "document.querySelector('.thread-chat-messages')?.scrollTo({top: 999999, behavior: 'smooth'})");
-        }
-        catch (Exception) when (!_isDisposed)
-        {
-            // Ignore JS interop failures
-        }
-    }
-
     private void CancelSubmission()
     {
         if (submissionHandler.IsInputEnabled || isCancelling)
@@ -2097,23 +2105,40 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         StateHasChanged();
     }
 
-    private void OnChipClicked(string path)
-    {
-        // Navigate to the referenced node
-        NavigationManager.NavigateTo($"/{path}");
-    }
+    // Both chip kinds — plain @-reference chips and the context chip — open the referenced node in a
+    // modal preview LAYERED OVER the thread (issue #131), never navigating the main view away or
+    // replacing the side-panel thread. The old behaviour (NavigateTo for @-chips, OpenWithContent for
+    // context chips) left the conversation with no way back.
+    private Task OnChipClicked(string path) => OpenNodePreviewAsync(path);
+
+    private Task OnContextChipClicked(string? path) => OpenNodePreviewAsync(path);
 
     /// <summary>
-    /// Click on a context chip (the hero header's chip + the composer's context chip) — peeks the
-    /// thread's starting-point ("main") node in the SIDE PANEL so the user can see the entire context
-    /// object WITHOUT leaving the conversation. Distinct from <see cref="OnChipClicked"/> (used by plain
-    /// @-reference chips), which navigates the main view.
+    /// Opens <paramref name="path"/> in a modal dialog on top of the thread so the user can inspect the
+    /// full node — its own default layout area, exactly as its page renders it — without leaving the
+    /// conversation. The thread stays mounted underneath; dismissing the dialog returns to it untouched.
     /// </summary>
-    private void OnContextChipClicked(string? path)
+    private async Task OpenNodePreviewAsync(string? path)
     {
         if (string.IsNullOrEmpty(path)) return;
-        SidePanelState.SetTitle(LastSegment(path));
-        SidePanelState.OpenWithContent(path);
+        var parameters = new DialogParameters<string>
+        {
+            Title = LastSegment(path),
+            PrimaryAction = string.Empty,   // no primary/confirm button — this is a read-only preview
+            SecondaryAction = "Close",
+            Width = "min(1100px, 90vw)",
+            TrapFocus = true,
+            Modal = true,
+            PreventScroll = true,
+        };
+        try
+        {
+            await DialogService.ShowDialogAsync<NodePreviewDialog, string>(path, parameters);
+        }
+        catch (Exception ex) when (!_isDisposed)
+        {
+            Logger.LogDebug(ex, "[ThreadChat:{InstanceId}] Failed to open node preview for {Path}", _instanceId, path);
+        }
     }
 
     // ─── Hero-header: inline title / description editing + Mark Done ───
@@ -2541,16 +2566,30 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         if (string.IsNullOrWhiteSpace(query) || !query.StartsWith("@"))
             return Observable.Return<IReadOnlyList<CompletionItem>>(Array.Empty<CompletionItem>());
 
-        var currentAddress = NavigationService.CurrentNamespace ?? initialContext ?? "";
+        // 🎯 Autocomplete context = the SPACE root, never a satellite. When viewing a thread at
+        // {space}/_Thread/abc, NavigationService.CurrentNamespace resolves to that FULL thread path;
+        // passed verbatim it points the orchestrator's Source A/B at the thread hub → a 2s per-source
+        // timeout and no space-level suggestions. NormalizeContextPath strips the satellite suffix
+        // (_Thread/_Activity/_Access/…) so the query targets the owning space.
+        var currentAddress = NormalizeContextPath(NavigationService.CurrentNamespace ?? initialContext ?? "");
 
         return Observable.Defer(() =>
         {
             SetCompletionsInflight(true);
+            var lastSnapshot = (IReadOnlyList<CompletionItem>)Array.Empty<CompletionItem>();
             return RunUnderCircuitUser(CompletionOrchestrator.GetCompletions(query, currentAddress)
                 .SelectMany(batch => batch.Items
                     .Select(item => AutocompleteToCompletion(item, batch.Category, batch.CategoryPriority)))
                 .ScanTopN(CompletionTopN, CompletionBySortKey)
                 .DistinctUntilChanged(SnapshotKey)
+                .Do(snapshot => lastSnapshot = snapshot)
+                // When the search finishes with nothing, surface a single non-interactive "No results"
+                // row rather than an empty list (Monaco hides an empty suggest widget). This confirms to
+                // the user that the @ trigger DID fire and the search ran — distinguishing it from a
+                // suppressed trigger. Emitted only at completion, so real results never flash a placeholder.
+                .Concat(Observable.Defer(() => lastSnapshot.Count == 0
+                    ? Observable.Return(NoResultsPlaceholder(query))
+                    : Observable.Empty<IReadOnlyList<CompletionItem>>()))
                 .Catch<IReadOnlyList<CompletionItem>, Exception>(ex =>
                 {
                     Logger.LogError(ex, "Error streaming completions for query: {Query}", query);
@@ -2559,6 +2598,27 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 .Finally(() => SetCompletionsInflight(false)));
         });
     }
+
+    /// <summary>
+    /// A single non-interactive placeholder row shown when an @-query returns no matches.
+    /// <c>filterText</c> resolves to the query (MonacoEditorView.razor.js sets filterText ← insertText),
+    /// so Monaco does not fuzzy-filter it away; <c>InsertText</c> = the query makes accidental acceptance
+    /// a no-op (the typed text is left untouched), and the empty <c>Path</c> makes
+    /// <see cref="OnCompletionItemAccepted"/> return early without adding a chip.
+    /// </summary>
+    private static IReadOnlyList<CompletionItem> NoResultsPlaceholder(string query) =>
+        new[]
+        {
+            new CompletionItem
+            {
+                Label = $"No results for '{query}'",
+                InsertText = query,
+                Path = string.Empty,
+                Kind = CompletionItemKind.Text,
+                Category = "No results",
+                SortKey = "9999_noresults",
+            }
+        };
 
     /// <summary>
     /// Slash-skill completions: lists <c>nodeType:Skill</c> nodes (built-ins imported to PG plus any
@@ -3224,7 +3284,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     /// per-message / missing-probe / delegation streams), clears the tracking dictionaries, and unhooks
     /// the side-panel action handler before delegating to the base implementation.
     /// </summary>
-    public override ValueTask DisposeAsync()
+    public override async ValueTask DisposeAsync()
     {
         if (!_isDisposed)
         {
@@ -3252,8 +3312,24 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             delegationSubs.Clear();
             delegationHeaders.Clear();
             SidePanelState.OnActionRequested -= OnSidePanelAction;
+
+            // #128: tear down the JS auto-scroll observer, then release the interop references.
+            // On a full circuit teardown the JS side is already gone (JSDisconnectedException) —
+            // that is expected and needs no cleanup.
+            try
+            {
+                if (_scrollHandle is not null)
+                {
+                    await _scrollHandle.InvokeVoidAsync("dispose");
+                    await _scrollHandle.DisposeAsync();
+                }
+                if (_scrollModule is not null)
+                    await _scrollModule.DisposeAsync();
+            }
+            catch (JSDisconnectedException) { /* circuit already gone — nothing to tear down */ }
+            catch (Exception) { /* best-effort cleanup on teardown */ }
         }
 
-        return base.DisposeAsync();
+        await base.DisposeAsync();
     }
 }

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
@@ -1164,6 +1164,25 @@
 
 .thread-msg-tool-error { color: var(--error-foreground-rest, #d93636); }
 
+/* Collapsible group wrapping a whole round's tool calls — one summary line that
+   folds the entire block away once the round is complete (see #129). */
+.thread-msg-tool-group > summary.thread-msg-tool-group-summary {
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.35em;
+    font-size: 0.82em;
+    opacity: 0.75;
+    padding: 2px 0;
+    user-select: none;
+}
+
+.thread-msg-tool-group > summary.thread-msg-tool-group-summary::-webkit-details-marker { display: none; }
+.thread-msg-tool-group > summary.thread-msg-tool-group-summary::marker { content: ''; }
+
+.thread-msg-tool-group[open] > summary.thread-msg-tool-group-summary { opacity: 1; }
+
 .thread-msg-tool-path,
 .thread-msg-tool-action {
     color: var(--accent-fill-rest);

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.js
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.js
@@ -1,0 +1,52 @@
+// Auto-scroll for the thread chat message list.
+//
+// Root-cause fix for #128: the old C# path scrolled via a Task.Yield() timing guess + an
+// eval() querySelector, and only fired on message-COUNT changes — so it ran before the browser
+// had painted the new height (undershoot) and never followed streamed text as it arrived.
+//
+// This module observes the ACTUAL scroll container and reacts to EVERY DOM mutation (new nodes
+// AND streamed character data), scheduling the scroll inside requestAnimationFrame — the browser's
+// native post-paint callback, so the height is always current when we scroll. It is class-agnostic
+// (no dependency on per-bubble class names) and "sticks to bottom" only while the user is already
+// near the bottom, so scrolling up to read history is never yanked back down.
+
+export function attach(container) {
+    if (!container)
+        return null;
+
+    // px from the bottom within which we consider the user "following" the conversation.
+    const STICK_THRESHOLD = 120;
+
+    let raf = 0;
+    let stick = true;
+
+    const distanceFromBottom = () =>
+        container.scrollHeight - container.scrollTop - container.clientHeight;
+
+    const toBottom = () => { container.scrollTop = container.scrollHeight; };
+
+    // The user's own scrolling decides whether we keep following. Scrolling up to read history
+    // releases the stick; scrolling back near the bottom re-engages it.
+    const onScroll = () => { stick = distanceFromBottom() <= STICK_THRESHOLD; };
+    container.addEventListener('scroll', onScroll, { passive: true });
+
+    const observer = new MutationObserver(() => {
+        cancelAnimationFrame(raf);
+        raf = requestAnimationFrame(() => {
+            if (stick)
+                toBottom();
+        });
+    });
+    observer.observe(container, { childList: true, subtree: true, characterData: true });
+
+    // Snap to the bottom once on attach so an opened thread starts at the latest message.
+    requestAnimationFrame(toBottom);
+
+    return {
+        dispose: () => {
+            cancelAnimationFrame(raf);
+            observer.disconnect();
+            container.removeEventListener('scroll', onScroll);
+        }
+    };
+}

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -569,11 +569,14 @@ export function registerCompletionProvider(editorId, config) {
                     // that wrongly suppressed the trigger after legitimate word boundaries that are not
                     // whitespace — punctuation like ',', '.', ':', '!', '(' or a non-ASCII letter — so
                     // "Check @AgenticPension," followed by "@" (or "see.@Fund", "(@Fund") now triggers.
+                    // The boundary excludes a preceding '\w' (email "foo@bar") AND a preceding '/' — the
+                    // latter keeps the old intent of NOT re-opening a new @-reference INSIDE an existing
+                    // path token (e.g. "@/path/@content", where the second '@' follows a '/').
                     const atIndex = textUntilPosition.lastIndexOf(trigger);
                     if (atIndex >= 0) {
                         const afterTrigger = textUntilPosition.substring(atIndex + trigger.length);
                         const charBefore = atIndex > 0 ? textUntilPosition[atIndex - 1] : '';
-                        const onWordBoundary = atIndex === 0 || !/\w/.test(charBefore);
+                        const onWordBoundary = atIndex === 0 || !/[\w/]/.test(charBefore);
                         const withinToken = /^[\w\-\.\/:]*$/.test(afterTrigger);
                         if (onWordBoundary && withinToken) {
                             triggerMatch = [trigger + afterTrigger, afterTrigger];

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -549,30 +549,37 @@ export function registerCompletionProvider(editorId, config) {
 
                 // @ can be followed by paths with slashes: @agent/Name, @content/path/file
                 // / is only a trigger at word boundary (for commands like /agent)
-                // For @, require start-of-string or whitespace BEFORE the @ — this prevents
-                // "@/path/@content/..." from triggering a new @-reference inside an existing path.
-                let regex;
                 if (trigger === '/') {
-                    regex = new RegExp(`(?:^|\\s)${escapedTrigger}([\\w\\-\\.]+)?$`);
-                } else {
-                    regex = new RegExp(`(?:^|\\s|")${escapedTrigger}([\\w\\-\\./:]+)?$`);
-                }
-
-                const match = textUntilPosition.match(regex);
-                if (match) {
-                    if (trigger === '/') {
+                    const regex = new RegExp(`(?:^|\\s)${escapedTrigger}([\\w\\-\\.]+)?$`);
+                    const match = textUntilPosition.match(regex);
+                    if (match) {
                         // Adjust match to not include the leading space
                         const fullMatch = match[0];
                         const slashIndex = fullMatch.indexOf('/');
                         match[0] = fullMatch.substring(slashIndex);
-                    } else {
-                        // Adjust @ match to not include the leading space/quote
-                        const fullMatch = match[0];
-                        const atIndex = fullMatch.indexOf('@');
-                        match[0] = fullMatch.substring(atIndex);
+                        triggerMatch = match;
+                        break;
                     }
-                    triggerMatch = match;
-                    break;
+                } else {
+                    // @-reference trigger. Fire whenever the cursor is INSIDE an @-token being typed:
+                    // the most recent '@' before the cursor must (a) sit on a word boundary — i.e. NOT
+                    // immediately follow an alphanumeric/underscore, which would make it an email like
+                    // "foo@bar" — and (b) be followed only by valid path characters up to the cursor
+                    // (no whitespace / break). This replaces the old positive lookbehind (?:^|\s|")
+                    // that wrongly suppressed the trigger after legitimate word boundaries that are not
+                    // whitespace — punctuation like ',', '.', ':', '!', '(' or a non-ASCII letter — so
+                    // "Check @AgenticPension," followed by "@" (or "see.@Fund", "(@Fund") now triggers.
+                    const atIndex = textUntilPosition.lastIndexOf(trigger);
+                    if (atIndex >= 0) {
+                        const afterTrigger = textUntilPosition.substring(atIndex + trigger.length);
+                        const charBefore = atIndex > 0 ? textUntilPosition[atIndex - 1] : '';
+                        const onWordBoundary = atIndex === 0 || !/\w/.test(charBefore);
+                        const withinToken = /^[\w\-\.\/:]*$/.test(afterTrigger);
+                        if (onWordBoundary && withinToken) {
+                            triggerMatch = [trigger + afterTrigger, afterTrigger];
+                            break;
+                        }
+                    }
                 }
             }
 

--- a/src/MeshWeaver.Blazor/Components/ThreadMessageBubbleView.razor
+++ b/src/MeshWeaver.Blazor/Components/ThreadMessageBubbleView.razor
@@ -125,6 +125,24 @@
                 }
             </text>;
 
+        @* Collapsible group wrapping the whole round's tool calls — folds the block to a single
+           summary line once complete so it stops pushing the reply off-screen (see #129). Open while
+           any call runs, or when there's no assistant text (tool-only cell); collapsed once complete
+           with a reply present. *@
+        var anyPending = toolCalls!.Any(c => c.Result is null);
+        var failCount = toolCalls!.Count(c => !c.IsSuccess && c.Result is not null);
+        var anyFailed = failCount > 0;
+        var groupHasText = !string.IsNullOrWhiteSpace(messageText);
+        var groupOpen = anyPending || !groupHasText;
+        var groupIcon = anyPending ? "↗" : (anyFailed ? "✗" : "✓");
+        var groupLabel = anyFailed
+            ? $"{toolCalls!.Count} tool calls ({failCount} failed)"
+            : $"{toolCalls!.Count} tool calls";
+        <details class="thread-msg-tool-group" open="@groupOpen">
+        <summary class="thread-msg-tool-group-summary">
+            <span class="thread-msg-tool-done @(anyFailed ? "thread-msg-tool-error" : "")">@groupIcon</span>
+            @groupLabel
+        </summary>
         <div class="thread-msg-tool-calls">
             @foreach (var call in toolView.Visible)
             {
@@ -158,6 +176,7 @@
                 }
             }
         </div>
+        </details>
     }
 </div>
 
@@ -347,6 +366,23 @@
     fluent-stack-item:has(.thread-msg-is-executing) ~ fluent-stack-item .thread-msg-actions {
         display: none;
     }
+
+    /* Collapsible group wrapping a whole round's tool calls — one summary line that
+       folds the entire block away once the round is complete (see #129). */
+    .thread-msg-tool-group > summary.thread-msg-tool-group-summary {
+        cursor: pointer;
+        list-style: none;
+        display: flex;
+        align-items: center;
+        gap: 0.35em;
+        font-size: 0.82em;
+        opacity: 0.75;
+        padding: 2px 0;
+        user-select: none;
+    }
+    .thread-msg-tool-group > summary.thread-msg-tool-group-summary::-webkit-details-marker { display: none; }
+    .thread-msg-tool-group > summary.thread-msg-tool-group-summary::marker { content: ''; }
+    .thread-msg-tool-group[open] > summary.thread-msg-tool-group-summary { opacity: 1; }
 
     /* Tool calls — inline entries */
     .thread-msg-tool-calls {


### PR DESCRIPTION
Four independent AI-chat UI fixes. Closes #128, #129, #130, #131.

### #130 — `@` autocomplete in the composer
- **Trigger after punctuation** (`MonacoEditorView.razor.js`): replaced the strict positive lookbehind `(?:^|\s|")` with a word-boundary rule — the `@` trigger fires unless it immediately follows an alphanumeric/underscore (an email like `foo@bar`). Now fires after `,` `.` `:` `!` `(` and non-ASCII letters; still blocks emails and re-triggering inside an existing `@path`.
- **Empty-results feedback** (`ThreadChatView.GetCompletions`): emits a single non-interactive `No results for '@term'` row when an `@`-query completes empty (`filterText` = query so Monaco keeps it; empty `Path` so accepting is a no-op).
- **Namespace = space, not thread**: `CurrentNamespace` now runs through `NormalizeContextPath`, stripping the `_Thread`/satellite suffix so the orchestrator targets the owning space hub.
- Verified `MarkdownReferenceExtractor`'s path regex already covers hyphens/digits/underscores/colons — no gap.

### #129 — collapsible tool-call group
Wrapped the whole round's tool calls in an outer `<details class="thread-msg-tool-group">` in both render paths (`ThreadChatView.razor` + `ThreadMessageBubbleView.razor`), with a computed summary (`↗ / ✗ / ✓ N tool calls`), auto-collapsed once complete with a reply present.

### #128 — streaming auto-scroll
Removed the `Task.Yield()` + `eval`/`querySelector` band-aid. New `ThreadChatView.razor.js` attaches a `MutationObserver` + `requestAnimationFrame` stick-to-bottom module to the real `.thread-chat-messages` container — post-paint, follows streamed text, only sticks when near the bottom. Also fixed the three `ChatMessageList.razor.js` defects (per-instance first-scroll flag, removed `console.log`s, container-relative boundary check).

### #131 — chip opens node in a modal, not by navigating away
Both chip kinds now open the referenced node in a modal dialog (`NodePreviewDialog`) layered over the thread, rendering the node's own default layout area; dismiss returns to the conversation untouched. Replaces `NavigateTo` / side-panel `OpenWithContent`.

---
Built clean under the CI flags locally (`-c Release -p:CIRun=true -warnaserror`, 0 warnings). Visual behaviours (scroll, modal render, collapse) still merit a runtime/e2e pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
