### PR TITLE
fix(graph): atomically publish compiled node DLL — close partial-DLL load race (#177 flake)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -1368,26 +1368,37 @@ internal class MeshNodeCompilationService(
         Func<string, string> emitToReleaseDir)
     {
         string? lastDllPath = null;
+
+        static void TryDeleteDir(string dir)
+        {
+            try { Directory.Delete(dir, recursive: true); }
+            catch { /* best-effort cleanup */ }
+        }
+
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
             var timestamp = DateTimeOffset.UtcNow.Ticks.ToString("x");
-            var releaseDir = Path.Combine(cacheDirectory, $"{nodeName}_{timestamp}");
+            // Unique published name. Discovery orders by the dir's LastWriteTime, NOT by parsing the
+            // ticks out of the name (see TryGetLatestCachedDllPath), so a GUID suffix guarantees the
+            // atomic Directory.Move below never collides — on a coarse clock or two rapid compiles —
+            // while still matching the `{nodeName}_*` glob.
+            var releaseDir = Path.Combine(cacheDirectory, $"{nodeName}_{timestamp}_{Guid.NewGuid():N}");
+            lastDllPath = Path.Combine(releaseDir, $"{nodeName}.dll");
 
             // 🚨 Emit into a STAGING dir whose name does NOT match the `{nodeName}_*` discovery glob
             // (TryGetLatestCachedDllPath), then atomically publish it by renaming to the discoverable
-            // `{nodeName}_{ticks}` name only AFTER the DLL is fully written + verified. The DLL file
-            // exists at 0 bytes and grows during compilation.Emit (File.Create + Emit is NOT atomic);
-            // without staging, a concurrent reader can discover the half-written DLL and
-            // LoadFromAssemblyPath a truncated image → a native crash (SIGSEGV) or a BadImageFormat
-            // that deletes the artifact and churns the compile. A directory rename on the same
-            // filesystem is atomic, so a reader sees either nothing or the COMPLETE artifact.
+            // name only AFTER the DLL is fully written + verified. The DLL file exists at 0 bytes and
+            // grows during compilation.Emit (File.Create + Emit is NOT atomic); without staging, a
+            // concurrent reader can discover the half-written DLL and LoadFromAssemblyPath a truncated
+            // image → a native crash (SIGSEGV) or a BadImageFormat that deletes the artifact and churns
+            // the compile. A directory rename on the same filesystem is atomic, so a reader sees either
+            // nothing or the COMPLETE artifact.
             var stagingDir = Path.Combine(cacheDirectory, $".staging-{nodeName}-{timestamp}-{Guid.NewGuid():N}");
             Directory.CreateDirectory(stagingDir);
 
-            // The real emit (a compile error throws straight through — see method remarks). On a
-            // genuine compile error the half-written staging dir is discarded so a failed emit never
-            // leaves a partial artifact behind (the old code leaked a glob-discoverable
-            // `{nodeName}_{ticks}` dir here — the same partial-DLL hazard).
+            // The real emit (a genuine compile error throws straight through — never retried). Discard
+            // the half-written staging dir first so a failed emit leaves no partial artifact behind (the
+            // old code leaked a glob-discoverable `{nodeName}_{ticks}` dir here — the same hazard).
             string stagedDllPath;
             try
             {
@@ -1395,28 +1406,35 @@ internal class MeshNodeCompilationService(
             }
             catch
             {
-                try { Directory.Delete(stagingDir, recursive: true); } catch { /* best-effort */ }
+                TryDeleteDir(stagingDir);
                 throw;
             }
-            lastDllPath = Path.Combine(releaseDir, $"{nodeName}.dll");
 
-            // Roslyn reported success — confirm the bytes are genuinely on disk BEFORE publishing. On
-            // an ephemeral cache directory the file can be evicted between emit and the next read.
-            if (File.Exists(stagedDllPath) && new FileInfo(stagedDllPath).Length > 0)
+            // Confirm the bytes are genuinely on disk, then atomically publish. EVERY fault here is a
+            // RETRYABLE publish failure — an ephemeral-cache eviction racing the size read, or a
+            // transient rename IO error — so discard staging and re-emit rather than aborting the compile.
+            try
             {
-                // Atomic publish: the whole artifact becomes discoverable in one rename.
-                Directory.Move(stagingDir, releaseDir);
-                return lastDllPath;
+                if (File.Exists(stagedDllPath) && new FileInfo(stagedDllPath).Length > 0)
+                {
+                    Directory.Move(stagingDir, releaseDir);
+                    return lastDllPath;
+                }
+
+                logger.LogWarning(
+                    "Emit for {NodeName} reported success but the assembly was missing or empty at " +
+                    "{DllPath} after flush (attempt {Attempt}/{Max}); re-emitting.",
+                    nodeName, stagedDllPath, attempt, maxAttempts);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogWarning(ex,
+                    "Publishing the emitted assembly for {NodeName} failed (attempt {Attempt}/{Max}); re-emitting.",
+                    nodeName, attempt, maxAttempts);
             }
 
-            logger.LogWarning(
-                "Emit for {NodeName} reported success but the assembly was missing or empty at " +
-                "{DllPath} after flush (attempt {Attempt}/{Max}); re-emitting.",
-                nodeName, stagedDllPath, attempt, maxAttempts);
-
-            // Drop the empty/partial staging directory so the retry starts clean.
-            try { Directory.Delete(stagingDir, recursive: true); }
-            catch (Exception ex) { logger.LogDebug(ex, "Could not clean up empty staging dir {StagingDir}", stagingDir); }
+            // Drop the staging directory so the retry starts clean.
+            TryDeleteDir(stagingDir);
         }
 
         throw new CompilationException(nodeName,

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -1372,24 +1372,51 @@ internal class MeshNodeCompilationService(
         {
             var timestamp = DateTimeOffset.UtcNow.Ticks.ToString("x");
             var releaseDir = Path.Combine(cacheDirectory, $"{nodeName}_{timestamp}");
-            Directory.CreateDirectory(releaseDir);
 
-            // The real emit (a compile error throws straight through — see method remarks).
-            lastDllPath = emitToReleaseDir(releaseDir);
+            // 🚨 Emit into a STAGING dir whose name does NOT match the `{nodeName}_*` discovery glob
+            // (TryGetLatestCachedDllPath), then atomically publish it by renaming to the discoverable
+            // `{nodeName}_{ticks}` name only AFTER the DLL is fully written + verified. The DLL file
+            // exists at 0 bytes and grows during compilation.Emit (File.Create + Emit is NOT atomic);
+            // without staging, a concurrent reader can discover the half-written DLL and
+            // LoadFromAssemblyPath a truncated image → a native crash (SIGSEGV) or a BadImageFormat
+            // that deletes the artifact and churns the compile. A directory rename on the same
+            // filesystem is atomic, so a reader sees either nothing or the COMPLETE artifact.
+            var stagingDir = Path.Combine(cacheDirectory, $".staging-{nodeName}-{timestamp}-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(stagingDir);
 
-            // Roslyn reported success — confirm the bytes are genuinely on disk. On an ephemeral
-            // cache directory the file can be evicted between emit and the next read.
-            if (File.Exists(lastDllPath) && new FileInfo(lastDllPath).Length > 0)
+            // The real emit (a compile error throws straight through — see method remarks). On a
+            // genuine compile error the half-written staging dir is discarded so a failed emit never
+            // leaves a partial artifact behind (the old code leaked a glob-discoverable
+            // `{nodeName}_{ticks}` dir here — the same partial-DLL hazard).
+            string stagedDllPath;
+            try
+            {
+                stagedDllPath = emitToReleaseDir(stagingDir);
+            }
+            catch
+            {
+                try { Directory.Delete(stagingDir, recursive: true); } catch { /* best-effort */ }
+                throw;
+            }
+            lastDllPath = Path.Combine(releaseDir, $"{nodeName}.dll");
+
+            // Roslyn reported success — confirm the bytes are genuinely on disk BEFORE publishing. On
+            // an ephemeral cache directory the file can be evicted between emit and the next read.
+            if (File.Exists(stagedDllPath) && new FileInfo(stagedDllPath).Length > 0)
+            {
+                // Atomic publish: the whole artifact becomes discoverable in one rename.
+                Directory.Move(stagingDir, releaseDir);
                 return lastDllPath;
+            }
 
             logger.LogWarning(
                 "Emit for {NodeName} reported success but the assembly was missing or empty at " +
                 "{DllPath} after flush (attempt {Attempt}/{Max}); re-emitting.",
-                nodeName, lastDllPath, attempt, maxAttempts);
+                nodeName, stagedDllPath, attempt, maxAttempts);
 
-            // Drop the empty/partial directory so the retry starts clean.
-            try { Directory.Delete(releaseDir, recursive: true); }
-            catch (Exception ex) { logger.LogDebug(ex, "Could not clean up empty release dir {ReleaseDir}", releaseDir); }
+            // Drop the empty/partial staging directory so the retry starts clean.
+            try { Directory.Delete(stagingDir, recursive: true); }
+            catch (Exception ex) { logger.LogDebug(ex, "Could not clean up empty staging dir {StagingDir}", stagingDir); }
         }
 
         throw new CompilationException(nodeName,

--- a/test/MeshWeaver.Graph.Test/EmitToDiskWithRetryTest.cs
+++ b/test/MeshWeaver.Graph.Test/EmitToDiskWithRetryTest.cs
@@ -147,4 +147,50 @@ public class EmitToDiskWithRetryTest : IDisposable
         ex.Message.Should().Contain("; expected");
         attempts.Should().Be(1, "a deterministic compile error must NOT be retried");
     }
+
+    [Fact]
+    public void Successful_emit_publishes_to_a_discoverable_dir_and_leaves_no_staging()
+    {
+        // Atomic-publish contract: the artifact is emitted into a NON-discoverable staging dir and
+        // renamed into the `{nodeName}_*` discovery namespace only once complete, so a concurrent
+        // TryGetLatestCachedDllPath never sees a half-written DLL (loading a truncated image is a
+        // native crash / BadImageFormat). After success exactly one discoverable dir holds the DLL
+        // and no `.staging-*` dir is left behind.
+        const string nodeName = "Demo_AtomicPublish";
+
+        var result = MeshNodeCompilationService.EmitToDiskWithRetry(
+            _cacheDir, nodeName, maxAttempts: 3, NullLogger.Instance,
+            releaseDir => WriteAssembly(releaseDir, nodeName));
+
+        File.Exists(result).Should().BeTrue();
+        Path.GetDirectoryName(result)!.Should().NotContain(".staging-");
+        Directory.GetDirectories(_cacheDir, $"{nodeName}_*").Should()
+            .ContainSingle("the published artifact lives in exactly one discoverable dir");
+        Directory.GetDirectories(_cacheDir, ".staging-*").Should()
+            .BeEmpty("staging is renamed away on publish, never left behind");
+    }
+
+    [Fact]
+    public void Compile_error_leaves_no_discoverable_partial_artifact()
+    {
+        // A failed emit must NOT pollute the discovery namespace with a partial DLL — the staging dir
+        // (and any half-written bytes in it) is discarded, so TryGetLatestCachedDllPath can never pick
+        // up the wreckage of a failed compile.
+        const string nodeName = "Demo_ErrorNoPartial";
+
+        Assert.Throws<CompilationException>(() =>
+            MeshNodeCompilationService.EmitToDiskWithRetry(
+                _cacheDir, nodeName, maxAttempts: 3, NullLogger.Instance,
+                releaseDir =>
+                {
+                    // Roslyn wrote a partial DLL, then the compile failed.
+                    File.WriteAllBytes(Path.Combine(releaseDir, $"{nodeName}.dll"), new byte[] { 0x4D, 0x5A });
+                    throw new CompilationException(nodeName, "CS1002: ; expected");
+                }));
+
+        Directory.GetDirectories(_cacheDir, $"{nodeName}_*").Should()
+            .BeEmpty("a failed compile must leave no discoverable artifact");
+        Directory.GetDirectories(_cacheDir, ".staging-*").Should()
+            .BeEmpty("the failed staging dir is cleaned up");
+    }
 }


### PR DESCRIPTION
## Atomic-publish the compiled node DLL — close a partial-DLL load race

### Symptom (#177's flaky run)
`CompileActivityNoPhantomPathTest.CompiledNodeType_LastCompilationActivityPath_PointsAtAnExistingActivityNode` failed on `main` run `0cac4e76`: the compile-status stream never reached `Ok`/`Error` within 40 s (line 86), then the test process **crashed with SIGSEGV (exit 139)**. A ~1/12 residual of the compile-flake family; the `#173` single-driver fix was already present in that commit, so this is a *different* remaining window.

### Root cause — the cache can hand out a half-written DLL
`MeshNodeCompilationService.EmitToDiskWithRetry` emitted the assembly **directly into the glob-discoverable `{cacheDir}/{nodeName}_{ticks}/` dir**: `File.Create(dllPath)` then `compilation.Emit(dllStream, …)`. The DLL file therefore **exists at 0 bytes and grows during Emit** (create + emit is not atomic). Meanwhile `CompilationCacheService.TryGetLatestCachedDllPath` discovers a cached DLL by `File.Exists(candidateDll)` only — it does **not** check the file is fully written. So a concurrent reader (any resolve/scope path, not just the compile driver `#173` removed) can discover the mid-Emit DLL and `LoadFromAssemblyPath` a **truncated image** → a native **SIGSEGV** (a fully-corrupt image throws `BadImageFormatException`, which the load path catches + deletes → recompile churn that keeps the status from settling). Both of #177's symptoms.

### Fix — stage then atomically publish
`EmitToDiskWithRetry` now emits into a **non-discoverable** `.staging-{nodeName}-…` dir (does not match the `{nodeName}_*` discovery glob), verifies the bytes landed, then **`Directory.Move`s it into the `{nodeName}_{ticks}` name** — an atomic same-filesystem rename. A reader now sees either nothing or the **complete** artifact, never a partial DLL. A failed compile discards its staging dir, so a failed emit no longer leaves a discoverable partial DLL either (the old code leaked one).

The only cache enumeration is `TryGetLatestCachedDllPath`'s `{nodeName}_*` glob, which never matches `.staging-*`, so nothing else is affected.

### Tests
- `EmitToDiskWithRetryTest`: 5 existing pass unchanged + 2 new — `Successful_emit_publishes_to_a_discoverable_dir_and_leaves_no_staging`, `Compile_error_leaves_no_discoverable_partial_artifact`.
- Compile integration tests green (10/10): `CompileActivityNoPhantomPathTest`, `CompileSingleDriverConsistencyTest` (the #173 ratchet), `CodeEditRecompile*`, `FrameworkStale*`.

### Confidence
This closes a **real, unit-proven** non-atomic-publish hazard that matches #177's SIGSEGV signature exactly. Because the flake is rare (~1/12) it can't be *proven* eliminated in one PR — CI over subsequent runs is the confirmation. It's a correct, low-risk fix regardless (a cache must never expose a half-written file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
