### PR TITLE
fix(data): terminate RouteStreamMessage self-parent walk — cure the round-3 chat vanish (10-msg test green)

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -245,7 +245,21 @@ public static class DataExtensions
         {
             syncHub = current.GetHostedHub(request.Target!, create: HostedHubCreation.Never);
             if (syncHub is not null) break;
-            current = current.Configuration.ParentHub;
+            var parent = current.Configuration.ParentHub;
+            // 🚨 TERMINATE the parent-chain walk on a self-parent. `Configuration.ParentHub`
+            // resolves `IMessageHub` from the parent DI scope, and for a root/mesh hub that is
+            // the hub ITSELF (parent == current) — so without this guard the walk NEVER advances:
+            // when the sync sub-hub for this StreamId is absent (a disconnected circuit's stream,
+            // a reaped/never-created sync hub), a SINGLE StreamMessage spins the hub's DrainOne
+            // thread forever at 100% CPU inside GetHostedHub → the hub can process nothing else,
+            // starving that hub's SignalR keepalive (the round-3 composer-vanish) and leaving a
+            // silent, pegged-core, undisposable zombie portal hub (the 8s disposal-deadlock
+            // watchdog can't interrupt a running synchronous loop). Making the per-probe cost
+            // cheaper (the cached _parentHub, the allocation-free AddressComparer) only makes the
+            // infinite loop iterate faster — the loop itself must terminate. Mirrors the identical
+            // guard in MessageHubExtensions.BeginAsyncOperation, which walks the same chain.
+            if (ReferenceEquals(parent, current)) break;
+            current = parent;
         }
         if (syncHub is null)
             return Observable.Return(request.Ignored());

--- a/src/MeshWeaver.Messaging.Contract/Address.cs
+++ b/src/MeshWeaver.Messaging.Contract/Address.cs
@@ -270,22 +270,101 @@ public class AddressComparer : IEqualityComparer<Address>
     /// <param name="x">The first address.</param>
     /// <param name="y">The second address.</param>
     /// <returns>True if both are null or have matching type and id.</returns>
+    /// <remarks>
+    /// 🚨 HOT PATH — this comparer keys the hosted-hub registry
+    /// (<c>HostedHubsCollection.messageHubs</c>). <c>RouteStreamMessage</c> probes it per
+    /// parent-chain level for EVERY inbound <c>StreamMessage</c> (DataChangedEvent), so under
+    /// multi-round chat load it runs at a very high rate. It therefore compares directly over
+    /// <see cref="Address.Segments"/> and NEVER materialises <see cref="Address.Id"/> — the old
+    /// <c>x.Id.Equals(y.Id)</c> forced a LINQ <c>Segments.Skip(1)</c> + <c>string.Join</c>
+    /// allocation (48 bytes) on every probe, which a dotnet-stack of a wedged e2e pod showed as
+    /// the sole CPU frame (<c>RouteStreamMessage → GetHostedHub → AddressComparer.GetHashCode</c>)
+    /// pegging ~1.2 cores and starving the Blazor circuit's SignalR keepalive. Semantics are
+    /// identical to "Type + Id (segments-after-first joined by '/')": <see cref="Address.Type"/> is
+    /// <c>Segments[0]</c> and the tail is compared as its virtual '/'-join, so differently-segmented
+    /// tails that join to the same string (e.g. <c>["a","b/c"]</c> vs <c>["a","b","c"]</c>) still
+    /// match — WITHOUT allocating.
+    /// </remarks>
     public bool Equals(Address? x, Address? y)
     {
         if (ReferenceEquals(x, y))
             return true;
         if (x is null || y is null)
             return false;
-        return x.Type.Equals(y.Type) && x.Id.Equals(y.Id);
+        var xs = x.Segments;
+        var ys = y.Segments;
+        // Type = Segments[0].
+        var xt = xs.Length > 0 ? xs[0] : "";
+        var yt = ys.Length > 0 ? ys[0] : "";
+        if (!string.Equals(xt, yt, StringComparison.Ordinal))
+            return false;
+        // Id = Segments[1..] joined by '/'. Compare the two virtual joins char-by-char.
+        int xi = 1, xc = 0, yi = 1, yc = 0;
+        while (true)
+        {
+            var hasX = NextTailChar(xs, ref xi, ref xc, out var cx);
+            var hasY = NextTailChar(ys, ref yi, ref yc, out var cy);
+            if (hasX != hasY)
+                return false;      // one tail ended before the other
+            if (!hasX)
+                return true;       // both tails exhausted together
+            if (cx != cy)
+                return false;
+        }
     }
 
     /// <summary>
     /// Computes a hash code from the address's type and id, consistent with <see cref="Equals(Address?, Address?)"/>.
