### PR TITLE
fix(ai+orleans): bound AI streaming + give the stuck-round watchdog a real escape hatch

### DIFF
--- a/src/MeshWeaver.AI/AiStreamingLimits.cs
+++ b/src/MeshWeaver.AI/AiStreamingLimits.cs
@@ -1,0 +1,18 @@
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// Mesh-scoped override for the hard wall-clock cap on a single AI streaming round
+/// (see <c>ThreadExecution.MaxStreamingDuration</c> for the production default and the
+/// full rationale — issue #147). Register as a singleton in the mesh's service
+/// collection to override the cap; when absent, the production default applies.
+/// <para>Primary consumer: tests, which register a short cap to pin the
+/// streaming-timeout behavior deterministically (an instance singleton owned by the
+/// mesh — never a mutable static — per the no-static-state rule).</para>
+/// </summary>
+/// <param name="MaxStreamingDuration">
+/// The wall-clock ceiling for one streaming round at the AI I/O boundary. When the
+/// ceiling is reached, the round's linked CancellationTokenSource fires and the round
+/// terminates as a graceful ERROR (response cell <c>Status = Error</c>), never a
+/// silent hang.
+/// </param>
+public sealed record AiStreamingLimits(TimeSpan MaxStreamingDuration);

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -583,6 +583,19 @@ internal static class ThreadExecution
                         .Timeout(WatchdogRescueBudget)
                         .Subscribe(_ => { }, ex =>
                         {
+                            // Escalate ONLY on the landing-budget timeout — that is the proof the
+                            // action block is blocked. Any other error (validation, access,
+                            // serialization) fails FAST on a healthy hub: deactivating there would
+                            // tear down a healthy grain for a defect deactivate-and-retry cannot
+                            // cure. Those keep the log-and-give-up behavior.
+                            if (ex is not TimeoutException)
+                            {
+                                logger?.LogWarning(ex,
+                                    "[ThreadExec] Init watchdog: force-Idle Update failed for " +
+                                    "{ThreadPath} (non-timeout — hub is responsive, not escalating).",
+                                    threadPath);
+                                return;
+                            }
                             logger?.LogWarning(ex,
                                 "[ThreadExec] Init watchdog: force-Idle Update did not land within " +
                                 "{Budget:F0}s for {ThreadPath} — the hub's action block is blocked (#147).",

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -563,8 +563,44 @@ internal static class ThreadExecution
                             }
                             : node;
                     })
-                        .Subscribe(_ => { }, ex => logger?.LogWarning(ex,
-                            "[ThreadExec] Init watchdog: force-Idle Update failed for {ThreadPath}", threadPath));
+                        // #147 escape hatch. The force-Idle rescue write above rides the hub's own
+                        // action block — which on Orleans runs on the grain's
+                        // ActivationTaskScheduler. In the wedge this watchdog exists for (a
+                        // streaming continuation that never resumed occupying the scheduler slot,
+                        // 1376-message backlog), the rescue write joins the blocked queue and can
+                        // NEVER land: the watchdog fired correctly but could not rescue. A healthy
+                        // hub applies an own-node Update in milliseconds, so a write that neither
+                        // completes within WatchdogRescueBudget nor errors is proof the action
+                        // block is dead → escalate OUT-OF-BAND: RequestGrainDeactivation invokes
+                        // Grain.DeactivateOnIdle via the callback the grain registered at
+                        // activation (this Throttle emission runs on a ThreadPool timer, off the
+                        // blocked scheduler). Deactivation disposes the hub → RegisterForDisposal
+                        // fires executionCts.Cancel() → the stuck call is torn down; the next
+                        // access re-activates fresh and this same recovery drives the persisted
+                        // state to a valid one. In monolith hosting no callback is registered —
+                        // RequestGrainDeactivation returns false (no-op) and the rescue write
+                        // above is the whole story, as before.
+                        .Timeout(WatchdogRescueBudget)
+                        .Subscribe(_ => { }, ex =>
+                        {
+                            logger?.LogWarning(ex,
+                                "[ThreadExec] Init watchdog: force-Idle Update did not land within " +
+                                "{Budget:F0}s for {ThreadPath} — the hub's action block is blocked (#147).",
+                                WatchdogRescueBudget.TotalSeconds, threadPath);
+                            if (hub.RequestGrainDeactivation())
+                                logger?.LogWarning(
+                                    "[ThreadExec] Init watchdog: requested OUT-OF-BAND grain " +
+                                    "deactivation for wedged {ThreadPath} — hub disposal will cancel " +
+                                    "the round's CancellationTokenSource and the grain re-activates " +
+                                    "fresh on next access (#147).",
+                                    threadPath);
+                            else
+                                logger?.LogWarning(
+                                    "[ThreadExec] Init watchdog: no grain deactivation callback " +
+                                    "registered for {ThreadPath} (monolith hosting) — rescue write " +
+                                    "failed and no escape hatch is available.",
+                                    threadPath);
+                        });
                 },
                 ex => logger?.LogWarning(ex,
                     "[ThreadExec] Init watchdog stream faulted for {ThreadPath}", threadPath));
