### PR TITLE
fix(graph): advance the release watcher's dispatch high-water only on the Update COMMIT path

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -587,32 +587,47 @@ internal static class NodeTypeCompilationHelpers
         var parkRegistry = hub.ServiceProvider.GetService<NodeTypeCompileParkRegistry>();
 
         // 🚨 MONOTONIC high-water mark of the highest RequestedReleaseAt this
-        // process has OBSERVED-and-dispatched (the on-node
-        // LastReleaseRequestHandledAt is the cross-silo / restart equivalent).
-        // It is the FLAP-BACK guard.
+        // process has COMMITTED — advanced ONLY where LastReleaseRequestHandledAt
+        // is actually stamped (the on-node stamp is the cross-silo / restart
+        // equivalent). It is the FLAP-BACK guard.
         //
         // Under load, two concurrent cross-hub RequestedReleaseAt patches can
         // apply OUT OF ORDER at the owner, so this OWN stream can momentarily
         // re-emit a node whose RequestedReleaseAt has FLAPPED BACK to an OLDER
         // value AFTER we already saw the newer one (captured trace:
-        // RRW-FIRED req=665 → the node re-emits reqAt=399). Two failures follow
-        // if we ever trust the live value at dispatch time:
-        //   (a) the Update lambda RE-READING def.RequestedReleaseAt would see 399,
-        //       stamp LastReleaseRequestHandledAt = 399 and SKIP the Pending flip
-        //       (399 <= handled) → the genuine recompile NEVER runs → the test's
-        //       WaitForLatestRelease / Status==Ok times out (the whole flake);
-        //   (b) the flapped-back 399 emission would itself spuriously re-fire.
-        // Fix: gate the outer Where on `req > high-water` (a flapped-back older
-        // value can never re-trigger and can never un-handle one already in
-        // flight), and inside the action CARRY the value the Where OBSERVED into
-        // the Update — never re-read def.RequestedReleaseAt live.
+        // RRW-FIRED req=665 → the node re-emits reqAt=399). If the Update lambda
+        // RE-READ def.RequestedReleaseAt it would see 399, stamp
+        // LastReleaseRequestHandledAt = 399 and SKIP the Pending flip
+        // (399 <= handled) → the genuine recompile NEVER runs. Fix: the action
+        // CARRIES the value the Where OBSERVED into the Update — never a live
+        // re-read — and the on-node stamp is written monotonically.
         //
-        // The companion data-layer guard (DataExtensions.DropStaleMonotonicTriggers)
-        // stops the flap-back at its source; this watcher is correct even without
-        // it. The high-water also short-circuits redundant Updates when the
-        // framework re-emits the same trigger faster than our own Update can
-        // round-trip — the role the former `localLastDispatched` served.
-        DateTimeOffset? dispatchHighWater = null;
+        // 🚨 COMMIT-time advance, NEVER dispatch-time (issue #185). The Update
+        // below has bail paths (trigger already handled; status flipped to
+        // Pending/Compiling by an earlier trigger's commit or a concurrent
+        // kickoff) that return `curr` WITHOUT stamping LastReleaseRequestHandledAt.
+        // The old code advanced the high-water EAGERLY in the Subscribe callback,
+        // so a trigger whose Update bailed was left with high-water >= trigger
+        // while the on-node stamp stayed below it — the post-settle re-emission
+        // then failed `req > high-water` and the trigger was LOST for the life of
+        // the process (deterministic repro: ReleaseRequestWatcherHighWaterTest).
+        // Advancing only on the commit path keeps the in-memory mark exactly in
+        // step with the on-node stamp, so a bailed trigger stays live and
+        // re-fires on the next settled emission — the recovery the settled-gate
+        // comment below promises. Cost: between dispatch and commit, a duplicate
+        // or flapped-back emission can re-enter the Subscribe and queue a
+        // redundant Update — which then bails on the `triggerAt <= handled` /
+        // status guards (no double compile, no stale stamp: the carried-trigger
+        // + monotonic-stamp write is what handles flap-back correctness; the
+        // data-layer guard DataExtensions.DropStaleMonotonicTriggers additionally
+        // stops flap-back at its source).
+        //
+        // Tear-free by construction: the mark is advanced inside the Update
+        // lambda (the owner's serialized write path) while the Where reads it on
+        // the reduced-stream emission path — two different serialized contexts,
+        // so the mark uses Interlocked over UTC ticks instead of a bare
+        // Nullable<DateTimeOffset> local.
+        var dispatchHighWater = new MonotonicHighWaterMark();
 
         // 🚨 Gate on Status being SETTLED (Ok / Error / null) — never fire
         // while a compile is in-flight (Pending or Compiling). If we fired
