### PR TITLE
fix(graph): eliminate the compile-flake population (single compile driver + complete terminal write + search ordering)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -528,7 +528,7 @@ internal static class NodeTypeCompilationHelpers
     /// so <see cref="InstallSourcesWatcher"/> can share the same condition —
     /// keeps the "what counts as static?" question in one place.</para>
     /// </summary>
-    private static bool IsStaticOnlyNodeType(MeshNode node, NodeTypeDefinition def) =>
+    internal static bool IsStaticOnlyNodeType(MeshNode node, NodeTypeDefinition def) =>
         node.HubConfiguration is not null
         && string.IsNullOrWhiteSpace(def.Configuration)
         && string.IsNullOrWhiteSpace(def.HubConfiguration)
@@ -1074,12 +1074,27 @@ internal static class NodeTypeCompilationHelpers
                     // node, so no reader can subscribe to a phantom `compile-*` path.
                     var resolvedActivityPath = outcome.ActivityPath;
 
-                    string? newReleasePath = null;
-                    if (ok)
+                    // 🚨 Release create is OBSERVED + BOUNDED (same guard as the activity
+                    // create): TryCreateReleaseNode emits the path only after the create
+                    // LANDED, or null on timeout/fault. The terminal write below runs in
+                    // its OnNext, so LatestReleasePath is never stamped with a path that
+                    // does not exist yet — a reader following the field right after the
+                    // Ok write used to hit a hard path-resolution NotFound (the
+                    // NodeTypeReleaseGateTest 2-core flake).
+                    var releasePathObservable = ok
+                        ? MeshDataSourceExtensions.TryCreateReleaseNode(
+                            hub, hubPath, outcome.Result!, outcome.PendingNode, resolvedActivityPath, logger)
+                        : Observable.Return<string?>(null);
+
+                    releasePathObservable
+                        .Take(1)
+                        .Subscribe(newReleasePath =>
                     {
-                        newReleasePath = MeshDataSourceExtensions.TryCreateReleaseNode(
-                            hub, hubPath, outcome.Result!, outcome.PendingNode, resolvedActivityPath, logger);
-                    }
+                    // Terminal writes run under System — same rule as every other
+                    // deferred pipeline in RunCompile (the ambient scope from the
+                    // compile subscription does not flow into this create-response
+                    // callback thread).
+                    using var terminalScope = accessService?.ImpersonateAsSystem();
 
                     // Write the FULL compile log + terminal status to the activity
                     // node (the official progress surface) in ONE atomic update:
@@ -1211,6 +1226,9 @@ internal static class NodeTypeCompilationHelpers
                         },
                         ex => logger?.LogWarning(ex,
                             "Compile: failed to write post-compile status for {HubPath}", hubPath));
+                    },
+                    ex => logger?.LogWarning(ex,
+                        "Compile: release-create observation faulted for {HubPath}", hubPath));
                 },
                 ex => logger?.LogWarning(ex, "Compile faulted for {HubPath}", hubPath));
 

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompileActivityHandler.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompileActivityHandler.cs
@@ -344,15 +344,32 @@ internal static class NodeTypeCompileActivityHandler
                             $"Roslyn failed: {errMsg}", Microsoft.Extensions.Logging.LogLevel.Error));
                     }
 
