### PR TITLE
fix(content-indexing): make vector-index Document search hits resolvable (excerpt reader was unreachable — Not Found)

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -237,19 +237,34 @@ public class MeshOperations
         // Single-node content read via GetDataRequest + MeshNodeReference + RegisterCallback.
         // See Doc/Architecture/CqrsAndContentAccess.md — queries are for sets only.
         return TryResolveUnifiedPath(resolvedPath)
-            .SelectMany(unified => unified != null
-                ? Observable.Return(unified)
-                : FetchNode(resolvedPath).SelectMany(node =>
-                    {
-                        if (node is null)
-                            return GetWithBrokenNodeTypeFallback(resolvedPath);
-                        return LookupCompilationError(node)
-                            .Select(compileError => compileError != null
-                                ? JsonSerializer.Serialize(
-                                    new { node, compilationError = compileError },
-                                    hub.JsonSerializerOptions)
-                                : JsonSerializer.Serialize(node, hub.JsonSerializerOptions));
-                    }))
+            .SelectMany(unified =>
+            {
+                // A unified (UCR) interpretation that ERRORS may be shadowing a real node whose
+                // own path contains a UCR keyword as an interior segment: Document nodes live at
+                // {collection}/_Documents/{slug}, and the collection segment ("content") is a UCR
+                // keyword — the unified read hijacks the path and fails with "Content collection
+                // '_Documents' not found". The node namespace is authoritative: on a unified
+                // error, fall back to the node read and surface the unified error only when no
+                // node exists at the full path either.
+                var unifiedError = unified is not null
+                    && unified.StartsWith("Error:", StringComparison.Ordinal) ? unified : null;
+                if (unified is not null && unifiedError is null)
+                    return Observable.Return(unified);
+
+                return FetchNode(resolvedPath).SelectMany(node =>
+                {
+                    if (node is null)
+                        return unifiedError is not null
+                            ? Observable.Return(unifiedError)
+                            : GetWithBrokenNodeTypeFallback(resolvedPath);
+                    return LookupCompilationError(node)
+                        .Select(compileError => compileError != null
+                            ? JsonSerializer.Serialize(
+                                new { node, compilationError = compileError },
+                                hub.JsonSerializerOptions)
+                            : JsonSerializer.Serialize(node, hub.JsonSerializerOptions));
+                });
+            })
             .Catch((Exception ex) =>
             {
                 logger.LogWarning(ex, "Error getting data at path {Path}", resolvedPath);

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/DocumentIndexingExtensions.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/DocumentIndexingExtensions.cs
@@ -30,6 +30,25 @@ public static class DocumentIndexingExtensions
         where TBuilder : MeshBuilder
     {
         builder.AddDocumentType();
+        // Register the Document content type on the MESH hub and on every per-node hub (the same
+        // two surfaces AddAI covers for Thread content). WithContentType<Document> only registers
+        // on the Document per-node hub itself — but the WRITE goes through the mesh hub
+        // (MeshDocumentSink → CreateOrUpdateNodeRequest) and READS go through whichever hub calls
+        // GetMeshNodeStream (portal, cache, query). Without the mesh-wide registration the content
+        // serialises WITHOUT a $type discriminator and every reader gets back an untyped
+        // JsonElement ("stayed an untyped JsonElement (TypeRegistry lacks the $type
+        // discriminator)") — the renders-empty / reactive-waits-time-out / page-not-found class of
+        // bug (see MeshExtensions.AddMeshTypes' User/UserActivityRecord registration rationale).
+        builder.ConfigureHub(config =>
+        {
+            config.TypeRegistry.WithType(typeof(Document), nameof(Document));
+            return config;
+        });
+        builder.ConfigureDefaultNodeHub(config =>
+        {
+            config.TypeRegistry.WithType(typeof(Document), nameof(Document));
+            return config;
+        });
         builder.ConfigureServices(services =>
         {
             services.AddSingleton<IDocumentSink>(sp =>

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/MeshDocumentSink.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/MeshDocumentSink.cs
@@ -22,6 +22,18 @@ namespace MeshWeaver.ContentCollections.Indexing.Graph;
 /// </summary>
 public sealed class MeshDocumentSink(IMessageHub hub) : IDocumentSink
 {
+    // Cap on the DocumentExists probe. It runs on every hash-gate skip during a reindex, so a
+    // degraded mesh must not stall the walk for the full default request budget per file; per the
+    // IDocumentSink contract a timed-out probe reads as "absent" and the (idempotent) heal runs.
+    private static readonly TimeSpan ExistsProbeTimeout = TimeSpan.FromSeconds(5);
+
+    // Positive-existence cache (instance field on a mesh-scoped singleton — its lifetime IS the
+    // mesh, per the no-static-collections rule). A Document's path is deterministic and the sink
+    // is the only writer, so once a path is known to exist later skips need no mesh round-trip.
+    // POSITIVE-only: a stale "exists" merely reproduces the pre-heal behavior (no rewrite), while
+    // a cached negative could suppress the heal forever — so absence is always re-probed.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, bool> _knownDocuments = new();
+
     /// <inheritdoc />
     public IObservable<Unit> WriteDocument(DocumentInfo doc)
     {
@@ -58,7 +70,10 @@ public sealed class MeshDocumentSink(IMessageHub hub) : IDocumentSink
                 // the indexing pipeline surfaces it rather than silently dropping the document.
                 if (response.Success
                     || (response.Error?.Contains("already exists", StringComparison.OrdinalIgnoreCase) ?? false))
+                {
+                    _knownDocuments[path] = true;
                     return Observable.Return(Unit.Default);
+                }
 
                 return Observable.Throw<Unit>(new InvalidOperationException(
                     $"Failed to write Document node at '{path}': {response.Error}"));
@@ -66,10 +81,21 @@ public sealed class MeshDocumentSink(IMessageHub hub) : IDocumentSink
     }
 
     /// <inheritdoc />
-    public IObservable<bool> DocumentExists(string collectionPath, string filePath) =>
+    public IObservable<bool> DocumentExists(string collectionPath, string filePath)
+    {
+        var path = DocumentPaths.For(collectionPath, filePath);
+        if (_knownDocuments.ContainsKey(path))
+            return Observable.Return(true);
+
         // One-shot request/response read of the node at the deterministic path; null (not found,
         // timeout, routing failure) counts as absent — per the interface contract, indeterminate
         // leans towards a heal because the write is an idempotent upsert.
-        hub.GetMeshNode(DocumentPaths.For(collectionPath, filePath))
-            .Select(node => node is not null);
+        return hub.GetMeshNode(path, ExistsProbeTimeout)
+            .Select(node =>
+            {
+                if (node is not null)
+                    _knownDocuments[path] = true;
+                return node is not null;
+            });
+    }
 }

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/MeshDocumentSink.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/MeshDocumentSink.cs
@@ -64,4 +64,12 @@ public sealed class MeshDocumentSink(IMessageHub hub) : IDocumentSink
                     $"Failed to write Document node at '{path}': {response.Error}"));
             });
     }
+
+    /// <inheritdoc />
+    public IObservable<bool> DocumentExists(string collectionPath, string filePath) =>
+        // One-shot request/response read of the node at the deterministic path; null (not found,
+        // timeout, routing failure) counts as absent — per the interface contract, indeterminate
+        // leans towards a heal because the write is an idempotent upsert.
+        hub.GetMeshNode(DocumentPaths.For(collectionPath, filePath))
+            .Select(node => node is not null);
 }