@@ -630,9 +645,10 @@ internal static class NodeTypeCompilationHelpers
         return ownStream
             .Where(node => node?.Content is NodeTypeDefinition def
                 && def.RequestedReleaseAt is { } req
-                // Strictly past our process-local high-water — a flapped-back older
-                // value (or a duplicate emission of the same trigger) never matches.
-                && (dispatchHighWater is null || req > dispatchHighWater.Value)
+                // Strictly past our process-local COMMIT high-water — a flapped-back
+                // older value (or a duplicate emission of an already-committed
+                // trigger) never matches.
+                && dispatchHighWater.IsPast(req)
                 // …and strictly past the on-node last-handled stamp (cross-silo /
                 // restart consistency; owner-written via UpdateOwn, so it never flaps).
                 && (def.LastReleaseRequestHandledAt is null
@@ -649,9 +665,11 @@ internal static class NodeTypeCompilationHelpers
                     // action block (see the high-water comment above).
                     if (node.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions)?.RequestedReleaseAt
                         is not { } triggerAt) return;
-                    // Advance the high-water monotonically. The Where already proved
-                    // triggerAt > dispatchHighWater, so this only ever moves forward.
-                    dispatchHighWater = triggerAt;
+                    // 🚨 NO high-water advance here. The mark advances ONLY on the
+                    // Update's COMMIT path below — where LastReleaseRequestHandledAt
+                    // is actually stamped. Advancing eagerly at dispatch time lost
+                    // any trigger whose Update bailed (issue #185; see the
+                    // high-water comment above).
                     // 🅿️ Deliberate retry → un-park so the explicit rebuild is allowed through
                     // the compile watcher's parked short-circuit (and the attempt budget resets).
                     parkRegistry?.Unpark(hubPath);
@@ -671,13 +689,20 @@ internal static class NodeTypeCompilationHelpers
                             return curr;
                         // Double-check status inside the lambda — OWN's state may have
                         // transitioned to Pending/Compiling between the outer Where
-                        // matching and this lambda running. Returning `curr` unchanged
-                        // is safe: an in-flight compile carries this request to a
-                        // terminal status, and a still-unhandled fresher request
-                        // re-fires on the next settled emission.
+                        // matching and this lambda running (an earlier trigger's commit
+                        // in the same burst, or a concurrent kickoff). Returning `curr`
+                        // unchanged is safe BECAUSE the high-water was not advanced for
+                        // this trigger: it stays strictly above both gates, so the next
+                        // settled emission (Status = Ok / Error after the in-flight
+                        // compile) re-fires it and drives a fresh Pending flip → fresh
+                        // compile with the user's latest edits.
                         if (def.CompilationStatus is CompilationStatus.Pending
                                                   or CompilationStatus.Compiling)
                             return curr;
+                        // COMMIT: this is the one path that stamps
+                        // LastReleaseRequestHandledAt — advance the in-memory
+                        // high-water in the same breath so the two marks never diverge.
+                        dispatchHighWater.Advance(triggerAt);
                         return curr with
                         {
                             Content = def with
@@ -700,6 +725,39 @@ internal static class NodeTypeCompilationHelpers
                 },
                 ex => logger?.LogWarning(ex,
                     "[ReleaseRequestWatcher] {HubPath}: stream faulted", hubPath));