-                    // Release MeshNode created BEFORE the parent's Ok write so the
-                    // parent's LatestReleasePath points at an existing node.
-                    // Release.CompilationActivityPath links back to this activity so
-                    // the UI can follow Release → Activity to see the full build detail.
-                    string? newReleasePath = null;
+                    // Release MeshNode created — and CONFIRMED — BEFORE the parent's Ok
+                    // write so the parent's LatestReleasePath points at an EXISTING node.
+                    // TryCreateReleaseNode is observed + bounded: it emits the path only
+                    // after the create landed (null on dispatch-failure/timeout), so a
+                    // reader following LatestReleasePath right after the terminal write
+                    // can never hit a phantom-path NotFound (the NodeTypeReleaseGateTest
+                    // 2-core flake). Release.CompilationActivityPath links back to this
+                    // activity so the UI can follow Release → Activity for build detail.
+                    var releasePathObservable = ok
+                        ? MeshDataSourceExtensions.TryCreateReleaseNode(
+                            activityHub, parentPath, outcome.Result!, outcome.PendingNode, activityPath, logger)
+                        : System.Reactive.Linq.Observable.Return<string?>(null);
+
+                    releasePathObservable
+                        .Take(1)
+                        .Subscribe(newReleasePath =>
+                    {
+                    // Terminal writes run under System: the create-response emission can
+                    // carry the release-REQUESTER's context (TryCreateReleaseNode stamps
+                    // the user on the Release node), but the parent status write is
+                    // infrastructure — a requester without Update on the parent partition
+                    // must not fail the terminal write closed.
+                    using var terminalScope = activityHub.ServiceProvider
+                        .GetService<AccessService>()?.ImpersonateAsSystem();
                     if (ok)
                     {
-                        newReleasePath = MeshDataSourceExtensions.TryCreateReleaseNode(
-                            activityHub, parentPath, outcome.Result!, outcome.PendingNode, activityPath, logger);
                         if (newReleasePath is not null)
                         {
                             activityMessages.Add(new LogMessage(
@@ -360,12 +377,12 @@ internal static class NodeTypeCompileActivityHandler
                                 Microsoft.Extensions.Logging.LogLevel.Information));
                             logger?.LogInformation(
                                 "[NTCA] Release {ReleasePath} linked to activity {ActivityPath} + assembly {AssemblyLocation}",
-                                newReleasePath, activityPath, outcome.Result.AssemblyLocation);
+                                newReleasePath, activityPath, outcome.Result!.AssemblyLocation);
                         }
                         else
                         {
                             activityMessages.Add(new LogMessage(
-                                "Release node NOT created (no IMeshService available) — assembly still usable directly",
+                                "Release node NOT created (create did not land / no IMeshService) — assembly still usable directly",
                                 Microsoft.Extensions.Logging.LogLevel.Warning));
                         }
                     }
@@ -436,6 +453,9 @@ internal static class NodeTypeCompileActivityHandler
                        // → activation falls back to default config and IWorkspace fails
                        // to activate (no AddData). Found via CodeEditRecompileTest.
                        compiledVersion: ok ? outcome.Result?.Version : null);
+                    },
+                    ex => logger?.LogWarning(ex,
+                        "[NTCA] release-create observation faulted for {ParentPath}", parentPath));
                 },
                 ex => logger?.LogWarning(ex, "[NTCA] compile chain faulted for {ParentPath}", parentPath));
 

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
@@ -43,18 +43,37 @@ internal static class NodeTypeContractHandler
             return request.Processed();
         }
 
-        // Reactive chain: read own MeshNode → compile if needed → post response.
+        // Reactive chain: ensure a compile is DISPATCHED (never run inline) → wait
+        // for it to settle → hydrate → post response.
         // No await, no Task in the hub flow (Doc/Architecture/AsynchronousCalls.md).
         //
-        // AwaitCompilationSettled holds the read until any in-progress compile
+        // 🚨 SINGLE COMPILE DRIVER. This handler must NEVER run Roslyn concurrently
+        // with the watcher-dispatched activity compile (InstallCompileWatcher →
+        // HandleDispatchCompile → RunCompile). On a FRESH NodeType (CompilationStatus
+        // still null) the old chain treated `null` as settled, raced past
+        // AwaitCompilationSettled, and ran CompileAndGetConfigurations INLINE while
+        // the first-build kickoff flipped Pending and dispatched the SAME compile
+        // through the watcher — two concurrent compiles on one NodeType. The loser
+        // then read the winner's DLL mid-emit ("Failed to load assembly … the build
+        // is not usable"), deleted it, and wrote a terminal state the other write-back
+        // half-overwrote — the compile-heavy 2-core CI flake
+        // (MeshNodeCompilationIntegrationTest / OrleansDynamicCompilationTest /
+        // FrameworkStaleInstanceRenderTest settling at Ok+assembly but
+        // CompiledFrameworkVersion empty ⇒ HasUsableBuild=false ⇒ wedge). Exactly the
+        // race HandleCreateRelease already fixed by delegating to the watcher
+        // (DispatchPendingFlip); this applies the same rule here: the STATUS FIELD is
+        // the single-flight lock, the watcher is the only Roslyn driver for a
+        // triggered compile.
+        //
+        // AwaitCompilationSettled then holds the read until the dispatched compile
         // finishes: a naive Take(1) would hand the requester the previous
         // release's AssemblyLocation while V2 is mid-compile, and every fresh
         // instance hub activated in that gap would render the stale layout.
