### PR TITLE
feat(python): live pandas mesh node + interactive PandasExplorer frontend

### DIFF
--- a/clients/python/meshweaver/examples/__init__.py
+++ b/clients/python/meshweaver/examples/__init__.py
@@ -1,0 +1,8 @@
+"""Runnable MeshWeaver Python examples.
+
+Each module here is a self-contained, runnable showcase of the participant model — connect a Python
+process to the mesh, do real Python work, and surface the result back to the mesh as first-class content.
+
+* :mod:`meshweaver.examples.pandas_node` — a Python-backed mesh node that HOLDS and CONTROLS a live
+  pandas DataFrame and renders its current state back as a real :class:`DataGridControl` (not markdown).
+"""

--- a/clients/python/meshweaver/examples/pandas_node.py
+++ b/clients/python/meshweaver/examples/pandas_node.py
@@ -1,0 +1,337 @@
+"""A Python-backed mesh node that HOLDS and CONTROLS a live pandas DataFrame.
+
+This is the interactive successor to ``Doc/Architecture/CallingPython`` (the participant-model prose).
+Where the kernel worker (:mod:`meshweaver.worker`) runs a Python snippet in a *fresh* namespace and throws
+it away, a :class:`PandasNode` OWNS an in-process :class:`pandas.DataFrame` as real, long-lived Python
+state and lets the mesh drive it:
+
+* **create / replace / append / reset** — mutate the held frame,
+* **groupby / describe / rolling** — analyse it (a pandas showcase),
+* **render** — serialise its *current* state back as a real :class:`DataGridControl` UiControl (the exact
+  wire JSON ``Controls.DataGrid(rows).WithColumn(...)`` produces on the C# side), so the existing Blazor
+  and React grid renderers show a **live, sortable grid — never markdown or an HTML string**.
+
+Two interaction surfaces, both against the SAME live frame:
+
+1. Typed ``PandasCommand`` messages (``load`` / ``append`` / ``reset`` / ``render`` / ``groupby`` /
+   ``describe`` / ``rolling``). The mesh routes them to this participant's address by target — the
+   message type is opaque to the mesh (it round-trips as ``RawJson``), so no server-side registration
+   is needed.
+2. ``SubmitCodeRequest`` — pandas code executed against a **persistent** namespace where the frame lives
+   as ``df``. Unlike :func:`meshweaver.worker.execute_python`, the namespace SURVIVES across calls, so
+   ``df["margin"] = df["sales"] - df["cost"]`` in one submission is visible to the next. That persistent
+   ``df`` IS "an object created and controlled in Python".
+
+Run the self-contained showcase (no mesh needed) — prints the DataGrid JSON the GUI would render::
+
+    python -m meshweaver.examples.pandas_node --demo
+
+Or serve as a real mesh participant that other participants / agents drive over gRPC::
+
+    python -m meshweaver.examples.pandas_node --url https://memex.meshweaver.cloud --token mw_... --address py/pandas
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import asyncio
+import contextlib
+import io
+import json
+import traceback
+from typing import Any, Optional
+
+import pandas as pd
+import pandas.api.types as pdt
+
+from .. import envelope
+from ..connection import connect as _connect
+from ..worker import _jsonable
+
+DEFAULT_ADDRESS = "py/pandas"
+
+# Message-type discriminators. PandasCommand/PandasAck/PandasError are this node's own protocol —
+# unregistered on the mesh, so they round-trip as RawJson and route purely by target address.
+COMMAND_TYPE = "PandasCommand"
+ACK_TYPE = "PandasAck"
+ERROR_TYPE = "PandasError"
+# GRID_TYPE is the mesh's own registered UiControl: the response message IS a DataGridControl, so a
+# receiving hub deserialises it into MeshWeaver.Layout.DataGrid.DataGridControl and the GUI renders it.
+GRID_TYPE = "DataGridControl"
+
+
+# --- pandas -> DataGridControl (the UiControl wire contract) ---------------------------------------
+
+def _column(name: str, dtype: Any) -> dict[str, Any]:
+    """One grid column derived from a DataFrame column's dtype.
+
+    The ``$type`` is the discriminator the mesh's TypeRegistry resolves to a
+    ``PropertyColumnControl<T>`` — a constructed generic serialises as ``Name`1[Arg]`` (the CLR
+    ``Type.Name`` of the open generic + the registered short name of the type argument; see
+    ``TypeRegistry.FormatType``). Numeric columns carry a .NET format string so the grid right-aligns
+    and thousands-separates them exactly as a hand-written C# column would."""
+    if pdt.is_bool_dtype(dtype):
+        clr, fmt = "Boolean", None
+    elif pdt.is_integer_dtype(dtype):
+        clr, fmt = "Int64", "N0"
+    elif pdt.is_float_dtype(dtype):
+        clr, fmt = "Double", "N2"
+    elif pdt.is_datetime64_any_dtype(dtype):
+        clr, fmt = "DateTime", "yyyy-MM-dd"
+    else:
+        clr, fmt = "String", None
+    col: dict[str, Any] = {
+        "$type": f"PropertyColumnControl`1[{clr}]",
+        "property": name,
+        "title": name.replace("_", " ").strip().title(),
+    }
+    if fmt is not None:
+        col["format"] = fmt
+    return col
+
+
+def frame_to_datagrid(df: pd.DataFrame) -> dict[str, Any]:
+    """Serialise a DataFrame to the ``DataGridControl`` UiControl JSON the MeshWeaver GUI renders.
+
+    * ``columns`` are derived from the frame's dtypes (typed ``PropertyColumnControl<T>`` + numeric format),
+    * ``data`` are the frame's records, made JSON-safe by pandas (NaN → null, numpy scalars → JSON numbers,
+      timestamps → ISO strings).
+
+    The returned dict is the payload minus its ``$type`` (the caller stamps ``DataGridControl`` via
+    :meth:`MeshConnection.respond`). It is the SAME shape ``Controls.DataGrid(rows).WithColumn(
+    new PropertyColumnControl<double>{ Property = "sales" }.WithFormat("N2"))`` produces on the C# side."""
+    columns = [_column(str(name), dtype) for name, dtype in df.dtypes.items()]
+    data = json.loads(df.to_json(orient="records", date_format="iso"))
+    return {"data": data, "columns": columns}
+
+
+# --- the participant that owns the frame -----------------------------------------------------------
+
+class PandasNode:
+    """A mesh participant that OWNS an in-process pandas DataFrame and controls it over the mesh.
+
+    Construct with a connected :class:`MeshConnection` (or any object exposing ``serve`` / ``respond`` /
+    ``post`` — that's what the tests and the ``--demo`` driver pass). The frame is real Python state on
+    ``self``; :meth:`handle` reacts to inbound deliveries and mutates / queries / renders it."""
+
+    def __init__(self, connection: Any, frame: Optional[pd.DataFrame] = None):
+        self._c = connection
+        self._df = pd.DataFrame() if frame is None else frame.copy()
+        self._ns: dict[str, Any] = {"pd": pd}  # persistent namespace for the SubmitCodeRequest surface
+        connection.serve(self.handle)
+
+    @property
+    def dataframe(self) -> pd.DataFrame:
+        """The live frame — the object controlled in Python."""
+        return self._df
+
+    async def handle(self, delivery: "envelope.Delivery") -> None:
+        """Dispatch an inbound delivery to the matching surface; ignore anything that isn't ours."""
+        if delivery.message_type == COMMAND_TYPE:
+            await self._handle_command(delivery)
+        elif delivery.message_type == "SubmitCodeRequest":
+            await self._handle_code(delivery)
+        # else: not ours — another participant may share this address later.
+
+    # ---- typed command surface --------------------------------------------------------------------
+
+    async def _handle_command(self, delivery: "envelope.Delivery") -> None:
+        msg = delivery.message
+        command = str(msg.get("command") or msg.get("Command") or "").lower()
+        try:
+            kind, payload = self._apply(command, msg)
+        except Exception as ex:  # a bad command never wedges the node — it replies with an error
+            await self._c.respond(delivery, ERROR_TYPE, {"command": command, "error": f"{type(ex).__name__}: {ex}"})
+            return
+        await self._c.respond(delivery, GRID_TYPE if kind == "grid" else ACK_TYPE, payload)
+
+    def _apply(self, command: str, msg: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        """Apply one command to the held frame, returning ``("grid"|"ack", payload)``.
+
+        ``load`` / ``append`` / ``reset`` MUTATE the held frame; ``render`` / ``groupby`` / ``describe`` /
+        ``rolling`` produce a DataGrid view (the analytical ones read the frame without mutating it)."""
+        if command == "load":
+            self._df = pd.DataFrame(msg.get("data") or [])
+            return "ack", self._summary()
+        if command == "append":
+            rows = pd.DataFrame(msg.get("rows") or [])
+            self._df = pd.concat([self._df, rows], ignore_index=True)
+            return "ack", self._summary()
+        if command == "reset":
+            self._df = pd.DataFrame()
+            return "ack", self._summary()
+        if command == "render":
+            return "grid", frame_to_datagrid(self._df)
+        if command == "describe":
+            desc = self._df.describe().reset_index().rename(columns={"index": "statistic"})
+            return "grid", frame_to_datagrid(desc)
+        if command == "groupby":
+            by = msg.get("by")
+            agg = msg.get("agg") or "sum"
+            grouped = self._df.groupby(by).agg(agg, numeric_only=True).reset_index()
+            return "grid", frame_to_datagrid(grouped)
+        if command == "rolling":
+            col = msg.get("column")
+            window = int(msg.get("window") or 3)
+            view = self._df.copy()
+            view[f"{col}_rolling_mean"] = view[col].rolling(window=window).mean()
+            return "grid", frame_to_datagrid(view)
+        raise ValueError(f"unknown command '{command}'")
+
+    def _summary(self) -> dict[str, Any]:
+        return {"rowCount": int(len(self._df)), "columns": [str(c) for c in self._df.columns]}
+
+    # ---- code surface (state persists across calls) -----------------------------------------------
+
+    async def _handle_code(self, delivery: "envelope.Delivery") -> None:
+        """Run a Python snippet against the PERSISTENT namespace, then reply + patch the Activity node.
+
+        The held frame is exposed as ``df`` before the run and re-captured after, so a snippet that
+        reassigns or mutates ``df`` changes the node's live state for every later call. This is the
+        difference from :func:`meshweaver.worker.execute_python`, which uses a throwaway namespace."""
+        msg = delivery.message
+        code = msg.get("code") or msg.get("Code") or ""
+        activity_path = msg.get("activityLogPath") or msg.get("ActivityLogPath")
+        result = self._run_code(code)
+        status = "Succeeded" if result["error"] is None else "Failed"
+        if activity_path:
+            messages = [{"message": m} for m in (result["output"], result["error"]) if m]
+            await self._c.post(
+                target=activity_path,
+                message_type="PatchDataRequest",
+                message={"path": activity_path, "change": {"content": {
+                    "status": status, "messages": messages, "returnValue": result["returnValue"],
+                }}},
+            )
+        await self._c.respond(delivery, "SubmitCodeResponse", {
+            "status": status, "returnValue": result["returnValue"], "output": result["output"],
+            "error": result["error"], "rowCount": int(len(self._df)),
+        })
+
+    def _run_code(self, code: str) -> dict[str, Any]:
+        self._ns["df"] = self._df  # expose the held frame
+        out = io.StringIO()
+        return_value: Any = None
+        error: Optional[str] = None
+        try:
+            tree = ast.parse(code, mode="exec")
+            trailing = None
+            if tree.body and isinstance(tree.body[-1], ast.Expr):
+                trailing = ast.Expression(tree.body.pop().value)  # REPL: peel the trailing expression
+            with contextlib.redirect_stdout(out):
+                exec(compile(tree, "<pandas-node>", "exec"), self._ns)  # noqa: S102
+                if trailing is not None:
+                    return_value = eval(compile(trailing, "<pandas-node>", "eval"), self._ns)  # noqa: S307
+        except BaseException:  # surface everything as output; a node never wedges on a bad snippet
+            error = traceback.format_exc()
+        held = self._ns.get("df")
+        if isinstance(held, pd.DataFrame):
+            self._df = held  # persist any reassignment/mutation of df back onto the held object
+        return {"output": out.getvalue(), "returnValue": _jsonable(return_value), "error": error}
+
+
+# --- the interactive, self-contained showcase ------------------------------------------------------
+
+def sample_sales_frame() -> pd.DataFrame:
+    """A tiny monthly sales frame across two regions — the pandas showcase dataset."""
+    return pd.DataFrame({
+        "month": ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+        "region": ["EMEA", "EMEA", "EMEA", "APAC", "APAC", "APAC"],
+        "sales": [120.0, 135.5, 128.0, 98.0, 143.0, 150.0],
+        "units": [12, 14, 13, 9, 15, 16],
+    })
+
+
+class RecordingConnection:
+    """An in-process stand-in for :class:`MeshConnection` that records what the node would send.
+
+    Lets the demo (and the tests) drive a :class:`PandasNode` through the exact same handler path a live
+    mesh would, without a gRPC channel — the same duck-typing the SDK's own tests use."""
+
+    def __init__(self) -> None:
+        self.responses: list[tuple[str, dict[str, Any]]] = []
+        self.posts: list[tuple[str, str, dict[str, Any]]] = []
+        self._handler = None
+
+    def serve(self, handler: Any) -> None:
+        self._handler = handler
+
+    async def respond(self, to: Any, message_type: str, message: dict[str, Any]) -> None:
+        self.responses.append((message_type, message))
+
+    async def post(self, target: str, message_type: str, message: dict[str, Any]) -> None:
+        self.posts.append((target, message_type, message))
+
+    async def send_command(self, node: "PandasNode", command: str, **fields: Any) -> tuple[str, dict[str, Any]]:
+        """Route a PandasCommand to the node the way the mesh would, and return its response."""
+        delivery = envelope.Delivery(
+            id="demo", sender="py/demo-driver", target=DEFAULT_ADDRESS, request_id=None,
+            message_type=COMMAND_TYPE, message={"$type": COMMAND_TYPE, "command": command, **fields}, raw={},
+        )
+        await node.handle(delivery)
+        return self.responses[-1]
+
+
+async def run_demo() -> dict[str, Any]:
+    """Scripted end-to-end: create a frame → mutate it → render it → analyse it. Returns the payloads."""
+    conn = RecordingConnection()
+    node = PandasNode(conn)
+
+    # 1) create the live frame in Python
+    await conn.send_command(node, "load", data=json.loads(sample_sales_frame().to_json(orient="records")))
+    started_rows = int(len(node.dataframe))
+
+    # 2) MUTATE it over the mesh: append two months
+    await conn.send_command(node, "append", rows=[
+        {"month": "Jul", "region": "APAC", "sales": 161.0, "units": 17},
+        {"month": "Aug", "region": "EMEA", "sales": 152.0, "units": 15},
+    ])
+
+    # 3) render the CURRENT frame back as a real DataGrid
+    _, grid = await conn.send_command(node, "render")
+
+    # 4) pandas showcase: groupby region (sum) + a 3-month rolling mean of sales
+    _, grouped = await conn.send_command(node, "groupby", by="region", agg="sum")
+    _, rolling = await conn.send_command(node, "rolling", column="sales", window=3)
+
+    return {
+        "started_rows": started_rows,
+        "row_count": int(len(node.dataframe)),
+        "grid": grid,
+        "grouped": grouped,
+        "rolling": rolling,
+    }
+
+
+async def serve(url: str, token: Optional[str] = None, address: str = DEFAULT_ADDRESS) -> None:
+    """Connect as a stable ``py/*`` participant and serve the held frame until cancelled."""
+    conn = await _connect(url, token=token, address=address)
+    PandasNode(conn)
+    print(f"meshweaver pandas node serving as {conn.address} -> {url}")
+    try:
+        await asyncio.Event().wait()  # run forever; inbound deliveries drive the node
+    finally:
+        await conn.close()
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="meshweaver.examples.pandas_node",
+                                description="A Python-backed mesh node holding a live pandas DataFrame.")
+    p.add_argument("--demo", action="store_true", help="run the self-contained scripted showcase (no mesh)")
+    p.add_argument("--url", default=None, help="portal gRPC endpoint, e.g. https://memex.meshweaver.cloud")
+    p.add_argument("--token", default=None, help="MeshWeaver API token (validated server-side)")
+    p.add_argument("--address", default=DEFAULT_ADDRESS, help="stable participant address the mesh targets")
+    args = p.parse_args()
+
+    if args.demo or not args.url:
+        result = asyncio.run(run_demo())
+        print(json.dumps(result["grid"], indent=2))
+        print(f"\n# live frame now has {result['row_count']} rows "
+              f"(started at {result['started_rows']}, appended 2 over the mesh)")
+        return
+
+    asyncio.run(serve(args.url, token=args.token, address=args.address))
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -10,10 +10,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# The pandas node example (meshweaver.examples.pandas_node) holds a live DataFrame.
+examples = [
+    "pandas>=2.0",
+]
 dev = [
     "grpcio-tools>=1.68",
     "pytest>=8",
     "pytest-asyncio>=0.24",
+    "pandas>=2.0",
 ]
 
 [build-system]

