### PR TITLE
fix(local+chat): arm64 build pin + /data perms + side-panel error boundary

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -254,9 +254,14 @@ image_build_local() {                                  # §3 Option B
 
   base_build_local "${1:-}"                            # ensure the CLI-bearing base exists FIRST
   step "Building native arm64 portal image (layered on the CLI base) into Colima's Docker store (§3 Option B)"
+  # ARM64 PIN: the .csproj now declares <RuntimeIdentifiers>linux-x64;linux-arm64</RuntimeIdentifiers>
+  # (main's multi-arch container work), so a bare -t:PublishContainer builds a multi-arch image INDEX and
+  # Colima's arm64 node can load the x64 assembly → "assembly architecture is not compatible" crashloop.
+  # Pin the single native RID so the local image is arm64-only (restores this step's documented intent).
   dotnet publish "$repo/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj" \
     -c Release -t:PublishContainer -p:ContainerRepository=memex-portal-ai-local \
     -p:ContainerBaseImage="$PORTAL_BASE_REF" \
+    -p:ContainerRuntimeIdentifier=linux-arm64 \
     -maxcpucount:"${MEMEX_BUILD_CPUS:-6}"   # WEDGE FIX: cap parallelism so ONE build can't saturate the host
   # Fail LOUD if the publish lost the co-hosted CLIs (e.g. the ContainerBaseImage didn't layer in
   # because the local registry was empty). A CLI-less portal silently ships a broken Claude Code /
@@ -269,8 +274,10 @@ image_build_local() {                                  # §3 Option B
   docker tag memex-portal-ai-local:latest "$PORTAL_IMAGE"
   ok "Portal image verified: claude + node CLIs are baked in"
   step "Building migration image (§3 Option B)"
+  # ARM64 PIN — same reason as the portal publish above (Migration.csproj is also multi-RID).
   dotnet publish "$repo/memex/aspire/Memex.Database.Migration/Memex.Database.Migration.csproj" \
     -c Release -t:PublishContainer -p:ContainerRepository=memex-migration-local \
+    -p:ContainerRuntimeIdentifier=linux-arm64 \
     -maxcpucount:"${MEMEX_BUILD_CPUS:-6}"   # WEDGE FIX: cap parallelism (see portal publish above)
   docker tag memex-migration-local:latest "$MIGRATION_IMAGE"
   ok "Images tagged $PORTAL_IMAGE / $MIGRATION_IMAGE (visible to k3s via IfNotPresent)"
@@ -344,6 +351,14 @@ helm_deploy() {
     --set persistDataVolume=true \
     -n "$NAMESPACE" --create-namespace \
     --force-conflicts
+
+  # DATA-VOLUME PERMS: persistDataVolume mounts the hostPath /var/lib/memex-portal-data at /data.
+  # k8s creates it (DirectoryOrCreate) root-owned 0755, but the portal runs NON-root and must write
+  # /data/dataprotection-keys (persisted DP keys, 678690598) → without this it crashloops with
+  # "Access to the path '/data/dataprotection-keys' is denied". Make the node dir writable so a fresh
+  # node (or a first deploy) doesn't hit the crash. Idempotent; single-node k3s so all pods share it.
+  colima ssh -- 'sudo mkdir -p /var/lib/memex-portal-data && sudo chmod 0777 /var/lib/memex-portal-data' 2>/dev/null \
+    || warn "could not make /var/lib/memex-portal-data writable on the node — portal may crashloop on DataProtection keys"
 }
 
 # ---------------------------------------------------------------------------

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadSidePanelContent.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadSidePanelContent.razor
@@ -34,10 +34,16 @@
     <ChildContent>
         @if (!string.IsNullOrEmpty(selectedThreadPath))
         {
-            @* Render the thread's layout area — same as main panel. LayoutAreaView manages its own stream. *@
-            <LayoutAreaView @key="@selectedThreadPath"
-                            ViewModel="@GetThreadLayoutArea()"
-                            Area="@($"sidepanel-{selectedThreadPath}")" />
+            @* Render the thread's layout area — same as main panel. LayoutAreaView manages its own stream.
+               Wrapped in ChatErrorBoundary (like the new-chat fallback below) so a render/lifecycle throw
+               in the area's control tree surfaces as an inline error instead of tearing down the whole
+               circuit — the "side panel disappeared, must refresh" symptom. LayoutAreaView already contains
+               its own STREAM onErrors (keep last-good display); this covers the synchronous render path it can't. *@
+            <ChatErrorBoundary @key="@($"thread-eb-{selectedThreadPath}")">
+                <LayoutAreaView @key="@selectedThreadPath"
+                                ViewModel="@GetThreadLayoutArea()"
+                                Area="@($"sidepanel-{selectedThreadPath}")" />
+            </ChatErrorBoundary>
         }
         else if (GetThreadComposerLayoutArea() is { } chatInputArea)
         {
@@ -46,9 +52,11 @@
                {user}/_Thread/ThreadComposer (see ThreadComposerView). @key includes the primary path so
                it rebuilds on context change. *@
             <div style="flex: 1; min-height: 0; display: flex; flex-direction: column;">
-                <LayoutAreaView @key="@($"chatinput-{lastPrimaryPath ?? string.Empty}")"
-                                ViewModel="@chatInputArea"
-                                Area="@($"chatinput-{lastPrimaryPath ?? string.Empty}")" />
+                <ChatErrorBoundary @key="@($"chatinput-eb-{lastPrimaryPath ?? string.Empty}")">
+                    <LayoutAreaView @key="@($"chatinput-{lastPrimaryPath ?? string.Empty}")"
+                                    ViewModel="@chatInputArea"
+                                    Area="@($"chatinput-{lastPrimaryPath ?? string.Empty}")" />
+                </ChatErrorBoundary>
             </div>
         }
         else


### PR DESCRIPTION
Two fixes surfaced while deploying the merged tree to the local k3s portal (memex.localhost).

## `fix(local)` — unblock local Apple-Silicon deploys (`c3eaec62b`)
After main's multi-arch + persisted-DataProtection work, `memex-local update --build` crashlooped twice:
1. **arm64**: `Memex.Portal.Distributed`/`Migration` csproj now declare `<RuntimeIdentifiers>linux-x64;linux-arm64</RuntimeIdentifiers>`, so a bare `-t:PublishContainer` builds a multi-arch image **index**; Colima's arm64 node then loads the x64 assembly → `assembly architecture is not compatible` crashloop. Pin `-p:ContainerRuntimeIdentifier=linux-arm64` on both publishes (restores the step's documented "native arm64" intent).
2. **/data perms**: `persistDataVolume` mounts hostPath `/var/lib/memex-portal-data` at `/data`, created root-owned 0755 by `DirectoryOrCreate`; the non-root portal must write `/data/dataprotection-keys` → `Access to the path is denied` crashloop. `chmod` the node dir writable in `helm_deploy`.

## `fix(chat)` — contain side-panel render faults (`dd99231da`)
The side panel rendered its thread + composer layout areas via bare `LayoutAreaView` (only the identity-resolving fallback was wrapped). A synchronous render/lifecycle throw therefore tore down the whole Blazor circuit — the "side panel disappeared, must refresh" symptom. Wrap both modes in `ChatErrorBoundary` (same as the fallback) so a fault surfaces inline and the rest of the app stays alive. Complements the keying/teardown vanish fixes already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)