+    }
+
+    /// <summary>
+    /// Process-local monotonic high-water mark over <see cref="DateTimeOffset"/>
+    /// instants for <see cref="InstallReleaseRequestWatcher"/>. Stored as UTC ticks
+    /// behind <see cref="System.Threading.Interlocked"/> because the mark is
+    /// advanced on the owner's serialized write path (inside the Update lambda's
+    /// commit branch) while the watcher's Where reads it on the reduced-stream
+    /// emission path — two different serialized contexts, and a bare
+    /// <c>Nullable&lt;DateTimeOffset&gt;</c> (16 bytes) is not tear-free across
+    /// them. Instance per watcher install (captured in the subscription closure);
+    /// never static (NoStaticState.md).
+    /// </summary>
+    private sealed class MonotonicHighWaterMark
+    {
+        // long.MinValue = "nothing committed yet": every real trigger is past it.
+        private long utcTicks = long.MinValue;
+
+        /// <summary>True when <paramref name="candidate"/> is STRICTLY past the mark.</summary>
+        public bool IsPast(DateTimeOffset candidate) =>
+            candidate.UtcTicks > System.Threading.Interlocked.Read(ref utcTicks);
+
+        /// <summary>Advances the mark to <paramref name="candidate"/> if (and only if)
+        /// it moves forward — monotonic under concurrent advancers.</summary>
+        public void Advance(DateTimeOffset candidate)
+        {
+            var c = candidate.UtcTicks;
+            long seen;
+            while (c > (seen = System.Threading.Interlocked.Read(ref utcTicks))
+                   && System.Threading.Interlocked.CompareExchange(ref utcTicks, c, seen) != seen)
+            {
+            }
+        }
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/ReleaseRequestWatcherHighWaterTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ReleaseRequestWatcherHighWaterTest.cs
@@ -28,11 +28,13 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// <para><b>The forced interleaving</b> (all four writes serialize FIFO on the
 /// owner's MeshNode stream hub as <c>UpdateStreamRequest</c>s):</para>
 /// <list type="number">
-///   <item>A gate write parks the owner's stream action block, so the two
-///     trigger writes P1 (req=T1) and P2 (req=T2) are BOTH enqueued before
-///     either applies. This is what makes the interleaving deterministic:
-///     the watcher's own Update U1 is only posted after P1 applies (after the
-///     gate opens), so U1 provably lands BEHIND P2 in the queue.</item>
+///   <item>A gate write parks the owner's stream action block (a handshake
+///     latch confirms the park has ENGAGED before anything else is posted),
+///     so the two trigger writes P1 (req=T1) and P2 (req=T2) are BOTH
+///     enqueued before either applies. This is what makes the interleaving
+///     deterministic: the watcher's own Update U1 is only posted after P1
+///     applies (after the gate opens), so U1 provably lands BEHIND P2 in
+///     the queue.</item>
 ///   <item>P1 applies → emission (req=T1, status settled) → watcher fires,
 ///     posts U1.</item>
 ///   <item>P2 applies → emission (req=T2, status STILL settled — U1 hasn't
@@ -52,7 +54,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// <c>LastReleaseRequestHandledAt</c> is actually stamped.</para>
 /// </summary>
 public class ReleaseRequestWatcherHighWaterTest(ITestOutputHelper output)
-    : MonolithMeshTestBase(output), IDisposable
+    : MonolithMeshTestBase(output)
 {
     private readonly string _cacheDir = Path.Combine(
         Path.GetTempPath(), $"MeshWeaverHighWaterTest-{Guid.NewGuid():N}");
@@ -70,9 +72,12 @@ public class ReleaseRequestWatcherHighWaterTest(ITestOutputHelper output)
                 }));
     }
 
-    public new void Dispose()
+    /// <summary>Async disposal — xUnit v3 awaits this naturally, so the mesh tears
+    /// down exactly once with no sync-over-async blocking; the per-test compile
+    /// cache dir is cleaned after the mesh (and its compile pipeline) is gone.</summary>
+    public override async ValueTask DisposeAsync()
     {
-        base.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        await base.DisposeAsync();
         if (Directory.Exists(_cacheDir))
             try { Directory.Delete(_cacheDir, recursive: true); } catch { }
     }
@@ -142,17 +147,34 @@ public class ReleaseRequestWatcherHighWaterTest(ITestOutputHelper output)
         //    can only be posted after P1 applies — after the gate opens — so it
         //    provably lands behind P2. Both trigger emissions therefore pass
         //    the watcher's settled-status Where before U1 flips Pending.
