### PR TITLE
fix(chat): composer auto-grows with content; first Enter submits slash commands

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -845,6 +845,9 @@ else
         @if (_connectProvider is null)
         {
         <div class="input-container" @onkeydown="@OnInputKeyDown">
+            @* AutoGrow: the composer expands with the content from 80px up to the adaptive
+               max (mirrors the command palette's min(440px, calc(100vh - 180px)) pattern),
+               then scrolls internally — no more invisible scrolling in a fixed 80px box. *@
             <MonacoEditorView @ref="monacoEditor"
                               Value="@MessageText"
                               ValueChanged="@OnMessageTextChanged"
@@ -852,7 +855,8 @@ else
                               OnCompletionAccepted="OnCompletionItemAccepted"
                               Placeholder="@placeholderText"
                               Height="80px"
-                              MaxHeight="200px"
+                              MaxHeight="min(400px, calc(100vh - 280px))"
+                              AutoGrow="true"
                               CompletionProvider="@GetCompletionConfig()"
                               CompletionCallback="@GetCompletions" />
         </div>

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor
@@ -130,7 +130,19 @@
     [Parameter]
     public bool CodeEditMode { get; set; } = false;
 
-    private string ContainerStyle => $"height: {Height}; max-height: {MaxHeight}; min-height: 40px;";
+    /// <summary>
+    /// When true, the editor container grows with its content — from <see cref="Height"/>
+    /// (the minimum) up to <see cref="MaxHeight"/>, then scrolls internally. Driven by
+    /// Monaco's <c>onDidContentSizeChange</c> in the JS module. Default is false: the
+    /// container keeps the fixed <see cref="Height"/> (existing consumers unaffected).
+    /// </summary>
+    [Parameter]
+    public bool AutoGrow { get; set; } = false;
+
+    private string ContainerStyle => AutoGrow
+        // Auto-grow: JS drives the height from the content size; CSS clamps the range.
+        ? $"max-height: {MaxHeight}; min-height: {Height};"
+        : $"height: {Height}; max-height: {MaxHeight}; min-height: 40px;";
 
     private string GetMonacoTheme() => isDarkMode ? "vs-dark" : "vs";
 
@@ -224,7 +236,7 @@
 
         if (jsModule != null)
         {
-            await jsModule.InvokeVoidAsync("initEditor", EditorId, Placeholder, dotNetRef, CodeEditMode, ShowLineNumbers);
+            await jsModule.InvokeVoidAsync("initEditor", EditorId, Placeholder, dotNetRef, CodeEditMode, ShowLineNumbers, AutoGrow);
 
             // Register completion provider if configured
             await TryRegisterCompletionProvider();

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -247,7 +247,7 @@ export function waitForMonaco() {
     return true;
 }
 
-export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = false, showLineNumbers = false) {
+export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = false, showLineNumbers = false, autoGrow = false) {
     const container = document.getElementById(editorId);
     if (!container) {
         // Component may have been disposed before JS init completed — not an error
@@ -269,7 +269,9 @@ export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = fals
         completionConfig: null,
         completionDisposable: null,
         codeEditMode: codeEditMode,
-        showLineNumbers: showLineNumbers
+        showLineNumbers: showLineNumbers,
+        autoGrow: autoGrow,
+        resizeTimeout: null
     });
 
     // Add placeholder styling
@@ -301,6 +303,23 @@ export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = fals
             }
         });
 
