### PR TITLE
fix(layout): property forms — free-text fields span the full row and read-only values wrap

### DIFF
--- a/src/MeshWeaver.Layout/Domain/EditLayoutArea.cs
+++ b/src/MeshWeaver.Layout/Domain/EditLayoutArea.cs
@@ -250,7 +250,7 @@ public static class EditLayoutArea
             foreach (var prop in regularProps)
             {
                 var control = host.Hub.ServiceProvider.MapToToggleableControl(prop, dataId, canEdit, host, isToggleable, boundDataContext);
-                propsGrid = propsGrid.WithView(control, s => s.WithXs(12).WithMd(6).WithLg(4));
+                propsGrid = propsGrid.WithView(control, s => s.WithPropertyCellSizing(prop));
             }
 
             stack = stack.WithView(propsGrid);
@@ -282,6 +282,35 @@ public static class EditLayoutArea
         string dataId,
         bool canEdit,
         bool isToggleable = true) => BuildPropertyForm(host, contentType, dataId, canEdit, isToggleable);
+
+    /// <summary>
+    /// Applies the responsive grid-cell sizing for a property rendered in the auto-generated property form.
+    /// Plain free-text string properties span the full row (<c>Xs(12)</c> at every breakpoint) so long values
+    /// stay readable without entering edit mode; structured values (numbers, dates, booleans, enums,
+    /// dimension / mesh-node references, fixed option lists — all short labels) keep the compact responsive
+    /// cells (<c>Xs(12).Md(6).Lg(4)</c>, up to three per row on large screens).
+    /// </summary>
+    /// <param name="skin">The grid item skin to configure.</param>
+    /// <param name="property">The property rendered in this grid cell.</param>
+    /// <returns>A new <see cref="LayoutGridItemSkin"/> with the sizing appropriate for the property.</returns>
+    public static LayoutGridItemSkin WithPropertyCellSizing(this LayoutGridItemSkin skin, PropertyInfo property)
+        => IsFreeTextProperty(property)
+            ? skin.WithXs(12)
+            : skin.WithXs(12).WithMd(6).WithLg(4);
+
+    /// <summary>
+    /// Determines whether a property renders as plain free text: a <see cref="string"/> property without a
+    /// <see cref="DimensionAttribute"/>, without a <see cref="MeshNodeAttribute"/> reference, and without fixed
+    /// <see cref="UiControlAttribute.Options"/> — i.e. its value length is unbounded, so it needs the full row
+    /// to be readable. Structured references and option-backed strings render as short labels and stay compact.
+    /// </summary>
+    /// <param name="property">The property to classify.</param>
+    /// <returns><c>true</c> when the property is a plain free-text string; otherwise <c>false</c>.</returns>
+    public static bool IsFreeTextProperty(PropertyInfo property)
+        => property.PropertyType == typeof(string)
+           && property.GetCustomAttribute<DimensionAttribute>() == null
+           && property.GetCustomAttribute<MeshNodeAttribute>() == null
+           && property.GetCustomAttribute<UiControlAttribute>()?.Options == null;
 
     /// <summary>
     /// Gets the consistent data ID for a node path. Used by both header and property overview.

--- a/src/MeshWeaver.Layout/EditorExtensions.cs
+++ b/src/MeshWeaver.Layout/EditorExtensions.cs
@@ -980,10 +980,12 @@ public static class EditorExtensions
         }
         else
         {
+            // Generic (free-text) read-only label: wrap long values instead of clipping so the
+            // content is readable without entering edit mode (see issue #195).
             readOnlyControl = new LabelControl(new JsonPointerReference(propName))
             {
                 DataContext = EffectiveDataContext(dataId, boundDataContext)
-            }.WithStyle("padding: 8px; min-height: 32px; background: var(--neutral-fill-rest); border-radius: 4px;");
+            }.WithStyle("padding: 8px; min-height: 32px; background: var(--neutral-fill-rest); border-radius: 4px; white-space: pre-wrap; word-break: break-word;");
         }
 
         if (isEditable)