@@ -579,6 +615,37 @@ internal static class ThreadExecution
     /// but live round — healthy work bumps <c>LastModified</c> far more often.
     /// </summary>
     private static readonly TimeSpan StuckGracePeriod = TimeSpan.FromSeconds(90);
+
+    /// <summary>
+    /// Budget for the stuck-round watchdog's force-Idle rescue write to LAND. A healthy
+    /// hub applies an own-node <c>stream.Update</c> in milliseconds; when the write does
+    /// not complete within this window the hub's action block itself is blocked — the
+    /// #147 wedge, where the grain's ActivationTaskScheduler slot is occupied by a
+    /// continuation that never resumed, so the rescue write joins the dead backlog and
+    /// can never be processed. Past this budget the watchdog escalates to the
+    /// out-of-band grain deactivation escape hatch
+    /// (<see cref="MessageHubExtensions.RequestGrainDeactivation"/>).
+    /// </summary>
+    private static readonly TimeSpan WatchdogRescueBudget = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Hard wall-clock cap on a single streaming round at the AI I/O boundary (#147).
+    /// The primary defect behind the permanently-wedged thread grain was an UNBOUNDED
+    /// external network wait: an LLM streaming call that never produced another update
+    /// (and never faulted) parked its continuation forever, occupying the grain's
+    /// scheduler slot — 1376 messages queued, recovery only via pod restart. With this
+    /// cap the continuation ALWAYS resumes: the round's linked CancellationTokenSource
+    /// fires and the round terminates as a graceful ERROR (response cell
+    /// <c>Status = Error</c> naming the timeout), so the wedge cannot form.
+    /// <para>Generous enough for legitimate long rounds INCLUDING nested delegation
+    /// trees (a delegating parent holds its round open while sub-threads work) —
+    /// deliberately matched to the grain-side backstop
+    /// <c>MessageHubGrain.MaxLongRunningOperationDuration</c> (30 min), so the
+    /// in-process graceful error fires no later than the grain's own
+    /// stop-extending-lifetime cap. Tests override via <see cref="AiStreamingLimits"/>
+    /// (mesh-scoped singleton, never a mutable static).</para>
+    /// </summary>
+    private static readonly TimeSpan MaxStreamingDuration = TimeSpan.FromMinutes(30);
 
     /// <summary>
     /// True when the thread carries an in-flight <c>delegate_to_agent</c> tool call
@@ -1604,7 +1671,23 @@ internal static class ThreadExecution
                     if (userAccessContext != null)
                         parentHub.ServiceProvider.GetService<AccessService>()?.SetContext(userAccessContext);
 
-                    var ct = executionCts.Token;
+                    // #147: hard wall-clock cap at the I/O boundary. Link to executionCts so a
+                    // user Stop / hub disposal still cancels immediately; CancelAfter adds the
+                    // MaxStreamingDuration ceiling on top. An unbounded external network wait was
+                    // the primary wedge defect (an LLM stream that never yielded another update
+                    // parked the continuation forever) — with the cap, the continuation ALWAYS
+                    // resumes. A timeout-induced cancellation is surfaced as a graceful round
+                    // ERROR (converted to TimeoutException below → the generic catch writes
+                    // Status=Error to the response cell); the requested-cancel path
+                    // (executionCts) keeps its Cancelled semantics. Disposed in the finally,
+                    // before executionCts.
+                    var maxStreamingDuration =
+                        parentHub.ServiceProvider.GetService<AiStreamingLimits>()?.MaxStreamingDuration
+                        ?? MaxStreamingDuration;
+                    var streamingTimeoutCts =
+                        CancellationTokenSource.CreateLinkedTokenSource(executionCts.Token);
+                    streamingTimeoutCts.CancelAfter(maxStreamingDuration);
+                    var ct = streamingTimeoutCts.Token;
                     // responseText / capturedResponseText / segment.ResponseText were
                     // wired just before the first push (above) so a check_inbox
                     // racing the round start still sees the live accumulator.
@@ -1621,15 +1704,14 @@ internal static class ThreadExecution
                     // the output cell records what really ran, not just what was asked.
                     string? actualModel = null;
 
-                    // No time-limit watchdog. A streaming session blocked on an
-                    // unresponsive AI endpoint, a long-running delegation, or a
-                    // sub-thread doing its own multi-minute work is indistinguishable
-                    // from a "stuck" pipeline from the parent's perspective — and an
-                    // arbitrary deadline that fires `executionCts.Cancel()` would
-                    // tear those down even when something is happening down the tree.
-                    // Manual cancellation via the Stop button (RequestedStatus =
-                    // Cancelled on the thread node, see RequestViaStreamUpdate.md) is
-                    // the only legitimate cancel.
+                    // Cancellation sources, in order of intent:
+                    //   • Stop button / delegation cancel / hub disposal → executionCts →
+                    //     graceful Cancelled (the filtered catch below).
+                    //   • MaxStreamingDuration wall-clock cap → streamingTimeoutCts alone →
+                    //     graceful ERROR (the generic catch below). The cap is generous
+                    //     enough that a legitimate delegation tree completes well within it;
+                    //     only a genuinely-hung endpoint exceeds it (#147). Sub-thread
+                    //     staleness within the cap remains the HeartbeatTicker's job.
 
                     try
                     {
@@ -1993,7 +2075,13 @@ internal static class ThreadExecution
                     NotifyParentCompletion(parentHub, threadPath, finalText, true, aggregatedChanges);
                     EmitCompletionNotification(parentHub, threadPath, finalText, request.AgentName);
                     }
-                    catch (OperationCanceledException)
+                    // Only a REQUESTED cancel (Stop button via RequestedStatus=Cancelled, delegation
+                    // cancel, hub disposal — everything that fires executionCts) is a graceful
+                    // Cancelled. A wall-clock streaming timeout also surfaces as
+                    // OperationCanceledException (the linked streamingTimeoutCts fired WITHOUT
+                    // executionCts) but must NOT masquerade as a user cancel — it falls through to
+                    // the generic catch below and terminates as a round ERROR (#147).
+                    catch (OperationCanceledException) when (executionCts.IsCancellationRequested)
                     {
                         logger.LogInformation("[ThreadExec] CANCELLED: {Time:HH:mm:ss.fff} threadPath={ThreadPath}", DateTime.UtcNow, threadPath);
                         // ToString must be under logLock — UpdateDelegationStatus
@@ -2075,8 +2163,23 @@ internal static class ThreadExecution
                         NotifyParentCompletion(parentHub, threadPath, cancelText, false, cancelNodeChanges);
                         EmitCompletionNotification(parentHub, threadPath, "Cancelled", request.AgentName);
                     }
-                    catch (Exception ex)
+                    catch (Exception exRaw)
                     {
+                        // #147: a wall-clock streaming-timeout cancellation (streamingTimeoutCts
+                        // fired, executionCts did NOT) reaches here as OperationCanceledException.
+                        // Convert it to a descriptive TimeoutException so the standard error path
+                        // below (response cell → Status=Error, thread → Idle, parent notified)
+                        // tells the user WHY the round was aborted instead of a bare "The
+                        // operation was canceled." — never a silent swallow, never a fake cancel.
+                        var ex = exRaw is OperationCanceledException
+                                 && streamingTimeoutCts.IsCancellationRequested
+                                 && !executionCts.IsCancellationRequested
+                            ? new TimeoutException(
+                                $"AI streaming exceeded the maximum round duration of " +
+                                $"{maxStreamingDuration} and was aborted (#147). The model endpoint " +
+                                "stopped responding mid-stream; resubmit to retry.",
+                                exRaw)
+                            : exRaw;
                         logger.LogError(ex, "[ThreadExec] ERROR: {Time:HH:mm:ss.fff} threadPath={ThreadPath}", DateTime.UtcNow, threadPath);
                         // Same lock-guarded snapshot as the cancellation path.
                         string errorTextBase;
@@ -2188,6 +2291,10 @@ internal static class ThreadExecution
                         // BEFORE this, so Reset here cannot lose a fold.
                         ThreadInboxChannel.For(parentHub).Reset();
                         parentHub.Set<CancellationTokenSource>(null!);
+                        // Linked timeout source first (unregisters from executionCts), then the
+                        // round CTS itself. Both catch blocks above read IsCancellationRequested
+                        // BEFORE this finally runs, so disposal never races the classification.
+                        streamingTimeoutCts.Dispose();
                         executionCts.Dispose();
                         // No per-_Exec stream handle to dispose — writes went through
                         // IMeshNodeStreamCache.Update, whose upstream handle is owned

--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -270,7 +270,25 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                 return node.HubConfiguration!(config)
                     .WithTaskScheduler(grainScheduler)
                     .Set(new GrainKeepAliveCallback(() => DelayDeactivation(TimeSpan.FromMinutes(10))))
-                    .Set(new GrainLongRunningOperationCallback(BeginLongRunningOperation));
+                    .Set(new GrainLongRunningOperationCallback(BeginLongRunningOperation))
+                    // #147 escape hatch: the hub's action block runs on THIS grain's
+                    // ActivationTaskScheduler (WithTaskScheduler above), so when a stuck round
+                    // wedges that scheduler, any rescue that is itself a hub message can never be
+                    // processed. This callback lets the stuck-round watchdog (which fires on a
+                    // ThreadPool timer, OFF the blocked scheduler) deactivate the grain directly:
+                    // deactivation disposes the hub → RegisterForDisposal fires
+                    // executionCts.Cancel() → the hung AI call is torn down, and the queued
+                    // deliveries are NACKed instead of piling up forever.
+                    .Set(new GrainDeactivateCallback(() =>
+                    {
+                        logger.LogWarning(
+                            "Grain {GrainId}: out-of-band deactivation requested via " +
+                            "GrainDeactivateCallback — a stuck round could not be rescued through " +
+                            "the hub's message queue (#147). Deactivating so hub disposal cancels " +
+                            "the in-flight operation.",
+                            this.GetPrimaryKeyString());
+                        DeactivateOnIdle();
+                    }));
             })!;
 
             hub.RegisterForDisposal(_ => DeactivateOnIdle());