+        // Auto-grow (opt-in): follow the content height so the composer expands with the
+        // text instead of scrolling invisibly inside a fixed box (issue #178). The container's
+        // CSS min-height/max-height clamp the range; automaticLayout's ResizeObserver re-lays
+        // the editor out when the container height changes. Debounced so rapid typing doesn't
+        // thrash the DOM; shrink-back on delete works the same way (smaller contentHeight).
+        if (autoGrow) {
+            editorInstance.onDidContentSizeChange((e) => {
+                const st = editorState.get(editorId);
+                if (!st) return;
+                if (st.resizeTimeout) clearTimeout(st.resizeTimeout);
+                st.resizeTimeout = setTimeout(() => {
+                    const c = document.getElementById(editorId);
+                    if (c) c.style.height = e.contentHeight + 'px';
+                }, 50);
+            });
+        }
+
         // Handle Enter key - in code edit mode, Enter inserts newline; in chat mode, Enter submits
         const state = editorState.get(editorId);
         if (!state?.codeEditMode) {
@@ -308,12 +327,17 @@ export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = fals
             editorInstance.onKeyDown(async (e) => {
                 // Check for Enter key without modifiers
                 if (e.keyCode === monaco.KeyCode.Enter && !e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
-                    // Check if suggest widget is visible
-                    // States: 0=Hidden, 1=Loading, 2=Empty, 3=Open, 4=Frozen, 5=Details
-                    // Use > 0 to handle undefined/null case (where !== 0 would wrongly be true)
-                    const suggestController = editorInstance.getContribution('editor.contrib.suggestController');
-                    const suggestState = suggestController?.model?.state;
-                    const isSuggestVisible = typeof suggestState === 'number' && suggestState > 0;
+                    // Block submit ONLY when the suggest widget is ACTUALLY on screen (it owns
+                    // Enter then: accept the selected suggestion). The previous check read
+                    // suggestController.model.state > 0, which is truthy for the whole suggest
+                    // SESSION — including the async-completion loading window with nothing
+                    // rendered yet. Typing "/model" and pressing Enter inside the completion
+                    // debounce therefore swallowed the first Enter with no visible widget
+                    // (issue #174: commands need multiple attempts). The rendered widget adds
+                    // .suggest-widget.visible to the editor DOM — check that instead: it is
+                    // exactly what the user sees, and version-stable across Monaco builds.
+                    const suggestWidget = editorInstance.getDomNode()?.querySelector('.suggest-widget');
+                    const isSuggestVisible = !!suggestWidget && suggestWidget.classList.contains('visible');
 
                     if (!isSuggestVisible) {
                         e.preventDefault();


### PR DESCRIPTION
Closes #178. Closes #174.

## Composer auto-grow (#178)
`MonacoEditorView` gains an **opt-in `AutoGrow` parameter**: the container follows Monaco's `onDidContentSizeChange` (50 ms debounce) from `Height` (now the minimum) up to `MaxHeight`, then scrolls internally; `AutomaticLayout`'s ResizeObserver re-lays the editor out on each container change, and shrink-back on delete works the same way. The chat composer opts in with an adaptive cap `min(400px, calc(100vh - 280px))` — the same viewport-aware pattern the command palette already uses. Every other `MonacoEditorView` consumer (SearchBox, MeshNodeEditor, notebook cells, …) keeps the fixed-height default — zero behavior change unless opted in.

React client needs no change — its Fluent `Textarea` already has `resize="vertical"`.

## First-Enter swallow on slash commands (#174)
The Enter handler suppressed submission whenever `suggestController.model.state > 0` — which is truthy for the whole suggest *session*, including the async-completion loading window with **nothing rendered**. Typing `/model` and hitting Enter inside the 50 ms completion debounce swallowed the first Enter with no widget on screen; only a cursor move + second Enter got through. The gate now checks what the user actually sees — the rendered `.suggest-widget.visible` element in the editor DOM. Enter submits unless the suggestions are genuinely visible, in which case it still accepts the selected suggestion as before.

## Verification
- `dotnet build src/MeshWeaver.Blazor.Portal -c Release -warnaserror`: clean (0 warnings).
- Manual checklist: composer grows from 80 px with multi-line paste, clamps at the adaptive max and scrolls; empties back to 80 px; `/model` + immediate Enter submits on the first attempt; visible suggestion list still consumes Enter to accept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)