--- a/src/MeshWeaver.ContentCollections.Indexing/ContentIndexingService.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/ContentIndexingService.cs
@@ -104,10 +104,50 @@ public sealed class ContentIndexingService
                     _logger.LogDebug(
                         "Hash gate: '{FilePath}' in '{Collection}' unchanged ({Hash}); skipping.",
                         filePath, collectionPath, hash);
-                    return Observable.Return(IndexResult.Skipped);
+                    // Chunks are up to date — but the per-file Document may still be MISSING
+                    // (chunks indexed before the document branch was wired, or the Document write
+                    // failed). A search hit for such a file resolves to a Document node that does
+                    // not exist → the click lands on Not Found, and the gate would skip it forever.
+                    // Heal: when the document branch is wired and no Document exists, run
+                    // extract + summarize + sink for THIS file only (the chunk store is untouched).
+                    return EnsureDocument(collectionPath, filePath, fileName, bytes, hash)
+                        .Select(_ => IndexResult.Skipped);
                 }
 
                 return IndexChanged(collectionPath, filePath, fileName, bytes, hash);
+            });
+    }
+
+    /// <summary>
+    /// The hash-gate HEAL: when the document branch is wired but no <c>Document</c> exists for the
+    /// (unchanged) file, extracts the text again and runs the summarize + sink branch, reporting
+    /// the stored chunk count. No-op (single <see cref="Unit"/>) when the branch isn't wired, the
+    /// Document already exists, or the file has no extractable text.
+    /// </summary>
+    private IObservable<Unit> EnsureDocument(
+        string collectionPath, string filePath, string fileName, byte[] bytes, string hash)
+    {
+        if (_summarizer is null || _documentSink is null)
+            return Observable.Return(Unit.Default);
+
+        return _documentSink.DocumentExists(collectionPath, filePath)
+            .Take(1)
+            .SelectMany(exists =>
+            {
+                if (exists)
+                    return Observable.Return(Unit.Default);
+
+                _logger.LogInformation(
+                    "Hash gate: '{FilePath}' in '{Collection}' unchanged but its Document is missing; healing.",
+                    filePath, collectionPath);
+                return _store.GetChunkCount(collectionPath, filePath)
+                    .Take(1)
+                    .SelectMany(chunkCount => _extractor.ExtractText(fileName, bytes)
+                        .Take(1)
+                        .SelectMany(text => string.IsNullOrWhiteSpace(text)
+                            ? Observable.Return(Unit.Default)
+                            : WriteDocumentBranch(
+                                collectionPath, filePath, fileName, text, bytes, hash, chunkCount)));
             });
     }
 