+    /// Allocation-free — see the remarks on <see cref="Equals(Address?, Address?)"/> for why the hot
+    /// hosted-hub routing probe must never materialise <see cref="Address.Id"/>.
     /// </summary>
     /// <param name="obj">The address to hash.</param>
     /// <returns>A hash code combining the type and id.</returns>
     public int GetHashCode(Address obj)
     {
-        return HashCode.Combine(obj.Type, obj.Id);
+        var segs = obj.Segments;
+        var hash = new HashCode();
+        // Type = Segments[0].
+        hash.Add(segs.Length > 0 ? segs[0] : "");
+        // Id = Segments[1..] joined by '/', hashed char-by-char so segmentation differences that
+        // join to the same string hash identically (matches the join-based Equals above).
+        int i = 1, c = 0;
+        while (NextTailChar(segs, ref i, ref c, out var ch))
+            hash.Add(ch);
+        return hash.ToHashCode();
+    }
+
+    /// <summary>
+    /// Emits the next character of <c>string.Join("/", segments[1..])</c> — the address <c>Id</c> —
+    /// advancing the segment/char cursors, WITHOUT allocating the joined string. Returns false when
+    /// the tail is exhausted. The '/' separator sits BETWEEN consecutive tail segments (matching
+    /// <see cref="string.Join(string, string[])"/>, including consecutive separators for empty
+    /// segments).
+    /// </summary>
+    private static bool NextTailChar(string[] segments, ref int segIdx, ref int chrIdx, out char ch)
+    {
+        while (segIdx < segments.Length)
+        {
+            var seg = segments[segIdx];
+            if (chrIdx < seg.Length)
+            {
+                ch = seg[chrIdx];
+                chrIdx++;
+                return true;
+            }
+            // Current segment consumed. Emit a separator before the next tail segment (if any).
+            if (segIdx + 1 < segments.Length)
+            {
+                ch = '/';
+                segIdx++;
+                chrIdx = 0;
+                return true;
+            }
+            // No more tail segments.
+            segIdx++;
+            chrIdx = 0;
+        }
+        ch = '\0';
+        return false;
     }
 }

