### PR TITLE
feat(spaces): delete space drops whole partition; sync direction + multiple sync sources; Partitions admin overview

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
@@ -68,11 +68,38 @@ Under **Repository**:
 |---|---|
 | **Repository URL** | `https://github.com/owner/repo`. |
 | **Branch** | The branch to commit to (default `main`). |
+| **Sync direction** | `Bidirectional` (default), `ExportOnly`, or `ImportOnly` — see below. |
 | **Create the branch if it doesn't exist** | When on, a missing branch is created as a fresh snapshot commit. |
 | **Create the repository (private) if it doesn't exist** | When on, a missing repo is created **private** under the owner/org. |
 | **Subdirectory** (optional) | Mirror the Space into this folder of the repo. Files outside it are left untouched. Empty = repository root. |
 
 Click **Save repository settings**.
+
+### Sync direction — unidirectional or bidirectional
+
+Each source syncs in a configurable direction, enforced by `GitHubSyncService` on every
+operation (the GUI additionally hides what would be rejected):
+
+| Direction | Commit ("Sync now") | Checkout / re-import |
+|---|---|---|
+| **Bidirectional** (default) | ✓ | ✓ |
+| **ExportOnly** — mesh → repo | ✓ | ✗ rejected — the repo can never overwrite the mesh |
+| **ImportOnly** — repo → mesh | ✗ rejected — the mesh can never overwrite the repo | ✓ |
+
+Use `ImportOnly` for a Space that mirrors an upstream repository you don't own, and
+`ExportOnly` for a backup/publishing target that must never feed edits back.
+
+### Multiple sync sources
+
+A Space can sync with **more than one repository**. The Repository section above edits
+the **primary** source (`{space}/_GitSync`); every additional source is its own config
+node at `{space}/_GitSync/{sourceId}` with its own repository, branch, subdirectory and
+direction. Manage them in the **Additional sync sources** section of the same settings
+tab (or, platform admins, on **Global Settings → Administration → Partitions**): add a
+source by name, edit its settings through the same data-bound editor, sync it with its
+own direction-aware buttons, and remove it when no longer needed. Programmatically:
+`GitHubSyncService.AddSyncSource / WatchConfigNodes / RemoveSyncSource`, and every sync
+operation takes an optional `sourceId` (null = the primary).
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/DataMesh/Spaces.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/Spaces.md
@@ -100,6 +100,25 @@ Creating a Space `Acme` (empty namespace, id `Acme`) automatically produces:
 > the Space node *is* the landing page, and a stray Overview node just duplicates
 > it. The text below is everything you need to make `Acme` itself look good.
 
+## Deleting a Space
+
+Deleting a Space removes the **entire partition** from the system — the exact inverse
+of creating one. Use the Space's node menu (top-right **⋯**) → **Delete** (type
+`DELETE` to confirm), or send a recursive `DeleteNodeRequest` at the Space's path.
+The operation:
+
+- recursively deletes the Space node and every node inside the partition;
+- **drops the partition's backing store** — on Postgres the whole schema
+  (`acme.mesh_nodes` and every satellite table: threads, access, activities, …)
+  in one `DROP SCHEMA … CASCADE`;
+- removes the `Admin/Partition/Acme` partition definition;
+- evicts the provisioning caches, so a Space with the **same id can be created again**
+  afterwards and provisions from scratch.
+
+This is **irreversible** — there is no recycle bin for a dropped partition. Only
+users holding Delete on the Space (its Admins, or a global admin) can do it. Global
+admins can also reach it from **Global Settings → Administration → Partitions**.
+
 ## Authoring your Space's home page
 
 When someone opens `Acme`, the Space's **Overview** renders, in order: a header

--- a/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
+++ b/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
@@ -122,16 +122,18 @@ public static class GitHubActivityExtensions
             }, onActivityCreated);
     }
 