--- a/src/MeshWeaver.Messaging.Contract/HeartBeatEvent.cs
+++ b/src/MeshWeaver.Messaging.Contract/HeartBeatEvent.cs
@@ -27,3 +27,23 @@ public record GrainKeepAliveCallback(Action KeepAlive);
 /// In monolith mode, no callback is set — returns a no-op disposable.
 /// </summary>
 public record GrainLongRunningOperationCallback(Func<IDisposable> BeginOperation);
+
+/// <summary>
+/// Registered on the hub configuration by the Orleans grain during activation
+/// (alongside <see cref="GrainKeepAliveCallback"/>). Requests IMMEDIATE grain
+/// deactivation (<c>Grain.DeactivateOnIdle</c>) as an OUT-OF-BAND escape hatch that
+/// does NOT ride the hub's message queue.
+/// <para>WHY: the hosted hub's action block runs on the grain's
+/// ActivationTaskScheduler. When a round wedges that scheduler (issue #147: an LLM
+/// streaming continuation that never resumed occupied the single scheduler slot,
+/// queueing 1376 messages), every rescue that is itself a hub message — including the
+/// stuck-round watchdog's force-Idle <c>stream.Update</c> — joins the blocked backlog
+/// and can never be processed. Invoking this callback deactivates the grain WITHOUT
+/// going through the blocked action block; deactivation disposes the hub, which fires
+/// the round's <c>executionCts.Cancel()</c> via <c>RegisterForDisposal</c>, tearing
+/// down the stuck call. The next access re-activates the grain fresh.</para>
+/// <para>In monolith mode, no callback is set — there is no grain scheduler to wedge,
+/// so callers treat the absence as a no-op (see
+/// <c>MessageHubExtensions.RequestGrainDeactivation</c>).</para>
+/// </summary>
+public record GrainDeactivateCallback(Action Invoke);