--- a/test/MeshWeaver.Data.Test/StreamRouteSelfParentTerminationTest.cs
+++ b/test/MeshWeaver.Data.Test/StreamRouteSelfParentTerminationTest.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using MeshWeaver.ShortGuid;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Deterministic repro of the TRUE root behind the <c>SidePanelChatTenMessagesTest</c> round-3
+/// composer-vanish: <see cref="DataExtensions"/>.<c>RouteStreamMessage</c> walks the hub's
+/// parent chain (<c>current = current.Configuration.ParentHub</c>) looking for the sync sub-hub
+/// for a <see cref="StreamMessage"/>'s StreamId. A root/mesh hub is a SELF-PARENT — its
+/// <c>ParentServiceProvider</c> resolves <c>IMessageHub</c> to itself — so when the sync sub-hub
+/// is ABSENT (a disconnected circuit's stream, a reaped/never-created sync hub), the walk NEVER
+/// advances: <c>current</c> stays the same hub forever. A SINGLE <c>DataChangedEvent</c> then
+/// spins that hub's <c>DrainOne</c> thread at 100% CPU inside <c>GetHostedHub</c> → the hub can
+/// process nothing else → its SignalR keepalive is starved (chat vanishes) and it becomes an
+/// undisposable, silently-pegged zombie (the 8s disposal-deadlock watchdog cannot interrupt a
+/// running synchronous loop). A live dotnet-stack of the wedged e2e pod showed exactly this
+/// single frame (<c>DrainOne → NotifyAsync → RouteMessageAsync → RouteStreamMessage →
+/// GetHostedHub → AddressComparer.GetHashCode</c>), persisting even when idle.
+///
+/// <para>The fix adds the self-parent termination guard the sibling walk
+/// (<c>MessageHubExtensions.BeginAsyncOperation</c>) already has. With it, the not-found walk
+/// terminates and the message is dropped (Ignored) — the drain stays responsive. This test posts
+/// the poison StreamMessage to a self-parent, AddData-wired mesh hub and asserts the drain still
+/// answers a follow-up request; without the guard the follow-up never returns (the drain wedges).</para>
+/// </summary>
+public class StreamRouteSelfParentTerminationTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    public record Ping : IRequest<Pong>;
+    public record Pong;
+
+    protected override MessageHubConfiguration ConfigureMesh(MessageHubConfiguration conf)
+        => base.ConfigureMesh(conf)
+            // AddData wires RouteStreamMessage onto the mesh hub (the self-parent root).
+            .AddData()
+            .WithTypes(typeof(Ping), typeof(Pong))
+            .WithHandler<Ping>((hub, request) =>
+            {
+                hub.Post(new Pong(), o => o.ResponseFor(request));
+                return request.Processed();
+            });
+
+    [Fact]
+    public async Task StreamMessageToSelfParentHub_WithAbsentSyncHub_DoesNotWedgeTheDrain()
+    {
+        // The repro requires the production self-parent shape: the mesh hub's ParentHub is itself.
+        Mesh.Configuration.ParentHub.Should().BeSameAs(Mesh,
+            "a root/mesh hub resolves its own IMessageHub as ParentHub — the self-parent chain that "
+            + "makes RouteStreamMessage's walk non-terminating");
+
+        // Warm up: prove the drain is live (and initialization has completed) before the poison.
+        (await Mesh.Observe(new Ping(), o => o.WithTarget(Mesh.Address))
+            .Should().Within(15.Seconds()).Emit())
+            .Message.Should().BeOfType<Pong>();
+
+        // POISON: a StreamMessage (DataChangedEvent) targeted at the mesh, for a StreamId that has
+        // NO sync sub-hub. RouteStreamMessage walks the parent chain; on the self-parent mesh hub
+        // the walk must TERMINATE (drop the message) instead of spinning DrainOne forever.
+        Mesh.Post(
+            new DataChangedEvent(Guid.NewGuid().AsString(), 1, new RawJson("{}"), ChangeType.Full, null),
+            o => o.WithTarget(Mesh.Address));
+
+        // The drain must still answer — a wedged (infinitely-walking) DrainOne would never reach
+        // this Ping, and the Emit() would time out. This is the assertion that fails without the guard.
+        (await Mesh.Observe(new Ping(), o => o.WithTarget(Mesh.Address))
+            .Should().Within(10.Seconds()).Emit())
+            .Message.Should().BeOfType<Pong>(
+                "the mesh drain must stay responsive after routing a StreamMessage whose sync sub-hub is absent");
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/StreamRoutingHotPathTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/StreamRoutingHotPathTest.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using MeshWeaver.ShortGuid;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Pins the StreamMessage routing hot path: <c>GetHostedHub(sync/{id}, Never)</c> is a pure
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/> read keyed by <see cref="AddressComparer"/>.
+/// <c>RouteStreamMessage</c> probes it per parent-chain level for EVERY inbound
+/// <c>DataChangedEvent</c>. Under multi-round chat load (many accumulated sync streams still being
+/// fanned change events while a circuit is DOWN-but-not-closed) this probe runs at a very high rate.
+///
+/// <para>The defect: <see cref="AddressComparer.GetHashCode"/> / <see cref="AddressComparer.Equals"/>
+/// materialise <see cref="Address.Id"/> — a LINQ <c>Segments.Skip(1)</c> + <c>string.Join</c> that
+/// ALLOCATES on every probe. A dotnet-stack of the wedged e2e pod showed this as the ONLY CPU_TIME
+/// frame (<c>RouteStreamMessage → GetHostedHub → AddressComparer.GetHashCode</c>), pegging ~1.2
+/// cores and starving the Blazor circuit's SignalR keepalive → circuit drop → composer vanishes.</para>
+///
+/// <para>The fix makes the comparer allocation-free (hash/compare directly over segments, no
+/// materialised <c>Id</c>). This asserts the per-lookup allocation is bounded near-zero and the
+/// lookup cost does NOT scale with the number of live sync hubs (O(1) in N).</para>
+/// </summary>
+public class StreamRoutingHotPathTest
+{
+    private static Address SyncAddress(string id) => new(SynchronizationAddressType, id);
+    private const string SynchronizationAddressType = "sync";
+
+    private static ConcurrentDictionary<Address, object> BuildHostedHubMap(int count)
+    {
+        // Mirrors HostedHubsCollection.messageHubs exactly: keyed by AddressComparer.Instance.
+        var map = new ConcurrentDictionary<Address, object>(new AddressComparer());
+        for (var i = 0; i < count; i++)
+            map[SyncAddress(Guid.NewGuid().AsString())] = new object();
+        return map;
+    }
+
+    private static long MeasureAllocPerLookup(ConcurrentDictionary<Address, object> map, int lookups)
+    {
+        // Each iteration builds a FRESH miss target (as RouteStreamMessage does per message —
+        // SynchronizationAddress.Create allocates a new Address per DataChangedEvent) and probes.
+        var targets = new Address[lookups];
+        for (var i = 0; i < lookups; i++)
+            targets[i] = SyncAddress(Guid.NewGuid().AsString()); // guaranteed miss (fresh guid)
+
+        // Warm up JIT + comparer.
+        for (var i = 0; i < 1000; i++)
+            map.TryGetValue(targets[i % lookups], out _);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < lookups; i++)
+            map.TryGetValue(targets[i], out _);
+        var after = GC.GetAllocatedBytesForCurrentThread();
+        // Subtract nothing but the pre-allocated targets array (built above, outside the window).
+        return (after - before) / lookups;
+    }
+
+    [Fact]
+    public void MissLookup_IsAllocationFree_AndBounded()
+    {
+        const int lookups = 200_000;
+
+        // The map size (number of live sync hubs) must NOT change per-lookup cost.
+        var small = BuildHostedHubMap(50);
+        var large = BuildHostedHubMap(5_000);
+
+        var allocSmall = MeasureAllocPerLookup(small, lookups);
+        var allocLarge = MeasureAllocPerLookup(large, lookups);
+
+        var sw = Stopwatch.StartNew();
+        MeasureAllocPerLookup(large, lookups);
+        sw.Stop();
+        var nsPerLookup = sw.Elapsed.TotalMilliseconds * 1_000_000 / lookups;
+
+        Console.WriteLine($"[HOTPATH] bytes/lookup small(N=50)={allocSmall}  large(N=5000)={allocLarge}  ~{nsPerLookup:F1} ns/lookup");
+
+        // O(1) in N: cost independent of the number of live sync hubs.
+        allocLarge.Should().Be(allocSmall, "per-lookup allocation must not scale with the number of live sync hubs");
+        // Allocation-free routing probe: the whole point of the fix.
+        allocLarge.Should().Be(0, "the sync-hub routing probe must not allocate — an allocating hot comparer pegs the drain thread and starves the SignalR keepalive");
+    }
+
+    // ---- Semantics: the allocation-free comparer must be IDENTICAL to the old "Type + Id(join)" one ----
+
+    [Fact]
+    public void Equals_MatchesTypePlusJoinedId_Exactly()
+    {
+        var cmp = new AddressComparer();
+
+        // Same type + same joined tail, DIFFERENT segmentation → equal (Id = "a/b" both ways).
+        var multi = new Address("node", "a", "b");   // Segments = [node, a, b]
+        var single = new Address("node", "a/b");      // Segments = [node, a/b] (embedded slash)
+        cmp.Equals(multi, single).Should().BeTrue("Type 'node' + Id 'a/b' match regardless of segmentation");
+        cmp.GetHashCode(multi).Should().Be(cmp.GetHashCode(single), "equal addresses must hash equally");
+
+        // This join-equivalence is exercised for real: kernelExec/{path} ids embed '/'.
+        var exec = new Address("kernelExec", "activity/x/y");
+        var execParsed = (Address)"kernelExec/activity/x/y"; // parsed → [kernelExec, activity, x, y]
+        cmp.Equals(exec, execParsed).Should().BeTrue();
+        cmp.GetHashCode(exec).Should().Be(cmp.GetHashCode(execParsed));
+
+        // Different id → not equal.
+        cmp.Equals(new Address("node", "a", "b"), new Address("node", "a", "c")).Should().BeFalse();
+        // Different type → not equal.
+        cmp.Equals(new Address("sync", "x"), new Address("node", "x")).Should().BeFalse();
+        // Single-segment addresses.
+        cmp.Equals(new Address("mesh"), new Address("mesh")).Should().BeTrue();
+        cmp.Equals(new Address("mesh"), new Address("app")).Should().BeFalse();
+        // Host is ignored by AddressComparer (Type + Id only).
+        var bare = new Address("sync", "x");
+        var hosted = new Address("sync", "x").WithHost(new Address("portal", "c1"));
+        cmp.Equals(bare, hosted).Should().BeTrue("AddressComparer ignores Host");
+        cmp.GetHashCode(bare).Should().Be(cmp.GetHashCode(hosted));
+    }
+
+    [Fact]
+    public void HashConsistency_EqualImpliesSameHash_OverManySamples()
+    {
+        var cmp = new AddressComparer();
+        // A fresh guid id parsed vs multi-arg must round-trip through a dictionary correctly.
+        var dict = new System.Collections.Generic.Dictionary<Address, int>(cmp);
+        for (var i = 0; i < 2000; i++)
+        {
+            var a = i.ToString();
+            var b = Guid.NewGuid().AsString();
+            var stored = new Address("node", a + "/" + b);          // [node, "a/b"]
+            var lookup = new Address("node", a, b);                  // [node, a, b] — Id joins to "a/b"
+            dict[stored] = i;
+            dict.TryGetValue(lookup, out var found).Should().BeTrue("join-equivalent lookup must hit");
+            found.Should().Be(i);
+        }
+    }
+}


### PR DESCRIPTION
THE root of the recurring chat-vanish (same stack as the session's opening heap dump): RouteStreamMessage's parent-hub walk never terminates for a self-parent root/portal hub, so a single DataChangedEvent to an absent sync sub-hub spins DrainOne at 100% CPU → starves the circuit keepalive → composer vanishes. Adds the self-parent guard the sibling walk already has. Deterministic repro red→green; the e2e 10-message test is GREEN (all rounds, no vanish, CPU 1.1→0.4 cores); Messaging.Hub 75/75, Data 274/274, Hosting 50/50, Release -warnaserror clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)