### PR TITLE
fix: zombie portal hubs + side-panel chat-vanish (circuit-close disposal, watchdog teardown, direct thread render)

### DIFF
--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   react:
-    name: "@meshweaver/react (typecheck + test)"
+    name: "@meshweaver/react (typecheck + test + build)"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -27,7 +27,8 @@ jobs:
           node-version: 20
       - run: npm install --no-audit --no-fund
       - run: npm run typecheck
-      - run: npm test
+      - run: npm test # vitest: renderer core, control gallery, ThreadChat (live thread-node stream), Blazor-parity ratchet
+      - run: npm run build # the publishable lib (tsconfig.lib.json) must stay green, not just the test graph
 
   python-sdk:
     name: "meshweaver (Python test)"
@@ -71,7 +72,7 @@ jobs:
           node-version: 20
       - run: npm install --no-audit --no-fund
       - run: npm run typecheck # runs buf generate (from the canonical mesh.proto) then tsc
-      - run: npm test # vitest: envelope round-trip + in-memory Connect/Deliver correlation & demux
+      - run: npm test # vitest: envelope round-trip, in-memory Connect/Deliver correlation & demux, thread ops (startThread/submitMessage wire shapes)
 
   react-native:
     name: "RN connector (typecheck)"
@@ -98,7 +99,7 @@ jobs:
       - run: npx tsc --noEmit
 
   portal:
-    name: "Portal example (build)"
+    name: "Portal example (typecheck + build)"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -112,5 +113,11 @@ jobs:
       - name: Install renderer deps
         working-directory: clients/react
         run: npm install --no-audit --no-fund
+      # The live mode source-aliases @meshweaver/client-web (../grpc-web/src) — install its deps and
+      # generate src/gen so the portal's tsc + vite can follow the alias.
+      - name: Install + generate grpc-web client
+        working-directory: clients/grpc-web
+        run: npm install --no-audit --no-fund && npm run gen
       - run: npm install --no-audit --no-fund
+      - run: npx tsc --noEmit # vite build transpiles without type-checking — check types explicitly
       - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,4 @@ samples/Graph/Data/VUser/
 !.claude/skills/
 !.claude/skills/debug/
 !.claude/skills/release/
+memex/aspire/Memex.Portal.Distributed/wwwroot/app/

--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -170,9 +170,11 @@
     <Project Path="test/MeshWeaver.Autocomplete.Test/MeshWeaver.Autocomplete.Test.csproj" />
     <Project Path="test/MeshWeaver.Query.Test/MeshWeaver.Query.Test.csproj" />
     <Project Path="test/MeshWeaver.Reactive.Assertions.Test/MeshWeaver.Reactive.Assertions.Test.csproj" />
+    <Project Path="test/MeshWeaver.Portal.E2E.Test/MeshWeaver.Portal.E2E.Test.csproj" />
+    <Project Path="test/MeshWeaver.Serialization.Test/MeshWeaver.Serialization.Test.csproj" />
+    <Project Path="test/MeshWeaver.MemexTemplate.Test/MeshWeaver.MemexTemplate.Test.csproj" />
     <Project Path="test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj" />
   </Folder>
-  <Project Path="test/MeshWeaver.MemexTemplate.Test/MeshWeaver.MemexTemplate.Test.csproj" />
   <Folder Name="/tools/">
     <File Path="tools/generate-memex-template.cs" />
     <Project Path="tools/MeshWeaver.Cli/MeshWeaver.Cli.csproj" />

--- a/clients/grpc-web/src/index.ts
+++ b/clients/grpc-web/src/index.ts
@@ -24,3 +24,13 @@ export { Mesh, type MeshOptions } from "./mesh";
 export { MeshWebConnection, connect, type ConnectOptions } from "./connection";
 export { type Delivery } from "./envelope";
 export { type MeshNode } from "./types";
+export {
+  generateSpeakingId,
+  buildThreadNode,
+  createUserMessage,
+  buildSubmitPatch,
+  isOwnerlessThreadPath,
+  THREAD_PARTITION,
+  type StartThreadOptions,
+  type SubmitMessageOptions,
+} from "./threads";

--- a/clients/grpc-web/src/jsonPatch.ts
+++ b/clients/grpc-web/src/jsonPatch.ts
@@ -1,0 +1,99 @@
+// Minimal RFC 6902 JSON-patch application — the shape the mesh's sync streams deliver for
+// ChangeType.Patch (JsonSynchronizationStream.ToJsonPatch): an ARRAY of {op, path, value, from}.
+// Node streams (MeshNodeReference) patch at the ROOT of the node JSON (CreateSingleObjectPatch),
+// so segments are plain property names / array indices (RFC 6901-escaped).
+
+export type Json = unknown;
+
+export interface PatchOperation {
+  op: string;
+  path: string;
+  value?: Json;
+  from?: string;
+}
+
+function unescapeSegment(seg: string): string {
+  return seg.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+function splitPointer(pointer: string): string[] {
+  if (!pointer) return [];
+  return pointer.split("/").slice(1).map(unescapeSegment);
+}
+
+function getAt(root: Json, parts: string[]): Json {
+  let cur: Json = root;
+  for (const part of parts) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = Array.isArray(cur) ? cur[Number(part)] : (cur as Record<string, Json>)[part];
+  }
+  return cur;
+}
+
+/** Immutable set — RFC 6902 semantics: on arrays, `add` INSERTS at the index ("-" appends). */
+function setAt(root: Json, parts: string[], value: Json, insert: boolean): Json {
+  if (parts.length === 0) return value;
+  const [head, ...rest] = parts;
+  if (Array.isArray(root)) {
+    const clone = [...root];
+    const idx = head === "-" ? clone.length : Number(head);
+    if (rest.length === 0) {
+      if (insert) clone.splice(idx, 0, value);
+      else clone[idx] = value;
+    } else {
+      clone[idx] = setAt(clone[idx], rest, value, insert);
+    }
+    return clone;
+  }
+  const clone: Record<string, Json> = { ...((root ?? {}) as Record<string, Json>) };
+  clone[head] = rest.length === 0 ? value : setAt(clone[head], rest, value, insert);
+  return clone;
+}
+
+/** Immutable remove — splices arrays, deletes object properties; missing paths are tolerated. */
+function removeAt(root: Json, parts: string[]): Json {
+  if (parts.length === 0) return {};
+  if (root == null || typeof root !== "object") return root;
+  const [head, ...rest] = parts;
+  if (Array.isArray(root)) {
+    const clone = [...root];
+    const idx = Number(head);
+    if (rest.length === 0) clone.splice(idx, 1);
+    else clone[idx] = removeAt(clone[idx], rest);
+    return clone;
+  }
+  const clone: Record<string, Json> = { ...(root as Record<string, Json>) };
+  if (rest.length === 0) delete clone[head];
+  else clone[head] = removeAt(clone[head], rest);
+  return clone;
+}
+
+/** Apply an RFC 6902 patch array immutably ("test" and unknown ops are folding no-ops). */
+export function applyJsonPatch(state: Json, ops: PatchOperation[]): Json {
+  let next: Json = state;
+  for (const op of ops) {
+    const parts = splitPointer(op.path);
+    switch (op.op) {
+      case "add":
+      case "replace":
+        next = setAt(next, parts, op.value, op.op === "add");
+        break;
+      case "remove":
+        next = removeAt(next, parts);
+        break;
+      case "move": {
+        const from = splitPointer(op.from ?? "");
+        const moved = getAt(next, from);
+        next = removeAt(next, from);
+        next = setAt(next, parts, moved, true);
+        break;
+      }
+      case "copy":
+        next = setAt(next, parts, getAt(next, splitPointer(op.from ?? "")), true);
+        break;
+      default:
+        break;
+    }
+  }
+  return next;
+}

--- a/clients/grpc-web/src/mesh.ts
+++ b/clients/grpc-web/src/mesh.ts
@@ -6,8 +6,17 @@
 // underneath is already correct + tested.
 
 import { connect as connectTransport, MeshWebConnection, type ConnectOptions } from "./connection";
+import { applyJsonPatch, type PatchOperation } from "./jsonPatch";
 import { meshNodeFromChange, type MeshNode } from "./types";
 import { newId } from "./envelope";
+import {
+  buildSubmitPatch,
+  buildThreadNode,
+  createUserMessage,
+  isOwnerlessThreadPath,
+  type StartThreadOptions,
+  type SubmitMessageOptions,
+} from "./threads";
 
 export interface MeshOptions extends ConnectOptions {
   meshAddress?: string; // WIRE: confirm the portal's mesh-service address
@@ -25,6 +34,11 @@ export class Mesh {
   static async connect(url: string, opts: MeshOptions = {}): Promise<Mesh> {
     const conn = await connectTransport(url, opts);
     return new Mesh(conn, opts.meshAddress ?? "mesh/main");
+  }
+
+  /** Wrap an ALREADY-connected transport (e.g. the one a GrpcAreaSource renders from) in the ops surface. */
+  static from(connection: MeshWebConnection, meshAddress = "mesh/main"): Mesh {
+    return new Mesh(connection, meshAddress);
   }
 
   /** The underlying connection — pass to a GrpcAreaSource to render a live layout area. */
@@ -50,20 +64,49 @@ export class Mesh {
     throw new Error("stream closed before first state");
   }
 
-  /** Subscribe to a node's live state — yields on every change (Full, then merge-patches). */
+  /**
+   * Subscribe to a node's live state — yields on every change. Wire (pinned against the server
+   * source): SubscribeRequest's Reference is the POLYMORPHIC WorkspaceReference, for a node stream
+   * a MeshNodeReference(Path) — the `$type` discriminator is required. Changes arrive as
+   * DataChangedEvent: ChangeType "Full" carries the whole node JSON; "Patch" an RFC 6902 patch
+   * array at the node root (JsonSynchronizationStream.CreateSingleObjectPatch) — folded here.
+   */
   async *watch(path: string): AsyncIterableIterator<MeshNode> {
     const streamId = newId();
-    // WIRE: confirm the reference shape for a node path.
-    for await (const delivery of this.conn.watch(path, streamId, "SubscribeRequest", { reference: { path } })) {
-      yield meshNodeFromChange(delivery.message);
+    let node: Record<string, unknown> | null = null;
+    for await (const delivery of this.conn.watch(path, streamId, "SubscribeRequest", {
+      reference: { $type: "MeshNodeReference", path },
+    })) {
+      const m = delivery.message;
+      const rawChange = m["change"] ?? m["Change"];
+      if (rawChange === undefined) {
+        // Flat node fields on the message itself (in-memory fakes / legacy shapes).
+        yield meshNodeFromChange(m);
+        continue;
+      }
+      const change = typeof rawChange === "string" ? JSON.parse(rawChange) : rawChange;
+      const changeType = String(m["changeType"] ?? m["ChangeType"] ?? "Full");
+      if (change == null || changeType === "NoUpdate") continue;
+      node =
+        changeType === "Patch" || changeType === "1"
+          ? (applyJsonPatch(node ?? {}, change as PatchOperation[]) as Record<string, unknown>)
+          : (change as Record<string, unknown>);
+      yield meshNodeFromChange(node);
     }
   }
 
   // ---- writes (carry the caller's identity, server-stamped) -----------------
 
-  /** Field-level partial update (content deep-merges, RFC 7396) — the canonical mutation. */
+  /**
+   * Field-level partial update (content deep-merges, RFC 7396) — the canonical mutation. Wire:
+   * PatchDataRequest(WorkspaceReference Reference, RawJson Patch), targeted at the owning per-node
+   * hub (the path address) — the same JSON-merge request `GetMeshNodeStream(path).Update(...)` posts.
+   */
   patch(path: string, fields: Record<string, unknown>): void {
-    this.conn.post(path, "PatchDataRequest", { path, change: fields }); // WIRE: partial-update request type
+    this.conn.post(path, "PatchDataRequest", {
+      reference: { $type: "MeshNodeReference", path },
+      patch: fields,
+    });
   }
 
   /** Create a node (node-lifecycle on the mesh hub — routes, doesn't mutate). */
@@ -94,5 +137,58 @@ export class Mesh {
    */
   execute(path: string): void {
     this.patch(path, { requestedStatus: "Running" }); // WIRE: confirm the activity control-plane field
+  }
+
+  // ---- chat threads (the client twin of MeshWeaver.AI.HubThreadExtensions) --
+
+  /**
+   * Create a new chat thread under `namespacePath` with the first user message queued — the
+   * in-language port of `hub.StartThread(...)`: ONE CreateNodeRequest carrying the thread node
+   * pre-seeded with content.pendingUserMessages, targeted at the namespace's hub (node-lifecycle,
+   * not a mutation). The per-thread submission watcher dispatches the first round when the thread
+   * hub activates. Follow the round with `watch(path)` (the same stream the GUI binds).
+   *
+   * NOTE: the .NET portal additionally falls back to the user's own partition on an access denial —
+   * that is portal UX; the SDK surfaces the error to the caller instead.
+   */
+  async startThread(
+    namespacePath: string,
+    userText: string,
+    opts: StartThreadOptions = {},
+  ): Promise<{ path: string; userMessageId: string; node: Record<string, unknown> }> {
+    const { node, path, userMessageId } = buildThreadNode(namespacePath, userText, opts);
+    // Target the namespace address, exactly like hub.Post(CreateNodeRequest, o => o.WithTarget(new Address(ns))).
+    const resp = await this.conn.observe(namespacePath, "CreateNodeRequest", { node });
+    const success = (resp.message["success"] ?? resp.message["Success"]) as boolean | undefined;
+    if (success === false) {
+      const error = (resp.message["error"] ?? resp.message["Error"]) as string | undefined;
+      throw new Error(`Thread creation failed: ${error ?? "unknown"}`);
+    }
+    const created = (resp.message["node"] ?? resp.message["Node"]) as Record<string, unknown> | undefined;
+    return { path, userMessageId, node: created ?? node };
+  }
+
+  /**
+   * Queue a user message on an existing thread — the port of `hub.SubmitMessage(...)`: a JSON-merge
+   * patch adding the id to content.userMessageIds + the payload to content.pendingUserMessages (the
+   * client-side `stream.Update`; the owning hub serialises the patch). Resolves to the new message
+   * id, or null when there is nothing to submit (whitespace-only text — mirrors the .NET no-op).
+   *
+   * NOTE: userMessageIds is an ARRAY, and merge-patch replaces arrays wholesale — so this reads the
+   * thread first and sends the appended list. Unlike the .NET stream.Update (which diffs against the
+   * owner-fresh state), the read here can be momentarily stale under concurrent submitters.
+   */
+  async submitMessage(threadPath: string, userText: string, opts: SubmitMessageOptions = {}): Promise<string | null> {
+    if (!threadPath) throw new Error("submitMessage requires threadPath. Use startThread for new threads.");
+    if (isOwnerlessThreadPath(threadPath))
+      throw new Error(`submitMessage refused a top-level/ownerless threadPath: ${threadPath}`);
+    if (userText.trim().length === 0) return null; // nothing to submit — never enqueue an empty round
+
+    const current = await this.get(threadPath);
+    const currentIds = ((current.content["userMessageIds"] ?? current.content["UserMessageIds"]) as string[]) ?? [];
+    const msgId = newId().slice(0, 8);
+    const message = createUserMessage(userText, opts);
+    this.patch(threadPath, buildSubmitPatch(currentIds, msgId, message, opts));
+    return msgId;
   }
 }

--- a/clients/grpc-web/src/testTransport.ts
+++ b/clients/grpc-web/src/testTransport.ts
@@ -35,9 +35,16 @@ export class Pushable<T> {
   }
 }
 
+export interface FakeMeshOptions {
+  /** Observe every delivery the client sends — assert on fire-and-forget posts (e.g. PatchDataRequest). */
+  onDeliver?: (d: ReturnType<typeof parseDelivery>) => void;
+  /** Content the fake node-watch answers with (default `{ done: false }`). */
+  nodeContent?: Record<string, unknown>;
+}
+
 // Responses correlate by RequestId == the request delivery's id; live changes carry the streamId the
 // client demuxes on (both addressed back to the sender).
-export function fakeMeshTransport() {
+export function fakeMeshTransport(opts: FakeMeshOptions = {}) {
   const conns = new Map<string, Pushable<Frame>>();
   const respond = (out: Pushable<Frame>, d: ReturnType<typeof parseDelivery>, message: Record<string, unknown>) =>
     out.push(create(ServerFrameSchema, {
@@ -60,6 +67,7 @@ export function fakeMeshTransport() {
       async deliver(req) {
         const out = conns.get(req.connectionId);
         const d = parseDelivery(req.delivery);
+        opts.onDeliver?.(d);
         if (out) {
           const streamId = d.message.streamId as string | undefined;
           const reference = d.message.reference as { area?: string; path?: string } | undefined;
@@ -80,8 +88,9 @@ export function fakeMeshTransport() {
               break;
             case "SubscribeRequest":
               if (reference?.path) {
-                // A node watch — the change carries the node fields meshNodeFromChange reads.
-                push(out, d, { $type: "DataChangedEvent", streamId, path: reference.path, name: "Node", content: { done: false } });
+                // A node watch — wire-faithful DataChangedEvent: a Full change carrying the whole
+                // node JSON as raw inline JSON (RawJson serializes verbatim, not stringified).
+                push(out, d, { $type: "DataChangedEvent", streamId, changeType: "Full", change: { path: reference.path, name: "Node", content: opts.nodeContent ?? { done: false } } });
               } else {
                 // A layout-area watch — a Full snapshot in the `change` string.
                 push(out, d, { $type: "DataChangedEvent", streamId, changeType: "Full", change: JSON.stringify({ areas: { main: { $type: "LayoutStackControl" } } }) });

--- a/clients/grpc-web/src/threads.test.ts
+++ b/clients/grpc-web/src/threads.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { Mesh } from "./mesh";
+import { buildThreadNode, generateSpeakingId, isOwnerlessThreadPath } from "./threads";
+import { fakeMeshTransport } from "./testTransport";
+import type { Delivery } from "./envelope";
+
+// patch/post are fire-and-forget (the Deliver promise isn't surfaced) — wait on the actual
+// condition (the delivery arriving at the fake router), not a fixed sleep.
+async function until<T>(get: () => T | undefined, tries = 100): Promise<T> {
+  for (let i = 0; i < tries; i++) {
+    const v = get();
+    if (v !== undefined) return v;
+    await new Promise((r) => setTimeout(r, 1));
+  }
+  throw new Error("condition not met within the deadline");
+}
+
+// The chat-thread submission surface — the client twin of MeshWeaver.AI.HubThreadExtensions.
+// startThread must send ONE CreateNodeRequest with the seeded thread node (pendingUserMessages +
+// composer), targeted at the namespace hub; submitMessage must read the thread and send a JSON-merge
+// PatchDataRequest appending to userMessageIds + pendingUserMessages.
+describe("threads (pure helpers)", () => {
+  it("generateSpeakingId slugs the text and appends a unique suffix", () => {
+    const id = generateSpeakingId("Hello, can you help me with this?");
+    expect(id).toMatch(/^hello-can-you-help-me-with-this-[a-z0-9]{4}$/);
+  });
+
+  it("buildThreadNode anchors under {namespace}/_Thread and seeds the first message", () => {
+    const { node, path, userMessageId } = buildThreadNode("rbuergi/Notes", "Summarize my inbox", {
+      agentName: "Coder",
+      createdBy: "rbuergi",
+    });
+    expect(path).toMatch(/^rbuergi\/Notes\/_Thread\/summarize-my-inbox-[a-z0-9]{4}$/);
+    expect(node.nodeType).toBe("Thread");
+    expect(node.mainNode).toBe("rbuergi/Notes");
+    const content = node.content as Record<string, unknown>;
+    expect(content.userMessageIds).toEqual([userMessageId]);
+    expect(content.messages).toEqual([userMessageId]);
+    const pending = content.pendingUserMessages as Record<string, Record<string, unknown>>;
+    expect(pending[userMessageId].role).toBe("user");
+    expect(pending[userMessageId].text).toBe("Summarize my inbox");
+    expect(pending[userMessageId].status).toBe("Submitted");
+    // The composer is the single source of the round's selection.
+    expect((content.composer as Record<string, unknown>).agentName).toBe("Coder");
+  });
+
+  it("buildThreadNode does not nest _Thread for delegation sub-thread namespaces", () => {
+    const { path } = buildThreadNode("acme/_Thread/parent-1234/resp-1", "sub task");
+    expect(path).toMatch(/^acme\/_Thread\/parent-1234\/resp-1\/sub-task-[a-z0-9]{4}$/);
+  });
+
+  it("buildThreadNode fails fast on an ownerless namespace (no NotFound storm)", () => {
+    expect(() => buildThreadNode("", "hi")).toThrow(/namespacePath/);
+  });
+
+  it("buildThreadNode with whitespace-only text creates the thread but queues NO round", () => {
+    const { node } = buildThreadNode("rbuergi", "   ");
+    const content = node.content as Record<string, unknown>;
+    expect(content.pendingUserMessages).toBeUndefined();
+    expect(content.userMessageIds).toBeUndefined();
+  });
+
+  it("isOwnerlessThreadPath flags bare _Thread paths and accepts owned ones", () => {
+    expect(isOwnerlessThreadPath("_Thread/abcd-1234")).toBe(true);
+    expect(isOwnerlessThreadPath("")).toBe(true);
+    expect(isOwnerlessThreadPath("rbuergi/_Thread/abcd-1234")).toBe(false);
+  });
+});
+
+describe("Mesh thread ops (gRPC-web, in-memory)", () => {
+  it("startThread sends CreateNodeRequest to the namespace hub and resolves the thread path", async () => {
+    const sent: Delivery[] = [];
+    const mesh = await Mesh.connect("memory://", { transport: fakeMeshTransport({ onDeliver: (d) => sent.push(d) }) });
+    const { path, userMessageId } = await mesh.startThread("rbuergi", "Hello from RN", { agentName: "Coder" });
+
+    expect(path).toMatch(/^rbuergi\/_Thread\/hello-from-rn-[a-z0-9]{4}$/);
+    const create = sent.find((d) => d.messageType === "CreateNodeRequest")!;
+    expect(create.target).toBe("rbuergi"); // targeted at the namespace address, like the .NET StartThread
+    const node = create.message.node as Record<string, unknown>;
+    const content = node.content as Record<string, unknown>;
+    expect((content.pendingUserMessages as Record<string, unknown>)[userMessageId]).toBeDefined();
+    mesh.close();
+  });
+
+  it("submitMessage patches userMessageIds (append) + pendingUserMessages (merge) on the thread node", async () => {
+    const sent: Delivery[] = [];
+    const mesh = await Mesh.connect("memory://", {
+      transport: fakeMeshTransport({
+        onDeliver: (d) => sent.push(d),
+        nodeContent: { userMessageIds: ["aaaa1111"], pendingUserMessages: {} },
+      }),
+    });
+    const msgId = await mesh.submitMessage("rbuergi/_Thread/t-1", "and another thing", { modelName: "gpt" });
+
+    expect(msgId).toMatch(/^[a-z0-9]{8}$/);
+    const patch = await until(() => sent.find((d) => d.messageType === "PatchDataRequest"));
+    expect(patch.target).toBe("rbuergi/_Thread/t-1");
+    // PatchDataRequest(Reference, Patch): the merge document rides in `patch`, the node in `reference`.
+    expect(patch.message.reference).toEqual({ $type: "MeshNodeReference", path: "rbuergi/_Thread/t-1" });
+    const change = patch.message.patch as Record<string, unknown>;
+    const content = change.content as Record<string, unknown>;
+    expect(content.userMessageIds).toEqual(["aaaa1111", msgId]); // full array — merge-patch replaces arrays
+    const pending = content.pendingUserMessages as Record<string, Record<string, unknown>>;
+    expect(pending[msgId!].text).toBe("and another thing");
+    expect((content.composer as Record<string, unknown>).modelName).toBe("gpt"); // selection folds into the composer
+    mesh.close();
+  });
+
+  it("submitMessage is a no-op for whitespace-only text (never enqueue an empty round)", async () => {
+    const sent: Delivery[] = [];
+    const mesh = await Mesh.connect("memory://", { transport: fakeMeshTransport({ onDeliver: (d) => sent.push(d) }) });
+    const msgId = await mesh.submitMessage("rbuergi/_Thread/t-1", "   ");
+    expect(msgId).toBeNull();
+    // Negative assertion — let any (wrongly) issued fire-and-forget delivery settle first.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(sent.find((d) => d.messageType === "PatchDataRequest")).toBeUndefined();
+    mesh.close();
+  });
+
+  it("submitMessage rejects an ownerless threadPath", async () => {
+    const mesh = await Mesh.connect("memory://", { transport: fakeMeshTransport() });
+    await expect(mesh.submitMessage("_Thread/t-1", "hi")).rejects.toThrow(/ownerless/);
+    mesh.close();
+  });
+});

--- a/clients/grpc-web/src/threads.ts
+++ b/clients/grpc-web/src/threads.ts
@@ -1,0 +1,180 @@
+// Chat-thread submission for the browser/RN client — the in-language port of the canonical .NET
+// surface `MeshWeaver.AI.HubThreadExtensions` (hub.StartThread / hub.SubmitMessage) + its pure
+// helpers (`ThreadNodeType.BuildThreadNode`, `ThreadInput.CreateUserMessage/ApplyUserInput`).
+//
+// Same contract as the .NET side:
+//   - StartThread  = CreateNodeRequest with a thread node at {namespace}/_Thread/{speakingId},
+//     pre-seeded with the first user message in content.pendingUserMessages (the submission
+//     watcher dispatches the first round as soon as the thread hub activates).
+//   - SubmitMessage = a JSON-merge patch (RFC 7396) on the thread node adding the message id to
+//     content.userMessageIds and the payload to content.pendingUserMessages — the client twin of
+//     `workspace.GetMeshNodeStream(threadPath).Update(...)`. The owning hub serialises the patch.
+//
+// The hub serialises with camelCase properties + string enums (SerializationExtensions), so the
+// JSON built here is camelCase and enum-valued strings ("Submitted", "ExecutedInput").
+// WIRE: annotated where the exact shape must be confirmed against a running mesh (same convention
+// as mesh.ts) — capture a sample from the C# round-trip test.
+
+import { newId } from "./envelope";
+
+/** The `_Thread` satellite partition segment (ThreadNodeType.ThreadPartition). */
+export const THREAD_PARTITION = "_Thread";
+
+export interface StartThreadOptions {
+  agentName?: string;
+  modelName?: string;
+  harness?: string;
+  contextPath?: string;
+  contextReference?: string;
+  attachments?: string[];
+  createdBy?: string;
+  authorName?: string;
+  /** Pre-chosen speaking id for the thread node; generated from the text when omitted. */
+  speakingId?: string;
+  /** Point the thread at an existing node (e.g. an inbound Email) as its MainNode. */
+  mainNode?: string;
+}
+
+export interface SubmitMessageOptions {
+  agentName?: string;
+  modelName?: string;
+  harness?: string;
+  contextPath?: string;
+  attachments?: string[];
+  createdBy?: string;
+  authorName?: string;
+}
+
+/**
+ * Port of ThreadNodeType.GenerateSpeakingId: "Hello, can you help?" → "hello-can-you-help-a3f9".
+ * First ~50 chars, lowercased, non-alphanumerics collapsed to hyphens, 4-char unique suffix.
+ */
+export function generateSpeakingId(messageText: string): string {
+  let slug = (messageText.length > 50 ? messageText.slice(0, 50) : messageText)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (slug.length > 40) slug = slug.slice(0, 40).replace(/-+$/g, "");
+  const suffix = newId().slice(0, 4);
+  return slug.length === 0 ? suffix : `${slug}-${suffix}`;
+}
+
+/** Port of ThreadInput.CreateUserMessage — the camelCase JSON of a user ThreadMessage. */
+export function createUserMessage(text: string, opts: SubmitMessageOptions = {}): Record<string, unknown> {
+  const message: Record<string, unknown> = {
+    role: "user",
+    text,
+    timestamp: new Date().toISOString(),
+    // String enums (EnumMemberJsonStringEnumConverter on the hub).
+    type: "ExecutedInput",
+    status: "Submitted",
+  };
+  if (opts.authorName) message.authorName = opts.authorName;
+  if (opts.createdBy) message.createdBy = opts.createdBy;
+  if (opts.agentName) message.agentName = opts.agentName;
+  if (opts.modelName) message.modelName = opts.modelName;
+  if (opts.harness) message.harness = opts.harness;
+  if (opts.contextPath) message.contextPath = opts.contextPath;
+  if (opts.attachments?.length) message.attachments = opts.attachments;
+  // NOTE: submitterObjectId/-Name are deliberately NOT set client-side — identity is stamped by the
+  // server from the bearer token (the server never trusts a client-claimed AccessContext).
+  return message;
+}
+
+/**
+ * Port of ThreadNodeType.BuildThreadNode + HubThreadExtensions.StartThread's seeding: the thread
+ * node at {namespacePath}/_Thread/{speakingId}, pre-seeded with the first user message queued in
+ * content.pendingUserMessages and the composer carrying the sticky selection.
+ * Returns the node plus the generated ids.
+ */
+export function buildThreadNode(
+  namespacePath: string,
+  userText: string,
+  opts: StartThreadOptions = {},
+): { node: Record<string, unknown>; path: string; userMessageId: string } {
+  if (!namespacePath) throw new Error("startThread requires namespacePath.");
+
+  const speakingId = opts.speakingId ?? generateSpeakingId(userText);
+  // Sub-threads (delegations) already live under a _Thread segment — don't nest another.
+  const ns = namespacePath.includes(`/${THREAD_PARTITION}/`)
+    ? namespacePath
+    : `${namespacePath}/${THREAD_PARTITION}`;
+
+  // 🚫 Ownerless guard (ActivityNodeGuard.IsOwnerless): a bare _Thread/{id} has no partition /
+  // per-node hub to route to — fail fast instead of NotFound-storming the router.
+  if (ns === THREAD_PARTITION || ns.startsWith(`${THREAD_PARTITION}/`))
+    throw new Error(`startThread refused a top-level/ownerless thread under '${ns}'.`);
+
+  const name = userText.length > 60 ? userText.slice(0, 57) + "..." : userText;
+  const userMessageId = newId().slice(0, 8);
+
+  // Thread.Composer is the single source of truth for the round's selection — always seeded.
+  const composer: Record<string, unknown> = {};
+  if (opts.agentName) composer.agentName = opts.agentName;
+  if (opts.modelName) composer.modelName = opts.modelName;
+  if (opts.harness) composer.harness = opts.harness;
+  if (opts.contextPath) composer.contextPath = opts.contextPath;
+  if (opts.contextReference) composer.contextReference = opts.contextReference;
+
+  const hasFirstMessage = userText.trim().length > 0;
+  const content: Record<string, unknown> = {
+    // WIRE: polymorphic content discriminator — the hub serialises Thread content with the short
+    // $type name; confirm against a captured CreateNodeRequest from the C# round-trip test.
+    $type: "Thread",
+    composer,
+  };
+  if (opts.createdBy) content.createdBy = opts.createdBy;
+  if (hasFirstMessage) {
+    content.messages = [userMessageId];
+    content.userMessageIds = [userMessageId];
+    content.pendingUserMessages = {
+      [userMessageId]: createUserMessage(userText, opts),
+    };
+  }
+
+  const path = `${ns}/${speakingId}`;
+  const node: Record<string, unknown> = {
+    id: speakingId,
+    namespace: ns,
+    path,
+    name,
+    nodeType: "Thread",
+    mainNode: opts.mainNode ?? namespacePath,
+    content,
+  };
+  return { node, path, userMessageId };
+}
+
+/**
+ * Port of ThreadInput.ApplyUserInput as a JSON-MERGE PATCH (RFC 7396) against the thread node:
+ * appends to userMessageIds (arrays replace wholesale under merge-patch, so the caller supplies the
+ * CURRENT ids), adds the pending payload (objects deep-merge, so only the new key is sent), and
+ * folds any explicit agent/model/harness selection into the composer.
+ */
+export function buildSubmitPatch(
+  currentUserMessageIds: readonly string[],
+  msgId: string,
+  message: Record<string, unknown>,
+  opts: SubmitMessageOptions = {},
+): Record<string, unknown> {
+  const content: Record<string, unknown> = {
+    userMessageIds: currentUserMessageIds.includes(msgId)
+      ? [...currentUserMessageIds]
+      : [...currentUserMessageIds, msgId],
+    pendingUserMessages: { [msgId]: message },
+  };
+  const composer: Record<string, unknown> = {};
+  if (opts.agentName) composer.agentName = opts.agentName;
+  if (opts.modelName) composer.modelName = opts.modelName;
+  if (opts.harness) composer.harness = opts.harness;
+  if (Object.keys(composer).length > 0) content.composer = composer;
+  return { content };
+}
+
+/** Ownerless-threadPath guard for submitMessage (the SubmitMessage twin of the StartThread guard). */
+export function isOwnerlessThreadPath(threadPath: string): boolean {
+  if (!threadPath) return true;
+  const segments = threadPath.split("/").filter((s) => s.length > 0);
+  // A bare _Thread/{id} (no owner segment before the partition) has no per-node hub to route to.
+  return segments[0] === THREAD_PARTITION;
+}

--- a/clients/portal-next/.gitignore
+++ b/clients/portal-next/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+next-env.d.ts
+*.tsbuildinfo

--- a/clients/portal-next/DEPLOY.md
+++ b/clients/portal-next/DEPLOY.md
@@ -1,0 +1,93 @@
+# Deploying portal-next (memex-local / helm)
+
+The Next.js portal runs as its own Deployment beside `memex-portal`, and the existing portal
+ingress gains one extra path: `/next` → this service. Nothing in `deploy/` needs to change for a
+local experiment — the snippets below are additive manifests you can `kubectl apply` into the
+same namespace (or fold into `deploy/helm` as a `portal-next` template when it graduates).
+
+## 1. Image
+
+```bash
+# From the repo root — the build context is clients/ (the app compiles ../react + ../grpc-web sources)
+docker build -f clients/portal-next/Dockerfile -t meshweaver/portal-next:dev clients/
+```
+
+## 2. Deployment + Service
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: portal-next-deployment
+  labels: { app.kubernetes.io/component: portal-next }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app.kubernetes.io/component: portal-next }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/component: portal-next }
+    spec:
+      containers:
+        - name: portal-next
+          image: meshweaver/portal-next:dev
+          ports: [{ containerPort: 3000 }]
+          env:
+            # Server-side token mint + snapshot fetch go straight to the portal Service,
+            # skipping the ingress round-trip. The BROWSER still talks same-origin
+            # (cookies + gRPC-web are ingress-routed), so this only affects SSR.
+            - name: PORTAL_ORIGIN
+              value: "http://memex-portal-service:8080"
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits: { memory: 512Mi }
+          readinessProbe:
+            httpGet: { path: /next, port: 3000 }
+          livenessProbe:
+            httpGet: { path: /next, port: 3000 }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: portal-next-service
+spec:
+  selector: { app.kubernetes.io/component: portal-next }
+  ports: [{ port: 3000, targetPort: 3000 }]
+```
+
+## 3. Ingress path
+
+The chart's portal ingress (`deploy/helm/templates/memex-portal/ingress.yaml`) routes `/` to
+`memex-portal-service`; add the `/next` prefix BEFORE it on the same host rule (nginx matches the
+longest prefix first regardless of order, but keeping it first reads correctly):
+
+```yaml
+          - path: "/next"
+            pathType: "Prefix"
+            backend:
+              service:
+                name: "portal-next-service"
+                port: { number: 3000 }
+          # existing:
+          - path: "/"
+            pathType: "Prefix"
+            backend:
+              service:
+                name: "memex-portal-service"
+                port: { number: 8080 }
+```
+
+The app is built with `basePath: "/next"`, so no rewrite annotation is needed — it expects the
+prefix. TLS terminates at the ingress as today; the portal session cookie flows to `/next/*`
+because it is the SAME host (cookie path `/`), which is what authorizes the per-request
+server-side token mint.
+
+## Notes
+
+- **Stateless by design**: every request mints a short-lived token from the forwarded cookies and
+  fetches a REST snapshot; the server never opens a gRPC/stream subscription. Scale horizontally
+  at will; no sticky sessions.
+- The live layer is browser-only (same-origin `/api/tokens` + gRPC-web at the origin root),
+  identical to the Vite SPA at `/app`.
+- `/frontend/blazor` ("Back to classic") and `/frontend/react` remain portal endpoints — the
+  `mw-frontend` cookie toggle works unchanged on the shared host.

--- a/clients/portal-next/Dockerfile
+++ b/clients/portal-next/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+# MeshWeaver portal-next — Next.js standalone runner.
+#
+# Build CONTEXT is the clients/ directory (the app aliases @meshweaver/react and
+# @meshweaver/client-web to their SOURCE trees in ../react and ../grpc-web):
+#
+#   docker build -f portal-next/Dockerfile -t meshweaver/portal-next:dev clients/
+#
+# Dockerfile.dockerignore (BuildKit, sits next to this file) keeps node_modules/.next/dist
+# out of the context; all deps install fresh from portal-next/package-lock.json — the
+# webpack resolve.modules override makes the sibling sources resolve every bare import
+# from portal-next/node_modules, so ../react and ../grpc-web need no install of their own.
+
+FROM node:22-alpine AS build
+WORKDIR /workspace
+COPY react/ react/
+COPY grpc-web/ grpc-web/
+COPY portal-next/ portal-next/
+WORKDIR /workspace/portal-next
+RUN npm ci --no-audit --no-fund
+RUN npm run build
+
+FROM node:22-alpine AS runner
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+WORKDIR /app
+# outputFileTracingRoot is the monorepo root (clients/), so the standalone bundle nests
+# the app under portal-next/.
+COPY --from=build /workspace/portal-next/.next/standalone ./
+COPY --from=build /workspace/portal-next/.next/static ./portal-next/.next/static
+USER node
+EXPOSE 3000
+# PORTAL_ORIGIN (optional): the portal origin for server-side token mint + snapshot fetch.
+# Defaults to the incoming request's forwarded host — correct when the same ingress host
+# fronts both the portal and this app; set it to the in-cluster portal Service URL to skip
+# the ingress round-trip (e.g. http://memex-portal-service:8080).
+CMD ["node", "portal-next/server.js"]

--- a/clients/portal-next/Dockerfile.dockerignore
+++ b/clients/portal-next/Dockerfile.dockerignore
@@ -1,0 +1,11 @@
+# BuildKit per-Dockerfile ignore (applies when building with -f portal-next/Dockerfile).
+# Sources only — dependencies install inside the image from portal-next's lockfile.
+**/node_modules
+**/.next
+**/dist
+**/coverage
+**/*.tsbuildinfo
+portal/
+python/
+typescript/
+react-native/

--- a/clients/portal-next/app/[[...meshPath]]/AreaSnapshot.tsx
+++ b/clients/portal-next/app/[[...meshPath]]/AreaSnapshot.tsx
@@ -1,0 +1,36 @@
+// Async server component — ONE bounded snapshot round-trip per request, then done:
+//   1. forward the incoming request's cookies to POST {portal}/api/tokens (short-lived token,
+//      request-scoped, never persisted, never sent to the client);
+//   2. resolve the mesh path ("" → the user's home partition, from the mint's nodePath);
+//   3. fetch the node snapshot over REST (POST /api/mesh/get) and synthesize the SSR preview tree.
+// The result is passed as plain JSON props into the <LiveArea> client boundary, whose initial
+// render Next streams as HTML inside the page's Suspense boundary. No gRPC, no streams, no state.
+
+import { cookies, headers } from "next/headers";
+import {
+  buildInitialTree,
+  fetchNodeSnapshot,
+  mintToken,
+  resolvePortalOrigin,
+} from "../../src/server/snapshot";
+import { LiveArea } from "../../src/client/LiveArea";
+
+export async function AreaSnapshot({ path }: { path: string }) {
+  const origin = resolvePortalOrigin(headers());
+  const cookieHeader = cookies()
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join("; ");
+
+  const mint = await mintToken(origin, cookieHeader);
+  const resolvedPath = path || mint?.userId || "";
+  const snapshot = mint && resolvedPath ? await fetchNodeSnapshot(origin, mint.rawToken, resolvedPath) : null;
+
+  return (
+    <LiveArea
+      path={resolvedPath}
+      initialTree={snapshot ? buildInitialTree(snapshot) : null}
+      unauthenticated={!mint}
+    />
+  );
+}

--- a/clients/portal-next/app/[[...meshPath]]/page.tsx
+++ b/clients/portal-next/app/[[...meshPath]]/page.tsx
@@ -1,0 +1,36 @@
+// The one dynamic route: URL path → mesh path. `/next/Doc/GUI` renders the default layout area of
+// mesh node "Doc/GUI"; the bare `/next` renders the authenticated user's home partition (resolved
+// server-side from the token mint's nodePath — the SPA's no-hash default).
+//
+// Streaming SSR: the page returns instantly with the skeleton fallback; the async <AreaSnapshot>
+// server component (token mint + REST snapshot per request — stateless, no server-held streams)
+// streams its HTML into the boundary when the snapshot arrives.
+
+import { Suspense } from "react";
+import { meshPathFromSegments } from "../../src/meshPath";
+import { AreaSnapshot } from "./AreaSnapshot";
+
+// Every request depends on the caller's cookies (per-request token mint) — never prerender.
+export const dynamic = "force-dynamic";
+
+export default function MeshPage({ params }: { params: { meshPath?: string[] } }) {
+  const path = meshPathFromSegments(params.meshPath);
+  return (
+    <Suspense fallback={<AreaSkeleton path={path} />}>
+      <AreaSnapshot path={path} />
+    </Suspense>
+  );
+}
+
+/** Plain-HTML skeleton — part of the first flush, styled without Griffel so it needs no
+ *  extraction and cannot block on anything. */
+function AreaSkeleton({ path }: { path: string }) {
+  return (
+    <div data-mw-skeleton aria-busy="true" style={{ opacity: 0.6 }}>
+      <div style={{ height: 32, width: 320, borderRadius: 6, background: "var(--colorNeutralBackground3, #ebebeb)" }} />
+      <div style={{ height: 16, width: 200, borderRadius: 6, background: "var(--colorNeutralBackground3, #ebebeb)", marginTop: 12 }} />
+      <div style={{ height: 120, borderRadius: 6, background: "var(--colorNeutralBackground3, #ebebeb)", marginTop: 20 }} />
+      <p style={{ marginTop: 16, fontSize: 12 }}>Loading {path ? `“${path}”` : "your home"}…</p>
+    </div>
+  );
+}

--- a/clients/portal-next/app/layout.tsx
+++ b/clients/portal-next/app/layout.tsx
@@ -1,0 +1,26 @@
+// Root layout (server component): document shell + the client provider stack. The PortalShell
+// chrome renders in the FIRST HTML flush; routed pages stream into <main> below it (each page
+// wraps its area in a Suspense boundary — see app/[[...meshPath]]/page.tsx).
+
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { Providers } from "../src/client/Providers";
+import { PortalShell } from "../src/client/PortalShell";
+
+export const metadata: Metadata = {
+  title: "MeshWeaver",
+  description:
+    "MeshWeaver portal — Next.js streaming-SSR shell over @meshweaver/react, with per-request server snapshots and client-side live takeover over gRPC-web.",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, fontFamily: "'Segoe UI', system-ui, sans-serif" }}>
+        <Providers>
+          <PortalShell>{children}</PortalShell>
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/clients/portal-next/next.config.mjs
+++ b/clients/portal-next/next.config.mjs
@@ -1,0 +1,53 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Next.js + streaming-SSR variant of the React portal.
+ *
+ * - `output: "standalone"` — self-contained node server for the Docker image.
+ * - `basePath: "/next"` — served parallel to the Vite SPA's /app (ingress routes /next here).
+ * - Monorepo source aliasing, mirroring clients/portal/vite.config.ts: the renderer
+ *   (@meshweaver/react) and the gRPC-web transport (@meshweaver/client-web) resolve to their
+ *   SOURCE trees — no build/link step. `experimental.externalDir` lets SWC compile files
+ *   outside this app directory.
+ */
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "standalone",
+  basePath: "/next",
+  reactStrictMode: true,
+  experimental: {
+    // Compile the ../react and ../grpc-web sources (outside this app dir).
+    externalDir: true,
+    // Monorepo root for standalone output tracing (clients/) — server.js lands under
+    // .next/standalone/portal-next/server.js (see Dockerfile).
+    outputFileTracingRoot: path.join(here, ".."),
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      // Order matters: the more specific subpath before the package root.
+      "@meshweaver/react/core": path.resolve(here, "../react/src/core.ts"),
+      "@meshweaver/react": path.resolve(here, "../react/src/index.tsx"),
+      "@meshweaver/client-web": path.resolve(here, "../grpc-web/src/index.ts"),
+    };
+    // The renderer source uses ESM ".js" specifiers for its own ".ts/.tsx" modules.
+    config.resolve.extensionAlias = {
+      ...config.resolve.extensionAlias,
+      ".js": [".tsx", ".ts", ".js"],
+    };
+    // Vite's `dedupe` equivalent: resolve bare imports (including those made FROM the aliased
+    // ../react and ../grpc-web sources) against THIS app's node_modules first, so exactly one
+    // copy of react / fluent is bundled — and the Docker build needs no node_modules in
+    // ../react / ../grpc-web at all.
+    config.resolve.modules = [
+      path.resolve(here, "node_modules"),
+      ...(config.resolve.modules ?? ["node_modules"]),
+    ];
+    return config;
+  },
+};
+
+export default nextConfig;

--- a/clients/portal-next/package-lock.json
+++ b/clients/portal-next/package-lock.json
@@ -1,0 +1,6471 @@
+{
+  "name": "@meshweaver/portal-next",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@meshweaver/portal-next",
+      "version": "0.1.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.2.0",
+        "@connectrpc/connect": "^2.0.0",
+        "@connectrpc/connect-web": "^2.0.0",
+        "@fluentui/react-components": "^9.54.0",
+        "@fluentui/react-icons": "^2.0.260",
+        "next": "^14.2.5",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-markdown": "^9.0.1",
+        "remark-gfm": "^4.0.0",
+        "server-only": "^0.0.1"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
+        "@types/node": "^22.10.0",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.0",
+        "jsdom": "^29.1.1",
+        "typescript": "^5.6.0",
+        "vitest": "^4.1.9"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.2.tgz",
+      "integrity": "sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/devtools": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/devtools/-/devtools-0.2.3.tgz",
+      "integrity": "sha512-ZTcxTvgo9CRlP7vJV62yCxdqmahHTGpSTi5QaTDgGoyQq0OyjaVZhUhXv/qdkQFOI3Sxlfmz0XGG4HaZMsDf8Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@fluentui/keyboard-keys": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
+      "integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/priority-overflow": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.4.0.tgz",
+      "integrity": "sha512-NwhNNwCTbXYdLYwa6Ha484qCLHgRFo5vOv7BGaq0REcY2rkgwcDHVlbchwsGV7D3XgTZCjzDu54SSPmk5NOxXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-accordion": {
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.12.1.tgz",
+      "integrity": "sha512-F7xVaP0OR7JMCxrBwI3ryNhKof9Yi2c6RhYPsQy7rh2+KMGLGgYLsrDJyHmSejjxp4Bs11plXGdU38SN5j1hgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-alert": {
+      "version": "9.0.0-beta.142",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.142.tgz",
+      "integrity": "sha512-YrbMX1wF7huOByxP2J+2aUWatpODd1MXhqam95oeLUnoJUViBK6ZZuBYba7m0OTsRMUA4pB1WfjvuIGsnSQKtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-icons": "^2.0.239",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-aria": {
+      "version": "9.17.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.13.tgz",
+      "integrity": "sha512-f5qSP5aD2ZbYgQn4hCjQzqh8mHJNeN/vsC9Nwth5uJlGNdIAPbPO+dXVC18DkYqNU8O9A5Ae/uJPRbxoH23zbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-avatar": {
+      "version": "9.11.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.11.3.tgz",
+      "integrity": "sha512-O8PoDUf1OUXDviECFvxdxo88kCEJLlP4TtCXyE58PKuAywrVeqmOA7eNy6/xhaGVuyDO8l9YJh05sYkyLiNLIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-badge": "^9.5.4",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-badge": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.5.4.tgz",
+      "integrity": "sha512-jxS6H6+KCk62MeueCf7cT2fRbdnN6h/lCOIyXWJLpPf9Mx+LWWP3KAfKik3BuDY28oy1pDYIuvFucDL+OMAb/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-breadcrumb": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.4.tgz",
+      "integrity": "sha512-KcxyQAC+xTO/n2BMBj2lLKgQL2/eyTlkUhElHv9SKqP29Ks8EPYSovYpDtSfbtx8Dle+8NSUnhAvnO1kE/+fMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-link": "^9.8.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-button": {
+      "version": "9.10.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.10.1.tgz",
+      "integrity": "sha512-8Ow/ck9a/RLh3cJ6ZPF4asmGnNfqXr/Kengk+zTkMuppk+pFL3X6WEMrJLSOUKKZtx0Tp1UBuUPA6RL6Ive5WQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-card": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.7.1.tgz",
+      "integrity": "sha512-4t65Y9pRW9W7kf/Yyc7S796le2WFKfXFTCuzfkFS+AHUM7JlrmMUOnQLA0i24WDNS6ArA0vo6EbMDnUcjgV9Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-text": "^9.6.18",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-carousel": {
+      "version": "9.9.10",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.10.tgz",
+      "integrity": "sha512-Ml3Vqi9KNA+mRG1FUiIjk/HCYqEjRZKSE8jQviMSQDLe4Rb6EO16FhtuFuIOz/ls47y/Sx6zTnb1t+HiFatpJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "embla-carousel": "^8.5.1",
+        "embla-carousel-autoplay": "^8.5.1",
+        "embla-carousel-fade": "^8.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-checkbox": {
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.6.3.tgz",
+      "integrity": "sha512-VzePhN5Nz3D69Fu7SnPUCrMfkrbhfqGpNJDis85+W7dvOo9cyUou6yRreHsSzxVkRyE9swcA1LnsKJS6oVn9ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-color-picker": {
+      "version": "9.2.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.18.tgz",
+      "integrity": "sha512-zbsQ+hVJeGwXVTjneA42i4UuHRACfcTnBs3BUcDT22lBDQjJxhYYZzmj5ksM92M2ZU0fMHV8K5OfSyCnZU5mqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.3.4",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-combobox": {
+      "version": "9.17.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.17.3.tgz",
+      "integrity": "sha512-QuWcM6fvqnfUzpkJApQbXfbIQ6iQkMGgrsdwmJHkB4Q/E6zT0aLZoEjEx2P5QkMz9m5D7LzeZWmFIOEFq8SzFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components": {
+      "version": "9.74.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.74.3.tgz",
+      "integrity": "sha512-HdcLR4V9KZnduui0v4UfBIyJrO4G8eZf3W4iu8hssykl0hN1uneNNJmsVZExT8G8ybFen85ucqMOxCXQ3L7raw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-accordion": "^9.12.1",
+        "@fluentui/react-alert": "9.0.0-beta.142",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-badge": "^9.5.4",
+        "@fluentui/react-breadcrumb": "^9.4.4",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-card": "^9.7.1",
+        "@fluentui/react-carousel": "^9.9.10",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-color-picker": "^9.2.18",
+        "@fluentui/react-combobox": "^9.17.3",
+        "@fluentui/react-dialog": "^9.18.2",
+        "@fluentui/react-divider": "^9.7.3",
+        "@fluentui/react-drawer": "^9.13.1",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-image": "^9.4.3",
+        "@fluentui/react-infobutton": "9.0.0-beta.117",
+        "@fluentui/react-infolabel": "^9.4.22",
+        "@fluentui/react-input": "^9.8.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-link": "^9.8.3",
+        "@fluentui/react-list": "^9.6.16",
+        "@fluentui/react-menu": "^9.25.1",
+        "@fluentui/react-message-bar": "^9.7.3",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-nav": "^9.4.2",
+        "@fluentui/react-overflow": "^9.9.0",
+        "@fluentui/react-persona": "^9.7.5",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-progress": "^9.5.3",
+        "@fluentui/react-provider": "^9.22.18",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-rating": "^9.4.3",
+        "@fluentui/react-search": "^9.4.4",
+        "@fluentui/react-select": "^9.5.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-skeleton": "^9.7.4",
+        "@fluentui/react-slider": "^9.6.4",
+        "@fluentui/react-spinbutton": "^9.6.4",
+        "@fluentui/react-spinner": "^9.8.4",
+        "@fluentui/react-swatch-picker": "^9.5.4",
+        "@fluentui/react-switch": "^9.7.4",
+        "@fluentui/react-table": "^9.19.17",
+        "@fluentui/react-tabs": "^9.12.3",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-tag-picker": "^9.9.0",
+        "@fluentui/react-tags": "^9.9.2",
+        "@fluentui/react-teaching-popover": "^9.7.2",
+        "@fluentui/react-text": "^9.6.18",
+        "@fluentui/react-textarea": "^9.7.4",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-toast": "^9.8.1",
+        "@fluentui/react-toolbar": "^9.8.3",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-tree": "^9.16.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@fluentui/react-virtualizer": "9.0.0-alpha.114",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.18.tgz",
+      "integrity": "sha512-A9YdkKonDlNSTnD8SCcSMhj0O6mAyMtXMERWH5mA1UqdtVxzJ4Y/muNd3Nk5rwAaLPUZ5HWMabtt2Ewa/BxARA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0",
+        "scheduler": ">=0.19.0"
+      }
+    },
+    "node_modules/@fluentui/react-dialog": {
+      "version": "9.18.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.18.2.tgz",
+      "integrity": "sha512-acW70/CxibJC19bQVbrJyxYiuIP9nX593O/Tya4x9wMEEcnTHZ6RW8liS6kbYYEL/AERYRuOYkLJ++TNniTxSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-divider": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.7.3.tgz",
+      "integrity": "sha512-uhqpu+JfSaLEqFNtDQFYFo/gM1QoRV2I1iUYTMsO2iqEis4zZmMsQETti7lTv29SITWIky3e8pkRoC6xyQBLsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-drawer": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.13.1.tgz",
+      "integrity": "sha512-nZBWG0290IcCshpt2wjORDD8fLOsccSPdp0EW45CxK09/JR+4hkGbbIj8x14GW7GYu4RsGzk18OYga0kY+4j2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-dialog": "^9.18.2",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-field": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.5.3.tgz",
+      "integrity": "sha512-5PJXFTGS9W4CBJW6Nh2Tqe5p8RxMMCPbsIyIcYUXIxCZTXDGrx1jZ+af8lWKJFlcfWOlFxyK+QE14UXl+lqzqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-icons": {
+      "version": "2.0.331",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.331.tgz",
+      "integrity": "sha512-SY3Js+SW20T0qqt8uo1pWwi1njWisOzblIFqVoACql+ZrcSkXeifI+CQMCVdf5BZTAk0NnsUGb0pV9048SKpZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.6.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-image": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.4.3.tgz",
+      "integrity": "sha512-BQSsT3kVdpR3s02Zq9zpqj0NjaijWOVKPLBchp9XqWlygO15dkykNt2LRoHAkZRgpnlh2D8zBCw9qQ4ubzYNaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infobutton": {
+      "version": "9.0.0-beta.117",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.117.tgz",
+      "integrity": "sha512-h01PQzH736I/7mhjNcYi8cFjspCqgSmQukXbzCsESzB1VnAkx8djqy5A8f/mV1HmHw7vBAIX8VdH+ddtx8WyXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.237",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infolabel": {
+      "version": "9.4.22",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.22.tgz",
+      "integrity": "sha512-K5W+g+HfGu5ltl5BGekZJB2z0ACLidIW7KFQ5Qj+UG1kpoB3G4q10HTm5gY74VjXP/GrM5RVx8IcnHRqyAfR1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-input": {
+      "version": "9.8.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.8.4.tgz",
+      "integrity": "sha512-Lpdu0TBBSbv3VasaCz3blNeEgQS7XhtLTmiYXZj5g8Hrk7gNDJORDPYRrXcRjOUPGkV/InB4JY+GeXy2cYfOaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.4.tgz",
+      "integrity": "sha512-npqPWSJ2qciCRB4B/cyWyrTbf8V8Z2Kfr9HnZqrUBDgEvq72rRGb+gml6naxGNzhaT4NBLQLZmdPZqt+1wZ4ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-label": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.4.3.tgz",
+      "integrity": "sha512-/tYFciaorFym7Q2yDCdRYeP3JzLtw5eYt2yCvRlmBsugtKmn2f/kOu+b2cB37kWizbXjSdOGhCrTL8J1EUlIZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-link": {
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.8.3.tgz",
+      "integrity": "sha512-3Cd+UWgLpP6E6/NZaomCqZd965gruWXz2+gqUDfP7nBTLaCgOIuFQe0HAgSYi0ys4xli3cDtKeytqZJ7ReA6gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-list": {
+      "version": "9.6.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.16.tgz",
+      "integrity": "sha512-ZWsLxr1ZDe6hmvGLGlHQIPt1E70xsWHaHn+QGxB0XUxjq64SnxCDm4HCSPZ40MS3Hqgd4eQdnmPUS9d6odcYUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-menu": {
+      "version": "9.25.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.25.1.tgz",
+      "integrity": "sha512-nP2bUB0Blrz5cqG6JnaHKznD2zGv134vuiCStk0op1/IErIPoU6wJj6H+unYVhFwyHCReyPZcp/pQZWkSWErJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-message-bar": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.7.3.tgz",
+      "integrity": "sha512-LxcoTatsPPYj8Y5fx9QeJYOlXs6C4HIgmXTUaqNTCnFquNrcBHU4RtzUEq/6ssJ8jP/dy8Z03Bk4dE31RCV5MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-link": "^9.8.3",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion": {
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.16.1.tgz",
+      "integrity": "sha512-sbrNuauwI5uw20XOAqPjXBfgBqPreHc5AxU7bJ6yoLUHL2gDKo7KGAIvLEd216GX37mgPkb3dx9rarIVGx3uvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion-components-preview": {
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.6.tgz",
+      "integrity": "sha512-9aNzHAHNdfbH/8/mYGy5YVrUOGnpiru3YrqQ7KhCRWXvlce7yV3WF5CzN1g/uNh3MFmKGwQeW4ui6xJOfEaI4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-motion": "*",
+        "@fluentui/react-utilities": "*",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-nav": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.4.2.tgz",
+      "integrity": "sha512-1nZgZwZHgJ1P73E0Aw4UrTqri9BMSShI7otuktdATB5iHolDHE+9JtQjr3OQJ0QR+YyXgD8bMWiKvSa6p/Pdlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-divider": "^9.7.3",
+        "@fluentui/react-drawer": "^9.13.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.3",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-overflow": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.9.0.tgz",
+      "integrity": "sha512-u8M7yqlzmvdYezlvVjGJUH38ik5fb59aSSGOsJyepnXM5HwnyFb9ecBwqAFAGi23lw+wz07V0aeYMEzK7q+slw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/priority-overflow": "^9.4.0",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-persona": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.7.5.tgz",
+      "integrity": "sha512-5MlVpl3+l+UW7vTf/d1qKP6EANBkxoXjmxmbNZpiuXjIE2QJFcVRBplWXwEPgt3GAOGnix1wPVkUgHElUJOCEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-badge": "^9.5.4",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-popover": {
+      "version": "9.14.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.14.4.tgz",
+      "integrity": "sha512-Ofn4kh+WfC647n9ap0mtoN47eP0FsP/ZIjoZf1GfW6Co+A3zAZN+V7z6AayCPvbvdv8vKFQ0diHeUBrIu9Pz3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-portal": {
+      "version": "9.8.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.14.tgz",
+      "integrity": "sha512-od8RN6dny6N/qGFm2uv5UV+ugGOKupFeCIF+R0rU5SimSvix6o+wv5rPrH9JHRHFqjDIi5kRh9hk/rZfgsnuaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-positioning": {
+      "version": "9.22.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.3.tgz",
+      "integrity": "sha512-2j2k87k7yVX8LYd9q3SniXYVGqED6JFRdTNeyamDf4DTk9/ECxTl2nKTmKedkDodddR5RRXpAtJXv874Mi9eyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/devtools": "^0.2.3",
+        "@floating-ui/dom": "^1.6.12",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-progress": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.5.3.tgz",
+      "integrity": "sha512-GVrZzo9QCBOyMZC/K8Q4VTbD76hgG/Xuvhr8gyqOxnuHS9lTfnPJyEZ+T+F36LmpDb6d/XmDcwKjIcyg359ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-provider": {
+      "version": "9.22.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.18.tgz",
+      "integrity": "sha512-kLtBaw6WIzyJJCmzeublw1ifidVPnpzGS39lYjzWdO6vHwuizs5ARCgwlGXxkB+kAlG2Mma/cPFUdYOa0J2f2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/core": "^1.16.0",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-radio": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.6.4.tgz",
+      "integrity": "sha512-punC09igeQT+3Fc67lteh4ibzi8kIAQyKJSh8gdYj9mA4WlAIAcdUIQ4cnqT57hRoz0zuUtZGXpP1y2Kbr8M+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-rating": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.4.3.tgz",
+      "integrity": "sha512-kolMzzTl9/fg54jY1iy8w54BktkKFKGLaEeiESXAbtSZiUyNIj1BADMbIG3kysbVnhkYK8Q5h0kxZPsblrL/ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-search": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.4.4.tgz",
+      "integrity": "sha512-mLDqzL00XkSfJrtIZN34tQO2eBrjlPr33HuD9m3zUUQTq5g7wvA0LomT7m3RQPCJfV6FcOcMDmVfotqDUmttzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-input": "^9.8.4",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-select": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.5.3.tgz",
+      "integrity": "sha512-Qt4ovfXQRx11ou7OaoD0O1CNawfIzTS+Q39fX+wwLwL2yfn15oWnQGGVuQD3hWh0dh7k9cmOErRIrOKeI2wmXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-shared-contexts": {
+      "version": "9.26.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
+      "integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-theme": "^9.2.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-skeleton": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.7.4.tgz",
+      "integrity": "sha512-lIDvfFDldqOkmiwQU0ZEdnKnj/xxnNOGeuciuPz7ao+RyvDYf87Uo1RvTpMTveRCmpPC9z5rOX0EZZK+PhX7Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-slider": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.6.4.tgz",
+      "integrity": "sha512-hPpbAe6pT00FG717A7wV6QCx4+WizhvT9AI/IbEifjKTQ9uxKhodDQNk8WqEXA1ziFoSifDHGAKbcOn/kdr4Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinbutton": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.6.4.tgz",
+      "integrity": "sha512-+t4B6anAWSXFJgmnNXOvC7S/ZWU23MOCDWrvRXKz3fki9fENN85HiRmlnx4fR8akYItVDscqQacRQRxAL8F0oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinner": {
+      "version": "9.8.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.8.4.tgz",
+      "integrity": "sha512-vgfsJosM6hMixFCR7mP856xKx0xXa5Vz4Y95t37Xne2yzJ47bTfqQ62kof7U1AyvaSEeDIp76cwKMyv3lQUD3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-swatch-picker": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.4.tgz",
+      "integrity": "sha512-UwrtK3vP2Ruo2nAI+bbu56XhtpEIwi1XvHFXpVyRWGNQI9362lMS3F4CjwDlyPR24GeF+kEgZeF7QaruTVmagQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-switch": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.7.4.tgz",
+      "integrity": "sha512-P4Xh+zrEOXO7mUmHDPo2G/yfQYwXWArrBOBKCLKOw6qI7KjuzBJxmy1Zqm94/drRr1EKVpBaZckSiT8X8N0TNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-label": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-table": {
+      "version": "9.19.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.17.tgz",
+      "integrity": "sha512-SPhAlS6yQ/53GB/1XUzCum63ktzmNaZVWswshr6SCo7oUERxdszr6xHJ5bSvgNczlApuLzZVz6Vnxe2s7+bsCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabs": {
+      "version": "9.12.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.12.3.tgz",
+      "integrity": "sha512-CkQmrErImxvGDgrNIh+v0GbXzTKx1YSiBXYuFIhjdFaTnTk5CE79xwZp3mIkZK4SUns0HcH5wchjuO1L5LfcRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabster": {
+      "version": "9.26.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.16.tgz",
+      "integrity": "sha512-napGx7dGdLoKoUpKlzc2Til43UMUTtr9J1GWrOFvCT6aZLTox5GjtoxQM/IPhcZ09jJOOUMbVF8ScA5u3/uyTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "keyborg": "^2.14.1",
+        "tabster": "^8.8.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tag-picker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.9.0.tgz",
+      "integrity": "sha512-DYe0p4eFkCTi0HbKFWgr+MmaVhvggGnnUG4vTsgZ9zGADXPAkcVebjSGoF3LeYvRwp73t+qQRe8dT0lvBofTpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-combobox": "^9.17.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-tags": "^9.9.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tags": {
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.9.2.tgz",
+      "integrity": "sha512-yJmUrx3b1m4OYoXGt1+hUgZzghoTuHGGHkXyTwmCUCKX7BKAXQBbOu0VHyxmG+VDkPhpO3773ObQCFXCdTavrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-teaching-popover": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.7.2.tgz",
+      "integrity": "sha512-984lSUplfBiLTKpNSGvzPaBMmQ8pSM0u/Ucv4QoB2QB9U771pu8NtuNvtiuhQe5f6yC3wblIFHnTVrlZW66TWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-popover": "^9.14.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-text": {
+      "version": "9.6.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.18.tgz",
+      "integrity": "sha512-iED0KJPtU44M5kByfg93n/Zwwky0BhyRHaWFcIeB6jsCVAeCf8kUSS2Nr+7zQocf60DFHgMF7y4XEl0rRe+PHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-textarea": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.7.4.tgz",
+      "integrity": "sha512-Zq2D8u2ssneLVY4OuvMWYT5Er3yAo3OKmTWmPNsJ6F9dISIc7UullDwuBoKYES943EBzSfNyKZQwCY7Bo1BGuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-theme": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.1.tgz",
+      "integrity": "sha512-lJxfz7LmmglFz+c9C41qmMqaRRZZUPtPPl9DWQ79vH+JwZd4dkN7eA78OTRwcGCOTPEKoLTX72R+EFaWEDlX+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/tokens": "1.0.0-alpha.23",
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-toast": {
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.8.1.tgz",
+      "integrity": "sha512-J9nKVwbwmBxDNrArgJ9GHypWH43WW0XJhNWvC6ED4dGrvgc8Rnw7bKxI7swG46OTMJNCkwrOnGNEu5YGkMigfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-toolbar": {
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.8.3.tgz",
+      "integrity": "sha512-/R12jBM1cllfvim9x+NxL4/5ObDdih42yHsswecVGhwK/rituz37UEWWr1MkapMCDnr/gVRVb4QEsbFXX3lpNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-divider": "^9.7.3",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tooltip": {
+      "version": "9.10.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.10.3.tgz",
+      "integrity": "sha512-QDc5XQyODm0BIQ5VCbM59n0pEXNCMk2a9OQ7B5eDWoqnvTxj++ul1XQb6EF0libbkjFl7zTsaaHnhIOzsVEq0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-portal": "^9.8.14",
+        "@fluentui/react-positioning": "^9.22.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tree": {
+      "version": "9.16.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.16.3.tgz",
+      "integrity": "sha512-Uf4ero9GhHoe8B6ZONKTIriPnd8cuyPFGXbPo+AG4t4vB5QO8qSZmwrR89btd2Xbr1zWQoMmJJFDn83S+3Te8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.13",
+        "@fluentui/react-avatar": "^9.11.3",
+        "@fluentui/react-button": "^9.10.1",
+        "@fluentui/react-checkbox": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.18",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-motion": "^9.16.1",
+        "@fluentui/react-motion-components-preview": "^0.15.6",
+        "@fluentui/react-radio": "^9.6.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-utilities": {
+      "version": "9.26.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.5.tgz",
+      "integrity": "sha512-lLWhnfMVEu+cWx3o9uTA5sDwo4U9PnpDJGVtheZ1bOCdh1YiQsJxeFM7n6nLE72UK2w+ATkGZQPYZA4QW1JLPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-virtualizer": {
+      "version": "9.0.0-alpha.114",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.114.tgz",
+      "integrity": "sha512-hD44CrZh84P1Rsd+ACPdmre3j20OevkoMKxMRzMXWlSIYKbT+m5I5yM3XxxSvKb1Qr77LeBPTTJs6apvMcfRiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-utilities": "^9.26.5",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/tokens": {
+      "version": "1.0.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
+      "integrity": "sha512-uxrzF9Z+J10naP0pGS7zPmzSkspSS+3OJDmYIK3o1nkntQrgBXq3dBob4xSlTDm5aOQ0kw6EvB9wQgtlyy4eKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@griffel/core": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.21.2.tgz",
+      "integrity": "sha512-vDvEdbIe7OhU15UkvUHe+Ut2sgCZ5PBj/RYLFwjUtkXS4ewNK9P6b4YRFNI2zgaNYI7GOuZqG7DLyaQbUP3+jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.0",
+        "@griffel/style-types": "^1.4.2",
+        "csstype": "^3.2.3",
+        "rtl-css-js": "^1.16.1",
+        "stylis": "^4.4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@griffel/react": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.7.4.tgz",
+      "integrity": "sha512-XsB+YOC4MOBg6GF5CJWJLf8ZI2AtXE8EvQdwJEmFNKX0cQu/An0azl3v9+sjA73zsIG2Wayo2pkT0JANYnKauA==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/core": "^1.21.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@griffel/style-types": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.4.2.tgz",
+      "integrity": "sha512-MsSghfpyxR2MpTrYdcCozISsSLkmFjNw94wNPi4bDBRLW8W43718W/ZjmUdVkoM0KXMtJPYuEkx8Mzibqb03qA==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.383",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.383.tgz",
+      "integrity": "sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-fade": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
+      "integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyborg": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.14.1.tgz",
+      "integrity": "sha512-/WmmVBa6Me3hIKAOIyIq1sql+6oydQZzGMBDLNfOcJ8710byMsq3KSLS8GQhBJHOMtvnXnUBrDAIbABcZVipcg==",
+      "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.35",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabster": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/tabster/-/tabster-8.8.0.tgz",
+      "integrity": "sha512-eGFXgtvKOQP5BywDI9Ngs+Atm6TRj45epAAqWKyVoi+HmOmdamEB//1H/FttLdNly/+Cz+GJ4RN8TnXTw0KwfA==",
+      "license": "MIT",
+      "dependencies": {
+        "keyborg": "^2.14.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
+      "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.5"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
+      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/clients/portal-next/package.json
+++ b/clients/portal-next/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@meshweaver/portal-next",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Next.js + streaming-SSR variant of the MeshWeaver React portal — server-side area snapshot per request (stateless, no server-held streams), Suspense-streamed HTML, client live takeover over gRPC-web.",
+  "scripts": {
+    "dev": "next dev -p 3300",
+    "build": "next build",
+    "start": "next start -p 3300",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": "^2.2.0",
+    "@connectrpc/connect": "^2.0.0",
+    "@connectrpc/connect-web": "^2.0.0",
+    "@fluentui/react-components": "^9.54.0",
+    "@fluentui/react-icons": "^2.0.260",
+    "next": "^14.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-markdown": "^9.0.1",
+    "remark-gfm": "^4.0.0",
+    "server-only": "^0.0.1"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^22.10.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^29.1.1",
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.9"
+  }
+}

--- a/clients/portal-next/src/client/LiveArea.tsx
+++ b/clients/portal-next/src/client/LiveArea.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+// The SSR → live handoff for one mesh area.
+//
+// The async server component (app/[[...meshPath]]/AreaSnapshot.tsx) fetches the per-request
+// snapshot and passes the synthesized {areas,data} tree as props into this client boundary. Next
+// SSRs this component's INITIAL render into the streamed HTML — a MeshAreaView over a
+// StaticAreaSource seeded from the snapshot — so the first paint is real, styled markup. After
+// hydration the session's gRPC-web connection (LiveConnectionProvider) opens the node's default
+// layout area; once the live stream has folded its first frame the displayed AreaSource swaps in
+// place (same rootArea "", so the view simply rebinds). The server held no stream at any point;
+// the live subscription exists only in the browser.
+
+import { useMemo, useSyncExternalStore } from "react";
+import { MessageBar, MessageBarBody } from "@fluentui/react-components";
+import { MeshAreaView, StaticAreaSource } from "@meshweaver/react";
+import type { AreaSource, AreaTree } from "@meshweaver/react";
+import { DEFAULT_ROOT_AREA } from "./live";
+import { useLiveConnection } from "./LiveConnection";
+import { useHydratedTheme } from "./useHydratedTheme";
+
+export interface LiveAreaProps {
+  /** The resolved mesh path (the URL path, or the user's home partition for the default route). */
+  path: string;
+  /** The SSR snapshot tree (null when no snapshot could be fetched — shell-only fallback). */
+  initialTree: AreaTree | null;
+  /** True when the server-side token mint failed (no authenticated session was forwarded). */
+  unauthenticated?: boolean;
+}
+
+/** True once a source has folded its first Full frame (an empty tree is the pre-frame state). */
+function hasContent(source: AreaSource): boolean {
+  const state = source.getState();
+  return state.areas != null && Object.keys(state.areas).length > 0;
+}
+
+const noSubscription = () => () => {};
+
+export function LiveArea({ path, initialTree, unauthenticated }: LiveAreaProps) {
+  const { theme } = useHydratedTheme();
+  const live = useLiveConnection();
+
+  // The SSR seed — one StaticAreaSource per snapshot; identity is stable across re-renders
+  // because the RSC payload passes the same props object to every client render.
+  const staticSource = useMemo(() => (initialTree ? new StaticAreaSource(initialTree) : null), [initialTree]);
+
+  // The live source appears when the connection is up (created once per path, cached by the
+  // provider for the connection's lifetime — instant back-nav).
+  const liveSource = live.state.kind === "live" && path ? live.getAreaSource(path) : null;
+
+  // Swap only when the live stream has actually delivered content — flipping to an empty live
+  // source would blank the SSR snapshot. Server snapshot: always false (no stream on the server).
+  const liveReady = useSyncExternalStore(
+    liveSource ? liveSource.subscribe : noSubscription,
+    () => (liveSource ? hasContent(liveSource) : false),
+    () => false,
+  );
+
+  const active = liveReady && liveSource ? liveSource : staticSource;
+  const streamError = live.areaErrors[path];
+  const offline = live.state.kind === "offline";
+
+  return (
+    <div data-mw-live-area data-mw-path={path} data-mw-live={active != null && active === liveSource ? "true" : "false"} style={{ height: "100%" }}>
+      {offline && (
+        <div data-mw-offline style={{ marginBottom: 16 }}>
+          <MessageBar intent="warning">
+            <MessageBarBody>
+              No live mesh connection on this origin ({(live.state as { reason: string }).reason}). Showing the
+              server-rendered snapshot only.
+            </MessageBarBody>
+          </MessageBar>
+        </div>
+      )}
+      {streamError && (
+        <div data-mw-area-error style={{ marginBottom: 16 }}>
+          <MessageBar intent="error">
+            <MessageBarBody>Live area “{path}” failed: {streamError}</MessageBarBody>
+          </MessageBar>
+        </div>
+      )}
+      {unauthenticated && !active && (
+        <MessageBar intent="info">
+          <MessageBarBody>
+            Not signed in — the server could not mint a mesh token from this session. Sign in to the portal on this
+            origin, then reload.
+          </MessageBarBody>
+        </MessageBar>
+      )}
+      {active ? (
+        <MeshAreaView
+          source={active}
+          rootArea={DEFAULT_ROOT_AREA}
+          theme={theme}
+          ops={live.state.kind === "live" ? live.state.mesh.ops : null}
+        />
+      ) : !unauthenticated ? (
+        <div data-mw-connecting style={{ padding: 48, textAlign: "center", opacity: 0.7 }}>
+          Connecting to the mesh…
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/clients/portal-next/src/client/LiveConnection.tsx
+++ b/clients/portal-next/src/client/LiveConnection.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+// The one live-mesh connection for the whole browser session, held in a client provider that the
+// App Router layout keeps mounted across navigations. One gRPC-web connection; one live AreaSource
+// per visited mesh path, kept for the connection's lifetime (instant back-nav — the area stream
+// stays subscribed), exactly like the Vite SPA's per-path source map. All of this is CLIENT state:
+// the server renders per-request snapshots only and holds no streams (see server/snapshot.ts).
+
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+import type { AreaSource } from "@meshweaver/react/core";
+import { connectLive, createLiveAreaSource, type LiveMesh } from "./live";
+
+export type LiveState =
+  | { kind: "connecting" }
+  | { kind: "live"; mesh: LiveMesh }
+  | { kind: "offline"; reason: string };
+
+export interface LiveConnection {
+  state: LiveState;
+  /** Per-path live area stream errors (the stream faulted after subscribe). */
+  areaErrors: Record<string, string>;
+  /** The live AreaSource for a mesh path — created on first use, cached per connection.
+   *  Returns null until the connection is live. */
+  getAreaSource(path: string): AreaSource | null;
+}
+
+const LiveConnectionContext = createContext<LiveConnection>({
+  // Default context (also what SSR renders): not connected yet, no sources.
+  state: { kind: "connecting" },
+  areaErrors: {},
+  getAreaSource: () => null,
+});
+
+export function useLiveConnection(): LiveConnection {
+  return useContext(LiveConnectionContext);
+}
+
+export function LiveConnectionProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<LiveState>({ kind: "connecting" });
+  const [areaErrors, setAreaErrors] = useState<Record<string, string>>({});
+  // Instance (per-provider) source cache — dies with the provider/connection, never module-static.
+  const sourcesRef = useRef(new Map<string, AreaSource>());
+
+  // Join the mesh once on mount (client only) — the browser mints its own token same-origin.
+  useEffect(() => {
+    let cancelled = false;
+    let mesh: LiveMesh | null = null;
+    connectLive().then(
+      (m) => {
+        mesh = m;
+        if (cancelled) m.close();
+        else setState({ kind: "live", mesh: m });
+      },
+      (error) => {
+        if (!cancelled) setState({ kind: "offline", reason: String((error as Error)?.message ?? error) });
+      },
+    );
+    return () => {
+      cancelled = true;
+      mesh?.close();
+      sourcesRef.current.clear();
+    };
+  }, []);
+
+  const connection = state.kind === "live" ? state.mesh.connection : null;
+
+  const getAreaSource = useCallback(
+    (path: string): AreaSource | null => {
+      if (!connection || !path) return null;
+      const cached = sourcesRef.current.get(path);
+      if (cached) return cached;
+      const source = createLiveAreaSource(connection, path, (error) =>
+        setAreaErrors((e) => ({ ...e, [path]: String((error as Error)?.message ?? error) })),
+      );
+      sourcesRef.current.set(path, source);
+      return source;
+    },
+    [connection],
+  );
+
+  return (
+    <LiveConnectionContext.Provider value={{ state, areaErrors, getAreaSource }}>
+      {children}
+    </LiveConnectionContext.Provider>
+  );
+}

--- a/clients/portal-next/src/client/PortalShell.tsx
+++ b/clients/portal-next/src/client/PortalShell.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+// The portal chrome (header + nav) around the routed mesh area — ported from the Vite SPA's
+// Portal.tsx, with Next's router in place of the hash route: nav items are <Link>s and the active
+// item derives from usePathname(). The chrome lives in the App Router layout, so it renders in the
+// FIRST HTML flush and persists across navigations while pages stream in below it.
+
+import { useMemo, type ReactNode } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Avatar, Button, FluentProvider, Input, Text, Tooltip } from "@fluentui/react-components";
+import {
+  ArrowHookUpLeft20Regular,
+  Board20Regular,
+  Book20Regular,
+  Search20Regular,
+} from "@fluentui/react-icons";
+import { ThemeToggle } from "@meshweaver/react";
+import { hrefForMeshPath } from "../meshPath";
+import { useLiveConnection } from "./LiveConnection";
+import { useHydratedTheme } from "./useHydratedTheme";
+
+const nav = [
+  { path: "", label: "Home", icon: <Board20Regular /> },
+  { path: "Doc", label: "Documentation", icon: <Book20Regular /> },
+];
+
+export function PortalShell({ children }: { children: ReactNode }) {
+  const { theme, mounted } = useHydratedTheme();
+  const live = useLiveConnection();
+  const pathname = usePathname() ?? "/";
+  const currentPath = useMemo(() => decodeURIComponent(pathname).replace(/^\/+|\/+$/g, ""), [pathname]);
+  const userName = live.state.kind === "live" ? live.state.mesh.userId : "Guest";
+
+  return (
+    <FluentProvider theme={theme} style={{ height: "100vh" }}>
+      <div style={{ display: "grid", gridTemplateRows: "52px 1fr", height: "100vh" }}>
+        <header
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+            padding: "0 16px",
+            borderBottom: "1px solid var(--colorNeutralStroke2)",
+          }}
+        >
+          <Text weight="bold" size={400}>
+            ⬡ MeshWeaver
+          </Text>
+          <Input contentBefore={<Search20Regular />} placeholder="Search the mesh…" style={{ maxWidth: 360, flex: 1 }} />
+          <div style={{ flex: 1 }} />
+          {/* Switch back to the classic Blazor shell — same toggle the Vite SPA carries: the
+              portal's GET /frontend/blazor sets the mw-frontend override cookie and redirects.
+              Also set the cookie client-side so the choice sticks when this app is served
+              standalone (no portal endpoint on this origin). */}
+          <Tooltip content="Switch back to the classic Blazor portal" relationship="description">
+            <Button
+              appearance="subtle"
+              icon={<ArrowHookUpLeft20Regular />}
+              onClick={() => {
+                document.cookie = "mw-frontend=Blazor; path=/; max-age=31536000; samesite=lax";
+                window.location.href = "/frontend/blazor";
+              }}
+            >
+              Back to classic
+            </Button>
+          </Tooltip>
+          {/* Theme toggle reads localStorage — render only after mount (SSR-consistent). */}
+          {mounted ? <ThemeToggle /> : null}
+          <Avatar name={userName} size={32} color="colorful" />
+        </header>
+
+        <div style={{ display: "grid", gridTemplateColumns: "220px 1fr", minHeight: 0 }}>
+          <nav
+            style={{
+              borderRight: "1px solid var(--colorNeutralStroke2)",
+              padding: 8,
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+              background: "var(--colorNeutralBackground2)",
+            }}
+          >
+            {nav.map((n) => {
+              const active = n.path === "" ? currentPath === "" : currentPath === n.path || currentPath.startsWith(`${n.path}/`);
+              return (
+                <Link
+                  key={n.path || "home"}
+                  href={hrefForMeshPath(n.path)}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    padding: "8px 10px",
+                    borderRadius: 6,
+                    textDecoration: "none",
+                    color: "inherit",
+                    font: "inherit",
+                    background: active ? "var(--colorNeutralBackground1Selected)" : "transparent",
+                    fontWeight: active ? 600 : 400,
+                  }}
+                >
+                  {n.icon}
+                  {n.label}
+                </Link>
+              );
+            })}
+          </nav>
+
+          <main style={{ overflow: "auto", padding: 24, minWidth: 0 }}>{children}</main>
+        </div>
+      </div>
+    </FluentProvider>
+  );
+}

--- a/clients/portal-next/src/client/Providers.tsx
+++ b/clients/portal-next/src/client/Providers.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+// SSR style extraction + session-scoped providers.
+//
+// Fluent UI v9 styles with Griffel; under streaming SSR the CSS must be flushed INTO the HTML
+// stream or the server-rendered markup arrives unstyled. This is the documented App-Router
+// pattern: a request-scoped DOM renderer + useServerInsertedHTML, which Next calls on every
+// stream flush — renderToStyleElements emits the styles accumulated so far, so Suspense content
+// flushed late still carries its CSS (duplicate <style> elements across flushes are idempotent).
+// <RendererProvider> makes every makeStyles/FluentProvider below use this renderer; <SSRProvider>
+// keeps Fluent's generated ids stable across server and client.
+
+import { useState, type ReactNode } from "react";
+import { useServerInsertedHTML } from "next/navigation";
+// Griffel SSR utils via Fluent's OWN re-export — guarantees the renderer context is the same
+// module instance the Fluent components read (a direct @griffel/react import can resolve to a
+// second copy under some loaders — the dual-package hazard).
+import { createDOMRenderer, renderToStyleElements, RendererProvider, SSRProvider } from "@fluentui/react-components";
+import { LiveConnectionProvider } from "./LiveConnection";
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [renderer] = useState(() => createDOMRenderer());
+
+  useServerInsertedHTML(() => <>{renderToStyleElements(renderer)}</>);
+
+  return (
+    <RendererProvider renderer={renderer}>
+      <SSRProvider>
+        <LiveConnectionProvider>{children}</LiveConnectionProvider>
+      </SSRProvider>
+    </RendererProvider>
+  );
+}

--- a/clients/portal-next/src/client/live.ts
+++ b/clients/portal-next/src/client/live.ts
@@ -1,0 +1,85 @@
+// Live mesh connection for the Next portal — the CLIENT half of the SSR/live split, ported from
+// clients/portal/src/live.ts (the Vite SPA). After hydration the browser mints its own short-lived
+// token same-origin (POST /api/tokens, cookie-authorized) and joins the mesh over gRPC-web
+// (POST {origin}/meshweaver.v1.Mesh/Connect + /Deliver — mapped at the ORIGIN ROOT, independent of
+// this app's /next basePath). The token lives in memory only — never persisted.
+//
+// The mint response's nodePath ("{userId}/ApiToken/…") reveals the caller's home partition, which
+// is the default route — the same derivation the server-side snapshot module uses.
+//
+// This file is client-only by construction (window.location default); the server-side counterpart
+// (src/server/snapshot.ts) is REST-only and never opens a stream.
+
+import { GrpcAreaSource, type AreaSource } from "@meshweaver/react/core";
+import type { MeshNodeState, MeshOps, ThreadSubmitOptions } from "@meshweaver/react/core";
+import { connect, Mesh, type MeshWebConnection } from "@meshweaver/client-web";
+
+export interface LiveMesh {
+  connection: MeshWebConnection;
+  /** The thread/node operations surface ThreadChat consumes (Mesh.from(connection), adapted). */
+  ops: MeshOps;
+  /** The signed-in user's mesh id (their home partition) — the default route. */
+  userId: string;
+  close(): void;
+}
+
+/** Mint a short-lived API token off the browser session, then join the mesh over gRPC-web. */
+export async function connectLive(baseUrl: string = window.location.origin): Promise<LiveMesh> {
+  const resp = await fetch(`${baseUrl}/api/tokens`, {
+    method: "POST",
+    credentials: "same-origin", // the session cookie authorizes the mint
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ label: "react-portal-next", expiresInDays: 1 }),
+  });
+  if (!resp.ok) throw new Error(`token mint failed (${resp.status} ${resp.statusText})`);
+  const { rawToken, nodePath } = (await resp.json()) as { rawToken?: string; nodePath?: string };
+  if (!rawToken) throw new Error("token mint returned no rawToken");
+
+  const connection = await connect(baseUrl, { token: rawToken });
+  const mesh = Mesh.from(connection);
+  return {
+    connection,
+    ops: adaptOps(mesh),
+    userId: (nodePath ?? "").split("/")[0] ?? "",
+    close: () => connection.close(),
+  };
+}
+
+/**
+ * Live AreaSource for a mesh node path — subscribes the node's DEFAULT layout area (area "": the
+ * server resolves the default and the first frame carries the areas[""] indirection, so the
+ * renderer's root key is ""). `onError` fires if the live stream faults.
+ */
+export function createLiveAreaSource(
+  connection: MeshWebConnection,
+  path: string,
+  onError: (error: unknown) => void,
+): AreaSource {
+  const source = new GrpcAreaSource(connection, path, { area: "" });
+  source.start().catch(onError);
+  return source;
+}
+
+/** Root area key of a default-area subscription (matches the SSR preview tree's root, so live
+ *  takeover swaps the AreaSource under the SAME MeshAreaView rootArea). */
+export const DEFAULT_ROOT_AREA = "";
+
+// Mesh satisfies MeshOps in spirit, but not structurally to the letter (MeshNode.path is optional
+// where MeshNodeState.path is required) — adapt instead of casting.
+function adaptOps(mesh: Mesh): MeshOps {
+  return {
+    watch: (path: string) => watchNode(mesh, path),
+    startThread: (namespacePath: string, userText: string, opts?: ThreadSubmitOptions) =>
+      mesh.startThread(namespacePath, userText, opts),
+    submitMessage: (threadPath: string, userText: string, opts?: ThreadSubmitOptions) =>
+      mesh.submitMessage(threadPath, userText, opts),
+    patch: (path: string, fields: Record<string, unknown>) => mesh.patch(path, fields),
+    search: (query: string, basePath?: string, limit?: number) => mesh.search(query, basePath, limit),
+  };
+}
+
+async function* watchNode(mesh: Mesh, path: string): AsyncIterable<MeshNodeState> {
+  for await (const node of mesh.watch(path)) {
+    yield { ...node.raw, path: node.path ?? path, name: node.name, nodeType: node.nodeType, content: node.content };
+  }
+}

--- a/clients/portal-next/src/client/useHydratedTheme.ts
+++ b/clients/portal-next/src/client/useHydratedTheme.ts
@@ -1,0 +1,27 @@
+"use client";
+
+// Hydration-safe theming: the server (and the client's FIRST render, which must match it) pins the
+// light theme; after mount the user's persisted light/dark/system preference takes over via the
+// renderer's useThemeMode (localStorage["theme"] + prefers-color-scheme — browser-only APIs, hence
+// the mounted gate). Same key/shape as the Blazor portal and the Vite SPA.
+
+import { useEffect, useState } from "react";
+import type { Theme } from "@fluentui/react-components";
+import { fluentThemeFor, useThemeMode, type ThemeState } from "@meshweaver/react";
+
+export interface HydratedTheme extends Omit<ThemeState, "theme"> {
+  theme: Theme;
+  /** False during SSR + the hydration render; true once client-only state may differ from SSR. */
+  mounted: boolean;
+}
+
+export function useHydratedTheme(): HydratedTheme {
+  const themeState = useThemeMode();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  return {
+    ...themeState,
+    mounted,
+    theme: mounted ? themeState.theme : fluentThemeFor("light"),
+  };
+}

--- a/clients/portal-next/src/meshPath.ts
+++ b/clients/portal-next/src/meshPath.ts
@@ -1,0 +1,35 @@
+// URL path <-> mesh path mapping for the [[...meshPath]] optional catch-all route.
+//
+// `/next/Doc/GUI` → segments ["Doc","GUI"] → mesh path "Doc/GUI"; `/next` (no segments) → ""
+// meaning "the authenticated user's home" (resolved server-side from the token mint's nodePath,
+// mirroring the SPA's no-hash default — see live.ts / server/snapshot.ts).
+
+/** Join the catch-all segments into a mesh path. Decodes each segment, drops empties and any
+ *  traversal noise; "" means "no explicit path" (→ the user's home partition). */
+export function meshPathFromSegments(segments: readonly string[] | undefined | null): string {
+  if (!segments || segments.length === 0) return "";
+  return segments
+    .map((s) => {
+      try {
+        return decodeURIComponent(s);
+      } catch {
+        return s; // malformed escape — keep the raw segment rather than 500
+      }
+    })
+    .map((s) => s.replace(/\/+$/g, "").trim())
+    .filter((s) => s.length > 0 && s !== "." && s !== "..")
+    .join("/");
+}
+
+/** App-relative href for a mesh path ("" → "/", the home route). basePath is applied by Next. */
+export function hrefForMeshPath(path: string): string {
+  if (!path) return "/";
+  return (
+    "/" +
+    path
+      .split("/")
+      .filter((s) => s.length > 0)
+      .map((s) => encodeURIComponent(s))
+      .join("/")
+  );
+}

--- a/clients/portal-next/src/server/snapshot.ts
+++ b/clients/portal-next/src/server/snapshot.ts
@@ -1,0 +1,184 @@
+// Server-side, STATELESS snapshot access to the portal — one request in, one snapshot out.
+//
+// 🚨 HARD RULE (the whole point of this architecture): the server NEVER opens a gRPC/stream
+// subscription. Everything here is a bounded HTTPS request/response against the portal origin —
+// mint a short-lived token off the INCOMING request's cookies, fetch a snapshot, render, done.
+// Live state is exclusively the CLIENT's job (see client/live.ts — the browser mints its own
+// token same-origin, exactly like the Vite SPA).
+//
+// Snapshot surface (investigated against the source):
+//   - Token mint: POST {origin}/api/tokens (cookie-authorized; ApiTokenController in
+//     memex/Memex.Portal.Shared/Authentication/ApiTokenController.cs). Response
+//     { rawToken, nodePath, … } — nodePath is "{userId}/ApiToken/…", which reveals the caller's
+//     home partition (the SPA derives its default route the same way). The token is held in
+//     request-scoped locals ONLY — never persisted, never sent to the client.
+//   - Node snapshot: POST {origin}/api/mesh/get (MeshApiEndpoints.MapMeshApi — the REST
+//     transport-mirror of the MCP tools, Bearer mw_… authorized). Returns the MeshNode JSON, or
+//     a bare "Error: …" / "Not found: …" sentinel string (MeshOperations contract).
+//   - ⚠️ There is NO REST render-area endpoint: MapMeshApi maps get/search/create/update/patch/
+//     delete/move/copy/recycle/compile/diagnostics/execute-script/mirror/navigate-to/base-url/
+//     upload — no render. The MCP `render_area` tool (McpMeshPlugin.RenderArea) does NOT return
+//     the rendered UiControl tree either — it returns an MCP-UI iframe embed pointing at the
+//     portal URL. Neither shape is hydratable, so the SSR snapshot is the documented FALLBACK:
+//     an app-shell + a node-snapshot preview tree (title/type/markdown synthesized from
+//     /api/mesh/get), replaced by the live gRPC-web area after hydration.
+
+import "server-only";
+import * as React from "react";
+import type { AreaTree, Json, UiControl } from "@meshweaver/react/core";
+
+// React.cache exists in Next's vendored server runtime (per-request memoization). Stable react
+// (vitest) doesn't export it — fall through to the uncached function there.
+const requestCache: <T extends (...args: never[]) => unknown>(fn: T) => T =
+  (React as { cache?: <T>(fn: T) => T }).cache ?? ((fn) => fn);
+
+export interface MintedToken {
+  rawToken: string;
+  /** "{userId}/ApiToken/…" — the caller's home partition prefix. */
+  nodePath: string;
+  /** The signed-in user's mesh id (home partition) — the default route. */
+  userId: string;
+}
+
+/** Resolve the portal origin: PORTAL_ORIGIN env wins; otherwise same host as the incoming
+ *  request (x-forwarded-proto/host aware — the ingress fronts both the portal and this app). */
+export function resolvePortalOrigin(headers: Headers, env: NodeJS.ProcessEnv = process.env): string {
+  const configured = env.PORTAL_ORIGIN;
+  if (configured) return configured.replace(/\/+$/, "");
+  const host = headers.get("x-forwarded-host") ?? headers.get("host") ?? "localhost";
+  const proto =
+    headers.get("x-forwarded-proto") ?? (/^(localhost|127\.0\.0\.1)(:\d+)?$/.test(host) ? "http" : "https");
+  return `${proto}://${host}`;
+}
+
+/**
+ * Mint a short-lived API token by forwarding the incoming request's cookies to the portal's
+ * cookie-authorized mint endpoint. Returns null when the session is not authenticated (or no
+ * portal lives on the origin) — SSR then degrades to the app shell and the client still attempts
+ * its own takeover. Wrapped in React's per-request `cache` so multiple areas in one render share
+ * one mint.
+ */
+export const mintToken = requestCache(async (origin: string, cookieHeader: string): Promise<MintedToken | null> => {
+  if (!cookieHeader) return null;
+  try {
+    const resp = await fetch(`${origin}/api/tokens`, {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        "content-type": "application/json",
+        cookie: cookieHeader, // the incoming request's session cookie authorizes the mint
+      },
+      body: JSON.stringify({ label: "portal-next-ssr", expiresInDays: 1 }),
+    });
+    if (!resp.ok) return null;
+    const body = (await resp.json()) as { rawToken?: string; nodePath?: string };
+    if (!body.rawToken) return null;
+    const nodePath = body.nodePath ?? "";
+    return { rawToken: body.rawToken, nodePath, userId: nodePath.split("/")[0] ?? "" };
+  } catch {
+    return null; // no portal on this origin / network error — SSR degrades gracefully
+  }
+});
+
+/** Tolerant property pick — the hub serializer casing differs between hosts (camel vs Pascal),
+ *  exactly like the grpc-web client's `m["change"] ?? m["Change"]` reads. */
+function pick(obj: Json, key: string): Json {
+  if (obj == null || typeof obj !== "object") return undefined;
+  const pascal = key.charAt(0).toUpperCase() + key.slice(1);
+  return (obj as Record<string, Json>)[key] ?? (obj as Record<string, Json>)[pascal];
+}
+
+export interface NodeSnapshot {
+  path: string;
+  name: string;
+  nodeType?: string;
+  /** Best-effort markdown-ish body extracted from the node content (may be undefined). */
+  markdown?: string;
+}
+
+/**
+ * Fetch the MeshNode snapshot over REST (`POST /api/mesh/get`). Handles the MeshOperations
+ * response contract: a JSON document on success, or a bare "Error: …" / "Not found: …" string
+ * (shipped as-is with an application/json content type — NOT valid JSON, so parse defensively).
+ */
+export async function fetchNodeSnapshot(
+  origin: string,
+  token: string,
+  path: string,
+): Promise<NodeSnapshot | null> {
+  try {
+    const resp = await fetch(`${origin}/api/mesh/get`, {
+      method: "POST",
+      cache: "no-store",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({ path }),
+    });
+    if (!resp.ok) return null;
+    const text = await resp.text();
+    if (text.startsWith("Error:") || text.startsWith("Not found:")) return null;
+    let parsed: Json;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return null;
+    }
+    if (parsed == null || typeof parsed !== "object") return null;
+    // A broken-NodeType read arrives wrapped: { node, compilationError }.
+    const node = pick(parsed, "node") ?? parsed;
+    return toSnapshot(node, path);
+  } catch {
+    return null;
+  }
+}
+
+function toSnapshot(node: Json, fallbackPath: string): NodeSnapshot | null {
+  if (node == null || typeof node !== "object") return null;
+  const path = asString(pick(node, "path")) ?? fallbackPath;
+  const name = asString(pick(node, "name")) ?? path.split("/").pop() ?? path;
+  const nodeType = asString(pick(node, "nodeType"));
+  const content = pick(node, "content");
+  const markdown =
+    typeof content === "string"
+      ? content
+      : (asString(pick(content, "markdown")) ??
+        asString(pick(content, "text")) ??
+        asString(pick(content, "description")));
+  return { path, name, nodeType, markdown };
+}
+
+function asString(v: Json): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/** Root area key of the SSR preview tree — the same key the live default-area subscription uses
+ *  (the server resolves the default area into areas[""]), so live takeover swaps the source only. */
+export const SSR_ROOT_AREA = "";
+
+/**
+ * Synthesize the SSR preview AreaTree from a node snapshot — rendered server-side through the
+ * EXISTING @meshweaver/react registry (same {areas,data} shape the mesh streams; see
+ * clients/portal/src/sample.ts for the canonical literal-tree form). This is honest "app shell+"
+ * content: the node's real name/type/markdown as first paint, replaced by the live area.
+ */
+export function buildInitialTree(snapshot: NodeSnapshot): AreaTree {
+  const ref = (area: string): UiControl => ({ $type: "NamedArea", area });
+  const children = [ref("ssrTitle"), ref("ssrMeta")];
+  const areas: Record<string, UiControl> = {
+    [SSR_ROOT_AREA]: {
+      $type: "Stack",
+      skins: [{ $type: "LayoutStack", verticalGap: 12 }],
+      areas: children,
+    },
+    ssrTitle: { $type: "Label", typo: "PageTitle", data: snapshot.name },
+    ssrMeta: {
+      $type: "Label",
+      typo: "Subtitle",
+      data: snapshot.nodeType ? `${snapshot.nodeType} · ${snapshot.path}` : snapshot.path,
+    },
+  };
+  if (snapshot.markdown) {
+    children.push(ref("ssrBody"));
+    areas.ssrBody = { $type: "Markdown", data: snapshot.markdown };
+  }
+  return { areas };
+}

--- a/clients/portal-next/test/meshPath.test.ts
+++ b/clients/portal-next/test/meshPath.test.ts
@@ -1,0 +1,39 @@
+// URL ↔ mesh path mapping for the [[...meshPath]] route.
+import { describe, expect, it } from "vitest";
+import { hrefForMeshPath, meshPathFromSegments } from "../src/meshPath";
+
+describe("meshPathFromSegments", () => {
+  it("maps no segments to the empty (home) path", () => {
+    expect(meshPathFromSegments(undefined)).toBe("");
+    expect(meshPathFromSegments(null)).toBe("");
+    expect(meshPathFromSegments([])).toBe("");
+  });
+
+  it("joins segments into a mesh path", () => {
+    expect(meshPathFromSegments(["Doc", "GUI"])).toBe("Doc/GUI");
+    expect(meshPathFromSegments(["rbuergi"])).toBe("rbuergi");
+  });
+
+  it("decodes URL-encoded segments (Next delivers catch-all segments raw)", () => {
+    expect(meshPathFromSegments(["My%20Space", "Sub%2FArea"])).toBe("My Space/Sub/Area");
+  });
+
+  it("tolerates malformed escapes instead of throwing", () => {
+    expect(meshPathFromSegments(["100%"])).toBe("100%");
+  });
+
+  it("drops empty and traversal segments", () => {
+    expect(meshPathFromSegments(["", "Doc", ".", "..", "GUI", ""])).toBe("Doc/GUI");
+  });
+});
+
+describe("hrefForMeshPath", () => {
+  it("maps home to /", () => {
+    expect(hrefForMeshPath("")).toBe("/");
+  });
+
+  it("encodes each segment", () => {
+    expect(hrefForMeshPath("Doc/GUI")).toBe("/Doc/GUI");
+    expect(hrefForMeshPath("My Space/Notes")).toBe("/My%20Space/Notes");
+  });
+});

--- a/clients/portal-next/test/seeding.test.tsx
+++ b/clients/portal-next/test/seeding.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+// Snapshot → StaticAreaSource seeding: the tree synthesized by the server module renders through
+// the real @meshweaver/react registry, seeded into a StaticAreaSource exactly as the LiveArea
+// client boundary does before live takeover.
+import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { webLightTheme } from "@fluentui/react-components";
+import { MeshAreaView, StaticAreaSource } from "@meshweaver/react";
+import { buildInitialTree, SSR_ROOT_AREA, type NodeSnapshot } from "../src/server/snapshot";
+
+const snapshot: NodeSnapshot = {
+  path: "Doc/GUI",
+  name: "GUI Documentation",
+  nodeType: "Markdown",
+  markdown: "The **mesh** streams layout areas.",
+};
+
+describe("snapshot → StaticAreaSource seeding", () => {
+  it("builds the preview tree rooted at the live default-area key", () => {
+    const tree = buildInitialTree(snapshot);
+    expect(tree.areas?.[SSR_ROOT_AREA]).toBeTruthy();
+    expect(SSR_ROOT_AREA).toBe(""); // the live subscription's root — takeover swaps the source only
+    expect(tree.areas?.ssrTitle).toMatchObject({ $type: "Label", data: "GUI Documentation" });
+    expect(tree.areas?.ssrBody).toMatchObject({ $type: "Markdown" });
+  });
+
+  it("omits the body area when the node carries no markdown-ish content", () => {
+    const tree = buildInitialTree({ path: "A", name: "A" });
+    expect(tree.areas?.ssrBody).toBeUndefined();
+  });
+
+  it("renders the seeded tree through the real registry", async () => {
+    const source = new StaticAreaSource(buildInitialTree(snapshot));
+    render(<MeshAreaView source={source} rootArea={SSR_ROOT_AREA} theme={webLightTheme} />);
+
+    expect(screen.getByText("GUI Documentation")).toBeTruthy();
+    expect(screen.getByText("Markdown · Doc/GUI")).toBeTruthy();
+    // react-markdown renders the body: the bold run arrives as a <strong>.
+    expect((await screen.findByText("mesh")).tagName).toBe("STRONG");
+    cleanup();
+  });
+});

--- a/clients/portal-next/test/ssr.test.tsx
+++ b/clients/portal-next/test/ssr.test.tsx
@@ -1,0 +1,53 @@
+// SSR smoke: a UiControl tree renders to HTML MARKUP on the server (node environment, no DOM) —
+// what Next streams inside the page's Suspense boundary — and Griffel's renderer collects the
+// styles for useServerInsertedHTML to flush into the stream.
+import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+// Griffel SSR utils via Fluent's re-export — the same module instance the components use
+// (see Providers.tsx).
+import { createDOMRenderer, RendererProvider, renderToStyleElements, webLightTheme } from "@fluentui/react-components";
+import { MeshAreaView, StaticAreaSource } from "@meshweaver/react";
+import { buildInitialTree, SSR_ROOT_AREA } from "../src/server/snapshot";
+import { LiveArea } from "../src/client/LiveArea";
+
+const snapshot = {
+  path: "Northwind/Dashboard",
+  name: "Northwind Dashboard",
+  nodeType: "Space",
+  markdown: "Sales overview for the current quarter.",
+};
+
+describe("server-side rendering", () => {
+  it("renders a control tree to markup via renderToString", () => {
+    const source = new StaticAreaSource(buildInitialTree(snapshot));
+    const renderer = createDOMRenderer();
+
+    const html = renderToString(
+      <RendererProvider renderer={renderer}>
+        <MeshAreaView source={source} rootArea={SSR_ROOT_AREA} theme={webLightTheme} />
+      </RendererProvider>,
+    );
+
+    expect(html).toContain("Northwind Dashboard");
+    expect(html).toContain("Space · Northwind/Dashboard");
+    expect(html).toContain("Sales overview for the current quarter.");
+
+    // Griffel collected the makeStyles CSS server-side — the style elements
+    // useServerInsertedHTML flushes into the HTML stream.
+    const styles = renderToStyleElements(renderer);
+    expect(styles.length).toBeGreaterThan(0);
+  });
+
+  it("SSRs the LiveArea client boundary from its snapshot seed (no connection provider)", () => {
+    const renderer = createDOMRenderer();
+    const html = renderToString(
+      <RendererProvider renderer={renderer}>
+        <LiveArea path="Northwind/Dashboard" initialTree={buildInitialTree(snapshot)} />
+      </RendererProvider>,
+    );
+
+    expect(html).toContain("data-mw-live-area");
+    expect(html).toContain('data-mw-live="false"'); // never live on the server — no stream exists
+    expect(html).toContain("Northwind Dashboard");
+  });
+});

--- a/clients/portal-next/test/stubs/server-only.ts
+++ b/clients/portal-next/test/stubs/server-only.ts
@@ -1,0 +1,3 @@
+// Test stub for the "server-only" guard package (which throws when imported outside a Next
+// server bundle). The real guard still protects the app build; tests exercise the module in node.
+export {};

--- a/clients/portal-next/test/token.test.ts
+++ b/clients/portal-next/test/token.test.ts
@@ -1,0 +1,146 @@
+// The server-side token forward: the INCOMING request's cookies go to the portal origin's
+// POST /api/tokens; the minted token is returned to the caller's request scope only.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchNodeSnapshot, mintToken, resolvePortalOrigin } from "../src/server/snapshot";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+function mockFetch(handler: (url: string, init: RequestInit) => Response | Promise<Response>) {
+  const spy = vi.fn((url: string | URL | Request, init?: RequestInit) => Promise.resolve(handler(String(url), init ?? {})));
+  globalThis.fetch = spy as unknown as typeof fetch;
+  return spy;
+}
+
+describe("mintToken", () => {
+  it("forwards the incoming request's cookies to the portal's mint endpoint", async () => {
+    const spy = mockFetch(
+      () =>
+        new Response(JSON.stringify({ rawToken: "mw_abc", nodePath: "rbuergi/ApiToken/xyz" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const minted = await mintToken("https://portal.example", ".AspNetCore.Cookies=chunk1; other=2");
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [url, init] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://portal.example/api/tokens");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).cookie).toBe(".AspNetCore.Cookies=chunk1; other=2");
+    expect(JSON.parse(String(init.body))).toMatchObject({ expiresInDays: 1 });
+
+    expect(minted).toEqual({ rawToken: "mw_abc", nodePath: "rbuergi/ApiToken/xyz", userId: "rbuergi" });
+  });
+
+  it("derives the user's home partition from the mint nodePath (the default route)", async () => {
+    mockFetch(
+      () => new Response(JSON.stringify({ rawToken: "mw_1", nodePath: "acme-admin/ApiToken/1" }), { status: 200 }),
+    );
+    const minted = await mintToken("https://p", "c=1; unique-a");
+    expect(minted?.userId).toBe("acme-admin");
+  });
+
+  it("returns null when there is no cookie to forward (anonymous request)", async () => {
+    const spy = mockFetch(() => new Response("{}", { status: 200 }));
+    expect(await mintToken("https://p", "")).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns null on an unauthenticated mint (401) instead of throwing", async () => {
+    mockFetch(() => new Response("", { status: 401 }));
+    expect(await mintToken("https://p", "c=1; unique-b")).toBeNull();
+  });
+
+  it("returns null when the origin has no portal (network error)", async () => {
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch;
+    expect(await mintToken("https://p", "c=1; unique-c")).toBeNull();
+  });
+});
+
+describe("fetchNodeSnapshot", () => {
+  it("POSTs /api/mesh/get with the Bearer token and parses the node JSON", async () => {
+    const spy = mockFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            path: "Doc/GUI",
+            name: "GUI Documentation",
+            nodeType: "Markdown",
+            content: { markdown: "# Hello mesh" },
+          }),
+          { status: 200 },
+        ),
+    );
+
+    const snap = await fetchNodeSnapshot("https://portal.example", "mw_abc", "Doc/GUI");
+
+    const [url, init] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://portal.example/api/mesh/get");
+    expect((init.headers as Record<string, string>).authorization).toBe("Bearer mw_abc");
+    expect(JSON.parse(String(init.body))).toEqual({ path: "Doc/GUI" });
+
+    expect(snap).toEqual({
+      path: "Doc/GUI",
+      name: "GUI Documentation",
+      nodeType: "Markdown",
+      markdown: "# Hello mesh",
+    });
+  });
+
+  it("tolerates PascalCase hub serialization", async () => {
+    mockFetch(
+      () =>
+        new Response(JSON.stringify({ Path: "A/B", Name: "B", NodeType: "Space", Content: { Description: "desc" } }), {
+          status: 200,
+        }),
+    );
+    const snap = await fetchNodeSnapshot("https://p", "t", "A/B");
+    expect(snap).toEqual({ path: "A/B", name: "B", nodeType: "Space", markdown: "desc" });
+  });
+
+  it("handles the MeshOperations 'Error:'/'Not found:' sentinel strings (shipped as raw text)", async () => {
+    mockFetch(() => new Response("Not found: No/Such/Node", { status: 200 }));
+    expect(await fetchNodeSnapshot("https://p", "t", "No/Such/Node")).toBeNull();
+
+    mockFetch(() => new Response("Error: access denied", { status: 200 }));
+    expect(await fetchNodeSnapshot("https://p", "t", "X")).toBeNull();
+  });
+
+  it("unwraps the broken-NodeType envelope ({ node, compilationError })", async () => {
+    mockFetch(
+      () =>
+        new Response(JSON.stringify({ node: { path: "T/Broken", name: "Broken" }, compilationError: "CS0103" }), {
+          status: 200,
+        }),
+    );
+    const snap = await fetchNodeSnapshot("https://p", "t", "T/Broken");
+    expect(snap?.name).toBe("Broken");
+  });
+});
+
+describe("resolvePortalOrigin", () => {
+  const env = (vars: Record<string, string>) => vars as unknown as NodeJS.ProcessEnv;
+
+  it("prefers the PORTAL_ORIGIN env", () => {
+    const h = new Headers({ host: "ignored.example" });
+    expect(resolvePortalOrigin(h, env({ PORTAL_ORIGIN: "https://memex.meshweaver.cloud/" }))).toBe(
+      "https://memex.meshweaver.cloud",
+    );
+  });
+
+  it("defaults to the forwarded host (same-host deployment behind the ingress)", () => {
+    const h = new Headers({ "x-forwarded-host": "memex.meshweaver.cloud", "x-forwarded-proto": "https", host: "pod" });
+    expect(resolvePortalOrigin(h, env({}))).toBe("https://memex.meshweaver.cloud");
+  });
+
+  it("uses http for bare localhost", () => {
+    const h = new Headers({ host: "localhost:3300" });
+    expect(resolvePortalOrigin(h, env({}))).toBe("http://localhost:3300");
+  });
+});

--- a/clients/portal-next/tsconfig.json
+++ b/clients/portal-next/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@meshweaver/react/core": ["../react/src/core.ts"],
+      "@meshweaver/react": ["../react/src/index.tsx"],
+      "@meshweaver/client-web": ["../grpc-web/src/index.ts"]
+    }
+  },
+  "include": ["next-env.d.ts", "app/**/*", "src/**/*", "test/**/*", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/clients/portal-next/vitest.config.ts
+++ b/clients/portal-next/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+// Mirrors next.config.mjs: renderer + transport aliased to SOURCE, single react/fluent copy.
+// "server-only" is a Next-bundler guard package (its default export throws outside a server
+// bundle) — stubbed here so the server snapshot module is unit-testable.
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    dedupe: ["react", "react-dom", "@fluentui/react-components"],
+    alias: {
+      "@meshweaver/react/core": path.resolve(here, "../react/src/core.ts"),
+      "@meshweaver/react": path.resolve(here, "../react/src/index.tsx"),
+      "@meshweaver/client-web": path.resolve(here, "../grpc-web/src/index.ts"),
+      "server-only": path.resolve(here, "test/stubs/server-only.ts"),
+    },
+  },
+  test: {
+    environment: "node", // per-file overrides via "@vitest-environment jsdom" docblocks
+    globals: true,
+    include: ["test/**/*.test.{ts,tsx}"],
+  },
+});

--- a/clients/portal/src/Portal.tsx
+++ b/clients/portal/src/Portal.tsx
@@ -1,23 +1,134 @@
-import { useState } from "react";
-import { Avatar, FluentProvider, Input, Text, webLightTheme } from "@fluentui/react-components";
-import { Board20Regular, Search20Regular, Table20Regular, Person20Regular } from "@fluentui/react-icons";
-import { RegistryProvider, RenderArea, ScopeProvider, StaticAreaSource, fluentPack } from "@meshweaver/react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Avatar,
+  Button,
+  FluentProvider,
+  Input,
+  MessageBar,
+  MessageBarBody,
+  Spinner,
+  Text,
+  Tooltip,
+} from "@fluentui/react-components";
+import {
+  ArrowHookUpLeft20Regular,
+  Board20Regular,
+  Book20Regular,
+  Search20Regular,
+  Table20Regular,
+  Person20Regular,
+} from "@fluentui/react-icons";
+import {
+  MeshAreaView,
+  EmbeddedAreaProvider,
+  GrpcAreaSource,
+  RegistryProvider,
+  RenderArea,
+  ScopeProvider,
+  StaticAreaSource,
+  ThemeToggle,
+  fluentPack,
+  useThemeMode,
+} from "@meshweaver/react";
+import type { AreaSource } from "@meshweaver/react";
 import { portalAreas } from "./sample";
+import { DEFAULT_ROOT_AREA, connectLive, createLiveAreaSource, type LiveMesh } from "./live";
 
-// A MeshWeaver web portal: an app shell (header + nav) around a switchable mesh layout area — the web
-// analog of the Blazor portal / MAUI app. The chrome is plain Fluent; the content is the renderer.
-const source = new StaticAreaSource(portalAreas);
+// A MeshWeaver web portal: an app shell (header + nav) around a mesh layout area — the web analog
+// of the Blazor portal / MAUI app. The chrome is plain Fluent; the content is the renderer.
+//
+// LIVE MODE: on load the shell joins the mesh over same-origin gRPC-web (see live.ts for the
+// route + token bootstrap) and renders REAL layout areas: the hash route `#/{meshPath}` addresses
+// any mesh node's default area (`/app/#/Doc/GUI` mirrors the Blazor portal's /Doc/GUI), and no
+// hash renders the signed-in user's home — what Blazor shows at /{user}. ThreadChat works through
+// MeshOpsProvider (MeshAreaView's ops prop, wired to Mesh.from(connection)).
+// When the connection cannot be established (no portal on this origin, or the session is not
+// authenticated) the shell falls back to the bundled SAMPLE data with an "offline sample mode"
+// banner — the same demo the standalone `vite dev` shows.
+const sampleSource = new StaticAreaSource(portalAreas);
 
-const nav = [
+const sampleNav = [
   { key: "home", label: "Dashboard", icon: <Board20Regular /> },
   { key: "accounts", label: "Accounts", icon: <Table20Regular /> },
   { key: "profile", label: "Profile", icon: <Person20Regular /> },
 ];
 
+type LiveState =
+  | { kind: "connecting" }
+  | { kind: "live"; mesh: LiveMesh }
+  | { kind: "offline"; reason: string };
+
+/** The mesh path addressed by the hash route (`#/Doc/GUI` → `Doc/GUI`); "" when no route is set. */
+function readHashPath(): string {
+  const h = window.location.hash;
+  if (!h.startsWith("#/")) return "";
+  return decodeURIComponent(h.slice(2)).replace(/\/+$/, "");
+}
+
+function useHashPath(): string {
+  const [path, setPath] = useState(readHashPath);
+  useEffect(() => {
+    const onChange = () => setPath(readHashPath());
+    window.addEventListener("hashchange", onChange);
+    return () => window.removeEventListener("hashchange", onChange);
+  }, []);
+  return path;
+}
+
 export function Portal() {
-  const [area, setArea] = useState("home");
+  const [sampleArea, setSampleArea] = useState("home");
+  const [live, setLive] = useState<LiveState>({ kind: "connecting" });
+  const [areaErrors, setAreaErrors] = useState<Record<string, string>>({});
+  const hashPath = useHashPath();
+  // Light/dark/system — persisted under localStorage["theme"] (the Blazor portal's key), following
+  // the OS preference in system mode. All chrome below uses design tokens, so it restyles with it.
+  const { theme } = useThemeMode();
+
+  // Join the mesh once on mount; fall back to the sample when the origin has no portal / session.
+  useEffect(() => {
+    let cancelled = false;
+    let mesh: LiveMesh | null = null;
+    connectLive().then(
+      (m) => {
+        mesh = m;
+        if (cancelled) m.close();
+        else setLive({ kind: "live", mesh: m });
+      },
+      (error) => {
+        if (!cancelled) setLive({ kind: "offline", reason: String((error as Error)?.message ?? error) });
+      },
+    );
+    return () => {
+      cancelled = true;
+      mesh?.close();
+    };
+  }, []);
+
+  const connection = live.kind === "live" ? live.mesh.connection : null;
+  // One live source per visited path, kept for the connection's lifetime (instant back-nav; the
+  // area stream stays subscribed). The map dies with the connection.
+  const liveSources = useMemo(() => new Map<string, AreaSource>(), [connection]);
+  const livePath = live.kind === "live" ? hashPath || live.mesh.userId : "";
+  let liveSource: AreaSource | null = null;
+  if (connection && livePath) {
+    liveSource = liveSources.get(livePath) ?? null;
+    if (!liveSource) {
+      liveSource = createLiveAreaSource(connection, livePath, (error) =>
+        setAreaErrors((e) => ({ ...e, [livePath]: String((error as Error)?.message ?? error) })),
+      );
+      liveSources.set(livePath, liveSource);
+    }
+  }
+
+  const liveNav = [
+    { key: "", label: "Home", icon: <Board20Regular /> },
+    { key: "Doc", label: "Documentation", icon: <Book20Regular /> },
+  ];
+  const isLive = live.kind === "live";
+  const userName = isLive ? live.mesh.userId : "Guest";
+
   return (
-    <FluentProvider theme={webLightTheme} style={{ height: "100vh" }}>
+    <FluentProvider theme={theme} style={{ height: "100vh" }}>
       <div style={{ display: "grid", gridTemplateRows: "52px 1fr", height: "100vh" }}>
         <header
           style={{
@@ -33,7 +144,25 @@ export function Portal() {
           </Text>
           <Input contentBefore={<Search20Regular />} placeholder="Search the mesh…" style={{ maxWidth: 360, flex: 1 }} />
           <div style={{ flex: 1 }} />
-          <Avatar name="Roland Bürgi" size={32} color="colorful" />
+          {/* The mirror of the Blazor user menu's "Try the new frontend": switch back to the classic
+              shell. Navigates to the portal's frontend-toggle endpoint (GET /frontend/blazor), which
+              sets the mw-frontend override cookie to Blazor and redirects to the classic portal —
+              fully reversible from the Blazor side. Also clears the cookie client-side so the choice
+              sticks even when the React app is served standalone (no portal endpoint on this origin). */}
+          <Tooltip content="Switch back to the classic Blazor portal" relationship="description">
+            <Button
+              appearance="subtle"
+              icon={<ArrowHookUpLeft20Regular />}
+              onClick={() => {
+                document.cookie = "mw-frontend=Blazor; path=/; max-age=31536000; samesite=lax";
+                window.location.href = "/frontend/blazor";
+              }}
+            >
+              Back to classic
+            </Button>
+          </Tooltip>
+          <ThemeToggle />
+          <Avatar name={userName} size={32} color="colorful" />
         </header>
 
         <div style={{ display: "grid", gridTemplateColumns: "220px 1fr", minHeight: 0 }}>
@@ -47,37 +176,92 @@ export function Portal() {
               background: "var(--colorNeutralBackground2)",
             }}
           >
-            {nav.map((n) => (
-              <button
-                key={n.key}
-                onClick={() => setArea(n.key)}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 8,
-                  padding: "8px 10px",
-                  border: "none",
-                  borderRadius: 6,
-                  cursor: "pointer",
-                  textAlign: "left",
-                  font: "inherit",
-                  background: area === n.key ? "var(--colorNeutralBackground1Selected)" : "transparent",
-                  fontWeight: area === n.key ? 600 : 400,
-                }}
-              >
-                {n.icon}
-                {n.label}
-              </button>
-            ))}
+            {(isLive ? liveNav : sampleNav).map((n) => {
+              const active = isLive ? hashPath === n.key || (!hashPath && n.key === "") : sampleArea === n.key;
+              return (
+                <button
+                  key={n.key}
+                  onClick={() => {
+                    if (isLive) window.location.hash = n.key ? `#/${n.key}` : "#/";
+                    else setSampleArea(n.key);
+                  }}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    padding: "8px 10px",
+                    border: "none",
+                    borderRadius: 6,
+                    cursor: "pointer",
+                    textAlign: "left",
+                    font: "inherit",
+                    background: active ? "var(--colorNeutralBackground1Selected)" : "transparent",
+                    fontWeight: active ? 600 : 400,
+                  }}
+                >
+                  {n.icon}
+                  {n.label}
+                </button>
+              );
+            })}
           </nav>
 
           <main style={{ overflow: "auto", padding: 24, minWidth: 0 }}>
-            {/* The renderer core + the Fluent pack (no nested FluentProvider — the shell supplies it). */}
-            <RegistryProvider pack={fluentPack}>
-              <ScopeProvider source={source} area={area}>
-                <RenderArea areaKey={area} />
-              </ScopeProvider>
-            </RegistryProvider>
+            {live.kind === "connecting" && (
+              <div data-mw-connecting style={{ display: "flex", justifyContent: "center", padding: 48 }}>
+                <Spinner label="Connecting to the mesh…" />
+              </div>
+            )}
+
+            {live.kind === "offline" && (
+              <>
+                <div data-mw-offline style={{ marginBottom: 16 }}>
+                  <MessageBar intent="warning">
+                    <MessageBarBody>
+                      Offline sample mode — no live mesh connection on this origin ({live.reason}). Showing bundled
+                      sample data.
+                    </MessageBarBody>
+                  </MessageBar>
+                </div>
+                {/* The renderer core + the Fluent pack (no nested FluentProvider — the shell supplies it). */}
+                <RegistryProvider pack={fluentPack}>
+                  <ScopeProvider source={sampleSource} area={sampleArea}>
+                    <RenderArea areaKey={sampleArea} />
+                  </ScopeProvider>
+                </RegistryProvider>
+              </>
+            )}
+
+            {isLive && (
+              <div data-mw-live-area data-mw-path={livePath} style={{ height: "100%" }}>
+                {areaErrors[livePath] ? (
+                  <div data-mw-area-error>
+                    <MessageBar intent="error">
+                      <MessageBarBody>
+                        Live area “{livePath}” failed: {areaErrors[livePath]}
+                      </MessageBarBody>
+                    </MessageBar>
+                  </div>
+                ) : liveSource && connection ? (
+                  // The live renderer: the node's default layout area streamed over gRPC-web,
+                  // with the thread ops surface (ThreadChat) provided via MeshOpsProvider and
+                  // nested LayoutAreaControl embeds hydrating through their own live sources.
+                  <EmbeddedAreaProvider
+                    factory={(address, ref) => {
+                      const src = new GrpcAreaSource(connection, address, {
+                        area: ref.area ?? "",
+                        id: ref.id as string | undefined,
+                        layout: ref.layout,
+                      });
+                      void src.start();
+                      return { source: src, rootArea: ref.area ?? "" };
+                    }}
+                  >
+                    <MeshAreaView source={liveSource} rootArea={DEFAULT_ROOT_AREA} theme={theme} ops={live.mesh.ops} />
+                  </EmbeddedAreaProvider>
+                ) : null}
+              </div>
+            )}
           </main>
         </div>
       </div>

--- a/clients/portal/src/live.ts
+++ b/clients/portal/src/live.ts
@@ -1,0 +1,92 @@
+// Live mesh connection for the portal example — same-origin gRPC-web (the Connect+Deliver split).
+//
+// Connection route (pinned against the server source): `MapMeshWeaverGrpc()` maps the
+// `meshweaver.v1.Mesh` service at the ORIGIN ROOT (POST {origin}/meshweaver.v1.Mesh/Connect and
+// /Deliver, grpc-web enabled — GrpcHostingExtensions). The SPA is served under /app/, but that is
+// only where its static assets live — the transport base URL is `location.origin`.
+//
+// Auth (GrpcConnectionRegistry.Authenticate): the gRPC connection is identified by a Bearer
+// `mw_…` API token in the call metadata — the browser's session COOKIE is NOT read on this path
+// (no token ⇒ Anonymous ⇒ the user's content is RLS-denied). The SPA is served to an
+// already-authenticated browser session, so it bootstraps a short-lived token from the portal's
+// cookie-authorized mint endpoint (POST /api/tokens — the same endpoint the E2E fixture's
+// MintTokenAsync uses) via a same-origin fetch. The token lives in memory only — never persisted.
+//
+// The mint response's nodePath (`{userId}/ApiToken/…`) reveals the caller's mesh partition — the
+// ApiTokenController routes the token node into exactly the user's home partition — which gives
+// the SPA its default route (the user's home, mirroring what the Blazor portal shows at /{user})
+// without a separate who-am-I endpoint.
+
+import { GrpcAreaSource, type AreaSource } from "@meshweaver/react/core";
+import type { MeshNodeState, MeshOps, ThreadSubmitOptions } from "@meshweaver/react/core";
+import { connect, Mesh, type MeshWebConnection } from "@meshweaver/client-web";
+
+export interface LiveMesh {
+  connection: MeshWebConnection;
+  /** The thread/node operations surface ThreadChat consumes (Mesh.from(connection), adapted). */
+  ops: MeshOps;
+  /** The signed-in user's mesh id (their home partition) — the default route. */
+  userId: string;
+  close(): void;
+}
+
+/** Mint a short-lived API token off the browser session, then join the mesh over gRPC-web. */
+export async function connectLive(baseUrl: string = window.location.origin): Promise<LiveMesh> {
+  const resp = await fetch(`${baseUrl}/api/tokens`, {
+    method: "POST",
+    credentials: "same-origin", // the session cookie authorizes the mint
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ label: "react-portal", expiresInDays: 1 }),
+  });
+  if (!resp.ok) throw new Error(`token mint failed (${resp.status} ${resp.statusText})`);
+  const { rawToken, nodePath } = (await resp.json()) as { rawToken?: string; nodePath?: string };
+  if (!rawToken) throw new Error("token mint returned no rawToken");
+
+  const connection = await connect(baseUrl, { token: rawToken });
+  const mesh = Mesh.from(connection);
+  return {
+    connection,
+    ops: adaptOps(mesh),
+    userId: (nodePath ?? "").split("/")[0] ?? "",
+    close: () => connection.close(),
+  };
+}
+
+/**
+ * Live AreaSource for a mesh node path — subscribes the node's DEFAULT layout area (area "": the
+ * server resolves the default and the first frame carries the areas[""] indirection, so the
+ * renderer's root key is ""). This mirrors the Blazor AreaPage, which resolves /{path} to the node
+ * address + a null-area LayoutAreaReference. `onError` fires if the live stream faults.
+ */
+export function createLiveAreaSource(
+  connection: MeshWebConnection,
+  path: string,
+  onError: (error: unknown) => void,
+): AreaSource {
+  const source = new GrpcAreaSource(connection, path, { area: "" });
+  source.start().catch(onError);
+  return source;
+}
+
+/** Root area key of a default-area subscription (the server's NamedArea indirection lives there). */
+export const DEFAULT_ROOT_AREA = "";
+
+// Mesh satisfies MeshOps in spirit, but not structurally to the letter (MeshNode.path is optional
+// where MeshNodeState.path is required) — adapt instead of casting.
+function adaptOps(mesh: Mesh): MeshOps {
+  return {
+    watch: (path: string) => watchNode(mesh, path),
+    startThread: (namespacePath: string, userText: string, opts?: ThreadSubmitOptions) =>
+      mesh.startThread(namespacePath, userText, opts),
+    submitMessage: (threadPath: string, userText: string, opts?: ThreadSubmitOptions) =>
+      mesh.submitMessage(threadPath, userText, opts),
+    patch: (path: string, fields: Record<string, unknown>) => mesh.patch(path, fields),
+    search: (query: string, basePath?: string, limit?: number) => mesh.search(query, basePath, limit),
+  };
+}
+
+async function* watchNode(mesh: Mesh, path: string): AsyncIterable<MeshNodeState> {
+  for await (const node of mesh.watch(path)) {
+    yield { ...node.raw, path: node.path ?? path, name: node.name, nodeType: node.nodeType, content: node.content };
+  }
+}

--- a/clients/portal/tsconfig.json
+++ b/clients/portal/tsconfig.json
@@ -12,7 +12,8 @@
     "baseUrl": ".",
     "paths": {
       "@meshweaver/react/core": ["../react/src/core.ts"],
-      "@meshweaver/react": ["../react/src/index.tsx"]
+      "@meshweaver/react": ["../react/src/index.tsx"],
+      "@meshweaver/client-web": ["../grpc-web/src/index.ts"]
     }
   },
   "include": ["src"]

--- a/clients/portal/vite.config.ts
+++ b/clients/portal/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
     alias: {
       "@meshweaver/react/core": path.resolve(here, "../react/src/core.ts"),
       "@meshweaver/react": path.resolve(here, "../react/src/index.tsx"),
+      // The live transport (gRPC-web Connect+Deliver split); its generated stubs come from
+      // `npm run gen` in clients/grpc-web, its deps resolve from clients/grpc-web/node_modules.
+      "@meshweaver/client-web": path.resolve(here, "../grpc-web/src/index.ts"),
     },
   },
 });

--- a/clients/react/package.json
+++ b/clients/react/package.json
@@ -37,6 +37,8 @@
   "dependencies": {
     "@fluentui/react-components": "^9.54.0",
     "@fluentui/react-icons": "^2.0.260",
+    "@monaco-editor/react": "^4.7.0",
+    "chart.js": "^4.4.1",
     "react-markdown": "^9.0.1",
     "remark-gfm": "^4.0.0"
   },

--- a/clients/react/src/area/pointer.ts
+++ b/clients/react/src/area/pointer.ts
@@ -10,9 +10,29 @@ function escape(p: string): string {
   return p.replace(/~/g, "~0").replace(/\//g, "~1");
 }
 
+/**
+ * Decode one wire pointer segment. On the wire, EntityStore instance keys are JSON-ENCODED
+ * property names (the server's InstanceCollectionConverter / LayoutAreaReference.GetDataPointer:
+ * a data id "model" becomes the segment `"model"` — WITH literal quotes). The live source folds
+ * DECODED (plain) keys into the tree, so binding pointers that arrive wire-encoded
+ * (`/data/"model"/name`) must decode their quoted segments to resolve. Plain segments pass through.
+ */
+export function decodePointerSegment(seg: string): string {
+  const un = unescape(seg);
+  if (un.length >= 2 && un.startsWith('"') && un.endsWith('"')) {
+    try {
+      const parsed: unknown = JSON.parse(un);
+      if (typeof parsed === "string") return parsed;
+    } catch {
+      /* not a JSON-encoded key — keep the raw segment */
+    }
+  }
+  return un;
+}
+
 export function getPointer(root: Json, pointer: string): Json {
   if (!pointer || pointer === "/" || pointer === "#") return root;
-  const parts = pointer.replace(/^#/, "").split("/").slice(1).map(unescape);
+  const parts = pointer.replace(/^#/, "").split("/").slice(1).map(decodePointerSegment);
   let cur: Json = root;
   for (const part of parts) {
     if (cur == null) return undefined;
@@ -23,7 +43,7 @@ export function getPointer(root: Json, pointer: string): Json {
 
 /** Immutably set the value at a JSON pointer, creating intermediate objects as needed. */
 export function setPointer(root: Json, pointer: string, value: Json): Json {
-  const parts = pointer.replace(/^#/, "").split("/").slice(1).map(unescape);
+  const parts = pointer.replace(/^#/, "").split("/").slice(1).map(decodePointerSegment);
   if (parts.length === 0) return value;
   const clone = Array.isArray(root) ? [...root] : { ...(root ?? {}) };
   let cur: Json = clone;

--- a/clients/react/src/area/types.ts
+++ b/clients/react/src/area/types.ts
@@ -36,9 +36,10 @@ export interface AreaTree {
 }
 
 export interface MeshEvent {
-  kind: "click" | "blur" | "update";
+  kind: "click" | "blur" | "update" | "closeDialog";
   area: string;
   pointer?: string;
+  /** For "update": the new value. For "closeDialog": the DialogCloseState ("OK" | "Cancel"). */
   value?: Json;
 }
 

--- a/clients/react/src/controls/appearance.tsx
+++ b/clients/react/src/controls/appearance.tsx
@@ -1,0 +1,64 @@
+// The Appearance control — Blazor renders this as AppearanceView: the theme settings panel
+// (mode select persisted in localStorage["theme"], reset button). This is the React mirror of the
+// same panel, bound to the same storage via useThemeMode. Accent color / text direction picking
+// (Blazor's OfficeColor + Direction) are not ported yet — see the parity ratchet.
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Button, Divider, Dropdown, Field, Option, Text } from "@fluentui/react-components";
+import { clearStoredTheme, useThemeMode, type ThemeMode } from "../theme/themeMode.js";
+
+const modes: { value: ThemeMode; text: string }[] = [
+  { value: "system", text: "System" },
+  { value: "light", text: "Light" },
+  { value: "dark", text: "Dark" },
+];
+
+function AppearanceView(): ReactNode {
+  const { mode, setMode } = useThemeMode();
+  const [status, setStatus] = useState("");
+  const current = modes.find((m) => m.value === mode) ?? modes[0];
+  return (
+    <div style={{ maxWidth: 500, display: "flex", flexDirection: "column", gap: 16 }}>
+      <Field label="Theme">
+        <Dropdown
+          value={current.text}
+          selectedOptions={[current.value]}
+          onOptionSelect={(_, d) => {
+            if (d.optionValue) {
+              setMode(d.optionValue as ThemeMode);
+              setStatus("");
+            }
+          }}
+        >
+          {modes.map((m) => (
+            <Option key={m.value} value={m.value}>
+              {m.text}
+            </Option>
+          ))}
+        </Dropdown>
+      </Field>
+      <Text size={200}>These values are persisted in LocalStorage and will be recovered during your next visits.</Text>
+      <Divider />
+      <div>
+        <Button
+          onClick={() => {
+            clearStoredTheme();
+            setStatus("Settings reset!");
+          }}
+        >
+          Reset settings
+        </Button>
+      </div>
+      {status ? (
+        <Text size={200} italic weight="bold">
+          {status}
+        </Text>
+      ) : null}
+    </div>
+  );
+}
+
+export const appearanceControls = {
+  Appearance: AppearanceView,
+};

--- a/clients/react/src/controls/chart.test.tsx
+++ b/clients/react/src/controls/chart.test.tsx
@@ -1,0 +1,152 @@
+// ChartControl → Chart.js mapping parity. The wire contract is ChartControl + ChartSeries
+// (src/MeshWeaver.Layout/Chart) — series discriminated by $type ("bar"|"column"|"line"|"pie"|…) —
+// and the SAME payload must fold into a Chart.js config that mirrors what the Blazor side renders:
+// column = vertical bars, bar = horizontal (indexAxis y), line tension/fill, doughnut cutout,
+// stacked scales, legend/title plumbing.
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource } from "../core.js";
+import { chartConfigFor, chartTypeFor } from "./chart.js";
+
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = ((q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null })) as unknown as typeof window.matchMedia;
+});
+
+describe("chartTypeFor — wire $type discriminators", () => {
+  it("maps every ChartSeries discriminator to its Chart.js type", () => {
+    expect(chartTypeFor("column")).toEqual({ type: "bar", horizontal: false });
+    expect(chartTypeFor("bar")).toEqual({ type: "bar", horizontal: true }); // BarSeries = horizontal
+    expect(chartTypeFor("line").type).toBe("line");
+    expect(chartTypeFor("pie").type).toBe("pie");
+    expect(chartTypeFor("doughnut").type).toBe("doughnut");
+    expect(chartTypeFor("radar").type).toBe("radar");
+    expect(chartTypeFor("polar").type).toBe("polarArea");
+    expect(chartTypeFor("scatter").type).toBe("scatter");
+    expect(chartTypeFor("bubble").type).toBe("bubble");
+  });
+
+  it("tolerates serialized class names besides the JsonDerivedType tags", () => {
+    expect(chartTypeFor("LineSeries").type).toBe("line");
+    expect(chartTypeFor("DoughnutSeries").type).toBe("doughnut");
+  });
+});
+
+describe("chartConfigFor — the ChartControl wire payload", () => {
+  const labels = ["Q1", "Q2", "Q3"];
+
+  it("builds a column (vertical bar) chart with title, legend and labels", () => {
+    const cfg = chartConfigFor({
+      title: "Revenue",
+      showLegend: true,
+      legendPosition: "Bottom",
+      labels,
+      series: [{ $type: "column", label: "2025", data: [1, 2, 3] }],
+    });
+    expect(cfg.type).toBe("bar");
+    expect(cfg.options.indexAxis).toBeUndefined();
+    expect(cfg.data.labels).toEqual(labels);
+    expect(cfg.data.datasets[0]).toMatchObject({ label: "2025", data: [1, 2, 3] });
+    expect(cfg.options.plugins.title).toEqual({ display: true, text: "Revenue" });
+    expect(cfg.options.plugins.legend).toEqual({ display: true, position: "bottom" });
+  });
+
+  it("renders BarSeries horizontally (indexAxis y) — the Radzen bar/column split", () => {
+    const cfg = chartConfigFor({ labels, series: [{ $type: "bar", data: [1, 2, 3] }] });
+    expect(cfg.type).toBe("bar");
+    expect(cfg.options.indexAxis).toBe("y");
+  });
+
+  it("maps line series props (tension, fill = area chart, pointRadius)", () => {
+    const cfg = chartConfigFor({
+      labels,
+      series: [{ $type: "line", data: [4, 5, 6], tension: 0.4, fill: true, pointRadius: 2 }],
+    });
+    expect(cfg.type).toBe("line");
+    expect(cfg.data.datasets[0]).toMatchObject({ tension: 0.4, fill: true, pointRadius: 2 });
+  });
+
+  it("pie/doughnut: circular charts get per-slice colors and no cartesian scales", () => {
+    const cfg = chartConfigFor({ labels, series: [{ $type: "doughnut", data: [1, 2, 3], cutout: "60%" }] });
+    expect(cfg.type).toBe("doughnut");
+    expect(cfg.options.scales).toBeUndefined();
+    expect(Array.isArray(cfg.data.datasets[0].backgroundColor)).toBe(true);
+    expect(cfg.data.datasets[0].backgroundColor).toHaveLength(3);
+    expect(cfg.data.datasets[0].cutout).toBe("60%");
+  });
+
+  it("isStacked stacks both axes; categoryAxisLabelAngle rotates ticks; disableAnimation kills animation", () => {
+    const cfg = chartConfigFor({
+      labels,
+      isStacked: true,
+      disableAnimation: true,
+      categoryAxisLabelAngle: -45,
+      series: [
+        { $type: "column", label: "A", data: [1, 2, 3] },
+        { $type: "column", label: "B", data: [4, 5, 6] },
+      ],
+    });
+    expect(cfg.options.scales.x.stacked).toBe(true);
+    expect(cfg.options.scales.y.stacked).toBe(true);
+    expect(cfg.options.scales.x.ticks.maxRotation).toBe(45);
+    expect(cfg.options.animation).toBe(false);
+  });
+
+  it("mixed cartesian series get per-dataset types (column base + line overlay)", () => {
+    const cfg = chartConfigFor({
+      labels,
+      series: [
+        { $type: "column", data: [1, 2, 3] },
+        { $type: "line", data: [2, 2, 2] },
+      ],
+    });
+    expect(cfg.type).toBe("bar");
+    expect(cfg.data.datasets[0].type).toBeUndefined();
+    expect(cfg.data.datasets[1].type).toBe("line");
+  });
+
+  it("scatter/bubble pass point objects through untouched", () => {
+    const cfg = chartConfigFor({ series: [{ $type: "bubble", data: [{ x: 1, y: 2, r: 3 }] }] });
+    expect(cfg.type).toBe("bubble");
+    expect(cfg.data.datasets[0].data).toEqual([{ x: 1, y: 2, r: 3 }]);
+  });
+
+  it("wire colors win over the palette; hidden series stay hidden", () => {
+    const cfg = chartConfigFor({
+      labels,
+      series: [{ $type: "column", data: [1], backgroundColor: "#123456", hidden: true }],
+    });
+    expect(cfg.data.datasets[0].backgroundColor).toBe("#123456");
+    expect(cfg.data.datasets[0].hidden).toBe(true);
+  });
+});
+
+describe("ChartView — DOM rendering", () => {
+  it("renders an accessible canvas sized by width/height from a realistic payload", () => {
+    const source = new StaticAreaSource({
+      data: {},
+      areas: {
+        main: {
+          $type: "Chart",
+          title: "Sales by quarter",
+          labels: ["Q1", "Q2"],
+          series: [{ $type: "column", label: "2026", data: [10, 20] }],
+          height: "240px",
+        },
+      },
+    });
+    render(<MeshAreaView source={source} rootArea="main" />);
+    const canvas = screen.getByRole("img", { name: "Sales by quarter" });
+    expect(canvas.tagName).toBe("CANVAS");
+    expect((canvas.parentElement as HTMLElement).style.height).toBe("240px");
+  });
+
+  it("shows the no-data message when the series are empty (Blazor parity)", () => {
+    const source = new StaticAreaSource({ data: {}, areas: { main: { $type: "Chart", series: [] } } });
+    render(<MeshAreaView source={source} rootArea="main" />);
+    expect(screen.getByText("No chart data available")).toBeTruthy();
+  });
+});

--- a/clients/react/src/controls/chart.tsx
+++ b/clients/react/src/controls/chart.tsx
@@ -1,0 +1,225 @@
+// ChartControl on Chart.js — the SAME wire contract the Blazor side binds
+// (src/MeshWeaver.Layout/Chart/ChartControl.cs + ChartSeries.cs, rendered by RadzenChartView):
+//   { title, subtitle, showLegend, legendPosition ("Top"|"Bottom"|"Left"|"Right"), labels: string[],
+//     series: [{ $type: "bar"|"column"|"line"|"pie"|"doughnut"|"radar"|"polar"|"scatter"|"bubble",
+//                data, label, backgroundColor, borderColor, borderWidth, hidden, tension, fill,
+//                pointRadius, cutout, barPercentage, categoryPercentage }],
+//     isStacked, disableAnimation, width (default "100%"), height (default "400px"),
+//     categoryAxisLabelAngle (default -45) }
+// ($type discriminators are the JsonDerivedType tags on ChartSeries; class names are tolerated.)
+//
+// The mapping to a Chart.js config is a PURE function (chartConfigFor) pinned by tests; the view
+// dynamically imports chart.js/auto (client-only, code-split — the lib bundle stays lean) and
+// falls back to an empty canvas in hosts without a 2D canvas (jsdom, SSR).
+
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { Text } from "@fluentui/react-components";
+import type { Json, UiControl } from "../area/types.js";
+import { useResolve } from "../area/context.js";
+import { str } from "./common.js";
+
+interface WireSeries {
+  $type?: string;
+  data?: Json[];
+  label?: Json;
+  backgroundColor?: Json;
+  borderColor?: Json;
+  borderWidth?: Json;
+  hidden?: Json;
+  tension?: Json;
+  fill?: Json;
+  pointRadius?: Json;
+  cutout?: Json;
+  barPercentage?: Json;
+  categoryPercentage?: Json;
+  [key: string]: Json;
+}
+
+export interface ChartInputs {
+  title?: Json;
+  subtitle?: Json;
+  showLegend?: Json;
+  legendPosition?: Json;
+  labels?: Json;
+  series?: Json;
+  isStacked?: Json;
+  disableAnimation?: Json;
+  categoryAxisLabelAngle?: Json;
+}
+
+/** The default series palette (matches the hand-rolled chart this replaces; Blazor lets Radzen pick). */
+export const chartPalette = ["#0f6cbd", "#107c10", "#d83b01", "#5c2e91", "#008272", "#c239b3", "#986f0b"];
+
+/** Wire `$type` → Chart.js chart type. Tolerates the class names ("BarSeries") besides the tags. */
+export function chartTypeFor(seriesType: string | undefined): { type: string; horizontal: boolean } {
+  const t = (seriesType ?? "").toLowerCase().replace(/series$/, "");
+  switch (t) {
+    case "bar":
+      return { type: "bar", horizontal: true }; // Blazor's BarSeries = horizontal bars
+    case "column":
+      return { type: "bar", horizontal: false };
+    case "line":
+      return { type: "line", horizontal: false };
+    case "pie":
+      return { type: "pie", horizontal: false };
+    case "doughnut":
+      return { type: "doughnut", horizontal: false };
+    case "radar":
+      return { type: "radar", horizontal: false };
+    case "polar":
+      return { type: "polarArea", horizontal: false };
+    case "scatter":
+      return { type: "scatter", horizontal: false };
+    case "bubble":
+      return { type: "bubble", horizontal: false };
+    default:
+      return { type: "bar", horizontal: false };
+  }
+}
+
+const CIRCULAR = new Set(["pie", "doughnut", "polarArea"]);
+
+function seriesData(s: WireSeries): Json[] {
+  const raw = Array.isArray(s.data) ? s.data : Array.isArray(s.values) ? (s.values as Json[]) : [];
+  return raw.map((v) => (v != null && typeof v === "object" ? v : Number(v)));
+}
+
+/** Build the Chart.js config for the resolved ChartControl props. Pure — pinned by chart.test.tsx. */
+export function chartConfigFor(p: ChartInputs): Json {
+  const labels = (Array.isArray(p.labels) ? p.labels : []).map(str);
+  const series = (Array.isArray(p.series) ? (p.series as WireSeries[]) : []).filter((s) => s != null);
+  const kinds = series.map((s) => chartTypeFor(s.$type));
+  const base = kinds[0] ?? { type: "bar", horizontal: false };
+  const circular = CIRCULAR.has(base.type);
+  const mixed = kinds.some((k) => k.type !== base.type);
+
+  const datasets = series.map((s, i) => {
+    const kind = kinds[i];
+    const data = seriesData(s);
+    // Circular charts color per-slice; cartesian per-dataset. Wire colors win when present.
+    const autoColor = CIRCULAR.has(kind.type) ? data.map((_, j) => chartPalette[j % chartPalette.length]) : chartPalette[i % chartPalette.length];
+    const ds: Record<string, Json> = {
+      label: s.label != null ? str(s.label) : undefined,
+      data,
+      backgroundColor: s.backgroundColor ?? autoColor,
+      borderColor: s.borderColor ?? (kind.type === "line" || kind.type === "radar" ? autoColor : undefined),
+      borderWidth: s.borderWidth,
+      hidden: s.hidden === true ? true : undefined,
+      tension: s.tension != null ? Number(s.tension) : undefined,
+      fill: s.fill != null ? s.fill : undefined,
+      pointRadius: s.pointRadius != null ? Number(s.pointRadius) : undefined,
+      cutout: s.cutout != null ? s.cutout : undefined,
+      barPercentage: s.barPercentage != null ? Number(s.barPercentage) : undefined,
+      categoryPercentage: s.categoryPercentage != null ? Number(s.categoryPercentage) : undefined,
+    };
+    if (mixed && kind.type !== base.type) ds.type = kind.type;
+    for (const k of Object.keys(ds)) if (ds[k] === undefined) delete ds[k];
+    return ds;
+  });
+
+  const title = str(p.title);
+  const subtitle = str(p.subtitle);
+  const angle = p.categoryAxisLabelAngle != null ? Math.abs(Number(p.categoryAxisLabelAngle)) : 45;
+  const stacked = p.isStacked === true;
+
+  const config: Record<string, Json> = {
+    type: base.type,
+    data: { labels, datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      ...(base.horizontal ? { indexAxis: "y" } : {}),
+      ...(p.disableAnimation === true ? { animation: false } : {}),
+      plugins: {
+        title: { display: title.length > 0, text: title },
+        subtitle: { display: subtitle.length > 0, text: subtitle },
+        legend: {
+          display: p.showLegend === true,
+          position: str(p.legendPosition).toLowerCase() || "top",
+        },
+      },
+      ...(circular
+        ? {}
+        : {
+            scales: {
+              x: { stacked, ticks: { maxRotation: angle, minRotation: 0, autoSkip: true } },
+              y: { stacked, beginAtZero: true },
+            },
+          }),
+    },
+  };
+  return config;
+}
+
+interface ChartLike {
+  destroy(): void;
+}
+
+export function ChartView({ control }: { control: UiControl }): ReactNode {
+  const title = str(useResolve(control.title));
+  const subtitle = useResolve(control.subtitle);
+  const labels = useResolve(control.labels);
+  const series = useResolve(control.series);
+  const showLegend = useResolve(control.showLegend);
+  const legendPosition = useResolve(control.legendPosition);
+  const isStacked = useResolve(control.isStacked);
+  const disableAnimation = useResolve(control.disableAnimation);
+  const angle = useResolve(control.categoryAxisLabelAngle);
+  const width = str(useResolve(control.width)) || "100%";
+  const height = str(useResolve(control.height)) || "400px";
+
+  const config = useMemo(
+    () =>
+      chartConfigFor({
+        title,
+        subtitle,
+        labels,
+        series,
+        showLegend,
+        legendPosition,
+        isStacked,
+        disableAnimation,
+        categoryAxisLabelAngle: angle,
+      }),
+    [title, subtitle, labels, series, showLegend, legendPosition, isStacked, disableAnimation, angle],
+  );
+  const configKey = useMemo(() => JSON.stringify(config), [config]);
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    let live = true;
+    let chart: ChartLike | undefined;
+    import("chart.js/auto")
+      .then(({ default: Chart }) => {
+        if (!live) return;
+        const ctx = canvas.getContext?.("2d");
+        if (!ctx) return; // no 2D canvas (jsdom / SSR) — the empty canvas stands in
+        chart = new Chart(ctx as never, JSON.parse(configKey)) as unknown as ChartLike;
+      })
+      .catch(() => undefined);
+    return () => {
+      live = false;
+      chart?.destroy();
+    };
+  }, [configKey]);
+
+  const hasData = Array.isArray(series) && series.length > 0;
+  if (!hasData)
+    return (
+      <Text italic size={200}>
+        No chart data available
+      </Text>
+    );
+  return (
+    <div style={{ position: "relative", width, height }}>
+      <canvas ref={canvasRef} role="img" aria-label={title || "Chart"} />
+    </div>
+  );
+}
+
+export const chartControls = {
+  Chart: ChartView,
+};

--- a/clients/react/src/controls/containers.tsx
+++ b/clients/react/src/controls/containers.tsx
@@ -1,8 +1,22 @@
 import type { ReactNode } from "react";
-import { Card, Divider, Link, MessageBar, MessageBarBody, Text, Title3 } from "@fluentui/react-components";
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  Link,
+  MessageBar,
+  MessageBarBody,
+  Spinner,
+} from "@fluentui/react-components";
 import type { Json, UiControl } from "../area/types.js";
-import { useResolve } from "../area/context.js";
+import { ScopeProvider, useAreaState, useEmit, useResolve, useScope } from "../area/context.js";
 import { RenderArea } from "../render/ControlRenderer.js";
+import { useAreaSourceFactory, type EmbeddedAreaHandle } from "../render/embeddedArea.js";
 import { str, useText } from "./common.js";
 
 /** A leaf that renders a referenced area by key/path. */
@@ -11,35 +25,120 @@ function NamedAreaView({ control }: { control: UiControl }): ReactNode {
   return area ? <RenderArea areaKey={area} /> : null;
 }
 
-/** Embeds a layout area from another address — needs a second stream; shown as a marker for now. */
+// ---- LayoutArea (nested area embed) ---------------------------------------------------------------
+// LayoutAreaControl wire (src/MeshWeaver.Layout/LayoutAreaControl.cs):
+//   { address, reference: { area, id?, layout? }, showProgress (default true), progressMessage,
+//     spinnerType: "Ring"|"Dots"|"Skeleton"|"None" }
+// The REAL embed opens a second AreaSource for the referenced (address, area, id) via the host's
+// AreaSourceFactory (render/embeddedArea.tsx) and renders the nested tree in its own scope — the
+// React mirror of Blazor's LayoutAreaView binding a second synchronization stream. Hosts without a
+// factory (static demos, unit tests) get the link marker instead.
+
+/** Renders inside the NESTED source's scope: spinner until the root area arrives, then the tree. */
+function EmbeddedAreaBody({ rootArea, showProgress, progressMessage }: { rootArea: string; showProgress: boolean; progressMessage?: string }): ReactNode {
+  const state = useAreaState();
+  const loaded = state.areas?.[rootArea] != null;
+  if (!loaded) return showProgress ? <Spinner size="small" label={progressMessage || undefined} /> : null;
+  return <RenderArea areaKey={rootArea} />;
+}
+
 function LayoutAreaView({ control }: { control: UiControl }): ReactNode {
-  const ref = control.reference as Json;
+  const factory = useAreaSourceFactory();
+  const rawAddress = useResolve(control.address);
+  const address = typeof rawAddress === "string" ? rawAddress : str(rawAddress?.address ?? rawAddress?.path ?? "");
+  const ref = (control.reference ?? {}) as Json;
+  const area = str(ref.area ?? ref.Area ?? "");
+  const id = ref.id ?? ref.Id;
+  const layout = ref.layout ?? ref.Layout;
+  const showProgress = useResolve(control.showProgress) !== false;
+  const progressMessage = str(useResolve(control.progressMessage));
+  const spinnerType = str(control.spinnerType);
+  const key = `${address}|${area}|${id == null ? "" : str(id)}|${str(layout)}`;
+
+  const [handle, setHandle] = useState<EmbeddedAreaHandle | null>(null);
+  useEffect(() => {
+    if (!factory || !address) return;
+    const h = factory(address, { area: area || undefined, id, layout: layout ? String(layout) : undefined });
+    setHandle(h);
+    return () => {
+      h?.dispose?.();
+      setHandle(null);
+    };
+    // key captures address/area/id/layout; factory identity changes re-open the subscription.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [factory, key]);
+
+  if (!factory || !address) {
+    // No nested-area support in this host — the informative marker (previous behavior).
+    return (
+      <MessageBar intent="info">
+        <MessageBarBody>
+          Embedded layout area <b>{area}</b> @ {address}
+        </MessageBarBody>
+      </MessageBar>
+    );
+  }
+  if (!handle) return showProgress && spinnerType !== "None" ? <Spinner size="small" label={progressMessage || undefined} /> : null;
+
+  const rootArea = handle.rootArea ?? area;
   return (
-    <MessageBar intent="info">
-      <MessageBarBody>
-        Embedded layout area <b>{str(ref?.area ?? ref?.Area)}</b> @ {useText(control.address)}
-      </MessageBarBody>
-    </MessageBar>
+    <ScopeProvider source={handle.source} area={rootArea}>
+      <EmbeddedAreaBody rootArea={rootArea} showProgress={showProgress && spinnerType !== "None"} progressMessage={progressMessage} />
+    </ScopeProvider>
   );
 }
 
+/** Blazor's DialogView size → --dialog-width mapping (S/M/L). */
+function dialogWidth(size: string): string {
+  switch (size) {
+    case "S":
+      return "400px";
+    case "L":
+      return "800px";
+    default:
+      return "600px";
+  }
+}
+
+/**
+ * A real modal dialog — the mirror of Blazor's DialogView (FluentDialog): shown on mount, title in
+ * the header, ContentArea in the body, ActionsArea in the footer when HasActions (else a Close
+ * button when IsClosable), and a CloseDialogEvent posted back to the owning hub on dismissal.
+ */
 function DialogView({ control }: { control: UiControl }): ReactNode {
+  const [open, setOpen] = useState(true);
+  const emit = useEmit();
+  const { area } = useScope();
   const title = useText(control.title);
+  const size = str(useResolve(control.size)) || "M";
+  const isClosable = !!useResolve(control.isClosable);
+  const hasActions = !!useResolve(control.hasActions);
   const contentArea = (control.contentArea as UiControl | undefined)?.area;
   const actionsArea = (control.actionsArea as UiControl | undefined)?.area;
+  const close = (state: "OK" | "Cancel") => {
+    setOpen(false);
+    emit({ kind: "closeDialog", area, value: state });
+  };
   return (
-    <Card style={{ padding: 16, maxWidth: 520, boxShadow: "var(--shadow16)" }}>
-      {title ? <Title3>{title}</Title3> : null}
-      {contentArea ? <RenderArea areaKey={String(contentArea)} /> : null}
-      {actionsArea ? (
-        <>
-          <Divider />
-          <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-            <RenderArea areaKey={String(actionsArea)} />
-          </div>
-        </>
-      ) : null}
-    </Card>
+    <Dialog open={open} modalType="modal" onOpenChange={(_, d) => !d.open && close("Cancel")}>
+      <DialogSurface style={{ maxWidth: dialogWidth(size) }}>
+        <DialogBody>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogContent>{contentArea ? <RenderArea areaKey={String(contentArea)} /> : null}</DialogContent>
+          {hasActions && actionsArea ? (
+            <DialogActions>
+              <RenderArea areaKey={String(actionsArea)} />
+            </DialogActions>
+          ) : isClosable ? (
+            <DialogActions>
+              <Button appearance="secondary" onClick={() => close("OK")}>
+                Close
+              </Button>
+            </DialogActions>
+          ) : null}
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
   );
 }
 
@@ -48,56 +147,9 @@ function RedirectView({ control }: { control: UiControl }): ReactNode {
   return <Link href={href}>{href}</Link>;
 }
 
-interface Series {
-  name?: string;
-  data?: number[];
-  values?: number[];
-}
-
-function ChartView({ control }: { control: UiControl }): ReactNode {
-  const title = useText(control.title);
-  const labels = (useResolve(control.labels) as Json[]) ?? [];
-  const series = ((useResolve(control.series) as Series[]) ?? []).map((s) => ({
-    name: str(s.name),
-    data: (s.data ?? s.values ?? []).map(Number),
-  }));
-  const max = Math.max(1, ...series.flatMap((s) => s.data));
-  const colors = ["#0f6cbd", "#107c10", "#d83b01", "#5c2e91", "#008272"];
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-      {title ? <Text weight="semibold">{title}</Text> : null}
-      <div style={{ display: "flex", alignItems: "flex-end", gap: 12, height: 160, padding: "8px 0" }}>
-        {labels.map((lbl, i) => (
-          <div key={i} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4, flex: 1 }}>
-            <div style={{ display: "flex", alignItems: "flex-end", gap: 2, height: 120 }}>
-              {series.map((s, si) => (
-                <div
-                  key={si}
-                  title={`${s.name}: ${s.data[i] ?? 0}`}
-                  style={{ width: 14, height: `${((s.data[i] ?? 0) / max) * 120}px`, background: colors[si % colors.length], borderRadius: 2 }}
-                />
-              ))}
-            </div>
-            <Text size={100}>{str(lbl)}</Text>
-          </div>
-        ))}
-      </div>
-      <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-        {series.map((s, si) => (
-          <span key={si} style={{ display: "flex", alignItems: "center", gap: 4 }}>
-            <span style={{ width: 10, height: 10, background: colors[si % colors.length], borderRadius: 2 }} />
-            <Text size={200}>{s.name}</Text>
-          </span>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 export const containerControls = {
   NamedArea: NamedAreaView,
   LayoutArea: LayoutAreaView,
   Dialog: DialogView,
   Redirect: RedirectView,
-  Chart: ChartView,
 };

--- a/clients/react/src/controls/data.tsx
+++ b/clients/react/src/controls/data.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { useState } from "react";
 import {
   Card,
   DataGrid,
@@ -11,6 +12,7 @@ import {
   createTableColumn,
   type TableColumnDefinition,
 } from "@fluentui/react-components";
+import { ChevronDown20Regular, ChevronRight20Regular } from "@fluentui/react-icons";
 import type { Json, UiControl } from "../area/types.js";
 import { useResolve } from "../area/context.js";
 import { ControlRenderer } from "../render/ControlRenderer.js";
@@ -18,10 +20,12 @@ import { str } from "./common.js";
 
 type Row = Record<string, Json> & { __id: string };
 
-function formatValue(v: Json, format?: string): string {
+/** .NET-style numeric formatting ("N0", "C2", "P1"; "{0:N2}" tolerated). Shared with PivotGrid. */
+export function formatValue(v: Json, format?: string): string {
   if (v == null) return "";
-  if (format && typeof v === "number") {
-    const m = /^([NCP])(\d+)?$/i.exec(format);
+  const f = format?.replace(/^\{0:(.+)\}$/, "$1");
+  if (f && typeof v === "number") {
+    const m = /^([NCP])(\d+)?$/i.exec(f);
     if (m) {
       const digits = m[2] ? Number(m[2]) : m[1].toUpperCase() === "N" ? 0 : 2;
       const n = v.toLocaleString(undefined, { minimumFractionDigits: digits, maximumFractionDigits: digits });
@@ -75,9 +79,79 @@ function DataGridView({ control }: { control: UiControl }): ReactNode {
   );
 }
 
+// ---- Catalog ------------------------------------------------------------------------------------
+// CatalogControl wire (src/MeshWeaver.Layout/Catalog/CatalogControl.cs):
+//   { groups: [{ key, label, emoji, order, isExpanded, items: UiControl[], totalCount }],
+//     collapsibleSections, showCounts, sectionGap, cardHeight, ... }
+// Each item is a full UiControl tree — rendered through the registry, exactly like Blazor's
+// CatalogView dispatches each item view.
+
+interface CatalogGroupWire {
+  key?: string;
+  label?: string;
+  emoji?: string;
+  order?: number;
+  isExpanded?: boolean;
+  items?: UiControl[];
+  totalCount?: number;
+}
+
+function CatalogSection({ group, collapsible, showCounts, cardHeight }: { group: CatalogGroupWire; collapsible: boolean; showCounts: boolean; cardHeight: number }): ReactNode {
+  const [open, setOpen] = useState(group.isExpanded !== false);
+  const items = Array.isArray(group.items) ? group.items : [];
+  const count = group.totalCount || items.length;
+  return (
+    <section>
+      <div
+        role={collapsible ? "button" : undefined}
+        onClick={collapsible ? () => setOpen((o) => !o) : undefined}
+        style={{ display: "flex", alignItems: "center", gap: 6, cursor: collapsible ? "pointer" : "default", padding: "4px 0" }}
+      >
+        {collapsible ? (open ? <ChevronDown20Regular /> : <ChevronRight20Regular />) : null}
+        <Text weight="semibold" size={400}>
+          {group.emoji ? `${group.emoji} ` : ""}
+          {str(group.label ?? group.key)}
+        </Text>
+        {showCounts ? (
+          <Text size={200} style={{ color: "var(--colorNeutralForeground3)" }}>
+            ({count})
+          </Text>
+        ) : null}
+      </div>
+      {open ? (
+        <div style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}>
+          {items.map((item, i) => (
+            <div key={i} style={{ minHeight: cardHeight }}>
+              <ControlRenderer control={item} />
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 function CatalogView({ control }: { control: UiControl }): ReactNode {
-  const items = useResolve(control.data);
-  const arr = Array.isArray(items) ? items : [];
+  const groups = (useResolve(control.groups) as CatalogGroupWire[]) ?? [];
+  const legacyItems = useResolve(control.data);
+  const collapsible = control.collapsibleSections !== false;
+  const showCounts = control.showCounts !== false;
+  const sectionGap = Number(control.sectionGap ?? 16) || 16;
+  const cardHeight = Number(control.cardHeight ?? 140) || 140;
+
+  if (Array.isArray(groups) && groups.length > 0) {
+    const ordered = [...groups].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: sectionGap }}>
+        {ordered.map((g, i) => (
+          <CatalogSection key={g.key ?? i} group={g} collapsible={collapsible} showCounts={showCounts} cardHeight={cardHeight} />
+        ))}
+      </div>
+    );
+  }
+
+  // Legacy/demo shape: a flat `data` array of {name,title,description} records.
+  const arr = Array.isArray(legacyItems) ? legacyItems : [];
   return (
     <div style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}>
       {arr.map((it, i) => (
@@ -92,7 +166,5 @@ function CatalogView({ control }: { control: UiControl }): ReactNode {
 
 export const dataControls = {
   DataGrid: DataGridView,
-  PivotGrid: DataGridView,
   Catalog: CatalogView,
-  MeshNodeCollection: CatalogView,
 };

--- a/clients/react/src/controls/dialog.test.tsx
+++ b/clients/react/src/controls/dialog.test.tsx
@@ -1,0 +1,72 @@
+// Dialog parity with Blazor's DialogView (FluentDialog): a REAL modal — shown on mount, title in
+// the header, ContentArea in the body, ActionsArea in the footer when hasActions (else Close when
+// isClosable) — and dismissal posts a CloseDialogEvent (the "closeDialog" MeshEvent) exactly like
+// Blazor's HandleClose posts CloseDialogEvent(Area, StreamId, DialogCloseState).
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource, type AreaTree } from "../core.js";
+
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = ((q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null })) as unknown as typeof window.matchMedia;
+  if (!(globalThis as any).ResizeObserver)
+    (globalThis as any).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+});
+
+function dialogTree(overrides: Record<string, unknown> = {}): AreaTree {
+  return {
+    data: {},
+    areas: {
+      main: {
+        $type: "Dialog",
+        title: "Confirm action",
+        isClosable: true,
+        contentArea: { $type: "NamedArea", area: "$Dialog/ContentArea" },
+        actionsArea: { $type: "NamedArea", area: "$Dialog/ActionsArea" },
+        ...overrides,
+      },
+      "$Dialog/ContentArea": { $type: "Label", data: "Are you sure?" },
+      "$Dialog/ActionsArea": { $type: "Button", data: "Create", isClickable: true },
+    },
+  };
+}
+
+describe("Dialog — a real modal (Blazor DialogView parity)", () => {
+  it("opens as a modal with title and content area", () => {
+    render(<MeshAreaView source={new StaticAreaSource(dialogTree())} rootArea="main" />);
+    const dialog = screen.getByRole("dialog"); // rendered in a portal, not inline
+    expect(dialog.textContent).toContain("Confirm action");
+    expect(dialog.textContent).toContain("Are you sure?");
+    // No actions set → the closable footer shows the default Close button.
+    expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
+  });
+
+  it("renders the ActionsArea in the footer when hasActions (replacing Close)", () => {
+    render(<MeshAreaView source={new StaticAreaSource(dialogTree({ hasActions: true }))} rootArea="main" />);
+    expect(screen.getByRole("button", { name: "Create" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+  });
+
+  it("Close dismisses the dialog and emits the CloseDialogEvent (OK)", () => {
+    const source = new StaticAreaSource(dialogTree());
+    render(<MeshAreaView source={source} rootArea="main" />);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    const close = source.events.find((e) => e.kind === "closeDialog");
+    expect(close?.area).toBe("main");
+    expect(close?.value).toBe("OK");
+  });
+
+  it("applies Blazor's size widths (S=400px, M=600px, L=800px)", () => {
+    render(<MeshAreaView source={new StaticAreaSource(dialogTree({ size: "L" }))} rootArea="main" />);
+    const surface = document.querySelector(".fui-DialogSurface") as HTMLElement;
+    expect(surface?.style.maxWidth).toBe("800px");
+  });
+});

--- a/clients/react/src/controls/editForm.test.tsx
+++ b/clients/react/src/controls/editForm.test.tsx
@@ -1,0 +1,73 @@
+// EditForm parity — the container + item-skin contract of EditFormControl
+// (src/MeshWeaver.Layout/EditFormControl.cs, rendered by Blazor's EditFormView + PropertyView):
+// the control's child areas each carry a PropertySkin { name, label, description } wrapping the
+// bound field control; the EditFormSkin stacks them as a form. Fields data-bind per-edit through
+// the standard update event (the React counterpart of the Blazor model round-trip).
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource, type AreaTree } from "../core.js";
+
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = ((q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null })) as unknown as typeof window.matchMedia;
+});
+
+// The wire shape the Edit macro produces: an EditForm container whose child areas are the
+// property editors, each wrapped in a PropertySkin (name/label/description).
+function editFormTree(): AreaTree {
+  return {
+    data: { person: { name: "Ada", bio: "Pioneer" } },
+    areas: {
+      main: {
+        $type: "EditForm",
+        skins: [{ $type: "EditFormSkin" }],
+        areas: [
+          { $type: "NamedArea", area: "main/Name" },
+          { $type: "NamedArea", area: "main/Bio" },
+        ],
+      },
+      "main/Name": {
+        $type: "TextField",
+        data: { $type: "JsonPointerReference", pointer: "/data/person/name" },
+        skins: [{ $type: "PropertySkin", name: "name", label: "Full name", description: "The person's display name" }],
+      },
+      "main/Bio": {
+        $type: "TextArea",
+        data: { $type: "JsonPointerReference", pointer: "/data/person/bio" },
+        skins: [{ $type: "PropertySkin", name: "bio", label: "Biography" }],
+      },
+    },
+  };
+}
+
+describe("EditForm — form rendering from the container + PropertySkin payload", () => {
+  it("renders a form with labeled, described, value-bound fields", () => {
+    render(<MeshAreaView source={new StaticAreaSource(editFormTree())} rootArea="main" />);
+    expect(document.querySelector("form")).toBeTruthy();
+    expect(screen.getByText("Full name")).toBeTruthy();
+    expect(screen.getByText("The person's display name")).toBeTruthy();
+    expect(screen.getByText("Biography")).toBeTruthy();
+    expect(screen.getByDisplayValue("Ada")).toBeTruthy();
+    expect(screen.getByDisplayValue("Pioneer")).toBeTruthy();
+  });
+
+  it("edits write back to the field's pointer via the standard update event", () => {
+    const source = new StaticAreaSource(editFormTree());
+    render(<MeshAreaView source={source} rootArea="main" />);
+    fireEvent.change(screen.getByDisplayValue("Ada"), { target: { value: "Ada Lovelace" } });
+    expect(source.events).toContainEqual(
+      expect.objectContaining({ kind: "update", pointer: "/data/person/name", value: "Ada Lovelace" }),
+    );
+    expect((source.getState().data?.person as { name: string }).name).toBe("Ada Lovelace");
+  });
+
+  it("PropertySkin label falls back to name; missing description renders nothing extra", () => {
+    render(<MeshAreaView source={new StaticAreaSource(editFormTree())} rootArea="main" />);
+    // Bio has no description — only the label shows.
+    const bioLabel = screen.getByText("Biography");
+    expect(bioLabel).toBeTruthy();
+  });
+});

--- a/clients/react/src/controls/editors.tsx
+++ b/clients/react/src/controls/editors.tsx
@@ -1,55 +1,27 @@
+// Editor controls. CodeEditor / MarkdownEditor / DiffEditor render on real Monaco (controls/monaco.tsx
+// — lazily loaded, with a bound-textarea fallback until it arrives). EditForm is normally a SKIN
+// (EditFormControl is a container whose EditFormSkin renders in render/skins.tsx); the leaf entry
+// here covers a skinless EditForm control by rendering its child property areas as a form.
+
 import type { ReactNode } from "react";
-import { Textarea, Text } from "@fluentui/react-components";
+import { Text } from "@fluentui/react-components";
 import type { UiControl } from "../area/types.js";
-import { str, useField } from "./common.js";
-
-// Textarea-based editors. Swap in Monaco (@monaco-editor/react) here for full parity with the Blazor
-// BlazorMonaco editors — the binding (useField) stays the same.
-function CodeEditorView({ control }: { control: UiControl }): ReactNode {
-  const f = useField(control);
-  return (
-    <Textarea
-      value={str(f.value)}
-      disabled={f.disabled}
-      onChange={(_, d) => f.setValue(d.value)}
-      onBlur={f.onBlur}
-      textarea={{ style: { fontFamily: "var(--fontFamilyMonospace)", minHeight: 180 } }}
-      style={{ width: "100%" }}
-    />
-  );
-}
-
-function MarkdownEditorView({ control }: { control: UiControl }): ReactNode {
-  const f = useField(control);
-  return <Textarea value={str(f.value)} disabled={f.disabled} onChange={(_, d) => f.setValue(d.value)} onBlur={f.onBlur} style={{ width: "100%", minHeight: 160 }} />;
-}
-
-function DiffEditorView({ control }: { control: UiControl }): ReactNode {
-  const original = str(control.original ?? control.originalData);
-  const modified = str(control.modified ?? control.data);
-  return (
-    <div style={{ display: "flex", gap: 8 }}>
-      <pre style={paneStyle("removed")}>{original}</pre>
-      <pre style={paneStyle("added")}>{modified}</pre>
-    </div>
-  );
-}
-
-function paneStyle(kind: "added" | "removed"): React.CSSProperties {
-  return {
-    flex: 1,
-    margin: 0,
-    padding: 8,
-    overflow: "auto",
-    fontFamily: "var(--fontFamilyMonospace)",
-    fontSize: 12,
-    background: kind === "added" ? "rgba(16,124,16,0.08)" : "rgba(216,59,1,0.08)",
-    borderRadius: 4,
-  };
-}
+import { RenderChildren } from "../render/ControlRenderer.js";
+import { str } from "./common.js";
+import { CodeEditorView, DiffEditorView, MarkdownEditorView } from "./monaco.js";
 
 function EditFormView({ control }: { control: UiControl }): ReactNode {
-  return <Text italic size={200}>Edit form (auto-generated) — {str(control.$type)}</Text>;
+  if (Array.isArray(control.areas))
+    return (
+      <form onSubmit={(e) => e.preventDefault()} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <RenderChildren control={control} />
+      </form>
+    );
+  return (
+    <Text italic size={200}>
+      Edit form (auto-generated) — {str(control.$type)}
+    </Text>
+  );
 }
 
 export const editorControls = {

--- a/clients/react/src/controls/itemTemplate.test.tsx
+++ b/clients/react/src/controls/itemTemplate.test.tsx
@@ -1,0 +1,90 @@
+// ItemTemplate parity with Blazor's Components/ItemTemplate.razor: the `view` template renders once
+// per item of the bound `data` collection, each instance data-contexted to "{dataPointer}/{i}" so
+// RELATIVE template bindings read from — and write back to — that item.
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource, type AreaTree } from "../core.js";
+
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = ((q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null })) as unknown as typeof window.matchMedia;
+  if (!(globalThis as any).ResizeObserver)
+    (globalThis as any).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+});
+
+const ptr = (pointer: string) => ({ $type: "JsonPointerReference", pointer });
+
+function tree(): AreaTree {
+  return {
+    data: {
+      people: [
+        { name: "Ada", role: "Engineer" },
+        { name: "Grace", role: "Admiral" },
+        { name: "Edsger", role: "Professor" },
+      ],
+    },
+    areas: {
+      main: {
+        $type: "ItemTemplate",
+        data: ptr("/data/people"),
+        view: { $type: "Label", data: ptr("name") }, // relative binding → the item's field
+      },
+    },
+  };
+}
+
+describe("ItemTemplate — the repeater", () => {
+  it("renders the view once per item with per-item relative bindings", () => {
+    const { container } = render(<MeshAreaView source={new StaticAreaSource(tree())} rootArea="main" />);
+    expect(container.textContent).toContain("Ada");
+    expect(container.textContent).toContain("Grace");
+    expect(container.textContent).toContain("Edsger");
+    expect(container.textContent).not.toContain("Unsupported control");
+  });
+
+  it("template edits write back to the ITEM's pointer (dataContext scoping)", () => {
+    const source = new StaticAreaSource({
+      ...tree(),
+      areas: {
+        main: {
+          $type: "ItemTemplate",
+          data: ptr("/data/people"),
+          view: { $type: "TextField", data: ptr("name") },
+        },
+      },
+    });
+    render(<MeshAreaView source={source} rootArea="main" />);
+    const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
+    expect(inputs.map((i) => i.value)).toEqual(["Ada", "Grace", "Edsger"]);
+
+    fireEvent.change(inputs[1], { target: { value: "Grace Hopper" } });
+    const update = source.events.find((e) => e.kind === "update");
+    expect(update?.pointer).toBe("/data/people/1/name");
+    expect(update?.value).toBe("Grace Hopper");
+    expect((source.getState().data as any).people[1].name).toBe("Grace Hopper");
+    // The other items were untouched.
+    expect((source.getState().data as any).people[0].name).toBe("Ada");
+  });
+
+  it("lays out horizontally when orientation says so (Blazor Orientation.Horizontal = 0)", () => {
+    const t = tree();
+    (t.areas!.main as any).orientation = 0;
+    const { container } = render(<MeshAreaView source={new StaticAreaSource(t)} rootArea="main" />);
+    const row = Array.from(container.querySelectorAll("div")).find((d) => d.style.flexDirection === "row");
+    expect(row).toBeTruthy();
+  });
+
+  it("renders nothing gracefully for an empty or unbound collection", () => {
+    const t = tree();
+    (t.data as any).people = [];
+    const { container } = render(<MeshAreaView source={new StaticAreaSource(t)} rootArea="main" />);
+    expect(container.textContent).not.toContain("Unsupported control");
+  });
+});

--- a/clients/react/src/controls/itemTemplate.tsx
+++ b/clients/react/src/controls/itemTemplate.tsx
@@ -1,0 +1,49 @@
+// ItemTemplate — the repeater. Blazor (Components/ItemTemplate.razor) renders the `view` template
+// once per item of the bound `data` collection, giving each instance
+// DataContext = "{dataPointer}/{i}" so the template's RELATIVE bindings resolve (and write back)
+// against that item. The React mirror does exactly that with a per-item ScopeProvider dataContext —
+// the core's pointer resolver already composes relative pointers against the scope's dataContext.
+
+import type { CSSProperties, ReactNode } from "react";
+import { ScopeProvider, useBindingPointer, useResolve, useScope } from "../area/context.js";
+import type { UiControl } from "../area/types.js";
+import { ControlRenderer } from "../render/ControlRenderer.js";
+
+/** MeshWeaver.Layout.Orientation: Horizontal = 0, Vertical = 1 (serialized as number or name). */
+function isHorizontal(orientation: unknown): boolean {
+  if (orientation == null) return false; // Blazor default: vertical
+  if (typeof orientation === "number") return orientation === 0;
+  return String(orientation).toLowerCase() === "horizontal";
+}
+
+function ItemTemplateView({ control }: { control: UiControl }): ReactNode {
+  const { source, area } = useScope();
+  const items = useResolve(control.data);
+  // Absolute pointer of the bound collection (undefined for a literal array — then the template
+  // renders without per-item scope, matching Blazor which requires a bound Data for item binding).
+  const basePointer = useBindingPointer(control.data);
+  const horizontal = isHorizontal(useResolve(control.orientation));
+  const wrap = !!useResolve(control.wrap);
+  const view = control.view as UiControl | undefined;
+  const arr = Array.isArray(items) ? items : [];
+  if (!view) return null;
+  const style: CSSProperties = {
+    display: "flex",
+    flexDirection: horizontal ? "row" : "column",
+    flexWrap: wrap ? "wrap" : "nowrap",
+    gap: 8,
+  };
+  return (
+    <div style={style}>
+      {arr.map((_, i) => (
+        <ScopeProvider key={i} source={source} area={area} dataContext={basePointer ? `${basePointer}/${i}` : undefined}>
+          <ControlRenderer control={view} />
+        </ScopeProvider>
+      ))}
+    </div>
+  );
+}
+
+export const itemTemplateControls = {
+  ItemTemplate: ItemTemplateView,
+};

--- a/clients/react/src/controls/mesh.tsx
+++ b/clients/react/src/controls/mesh.tsx
@@ -1,12 +1,10 @@
 import type { ReactNode } from "react";
-import { Avatar, Badge, Input, Text } from "@fluentui/react-components";
-import { Search20Regular } from "@fluentui/react-icons";
-import type { UiControl } from "../area/types.js";
+import { Avatar, Badge, Card, Input, Text } from "@fluentui/react-components";
+import type { Json, UiControl } from "../area/types.js";
+import { useThemeMode } from "../theme/themeMode.js";
 import { str, useField, useText } from "./common.js";
-
-function MeshSearchView(): ReactNode {
-  return <Input contentBefore={<Search20Regular />} placeholder="Search the mesh…" />;
-}
+import { ThreadChatView } from "./threadChat.js";
+import { MeshNodeCollectionView, MeshSearchView } from "./meshLive.js";
 
 function MeshNodePickerView({ control }: { control: UiControl }): ReactNode {
   const f = useField(control);
@@ -42,6 +40,34 @@ function ThreadMessageBubbleView({ control }: { control: UiControl }): ReactNode
   );
 }
 
+/**
+ * Catalog card for a layout-area definition — the mirror of Blazor's LayoutAreaDefinitionView:
+ * a link card with title, description, and a thumbnail picked light/dark-aware
+ * (definition.thumbnailUrl → theme thumbnail → definition.imageUrl), cache-busted by thumbnailHash.
+ */
+function LayoutAreaDefinitionView({ control }: { control: UiControl }): ReactNode {
+  const { resolved } = useThemeMode();
+  const def = (control.definition ?? {}) as Json;
+  const hash = str(control.thumbnailHash);
+  const themed = resolved === "dark" ? control.darkThumbnailUrl : control.lightThumbnailUrl;
+  const raw = str(def.thumbnailUrl) || str(themed) || str(def.imageUrl);
+  const img = raw && hash ? `${raw}${raw.includes("?") ? "&" : "?"}v=${hash}` : raw;
+  const title = str(def.title ?? def.area);
+  return (
+    <a href={str(def.url) || undefined} style={{ textDecoration: "none" }}>
+      <Card style={{ width: 260, padding: 12, gap: 8 }}>
+        <Text weight="semibold">{title}</Text>
+        <div style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>
+          {img ? <img src={img} alt={`Thumbnail for ${title}`} width={80} height={80} style={{ objectFit: "cover", borderRadius: 4 }} /> : null}
+          <Text size={200} title={str(def.description)}>
+            {str(def.description)}
+          </Text>
+        </div>
+      </Card>
+    </a>
+  );
+}
+
 /** A clean labeled placeholder for the long-tail of specialized controls (full impls are follow-ups). */
 function placeholder(label: string) {
   return function Placeholder({ control }: { control: UiControl }): ReactNode {
@@ -54,19 +80,35 @@ function placeholder(label: string) {
   };
 }
 
+/**
+ * The remaining registered-but-placeholder $types — every entry needs a live mesh service
+ * (file storage, thread execution, import/export pipelines) beyond the AreaSource contract.
+ * parity.test.ts ratchets this list: it may only SHRINK as controls get real implementations.
+ */
+export const placeholderControlTypes = [
+  "FileBrowser",
+  "ExportDocument",
+  "NodeExport",
+  "NodeImport",
+  "DocumentSource",
+] as const;
+
+const placeholderLabels: Record<(typeof placeholderControlTypes)[number], string> = {
+  FileBrowser: "File browser",
+  ExportDocument: "Export document",
+  NodeExport: "Node export",
+  NodeImport: "Node import",
+  DocumentSource: "Document source",
+};
+
 export const meshControls = {
   MeshSearch: MeshSearchView,
-  SearchBox: MeshSearchView,
+  MeshNodeCollection: MeshNodeCollectionView,
+  // SearchBox renders via inputs.tsx's bound SearchBoxView.
   MeshNodePicker: MeshNodePickerView,
   UserProfile: UserProfileView,
   ThreadMessageBubble: ThreadMessageBubbleView,
-  FileBrowser: placeholder("File browser"),
-  ThreadChat: placeholder("Thread chat"),
-  ExportDocument: placeholder("Export document"),
-  NodeExport: placeholder("Node export"),
-  NodeImport: placeholder("Node import"),
-  DocumentSource: placeholder("Document source"),
-  ItemTemplate: placeholder("Item template"),
-  LayoutAreaDefinition: placeholder("Layout-area definition"),
-  Appearance: placeholder("Appearance"),
+  ThreadChat: ThreadChatView,
+  LayoutAreaDefinition: LayoutAreaDefinitionView,
+  ...Object.fromEntries(placeholderControlTypes.map((t) => [t, placeholder(placeholderLabels[t])])),
 };

--- a/clients/react/src/controls/meshLive.test.tsx
+++ b/clients/react/src/controls/meshLive.test.tsx
@@ -1,0 +1,94 @@
+// Live mesh controls parity — MeshSearch and MeshNodeCollection render from REAL queries through
+// the MeshOps contract (live/meshOps.tsx `search`), the same decoupling ThreadChat uses: the test
+// injects a fake MeshOps and asserts the composed query (hiddenQuery + visibleQuery, Blazor
+// MeshSearchView semantics) and the rendered result cards/rows.
+
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource, type AreaTree, type UiControl, type MeshOps } from "../core.js";
+
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = ((q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null })) as unknown as typeof window.matchMedia;
+});
+
+function fakeOps(results: Record<string, Record<string, unknown>[]> | Record<string, unknown>[]): MeshOps & { search: ReturnType<typeof vi.fn> } {
+  const search = vi.fn(async (query: string) => (Array.isArray(results) ? results : (results[query] ?? [])));
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    watch: async function* () {},
+    startThread: async () => ({ path: "t" }),
+    submitMessage: async () => null,
+    patch: () => {},
+    search,
+  } as unknown as MeshOps & { search: ReturnType<typeof vi.fn> };
+}
+
+function view(control: Record<string, unknown>, ops: MeshOps) {
+  const source = new StaticAreaSource({ data: {}, areas: { main: control as unknown as UiControl } } satisfies AreaTree);
+  return render(<MeshAreaView source={source} rootArea="main" ops={ops} />);
+}
+
+const nodes = [
+  { path: "acme/Story/First", name: "First story", nodeType: "Story", content: { description: "The first" } },
+  { path: "acme/Story/Second", name: "Second story", nodeType: "Story" },
+];
+
+describe("MeshSearch — query-backed results (Blazor MeshSearchView parity)", () => {
+  it("runs hiddenQuery + visibleQuery and renders result cards with name/type/description", async () => {
+    const ops = fakeOps(nodes);
+    view({ $type: "MeshSearch", title: "Stories", hiddenQuery: "nodeType:Story", visibleQuery: "laptop", namespace: "acme" }, ops);
+    expect(await screen.findByText("First story")).toBeTruthy();
+    expect(screen.getByText("Second story")).toBeTruthy();
+    expect(screen.getByText("The first")).toBeTruthy();
+    expect(screen.getAllByText("Story").length).toBeGreaterThan(0);
+    expect(ops.search).toHaveBeenCalledWith("nodeType:Story laptop", "acme");
+    // Results link to /{path}.
+    const link = screen.getByText("First story").closest("a");
+    expect(link?.getAttribute("href")).toBe("/acme/Story/First");
+  });
+
+  it("live search re-queries (debounced) as the user types", async () => {
+    const ops = fakeOps(nodes);
+    view({ $type: "MeshSearch", hiddenQuery: "nodeType:Story", placeholder: "Find…" }, ops);
+    fireEvent.change(screen.getByPlaceholderText("Find…"), { target: { value: "banana" } });
+    await waitFor(() => expect(ops.search).toHaveBeenCalledWith("nodeType:Story banana", undefined), { timeout: 2000 });
+  });
+
+  it("excludeBasePath drops the namespace root node; List mode renders rows", async () => {
+    const ops = fakeOps([{ path: "acme", name: "Acme root", nodeType: "Space" }, ...nodes]);
+    view({ $type: "MeshSearch", hiddenQuery: "scope:descendants", namespace: "acme", renderMode: "List" }, ops);
+    expect(await screen.findByText("First story")).toBeTruthy();
+    expect(screen.queryByText("Acme root")).toBeNull();
+  });
+
+  it("shows the empty message for a no-hit query, hides the box when showSearchBox=false", async () => {
+    const ops = fakeOps([]);
+    view({ $type: "MeshSearch", hiddenQuery: "nodeType:Nothing", showSearchBox: false }, ops);
+    expect(await screen.findByText("No items found.")).toBeTruthy();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+});
+
+describe("MeshNodeCollection — compact cards from queries (Blazor MeshNodeCollectionView parity)", () => {
+  it("runs all queries, merges by path, and renders avatar cards (name + type) linking to the node", async () => {
+    const byQuery = {
+      "path:acme/Story/* nodeType:Story": [nodes[0], nodes[1]],
+      "path:acme/* scope:children": [nodes[1]], // overlap — must dedup by path
+    };
+    const ops = fakeOps(byQuery);
+    view({ $type: "MeshNodeCollection", queries: Object.keys(byQuery) }, ops);
+    expect(await screen.findByText("First story")).toBeTruthy();
+    expect(screen.getAllByText("Second story")).toHaveLength(1);
+    expect(ops.search).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("First story").closest("a")?.getAttribute("href")).toBe("/acme/Story/First");
+  });
+
+  it("shows 'No items.' when empty and the add button is disabled", async () => {
+    const ops = fakeOps([]);
+    view({ $type: "MeshNodeCollection", queries: ["path:none/*"], showAdd: false }, ops);
+    expect(await screen.findByText("No items.")).toBeTruthy();
+  });
+});

--- a/clients/react/src/controls/meshLive.tsx
+++ b/clients/react/src/controls/meshLive.tsx
@@ -1,0 +1,251 @@
+// Live query-backed mesh controls, rendered through the MeshOps contract (live/meshOps.tsx):
+//
+//   - MeshSearchView ← src/MeshWeaver.Blazor/Components/MeshSearchView.razor
+//       MeshSearchControl wire: { title, hiddenQuery (always applied), visibleQuery (user-editable),
+//       placeholder, namespace, renderMode ("Flat"|"List"|…), maxColumns, showSearchBox, liveSearch,
+//       excludeBasePath, showEmptyMessage, showLoadingIndicator, createHref }
+//   - MeshNodeCollectionView ← Components/MeshNodeCollectionView.razor
+//       MeshNodeCollectionControl wire: { queries: string[], deletable, showAdd }
+//
+// Both run their queries through `useMeshOps().search` (the optional mesh-query member — the same
+// surface the ThreadChat agent/model selectors use), so any host that wires a MeshOpsProvider gets
+// live results; tests inject a fake. Without ops the search renders its box only and the collection
+// shows its empty state — no crash, no fake data.
+
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { Avatar, Badge, Button, Card, Input, Link, Spinner, Text } from "@fluentui/react-components";
+import { Add20Regular, Search20Regular } from "@fluentui/react-icons";
+import type { UiControl } from "../area/types.js";
+import { useResolve } from "../area/context.js";
+import { useMeshOps, type MeshOps } from "../live/meshOps.js";
+import { str, useText } from "./common.js";
+
+interface NodeResult {
+  path: string;
+  name: string;
+  nodeType: string;
+  description: string;
+  thumbnail?: string;
+}
+
+function toNodeResult(r: Record<string, unknown>): NodeResult {
+  const content = (r.content ?? {}) as Record<string, unknown>;
+  return {
+    path: str(r.path),
+    name: str(r.name) || str(r.path).split("/").pop() || str(r.path),
+    nodeType: str(r.nodeType),
+    description: str(r.description ?? content.description),
+    thumbnail: str(content.thumbnailUrl ?? content.imageUrl) || undefined,
+  };
+}
+
+/** Debounced value — live-search keystrokes coalesce before hitting the mesh. */
+function useDebounced<T>(value: T, ms: number): T {
+  const [v, setV] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setV(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return v;
+}
+
+/** Run a mesh query through MeshOps.search; empty results when ops/search are absent. */
+function useMeshQuery(ops: MeshOps | null, query: string, basePath?: string): { results: NodeResult[]; loading: boolean } {
+  const [state, setState] = useState<{ results: NodeResult[]; loading: boolean }>({ results: [], loading: false });
+  useEffect(() => {
+    if (!ops?.search || !query) {
+      setState({ results: [], loading: false });
+      return;
+    }
+    let live = true;
+    setState((s) => ({ ...s, loading: true }));
+    ops
+      .search(query, basePath || undefined)
+      .then((rs) => {
+        if (!live) return;
+        setState({ results: rs.map(toNodeResult).filter((n) => n.path.length > 0), loading: false });
+      })
+      .catch(() => {
+        if (live) setState({ results: [], loading: false });
+      });
+    return () => {
+      live = false;
+    };
+  }, [ops, query, basePath]);
+  return state;
+}
+
+// ---- MeshSearch -----------------------------------------------------------------------------------
+
+function ResultCard({ node }: { node: NodeResult }): ReactNode {
+  return (
+    <Link href={`/${node.path}`} style={{ textDecoration: "none" }}>
+      <Card style={{ padding: 12, gap: 4, height: "100%" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <Text weight="semibold" style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>
+            {node.name}
+          </Text>
+          {node.nodeType ? (
+            <Badge appearance="outline" size="small">
+              {node.nodeType}
+            </Badge>
+          ) : null}
+        </div>
+        {node.description ? (
+          <Text size={200} style={{ color: "var(--colorNeutralForeground3)" }}>
+            {node.description}
+          </Text>
+        ) : null}
+      </Card>
+    </Link>
+  );
+}
+
+function ResultRow({ node }: { node: NodeResult }): ReactNode {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", gap: 8, padding: "6px 0", borderBottom: "1px solid var(--colorNeutralStroke3)" }}>
+      <Link href={`/${node.path}`}>
+        <Text weight="semibold">{node.name}</Text>
+      </Link>
+      {node.nodeType ? (
+        <Badge appearance="outline" size="small">
+          {node.nodeType}
+        </Badge>
+      ) : null}
+      <Text size={200} style={{ color: "var(--colorNeutralForeground3)", flex: 1, minWidth: 0 }}>
+        {node.description}
+      </Text>
+    </div>
+  );
+}
+
+export function MeshSearchView({ control }: { control: UiControl }): ReactNode {
+  const ops = useMeshOps();
+  const title = useText(control.title);
+  const hiddenQuery = str(useResolve(control.hiddenQuery));
+  const initialVisible = str(useResolve(control.visibleQuery));
+  const placeholder = str(useResolve(control.placeholder)) || "Search the mesh…";
+  const ns = str(useResolve(control.namespace));
+  const renderMode = str(useResolve(control.renderMode)) || "Flat";
+  const showSearchBox = useResolve(control.showSearchBox) !== false;
+  const liveSearch = useResolve(control.liveSearch) !== false;
+  const excludeBasePath = useResolve(control.excludeBasePath) !== false;
+  const showEmptyMessage = useResolve(control.showEmptyMessage) !== false;
+  const showLoading = useResolve(control.showLoadingIndicator) !== false;
+  const createHref = str(useResolve(control.createHref));
+
+  const [visible, setVisible] = useState(initialVisible);
+  const [submitted, setSubmitted] = useState(initialVisible);
+  const term = useDebounced(liveSearch ? visible : submitted, 250);
+  const query = [hiddenQuery, term].map((s) => s.trim()).filter(Boolean).join(" ");
+  const { results, loading } = useMeshQuery(ops, query, ns);
+  const items = excludeBasePath && ns ? results.filter((n) => n.path !== ns) : results;
+  const list = renderMode === "List";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        {title ? (
+          <Text weight="semibold" size={400}>
+            {title}
+          </Text>
+        ) : null}
+        {showSearchBox ? (
+          <Input
+            contentBefore={<Search20Regular />}
+            placeholder={placeholder}
+            value={visible}
+            style={{ flex: 1, maxWidth: 420 }}
+            onChange={(_, d) => setVisible(d.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") setSubmitted(visible);
+            }}
+          />
+        ) : null}
+        {createHref ? (
+          <Link href={createHref}>
+            <Button icon={<Add20Regular />} appearance="subtle" aria-label="Create" />
+          </Link>
+        ) : null}
+      </div>
+      {loading && showLoading ? <Spinner size="tiny" label="Searching…" /> : null}
+      {!loading && items.length === 0 && showEmptyMessage && query ? (
+        <Text italic size={200}>
+          No items found.
+        </Text>
+      ) : null}
+      {list ? (
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          {items.map((n) => (
+            <ResultRow key={n.path} node={n} />
+          ))}
+        </div>
+      ) : (
+        <div style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}>
+          {items.map((n) => (
+            <ResultCard key={n.path} node={n} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- MeshNodeCollection ---------------------------------------------------------------------------
+
+export function MeshNodeCollectionView({ control }: { control: UiControl }): ReactNode {
+  const ops = useMeshOps();
+  const queries = (Array.isArray(control.queries) ? control.queries : []).map(str).filter(Boolean);
+  const showAdd = control.showAdd !== false;
+  const [items, setItems] = useState<NodeResult[] | null>(null);
+
+  useEffect(() => {
+    if (!ops?.search || queries.length === 0) {
+      setItems([]);
+      return;
+    }
+    let live = true;
+    Promise.all(queries.map((q) => ops.search!(q).catch(() => [] as Record<string, unknown>[])))
+      .then((all) => {
+        if (!live) return;
+        const merged = new Map<string, NodeResult>();
+        for (const n of all.flat().map(toNodeResult)) if (n.path) merged.set(n.path, n);
+        setItems([...merged.values()]);
+      })
+      .catch(() => {
+        if (live) setItems([]);
+      });
+    return () => {
+      live = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ops, queries.join("")]);
+
+  if (items == null) return <Spinner size="tiny" />;
+  if (items.length === 0 && !showAdd)
+    return (
+      <Text size={200} style={{ color: "var(--colorNeutralForeground3)", padding: 8 }}>
+        No items.
+      </Text>
+    );
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      {items.map((n) => (
+        <Link key={n.path} href={`/${n.path}`} style={{ textDecoration: "none" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 8px", borderRadius: 6 }}>
+            <Avatar name={n.name} image={n.thumbnail ? { src: n.thumbnail } : undefined} size={28} />
+            <div style={{ display: "flex", flexDirection: "column", minWidth: 0 }}>
+              <Text weight="semibold" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {n.name}
+              </Text>
+              <Text size={200} style={{ color: "var(--colorNeutralForeground3)" }}>
+                {n.nodeType}
+              </Text>
+            </div>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/clients/react/src/controls/monaco.test.tsx
+++ b/clients/react/src/controls/monaco.test.tsx
@@ -1,0 +1,152 @@
+// Monaco editor parity — CodeEditor / MarkdownEditor / DiffEditor render REAL Monaco
+// (@monaco-editor/react) with the Blazor Monaco views' prop mapping
+// (Monaco/CodeEditorView.razor: value/language/height/readonly defaults; Monaco/DiffEditorView.razor:
+// originalContent/modifiedContent/language/height, read-only side-by-side).
+// The module is mocked here (jsdom can't host the real editor), which also pins the exact props the
+// control hands Monaco — the wire-to-editor contract.
+
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource, type AreaTree, type UiControl } from "../core.js";
+import { monacoSettings } from "./monaco.js";
+
+interface CapturedProps {
+  language?: string;
+  height?: string;
+  theme?: string;
+  value?: string;
+  options?: Record<string, unknown>;
+  original?: string;
+  modified?: string;
+  onChange?: (v: string | undefined) => void;
+}
+
+vi.mock("@monaco-editor/react", () => {
+  const editorCalls: CapturedProps[] = [];
+  const diffCalls: CapturedProps[] = [];
+  const Editor = (props: CapturedProps) => {
+    editorCalls.push(props);
+    return <div data-testid="monaco-editor" data-language={props.language} data-theme={props.theme} data-readonly={String(props.options?.readOnly)} data-height={props.height} />;
+  };
+  const DiffEditor = (props: CapturedProps) => {
+    diffCalls.push(props);
+    return <div data-testid="monaco-diff" data-language={props.language} data-original={props.original} data-modified={props.modified} />;
+  };
+  return { default: Editor, Editor, DiffEditor, __editorCalls: editorCalls, __diffCalls: diffCalls };
+});
+
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = ((q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null })) as unknown as typeof window.matchMedia;
+});
+
+async function mockCalls(): Promise<{ editor: CapturedProps[]; diff: CapturedProps[] }> {
+  const mod = (await import("@monaco-editor/react")) as unknown as { __editorCalls: CapturedProps[]; __diffCalls: CapturedProps[] };
+  return { editor: mod.__editorCalls, diff: mod.__diffCalls };
+}
+
+function tree(control: Record<string, unknown>, data: Record<string, unknown> = {}): AreaTree {
+  return { data, areas: { main: control as unknown as UiControl } };
+}
+
+describe("monacoSettings — the CodeEditorControl → Monaco option mapping", () => {
+  it("applies the Blazor defaults (plaintext, 300px, line numbers on, not read-only)", () => {
+    const s = monacoSettings({}, false);
+    expect(s.language).toBe("plaintext");
+    expect(s.height).toBe("300px");
+    expect(s.theme).toBe("light");
+    expect(s.options).toMatchObject({ readOnly: false, lineNumbers: "on", minimap: { enabled: false }, wordWrap: "off" });
+  });
+
+  it("maps the wire props (language, readonly, height, lineNumbers, minimap, wordWrap, theme)", () => {
+    const s = monacoSettings(
+      { language: "csharp", readonly: true, height: "500px", lineNumbers: false, minimap: true, wordWrap: true, theme: "hc-black" },
+      true,
+    );
+    expect(s).toMatchObject({
+      language: "csharp",
+      height: "500px",
+      theme: "hc-black", // explicit theme wins over dark-mode default
+      options: { readOnly: true, lineNumbers: "off", minimap: { enabled: true }, wordWrap: "on" },
+    });
+    expect(monacoSettings({}, true).theme).toBe("vs-dark"); // dark mode default
+  });
+});
+
+describe("CodeEditorView — real Monaco with the bound value", () => {
+  it("mounts Monaco with language/height/readOnly from the control and the resolved value", async () => {
+    const source = new StaticAreaSource(
+      tree(
+        { $type: "CodeEditor", value: { $type: "JsonPointerReference", pointer: "/data/code" }, language: "csharp", height: "220px", readonly: true },
+        { code: "var x = 1;" },
+      ),
+    );
+    render(<MeshAreaView source={source} rootArea="main" />);
+    const el = await screen.findByTestId("monaco-editor");
+    expect(el.getAttribute("data-language")).toBe("csharp");
+    expect(el.getAttribute("data-height")).toBe("220px");
+    expect(el.getAttribute("data-readonly")).toBe("true");
+    const { editor } = await mockCalls();
+    expect(editor[editor.length - 1].value).toBe("var x = 1;");
+  });
+
+  it("edits write back through the standard update event to the value pointer", async () => {
+    const source = new StaticAreaSource(
+      tree({ $type: "CodeEditor", value: { $type: "JsonPointerReference", pointer: "/data/code" } }, { code: "before" }),
+    );
+    render(<MeshAreaView source={source} rootArea="main" />);
+    await screen.findByTestId("monaco-editor");
+    const { editor } = await mockCalls();
+    act(() => editor[editor.length - 1].onChange?.("after"));
+    const update = source.events.find((e) => e.kind === "update");
+    expect(update).toMatchObject({ kind: "update", area: "main", pointer: "/data/code", value: "after" });
+    expect(source.getState().data?.code).toBe("after");
+  });
+
+  it("MarkdownEditor forces markdown language + word wrap", async () => {
+    const source = new StaticAreaSource(tree({ $type: "MarkdownEditor", value: "# hi" }));
+    render(<MeshAreaView source={source} rootArea="main" />);
+    const el = await screen.findByTestId("monaco-editor");
+    expect(el.getAttribute("data-language")).toBe("markdown");
+    const { editor } = await mockCalls();
+    expect(editor[editor.length - 1].options?.wordWrap).toBe("on");
+  });
+});
+
+describe("DiffEditorView — read-only side-by-side diff", () => {
+  it("mounts the Monaco diff with originalContent/modifiedContent/language and pane labels", async () => {
+    const source = new StaticAreaSource(
+      tree({
+        $type: "DiffEditor",
+        originalContent: "old text",
+        modifiedContent: "new text",
+        originalLabel: "Version 3",
+        modifiedLabel: "Current",
+        language: "json",
+        height: "400px",
+      }),
+    );
+    render(<MeshAreaView source={source} rootArea="main" />);
+    const el = await screen.findByTestId("monaco-diff");
+    expect(el.getAttribute("data-original")).toBe("old text");
+    expect(el.getAttribute("data-modified")).toBe("new text");
+    expect(el.getAttribute("data-language")).toBe("json");
+    expect(screen.getByText("Version 3")).toBeTruthy();
+    expect(screen.getByText("Current")).toBeTruthy();
+    const { diff } = await mockCalls();
+    expect(diff[diff.length - 1].options).toMatchObject({ readOnly: true, renderSideBySide: true, originalEditable: false });
+  });
+
+  it("defaults language markdown / height 500px / Original+Current labels", async () => {
+    const source = new StaticAreaSource(tree({ $type: "DiffEditor", originalContent: "a", modifiedContent: "b" }));
+    render(<MeshAreaView source={source} rootArea="main" />);
+    const el = await screen.findByTestId("monaco-diff");
+    expect(el.getAttribute("data-language")).toBe("markdown");
+    expect(screen.getByText("Original")).toBeTruthy();
+    expect(screen.getByText("Current")).toBeTruthy();
+    const { diff } = await mockCalls();
+    expect(diff[diff.length - 1].height).toBe("500px");
+  });
+});

--- a/clients/react/src/controls/monaco.tsx
+++ b/clients/react/src/controls/monaco.tsx
@@ -1,0 +1,249 @@
+// Monaco-backed editors — the React mirror of the Blazor BlazorMonaco views:
+//   - CodeEditorView  ← src/MeshWeaver.Blazor/Components/Monaco/CodeEditorView.razor
+//       CodeEditorControl wire: { value, language, theme, readonly, height, lineNumbers, minimap,
+//       wordWrap, placeholder } (defaults: plaintext / 300px / line numbers on — the Blazor bindings).
+//   - MarkdownEditorView ← Monaco/MarkdownMonacoEditor.razor (MarkdownEditorControl: { value,
+//       readonly, height }) — markdown language + word wrap, same value binding.
+//   - DiffEditorView  ← Monaco/DiffEditorView.razor (DiffEditorControl: { originalContent,
+//       modifiedContent, originalLabel, modifiedLabel, language="markdown", height="500px" }) —
+//       read-only side-by-side diff.
+//
+// Monaco is CLIENT-ONLY and heavy, so it is loaded lazily via dynamic import: the library bundle
+// stays lean (vite code-splits @monaco-editor/react; the editor itself streams from the loader's
+// CDN at runtime). Until the module arrives — and in non-browser hosts where it never does — the
+// SAME bound value renders through the textarea/pre fallback, so the control is functional
+// everywhere and upgrade to Monaco is progressive.
+
+import type { CSSProperties, ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { Text, Textarea } from "@fluentui/react-components";
+import type { Json, UiControl } from "../area/types.js";
+import { useBindingPointer, useEmit, useResolve, useScope } from "../area/context.js";
+import { useThemeMode } from "../theme/themeMode.js";
+import { str } from "./common.js";
+
+type MonacoModule = typeof import("@monaco-editor/react");
+
+/** Lazily load @monaco-editor/react once per mount; null while loading / when unavailable. */
+function useMonaco(): MonacoModule | null {
+  const [mod, setMod] = useState<MonacoModule | null>(null);
+  useEffect(() => {
+    let live = true;
+    import("@monaco-editor/react")
+      .then((m) => {
+        if (live) setMod(m);
+      })
+      .catch(() => undefined); // non-browser host — the fallback stays
+    return () => {
+      live = false;
+    };
+  }, []);
+  return mod;
+}
+
+/** Bound editable value — CodeEditor/MarkdownEditor bind `value` (the Blazor ViewModel.Value), with
+ *  `data` tolerated for hand-written trees. Writes go back through the standard update event. */
+function useValueBinding(control: UiControl): { value: string; setValue: (v: string) => void; onBlur: () => void } {
+  const bound = control.value ?? control.data;
+  const value = str(useResolve(bound));
+  const pointer = useBindingPointer(bound);
+  const emit = useEmit();
+  const { area } = useScope();
+  return {
+    value,
+    setValue: (v: string) => {
+      if (pointer) emit({ kind: "update", area, pointer, value: v });
+    },
+    onBlur: () => emit({ kind: "blur", area }),
+  };
+}
+
+export interface MonacoSettings {
+  language: string;
+  height: string;
+  theme: string;
+  options: {
+    readOnly: boolean;
+    lineNumbers: "on" | "off";
+    minimap: { enabled: boolean };
+    wordWrap: "on" | "off";
+    placeholder?: string;
+    automaticLayout: boolean;
+    scrollBeyondLastLine: boolean;
+  };
+}
+
+/**
+ * Map the (resolved) CodeEditorControl props onto Monaco construction options — the same defaults
+ * the Blazor CodeEditorView binds ("plaintext", "300px", line numbers on). Pure; pinned by tests.
+ */
+export function monacoSettings(
+  p: {
+    language?: Json;
+    theme?: Json;
+    readonly?: Json;
+    height?: Json;
+    lineNumbers?: Json;
+    minimap?: Json;
+    wordWrap?: Json;
+    placeholder?: Json;
+  },
+  dark: boolean,
+): MonacoSettings {
+  return {
+    language: str(p.language) || "plaintext",
+    height: str(p.height) || "300px",
+    theme: str(p.theme) || (dark ? "vs-dark" : "light"),
+    options: {
+      readOnly: p.readonly === true,
+      lineNumbers: p.lineNumbers === false ? "off" : "on",
+      minimap: { enabled: p.minimap === true },
+      wordWrap: p.wordWrap === true ? "on" : "off",
+      placeholder: str(p.placeholder) || undefined,
+      automaticLayout: true,
+      scrollBeyondLastLine: false,
+    },
+  };
+}
+
+const monoFallbackStyle: CSSProperties = { fontFamily: "var(--fontFamilyMonospace)", minHeight: 180 };
+
+function MonacoValueEditor({ control, forceLanguage, wordWrapDefault }: { control: UiControl; forceLanguage?: string; wordWrapDefault?: boolean }): ReactNode {
+  const monaco = useMonaco();
+  const { resolved } = useThemeMode();
+  const binding = useValueBinding(control);
+  // Resolve every bindable prop unconditionally (hooks must not be short-circuited).
+  const language = useResolve(control.language);
+  const theme = useResolve(control.theme);
+  const readonly = useResolve(control.readonly);
+  const disabled = useResolve(control.disabled);
+  const height = useResolve(control.height);
+  const lineNumbers = useResolve(control.lineNumbers);
+  const minimap = useResolve(control.minimap);
+  const wordWrap = useResolve(control.wordWrap);
+  const placeholder = useResolve(control.placeholder);
+  const settings = monacoSettings(
+    {
+      language: forceLanguage ?? language,
+      theme,
+      readonly: readonly ?? disabled,
+      height,
+      lineNumbers,
+      minimap,
+      wordWrap: wordWrap ?? wordWrapDefault,
+      placeholder,
+    },
+    resolved === "dark",
+  );
+
+  // The bound-textarea fallback: shown until Monaco arrives (and as Monaco's own `loading` node),
+  // and permanently in hosts where the editor cannot load. Same binding — fully functional.
+  const fallback = (
+    <Textarea
+      aria-label={settings.options.placeholder ?? "Code editor"}
+      value={binding.value}
+      disabled={settings.options.readOnly}
+      placeholder={settings.options.placeholder}
+      onChange={(_, d) => binding.setValue(d.value)}
+      onBlur={binding.onBlur}
+      textarea={{ style: { ...monoFallbackStyle, minHeight: settings.height } }}
+      style={{ width: "100%" }}
+    />
+  );
+
+  if (!monaco) return fallback;
+  const Editor = monaco.default;
+  return (
+    <div style={{ width: "100%", height: settings.height }} onBlur={binding.onBlur}>
+      <Editor
+        height={settings.height}
+        language={settings.language}
+        theme={settings.theme}
+        value={binding.value}
+        options={settings.options}
+        loading={fallback}
+        onChange={(v) => {
+          if (!settings.options.readOnly) binding.setValue(v ?? "");
+        }}
+      />
+    </div>
+  );
+}
+
+export function CodeEditorView({ control }: { control: UiControl }): ReactNode {
+  return <MonacoValueEditor control={control} />;
+}
+
+export function MarkdownEditorView({ control }: { control: UiControl }): ReactNode {
+  return <MonacoValueEditor control={control} forceLanguage="markdown" wordWrapDefault />;
+}
+
+export function DiffEditorView({ control }: { control: UiControl }): ReactNode {
+  const monaco = useMonaco();
+  const { resolved } = useThemeMode();
+  const original = str(control.originalContent ?? control.original ?? control.originalData);
+  const modified = str(control.modifiedContent ?? control.modified ?? (control.originalContent != null ? control.data : undefined));
+  const originalLabel = str(control.originalLabel) || "Original";
+  const modifiedLabel = str(control.modifiedLabel) || "Current";
+  const language = str(control.language) || "markdown";
+  const height = str(control.height) || "500px";
+
+  const labels = (
+    <div style={{ display: "flex", gap: 8 }}>
+      <Text size={200} weight="semibold" style={{ flex: 1 }}>
+        {originalLabel}
+      </Text>
+      <Text size={200} weight="semibold" style={{ flex: 1 }}>
+        {modifiedLabel}
+      </Text>
+    </div>
+  );
+
+  if (!monaco) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {labels}
+        <div style={{ display: "flex", gap: 8 }}>
+          <pre style={diffPaneStyle("removed")}>{original}</pre>
+          <pre style={diffPaneStyle("added")}>{modified}</pre>
+        </div>
+      </div>
+    );
+  }
+
+  const Diff = monaco.DiffEditor;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      {labels}
+      <div style={{ width: "100%", height }}>
+        <Diff
+          height={height}
+          language={language}
+          theme={resolved === "dark" ? "vs-dark" : "light"}
+          original={original}
+          modified={modified}
+          options={{
+            readOnly: true,
+            originalEditable: false,
+            renderSideBySide: true,
+            enableSplitViewResizing: true,
+            automaticLayout: true,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function diffPaneStyle(kind: "added" | "removed"): CSSProperties {
+  return {
+    flex: 1,
+    margin: 0,
+    padding: 8,
+    overflow: "auto",
+    fontFamily: "var(--fontFamilyMonospace)",
+    fontSize: 12,
+    background: kind === "added" ? "rgba(16,124,16,0.08)" : "rgba(216,59,1,0.08)",
+    borderRadius: 4,
+  };
+}

--- a/clients/react/src/controls/pivot.test.tsx
+++ b/clients/react/src/controls/pivot.test.tsx
@@ -1,0 +1,137 @@
+// PivotGridControl parity — a REAL cross-tab from the wire contract
+// (src/MeshWeaver.Layout/Pivot/PivotGridControl.cs + PivotConfiguration.cs), not a DataGrid alias:
+// rows grouped by rowDimensions, columns by columnDimensions, measures aggregated per cell with
+// Sum/Average/Count/Min/Max, row + column totals, .NET number formats.
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource } from "../core.js";
+import { computePivot, formatCell, type PivotConfigWire } from "./pivot.js";
+
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = ((q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null })) as unknown as typeof window.matchMedia;
+});
+
+// Rows arrive camelCase on the wire while PropertyPath keeps the C# property name — computePivot
+// must bridge that (the same convention DataGrid columns use).
+const rows = [
+  { product: "Apples", region: "East", amount: 100, quantity: 2 },
+  { product: "Apples", region: "West", amount: 50, quantity: 1 },
+  { product: "Bananas", region: "East", amount: 30, quantity: 3 },
+  { product: "Apples", region: "East", amount: 20, quantity: 4 },
+];
+
+const config: PivotConfigWire = {
+  rowDimensions: [{ field: "Product", displayName: "Product", propertyPath: "Product" }],
+  columnDimensions: [{ field: "Region", displayName: "Region", propertyPath: "Region" }],
+  aggregates: [{ field: "Amount", displayName: "Amount", propertyPath: "Amount", function: "Sum", format: "N0" }],
+  showRowTotals: true,
+  showColumnTotals: true,
+};
+
+describe("computePivot", () => {
+  it("cross-tabs rows × columns with summed cells, row totals and column totals", () => {
+    const p = computePivot(rows, config);
+    expect(p.colKeys).toEqual([["East"], ["West"]]);
+    expect(p.rows.map((r) => r.keys[0])).toEqual(["Apples", "Bananas"]);
+    const apples = p.rows[0];
+    expect(apples.cells).toEqual([120, 50]); // East, West
+    expect(apples.totals).toEqual([170]);
+    const bananas = p.rows[1];
+    expect(bananas.cells).toEqual([30, null]); // no Bananas/West data → null
+    expect(bananas.totals).toEqual([30]);
+    expect(p.columnTotals?.cells).toEqual([150, 50]);
+    expect(p.columnTotals?.grand).toEqual([200]);
+  });
+
+  it("supports Average / Count / Min / Max (string enum names and ordinals)", () => {
+    const aggs = (fns: unknown[]) =>
+      computePivot(rows, {
+        rowDimensions: [{ field: "Product", propertyPath: "Product" }],
+        aggregates: fns.map((f, i) => ({ field: "Amount", propertyPath: "Amount", displayName: `A${i}`, function: f as never })),
+      });
+    const p = aggs(["Average", "Count", "Min", "Max"]);
+    const apples = p.rows[0];
+    // Apples amounts: 100, 50, 20
+    expect(apples.cells).toEqual([170 / 3, 3, 20, 100]);
+    // Ordinals (pre-string-enum wire): 1 = Average
+    expect(aggs([1]).rows[0].cells).toEqual([170 / 3]);
+  });
+
+  it("multiple aggregates render measures innermost (colKeys × aggregates)", () => {
+    const p = computePivot(rows, {
+      ...config,
+      aggregates: [
+        { field: "Amount", displayName: "Amount", propertyPath: "Amount", function: "Sum" },
+        { field: "Quantity", displayName: "Qty", propertyPath: "Quantity", function: "Sum" },
+      ],
+    });
+    // [East×Amount, East×Qty, West×Amount, West×Qty]
+    expect(p.rows[0].cells).toEqual([120, 6, 50, 1]);
+  });
+
+  it("respects Descending sortOrder on a dimension", () => {
+    const p = computePivot(rows, {
+      ...config,
+      rowDimensions: [{ field: "Product", propertyPath: "Product", sortOrder: "Descending" }],
+    });
+    expect(p.rows.map((r) => r.keys[0])).toEqual(["Bananas", "Apples"]);
+  });
+
+  it("no column dimensions → measures are the columns; empty data → no rows", () => {
+    const p = computePivot(rows, { rowDimensions: config.rowDimensions, aggregates: config.aggregates });
+    expect(p.colKeys).toEqual([[]]);
+    expect(p.rows[0].cells).toEqual([170]);
+    expect(computePivot([], config).rows).toEqual([]);
+  });
+});
+
+describe("formatCell — .NET format strings", () => {
+  // Expected values via toLocaleString so the assertion is host-locale-agnostic.
+  const loc = (v: number, digits: number) => v.toLocaleString(undefined, { minimumFractionDigits: digits, maximumFractionDigits: digits });
+  it("formats N0 / N2 / {0:N2} and blanks nulls", () => {
+    expect(formatCell(1234.5, "N0")).toBe(loc(1234.5, 0));
+    expect(formatCell(1234.5, "N2")).toBe(loc(1234.5, 2));
+    expect(formatCell(1234.5, "{0:N2}")).toBe(loc(1234.5, 2));
+    expect(formatCell(null, "N0")).toBe("");
+  });
+});
+
+describe("PivotGridView — DOM rendering from a realistic payload", () => {
+  function pivotTree(overrides: Record<string, unknown> = {}) {
+    return {
+      data: { rows },
+      areas: {
+        main: {
+          $type: "PivotGrid",
+          data: { $type: "JsonPointerReference", pointer: "/data/rows" },
+          configuration: config,
+          ...overrides,
+        },
+      },
+    };
+  }
+
+  it("renders the cross-tab: dimension headers, column groups, cells and totals", () => {
+    render(<MeshAreaView source={new StaticAreaSource(pivotTree())} rootArea="main" />);
+    const table = screen.getByRole("table");
+    const text = table.textContent ?? "";
+    expect(text).toContain("Product");
+    expect(text).toContain("East");
+    expect(text).toContain("West");
+    expect(text).toContain("Apples");
+    expect(text).toContain("120"); // Apples/East sum, N0
+    expect(text).toContain("170"); // Apples row total
+    expect(text).toContain("200"); // grand total
+    expect(screen.getAllByText("Total").length).toBeGreaterThanOrEqual(2); // header + totals row
+  });
+
+  it("pages rows when showPager is set", () => {
+    render(<MeshAreaView source={new StaticAreaSource(pivotTree({ showPager: true, pageSize: 1 }))} rootArea="main" />);
+    expect(screen.getByText("Page 1 of 2")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Next" })).toBeTruthy();
+  });
+});

--- a/clients/react/src/controls/pivot.tsx
+++ b/clients/react/src/controls/pivot.tsx
@@ -1,0 +1,358 @@
+// PivotGridControl — a REAL pivot (cross-tab), the React mirror of the Blazor RadzenPivotGridView.
+// Wire contract (src/MeshWeaver.Layout/Pivot/PivotGridControl.cs + PivotConfiguration.cs):
+//   { data: Row[], configuration: {
+//       rowDimensions:    [{ field, displayName, propertyPath, width, sortOrder }],
+//       columnDimensions: [{ field, displayName, propertyPath, sortOrder }],
+//       aggregates:       [{ field, displayName, propertyPath, function: "Sum"|"Average"|"Count"|"Min"|"Max",
+//                            format, textAlign, sortOrder }],
+//       showRowTotals, showColumnTotals, pageSize },
+//     showPager, pageSize }
+// The pivot computation is a PURE function (computePivot) pinned by pivot.test.tsx; the component
+// renders the result as a themed table (nested column-group header rows, measures innermost,
+// row/column totals, optional pager).
+
+import type { CSSProperties, ReactNode } from "react";
+import { useMemo, useState } from "react";
+import { Button, Text } from "@fluentui/react-components";
+import type { Json, UiControl } from "../area/types.js";
+import { useResolve } from "../area/context.js";
+import { formatValue } from "./data.js";
+import { str } from "./common.js";
+
+export interface PivotDimensionWire {
+  field: string;
+  displayName?: string;
+  propertyPath?: string;
+  width?: string;
+  sortOrder?: Json;
+}
+
+export interface PivotAggregateWire extends PivotDimensionWire {
+  function?: Json;
+  format?: string;
+  textAlign?: Json;
+}
+
+export interface PivotConfigWire {
+  rowDimensions?: PivotDimensionWire[];
+  columnDimensions?: PivotDimensionWire[];
+  aggregates?: PivotAggregateWire[];
+  showRowTotals?: boolean;
+  showColumnTotals?: boolean;
+  pageSize?: number;
+}
+
+export interface PivotRowOut {
+  /** One value per row dimension. */
+  keys: string[];
+  /** One value per leaf column (colKeys × aggregates, aggregates innermost); null = no data. */
+  cells: (number | null)[];
+  /** One value per aggregate — the row's total across all column groups. */
+  totals: (number | null)[];
+}
+
+export interface PivotResult {
+  rowDims: PivotDimensionWire[];
+  colDims: PivotDimensionWire[];
+  aggregates: PivotAggregateWire[];
+  /** Distinct column-dimension tuples, sorted (each level per its sortOrder). */
+  colKeys: string[][];
+  rows: PivotRowOut[];
+  /** Per leaf column when showColumnTotals; the trailing entries are the grand totals per aggregate. */
+  columnTotals: { cells: (number | null)[]; grand: (number | null)[] } | null;
+}
+
+interface Acc {
+  sum: number;
+  count: number;
+  min: number;
+  max: number;
+}
+
+function newAcc(): Acc {
+  return { sum: 0, count: 0, min: Number.POSITIVE_INFINITY, max: Number.NEGATIVE_INFINITY };
+}
+
+function accumulate(acc: Acc, v: number): void {
+  acc.sum += v;
+  acc.count += 1;
+  if (v < acc.min) acc.min = v;
+  if (v > acc.max) acc.max = v;
+}
+
+/** Aggregate function names arrive as strings (hub string-enum converter); ordinals tolerated. */
+function applyFn(acc: Acc | undefined, fn: Json): number | null {
+  if (!acc || acc.count === 0) return null;
+  const f = typeof fn === "number" ? ["Sum", "Average", "Count", "Min", "Max"][fn] : str(fn) || "Sum";
+  switch (f) {
+    case "Average":
+      return acc.sum / acc.count;
+    case "Count":
+      return acc.count;
+    case "Min":
+      return acc.min;
+    case "Max":
+      return acc.max;
+    default:
+      return acc.sum;
+  }
+}
+
+/** Read a row property — the wire serializes rows camelCase while PropertyPath keeps the C# name. */
+function readProp(row: Record<string, Json>, path: string): Json {
+  let cur: Json = row;
+  for (const part of path.split(".")) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    const camel = part.length > 0 ? part[0].toLowerCase() + part.slice(1) : part;
+    cur = part in cur ? cur[part] : cur[camel];
+  }
+  return cur;
+}
+
+function compareValues(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { numeric: true });
+}
+
+function sortTuples(tuples: string[][], dims: PivotDimensionWire[]): string[][] {
+  return [...tuples].sort((a, b) => {
+    for (let i = 0; i < dims.length; i++) {
+      const desc = str(dims[i]?.sortOrder) === "Descending" || dims[i]?.sortOrder === 1;
+      const c = compareValues(a[i] ?? "", b[i] ?? "");
+      if (c !== 0) return desc ? -c : c;
+    }
+    return 0;
+  });
+}
+
+const SEP = "\u0001"; // non-printable separator: tuple values cannot collide with composite keys
+
+/** Compute the cross-tab. Pure — pinned by pivot.test.tsx. */
+export function computePivot(data: Json, config: PivotConfigWire | undefined): PivotResult {
+  const rows: Record<string, Json>[] = (Array.isArray(data) ? data : []).filter((r) => r != null && typeof r === "object");
+  const rowDims = config?.rowDimensions ?? [];
+  const colDims = config?.columnDimensions ?? [];
+  const aggregates = config?.aggregates?.length ? config.aggregates : [];
+
+  const rowKeySet = new Map<string, string[]>();
+  const colKeySet = new Map<string, string[]>();
+  // cell accumulators per (rowKey, colKey, aggregate)
+  const cells = new Map<string, Acc>();
+
+  for (const row of rows) {
+    const rTuple = rowDims.map((d) => str(readProp(row, d.propertyPath ?? d.field)));
+    const cTuple = colDims.map((d) => str(readProp(row, d.propertyPath ?? d.field)));
+    const rKey = rTuple.join(SEP);
+    const cKey = cTuple.join(SEP);
+    if (!rowKeySet.has(rKey)) rowKeySet.set(rKey, rTuple);
+    if (!colKeySet.has(cKey)) colKeySet.set(cKey, cTuple);
+    aggregates.forEach((agg, ai) => {
+      const raw = readProp(row, agg.propertyPath ?? agg.field);
+      const v = raw == null || raw === "" ? NaN : Number(raw);
+      if (Number.isNaN(v)) return;
+      for (const key of [
+        `${rKey}${SEP}|${cKey}${SEP}|${ai}`, // cell
+        `${rKey}${SEP}|*${SEP}|${ai}`, // row total
+        `*${SEP}|${cKey}${SEP}|${ai}`, // column total
+        `*${SEP}|*${SEP}|${ai}`, // grand total
+      ]) {
+        let acc = cells.get(key);
+        if (!acc) cells.set(key, (acc = newAcc()));
+        accumulate(acc, v);
+      }
+    });
+  }
+
+  const colKeys = sortTuples([...colKeySet.values()], colDims);
+  const rowKeys = sortTuples([...rowKeySet.values()], rowDims);
+
+  const outRows: PivotRowOut[] = rowKeys.map((rTuple) => {
+    const rKey = rTuple.join(SEP);
+    const cellsOut: (number | null)[] = [];
+    for (const cTuple of colKeys)
+      aggregates.forEach((agg, ai) => {
+        cellsOut.push(applyFn(cells.get(`${rKey}${SEP}|${cTuple.join(SEP)}${SEP}|${ai}`), agg.function));
+      });
+    const totals = aggregates.map((agg, ai) => applyFn(cells.get(`${rKey}${SEP}|*${SEP}|${ai}`), agg.function));
+    return { keys: rTuple, cells: cellsOut, totals };
+  });
+
+  let columnTotals: PivotResult["columnTotals"] = null;
+  if (config?.showColumnTotals !== false) {
+    const cellsOut: (number | null)[] = [];
+    for (const cTuple of colKeys)
+      aggregates.forEach((agg, ai) => {
+        cellsOut.push(applyFn(cells.get(`*${SEP}|${cTuple.join(SEP)}${SEP}|${ai}`), agg.function));
+      });
+    const grand = aggregates.map((agg, ai) => applyFn(cells.get(`*${SEP}|*${SEP}|${ai}`), agg.function));
+    columnTotals = { cells: cellsOut, grand };
+  }
+
+  return { rowDims, colDims, aggregates, colKeys, rows: outRows, columnTotals };
+}
+
+// ---- rendering ----------------------------------------------------------------------------------
+
+const cellBorder = "1px solid var(--colorNeutralStroke2)";
+const headerStyle: CSSProperties = {
+  border: cellBorder,
+  padding: "6px 10px",
+  background: "var(--colorNeutralBackground3)",
+  fontWeight: 600,
+  textAlign: "left",
+  whiteSpace: "nowrap",
+};
+const cellStyle: CSSProperties = { border: cellBorder, padding: "6px 10px", textAlign: "right", fontVariantNumeric: "tabular-nums" };
+const dimCellStyle: CSSProperties = { border: cellBorder, padding: "6px 10px", textAlign: "left" };
+
+/** ".NET-style" number format for pivot cells: agg.format may be "N2" or "{0:N2}". */
+export function formatCell(v: number | null, format?: string): string {
+  if (v == null) return "";
+  const f = format?.replace(/^\{0:(.+)\}$/, "$1");
+  return formatValue(v, f || "N2");
+}
+
+/** Group consecutive column tuples that share a prefix up to `level` — for header colSpans. */
+function groupsAt(colKeys: string[][], level: number): { label: string; span: number }[] {
+  const groups: { label: string; span: number; prefix: string }[] = [];
+  for (const key of colKeys) {
+    const prefix = key.slice(0, level + 1).join(SEP);
+    const prev = groups[groups.length - 1];
+    if (prev && prev.prefix === prefix) prev.span += 1;
+    else groups.push({ label: key[level] ?? "", span: 1, prefix });
+  }
+  return groups;
+}
+
+export function PivotGridView({ control }: { control: UiControl }): ReactNode {
+  const data = useResolve(control.data);
+  const config = useResolve(control.configuration) as PivotConfigWire | undefined;
+  const pivot = useMemo(() => computePivot(data, config), [data, config]);
+  const showPager = control.showPager === true;
+  const pageSize = Number(control.pageSize ?? config?.pageSize ?? 50) || 50;
+  const [page, setPage] = useState(0);
+
+  const { rowDims, colDims, aggregates, colKeys, rows, columnTotals } = pivot;
+  if (aggregates.length === 0)
+    return (
+      <Text italic size={200}>
+        No pivot aggregates configured
+      </Text>
+    );
+
+  const showRowTotals = config?.showRowTotals !== false && colDims.length > 0;
+  const showMeasureRow = aggregates.length > 1 || colDims.length === 0;
+  const headerRowCount = colDims.length + (showMeasureRow ? 1 : 0) || 1;
+  const aggCount = aggregates.length;
+
+  const pageCount = showPager ? Math.max(1, Math.ceil(rows.length / pageSize)) : 1;
+  const current = Math.min(page, pageCount - 1);
+  const visibleRows = showPager ? rows.slice(current * pageSize, (current + 1) * pageSize) : rows;
+
+  return (
+    <div style={{ overflowX: "auto", width: "100%" }}>
+      <table role="table" style={{ borderCollapse: "collapse", minWidth: "100%", fontSize: 13 }}>
+        <thead>
+          {/* One header row per column dimension: grouped labels spanning their leaves. */}
+          {colDims.map((dim, level) => (
+            <tr key={`cd${level}`}>
+              {level === 0
+                ? rowDims.map((rd) => (
+                    <th key={rd.field} rowSpan={headerRowCount} style={{ ...headerStyle, width: rd.width }}>
+                      {rd.displayName ?? rd.field}
+                    </th>
+                  ))
+                : null}
+              {groupsAt(colKeys, level).map((g, i) => (
+                <th key={i} colSpan={g.span * aggCount} style={{ ...headerStyle, textAlign: "center" }}>
+                  {g.label}
+                </th>
+              ))}
+              {level === 0 && showRowTotals ? (
+                <th rowSpan={headerRowCount} colSpan={aggCount} style={{ ...headerStyle, textAlign: "center" }}>
+                  Total
+                </th>
+              ) : null}
+            </tr>
+          ))}
+          {showMeasureRow ? (
+            <tr>
+              {colDims.length === 0
+                ? rowDims.map((rd) => (
+                    <th key={rd.field} style={{ ...headerStyle, width: rd.width }}>
+                      {rd.displayName ?? rd.field}
+                    </th>
+                  ))
+                : null}
+              {colKeys.map((ck, i) =>
+                aggregates.map((agg) => (
+                  <th key={`${i}:${agg.field}`} style={{ ...headerStyle, textAlign: "right" }}>
+                    {agg.displayName ?? agg.field}
+                  </th>
+                )),
+              )}
+            </tr>
+          ) : null}
+        </thead>
+        <tbody>
+          {visibleRows.map((r, ri) => (
+            <tr key={ri}>
+              {r.keys.map((k, ki) => (
+                <td key={ki} style={dimCellStyle}>
+                  {k}
+                </td>
+              ))}
+              {r.cells.map((c, ci) => (
+                <td key={ci} style={cellStyle}>
+                  {formatCell(c, aggregates[ci % aggCount]?.format)}
+                </td>
+              ))}
+              {showRowTotals
+                ? r.totals.map((t, ti) => (
+                    <td key={`t${ti}`} style={{ ...cellStyle, fontWeight: 600 }}>
+                      {formatCell(t, aggregates[ti]?.format)}
+                    </td>
+                  ))
+                : null}
+            </tr>
+          ))}
+          {columnTotals ? (
+            <tr>
+              <td colSpan={Math.max(1, rowDims.length)} style={{ ...dimCellStyle, fontWeight: 600 }}>
+                Total
+              </td>
+              {columnTotals.cells.map((c, ci) => (
+                <td key={ci} style={{ ...cellStyle, fontWeight: 600 }}>
+                  {formatCell(c, aggregates[ci % aggCount]?.format)}
+                </td>
+              ))}
+              {showRowTotals
+                ? columnTotals.grand.map((g, gi) => (
+                    <td key={`g${gi}`} style={{ ...cellStyle, fontWeight: 700 }}>
+                      {formatCell(g, aggregates[gi]?.format)}
+                    </td>
+                  ))
+                : null}
+            </tr>
+          ) : null}
+        </tbody>
+      </table>
+      {showPager && pageCount > 1 ? (
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 0" }}>
+          <Button size="small" disabled={current === 0} onClick={() => setPage(current - 1)}>
+            Previous
+          </Button>
+          <Text size={200}>
+            Page {current + 1} of {pageCount}
+          </Text>
+          <Button size="small" disabled={current >= pageCount - 1} onClick={() => setPage(current + 1)}>
+            Next
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export const pivotControls = {
+  PivotGrid: PivotGridView,
+};

--- a/clients/react/src/controls/threadChat.test.tsx
+++ b/clients/react/src/controls/threadChat.test.tsx
@@ -1,0 +1,213 @@
+// ThreadChat parity with Blazor's ThreadChatView: the message list renders from the THREAD NODE's
+// live stream (thread node + per-message satellite cells at {threadPath}/{id}), queued messages come
+// from content.pendingUserMessages, the exec bar reflects Thread.status, and the composer is gated
+// exactly like Blazor (whitespace-only OR IsExecuting → disabled). Submission drains through the
+// canonical MeshOps surface — startThread for a new thread, submitMessage for an existing one; the
+// wire shapes those produce (CreateNodeRequest / RFC 7396 PatchDataRequest) are pinned by
+// @meshweaver/client-web's threads.test.ts, whose `Mesh` satisfies MeshOps structurally.
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource, type AreaTree } from "../core.js";
+import type { MeshNodeState, MeshOps, ThreadSubmitOptions } from "../live/meshOps.js";
+
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = ((q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null })) as unknown as typeof window.matchMedia;
+  if (!(globalThis as any).ResizeObserver)
+    (globalThis as any).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+});
+
+// A MeshOps fake backed by static node snapshots: watch(path) yields the snapshot once and then
+// stays open (like a live stream that has emitted its initial state).
+class FakeOps implements MeshOps {
+  readonly submitCalls: { path: string; text: string; opts?: ThreadSubmitOptions }[] = [];
+  readonly startCalls: { ns: string; text: string; opts?: ThreadSubmitOptions }[] = [];
+  readonly patchCalls: { path: string; fields: Record<string, unknown> }[] = [];
+  constructor(private readonly nodes: Record<string, Record<string, unknown>>) {}
+
+  async *watch(path: string): AsyncIterableIterator<MeshNodeState> {
+    const content = this.nodes[path];
+    if (content === undefined) throw new Error(`no node at ${path}`); // a missing satellite errors the stream
+    yield { path, name: path.split("/").pop(), content };
+    await new Promise<void>(() => undefined); // stream stays open (aborted via iterator.return on cleanup)
+  }
+
+  async startThread(ns: string, text: string, opts?: ThreadSubmitOptions) {
+    this.startCalls.push({ ns, text, opts });
+    return { path: `${ns}/_Thread/created-1234`, userMessageId: "aaaa1111" };
+  }
+
+  async submitMessage(path: string, text: string, opts?: ThreadSubmitOptions) {
+    this.submitCalls.push({ path, text, opts });
+    return "bbbb2222";
+  }
+
+  patch(path: string, fields: Record<string, unknown>): void {
+    this.patchCalls.push({ path, fields });
+  }
+}
+
+const THREAD = "rbuergi/_Thread/t-1";
+
+function chatTree(control: Record<string, unknown> = {}): AreaTree {
+  return { data: {}, areas: { main: { $type: "ThreadChat", threadPath: THREAD, ...control } } };
+}
+
+function renderChat(ops: MeshOps, control: Record<string, unknown> = {}) {
+  return render(<MeshAreaView source={new StaticAreaSource(chatTree(control))} rootArea="main" ops={ops} />);
+}
+
+describe("ThreadChat — message list from the thread node's live stream", () => {
+  it("renders user/assistant bubbles from Thread.messages via the per-message cells", async () => {
+    const ops = new FakeOps({
+      [THREAD]: { messages: ["m1", "m2"], status: "Idle" },
+      [`${THREAD}/m1`]: { role: "user", text: "Hello there" },
+      [`${THREAD}/m2`]: { role: "assistant", text: "Hi! **How** can I help?", agentName: "Coder" },
+    });
+    renderChat(ops);
+    await screen.findByText("Hello there");
+    // Markdown-rendered assistant text (the ** renders as <strong>).
+    await screen.findByText("How");
+    expect(document.querySelector('[data-role="user"]')).toBeTruthy();
+    expect(document.querySelector('[data-role="assistant"]')).toBeTruthy();
+    expect(screen.getByText(/Coder/)).toBeTruthy();
+  });
+
+  it("renders tool calls collapsed with their status glyph", async () => {
+    const ops = new FakeOps({
+      [THREAD]: { messages: ["m1"], status: "Idle" },
+      [`${THREAD}/m1`]: {
+        role: "assistant",
+        text: "done",
+        toolCalls: [
+          { name: "search", isSuccess: true, arguments: '{"q":"laptops"}' },
+          { name: "update", displayName: "Update node", isSuccess: false, status: "Failed" },
+        ],
+      },
+    });
+    renderChat(ops);
+    await screen.findByText(/search/);
+    expect(screen.getByText(/Update node/)).toBeTruthy();
+    const details = document.querySelectorAll("details");
+    expect(details.length).toBe(2);
+    expect(details[0].open).toBe(false); // collapsed by default, like Blazor
+  });
+
+  it("renders queued messages from pendingUserMessages before their cells exist", async () => {
+    const ops = new FakeOps({
+      [THREAD]: {
+        messages: [],
+        status: "Idle",
+        pendingUserMessages: { p1: { role: "user", text: "still queued" } },
+      },
+    });
+    renderChat(ops);
+    await screen.findByText("still queued");
+    expect(screen.getByText("queued…")).toBeTruthy();
+  });
+
+  it("shows the exec bar (status text + Stop) while the thread executes, and Stop flips requestedStatus", async () => {
+    const ops = new FakeOps({
+      [THREAD]: {
+        messages: [],
+        status: "Executing",
+        executionStatus: "Calling search…",
+        streamingText: "Here is what I found so far",
+        streamingToolCalls: [{ name: "search", status: "Streaming" }],
+      },
+    });
+    renderChat(ops);
+    await screen.findByText(/Calling search…/);
+    expect(screen.getByText(/Here is what I found so far/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Stop/ }));
+    expect(ops.patchCalls).toEqual([{ path: THREAD, fields: { content: { requestedStatus: "Cancelled" } } }]);
+  });
+});
+
+describe("ThreadChat — composer gating (Blazor: whitespace-only || IsExecuting → disabled)", () => {
+  it("Send is disabled for empty text and enables when text is typed", async () => {
+    const ops = new FakeOps({ [THREAD]: { messages: [], status: "Idle" } });
+    renderChat(ops);
+    const send = await screen.findByRole("button", { name: "Send" });
+    expect((send as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText("Message"), { target: { value: "hello" } });
+    expect((send as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.change(screen.getByLabelText("Message"), { target: { value: "   " } });
+    expect((send as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("Send and the textarea are disabled while the thread is executing", async () => {
+    const ops = new FakeOps({ [THREAD]: { messages: [], status: "StartingExecution" } });
+    renderChat(ops);
+    await screen.findByRole("status"); // the exec bar
+    expect((screen.getByRole("button", { name: "Send" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText("Message") as HTMLTextAreaElement).disabled).toBe(true);
+  });
+});
+
+describe("ThreadChat — submission through the canonical thread surface", () => {
+  it("submitMessage drains through the EXISTING thread with the composer's sticky selection", async () => {
+    const ops = new FakeOps({
+      [THREAD]: { messages: [], status: "Idle", composer: { agentName: "Agent/Coder", modelName: "Model/gpt" } },
+    });
+    renderChat(ops);
+    fireEvent.change(await screen.findByLabelText("Message"), { target: { value: "  and another thing  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => expect(ops.submitCalls.length).toBe(1));
+    expect(ops.submitCalls[0]).toEqual({
+      path: THREAD,
+      text: "and another thing",
+      opts: { agentName: "Agent/Coder", modelName: "Model/gpt" },
+    });
+    expect(ops.startCalls).toEqual([]); // never re-StartThread on an existing thread
+    expect((screen.getByLabelText("Message") as HTMLTextAreaElement).value).toBe(""); // composer cleared
+  });
+
+  it("with no threadPath, Enter starts a thread under the initial context and routes send #2 to it", async () => {
+    const ops = new FakeOps({
+      "rbuergi/_Thread/created-1234": { messages: [], status: "Idle" },
+    });
+    renderChat(ops, { threadPath: undefined, initialContext: "rbuergi" });
+    const input = await screen.findByLabelText("Message");
+    fireEvent.change(input, { target: { value: "Hello from React" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(ops.startCalls.length).toBe(1));
+    expect(ops.startCalls[0].ns).toBe("rbuergi");
+    expect(ops.startCalls[0].text).toBe("Hello from React");
+    expect(ops.startCalls[0].opts?.contextPath).toBe("rbuergi");
+    // The created path becomes the thread — message 2 must submit, not create a second thread.
+    fireEvent.change(input, { target: { value: "second message" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(ops.submitCalls.length).toBe(1));
+    expect(ops.submitCalls[0].path).toBe("rbuergi/_Thread/created-1234");
+    expect(ops.startCalls.length).toBe(1);
+  });
+
+  it("with no threadPath AND no context, Send stays disabled (nowhere to anchor the thread)", async () => {
+    const ops = new FakeOps({});
+    renderChat(ops, { threadPath: undefined });
+    fireEvent.change(await screen.findByLabelText("Message"), { target: { value: "hello" } });
+    expect((screen.getByRole("button", { name: "Send" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("surfaces a submit failure and restores the typed text (never a silent drop)", async () => {
+    const ops = new FakeOps({ [THREAD]: { messages: [], status: "Idle" } });
+    ops.submitMessage = async () => {
+      throw new Error("Access denied");
+    };
+    renderChat(ops);
+    const input = await screen.findByLabelText("Message");
+    fireEvent.change(input, { target: { value: "will fail" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await screen.findByRole("alert");
+    expect(screen.getByRole("alert").textContent).toContain("Access denied");
+    expect((input as HTMLTextAreaElement).value).toBe("will fail");
+  });
+});

--- a/clients/react/src/controls/threadChat.tsx
+++ b/clients/react/src/controls/threadChat.tsx
@@ -1,0 +1,478 @@
+// ThreadChat — the React port of the Blazor portal's ThreadChatView (src/MeshWeaver.Blazor.Portal/
+// Chat/ThreadChatView.razor): the full chat experience over a THREAD NODE's live stream.
+//
+// Data flow mirrors Blazor exactly — no parallel protocol:
+//   - The view watches the thread node (MeshOps.watch(threadPath)) and renders its Thread content:
+//     `messages` (ordered ids), `pendingUserMessages` (queued payloads keyed by id), `status`
+//     (Idle | StartingExecution | Executing | Cancelled | Done), `executionStatus`, `streamingText`,
+//     `streamingToolCalls`, `composer` (the sticky agent/model selection).
+//   - Each message id is a SATELLITE CELL at {threadPath}/{id} — one watch per id (the twin of
+//     Blazor's SyncMessageSubscriptions). A cell's content is a ThreadMessage
+//     (role/text/status/toolCalls/...). Until the cell exists, the bubble renders from the pending
+//     payload (queued state).
+//   - Submission goes through the canonical surface (the client twin of HubThreadExtensions):
+//     no thread yet → MeshOps.startThread (ONE CreateNodeRequest, seeded pendingUserMessages);
+//     existing thread → MeshOps.submitMessage (RFC 7396 merge-patch appending userMessageIds +
+//     pendingUserMessages). Stop → patch { content: { requestedStatus: "Cancelled" } } — the
+//     control-plane flip the owning hub's watcher reacts to.
+//
+// The composer is gated exactly like Blazor (ThreadChatView.razor line ~865):
+//   disabled = whitespace-only text || thread.IsExecuting (StartingExecution | Executing).
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
+import { Button, Dropdown, Option, Spinner, Text, Textarea, Tooltip } from "@fluentui/react-components";
+import { Send20Filled, Stop20Regular } from "@fluentui/react-icons";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Json, UiControl } from "../area/types.js";
+import { useResolve } from "../area/context.js";
+import { useMeshOps, type MeshNodeState, type MeshOps, type ThreadSubmitOptions } from "../live/meshOps.js";
+import { controlStyle } from "../render/style.js";
+import { str } from "./common.js";
+
+// ---- wire shapes (camelCase — SerializationExtensions serialises with camelCase + string enums) ---
+
+interface ToolCallJson {
+  name?: string;
+  displayName?: string;
+  arguments?: string;
+  result?: string;
+  isSuccess?: boolean;
+  status?: string; // Streaming | Success | Failed | Cancelled
+}
+
+interface ThreadMessageJson {
+  role?: string; // "user" | "assistant"
+  text?: string;
+  authorName?: string;
+  agentName?: string;
+  modelName?: string;
+  status?: string; // Queued | Submitted | Streaming | Completed | Cancelled | Error
+  toolCalls?: ToolCallJson[];
+  timestamp?: string;
+}
+
+interface ThreadJson {
+  messages?: string[];
+  userMessageIds?: string[];
+  pendingUserMessages?: Record<string, ThreadMessageJson>;
+  composer?: { agentName?: string; modelName?: string; harness?: string; contextPath?: string };
+  status?: string; // Idle | StartingExecution | Executing | Cancelled | Done
+  executionStatus?: string;
+  executionStartedAt?: string;
+  activeMessageId?: string;
+  streamingText?: string;
+  streamingToolCalls?: ToolCallJson[];
+  createdBy?: string;
+}
+
+// ---- node-stream plumbing (the grpc-web watch primitive, via the MeshOps context) ---------------
+
+/** Drive an async-iterable node watch into a callback; returns the stop function. */
+function watchInto(ops: MeshOps, path: string, onState: (n: MeshNodeState) => void): () => void {
+  let live = true;
+  const it = ops.watch(path)[Symbol.asyncIterator]();
+  void (async () => {
+    try {
+      while (live) {
+        const r = await it.next();
+        if (r.done) break;
+        if (live && r.value) onState(r.value);
+      }
+    } catch {
+      // A missing satellite surfaces as a stream error (the cache's DeliveryFailure). The bubble
+      // keeps rendering from the pending payload — never crash the view (Blazor marks it missing).
+    }
+  })();
+  return () => {
+    live = false;
+    void Promise.resolve(it.return?.()).catch(() => undefined);
+  };
+}
+
+/** The live state of one node (null until the first emission / when unset). */
+function useNodeState(ops: MeshOps | null, path: string | null): MeshNodeState | null {
+  const [node, setNode] = useState<MeshNodeState | null>(null);
+  useEffect(() => {
+    setNode(null);
+    if (!ops || !path) return;
+    return watchInto(ops, path, setNode);
+  }, [ops, path]);
+  return node;
+}
+
+/** One watch per message cell at {threadPath}/{id} — Blazor's SyncMessageSubscriptions. */
+function useMessageCells(
+  ops: MeshOps | null,
+  threadPath: string | null,
+  ids: readonly string[],
+): Record<string, ThreadMessageJson> {
+  const [cells, setCells] = useState<Record<string, ThreadMessageJson>>({});
+  const watchers = useRef(new Map<string, () => void>());
+  const paths = threadPath ? ids.map((id) => `${threadPath}/${id}`) : [];
+  const pathsKey = paths.join("\n");
+  useEffect(() => {
+    if (!ops) return;
+    const want = new Set(paths);
+    for (const [p, stop] of watchers.current) {
+      if (!want.has(p)) {
+        stop();
+        watchers.current.delete(p);
+      }
+    }
+    for (const p of paths) {
+      if (watchers.current.has(p)) continue;
+      watchers.current.set(
+        p,
+        watchInto(ops, p, (node) => setCells((c) => ({ ...c, [p]: (node.content ?? {}) as ThreadMessageJson }))),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ops, pathsKey]);
+  useEffect(
+    () => () => {
+      for (const stop of watchers.current.values()) stop();
+      watchers.current.clear();
+    },
+    [],
+  );
+  return cells;
+}
+
+/** Agent/model options from the mesh (nodeType:Agent / nodeType:Model), when the ops expose search. */
+function useSearchOptions(ops: MeshOps | null, query: string): { path: string; name: string }[] {
+  const [options, setOptions] = useState<{ path: string; name: string }[]>([]);
+  useEffect(() => {
+    if (!ops?.search) return;
+    let live = true;
+    ops
+      .search(query)
+      .then((rs) => {
+        if (!live) return;
+        setOptions(
+          rs.map((r) => ({ path: str(r.path), name: str(r.name) || str(r.path) })).filter((o) => o.path.length > 0),
+        );
+      })
+      .catch(() => undefined);
+    return () => {
+      live = false;
+    };
+  }, [ops, query]);
+  return options;
+}
+
+// ---- rendering ----------------------------------------------------------------------------------
+
+function ToolCallView({ call }: { call: ToolCallJson }): ReactNode {
+  const failed = call.isSuccess === false || call.status === "Failed";
+  const running = call.status === "Streaming";
+  const icon = running ? "●" : failed ? "✗" : "✓";
+  return (
+    <details style={{ fontSize: 12, margin: "2px 0", color: "var(--colorNeutralForeground3)" }}>
+      <summary style={{ cursor: "pointer" }}>
+        <span style={{ color: failed ? "var(--colorStatusDangerForeground1)" : undefined }}>{icon}</span>{" "}
+        {str(call.displayName) || str(call.name)}
+      </summary>
+      {call.arguments ? (
+        <pre style={{ whiteSpace: "pre-wrap", margin: "4px 0", fontFamily: "var(--fontFamilyMonospace)" }}>
+          {str(call.arguments)}
+        </pre>
+      ) : null}
+      {call.result ? (
+        <pre style={{ whiteSpace: "pre-wrap", margin: "4px 0", fontFamily: "var(--fontFamilyMonospace)" }}>
+          {str(call.result)}
+        </pre>
+      ) : null}
+    </details>
+  );
+}
+
+function MessageBubble({ msg, queued }: { msg: ThreadMessageJson; queued: boolean }): ReactNode {
+  const mine = /user/i.test(str(msg.role) || "user");
+  const isError = msg.status === "Error";
+  const streaming = msg.status === "Streaming";
+  const author = str(msg.authorName) || (mine ? "" : str(msg.agentName));
+  return (
+    <div style={{ display: "flex", justifyContent: mine ? "flex-end" : "flex-start" }}>
+      <div
+        data-role={mine ? "user" : "assistant"}
+        style={{
+          maxWidth: "80%",
+          padding: "8px 12px",
+          borderRadius: 12,
+          opacity: queued ? 0.7 : 1,
+          border: isError ? "1px solid var(--colorStatusDangerBorder1)" : undefined,
+          background: isError
+            ? "var(--colorStatusDangerBackground1)"
+            : mine
+              ? "var(--colorBrandBackground2)"
+              : "var(--colorNeutralBackground3)",
+        }}
+      >
+        {author ? (
+          <Text size={200} weight="semibold" block style={{ color: "var(--colorNeutralForeground3)" }}>
+            {author}
+            {msg.modelName ? ` · ${str(msg.modelName)}` : ""}
+          </Text>
+        ) : null}
+        {(msg.toolCalls ?? []).map((c, i) => (
+          <ToolCallView key={i} call={c} />
+        ))}
+        <div className="mw-markdown" style={{ fontSize: 14 }}>
+          <Markdown remarkPlugins={[remarkGfm]}>{str(msg.text)}</Markdown>
+        </div>
+        {queued ? (
+          <Text size={100} style={{ color: "var(--colorNeutralForeground3)" }}>
+            queued…
+          </Text>
+        ) : streaming ? (
+          <Text size={100} style={{ color: "var(--colorNeutralForeground3)" }}>
+            streaming…
+          </Text>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** The exec bar — visible while the thread executes: status line, streaming preview, tools, Stop. */
+function ExecutionBar({
+  thread,
+  onStop,
+}: {
+  thread: ThreadJson;
+  onStop: () => void;
+}): ReactNode {
+  const preview = str(thread.streamingText);
+  return (
+    <div
+      role="status"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        padding: "8px 12px",
+        borderRadius: 8,
+        background: "var(--colorNeutralBackground2)",
+        border: "1px solid var(--colorNeutralStroke2)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Spinner size="extra-tiny" />
+        <Text size={200} weight="semibold" style={{ flex: 1 }}>
+          ✦ {str(thread.executionStatus) || "Working…"}
+        </Text>
+        <Button size="small" appearance="subtle" icon={<Stop20Regular />} onClick={onStop}>
+          Stop
+        </Button>
+      </div>
+      {preview ? (
+        <Text size={200} style={{ color: "var(--colorNeutralForeground3)", whiteSpace: "pre-wrap" }}>
+          {preview.length > 300 ? `${preview.slice(0, 300)}…` : preview}
+        </Text>
+      ) : null}
+      {(thread.streamingToolCalls ?? []).length > 0 ? (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {(thread.streamingToolCalls ?? []).map((c, i) => (
+            <Text key={i} size={100} style={{ color: "var(--colorNeutralForeground3)" }}>
+              {c.status === "Streaming" ? "●" : c.isSuccess === false || c.status === "Failed" ? "✗" : "✓"}{" "}
+              {str(c.displayName) || str(c.name)}
+            </Text>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SelectorDropdown({
+  label,
+  value,
+  options,
+  onSelect,
+}: {
+  label: string;
+  value: string;
+  options: { path: string; name: string }[];
+  onSelect: (path: string) => void;
+}): ReactNode {
+  if (options.length === 0) return null;
+  const selected = options.find((o) => o.path === value);
+  return (
+    <Dropdown
+      aria-label={label}
+      placeholder={label}
+      size="small"
+      value={selected?.name ?? (value || "")}
+      selectedOptions={value ? [value] : []}
+      onOptionSelect={(_, d) => onSelect(str(d.optionValue))}
+      style={{ minWidth: 120 }}
+    >
+      {options.map((o) => (
+        <Option key={o.path} value={o.path} text={o.name}>
+          {o.name}
+        </Option>
+      ))}
+    </Dropdown>
+  );
+}
+
+export function ThreadChatView({ control }: { control: UiControl }): ReactNode {
+  const ops = useMeshOps();
+  const vm = useResolve(control.threadViewModel) as Json;
+  const boundPath =
+    str(useResolve(control.threadPath)) || (vm && typeof vm === "object" ? str(vm.threadPath) : "");
+  const initialContext = str(useResolve(control.initialContext));
+  const hideEmptyState = !!useResolve(control.hideEmptyState);
+  const showFullHeader = !!useResolve(control.showFullHeader);
+
+  // Once submit creates the thread, all later sends drain through it (Blazor's onCreated sets
+  // threadPath the moment the node exists — message 2+ must never re-StartThread).
+  const [createdPath, setCreatedPath] = useState<string | null>(null);
+  const threadPath = createdPath ?? (boundPath || null);
+
+  const threadNode = useNodeState(ops, threadPath);
+  const thread = (threadNode?.content ?? {}) as ThreadJson;
+  const isExecuting = thread.status === "StartingExecution" || thread.status === "Executing";
+
+  const ids = useMemo(() => (Array.isArray(thread.messages) ? thread.messages.map(String) : []), [thread.messages]);
+  const pending = (thread.pendingUserMessages ?? {}) as Record<string, ThreadMessageJson>;
+  const cells = useMessageCells(ops, threadPath, ids);
+
+  // Ordered bubbles: the messages list (cell content, falling back to the pending payload), then
+  // any queued messages the watcher hasn't drained into `messages` yet.
+  const items = [
+    ...ids.map((id) => {
+      const cell = threadPath ? cells[`${threadPath}/${id}`] : undefined;
+      return { id, msg: cell ?? pending[id], queued: !cell && !!pending[id] };
+    }),
+    ...Object.keys(pending)
+      .filter((id) => !ids.includes(id))
+      .map((id) => ({ id, msg: pending[id], queued: true })),
+  ].filter((x): x is { id: string; msg: ThreadMessageJson; queued: boolean } => x.msg != null);
+
+  // Composer state — the selection defaults to the thread's embedded composer (the single source of
+  // the round's selection); an explicit pick overrides and folds back into the composer on submit.
+  const [text, setText] = useState("");
+  const [agent, setAgent] = useState<string | null>(null);
+  const [model, setModel] = useState<string | null>(null);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const composer = thread.composer ?? {};
+  const effectiveAgent = agent ?? str(composer.agentName);
+  const effectiveModel = model ?? str(composer.modelName);
+  const agentOptions = useSearchOptions(ops, "nodeType:Agent");
+  const modelOptions = useSearchOptions(ops, "nodeType:Model");
+
+  // Auto-scroll to the latest bubble (Blazor's ChatMessageList behavior).
+  const endRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    endRef.current?.scrollIntoView?.({ behavior: "smooth", block: "end" });
+  }, [items.length, thread.streamingText]);
+
+  const namespacePath = initialContext;
+  const canSend = !!ops && text.trim().length > 0 && !isExecuting && (!!threadPath || !!namespacePath);
+
+  const send = () => {
+    if (!canSend || !ops) return;
+    const userText = text.trim();
+    setText("");
+    setSendError(null);
+    const opts: ThreadSubmitOptions = {};
+    if (effectiveAgent) opts.agentName = effectiveAgent;
+    if (effectiveModel) opts.modelName = effectiveModel;
+    const submitted: Promise<unknown> = threadPath
+      ? ops.submitMessage(threadPath, userText, opts)
+      : ops
+          .startThread(namespacePath, userText, { ...opts, contextPath: initialContext || undefined })
+          .then((r) => setCreatedPath(r.path));
+    submitted.catch((err) => {
+      // Mirror Blazor's onError: SURFACE the failure and restore the typed text — a silent reset is
+      // the "message vanished, no idea why" symptom.
+      setSendError(err instanceof Error ? err.message : String(err));
+      setText(userText);
+    });
+  };
+
+  const stop = () => {
+    if (ops && threadPath) ops.patch(threadPath, { content: { requestedStatus: "Cancelled" } });
+  };
+
+  const onComposerKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  };
+
+  if (!ops) {
+    return (
+      <div style={{ padding: 16, color: "var(--colorNeutralForeground3)", ...controlStyle(control) }}>
+        <Text size={200}>Thread chat needs a live mesh connection — wrap the app in a MeshOpsProvider.</Text>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        minHeight: 0,
+        height: "100%",
+        ...controlStyle(control),
+      }}
+    >
+      {showFullHeader && threadNode?.name ? (
+        <Text size={500} weight="semibold">
+          {str(threadNode.name)}
+        </Text>
+      ) : null}
+
+      <div style={{ flex: 1, minHeight: 0, overflowY: "auto", display: "flex", flexDirection: "column", gap: 8 }}>
+        {items.length === 0 && !isExecuting && !hideEmptyState ? (
+          <div style={{ textAlign: "center", padding: 24, color: "var(--colorNeutralForeground3)" }}>
+            <Text size={400} block>
+              💬
+            </Text>
+            <Text size={200}>No messages yet — ask anything below.</Text>
+          </div>
+        ) : null}
+        {items.map((x) => (
+          <MessageBubble key={x.id} msg={x.msg} queued={x.queued} />
+        ))}
+        {isExecuting ? <ExecutionBar thread={thread} onStop={stop} /> : null}
+        <div ref={endRef} />
+      </div>
+
+      {sendError ? (
+        <Text size={200} role="alert" style={{ color: "var(--colorStatusDangerForeground1)" }}>
+          Couldn't send your message: {sendError}
+        </Text>
+      ) : null}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <Textarea
+          aria-label="Message"
+          placeholder="Type a message…"
+          value={text}
+          disabled={isExecuting}
+          onChange={(_, d) => setText(d.value)}
+          onKeyDown={onComposerKeyDown}
+          resize="vertical"
+        />
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <SelectorDropdown label="Agent" value={effectiveAgent} options={agentOptions} onSelect={setAgent} />
+          <SelectorDropdown label="Model" value={effectiveModel} options={modelOptions} onSelect={setModel} />
+          <div style={{ flex: 1 }} />
+          <Tooltip content="Send" relationship="label">
+            <Button appearance="primary" icon={<Send20Filled />} disabled={!canSend} onClick={send}>
+              Send
+            </Button>
+          </Tooltip>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clients/react/src/core.ts
+++ b/clients/react/src/core.ts
@@ -18,5 +18,19 @@ export {
   type LayoutAreaReference,
   type GrpcAreaOptions,
 } from "./live/grpcSource.js";
+export {
+  MeshOpsProvider,
+  useMeshOps,
+  type MeshOps,
+  type MeshNodeState,
+  type ThreadSubmitOptions,
+} from "./live/meshOps.js";
+export {
+  EmbeddedAreaProvider,
+  useAreaSourceFactory,
+  type AreaSourceFactory,
+  type EmbeddedAreaHandle,
+  type EmbeddedAreaReference,
+} from "./render/embeddedArea.js";
 export { getPointer, setPointer, mergePatch, resolve, bindingPointer } from "./area/pointer.js";
 export type { AreaSource, AreaTree, UiControl, Skin, NamedArea, MeshEvent, Json } from "./area/types.js";

--- a/clients/react/src/index.tsx
+++ b/clients/react/src/index.tsx
@@ -3,29 +3,42 @@
 // demo source, or the gRPC-backed live source. This is the web/Electron/React-Native-capable analog of
 // the MAUI MauiViewPack — the SAME UiControl tree, a Fluent React leaf pack.
 
-import { FluentProvider, webLightTheme, type Theme } from "@fluentui/react-components";
+import { FluentProvider, type Theme } from "@fluentui/react-components";
 import type { AreaSource } from "./area/types.js";
 import { ScopeProvider } from "./area/context.js";
 import { RenderArea } from "./render/ControlRenderer.js";
 import { RegistryProvider } from "./render/registryContext.js";
 import { fluentPack } from "./render/registry.js";
+import { useThemeMode } from "./theme/themeMode.js";
+import { MeshOpsProvider, type MeshOps } from "./live/meshOps.js";
 
 export interface MeshAreaViewProps {
   source: AreaSource;
   /** Key of the root area to render (a key in the source's `areas` map). */
   rootArea: string;
+  /** Pin a Fluent theme. When omitted the view follows the user's persisted light/dark/system
+   *  preference (localStorage "theme", the same key the Blazor portal uses) — see useThemeMode. */
   theme?: Theme;
+  /** Override the theme localStorage key (defaults to the Blazor-compatible "theme"). */
+  themeStorageKey?: string;
+  /** The mesh operations surface (node watches + thread submission) — controls that go beyond the
+   *  layout-area contract (ThreadChat) need it. `Mesh.from(connection)` from @meshweaver/client-web
+   *  satisfies it structurally. */
+  ops?: MeshOps | null;
 }
 
 /** Top-level: wraps Fluent's provider and renders the root layout area. */
-export function MeshAreaView({ source, rootArea, theme }: MeshAreaViewProps) {
+export function MeshAreaView({ source, rootArea, theme, themeStorageKey, ops }: MeshAreaViewProps) {
+  const { theme: preferredTheme } = useThemeMode({ storageKey: themeStorageKey });
   return (
-    <FluentProvider theme={theme ?? webLightTheme}>
-      <RegistryProvider pack={fluentPack}>
-        <ScopeProvider source={source} area={rootArea}>
-          <RenderArea areaKey={rootArea} />
-        </ScopeProvider>
-      </RegistryProvider>
+    <FluentProvider theme={theme ?? preferredTheme}>
+      <MeshOpsProvider ops={ops ?? null}>
+        <RegistryProvider pack={fluentPack}>
+          <ScopeProvider source={source} area={rootArea}>
+            <RenderArea areaKey={rootArea} />
+          </ScopeProvider>
+        </RegistryProvider>
+      </MeshOpsProvider>
     </FluentProvider>
   );
 }
@@ -41,6 +54,35 @@ export {
   type LayoutAreaReference,
   type GrpcAreaOptions,
 } from "./live/grpcSource.js";
+export {
+  MeshOpsProvider,
+  useMeshOps,
+  type MeshOps,
+  type MeshNodeState,
+  type ThreadSubmitOptions,
+} from "./live/meshOps.js";
 export { ScopeProvider, useAreaState, useResolve, useEmit, useScope } from "./area/context.js";
+export {
+  EmbeddedAreaProvider,
+  useAreaSourceFactory,
+  type AreaSourceFactory,
+  type EmbeddedAreaHandle,
+  type EmbeddedAreaReference,
+} from "./render/embeddedArea.js";
 export { getPointer, setPointer, mergePatch, resolve } from "./area/pointer.js";
 export type { AreaSource, AreaTree, UiControl, Skin, NamedArea, MeshEvent, Json } from "./area/types.js";
+export {
+  useThemeMode,
+  readStoredThemeMode,
+  writeStoredThemeMode,
+  clearStoredTheme,
+  resolveThemeMode,
+  fluentThemeFor,
+  systemPrefersDark,
+  DEFAULT_THEME_STORAGE_KEY,
+  type ThemeMode,
+  type ResolvedThemeMode,
+  type ThemeState,
+  type UseThemeModeOptions,
+} from "./theme/themeMode.js";
+export { ThemeToggle, type ThemeToggleProps } from "./theme/ThemeToggle.js";

--- a/clients/react/src/live/grpcSource.test.ts
+++ b/clients/react/src/live/grpcSource.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { GrpcAreaSource, type MeshConnectionLike } from "./grpcSource.js";
+import { getPointer } from "../area/pointer.js";
+
+// Wire-faithful fold tests — the frame shapes below are pinned against the SERVER source
+// (src/MeshWeaver.Data/Serialization): InstanceCollectionConverter JSON-encodes instance keys and
+// prepends a `$type` collection marker; JsonSynchronizationStream.ToJsonPatch emits RFC 6902 patch
+// ARRAYS whose pointer segments carry the same JSON-encoded keys. See grpcSource.ts "WIRE".
+
+interface Sent {
+  target: string;
+  messageType: string;
+  message: Record<string, unknown>;
+}
+
+/** In-memory MeshConnectionLike: scripts the watch frames, records every post. */
+function fakeConnection(frames: Record<string, unknown>[]) {
+  const sent: Sent[] = [];
+  let release: (() => void) | undefined;
+  const drained = new Promise<void>((r) => (release = r));
+  const connection: MeshConnectionLike = {
+    post: (target, messageType, message) => {
+      sent.push({ target, messageType, message });
+    },
+    // Mirrors MeshWebConnection.watch: it POSTS the subscribe message (streamId folded in),
+    // then yields the scripted mesh→client frames.
+    watch: async function* (target, streamId, subscribeType, subscribeMsg) {
+      sent.push({ target, messageType: subscribeType, message: { ...subscribeMsg, streamId } });
+      for (const message of frames) yield { message };
+      release!();
+      await new Promise<void>(() => {}); // stay open like the real stream
+    },
+  };
+  return { connection, sent, drained };
+}
+
+const fullFrame = {
+  streamId: "s1",
+  version: 1,
+  changeType: "Full",
+  change: {
+    areas: {
+      $type: "areas",
+      '""': { $type: "NamedAreaControl", area: "Content" },
+      '"Content"': { $type: "MarkdownControl", data: "# hello" },
+    },
+    data: {
+      $type: "data",
+      '"model"': { name: "Ada" },
+    },
+  },
+};
+
+describe("GrpcAreaSource wire folding", () => {
+  it("subscribes with the polymorphic $type on the LayoutAreaReference", async () => {
+    const { connection, sent, drained } = fakeConnection([]);
+    const source = new GrpcAreaSource(connection, "Doc/GUI", { area: "" }, { streamId: "s1" });
+    void source.start();
+    await drained;
+    expect(sent[0].messageType).toBe("SubscribeRequest");
+    expect(sent[0].message.reference).toEqual({ $type: "LayoutAreaReference", area: "" });
+    expect(sent[0].message.streamId).toBe("s1");
+  });
+
+  it("folds a Full snapshot: instance keys decoded, $type markers dropped", async () => {
+    const { connection, drained } = fakeConnection([fullFrame]);
+    const source = new GrpcAreaSource(connection, "Doc/GUI", { area: "" }, { streamId: "s1" });
+    void source.start();
+    await drained;
+    const state = source.getState();
+    expect(Object.keys(state.areas!).sort()).toEqual(["", "Content"]);
+    expect(state.areas![""].area).toBe("Content"); // default-area indirection renders by plain key
+    expect(state.areas!["Content"].$type).toBe("MarkdownControl");
+    expect((state.data as Record<string, unknown>)["model"]).toEqual({ name: "Ada" });
+  });
+
+  it("applies an RFC 6902 Patch with JSON-encoded key segments", async () => {
+    const patchFrame = {
+      streamId: "s1",
+      version: 2,
+      changeType: "Patch",
+      change: [
+        { op: "replace", path: '/areas/"Content"/data', value: "# updated" },
+        { op: "add", path: '/data/"model"/role', value: "Engineer" },
+        { op: "remove", path: '/data/"model"/name' },
+      ],
+    };
+    const { connection, drained } = fakeConnection([fullFrame, patchFrame]);
+    const source = new GrpcAreaSource(connection, "Doc/GUI", { area: "" }, { streamId: "s1" });
+    void source.start();
+    await drained;
+    const state = source.getState();
+    expect(state.areas!["Content"].data).toBe("# updated");
+    expect((state.data as Record<string, Record<string, unknown>>)["model"]).toEqual({ role: "Engineer" });
+  });
+
+  it("resolves a wire-encoded binding pointer against the folded tree", async () => {
+    const { connection, drained } = fakeConnection([fullFrame]);
+    const source = new GrpcAreaSource(connection, "Doc/GUI", { area: "" }, { streamId: "s1" });
+    void source.start();
+    await drained;
+    // Controls arrive with wire-encoded pointers (/data/"model"/name) — resolution must decode.
+    expect(getPointer(source.getState(), '/data/"model"/name')).toBe("Ada");
+  });
+
+  it("sends edits as an RFC 6902 PatchDataChangeRequest (raw array, wire pointer)", async () => {
+    const { connection, sent, drained } = fakeConnection([fullFrame]);
+    const source = new GrpcAreaSource(connection, "Doc/GUI", { area: "" }, { streamId: "s1" });
+    void source.start();
+    await drained;
+    source.emit({ kind: "update", area: "Content", pointer: '/data/"model"/name', value: "Grace" });
+    const patch = sent.find((s) => s.messageType === "PatchDataChangeRequest")!;
+    expect(patch.message.change).toEqual([{ op: "replace", path: '/data/"model"/name', value: "Grace" }]);
+    // ... and the optimistic local apply landed on the DECODED key.
+    expect((source.getState().data as Record<string, Record<string, unknown>>)["model"].name).toBe("Grace");
+  });
+});

--- a/clients/react/src/live/grpcSource.ts
+++ b/clients/react/src/live/grpcSource.ts
@@ -3,13 +3,28 @@
 // small MeshConnectionLike interface (the consumer passes a real MeshConnection), so the renderer
 // core has no transport dependency.
 //
-// 🔬 WIRE: the message-type names and field shapes below (SubscribeRequest / DataChangedEvent /
-// ClickedEvent / BlurEvent / the pointer-update request) are the layout-area protocol — pin them
-// against a running portal (capture one DataChangedEvent + one click/edit round-trip). Everything
-// else (folding, optimistic edits, demux) is correct as written.
+// WIRE (pinned against the server source, src/MeshWeaver.Data*/):
+//   - SubscribeRequest(StreamId, WorkspaceReference Reference) — Reference is POLYMORPHIC (abstract
+//     WorkspaceReference), so the subscribe JSON must carry the `$type` discriminator
+//     ("LayoutAreaReference", the TypeRegistry short name); without it the server cannot
+//     instantiate the abstract base and the subscribe is dropped.
+//   - An EMPTY reference.area subscribes the DEFAULT area: the server resolves it and the very
+//     first Full frame carries areas[""] = NamedAreaControl(resolvedArea) (LayoutAreaHost), so
+//     rendering root key "" follows the indirection.
+//   - DataChangedEvent.Change: ChangeType "Full" is a whole EntityStore snapshot; "Patch" is an
+//     RFC 6902 JSON-PATCH ARRAY (JsonSynchronizationStream.ToJsonPatch) — NOT an RFC 7396 merge.
+//   - EntityStore collections serialize as InstanceCollections: instance keys are JSON-ENCODED
+//     property names (`"Content"` arrives as the property `"\"Content\""`) plus a leading `$type`
+//     collection marker (InstanceCollectionConverter). Area lookups use PLAIN names
+//     (NamedArea.area → areas["Content"]), so keys are decoded at fold time; binding pointers keep
+//     their wire encoding and decode at resolution time (pointer.ts decodePointerSegment).
+//   - Client edits ride PatchDataChangeRequest(StreamId, …, RawJson Change, ChangeType) where the
+//     change is again an RFC 6902 patch array applied by the owner
+//     (JsonSynchronizationStream.ApplyPatchWithCorrectUnescaping); RawJson is raw inline JSON on
+//     the wire — never a stringified string.
 
 import type { AreaSource, AreaTree, Json, MeshEvent } from "../area/types.js";
-import { mergePatch, setPointer } from "../area/pointer.js";
+import { decodePointerSegment, mergePatch, setPointer } from "../area/pointer.js";
 
 /** The subset of @meshweaver/client's MeshConnection this source needs. */
 export interface MeshConnectionLike {
@@ -22,7 +37,8 @@ export interface MeshConnectionLike {
   post(target: string, messageType: string, message: Record<string, unknown>): void;
 }
 
-/** A MeshWeaver LayoutAreaReference: which area (and instance) to subscribe to on the target hub. */
+/** A MeshWeaver LayoutAreaReference: which area (and instance) to subscribe to on the target hub.
+ *  An empty/absent `area` subscribes the target's DEFAULT area (resolved server-side). */
 export interface LayoutAreaReference {
   area: string;
   id?: string;
@@ -58,7 +74,8 @@ export class GrpcAreaSource implements AreaSource {
   /** Open the area subscription and fold every change into the tree until the stream ends. */
   async start(): Promise<void> {
     for await (const delivery of this.connection.watch(this.address, this.streamId, "SubscribeRequest", {
-      reference: this.reference,
+      // The polymorphic $type is REQUIRED — Reference deserializes as abstract WorkspaceReference.
+      reference: { $type: "LayoutAreaReference", ...this.reference },
     })) {
       this.applyChange(delivery.message);
     }
@@ -67,10 +84,13 @@ export class GrpcAreaSource implements AreaSource {
   private applyChange(message: Record<string, unknown>): void {
     const raw = (message.change ?? message.Change) as Json;
     const change = typeof raw === "string" ? JSON.parse(raw) : raw;
-    if (change == null) return;
-    const changeType = String(message.changeType ?? message.ChangeType ?? "Patch");
-    // Full (or the enum's 0) replaces the snapshot; everything else is an RFC 7396 merge-patch.
-    this.state = changeType === "Full" || changeType === "0" ? change : mergePatch(this.state, change);
+    const changeType = String(message.changeType ?? message.ChangeType ?? "Full");
+    if (change == null || changeType === "NoUpdate") return;
+    this.state =
+      changeType === "Patch" || changeType === "1"
+        ? applyJsonPatch(this.state, change)
+        : // Full (or the enum's 0) / Instance replace the snapshot.
+          normalizeEntityStore(change);
     this.notify();
   }
 
@@ -82,16 +102,25 @@ export class GrpcAreaSource implements AreaSource {
       case "blur":
         this.connection.post(this.address, "BlurEvent", { area: event.area, streamId: this.streamId });
         break;
+      case "closeDialog":
+        // Mirrors Blazor's DialogView.HandleClose: CloseDialogEvent(Area, StreamId, DialogCloseState).
+        this.connection.post(this.address, "CloseDialogEvent", {
+          area: event.area,
+          streamId: this.streamId,
+          state: event.value ?? "OK",
+        });
+        break;
       case "update":
         if (!event.pointer) break;
-        // Optimistic local apply so the field reflects immediately; the server echoes the merge-patch.
+        // Optimistic local apply so the field reflects immediately (setPointer decodes the wire
+        // pointer's JSON-encoded segments, matching the fold); the server echoes the real patch.
         this.state = setPointer(this.state, event.pointer, event.value);
         this.notify();
         this.connection.post(this.address, "PatchDataChangeRequest", {
           streamId: this.streamId,
           changeType: "Patch",
-          // Sparse merge-patch: only the edited pointer (e.g. /data/name -> { data: { name: value } }).
-          change: JSON.stringify(setPointer({}, event.pointer, event.value)),
+          // RFC 6902 — one replace op at the (wire-encoded) pointer, as raw JSON (RawJson inlines).
+          change: [{ op: "replace", path: event.pointer, value: event.value }],
         });
         break;
     }
@@ -100,6 +129,149 @@ export class GrpcAreaSource implements AreaSource {
   private notify(): void {
     this.listeners.forEach((l) => l());
   }
+}
+
+// ---- wire folding ---------------------------------------------------------------------------
+
+interface PatchOp {
+  op: string;
+  path: string;
+  value?: Json;
+  from?: string;
+}
+
+/**
+ * Fold a wire EntityStore snapshot into the renderer's {areas,data} tree: decode the JSON-encoded
+ * instance keys of each collection and drop the `$type` collection markers, so lookups
+ * (areas["Content"], decoded binding pointers) see plain keys. Control/data VALUES stay
+ * wire-faithful — their internal binding pointers keep the encoding and decode at resolution.
+ */
+function normalizeEntityStore(store: Json): AreaTree {
+  if (store == null || typeof store !== "object" || Array.isArray(store)) return (store ?? {}) as AreaTree;
+  const out: Record<string, Json> = {};
+  for (const [collection, value] of Object.entries(store as Record<string, Json>)) {
+    if (collection === "$type") continue;
+    out[collection] = normalizeCollection(value);
+  }
+  return out;
+}
+
+/** Decode one InstanceCollection: JSON-encoded instance keys → plain, `$type` marker dropped. */
+function normalizeCollection(value: Json): Json {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return value;
+  const instances: Record<string, Json> = {};
+  for (const [key, item] of Object.entries(value as Record<string, Json>)) {
+    if (key === "$type") continue; // the collection-name marker, not an instance
+    instances[decodeWireKey(key)] = item;
+  }
+  return instances;
+}
+
+/** InstanceCollection keys arrive JSON-encoded (`"home"` → property `"\"home\""`); decode strings. */
+function decodeWireKey(key: string): string {
+  if (key.length >= 2 && key.startsWith('"') && key.endsWith('"')) {
+    try {
+      const parsed: unknown = JSON.parse(key);
+      if (typeof parsed === "string") return parsed;
+    } catch {
+      /* not JSON-encoded — keep the raw key */
+    }
+  }
+  return key;
+}
+
+/**
+ * Apply an RFC 6902 patch (the wire's ChangeType.Patch shape) immutably. Pointer segments carry
+ * the same JSON-encoded instance keys as snapshots — decodePointerSegment folds them onto the
+ * normalized tree. A non-array delta is tolerated as an RFC 7396 merge (in-memory test sources).
+ */
+function applyJsonPatch(state: AreaTree, ops: Json): AreaTree {
+  if (!Array.isArray(ops)) return mergePatch(state, ops);
+  let next: Json = state;
+  for (const op of ops as PatchOp[]) {
+    const parts = splitWirePointer(op.path);
+    switch (op.op) {
+      case "add":
+      case "replace":
+        next = setAtParts(next, parts, normalizeValueAtDepth(op.value, parts.length), op.op === "add");
+        break;
+      case "remove":
+        next = removeAtParts(next, parts);
+        break;
+      case "move": {
+        const from = splitWirePointer(op.from ?? "");
+        const moved = getAtParts(next, from);
+        next = removeAtParts(next, from);
+        next = setAtParts(next, parts, moved, true);
+        break;
+      }
+      case "copy":
+        next = setAtParts(next, parts, getAtParts(next, splitWirePointer(op.from ?? "")), true);
+        break;
+      default:
+        break; // "test" (and unknown ops) are no-ops for folding
+    }
+  }
+  return next as AreaTree;
+}
+
+/** A value landing at the root is a whole store; at depth 1 a whole collection — normalize keys. */
+function normalizeValueAtDepth(value: Json, depth: number): Json {
+  if (depth === 0) return normalizeEntityStore(value);
+  if (depth === 1) return normalizeCollection(value);
+  return value;
+}
+
+function splitWirePointer(pointer: string): string[] {
+  if (!pointer || pointer === "/") return pointer === "/" ? [""] : [];
+  return pointer.split("/").slice(1).map(decodePointerSegment);
+}
+
+function getAtParts(root: Json, parts: string[]): Json {
+  let cur: Json = root;
+  for (const part of parts) {
+    if (cur == null) return undefined;
+    cur = Array.isArray(cur) ? cur[Number(part)] : cur[part];
+  }
+  return cur;
+}
+
+/** Immutable set — RFC 6902 semantics: on arrays, `add` INSERTS at the index ("-" appends). */
+function setAtParts(root: Json, parts: string[], value: Json, insert: boolean): Json {
+  if (parts.length === 0) return value;
+  const [head, ...rest] = parts;
+  if (Array.isArray(root)) {
+    const clone = [...root];
+    const idx = head === "-" ? clone.length : Number(head);
+    if (rest.length === 0) {
+      if (insert) clone.splice(idx, 0, value);
+      else clone[idx] = value;
+    } else {
+      clone[idx] = setAtParts(clone[idx], rest, value, insert);
+    }
+    return clone;
+  }
+  const clone: Record<string, Json> = { ...((root ?? {}) as Record<string, Json>) };
+  clone[head] = rest.length === 0 ? value : setAtParts(clone[head], rest, value, insert);
+  return clone;
+}
+
+/** Immutable remove — splices arrays, deletes object properties; missing paths are tolerated. */
+function removeAtParts(root: Json, parts: string[]): Json {
+  if (parts.length === 0) return {};
+  const [head, ...rest] = parts;
+  if (root == null || typeof root !== "object") return root;
+  if (Array.isArray(root)) {
+    const clone = [...root];
+    const idx = Number(head);
+    if (rest.length === 0) clone.splice(idx, 1);
+    else clone[idx] = removeAtParts(clone[idx], rest);
+    return clone;
+  }
+  const clone: Record<string, Json> = { ...(root as Record<string, Json>) };
+  if (rest.length === 0) delete clone[head];
+  else clone[head] = removeAtParts(clone[head], rest);
+  return clone;
 }
 
 function newId(): string {

--- a/clients/react/src/live/meshOps.tsx
+++ b/clients/react/src/live/meshOps.tsx
@@ -1,0 +1,72 @@
+// The mesh OPERATIONS surface a live control needs beyond the layout-area AreaSource contract:
+// watching arbitrary NODE streams (a thread node + its per-message satellite cells) and the canonical
+// thread-submission ops (the client twin of MeshWeaver.AI.HubThreadExtensions — StartThread /
+// SubmitMessage). The react package stays transport-free (the same decoupling GrpcAreaSource gets via
+// MeshConnectionLike): @meshweaver/client-web's `Mesh` satisfies this interface STRUCTURALLY, so the
+// host app wires it with
+//
+//   import { Mesh } from "@meshweaver/client-web";
+//   const mesh = Mesh.from(connection);          // or await Mesh.connect(url, { token })
+//   <MeshOpsProvider ops={mesh}> ... <RenderArea/> ... </MeshOpsProvider>
+//
+// and every wire shape (CreateNodeRequest for StartThread, RFC 7396 PatchDataRequest for
+// SubmitMessage / control-plane flips) is produced — and tested — in @meshweaver/client-web.
+
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+
+/** One emission of a node's live stream (the shape meshNodeFromChange yields). */
+export interface MeshNodeState {
+  path: string;
+  name?: string;
+  nodeType?: string;
+  content: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface ThreadSubmitOptions {
+  agentName?: string;
+  modelName?: string;
+  harness?: string;
+  contextPath?: string;
+  attachments?: string[];
+  createdBy?: string;
+  authorName?: string;
+}
+
+export interface MeshOps {
+  /** Subscribe to a node's live state — yields on every change (initial state, then updates). */
+  watch(path: string): AsyncIterable<MeshNodeState>;
+  /**
+   * Create a thread under `namespacePath` with the first user message queued — ONE CreateNodeRequest
+   * carrying the seeded thread node (content.pendingUserMessages + composer), targeted at the
+   * namespace hub. The per-thread submission watcher dispatches the first round.
+   */
+  startThread(
+    namespacePath: string,
+    userText: string,
+    opts?: ThreadSubmitOptions,
+  ): Promise<{ path: string; userMessageId?: string }>;
+  /**
+   * Queue a user message on an existing thread — a JSON-merge PatchDataRequest appending to
+   * content.userMessageIds + content.pendingUserMessages (the client twin of
+   * `GetMeshNodeStream(threadPath).Update(...)`). Resolves to the new message id, or null for a
+   * whitespace-only no-op.
+   */
+  submitMessage(threadPath: string, userText: string, opts?: ThreadSubmitOptions): Promise<string | null>;
+  /** Field-level partial node update (RFC 7396) — control-plane flips like requestedStatus. */
+  patch(path: string, fields: Record<string, unknown>): void;
+  /** Optional mesh query — when present it feeds the agent/model selectors (nodeType:Agent / nodeType:Model). */
+  search?(query: string, basePath?: string, limit?: number): Promise<Record<string, unknown>[]>;
+}
+
+const MeshOpsCtx = createContext<MeshOps | null>(null);
+
+/** The MeshOps of the nearest provider, or null when the app renders without a live mesh connection. */
+export function useMeshOps(): MeshOps | null {
+  return useContext(MeshOpsCtx);
+}
+
+export function MeshOpsProvider({ ops, children }: { ops: MeshOps | null; children: ReactNode }) {
+  return <MeshOpsCtx.Provider value={ops}>{children}</MeshOpsCtx.Provider>;
+}

--- a/clients/react/src/render/ControlRenderer.tsx
+++ b/clients/react/src/render/ControlRenderer.tsx
@@ -20,7 +20,7 @@ export function ControlRenderer({ control }: { control?: UiControl | null }): Re
   if (skins.length > 0) {
     const skin = skins[skins.length - 1];
     const rest: UiControl = { ...control, skins: skins.slice(0, -1) };
-    const Wrapper = pack.skins[skin.$type] ?? pack.skins.__default ?? pack.defaultContainer;
+    const Wrapper = lookup(pack.skins, skin.$type, "Skin") ?? pack.skins.__default ?? pack.defaultContainer;
     return <Wrapper skin={skin} control={rest} />;
   }
 
@@ -29,8 +29,21 @@ export function ControlRenderer({ control }: { control?: UiControl | null }): Re
     return <Default skin={{ $type: "LayoutStack" }} control={control} />;
   }
 
-  const Comp = pack.controls[control.$type] ?? pack.fallback;
+  const Comp = lookup(pack.controls, control.$type, "Control") ?? pack.fallback;
   return <Comp control={control} />;
+}
+
+/**
+ * Registry lookup tolerant of the wire's C# `$type` names. The pack registers the suffix-stripped
+ * short names ("Stack", "Markdown", "LayoutStack"), but the live mesh serializes the class name —
+ * "StackControl" / "MarkdownControl" / "LayoutStackSkin" (TypeRegistry.FormatType → type.Name).
+ * Try the exact key first (static/demo trees), then the suffix-stripped one (live trees).
+ */
+function lookup<T>(map: Record<string, T>, type: string | undefined, suffix: string): T | undefined {
+  if (!type) return undefined;
+  if (map[type] !== undefined) return map[type];
+  if (type.length > suffix.length && type.endsWith(suffix)) return map[type.slice(0, -suffix.length)];
+  return undefined;
 }
 
 export interface ChildArea {

--- a/clients/react/src/render/embeddedArea.test.tsx
+++ b/clients/react/src/render/embeddedArea.test.tsx
@@ -1,0 +1,98 @@
+// LayoutAreaControl parity — the REAL nested-area embed. A LayoutAreaControl references another
+// area stream ((address, LayoutAreaReference)); with an AreaSourceFactory installed
+// (EmbeddedAreaProvider) the control opens a nested AreaSource and renders the referenced tree in
+// its own scope — the React mirror of Blazor's LayoutAreaView second synchronization stream. This
+// is what makes doc pages and composite views work.
+
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MeshAreaView, EmbeddedAreaProvider, type AreaSourceFactory } from "../index.js";
+import { StaticAreaSource, type AreaTree, type UiControl } from "../core.js";
+
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = ((q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null })) as unknown as typeof window.matchMedia;
+  if (!(globalThis as { ResizeObserver?: unknown }).ResizeObserver)
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+});
+
+function outerTree(reference: Record<string, unknown>): AreaTree {
+  return {
+    data: {},
+    areas: {
+      main: { $type: "LayoutArea", address: "app/docs", reference } as unknown as UiControl,
+    },
+  };
+}
+
+describe("LayoutArea — nested area embedding", () => {
+  it("opens a nested source via the factory and renders the referenced area's tree", async () => {
+    const nested = new StaticAreaSource({
+      data: { greeting: "Hello from the nested area" },
+      areas: {
+        Overview: { $type: "Label", data: { $type: "JsonPointerReference", pointer: "/data/greeting" } },
+      },
+    });
+    const dispose = vi.fn();
+    const factory: AreaSourceFactory = vi.fn((address, ref) => ({ source: nested, rootArea: ref.area ?? "", dispose }));
+
+    const { unmount } = render(
+      <EmbeddedAreaProvider factory={factory}>
+        <MeshAreaView source={new StaticAreaSource(outerTree({ area: "Overview", id: "42" }))} rootArea="main" />
+      </EmbeddedAreaProvider>,
+    );
+
+    expect(await screen.findByText("Hello from the nested area")).toBeTruthy();
+    expect(factory).toHaveBeenCalledWith("app/docs", { area: "Overview", id: "42", layout: undefined });
+
+    // Unmounting the embed closes the nested subscription.
+    unmount();
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the loading spinner until the referenced area arrives, then swaps in the content", async () => {
+    const nested = new StaticAreaSource({ data: {}, areas: {} });
+    const factory: AreaSourceFactory = () => ({ source: nested, rootArea: "Overview" });
+    render(
+      <EmbeddedAreaProvider factory={factory}>
+        <MeshAreaView source={new StaticAreaSource(outerTree({ area: "Overview" }))} rootArea="main" />
+      </EmbeddedAreaProvider>,
+    );
+    expect(await screen.findByRole("progressbar")).toBeTruthy();
+
+    // The nested stream's first frame lands → the spinner yields to the real tree.
+    nested.applyPatch({ areas: { Overview: { $type: "Label", data: "Loaded!" } } });
+    expect(await screen.findByText("Loaded!")).toBeTruthy();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+  });
+
+  it("follows the empty-reference default-area indirection (areas[''] NamedArea)", async () => {
+    // An empty reference.area subscribes the target's DEFAULT area: the first frame stores the
+    // indirection under the empty key (grpcSource wire contract).
+    const nested = new StaticAreaSource({
+      data: {},
+      areas: {
+        "": { $type: "NamedArea", area: "Resolved" },
+        Resolved: { $type: "Label", data: "Default area content" },
+      },
+    });
+    const factory: AreaSourceFactory = (_, ref) => ({ source: nested, rootArea: ref.area ?? "" });
+    render(
+      <EmbeddedAreaProvider factory={factory}>
+        <MeshAreaView source={new StaticAreaSource(outerTree({}))} rootArea="main" />
+      </EmbeddedAreaProvider>,
+    );
+    expect(await screen.findByText("Default area content")).toBeTruthy();
+  });
+
+  it("falls back to the informative marker when no factory is installed (static demos)", () => {
+    render(<MeshAreaView source={new StaticAreaSource(outerTree({ area: "Overview" }))} rootArea="main" />);
+    expect(screen.getByText(/Embedded layout area/)).toBeTruthy();
+    expect(screen.getByText("Overview")).toBeTruthy();
+  });
+});

--- a/clients/react/src/render/embeddedArea.tsx
+++ b/clients/react/src/render/embeddedArea.tsx
@@ -1,0 +1,48 @@
+// Nested layout-area embedding — the contract LayoutAreaControl renders through.
+//
+// A LayoutAreaControl references a DIFFERENT area stream ((address, LayoutAreaReference)); rendering
+// it for real needs a SECOND AreaSource. The renderer stays transport-free: the host installs an
+// AreaSourceFactory (e.g. one that opens a GrpcAreaSource on the shared connection and starts it),
+// and LayoutAreaView asks it for a source per referenced area. Without a provider the control falls
+// back to its link marker — static demos and tests keep working.
+//
+//   <EmbeddedAreaProvider factory={(address, ref) => {
+//     const src = new GrpcAreaSource(connection, address, ref);
+//     void src.start();
+//     return { source: src, rootArea: ref.area ?? "" };
+//   }}> ... </EmbeddedAreaProvider>
+
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+import type { AreaSource } from "../area/types.js";
+
+/** The reference of the embedded area — mirrors the wire LayoutAreaReference. */
+export interface EmbeddedAreaReference {
+  /** Area name; empty/absent subscribes the target's DEFAULT area (resolved server-side,
+   *  delivered as the `areas[""]` NamedArea indirection). */
+  area?: string;
+  id?: unknown;
+  layout?: string;
+}
+
+export interface EmbeddedAreaHandle {
+  source: AreaSource;
+  /** Root area key to render (defaults to the reference's area, "" for the server default). */
+  rootArea?: string;
+  /** Called when the embed unmounts or its reference changes — close the subscription here. */
+  dispose?: () => void;
+}
+
+/** Produce a live AreaSource for a referenced (address, area, id) — or null when unavailable. */
+export type AreaSourceFactory = (address: string, reference: EmbeddedAreaReference) => EmbeddedAreaHandle | null;
+
+const FactoryCtx = createContext<AreaSourceFactory | null>(null);
+
+/** The nearest factory, or null when the host renders without nested-area support. */
+export function useAreaSourceFactory(): AreaSourceFactory | null {
+  return useContext(FactoryCtx);
+}
+
+export function EmbeddedAreaProvider({ factory, children }: { factory: AreaSourceFactory | null; children: ReactNode }) {
+  return <FactoryCtx.Provider value={factory}>{children}</FactoryCtx.Provider>;
+}

--- a/clients/react/src/render/gallery.test.tsx
+++ b/clients/react/src/render/gallery.test.tsx
@@ -1,0 +1,91 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource, type AreaTree, type UiControl } from "../core.js";
+
+// Rendering-fidelity parity: mount ONE of every "leaf" control (the ones that don't need a live mesh
+// connection) through the real Fluent pack and prove each actually renders — no throw, and none fall
+// through to the "Unsupported control" fallback. This is a step beyond the registry check in parity.test.ts:
+// it catches a control that is registered but crashes on mount or renders nothing.
+//
+// Data/mesh controls (DataGrid, Chart, MeshSearch, ThreadChat, UserProfile, editors, …) need a live
+// AreaSource/hub and are covered by the registry-coverage test instead. Dialog is a portal-rendered
+// modal with its own test (controls/dialog.test.tsx); ItemTemplate's binding semantics are pinned in
+// controls/itemTemplate.test.tsx and the theme panel (Appearance) in theme/theme.test.tsx.
+
+// jsdom lacks the browser APIs several Fluent components probe on mount.
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = (q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null }) as unknown as MediaQueryList;
+  if (!(globalThis as any).ResizeObserver)
+    (globalThis as any).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+});
+
+const ref = (area: string) => ({ $type: "NamedArea", area });
+const ptr = (pointer: string) => ({ $type: "JsonPointerReference", pointer });
+const opts = [
+  { value: "a", text: "Alpha" },
+  { value: "b", text: "Beta" },
+];
+
+const leaves: Record<string, UiControl> = {
+  label: { $type: "Label", data: "Hello world", typo: "Header" },
+  badge: { $type: "Badge", data: "New" },
+  icon: { $type: "Icon", data: "Add" },
+  html: { $type: "Html", data: "<b>bold</b>" },
+  markdown: { $type: "Markdown", data: "# Heading\n\ntext" },
+  codeSample: { $type: "CodeSample", data: "const x = 1;" },
+  highlight: { $type: "Highlight", data: "const y = 2;" },
+  exception: { $type: "Exception", message: "boom", type: "InvalidOperation" },
+  spacer: { $type: "Spacer" },
+  button: { $type: "Button", data: "Click me", isClickable: true },
+  checkbox: { $type: "CheckBox", label: "Enabled", data: ptr("/data/flag") },
+  toggle: { $type: "Switch", label: "On", data: ptr("/data/flag") },
+  slider: { $type: "Slider", data: ptr("/data/num"), min: 0, max: 100 },
+  date: { $type: "Date", data: "2026-01-01" },
+  dateTime: { $type: "DateTime", data: "2026-01-01T10:00:00" },
+  select: { $type: "Select", data: ptr("/data/choice"), options: opts },
+  combobox: { $type: "Combobox", data: ptr("/data/choice"), options: opts },
+  listbox: { $type: "Listbox", data: ptr("/data/choice"), options: opts },
+  radioGroup: { $type: "RadioGroup", data: ptr("/data/choice"), options: opts },
+  textArea: { $type: "TextArea", label: "Notes", data: ptr("/data/txt") },
+  numberField: { $type: "NumberField", label: "Count", data: ptr("/data/num") },
+  menuItem: { $type: "MenuItem", title: "An item" },
+  searchBox: { $type: "SearchBox", data: ptr("/data/txt") },
+  navLink: { $type: "NavLink", title: "Home", url: "/" },
+  progress: { $type: "Progress", data: 0.5 },
+  spinner: { $type: "Spinner" },
+  appearance: { $type: "Appearance" }, // the theme settings panel (needs no mesh — localStorage only)
+  itemTemplate: { $type: "ItemTemplate", data: ptr("/data/people"), view: { $type: "Label", data: ptr("name") } },
+  layoutAreaDefinition: {
+    $type: "LayoutAreaDefinition",
+    definition: { area: "Overview", url: "/app/Overview", title: "Overview", description: "The overview area" },
+  },
+};
+
+const LEAVES = Object.keys(leaves);
+
+const gallery: AreaTree = {
+  data: { flag: true, num: 42, txt: "hello", choice: "a", people: [{ name: "Ada" }, { name: "Grace" }] },
+  areas: {
+    main: { $type: "Stack", skins: [{ $type: "LayoutStack" }], areas: LEAVES.map(ref) },
+    ...leaves,
+  },
+};
+
+describe("Fluent pack renders every safe control (no fallback, no throw)", () => {
+  it(`mounts a gallery of ${LEAVES.length} controls`, () => {
+    const { container } = render(<MeshAreaView source={new StaticAreaSource(gallery)} rootArea="main" />);
+    // None fell through to the fallback (which prints "Unsupported control: <type>").
+    expect(container.textContent).not.toContain("Unsupported control");
+    // Real content rendered.
+    expect(container.textContent).toContain("Hello world"); // the Label
+    expect(container.textContent).toContain("Ada"); // the ItemTemplate repeated its view per item
+    expect(container.querySelectorAll("*").length).toBeGreaterThan(LEAVES.length);
+  });
+});

--- a/clients/react/src/render/parity.test.ts
+++ b/clients/react/src/render/parity.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { controlRegistry } from "./registry.js";
+import { skinRegistry } from "./skins.js";
+import { placeholderControlTypes } from "../controls/mesh.js";
+
+// Feature-parity guard: the Fluent React pack must render every control the Blazor portal renders.
+// These lists are the authoritative Blazor vocabulary — the `*Control` / `*Skin` types in
+// src/MeshWeaver.Layout (the `$type` is the class name minus the "Control"/"Skin" suffix). When a new
+// control is added to Layout, add its $type here; this test then fails until the React pack covers it,
+// keeping the port at 1:1 with Blazor. Containers (Stack/Layout/Tabs/…) render via SKINS, so they live in
+// the skin list, not the control list; DataGrid columns (Property/Template/Data) render inside DataGrid.
+
+const BLAZOR_LEAF_CONTROLS = [
+  "Appearance", "Badge", "Button", "Catalog", "Chart", "CheckBox", "CodeEditor", "CodeSample",
+  "CollaborativeMarkdown", "Combobox", "DataGrid", "Date", "DateTime", "Dialog", "DiffEditor",
+  "DocumentSource", "Exception", "ExportDocument", "FileBrowser", "Highlight", "Html", "Icon",
+  "ItemTemplate", "Label", "LayoutArea", "LayoutAreaDefinition", "Listbox", "Markdown", "MarkdownEditor",
+  "MenuItem", "MeshNodeCollection", "MeshNodePicker", "MeshSearch", "NamedArea", "NavLink", "NodeExport",
+  "NodeImport", "NumberField", "PivotGrid", "Progress", "RadioGroup", "Redirect", "SearchBox", "Select",
+  "Slider", "Spacer", "Switch", "TextArea", "ThreadChat", "ThreadMessageBubble", "UserProfile",
+];
+
+// Container + item skins the portal renders (the `*Skin` types + the container dispatch).
+const BLAZOR_SKINS = [
+  "LayoutStack", "Layout", "LayoutGrid", "LayoutGridItem", "Card", "Splitter", "Tabs", "Tab", "Toolbar",
+  "NavMenu", "NavGroup", "Header", "Footer", "Main", "BodyContent", "Property", "EditForm", "Editor",
+];
+
+describe("React ↔ Blazor control parity", () => {
+  it("the Fluent pack registers every Blazor leaf control $type", () => {
+    const missing = BLAZOR_LEAF_CONTROLS.filter((t) => !(t in controlRegistry));
+    expect(missing, `Missing Blazor controls in the React pack: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("the Fluent pack registers every Blazor skin $type", () => {
+    const missing = BLAZOR_SKINS.filter((t) => !(t in skinRegistry));
+    expect(missing, `Missing Blazor skins in the React pack: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("registered controls are React components (functions), not accidental values", () => {
+    const bad = BLAZOR_LEAF_CONTROLS.filter((t) => t in controlRegistry && typeof controlRegistry[t] !== "function");
+    expect(bad, `Non-component control entries: ${bad.join(", ")}`).toEqual([]);
+  });
+
+  it("covers Blazor's full leaf set (no silent shortfall)", () => {
+    const covered = BLAZOR_LEAF_CONTROLS.filter((t) => t in controlRegistry).length;
+    expect(covered).toBe(BLAZOR_LEAF_CONTROLS.length); // 51/51 — full $type parity
+  });
+
+  // RATCHET: the registered-but-placeholder long-tail (controls whose real rendering needs a live
+  // mesh service beyond the AreaSource contract). Implementing one for real = remove it from
+  // placeholderControlTypes AND from this pinned list. Adding a NEW placeholder fails here — every
+  // new control must ship a real implementation.
+  it("the placeholder long-tail only ever shrinks", () => {
+    const pinned = ["DocumentSource", "ExportDocument", "FileBrowser", "NodeExport", "NodeImport"];
+    expect([...placeholderControlTypes].sort()).toEqual(pinned.sort());
+  });
+
+  // RATCHET: formerly-thin controls that now have REAL implementations — regressing one to an
+  // alias of another control (the old PivotGrid→DataGrid / MeshNodeCollection→Catalog /
+  // MeshSearch→SearchBox shortcuts) fails here. Each must stay its own component.
+  it("no control regresses to an alias of another (the thin-list stays empty)", () => {
+    expect(controlRegistry.PivotGrid).not.toBe(controlRegistry.DataGrid);
+    expect(controlRegistry.MeshNodeCollection).not.toBe(controlRegistry.Catalog);
+    expect(controlRegistry.MeshSearch).not.toBe(controlRegistry.SearchBox);
+    expect(controlRegistry.DiffEditor).not.toBe(controlRegistry.CodeEditor);
+    // CodeEditor/Editor and MarkdownEditor/CollaborativeMarkdown intentionally share views
+    // (same wire contract); Chart/PivotGrid/LayoutArea are pinned real by their own test files
+    // (chart.test.tsx, pivot.test.tsx, embeddedArea.test.tsx).
+  });
+});

--- a/clients/react/src/render/registry.tsx
+++ b/clients/react/src/render/registry.tsx
@@ -6,11 +6,15 @@ import { skinRegistry, DefaultStackSkin } from "./skins.js";
 import { displayControls } from "../controls/display.js";
 import { inputControls } from "../controls/inputs.js";
 import { dataControls } from "../controls/data.js";
+import { chartControls } from "../controls/chart.js";
+import { pivotControls } from "../controls/pivot.js";
 import { navControls } from "../controls/nav.js";
 import { feedbackControls } from "../controls/feedback.js";
 import { containerControls } from "../controls/containers.js";
 import { editorControls } from "../controls/editors.js";
 import { meshControls } from "../controls/mesh.js";
+import { appearanceControls } from "../controls/appearance.js";
+import { itemTemplateControls } from "../controls/itemTemplate.js";
 
 export type { ControlComponent };
 
@@ -19,11 +23,15 @@ export const controlRegistry: Record<string, ControlComponent> = {
   ...displayControls,
   ...inputControls,
   ...dataControls,
+  ...chartControls,
+  ...pivotControls,
   ...navControls,
   ...feedbackControls,
   ...containerControls,
   ...editorControls,
   ...meshControls,
+  ...appearanceControls,
+  ...itemTemplateControls,
 };
 
 export function FallbackControl({ control }: { control: UiControl }): ReactNode {

--- a/clients/react/src/render/skins.tsx
+++ b/clients/react/src/render/skins.tsx
@@ -13,6 +13,7 @@ import {
 } from "@fluentui/react-components";
 import { ChevronDown20Regular, ChevronRight20Regular } from "@fluentui/react-icons";
 import type { Skin, UiControl } from "../area/types.js";
+import { useResolve } from "../area/context.js";
 import { ControlRenderer, RenderArea, useChildAreas } from "./ControlRenderer.js";
 import { cssAlign, cssSize } from "./style.js";
 
@@ -172,12 +173,41 @@ function CardSkin({ control }: SkinProps): ReactNode {
   );
 }
 
+/**
+ * PropertySkin — the per-field wrapper of an EditForm, mirroring Blazor's PropertyView
+ * (src/MeshWeaver.Blazor/Components/PropertyView.razor): a label (Skin.Label, falling back to
+ * Name/title), an optional description line, then the bound field control.
+ */
 function PropertySkin({ skin, control }: SkinProps): ReactNode {
+  const label = useResolve(skin.label ?? skin.name ?? skin.title);
+  const description = useResolve(skin.description);
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      {skin.title != null ? <Text weight="semibold">{String(skin.title)}</Text> : null}
+      {label != null && String(label).length > 0 ? (
+        <Text weight="semibold" as="span">
+          <label htmlFor={skin.name != null ? String(skin.name) : undefined}>{String(label)}</label>
+        </Text>
+      ) : null}
+      {description != null && String(description).length > 0 ? (
+        <Text size={200} style={{ color: "var(--colorNeutralForeground3)" }}>
+          {String(description)}
+        </Text>
+      ) : null}
       <ControlRenderer control={control} />
     </div>
+  );
+}
+
+/**
+ * EditFormSkin — the form wrapper, mirroring Blazor's EditFormView: the child property areas
+ * stacked as a form (each wrapped in PropertySkin). Fields data-bind per-edit through the standard
+ * update event — the owning hub persists every change, so no explicit submit button is needed.
+ */
+function EditFormSkin({ control }: SkinProps): ReactNode {
+  return (
+    <form onSubmit={(e) => e.preventDefault()} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <Children control={control} />
+    </form>
   );
 }
 
@@ -209,7 +239,7 @@ export const skinRegistry: Record<string, SkinComponent> = {
   NavGroup: NavGroupSkin,
   Card: CardSkin,
   Property: PropertySkin,
-  EditForm: PlainLayoutSkin,
+  EditForm: EditFormSkin,
   Editor: PlainLayoutSkin,
   Main: semanticWrapper("main"),
   Header: semanticWrapper("header"),

--- a/clients/react/src/theme/ThemeToggle.tsx
+++ b/clients/react/src/theme/ThemeToggle.tsx
@@ -1,0 +1,59 @@
+// Header theme switcher — the React counterpart of the Blazor portal's theme selector in the
+// SiteSettingsPanel: the same three DesignThemeModes (Light / Dark / System), persisted under the
+// same localStorage key via useThemeMode.
+
+import type { ReactNode } from "react";
+import {
+  Button,
+  Menu,
+  MenuItemRadio,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Tooltip,
+  type MenuProps,
+} from "@fluentui/react-components";
+import { Desktop20Regular, WeatherMoon20Regular, WeatherSunny20Regular } from "@fluentui/react-icons";
+import { useThemeMode, type ThemeMode } from "./themeMode.js";
+
+export interface ThemeToggleProps {
+  /** Override the localStorage key (defaults to the Blazor-compatible "theme"). */
+  storageKey?: string;
+}
+
+const modeIcons: Record<ThemeMode, JSX.Element> = {
+  light: <WeatherSunny20Regular />,
+  dark: <WeatherMoon20Regular />,
+  system: <Desktop20Regular />,
+};
+
+/** A menu button cycling the theme mode: Light / Dark / System (the current mode is checked). */
+export function ThemeToggle({ storageKey }: ThemeToggleProps): ReactNode {
+  const { mode, resolved, setMode } = useThemeMode({ storageKey });
+  const onChange: MenuProps["onCheckedValueChange"] = (_, data) => {
+    const next = data.checkedItems[0] as ThemeMode | undefined;
+    if (next) setMode(next);
+  };
+  return (
+    <Menu checkedValues={{ mode: [mode] }} onCheckedValueChange={onChange}>
+      <MenuTrigger disableButtonEnhancement>
+        <Tooltip content={`Theme: ${mode}`} relationship="label">
+          <Button appearance="subtle" aria-label="Change theme" icon={resolved === "dark" ? modeIcons.dark : modeIcons.light} />
+        </Tooltip>
+      </MenuTrigger>
+      <MenuPopover>
+        <MenuList>
+          <MenuItemRadio name="mode" value="light" icon={modeIcons.light}>
+            Light
+          </MenuItemRadio>
+          <MenuItemRadio name="mode" value="dark" icon={modeIcons.dark}>
+            Dark
+          </MenuItemRadio>
+          <MenuItemRadio name="mode" value="system" icon={modeIcons.system}>
+            System
+          </MenuItemRadio>
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+}

--- a/clients/react/src/theme/theme.test.tsx
+++ b/clients/react/src/theme/theme.test.tsx
@@ -1,0 +1,210 @@
+// Light/dark mode parity with the Blazor portal's <FluentDesignTheme StorageName="theme">:
+// same three modes (system default / light / dark), same localStorage key + JSON shape, system mode
+// follows prefers-color-scheme live, and the resolved mode lands on <body data-theme> exactly like
+// Blazor's UpdateBodyDataSetTheme. The MeshAreaView integration asserts the actual Fluent design
+// tokens (webLightTheme/webDarkTheme CSS custom properties) applied to the DOM flip with the mode —
+// the mechanism by which every control in the pack restyles.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { act, fireEvent, render, renderHook, screen } from "@testing-library/react";
+import { FluentProvider, webDarkTheme, webLightTheme } from "@fluentui/react-components";
+import { MeshAreaView, StaticAreaSource } from "../index.js";
+import { ThemeToggle } from "./ThemeToggle.js";
+import { readStoredThemeMode, useThemeMode, writeStoredThemeMode } from "./themeMode.js";
+
+// ── Controllable prefers-color-scheme mock (jsdom has no matchMedia) ─────────────────────────────
+class MockMediaQueryList {
+  matches = false;
+  media = "(prefers-color-scheme: dark)";
+  private readonly listeners = new Set<(e: { matches: boolean }) => void>();
+  addEventListener = (_: string, cb: (e: { matches: boolean }) => void) => this.listeners.add(cb);
+  removeEventListener = (_: string, cb: (e: { matches: boolean }) => void) => this.listeners.delete(cb);
+  setPrefersDark(dark: boolean) {
+    this.matches = dark;
+    this.listeners.forEach((l) => l({ matches: dark }));
+  }
+}
+
+let mql: MockMediaQueryList;
+
+// jsdom under this vitest setup exposes NO localStorage (Node's experimental global shadows it as
+// undefined) — shim an in-memory Storage, same spirit as the matchMedia/ResizeObserver shims.
+class MemoryStorage {
+  private m = new Map<string, string>();
+  getItem = (k: string) => this.m.get(k) ?? null;
+  setItem = (k: string, v: string) => void this.m.set(k, String(v));
+  removeItem = (k: string) => void this.m.delete(k);
+  clear = () => this.m.clear();
+  key = (i: number) => Array.from(this.m.keys())[i] ?? null;
+  get length() {
+    return this.m.size;
+  }
+}
+
+beforeEach(() => {
+  mql = new MockMediaQueryList();
+  window.matchMedia = (() => mql) as unknown as typeof window.matchMedia;
+  if (!(globalThis as any).ResizeObserver)
+    (globalThis as any).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  Object.defineProperty(globalThis, "localStorage", { value: new MemoryStorage(), configurable: true });
+  delete document.body.dataset.theme;
+});
+
+/** Read a design-token custom property from the style rules FluentProvider injected. */
+function appliedToken(name: string): string | undefined {
+  for (const tag of Array.from(document.querySelectorAll("style"))) {
+    for (const rule of Array.from(tag.sheet?.cssRules ?? [])) {
+      const v = (rule as CSSStyleRule).style?.getPropertyValue(name);
+      if (v) return v.trim();
+    }
+  }
+  return undefined;
+}
+
+describe("useThemeMode — Blazor FluentDesignTheme semantics", () => {
+  it("defaults to system and resolves against the OS preference", () => {
+    const light = renderHook(() => useThemeMode());
+    expect(light.result.current.mode).toBe("system");
+    expect(light.result.current.resolved).toBe("light");
+    expect(light.result.current.theme).toBe(webLightTheme);
+    light.unmount();
+
+    mql.setPrefersDark(true);
+    const dark = renderHook(() => useThemeMode());
+    expect(dark.result.current.mode).toBe("system");
+    expect(dark.result.current.resolved).toBe("dark");
+    expect(dark.result.current.theme).toBe(webDarkTheme);
+  });
+
+  it("system mode follows prefers-color-scheme changes live", () => {
+    const { result } = renderHook(() => useThemeMode());
+    expect(result.current.resolved).toBe("light");
+    act(() => mql.setPrefersDark(true));
+    expect(result.current.resolved).toBe("dark");
+    expect(document.body.dataset.theme).toBe("dark");
+    act(() => mql.setPrefersDark(false));
+    expect(result.current.resolved).toBe("light");
+    expect(document.body.dataset.theme).toBe("light");
+  });
+
+  it("an explicit mode wins over the OS preference", () => {
+    mql.setPrefersDark(true);
+    const { result } = renderHook(() => useThemeMode());
+    act(() => result.current.setMode("light"));
+    expect(result.current.resolved).toBe("light");
+    expect(result.current.theme).toBe(webLightTheme);
+  });
+
+  it("reads the Blazor FluentDesignTheme localStorage shape under the same key", () => {
+    localStorage.setItem("theme", JSON.stringify({ mode: "dark", primaryColor: "default" }));
+    const { result } = renderHook(() => useThemeMode());
+    expect(result.current.mode).toBe("dark");
+    expect(result.current.resolved).toBe("dark");
+  });
+
+  it("tolerates a bare-string or garbage stored value (falls back to system)", () => {
+    localStorage.setItem("theme", "dark");
+    expect(readStoredThemeMode()).toBe("dark");
+    localStorage.setItem("theme", "{not json");
+    expect(readStoredThemeMode()).toBe("system");
+  });
+
+  it("setMode persists Blazor-compatible JSON, preserving sibling fields", () => {
+    localStorage.setItem("theme", JSON.stringify({ mode: "light", primaryColor: "#123456" }));
+    const { result } = renderHook(() => useThemeMode());
+    act(() => result.current.setMode("dark"));
+    expect(JSON.parse(localStorage.getItem("theme")!)).toEqual({ mode: "dark", primaryColor: "#123456" });
+    expect(document.body.dataset.theme).toBe("dark");
+  });
+
+  it("keeps every hook instance in the document in sync", () => {
+    const a = renderHook(() => useThemeMode());
+    const b = renderHook(() => useThemeMode());
+    act(() => a.result.current.setMode("dark"));
+    expect(b.result.current.mode).toBe("dark");
+    expect(b.result.current.resolved).toBe("dark");
+  });
+
+  it("writeStoredThemeMode + a storage event sync across tabs", () => {
+    const { result } = renderHook(() => useThemeMode());
+    writeStoredThemeMode("dark");
+    act(() => {
+      window.dispatchEvent(new StorageEvent("storage", { key: "theme", newValue: localStorage.getItem("theme") }));
+    });
+    expect(result.current.mode).toBe("dark");
+  });
+});
+
+describe("MeshAreaView applies the resolved design tokens", () => {
+  const tree = { data: {}, areas: { main: { $type: "Label", data: "themed" } } };
+
+  it("renders dark tokens when the stored mode is dark, light when light", () => {
+    localStorage.setItem("theme", JSON.stringify({ mode: "dark" }));
+    const dark = render(<MeshAreaView source={new StaticAreaSource(tree)} rootArea="main" />);
+    expect(appliedToken("--colorNeutralBackground1")).toBe(webDarkTheme.colorNeutralBackground1);
+    dark.unmount();
+
+    localStorage.setItem("theme", JSON.stringify({ mode: "light" }));
+    render(<MeshAreaView source={new StaticAreaSource(tree)} rootArea="main" />);
+    expect(appliedToken("--colorNeutralBackground1")).toBe(webLightTheme.colorNeutralBackground1);
+  });
+
+  it("an explicit theme prop still wins", () => {
+    localStorage.setItem("theme", JSON.stringify({ mode: "dark" }));
+    render(<MeshAreaView source={new StaticAreaSource(tree)} rootArea="main" theme={webLightTheme} />);
+    expect(appliedToken("--colorNeutralBackground1")).toBe(webLightTheme.colorNeutralBackground1);
+  });
+});
+
+describe("ThemeToggle", () => {
+  // An app shell following the hook (as the portal example does) hosting the toggle.
+  function Shell() {
+    const { theme } = useThemeMode();
+    return (
+      <FluentProvider theme={theme}>
+        <ThemeToggle />
+      </FluentProvider>
+    );
+  }
+
+  it("switches mode from the menu and persists it — controls restyle", () => {
+    const tree = { data: {}, areas: { main: { $type: "Label", data: "hello" } } };
+    render(
+      <>
+        <Shell />
+        <MeshAreaView source={new StaticAreaSource(tree)} rootArea="main" />
+      </>,
+    );
+    expect(appliedToken("--colorNeutralBackground1")).toBe(webLightTheme.colorNeutralBackground1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Change theme" }));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /dark/i }));
+
+    expect(JSON.parse(localStorage.getItem("theme")!).mode).toBe("dark");
+    expect(document.body.dataset.theme).toBe("dark");
+    // The MeshAreaView (its own useThemeMode subscriber) swapped its tokens to dark.
+    expect(appliedToken("--colorNeutralBackground1")).toBe(webDarkTheme.colorNeutralBackground1);
+  });
+});
+
+describe("Appearance control — the theme settings panel (Blazor AppearanceView parity)", () => {
+  it("renders a theme picker bound to the persisted mode, with reset", () => {
+    const tree = { data: {}, areas: { main: { $type: "Appearance" } } };
+    render(<MeshAreaView source={new StaticAreaSource(tree)} rootArea="main" />);
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "Dark" }));
+    expect(JSON.parse(localStorage.getItem("theme")!).mode).toBe("dark");
+    expect(appliedToken("--colorNeutralBackground1")).toBe(webDarkTheme.colorNeutralBackground1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset settings" }));
+    expect(localStorage.getItem("theme")).toBeNull();
+    expect(screen.getByText("Settings reset!")).toBeTruthy();
+    // Back to system (OS = light here).
+    expect(appliedToken("--colorNeutralBackground1")).toBe(webLightTheme.colorNeutralBackground1);
+  });
+});

--- a/clients/react/src/theme/themeMode.ts
+++ b/clients/react/src/theme/themeMode.ts
@@ -1,0 +1,177 @@
+// Light/dark theming with the SAME semantics as the Blazor portal's <FluentDesignTheme>:
+// - three modes: "system" (default), "light", "dark" — Blazor's DesignThemeModes;
+// - persisted in localStorage under the SAME key ("theme") and the SAME JSON shape
+//   ({ mode, primaryColor? }) the fluent-design-theme web component writes, so a user switching
+//   between the Blazor portal and a React app on the same origin keeps one preference;
+// - "system" follows prefers-color-scheme live;
+// - the resolved mode is mirrored onto <body data-theme="..."> (Blazor's UpdateBodyDataSetTheme)
+//   and the document color-scheme, so scrollbars/native inputs restyle too.
+//
+// The Fluent design tokens (--colorNeutralBackground1, …) are applied by <FluentProvider> from
+// webLightTheme/webDarkTheme — the React-v9 equivalent of Blazor's design-token stylesheet — so
+// every control in the pack restyles from the one switch.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { webDarkTheme, webLightTheme, type Theme } from "@fluentui/react-components";
+
+/** Blazor's DesignThemeModes: System / Light / Dark. */
+export type ThemeMode = "system" | "light" | "dark";
+export type ResolvedThemeMode = "light" | "dark";
+
+/** The storage key the Blazor portal uses (`<FluentDesignTheme StorageName="theme">`). */
+export const DEFAULT_THEME_STORAGE_KEY = "theme";
+
+/** Same-document sync between hook instances (a toggle in the header + an Appearance panel). */
+const THEME_CHANGE_EVENT = "meshweaver:theme-change";
+
+function normalizeMode(value: unknown): ThemeMode | undefined {
+  const s = String(value ?? "").toLowerCase();
+  return s === "light" || s === "dark" || s === "system" ? s : undefined;
+}
+
+/** Read the persisted mode — tolerant of the Blazor JSON shape ({ mode, primaryColor }), a bare
+ *  string ("dark"), or nothing/garbage (→ "system", the Blazor default). */
+export function readStoredThemeMode(storageKey: string = DEFAULT_THEME_STORAGE_KEY): ThemeMode {
+  try {
+    const raw = globalThis.localStorage?.getItem(storageKey);
+    if (!raw) return "system";
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed != null && typeof parsed === "object") return normalizeMode(parsed.mode) ?? "system";
+      return normalizeMode(parsed) ?? "system";
+    } catch {
+      return normalizeMode(raw) ?? "system";
+    }
+  } catch {
+    return "system";
+  }
+}
+
+/** Persist the mode in the Blazor FluentDesignTheme shape, preserving sibling fields
+ *  (primaryColor, …) a Blazor portal may have written under the same key. */
+export function writeStoredThemeMode(mode: ThemeMode, storageKey: string = DEFAULT_THEME_STORAGE_KEY): void {
+  try {
+    const raw = globalThis.localStorage?.getItem(storageKey);
+    let existing: Record<string, unknown> = {};
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed != null && typeof parsed === "object" && !Array.isArray(parsed)) existing = parsed;
+      } catch {
+        /* replace non-JSON garbage */
+      }
+    }
+    globalThis.localStorage?.setItem(storageKey, JSON.stringify({ ...existing, mode }));
+  } catch {
+    /* storage unavailable (SSR / privacy mode) — theme still works, just not persisted */
+  }
+  globalThis.dispatchEvent?.(new CustomEvent(THEME_CHANGE_EVENT, { detail: { storageKey, mode } }));
+}
+
+/** Clear the persisted theme (Blazor's "Reset settings" → ClearLocalStorage) and go back to system. */
+export function clearStoredTheme(storageKey: string = DEFAULT_THEME_STORAGE_KEY): void {
+  try {
+    globalThis.localStorage?.removeItem(storageKey);
+  } catch {
+    /* ignore */
+  }
+  globalThis.dispatchEvent?.(new CustomEvent(THEME_CHANGE_EVENT, { detail: { storageKey, mode: "system" } }));
+}
+
+function prefersDarkQuery(): MediaQueryList | undefined {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(prefers-color-scheme: dark)")
+    : undefined;
+}
+
+export function systemPrefersDark(): boolean {
+  return prefersDarkQuery()?.matches ?? false;
+}
+
+export function resolveThemeMode(mode: ThemeMode, prefersDark: boolean): ResolvedThemeMode {
+  return mode === "system" ? (prefersDark ? "dark" : "light") : mode;
+}
+
+/** The Fluent theme (design-token set) for a resolved mode. */
+export function fluentThemeFor(resolved: ResolvedThemeMode): Theme {
+  return resolved === "dark" ? webDarkTheme : webLightTheme;
+}
+
+export interface ThemeState {
+  /** The user's choice: light / dark / system. */
+  mode: ThemeMode;
+  /** What's actually on screen (system resolved against the OS preference). */
+  resolved: ResolvedThemeMode;
+  /** The Fluent theme to hand to <FluentProvider>. */
+  theme: Theme;
+  setMode: (mode: ThemeMode) => void;
+}
+
+export interface UseThemeModeOptions {
+  storageKey?: string;
+}
+
+/**
+ * The theme hook: mode persisted in localStorage (Blazor-compatible), defaulting to the OS
+ * preference, live-updating on prefers-color-scheme changes, and synced across every hook
+ * instance in the document (and across tabs via the storage event).
+ */
+export function useThemeMode(options: UseThemeModeOptions = {}): ThemeState {
+  const storageKey = options.storageKey ?? DEFAULT_THEME_STORAGE_KEY;
+  const [mode, setModeState] = useState<ThemeMode>(() => readStoredThemeMode(storageKey));
+  const [prefersDark, setPrefersDark] = useState<boolean>(systemPrefersDark);
+
+  // Follow the OS preference while in system mode.
+  useEffect(() => {
+    const mq = prefersDarkQuery();
+    if (!mq) return;
+    const onChange = () => setPrefersDark(mq.matches);
+    // Modern API with a fallback for environments that only ship the deprecated one.
+    if (typeof mq.addEventListener === "function") {
+      mq.addEventListener("change", onChange);
+      return () => mq.removeEventListener("change", onChange);
+    }
+    mq.addListener?.(onChange);
+    return () => mq.removeListener?.(onChange);
+  }, []);
+
+  // Stay in sync with other hook instances (same document) and other tabs (storage event).
+  useEffect(() => {
+    const onLocalChange = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.storageKey === storageKey) setModeState(readStoredThemeMode(storageKey));
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === storageKey || e.key === null) setModeState(readStoredThemeMode(storageKey));
+    };
+    window.addEventListener(THEME_CHANGE_EVENT, onLocalChange);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(THEME_CHANGE_EVENT, onLocalChange);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [storageKey]);
+
+  const resolved = resolveThemeMode(mode, prefersDark);
+
+  // Mirror the resolved mode onto the document — exactly what Blazor's UpdateBodyDataSetTheme does
+  // (body[data-theme]) plus color-scheme so native chrome (scrollbars, inputs) follows.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.body.dataset.theme = resolved;
+    document.documentElement.style.colorScheme = resolved;
+  }, [resolved]);
+
+  const setMode = useCallback(
+    (m: ThemeMode) => {
+      writeStoredThemeMode(m, storageKey);
+      setModeState(m);
+    },
+    [storageKey],
+  );
+
+  return useMemo(
+    () => ({ mode, resolved, theme: fluentThemeFor(resolved), setMode }),
+    [mode, resolved, setMode],
+  );
+}

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Blazor\MeshWeaver.Hosting.Blazor.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.SignalR\MeshWeaver.Hosting.SignalR.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Grpc\MeshWeaver.Hosting.Grpc.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
     <!-- Content → vector index (core tech): chunk/embed/store on a separate Postgres vector DB,

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -15,6 +15,7 @@ using MeshWeaver.Blazor.AI;
 using MeshWeaver.Blazor.GoogleMaps;
 using MeshWeaver.Blazor.Graph;
 using MeshWeaver.Blazor.Infrastructure;
+using MeshWeaver.Hosting.Grpc;
 using MeshWeaver.Blazor.Pages;
 using MeshWeaver.Blazor.Portal;
 using MeshWeaver.Blazor.Portal.Authentication;
@@ -517,6 +518,12 @@ public static class MemexConfiguration
                 .AddPortalType()
                 .AddAI(serveFromPartition);
 
+            // gRPC mesh transport (foreign participants py/*, node/*, and the React GUI's
+            // browser Connect+Deliver split). Registers the service + declares the
+            // participant address types stream-routed. Symmetric with Features:SignalR.
+            if (features.Grpc)
+                mb = mb.AddGrpcHub();
+
             // Each AI provider self-registers everything (catalog source +
             // IOptions binding + IChatClientFactory) via one builder extension.
             // The Models settings tab + the ModelProviderService read these out
@@ -813,10 +820,36 @@ public static class MemexConfiguration
             return next();
         });
 
+        // Frontend selection (Portal:Frontend / Portal:ReactAppUrl + the mw-frontend override
+        // cookie): redirect interactive page navigations to the React app when the effective
+        // frontend is React. Inert unless Portal:ReactAppUrl is configured. Must run before
+        // static files/routing so it sees every navigation; assets/transport paths pass through.
+        app.UseFrontendSelection();
+
+        // React GUI SPA: rewrite extension-less /app paths to the SPA entry BEFORE static files,
+        // so the bundle's index.html wins over Blazor's page catch-all (endpoint FALLBACKS lose
+        // to page routes regardless of literal precedence — the rewrite sidesteps routing).
+        app.Use((ctx, next) =>
+        {
+            var p = ctx.Request.Path.Value;
+            if (p is not null
+                && (p.Equals("/app", StringComparison.OrdinalIgnoreCase)
+                    || p.StartsWith("/app/", StringComparison.OrdinalIgnoreCase))
+                && !System.IO.Path.HasExtension(p))
+                ctx.Request.Path = "/app/index.html";
+            return next();
+        });
+
         // Static files middleware must run before routing to serve _content/* paths from RCLs
         app.UseStaticFiles();
 
         app.UseRouting();
+
+        // gRPC-web middleware — lets browsers / React Native reach the mesh gRPC service
+        // (Connect+Deliver split) without HTTP/2 bidi. Must sit between UseRouting and the
+        // endpoint maps. Inert for non-grpc-web requests.
+        if (features.Grpc)
+            app.UseMeshWeaverGrpcWeb();
         app.UseAuthentication();
         app.UseAuthorization();
         app.UseAntiforgery();
@@ -856,6 +889,11 @@ public static class MemexConfiguration
         if (features.SignalR)
             app.MapMeshWeaverSignalRHubs();
 
+        // gRPC mesh endpoint (meshweaver.v1.Mesh/Open, grpc-web enabled) — foreign-language
+        // workers and the React GUI connect here.
+        if (features.Grpc)
+            app.MapMeshWeaverGrpc();
+
         // Map MCP endpoint
         app.MapMeshMcp();
 
@@ -864,6 +902,11 @@ public static class MemexConfiguration
         app.MapMeshApi();
 
         app.MapMeshWeaver();
+
+        // Frontend toggle endpoint: GET /frontend/{react|blazor|clear} sets/clears the per-user
+        // override cookie and redirects — the reversible switch both shells link to.
+        app.MapFrontendSelection();
+
 
         // Social publishing — LinkedIn connect/pull endpoints. Must be AFTER
         // UseAuthentication so HttpContext.User is populated.

--- a/memex/Memex.Portal.Shared/MemexFeatureOptions.cs
+++ b/memex/Memex.Portal.Shared/MemexFeatureOptions.cs
@@ -35,6 +35,13 @@ public sealed record MemexFeatureOptions
     public bool SignalR { get; init; } = true;
 
     /// <summary>
+    /// gRPC mesh transport (<c>meshweaver.v1.Mesh/Open</c> + gRPC-web) for foreign-language
+    /// participants (Python/Node workers) and the browser React GUI's Connect+Deliver split.
+    /// On by default, symmetric with <see cref="SignalR"/>; close with <c>Features:Grpc=false</c>.
+    /// </summary>
+    public bool Grpc { get; init; } = true;
+
+    /// <summary>
     /// True when the deployment ships at least one in-process API provider OR one
     /// co-hosted CLI. When false, the portal has no built-in chat capability via
     /// catalog sources (users may still bring their own keys via ModelProviders) —

--- a/src/MeshWeaver.Blazor.Portal/Components/UserProfile.razor
+++ b/src/MeshWeaver.Blazor.Portal/Components/UserProfile.razor
@@ -23,6 +23,12 @@
                             <div class="user-id">@username</div>
                         </FluentPersona>
                     </FluentStack>
+                    @if (showFrontendToggle)
+                    {
+                        <FluentStack VerticalAlignment="VerticalAlignment.Center" Style="margin-top: 8px;">
+                            <FluentButton Appearance="Appearance.Stealth" OnClick="SwitchToNewFrontend">Try the new frontend</FluentButton>
+                        </FluentStack>
+                    }
                 </ChildContent>
             </FluentProfileMenu>
         </div>

--- a/src/MeshWeaver.Blazor.Portal/Components/UserProfile.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Components/UserProfile.razor.cs
@@ -10,6 +10,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Blazor.Portal.Components;
@@ -36,6 +37,10 @@ public partial class UserProfile : ComponentBase
     /// <summary>Access service supplying the current user's access context (name, object id).</summary>
     [Inject]
     public required AccessService AccessService { get; init; }
+
+    /// <summary>Application configuration — read for the frontend-selection feature (Portal:ReactAppUrl).</summary>
+    [Inject]
+    public required IConfiguration Configuration { get; init; }
 
     /// <summary>Portal application providing the message hub used for the platform-admin check.</summary>
     [Inject]
@@ -137,6 +142,17 @@ public partial class UserProfile : ComponentBase
             Navigation.NavigateTo($"/User/{userId}");
         }
     }
+
+    /// <summary>The "Try the new frontend" entry only shows when the deployment configured a React app URL.</summary>
+    private bool showFrontendToggle => FrontendSelection.IsEnabled(Configuration);
+
+    /// <summary>
+    /// Switch this user to the React frontend: a full-page navigation to the toggle endpoint, which
+    /// sets the override cookie and redirects to the React app. Reversed by the React shell's
+    /// "Back to classic" entry (GET /frontend/blazor).
+    /// </summary>
+    private void SwitchToNewFrontend()
+        => Navigation.NavigateTo($"{FrontendSelection.EndpointPrefix}/react", forceLoad: true);
 
     private void NavigateToSettings()
     {

--- a/src/MeshWeaver.Blazor.Portal/FrontendSelection.cs
+++ b/src/MeshWeaver.Blazor.Portal/FrontendSelection.cs
@@ -1,0 +1,170 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.Blazor.Portal;
+
+/// <summary>
+/// Frontend selection — choose the portal frontend per deployment and per user:
+/// <list type="bullet">
+/// <item><c>Portal:Frontend</c> — the deployment default: <c>"Blazor"</c> (default) or <c>"React"</c>.</item>
+/// <item><c>Portal:ReactAppUrl</c> — where the React app is served (e.g. <c>/app/</c> or an absolute
+/// URL). The whole feature is inert until this is configured, so existing deployments are unaffected.</item>
+/// <item>Per-user override — the <c>mw-frontend</c> cookie, set via the <c>GET /frontend/{target}</c>
+/// endpoint (<c>react</c> | <c>blazor</c> | <c>clear</c>). Theme and similar user preferences are
+/// client-side (localStorage via <c>FluentDesignTheme</c>); there is no server-side per-user
+/// preference store, so the override deliberately follows the same client-side pattern: a plain
+/// (non-HttpOnly) cookie the shell reads at the HTTP layer and the React app can read/clear too.</item>
+/// </list>
+/// The shell checks the effective choice in <see cref="UseFrontendSelection"/> (registered by the
+/// portal host before static files/routing): interactive HTML GET navigations are redirected to the
+/// React app when the effective frontend is React. Everything non-navigational (Blazor circuit,
+/// static assets, MCP/API/SignalR, auth flows, the /frontend endpoints themselves) passes through.
+/// The toggle is fully reversible from both sides: the Blazor user menu links to
+/// <c>/frontend/react</c> ("Try the new frontend"), the React shell links to <c>/frontend/blazor</c>
+/// ("Back to classic").
+/// </summary>
+public static class FrontendSelection
+{
+    /// <summary>The per-user override cookie. Values: <see cref="React"/> or <see cref="Blazor"/>.</summary>
+    public const string CookieName = "mw-frontend";
+
+    /// <summary>The React frontend selector value.</summary>
+    public const string React = "React";
+
+    /// <summary>The classic Blazor frontend selector value (the default).</summary>
+    public const string Blazor = "Blazor";
+
+    /// <summary>Configuration key for the deployment-default frontend ("Blazor" | "React").</summary>
+    public const string FrontendKey = "Portal:Frontend";
+
+    /// <summary>Configuration key for the React app URL. Empty/unset disables the feature.</summary>
+    public const string ReactAppUrlKey = "Portal:ReactAppUrl";
+
+    /// <summary>Route prefix of the selection endpoint (<c>/frontend/{target}</c>).</summary>
+    public const string EndpointPrefix = "/frontend";
+
+    // Never bounce anything that is not an interactive page navigation: framework/static assets,
+    // the Blazor circuit, mesh transports (MCP/REST/SignalR/gRPC), health probes, auth flows, and
+    // the selection endpoint itself.
+    private static readonly string[] ExcludedPrefixes =
+    [
+        "/_framework", "/_content", "/_blazor", "/static/", "/favicon.ico", "/mcp", "/bootstrap",
+        "/healthz", "/api", "/signalr", "/connect", "/frontend", "/signin", "/signout", "/login",
+        "/logout", "/MicrosoftIdentity", "/authentication",
+    ];
+
+    /// <summary>Whether frontend selection is configured for this deployment (a React app URL exists).</summary>
+    /// <param name="configuration">The application configuration.</param>
+    public static bool IsEnabled(IConfiguration configuration)
+        => !string.IsNullOrWhiteSpace(configuration[ReactAppUrlKey]);
+
+    /// <summary>
+    /// The effective frontend for the request: the user's cookie override when present, else the
+    /// deployment default (<c>Portal:Frontend</c>), else <see cref="Blazor"/>.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <param name="configuration">The application configuration.</param>
+    public static string EffectiveFrontend(HttpContext context, IConfiguration configuration)
+    {
+        var choice = context.Request.Cookies[CookieName];
+        if (string.IsNullOrWhiteSpace(choice))
+            choice = configuration[FrontendKey];
+        return string.Equals(choice, React, StringComparison.OrdinalIgnoreCase) ? React : Blazor;
+    }
+
+    /// <summary>
+    /// Whether this request is an interactive HTML page navigation that should be redirected to the
+    /// React app (feature enabled + effective frontend React + not an excluded/asset/React path).
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <param name="configuration">The application configuration.</param>
+    public static bool ShouldRedirectToReact(HttpContext context, IConfiguration configuration)
+    {
+        if (!IsEnabled(configuration))
+            return false;
+        if (!HttpMethods.IsGet(context.Request.Method))
+            return false;
+
+        var path = context.Request.Path.Value ?? "/";
+        if (ExcludedPrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+            return false;
+        // Static assets carry an extension (".css", ".js", ".png", ...) — only bounce extensionless
+        // page routes.
+        if (Path.HasExtension(path))
+            return false;
+
+        // Never bounce a request already inside the React app (when co-hosted under a relative base).
+        var reactUrl = configuration[ReactAppUrlKey]!;
+        if (reactUrl.StartsWith('/')
+            && path.StartsWith(reactUrl.TrimEnd('/'), StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        // Only interactive navigations (the browser asks for text/html); XHR/fetch pass through.
+        if (!context.Request.Headers.Accept.ToString().Contains("text/html", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return EffectiveFrontend(context, configuration) == React;
+    }
+
+    /// <summary>
+    /// Middleware: redirect interactive page navigations to the React app when the effective
+    /// frontend (deployment default + per-user cookie override) is React. Register before static
+    /// files/routing so the check runs on every navigation; it is a no-op unless
+    /// <c>Portal:ReactAppUrl</c> is configured.
+    /// </summary>
+    /// <param name="app">The application pipeline builder.</param>
+    public static IApplicationBuilder UseFrontendSelection(this IApplicationBuilder app)
+        => app.Use((context, next) =>
+        {
+            var configuration = context.RequestServices.GetRequiredService<IConfiguration>();
+            if (ShouldRedirectToReact(context, configuration))
+            {
+                context.Response.Redirect(configuration[ReactAppUrlKey]!);
+                return Task.CompletedTask;
+            }
+            return next();
+        });
+
+    /// <summary>
+    /// Maps <c>GET /frontend/{target}</c> — the reversible toggle both shells link to:
+    /// <c>react</c> sets the override cookie and redirects to the React app, <c>blazor</c> sets it
+    /// back and redirects to the classic shell, <c>clear</c> drops the override (deployment default
+    /// applies again).
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    public static IEndpointRouteBuilder MapFrontendSelection(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet(EndpointPrefix + "/{target}", (HttpContext context, string target) =>
+        {
+            var configuration = context.RequestServices.GetRequiredService<IConfiguration>();
+            // Deliberately NOT HttpOnly: the React app reads/clears the same preference client-side
+            // (the mirror of the theme's localStorage pattern).
+            var options = new CookieOptions
+            {
+                Path = "/",
+                MaxAge = TimeSpan.FromDays(365),
+                SameSite = SameSiteMode.Lax,
+                HttpOnly = false,
+                Secure = context.Request.IsHttps,
+            };
+            switch (target.ToLowerInvariant())
+            {
+                case "react":
+                    context.Response.Cookies.Append(CookieName, React, options);
+                    return Results.Redirect(configuration[ReactAppUrlKey] ?? "/");
+                case "blazor":
+                    context.Response.Cookies.Append(CookieName, Blazor, options);
+                    return Results.Redirect("/");
+                case "clear":
+                    context.Response.Cookies.Delete(CookieName, new CookieOptions { Path = "/" });
+                    return Results.Redirect("/");
+                default:
+                    return Results.BadRequest($"Unknown frontend '{target}' — use react, blazor, or clear.");
+            }
+        });
+        return endpoints;
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/GUI.md
+++ b/src/MeshWeaver.Documentation/Data/GUI.md
@@ -85,3 +85,5 @@ Browse the full set of controls, layout primitives, and data-binding guides:
 | [Side Panel](SidePanel) | Slide-in panels for detail views and settings |
 | [Reactive Dialogs](ReactiveDialogs) | Modal dialogs backed by observable state |
 | [Node Menu](NodeMenu) | Context menus on mesh nodes |
+| [React Frontend](React) | The client-side React frontend — same `UiControl` contract, rendered in the browser over gRPC-web: running it, rendering, theming, chat, testing |
+| [Custom React Controls](ReactCustomControls) | Extend the React renderer with your own control — server-side `$type` + a React registry entry |

--- a/src/MeshWeaver.Documentation/Data/GUI/React.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/React.md
@@ -1,0 +1,53 @@
+---
+Name: React Frontend
+Category: Documentation
+Description: The client-side React frontend — @meshweaver/react renders the same UiControl JSON contract as Blazor, streamed over gRPC-web with no server circuit. Architecture, parity state, and the topic map.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="2.2" fill="currentColor" stroke="none"/><ellipse cx="12" cy="12" rx="10" ry="4.2"/><ellipse cx="12" cy="12" rx="10" ry="4.2" transform="rotate(60 12 12)"/><ellipse cx="12" cy="12" rx="10" ry="4.2" transform="rotate(120 12 12)"/></svg>
+---
+
+# React Frontend
+
+MeshWeaver has two web frontends over **one UI contract**. The classic portal is Blazor Server: layout areas render server-side and DOM diffs stream to the browser over a SignalR circuit. The React frontend renders the **same layout areas client-side**: the browser receives the raw `UiControl` JSON tree (an `{areas, data}` snapshot plus patches) over the gRPC-web mesh transport and a React + Fluent UI renderer walks it. Same hubs, same layout areas, same data binding — a different last mile.
+
+> **The code on these pages does not execute in the portal.** The live `--render` blocks used elsewhere in the docs run *C#* in the portal's kernel; React/TSX cannot execute there. All TSX snippets in this section are plain fenced code, verified against the sources in `clients/react`, `clients/grpc-web`, and `clients/portal`.
+
+## The three packages
+
+| Package | Location | Role |
+|---|---|---|
+| `@meshweaver/react` | `clients/react` | The renderer: `$type` → Fluent UI React v9 component registry, skin dispatch, binding hooks, theming, `ThreadChat`. `@meshweaver/react/core` is the Fluent-free core for React Native / custom leaf packs. |
+| `@meshweaver/client-web` | `clients/grpc-web` | The browser/React-Native mesh transport over gRPC-web (Connect-ES) — `observe` / `post` / `watch` plus the `Mesh` operations surface (`search`, `patch`, `startThread`, `submitMessage`, …). |
+| portal app shell | `clients/portal` | The SPA served at `/app` on a portal deployment: header + nav chrome around the renderer — the web analog of the Blazor portal shell. |
+
+## Architecture vs. Blazor Server
+
+| | Blazor Server (classic) | React frontend |
+|---|---|---|
+| Rendering | Server-side; DOM diffs over the SignalR circuit | Client-side; the browser receives the `UiControl` JSON tree and renders it locally |
+| Transport | SignalR circuit (stateful, per-tab) | gRPC-web `Connect` (server-stream) + `Deliver` (unary) — see [Rendering Architecture](Rendering) |
+| Connection loss | The circuit **is** the UI state — a drop degrades to the reconnect overlay / a page reload | No server circuit. The UI state lives in the browser; the layout-area stream is a `Full` snapshot + patches, so re-opening the subscription re-syncs the tree instead of killing the UI |
+| Interactivity | Events round-trip to the server component | Events post back as mesh messages (`ClickedEvent`, `PatchDataChangeRequest`, …); edits apply optimistically and the server echoes the authoritative patch |
+| Extensibility | Blazor views registered per control type | A spreadable `$type` → component registry; new controls load at runtime via native ESM `import(url)` — see [Custom React Controls](../ReactCustomControls) |
+
+Both frontends bind data the same way conceptually: the backend layout area declares *what* to render, and every value read/write rides the area's data stream (see [Data Binding](../DataBinding) for the contract). The React renderer resolves the same `/data` JSON-pointer bindings with its `useResolve` hook.
+
+## Parity state
+
+Parity with the Blazor portal is **pinned by a test**, not by intention. `clients/react/src/render/parity.test.ts` lists the authoritative Blazor vocabulary — every `*Control` / `*Skin` type in `src/MeshWeaver.Layout` — and fails when the React pack misses one:
+
+- **51 / 51 leaf-control `$type`s registered** (Label, Markdown, DataGrid, Chart, ThreadChat, MeshSearch, CodeEditor, …), plus all 18 container/item skins (LayoutStack, LayoutGrid, Tabs, Card, Splitter, Toolbar, NavMenu, EditForm, …).
+- **5 of the 51 are registered placeholders** — controls whose real rendering needs a live mesh service beyond the area contract: `DocumentSource`, `ExportDocument`, `FileBrowser`, `NodeExport`, `NodeImport` (the `placeholderControlTypes` list in `clients/react/src/controls/mesh.tsx`). They render a clearly-labeled placeholder card, never a crash.
+- **The placeholder list is a ratchet**: the parity test pins it exactly, so implementing one for real means removing it from the list, and adding a *new* placeholder fails the build. The long-tail only ever shrinks.
+
+Everything else — containers, forms, grids, charts, markdown, nav, dialogs, editors, the chat — renders for real. See [Testing & Parity](Testing) for the full test story.
+
+## Topic map
+
+| Page | What it covers |
+|---|---|
+| [Getting Started](GettingStarted) | The served SPA at `/app`, the `Portal:Frontend` / `Portal:ReactAppUrl` configuration, the `/frontend/{react\|blazor\|clear}` toggle + `mw-frontend` cookie, and local dev with Vite |
+| [Rendering Architecture](Rendering) | The `UiControl` JSON contract, the `$type` → component registry, `MeshAreaView` + `AreaSource`, and how live areas hydrate over gRPC-web |
+| [Theming](Theming) | Light/dark/system with the same localStorage contract as Blazor — one preference across both frontends |
+| [Thread Chat](ThreadChat) | The React chat: thread-node watching, message satellites, composer gating, `startThread` / `submitMessage` |
+| [Custom React Controls](../ReactCustomControls) | Extending the renderer with your own control — server-side `UiControl` subclass + a React component for its `$type`, runtime ESM loading |
+| [Testing & Parity](Testing) | The parity ratchet, the vitest suites, and the transport round-trip test |

--- a/src/MeshWeaver.Documentation/Data/GUI/React/GettingStarted.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/React/GettingStarted.md
@@ -1,0 +1,126 @@
+---
+Name: Getting Started with the React Frontend
+Category: Documentation
+Description: Run the React frontend — the served SPA at /app, the Portal:Frontend / Portal:ReactAppUrl configuration, the /frontend toggle endpoints + mw-frontend cookie, and local dev with Vite.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+---
+
+# Getting Started with the React Frontend
+
+There are two ways to run the React frontend: **served by a portal** (the SPA at `/app`, sharing the portal's origin, auth, and gRPC-web endpoint) and **standalone with Vite** (local development against sample data or a remote mesh).
+
+## The served SPA at `/app`
+
+A portal deployment serves the built React app from its own `wwwroot/app` — the Vite production bundle (built with base `/app/`) copied into the portal's static files. Two pieces of middleware in the portal pipeline (`Memex.Portal.Shared/MemexConfiguration.cs`) make this work:
+
+1. **The SPA rewrite** — extension-less `/app` paths are rewritten to `/app/index.html` *before* static files run, so client-side routes deep inside the SPA always land on the bundle's entry page instead of Blazor's page catch-all:
+
+```csharp
+// React GUI SPA: rewrite extension-less /app paths to the SPA entry BEFORE static files.
+app.Use((ctx, next) =>
+{
+    var p = ctx.Request.Path.Value;
+    if (p is not null
+        && (p.Equals("/app", StringComparison.OrdinalIgnoreCase)
+            || p.StartsWith("/app/", StringComparison.OrdinalIgnoreCase))
+        && !System.IO.Path.HasExtension(p))
+        ctx.Request.Path = "/app/index.html";
+    return next();
+});
+```
+
+2. **The gRPC-web transport**, gated by the `Features:Grpc` flag — the browser's data plane. Three calls wire it end to end:
+
+```csharp
+// Mesh tier (ConfigureMemexMesh): registers the gRPC service + declares the
+// foreign-participant address types (py/*, node/*) stream-routed.
+if (features.Grpc)
+    mb = mb.AddGrpcHub();
+
+// Request pipeline (between UseRouting and the endpoint maps):
+if (features.Grpc)
+    app.UseMeshWeaverGrpcWeb();     // gRPC-web middleware — browsers can't do HTTP/2 bidi
+
+// Endpoints:
+if (features.Grpc)
+    app.MapMeshWeaverGrpc();        // meshweaver.v1.Mesh, grpc-web enabled
+```
+
+`AddGrpcHub` / `UseMeshWeaverGrpcWeb` / `MapMeshWeaverGrpc` live in `src/MeshWeaver.Hosting.Grpc/GrpcHostingExtensions.cs`. The `node/*` address type is what the browser connection registers under (each tab connects as participant `node/<id>`); without the stream-routing declaration, replies addressed to it would be treated as node lookups and dropped. The wire details are on [Rendering Architecture](../Rendering).
+
+### How the served SPA connects and routes
+
+On load the app shell (`clients/portal/src/Portal.tsx` + `live.ts`) joins the mesh over **same-origin gRPC-web**. The gRPC path is identified by a Bearer `mw_…` API token, not the browser cookie — so the SPA first mints a short-lived token off the already-authenticated session (`POST /api/tokens`, cookie-authorized, token held in memory only) and then connects. The mint response's `nodePath` (`{userId}/ApiToken/…`) reveals the signed-in user's partition, which becomes the default route — no separate who-am-I endpoint.
+
+Routing is hash-based over mesh paths, mirroring the Blazor portal's URL shape:
+
+| URL | Renders |
+|---|---|
+| `/app/#/{meshPath}` (e.g. `/app/#/Doc/GUI`) | That node's **default layout area**, live — the same area Blazor shows at `/{meshPath}` |
+| `/app` (no hash) | The signed-in user's home — what Blazor shows at `/{user}` |
+
+When no live connection can be established on the origin (standalone dev server, or an unauthenticated session), the shell falls back to bundled **sample data** with an "offline sample mode" banner — the same demo the standalone Vite server shows.
+
+## Choosing the frontend: `Portal:Frontend` + `Portal:ReactAppUrl`
+
+Frontend selection is implemented in `src/MeshWeaver.Blazor.Portal/FrontendSelection.cs` and is configured per deployment and overridable per user:
+
+| Setting | Meaning |
+|---|---|
+| `Portal:ReactAppUrl` | Where the React app is served (e.g. `/app/`, or an absolute URL). **The whole feature is inert until this is set** — existing deployments are unaffected. |
+| `Portal:Frontend` | The deployment default: `"Blazor"` (default) or `"React"`. |
+| `mw-frontend` cookie | The per-user override: `React` or `Blazor`. Wins over the deployment default. |
+
+The middleware (`UseFrontendSelection`, registered before static files/routing) redirects **interactive HTML GET navigations** to the React app when the effective frontend is React. Everything non-navigational passes through untouched: the Blazor circuit, static assets, MCP/API/SignalR/gRPC transports, health probes, auth flows, and the `/frontend` endpoints themselves. XHR/fetch requests (no `text/html` in `Accept`) and any path with a file extension also pass through.
+
+## The toggle: `/frontend/{react|blazor|clear}` + the `mw-frontend` cookie
+
+`MapFrontendSelection` maps one endpoint, `GET /frontend/{target}` — the reversible switch both shells link to:
+
+| Target | Effect |
+|---|---|
+| `/frontend/react` | Sets `mw-frontend=React` and redirects to `Portal:ReactAppUrl` |
+| `/frontend/blazor` | Sets `mw-frontend=Blazor` and redirects to `/` (the classic shell) |
+| `/frontend/clear` | Deletes the cookie — the deployment default applies again |
+
+The cookie is deliberately **not** HttpOnly (`Path=/`, `MaxAge` 365 days, `SameSite=Lax`): user preferences in MeshWeaver are client-side (the theme lives in localStorage — see [Theming](../Theming)), and the frontend choice follows the same pattern so the React app can read and clear it too.
+
+Both shells expose the toggle in their chrome:
+
+- **Blazor → React**: the user menu shows **"Try the new frontend"** (`UserProfile.razor`) — visible only when `FrontendSelection.IsEnabled(Configuration)`, i.e. when the deployment configured a React app URL. It navigates (full page load) to `/frontend/react`.
+- **React → Blazor**: the React shell's header shows **"Back to classic"** (`clients/portal/src/Portal.tsx`), which writes the cookie client-side (so the choice sticks even when the app is served standalone, with no portal endpoint on the origin) and navigates to `/frontend/blazor`.
+
+## Local development
+
+The app shell lives in `clients/portal`; in the monorepo its `vite.config.ts` aliases `@meshweaver/react` to the renderer *source* (`../react/src`), so there is no build/link step and renderer edits hot-reload straight into the shell:
+
+```bash
+cd clients/portal
+npm install
+npm run dev        # Vite dev server → http://localhost:5173
+```
+
+With no portal on `localhost:5173`, the shell runs in offline sample mode, rendering the `{areas, data}` trees from `src/sample.ts` through a `StaticAreaSource` — every control interactive, no backend required. Served from a portal origin, the same build connects live automatically (previous section).
+
+The renderer package itself has a richer standalone demo (~50 controls in one tree — cards, tabs, a data grid, a chart, data-bound form inputs) plus the test suites:
+
+```bash
+cd clients/react
+npm install
+npm run dev        # the demo area
+npm test           # vitest — renderer core, controls, parity ratchet
+```
+
+To produce the bundle a portal serves, build with the `/app/` base and place the output at the portal's `wwwroot/app`:
+
+```bash
+cd clients/portal
+npm run build -- --base=/app/
+# dist/ → <portal project>/wwwroot/app/
+```
+
+## Related
+
+- [React Frontend overview](/Doc/GUI/React) — architecture and parity state.
+- [Rendering Architecture](../Rendering) — how the SPA gets its data.
+- [Theming](../Theming) — the shared theme preference between both frontends.

--- a/src/MeshWeaver.Documentation/Data/GUI/React/Rendering.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/React/Rendering.md
@@ -1,0 +1,162 @@
+---
+Name: React Rendering Architecture
+Category: Documentation
+Description: How the React frontend renders a layout area — the UiControl JSON contract, the $type→component registry and skin dispatch, MeshAreaView + AreaSource, and live hydration over the gRPC-web Connect+Deliver split.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+---
+
+# React Rendering Architecture
+
+The renderer's design in one sentence: a **transport-free core** walks the `{areas, data}` `UiControl` tree, dispatching each control's `$type` against a swappable component registry — and everything live (subscriptions, patches, events) is hidden behind one small interface, `AreaSource`.
+
+```
+        layout-area stream  ({areas, data} UiControl tree + patches)
+                    │
+          ┌─────────┴─────────┐
+          │  renderer core    │   dispatch on $type, pop skins, resolve bindings, post events
+          │ (transport-free)  │   ← written ONCE (clients/react/src/render + area)
+          └─────────┬─────────┘
+       DOM leaf pack        RN leaf pack
+   web / Electron        iOS / Android
+```
+
+This is the same shape the platform uses everywhere: MAUI renders the identical tree with a native `MauiViewPack`, Blazor with its web views — the React renderer adds a Fluent UI React v9 pack (near 1:1 with the Blazor portal's Fluent UI Blazor components).
+
+## The wire model: `UiControl` trees
+
+A layout area is delivered as a single JSON object with an `areas` map (area key → control) and a `data` map (values that bindings point at). From `clients/react/src/area/types.ts`:
+
+```ts
+export interface UiControl {
+  $type: string;              // short name: "Stack", "Label", "DataGrid", ...
+  id?: Json;
+  dataContext?: string;       // pointer prefix for relative bindings
+  style?: Json;
+  class?: Json;
+  skins?: Skin[];             // container/wrapper skins, popped LIFO
+  isClickable?: boolean;
+  pageTitle?: Json;
+  [key: string]: Json;
+}
+
+export interface AreaTree {
+  areas?: Record<string, UiControl>;
+  data?: Record<string, Json>;
+}
+```
+
+Containers don't inline their children — they carry an `areas` list of `NamedArea` references, each pointing at another key in the `areas` map. A control property is either a literal value or a **binding**: a JSON pointer into `/data`, resolved (and written back) live. This is exactly the contract described in [Data Binding](/Doc/GUI/DataBinding); the React renderer is another consumer of it.
+
+## `AreaSource` — the one seam
+
+The renderer depends on nothing but this interface:
+
+```ts
+export interface AreaSource {
+  getState(): AreaTree;                          // current {areas, data} snapshot
+  subscribe(listener: () => void): () => void;   // change notification
+  emit(event: MeshEvent): void;                  // clicks, edits, blur, closeDialog
+}
+```
+
+Two implementations ship:
+
+- **`StaticAreaSource`** (`area/source.ts`) — an in-memory tree. Drives the demo and the tests; an `"update"` event optimistically writes the value at its pointer, exactly as a live stream would echo the merge-patch back. Ideal for developing a control against fixture JSON before touching a live portal.
+- **`GrpcAreaSource`** (`live/grpcSource.ts`) — subscribes to a live layout area on a hub and folds the stream into the tree (next section).
+
+## `MeshAreaView` — the composed entry point
+
+`MeshAreaView` (the package's top-level component, `clients/react/src/index.tsx`) stacks the four providers the renderer needs and renders the root area:
+
+```tsx
+export function MeshAreaView({ source, rootArea, theme, themeStorageKey, ops }: MeshAreaViewProps) {
+  const { theme: preferredTheme } = useThemeMode({ storageKey: themeStorageKey });
+  return (
+    <FluentProvider theme={theme ?? preferredTheme}>
+      <MeshOpsProvider ops={ops ?? null}>
+        <RegistryProvider pack={fluentPack}>
+          <ScopeProvider source={source} area={rootArea}>
+            <RenderArea areaKey={rootArea} />
+          </ScopeProvider>
+        </RegistryProvider>
+      </MeshOpsProvider>
+    </FluentProvider>
+  );
+}
+```
+
+- `FluentProvider` supplies the design tokens (see [Theming](../Theming)).
+- `MeshOpsProvider` supplies the optional mesh-operations surface controls like `ThreadChat` need beyond the area contract (see [Thread Chat](../ThreadChat)).
+- `RegistryProvider` installs the **leaf pack**; `ScopeProvider` + `RenderArea` scope the source and area key.
+
+## The registry: `$type` → component
+
+Dispatch is data-driven. The active pack is a plain record of maps (`render/registryContext.tsx`):
+
+```ts
+export type ControlComponent = (props: { control: UiControl }) => ReactNode;
+export type SkinComponent = (props: { skin: Skin; control: UiControl }) => ReactNode;
+
+export interface LeafPack {
+  controls: Record<string, ControlComponent>;  // $type → component (leaf controls)
+  skins: Record<string, SkinComponent>;        // skin $type → wrapper (Stack/Tabs/Card/…)
+  fallback: ControlComponent;                  // renders an unknown $type
+  defaultContainer: SkinComponent;             // container with no remaining skin
+}
+```
+
+The shipped web pack is `fluentPack` (`render/registry.tsx`): `controlRegistry` spreads the per-category maps (display, inputs, data, nav, feedback, containers, editors, mesh, appearance, item templates) and `skinRegistry` covers the container skins. Spreading your own entries over `controlRegistry` is the designed extension point — see [Custom React Controls](/Doc/GUI/ReactCustomControls).
+
+`ControlRenderer` (`render/ControlRenderer.tsx`) implements the dispatch:
+
+1. **Skins pop LIFO** — the last skin wraps (or, for layout skins, lays out) the control, recursing with the rest.
+2. A **container with no remaining skin** renders through `defaultContainer` (a flex stack).
+3. A **leaf** dispatches `$type` against `pack.controls`; unknown types render `pack.fallback` — a clearly-labeled "Unsupported control", never a crash.
+
+The lookup tolerates both `$type` spellings: registries hold the suffix-stripped short names (`"Stack"`, `"LayoutStack"`), while the live mesh serializes class names (`"StackControl"`, `"LayoutStackSkin"`) — the exact key is tried first, then the suffix-stripped one.
+
+Child areas resolve through the same primitives your own controls can use:
+
+```tsx
+export { ControlRenderer, RenderArea, RenderChildren, useChildAreas } from "./render/ControlRenderer.js";
+export { ScopeProvider, useAreaState, useResolve, useEmit, useScope } from "./area/context.js";
+```
+
+`useResolve(control.someProp)` returns the property's value whether it is a literal or a bound `/data` pointer; `useEmit()` posts events into the source; `useAreaState()` is the live tree (backed by `useSyncExternalStore`, so React re-renders exactly the consumers of changed state).
+
+## Live hydration: `GrpcAreaSource` over Connect + Deliver
+
+Browsers can't open the mesh's bidirectional gRPC `Open` stream (no HTTP/2 duplex from `fetch`), so the server splits the duplex into a **server-streaming `Connect`** (mesh → client) and a **unary `Deliver`** (client → mesh). `MeshWebConnection` in `@meshweaver/client-web` (`clients/grpc-web/src/connection.ts`) hides the split behind the same surface the Node SDK exposes — `observe` / `post` / `watch`:
+
+- `connect(url, { token })` opens the `Connect` stream; the first frame is an **ack carrying the `connection_id`** that every subsequent `Deliver` quotes back. The bearer token rides in gRPC-web call metadata; identity is stamped server-side, never claimed by the client.
+- Each browser tab joins the mesh as participant `node/<id>` — a stream-routed foreign-participant address type declared by `AddGrpcHub` (`src/MeshWeaver.Hosting.Grpc/GrpcHostingExtensions.cs`).
+- Received frames are demuxed: responses correlate to pending `observe` requests by `RequestId`; stream messages route to the matching `watch` subscription by `streamId`.
+
+`GrpcAreaSource` builds the area subscription on `watch`:
+
+```ts
+import { connect } from "@meshweaver/client-web";
+import { GrpcAreaSource, MeshAreaView } from "@meshweaver/react";
+
+const conn = await connect("https://memex.meshweaver.cloud", { token: "mw_..." });
+const source = new GrpcAreaSource(conn, "ACME/MyApp", { area: "Overview" });
+void source.start();   // folds the live area stream into {areas, data}
+// <MeshAreaView source={source} rootArea="Overview" />
+```
+
+The wire behavior it pins (documented in `live/grpcSource.ts` against the server sources):
+
+- The subscribe message is a `SubscribeRequest` whose `reference` **must carry the polymorphic `$type` discriminator** (`"LayoutAreaReference"`) — the server deserializes an abstract `WorkspaceReference` and drops the subscribe without it.
+- An **empty `reference.area` subscribes the default area**: the first `Full` frame carries `areas[""]` as a `NamedArea` pointing at the resolved area, and rendering root key `""` follows the indirection.
+- `ChangeType "Full"` is a whole snapshot; `"Patch"` is an **RFC 6902 JSON-patch array** (not an RFC 7396 merge), folded immutably into the tree.
+- Snapshot collections arrive as `InstanceCollections` with JSON-encoded instance keys (`"Content"` arrives as the property `"\"Content\""`); keys are decoded at fold time so area lookups use plain names.
+- Events post back as mesh messages: `click` → `ClickedEvent`, `blur` → `BlurEvent`, `closeDialog` → `CloseDialogEvent`, and `update` → `PatchDataChangeRequest` carrying a one-op RFC 6902 `replace` at the binding's pointer. Updates apply **optimistically** to the local tree; the owning hub applies the patch and echoes the authoritative change back down the stream.
+
+That last point is why a transport blip doesn't kill the UI the way a dropped Blazor circuit does: the browser holds the whole `{areas, data}` state, and re-opening the subscription yields a fresh `Full` snapshot to converge on — nothing server-side needs the old connection's memory.
+
+## Related
+
+- [React Frontend overview](/Doc/GUI/React) — the package map and parity state.
+- [Custom React Controls](/Doc/GUI/ReactCustomControls) — registering components for your own `$type`s.
+- [Layout Areas](/Doc/GUI/LayoutAreas) — how the hub decides what each area shows.
+- [Data Binding](/Doc/GUI/DataBinding) — the `/data` pointer contract `useResolve` implements.

--- a/src/MeshWeaver.Documentation/Data/GUI/React/Testing.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/React/Testing.md
@@ -1,0 +1,75 @@
+---
+Name: React Testing & Parity Scorecard
+Category: Documentation
+Description: How React↔Blazor parity is enforced — the parity ratchet test, the vitest suites, the transport round-trip test, and the opt-in ReactDocViewsTest E2E scorecard that renders every doc example through the React portal.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+---
+
+# React Testing & Parity Scorecard
+
+Parity with the Blazor portal is enforced by tests at three altitudes: the **registry** (does the React pack cover the Blazor control vocabulary?), the **renderer** (do the components actually render and bind?), and the **portal end-to-end** (do real documentation pages render through the React SPA against a live mesh?).
+
+## 1. The parity ratchet — `render/parity.test.ts`
+
+`clients/react/src/render/parity.test.ts` pins the authoritative Blazor vocabulary: the `*Control` / `*Skin` types in `src/MeshWeaver.Layout` (the `$type` is the class name minus the suffix). When a new control is added to Layout, its `$type` is added to the list — and the test fails until the React pack covers it, keeping the port at 1:1:
+
+- **`BLAZOR_LEAF_CONTROLS`** — all 51 leaf `$type`s must exist in `controlRegistry`, must be functions (React components, not accidental values), and coverage must be exactly 51/51 — no silent shortfall.
+- **`BLAZOR_SKINS`** — the 18 container/item skins must exist in `skinRegistry` (containers like Stack/Tabs/Toolbar render via *skins*, not the control map).
+- **The placeholder ratchet** — the registered-but-placeholder long-tail (`placeholderControlTypes` in `controls/mesh.tsx`: `DocumentSource`, `ExportDocument`, `FileBrowser`, `NodeExport`, `NodeImport`) is pinned exactly:
+
+```ts
+it("the placeholder long-tail only ever shrinks", () => {
+  const pinned = ["DocumentSource", "ExportDocument", "FileBrowser", "NodeExport", "NodeImport"];
+  expect([...placeholderControlTypes].sort()).toEqual(pinned.sort());
+});
+```
+
+Implementing one for real = remove it from `placeholderControlTypes` **and** from the pinned list. Adding a *new* placeholder fails here — every new control must ship a real implementation. The list only ever shrinks.
+
+## 2. The vitest suites
+
+```bash
+cd clients/react && npm test        # renderer + controls
+cd clients/grpc-web && npm test     # transport + thread submission
+```
+
+In `clients/react/src`:
+
+| Suite | Covers |
+|---|---|
+| `area/pointer.test.ts`, `area/source.test.ts` | JSON pointer resolution, RFC 7396 merge-patch, the `StaticAreaSource` contract (optimistic updates) |
+| `render/core.test.tsx` | The renderer core in jsdom: `$type` dispatch, skin popping, binding resolution, event emission |
+| `render/parity.test.ts` | The ratchet above |
+| `render/gallery.test.tsx` | Rendering the control gallery |
+| `controls/dialog.test.tsx`, `controls/itemTemplate.test.tsx`, `controls/threadChat.test.tsx` | Per-control behavior — the chat suite covers thread watching, queued bubbles, composer gating, submission |
+| `theme/theme.test.tsx` | The Blazor-compatible localStorage contract, mode resolution, cross-instance sync |
+| `live/grpcSource.test.ts` | Folding the live wire: `Full` snapshots, RFC 6902 patch arrays, JSON-encoded instance keys, event posting |
+
+In `clients/grpc-web/src`: `envelope.test.ts` (delivery JSON build/parse), `connection.test.ts` (the Connect+Deliver split, ack, demux), `mesh.test.ts` (the ops surface), `threads.test.ts` (the `startThread` / `submitMessage` wire shapes and guards).
+
+The server side of the split has its own C# round-trip test: `MeshGrpcTransportTest.WebSplit_request_round_trips_via_connect_and_deliver` (`test/MeshWeaver.Hosting.Grpc.Test`) proves a request posted through the unary `Deliver` comes back down the server-streaming `Connect`.
+
+## 3. The E2E scorecard — `ReactDocViewsTest`
+
+`test/MeshWeaver.Portal.E2E.Test/ReactDocViewsTest.cs` is the **doc-views-through-React scorecard**: it drives Playwright at `{E2E_BASE_URL}/app/#/{docPath}` for every documentation page with embedded interactive examples — the same page list the Blazor-side `DocExamplesRenderTest` covers — and asserts each page reaches real rendered content through the React SPA over live gRPC-web.
+
+- **Opt-in**: the whole class skips unless `E2E_REACT=true`. The React renderer is *expected* to fail on some of these pages while parity catches up — the suite measures the gap rather than gating CI.
+- **Auth**: the SPA mints its short-lived API token off the fixture's DevLogin session cookie (`POST /api/tokens`) — the test context needs nothing beyond what the Blazor E2E tests use.
+- **Per page**, three assertions:
+  1. the live shell engages (`[data-mw-live-area]` attached — the SPA connected and routed the doc path);
+  2. **no failure placeholders**: `[data-mw-offline]` (fell back to bundled sample data — a wiring defect, not a parity gap) and `[data-mw-area-error]` (the live layout-area stream faulted) must be absent, re-checked *after* content settles so a late stream fault fails too;
+  3. **real content**: the page's kernel-executed output marker becomes visible (e.g. `"live from the kernel"` on `Doc/GUI`), or — for pages without a marker — the area renders something beyond the "Building layout…" progress frame.
+- Each page is screenshotted to `/tmp/react-doc-views/` — the visual scorecard.
+
+One Playwright detail worth knowing when writing similar tests: never wait for `NetworkIdle` against the SPA — it holds the gRPC-web `Connect` stream open for its whole life, so the network never goes idle.
+
+```bash
+E2E_REACT=true dotnet test test/MeshWeaver.Portal.E2E.Test \
+  --filter "FullyQualifiedName~ReactDocViewsTest" --no-restore
+```
+
+## Related
+
+- [React Frontend overview](/Doc/GUI/React) — the current parity state these tests enforce.
+- [Getting Started](../GettingStarted) — how the SPA under test is served and connected.
+- [Writing Tests](/Doc/Architecture/WritingTests) — the repo-wide testing standards.

--- a/src/MeshWeaver.Documentation/Data/GUI/React/Theming.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/React/Theming.md
@@ -1,0 +1,81 @@
+---
+Name: Theming the React Frontend
+Category: Documentation
+Description: Light/dark/system theming with the SAME localStorage contract as the Blazor portal — one persisted preference across both frontends, Fluent design tokens, useThemeMode and ThemeToggle.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>
+---
+
+# Theming the React Frontend
+
+The React frontend themes with **the same semantics and the same persistence contract** as the Blazor portal's `<FluentDesignTheme>` — so a user switching between the two frontends on one origin keeps a single preference. Everything lives in `clients/react/src/theme/`.
+
+## The shared contract with Blazor
+
+Four points of deliberate compatibility (`theme/themeMode.ts`):
+
+1. **Three modes** — `"system"` (default), `"light"`, `"dark"` — Blazor's `DesignThemeModes`.
+2. **Same storage key, same JSON shape.** The preference persists in localStorage under the key `"theme"` (the Blazor portal's `<FluentDesignTheme StorageName="theme">` in `SiteSettingsPanel.razor`), as the same JSON object the fluent-design-theme web component writes: `{ mode, primaryColor? }`. Writing the mode **preserves sibling fields** a Blazor portal may have stored under the same key:
+
+```ts
+export const DEFAULT_THEME_STORAGE_KEY = "theme";
+
+// Reads tolerate the Blazor JSON shape ({ mode, primaryColor }), a bare string
+// ("dark"), or nothing/garbage (→ "system", the Blazor default).
+export function readStoredThemeMode(storageKey?: string): ThemeMode;
+
+// Writes keep { ...existing, mode } — primaryColor and friends survive.
+export function writeStoredThemeMode(mode: ThemeMode, storageKey?: string): void;
+
+// Blazor's "Reset settings" equivalent — clears the key, back to system.
+export function clearStoredTheme(storageKey?: string): void;
+```
+
+3. **`system` follows the OS live** — `prefers-color-scheme` is observed, so an OS-level switch restyles a running app without a reload.
+4. **The resolved mode is mirrored onto the document** — `document.body.dataset.theme` (the same `body[data-theme]` attribute Blazor's theme script sets) plus `document.documentElement.style.colorScheme`, so scrollbars and native inputs restyle too.
+
+## Design-token propagation
+
+The Fluent design tokens (`--colorNeutralBackground1`, `--colorBrandBackground2`, …) are applied by `<FluentProvider>` from `webLightTheme` / `webDarkTheme` — the React v9 equivalent of Blazor's design-token stylesheet. Every control in the pack styles itself from tokens, so the whole tree restyles from the one switch; custom controls should do the same (`color: "var(--colorNeutralForeground3)"`, never hard-coded colors).
+
+```ts
+export function resolveThemeMode(mode: ThemeMode, prefersDark: boolean): ResolvedThemeMode;
+export function fluentThemeFor(resolved: ResolvedThemeMode): Theme;  // webDarkTheme | webLightTheme
+```
+
+## `useThemeMode` — the hook
+
+```tsx
+import { useThemeMode } from "@meshweaver/react";
+
+function Shell() {
+  const { mode, resolved, theme, setMode } = useThemeMode();
+  // mode:     the user's choice — "light" | "dark" | "system"
+  // resolved: what's actually on screen — "light" | "dark"
+  // theme:    the Fluent theme object for <FluentProvider>
+  return <FluentProvider theme={theme}>…</FluentProvider>;
+}
+```
+
+The hook keeps every instance in sync: instances in the same document coordinate through a custom `meshweaver:theme-change` event (a toggle in the header and an appearance panel never disagree), and other tabs follow via the browser's `storage` event.
+
+`MeshAreaView` calls `useThemeMode` internally — when you don't pin a `theme` prop, the view follows the persisted preference automatically. `themeStorageKey` overrides the storage key for apps that must not share the Blazor preference.
+
+## `ThemeToggle` — the switcher
+
+`theme/ThemeToggle.tsx` is the React counterpart of the theme selector in the Blazor portal's site settings panel: a menu button offering Light / Dark / System with the current mode checked, persisting through `useThemeMode`:
+
+```tsx
+import { ThemeToggle } from "@meshweaver/react";
+
+<header>
+  …
+  <ThemeToggle />   {/* optional: <ThemeToggle storageKey="my-app-theme" /> */}
+</header>
+```
+
+The `clients/portal` app shell places it in the header next to the user avatar — the same spot the Blazor portal exposes its theme control.
+
+## Related
+
+- [React Frontend overview](/Doc/GUI/React)
+- [Getting Started](../GettingStarted) — the `mw-frontend` cookie follows the same client-side-preference pattern as the theme.

--- a/src/MeshWeaver.Documentation/Data/GUI/React/ThreadChat.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/React/ThreadChat.md
@@ -1,0 +1,84 @@
+---
+Name: Thread Chat in React
+Category: Documentation
+Description: The React chat — watching the thread node and its message satellites, composer gating, and submission via startThread/submitMessage: the same node shapes as the .NET HubThreadExtensions surface, no parallel protocol.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+---
+
+# Thread Chat in React
+
+`ThreadChatView` (`clients/react/src/controls/threadChat.tsx`) is the React port of the Blazor portal's `ThreadChatView.razor` — the full chat experience over a **thread node's live stream**. There is no chat protocol of its own: the view watches and writes the exact node shapes the .NET `HubThreadExtensions` surface defines (see [Thread Operations](/Doc/Architecture/ThreadOperations)), so both frontends, the SDKs, and the agents all converge on the same thread node.
+
+## `MeshOps` — what the chat needs beyond the area contract
+
+Most controls only need the layout-area [`AreaSource`](../Rendering). Chat needs two more capabilities — watching arbitrary **node** streams and the canonical thread-submission operations — expressed as the `MeshOps` interface (`clients/react/src/live/meshOps.tsx`):
+
+```ts
+export interface MeshOps {
+  /** Subscribe to a node's live state — yields on every change (initial state, then updates). */
+  watch(path: string): AsyncIterable<MeshNodeState>;
+  /** ONE CreateNodeRequest carrying the seeded thread node — the client twin of hub.StartThread. */
+  startThread(namespacePath: string, userText: string, opts?: ThreadSubmitOptions):
+    Promise<{ path: string; userMessageId?: string }>;
+  /** JSON-merge patch queueing a message on an existing thread — the twin of hub.SubmitMessage. */
+  submitMessage(threadPath: string, userText: string, opts?: ThreadSubmitOptions): Promise<string | null>;
+  /** Field-level partial node update (RFC 7396) — control-plane flips like requestedStatus. */
+  patch(path: string, fields: Record<string, unknown>): void;
+  /** Optional mesh query — feeds the agent/model selectors (nodeType:Agent / nodeType:Model). */
+  search?(query: string, basePath?: string, limit?: number): Promise<Record<string, unknown>[]>;
+}
+```
+
+The renderer stays transport-free: `@meshweaver/client-web`'s `Mesh` satisfies `MeshOps` **structurally**, so the host app wires it in one line:
+
+```tsx
+import { Mesh } from "@meshweaver/client-web";
+import { MeshOpsProvider } from "@meshweaver/react";
+
+const mesh = Mesh.from(connection);          // or: await Mesh.connect(url, { token })
+// <MeshOpsProvider ops={mesh}> … <RenderArea/> … </MeshOpsProvider>
+// (MeshAreaView takes the same thing as its `ops` prop.)
+```
+
+Without a provider the chat renders a hint ("Thread chat needs a live mesh connection") instead of crashing.
+
+## Data flow — mirrors Blazor exactly
+
+1. **The thread node is the state.** The view watches `MeshOps.watch(threadPath)` and renders the node's `Thread` content: `messages` (ordered ids), `pendingUserMessages` (queued payloads keyed by id), `status` (`Idle | StartingExecution | Executing | Cancelled | Done`), `executionStatus`, `streamingText`, `streamingToolCalls`, and `composer` (the sticky agent/model selection).
+2. **Each message is a satellite cell** at `{threadPath}/{id}` — one watch per id, the twin of Blazor's message subscriptions. A cell's content is a `ThreadMessage` (`role` / `text` / `status` / `toolCalls` / …). Until the cell exists, the bubble renders from the pending payload in `pendingUserMessages`, shown as *queued* — so a just-sent message appears instantly.
+3. **While the thread executes**, an execution bar shows the live `executionStatus`, a `streamingText` preview, the running `streamingToolCalls`, and a **Stop** button.
+
+## Submission — the canonical surface, not a wire protocol
+
+Sends go through the client twin of `HubThreadExtensions` (implemented in `clients/grpc-web/src/mesh.ts` + `threads.ts`):
+
+- **No thread yet** → `startThread(namespacePath, text, opts)`: **one `CreateNodeRequest`**, targeted at the namespace hub, carrying the thread node at `{namespace}/_Thread/{speakingId}` pre-seeded with the first user message in `content.pendingUserMessages` and the composer selection. The per-thread submission watcher on the hub dispatches the first round as soon as the thread hub activates. Once created, the view pins the returned path — message 2+ never re-creates.
+- **Existing thread** → `submitMessage(threadPath, text, opts)`: an **RFC 7396 merge-patch** on the thread node appending the id to `content.userMessageIds` and the payload to `content.pendingUserMessages` — the client-side analog of `workspace.GetMeshNodeStream(threadPath).Update(...)`; the owning hub serialises the patch. Whitespace-only text resolves to `null` and nothing is enqueued.
+- **Stop** → `patch(threadPath, { content: { requestedStatus: "Cancelled" } })` — the standard control-plane flip the owning hub's watcher reacts to (see [Activity Control Plane](/Doc/Architecture/ActivityControlPlane)).
+
+Guards match the server's: a top-level/ownerless `_Thread/{id}` path is refused client-side (`isOwnerlessThreadPath`) — such a path has no per-node hub to route to. Identity is **never** claimed client-side; the server stamps the submitter from the bearer token.
+
+Submission failures are surfaced, not swallowed — the error renders above the composer and the typed text is restored, mirroring Blazor's `onError` (a silent reset is the "message vanished, no idea why" symptom).
+
+## Composer gating
+
+The composer is gated exactly like Blazor's:
+
+```ts
+const isExecuting = thread.status === "StartingExecution" || thread.status === "Executing";
+const canSend = !!ops && text.trim().length > 0 && !isExecuting && (!!threadPath || !!namespacePath);
+```
+
+— disabled while the text is whitespace-only or the thread is executing. Enter sends, Shift+Enter inserts a newline.
+
+The **agent / model dropdowns** populate from the mesh when the ops expose `search` (`nodeType:Agent` / `nodeType:Model`); the selection defaults to the thread's embedded `composer` (the single source of the round's selection), and an explicit pick folds back into the composer on submit — so the choice sticks for the next round, in either frontend.
+
+## Rendering it
+
+`ThreadChat` is a registered control `$type` like any other: a backend layout area that emits a `ThreadChatControl` renders as this view in React (and as `ThreadChatView.razor` in Blazor). The control's bound properties — `threadPath` (or a `threadViewModel` carrying it), `initialContext` (the namespace for new threads), `hideEmptyState`, `showFullHeader` — resolve through the standard `useResolve` binding hook.
+
+## Related
+
+- [Thread Operations](/Doc/Architecture/ThreadOperations) — the canonical .NET submission surface these ops mirror.
+- [Rendering Architecture](../Rendering) — `MeshOpsProvider` in the `MeshAreaView` composition.
+- [Testing & Parity](../Testing) — the chat's vitest suite.

--- a/src/MeshWeaver.Documentation/Data/GUI/ReactCustomControls.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/ReactCustomControls.md
@@ -1,0 +1,212 @@
+---
+Name: Custom React Controls
+Category: Documentation
+Description: Extend the React renderer (@meshweaver/react) with your own control — define a UiControl subclass server-side, register a React component for its $type, and load new controls at runtime via native ESM import().
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="2.2" fill="currentColor" stroke="none"/><ellipse cx="12" cy="12" rx="10" ry="4.2"/><ellipse cx="12" cy="12" rx="10" ry="4.2" transform="rotate(60 12 12)"/><ellipse cx="12" cy="12" rx="10" ry="4.2" transform="rotate(120 12 12)"/></svg>
+---
+
+# Custom React Controls
+
+The React renderer (`@meshweaver/react`) renders the **same `UiControl` tree** the Blazor portal renders: a layout area is delivered as one JSON object with an `areas` map (area key → control) and a `data` map (values that bindings point at), updated via RFC 7396 merge-patches. Every control carries a `$type` discriminator, and the renderer dispatches on it.
+
+Extending the renderer therefore has exactly two halves:
+
+1. **Server side** — a `UiControl` subclass registered with the hub, so your layout areas can emit it.
+2. **React side** — a component registered for that `$type` in the renderer's control registry.
+
+> **Note — the code on this page does not execute in the portal.** The live `--render` blocks used elsewhere in these docs run *C#* in the portal's kernel; React/TSX cannot execute there. The snippets below are plain fenced code, verified against the `@meshweaver/react` sources.
+
+## 1. Define the control server-side
+
+A custom control is a record deriving from `UiControl<TControl>`, exactly like the built-in ones. The two constructor arguments name the client module and its API version. This is the same pattern the shipped `GoogleMapControl` uses (`src/MeshWeaver.GoogleMaps`):
+
+```csharp
+using MeshWeaver.Layout;
+
+namespace Acme.Widgets;
+
+/// <summary>A tiny inline trend chart. Wire $type: "Sparkline".</summary>
+public record SparklineControl() : UiControl<SparklineControl>("Acme.Widgets", "1.0.0")
+{
+    /// <summary>The numeric series to plot.</summary>
+    public IReadOnlyCollection<double>? Data { get; init; }
+
+    /// <summary>Stroke color (CSS color string).</summary>
+    public string? Stroke { get; init; }
+}
+```
+
+Register the type on every hub that serializes it, and — **only if the Blazor portal should also render it** — pair it with a Blazor view:
+
+```csharp
+public static MessageHubConfiguration AddSparkline(this MessageHubConfiguration configuration) =>
+    configuration
+        .WithTypes(typeof(SparklineControl))   // $type discriminator registration
+        // Blazor-only: the React client needs no server-side view registration —
+        // it resolves the $type in its own registry (next section).
+        .AddViews(registry => registry.WithView<SparklineControl, SparklineView>());
+```
+
+Any layout area can now return it:
+
+```csharp
+public static UiControl Trend(LayoutAreaHost host, RenderingContext _) =>
+    Controls.Stack
+        .WithView(Controls.Title("Weekly volume", 2))
+        .WithView(new SparklineControl { Data = [3, 5, 4, 9, 7, 12], Stroke = "#1e88e5" });
+```
+
+On the wire the control appears with its `$type` discriminator — **the class name minus the `Control` suffix** (`SparklineControl` → `"Sparkline"`, the same rule that maps `LabelControl` → `"Label"` and `DataGridControl` → `"DataGrid"`):
+
+```json
+{
+  "areas": {
+    "Trend/2": {
+      "$type": "Sparkline",
+      "data": [3, 5, 4, 9, 7, 12],
+      "stroke": "#1e88e5",
+      "moduleName": "Acme.Widgets",
+      "apiVersion": "1.0.0",
+      "skins": []
+    }
+  }
+}
+```
+
+## 2. Register a React component for the `$type`
+
+The renderer's dispatch is data-driven: `ControlRenderer` looks the control's `$type` up in the active **leaf pack** — a plain record of maps supplied through `RegistryProvider`:
+
+```ts
+// from @meshweaver/react (render/registryContext.tsx)
+export type ControlComponent = (props: { control: UiControl }) => ReactNode;
+export type SkinComponent = (props: { skin: Skin; control: UiControl }) => ReactNode;
+
+export interface LeafPack {
+  controls: Record<string, ControlComponent>;  // $type → component (leaf controls)
+  skins: Record<string, SkinComponent>;        // skin $type → wrapper (Stack/Tabs/Card/…)
+  fallback: ControlComponent;                  // renders an unknown $type
+  defaultContainer: SkinComponent;             // container with no remaining skin
+}
+```
+
+The shipped Fluent UI pack exports its registry as a spreadable object — *"Spread your own entries to extend or override"* is the designed extension point:
+
+```tsx
+import {
+  MeshAreaView, RegistryProvider, RenderArea, ScopeProvider,
+  controlRegistry, fluentPack, useResolve,
+  type ControlComponent, type LeafPack, type UiControl,
+} from "@meshweaver/react";
+
+/** The React component for $type "Sparkline". */
+const SparklineView: ControlComponent = ({ control }: { control: UiControl }) => {
+  // useResolve handles both literal values and bound /data pointers —
+  // the same resolution every built-in control uses.
+  const data = (useResolve(control.data) as number[] | undefined) ?? [];
+  const stroke = (useResolve(control.stroke) as string | undefined) ?? "currentColor";
+  const max = Math.max(...data, 1);
+  const points = data.map((v, i) => `${(i / Math.max(data.length - 1, 1)) * 100},${30 - (v / max) * 30}`).join(" ");
+  return (
+    <svg viewBox="0 0 100 30" width={100} height={30}>
+      <polyline points={points} fill="none" stroke={stroke} strokeWidth={2} />
+    </svg>
+  );
+};
+
+/** The Fluent pack + our control: spread to extend (or override) $type entries. */
+const myPack: LeafPack = {
+  ...fluentPack,
+  controls: { ...controlRegistry, Sparkline: SparklineView },
+};
+```
+
+To render with a custom pack, compose the same three providers `MeshAreaView` composes — `RegistryProvider` (which pack), `ScopeProvider` (which `AreaSource` + root area), `RenderArea`:
+
+```tsx
+import { FluentProvider, webLightTheme } from "@fluentui/react-components";
+
+export function App({ source }: { source: AreaSource }) {
+  return (
+    <FluentProvider theme={webLightTheme}>
+      <RegistryProvider pack={myPack}>
+        <ScopeProvider source={source} area="Trend">
+          <RenderArea areaKey="Trend" />
+        </ScopeProvider>
+      </RegistryProvider>
+    </FluentProvider>
+  );
+}
+```
+
+(If the stock pack suffices, `<MeshAreaView source={source} rootArea="Trend" />` does all of the above with the built-in Fluent pack.)
+
+### Where the data comes from — `AreaSource`
+
+The renderer is transport-agnostic: it consumes an `AreaSource` — the `{areas, data}` tree plus an event sink:
+
+```ts
+// from @meshweaver/react (area/types.ts)
+export interface AreaSource {
+  getState(): AreaTree;                          // current {areas, data} snapshot
+  subscribe(listener: () => void): () => void;   // change notification
+  emit(event: MeshEvent): void;                  // clicks, edits, blur, closeDialog
+}
+```
+
+- `StaticAreaSource` — an in-memory tree; ideal for developing a control against fixture JSON before touching a live portal.
+- `GrpcAreaSource` — subscribes to a live layout area on a hub (`new GrpcAreaSource(connection, address, { area: "Trend" })`, then `source.start()`), folds every merge-patch into the tree, and posts `ClickedEvent`/pointer-update events back.
+
+Inside your component, the binding hooks (`useResolve`, `useAreaState`, `useEmit`, `useScope`) give you the same two-way data binding the built-in controls use — a bound property is a `/data` pointer, edits are emitted as `update` events (`useEmit()({ kind: "update", area, pointer, value })`) and echoed back through the stream.
+
+## 3. One React singleton — plugins receive the host's React
+
+`@meshweaver/react` declares `react` and `react-dom` as **peerDependencies**, not dependencies. A control plugin must do the same:
+
+```jsonc
+// your plugin's package.json
+{
+  "peerDependencies": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  }
+}
+```
+
+Never bundle React into a plugin. Two React copies in one page break the rules of hooks **and** context identity: the renderer hands your component the leaf pack and the area scope through React context (`RegistryProvider`, `ScopeProvider`) — a component rendered by a *different* React instance sees `null` context and throws (`"MeshWeaver control rendered without a leaf pack"`). The host application owns the single React; plugins compile against it and receive it at runtime.
+
+## 4. Runtime loading — native ESM `import(url)`
+
+Because a pack is plain data (`Record<string, ControlComponent>`), controls can be added **without rebuilding the host**: publish the plugin as an ES module and load it with the browser's native dynamic `import()`:
+
+```tsx
+// The plugin module's contract: default-export its $type → component entries.
+// (plugin: export default { Sparkline: SparklineView } satisfies Record<string, ControlComponent>)
+const module = await import(/* @vite-ignore */ pluginUrl);
+
+const pack: LeafPack = {
+  ...fluentPack,
+  controls: { ...controlRegistry, ...module.default },
+};
+```
+
+Two requirements for this to work:
+
+1. **React must stay external.** Build the plugin with `react`/`react-dom` (and `@meshweaver/react`, if imported) marked as externals, and serve them to the browser via an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) so the plugin's `import "react"` resolves to the host's singleton — this is rule 3 enforced at the module-graph level.
+2. **Re-render with the new pack.** A pack is ordinary React state — load the module, merge its entries, set state. Controls whose `$type` arrived from the server before the plugin loaded render through `fallback` until then; the swap re-renders them for real.
+
+## Recap
+
+| Step | Server (C#) | Client (React) |
+|---|---|---|
+| Define | `record SparklineControl : UiControl<SparklineControl>(...)` | `const SparklineView: ControlComponent = ...` |
+| Register | `.WithTypes(typeof(SparklineControl))` | `controls: { ...controlRegistry, Sparkline: SparklineView }` |
+| Render | return it from any layout area | `RegistryProvider` + `ScopeProvider` + `RenderArea` (or `MeshAreaView` for the stock pack) |
+| Ship | part of your hub module | ESM module, React as peer/external, loadable via `import(url)` |
+
+## Related
+
+- [Layout Areas](../LayoutAreas) — how the hub decides what to render where.
+- [Data Binding](../DataBinding) — the `/data` pointer contract the binding hooks implement.
+- [Container Controls](../ContainerControl) — containers render via *skins* (`LeafPack.skins`), not the control map.
+- [User Interface architecture](/Doc/Architecture/UserInterface) — the control-tree model shared by Blazor, MAUI, and React.

--- a/src/MeshWeaver.Messaging.Hub/Serialization/ObjectPolymorphicConverter.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/ObjectPolymorphicConverter.cs
@@ -13,11 +13,33 @@ public class ObjectPolymorphicConverter(ITypeRegistry typeRegistry, ILogger? log
 {
     // Warn at most once per unregistered $type (per hub/options instance) so the receiving-hub diagnostic
     // can never become a log storm. Instance field — dies with the hub's serializer options (no static state).
+    // Bounded: '$type' is payload-controlled, so the dedup set is capped (adversarial junk types stop being
+    // deduped past the cap — they log per occurrence, which is visible, not a memory-DoS) and very long
+    // names are truncated before caching/logging.
+    private const int MaxWarnedTypeNames = 1000;
+    private const int MaxTypeNameLogLength = 256;
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> warnedUnregisteredRead = new();
+    private int warnCapNoticed;
 
     private void WarnUnregisteredDeserialization(string typeName)
     {
-        if (logger is null || !warnedUnregisteredRead.TryAdd(typeName, 0))
+        if (logger is null)
+            return;
+        if (typeName.Length > MaxTypeNameLogLength)
+            typeName = typeName[..MaxTypeNameLogLength] + "… (truncated)";
+        if (warnedUnregisteredRead.Count >= MaxWarnedTypeNames)
+        {
+            // Cap reached: stop caching (bounded memory) AND stop logging (bounded log volume) —
+            // one notice marks the transition. Real systems have dozens of distinct types; only
+            // payload-controlled junk '$type' storms ever get here.
+            if (System.Threading.Interlocked.Exchange(ref warnCapNoticed, 1) == 0)
+                logger.LogWarning(
+                    "Unregistered-$type warning cap ({Max} distinct names) reached — further distinct "
+                    + "unregistered '$type' values will not be logged (payload-controlled junk?).",
+                    MaxWarnedTypeNames);
+            return;
+        }
+        if (!warnedUnregisteredRead.TryAdd(typeName, 0))
             return;
         logger.LogWarning(
             "Received '$type':'{TypeName}' which is NOT registered in this (receiving) hub — it can only be read "

--- a/test/Memex.Portal.Shared.Test/FrontendSelectionTest.cs
+++ b/test/Memex.Portal.Shared.Test/FrontendSelectionTest.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using MeshWeaver.Blazor.Portal;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Frontend selection (Portal:Frontend / Portal:ReactAppUrl + the mw-frontend override cookie):
+/// the deployment default picks the frontend, the per-user cookie overrides it, and only
+/// interactive HTML page navigations are ever redirected to the React app — framework/static/
+/// transport/auth paths and the toggle endpoint itself always pass through. Inert unless
+/// Portal:ReactAppUrl is configured, so existing deployments are unaffected.
+/// </summary>
+public class FrontendSelectionTest
+{
+    private static IConfiguration Config(params (string Key, string Value)[] settings)
+    {
+        var dict = new Dictionary<string, string?>();
+        foreach (var (key, value) in settings)
+            dict[key] = value;
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+    }
+
+    private static IConfiguration Enabled(params (string Key, string Value)[] settings)
+    {
+        var all = new List<(string, string)> { (FrontendSelection.ReactAppUrlKey, "/app/") };
+        all.AddRange(settings);
+        return Config(all.ToArray());
+    }
+
+    private static DefaultHttpContext HtmlGet(string path, string? cookie = null)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = path;
+        context.Request.Headers.Accept = "text/html,application/xhtml+xml";
+        if (cookie != null)
+            context.Request.Headers.Cookie = $"{FrontendSelection.CookieName}={cookie}";
+        return context;
+    }
+
+    [Fact]
+    public void EffectiveFrontend_DefaultsToBlazor()
+    {
+        FrontendSelection.EffectiveFrontend(HtmlGet("/"), Config())
+            .Should().Be(FrontendSelection.Blazor);
+    }
+
+    [Fact]
+    public void EffectiveFrontend_ReadsTheDeploymentDefault()
+    {
+        FrontendSelection.EffectiveFrontend(HtmlGet("/"), Config((FrontendSelection.FrontendKey, "React")))
+            .Should().Be(FrontendSelection.React);
+    }
+
+    [Fact]
+    public void CookieOverride_BeatsTheDeploymentDefault_BothDirections()
+    {
+        // Deployment says React, the user opted back to classic:
+        FrontendSelection.EffectiveFrontend(
+                HtmlGet("/", cookie: "Blazor"),
+                Config((FrontendSelection.FrontendKey, "React")))
+            .Should().Be(FrontendSelection.Blazor);
+
+        // Deployment default (Blazor), the user opted into the new frontend:
+        FrontendSelection.EffectiveFrontend(HtmlGet("/", cookie: "React"), Config())
+            .Should().Be(FrontendSelection.React);
+    }
+
+    [Fact]
+    public void WithoutReactAppUrl_TheFeatureIsInert()
+    {
+        FrontendSelection.IsEnabled(Config()).Should().BeFalse();
+        FrontendSelection.ShouldRedirectToReact(
+                HtmlGet("/", cookie: "React"),
+                Config((FrontendSelection.FrontendKey, "React")))
+            .Should().BeFalse(because: "no Portal:ReactAppUrl means no redirect, ever");
+    }
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/ACME/Overview")]
+    [InlineData("/User/Alice")]
+    public void InteractiveNavigations_RedirectWhenReactIsEffective(string path)
+    {
+        FrontendSelection.ShouldRedirectToReact(HtmlGet(path, cookie: "React"), Enabled())
+            .Should().BeTrue();
+        FrontendSelection.ShouldRedirectToReact(HtmlGet(path), Enabled((FrontendSelection.FrontendKey, "React")))
+            .Should().BeTrue(because: "the deployment default applies when there is no override");
+        FrontendSelection.ShouldRedirectToReact(HtmlGet(path), Enabled())
+            .Should().BeFalse(because: "Blazor is the default frontend");
+    }
+
+    [Theory]
+    [InlineData("/_blazor/negotiate")]
+    [InlineData("/_framework/blazor.web.js")]
+    [InlineData("/_content/MeshWeaver.Blazor/css/app.css")]
+    [InlineData("/mcp")]
+    [InlineData("/api/mesh/upload")]
+    [InlineData("/signalr")]
+    [InlineData("/healthz")]
+    [InlineData("/signin-oidc")]
+    [InlineData("/frontend/react")]
+    public void ExcludedPrefixes_NeverRedirect(string path)
+    {
+        FrontendSelection.ShouldRedirectToReact(HtmlGet(path, cookie: "React"), Enabled())
+            .Should().BeFalse(because: $"'{path}' is not an interactive page navigation");
+    }
+
+    [Fact]
+    public void AssetsNonGetAndNonHtml_NeverRedirect()
+    {
+        FrontendSelection.ShouldRedirectToReact(HtmlGet("/site.css", cookie: "React"), Enabled())
+            .Should().BeFalse(because: "paths with an extension are assets");
+
+        var post = HtmlGet("/", cookie: "React");
+        post.Request.Method = "POST";
+        FrontendSelection.ShouldRedirectToReact(post, Enabled())
+            .Should().BeFalse(because: "only GET navigations are redirected");
+
+        var fetch = HtmlGet("/", cookie: "React");
+        fetch.Request.Headers.Accept = "application/json";
+        FrontendSelection.ShouldRedirectToReact(fetch, Enabled())
+            .Should().BeFalse(because: "XHR/fetch requests are not page navigations");
+    }
+
+    [Fact]
+    public void RequestsAlreadyInsideTheReactApp_NeverRedirect()
+    {
+        FrontendSelection.ShouldRedirectToReact(HtmlGet("/app/threads", cookie: "React"), Enabled())
+            .Should().BeFalse(because: "the React app itself must not bounce (redirect loop)");
+    }
+}

--- a/test/MeshWeaver.Portal.E2E.Test/ReactDocViewsTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/ReactDocViewsTest.cs
@@ -1,0 +1,163 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// React-frontend parity scorecard: renders every documentation page with embedded interactive
+/// examples through the REACT portal (the SPA served under <c>/app/</c>) and asserts each page
+/// reaches real rendered content — no offline fallback, no live-stream error, and (where the page
+/// has one) the kernel-executed output marker visible.
+///
+/// <para><b>Routing shape</b>: the React portal uses hash-based routing over mesh paths —
+/// <c>{E2E_BASE_URL}/app/#/{meshPath}</c> renders that node's DEFAULT layout area live over
+/// gRPC-web (the same area the Blazor portal renders at <c>/{meshPath}</c>). No hash renders the
+/// signed-in user's home. See <c>clients/portal/src/Portal.tsx</c> / <c>live.ts</c>.</para>
+///
+/// <para><b>Auth</b>: the SPA mints a short-lived API token off the browser session cookie
+/// (<c>POST /api/tokens</c>) and joins the mesh over same-origin gRPC-web — so the test context
+/// only needs the fixture's DevLogin cookie, exactly like the Blazor tests.</para>
+///
+/// <para><b>Opt-in gate</b>: the whole class skips unless <c>E2E_REACT=true</c>. The React
+/// renderer is EXPECTED to fail on many of these pages while parity catches up (embedded
+/// layout-area examples, kernel-rendered controls, …) — this suite is the scorecard that measures
+/// the gap, mirroring the Blazor-side <c>DocExamplesRenderTest</c> page-by-page.</para>
+///
+/// <para>Assertion strategy (per page):
+/// <list type="number">
+///   <item>Wait for the live area shell (<c>[data-mw-live-area]</c>) — proves the SPA connected
+///     (did not fall back to the offline sample) and routed the doc path.</item>
+///   <item>Assert the ABSENCE of the failure placeholders: <c>[data-mw-offline]</c> (connection
+///     fell back to bundled sample data) and <c>[data-mw-area-error]</c> (the live layout-area
+///     stream faulted).</item>
+///   <item>Wait for REAL content: the page's rendered-output text marker (kernel-executed output,
+///     DOM-agnostic — the same markers <c>DocExamplesRenderTest</c> uses) when the page has one;
+///     otherwise any non-trivial rendered DOM beyond the "Building layout…" progress frame.</item>
+/// </list></para>
+/// </summary>
+[Collection("portal-e2e")]
+public class ReactDocViewsTest(PortalFixture fixture)
+{
+    private static bool ReactEnabled =>
+        string.Equals(Environment.GetEnvironmentVariable("E2E_REACT"), "true", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Every doc page with embedded interactive examples — the same page list as the Blazor-side
+    /// <c>DocExamplesRenderTest.ExamplePages</c> (enumerated from
+    /// <c>grep -rl -- "--render" src/MeshWeaver.Documentation/Data</c>). Columns: doc path ·
+    /// rendered-output text marker (nullable; substring, matched inside the live area only — the
+    /// Blazor CSS selectors are dropped here because the React renderer emits different DOM).
+    /// </summary>
+    public static TheoryData<string, string?> ExamplePages => new()
+    {
+        // ---- GUI ----
+        { "Doc/GUI", "live from the kernel" },
+        { "Doc/GUI/LayoutAreas", "live render" },
+        { "Doc/GUI/LayoutGrid", "12 cols (100%)" },
+        { "Doc/GUI/DataGrid", "Widget" },
+        { "Doc/GUI/ContainerControl", "Welcome to the app" },
+        { "Doc/GUI/ContainerControl/Stack", "Stack layout demo" },
+        { "Doc/GUI/ContainerControl/Tabs", "General settings here" },
+        { "Doc/GUI/ContainerControl/Toolbar", null },
+        { "Doc/GUI/ContainerControl/Splitter", "Left Panel" },
+        { "Doc/GUI/Observables", "This text never changes" },
+        { "Doc/GUI/Editor", "Date/time picker" },
+        { "Doc/GUI/DataBinding", "NumberFieldControl" },
+        { "Doc/GUI/DataBinding/ItemTemplate", "Alice" },
+        { "Doc/GUI/Attributes", "Attribute Quick Reference" },
+        { "Doc/GUI/NodeMenu", "Permission" },
+        { "Doc/GUI/ReactiveDialogs", "Distribution Statistics" },
+        { "Doc/GUI/SidePanel", "Side Panel Header Controls" },
+        // ---- Architecture ----
+        { "Doc/Architecture/UserInterface", "Controls Language" },
+        { "Doc/Architecture/UserInterface/AvailableControls", "live in the kernel" },
+        { "Doc/Architecture/ScriptExecution", "Rebound per submission" },
+        { "Doc/Architecture/ScriptExecutionDemo", "🎆" },
+        { "Doc/Architecture/VectorSearch", "TextSearch" },
+        { "Doc/Architecture/BusinessRules", "C001" },
+        // ---- AI ----
+        { "Doc/AI/ExecuteScript", "Typical agent flow" },
+        // ---- DataMesh ----
+        { "Doc/DataMesh/InteractiveMarkdown", "Hello World" },
+        { "Doc/DataMesh/QuerySyntax", "nodeType:Organization" },
+        { "Doc/DataMesh/DataConfiguration", "Data Configuration Quick Reference" },
+        { "Doc/DataMesh/DataModeling", "Common Data Modeling Attributes" },
+        { "Doc/DataMesh/DataCubes", "Funding Ratio" },
+        { "Doc/DataMesh/NodeTypes", "This cell rendered at" },
+        { "Doc/DataMesh/NodeTypeConfiguration", "NodeType summary card" },
+        { "Doc/DataMesh/CreatingNodeTypes", "Primary key field" },
+        { "Doc/DataMesh/NodeOperations", "Node Operations at a Glance" },
+        { "Doc/DataMesh/CRUD", "Single entity by ID" },
+        { "Doc/DataMesh/VirtualDataSources", "Mesh query mirror" },
+        { "Doc/DataMesh/NugetPackages", "hello world framework" },
+        { "Doc/DataMesh/NodeTypeWithNuGet", "Determinant" },
+        { "Doc/DataMesh/UnifiedPath/ContentPrefix", "Collection Prefix" },
+        { "Doc/DataMesh/UnifiedPath/AreaPrefix", "Thumbnail area" },
+        { "Doc/DataMesh/UnifiedPath/DataPrefix", "All Products" },
+    };
+
+    [Theory(Timeout = 240_000)]
+    [MemberData(nameof(ExamplePages))]
+    public async Task ReactPortal_DocPage_RendersRealContent(string docPath, string? renderedTextMarker)
+    {
+        Assert.SkipUnless(ReactEnabled,
+            "React parity scorecard is opt-in — set E2E_REACT=true to run it against a portal serving the React SPA under /app/.");
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+
+        await using var context = await fixture.NewAuthenticatedContextAsync();
+        var page = await context.NewPageAsync();
+        await page.SetViewportSizeAsync(1400, 1000);
+
+        // NOTE: never WaitUntil=NetworkIdle here — the SPA holds the gRPC-web Connect stream open
+        // for its whole life, so the network never goes idle.
+        await page.GotoAsync($"{fixture.BaseUrl}/app/#/{docPath}",
+            new PageGotoOptions { WaitUntil = WaitUntilState.Load, Timeout = 60_000 });
+
+        // 1. The live shell must engage: the SPA minted a token and joined the mesh over gRPC-web.
+        var liveArea = page.Locator("[data-mw-live-area]");
+        await liveArea.WaitForAsync(
+            new LocatorWaitForOptions { State = WaitForSelectorState.Attached, Timeout = 30_000 });
+
+        // 2. No failure placeholders: offline fallback = the connection/auth path is broken (a
+        //    wiring defect, not a parity gap); area error = the live layout-area stream faulted.
+        (await page.Locator("[data-mw-offline]").CountAsync()).Should().Be(0,
+            $"the React portal must reach the live mesh for {docPath}, not fall back to offline sample mode");
+        (await page.Locator("[data-mw-area-error]").CountAsync()).Should().Be(0,
+            $"the live layout-area stream for {docPath} must not fault");
+
+        // 3. REAL rendered content inside the live area. The generous timeout covers the kernel's
+        //    first-cell Roslyn warm-up on pages whose marker is kernel-executed output.
+        if (renderedTextMarker is not null)
+        {
+            await liveArea.GetByText(renderedTextMarker).First.WaitForAsync(
+                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 120_000 });
+        }
+        else
+        {
+            // No page-specific marker — wait until the area rendered something beyond the
+            // "Building layout…" progress frame.
+            await page.WaitForFunctionAsync(
+                """
+                () => {
+                  const el = document.querySelector('[data-mw-live-area]');
+                  if (!el) return false;
+                  const text = (el.innerText || '').trim();
+                  return text.length > 0 && !text.includes('Building layout');
+                }
+                """,
+                null,
+                new PageWaitForFunctionOptions { Timeout = 120_000 });
+        }
+
+        Directory.CreateDirectory("/tmp/react-doc-views");
+        await page.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Path = $"/tmp/react-doc-views/{docPath.Replace('/', '-')}.png",
+            FullPage = true
+        });
+
+        // Re-check the error placeholders AFTER content settled (a late stream fault must fail too).
+        (await page.Locator("[data-mw-area-error]").CountAsync()).Should().Be(0,
+            $"the live layout-area stream for {docPath} must stay healthy after rendering");
+    }
+}

--- a/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
@@ -32,8 +32,6 @@ public class SidePanelChatTenMessagesTest(PortalFixture fixture)
         }
         """;
 
-    // The user bubble must appear far below the old 30s stall.
-    private static readonly int PromptBubbleMs = 15_000;
     // A real round with the small model; generous but bounded so a genuine wedge fails rather than hangs.
     private static readonly int RoundMs = 120_000;
 

--- a/test/MeshWeaver.Serialization.Test/CollectionsOfObjectTest.cs
+++ b/test/MeshWeaver.Serialization.Test/CollectionsOfObjectTest.cs
@@ -40,7 +40,7 @@ public class CollectionsOfObjectTest : TestBase
 
         // assert
         var actual = serialized.Should().NotBeNull().And.BeValidJson().Which;
-        actual.Should().HaveElement("$type").Which.Should().HaveValue(typeof(ContainerRecord).FullName);
+        actual.Should().HaveElement("$type").Which.Should().HaveValue(typeof(ContainerRecord).Name);
         var actualData = actual.Should().HaveElement("data").Which;
         actualData.Should().HaveElement("1").Which.Should().HaveValue("One");
         actualData.Should().HaveElement("3").Which.Should().HaveValue("Three");

--- a/test/MeshWeaver.Serialization.Test/RawJsonTest.cs
+++ b/test/MeshWeaver.Serialization.Test/RawJsonTest.cs
@@ -49,7 +49,7 @@ public class RawJsonTest(ITestOutputHelper output) : HubTestBase(output)
         // assert
         var actual = serialized.Should().NotBeNull().And.BeValidJson().Which;
         var actualMessage = actual.Should().HaveElement("message").Which;
-        actualMessage.Should().HaveElement("$type").Which.Should().HaveValue(typeof(SubscribeRequest).FullName);
+        actualMessage.Should().HaveElement("$type").Which.Should().HaveValue(typeof(SubscribeRequest).Name);
 
         // act
         var deserialized = JsonSerializer.Deserialize<MessageDelivery<RawJson>>(serialized, Mesh.JsonSerializerOptions);
@@ -65,7 +65,7 @@ public class RawJsonTest(ITestOutputHelper output) : HubTestBase(output)
                 .Content.Should().NotBeNullOrWhiteSpace()
                 .And.Subject;
         var jContent = rawJsonContent.Should().BeValidJson().Which;
-        jContent.Should().HaveElement("$type").Which.Should().HaveValue(typeof(SubscribeRequest).FullName);
+        jContent.Should().HaveElement("$type").Which.Should().HaveValue(typeof(SubscribeRequest).Name);
     }
 
     /// <summary>
@@ -139,7 +139,7 @@ public class RawJsonTest(ITestOutputHelper output) : HubTestBase(output)
         // assert
         var actual = serialized.Should().NotBeNull().And.BeValidJson().Which;
         var actualMessage = actual.Should().HaveElement("message").Which;
-        actualMessage.Should().HaveElement("$type").Which.Should().HaveValue(typeof(DataChangedEvent).FullName);
+        actualMessage.Should().HaveElement("$type").Which.Should().HaveValue(typeof(DataChangedEvent).Name);
 
         // act
         var deserialized = JsonSerializer.Deserialize<IMessageDelivery>(serialized, client.JsonSerializerOptions);
@@ -155,7 +155,7 @@ public class RawJsonTest(ITestOutputHelper output) : HubTestBase(output)
                 .Content.Should().NotBeNullOrWhiteSpace()
                 .And.Subject;
         var jContent = rawJsonContent.Should().BeValidJson().Which;
-        jContent.Should().HaveElement("$type").Which.Should().HaveValue(typeof(DataChangedEvent).FullName);
+        jContent.Should().HaveElement("$type").Which.Should().HaveValue(typeof(DataChangedEvent).Name);
         jContent.Should().HaveElement("version").Which.Should().HaveValue("10");
     }
 }

--- a/test/MeshWeaver.Serialization.Test/SerializationTest.cs
+++ b/test/MeshWeaver.Serialization.Test/SerializationTest.cs
@@ -47,6 +47,9 @@ public class SerializationTest(ITestOutputHelper output) : HubTestBase(output)
     protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
     {
         return base.ConfigureClient(configuration)
+            // Plumbing fixture with no user → posts as infrastructure (System), per the
+            // never-null AccessContext invariant (test-thread posts carry no circuit user).
+            .WithPostingIdentity(PostingIdentity.System)
             .WithTypes(typeof(BoomerangResponse), typeof(MyEvent), typeof(GetDataRequest), typeof(GetDataResponse))
             .WithRoutes(f =>
             f.RouteAddress(HostType,


### PR DESCRIPTION
## The wedge + chat-vanish fix stack

Root causes pinned via a live heap dump of a wedged e2e portal (7,162 leaked sync-stream hubs; the DEAD circuit's portal hub still draining stream traffic at ~1.2 cores 20 minutes after "Circuit closed"; RunLevel=Started).

### fix(messaging): tear down zombie hubs
- **Dispose the per-circuit portal hub on circuit close** (`CircuitAccessHandler.OnCircuitClosedAsync`). Nobody ever did — `PortalApplication.Dispose` deliberately no-ops — so every closed circuit (tab close, refresh, transport drop, E2E context) leaked a zombie hub whose hosted sync-stream children kept heartbeating + fanning out `DataChangedEvent`s forever. The accumulation saturated the single-threaded routing drain, starving live circuits' SignalR keepalive (the chat-vanish), and self-amplified after death.
- **The 8s disposal watchdog now runs REAL teardown** (`ForceTeardownAfterWatchdog`: hostedHubs → callbacks → dispose actions → messageService, `RunLevel=Dead` before signalling) instead of only signalling completion — signalling-without-teardown leaked every child when the phased `ShutdownRequest` starved on a flooded action block.
- Heartbeat keep-alive log Information→Debug (one line per HeartBeatEvent per sync stream every 45s ≈ 11% pod CPU + Loki ingest at accumulation scale).
- Deterministic repro: `Dispose_WhenActionBlockWedged_WatchdogTearsDownChildrenAndDisposables` — floods the action block below the storm-breaker threshold so the phased shutdown starves, then asserts the watchdog performed real teardown.

### fix(chat): side-panel vanish
- Render thread paths **directly** in the side panel — round-tripping a freshly-created thread through the eventually-consistent PathResolver hit the 10s timeout whose onError `SetContentPath(null)`'d the live chat.
- The hide rule compares **thread-slug identity**, not full paths — a background nav emission naming the panel's own thread under a different representation collapsed the active panel. Hide now logs.
- Register `PrefixReference`/`AutocompleteReference` (unregistered → untyped JsonElement → empty composer box), Create-New routes to `/{owner}/Chat` instead of raw-creating a Thread node, `{user}/Chat` self-heals, `ChatErrorBoundary` surfaces render errors.

### chore(local)
- Persist DataProtection keys on local k3s (gated `persistDataVolume`, prod default unchanged) — no more every-restart logout churn.
- Scrub atioz (client project) from the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)