-        // Same primitive used by HandleCreateRelease so request handling is
-        // serialised across the compile critical section.
-        hub.GetWorkspace().GetMeshNodeStream()
-            .AwaitCompilationSettled()
-            .Take(1)
+        var workspace = hub.GetWorkspace();
+        EnsureCompileDispatched(hub, workspace)
+            .SelectMany(_ => workspace.GetMeshNodeStream()
+                .AwaitCompilationSettled()
+                .Take(1))
             .Timeout(TimeSpan.FromSeconds(60))
             .SelectMany(node =>
             {
@@ -63,10 +82,10 @@ internal static class NodeTypeContractHandler
                     logger?.LogDebug(
                         "GetCompilationPathRequest at {HubPath}: MeshNode has no NodeTypeDefinition (Content={ContentType}).",
                         hubPath, node.Content?.GetType().Name ?? "null");
-                    return Observable.Return((GetCompilationPathResponse?)Fail(
+                    return Observable.Return(new ResolvedResponse(Fail(
                         null,
                         $"Node at '{hubPath}' is not a valid NodeType definition "
-                        + $"(Content type: {node.Content?.GetType().Name ?? "null"}).")!);
+                        + $"(Content type: {node.Content?.GetType().Name ?? "null"})."), false));
                 }
 
                 // Pinned release: resolve the explicitly requested Release MeshNode
@@ -91,9 +110,9 @@ internal static class NodeTypeContractHandler
                                     "GetCompilationPathRequest at {HubPath}: pinned release {ReleasePath} could not be resolved (releaseNode={ReleaseNode}).",
                                     hubPath, requestedReleasePath,
                                     releaseNode == null ? "null" : releaseNode.Content?.GetType().Name ?? "no-content");
-                                return Observable.Return<GetCompilationPathResponse?>(Fail(
+                                return Observable.Return(new ResolvedResponse(Fail(
                                     null,
-                                    $"Pinned release '{requestedReleasePath}' for '{hubPath}' could not be resolved."));
+                                    $"Pinned release '{requestedReleasePath}' for '{hubPath}' could not be resolved."), false));
                             }
                             // Use the persisted integer version the IAssemblyStore.Put
                             // used, not a parse of the display Version string.
@@ -106,17 +125,17 @@ internal static class NodeTypeContractHandler
                                         logger?.LogWarning(
                                             "GetCompilationPathRequest at {HubPath}: pinned release {ReleasePath} bytes not found in store (collection={Coll}, version={Version}).",
                                             hubPath, requestedReleasePath, release.AssemblyCollection, releaseVersion);
-                                        return Observable.Return<GetCompilationPathResponse?>(Fail(
+                                        return Observable.Return(new ResolvedResponse(Fail(
                                             null,
-                                            $"Pinned release '{requestedReleasePath}' assembly not found in store."));
+                                            $"Pinned release '{requestedReleasePath}' assembly not found in store."), false));
                                     }
                                     logger?.LogDebug(
                                         "GetCompilationPathRequest at {HubPath}: pinned release {ReleasePath} → {LocalPath}.",
                                         hubPath, requestedReleasePath, localPath);
                                     return compilationService.GetConfigurationsFromExistingAssembly(localPath!, hubPath)
-                                        .Select(result => BuildResponseFromLocal(
+                                        .Select(result => new ResolvedResponse(BuildResponseFromLocal(
                                             hubPath, node, localPath!, release.AssemblyCollection,
-                                            release.AssemblyContentPath, result));
+                                            release.AssemblyContentPath, result), false));
                                 });
                         });
                 }