-    /// <summary>Ask GitHub (live) for the configured branch's HEAD + whether the Space is up to date.</summary>
+    /// <summary>Ask GitHub (live) for the configured branch's HEAD + whether the Space is up to date.
+    /// <paramref name="sourceId"/> selects the sync source (null = the primary).</summary>
     public static IObservable<string> CheckBranchStateOnGitHub(
-        this IMessageHub hub, string spacePath, string userId, Action<string>? onActivityCreated = null)
+        this IMessageHub hub, string spacePath, string userId, Action<string>? onActivityCreated = null,
+        string? sourceId = null)
     {
         var sync = hub.ServiceProvider.GetRequiredService<GitHubSyncService>();
         return hub.RunActivity(spacePath, ActivityCategory.Unknown, $"Check branch of {spacePath}",
             ctx =>
             {
                 ctx.Log("Asking GitHub for the branch state…");
-                return sync.AskBranchState(spacePath, userId).Select(st =>
+                return sync.AskBranchState(spacePath, userId, sourceId).Select(st =>
                 {
                     ctx.Log($"Branch '{st.Branch}' is at {st.HeadCommitSha[..Math.Min(8, st.HeadCommitSha.Length)]} — " +
                             (st.UpToDate ? "your Space is up to date." : "your Space is behind (use Update to latest)."));

--- a/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
+++ b/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
@@ -27,16 +27,18 @@ namespace MeshWeaver.GitSync;
 /// </summary>
 public static class GitHubActivityExtensions
 {
-    /// <summary>Commit ("Sync now") — mirror the Space into the repo as one commit on the branch HEAD.</summary>
+    /// <summary>Commit ("Sync now") — mirror the Space into the repo as one commit on the branch HEAD.
+    /// <paramref name="sourceId"/> selects the sync source (null = the primary).</summary>
     public static IObservable<string> CommitToGitHub(
-        this IMessageHub hub, string spacePath, string userId, Action<string>? onActivityCreated = null)
+        this IMessageHub hub, string spacePath, string userId, Action<string>? onActivityCreated = null,
+        string? sourceId = null)
     {
         var sync = hub.ServiceProvider.GetRequiredService<GitHubSyncService>();
         return hub.RunActivity(spacePath, ActivityCategory.DataUpdate, $"Commit {spacePath} to GitHub",
             ctx =>
             {
                 ctx.Log("Serializing Space content and committing on the branch HEAD…");
-                return sync.SyncToGitHub(spacePath, userId).Select(r =>
+                return sync.SyncToGitHub(spacePath, userId, sourceId).Select(r =>
                 {
                     ctx.Log($"Committed {r.CommitSha[..Math.Min(8, r.CommitSha.Length)]} " +
                             $"({r.FilesWritten} written, {r.FilesDeleted} removed)" +
@@ -46,16 +48,18 @@ public static class GitHubActivityExtensions
             }, onActivityCreated);
     }
 
-    /// <summary>Checkout / update to latest — re-import the Space at the configured branch HEAD.</summary>
+    /// <summary>Checkout / update to latest — re-import the Space at the configured branch HEAD.
+    /// <paramref name="sourceId"/> selects the sync source (null = the primary).</summary>
     public static IObservable<string> UpdateToLatestFromGitHub(
-        this IMessageHub hub, string spacePath, string userId, Action<string>? onActivityCreated = null)
+        this IMessageHub hub, string spacePath, string userId, Action<string>? onActivityCreated = null,
+        string? sourceId = null)
     {
         var pr = hub.ServiceProvider.GetRequiredService<PullRequestService>();
         return hub.RunActivity(spacePath, ActivityCategory.Import, $"Update {spacePath} to latest",
             ctx =>
             {
                 ctx.Log("Fetching the branch HEAD from GitHub and importing the deltas…");
-                return pr.UpdateToLatest(spacePath, userId).Select(r =>
+                return pr.UpdateToLatest(spacePath, userId, sourceId).Select(r =>
                 {
                     ctx.Log($"Imported {r.Outcome} ({r.Count} node(s)).");
                     return Unit.Default;
@@ -63,17 +67,18 @@ public static class GitHubActivityExtensions
             }, onActivityCreated);
     }
 
-    /// <summary>Re-import the Space at a chosen commit / branch (mirror to that state).</summary>
+    /// <summary>Re-import the Space at a chosen commit / branch (mirror to that state).
+    /// <paramref name="sourceId"/> selects the sync source (null = the primary).</summary>
     public static IObservable<string> ReimportFromGitHub(
         this IMessageHub hub, string spacePath, string commitish, string userId,
-        Action<string>? onActivityCreated = null)
+        Action<string>? onActivityCreated = null, string? sourceId = null)
     {
         var sync = hub.ServiceProvider.GetRequiredService<GitHubSyncService>();
         return hub.RunActivity(spacePath, ActivityCategory.Import, $"Re-import {spacePath} at {commitish}",
             ctx =>
             {
                 ctx.Log($"Fetching {commitish} from GitHub and importing the deltas…");
-                return sync.ReimportAtCommit(spacePath, commitish, userId).Select(r =>
+                return sync.ReimportAtCommit(spacePath, commitish, userId, sourceId).Select(r =>
                 {
                     ctx.Log($"Re-imported {r.Outcome} ({r.Count} node(s)) at {commitish}.");
                     return Unit.Default;

--- a/src/MeshWeaver.GitSync/GitHubPartitionSyncSourceProvider.cs
+++ b/src/MeshWeaver.GitSync/GitHubPartitionSyncSourceProvider.cs
@@ -1,0 +1,48 @@
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// Exposes a Space's GitHub sync sources (<c>{space}/_GitSync</c> +
+/// <c>{space}/_GitSync/{sourceId}</c>, content <see cref="GitHubSyncConfig"/>) to the
+/// partition administration GUI through the <see cref="IPartitionSyncSourceProvider"/> seam —
+/// a thin delegate onto <see cref="GitHubSyncService"/>. The primary source is protected from
+/// removal (clear its repository URL instead); additional sources are removable.
+/// </summary>
+public sealed class GitHubPartitionSyncSourceProvider(GitHubSyncService sync, IMessageHub hub)
+    : IPartitionSyncSourceProvider
+{
+    /// <inheritdoc />
+    public string Kind => "GitHub";
+
+    /// <inheritdoc />
+    public Type ConfigContentType => typeof(GitHubSyncConfig);
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<MeshNode>> WatchSyncSources(string partition)
+        => sync.WatchConfigNodes(partition);
+
+    /// <inheritdoc />
+    public string Describe(MeshNode source)
+    {
+        var config = source.ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions);
+        if (config?.RepositoryUrl is not { Length: > 0 } url)
+            return "not configured";
+        var repo = url.Replace("https://github.com/", "", StringComparison.OrdinalIgnoreCase).TrimEnd('/');
+        return $"{repo}@{(string.IsNullOrWhiteSpace(config.Branch) ? "main" : config.Branch)} ({config.Direction})";
+    }
+
+    /// <inheritdoc />
+    public bool CanRemove(string partition, MeshNode source)
+        => !string.Equals(source.Path, GitHubSyncService.ConfigPath(partition), StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public IObservable<MeshNode> AddSyncSource(string partition, string name)
+        => sync.AddSyncSource(partition, name);
+
+    /// <inheritdoc />
+    public IObservable<bool> RemoveSyncSource(string partition, MeshNode source)
+        => sync.RemoveSyncSource(partition, source.Id);
+}

--- a/src/MeshWeaver.GitSync/GitHubSyncConfig.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfig.cs
@@ -3,8 +3,9 @@ using System.ComponentModel;
 namespace MeshWeaver.GitSync;
 
 /// <summary>
-/// Space-level GitHub sync configuration, stored as a MeshNode at
-/// <c>{spaceId}/_GitSync</c>. Holds the target repository the Space exports to —
+/// One GitHub sync source of a Space, stored as a MeshNode at <c>{spaceId}/_GitSync</c>
+/// (the primary source) or <c>{spaceId}/_GitSync/{sourceId}</c> (each additional source).
+/// Holds the repository the Space syncs with and the allowed <see cref="Direction"/> —
 /// NOT a secret (the per-user OAuth credential lives separately at
 /// <c>{userId}/_Provider/GitHub</c> and is never serialized into exported content).
 /// Editable by Space admins.
@@ -32,6 +33,14 @@ public record GitHubSyncConfig
     /// </summary>
     [Description("Subdirectory (optional — blank = repository root)")]
     public string? Subdirectory { get; init; }
+
+    /// <summary>
+    /// The direction this source is allowed to sync in: bidirectional (default), export-only
+    /// (mesh → repo — imports rejected) or import-only (repo → mesh — exports rejected).
+    /// Enforced by <see cref="GitHubSyncService"/> on every sync operation.
+    /// </summary>
+    [Description("Sync direction")]
+    public SyncDirection Direction { get; init; } = SyncDirection.Bidirectional;
 
     /// <summary>Create <see cref="Branch"/> if it does not exist yet. Default true.</summary>
     [Description("Create the branch if it doesn't exist")]

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -33,6 +33,11 @@ public static class GitHubSyncConfiguration
         services.AddSingleton<GitHubCredentialService>();
         services.AddSingleton<GitHubSyncService>();
         services.AddSingleton<PullRequestService>();
+        // Surfaces the per-space GitHub sync sources on the partition administration page
+        // (PartitionSyncAdminLayoutArea resolves all IPartitionSyncSourceProvider from DI).
+        services.AddSingleton<IPartitionSyncSourceProvider>(sp => new GitHubPartitionSyncSourceProvider(
+            sp.GetRequiredService<GitHubSyncService>(),
+            sp.GetRequiredService<IMessageHub>()));
         // On-disk per-user git working trees (clone/edit/commit/push) — the working-tree
         // counterpart to content sync, shared by the AI harness + the in-portal editor.
         // Root binds from GitWorkspace:Root (env GitWorkspace__Root=/workspace in the portal,

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -66,24 +66,44 @@ public sealed class GitHubSyncService
     /// <returns>The config node path.</returns>
     public static string ConfigPath(string spacePath) => $"{spacePath}/{ConfigId}";
 
+    /// <summary>
+    /// The sync-config node path for one of a Space's sync sources. The PRIMARY source
+    /// (null/empty <paramref name="sourceId"/>) lives at <c>{spacePath}/_GitSync</c>;
+    /// every additional source is a child: <c>{spacePath}/_GitSync/{sourceId}</c>. All
+    /// sources carry the same <see cref="GitHubSyncConfig"/> content (repo, branch,
+    /// <see cref="GitHubSyncConfig.Direction"/>, last-sync state).
+    /// </summary>
+    /// <param name="spacePath">The Space (partition root) path.</param>
+    /// <param name="sourceId">The source id, or null/empty for the primary source.</param>
+    /// <returns>The config node path for that source.</returns>
+    public static string ConfigPath(string spacePath, string? sourceId) =>
+        string.IsNullOrEmpty(sourceId) ? ConfigPath(spacePath) : $"{spacePath}/{ConfigId}/{sourceId}";
+
     // ══════════════════════════════════════════════════════════════════════════
     //  EXPORT — mesh → GitHub (the "sync back")
     // ══════════════════════════════════════════════════════════════════════════
 
     /// <summary>
-    /// Mirrors the Space subtree into its configured GitHub repo as a single commit,
-    /// authenticated as <paramref name="userId"/>, and stores the resulting commit
-    /// SHA on the Space's <see cref="GitHubSyncConfig"/>. Emits the push result.
+    /// Mirrors the Space subtree into the configured GitHub repo of one sync source as a
+    /// single commit, authenticated as <paramref name="userId"/>, and stores the resulting
+    /// commit SHA on that source's <see cref="GitHubSyncConfig"/>. Rejected when the
+    /// source's <see cref="GitHubSyncConfig.Direction"/> is
+    /// <see cref="SyncDirection.ImportOnly"/>. Emits the push result.
     /// </summary>
-    public IObservable<GitHubPushResult> SyncToGitHub(string spacePath, string userId)
+    public IObservable<GitHubPushResult> SyncToGitHub(string spacePath, string userId, string? sourceId = null)
     {
-        return ReadConfig(spacePath).Take(1).SelectMany(config =>
+        return ReadConfig(spacePath, sourceId).Take(1).SelectMany(config =>
         {
             if (config?.RepositoryUrl is not { Length: > 0 } repoUrl)
                 return Observable.Throw<GitHubPushResult>(new InvalidOperationException(
                     "No repository URL is set for this Space yet. In the Repository section above, enter a " +
                     "URL like https://github.com/owner/repo (the repo is created automatically if it doesn't " +
                     "exist), then Sync."));
+
+            if (config.Direction == SyncDirection.ImportOnly)
+                return Observable.Throw<GitHubPushResult>(new InvalidOperationException(
+                    $"This sync source is import-only (repo → mesh): exporting to {repoUrl} is not allowed. " +
+                    "Change the source's Sync direction to Bidirectional or Export-only to commit."));
 
             return credentials.Get(userId).Take(1).SelectMany(cred =>
             {
@@ -115,7 +135,7 @@ public sealed class GitHubSyncService
                         // node content (stream.Update read-modify-write) — never a full-content write,
                         // so a concurrent repo-field edit in the GUI editor is not clobbered.
                         return repoClient.Push(request).SelectMany(result =>
-                            RecordLastSync(spacePath, result.CommitSha).Select(_ => result));
+                            RecordLastSync(spacePath, result.CommitSha, sourceId).Select(_ => result));
                     }));
             });
         });
@@ -281,17 +301,24 @@ public sealed class GitHubSyncService
 
     /// <summary>
     /// Re-imports an existing Space to the state of <paramref name="commitish"/> (a
-    /// branch or commit SHA), mirroring the repo into the partition (add/update/prune),
-    /// and records the resolved commit SHA on the Space's config. This is the
-    /// "change the commit and re-import to that state" operation.
+    /// branch or commit SHA) from one sync source, mirroring the repo into the partition
+    /// (add/update/prune), and records the resolved commit SHA on that source's config.
+    /// Rejected when the source's <see cref="GitHubSyncConfig.Direction"/> is
+    /// <see cref="SyncDirection.ExportOnly"/>. This is the "change the commit and
+    /// re-import to that state" operation.
     /// </summary>
-    public IObservable<StaticRepoImportResult> ReimportAtCommit(string spacePath, string commitish, string userId)
+    public IObservable<StaticRepoImportResult> ReimportAtCommit(
+        string spacePath, string commitish, string userId, string? sourceId = null)
     {
-        return ReadConfig(spacePath).Take(1).SelectMany(config =>
+        return ReadConfig(spacePath, sourceId).Take(1).SelectMany(config =>
         {
             if (config?.RepositoryUrl is not { Length: > 0 } repoUrl)
                 return Observable.Throw<StaticRepoImportResult>(new InvalidOperationException(
                     "No GitHub repository configured for this Space."));
+            if (config.Direction == SyncDirection.ExportOnly)
+                return Observable.Throw<StaticRepoImportResult>(new InvalidOperationException(
+                    $"This sync source is export-only (mesh → repo): importing from {repoUrl} is not allowed. " +
+                    "Change the source's Sync direction to Bidirectional or Import-only to re-import."));
             return credentials.Get(userId).Take(1).SelectMany(cred =>
             {
                 if (cred?.AccessToken is not { Length: > 0 } token)
@@ -299,7 +326,7 @@ public sealed class GitHubSyncService
                         "Connect your GitHub account first."));
                 logger?.LogInformation("Re-importing {Space} at {Ref}", spacePath, commitish);
                 return FetchAndImport(repoUrl, commitish, config.Subdirectory, token, spacePath)
-                    .SelectMany(x => RecordLastSync(spacePath, x.CommitSha).Select(_ => x.Result));
+                    .SelectMany(x => RecordLastSync(spacePath, x.CommitSha, sourceId).Select(_ => x.Result));
             });
         });
     }
@@ -310,9 +337,9 @@ public sealed class GitHubSyncService
     /// branch?"). The branch name comes from the (local) config; the HEAD comes straight from
     /// GitHub, so the answer can never drift. Delegates rather than replicating branch state.
     /// </summary>
-    public IObservable<BranchState> AskBranchState(string spacePath, string userId)
+    public IObservable<BranchState> AskBranchState(string spacePath, string userId, string? sourceId = null)
     {
-        return ReadConfig(spacePath).Take(1).SelectMany(config =>
+        return ReadConfig(spacePath, sourceId).Take(1).SelectMany(config =>
         {
             if (config?.RepositoryUrl is not { Length: > 0 } repoUrl)
                 return Observable.Throw<BranchState>(new InvalidOperationException(
@@ -402,19 +429,79 @@ public sealed class GitHubSyncService
     /// the hidden <c>{space}/_GitSync</c> satellite path, whose per-node hub does not serve the
     /// single-node reducer reliably (it timed out → "not configured"). Emits the config or null.
     /// </summary>
-    public IObservable<GitHubSyncConfig?> WatchConfig(string spacePath) =>
-        WatchConfigNode(spacePath).Select(Extract<GitHubSyncConfig>);
+    public IObservable<GitHubSyncConfig?> WatchConfig(string spacePath, string? sourceId = null) =>
+        WatchConfigNode(spacePath, sourceId).Select(Extract<GitHubSyncConfig>);
 
-    /// <summary>Live <see cref="MeshNode"/> stream for the Space's <c>_GitSync</c> config node
+    /// <summary>Live <see cref="MeshNode"/> stream for one sync-source config node of the Space
     /// (or null when absent) — the synced <c>GetQuery</c>. The GUI editor binds to this node by
     /// path via <c>GetMeshNodeStream</c>; this stream is for service-side reads/displays.</summary>
-    public IObservable<MeshNode?> WatchConfigNode(string spacePath)
+    public IObservable<MeshNode?> WatchConfigNode(string spacePath, string? sourceId = null)
     {
-        var path = ConfigPath(spacePath);
+        var path = ConfigPath(spacePath, sourceId);
         return hub.GetWorkspace()
-            .GetQuery($"gitsync-cfg:{spacePath}", $"path:{path}")
+            .GetQuery($"gitsync-cfg:{path}", $"path:{path}")
             .Select(nodes => nodes?.FirstOrDefault(n => string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase)));
     }
+
+    /// <summary>
+    /// Live stream of ALL of the Space's sync-source config nodes: the primary
+    /// (<c>{space}/_GitSync</c>, when present) followed by every additional source
+    /// (<c>{space}/_GitSync/{sourceId}</c>), ordered by source id. Re-emits when a source is
+    /// added, removed, or edited — the synced <c>GetQuery</c> over the <c>_GitSync</c>
+    /// namespace, combined with the primary's own stream.
+    /// </summary>
+    public IObservable<IReadOnlyList<MeshNode>> WatchConfigNodes(string spacePath)
+    {
+        var primaryPath = ConfigPath(spacePath);
+        var children = hub.GetWorkspace()
+            .GetQuery($"gitsync-cfgs:{spacePath}", $"namespace:{primaryPath} nodeType:{ConfigNodeType}")
+            .Select(nodes => (nodes ?? [])
+                .Where(n => string.Equals(n.Namespace, primaryPath, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(n => n.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList());
+        return WatchConfigNode(spacePath).CombineLatest(children, (primary, extra) =>
+        {
+            var all = new List<MeshNode>();
+            if (primary is not null) all.Add(primary);
+            all.AddRange(extra);
+            return (IReadOnlyList<MeshNode>)all;
+        });
+    }
+
+    /// <summary>
+    /// Adds a sync source to the Space: creates the <c>{space}/_GitSync/{sourceId}</c>
+    /// config node (with defaults) named <paramref name="name"/>, where the id is the
+    /// sanitized name. Create-on-absent — adding a source whose id already exists returns
+    /// the existing node untouched. Configure the repo/branch/direction afterwards through
+    /// the standard node editor bound to the returned node's path.
+    /// </summary>
+    public IObservable<MeshNode> AddSyncSource(string spacePath, string name)
+    {
+        var sourceId = SanitizeSourceId(name);
+        if (string.IsNullOrEmpty(sourceId))
+            return Observable.Throw<MeshNode>(new ArgumentException(
+                "The sync-source name must contain at least one letter or digit.", nameof(name)));
+        return EnsureConfigNode(spacePath, sourceId, name);
+    }
+
+    /// <summary>
+    /// Removes an ADDITIONAL sync source (<c>{space}/_GitSync/{sourceId}</c>). The primary
+    /// source node is never removed this way — clear its repository URL instead.
+    /// </summary>
+    public IObservable<bool> RemoveSyncSource(string spacePath, string sourceId)
+    {
+        if (string.IsNullOrEmpty(sourceId))
+            return Observable.Throw<bool>(new ArgumentException(
+                "The primary sync source cannot be removed — clear its repository URL instead.",
+                nameof(sourceId)));
+        return meshService.DeleteNode(ConfigPath(spacePath, sourceId));
+    }
+
+    /// <summary>Sanitizes a display name into a node id: letters/digits/dash/underscore only.</summary>
+    private static string SanitizeSourceId(string name) =>
+        new string(name.Trim()
+            .Select(c => char.IsLetterOrDigit(c) ? c : '-')
+            .ToArray()).Trim('-');
 
     /// <summary>
     /// Create-on-absent the Space's <c>_GitSync</c> config node (with defaults) so the standard
@@ -424,9 +511,8 @@ public sealed class GitHubSyncService
     /// absent path (that NotFound-storms). Mirrors <c>AiSettingsNodeType.EnsureExists</c>.
     /// Returns the existing or newly-created node.
     /// </summary>
-    public IObservable<MeshNode> EnsureConfigNode(string spacePath)
+    public IObservable<MeshNode> EnsureConfigNode(string spacePath, string? sourceId = null, string? name = null)
     {
-        var path = ConfigPath(spacePath);
         // Capture identity synchronously BEFORE the async WatchConfigNode hop (same reason as
         // UpdateConfig). meshService.CreateNode captures the AccessContext at its CALL — which here
         // happens inside the SelectMany continuation, where the AsyncLocal has been dropped, so the
@@ -435,13 +521,17 @@ public sealed class GitHubSyncService
         // captured context on the create's subscribe so CreateNode's own capture picks it up.
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var ctx = accessService?.Context ?? accessService?.CircuitContext;
-        return WatchConfigNode(spacePath).Take(1).SelectMany(existing =>
+        return WatchConfigNode(spacePath, sourceId).Take(1).SelectMany(existing =>
         {
             if (existing is not null) return Observable.Return(existing);
-            var node = new MeshNode(ConfigId, spacePath)
+            // Primary source: {space}/_GitSync. Additional source: {space}/_GitSync/{sourceId}.
+            var node = string.IsNullOrEmpty(sourceId)
+                ? new MeshNode(ConfigId, spacePath)
+                : new MeshNode(sourceId, ConfigPath(spacePath));
+            node = node with
             {
                 NodeType = ConfigNodeType,
-                Name = "GitHub Sync",
+                Name = name ?? (string.IsNullOrEmpty(sourceId) ? "GitHub Sync" : sourceId),
                 State = MeshNodeState.Active,
                 MainNode = spacePath,
                 Content = new GitHubSyncConfig(),
@@ -452,19 +542,21 @@ public sealed class GitHubSyncService
                 ? meshService.CreateNode(node)
                 : Observable.Using(() => accessService.SwitchAccessContext(ctx), _ => meshService.CreateNode(node));
             return create
-                .Catch<MeshNode, Exception>(_ => WatchConfigNode(spacePath).Where(n => n is not null).Select(n => n!).Take(1));
+                .Catch<MeshNode, Exception>(_ => WatchConfigNode(spacePath, sourceId).Where(n => n is not null).Select(n => n!).Take(1));
         });
     }
 
     /// <summary>One-shot config read for actions (Sync / Re-import). The synced query's first
     /// emission already reflects a committed write (the GUI auto-saves the repo URL on edit, so by
     /// Sync time the config is present).</summary>
-    public IObservable<GitHubSyncConfig?> ReadConfig(string spacePath) => WatchConfig(spacePath).Take(1);
+    public IObservable<GitHubSyncConfig?> ReadConfig(string spacePath, string? sourceId = null)
+        => WatchConfig(spacePath, sourceId).Take(1);
 
     /// <summary>Persists the repository settings (preserving the recorded last-sync state).</summary>
     public IObservable<MeshNode> SaveConfig(
         string spacePath, string? repositoryUrl, string branch, string? subdirectory,
-        bool createBranchIfMissing, bool createRepoIfMissing)
+        bool createBranchIfMissing, bool createRepoIfMissing,
+        SyncDirection direction = SyncDirection.Bidirectional, string? sourceId = null)
         => UpdateConfig(spacePath, c => c with
         {
             RepositoryUrl = string.IsNullOrWhiteSpace(repositoryUrl) ? null : repositoryUrl.Trim(),
@@ -472,10 +564,12 @@ public sealed class GitHubSyncService
             Subdirectory = string.IsNullOrWhiteSpace(subdirectory) ? null : subdirectory.Trim().Trim('/'),
             CreateBranchIfMissing = createBranchIfMissing,
             CreateRepoIfMissing = createRepoIfMissing,
-        });
+            Direction = direction,
+        }, sourceId);
 
     /// <summary>Read-modify-write a config field (current value from the synced query; null when absent).</summary>
-    private IObservable<MeshNode> UpdateConfig(string spacePath, Func<GitHubSyncConfig, GitHubSyncConfig> update)
+    private IObservable<MeshNode> UpdateConfig(
+        string spacePath, Func<GitHubSyncConfig, GitHubSyncConfig> update, string? sourceId = null)
     {
         // 🚨 Capture the caller's identity SYNCHRONOUSLY, here on the calling thread, BEFORE the
         // ReadConfig hop. ReadConfig's SelectMany continuation can run on a pool thread where the
@@ -488,7 +582,8 @@ public sealed class GitHubSyncService
         // write's post via WithAccessContext so it never depends on the AsyncLocal surviving the hop.
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var ctx = accessService?.Context ?? accessService?.CircuitContext;
-        return ReadConfig(spacePath).SelectMany(current => WriteConfig(spacePath, ctx, update(current ?? new GitHubSyncConfig())));
+        return ReadConfig(spacePath, sourceId).SelectMany(current =>
+            WriteConfig(spacePath, ctx, update(current ?? new GitHubSyncConfig()), sourceId));
     }
 
     /// <summary>
@@ -497,10 +592,10 @@ public sealed class GitHubSyncService
     /// <c>GetMeshNodeStream(path).Update</c> (read-modify-write). Touching only those two fields
     /// means a concurrent GUI edit of the repository fields is never clobbered.
     /// </summary>
-    private IObservable<MeshNode> RecordLastSync(string spacePath, string commitSha)
+    private IObservable<MeshNode> RecordLastSync(string spacePath, string commitSha, string? sourceId = null)
     {
         var now = DateTimeOffset.UtcNow;
-        return hub.GetWorkspace().GetMeshNodeStream(ConfigPath(spacePath)).Update(node =>
+        return hub.GetWorkspace().GetMeshNodeStream(ConfigPath(spacePath, sourceId)).Update(node =>
         {
             var cur = Extract<GitHubSyncConfig>(node) ?? new GitHubSyncConfig();
             return node with { Content = cur with { LastSyncedAt = now, LastSyncCommitSha = commitSha } };
@@ -510,12 +605,15 @@ public sealed class GitHubSyncService
     /// <summary>Writes the FULL config (no read) — used by <see cref="SaveConfig"/> (a programmatic
     /// / test API). The GUI does NOT use this: it edits the node through the standard
     /// <c>MeshNodeContentEditorControl</c> which binds directly to the node stream.</summary>
-    private IObservable<MeshNode> WriteConfig(string spacePath, AccessContext? ctx, GitHubSyncConfig config)
+    private IObservable<MeshNode> WriteConfig(
+        string spacePath, AccessContext? ctx, GitHubSyncConfig config, string? sourceId = null)
     {
-        var node = new MeshNode(ConfigId, spacePath)
+        var node = (string.IsNullOrEmpty(sourceId)
+            ? new MeshNode(ConfigId, spacePath)
+            : new MeshNode(sourceId, ConfigPath(spacePath))) with
         {
             NodeType = ConfigNodeType,
-            Name = "GitHub Sync",
+            Name = string.IsNullOrEmpty(sourceId) ? "GitHub Sync" : sourceId,
             State = MeshNodeState.Active,
             MainNode = spacePath,
             Content = config,

--- a/src/MeshWeaver.GitSync/GitHubSyncSettingsTab.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncSettingsTab.cs
@@ -35,6 +35,7 @@ public static class GitHubSyncSettingsTab
 
     private const string ResultId = "ghSyncResult";
     private const string CommitFormId = "ghReimportForm";
+    private const string AddSourceFormId = "ghAddSourceForm";
     // Holds the path of the PR draft the user is currently editing (empty = none yet).
     private const string PrPathId = "ghPrPath";
     // Holds the path of the currently-running operation activity (empty = none). The progress
@@ -155,34 +156,13 @@ public static class GitHubSyncSettingsTab
         // Every long-running GitHub op runs as an ACTIVITY (Doc/Architecture/ActivityControlPlane):
         // the click calls the unified hub extension, which creates an activity + returns its path;
         // we stash the path so the progress panel below binds to it (live Messages/Status + Cancel).
+        // The button row is direction-aware: an import-only source offers no commit, an
+        // export-only source no checkout (the service enforces the same rule server-side).
         stack = stack.WithView(Section("Sync"));
-        stack = stack.WithView(Controls.Button("Sync now (commit)")
-            .WithAppearance(Appearance.Accent)
-            .WithClickAction(ctx =>
-            {
-                ctx.Host.Hub.CommitToGitHub(spacePath, userId,
-                        onActivityCreated: path => ctx.Host.UpdateData(ActivityPathId, path))
-                    .Subscribe(_ => { }, ex => ctx.Host.UpdateData(ResultId, Err(ex.Message)));
-                return Task.CompletedTask;
-            }));
-        stack = stack.WithView(Controls.Button("Update to latest (checkout)")
-            .WithAppearance(Appearance.Outline)
-            .WithClickAction(ctx =>
-            {
-                ctx.Host.Hub.UpdateToLatestFromGitHub(spacePath, userId,
-                        onActivityCreated: path => ctx.Host.UpdateData(ActivityPathId, path))
-                    .Subscribe(_ => { }, ex => ctx.Host.UpdateData(ResultId, Err(ex.Message)));
-                return Task.CompletedTask;
-            }));
-        stack = stack.WithView(Controls.Button("Check branch on GitHub")
-            .WithAppearance(Appearance.Outline)
-            .WithClickAction(ctx =>
-            {
-                ctx.Host.Hub.CheckBranchStateOnGitHub(spacePath, userId,
-                        onActivityCreated: path => ctx.Host.UpdateData(ActivityPathId, path))
-                    .Subscribe(_ => { }, ex => ctx.Host.UpdateData(ResultId, Err(ex.Message)));
-                return Task.CompletedTask;
-            }));
+        stack = stack.WithView((h, _) => sync.WatchConfig(spacePath)
+            .Select(cfg => (UiControl?)BuildSyncButtons(spacePath, userId, sourceId: null,
+                cfg?.Direction ?? SyncDirection.Bidirectional))
+            .StartWith((UiControl?)Controls.Stack.WithWidth("100%")));
 
         // Live activity progress panel: binds to the running operation's activity node — its
         // Messages stream live, the terminal Status shows the outcome, and Cancel flips
@@ -208,7 +188,23 @@ public static class GitHubSyncSettingsTab
             })));
         stack = stack.WithView(BuildReimportForm(spacePath, userId));
 
-        // ── 4. Pull request (AI-drafted → user edits the bound node → submit) ──
+        // ── 4. Additional sync sources ────────────────────────────────────────
+        // The Repository above is the PRIMARY sync source ({space}/_GitSync). A Space can sync
+        // with MORE repositories: each additional source is its own config node
+        // ({space}/_GitSync/{sourceId}) with its own repo, branch and direction, edited through
+        // the same standard node-content editor (bound directly to the node stream).
+        stack = stack.WithView(Section("Additional sync sources"));
+        stack = stack.WithView(Controls.Html(
+            "<p style=\"font-size:0.85rem;color:var(--neutral-foreground-hint);margin:0 0 8px 0;\">" +
+            "Sync this Space with more repositories — each source has its own repository, branch and " +
+            "sync direction (bidirectional, export-only or import-only).</p>"));
+        stack = stack.WithView((h, _) => sync.WatchConfigNodes(spacePath)
+            .Select(nodes => (UiControl?)BuildAdditionalSources(h, sync, spacePath, userId, nodes))
+            .StartWith((UiControl?)Controls.Stack.WithWidth("100%")));
+        host.UpdateData(AddSourceFormId, new Dictionary<string, object?> { ["name"] = "" });
+        stack = stack.WithView(BuildAddSourceForm(sync, spacePath));
+
+        // ── 5. Pull request (AI-drafted → user edits the bound node → submit) ──
         stack = stack.WithView(Section("Pull request"));
         stack = stack.WithView(Controls.Html(
             "<p style=\"font-size:0.85rem;color:var(--neutral-foreground-hint);margin:0 0 8px 0;\">" +
@@ -296,6 +292,131 @@ public static class GitHubSyncSettingsTab
             $"<a href=\"{Esc(connectUrl)}\" target=\"_top\" rel=\"noopener\" " +
             "style=\"color:var(--accent-fill-rest);font-weight:600;\">Connect GitHub →</a>" +
             " (one-time browser approval; authorize for the org whose repos you'll sync).</span></div>");
+    }
+
+    // ── Sync buttons (direction-aware, shared by the primary + additional sources) ──
+
+    /// <summary>
+    /// Builds the sync action row for one source, offering only the operations the source's
+    /// <see cref="SyncDirection"/> allows: commit for export-capable sources, checkout for
+    /// import-capable ones (the service enforces the same rule — this just hides what would
+    /// be rejected). All operations run as activities feeding the shared progress panel.
+    /// </summary>
+    private static UiControl BuildSyncButtons(string spacePath, string userId, string? sourceId, SyncDirection direction)
+    {
+        var row = Controls.Stack.WithOrientation(Orientation.Horizontal).WithStyle("gap:8px;flex-wrap:wrap;");
+        if (direction != SyncDirection.ImportOnly)
+            row = row.WithView(Controls.Button("Sync now (commit)")
+                .WithAppearance(Appearance.Accent)
+                .WithClickAction(ctx =>
+                {
+                    ctx.Host.Hub.CommitToGitHub(spacePath, userId,
+                            onActivityCreated: path => ctx.Host.UpdateData(ActivityPathId, path),
+                            sourceId: sourceId)
+                        .Subscribe(_ => { }, ex => ctx.Host.UpdateData(ResultId, Err(ex.Message)));
+                    return Task.CompletedTask;
+                }));
+        if (direction != SyncDirection.ExportOnly)
+            row = row.WithView(Controls.Button("Update to latest (checkout)")
+                .WithAppearance(Appearance.Outline)
+                .WithClickAction(ctx =>
+                {
+                    ctx.Host.Hub.UpdateToLatestFromGitHub(spacePath, userId,
+                            onActivityCreated: path => ctx.Host.UpdateData(ActivityPathId, path),
+                            sourceId: sourceId)
+                        .Subscribe(_ => { }, ex => ctx.Host.UpdateData(ResultId, Err(ex.Message)));
+                    return Task.CompletedTask;
+                }));
+        row = row.WithView(Controls.Button("Check branch on GitHub")
+            .WithAppearance(Appearance.Outline)
+            .WithClickAction(ctx =>
+            {
+                ctx.Host.Hub.CheckBranchStateOnGitHub(spacePath, userId,
+                        onActivityCreated: path => ctx.Host.UpdateData(ActivityPathId, path))
+                    .Subscribe(_ => { }, ex => ctx.Host.UpdateData(ResultId, Err(ex.Message)));
+                return Task.CompletedTask;
+            }));
+        return row;
+    }
+
+    // ── Additional sync sources (one config node per source under {space}/_GitSync/) ──
+
+    /// <summary>
+    /// Renders every ADDITIONAL sync source ({space}/_GitSync/{sourceId}) — the primary
+    /// (path == {space}/_GitSync) is skipped, it has its own Repository section above. Each
+    /// source shows the standard node-content editor (bound directly to its node stream) plus
+    /// its direction-aware sync buttons and a Remove button.
+    /// </summary>
+    private static UiControl BuildAdditionalSources(
+        LayoutAreaHost host, GitHubSyncService sync, string spacePath, string userId,
+        IReadOnlyList<MeshNode> nodes)
+    {
+        var primaryPath = GitHubSyncService.ConfigPath(spacePath);
+        var stack = Controls.Stack.WithWidth("100%").WithStyle("gap:16px;");
+        var any = false;
+        foreach (var node in nodes)
+        {
+            if (string.Equals(node.Path, primaryPath, StringComparison.OrdinalIgnoreCase))
+                continue;
+            any = true;
+            var sourceId = node.Id;
+            var config = node.ContentAs<GitHubSyncConfig>(host.Hub.JsonSerializerOptions);
+            var source = Controls.Stack.WithWidth("100%")
+                .WithStyle("padding:12px;background:var(--neutral-layer-2);border-radius:8px;gap:8px;");
+            source = source.WithView(Controls.Html(
+                $"<div style=\"font-weight:600;\">{Esc(node.Name ?? sourceId)}</div>"));
+            source = source.WithView(
+                MeshNodeContentEditorControl.ForType(node.Path, typeof(GitHubSyncConfig)));
+            source = source.WithView(BuildSyncButtons(
+                spacePath, userId, sourceId, config?.Direction ?? SyncDirection.Bidirectional));
+            source = source.WithView(Controls.Button("Remove source")
+                .WithAppearance(Appearance.Outline)
+                .WithClickAction(ctx =>
+                {
+                    // The source list live-binds to WatchConfigNodes; the delete re-emits
+                    // and the removed source disappears on its own.
+                    sync.RemoveSyncSource(spacePath, sourceId).Subscribe(
+                        _ => { },
+                        ex => ctx.Host.UpdateData(ResultId, Err(ex.Message)));
+                    return Task.CompletedTask;
+                }));
+            stack = stack.WithView(source);
+        }
+        if (!any)
+            stack = stack.WithView(Controls.Html(
+                "<p style=\"font-size:0.85rem;color:var(--neutral-foreground-hint);\">No additional sync sources.</p>"));
+        return stack;
+    }
+
+    private static UiControl BuildAddSourceForm(GitHubSyncService sync, string spacePath)
+    {
+        var row = Controls.Stack.WithOrientation(Orientation.Horizontal).WithStyle("gap:8px;align-items:flex-end;");
+        row = row.WithView(new TextFieldControl(new JsonPointerReference("name"))
+        {
+            Label = "New sync source name",
+            Placeholder = "e.g. upstream, mirror, backup",
+            DataContext = LayoutAreaReference.GetDataPointer(AddSourceFormId),
+        }.WithWidth("320px"));
+        row = row.WithView(Controls.Button("Add sync source")
+            .WithAppearance(Appearance.Outline)
+            .WithClickAction(ctx =>
+            {
+                ctx.Host.Stream.GetDataStream<Dictionary<string, object?>>(AddSourceFormId).Take(1).Subscribe(d =>
+                {
+                    var name = Str(d, "name");
+                    if (string.IsNullOrEmpty(name))
+                    {
+                        ctx.Host.UpdateData(ResultId, Err("Enter a name for the new sync source."));
+                        return;
+                    }
+                    sync.AddSyncSource(spacePath, name).Subscribe(
+                        node => ctx.Host.UpdateData(ResultId,
+                            Ok($"Sync source '{name}' added — configure its repository and direction above.")),
+                        ex => ctx.Host.UpdateData(ResultId, Err(ex.Message)));
+                });
+                return Task.CompletedTask;
+            }));
+        return row;
     }
 
     // ── Re-import form (transient action input — a commit/branch to import to, not node content) ──

--- a/src/MeshWeaver.GitSync/GitHubSyncSettingsTab.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncSettingsTab.cs
@@ -332,7 +332,8 @@ public static class GitHubSyncSettingsTab
             .WithClickAction(ctx =>
             {
                 ctx.Host.Hub.CheckBranchStateOnGitHub(spacePath, userId,
-                        onActivityCreated: path => ctx.Host.UpdateData(ActivityPathId, path))
+                        onActivityCreated: path => ctx.Host.UpdateData(ActivityPathId, path),
+                        sourceId: sourceId)
                     .Subscribe(_ => { }, ex => ctx.Host.UpdateData(ResultId, Err(ex.Message)));
                 return Task.CompletedTask;
             }));

--- a/src/MeshWeaver.GitSync/PullRequestService.cs
+++ b/src/MeshWeaver.GitSync/PullRequestService.cs
@@ -103,16 +103,16 @@ public sealed class PullRequestService
     /// to <see cref="GitHubSyncService.ReimportAtCommit"/>, which fetches + mirrors). This is
     /// the checkout operation: the working Space is brought to the latest repo state.
     /// </summary>
-    public IObservable<StaticRepoImportResult> UpdateToLatest(string spacePath, string userId)
+    public IObservable<StaticRepoImportResult> UpdateToLatest(string spacePath, string userId, string? sourceId = null)
     {
-        return sync.ReadConfig(spacePath).Take(1).SelectMany(config =>
+        return sync.ReadConfig(spacePath, sourceId).Take(1).SelectMany(config =>
         {
             if (config?.RepositoryUrl is not { Length: > 0 })
                 return Observable.Throw<StaticRepoImportResult>(new InvalidOperationException(
                     "No GitHub repository configured for this Space."));
             var branch = string.IsNullOrWhiteSpace(config.Branch) ? "main" : config.Branch;
             logger?.LogInformation("Updating {Space} to latest on {Branch}", spacePath, branch);
-            return sync.ReimportAtCommit(spacePath, branch, userId);
+            return sync.ReimportAtCommit(spacePath, branch, userId, sourceId);
         });
     }
 

--- a/src/MeshWeaver.GitSync/SyncDirection.cs
+++ b/src/MeshWeaver.GitSync/SyncDirection.cs
@@ -1,0 +1,29 @@
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// The direction a sync source is allowed to sync in. A source is the pairing of a Space
+/// with one configured repository (<see cref="GitHubSyncConfig"/>); the direction gates
+/// which operations <see cref="GitHubSyncService"/> permits against it:
+/// export = mesh → repo ("Sync now" commit), import = repo → mesh ("Update to latest" /
+/// "Re-import at commit").
+/// </summary>
+public enum SyncDirection
+{
+    /// <summary>
+    /// Default. Both directions are allowed: the Space can be committed to the repo AND
+    /// re-imported from it.
+    /// </summary>
+    Bidirectional = 0,
+
+    /// <summary>
+    /// Unidirectional mesh → repo. The Space exports (commits) to the repo; importing from
+    /// the repo is rejected so repo-side edits can never overwrite the mesh.
+    /// </summary>
+    ExportOnly,
+
+    /// <summary>
+    /// Unidirectional repo → mesh. The Space imports (checks out) from the repo; exporting
+    /// is rejected so the repo — the source of truth — is never overwritten from the mesh.
+    /// </summary>
+    ImportOnly,
+}

--- a/src/MeshWeaver.Graph/Configuration/PartitionDropPostDeletionHandler.cs
+++ b/src/MeshWeaver.Graph/Configuration/PartitionDropPostDeletionHandler.cs
@@ -1,0 +1,90 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Tears down a partition's entire backing store when its partition-owning root node is
+/// deleted — the deletion-side mirror of <c>OwnsPartitionProvisioningValidator</c>. Deleting
+/// a <c>Space</c> removes the space's nodes (the recursive delete), and this handler then
+/// (1) drops the partition's backing store on every <see cref="IPartitionStorageProvider"/>
+/// (the Postgres provider drops the schema with all satellite tables — threads, access,
+/// activities — in one <c>DROP SCHEMA … CASCADE</c>), and (2) deletes the
+/// <c>Admin/Partition/{id}</c> <see cref="PartitionDefinition"/> node that
+/// <c>SpacePostCreationHandler</c> emitted, so the partition disappears from the routing
+/// prime and partition listings mesh-wide.
+///
+/// <para>Sequenced store-drop → definition-delete: when the store drop fails, the
+/// definition node stays so the partition remains visible for a retry instead of turning
+/// into an invisible orphan schema. The definition delete runs under
+/// <c>ImpersonateAsSystem</c> (infrastructure cleanup in the Admin partition — the deleting
+/// user legitimately may not hold Admin-partition rights). 100% reactive — no
+/// <c>async</c>/<c>await</c>; the async DDL edge is sealed inside each provider's
+/// <c>IIoPool</c>.</para>
+/// </summary>
+public sealed class PartitionDropPostDeletionHandler(
+    IMessageHub hub,
+    ILogger<PartitionDropPostDeletionHandler>? logger = null) : INodePostDeletionHandler
+{
+    /// <inheritdoc />
+    public string NodeType => SpaceNodeType.NodeType;
+
+    /// <inheritdoc />
+    public IObservable<Unit> Handle(MeshNode deletedNode, string? deletedBy)
+    {
+        // Only a partition ROOT (top-level: namespace empty, path == id) owns a partition.
+        // A nested node of this type (which OwnsPartitionProvisioningValidator rejects on
+        // create anyway) must never drop the enclosing partition.
+        if (!string.IsNullOrEmpty(deletedNode.Namespace) || string.IsNullOrEmpty(deletedNode.Id))
+            return Observable.Return(Unit.Default);
+
+        var partition = deletedNode.Id;
+        var providers = hub.ServiceProvider.GetServices<IPartitionStorageProvider>().ToList();
+
+        // Sequential (.Concat) like provisioning, so concurrent DDL never races. A provider
+        // failure propagates — the delete pipeline surfaces it as a Warning on the activity.
+        var dropStores = providers
+            .Select(p => p.DeletePartition(partition))
+            .Concat()
+            .ToList()
+            .Do(_ => logger?.LogInformation(
+                "Dropped partition '{Partition}' across {Count} provider(s) after {NodeType} deletion by {User}",
+                partition, providers.Count, deletedNode.NodeType, deletedBy ?? "system"))
+            .Select(_ => Unit.Default);
+
+        return dropStores.Concat(DeletePartitionDefinition(partition)).TakeLast(1);
+    }
+
+    /// <summary>
+    /// Deletes the <c>Admin/Partition/{partition}</c> definition node under System
+    /// impersonation. Best-effort: an absent definition (e.g. a bootstrap-created partition
+    /// that never got one) or a failed delete is logged but does not fail the handler —
+    /// the backing store is already gone, which is the part that matters.
+    /// </summary>
+    private IObservable<Unit> DeletePartitionDefinition(string partition)
+    {
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        var defPath = $"{PartitionNodeType.Namespace}/{partition}";
+
+        return Observable.Using(
+                () => accessService.ImpersonateAsSystem(),
+                _ => meshService.DeleteNode(defPath))
+            .Do(deleted => logger?.LogInformation(
+                "Partition definition '{Path}' delete after partition drop: {Result}",
+                defPath, deleted ? "deleted" : "not deleted"))
+            .Catch<bool, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "Could not delete partition definition '{Path}' after dropping partition '{Partition}'",
+                    defPath, partition);
+                return Observable.Return(false);
+            })
+            .Select(_ => Unit.Default);
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs
@@ -198,6 +198,13 @@ public static class SpaceNodeType
                 new SpaceAdminInvariantValidator(
                     sp.GetRequiredService<IMessageHub>(),
                     sp.GetService<ILoggerFactory>()?.CreateLogger<SpaceAdminInvariantValidator>()));
+            // Deleting a Space removes the ENTIRE partition: after the recursive node
+            // delete, drop the backing store (Postgres schema incl. satellites) on every
+            // partition storage provider and remove the Admin/Partition/{id} definition.
+            services.AddSingleton<INodePostDeletionHandler>(sp =>
+                new PartitionDropPostDeletionHandler(
+                    sp.GetRequiredService<IMessageHub>(),
+                    sp.GetService<ILoggerFactory>()?.CreateLogger<PartitionDropPostDeletionHandler>()));
             return services;
         });
         // Space instances are NOT publicly readable — partition access controls visibility.

--- a/src/MeshWeaver.Graph/IPartitionSyncSourceProvider.cs
+++ b/src/MeshWeaver.Graph/IPartitionSyncSourceProvider.cs
@@ -1,0 +1,50 @@
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// DI seam between the partition administration GUI (<see cref="PartitionSyncAdminLayoutArea"/>,
+/// in this assembly) and a sync-source backend living in a HIGHER layer (e.g.
+/// <c>MeshWeaver.GitSync</c>'s per-space GitHub sources — GitSync references Graph, so Graph
+/// cannot call it directly). Each implementation exposes one KIND of sync source as config
+/// MeshNodes: the overview page lists them, binds the standard node-content editor
+/// (<see cref="MeshNodeContentEditorControl.ForType"/> over <see cref="ConfigContentType"/>)
+/// to each node's path, and adds/removes sources through this contract. Register as a
+/// mesh-scoped singleton; the page resolves all implementations and simply hides the
+/// section when none are registered.
+/// </summary>
+public interface IPartitionSyncSourceProvider
+{
+    /// <summary>Display name of this source kind (e.g. "GitHub").</summary>
+    string Kind { get; }
+
+    /// <summary>
+    /// The content type of a source's config node — drives the generated editor fields
+    /// (<see cref="MeshNodeEditorField.FromType"/>).
+    /// </summary>
+    Type ConfigContentType { get; }
+
+    /// <summary>
+    /// Live stream of the partition's sync-source config nodes. Re-emits when a source is
+    /// added, removed, or edited. Emits an empty list (never stalls) when the partition has
+    /// no sources.
+    /// </summary>
+    IObservable<IReadOnlyList<MeshNode>> WatchSyncSources(string partition);
+
+    /// <summary>
+    /// One-line summary of a source for list/grid display, e.g.
+    /// <c>"owner/repo@main (Bidirectional)"</c> or <c>"not configured"</c>.
+    /// </summary>
+    string Describe(MeshNode source);
+
+    /// <summary>Whether <paramref name="source"/> may be removed (a provider may protect
+    /// its primary/default source).</summary>
+    bool CanRemove(string partition, MeshNode source);
+
+    /// <summary>Adds a sync source named <paramref name="name"/> to the partition and emits
+    /// its config node. Idempotent on the derived source id.</summary>
+    IObservable<MeshNode> AddSyncSource(string partition, string name);
+
+    /// <summary>Removes the sync source backed by <paramref name="source"/>.</summary>
+    IObservable<bool> RemoveSyncSource(string partition, MeshNode source);
+}

--- a/src/MeshWeaver.Graph/PartitionSyncAdminLayoutArea.cs
+++ b/src/MeshWeaver.Graph/PartitionSyncAdminLayoutArea.cs
@@ -170,14 +170,17 @@ public static class PartitionSyncAdminLayoutArea
     /// </summary>
     private static IObservable<ImmutableArray<PartitionInfo>> DiscoverPartitions(LayoutAreaHost host)
     {
+        // Case-insensitive throughout — partition ids dedupe/order case-insensitively below,
+        // so a Space root whose casing differs from IStaticRepoSource.Partition must still
+        // resolve its static-source names.
         var staticSources = host.Hub.ServiceProvider.GetServices<IStaticRepoSource>()
-            .GroupBy(s => s.Partition, StringComparer.Ordinal)
+            .GroupBy(s => s.Partition, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
                 g => g.Key,
                 g => string.Join(", ", g.Select(s => s.GetType().Name)
                     .Distinct(StringComparer.Ordinal)
                     .OrderBy(n => n, StringComparer.Ordinal)),
-                StringComparer.Ordinal);
+                StringComparer.OrdinalIgnoreCase);
 
         var meshService = host.Hub.ServiceProvider.GetService<IMeshService>();
         var spaceRoots = meshService is null

--- a/src/MeshWeaver.Graph/PartitionSyncAdminLayoutArea.cs
+++ b/src/MeshWeaver.Graph/PartitionSyncAdminLayoutArea.cs
@@ -8,6 +8,7 @@ using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Layout.DataGrid;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using MeshWeaver.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,27 +17,42 @@ using Microsoft.Extensions.Logging;
 namespace MeshWeaver.Graph;
 
 /// <summary>
-/// Platform-admin "Partition Sync" overview. Lists every syncable partition (one per
-/// distinct <see cref="IStaticRepoSource.Partition"/>) with its source type(s) and live
-/// sync status, and lets a global admin flip each partition between <b>Synced</b> and
-/// <b>Not synced</b>. "Not synced" sets the partition ROOT's
-/// <see cref="MeshNode.SyncBehavior"/> to <see cref="SyncBehavior.ExcludeThisAndChildren"/>,
-/// which decouples the whole partition from static-repo import — e.g. so admin-managed API
-/// keys in the <c>Provider</c> partition are never reset by the next import. See
-/// <c>Doc/Architecture/StaticRepoImport.md</c> and <see cref="StopSyncLayoutArea"/>.
+/// Platform-admin "Partitions" overview. Lists EVERY partition in the mesh — one row per
+/// partition ROOT node (namespace empty, id = partition) — with the main node's properties,
+/// its sync status, and its sync sources. From here a global admin can:
+/// <list type="bullet">
+///   <item>flip a partition between <b>Synced</b> and <b>Not synced</b> ("Not synced" sets the
+///     root's <see cref="MeshNode.SyncBehavior"/> to <see cref="SyncBehavior.ExcludeThisAndChildren"/>,
+///     decoupling the whole partition from static-repo import — e.g. so admin-managed API keys
+///     in the <c>Provider</c> partition are never reset; see <c>Doc/Architecture/StaticRepoImport.md</c>);</item>
+///   <item>edit each sync source's settings in place (repository, branch,
+///     <b>sync direction</b> — bidirectional / export-only / import-only) through the standard
+///     node-content editor, bound DIRECTLY to the source's config node stream;</item>
+///   <item>add / remove sync sources (via the <see cref="IPartitionSyncSourceProvider"/> seam —
+///     e.g. GitHub sources from <c>MeshWeaver.GitSync</c>);</item>
+///   <item>navigate to the partition, or delete the space (which drops the ENTIRE partition —
+///     see <c>PartitionDropPostDeletionHandler</c>).</item>
+/// </list>
 /// </summary>
 public static class PartitionSyncAdminLayoutArea
 {
-    /// <summary>Area name for the partition-sync overview.</summary>
+    /// <summary>Area name for the partitions overview.</summary>
     public const string PartitionSyncArea = "PartitionSync";
 
     private const string SettingsTabId = "PartitionSync";
 
+    /// <summary>Data id holding the currently selected partition (the detail panel binds to it).</summary>
+    private const string SelectedPartitionId = "partitionsOverviewSelected";
+
+    /// <summary>Data id of the add-sync-source form input.</summary>
+    private const string AddSourceFormId = "partitionsOverviewAddSource";
+
     /// <summary>
-    /// One syncable partition: its namespace/root id plus a human-readable list of the
-    /// <see cref="IStaticRepoSource"/> implementation type name(s) that materialize into it.
+    /// One partition: its namespace/root id plus a human-readable list of the
+    /// <see cref="IStaticRepoSource"/> implementation type name(s) that materialize into it
+    /// (empty for partitions without a static source).
     /// </summary>
-    private sealed record PartitionInfo(string Partition, string Source);
+    private sealed record PartitionInfo(string Partition, string StaticSource);
 
     /// <summary>
     /// Plain row record bound into the <see cref="DataGridControl"/> (camelCased property names).
@@ -45,14 +61,20 @@ public static class PartitionSyncAdminLayoutArea
     {
         /// <summary>The partition namespace/root id.</summary>
         public string Partition { get; init; } = string.Empty;
-        /// <summary>Human-readable list of the source type name(s) that materialize into the partition.</summary>
-        public string Source { get; init; } = string.Empty;
+        /// <summary>The partition main node's display name.</summary>
+        public string Name { get; init; } = string.Empty;
+        /// <summary>The partition main node's node type (e.g. "Space").</summary>
+        public string Type { get; init; } = string.Empty;
+        /// <summary>Who created the partition main node.</summary>
+        public string CreatedBy { get; init; } = string.Empty;
         /// <summary>The partition's current sync status ("Synced" or "Not synced").</summary>
         public string Status { get; init; } = string.Empty;
+        /// <summary>Summary of the partition's sync sources (static repo + configured git sources with direction).</summary>
+        public string Sources { get; init; } = string.Empty;
     }
 
     /// <summary>
-    /// Registers a global-admin "Partition Sync" tab on the node's Settings page. The provider
+    /// Registers the global-admin "Partitions" tab on the node's Settings page. The provider
     /// only yields the tab once the viewer is confirmed a global admin (Admin-partition
     /// <see cref="MeshWeaver.Mesh.Security.Permission.All"/>); the tab content embeds the reactive
     /// <see cref="PartitionSyncOverview"/> area, which gates again as defense-in-depth.
@@ -71,14 +93,15 @@ public static class PartitionSyncAdminLayoutArea
 
         var tab = new SettingsMenuItemDefinition(
             Id: SettingsTabId,
-            Label: "Partition Sync",
+            Label: "Partitions",
             ContentBuilder: BuildPartitionSyncTab,
             Group: "Administration",
             Icon: FluentIcons.ArrowSync(),
             GroupIcon: FluentIcons.Shield(),
             Order: 310,
-            Keywords: ["partition sync", "sync", "static repo", "import", "synced",
-                "not synced", "decouple", "api keys", "provider", "administration", "platform"]);
+            Keywords: ["partitions", "partition overview", "spaces", "partition sync", "sync", "sync source",
+                "sync direction", "static repo", "import", "export", "synced", "not synced", "decouple",
+                "api keys", "provider", "administration", "platform", "delete space"]);
 
         // Same shape as the Global Administration tab: wait for the POSITIVE admin confirmation
         // (filter true) with a bounded timeout — NOT the first emission, which can be a premature
@@ -96,13 +119,13 @@ public static class PartitionSyncAdminLayoutArea
     /// <summary>
     /// Settings-tab content: embeds the reactive <see cref="PartitionSyncOverview"/> area. The
     /// embedded observable stays live (CombineLatest over the partition root streams), so the
-    /// status column + toggle labels update as soon as a write lands.
+    /// grid + detail panel update as soon as a write lands.
     /// </summary>
     private static UiControl BuildPartitionSyncTab(LayoutAreaHost host, StackControl stack, MeshNode? node)
         => stack.WithView(BuildArea(host));
 
     /// <summary>
-    /// The reactive Partition Sync area, registrable via
+    /// The reactive Partitions area, registrable via
     /// <c>AddLayout(layout =&gt; layout.WithView(PartitionSyncArea, PartitionSyncOverview))</c>.
     /// </summary>
     [Browsable(false)]
@@ -137,58 +160,113 @@ public static class PartitionSyncAdminLayoutArea
     private static UiControl AccessDenied()
         => Controls.Markdown("Access denied — platform admins only.");
 
+    // ── Partition discovery ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Discovers every partition: the union of all partition ROOT nodes (top-level
+    /// <c>Space</c> nodes — every space, user-created or importer-created, is one) and the
+    /// partitions registered by an <see cref="IStaticRepoSource"/> (present even before
+    /// their first import materializes the root). Ordered for a stable layout.
+    /// </summary>
+    private static IObservable<ImmutableArray<PartitionInfo>> DiscoverPartitions(LayoutAreaHost host)
+    {
+        var staticSources = host.Hub.ServiceProvider.GetServices<IStaticRepoSource>()
+            .GroupBy(s => s.Partition, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => string.Join(", ", g.Select(s => s.GetType().Name)
+                    .Distinct(StringComparer.Ordinal)
+                    .OrderBy(n => n, StringComparer.Ordinal)),
+                StringComparer.Ordinal);
+
+        var meshService = host.Hub.ServiceProvider.GetService<IMeshService>();
+        var spaceRoots = meshService is null
+            ? Observable.Return(new List<MeshNode>())
+            : meshService.Query<MeshNode>(MeshQueryRequest.FromQuery("nodeType:Space"))
+                .Where(change => change.ChangeType == QueryChangeType.Initial)
+                .Take(1)
+                .Select(change => change.Items.Where(n => string.IsNullOrEmpty(n.Namespace)).ToList())
+                .Timeout(TimeSpan.FromSeconds(10))
+                .Catch<List<MeshNode>, Exception>(_ => Observable.Return(new List<MeshNode>()));
+
+        return spaceRoots.Select(spaces => spaces
+            .Select(n => n.Id)
+            .Concat(staticSources.Keys)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+            .Select(p => new PartitionInfo(p, staticSources.GetValueOrDefault(p, "")))
+            .ToImmutableArray());
+    }
+
     private static IObservable<UiControl?> BuildAdminView(LayoutAreaHost host)
     {
         var logger = host.Hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger(typeof(PartitionSyncAdminLayoutArea));
+        var providers = host.Hub.ServiceProvider.GetServices<IPartitionSyncSourceProvider>().ToList();
 
-        // Distinct syncable partitions, grouped so a partition served by several sources shows
-        // all their type names. Ordered for a stable layout.
-        var partitions = host.Hub.ServiceProvider.GetServices<IStaticRepoSource>()
-            .GroupBy(s => s.Partition, StringComparer.Ordinal)
-            .OrderBy(g => g.Key, StringComparer.Ordinal)
-            .Select(g => new PartitionInfo(
-                g.Key,
-                string.Join(", ", g.Select(s => s.GetType().Name)
-                    .Distinct(StringComparer.Ordinal)
-                    .OrderBy(n => n, StringComparer.Ordinal))))
-            .ToImmutableArray();
+        return DiscoverPartitions(host).Select(partitions =>
+        {
+            if (partitions.Length == 0)
+                return Observable.Return<UiControl?>(Controls.Stack
+                    .WithView(Controls.Title("Partitions", 1))
+                    .WithView(Controls.Markdown("*No partitions found.*")));
 
-        if (partitions.Length == 0)
-            return Observable.Return<UiControl?>(Controls.Stack
-                .WithView(Controls.Title("Partition Sync", 1))
-                .WithView(Controls.Markdown("*No syncable partitions are registered.*")));
-
-        // Live: one stream per partition ROOT (namespace="", path==partition). Each starts with
-        // null so CombineLatest fires immediately (optimistic "Synced") and updates as roots load
-        // and as toggles land.
-        var streams = partitions.Select(p =>
-            host.Workspace.GetMeshNodeStream(p.Partition)
+            // Live: one row stream per partition — the ROOT node stream (namespace="",
+            // path==partition; starts with null so CombineLatest fires immediately) combined
+            // with the partition's sync-source summary.
+            var rowStreams = partitions.Select(p => host.Workspace
+                .GetMeshNodeStream(p.Partition)
                 .Select(n => (MeshNode?)n)
-                .StartWith((MeshNode?)null));
-
-        return Observable.CombineLatest(streams)
-            .Select(nodes =>
-            {
-                var rows = partitions
-                    .Select((p, i) => new PartitionSyncRow
+                .StartWith((MeshNode?)null)
+                .CombineLatest(
+                    SourcesSummary(providers, p.Partition, p.StaticSource),
+                    (node, sources) => new PartitionSyncRow
                     {
                         Partition = p.Partition,
-                        Source = p.Source,
-                        Status = IsSynced(nodes[i]) ? "Synced" : "Not synced",
-                    })
-                    .ToImmutableArray();
+                        Name = node?.Name ?? p.Partition,
+                        Type = node?.NodeType ?? "",
+                        CreatedBy = node?.CreatedBy ?? "",
+                        Status = IsSynced(node) ? "Synced" : "Not synced",
+                        Sources = sources,
+                    }));
 
-                return (UiControl?)BuildView(host, rows, logger);
-            });
+            return Observable.CombineLatest(rowStreams)
+                .Select(rows => (UiControl?)BuildView(host, [.. rows], providers, logger));
+        }).Switch();
+    }
+
+    /// <summary>
+    /// One-line summary of the partition's sync sources: the static-repo source type name(s)
+    /// plus each provider-managed source (e.g. GitHub repo@branch with its direction).
+    /// </summary>
+    private static IObservable<string> SourcesSummary(
+        IReadOnlyList<IPartitionSyncSourceProvider> providers, string partition, string staticSource)
+    {
+        var staticPart = string.IsNullOrEmpty(staticSource) ? null : $"Static: {staticSource}";
+        if (providers.Count == 0)
+            return Observable.Return(staticPart ?? "—");
+
+        var streams = providers.Select(p => p.WatchSyncSources(partition)
+            .Select(nodes => nodes.Select(n => $"{p.Kind}: {p.Describe(n)}").ToList())
+            .StartWith(new List<string>()));
+        return Observable.CombineLatest(streams).Select(lists =>
+        {
+            var parts = new List<string>();
+            if (staticPart is not null) parts.Add(staticPart);
+            parts.AddRange(lists.SelectMany(l => l));
+            return parts.Count == 0 ? "—" : string.Join(" · ", parts);
+        });
     }
 
     // Anything other than the whole-subtree exclusion is treated as Synced (null/Include/ThisOnly).
     private static bool IsSynced(MeshNode? node)
         => node?.SyncBehavior != SyncBehavior.ExcludeThisAndChildren;
 
+    // ── View composition ───────────────────────────────────────────────────────
+
     private static UiControl BuildView(
-        LayoutAreaHost host, ImmutableArray<PartitionSyncRow> rows, ILogger? logger)
+        LayoutAreaHost host, ImmutableArray<PartitionSyncRow> rows,
+        IReadOnlyList<IPartitionSyncSourceProvider> providers, ILogger? logger)
     {
         var id = Guid.NewGuid().ToString();
         host.RegisterForDisposal(Observable.Return(rows).Subscribe(data => host.UpdateData(id, data)));
@@ -197,41 +275,115 @@ public static class PartitionSyncAdminLayoutArea
             .WithColumn(new PropertyColumnControl<string>
                 { Property = nameof(PartitionSyncRow.Partition).ToCamelCase() }.WithTitle("Partition"))
             .WithColumn(new PropertyColumnControl<string>
-                { Property = nameof(PartitionSyncRow.Source).ToCamelCase() }.WithTitle("Source"))
+                { Property = nameof(PartitionSyncRow.Name).ToCamelCase() }.WithTitle("Name"))
+            .WithColumn(new PropertyColumnControl<string>
+                { Property = nameof(PartitionSyncRow.Type).ToCamelCase() }.WithTitle("Type"))
+            .WithColumn(new PropertyColumnControl<string>
+                { Property = nameof(PartitionSyncRow.CreatedBy).ToCamelCase() }.WithTitle("Created By"))
             .WithColumn(new PropertyColumnControl<string>
                 { Property = nameof(PartitionSyncRow.Status).ToCamelCase() }.WithTitle("Status"))
+            .WithColumn(new PropertyColumnControl<string>
+                { Property = nameof(PartitionSyncRow.Sources).ToCamelCase() }.WithTitle("Sync Sources"))
             .Resizable();
 
-        // DataGrid has no row-click, so render one toggle button per partition next to the grid.
-        var buttonRow = Controls.Stack
+        // DataGrid has no row-click, so render one select button per partition; the detail
+        // panel below binds to the selection.
+        var selectRow = Controls.Stack
             .WithOrientation(Orientation.Horizontal)
             .WithHorizontalGap(8)
             .WithStyle("flex-wrap: wrap;");
         foreach (var row in rows)
-            buttonRow = buttonRow.WithView(BuildToggleButton(row, logger));
+        {
+            var partition = row.Partition;
+            selectRow = selectRow.WithView(Controls.Button(partition)
+                .WithAppearance(Appearance.Outline)
+                .WithClickAction(ctx =>
+                {
+                    ctx.Host.UpdateData(SelectedPartitionId, partition);
+                    // Reset the add-source input when switching partitions.
+                    ctx.Host.UpdateData(AddSourceFormId, new Dictionary<string, object?> { ["name"] = "" });
+                    return Task.CompletedTask;
+                }));
+        }
 
-        return Controls.Stack
-            .WithView(Controls.Title("Partition Sync", 1))
+        var stack = Controls.Stack
+            .WithView(Controls.Title("Partitions", 1))
             .WithView(Controls.Markdown(
-                "Toggle each partition between **Synced** and **Not synced**. "
-                + "Setting a partition to **Not synced** excludes its whole subtree from "
-                + "static-repo import, so admin-managed content (e.g. API keys) is never reset."))
+                "Every partition in the mesh, with its main node (namespace empty, id = partition), "
+                + "sync status and sync sources. Select a partition below to manage it: toggle "
+                + "static-repo sync, edit each sync source's settings (repository, branch, "
+                + "**sync direction** — bidirectional, export-only or import-only), add or remove "
+                + "sync sources, or delete the space (which removes the entire partition)."))
             .WithView(grid)
-            .WithView(Controls.Title("Toggle synchronization", 2))
-            .WithView(buttonRow);
+            .WithView(Controls.Title("Manage partition", 2))
+            .WithView(selectRow);
+
+        // The detail panel — bound to the selected partition, live inner streams via Switch.
+        stack = stack.WithView((h, _) => h.Stream.GetDataStream<string>(SelectedPartitionId)
+            .Select(partition => string.IsNullOrEmpty(partition)
+                ? Observable.Return<UiControl?>(Controls.Markdown("*Select a partition to manage it.*"))
+                : BuildDetailStream(h, partition, providers, logger))
+            .Switch()
+            .StartWith((UiControl?)Controls.Markdown("*Select a partition to manage it.*")));
+
+        return stack;
     }
 
-    private static UiControl BuildToggleButton(PartitionSyncRow row, ILogger? logger)
+    /// <summary>
+    /// The live detail panel for one partition: the main node's properties, the sync toggle +
+    /// navigation/delete actions, and every sync source with its data-bound editor.
+    /// </summary>
+    private static IObservable<UiControl?> BuildDetailStream(
+        LayoutAreaHost host, string partition,
+        IReadOnlyList<IPartitionSyncSourceProvider> providers, ILogger? logger)
     {
-        var synced = row.Status == "Synced";
-        var partitionPath = row.Partition;
-        return Controls.Button(synced
-                ? $"Set Not synced: {row.Partition}"
-                : $"Set Synced: {row.Partition}")
+        var root = host.Workspace.GetMeshNodeStream(partition)
+            .Select(n => (MeshNode?)n)
+            .StartWith((MeshNode?)null);
+
+        var sourcesStreams = providers
+            .Select(p => p.WatchSyncSources(partition)
+                .Select(nodes => (Provider: p, Nodes: nodes))
+                .StartWith((Provider: p, Nodes: (IReadOnlyList<MeshNode>)[])))
+            .ToList();
+
+        var sources = sourcesStreams.Count == 0
+            ? Observable.Return(new List<(IPartitionSyncSourceProvider Provider, IReadOnlyList<MeshNode> Nodes)>())
+            : Observable.CombineLatest(sourcesStreams).Select(x => x.ToList());
+
+        return root.CombineLatest(sources,
+            (node, sourceGroups) => (UiControl?)BuildDetailPanel(partition, node, sourceGroups, logger));
+    }
+
+    private static UiControl BuildDetailPanel(
+        string partition, MeshNode? node,
+        List<(IPartitionSyncSourceProvider Provider, IReadOnlyList<MeshNode> Nodes)> sourceGroups,
+        ILogger? logger)
+    {
+        var stack = Controls.Stack.WithWidth("100%").WithStyle("gap: 12px;");
+        stack = stack.WithView(Controls.Title(node?.Name ?? partition, 3));
+
+        // Main node properties (namespace empty, id = partition).
+        stack = stack.WithView(Controls.Markdown(node is null
+            ? $"*The partition root node `{partition}` is not materialized (yet).*"
+            : $"- **Partition:** `{partition}`\n"
+              + $"- **Name:** {node.Name ?? partition}\n"
+              + $"- **Node type:** {node.NodeType}\n"
+              + $"- **Created:** {node.CreatedDate:yyyy-MM-dd HH:mm} UTC by {node.CreatedBy ?? "—"}\n"
+              + $"- **Last modified:** {node.LastModified:yyyy-MM-dd HH:mm} UTC by {node.LastModifiedBy ?? "—"}\n"
+              + $"- **Sync behavior:** {node.SyncBehavior} ({(IsSynced(node) ? "Synced" : "Not synced")})"));
+
+        // Actions: toggle static-repo sync, open the partition, delete the space.
+        var actions = Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithHorizontalGap(8)
+            .WithStyle("flex-wrap: wrap;");
+        var synced = IsSynced(node);
+        actions = actions.WithView(Controls.Button(synced ? "Set Not synced" : "Set Synced")
             .WithAppearance(synced ? Appearance.Lightweight : Appearance.Accent)
             .WithClickAction(ctx =>
             {
-                ctx.Host.Workspace.GetMeshNodeStream(partitionPath)
+                ctx.Host.Workspace.GetMeshNodeStream(partition)
                     .Update(n => n with
                     {
                         SyncBehavior = n.SyncBehavior == SyncBehavior.Include
@@ -239,9 +391,94 @@ public static class PartitionSyncAdminLayoutArea
                             : SyncBehavior.Include
                     })
                     .Subscribe(_ => { },
-                        ex => logger?.LogWarning(ex, "Partition sync toggle failed for {Path}", partitionPath));
+                        ex => logger?.LogWarning(ex, "Partition sync toggle failed for {Path}", partition));
                 return Task.CompletedTask;
-            });
+            }));
+        actions = actions.WithView(Controls.Button("Open")
+            .WithAppearance(Appearance.Outline)
+            .WithIconStart(FluentIcons.Open())
+            .WithNavigateToHref($"/{partition}"));
+        actions = actions.WithView(Controls.Button("Delete space…")
+            .WithAppearance(Appearance.Outline)
+            .WithIconStart(FluentIcons.Delete())
+            .WithStyle("color: var(--error, #d32f2f);")
+            .WithNavigateToHref(MeshNodeLayoutAreas.BuildUrl(partition, MeshNodeLayoutAreas.DeleteArea)));
+        stack = stack.WithView(actions);
+
+        // Sync sources — each config node edited through the STANDARD node-content editor,
+        // bound directly to the node stream (no /data replica, no save subscription).
+        foreach (var (provider, nodes) in sourceGroups)
+        {
+            stack = stack.WithView(Controls.Title($"{provider.Kind} sync sources", 4));
+            if (nodes.Count == 0)
+                stack = stack.WithView(Controls.Markdown("*No sync sources configured.*"));
+            foreach (var source in nodes)
+            {
+                var sourceStack = Controls.Stack.WithWidth("100%")
+                    .WithStyle("padding: 12px; background: var(--neutral-layer-2); border-radius: 8px; gap: 8px;");
+                sourceStack = sourceStack.WithView(Controls.Markdown(
+                    $"**{source.Name ?? source.Id}** — {provider.Describe(source)}"));
+                sourceStack = sourceStack.WithView(
+                    MeshNodeContentEditorControl.ForType(source.Path, provider.ConfigContentType));
+                if (provider.CanRemove(partition, source))
+                {
+                    var capturedSource = source;
+                    sourceStack = sourceStack.WithView(Controls.Button("Remove source")
+                        .WithAppearance(Appearance.Outline)
+                        .WithClickAction(ctx =>
+                        {
+                            // The detail panel live-binds to WatchSyncSources; the delete
+                            // re-emits and the removed source disappears on its own.
+                            provider.RemoveSyncSource(partition, capturedSource)
+                                .Subscribe(_ => { },
+                                    ex => logger?.LogWarning(ex,
+                                        "Removing sync source {Path} failed", capturedSource.Path));
+                            return Task.CompletedTask;
+                        }));
+                }
+                stack = stack.WithView(sourceStack);
+            }
+            stack = stack.WithView(BuildAddSourceForm(provider, partition, logger));
+        }
+
+        return stack;
+    }
+
+    private static UiControl BuildAddSourceForm(
+        IPartitionSyncSourceProvider provider, string partition, ILogger? logger)
+    {
+        var row = Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithHorizontalGap(8)
+            .WithStyle("align-items: flex-end;");
+        row = row.WithView(new TextFieldControl(new JsonPointerReference("name"))
+        {
+            Label = $"New {provider.Kind} sync source",
+            Placeholder = "e.g. upstream, mirror, backup",
+            DataContext = LayoutAreaReference.GetDataPointer(AddSourceFormId),
+        }.WithWidth("280px"));
+        row = row.WithView(Controls.Button("Add sync source")
+            .WithAppearance(Appearance.Outline)
+            .WithClickAction(ctx =>
+            {
+                ctx.Host.Stream.GetDataStream<Dictionary<string, object?>>(AddSourceFormId)
+                    .Take(1)
+                    .Subscribe(form =>
+                    {
+                        var name = form.GetValueOrDefault("name") is { } v ? v.ToString()?.Trim() : null;
+                        if (string.IsNullOrEmpty(name))
+                            return;
+                        // The sources list live-binds to WatchSyncSources; the create re-emits
+                        // and the new source's editor appears on its own.
+                        provider.AddSyncSource(partition, name)
+                            .Subscribe(_ => ctx.Host.UpdateData(AddSourceFormId,
+                                    new Dictionary<string, object?> { ["name"] = "" }),
+                                ex => logger?.LogWarning(ex,
+                                    "Adding sync source '{Name}' to {Partition} failed", name, partition));
+                    });
+                return Task.CompletedTask;
+            }));
+        return row;
     }
 
     private static string? ResolveViewerId(LayoutAreaHost host)

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionStorageProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlPartitionStorageProvider.cs
@@ -386,6 +386,47 @@ public sealed class PostgreSqlPartitionStorageProvider : IPartitionStorageProvid
     }
 
     /// <summary>
+    /// Drops the partition's backing schema — the inverse of
+    /// <see cref="EnsurePartitionProvisioned"/>. <c>DROP SCHEMA IF EXISTS … CASCADE</c>
+    /// removes the partition's <c>mesh_nodes</c> and every satellite table in one atomic
+    /// DDL statement, then evicts the provisioning caches (<see cref="_schemasInitialized"/>,
+    /// <see cref="_provisioned"/>, <see cref="_registeredPartitions"/>) so a later re-create
+    /// of the same partition provisions from scratch instead of replaying the cached
+    /// "already provisioned" promise against a schema that no longer exists. Idempotent —
+    /// dropping an absent schema is a no-op. The async DB edge is sealed inside
+    /// <see cref="IIoPool"/> (never <c>Observable.FromAsync</c>).
+    /// </summary>
+    public IObservable<Unit> DeletePartition(string @namespace)
+    {
+        if (string.IsNullOrEmpty(@namespace))
+            return Observable.Return(Unit.Default);
+
+        var schema = _registeredPartitions.TryGetValue(@namespace, out var def)
+                     && !string.IsNullOrEmpty(def.Schema)
+            ? def.Schema!
+            : @namespace.ToLowerInvariant();
+
+        return _ioPool.Invoke(async ct =>
+        {
+            await ExecuteDdlWithRetryAsync(async attemptCt =>
+            {
+                // Schema name is identifier-quoted — it derives from a node id, not raw SQL.
+                await using var cmd = _baseDataSource.CreateCommand(
+                    $"DROP SCHEMA IF EXISTS \"{schema.Replace("\"", "\"\"")}\" CASCADE");
+                await cmd.ExecuteNonQueryAsync(attemptCt).ConfigureAwait(false);
+            }, ct, _logger).ConfigureAwait(false);
+
+            _schemasInitialized.TryRemove(schema, out _);
+            _provisioned.TryRemove(schema, out _);
+            _registeredPartitions.TryRemove(@namespace, out _);
+            _logger?.LogInformation(
+                "PostgreSqlPartitionStorageProvider: dropped schema {Schema} for deleted partition {Namespace}",
+                schema, @namespace);
+            return Unit.Default;
+        });
+    }
+
+    /// <summary>
     /// Tests / boot-time callers can pre-register a known
     /// <see cref="PartitionDefinition"/> so the router resolves its real schema
     /// (notably the <c>_</c>-prefix globals whose schema ≠ lowercased namespace)

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -1085,16 +1085,27 @@ public static class MeshExtensions
                                                 meshHub, storage, path, collected.ToDelete,
                                                 capturedRequest, request.AccessContext, logger, collectedMessages)
                                             .Timeout(opts.Timeout)
+                                            // 5. Post-deletion side effects for the ROOT node — e.g.
+                                            //    dropping the backing partition store when a
+                                            //    partition-owning Space root is deleted. The subtree
+                                            //    is already gone, so a handler failure can't
+                                            //    un-delete anything: it lands as a Warning on the
+                                            //    activity and the response stays Ok.
+                                            .SelectMany(deletedPaths =>
+                                                RunPostDeletionHandlersObs(
+                                                        hub, rootNode, capturedRequest.DeletedBy, logger, collectedMessages)
+                                                    .Select(_ => deletedPaths))
                                             .Do(deletedPaths =>
                                             {
+                                                var messages = collectedMessages.ToImmutable();
                                                 var okLog = baseActivity with
                                                 {
-                                                    Messages = collectedMessages.ToImmutable(),
+                                                    Messages = messages,
                                                     AffectedPaths = deletedPaths.ToImmutableList(),
                                                     End = DateTime.UtcNow,
-                                                    Status = warningMsgs.IsEmpty
-                                                        ? ActivityStatus.Succeeded
-                                                        : ActivityStatus.Warning
+                                                    Status = messages.Any(m => m.LogLevel >= LogLevel.Warning)
+                                                        ? ActivityStatus.Warning
+                                                        : ActivityStatus.Succeeded
                                                 };
 
                                                 logger.LogInformation(
@@ -1636,6 +1647,50 @@ public static class MeshExtensions
                 return handleObs.Concat(saveExtras);
             })
             .Concat();
+    }
+
+    /// <summary>
+    /// Runs the registered <see cref="INodePostDeletionHandler"/>s matching the deleted
+    /// ROOT node's type, sequentially (<c>Concat</c>), after the subtree has been removed
+    /// from persistence. A handler failure is logged and appended to
+    /// <paramref name="collectedMessages"/> as a Warning — the nodes are already gone, so
+    /// the delete response stays Ok (with Warning status) rather than reporting a failure
+    /// for a deletion that DID happen. Emits exactly once (also with zero handlers) so the
+    /// delete chain's <c>SelectMany</c> always proceeds to post the response.
+    /// </summary>
+    private static IObservable<System.Reactive.Unit> RunPostDeletionHandlersObs(
+        IMessageHub hub,
+        MeshNode node,
+        string? deletedBy,
+        ILogger logger,
+        ImmutableList<LogMessage>.Builder collectedMessages)
+    {
+        if (string.IsNullOrEmpty(node.NodeType))
+            return Observable.Return(System.Reactive.Unit.Default);
+
+        var handlers = hub.ServiceProvider.GetServices<INodePostDeletionHandler>()
+            .Where(h => h.NodeType.Equals(node.NodeType, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (handlers.Count == 0)
+            return Observable.Return(System.Reactive.Unit.Default);
+
+        return handlers
+            .Select(handler => handler.Handle(node, deletedBy)
+                .Catch<System.Reactive.Unit, Exception>(ex =>
+                {
+                    logger.LogError(ex,
+                        "Post-deletion handler {Handler} failed for node {Path}",
+                        handler.GetType().Name, node.Path);
+                    lock (collectedMessages)
+                        collectedMessages.Add(new LogMessage(
+                            $"Post-deletion cleanup ({handler.GetType().Name}) failed for '{node.Path}': {ex.Message}",
+                            LogLevel.Warning));
+                    return Observable.Return(System.Reactive.Unit.Default);
+                }))
+            .Concat()
+            .ToList()
+            .Select(_ => System.Reactive.Unit.Default);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -1110,7 +1110,8 @@ public static class MeshExtensions
 
                                                 logger.LogInformation(
                                                     "[DeleteNode] succeeded path={Path} count={Count} warnings={Warnings} by={DeletedBy}",
-                                                    path, deletedPaths.Count, warningMsgs.Count,
+                                                    path, deletedPaths.Count,
+                                                    messages.Count(m => m.LogLevel >= LogLevel.Warning),
                                                     capturedRequest.DeletedBy ?? "system");
 
                                                 // MeshChangeEvent.Deleted is published per-path inside

--- a/src/MeshWeaver.Mesh.Contract/Services/INodeValidator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/INodeValidator.cs
@@ -262,3 +262,29 @@ public interface INodePostCreationHandler
     /// <returns>Additional nodes to persist</returns>
     IEnumerable<MeshNode> GetAdditionalNodes(MeshNode createdNode) => [];
 }
+
+/// <summary>
+/// Post-deletion handler invoked after a node (and, for a recursive delete, its subtree)
+/// has been successfully removed from persistence — the deletion-side mirror of
+/// <see cref="INodePostCreationHandler"/>. Used for side effects that must follow the
+/// node's removal, e.g. tearing down the backing partition store when a partition-owning
+/// root (<c>Space</c>) is deleted. Register via DI as a singleton; matched by NodeType.
+/// Handlers run only for the ROOT of the delete operation, not for every descendant.
+/// </summary>
+public interface INodePostDeletionHandler
+{
+    /// <summary>
+    /// The node type this handler applies to (e.g. "Space").
+    /// </summary>
+    string NodeType { get; }
+
+    /// <summary>
+    /// Executes after the node has been removed from persistence. Reactive — returns
+    /// <see cref="IObservable{T}"/> (never Task); compose any mesh writes with the reactive
+    /// primitives. Failures are logged and surfaced as warnings on the deletion activity —
+    /// they never un-delete the node, so the response stays Ok.
+    /// </summary>
+    /// <param name="deletedNode">The node as it was loaded before deletion</param>
+    /// <param name="deletedBy">The ObjectId of the deleting user (may be null)</param>
+    IObservable<Unit> Handle(MeshNode deletedNode, string? deletedBy);
+}

--- a/src/MeshWeaver.Mesh.Contract/Services/IPartitionStorageProvider.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IPartitionStorageProvider.cs
@@ -165,6 +165,28 @@ public interface IPartitionStorageProvider
         => System.Reactive.Linq.Observable.Return<bool?>(null);
 
     /// <summary>
+    /// Tears down whatever backing store this provider holds for a top-level partition —
+    /// the inverse of <see cref="EnsurePartitionProvisioned"/>. The Postgres provider drops
+    /// the partition's schema (all tables, satellites included) and evicts its provisioning
+    /// caches so a later re-create of the same partition provisions from scratch. Idempotent:
+    /// deleting a partition whose backing store does not exist emits and completes normally.
+    /// Emits exactly once and completes; a genuine failure propagates through OnError.
+    ///
+    /// <para><b>Reactive surface — no <c>await</c>.</b> Any actual I/O (the Postgres
+    /// <c>DROP SCHEMA … CASCADE</c> round-trip) stays at the IO boundary inside the
+    /// implementation, bounded by the provider's <c>IIoPool</c>. This is driven by the
+    /// partition-owning delete flow (deleting a <c>Space</c>/<c>User</c> root) — the ONE
+    /// trigger for partition removal, mirroring how <c>OwnsPartitionProvisioningValidator</c>
+    /// is the one trigger for creation.</para>
+    ///
+    /// <para>Default is a no-op: providers whose storage has no per-partition backing store
+    /// (InMemory, EmbeddedResource, StaticNode) emit immediately — the recursive node delete
+    /// has already removed their rows.</para>
+    /// </summary>
+    IObservable<System.Reactive.Unit> DeletePartition(string @namespace)
+        => System.Reactive.Linq.Observable.Return(System.Reactive.Unit.Default);
+
+    /// <summary>
     /// Contexts this partition opts into. Consumers iterating
     /// partitions for a given context (search, autocomplete, browse)
     /// skip every partition that doesn't include the context. The

--- a/test/MeshWeaver.GitSync.Test/GitHubSyncSettingsTabTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubSyncSettingsTabTest.cs
@@ -64,12 +64,14 @@ public class GitHubSyncSettingsTabTest(ITestOutputHelper output) : GitHubSyncTes
         await CreateSpace(space, "PR Gui Space");
 
         // Select the GitHub Sync tab so its content pane (BuildContent) renders — wait until the
-        // PR section's draft button text appears. This proves the new "Pull request" section is
-        // wired into the layout area, not just the tab label.
+        // PR section's draft button AND the (reactive, direction-aware) sync buttons appear. The
+        // sync button row is data-bound to the source's config stream, so it lands asynchronously
+        // relative to the static sections.
         var json = await RenderSettings(
             new Address(space),
             new LayoutAreaReference("Settings") { Id = GitHubSyncSettingsTab.TabId },
-            j => j.GetRawText().Contains("Draft pull request with AI"));
+            j => j.GetRawText().Contains("Draft pull request with AI")
+                 && j.GetRawText().Contains("Sync now (commit)"));
 
         Assert.Contains("Draft pull request with AI", json);
         Assert.Contains("Pull request", json);          // the section heading

--- a/test/MeshWeaver.GitSync.Test/MeshNodeContentEditorTest.cs
+++ b/test/MeshWeaver.GitSync.Test/MeshNodeContentEditorTest.cs
@@ -24,9 +24,9 @@ public class MeshNodeContentEditorTest(ITestOutputHelper output) : GitHubSyncTes
         var fields = MeshNodeEditorField.FromType(typeof(GitHubSyncConfig));
         var keys = fields.Select(f => f.Key).ToArray();
 
-        // The five editable properties, by camelCase key — and NOT the [Browsable(false)] last-sync fields.
+        // The six editable properties, by camelCase key — and NOT the [Browsable(false)] last-sync fields.
         Assert.Equal(
-            new[] { "repositoryUrl", "branch", "subdirectory", "createBranchIfMissing", "createRepoIfMissing" },
+            new[] { "repositoryUrl", "branch", "subdirectory", "direction", "createBranchIfMissing", "createRepoIfMissing" },
             keys);
         Assert.DoesNotContain("lastSyncedAt", keys);
         Assert.DoesNotContain("lastSyncCommitSha", keys);
@@ -35,6 +35,13 @@ public class MeshNodeContentEditorTest(ITestOutputHelper output) : GitHubSyncTes
         Assert.Equal(MeshNodeEditorFieldKind.Text, fields.First(f => f.Key == "repositoryUrl").Kind);
         Assert.Equal(MeshNodeEditorFieldKind.Bool, fields.First(f => f.Key == "createBranchIfMissing").Kind);
         Assert.Equal("Repository URL", fields.First(f => f.Key == "repositoryUrl").Label);
+
+        // The sync direction renders as an enum dropdown over the SyncDirection members.
+        var direction = fields.First(f => f.Key == "direction");
+        Assert.Equal(MeshNodeEditorFieldKind.Enum, direction.Kind);
+        Assert.Equal(
+            new[] { nameof(SyncDirection.Bidirectional), nameof(SyncDirection.ExportOnly), nameof(SyncDirection.ImportOnly) },
+            direction.Options);
     }
 
     [Fact(Timeout = 60000)]

--- a/test/MeshWeaver.GitSync.Test/SyncDirectionAndSourcesTest.cs
+++ b/test/MeshWeaver.GitSync.Test/SyncDirectionAndSourcesTest.cs
@@ -1,0 +1,98 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.GitSync;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Sync direction enforcement (unidirectional import-only / export-only vs bidirectional)
+/// and multiple sync sources per Space: the primary at <c>{space}/_GitSync</c> plus
+/// additional sources at <c>{space}/_GitSync/{sourceId}</c>, each with its own repository
+/// and direction, synced and removed independently.
+/// </summary>
+public class SyncDirectionAndSourcesTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    [Fact(Timeout = 120000)]
+    public async Task ImportOnlySource_RejectsExport()
+    {
+        await Connect();
+        var a = "GhDi" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(a);
+        await CreateMarkdown($"{a}/Page", "Page", "# Page");
+        await Sync.SaveConfig(a, "https://github.com/test/import-only", "main", null, true, true,
+                SyncDirection.ImportOnly)
+            .Timeout(30.Seconds()).ToTask();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Sync.SyncToGitHub(a, UserId).Timeout(30.Seconds()).ToTask());
+        Assert.Contains("import-only", ex.Message);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task ExportOnlySource_RejectsImport()
+    {
+        await Connect();
+        var a = "GhDe" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(a);
+        await CreateMarkdown($"{a}/Page", "Page", "# Page");
+        await Sync.SaveConfig(a, "https://github.com/test/export-only", "main", null, true, true,
+                SyncDirection.ExportOnly)
+            .Timeout(30.Seconds()).ToTask();
+
+        // Export is allowed on an export-only source…
+        var pushed = await Sync.SyncToGitHub(a, UserId).Timeout(60.Seconds()).ToTask();
+        Assert.False(string.IsNullOrEmpty(pushed.CommitSha));
+
+        // …importing back is not.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Sync.ReimportAtCommit(a, pushed.CommitSha, UserId).Timeout(30.Seconds()).ToTask());
+        Assert.Contains("export-only", ex.Message);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task AdditionalSource_AddSyncRemove_RoundTrips()
+    {
+        await Connect();
+        var a = "GhMs" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(a);
+        await CreateMarkdown($"{a}/Page", "Page", "# Page");
+
+        // Primary + one additional source, each with its own repository.
+        await Sync.SaveConfig(a, "https://github.com/test/primary", "main", null, true, true)
+            .Timeout(30.Seconds()).ToTask();
+        var added = await Sync.AddSyncSource(a, "Mirror").Timeout(30.Seconds()).ToTask();
+        Assert.Equal($"{a}/_GitSync/Mirror", added.Path);
+        await Sync.SaveConfig(a, "https://github.com/test/mirror", "main", null, true, true,
+                SyncDirection.ExportOnly, sourceId: "Mirror")
+            .Timeout(30.Seconds()).ToTask();
+
+        // Both sources are listed (primary first, then the additional one).
+        var sources = await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => Sync.WatchConfigNodes(a).Take(1))
+            .Where(list => list.Count == 2)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+        Assert.Contains(sources, n => n.Path == GitHubSyncService.ConfigPath(a));
+        Assert.Contains(sources, n => n.Path == $"{a}/_GitSync/Mirror");
+
+        // Sync the ADDITIONAL source: the commit lands in ITS repository and the last-sync
+        // state is recorded on ITS config node — the primary stays untouched.
+        var pushed = await Sync.SyncToGitHub(a, UserId, "Mirror").Timeout(60.Seconds()).ToTask();
+        Assert.Contains(Fake.Tree("https://github.com/test/mirror"), f => f.Path == "Page.md");
+        var mirrorCfg = await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => Sync.ReadConfig(a, "Mirror"))
+            .Where(c => c?.LastSyncCommitSha == pushed.CommitSha)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+        Assert.NotNull(mirrorCfg!.LastSyncedAt);
+        var primaryCfg = await Sync.ReadConfig(a).Timeout(10.Seconds()).ToTask();
+        Assert.Null(primaryCfg!.LastSyncCommitSha);
+
+        // Remove the additional source — only the primary remains.
+        Assert.True(await Sync.RemoveSyncSource(a, "Mirror").Timeout(30.Seconds()).ToTask());
+        var afterRemove = await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => Sync.WatchConfigNodes(a).Take(1))
+            .Where(list => list.Count == 1)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+        Assert.Equal(GitHubSyncService.ConfigPath(a), afterRemove[0].Path);
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PartitionLifecycleTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PartitionLifecycleTests.cs
@@ -60,6 +60,24 @@ public class PartitionLifecycleTests(PostgreSqlFixture fixture, ITestOutputHelpe
             .DefaultIfEmpty(Unit.Default)
             .ToTask();
 
+    /// <summary>
+    /// Tear a partition down the platform way — every provider's
+    /// <see cref="IPartitionStorageProvider.DeletePartition"/> (PG → <c>DROP SCHEMA … CASCADE</c>).
+    /// This is what deleting a partition-owning root (Space) triggers via
+    /// <c>PartitionDropPostDeletionHandler</c>.
+    /// </summary>
+    private Task DeletePartition(string ns) =>
+        Mesh.ServiceProvider.GetServices<IPartitionStorageProvider>()
+            .Select(p => p.DeletePartition(ns))
+            .Concat()
+            .DefaultIfEmpty(Unit.Default)
+            .ToTask();
+
+    private IObservable<long> SchemaCount(string schema) =>
+        _fixture.DataSource.ScalarLong(
+            "SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = @s",
+            new[] { ("s", (object)schema) });
+
     [Fact(Timeout = 60000)]
     public async Task ProvisionedPartition_Write_EnablesSubsequentReads()
     {
@@ -158,6 +176,26 @@ public class PartitionLifecycleTests(PostgreSqlFixture fixture, ITestOutputHelpe
         var deleted = await meshService.DeleteNode(path)
             .Should().Within(30.Seconds()).Emit();
         deleted.Should().BeTrue();
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task DeletePartition_DropsSchema_AndReprovisionRecreatesIt()
+    {
+        var ns = $"pg9c_drop_{Guid.NewGuid():N}".ToLowerInvariant()[..18];
+        await ProvisionPartition(ns);
+        await SchemaCount(ns).Should().Within(30.Seconds()).Be(1L);
+
+        // Drop — the inverse of provisioning. Idempotent: a second drop of the now-absent
+        // schema completes without error.
+        await DeletePartition(ns);
+        await SchemaCount(ns).Should().Within(30.Seconds()).Be(0L);
+        await DeletePartition(ns);
+
+        // Re-provisioning after a drop must recreate the schema — the provider's
+        // provisioning promise-cache was evicted by the drop (else the cached "already
+        // provisioned" completion would replay and every write would 42P01 forever).
+        await ProvisionPartition(ns);
+        await SchemaCount(ns).Should().Within(30.Seconds()).Be(1L);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceDeletionPartitionDropTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceDeletionPartitionDropTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Deleting a Space removes the ENTIRE partition from the system — the deletion-side
+/// mirror of the fool-proof Space create. The recursive node delete runs first, then
+/// <c>PartitionDropPostDeletionHandler</c> drops the Postgres schema (all satellite tables
+/// with it) via <see cref="IPartitionStorageProvider.DeletePartition"/> and removes the
+/// <c>Admin/Partition/{id}</c> definition. Space-enabled mesh shape (RLS + Graph +
+/// SpaceType), same as <c>SpaceMainTableChildCreateTests</c>.
+/// </summary>
+[Collection("PostgreSql")]
+public class SpaceDeletionPartitionDropTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private readonly PostgreSqlFixture _fixture = fixture;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new Npgsql.NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
+        {
+            MaxPoolSize = 16,
+            ConnectionIdleLifetime = 10
+        };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services =>
+                services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString))
+            .AddRowLevelSecurity()
+            .AddGraph()
+            .AddSpaceType();
+    }
+
+    private IObservable<long> SchemaCount(string schema) =>
+        _fixture.DataSource.ScalarLong(
+            "SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = @s",
+            new[] { ("s", (object)schema) });
+
+    /// <summary>
+    /// The real user flow end-to-end: create a Space (partition provisioned), delete it,
+    /// and the whole partition is gone — schema dropped, <c>Admin/Partition/{id}</c>
+    /// definition removed. Re-creating a space with the same id afterwards provisions a
+    /// fresh schema (the provider's provisioning promise-cache was evicted) and serves
+    /// writes again.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task DeletingSpace_DropsWholePartition_AndSameIdCanBeRecreated()
+    {
+        var spaceId = $"pgdrop{Guid.NewGuid():N}".ToLowerInvariant()[..16];
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        var created = await meshService.CreateNode(new MeshNode(spaceId)
+        {
+            NodeType = SpaceNodeType.NodeType,
+            Name = "To Drop",
+            State = MeshNodeState.Active,
+            Content = new Space { Name = "To Drop" },
+        }).Should().Within(60.Seconds()).Emit();
+        created.Should().NotBeNull();
+        await SchemaCount(spaceId).Should().Within(30.Seconds()).Be(1L);
+
+        // Some content in the partition, so the recursive delete has real work.
+        await meshService.CreateNode(new MeshNode("page", spaceId)
+        {
+            NodeType = "Markdown",
+            Name = "page",
+            State = MeshNodeState.Active,
+        }).Should().Within(30.Seconds()).Emit();
+
+        var deleted = await meshService.DeleteNode(spaceId).Should().Within(60.Seconds()).Emit();
+        deleted.Should().BeTrue();
+
+        // The whole partition is gone: schema dropped, Admin/Partition definition removed.
+        await SchemaCount(spaceId).Should().Within(30.Seconds()).Be(0L);
+        await Observable.Interval(TimeSpan.FromMilliseconds(100))
+            .StartWith(0L)
+            .SelectMany(_ => ReadNode($"{PartitionNodeType.Namespace}/{spaceId}"))
+            .Should().Within(15.Seconds()).Match(n => n is null,
+                "deleting a Space must remove its Admin/Partition definition");
+
+        // Same id can be recreated — provisioning starts from scratch and writes work.
+        await meshService.CreateNode(new MeshNode(spaceId)
+        {
+            NodeType = SpaceNodeType.NodeType,
+            Name = "Recreated",
+            State = MeshNodeState.Active,
+            Content = new Space { Name = "Recreated" },
+        }).Should().Within(60.Seconds()).Emit();
+        await SchemaCount(spaceId).Should().Within(30.Seconds()).Be(1L);
+        var reseeded = await meshService.CreateNode(new MeshNode("page", spaceId)
+        {
+            NodeType = "Markdown",
+            Name = "page",
+            State = MeshNodeState.Active,
+        }).Should().Within(30.Seconds()).Emit();
+        reseeded.Path.Should().Be($"{spaceId}/page");
+    }
+}

--- a/test/MeshWeaver.NodeOperations.Test/GlobalAdminSpaceCrudTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/GlobalAdminSpaceCrudTest.cs
@@ -123,6 +123,42 @@ public class GlobalAdminSpaceCrudTest(ITestOutputHelper output) : MonolithMeshTe
     }
 
     [Fact(Timeout = 60000)]
+    public async Task DeletingSpace_RemovesPartitionDefinition()
+    {
+        var spaceId = $"TestSpace_{Guid.NewGuid():N}"[..20];
+
+        var spaceNode = MeshNode.FromPath(spaceId) with
+        {
+            Name = "Partition Cleanup",
+            NodeType = SpaceNodeType.NodeType,
+            Content = new Space { Name = "Partition Cleanup" }
+        };
+        await NodeFactory.CreateNode(spaceNode).Should().Emit();
+
+        // The create emitted the Admin/Partition/{id} definition (routing prime).
+        var defPath = $"{PartitionNodeType.Namespace}/{spaceId}";
+        await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .StartWith(0L)
+            .SelectMany(_ => ReadNode(defPath))
+            .Should().Within(15.Seconds()).Match(n => n is not null,
+                "creating a Space emits its Admin/Partition definition");
+
+        await NodeFactory.DeleteNode(spaceId).Should().Emit();
+
+        // The post-deletion handler removes the ENTIRE partition: the space node is gone
+        // AND the Admin/Partition/{id} definition is cleaned up.
+        await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .StartWith(0L)
+            .SelectMany(_ => ReadNode(spaceId))
+            .Should().Within(10.Seconds()).Match(n => n is null, "Deleted space should not be found");
+        await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .StartWith(0L)
+            .SelectMany(_ => ReadNode(defPath))
+            .Should().Within(10.Seconds()).Match(n => n is null,
+                "deleting a Space must remove its Admin/Partition definition");
+    }
+
+    [Fact(Timeout = 60000)]
     public async Task GlobalAdmin_HasAllPermissionsOnSpace()
     {
         var spaceId = $"TestSpace_{Guid.NewGuid():N}"[..20];


### PR DESCRIPTION
Closes #183.

## What

### 1. Deleting a Space removes the ENTIRE partition
- `IPartitionStorageProvider.DeletePartition(namespace)` — the inverse of `EnsurePartitionProvisioned`. Postgres: `DROP SCHEMA … CASCADE` through the per-adapter io pool (DDL-race retry), evicting `_schemasInitialized` / `_provisioned` / `_registeredPartitions` so a same-id re-create provisions from scratch. Other providers keep the no-op default (single path-keyed stores — the recursive node delete already removed their rows).
- New `INodePostDeletionHandler` seam (mirror of `INodePostCreationHandler`), invoked in `HandleDeleteNodeRequest` for the ROOT of the operation after the subtree commit; failures surface as Warnings on the deletion activity (the nodes are already gone — the response stays Ok).
- `PartitionDropPostDeletionHandler` (registered with the Space type): drops the backing store on every provider (sequential, like provisioning), then deletes the `Admin/Partition/{id}` definition under system impersonation (store-drop first — a failed drop keeps the definition visible for retry instead of leaving an invisible orphan schema).

### 2. Sync direction — unidirectional or bidirectional
- `SyncDirection` (`Bidirectional` default / `ExportOnly` / `ImportOnly`) on `GitHubSyncConfig`, enforced in `GitHubSyncService.SyncToGitHub` (rejects import-only) and `ReimportAtCommit` (rejects export-only; `UpdateToLatest` inherits).
- The settings tab renders direction-aware sync buttons (an import-only source offers no commit, an export-only source no checkout).

### 3. Multiple sync sources per Space
- Primary stays at `{space}/_GitSync`; additional sources are child config nodes `{space}/_GitSync/{sourceId}`, each with its own repo/branch/subdirectory/direction.
- `AddSyncSource` / `WatchConfigNodes` / `RemoveSyncSource`; optional `sourceId` threaded through the service, the activity extensions and the settings tab ("Additional sync sources" section: per-source data-bound editor + direction-aware actions + remove + add-by-name).

### 4. Partitions admin overview (Global Settings → Administration → Partitions)
- Rewrote `PartitionSyncAdminLayoutArea`: every partition root (top-level `Space` query + `IStaticRepoSource` registrations) in a grid with main-node properties, sync status and a sync-sources summary; per-partition detail panel with the Synced/Not-synced toggle, sync-source editors bound directly to each config node stream, add/remove source, Open and Delete navigation.
- New `IPartitionSyncSourceProvider` DI seam so GitSync contributes its sources to the Graph-hosted page without a circular project reference; the section degrades gracefully when GitSync isn't wired.

## Tests
- `SpaceDeletionPartitionDropTests` (PG, e2e): create Space → schema exists → delete → schema + `Admin/Partition/{id}` gone → re-create same id → fresh schema serves writes.
- `PartitionLifecycleTests.DeletePartition_DropsSchema_AndReprovisionRecreatesIt` (+ idempotent double-drop; promise-cache eviction).
- `SyncDirectionAndSourcesTest`: import-only rejects export, export-only rejects import (after a successful export), add/sync/remove of an additional source with per-source last-sync state.
- `GlobalAdminSpaceCrudTest.DeletingSpace_RemovesPartitionDefinition` (monolith).
- Updated `MeshNodeContentEditorTest` (direction enum field) and `GitHubSyncSettingsTabTest` (reactive sync-button row).

Full solution builds clean with CI flags (`-c Release -p:CIRun=true -warnaserror`). Docs updated: `Spaces.md` ("Deleting a Space"), `GitHubSync.md` (direction + multiple sources); `DocumentationLinkIntegrityTest` green.

## Notes
- The overview page itself has no dedicated GUI render test (its predecessor had none either); the seams beneath it are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)