--- a/clients/python/scripts/gen_proto.sh
+++ b/clients/python/scripts/gen_proto.sh
@@ -12,7 +12,7 @@ out_dir="$pkg_root/meshweaver/_generated"
 mkdir -p "$out_dir"
 touch "$out_dir/__init__.py"
 
-python -m grpc_tools.protoc \
+"${PYTHON:-python3}" -m grpc_tools.protoc \
     -I "$proto_dir" \
     --python_out="$out_dir" \
     --grpc_python_out="$out_dir" \

--- a/clients/python/tests/test_pandas_node.py
+++ b/clients/python/tests/test_pandas_node.py
@@ -1,0 +1,155 @@
+"""The pandas mesh node: a live in-process DataFrame controlled over the mesh, rendered as a real
+DataGridControl. Driven by a recording connection (no gRPC) — the same duck-typing test_worker uses.
+
+These are the "it's live, not static" proofs: a mutation over the mesh changes the held frame, and the
+render surface emits the exact DataGridControl wire JSON the C# GUI renderer consumes."""
+import pandas as pd
+import pytest
+
+from meshweaver.examples.pandas_node import (
+    COMMAND_TYPE,
+    GRID_TYPE,
+    PandasNode,
+    RecordingConnection,
+    frame_to_datagrid,
+    run_demo,
+    sample_sales_frame,
+)
+from meshweaver.envelope import Delivery
+
+
+def _submit_code(code: str, activity: str = "ACME/_Activity/1") -> Delivery:
+    return Delivery(
+        id="c1", sender="@code/ACME/Source/1", target="py/pandas", request_id=None,
+        message_type="SubmitCodeRequest",
+        message={"$type": "SubmitCodeRequest", "code": code, "activityLogPath": activity}, raw={},
+    )
+
+
+# ---- frame_to_datagrid: the DataGridControl wire contract -----------------------------------------
+
+def test_datagrid_columns_are_typed_property_columns_with_formats():
+    grid = frame_to_datagrid(sample_sales_frame())
+    by_prop = {c["property"]: c for c in grid["columns"]}
+    # String columns -> PropertyColumnControl`1[String], no format.
+    assert by_prop["month"]["$type"] == "PropertyColumnControl`1[String]"
+    assert "format" not in by_prop["region"]
+    # Numeric columns -> typed generic + a .NET numeric format string.
+    assert by_prop["sales"]["$type"] == "PropertyColumnControl`1[Double]"
+    assert by_prop["sales"]["format"] == "N2"
+    assert by_prop["units"]["$type"] == "PropertyColumnControl`1[Int64]"
+    assert by_prop["units"]["format"] == "N0"
+    # Titles are humanised from the column name.
+    assert by_prop["units"]["title"] == "Units"
+
+
+def test_datagrid_data_are_json_safe_records():
+    grid = frame_to_datagrid(sample_sales_frame())
+    assert len(grid["data"]) == 6
+    first = grid["data"][0]
+    assert first == {"month": "Jan", "region": "EMEA", "sales": 120.0, "units": 12}
+    # NaN must serialise to null (JSON-safe), not a float nan.
+    view = sample_sales_frame()
+    view.loc[0, "sales"] = float("nan")
+    assert frame_to_datagrid(view)["data"][0]["sales"] is None
+
+
+async def test_bool_and_datetime_dtypes_map_to_typed_columns():
+    df = pd.DataFrame({"active": [True, False], "day": pd.to_datetime(["2024-01-01", "2024-02-01"])})
+    by_prop = {c["property"]: c for c in frame_to_datagrid(df)["columns"]}
+    assert by_prop["active"]["$type"] == "PropertyColumnControl`1[Boolean]"
+    assert by_prop["day"]["$type"] == "PropertyColumnControl`1[DateTime]"
+    assert by_prop["day"]["format"] == "yyyy-MM-dd"
+
+
+# ---- the live object: mutation over the mesh changes real state -----------------------------------
+
+async def test_load_then_append_mutates_the_held_frame():
+    conn = RecordingConnection()
+    node = PandasNode(conn)
+    await conn.send_command(node, "load", data=[{"month": "Jan", "sales": 100.0}])
+    assert len(node.dataframe) == 1
+    mtype, ack = await conn.send_command(node, "append", rows=[{"month": "Feb", "sales": 110.0}])
+    assert mtype == "PandasAck"
+    assert ack["rowCount"] == 2                 # the real object grew
+    assert list(node.dataframe["month"]) == ["Jan", "Feb"]
+
+
+async def test_render_returns_a_datagrid_control_of_current_state():
+    conn = RecordingConnection()
+    node = PandasNode(conn, sample_sales_frame())
+    mtype, grid = await conn.send_command(node, "render")
+    assert mtype == GRID_TYPE                   # responds AS a DataGridControl (mesh-registered UiControl)
+    assert len(grid["data"]) == 6
+    assert {c["property"] for c in grid["columns"]} == {"month", "region", "sales", "units"}
+
+
+async def test_groupby_is_a_real_pandas_aggregation():
+    conn = RecordingConnection()
+    node = PandasNode(conn, sample_sales_frame())
+    _, grid = await conn.send_command(node, "groupby", by="region", agg="sum")
+    sums = {row["region"]: row["sales"] for row in grid["data"]}
+    assert sums["EMEA"] == 120.0 + 135.5 + 128.0
+    assert sums["APAC"] == 98.0 + 143.0 + 150.0
+
+
+async def test_rolling_mean_adds_a_computed_column():
+    conn = RecordingConnection()
+    node = PandasNode(conn, sample_sales_frame())
+    _, grid = await conn.send_command(node, "rolling", column="sales", window=3)
+    col = [row["sales_rolling_mean"] for row in grid["data"]]
+    assert col[0] is None and col[1] is None          # first (window-1) rows are NaN -> null
+    # to_json truncates doubles to 10 dp — real wire characteristic, so compare with tolerance.
+    assert col[2] == pytest.approx((120.0 + 135.5 + 128.0) / 3)
+    # rolling is a view: it did NOT mutate the held frame.
+    assert "sales_rolling_mean" not in node.dataframe.columns
+
+
+async def test_unknown_command_replies_error_never_raises():
+    conn = RecordingConnection()
+    node = PandasNode(conn)
+    mtype, payload = await conn.send_command(node, "explode")
+    assert mtype == "PandasError"
+    assert "unknown command" in payload["error"]
+
+
+# ---- the code surface: the frame persists across SubmitCodeRequests -------------------------------
+
+async def test_submit_code_persists_frame_state_across_calls():
+    conn = RecordingConnection()
+    node = PandasNode(conn, sample_sales_frame())
+    # First submission adds a derived column to the HELD frame.
+    await node.handle(_submit_code("df['margin'] = df['sales'] - df['units']"))
+    assert "margin" in node.dataframe.columns
+    # A LATER submission sees that column — proof the namespace/frame persists (worker's does not).
+    await node.handle(_submit_code("df['margin'].sum()"))
+    _, resp = conn.responses[-1]
+    assert resp["status"] == "Succeeded"
+    expected = float((sample_sales_frame()["sales"] - sample_sales_frame()["units"]).sum())
+    assert float(resp["returnValue"]) == expected
+
+
+async def test_submit_code_writes_back_to_activity_node():
+    conn = RecordingConnection()
+    node = PandasNode(conn, sample_sales_frame())
+    await node.handle(_submit_code("print('rows:', len(df))\nlen(df)"))
+    target, mtype, message = conn.posts[0]
+    assert target == "ACME/_Activity/1"
+    assert mtype == "PatchDataRequest"
+    content = message["change"]["content"]
+    assert content["status"] == "Succeeded"
+    assert content["returnValue"] == 6
+    assert any("rows: 6" in m["message"] for m in content["messages"])
+
+
+# ---- the scripted end-to-end demo -----------------------------------------------------------------
+
+async def test_run_demo_is_live_end_to_end():
+    result = await run_demo()
+    assert result["started_rows"] == 6
+    assert result["row_count"] == 8                     # appended two rows over the mesh
+    assert len(result["grid"]["data"]) == 8             # the rendered grid reflects the mutation
+    # groupby totals include the appended rows.
+    sums = {r["region"]: r["sales"] for r in result["grouped"]["data"]}
+    assert sums["APAC"] == 98.0 + 143.0 + 150.0 + 161.0
+    assert sums["EMEA"] == 120.0 + 135.5 + 128.0 + 152.0