@@ -141,7 +160,8 @@ internal static class NodeTypeContractHandler
                                     "GetCompilationPathRequest at {HubPath}: latest assembly not in store (collection={Coll}, version={Version}) — falling back to fresh compile.",
                                     hubPath, def.LatestAssemblyCollection, compileVersion);
                                 return compilationService.CompileAndGetConfigurations(node)
-                                    .Select(result => BuildResponse(hubPath, node, result));
+                                    .Select(result => new ResolvedResponse(
+                                        BuildResponse(hubPath, node, result), true));
                             }
                             logger?.LogDebug(
                                 "GetCompilationPathRequest at {HubPath}: using existing assembly at {LocalPath}.",
@@ -151,15 +171,27 @@ internal static class NodeTypeContractHandler
                                     hub, def.LastCompilationActivityPath, result,
                                     res => BuildResponseFromLocal(
                                         hubPath, node, localPath!, def.LatestAssemblyCollection,
-                                        def.LatestAssemblyPath, res)));
+                                        def.LatestAssemblyPath, res)))
+                                .Select(response => new ResolvedResponse(response, false));
                         });
                 }
 
+                // Terminal state without a published release + durable assembly refs:
+                // either the dispatched compile FAILED (settled Error — CompileAnd…
+                // below re-derives the diagnostics for the response; the watcher's
+                // park registry keeps this bounded), or this NodeType has nothing the
+                // watcher compiles (static-only) / the compile predates the durable
+                // store fields. The dispatched compile has SETTLED by here, so this
+                // call cannot overlap the activity's Roslyn run — a fresh success is
+                // a cache-hit load of the just-produced DLL, not a second emit.
                 return compilationService.CompileAndGetConfigurations(node)
-                    .Select(result => BuildResponse(hubPath, node, result));
+                    .Select(result => new ResolvedResponse(
+                        BuildResponse(hubPath, node, result), true));
             })
