### PR TITLE
fix(build): unred main — use PromptBubbleMs in the bubble-count poll (CS0414 under -warnaserror)

### DIFF
--- a/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
@@ -123,7 +123,7 @@ public class SidePanelChatTenMessagesTest(PortalFixture fixture)
 
             // (a) The user's bubble landed — poll the COUNT (>= i+1), robust to bubbles re-keying on the
             //     thread rebind (a specific .Nth(i) wait is brittle across re-renders).
-            (await PollAsync(async () => await userBubbles.CountAsync() >= i + 1, TimeSpan.FromSeconds(15)))
+            (await PollAsync(async () => await userBubbles.CountAsync() >= i + 1, TimeSpan.FromMilliseconds(PromptBubbleMs)))
                 .Should().BeTrue($"the user bubble for message {i + 1} must appear (saw {await userBubbles.CountAsync()})");
 
             // No submit error surfaced.


### PR DESCRIPTION
Main has been red since the #149 merge: the merge union left `SidePanelChatTenMessagesTest.PromptBubbleMs` declared but unused (the 15 s was hardcoded at the poll site), and `-warnaserror` promotes CS0414 to an error on every main run. (#162's merge resolved the sibling duplicate-method error; this is the last one.)

Fix: use the named constant at the poll site it documents.

Red main blocks the pull-based self-update — merging as soon as CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)