+        //
+        //    `parked` is the handshake that PROVES the park engaged: it is set at
+        //    the top of the gate lambda (i.e. the gate write is actively executing
+        //    on the owner's serialized write path), and the test blocks on it
+        //    BEFORE enqueueing the triggers. Without it, on a busy runner the gate
+        //    write could still be queued when the triggers are posted and only
+        //    execute after gate.Set() — nothing parked, the interleaving silently
+        //    degrades to ordinary timing, and the test could false-PASS a future
+        //    regression. Cross-thread ManualResetEventSlim handshake is the
+        //    project's established pattern for synchronous Subscribe-side signals
+        //    (see DeleteNodeBehaviorTest); both waits are bounded so a broken run
+        //    can never wedge the suite.
+        using var parked = new ManualResetEventSlim(false);
         using var gate = new ManualResetEventSlim(false);
         ownWs.GetMeshNodeStream().Update(curr =>
         {
-            // Park the serialized write queue until both triggers are enqueued.
-            // Bounded so a broken run can never wedge the suite.
+            // Handshake: the serialized write queue is now provably parked.
+            parked.Set();
             if (!gate.Wait(TimeSpan.FromSeconds(20)))
                 Output.WriteLine("!!! gate wait timed out — interleaving no longer forced");
             return curr; // no-op
         }).Subscribe(
             _ => { },
             ex => Output.WriteLine($"gate write failed: {ex}"));
+
+        parked.Wait(TimeSpan.FromSeconds(20)).Should().BeTrue(
+            "the gate write must be executing (owner write queue parked) before the "
+            + "triggers are enqueued — otherwise the lost-trigger interleaving is not forced");
 
         var t1 = DateTimeOffset.UtcNow;
         var t2 = t1.AddMilliseconds(200);