--- a/samples/Graph/Data/PythonDemo/PandasExplorer.json
+++ b/samples/Graph/Data/PythonDemo/PandasExplorer.json
@@ -1,0 +1,17 @@
+{
+  "id": "PandasExplorer",
+  "namespace": "PythonDemo",
+  "name": "Pandas Explorer",
+  "nodeType": "NodeType",
+  "category": "Types",
+  "description": "An interactive frontend (buttons + input) that drives a live pandas DataFrame held in the Python py/pandas mesh participant and renders its current state as a real DataGrid.",
+  "isPersistent": true,
+  "content": {
+    "$type": "NodeTypeDefinition",
+    "namespace": "PythonDemo",
+    "displayName": "Pandas Explorer",
+    "iconName": "Table",
+    "description": "Buttons + text input that control a Python-held pandas DataFrame over the mesh; the grid renders the live frame returned by the participant.",
+    "configuration": "config => config.WithContentType<PandasExplorer>().AddLayout(layout => layout.AddPandasExplorerLayoutAreas().WithDefaultArea(\"Explorer\"))"
+  }
+}

--- a/samples/Graph/Data/PythonDemo/PandasExplorer/LiveFrame.json
+++ b/samples/Graph/Data/PythonDemo/PandasExplorer/LiveFrame.json
@@ -1,0 +1,13 @@
+{
+  "id": "LiveFrame",
+  "namespace": "PythonDemo/PandasExplorer",
+  "name": "Live sales frame",
+  "nodeType": "PythonDemo/PandasExplorer",
+  "description": "Interactive explorer instance — drives the py/pandas participant. Shows the no-node notice until a Python pandas node attaches.",
+  "isPersistent": true,
+  "content": {
+    "$type": "PandasExplorer",
+    "name": "Live sales frame",
+    "description": "Monthly sales by region, held live in a Python pandas DataFrame."
+  }
+}