--- a/src/MeshWeaver.Messaging.Hub/MessageHubExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHubExtensions.cs
@@ -223,4 +223,41 @@ public static class MessageHubExtensions
         // (no grain to delay-deactivate), so a no-op is the correct shape.
         return Disposable.Empty;
     }
+
+    /// <summary>
+    /// Requests immediate deactivation of the Orleans grain hosting this hub, WITHOUT
+    /// going through the hub's message queue. Walks the parent hub chain (like
+    /// <see cref="BeginAsyncOperation"/>) because <see cref="GrainDeactivateCallback"/>
+    /// is set on the grain's top-level hub, not on child hubs (threads' <c>_Exec</c>,
+    /// messages, …).
+    /// <para>This is the #147 escape hatch: the grain-hosted hub's action block runs on
+    /// the grain's ActivationTaskScheduler, so when a stuck round wedges that scheduler
+    /// every message-shaped rescue (including a watchdog's <c>stream.Update</c>) joins
+    /// the blocked backlog and is never processed. The callback deactivates the grain
+    /// out-of-band; deactivation disposes the hub, which cancels the round's
+    /// CancellationTokenSource via <c>RegisterForDisposal</c> and tears down the stuck
+    /// call. The next access re-activates the grain fresh.</para>
+    /// </summary>
+    /// <param name="hub">The hub (or a child of the hub) whose hosting grain should deactivate.</param>
+    /// <returns>
+    /// <c>true</c> when a grain callback was found and invoked; <c>false</c> in monolith
+    /// hosting (no grain — nothing to deactivate; callers treat this as a no-op).
+    /// </returns>
+    public static bool RequestGrainDeactivation(this IMessageHub hub)
+    {
+        var current = hub;
+        while (current != null)
+        {
+            var callback = current.Configuration.Get<GrainDeactivateCallback>();
+            if (callback != null)
+            {
+                callback.Invoke();
+                return true;
+            }
+            var parent = current.Configuration.ParentHub;
+            if (parent == current) break;
+            current = parent;
+        }
+        return false;
+    }
 }