--- a/test/MeshWeaver.Hosting.Monolith.Test/ReleaseRequestWatcherHighWaterTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ReleaseRequestWatcherHighWaterTest.cs
@@ -1,0 +1,198 @@
+using System;
+using System.IO;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Deterministic repro for issue #185 residual 1: <c>InstallReleaseRequestWatcher</c>
+/// advanced its process-local <c>dispatchHighWater</c> EAGERLY in the Subscribe
+/// callback — BEFORE the <c>workspace.GetMeshNodeStream().Update(...)</c> that
+/// stamps <c>LastReleaseRequestHandledAt</c> commits. The Update lambda has bail
+/// paths (status already Pending/Compiling, trigger already handled) that return
+/// <c>curr</c> WITHOUT stamping — yet the high-water was already past the trigger,
+/// so the post-settle re-emission failed the <c>req &gt; dispatchHighWater</c> gate
+/// and the trigger was LOST for the lifetime of the process.
+///
+/// <para><b>The forced interleaving</b> (all four writes serialize FIFO on the
+/// owner's MeshNode stream hub as <c>UpdateStreamRequest</c>s):</para>
+/// <list type="number">
+///   <item>A gate write parks the owner's stream action block, so the two
+///     trigger writes P1 (req=T1) and P2 (req=T2) are BOTH enqueued before
+///     either applies. This is what makes the interleaving deterministic:
+///     the watcher's own Update U1 is only posted after P1 applies (after the
+///     gate opens), so U1 provably lands BEHIND P2 in the queue.</item>
+///   <item>P1 applies → emission (req=T1, status settled) → watcher fires,
+///     posts U1.</item>
+///   <item>P2 applies → emission (req=T2, status STILL settled — U1 hasn't
+///     applied) → watcher fires again (T2 &gt; T1), posts U2.</item>
+///   <item>U1 applies → commits Pending + stamps LastReleaseRequestHandledAt=T1
+///     → compile dispatches.</item>
+///   <item>U2 applies → status is Pending → bail → NO stamp. With the eager
+///     advance, dispatchHighWater is already T2, so when the compile settles
+///     the re-emission (req=T2 &gt; handled=T1, status Ok) fails
+///     <c>req &gt; dispatchHighWater</c> — T2 never dispatches. LOST.</item>
+/// </list>
+///
+/// <para><b>The contract this test pins</b> (the watcher's own in-code promise:
+/// "a still-unhandled fresher request re-fires on the next settled emission"):
+/// after the burst settles, <c>LastReleaseRequestHandledAt</c> must reach T2.
+/// Fixed by advancing the high-water ONLY on the Update COMMIT path — where
+/// <c>LastReleaseRequestHandledAt</c> is actually stamped.</para>
+/// </summary>
+public class ReleaseRequestWatcherHighWaterTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output), IDisposable
+{
+    private readonly string _cacheDir = Path.Combine(
+        Path.GetTempPath(), $"MeshWeaverHighWaterTest-{Guid.NewGuid():N}");
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        Directory.CreateDirectory(_cacheDir);
+        return base.ConfigureMesh(builder)
+            .ConfigureServices(services => services
+                .Configure<CompilationCacheOptions>(o =>
+                {
+                    o.CacheDirectory = _cacheDir;
+                    o.EnableCompilationCache = true;
+                    o.EnableDiskCache = true;
+                }));
+    }
+
+    public new void Dispose()
+    {
+        base.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        if (Directory.Exists(_cacheDir))
+            try { Directory.Delete(_cacheDir, recursive: true); } catch { }
+    }
+
+    private const string CodeV1 = """
+        using MeshWeaver.Layout.Composition;
+        public static class HighWaterLayoutAreas
+        {
+            public static UiControl Overview(LayoutAreaHost host, RenderingContext _)
+                => Controls.Html("<div id='marker'>HIGHWATER_V1</div>");
+        }
+        """;
+
+    [Fact(Timeout = 60000)]
+    public async Task BurstOfTwoReleaseTriggers_SecondTriggerIsNotLost()
+    {
+        var typePath = $"{TestPartition}/HighWaterType";
+
+        // 1. Create the NodeType + a valid source; the first-build kickoff
+        //    compiles it. Wait for the settled Ok state (this also guarantees
+        //    RequestedReleaseAt / LastReleaseRequestHandledAt are still null —
+        //    the kickoff flips Pending directly, never the release trigger).
+        await NodeFactory.CreateNode(new MeshNode("HighWaterType", TestPartition)
+        {
+            Name = "High Water Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Repro for the eager high-water advance (issue #185).",
+                Configuration = "config => config.AddDefaultLayoutAreas().AddLayout(layout => layout.WithView(\"Overview\", HighWaterLayoutAreas.Overview))",
+            }
+        }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("code", $"{typePath}/Source")
+        {
+            Name = "Code",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = CodeV1, Language = "csharp" }
+        }).Should().Within(30.Seconds()).Emit();
+
+        await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(50.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LatestReleasePath)
+                && d.RequestedReleaseAt is null
+                && d.LastReleaseRequestHandledAt is null);
+        Output.WriteLine("=== first build settled Ok ===");
+
+        // Diagnostic tail: print every (status, req, handled) transition so a
+        // timeout failure shows exactly where the state machine stopped.
+        using var diag = Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Where(n => n?.Content is NodeTypeDefinition)
+            .Select(n => (NodeTypeDefinition)n!.Content!)
+            .DistinctUntilChanged(d => (d.CompilationStatus, d.RequestedReleaseAt, d.LastReleaseRequestHandledAt))
+            .Subscribe(d => Output.WriteLine(
+                $"[node] status={d.CompilationStatus} req={d.RequestedReleaseAt:O} handled={d.LastReleaseRequestHandledAt:O}"));
+
+        // 2. Grab the per-NodeType hub — the OWNER. Its own-stream writes are
+        //    the ones that serialize FIFO with the watcher's Update.
+        var nodeHub = Mesh.GetHostedHub(new Address(typePath), HostedHubCreation.Never);
+        nodeHub.Should().NotBeNull("the per-NodeType hub must be live after the first compile");
+        var ownWs = nodeHub!.GetWorkspace();
+
+        // 3. Park the owner's MeshNode stream action block with a no-op gate
+        //    write, then enqueue BOTH trigger writes while it is parked. This
+        //    forces the queue order [gate, P1, P2, U1, U2]: the watcher's U1
+        //    can only be posted after P1 applies — after the gate opens — so it
+        //    provably lands behind P2. Both trigger emissions therefore pass
+        //    the watcher's settled-status Where before U1 flips Pending.
+        using var gate = new ManualResetEventSlim(false);
+        ownWs.GetMeshNodeStream().Update(curr =>
+        {
+            // Park the serialized write queue until both triggers are enqueued.
+            // Bounded so a broken run can never wedge the suite.
+            if (!gate.Wait(TimeSpan.FromSeconds(20)))
+                Output.WriteLine("!!! gate wait timed out — interleaving no longer forced");
+            return curr; // no-op
+        }).Subscribe(
+            _ => { },
+            ex => Output.WriteLine($"gate write failed: {ex}"));
+
+        var t1 = DateTimeOffset.UtcNow;
+        var t2 = t1.AddMilliseconds(200);
+        ownWs.GetMeshNodeStream().Update(curr =>
+            curr.Content is not NodeTypeDefinition d
+                ? curr
+                : curr with
+                {
+                    Content = d with { RequestedReleaseAt = t1, RequestedReleaseForce = true }
+                })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"P1 write failed: {ex}"));
+        ownWs.GetMeshNodeStream().Update(curr =>
+            curr.Content is not NodeTypeDefinition d
+                ? curr
+                : curr with
+                {
+                    Content = d with { RequestedReleaseAt = t2, RequestedReleaseForce = true }
+                })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"P2 write failed: {ex}"));
+
+        Output.WriteLine($"=== triggers enqueued: t1={t1:O} t2={t2:O} — opening gate ===");
+        gate.Set();
+
+        // 4. The CONTRACT: every trigger is eventually handled. The watcher's
+        //    Update for T2 bails (status is Pending from T1's dispatch), so T2
+        //    must re-fire on the post-settle emission and be stamped. With the
+        //    eager high-water advance, that re-fire is gated off and
+        //    LastReleaseRequestHandledAt stays at t1 forever — this wait times
+        //    out, pinning the lost trigger.
+        await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(45.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.LastReleaseRequestHandledAt is { } handled
+                && handled >= t2);
+        Output.WriteLine("=== t2 handled ===");
+
+        // And the whole machine settles cleanly afterwards.
+        await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(45.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok);
+    }
+}