-            .SelectMany(response =>
+            .SelectMany(resolved =>
             {
+                var response = resolved.Response;
+                var freshCompile = resolved.FreshCompile;
                 // Write compile state back to the MeshNode FIRST, then post the
                 // response. Sequencing matters: callers that bridge
                 // GetCompilationPathRequest → Get the MeshNode immediately must
@@ -169,7 +201,7 @@ internal static class NodeTypeContractHandler
                 IObservable<GetCompilationPathResponse> writeBack;
                 try
                 {
-                    writeBack = hub.GetWorkspace().GetMeshNodeStream().Update(curr =>
+                    writeBack = workspace.GetMeshNodeStream().Update(curr =>
                     {
                         if (curr.Content is not NodeTypeDefinition def)
                             return curr;
@@ -189,7 +221,24 @@ internal static class NodeTypeContractHandler
                                     // populate them (Null store).
                                     LatestAssemblyCollection = response.Collection ?? def.LatestAssemblyCollection,
                                     LatestAssemblyPath = response.ContentPath ?? def.LatestAssemblyPath,
-                                    LastCompiledVersion = curr.Version
+                                    LastCompiledVersion = curr.Version,
+                                    // 🚨 A FRESH compile's success write must be COMPLETE —
+                                    // stamp the framework version the build ran against,
+                                    // exactly like the activity write-back (RunCompile).
+                                    // Leaving it unstamped produced the wedge state
+                                    // Ok + assembly-set + CompiledFrameworkVersion='' ⇒
+                                    // HasUsableBuild=false forever (nothing re-triggers:
+                                    // kickoff needs status null) — the 2-core CI flake's
+                                    // terminal signature. Safe: a fresh success is either a
+                                    // real Roslyn run against the live framework or a
+                                    // cache-hit DLL the loader already verified is NEWER
+                                    // than the framework build (LoadNodeAssembly deletes
+                                    // older-than-framework DLLs). Hydrate paths
+                                    // (freshCompile=false) keep the persisted value — they
+                                    // must never erase an ABI-staleness marker.
+                                    CompiledFrameworkVersion = freshCompile
+                                        ? NodeTypeCompilationHelpers.FrameworkVersion
+                                        : def.CompiledFrameworkVersion
                                 }
                             };
                         return curr with
@@ -230,6 +279,55 @@ internal static class NodeTypeContractHandler
                 });
 
         return request.Processed();
+    }
+
+    /// <summary>
+    /// Branch result: the response to post plus whether it came from a FRESH
+    /// <see cref="IMeshNodeCompilationService.CompileAndGetConfigurations"/> run
+    /// (drives the <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/> stamp
+    /// in the write-back) as opposed to a hydrate of an existing assembly (which
+    /// must never re-stamp — that would erase an ABI-staleness marker).
+    /// </summary>
+    private sealed record ResolvedResponse(GetCompilationPathResponse? Response, bool FreshCompile);
+
+    /// <summary>
+    /// 🚨 The single-compile-driver gate. Ensures a NEVER-COMPILED dynamic NodeType
+    /// (CompilationStatus == null, no usable build, not static-only) has a compile
+    /// DISPATCHED through the status control plane — one status-guarded flip to
+    /// <see cref="CompilationStatus.Pending"/> that <c>InstallCompileWatcher</c> turns
+    /// into the one activity compile — before the caller waits on
+    /// <c>AwaitCompilationSettled</c>. Idempotent with the first-build kickoff
+    /// (<c>InstallCompileWatcher</c>'s <c>firstBuildKickoffSub</c>): both guard on
+    /// <c>CompilationStatus is null</c>, and the per-NodeType hub's serialized action
+    /// block makes exactly ONE of them transition the status, so exactly one compile
+    /// runs. Any non-null status returns unchanged — the status machine already owns
+    /// the compile lifecycle (Pending/Compiling hold the settled-wait; Ok/Error are
+    /// terminal and handled by the response branches).
+    /// <para>Runs as System — dispatching a first build is infrastructure, same as the
+    /// kickoff; the requester (often an instance activation) only needs READ rights and
+    /// must not be denied for lacking Edit on the NodeType node.</para>
+    /// <para>A no-op flip still emits the current node (the handle's no-op completion
+    /// contract), so the chain never hangs here.</para>
+    /// </summary>
+    private static IObservable<MeshNode> EnsureCompileDispatched(
+        IMessageHub hub, IWorkspace workspace)
+    {
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        return Observable.Using(
+                () => (IDisposable?)accessService?.ImpersonateAsSystem()
+                      ?? System.Reactive.Disposables.Disposable.Empty,
+                _ => workspace.GetMeshNodeStream().Update(curr =>
+                {
+                    if (curr.Content is not NodeTypeDefinition def) return curr;
+                    if (def.CompilationStatus is not null) return curr;
+                    if (NodeTypeCompilationHelpers.HasUsableBuild(curr, def)) return curr;
+                    if (NodeTypeCompilationHelpers.IsStaticOnlyNodeType(curr, def)) return curr;
+                    return curr with
+                    {
+                        Content = def with { CompilationStatus = CompilationStatus.Pending }
+                    };
+                }))
+            .Take(1);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -425,15 +425,24 @@ public static class MeshDataSourceExtensions
     /// Best-effort: write a <c>Release</c> MeshNode at
     /// <c>{nodeTypePath}/Release/{version}</c> capturing the compiled assembly
     /// path + the markdown release notes from the NodeType's
-    /// <c>NodeTypeDefinition.ReleaseNotes</c> field. Returns the new release
-    /// path on success, or <c>null</c> if the create couldn't be dispatched
-    /// (no IMeshService available — early startup, test fixture, etc.).
+    /// <c>NodeTypeDefinition.ReleaseNotes</c> field.
     ///
-    /// <para>Failures are swallowed: the release MeshNode is observability +
-    /// history. Compile correctness must not depend on the create succeeding.
-    /// See <c>Doc/Architecture/Postmortems/NodeTypeReleaseRedesign.md</c>.</para>
+    /// <para>🚨 OBSERVED + BOUNDED — never advertise a path before it exists. The
+    /// returned observable emits the new release path ONLY after the create has
+    /// LANDED (the <c>CreateNode</c> response), or <c>null</c> when it couldn't be
+    /// dispatched / didn't land within the bound. The old fire-and-forget shape
+    /// returned the path immediately and the caller stamped it into
+    /// <c>NodeTypeDefinition.LatestReleasePath</c> — a reader following that field
+    /// right after the terminal Ok write then hit a hard path-resolution NotFound
+    /// (the un-created node faulted the read stream — the NodeTypeReleaseGateTest
+    /// 2-core flake). Same rule as RunCompile's activity-create guard: the stamp
+    /// follows the create; it is never a path that does not exist.</para>
+    ///
+    /// <para>Failures are swallowed (emit <c>null</c>): the release MeshNode is
+    /// observability + history. Compile correctness must not depend on the create
+    /// succeeding. See <c>Doc/Architecture/Postmortems/NodeTypeReleaseRedesign.md</c>.</para>
     /// </summary>
-    internal static string? TryCreateReleaseNode(
+    internal static IObservable<string?> TryCreateReleaseNode(
         IMessageHub hub,
         string nodeTypePath,
         NodeCompilationResult result,
@@ -444,7 +453,7 @@ public static class MeshDataSourceExtensions
         try
         {
             var meshService = hub.ServiceProvider.GetService<IMeshService>();
-            if (meshService is null) return null;
+            if (meshService is null) return Observable.Return<string?>(null);
 
             // Markdown release notes the author wrote on the NodeType's
             // ReleaseNotes field BEFORE clicking Create Release — sourced
@@ -542,35 +551,40 @@ public static class MeshDataSourceExtensions
             // release is attributable to its author (owner = caller). When no user requested it
             // (the System-driven Doc-release seed, or the first-build kickoff), RequestedReleaseBy
             // is null and the create falls through under the ambient System scope.
+            // Observable.Using acquires the scope AT SUBSCRIBE so both the CreateNode call and
+            // its subscription run inside it — CreateNode captures the caller's identity for
+            // the stored MeshNode.CreatedBy.
             var requestedBy = pendingNode.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions)?.RequestedReleaseBy;
             var accessService = hub.ServiceProvider.GetService<AccessService>();
-            var userScope = !string.IsNullOrEmpty(requestedBy) && accessService is not null
-                ? accessService.SwitchAccessContext(new AccessContext
+
+            // OBSERVED create: emit the path only once the create response lands.
+            // Bounded — a hung owner must never block the compile's terminal write;
+            // on timeout/fault emit null so the parent never advertises a phantom
+            // Release path (mirrors RunCompile's activity-create guard).
+            return Observable.Using(
+                    () => !string.IsNullOrEmpty(requestedBy) && accessService is not null
+                        ? accessService.SwitchAccessContext(new AccessContext
+                        {
+                            ObjectId = requestedBy,
+                            Name = requestedBy
+                        })
+                        : System.Reactive.Disposables.Disposable.Empty,
+                    _ => meshService.CreateNode(node).Take(1))
+                .Select(_ => (string?)releasePath)
+                .Timeout(TimeSpan.FromSeconds(10), Observable.Return<string?>(null))
+                .Catch<string?, Exception>(ex =>
                 {
-                    ObjectId = requestedBy,
-                    Name = requestedBy
-                })
-                : null;
-
-            // Fire-and-forget — observability, not correctness. If the create
-            // fails (replication race, transient mesh-side error) we log and
-            // skip; the next compile retry creates a fresh release. The Subscribe
-            // runs synchronously inside userScope, so CreateNode captures the
-            // caller's identity for the stored MeshNode.CreatedBy.
-            using (userScope)
-                meshService.CreateNode(node).Subscribe(
-                    _ => { },
-                    ex => logger?.LogWarning(ex,
+                    logger?.LogWarning(ex,
                         "CompileWatcher: failed to create Release node at {ReleasePath}",
-                        releasePath));
-
-            return releasePath;
+                        releasePath);
+                    return Observable.Return<string?>(null);
+                });
         }
         catch (Exception ex)
         {
             logger?.LogWarning(ex,
                 "CompileWatcher: TryCreateReleaseNode threw for {NodeTypePath}", nodeTypePath);
-            return null;
+            return Observable.Return<string?>(null);
         }
     }
 

--- a/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
@@ -256,6 +256,22 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                         ? matchedNodes.OrderByDescending(n => GetSortableValue(n, parsedQuery.OrderBy.Property))
                         : matchedNodes.OrderBy(n => GetSortableValue(n, parsedQuery.OrderBy.Property));
                 }
+                else if (!string.IsNullOrEmpty(parsedQuery.TextSearch))
+                {
+                    // 🚨 Free-text results are RANKED BY RELEVANCE before the Limit clip.
+                    // The evaluator's Matches() already computes a fuzzy score per node but
+                    // discarded it, leaving matches in STORE-ENUMERATION order — a broad
+                    // substring term ("alice" matching dozens of content bodies) then filled
+                    // the Take(limit) window with whatever the storage walk yielded first,
+                    // and whether a NAME-matching node survived the clip depended on
+                    // file-system directory enumeration order. That is the CI-only
+                    // SearchQueryTests.TextSearch_CaseInsensitive flake (10 content matches
+                    // returned, the Alice-named nodes clipped away on ext4 ordering).
+                    // OrderByDescending is stable, so equal-score ties keep the walk order.
+                    // An explicit sort: (OrderBy above) still wins over relevance.
+                    sorted = matchedNodes.OrderByDescending(n =>
+                        _evaluator.GetFuzzyScore(n, parsedQuery.TextSearch));
+                }
 
                 IEnumerable<object> projected = sorted.Select(node =>
                     parsedQuery.Select != null

--- a/test/MeshWeaver.Hosting.Monolith.Test/CompileSingleDriverConsistencyTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CompileSingleDriverConsistencyTest.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the SINGLE-COMPILE-DRIVER invariant behind the compile-heavy 2-core CI
+/// flake (MeshNodeCompilationIntegrationTest / OrleansDynamicCompilationTest /
+/// FrameworkStaleInstanceRenderTest rotating 60s timeouts).
+///
+/// <para><b>The defect this ratchets against:</b> on a FRESH dynamic NodeType
+/// (CompilationStatus still null) the <c>GetCompilationPathRequest</c> handler
+/// treated <c>null</c> as "settled", raced past <c>AwaitCompilationSettled</c>,
+/// and ran Roslyn INLINE — concurrently with the first-build kickoff's
+/// watcher-dispatched activity compile of the SAME NodeType. Under 2-core
+/// contention the loser read the winner's DLL mid-emit ("Failed to load
+/// assembly … the build is not usable"), deleted it, and terminal-wrote
+/// <c>Error</c>; the surviving handler write-back then stamped <c>Ok</c> +
+/// assembly refs but NOT <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/>
+/// — the wedge signature <c>Ok + LatestAssemblyPath set + fv=''</c> that makes
+/// <c>HasUsableBuild</c> false forever (nothing re-triggers: the kickoff needs
+/// status null). The fix makes the handler DISPATCH through the status control
+/// plane (flip Pending, watcher drives the one compile) and wait, exactly like
+/// <c>HandleCreateRelease</c>'s <c>DispatchPendingFlip</c>; and makes every
+/// fresh-compile success write COMPLETE (framework version stamped).</para>
+///
+/// <para>Post-fix these assertions are DETERMINISTIC (the response can only be
+/// posted after the single compile's terminal write); pre-fix they flake under
+/// contention — the same population CI's 2-vCPU runners sample every merge.</para>
+/// </summary>
+public class CompileSingleDriverConsistencyTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddGraph();
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private IObservable<MeshNode> CreateNodeType(string nodeTypeId)
+    {
+        var nodeTypePath = $"type/{nodeTypeId}";
+        var typeNode = MeshNode.FromPath(nodeTypePath) with
+        {
+            Name = nodeTypeId,
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Configuration = $"config => config.WithContentType<{nodeTypeId}>()"
+            },
+            State = MeshNodeState.Active
+        };
+        return MeshService.CreateNode(typeNode)
+            .SelectMany(_ => MeshService.CreateNode(new MeshNode("code", $"{nodeTypePath}/Source")
+            {
+                NodeType = "Code",
+                Name = "code",
+                Content = new CodeConfiguration
+                {
+                    Code = $$"""
+                        public record {{nodeTypeId}}
+                        {
+                            public string Id { get; init; } = string.Empty;
+                        }
+                        """,
+                    Language = "csharp"
+                },
+                State = MeshNodeState.Active
+            }));
+    }
+
+    private IObservable<GetCompilationPathResponse> Compile(string nodeTypePath) =>
+        Mesh.Observe(
+                (IRequest<GetCompilationPathResponse>)new GetCompilationPathRequest(),
+                o => o.WithTarget(new Address(nodeTypePath)))
+            .Select(d => d.Message);
+
+    /// <summary>
+    /// A successful first compile must leave the NodeType in a CONSISTENT,
+    /// usable-build terminal state — Status=Ok AND assembly refs AND a
+    /// non-empty CompiledFrameworkVersion — never the half-written
+    /// Ok-with-empty-framework-version wedge the double-driver race produced.
+    /// </summary>
+    [Fact]
+    public async Task FreshCompile_TerminalStateIsComplete()
+    {
+        var nodeTypeId = $"SingleDriver{Guid.NewGuid():N}";
+        var nodeTypePath = $"type/{nodeTypeId}";
+
+        await CreateNodeType(nodeTypeId).Should().Within(30.Seconds()).Emit();
+
+        var response = await Compile(nodeTypePath).Should().Within(60.Seconds()).Emit();
+        response.Success.Should().BeTrue($"first compile should succeed; error: {response.Error}");
+        response.AssemblyLocation.Should().NotBeNullOrEmpty();
+
+        // The response is only posted AFTER the terminal write (single driver:
+        // the handler waits for the dispatched compile to settle, then hydrates),
+        // so the own node must ALREADY be complete — no separate compile can be
+        // in flight to "finish" it later.
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream(nodeTypePath)
+            .Should().Within(30.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok);
+
+        var def = (NodeTypeDefinition)node.Content!;
+        def.CompilationError.Should().BeNull();
+        def.LatestAssemblyPath.Should().NotBeNullOrEmpty(
+            "the terminal write must carry the durable assembly reference");
+        def.LatestAssemblyCollection.Should().NotBeNullOrEmpty();
+        def.CompiledFrameworkVersion.Should().NotBeNullOrEmpty(
+            "a successful compile's terminal write must stamp the framework version — "
+            + "Ok with an empty CompiledFrameworkVersion is the double-driver wedge state "
+            + "(HasUsableBuild=false forever, nothing re-triggers)");
+    }
+
+    /// <summary>
+    /// Two concurrent GetCompilationPathRequests on the SAME fresh NodeType must
+    /// both succeed off the ONE dispatched compile — the status field is the
+    /// single-flight lock; neither request may drive a second Roslyn run that
+    /// races the first on the shared cache DLL.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentRequests_OnFreshNodeType_BothSucceedConsistently()
+    {
+        var nodeTypeId = $"SingleDriverPair{Guid.NewGuid():N}";
+        var nodeTypePath = $"type/{nodeTypeId}";
+
+        await CreateNodeType(nodeTypeId).Should().Within(30.Seconds()).Emit();
+
+        var both = await Observable.Zip(Compile(nodeTypePath), Compile(nodeTypePath))
+            .Should().Within(90.Seconds()).Emit();
+
+        foreach (var response in both)
+        {
+            response.Success.Should().BeTrue(
+                $"every concurrent requester must be served off the single compile; error: {response.Error}");
+            response.AssemblyLocation.Should().NotBeNullOrEmpty();
+        }
+
+        // Same terminal-consistency bar as the single-request case.
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream(nodeTypePath)
+            .Should().Within(30.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok);
+        var def = (NodeTypeDefinition)node.Content!;
+        def.CompiledFrameworkVersion.Should().NotBeNullOrEmpty();
+        def.LatestAssemblyPath.Should().NotBeNullOrEmpty();
+    }
+}


### PR DESCRIPTION
Root-causes the 2-core CI flake family that's been reddening branch runs (MeshNodeCompilation, OrleansDynamicCompilation, NodeTypeReleaseGate, FrameworkStale, SearchQueryTests). NOT the remembered wall-clock/base-Full model (that mechanism no longer exists — memory corrected); reproduced and pinned the real owner-side races. 5/5 full-suite iterations green @2 cores; Orleans 122/122, Query 342/342, Data 273/273, solution Release -warnaserror clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)