--- a/test/MeshWeaver.AI.Test/StreamingTimeoutTest.cs
+++ b/test/MeshWeaver.AI.Test/StreamingTimeoutTest.cs
@@ -1,0 +1,175 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.ShortGuid;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshThread = MeshWeaver.AI.Thread;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the #147 streaming wall-clock cap: an LLM stream that yields one token and then
+/// NEVER produces another update (and never faults) is the primary wedge defect — the
+/// awaiting continuation parked forever, occupying the grain's scheduler slot with no
+/// recovery short of a pod restart. With the cap, the round's linked
+/// CancellationTokenSource fires at <see cref="AiStreamingLimits.MaxStreamingDuration"/>
+/// and the round MUST terminate as a graceful ERROR: response cell
+/// <see cref="ThreadMessageStatus.Error"/> naming the timeout, thread back to
+/// <see cref="ThreadExecutionStatus.Idle"/> — NEVER a silent hang, and NEVER
+/// masquerading as a user cancel (<see cref="ThreadExecutionStatus.Cancelled"/> is
+/// reserved for the Stop button / hub disposal via executionCts).
+/// </summary>
+public class StreamingTimeoutTest : AITestBase
+{
+    public StreamingTimeoutTest(ITestOutputHelper output) : base(output) { }
+
+    /// <summary>
+    /// Short cap so the test pins the timeout deterministically. The clock starts inside
+    /// the round's I/O-pool lambda (after init / history load), so this bounds only the
+    /// streaming wait itself. Production default is 30 min (ThreadExecution.MaxStreamingDuration).
+    /// </summary>
+    private static readonly TimeSpan TestCap = TimeSpan.FromSeconds(3);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IChatClientFactory>(new HangingChatClientFactory());
+                // Mesh-scoped override (instance singleton, dies with the mesh — never a
+                // mutable static): the production 30-min cap shrunk to seconds.
+                services.AddSingleton(new AiStreamingLimits(TestCap));
+                return services;
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddAITypes();
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    [Fact]
+    public async Task StreamHangsForever_RoundEndsWithTimeoutError_NotSilentWedge()
+    {
+        var threadId = Guid.NewGuid().AsString();
+        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
+        {
+            Name = $"Streaming Timeout Test Thread {threadId}",
+            NodeType = ThreadNodeType.NodeType,
+            MainNode = MonolithMeshTestBase.TestPartition,
+            Content = new MeshThread { CreatedBy = "rbuergi@systemorph.com" }
+        }).Should().Emit();
+
+        var client = GetClient();
+        client.SubmitMessage(
+            threadPath, "trigger the hanging stream",
+            modelName: "hanging-model", createdBy: "rbuergi@systemorph.com");
+
+        // The round must reach the terminal state via the wall-clock cap: TestCap after
+        // the streaming lambda arms the linked CTS, the OperationCanceledException
+        // resumes the parked continuation, is converted to TimeoutException, and the
+        // standard error path lands the thread back at Idle. Budget = cap + generous
+        // slack for init + the terminal writes under CI load — far below the 90 s
+        // stuck-round watchdog grace, proving it's the cap (not the watchdog) rescuing.
+        var terminal = await Mesh.GetWorkspace().GetMeshNodeStream(threadPath)
+            .Select(n => n?.Content as MeshThread)
+            .Where(t => t is not null)
+            .Should().Within(TimeSpan.FromSeconds(45))
+            .Match(t => t!.Status == ThreadExecutionStatus.Idle && t.IngestedMessageIds.Count >= 1);
+
+        terminal!.Status.Should().Be(ThreadExecutionStatus.Idle,
+            "a timed-out round is a round ERROR landing at Idle — Cancelled is reserved " +
+            "for a requested cancel (Stop button / hub disposal), and a node parked at " +
+            "Executing is exactly the #147 wedge");
+        terminal.ActiveMessageId.Should().BeNull("the timed-out round must release its active cell");
+
+        // The response cell carries the timeout as a graceful, explanatory ERROR.
+        terminal.Messages.Should().HaveCountGreaterThanOrEqualTo(2, "user cell + error response cell");
+        var responseCellPath = $"{threadPath}/{terminal.Messages[^1]}";
+        var cell = await Mesh.GetWorkspace().GetMeshNodeStream(responseCellPath)
+            .Select(n => n?.Content as ThreadMessage)
+            .Should().Within(TimeSpan.FromSeconds(10))
+            .Match(m => m is { Status: ThreadMessageStatus.Error });
+        cell!.Text.Should().Contain("exceeded the maximum round duration",
+            "the timeout's message must surface on the error cell so the user sees WHY " +
+            "the round was aborted — never a silent swallow, never a bare 'operation was canceled'");
+    }
+
+    // ─── Chat client that yields one token, then hangs forever (until cancelled) ───
+
+    /// <summary>
+    /// Reproduces the #147 defect shape: a genuinely-hung model endpoint. One real token
+    /// (the round is past the Executing flip, genuinely streaming), then an await that
+    /// only the CancellationToken can complete — exactly like an LLM connection that
+    /// stays open but never sends another byte.
+    /// </summary>
+    private sealed class HangingChatClient : IChatClient
+    {
+        public ChatClientMetadata Metadata => new("HangingProvider");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("non-streaming path must not be used");
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "partial ");
+            // Hang until the round's linked timeout CTS fires. Task.Delay throws
+            // TaskCanceledException (an OperationCanceledException) — the same shape a
+            // hung HTTP read surfaces when its token is cancelled.
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(IChatClient) ? this : null;
+
+        public void Dispose() { }
+    }
+
+    private sealed class HangingChatClientFactory : IChatClientFactory
+    {
+        public string Name => "HangingFactory";
+        public IReadOnlyList<string> Models => ["hanging-model"];
+        public int Order => 0;
+
+        public Microsoft.Agents.AI.ChatClientAgent CreateAgent(
+            AgentConfiguration config,
+            IAgentChat chat,
+            IReadOnlyDictionary<string, Microsoft.Agents.AI.ChatClientAgent> existingAgents,
+            IReadOnlyList<AgentConfiguration> hierarchyAgents,
+            string? modelName = null)
+            => new(
+                chatClient: new HangingChatClient(),
+                instructions: config.Instructions ?? "You hang mid-stream.",
+                name: config.Id,
+                description: config.Description ?? config.Id,
+                tools: [],
+                loggerFactory: null,
+                services: null);
+
+        public Task<Microsoft.Agents.AI.ChatClientAgent> CreateAgentAsync(
+            AgentConfiguration config,
+            IAgentChat chat,
+            IReadOnlyDictionary<string, Microsoft.Agents.AI.ChatClientAgent> existingAgents,
+            IReadOnlyList<AgentConfiguration> hierarchyAgents,
+            string? modelName = null)
+            => Task.FromResult(CreateAgent(config, chat, existingAgents, hierarchyAgents, modelName));
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/RequestGrainDeactivationTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/RequestGrainDeactivationTest.cs
@@ -1,0 +1,64 @@
+using System.Threading;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Pins the #147 out-of-band grain deactivation escape hatch
+/// (<see cref="MessageHubExtensions.RequestGrainDeactivation"/>). The Orleans grain
+/// registers a <see cref="GrainDeactivateCallback"/> on its top-level hub's
+/// configuration during activation; the stuck-round watchdog invokes it when its
+/// force-Idle rescue write cannot land (the hub's action block — running on the
+/// grain's ActivationTaskScheduler — is wedged, so message-shaped rescues join the
+/// blocked backlog forever). Three contracts:
+/// <list type="bullet">
+/// <item>monolith hosting (no callback anywhere) → <c>false</c>, a safe no-op;</item>
+/// <item>callback on the hub itself (the grain topology) → invoked, <c>true</c>;</item>
+/// <item>callback on an ancestor, invoked from a child hub (threads' <c>_Exec</c>,
+/// message cells) → found via the parent-chain walk, same as
+/// <c>BeginAsyncOperation</c> / the HeartBeatEvent handler.</item>
+/// </list>
+/// </summary>
+public class RequestGrainDeactivationTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    [Fact]
+    public void NoCallbackRegistered_MonolithHosting_ReturnsFalse()
+    {
+        // No grain hosting → no GrainDeactivateCallback anywhere in the chain. The
+        // watchdog treats false as "no escape hatch available" and relies on the
+        // rescue write alone — there is no grain scheduler to wedge in monolith.
+        var hub = Mesh.GetHostedHub(new Address("plainhub", "1"), x => x, HostedHubCreation.Always)!;
+        hub.RequestGrainDeactivation().Should().BeFalse();
+    }
+
+    [Fact]
+    public void CallbackOnOwnConfiguration_IsInvokedOnce()
+    {
+        // Mirrors MessageHubGrain.CompleteActivation: the callback is Set on the
+        // grain's top-level hub configuration.
+        var invoked = 0;
+        var hub = Mesh.GetHostedHub(new Address("grainhub", "1"),
+            c => c.Set(new GrainDeactivateCallback(() => Interlocked.Increment(ref invoked))),
+            HostedHubCreation.Always)!;
+
+        hub.RequestGrainDeactivation().Should().BeTrue();
+        invoked.Should().Be(1);
+    }
+
+    [Fact]
+    public void CallbackOnAncestor_FoundFromChildHub()
+    {
+        // The watchdog may run on a hub BELOW the grain's top-level hub (e.g. a
+        // thread's _Exec hosted hub). The extension must walk the parent chain,
+        // exactly like BeginAsyncOperation / HandleHeartBeat.
+        var invoked = 0;
+        var parent = Mesh.GetHostedHub(new Address("grainhub", "parent"),
+            c => c.Set(new GrainDeactivateCallback(() => Interlocked.Increment(ref invoked))),
+            HostedHubCreation.Always)!;
+        var child = parent.GetHostedHub(new Address("execchild", "1"), x => x, HostedHubCreation.Always)!;
+
+        child.RequestGrainDeactivation().Should().BeTrue();
+        invoked.Should().Be(1);
+    }
+}