--- a/test/MeshWeaver.Layout.Test/PropertyCellSizingTest.cs
+++ b/test/MeshWeaver.Layout.Test/PropertyCellSizingTest.cs
@@ -1,0 +1,223 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Domain;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Layout.Domain;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Shared test domain for the property-cell sizing tests (issue #195):
+/// plain free-text strings span the full grid row, structured values keep compact cells.
+/// </summary>
+public static class PropertyCellSizingDomain
+{
+    /// <summary>Status enum used to verify enum properties keep the compact cell.</summary>
+    public enum SizingStatus
+    {
+        /// <summary>Open state.</summary>
+        Open,
+        /// <summary>Closed state.</summary>
+        Closed
+    }
+
+    /// <summary>Dimension type referenced by <see cref="SizingEntity.DimensionRef"/>.</summary>
+    public record SizingDimension
+    {
+        /// <summary>The dimension key.</summary>
+        [Key]
+        public string SystemName { get; init; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Entity covering the property-kind discrimination: free-text strings vs structured values
+    /// (numbers, dates, bools, enums, dimension / mesh-node references, fixed option lists).
+    /// </summary>
+    public record SizingEntity
+    {
+        /// <summary>Plain string without structure attributes — free text, spans the full row.</summary>
+        [Key]
+        public string Id { get; init; } = string.Empty;
+
+        /// <summary>Plain free-text string — spans the full row.</summary>
+        [Display(Name = "Notes")]
+        public string Notes { get; init; } = string.Empty;
+
+        /// <summary>Number — keeps the compact cell.</summary>
+        [Display(Name = "Count")]
+        public int Count { get; init; }
+
+        /// <summary>Enum — keeps the compact cell.</summary>
+        [Display(Name = "Status")]
+        public SizingStatus Status { get; init; }
+
+        /// <summary>Date — keeps the compact cell.</summary>
+        [Display(Name = "Due Date")]
+        public DateTime? DueDate { get; init; }
+
+        /// <summary>Boolean — keeps the compact cell.</summary>
+        [Display(Name = "Is Active")]
+        public bool IsActive { get; init; }
+
+        /// <summary>Dimension reference (short label) — keeps the compact cell.</summary>
+        [Dimension(typeof(SizingDimension))]
+        [Display(Name = "Dimension")]
+        public string? DimensionRef { get; init; }
+
+        /// <summary>Mesh-node reference (stores a node path, rendered as a short label) — keeps the compact cell.</summary>
+        [MeshNode("nodeType:Story")]
+        [Display(Name = "Node")]
+        public string? NodeRef { get; init; }
+
+        /// <summary>String backed by fixed options (select, short label) — keeps the compact cell.</summary>
+        [UiControl(Options = new[] { "Small", "Medium", "Large" })]
+        [Display(Name = "Size")]
+        public string? Size { get; init; }
+    }
+
+    /// <summary>Resolves a property of <see cref="SizingEntity"/> by name.</summary>
+    /// <param name="name">The property name.</param>
+    public static PropertyInfo Property(string name) => typeof(SizingEntity).GetProperty(name)!;
+}
+
+/// <summary>
+/// Unit tests for <see cref="EditLayoutArea.WithPropertyCellSizing"/> /
+/// <see cref="EditLayoutArea.IsFreeTextProperty"/>: the sizing decision that lets long
+/// free-text values span the full row while structured values keep the compact
+/// Xs(12).Md(6).Lg(4) cells (issue #195).
+/// </summary>
+public class PropertyCellSizingTest
+{
+    /// <summary>
+    /// Plain free-text string properties (no [Dimension], no [MeshNode], no fixed Options)
+    /// span the full row: Xs(12) with no Md/Lg overrides (FluentGridItem cascades the last
+    /// defined smaller breakpoint upward, so Xs(12) alone means full width at every breakpoint).
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(PropertyCellSizingDomain.SizingEntity.Id))]
+    [InlineData(nameof(PropertyCellSizingDomain.SizingEntity.Notes))]
+    public void FreeTextString_SpansFullRow(string propertyName)
+    {
+        var property = PropertyCellSizingDomain.Property(propertyName);
+
+        EditLayoutArea.IsFreeTextProperty(property).Should().BeTrue();
+
+        var skin = new LayoutGridItemSkin().WithPropertyCellSizing(property);
+        skin.Xs.Should().Be(12);
+        skin.Md.Should().BeNull("free-text values must keep the full row on medium screens");
+        skin.Lg.Should().BeNull("free-text values must keep the full row on large screens");
+    }
+
+    /// <summary>
+    /// Structured values — numbers, dates, booleans, enums, dimension / mesh-node references,
+    /// and option-backed strings — keep the compact responsive cells (Xs(12).Md(6).Lg(4)).
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(PropertyCellSizingDomain.SizingEntity.Count))]
+    [InlineData(nameof(PropertyCellSizingDomain.SizingEntity.Status))]
+    [InlineData(nameof(PropertyCellSizingDomain.SizingEntity.DueDate))]
+    [InlineData(nameof(PropertyCellSizingDomain.SizingEntity.IsActive))]
+    [InlineData(nameof(PropertyCellSizingDomain.SizingEntity.DimensionRef))]
+    [InlineData(nameof(PropertyCellSizingDomain.SizingEntity.NodeRef))]
+    [InlineData(nameof(PropertyCellSizingDomain.SizingEntity.Size))]
+    public void StructuredValue_KeepsCompactCell(string propertyName)
+    {
+        var property = PropertyCellSizingDomain.Property(propertyName);
+
+        EditLayoutArea.IsFreeTextProperty(property).Should().BeFalse();
+
+        var skin = new LayoutGridItemSkin().WithPropertyCellSizing(property);
+        skin.Xs.Should().Be(12);
+        skin.Md.Should().Be(6);
+        skin.Lg.Should().Be(4);
+    }
+}
+
+/// <summary>
+/// Integration test: BuildPropertyForm applies the per-property cell sizing to the rendered
+/// layout grid — the grid item skins that reach the client carry Xs(12) full-width for
+/// free-text strings and Xs(12).Md(6).Lg(4) for structured values (issue #195).
+/// </summary>
+[Collection("PropertyCellSizingRenderTests")]
+public class PropertyFormCellSizingRenderTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string SizingFormView = nameof(SizingFormView);
+
+    private UiControl SizingFormViewDefinition(LayoutAreaHost host, RenderingContext ctx)
+    {
+        var dataId = "sizing_entity";
+        host.UpdateData(dataId, new PropertyCellSizingDomain.SizingEntity
+        {
+            Id = "sizing-1",
+            Notes = "A long extracted value that must be readable without entering edit mode.",
+            Count = 42,
+            Status = PropertyCellSizingDomain.SizingStatus.Open,
+            DueDate = new DateTime(2026, 1, 1),
+            IsActive = true
+        });
+
+        return EditLayoutArea.BuildPropertyForm(host, typeof(PropertyCellSizingDomain.SizingEntity), dataId, canEdit: true);
+    }
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+    {
+        return base.ConfigureHost(configuration)
+            .AddLayout(layout => layout.WithView(SizingFormView, SizingFormViewDefinition));
+    }
+
+    /// <summary>
+    /// Renders the property form and asserts the grid item skin of every property cell:
+    /// the free-text string cells span the full row, the structured cells stay compact.
+    /// </summary>
+    [Fact]
+    public async Task PropertyForm_SizesCellsByPropertyKind()
+    {
+        var host = GetHost();
+        var workspace = host.GetWorkspace();
+        var area = workspace.GetStream(new LayoutAreaReference(SizingFormView));
+
+        var control = await area
+            .GetControlStream(SizingFormView)
+            .Should().Within(10.Seconds()).Match(x => x is StackControl);
+        var formStack = (StackControl)control!;
+
+        // BuildPropertyForm puts the regular properties into a LayoutGrid as the first area.
+        var gridAreaId = formStack.Areas.First().Area.ToString()!;
+        var gridControl = await area
+            .GetControlStream(gridAreaId)
+            .Should().Within(10.Seconds()).Match(x => x is LayoutGridControl);
+        var grid = (LayoutGridControl)gridControl!;
+
+        // Grid areas follow the declaration order of the (browsable, non-title) properties.
+        var expectedProperties = typeof(PropertyCellSizingDomain.SizingEntity).GetProperties()
+            .Where(p => !EditLayoutArea.IsTitleProperty(p.Name))
+            .ToList();
+        grid.Areas.Should().HaveCount(expectedProperties.Count);
+
+        for (var i = 0; i < expectedProperties.Count; i++)
+        {
+            var property = expectedProperties[i];
+            var skin = grid.Areas[i].Skins.OfType<LayoutGridItemSkin>().Single();
+
+            skin.Xs.Should().Be(12, $"every property cell spans the full row on XS ({property.Name})");
+
+            if (EditLayoutArea.IsFreeTextProperty(property))
+            {
+                skin.Md.Should().BeNull($"free-text property {property.Name} must span the full row on MD");
+                skin.Lg.Should().BeNull($"free-text property {property.Name} must span the full row on LG");
+            }
+            else
+            {
+                skin.Md.Should().Be(6, $"structured property {property.Name} keeps the compact MD cell");
+                skin.Lg.Should().Be(4, $"structured property {property.Name} keeps the compact LG cell");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #195.

Auto-generated node detail pages forced EVERY property into the same responsive ⅓-width cell (`Xs(12).Md(6).Lg(4)`), so long free-text values (e.g. extracted Geschäftsbericht content in `AgenticPension/Erhebung/*` "Wert (roh)") clipped and were only readable after click-to-edit.

## Changes (per the issue's own proposal)
- `EditLayoutArea.BuildPropertyForm` now sizes cells via a new documented extension `WithPropertyCellSizing(this LayoutGridItemSkin, PropertyInfo)`:
  - **free text** — `string` property with no `[Dimension]`, no `[MeshNode]`, no fixed `UiControlAttribute.Options` — spans the **full row** (`Xs(12)` only; FluentGridItem cascades the smaller breakpoint upward, so full width everywhere);
  - **structured values** (numbers, dates, bools, enums, dimension/mesh-node refs, options-backed strings) keep the compact `Xs(12).Md(6).Lg(4)`.
- `EditorExtensions.BuildReadonlyControl`: the generic free-text read-only label gets `white-space: pre-wrap; word-break: break-word;` (the issue's spec) so long values wrap instead of clipping — style verified to reach the DOM through `FluentLabel Style`.
- Markdown (`SeparateEditView`) and collection properties already render full-width outside the grid — untouched.

## Issue item 2 is obsolete
`MeshNodePropertyEditor.cs` no longer exists on main (deleted in `1baa30908`, node-bound DataContext migration); `OverviewLayoutArea.BuildPropertyOverview` delegates to `EditLayoutArea.BuildPropertyForm`, so the single sizing site covers both renderers the issue names. Repo-wide grep confirms no other property-form sizing sites.

## Tests
- New `PropertyCellSizingTest`: 9/9 — free-text theories (incl. a `[Key]` string) get full-row; `[Dimension]`/`[MeshNode]`/Options-backed strings/int/date/bool/enum stay compact.
- New `PropertyFormCellSizingRenderTest`: 1/1 — rendered `LayoutGridControl` areas carry the expected skins end-to-end through JSON round-trip.
- Regressions green: `MapToToggleableControlTest` 6/6, `DomainLayoutServiceTest` 2/2, `InlineEditingTest` 6/6, `OverviewLayoutAreaTest` 9/9, `InlineEditingWorkflowTest` 6/6.
- Full solution `-c Release -p:CIRun=true -warnaserror`: clean.

Visual confirmation on a live portal (e.g. `AgenticPension/Jahresbericht/*`) remains to be eyeballed after deploy — skins/styles are asserted at the control-tree level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)