--- a/src/MeshWeaver.ContentCollections.Indexing/IDocumentSink.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/IDocumentSink.cs
@@ -26,4 +26,15 @@ public interface IDocumentSink
     /// the write runs on subscribe. Composed (never awaited) by <see cref="ContentIndexingService"/>.
     /// </summary>
     IObservable<Unit> WriteDocument(DocumentInfo doc);
+
+    /// <summary>
+    /// Whether a <c>Document</c> already exists for <c>(collectionPath, filePath)</c>. Drives the
+    /// hash-gate HEAL in <see cref="ContentIndexingService.IndexFile"/>: a file whose chunks are
+    /// up to date may still be missing its per-file Document (indexed before the document branch
+    /// was wired, or its write failed) — the gate skips re-chunking but must not skip a missing
+    /// Document forever. Cold; emits one value then completes. Indeterminate probes should lean
+    /// towards <c>false</c>: <see cref="WriteDocument"/> is an idempotent upsert, so a spurious
+    /// heal is harmless while a spurious "exists" wedges the missing Document permanently.
+    /// </summary>
+    IObservable<bool> DocumentExists(string collectionPath, string filePath);
 }

--- a/test/MeshWeaver.AI.Test/DocumentNodeGetTest.cs
+++ b/test/MeshWeaver.AI.Test/DocumentNodeGetTest.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections.Indexing;
+using MeshWeaver.ContentCollections.Indexing.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// <c>MeshOperations.Get</c> on a node whose PATH contains a UCR keyword as an interior segment.
+/// Document nodes live at <c>{collection}/_Documents/{slug}</c> and content collections are
+/// conventionally named <c>content</c> — a UCR keyword — so the unified (UCR) interpretation
+/// hijacks the path into collection-file resolution. Prod repro (atioz 2026-07-02): <c>get</c> on
+/// an existing Document node returned "Error: Content collection '_Documents' not found" instead
+/// of the node. The node namespace is authoritative: an existing node at the full path must win.
+/// </summary>
+public class DocumentNodeGetTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The collection segment is deliberately the UCR keyword <c>content</c>.</summary>
+    private const string Collection = TestPartition + "/content";
+
+    /// <summary>Registers the Document NodeType + sink on the test mesh.</summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddDocumentIndexing();
+
+    [Fact(Timeout = 60_000)]
+    public async Task Get_DocumentNodePath_ReturnsTheNode_NotTheCollectionError()
+    {
+        const string filePath = "vertrag_2025.txt";
+        var sink = new MeshDocumentSink(Mesh);
+        await sink.WriteDocument(new DocumentInfo(
+                Collection, filePath, filePath, "Summary of the contract.",
+                ContentHash: "abc123", Mime: "text/plain", SizeBytes: 42, ChunkCount: 3))
+            .FirstAsync().ToTask();
+
+        var path = DocumentPaths.For(Collection, filePath);
+
+        // The Document write is debounced/persisted — wait until the node is readable before Get.
+        await Observable.Interval(TimeSpan.FromMilliseconds(100))
+            .StartWith(0L)
+            .SelectMany(_ => Mesh.GetMeshNode(path, 5.Seconds()))
+            .Where(n => n is not null)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask();
+
+        var result = await new MeshOperations(Mesh).Get(path).FirstAsync().ToTask();
+
+        result.Should().NotStartWith("Error:",
+            "an existing node at the full path must win over the UCR collection interpretation");
+        result.Should().Contain("\"nodeType\":\"Document\"");
+        result.Should().Contain(filePath);
+    }
+}

