### PR TITLE
fix: unblock red main — CS0414 build break + Serialization.Test (AccessContext + registry $type)

### DIFF
--- a/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
@@ -123,7 +123,7 @@ public class SidePanelChatTenMessagesTest(PortalFixture fixture)
 
             // (a) The user's bubble landed — poll the COUNT (>= i+1), robust to bubbles re-keying on the
             //     thread rebind (a specific .Nth(i) wait is brittle across re-renders).
-            (await PollAsync(async () => await userBubbles.CountAsync() >= i + 1, TimeSpan.FromSeconds(15)))
+            (await PollAsync(async () => await userBubbles.CountAsync() >= i + 1, PromptBubbleDuration))
                 .Should().BeTrue($"the user bubble for message {i + 1} must appear (saw {await userBubbles.CountAsync()})");
 
             // No submit error surfaced.
@@ -158,6 +158,9 @@ public class SidePanelChatTenMessagesTest(PortalFixture fixture)
 
     // A real LLM round can take a while; poll the assistant-bubble count up to this bound.
     private static readonly TimeSpan RoundDuration = TimeSpan.FromMilliseconds(RoundMs);
+
+    // The user's own bubble should land quickly (well under the old 30s stall) — poll it up to this bound.
+    private static readonly TimeSpan PromptBubbleDuration = TimeSpan.FromMilliseconds(PromptBubbleMs);
 
     private static async Task<bool> PollAsync(Func<Task<bool>> predicate, TimeSpan timeout)
     {


### PR DESCRIPTION
## Unblock red `main`

`main` (post-#162) was failing the `MeshWeaver Build and Test` run for two independent reasons. This PR fixes both.

### 1. `CS0414` build break (E2E test)
`SidePanelChatTenMessagesTest.PromptBubbleMs` was assigned but never referenced → error under `-warnaserror`. The field was meant to bound the "user bubble landed" poll (its comment: *"must appear far below the old 30s stall"*), but the poll hardcoded `TimeSpan.FromSeconds(15)`. **Wired the field into the poll** (mirroring `RoundMs → RoundDuration`), preserving the intended named bound. `15_000 ms == FromSeconds(15)`, no behaviour change.

### 2. `Serialization.Test` failures (unmasked once the build passed — from #162's serialization work)
- **AccessContext**: `BoomerangTest`, `TestSerializationFailureHandling` post application messages without an identity, which #162's fail-closed AccessContext guard correctly rejects. Stamp the sender hub's identity via `PostOptions.ImpersonateAsHub()` (the sanctioned identity for infrastructure/serialization posts).
- **`$type` discriminator**: `RawJsonTest.WayBack`/`WayForward` and `CollectionsOfObjectTest` asserted the CLR **FullName**, but `ObjectPolymorphicConverter` now writes the **type-registry short name** (`GetOrAddType`). This is the intended contract — see `TypeRegistryTest.FullNameAlias_ResolvesBothDiscriminators_ButWritesShortName` and `SchemaValidationTest`; a read-time full-name **alias** keeps old payloads deserializable across a rolling deploy. Assertions updated to `typeof(X).Name`.

Full `Serialization.Test` project passes locally (11/11); both touched test projects build clean under `-c Release -p:CIRun=true -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
