### PR TITLE
fix(content): GUI file upload raises the IContentUploadObserver seam

### DIFF
--- a/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor.cs
+++ b/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor.cs
@@ -229,9 +229,11 @@ public partial class FileBrowser
                 // (MeshOperations.Upload → hub.RaiseContentUploaded) so a GUI upload
                 // auto-indexes like any other upload. Fire-and-forget by contract — the
                 // indexing runs as its own Activity and never blocks the upload (#170).
-                var relativePath = string.IsNullOrEmpty(CurrentPath)
-                    ? file.Name
-                    : $"{CurrentPath.Trim('/')}/{file.Name}".TrimStart('/');
+                // CurrentPath can carry '\' separators on Windows (the Embed breadcrumb
+                // builds it via Path.Combine) — normalize so the seam always gets the
+                // MCP shape (forward-slash, collection-relative, no leading slash).
+                var folder = (CurrentPath ?? "").Replace('\\', '/').Trim('/');
+                var relativePath = string.IsNullOrEmpty(folder) ? file.Name : $"{folder}/{file.Name}";
                 Hub.RaiseContentUploaded(QualifiedCollectionPath, relativePath);
 
                 ToastService.ShowSuccess($"File {file.Name} successfully uploaded.");

--- a/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor.cs
+++ b/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor.cs
@@ -224,12 +224,41 @@ public partial class FileBrowser
             {
                 await Collection.SaveFileAsync(CurrentPath!, file.Name, file.Stream!);
                 progressPercent = 100;
+
+                // Post-upload seam: raise the SAME observer the MCP upload path raises
+                // (MeshOperations.Upload → hub.RaiseContentUploaded) so a GUI upload
+                // auto-indexes like any other upload. Fire-and-forget by contract — the
+                // indexing runs as its own Activity and never blocks the upload (#170).
+                var relativePath = string.IsNullOrEmpty(CurrentPath)
+                    ? file.Name
+                    : $"{CurrentPath.Trim('/')}/{file.Name}".TrimStart('/');
+                Hub.RaiseContentUploaded(QualifiedCollectionPath, relativePath);
+
                 ToastService.ShowSuccess($"File {file.Name} successfully uploaded.");
             }
         }
         catch (Exception e)
         {
             ToastService.ShowError($"Error uploading {file.Name}: {e.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The node-qualified collection path (<c>{address}/{collection}</c>) that upload
+    /// observers expect — the same shape <c>MeshOperations.Upload</c> raises and the same
+    /// composition <see cref="GetLink(FileItem)"/> uses for download URLs. Falls back to
+    /// <see cref="CollectionName"/> as-is when no <see cref="Address"/> is set or the name
+    /// is already qualified with it.
+    /// </summary>
+    private string QualifiedCollectionPath
+    {
+        get
+        {
+            var address = Address?.ToString();
+            return string.IsNullOrEmpty(address)
+                   || CollectionName!.StartsWith(address + "/", StringComparison.OrdinalIgnoreCase)
+                ? CollectionName!
+                : $"{address}/{CollectionName}";
         }
     }
 


### PR DESCRIPTION
Closes #170.

A file uploaded through the portal **FileBrowser** was written to the content collection but never indexed — the auto-index-on-upload seam (`IContentUploadObserver`) was only raised by the MCP upload path (`MeshOperations.Upload`), so GUI-uploaded files stayed unsearchable (0 chunks, no `Document` node) until a manual whole-collection re-index.

**Fix (at the true source, no re-index workaround):** `FileBrowser.OnFileUploadedAsync` now raises the same seam after a successful save — `Hub.RaiseContentUploaded(qualifiedCollectionPath, relativePath)`:
- the collection path is node-qualified (`{address}/{collection}`) — the same shape `MeshOperations.Upload` raises and the same composition the component's own download URLs use; falls back to `CollectionName` as-is when no `Address` is set or the name is already qualified;
- the file path is collection-relative (`{folder}/{name}`, no leading slash), matching the MCP path;
- fire-and-forget per the observer contract — the indexing runs as its own Activity (`ContentIndexingObserver`) and never blocks the upload. No AccessContext plumbing needed (indexing is a backend operation; visibility was gated at upload time).

The seam→index pipeline itself is covered by `ContentIndexingPipelineTest.Upload_FiresIndexingActivity_WritesDocumentAndChunks`; this PR adds the missing call at the GUI source.

**Noted follow-ups (out of scope, from the same investigation):** the `FileContentProvider.SaveFileContent` path (AI text saves) and `ContentImportExtensions` bulk import also miss the seam — tracked in a comment on #170.

`dotnet build src/MeshWeaver.Blazor -c Release -warnaserror`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)