### PR DESCRIPTION
Addresses residual 1 of #185 (the watcher eager high-water advance) — residuals 2 (flake-repro workflow) and 3 remain open, so this does not close the issue.

## Verdict: the lost trigger was REAL
Pinned first with a deterministic repro per repo rules — `ReleaseRequestWatcherHighWaterTest` parks the owner's serialized write queue with a gate write and enqueues two triggers while parked, forcing the exact interleaving with no timing races. **Red on unmodified main** (frozen at `status=Ok, req=T2, handled=T1` — the trigger lost for the life of the process), green with the fix.

## The interleaving (bail path C)
Two triggers T1 < T2 enqueue back-to-back → emission E1 advances the high-water **eagerly** to T1 and posts U1 → E2 (still settled, U1 not yet applied) advances eagerly to **T2** and posts U2 → U1 commits (Pending, `handled=T1`) → U2 bails on the status guard **without stamping** → compile settles → the recovery re-emission `req=T2 > handled=T1` fails `req > dispatchHighWater` (T2 > T2 is false) → T2 never dispatches. The in-code claim that "the in-flight compile carries this request to a terminal status" was false — the settled re-emission *was* the intended recovery, and the eager advance gated it off. Bail A (untyped-degrade) had the same lossy shape; bail B (`triggerAt <= handled`) is genuinely safe.

## Fix
Re-derives #124's refinement against post-#173 code: the high-water advances **only in the Update lambda's commit branch**, in the same breath as the `LastReleaseRequestHandledAt` stamp — the in-memory mark can no longer run ahead of the on-node stamp, so a bailed trigger stays live and re-fires on the next settled emission. Since commit runs on the owner's write path while the `Where` reads on the emission path, the mark is a per-install `MonotonicHighWaterMark` (Interlocked over UTC ticks — no torn reads, no static state). Flap-back correctness unchanged (carried trigger + monotonic stamp + `DropStaleMonotonicTriggers`); the only cost is an occasional redundant Update in the dispatch-to-commit window, which bails on the existing guards.

## Tests
- New deterministic repro/`ReleaseRequestWatcherHighWaterTest` (red on main → green): documents the guarantee.
- Regressions: `CodeEditRecompileTest` 5/5, `NodeTypeReleaseGateTest` 4/4, `NodeTypeReleaseTest` (Monolith + Graph) and `NodeTypeCompilationHelpersTest` 33/33.
- Full-solution `dotnet build -c Release -warnaserror`: clean, including after merging current main.
- No overlap with #190 (it touches only `MeshNodeCompilationService.EmitToDiskWithRetry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)