### PR DESCRIPTION
Closes #147.

## Root cause (from the issue)
The grain-hosted hub's action block runs on the Orleans `ActivationTaskScheduler`. An LLM streaming call with **no timeout** stopped yielding; the awaiting continuation never resumed and occupied the single scheduler slot for 1h+ — 1,376 messages queued, and the stuck-round watchdog's force-Idle `stream.Update` rode the same blocked queue so it could never rescue. Recovery required a pod restart.

## Fixes (Fix 4 + Fix 2 from the issue; Fix 1 already landed in c05e6f23a via #150)

**1. Hard wall-clock cap at the AI I/O boundary** (`ThreadExecution`): the round token is now a `CancellationTokenSource` linked to `executionCts` with `CancelAfter(MaxStreamingDuration = 30 min` — deliberately matched to the grain-side `MaxLongRunningOperationDuration` backstop; overridable via the new mesh-scoped `AiStreamingLimits` singleton for tests`)`. The continuation now **always resumes**, so the wedge cannot form. Timeout ≠ cancel: the Cancelled catch is filtered on `executionCts.IsCancellationRequested`; a timeout falls to the generic path as a descriptive `TimeoutException` → response cell `Status=Error` naming the timeout, thread → Idle, parent notified. Never a silent swallow.

**2. Out-of-band grain-deactivation escape hatch**: `MessageHubGrain` registers a `GrainDeactivateCallback` (`DeactivateOnIdle` + LogWarning) on the hub configuration alongside the existing grain callbacks; new `hub.RequestGrainDeactivation()` walks the parent chain (same pattern as `BeginAsyncOperation`; monolith → `false`, safe no-op). The stuck-round watchdog bounds its rescue write with a 10 s landing budget — an own-node Update on a healthy hub lands in ms — and **only when the write provably cannot land** escalates to deactivation (unconditional deactivation would race the healthy-path rescue and tear down healthy hubs). Deactivation disposes the hub → `executionCts.Cancel()` fires via the existing disposal wiring → the stuck call tears down; next access re-activates fresh.

## Tests
- New `StreamingTimeoutTest`: a chat client that yields one token then hangs forever on the token (the exact defect shape) — round lands Idle with an Error cell naming the timeout; not Cancelled, not a hang.
- New `RequestGrainDeactivationTest`: monolith no-op, own-config invoke, parent-chain walk.
- Regressions green: `RoundFaultTerminalStateTest`, `CancelThreadExecutionTest`, `IsExecutingLifecycleTest`, `MessageHubGrainKeepAliveTest` (4), `OrleansSubmitFromIdleTest` (2 — real grain activation with the new callback).
- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.AI`, `MeshWeaver.Hosting.Orleans`, `MeshWeaver.Messaging.Hub`.

Known gap (stated, not hidden): no TestCluster test drives a *wedged* grain end-to-end (the in-grain hub isn't reachable from the cluster harness); coverage is the unit tests + activation tests + the pre-existing wedged-dispose test proving disposables fire on a blocked action block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)