--- a/samples/Graph/Data/PythonDemo/PandasExplorer/Source/PandasExplorer.cs
+++ b/samples/Graph/Data/PythonDemo/PandasExplorer/Source/PandasExplorer.cs
@@ -1,0 +1,146 @@
+// <meshweaver>
+// Id: PandasExplorer
+// DisplayName: Pandas Explorer Data Model
+// </meshweaver>
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using MeshWeaver.Domain;
+using MeshWeaver.Layout.DataGrid;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+
+/// <summary>
+/// Content of a <c>PandasExplorer</c> node — the marker record for the interactive frontend
+/// (<see cref="PandasExplorerLayoutAreas"/>) that DRIVES the Python <c>py/pandas</c> participant
+/// (<c>clients/python/meshweaver/examples/pandas_node.py</c>). The node holds no data itself; the
+/// live <c>pandas.DataFrame</c> lives in the Python process. This record only carries the display
+/// name so the node is addressable and browsable.
+/// </summary>
+public record PandasExplorer
+{
+    /// <summary>Display name of the explorer node (mirrored onto <see cref="MeshNode.Name"/>).</summary>
+    [Required]
+    [MeshNodeProperty(nameof(MeshNode.Name))]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Optional blurb rendered above the interactive controls.</summary>
+    public string? Description { get; init; }
+}
+
+/// <summary>
+/// The wire message the frontend POSTS to the <c>py/pandas</c> participant. It is the .NET half of the
+/// Python <c>PandasCommand</c> protocol (<c>load</c> / <c>append</c> / <c>reset</c> mutate the held
+/// frame; <c>render</c> / <c>groupby</c> / <c>rolling</c> / <c>describe</c> return a grid). The mesh
+/// serialises this with the <c>$type: "PandasCommand"</c> discriminator (the short type name) and
+/// camelCase field names — exactly what <c>pandas_node.PandasNode._apply</c> reads off the message.
+/// The participant answers grid commands with a <see cref="DataGridControl"/> and mutations with an ack.
+/// </summary>
+public record PandasCommand : IRequest<DataGridControl>
+{
+    /// <summary>Command verb: <c>load</c>, <c>append</c>, <c>reset</c>, <c>render</c>, <c>groupby</c>, <c>rolling</c> or <c>describe</c>.</summary>
+    public string Command { get; init; } = "render";
+
+    /// <summary>Group-by column for <c>groupby</c>.</summary>
+    public string? By { get; init; }
+
+    /// <summary>Aggregation for <c>groupby</c> (e.g. <c>sum</c>, <c>mean</c>).</summary>
+    public string? Agg { get; init; }
+
+    /// <summary>Target column for <c>rolling</c>.</summary>
+    public string? Column { get; init; }
+
+    /// <summary>Window size for <c>rolling</c>.</summary>
+    public int? Window { get; init; }
+
+    /// <summary>Rows to concatenate for <c>append</c>.</summary>
+    public object[]? Rows { get; init; }
+
+    /// <summary>Records to replace the frame with for <c>load</c>.</summary>
+    public object[]? Data { get; init; }
+
+    /// <summary>A monthly sales frame across two regions — the same showcase dataset the Python demo seeds.</summary>
+    public static object[] SampleSales() =>
+    [
+        new { month = "Jan", region = "EMEA", sales = 120.0, units = 12 },
+        new { month = "Feb", region = "EMEA", sales = 135.5, units = 14 },
+        new { month = "Mar", region = "EMEA", sales = 128.0, units = 13 },
+        new { month = "Apr", region = "APAC", sales = 98.0, units = 9 },
+        new { month = "May", region = "APAC", sales = 143.0, units = 15 },
+        new { month = "Jun", region = "APAC", sales = 150.0, units = 16 },
+    ];
+
+    /// <summary>Replace the held frame with the sample sales data.</summary>
+    public static PandasCommand LoadSample() => new() { Command = "load", Data = SampleSales() };
+
+    /// <summary>Append two more months over the mesh — mutates the held frame.</summary>
+    public static PandasCommand AppendTwo() => new()
+    {
+        Command = "append",
+        Rows =
+        [
+            new { month = "Jul", region = "APAC", sales = 161.0, units = 17 },
+            new { month = "Aug", region = "EMEA", sales = 152.0, units = 15 },
+        ],
+    };
+
+    /// <summary>Clear the held frame.</summary>
+    public static PandasCommand Reset() => new() { Command = "reset" };
+}
+
+/// <summary>
+/// The frontend's internal trigger record: which read-only view of the frame to render next. Buttons
+/// flip this in the layout-area data store; the grid sub-area re-observes it and posts the matching
+/// <see cref="PandasCommand"/>. The <see cref="Nonce"/> makes every button press a distinct value so a
+/// repeated command (e.g. two "Refresh" clicks) still re-fires through <c>DistinctUntilChanged</c>.
+/// Only grid-producing verbs live here — mutations post directly and then flip this to <c>render</c>.
+/// </summary>
+public record PandasViewCommand
+{
+    /// <summary>Grid-producing verb: <c>render</c>, <c>groupby</c>, <c>rolling</c> or <c>describe</c>.</summary>
+    public string Command { get; init; } = "render";
+
+    /// <summary>Group-by column when <see cref="Command"/> is <c>groupby</c>.</summary>
+    public string? By { get; init; }
+
+    /// <summary>Rolling column when <see cref="Command"/> is <c>rolling</c>.</summary>
+    public string? Column { get; init; }
+
+    /// <summary>Rolling window when <see cref="Command"/> is <c>rolling</c>.</summary>
+    public int? Window { get; init; }
+
+    /// <summary>Distinct token so identical commands still re-emit through DistinctUntilChanged.</summary>
+    public string Nonce { get; init; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>Render the frame's current state.</summary>
+    public static PandasViewCommand Render() => new();
+
+    /// <summary>Group the frame by <paramref name="by"/> (sum).</summary>
+    public static PandasViewCommand GroupBy(string by) => new() { Command = "groupby", By = by };
+
+    /// <summary>Add a rolling mean of <paramref name="column"/> over <paramref name="window"/> rows.</summary>
+    public static PandasViewCommand Rolling(string column, int window) =>
+        new() { Command = "rolling", Column = column, Window = window };
+
+    /// <summary>Descriptive statistics of the frame.</summary>
+    public static PandasViewCommand Describe() => new() { Command = "describe" };
+
+    /// <summary>Projects this view onto the wire <see cref="PandasCommand"/> the participant understands.</summary>
+    public PandasCommand ToCommand() => new()
+    {
+        Command = Command,
+        By = By,
+        Agg = By is null ? null : "sum",
+        Column = Column,
+        Window = Window,
+    };
+
+    /// <summary>Human-readable caption for the rendered view.</summary>
+    public string Caption() => Command switch
+    {
+        "groupby" => $"grouped by {By} (sum)",
+        "rolling" => $"{Window}-row rolling mean of {Column}",
+        "describe" => "descriptive statistics",
+        _ => "current state",
+    };
+}

--- a/samples/Graph/Data/PythonDemo/PandasExplorer/Source/PandasExplorerLayoutAreas.cs
+++ b/samples/Graph/Data/PythonDemo/PandasExplorer/Source/PandasExplorerLayoutAreas.cs
@@ -1,0 +1,205 @@
+// <meshweaver>
+// Id: PandasExplorerLayoutAreas
+// DisplayName: Pandas Explorer Layout Areas
+// </meshweaver>
+
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Layout.DataGrid;
+using MeshWeaver.Messaging;
+
+/// <summary>
+/// The INTERACTIVE frontend for the Python <c>py/pandas</c> participant
+/// (<c>clients/python/meshweaver/examples/pandas_node.py</c>). A toolbar of real framework buttons +
+/// a text input DRIVE a live <c>pandas.DataFrame</c> that lives in a Python process, and the grid
+/// below shows the frame's current state as a genuine <see cref="DataGridControl"/> — never markdown
+/// or an HTML string.
+/// <para>
+/// Everything is reactive end-to-end: a button flips a trigger in the layout-area data store, the
+/// grid sub-area re-observes it and POSTS the matching <see cref="PandasCommand"/> to <c>py/pandas</c>,
+/// and the returned <see cref="DataGridControl"/> replaces the grid. When NO Python participant is
+/// attached (the default in prod / CI), the post fails or times out and the area degrades to an
+/// informative notice — it never hangs and never shows a raw error.
+/// </para>
+/// </summary>
+public static class PandasExplorerLayoutAreas
+{
+    /// <summary>Stable mesh address of the Python participant holding the DataFrame.</summary>
+    private static readonly Address PandasParticipant = new("py", "pandas");
+
+    /// <summary>The single interactive area name.</summary>
+    public const string ExplorerArea = "Explorer";
+
+    // Layout-area data-store keys.
+    private const string TriggerId = "pandasViewCommand";      // which read-only view to render next
+    private const string GroupByColumnId = "pandasGroupByColumn"; // bound to the text input
+    private const string DefaultGroupBy = "region";
+
+    // Bounded wait for the Python round-trip: long enough for a real participant, short enough that
+    // the no-node path degrades promptly instead of hanging.
+    private static readonly TimeSpan BackendTimeout = TimeSpan.FromSeconds(8);
+
+    private const string Intro =
+        "This grid is rendered by a **Python** process — a `pandas.DataFrame` held live in the "
+        + "`py/pandas` mesh participant. The buttons below post `PandasCommand` messages that mutate "
+        + "and analyse that frame; the grid re-renders from whatever the Python node returns.";
+
+    private const string NoNodeText =
+        "**No Python pandas node attached.**\n\n"
+        + "This area drives a live `pandas.DataFrame` held in a Python process. Start the participant "
+        + "and it appears here automatically:\n\n"
+        + "```bash\npython -m meshweaver.examples.pandas_node \\\n"
+        + "    --url https://memex.meshweaver.cloud --token mw_… --address py/pandas\n```";
+
+    /// <summary>Registers the interactive Explorer view.</summary>
+    public static LayoutDefinition AddPandasExplorerLayoutAreas(this LayoutDefinition layout) =>
+        layout.WithView(ExplorerArea, Explorer);
+
+    /// <summary>
+    /// The Explorer area: a static header + toolbar, and a reactive grid sub-area that talks to the
+    /// Python participant. The toolbar renders once; only the grid re-renders as commands flow.
+    /// </summary>
+    public static IObservable<UiControl?> Explorer(LayoutAreaHost host, RenderingContext _)
+    {
+        // Seed the group-by input once (so the "Group by" button always has a column to read).
+        host.UpdateData(GroupByColumnId, DefaultGroupBy);
+
+        return Observable.Return<UiControl?>(
+            Controls.Stack
+                .WithView(Controls.Title("Pandas Explorer", 2), "title")
+                .WithView(Controls.Markdown(Intro), "intro")
+                .WithView(BuildToolbar(host), "toolbar")
+                .WithView((h, _) => GridRegion(h), "grid"));
+    }
+
+    // ---- the reactive grid ------------------------------------------------------------------------
+
+    /// <summary>
+    /// Observes the current view-command trigger and renders the corresponding grid. <c>Switch</c>
+    /// cancels an in-flight request when a newer command arrives, so a click storm never piles up
+    /// round-trips.
+    /// </summary>
+    private static IObservable<UiControl> GridRegion(LayoutAreaHost host) =>
+        host.GetDataStream<PandasViewCommand>(TriggerId)
+            .StartWith(PandasViewCommand.Render())
+            .Where(view => view is not null)
+            .Select(view => RenderGrid(host, view!))
+            .Switch();
+
+    /// <summary>
+    /// Posts one grid-producing <see cref="PandasCommand"/> to <c>py/pandas</c> and maps the response
+    /// to a control. Shows a loading placeholder first; a timeout / delivery failure / unexpected
+    /// response all degrade to the informative no-node notice.
+    /// </summary>
+    private static IObservable<UiControl> RenderGrid(LayoutAreaHost host, PandasViewCommand view)
+    {
+        var delivery = host.Hub.Post(view.ToCommand(), o => o.WithTarget(PandasParticipant));
+        if (delivery is null)
+            return Observable.Return(NoNode());
+
+        return host.Hub.Observe(delivery)
+            .Select(response => response.Message is DataGridControl grid
+                ? GridView(view, grid)
+                : NoNode("The Python participant returned an unexpected response."))
+            .Take(1)
+            .Timeout(BackendTimeout)
+            .Catch((Exception _) => Observable.Return(NoNode()))
+            .StartWith(Loading(view));
+    }
+
+    private static UiControl GridView(PandasViewCommand view, DataGridControl grid) =>
+        Controls.Stack
+            .WithView(Controls.Markdown($"**Live DataFrame** — {view.Caption()}"), "status")
+            .WithView(grid, "table");
+
+    private static UiControl Loading(PandasViewCommand view) =>
+        Controls.Stack
+            .WithView(Controls.Markdown($"_Asking the Python participant to render the {view.Caption()}…_"), "status")
+            .WithView(Controls.Progress("Contacting py/pandas…", 0), "table");
+
+    private static UiControl NoNode(string? detail = null) =>
+        Controls.Stack
+            .WithView(Controls.Markdown(detail is null ? NoNodeText : $"{NoNodeText}\n\n_{detail}_"), "status")
+            // A disabled/empty grid keeps the layout stable until a participant attaches.
+            .WithView(Controls.DataGrid(Array.Empty<object>()), "table");
+
+    // ---- the controls (the point) -----------------------------------------------------------------
+
+    private static UiControl BuildToolbar(LayoutAreaHost host)
+    {
+        var groupByColumn = (new TextFieldControl(new JsonPointerReference(""))
+                .WithPlaceholder("group-by column")
+                .WithImmediate(true) with
+            {
+                DataContext = LayoutAreaReference.GetDataPointer(GroupByColumnId),
+            }).WithStyle("min-width: 160px;");
+
+        return Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithStyle("display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin: 8px 0 16px 0;")
+            // load / append MUTATE the held frame, then refresh the grid.
+            .WithView(Button("Load sample sales", Appearance.Accent,
+                ctx => Mutate(ctx.Host, PandasCommand.LoadSample())), "load")
+            .WithView(Button("Append 2 rows", Appearance.Neutral,
+                ctx => Mutate(ctx.Host, PandasCommand.AppendTwo())), "append")
+            // group-by reads the text input, then renders a grouped view.
+            .WithView(Button("Group by", Appearance.Neutral, ctx => GroupBy(ctx.Host)), "groupby")
+            .WithView(groupByColumn, "groupByColumn")
+            // analytical views — read-only, do not mutate the frame.
+            .WithView(Button("Rolling mean (3)", Appearance.Neutral,
+                ctx => View(ctx.Host, PandasViewCommand.Rolling("sales", 3))), "rolling")
+            .WithView(Button("Describe", Appearance.Neutral,
+                ctx => View(ctx.Host, PandasViewCommand.Describe())), "describe")
+            .WithView(Button("Refresh", Appearance.Neutral,
+                ctx => View(ctx.Host, PandasViewCommand.Render())), "refresh")
+            .WithView(Button("Reset", Appearance.Neutral,
+                ctx => Mutate(ctx.Host, PandasCommand.Reset())), "reset");
+    }
+
+    private static ButtonControl Button(string text, string appearance, Action<UiActionContext> onClick) =>
+        Controls.Button(text)
+            .WithAppearance(appearance)
+            .WithClickAction(ctx =>
+            {
+                onClick(ctx);
+                return Task.CompletedTask;
+            });
+
+    /// <summary>Flip the trigger to a new read-only view — the grid sub-area re-renders it.</summary>
+    private static void View(LayoutAreaHost host, PandasViewCommand view) =>
+        host.UpdateData(TriggerId, view);
+
+    /// <summary>Read the current group-by column from the input, then render the grouped view.</summary>
+    private static void GroupBy(LayoutAreaHost host) =>
+        host.GetDataStream<string>(GroupByColumnId)
+            .Take(1)
+            .Subscribe(column =>
+                View(host, PandasViewCommand.GroupBy(
+                    string.IsNullOrWhiteSpace(column) ? DefaultGroupBy : column!.Trim())));
+
+    /// <summary>
+    /// Post a mutation (<c>load</c> / <c>append</c> / <c>reset</c>) and, once the participant acks,
+    /// refresh the grid so it reflects the new frame state. Race-free: the render only fires after
+    /// the mutation is applied. On failure the trigger still flips to render, which shows the notice.
+    /// </summary>
+    private static void Mutate(LayoutAreaHost host, PandasCommand mutation)
+    {
+        var delivery = host.Hub.Post(mutation, o => o.WithTarget(PandasParticipant));
+        if (delivery is null)
+        {
+            View(host, PandasViewCommand.Render());
+            return;
+        }
+
+        host.Hub.Observe(delivery)
+            .Take(1)
+            .Timeout(BackendTimeout)
+            .Subscribe(
+                _ => View(host, PandasViewCommand.Render()),
+                _ => View(host, PandasViewCommand.Render()));
+    }
+}

--- a/src/MeshWeaver.Application.Styles/CustomIcons.cs
+++ b/src/MeshWeaver.Application.Styles/CustomIcons.cs
@@ -15,6 +15,29 @@ public static class CustomIcons
     /// </summary>
     public static Icon CSharp() => new Icon(Provider, "CSharp") { Size = IconSize.Size20 };
 
+    /// <summary>Python programming language icon.</summary>
+    public static Icon Python() => new Icon(Provider, "Python") { Size = IconSize.Size20 };
+
+    /// <summary>JavaScript programming language icon.</summary>
+    public static Icon JavaScript() => new Icon(Provider, "JavaScript") { Size = IconSize.Size20 };
+
+    /// <summary>TypeScript programming language icon.</summary>
+    public static Icon TypeScript() => new Icon(Provider, "TypeScript") { Size = IconSize.Size20 };
+
+    /// <summary>
+    /// Maps a <c>CodeConfiguration.Language</c>-style identifier (as stored on a Code node) to the
+    /// matching language glyph. Unknown / null languages fall back to the C# icon. This is the
+    /// single place that decides "which language is this Code node" for icon purposes — used by the
+    /// Code node's Overview nav menu so a Python / JS / TS file reads as such at a glance.
+    /// </summary>
+    public static Icon ForLanguage(string? language) => (language?.Trim().ToLowerInvariant()) switch
+    {
+        "python" or "py" => Python(),
+        "javascript" or "js" or "jsx" or "node" => JavaScript(),
+        "typescript" or "ts" or "tsx" => TypeScript(),
+        _ => CSharp(),
+    };
+
     /// <summary>
     /// Gets the SVG inner content for a custom icon.
     /// FluentUI expects path/rect/g/circle elements, not full SVG.
@@ -28,6 +51,16 @@ public static class CustomIcons
                 <path d="M4 10c0-3.3 2.2-6 5-6 1.8 0 3.4 1 4.3 2.5l-1.5 1c-.6-1-1.6-1.7-2.8-1.7-1.9 0-3.2 1.8-3.2 4.2s1.3 4.2 3.2 4.2c1.2 0 2.2-.7 2.8-1.7l1.5 1c-.9 1.5-2.5 2.5-4.3 2.5-2.8 0-5-2.7-5-6z"/>
                 <path d="M14 7h1.5v6H14V7zm2.5 0H18v6h-1.5V7zm-1.25 1.5v1h3v-1h-3zm0 2v1h3v-1h-3z"/>
             </g>
+            """,
+        // Simple text glyphs ("Py" / "JS" / "TS") — recognisable at a glance next to a Code node.
+        "Python" => """
+            <text x="10" y="14" text-anchor="middle" font-family="sans-serif" font-size="9" font-weight="700" fill="currentColor">Py</text>
+            """,
+        "JavaScript" => """
+            <text x="10" y="14" text-anchor="middle" font-family="sans-serif" font-size="9" font-weight="700" fill="currentColor">JS</text>
+            """,
+        "TypeScript" => """
+            <text x="10" y="14" text-anchor="middle" font-family="sans-serif" font-size="9" font-weight="700" fill="currentColor">TS</text>
             """,
         _ => null
     };

--- a/src/MeshWeaver.Documentation/Data/DataMesh/CallingPython.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/CallingPython.md
@@ -221,6 +221,7 @@ The deployed sample instance's `Report` area is embedded below (on a host withou
 
 ## Related
 
+- [A pandas node in Python](../PythonPandasNode) — the stateful counterpart: a Python **participant** that holds a live `pandas.DataFrame` and renders it back as a real `DataGridControl`.
 - [Controlled I/O Pooling](/Doc/Architecture/ControlledIoPooling) — the `IIoPool` contract, pool names and caps.
 - [Asynchronous Calls](/Doc/Architecture/AsynchronousCalls) — the no-async rule book for hub-reachable code.
 - [Creating Node Types](../CreatingNodeTypes) — the base walkthrough for content records and layout areas.

--- a/src/MeshWeaver.Documentation/Data/DataMesh/NodeTypes.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/NodeTypes.md
@@ -113,6 +113,10 @@ Pull in third-party libraries (Math.NET, Markdig, and more) by dropping a `#r "n
 
 Compute a layout area's content in an external `python3` process through the bounded Process I/O pool — reactive end to end, degrading gracefully when Python is absent.
 
+### [A pandas node in Python](/Doc/DataMesh/PythonPandasNode)
+
+Connect a Python process to the mesh as a participant, hold a live `pandas.DataFrame` inside it, control that object over the mesh, and render its state back as a real `DataGridControl`.
+
 ### [Testing Node Types](/Doc/DataMesh/NodeTypes/Testing)
 
 Stand up a `MonolithMeshTestBase` test project against a samples directory, render layout areas against a real client, and assert on the streaming response.

--- a/src/MeshWeaver.Documentation/Data/DataMesh/PythonPandasNode.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/PythonPandasNode.md
@@ -1,0 +1,152 @@
+---
+Name: A pandas node in Python
+Category: Documentation
+Description: Hold a live pandas DataFrame inside a Python mesh participant, control it over the mesh, and render its state back as a real DataGrid control — not markdown.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18M9 3v18M15 3v18"/></svg>
+---
+
+# A pandas node in Python
+
+[Calling Python](../CallingPython) runs `python3` as a **stateless external process**: the mesh shells out, Python prints, the process dies. This page is the interactive counterpart. Here a Python process **connects to the mesh as a participant** (over gRPC, exactly like the MAUI / Blazor-WASM clients) and **owns a live object** — a `pandas.DataFrame` — that the mesh can drive over many round trips. The frame is real, long-lived Python state; the mesh creates it, mutates it, queries it, and renders its **current** state back as a genuine `DataGridControl`.
+
+| | [Calling Python](../CallingPython) | This page |
+|---|---|---|
+| Python is a… | short-lived process | connected mesh **participant** (`py/pandas`) |
+| State | none (fresh each call) | a **live DataFrame held in the participant** |
+| Output | markdown text | a real **`DataGridControl`** (sortable, formatted) |
+
+The working code lives in the Python client package: `clients/python/meshweaver/examples/pandas_node.py` (tests: `clients/python/tests/test_pandas_node.py`). The participant model itself is in `clients/python/README.md`.
+
+## Two ways to control the frame
+
+Both surfaces act on the **same** held DataFrame:
+
+1. **Typed `PandasCommand` messages** — `load` / `append` / `reset` (mutate), `render` / `groupby` / `describe` / `rolling` (analyse). The mesh routes them to the participant's address by *target*; the message type is opaque to the mesh (it round-trips as `RawJson`), so nothing needs server-side registration.
+2. **`SubmitCodeRequest`** — pandas code run against a **persistent** namespace where the frame lives as `df`. Unlike the stateless kernel worker (`meshweaver.worker.execute_python`, a fresh namespace per call), this namespace *survives* across calls, so `df["margin"] = df["sales"] - df["units"]` in one submission is visible to the next. That persistent `df` **is** "an object created and controlled in Python".
+
+```mermaid
+graph LR
+    A[mesh participant / agent] -- PandasCommand / SubmitCode --> B[py/pandas participant]
+    B -- holds --> D[(live pandas DataFrame)]
+    B -- render --> G[DataGridControl JSON]
+    G -- deserialises to --> H[typed DataGridControl<br/>GUI renders a real grid]
+```
+
+## pandas → DataGrid: the wire contract
+
+The node never emits markdown or an HTML string. `frame_to_datagrid` maps the frame's dtypes to typed `PropertyColumnControl<T>` columns (with .NET numeric formats) and its records to JSON-safe rows — the **exact** shape `Controls.DataGrid(rows).WithColumn(new PropertyColumnControl<double>{ Property = "sales" }.WithFormat("N2"))` produces on the C# side:
+
+```python
+def _column(name, dtype):
+    if pdt.is_bool_dtype(dtype):            clr, fmt = "Boolean", None
+    elif pdt.is_integer_dtype(dtype):       clr, fmt = "Int64", "N0"
+    elif pdt.is_float_dtype(dtype):         clr, fmt = "Double", "N2"
+    elif pdt.is_datetime64_any_dtype(dtype): clr, fmt = "DateTime", "yyyy-MM-dd"
+    else:                                    clr, fmt = "String", None
+    col = {"$type": f"PropertyColumnControl`1[{clr}]", "property": name,
+           "title": name.replace("_", " ").title()}
+    if fmt is not None:
+        col["format"] = fmt
+    return col
+
+def frame_to_datagrid(df):
+    columns = [_column(str(n), d) for n, d in df.dtypes.items()]
+    data = json.loads(df.to_json(orient="records", date_format="iso"))  # NaN→null, ints/floats, ISO dates
+    return {"data": data, "columns": columns}
+```
+
+The ``$type`` for a column is the discriminator the mesh's type registry resolves to a `PropertyColumnControl<T>`: a constructed generic serialises as ``Name`1[Arg]`` (the open generic's `Type.Name` + the registered short name of the argument — `Double`, `Int64`, …). C# emits the same string with the backtick JSON-escaped as ```; both decode to the identical value.
+
+## The participant that owns the frame
+
+```python
+class PandasNode:
+    def __init__(self, connection, frame=None):
+        self._c = connection
+        self._df = pd.DataFrame() if frame is None else frame.copy()
+        connection.serve(self.handle)          # register as the inbound handler
+
+    async def handle(self, delivery):
+        if delivery.message_type == "PandasCommand":
+            await self._handle_command(delivery)
+        elif delivery.message_type == "SubmitCodeRequest":
+            await self._handle_code(delivery)   # runs against the PERSISTENT namespace
+
+    def _apply(self, command, msg):
+        if command == "load":     self._df = pd.DataFrame(msg.get("data") or []);            return "ack", self._summary()
+        if command == "append":   self._df = pd.concat([self._df, pd.DataFrame(msg["rows"])], ignore_index=True); return "ack", self._summary()
+        if command == "render":   return "grid", frame_to_datagrid(self._df)
+        if command == "groupby":  return "grid", frame_to_datagrid(self._df.groupby(msg["by"]).agg(msg.get("agg","sum"), numeric_only=True).reset_index())
+        if command == "rolling":
+            view = self._df.copy()
+            view[f"{msg['column']}_rolling_mean"] = view[msg["column"]].rolling(int(msg.get("window",3))).mean()
+            return "grid", frame_to_datagrid(view)
+        raise ValueError(f"unknown command '{command}'")
+```
+
+A `render` (or any analytical command) replies with the grid **as a `DataGridControl`** — `respond(delivery, "DataGridControl", payload)` — so a receiving hub deserialises it straight into `MeshWeaver.Layout.DataGrid.DataGridControl` and the Blazor / React renderer shows a live grid.
+
+## The interactive frontend — the `PandasExplorer` node
+
+The Python participant is the backend. **A .NET NodeType is the frontend that drives it.** `PandasExplorer` (`samples/Graph/Data/PythonDemo/PandasExplorer/`) is an ordinary mesh NodeType whose layout area (`PandasExplorerLayoutAreas.Explorer`) is a toolbar of **real framework controls** above a **live `DataGridControl`** — no hand-rolled HTML, no markdown for the data.
+
+```mermaid
+graph LR
+    U[user] -- clicks a button --> F[PandasExplorer layout area]
+    F -- PandasCommand --> P[py/pandas participant]
+    P -- holds --> D[(live DataFrame)]
+    P -- DataGridControl --> F
+    F -- renders --> G[real DataGrid]
+```
+
+Every control maps to one `PandasCommand` posted to `py/pandas`; the grid then re-renders from whatever the participant returns:
+
+| Control | Posts | Effect |
+|---|---|---|
+| **Load sample sales** | `load` (6 rows) | replaces the held frame, then re-renders |
+| **Append 2 rows** | `append` | grows the held frame, then re-renders |
+| **Group by** + text input | `groupby` (by = the typed column, default `region`) | grouped sum view |
+| **Rolling mean (3)** | `rolling` (column `sales`, window 3) | adds a rolling-mean column |
+| **Describe** | `describe` | descriptive statistics |
+| **Refresh** | `render` | re-renders the current frame |
+| **Reset** | `reset` | clears the held frame |
+
+The whole flow is **reactive, never `async`** (a rule of the actor-model mesh): a click flips a trigger in the layout-area data store, the grid sub-area re-observes it, `Hub.Post(command, o => o.WithTarget("py/pandas"))` fires and `Hub.Observe(delivery)` awaits the reply — composed with `Timeout` + `Catch`, so the grid degrades gracefully instead of hanging. Mutations (`load`/`append`/`reset`) chain their re-render off the participant's ack, so the grid always reflects the new frame state (race-free).
+
+**Graceful when no Python node is attached** (the default in prod / CI): the post times out or fails to route, `Catch` routes to an informative notice — *"No Python pandas node attached — run `python -m meshweaver.examples.pandas_node …`"* — plus a disabled empty grid. It never hangs and never surfaces a raw error. So the `PandasExplorer` node renders meaningfully everywhere; start the Python participant and the grid comes alive.
+
+The frontend↔backend contract is pinned by tests in `test/MeshWeaver.Layout.Test/PandasExplorerAreaTest.cs`: driving the area against an in-process fake `py/pandas` responder, the grid renders **from the backend's `DataGridControl`**, the *Group by* button posts a real `groupby` `PandasCommand`, and the no-participant path renders the notice — all bounded, no hang.
+
+## Can an entire node type live in Python?
+
+Partly — and this sample shows exactly where the line is today. A MeshWeaver NodeType is three things: a **content model**, a **behaviour** (holding state, computing), and a **view** (a `UiControl` tree). The Python participant already owns the **behaviour and the state** — the live `DataFrame` *is* the node's state, controlled entirely from Python — and it even authors part of the **view** by emitting a real `DataGridControl` (not markdown). What still lives in .NET is the **layout area that wires controls to commands** and the **NodeType registration** (`WithContentType` / `AddLayout`). So the pattern is a thin C# frontend over an arbitrarily rich Python backend: the object is *created and controlled in Python*, and the .NET side is just the reactive shell that drives it and renders what it returns.
+
+## Run it
+
+Self-contained showcase — create a frame, append two rows over the mesh, render it, then group + roll (no mesh needed; prints the DataGrid JSON the GUI would render):
+
+```bash
+cd clients/python
+pip install -e ".[dev,examples]"
+scripts/gen_proto.sh
+python -m meshweaver.examples.pandas_node --demo
+```
+
+Serve as a real participant other participants / agents drive over gRPC:
+
+```bash
+python -m meshweaver.examples.pandas_node --url https://memex.meshweaver.cloud --token mw_… --address py/pandas
+```
+
+## Proof it's a real grid, not markdown
+
+The bytes `--demo` emits are checked end to end:
+
+- **Python** (`tests/test_pandas_node.py`) — appending over the mesh grows the *held* frame (6 → 8 rows), the rendered grid reflects the mutation, and `groupby` / `rolling` compute real pandas values.
+- **C#** (`test/MeshWeaver.Layout.Test/PandasDataGridWireTest.cs`) — those **exact captured bytes** deserialise, through the mesh's own `JsonSerializerOptions`, into a real `DataGridControl` whose columns are typed `PropertyColumnControl<string>` / `<double>` / `<long>` carrying `N2` / `N0` formats, over 8 data rows. Same wire contract a hand-written C# `Controls.DataGrid(...)` produces.
+
+## Related
+
+- [Calling Python](../CallingPython) — the stateless process pattern (a layout area shells out to `python3`).
+- [Controlled I/O Pooling](/Doc/Architecture/ControlledIoPooling) — why the C# side bridges every async/blocking edge through `IIoPool`.
+- [Query Syntax](../QuerySyntax) — the query language a participant uses to find nodes to feed a frame.

--- a/src/MeshWeaver.Graph/CodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CodeLayoutAreas.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Text.Json;
 using Humanizer;
 using MeshWeaver.Application.Styles;
 using MeshWeaver.Data;
@@ -36,6 +37,14 @@ public static class CodeLayoutAreas
 
     private const string CodeDataId = "code";
     private const string SiblingNodesDataId = "siblingCodeNodes";
+
+    /// <summary>
+    /// Languages a Code node can be authored in. C# runs in-process on the Roslyn kernel; Python routes
+    /// to a connected <c>py/python-kernel</c> worker participant (see <c>CodeNodeType.HandleExecuteScript</c>);
+    /// the rest are first-class for authoring / syntax highlighting / display. Immutable constant lookup.
+    /// </summary>
+    private static readonly string[] LanguageOptions =
+        { "csharp", "python", "typescript", "javascript", "json", "sql", "markdown" };
 
     /// <summary>
     /// Adds the Code views to the hub's layout for Code nodes.
@@ -311,7 +320,7 @@ public static class CodeLayoutAreas
                 var label = sibling.Name ?? sibling.Id;
                 var siblingHref = new LayoutAreaReference(OverviewArea).ToHref(sibling.Path);
                 codeGroup = codeGroup.WithView(
-                    new NavLinkControl(label, CustomIcons.CSharp(), siblingHref)
+                    new NavLinkControl(label, CustomIcons.ForLanguage(SiblingLanguage(sibling)), siblingHref)
                 );
             }
         }
@@ -325,6 +334,22 @@ public static class CodeLayoutAreas
         navMenu = navMenu.WithNavGroup(codeGroup);
 
         return navMenu;
+    }
+
+    /// <summary>
+    /// Best-effort language of a sibling Code node, read from its <see cref="CodeConfiguration"/> content
+    /// (typed or still-raw JSON). Used to pick the nav-menu glyph; falls back to null (→ the C# icon).
+    /// </summary>
+    private static string? SiblingLanguage(MeshNode node)
+    {
+        if (node.Content is CodeConfiguration code)
+            return code.Language;
+        if (node.Content is JsonElement json
+            && json.ValueKind == JsonValueKind.Object
+            && json.TryGetProperty("language", out var language)
+            && language.ValueKind == JsonValueKind.String)
+            return language.GetString();
+        return null;
     }
 
     /// <summary>
@@ -355,6 +380,7 @@ public static class CodeLayoutAreas
         var stack = Controls.Stack.WithWidth("100%").WithStyle("padding: 24px;");
         var codeDataId = Guid.NewGuid().AsString();
         var displayNameDataId = Guid.NewGuid().AsString();
+        var languageDataId = Guid.NewGuid().AsString();
 
         var initialCode = codeConfig.Code ?? "";
         var language = codeConfig.Language ?? "csharp";
@@ -362,6 +388,7 @@ public static class CodeLayoutAreas
 
         host.UpdateData(codeDataId, initialCode);
         host.UpdateData(displayNameDataId, nodeName);
+        host.UpdateData(languageDataId, language);
 
         // Header
         stack = stack.WithView(Controls.H2($"Edit: {nodeName}")
@@ -379,6 +406,19 @@ public static class CodeLayoutAreas
             { DataContext = LayoutAreaReference.GetDataPointer(displayNameDataId) });
 
         stack = stack.WithView(displayNameRow);
+
+        // Language selector — pick C#, Python, TypeScript, JavaScript, … so a Code node can be DEFINED
+        // in any first-class language (persisted onto CodeConfiguration.Language on Save). Python code
+        // then executes on the connected py/python-kernel worker; C# runs in-process on the Roslyn kernel.
+        var languageRow = Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithStyle("gap: 12px; align-items: center; margin-bottom: 16px;")
+            .WithView(Controls.Label("Language:").WithStyle("font-weight: 500;"))
+            .WithView((new SelectControl(new JsonPointerReference(""), Array.Empty<object>())
+                    .WithOptions(LanguageOptions)) with
+                { DataContext = LayoutAreaReference.GetDataPointer(languageDataId) });
+
+        stack = stack.WithView(languageRow);
 
         // Monaco editor. LSP opt-in: when this Code node sits under a NodeType's Source/
         // subtree, enable live Roslyn diagnostics (Stage-1 IMeshLanguageService). The
@@ -426,11 +466,23 @@ public static class CodeLayoutAreas
             .WithIconStart(FluentIcons.Save())
             .WithClickAction(actx =>
             {
-                host.Stream.GetDataStream<string>(codeDataId)
+                // Snapshot both the edited code AND the chosen language (both seeded, so each Take(1)
+                // emits its current value) and persist them together.
+                host.Stream.GetDataStream<string>(codeDataId).Take(1)
+                    .CombineLatest(host.Stream.GetDataStream<string>(languageDataId).Take(1),
+                        (currentCode, currentLanguage) => (currentCode, currentLanguage))
                     .Take(1)
-                    .Subscribe(currentCode =>
+                    .Subscribe(edited =>
                     {
-                        var updatedCodeConfiguration = codeConfig with { Code = currentCode };
+                        var (currentCode, currentLanguage) = edited;
+                        var chosenLanguage = string.IsNullOrWhiteSpace(currentLanguage)
+                            ? codeConfig.Language
+                            : currentLanguage;
+                        var updatedCodeConfiguration = codeConfig with
+                        {
+                            Code = currentCode,
+                            Language = chosenLanguage!,
+                        };
                         var delivery = actx.Host.Hub.Post(
                             new DataChangeRequest { ChangedBy = actx.Host.Stream.ClientId }.WithUpdates(updatedCodeConfiguration),
                             o => o.WithTarget(hubAddress))!;

--- a/test/MeshWeaver.Layout.Test/MeshWeaver.Layout.Test.csproj
+++ b/test/MeshWeaver.Layout.Test/MeshWeaver.Layout.Test.csproj
@@ -15,4 +15,12 @@
     <PackageReference Include="Microsoft.Reactive.Testing" />
   </ItemGroup>
 
+  <!-- Link-compile the PandasExplorer sample sources (runtime-compiled mesh Code nodes) so the
+       interactive frontend has a single source of truth: the same files deployed to the mesh are
+       compiled + tested here, and the -warnaserror gate covers them. -->
+  <ItemGroup>
+    <Compile Include="..\..\samples\Graph\Data\PythonDemo\PandasExplorer\Source\PandasExplorer.cs" Link="PandasExplorerSample\PandasExplorer.cs" />
+    <Compile Include="..\..\samples\Graph\Data\PythonDemo\PandasExplorer\Source\PandasExplorerLayoutAreas.cs" Link="PandasExplorerSample\PandasExplorerLayoutAreas.cs" />
+  </ItemGroup>
+
 </Project>

--- a/test/MeshWeaver.Layout.Test/PandasDataGridWireTest.cs
+++ b/test/MeshWeaver.Layout.Test/PandasDataGridWireTest.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.DataGrid;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Cross-language proof for <c>meshweaver.examples.pandas_node</c> (the Python-backed mesh node that holds
+/// a live pandas DataFrame): the DataGrid JSON that node emits is the SAME wire contract the C# GUI
+/// renders. The <see cref="PythonPandasNodeWire"/> constant below is captured VERBATIM from
+/// <c>python -m meshweaver.examples.pandas_node --demo</c> (with the <c>$type</c> the participant's
+/// <c>respond("DataGridControl", …)</c> stamps on the wire). We deserialize those exact bytes with the
+/// mesh's own <see cref="JsonSerializerOptions"/> and prove they become a real, typed
+/// <see cref="DataGridControl"/> — not markdown, not an HTML string.
+/// </summary>
+public class PandasDataGridWireTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration).AddLayout(x => x);
+
+    // Captured verbatim from `python -m meshweaver.examples.pandas_node --demo`, wrapped with the
+    // top-level "$type":"DataGridControl" that MeshConnection.respond stamps on the outbound message.
+    private const string PythonPandasNodeWire =
+        """
+        {
+          "$type": "DataGridControl",
+          "data": [
+            {"month":"Jan","region":"EMEA","sales":120.0,"units":12},
+            {"month":"Feb","region":"EMEA","sales":135.5,"units":14},
+            {"month":"Mar","region":"EMEA","sales":128.0,"units":13},
+            {"month":"Apr","region":"APAC","sales":98.0,"units":9},
+            {"month":"May","region":"APAC","sales":143.0,"units":15},
+            {"month":"Jun","region":"APAC","sales":150.0,"units":16},
+            {"month":"Jul","region":"APAC","sales":161.0,"units":17},
+            {"month":"Aug","region":"EMEA","sales":152.0,"units":15}
+          ],
+          "columns": [
+            {"$type":"PropertyColumnControl`1[String]","property":"month","title":"Month"},
+            {"$type":"PropertyColumnControl`1[String]","property":"region","title":"Region"},
+            {"$type":"PropertyColumnControl`1[Double]","property":"sales","title":"Sales","format":"N2"},
+            {"$type":"PropertyColumnControl`1[Int64]","property":"units","title":"Units","format":"N0"}
+          ]
+        }
+        """;
+
+    [HubFact]
+    public void PythonPandasNode_DataGrid_DeserializesToARealDataGridControl()
+    {
+        var host = GetHost();
+
+        // The exact Python bytes deserialize, via the mesh's own options, into a first-class UiControl.
+        var control = JsonSerializer.Deserialize<UiControl>(PythonPandasNodeWire, host.JsonSerializerOptions);
+        var grid = Assert.IsType<DataGridControl>(control);
+
+        // Four columns, one per DataFrame dtype. The Python `$type` discriminators (a literal backtick;
+        // C# emits the same character as ` — wire-equivalent JSON) each resolve to the EXACT typed
+        // PropertyColumnControl<T> the grid renderer binds. That is what makes it a real, sortable,
+        // correctly-formatted grid rather than opaque JSON — the columns deserialize to typed controls.
+        Assert.Equal(4, grid.Columns.Count);
+
+        var month = Assert.IsType<PropertyColumnControl<string>>(grid.Columns[0]);
+        Assert.Equal("month", month.Property);
+        Assert.IsType<PropertyColumnControl<string>>(grid.Columns[1]);
+
+        // The numeric columns are typed AND carry the .NET format strings the grid uses to format cells.
+        var sales = Assert.IsType<PropertyColumnControl<double>>(grid.Columns[2]);
+        Assert.Equal("sales", sales.Property);
+        Assert.Equal("N2", sales.Format?.ToString());
+        var units = Assert.IsType<PropertyColumnControl<long>>(grid.Columns[3]);
+        Assert.Equal("N0", units.Format?.ToString());
+
+        // The rows are the live frame's data — including the two rows appended over the mesh in the demo.
+        var data = (JsonElement)grid.Data;
+        Assert.Equal(8, data.GetArrayLength());
+        var jul = data[6];
+        Assert.Equal("Jul", jul.GetProperty("month").GetString());
+        Assert.Equal(161.0, jul.GetProperty("sales").GetDouble());
+        Assert.Equal(17, jul.GetProperty("units").GetInt64());
+    }
+
+    [HubFact]
+    public void CSharp_EquivalentDataGrid_ProducesTheSameColumnDiscriminators()
+    {
+        var host = GetHost();
+
+        // The hand-written C# equivalent of what the Python node emits — the exact idiom from the Pricing
+        // sample. Serialising it shows the C# side produces the SAME column $type discriminators, so the
+        // Python node is speaking the framework's own DataGrid contract.
+        var grid = Controls.DataGrid(new object[]
+            {
+                new { month = "Jan", region = "EMEA", sales = 120.0, units = 12L },
+            })
+            .WithColumn(new PropertyColumnControl<string> { Property = "month" }.WithTitle("Month"))
+            .WithColumn(new PropertyColumnControl<string> { Property = "region" }.WithTitle("Region"))
+            .WithColumn(new PropertyColumnControl<double> { Property = "sales" }.WithTitle("Sales").WithFormat("N2"))
+            .WithColumn(new PropertyColumnControl<long> { Property = "units" }.WithTitle("Units").WithFormat("N0"));
+
+        var json = JsonSerializer.Serialize(grid, host.JsonSerializerOptions);
+        Output.WriteLine(json);
+
+        // The C# JSON encoder escapes the generic-discriminator backtick as ` (the Python node emits
+        // the literal backtick — both decode to the same string), so assert on the encoder-independent
+        // outcome: the C# grid round-trips back into the SAME typed columns the Python wire deserialises to.
+        var roundtrip = Assert.IsType<DataGridControl>(
+            JsonSerializer.Deserialize<UiControl>(json, host.JsonSerializerOptions));
+        Assert.Equal(4, roundtrip.Columns.Count);
+        Assert.IsType<PropertyColumnControl<string>>(roundtrip.Columns[0]);
+        Assert.IsType<PropertyColumnControl<double>>(roundtrip.Columns[2]);
+        Assert.IsType<PropertyColumnControl<long>>(roundtrip.Columns[3]);
+    }
+}

--- a/test/MeshWeaver.Layout.Test/PandasExplorerAreaTest.cs
+++ b/test/MeshWeaver.Layout.Test/PandasExplorerAreaTest.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.DataGrid;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Records every <see cref="PandasCommand"/> a fake <c>py/pandas</c> responder receives, so a test can
+/// assert which command a button click posted. Mesh-scoped singleton (dies with the mesh — no static
+/// state, no <c>Clear()</c>). A ReplaySubject so an assertion subscribing after the fact still sees it.
+/// </summary>
+public sealed class PandasCommandRecorder
+{
+    private readonly ReplaySubject<PandasCommand> commands = new();
+
+    /// <summary>Every command the fake participant has received.</summary>
+    public IObservable<PandasCommand> Commands => commands;
+
+    /// <summary>Records a received command.</summary>
+    public void Record(PandasCommand command) => commands.OnNext(command);
+}
+
+/// <summary>
+/// Drives the interactive PandasExplorer frontend (<c>PandasExplorerLayoutAreas</c>) against an
+/// in-process fake <c>py/pandas</c> participant that mirrors the Python node's contract:
+/// <c>PandasCommand</c> in → <see cref="DataGridControl"/> out. Proves the area renders the grid FROM
+/// the backend response, and that a button click posts the correct <c>PandasCommand</c> to <c>py/pandas</c>.
+/// </summary>
+public class PandasExplorerAreaTest : HubTestBase
+{
+    private const string Area = PandasExplorerLayoutAreas.ExplorerArea;
+
+    public PandasExplorerAreaTest(ITestOutputHelper output) : base(output)
+    {
+        // Shared across the host (which drives the area) and the fake py/pandas responder hub.
+        Services.AddSingleton<PandasCommandRecorder>();
+    }
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithTypes(typeof(PandasCommand))
+            .AddLayout(layout => layout.AddPandasExplorerLayoutAreas());
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    // Route py/pandas to a hosted hub that stands in for the Python participant.
+    protected override MessageHubConfiguration ConfigureMesh(MessageHubConfiguration conf)
+        => base.ConfigureMesh(conf)
+            .WithRoutes(routes => routes.RouteAddressToHostedHub("py", c => c
+                .WithTypes(typeof(PandasCommand))
+                .AddLayout(x => x)
+                .WithHandler<PandasCommand>(RespondWithGrid)
+                .WithPostingIdentity(PostingIdentity.System)));
+
+    private static IMessageDelivery RespondWithGrid(IMessageHub hub, IMessageDelivery<PandasCommand> request)
+    {
+        hub.ServiceProvider.GetRequiredService<PandasCommandRecorder>().Record(request.Message);
+        // Mirror the Python node: grid/analytical commands reply AS a DataGridControl; mutations reply
+        // with an ack — here we always reply with a grid, which is enough to drive the frontend.
+        hub.Post(SampleGrid(), o => o.ResponseFor(request));
+        return request.Processed();
+    }
+
+    // The exact idiom from PandasDataGridWireTest — a real DataGridControl with typed, formatted columns.
+    private static DataGridControl SampleGrid() =>
+        Controls.DataGrid(new object[]
+            {
+                new { month = "Jan", region = "EMEA", sales = 120.0, units = 12L },
+                new { month = "Feb", region = "EMEA", sales = 135.5, units = 14L },
+                new { month = "Mar", region = "EMEA", sales = 128.0, units = 13L },
+                new { month = "Apr", region = "APAC", sales = 98.0, units = 9L },
+                new { month = "May", region = "APAC", sales = 143.0, units = 15L },
+                new { month = "Jun", region = "APAC", sales = 150.0, units = 16L },
+            })
+            .WithColumn(new PropertyColumnControl<string> { Property = "month" }.WithTitle("Month"))
+            .WithColumn(new PropertyColumnControl<string> { Property = "region" }.WithTitle("Region"))
+            .WithColumn(new PropertyColumnControl<double> { Property = "sales" }.WithTitle("Sales").WithFormat("N2"))
+            .WithColumn(new PropertyColumnControl<long> { Property = "units" }.WithTitle("Units").WithFormat("N0"));
+
+    [HubFact]
+    public async Task Area_renders_the_DataGrid_from_the_backend_response()
+    {
+        var reference = new LayoutAreaReference(Area);
+        var stream = GetClient().GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(CreateHostAddress(), reference);
+
+        // The grid the area shows is the DataGridControl the backend returned — 4 typed columns.
+        var grid = await stream.GetControlStream($"{Area}/grid/table")
+            .Where(c => c is DataGridControl { Columns.Count: 4 })
+            .Select(c => (DataGridControl)c!)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+
+        Assert.Equal(4, grid.Columns.Count);
+
+        // The initial render actually contacted the participant with a `render` command.
+        var recorder = ServiceProvider.GetRequiredService<PandasCommandRecorder>();
+        await recorder.Commands.Where(c => c.Command == "render")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(10)).ToTask();
+    }
+
+    [HubFact]
+    public async Task GroupBy_button_posts_a_groupby_PandasCommand_to_py_pandas()
+    {
+        var reference = new LayoutAreaReference(Area);
+        var client = GetClient();
+        var stream = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(CreateHostAddress(), reference);
+
+        // Wait for the toolbar button to render before clicking it.
+        await stream.GetControlStream($"{Area}/toolbar/groupby")
+            .Where(c => c is not null).FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+
+        var recorder = ServiceProvider.GetRequiredService<PandasCommandRecorder>();
+        client.Post(new ClickedEvent($"{Area}/toolbar/groupby", stream.StreamId),
+            o => o.WithTarget(CreateHostAddress()));
+
+        // The click drove a real groupby command, carrying the seeded group-by column.
+        var groupBy = await recorder.Commands.Where(c => c.Command == "groupby")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(20)).ToTask();
+        Assert.Equal("region", groupBy.By);
+        Assert.Equal("sum", groupBy.Agg);
+    }
+}
+
+/// <summary>
+/// The graceful no-participant path: with NO <c>py/pandas</c> routed (the default in prod / CI), the
+/// area posts, the delivery fails / times out, and the grid degrades to an informative notice — it
+/// never hangs and never surfaces a raw error.
+/// </summary>
+public class PandasExplorerNoParticipantTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string Area = PandasExplorerLayoutAreas.ExplorerArea;
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithTypes(typeof(PandasCommand))
+            .AddLayout(layout => layout.AddPandasExplorerLayoutAreas());
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    [HubFact]
+    public async Task No_participant_degrades_to_the_informative_notice()
+    {
+        var reference = new LayoutAreaReference(Area);
+        var stream = GetClient().GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(CreateHostAddress(), reference);
+
+        var notice = await stream.GetControlStream($"{Area}/grid/status")
+            .Where(c => c is MarkdownControl m && (m.Markdown?.ToString() ?? "").Contains("No Python pandas node"))
+            .Select(c => (MarkdownControl)c!)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+
+        Assert.Contains("py/pandas", notice.Markdown?.ToString() ?? "");
+    }
+}


### PR DESCRIPTION
A genuinely interactive Python-mesh integration: a `py/pandas` participant holds a live pandas DataFrame as persistent in-process state (added a persistent namespace since CodeWorker discards state), controllable over the mesh via typed PandasCommand + code, rendered back as a real typed DataGridControl (byte-exact through the .NET serializer — no markdown/HTML). The PandasExplorer NodeType is the frontend: buttons + a text input each post a command to the participant and re-render the returned DataGrid — a proper frontend driving a live Python object — with a graceful no-node-attached state. Also makes language first-class in Code nodes (the language selector — the missing UI to author Python nodes). pytest 28/28, wire test 2/2, area tests 3/3, link-integrity green, Release -warnaserror clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)