--- a/test/MeshWeaver.ContentCollections.Indexing.Graph.Test/DocumentBlocksAreaRenderTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Graph.Test/DocumentBlocksAreaRenderTest.cs
@@ -1,0 +1,148 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using MeshWeaver.ContentCollections.Indexing;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Indexing.Graph.Test;
+
+/// <summary>
+/// Renders <see cref="DocumentLayoutAreas.Blocks"/> — the content-index-block reader (excerpt +
+/// prev/next navigation) — through the standard per-node layout-area machinery, i.e. the exact
+/// path the portal GUI takes when a vector-index search hit is opened.
+///
+/// <para>Covers BOTH content shapes: a Document written through the pipeline (typed content) AND
+/// the LEGACY persisted shape (content = raw JSON without a <c>$type</c> discriminator — what
+/// production carried while the mesh hub's TypeRegistry lacked the <c>Document</c> registration).
+/// Legacy rows must still render: <c>ContentAs&lt;Document&gt;</c> recovers the untyped JSON at the
+/// read site.</para>
+/// </summary>
+public class DocumentBlocksAreaRenderTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    // The collection segment is deliberately "content" — the production naming whose search hits
+    // land on {collection}/_Documents/{slug} node paths.
+    private const string Collection = TestPartition + "/content";
+    private const string FilePath = "vertrag_2025.txt";
+
+    /// <summary>Registers the full indexing pipeline with in-memory store + deterministic fakes.</summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddContentIndexingPipeline(
+                _ => new InMemoryChunkedContentVectorStore(),
+                _ => new FakeEmbedder(),
+                _ => new FakeSummarizer(),
+                new ContentIndexingOptions { ChunkSize = 120, ChunkOverlap = 20 });
+
+    private IChunkedContentVectorStore Store =>
+        Mesh.ServiceProvider.GetRequiredService<IChunkedContentVectorStore>();
+
+    private async Task SeedChunks(params string[] texts)
+    {
+        var chunks = texts
+            .Select((text, index) => new ContentChunk(
+                Collection, FilePath, index, text, ContentHash: "deadbeef", Embedding: null))
+            .ToArray();
+        await Store.ReplaceFileChunks(Collection, FilePath, chunks)
+            .FirstAsync().ToTask(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// Renders the Blocks area on the Document node at <paramref name="path"/> and waits until the
+    /// wire store contains <paramref name="expected"/>.
+    /// </summary>
+    private async Task<string> RenderBlocksUntil(string path, string expected)
+    {
+        var reference = new LayoutAreaReference(DocumentLayoutAreas.BlocksArea);
+        var stream = Mesh.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(path), reference);
+        return await stream
+            .Select(change => change.Value.GetRawText())
+            .Where(json => json.Contains(expected, StringComparison.Ordinal))
+            .Should().Within(40.Seconds())
+            .Match(_ => true);
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task LegacyUntypedDocumentNode_BlocksArea_RendersExcerptAndNavigation()
+    {
+        await SeedChunks(
+            "Erster Vertragsblock mit dem massgeblichen Passus.",
+            "Zweiter Vertragsblock mit weiteren Bestimmungen.");
+
+        // The LEGACY persisted shape: content is a raw JsonElement with camelCase fields and NO
+        // $type discriminator — byte-for-byte what production rows carried while the type was
+        // unregistered on the writing hub.
+        var path = DocumentPaths.For(Collection, FilePath);
+        var legacyContent = JsonSerializer.SerializeToElement(new
+        {
+            name = FilePath,
+            summary = "Zusammenfassung des Vertrags.",
+            collectionPath = Collection,
+            filePath = FilePath,
+            mime = "text/plain",
+            sizeBytes = 42L,
+            contentHash = "deadbeef",
+            chunkCount = 2,
+            indexedAt = DateTimeOffset.UtcNow,
+        });
+        var node = MeshNode.FromPath(path) with
+        {
+            NodeType = DocumentNodeType.NodeType,
+            Name = FilePath,
+            State = MeshNodeState.Active,
+            Content = legacyContent,
+        };
+        var created = await Mesh.ServiceProvider.GetRequiredService<IMeshService>()
+            .CreateNode(node).FirstAsync().ToTask(TestContext.Current.CancellationToken);
+        created.Should().NotBeNull();
+
+        // The block reader renders the FIRST chunk's text (the excerpt) …
+        var json = await RenderBlocksUntil(path, "Erster Vertragsblock");
+        // … with forward navigation to the next block (index 0 of 2 ⇒ Next, no Previous).
+        json.Should().Contain("Next");
+        json.Should().NotContain("No document data");
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task PipelineWrittenDocumentNode_BlocksArea_RendersExcerptAndNavigation()
+    {
+        // Index through the real service + real sink — the post-fix (typed) write path.
+        var body = string.Concat(Enumerable.Repeat(
+            "Der massgebliche Passus über die Rentenverpflichtungen steht in diesem Vertrag. ", 6));
+        var service = Mesh.ServiceProvider.GetRequiredService<ContentIndexingService>();
+        var result = await service
+            .IndexFile(Collection, FilePath, FilePath, System.Text.Encoding.UTF8.GetBytes(body))
+            .FirstAsync().ToTask(TestContext.Current.CancellationToken);
+        result.Status.Should().Be(IndexStatus.Indexed);
+
+        var path = DocumentPaths.For(Collection, FilePath);
+        var json = await RenderBlocksUntil(path, "Der massgebliche Passus");
+        json.Should().Contain("Next");
+        json.Should().NotContain("No document data");
+    }
+
+    // ----- deterministic test doubles (chunk/summarize leaves, NOT the sink) -----
+
+    private sealed class FakeSummarizer : ISummarizer
+    {
+        public IObservable<string> Summarize(string text, string fileName) =>
+            Observable.Defer(() => Observable.Return(
+                "SUMMARY: " + (text.Length <= 40 ? text : text[..40])));
+    }
+
+    private sealed class FakeEmbedder : IChunkEmbedder
+    {
+        public int Dimensions => 8;
+
+        public IObservable<float[]> Embed(string text) =>
+            Observable.Defer(() => Observable.Return(new float[Dimensions]));
+    }
+}

--- a/test/MeshWeaver.ContentCollections.Indexing.Graph.Test/MeshDocumentSinkTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Graph.Test/MeshDocumentSinkTest.cs
@@ -102,6 +102,45 @@ public class MeshDocumentSinkTest(ITestOutputHelper output) : MonolithMeshTestBa
         document.IndexedAt.Should().NotBe(default);
     }
 
+    /// <summary>
+    /// Pins the serialization boundary the in-memory store never crosses: on a JSON-backed store
+    /// (Postgres jsonb) the Document content is serialized with the MESH hub's options (the write
+    /// travels MeshDocumentSink → CreateOrUpdateNodeRequest → mesh hub → storage), NOT the
+    /// Document per-node hub's. Prod repro (atioz 2026-07-01): the mesh hub's TypeRegistry lacked
+    /// <c>Document</c>, content persisted WITHOUT a <c>$type</c> discriminator, and every reader got
+    /// an untyped JsonElement ("stayed an untyped JsonElement (TypeRegistry lacks the $type
+    /// discriminator)") — document pages rendered empty / not found.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task DocumentContent_RoundTripsTyped_ThroughMeshHubSerializer()
+    {
+        var (service, _, _) = BuildService();
+
+        const string fileName = "roundtrip.txt";
+        var filePath = $"docs/{fileName}";
+        var bytes = Encoding.UTF8.GetBytes("Round-trip body long enough to chunk and summarize.");
+
+        var result = await service.IndexFile(Collection, filePath, fileName, bytes)
+            .FirstAsync().ToTask();
+        result.Status.Should().Be(IndexStatus.Indexed);
+
+        var node = await ReadDocumentNode(DocumentPaths.For(Collection, filePath));
+
+        // Serialize with the MESH hub's options — the exact boundary a jsonb store exercises.
+        var json = System.Text.Json.JsonSerializer.Serialize(node, Mesh.JsonSerializerOptions);
+        using (var parsed = System.Text.Json.JsonDocument.Parse(json))
+        {
+            parsed.RootElement.GetProperty("content").TryGetProperty("$type", out var discriminator)
+                .Should().BeTrue("the mesh hub must emit the Document $type discriminator");
+            discriminator.GetString().Should().Be(nameof(Document));
+        }
+
+        // And back: a reader deserializing with the same options gets TYPED content.
+        var roundTripped = System.Text.Json.JsonSerializer.Deserialize<MeshNode>(json, Mesh.JsonSerializerOptions);
+        roundTripped!.Content.Should().BeOfType<Document>()
+            .Which.FilePath.Should().Be(filePath);
+    }
+
     [Fact(Timeout = 60_000)]
     public async Task ReindexIdenticalBytes_IsSkipped_NodeUnchanged()
     {

--- a/test/MeshWeaver.ContentCollections.Indexing.Graph.Test/MeshWeaver.ContentCollections.Indexing.Graph.Test.csproj
+++ b/test/MeshWeaver.ContentCollections.Indexing.Graph.Test/MeshWeaver.ContentCollections.Indexing.Graph.Test.csproj
@@ -12,6 +12,10 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
+    <!-- Layout-area rendering (DocumentBlocksAreaRenderTest): LayoutAreaReference + the
+         workspace GetRemoteStream extension. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Data\MeshWeaver.Data.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/MeshWeaver.ContentCollections.Indexing.Test/DocumentSummaryIndexingTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Test/DocumentSummaryIndexingTest.cs
@@ -117,6 +117,33 @@ public class DocumentSummaryIndexingTest : IDisposable
     }
 
     [Fact]
+    public async Task Skip_WithMissingDocument_HealsTheDocument()
+    {
+        const string body = "Chunked before the document branch existed; the document is missing.";
+        var filePath = WriteFile("legacy.txt", body);
+
+        (await Index(filePath, "legacy.txt")).Status.Should().Be(IndexStatus.Indexed);
+        _sink.Writes.Should().Be(1);
+
+        // Simulate the legacy state: chunks + hash stored, but no Document (the file was indexed
+        // by a build without the document branch, or the Document write failed). Without the heal
+        // the hash gate skips this file FOREVER and its search hits land on a Not Found node.
+        _sink.Forget(Collection, filePath);
+
+        var second = await Index(filePath, "legacy.txt");
+        second.Status.Should().Be(IndexStatus.Skipped);
+
+        // The heal ran the document branch exactly once more; the chunk store was untouched.
+        _summarizer.Calls.Should().Be(2);
+        _sink.Writes.Should().Be(2);
+        var doc = _sink.LastDocument!;
+        doc.FilePath.Should().Be(filePath);
+        doc.ContentHash.Should().Be(Sha256Hex(Encoding.UTF8.GetBytes(body)));
+        doc.ChunkCount.Should().BeGreaterThan(0);
+        doc.Summary.Should().Be(FakeSummarizer.Expected(body));
+    }
+
+    [Fact]
     public async Task ModifiedBytes_ReRunBothSummaryAndDocument()
     {
         var filePath = WriteFile("changing.txt", "Original content about pensions.");

--- a/test/MeshWeaver.ContentCollections.Indexing.Test/FakeDocumentSink.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Test/FakeDocumentSink.cs
@@ -12,6 +12,7 @@ namespace MeshWeaver.ContentCollections.Indexing.Test;
 public sealed class FakeDocumentSink : IDocumentSink
 {
     private int _writes;
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<(string Collection, string File), DocumentInfo> _documents = new();
 
     /// <summary>The most recent <see cref="DocumentInfo"/> handed to <see cref="WriteDocument"/>, or null if none.</summary>
     public DocumentInfo? LastDocument { get; private set; }
@@ -23,7 +24,19 @@ public sealed class FakeDocumentSink : IDocumentSink
         Observable.Defer(() =>
         {
             LastDocument = doc;
+            _documents[(doc.CollectionPath, doc.FilePath)] = doc;
             Interlocked.Increment(ref _writes);
             return Observable.Return(Unit.Default);
         });
+
+    public IObservable<bool> DocumentExists(string collectionPath, string filePath) =>
+        Observable.Defer(() => Observable.Return(_documents.ContainsKey((collectionPath, filePath))));
+
+    /// <summary>
+    /// Drops the recorded document for <c>(collectionPath, filePath)</c> — simulates a file whose
+    /// chunks were indexed before the document branch existed (or whose Document write failed), so
+    /// tests can assert the hash-gate HEAL re-creates it.
+    /// </summary>
+    public void Forget(string collectionPath, string filePath) =>
+        _documents.TryRemove((collectionPath, filePath), out _);
 }


### PR DESCRIPTION
## Problem

Opening a vector-index document search hit on prod (atioz) landed on **Not Found**, and `get` on an existing Document node via MCP returned `Error: Content collection '_Documents' not found`. The excerpt facility itself (the `Blocks` reader with highlighted passage + prev/next navigation, #127) was fine — its click target was unresolvable.

## Three stacked root causes, each fixed at the root

1. **Document content persisted WITHOUT a `$type` discriminator.** `typeof(Document)` was registered only in the Document per-node hub config (`WithContentType`), but `MeshDocumentSink` writes through the **mesh** hub — its registry never knew the type, so jsonb rows carried no discriminator and every reader got an untyped `JsonElement` (prod log: *"stayed an untyped JsonElement (TypeRegistry lacks the $type discriminator) — renders empty, reactive waits time out"*). Fixed by registering the type on `ConfigureHub` + `ConfigureDefaultNodeHub` in `AddDocumentIndexing` (the `AddAITypes` pattern; same defect class as the User/UserActivityRecord registrations in `AddMeshTypes`). Legacy untyped rows still render — `ContentAs<Document>` recovers them at the read site — so **no data migration is needed**.

2. **UCR `content` keyword shadowing real node paths.** Document nodes live at `{collection}/_Documents/{slug}` and the conventional collection segment `content` is a UCR keyword, so `MeshOperations.Get` hijacked the path into collection-file resolution. The node namespace is authoritative: on a unified-read **error**, fall back to the node read; surface the UCR error only when no node exists at the full path either. Successful UCR reads are untouched.

3. **The hash gate never healed a missing Document.** `IndexFile` skipped unchanged files entirely, so a file chunked before the document branch shipped kept its search hit pointing at a nonexistent node forever. On the skip path, `IDocumentSink.DocumentExists` is probed and a missing Document is healed (extract + summarize + sink for that file only; the chunk store is untouched; `WriteDocument` is an idempotent upsert).

## Test evidence — each fix is pinned (fails with its fix reverted)

- `MeshDocumentSinkTest.DocumentContent_RoundTripsTyped_ThroughMeshHubSerializer` — serializes the written node with the **mesh hub's** options, the jsonb boundary the in-memory test store never crosses (why existing tests were green while prod was broken).
- `DocumentNodeGetTest.Get_DocumentNodePath_ReturnsTheNode_NotTheCollectionError` — real sink + a collection literally named `content`.
- `DocumentSummaryIndexingTest.Skip_WithMissingDocument_HealsTheDocument` — plus the existing skip/version-stability tests proving the heal never rewrites an existing Document.
- `DocumentBlocksAreaRenderTest` — renders the Blocks reader (excerpt + Next navigation) through the standard per-node layout-area machinery for BOTH content shapes: pipeline-written (typed) and the legacy untyped prod shape.

Suites: ContentCollections.Indexing.Test 42/42 · ContentCollections.Indexing.Graph.Test 27/27 · the new AI.Test case green. Full solution builds clean under `-c Release -warnaserror` on the branch merged with current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)