### PR TITLE
fix(ai): provider-gate the AzureFoundry catch-all + /{user}/Chat area + Address Id/Path caching

### DIFF
--- a/src/MeshWeaver.AI.AzureFoundry/AzureFoundryChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI.AzureFoundry/AzureFoundryChatClientAgentFactory.cs
@@ -56,8 +56,14 @@ public class AzureFoundryChatClientAgentFactory(
     /// </summary>
     public override bool Supports(string modelName)
     {
-        if (string.IsNullOrEmpty(modelName)
-            || modelName.StartsWith("claude", StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrEmpty(modelName))
+            return false;
+        // The picker persists EITHER a bare id ("claude-…") OR a full LanguageModel node path
+        // ("Provider/Anthropic/claude-…") — test the LAST segment so a path-shaped Claude name
+        // is excluded even when the resolver snapshot is cold and can't name the provider yet.
+        var lastSlash = modelName.LastIndexOf('/');
+        var bareId = lastSlash >= 0 ? modelName[(lastSlash + 1)..] : modelName;
+        if (bareId.StartsWith("claude", StringComparison.OrdinalIgnoreCase))
             return false;
         var provider = Hub.ServiceProvider.GetService<ChatClientCredentialResolver>()
             ?.GetProviderForModel(modelName);

--- a/src/MeshWeaver.AI.AzureFoundry/AzureFoundryChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI.AzureFoundry/AzureFoundryChatClientAgentFactory.cs
@@ -45,11 +45,25 @@ public class AzureFoundryChatClientAgentFactory(
     /// DeepSeek, and any other model the deployment exposes through the /models path.
     /// Excludes claude-* (which goes through the dedicated Anthropic endpoint via
     /// <see cref="AzureClaudeChatClientAgentFactory"/>). This catch-all serves the
-    /// chat-selected model without any Models[] enumeration on the deployment side.
+    /// chat-selected model without any Models[] enumeration on the deployment side —
+    /// but ONLY for models whose declared provider is AzureFoundry or unknown. A model
+    /// the catalog declares under ANOTHER provider (e.g.
+    /// <c>Provider/OpenAICompatible/qwen-small</c> → Ollama) must route to that
+    /// provider's factory; the unconditional catch-all at Order 0 used to hijack it,
+    /// build an Azure ChatCompletionsClient against the foreign endpoint, and fail every
+    /// round with 403 (the e2e chat-round breaker, 2026-07-02). Same gating rule the
+    /// resolver documents on <see cref="ChatClientCredentialResolver.GetProviderForModel"/>.
     /// </summary>
-    public override bool Supports(string modelName) =>
-        !string.IsNullOrEmpty(modelName)
-        && !modelName.StartsWith("claude", StringComparison.OrdinalIgnoreCase);
+    public override bool Supports(string modelName)
+    {
+        if (string.IsNullOrEmpty(modelName)
+            || modelName.StartsWith("claude", StringComparison.OrdinalIgnoreCase))
+            return false;
+        var provider = Hub.ServiceProvider.GetService<ChatClientCredentialResolver>()
+            ?.GetProviderForModel(modelName);
+        return provider is null
+               || string.Equals(provider, "AzureFoundry", StringComparison.OrdinalIgnoreCase);
+    }
 
     /// <summary>
     /// Builds an <see cref="IChatClient"/> for the model selected for the given

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -35,6 +35,15 @@ public static class UserActivityLayoutAreas
     /// <summary>Area name for the chat composer region embedded via <c>@@("area/Composer")</c>.</summary>
     public const string ComposerArea = "Composer";
 
+    /// <summary>
+    /// The user-facing chat URL contract: <c>/{user}/Chat</c> — one string serving as BOTH the URL
+    /// segment links navigate to (<c>WithCreateHref</c>, chat menu) AND the layout-area name that
+    /// URL resolves to (AreaPage renders prefix=<c>{user}</c>, remainder=<c>Chat</c> as area "Chat"
+    /// on the user hub). Kept separate from <see cref="ComposerArea"/>, whose name is persisted in
+    /// user home markdown (<c>@@("area/Composer")</c>) and cannot be renamed.
+    /// </summary>
+    public const string ChatArea = "Chat";
+
     /// <summary>Link to the doc page that explains the configurable Body-page + <c>@@</c>-region model.</summary>
     internal const string ConfigGuideLink = "/Doc/GUI/ConfigurablePages";
 
@@ -62,7 +71,15 @@ public static class UserActivityLayoutAreas
             .WithView(PinnedArea, PinnedAreaView)
             .WithView(ThreadsArea, ThreadsAreaView)
             .WithView(CatalogArea, CatalogAreaView)
-            .WithView(ComposerArea, ComposerAreaView));
+            .WithView(ComposerArea, ComposerAreaView)
+            // "/{user}/Chat" (ChatArea) is a well-known URL (thread-catalog Create-New, chat menu
+            // links). Since ChatNodeType was removed there is NO {user}/Chat node any more: the URL
+            // resolves to prefix={user} + remainder="Chat", which AreaPage renders as area "Chat"
+            // on this hub. Without this registration that's "no renderer for area Chat", and a
+            // LEGACY {user}/Chat node from an older deployment resolves as invalid-NodeType
+            // ("No node found at '{user}/Chat'… remainder='Chat'" — the prod memex report,
+            // 2026-07-02). The composer is node-less — serve it directly.
+            .WithView(ChatArea, ComposerAreaView));
 
     /// <summary>
     /// Renders the user's page. Shows a personal dashboard to the owner,
@@ -282,9 +299,9 @@ public static class UserActivityLayoutAreas
             // "Create New" must NOT raw-create a Thread node — CreateNodeType="Thread" does a bare CreateNode
             // that BYPASSES StartThread (AGENTS.md-forbidden: a hand-assembled Thread has no submission wiring
             // / composer, so it renders as an empty message box). Instead navigate to the per-user new-chat
-            // composer at {owner}/Chat (the Chat node's Overview = the side-panel ThreadChatControl); sending
+            // composer at /{owner}/Chat (the ChatArea layout area — node-less ThreadChatControl); sending
             // there starts a proper thread via StartThread.
-            .WithCreateHref($"/{nodeOwnerId}/Chat");
+            .WithCreateHref($"/{nodeOwnerId}/{ChatArea}");
 
     /// <summary>
     /// The fluent catalog: a skinned <see cref="TabsControl"/> whose tabs are labelled

--- a/src/MeshWeaver.Messaging.Contract/Address.cs
+++ b/src/MeshWeaver.Messaging.Contract/Address.cs
@@ -22,11 +22,20 @@ public sealed record Address
     /// </summary>
     public string Type => Segments.Length > 0 ? Segments[0] : "";
 
+    // Id/Path are pure functions of Segments (host-independent), so the lazy caches survive
+    // `with { Host = … }` copies correctly (record with-ers copy private fields). Caching matters:
+    // AddressComparer hashes/compares via Id on EVERY hosted-hub dictionary lookup, and the message
+    // router does several lookups per routed message — recomputing string.Join per hash call was the
+    // hot frame (String.Join inside AddressComparer.GetHashCode) burning a full core under heartbeat
+    // fan-out load on the wedged e2e portal (2026-07-02). Benign race: recompute is idempotent.
+    private string? cachedId;
+    private string? cachedPath;
+
     /// <summary>
     /// Gets segments after the first one joined with "/".
     /// For backward compatibility.
     /// </summary>
-    public string Id => Segments.Length > 1
+    public string Id => cachedId ??= Segments.Length > 1
         ? string.Join("/", Segments.Skip(1))
         : "";
 
@@ -45,22 +54,22 @@ public sealed record Address
     /// Returns the path (segments joined with "/") without host information.
     /// Use this instead of ToString() when you need the node path for persistence or display.
     /// </summary>
-    public string Path => string.Join("/", Segments);
+    public string Path => cachedPath ??= string.Join("/", Segments);
 
     /// <summary>
     /// Returns the segment path, appending <c>~host</c> when this address is hosted.
     /// </summary>
     public override string ToString() => Host is null
-        ? string.Join("/", Segments)
-        : string.Join("/", Segments) + '~' + Host;
+        ? Path
+        : Path + '~' + Host;
 
     /// <summary>
     /// Returns full string representation including host if present.
     /// Format: "outermost_host~...~inner_segments"
     /// </summary>
     public string ToFullString() => Host != null
-        ? $"{Host.ToFullString()}~{string.Join("/", Segments)}"
-        : string.Join("/", Segments);
+        ? $"{Host.ToFullString()}~{Path}"
+        : Path;
 
     /// <summary>
     /// Two addresses are equal when their segments match in order and their hosts


### PR DESCRIPTION
## Three follow-ups from the chat-round debugging session

### Provider-gate the AzureFoundry catch-all (the 403 round-breaker)
`AzureFoundryChatClientAgentFactory.Supports` claimed every non-claude model at Order 0. A model the catalog declares under **another** provider (`Provider/OpenAICompatible/qwen-small` → Ollama) was hijacked into an Azure `ChatCompletionsClient` against the foreign endpoint → **403 on every chat round** (each "reply" was an error bubble). Now gated on the model's declared provider via `ChatClientCredentialResolver.GetProviderForModel` — the exact rule the resolver documents; bare/undeclared names keep the catch-all so legit AzureFoundry gateway usage is unchanged.

### `/{user}/Chat` renders the node-less composer
Since `ChatNodeType` was removed there is no `{user}/Chat` node: fresh users hit "no renderer for area Chat", and a **legacy** node resolves as invalid-NodeType — the "No node found at 'rbuergi/Chat'… remainder='Chat'" error reported on prod memex. One `ChatArea` constant now owns both the URL segment (`WithCreateHref`) and the area registration (`ComposerArea` stays untouched — `@@("area/Composer")` is persisted in user home markdown).

### Address Id/Path lazy caching
`Address.Id`/`Path` recomputed LINQ + `string.Join` on every access; the router touches them per routed message. Both are pure functions of `Segments` (host-independent → caches survive `with { Host = … }` copies). Complements #181's allocation-free `AddressComparer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)