### PR TITLE
feat(training-ux): bottom cell toolbar + copy-to-home, spinner RCA (3 root fixes), PromptCell, executable idea pages, svg icon sizing

### DIFF
--- a/src/MeshWeaver.AI/Data/Agent/TrainingSim.md
+++ b/src/MeshWeaver.AI/Data/Agent/TrainingSim.md
@@ -1,0 +1,29 @@
+---
+nodeType: Agent
+name: TrainingSim
+description: The in-course demo agent behind PromptCell exercises — turns a learner's data/analysis prompt into ONE concise, well-commented C# script cell with its result. Never touches nodes outside the exercise context.
+icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.7 4.3L18 9l-4.3 1.7L12 15l-1.7-4.3L6 9l4.3-1.7z"/><path d="M5 17l.9 2.1L8 20l-2.1.9L5 23l-.9-2.1L2 20l2.1-.9z"/><rect x="14" y="16" width="8" height="6" rx="1"/><path d="M16 19h4"/></svg>
+category: Agents
+exposedInNavigator: false
+plugins:
+  - Mesh
+---
+
+You are **TrainingSim**, the in-course demo agent for the Agentic Engineering training. Learners on a course page or exercise send you a data/analysis prompt through a PromptCell; you show them what an agent round looks like: **one code cell in, one result out**.
+
+# The one shape you produce
+
+Every answer is exactly:
+
+1. **ONE concise, well-commented C# script cell** — the course's in-RAM data idioms: a small `record`, an inline array or dictionary of literal values, LINQ over it, and a framework control as the last expression (`Controls.DataGrid(rows)`, a `Charts.Column/Bar/Line/Pie(...)` chart, or a `SliceBy(...).To*Chart(...)` pivot). Comments explain the WHY of each step in one short line — the cell is teaching material, not production code.
+2. **Execute it and return the result** beneath the cell — the rendered control or value, plus at most one sentence of framing.
+
+Nothing else: no multi-file plans, no alternative solutions, no follow-up questions unless the prompt is genuinely unanswerable as a single cell (then ask ONE question).
+
+# Hard rules
+
+- **One code block + one result per answer.** If the ask doesn't fit one cell, produce the best single-cell version and say in one line what was cut.
+- **In-RAM data only.** Fabricate small plausible literal datasets inline (5–10 rows). Never load files, never call external services.
+- **Never touch nodes outside the current exercise context.** You may read the exercise's own context node when one is provided; you never create, update, move, or delete mesh nodes anywhere. Your product is the code cell and its result, not mesh state.
+- **Framework controls, never hand-built HTML.** Tables are `Controls.DataGrid`, charts are the `Charts` / `SliceBy` API — exactly what the course pages teach.
+- Keep the whole answer short: the code block, the result, one framing sentence. Learners read dozens of these per session.

--- a/src/MeshWeaver.AI/TrainingSimResponder.cs
+++ b/src/MeshWeaver.AI/TrainingSimResponder.cs
@@ -1,0 +1,118 @@
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using MeshWeaver.Layout;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// LIVE-mode adapter for <see cref="PromptCell"/>: wires the cell's
+/// <c>Responder</c> contract to a REAL agent thread. The prompt is submitted
+/// through the canonical <see cref="HubThreadExtensions.StartThread"/> surface
+/// (agent <see cref="AgentName"/> — the dedicated in-course demo agent), the
+/// reply is observed via <see cref="ThreadFlow.ObserveResponses"/> (the standard
+/// mesh-node-stream observation — no polling), and projected into the cell's
+/// <see cref="PromptCellResponse"/> shape (first fenced code block → code pane,
+/// remainder → output pane).
+/// <para>The Simulated mode needs none of this — <see cref="PromptCell.Simulated"/>
+/// lives in MeshWeaver.Layout with no AI reference. This adapter is the thin
+/// LIVE half, kept here because it needs the thread-submission surface.</para>
+/// </summary>
+public static class TrainingSimResponder
+{
+    /// <summary>The dedicated training agent (Data/Agent/TrainingSim.md).</summary>
+    public const string AgentName = "TrainingSim";
+
+    /// <summary>
+    /// Upper bound on one live round. When it trips, the failure is SURFACED to
+    /// the cell's output pane ("could not answer") — a graceful sink, never a
+    /// silent spinner.
+    /// </summary>
+    public static readonly TimeSpan RoundTimeout = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Builds a LIVE responder: each submitted prompt starts a thread under
+    /// <paramref name="namespacePath"/> with the training agent and completes
+    /// with the projected reply. Errors (thread refused, round failed, timeout)
+    /// propagate as OnError — <see cref="PromptCell"/> renders them in the
+    /// exchange pane.
+    /// </summary>
+    /// <param name="hub">The hub used to submit and observe (client-side hub).</param>
+    /// <param name="namespacePath">The exercise namespace the thread anchors under.</param>
+    /// <param name="agentName">Override for the agent (default <see cref="AgentName"/>).</param>
+    /// <param name="contextPath">Optional context node the agent reads.</param>
+    public static Func<string, IObservable<PromptCellResponse>> Live(
+        IMessageHub hub,
+        string namespacePath,
+        string? agentName = null,
+        string? contextPath = null)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        if (string.IsNullOrEmpty(namespacePath))
+            throw new ArgumentException("namespacePath is required", nameof(namespacePath));
+        var agent = string.IsNullOrEmpty(agentName) ? AgentName : agentName!;
+
+        return prompt => Observable.Create<PromptCellResponse>(observer =>
+        {
+            var replySubscription = new SerialDisposable();
+            hub.StartThread(
+                namespacePath,
+                prompt,
+                agentName: agent,
+                contextPath: contextPath,
+                onCreated: node => replySubscription.Disposable =
+                    ThreadFlow.ObserveResponses(hub, node.Path)
+                        .Take(1)
+                        .Timeout(RoundTimeout)
+                        .Subscribe(
+                            reply =>
+                            {
+                                observer.OnNext(Project(reply.Message));
+                                observer.OnCompleted();
+                            },
+                            observer.OnError),
+                onError: error => observer.OnError(new InvalidOperationException(error)));
+            return replySubscription;
+        });
+    }
+
+    /// <summary>
+    /// Projects an assistant reply into the cell's three-pane shape: the FIRST
+    /// fenced code block becomes the code pane; everything else renders as the
+    /// output markdown. A reply without a fence yields an empty code pane.
+    /// </summary>
+    public static PromptCellResponse Project(ThreadMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        var text = message.Text ?? "";
+        var (code, remainder) = ExtractFirstCodeFence(text);
+        var output = string.IsNullOrWhiteSpace(remainder)
+            ? Controls.Markdown("_(no further output)_")
+            : Controls.Markdown(remainder);
+        return new PromptCellResponse(code, output);
+    }
+
+    /// <summary>
+    /// Splits <paramref name="text"/> at its first triple-backtick fence:
+    /// returns the fence BODY (without the fence lines / language tag) and the
+    /// text with that fence removed. No fence → ("", text).
+    /// </summary>
+    internal static (string Code, string Remainder) ExtractFirstCodeFence(string text)
+    {
+        const string fence = "```";
+        var open = text.IndexOf(fence, StringComparison.Ordinal);
+        if (open < 0)
+            return ("", text);
+        var bodyStart = text.IndexOf('\n', open);
+        if (bodyStart < 0)
+            return ("", text);
+        bodyStart++; // past the "```lang" line
+        var close = text.IndexOf(fence, bodyStart, StringComparison.Ordinal);
+        if (close < 0)
+            return ("", text);
+        var code = text[bodyStart..close].TrimEnd('\n', '\r');
+        var closeEnd = close + fence.Length;
+        var remainder = (text[..open] + text[closeEnd..]).Trim();
+        return (code, remainder);
+    }
+}

--- a/src/MeshWeaver.Blazor/Components/MeshNodeCardView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/MeshNodeCardView.razor.css
@@ -33,6 +33,18 @@
     flex-shrink: 0;
 }
 
+/* Inline-SVG icon. Node icons authored as a raw <svg> with a viewBox but NO
+   width/height are injected via MarkupString, so they carry no CSS-isolation
+   scope attribute — a scoped rule can't reach them — and with no intrinsic
+   size they render at the browser default (~300×150) and collapse/overflow,
+   i.e. a blank tile. Constrain any inline SVG to fill the icon box (same fix
+   as MeshSearchView / MeshNodePickerView). */
+::deep .mesh-node-card-image svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
 
 .mesh-node-card-placeholder {
     width: 48px;

--- a/src/MeshWeaver.Blazor/Components/MeshNodeCollectionView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/MeshNodeCollectionView.razor.css
@@ -41,6 +41,16 @@
     flex-shrink: 0;
 }
 
+/* Inline-SVG icon. A viewBox-only <svg> injected via MarkupString has no
+   intrinsic size and no CSS-isolation scope attribute, so without this rule
+   it renders at the browser default size and the avatar shows blank. Same
+   fix as MeshSearchView / MeshNodePickerView. */
+::deep .mesh-node-collection-avatar svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
 ::deep .mesh-node-collection-avatar-icon {
     width: 36px;
     height: 36px;

--- a/src/MeshWeaver.Documentation/Data/GUI/ChartGallery.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/ChartGallery.md
@@ -1,0 +1,94 @@
+---
+Name: Charts at a glance
+Category: Documentation
+Description: A gallery of the Charts API — column, bar, line, pie, and stacked charts from small in-RAM arrays, each framed as the prompt that would produce it.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><rect x="7" y="12" width="3" height="6"/><rect x="12" y="8" width="3" height="10"/><rect x="17" y="5" width="3" height="13"/></svg>
+---
+
+Every chart on this page is a **live, executable cell**: a handful of in-RAM values, one fluent `Charts.*` call, and the rendered chart beneath it. Each cell opens with the *prompt that would produce it* — the exact sentence you could hand an agent to get this chart back as a code cell. The API lives in `MeshWeaver.Layout.Chart` ([`ChartControl`](/Doc/GUI/DisplayControls) family); for slicing a dataset into series first, see the pivot side in [Pivot tricks](../PivotTricks).
+
+## Column — compare categories
+
+> *Prompt: "Show me quarterly revenue for this year as a column chart."*
+
+```csharp --render ColumnDemo --show-code
+using MeshWeaver.Layout.Chart;
+
+// Four quarters of revenue (CHF k) — plain arrays are all a chart needs.
+var revenue = new double[] { 480, 520, 610, 730 };
+var quarters = new[] { "Q1", "Q2", "Q3", "Q4" };
+
+Charts.Column(revenue, quarters, "Revenue (CHF k)")
+    .WithTitle("Quarterly revenue")
+```
+
+## Bar — compare categories with long labels
+
+> *Prompt: "Rank our product lines by units sold, horizontal bars so the names stay readable."*
+
+```csharp --render BarDemo --show-code
+using MeshWeaver.Layout.Chart;
+
+var units = new double[] { 1240, 990, 640, 410 };
+var products = new[] { "Espresso machines", "Grinders", "Filter kits", "Accessories" };
+
+Charts.Bar(units, products, "Units sold")
+    .WithTitle("Product lines by units")
+```
+
+## Line — a trend over time
+
+> *Prompt: "Plot monthly active users for the first half of the year as a line."*
+
+```csharp --render LineDemo --show-code
+using MeshWeaver.Layout.Chart;
+
+var mau = new double[] { 3.1, 3.4, 3.9, 4.6, 5.2, 6.0 };
+var months = new[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun" };
+
+Charts.Line(mau, months, "MAU (k)")
+    .WithTitle("Monthly active users")
+```
+
+## Pie — shares of a whole
+
+> *Prompt: "What's our traffic split by channel? Pie chart, one slice per channel."*
+
+```csharp --render PieDemo --show-code
+using MeshWeaver.Layout.Chart;
+
+var visits = new double[] { 44, 27, 18, 11 };
+var channels = new[] { "Organic", "Paid", "Referral", "Direct" };
+
+Charts.Pie(visits, channels)
+    .WithTitle("Traffic by channel")
+```
+
+## Stacked column — two dimensions in one chart
+
+For two dimensions — categories on the axis, a second dimension stacked inside each column — slice the rows first, then chart the slices. This is the same `SliceBy` pipeline the [data-cube pages](/Doc/DataMesh/DataCubes) build on.
+
+> *Prompt: "Break revenue down by region AND year: one column per year, stacked by region."*
+
+```csharp --render StackedDemo --show-code
+using MeshWeaver.Layout.Chart;
+
+record Sale(string Region, string Year, double Amount);
+
+var sales = new[]
+{
+    new Sale("EMEA", "2024", 320), new Sale("EMEA", "2025", 390),
+    new Sale("Americas", "2024", 280), new Sale("Americas", "2025", 335),
+    new Sale("APAC", "2024", 150), new Sale("APAC", "2025", 205),
+};
+
+sales
+    .SliceBy(s => s.Year)     // one column per year
+    .SliceBy(s => s.Region)   // stacked by region inside each column
+    .ToStackedColumnChart(g => g.Sum(s => s.Amount))
+    .WithTitle("Revenue by year, stacked by region (CHF k)")
+```
+
+Swap `ToStackedColumnChart` for `ToColumnChart` (grouped columns), `ToBarChart` / `ToStackedBarChart` (horizontal), or `ToLineChart` (one line per slice) — the slicing stays identical.
+
+Try these in the Agentic Engineering exercises.

--- a/src/MeshWeaver.Documentation/Data/GUI/PivotTricks.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/PivotTricks.md
@@ -1,0 +1,132 @@
+---
+Name: Pivot tricks
+Category: Documentation
+Description: Pivot and slice patterns over an in-RAM cube — rows-by-X columns-by-Y grids, totals, top-N, and YoY deltas, each framed as the prompt that would produce it.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 3v18"/><path d="M13 13l4 4"/><path d="M17 13v4h-4"/></svg>
+---
+
+Pivoting is the fastest way from a flat list of facts to an answer-shaped table. Every cell on this page is **live and executable** over the same tiny in-RAM cube — a flat `Sale(Region, Product, Year, Amount)` array — and opens with the *prompt that would produce it*. The pivot API lives in `MeshWeaver.Layout.Pivot` (`ToPivotGrid` + `GroupRowsBy` / `GroupColumnsBy` / `Aggregate`); the chart-side twin of the same slicing idea is in [Charts at a glance](../ChartGallery).
+
+## Rows by X, columns by Y
+
+> *Prompt: "Pivot sales: regions as rows, years as columns, sum of amount."*
+
+```csharp --render PivotBasicDemo --show-code
+using MeshWeaver.Layout.Pivot;
+
+record Sale(string Region, string Product, string Year, double Amount);
+
+var sales = new[]
+{
+    new Sale("EMEA", "Espresso", "2024", 210), new Sale("EMEA", "Espresso", "2025", 260),
+    new Sale("EMEA", "Grinder", "2024", 110),  new Sale("EMEA", "Grinder", "2025", 130),
+    new Sale("Americas", "Espresso", "2024", 180), new Sale("Americas", "Espresso", "2025", 215),
+    new Sale("Americas", "Grinder", "2024", 100),  new Sale("Americas", "Grinder", "2025", 120),
+    new Sale("APAC", "Espresso", "2024", 90),  new Sale("APAC", "Espresso", "2025", 135),
+    new Sale("APAC", "Grinder", "2024", 60),   new Sale("APAC", "Grinder", "2025", 70),
+};
+
+sales.ToPivotGrid(pivot => pivot
+    .GroupRowsBy(s => s.Region)
+    .GroupColumnsBy(s => s.Year)
+    .Aggregate(s => s.Amount, agg => agg.WithFunction(AggregateFunction.Sum)))
+```
+
+## Totals — close the table
+
+> *Prompt: "Same pivot, but add row and column totals so I can sanity-check the sums."*
+
+```csharp --render PivotTotalsDemo --show-code
+using MeshWeaver.Layout.Pivot;
+
+record Sale(string Region, string Product, string Year, double Amount);
+
+var sales = new[]
+{
+    new Sale("EMEA", "Espresso", "2024", 210), new Sale("EMEA", "Espresso", "2025", 260),
+    new Sale("EMEA", "Grinder", "2024", 110),  new Sale("EMEA", "Grinder", "2025", 130),
+    new Sale("Americas", "Espresso", "2024", 180), new Sale("Americas", "Espresso", "2025", 215),
+    new Sale("Americas", "Grinder", "2024", 100),  new Sale("Americas", "Grinder", "2025", 120),
+    new Sale("APAC", "Espresso", "2024", 90),  new Sale("APAC", "Espresso", "2025", 135),
+    new Sale("APAC", "Grinder", "2024", 60),   new Sale("APAC", "Grinder", "2025", 70),
+};
+
+sales.ToPivotGrid(pivot => pivot
+    .GroupRowsBy(s => s.Region)
+    .GroupColumnsBy(s => s.Year)
+    .Aggregate(s => s.Amount, agg => agg.WithFunction(AggregateFunction.Sum))
+    .WithRowTotals()
+    .WithColumnTotals())
+```
+
+Two row dimensions work the same way — chain a second `GroupRowsBy(s => s.Product)` and the grid nests products under regions.
+
+## Top-N — cut the long tail
+
+Top-N is a LINQ fold **before** the render: aggregate, order, take, and hand the finished rows to a [DataGrid](../DataGrid).
+
+> *Prompt: "Give me the top 3 region-product combinations by total sales, as a table."*
+
+```csharp --render TopNDemo --show-code
+record Sale(string Region, string Product, string Year, double Amount);
+
+var sales = new[]
+{
+    new Sale("EMEA", "Espresso", "2024", 210), new Sale("EMEA", "Espresso", "2025", 260),
+    new Sale("EMEA", "Grinder", "2024", 110),  new Sale("EMEA", "Grinder", "2025", 130),
+    new Sale("Americas", "Espresso", "2024", 180), new Sale("Americas", "Espresso", "2025", 215),
+    new Sale("Americas", "Grinder", "2024", 100),  new Sale("Americas", "Grinder", "2025", 120),
+    new Sale("APAC", "Espresso", "2024", 90),  new Sale("APAC", "Espresso", "2025", 135),
+    new Sale("APAC", "Grinder", "2024", 60),   new Sale("APAC", "Grinder", "2025", 70),
+};
+
+record TopRow(string Region, string Product, double Total);
+
+var top3 = sales
+    .GroupBy(s => (s.Region, s.Product))
+    .Select(g => new TopRow(g.Key.Region, g.Key.Product, g.Sum(s => s.Amount)))
+    .OrderByDescending(r => r.Total)
+    .Take(3)
+    .ToArray();
+
+Controls.DataGrid(top3)
+```
+
+## YoY deltas — the comparison column
+
+Year-over-year is a self-join on the year dimension: pivot the two years side by side in LINQ, compute the delta, render the finished comparison.
+
+> *Prompt: "Compare 2025 vs 2024 sales per region and show the growth in percent."*
+
+```csharp --render YoyDemo --show-code
+record Sale(string Region, string Product, string Year, double Amount);
+
+var sales = new[]
+{
+    new Sale("EMEA", "Espresso", "2024", 210), new Sale("EMEA", "Espresso", "2025", 260),
+    new Sale("EMEA", "Grinder", "2024", 110),  new Sale("EMEA", "Grinder", "2025", 130),
+    new Sale("Americas", "Espresso", "2024", 180), new Sale("Americas", "Espresso", "2025", 215),
+    new Sale("Americas", "Grinder", "2024", 100),  new Sale("Americas", "Grinder", "2025", 120),
+    new Sale("APAC", "Espresso", "2024", 90),  new Sale("APAC", "Espresso", "2025", 135),
+    new Sale("APAC", "Grinder", "2024", 60),   new Sale("APAC", "Grinder", "2025", 70),
+};
+
+record YoyRow(string Region, double Y2024, double Y2025, string Growth);
+
+var yoy = sales
+    .GroupBy(s => s.Region)
+    .Select(g =>
+    {
+        var y24 = g.Where(s => s.Year == "2024").Sum(s => s.Amount);
+        var y25 = g.Where(s => s.Year == "2025").Sum(s => s.Amount);
+        return new YoyRow(g.Key, y24, y25, $"{(y25 - y24) / y24:P1}");
+    })
+    .OrderByDescending(r => r.Y2025)
+    .ToArray();
+
+Controls.DataGrid(yoy)
+```
+
+The same fold feeds a chart directly — pipe `yoy` into the `SliceBy(...).ToColumnChart(...)` pipeline from [Charts at a glance](../ChartGallery) and the comparison becomes grouped columns.
+
+Try these in the Agentic Engineering exercises.

--- a/src/MeshWeaver.Graph/CodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CodeLayoutAreas.cs
@@ -12,10 +12,12 @@ using MeshWeaver.Layout.Composition;
 using MeshWeaver.Layout.Domain;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Activity;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using MeshWeaver.ShortGuid;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Graph;
 
@@ -48,6 +50,10 @@ public static class CodeLayoutAreas
     public const string CancelButtonArea = "Cancel";
     /// <summary>Area id of the Edit button inside the cell toolbar.</summary>
     public const string EditButtonArea = "Edit";
+    /// <summary>Area id of the Cancel button inside the copy-to-home dialog.</summary>
+    public const string CopyDialogCancelArea = "CopyDialogCancel";
+    /// <summary>Area id of the Confirm button inside the copy-to-home dialog.</summary>
+    public const string CopyDialogConfirmArea = "CopyDialogConfirm";
 
     private const string CodeDataId = "code";
     private const string SiblingNodesDataId = "siblingCodeNodes";
@@ -88,6 +94,15 @@ public static class CodeLayoutAreas
     {
         var nodeStream = host.Workspace.GetMeshNodeStream();
 
+        // The VIEWER's effective permissions on this node — the canonical reactive
+        // check (hub.GetEffectivePermissions; resolves the caller from the ambient
+        // AccessContext at call time, same as GitHubSyncSettingsTab / CopyLayoutArea).
+        // Drives the Edit button's shape: Update permission → direct edit
+        // navigation; no Update → the copy-to-home dialog trigger.
+        var permissionStream = host.Hub
+            .GetEffectivePermissions(host.Hub.Address.ToString())
+            .DistinctUntilChanged();
+
         // The LAST run's live ActivityLog: keyed off the node's LastActivityPath
         // and re-switched whenever a new run stamps a fresh path. Drives the cell
         // toolbar's Cancel visibility reactively — the toolbar re-renders when the
@@ -106,11 +121,11 @@ public static class CodeLayoutAreas
             .DistinctUntilChanged(log => (log?.Status, log?.RequestedStatus))
             .StartWith((ActivityLog?)null);
 
-        return nodeStream.CombineLatest(lastActivityStream,
-            (node, lastActivity) => (UiControl?)BuildContent(host, node, lastActivity));
+        return nodeStream.CombineLatest(lastActivityStream, permissionStream,
+            (node, lastActivity, permissions) => (UiControl?)BuildContent(host, node, lastActivity, permissions));
     }
 
-    private static UiControl BuildContent(LayoutAreaHost host, MeshNode? node, ActivityLog? lastActivity)
+    private static UiControl BuildContent(LayoutAreaHost host, MeshNode? node, ActivityLog? lastActivity, Permission permissions)
     {
         var hubAddress = host.Hub.Address;
         var codeConfig = node.ContentAs<CodeConfiguration>(host.Hub.JsonSerializerOptions);
@@ -126,16 +141,14 @@ public static class CodeLayoutAreas
         stack = stack.WithView(Controls.H1(title).WithStyle("margin: 0 0 16px 0;"));
 
         // ── Notebook cell ────────────────────────────────────────────────────
-        // One visually framed block: toolbar on the top edge, code beneath it,
-        // output attached directly under the code inside the same frame.
+        // One visually framed block: code on top, the run's output attached
+        // directly under it, and the toolbar as a composer-style bar on the
+        // BOTTOM edge (2026-07-03 UX feedback: the controls belong at the foot
+        // of the cell, like a chat composer, not above the code).
         var cell = Controls.Stack
             .WithWidth("100%")
             .WithStyle("border: 1px solid var(--neutral-stroke-rest); border-radius: 6px; " +
                        "overflow: hidden; background: var(--neutral-layer-1);");
-
-        cell = cell.WithView(
-            BuildCellToolbar(hubAddress, codeConfig, isExecutable, language, lastActivity),
-            CellToolbarArea);
 
         // Code segment (markdown fence rendering, unchanged).
         if (!string.IsNullOrEmpty(codeConfig?.Code))
@@ -179,6 +192,13 @@ public static class CodeLayoutAreas
             }
         }
 
+        // Toolbar LAST — the composer bar at the bottom of the cell frame,
+        // below the output segment.
+        cell = cell.WithView(
+            BuildCellToolbar(hubAddress, codeConfig, isExecutable, language, lastActivity,
+                canEdit: permissions.HasFlag(Permission.Update)),
+            CellToolbarArea);
+
         stack = stack.WithView(cell, CellArea);
 
         // No activity history below the cell (removed 2026-07-02 on UX feedback:
@@ -190,22 +210,28 @@ public static class CodeLayoutAreas
     }
 
     /// <summary>
-    /// The cell's toolbar: ▶ Run (accent), ⏹ Cancel (only while the last run is
-    /// actually running and no cancel is already in flight — the shared
+    /// The cell's toolbar — the composer bar on the BOTTOM edge of the cell:
+    /// ▶ Run (accent), ⏹ Cancel (only while the last run is actually running and
+    /// no cancel is already in flight — the shared
     /// <see cref="ActivityLayoutAreas.IsCancelButtonVisible"/> predicate), ✎ Edit,
     /// then subtle right-aligned metadata (language badge, last-run provenance).
+    /// <para>Edit is rights-gated: with <see cref="Permission.Update"/> on the node
+    /// it navigates straight to the Edit area; without it, it opens the
+    /// copy-to-home dialog (<see cref="OpenCopyToHomeDialog"/>) offering to copy
+    /// the node into the viewer's own home space via the standard copy machinery.</para>
     /// </summary>
     private static UiControl BuildCellToolbar(
         Address hubAddress,
         CodeConfiguration? codeConfig,
         bool isExecutable,
         string language,
-        ActivityLog? lastActivity)
+        ActivityLog? lastActivity,
+        bool canEdit)
     {
         var toolbar = Controls.Stack
             .WithOrientation(Orientation.Horizontal)
             .WithStyle("display: flex; align-items: center; gap: 8px; padding: 6px 10px; " +
-                       "background: var(--neutral-layer-2); border-bottom: 1px solid var(--neutral-stroke-rest);");
+                       "background: var(--neutral-layer-2); border-top: 1px solid var(--neutral-stroke-rest);");
 
         if (isExecutable)
         {
@@ -247,11 +273,31 @@ public static class CodeLayoutAreas
             }
         }
 
-        toolbar = toolbar.WithView(Controls.Button("")
-                .WithIconStart(FluentIcons.Edit())
-                .WithAppearance(Appearance.Accent)
-                .WithNavigateToHref(new LayoutAreaReference(EditArea).ToHref(hubAddress)),
-            EditButtonArea);
+        if (canEdit)
+        {
+            // Direct edit navigation — ONLY for viewers holding Update on the node.
+            toolbar = toolbar.WithView(Controls.Button("")
+                    .WithIconStart(FluentIcons.Edit())
+                    .WithAppearance(Appearance.Accent)
+                    .WithNavigateToHref(new LayoutAreaReference(EditArea).ToHref(hubAddress)),
+                EditButtonArea);
+        }
+        else
+        {
+            // Read-only viewer: Edit still shows, but opens the copy-to-home
+            // dialog instead of navigating (no NavigateToHref — the click action
+            // drives the DialogControl area). Identity resolution + the actual
+            // copy happen at CLICK time under the clicker's AccessContext.
+            var sourcePath = hubAddress.ToString();
+            toolbar = toolbar.WithView(Controls.Button("Edit")
+                    .WithIconStart(FluentIcons.Edit())
+                    .WithClickAction(ctx =>
+                    {
+                        OpenCopyToHomeDialog(ctx, sourcePath);
+                        return Task.CompletedTask;
+                    }),
+                EditButtonArea);
+        }
 
         // Right-aligned, subtle metadata: language badge + last-run provenance.
         var meta = Controls.Stack
@@ -272,6 +318,119 @@ public static class CodeLayoutAreas
         toolbar = toolbar.WithView(meta);
 
         return toolbar;
+    }
+
+    /// <summary>
+    /// Opens the read-only-viewer Edit dialog: explains the node is read-only for
+    /// the current viewer and offers to copy it into their home space (Confirm /
+    /// Cancel). Confirm runs the standard <see cref="NodeCopyHelper.CopyNodeTree"/>
+    /// machinery into <c>{viewerHome}/{nodeId}</c> and navigates to the copy's
+    /// Edit area. Anonymous / hub-shaped identities (no home partition) get a
+    /// sign-in hint instead.
+    /// </summary>
+    private static void OpenCopyToHomeDialog(UiActionContext ctx, string sourcePath)
+    {
+        var hub = ctx.Host.Hub;
+        var viewerHome = ResolveViewerHome(hub.ServiceProvider.GetService<AccessService>());
+        if (viewerHome is null)
+        {
+            ctx.Host.UpdateArea(DialogControl.DialogArea, Controls.Dialog(
+                    Controls.Markdown(
+                        "**Sign in required.** This content is read-only, and copying it " +
+                        "into your own home space requires a signed-in account."),
+                    "Read-only content")
+                .WithSize("S").WithClosable(true));
+            return;
+        }
+
+        var nodeId = sourcePath[(sourcePath.LastIndexOf('/') + 1)..];
+        var copyPath = $"{viewerHome}/{nodeId}";
+
+        var body = Controls.Stack
+            .WithStyle("gap: 16px;")
+            .WithView(Controls.Markdown(
+                "This content is read-only for you. We'll copy it to your home space " +
+                "where you can edit your own version."))
+            .WithView(Controls.Stack
+                .WithOrientation(Orientation.Horizontal)
+                .WithStyle("gap: 8px; justify-content: flex-end;")
+                .WithView(Controls.Button("Cancel")
+                        .WithAppearance(Appearance.Neutral)
+                        .WithClickAction(c =>
+                        {
+                            c.Host.UpdateArea(DialogControl.DialogArea, null!);
+                            return Task.CompletedTask;
+                        }),
+                    CopyDialogCancelArea)
+                .WithView(Controls.Button("Copy to my home")
+                        .WithAppearance(Appearance.Accent)
+                        .WithIconStart(FluentIcons.Copy())
+                        .WithClickAction(c =>
+                        {
+                            CopyToHomeAndNavigate(c, sourcePath, viewerHome, copyPath);
+                            return Task.CompletedTask;
+                        }),
+                    CopyDialogConfirmArea));
+
+        ctx.Host.UpdateArea(DialogControl.DialogArea,
+            Controls.Dialog(body, "Copy to your home space?").WithSize("M").WithClosable(true));
+    }
+
+    /// <summary>
+    /// Confirm handler of the copy-to-home dialog: deep-copies the node subtree
+    /// into the viewer's home partition via the standard
+    /// <see cref="NodeCopyHelper.CopyNodeTree"/> (permission checks live in the
+    /// upsert handlers — the viewer needs Create on their own home, which they
+    /// always hold), closes the dialog, and navigates to the copy's Edit area.
+    /// </summary>
+    private static void CopyToHomeAndNavigate(
+        UiActionContext ctx, string sourcePath, string targetNamespace, string copyPath)
+    {
+        var hub = ctx.Host.Hub;
+        var logger = hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>();
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+
+        NodeCopyHelper.CopyNodeTree(
+                meshService, meshService, hub, sourcePath, targetNamespace, force: false, logger)
+            .Subscribe(
+                copied =>
+                {
+                    logger?.LogInformation(
+                        "Copy-to-home complete: {Count} node(s) from {Source} to {Target}",
+                        copied, sourcePath, targetNamespace);
+                    ctx.Host.UpdateArea(DialogControl.DialogArea, null!);
+                    ctx.Host.UpdateArea(ctx.Area,
+                        new RedirectControl(new LayoutAreaReference(EditArea).ToHref(copyPath)));
+                },
+                ex =>
+                {
+                    logger?.LogWarning(ex, "Copy-to-home failed for {Source} -> {Target}",
+                        sourcePath, targetNamespace);
+                    ctx.Host.UpdateArea(DialogControl.DialogArea, Controls.Dialog(
+                            Controls.Markdown($"**Copy failed:**\n\n{ex.Message}"),
+                            "Copy Failed")
+                        .WithSize("M").WithClosable(true));
+                });
+    }
+
+    /// <summary>
+    /// The signed-in viewer's HOME partition, resolved from the ambient
+    /// <see cref="AccessService"/> (per-delivery context first, then the durable
+    /// circuit context) — mirroring <c>AgentPickerProjection.ResolveUserHome</c>.
+    /// System / anonymous / hub-shaped principals yield <c>null</c>: they have no
+    /// home partition to copy into.
+    /// </summary>
+    private static string? ResolveViewerHome(AccessService? accessService)
+    {
+        if (accessService is null)
+            return null;
+        foreach (var candidate in new[] { accessService.Context?.ObjectId, accessService.CircuitContext?.ObjectId })
+            if (!string.IsNullOrEmpty(candidate)
+                && candidate != WellKnownUsers.System
+                && !string.Equals(candidate, WellKnownUsers.Anonymous, StringComparison.OrdinalIgnoreCase)
+                && !AccessService.LooksLikeHubPrincipal(candidate))
+                return candidate;
+        return null;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
+++ b/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
@@ -137,6 +137,30 @@ public static class MeshNodeImageHelper
         => !string.IsNullOrEmpty(icon) && !IsImageUrl(icon) && !IsInlineSvg(icon) && !IsFluentIconName(icon);
 
     /// <summary>
+    /// Ensures an inline <c>&lt;svg&gt;</c> renders at an explicit pixel size when injected
+    /// as a raw HTML string (e.g. <c>Controls.Html</c> surfaces, where no scoped CSS can
+    /// reach the markup). Node icons are typically authored with a <c>viewBox</c> but NO
+    /// <c>width</c>/<c>height</c>; without an intrinsic size such an svg renders at the
+    /// browser default (~300×150) and overflows/collapses — a blank tile. Injects a
+    /// <c>style</c> attribute right after the opening <c>&lt;svg</c> tag; because a
+    /// duplicate attribute's FIRST occurrence wins in HTML parsing, the injected size
+    /// takes precedence over any author-supplied inline style.
+    /// </summary>
+    /// <param name="svg">The inline svg markup (anything before the first <c>&lt;svg</c> is preserved).</param>
+    /// <param name="pixels">The square size, in CSS pixels, the svg should occupy.</param>
+    public static string SizeInlineSvg(string svg, int pixels)
+    {
+        if (string.IsNullOrEmpty(svg))
+            return svg;
+        var idx = svg.IndexOf("<svg", StringComparison.OrdinalIgnoreCase);
+        if (idx < 0)
+            return svg;
+        var insertAt = idx + "<svg".Length;
+        return svg.Insert(insertAt,
+            $" style=\"width: {pixels}px; height: {pixels}px; display: block;\"");
+    }
+
+    /// <summary>
     /// Legacy method — returns the icon only if it's an image URL.
     /// Prefer <see cref="GetIconForRendering"/> which also returns SVG and emoji icons.
     /// </summary>

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -398,7 +398,12 @@ public static class MeshNodeLayoutAreas
             }
             else if (iconValue.TrimStart().StartsWith("<svg", StringComparison.OrdinalIgnoreCase))
             {
-                tile = Controls.Html($"<div style=\"{tileStyle}\">{iconValue}</div>");
+                // Raw-HTML surface — no scoped CSS can size the injected svg, so a
+                // viewBox-only icon would render at the browser default (~300×150)
+                // and show a blank tile. Inject the size into the markup itself
+                // (mirrors the 48px img sizing above).
+                tile = Controls.Html(
+                    $"<div style=\"{tileStyle}\">{MeshNodeImageHelper.SizeInlineSvg(iconValue, 48)}</div>");
             }
             else if (rawIcon != null && MeshNodeImageHelper.IsFluentIconName(rawIcon))
             {

--- a/src/MeshWeaver.Graph/Security/SatelliteAccessRule.cs
+++ b/src/MeshWeaver.Graph/Security/SatelliteAccessRule.cs
@@ -34,8 +34,19 @@ public class SatelliteAccessRule(string nodeType, IMessageHub hub) : INodeTypeAc
     /// <returns>An observable that emits whether access is permitted.</returns>
     public IObservable<bool> HasAccess(NodeValidationContext context, string? userId)
     {
+        // A missing identity is ANONYMOUS — not an automatic deny. The standard
+        // path-based check (RlsNodeValidator.CheckPermission) evaluates a null
+        // user as WellKnownUsers.Anonymous, so a partition whose policy grants
+        // PublicRead is readable by logged-out viewers. Hard-denying here made
+        // every satellite STRICTER than its MainNode: a public-read viewer could
+        // read a Code node but never its `_Activity` satellite, so the embedded
+        // run-output pane hung on its spinner forever (2026-07-03). Delegating
+        // with the Anonymous identity keeps closed-by-default semantics: only a
+        // PublicRead policy (or an explicit Anonymous role grant) yields Read,
+        // and write-class operations still require Update on the MainNode,
+        // which Anonymous never holds unless explicitly granted.
         if (string.IsNullOrEmpty(userId))
-            return Observable.Return(false);
+            userId = WellKnownUsers.Anonymous;
 
         var mainNodePath = context.Node.MainNode;
         // Degenerate case: no MainNode (or self-referencing). The rule has no

--- a/src/MeshWeaver.Kernel.Hub/CapturingTextWriter.cs
+++ b/src/MeshWeaver.Kernel.Hub/CapturingTextWriter.cs
@@ -3,27 +3,36 @@ using System.Text;
 namespace MeshWeaver.Kernel.Hub;
 
 /// <summary>
-/// Process-wide <c>Console.Out</c> replacement that delegates writes to an
-/// <see cref="AsyncLocal{T}"/> target when one is set, falling back to the
-/// original writer otherwise.
+/// Process-wide <c>Console.Out</c> / <c>Console.Error</c> replacement that delegates
+/// writes to an <see cref="AsyncLocal{T}"/> target when one is set, falling back to
+/// the original writer otherwise.
 ///
 /// <para>Why AsyncLocal: the kernel runs scripts on the thread-pool with async
-/// continuations. <c>Console.SetOut</c> is process-global, so naively swapping
-/// it around a single script execution would either (a) leak captured output
-/// from concurrent kernel sessions into the wrong cell, or (b) leave Console.Out
-/// permanently broken if two captures interleaved. AsyncLocal scopes the target
-/// to the logical execution context — each script's continuations see only
-/// their own writer, and host-process code outside any capture scope hits the
-/// fallback unchanged.</para>
+/// continuations. <c>Console.SetOut</c>/<c>Console.SetError</c> are process-global,
+/// so naively swapping them around a single script execution would either (a) leak
+/// captured output from concurrent kernel sessions into the wrong cell, or (b) leave
+/// the console writers permanently broken if two captures interleaved. AsyncLocal
+/// scopes the target to the logical execution context — each script's continuations
+/// see only their own writer, and host-process code outside any capture scope hits
+/// the fallback unchanged.</para>
+///
+/// <para>Both standard streams are hooked: <c>Console.WriteLine</c> lands on the
+/// capture's stdout target, <c>Console.Error.WriteLine</c> on its stderr target —
+/// so a script's error prints reach the ActivityLog (as error-level messages)
+/// instead of vanishing into the host process's stderr.</para>
 /// </summary>
-internal sealed class CapturingTextWriter(TextWriter fallback) : TextWriter
+internal sealed class CapturingTextWriter(AsyncLocal<TextWriter?> channel, TextWriter fallback) : TextWriter
 {
-    private static readonly AsyncLocal<TextWriter?> CurrentTarget = new();
-    private static int installed;
+    // AsyncLocal flow-state (NOT a cache/collection): scopes each capture to its own
+    // logical execution context. One channel per standard stream.
+    private static readonly AsyncLocal<TextWriter?> CurrentOutTarget = new();
+    private static readonly AsyncLocal<TextWriter?> CurrentErrorTarget = new();
+    private static int installedOut;
+    private static int installedError;
 
     public override Encoding Encoding => fallback.Encoding;
 
-    private TextWriter Active => CurrentTarget.Value ?? fallback;
+    private TextWriter Active => channel.Value ?? fallback;
 
     public override void Write(char value) => Active.Write(value);
     public override void Write(string? value) => Active.Write(value);
@@ -33,18 +42,27 @@ internal sealed class CapturingTextWriter(TextWriter fallback) : TextWriter
     public override void Flush() => Active.Flush();
 
     /// <summary>
-    /// Begin capturing writes to <paramref name="target"/> on the current async-flow.
-    /// Dispose the returned scope to restore the previous target. Idempotently
-    /// installs the global Console.Out hook on first use.
+    /// Begin capturing <c>Console.Out</c> writes to <paramref name="outTarget"/> and
+    /// <c>Console.Error</c> writes to <paramref name="errorTarget"/> on the current
+    /// async-flow. Dispose the returned scope to restore the previous targets.
+    /// Idempotently installs the global console hooks on first use.
     /// </summary>
-    public static IDisposable Capture(TextWriter target)
+    public static IDisposable Capture(TextWriter outTarget, TextWriter errorTarget)
     {
-        if (Interlocked.CompareExchange(ref installed, 1, 0) == 0)
-            Console.SetOut(new CapturingTextWriter(Console.Out));
+        if (Interlocked.CompareExchange(ref installedOut, 1, 0) == 0)
+            Console.SetOut(new CapturingTextWriter(CurrentOutTarget, Console.Out));
+        if (Interlocked.CompareExchange(ref installedError, 1, 0) == 0)
+            Console.SetError(new CapturingTextWriter(CurrentErrorTarget, Console.Error));
 
-        var prev = CurrentTarget.Value;
-        CurrentTarget.Value = target;
-        return new Restorer(() => CurrentTarget.Value = prev);
+        var prevOut = CurrentOutTarget.Value;
+        var prevError = CurrentErrorTarget.Value;
+        CurrentOutTarget.Value = outTarget;
+        CurrentErrorTarget.Value = errorTarget;
+        return new Restorer(() =>
+        {
+            CurrentOutTarget.Value = prevOut;
+            CurrentErrorTarget.Value = prevError;
+        });
     }
 
     private sealed class Restorer(Action restore) : IDisposable

--- a/src/MeshWeaver.Kernel.Hub/KernelContainer.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelContainer.cs
@@ -72,7 +72,19 @@ public class KernelContainer(IServiceProvider serviceProvider)
 
         return config
             .AddLayout(layout =>
-                layout.WithView(_ => true,
+                // 🚨 The kernel's view domain is ONLY its dynamic script areas (the
+                // submission-id areas its area dictionary owns) — NEVER areas owned by a
+                // named renderer (Progress/Overview/Thumbnail on an Activity hub, …).
+                // Every renderer matching an area first disposes and REMOVES the area's
+                // existing content (RenderObservable → DisposeExistingAreas), so a
+                // `_ => true` catch-all destroyed every named area on every hub hosting
+                // the kernel: no Activity layout area ever rendered, and the code cell's
+                // output pane (LayoutAreaControl(activityPath, Progress)) spun forever
+                // for every viewer, runner included (2026-07-03 RCA; pinned by
+                // CodeCellOutputCaptureTest). `layout` here is the definition built by
+                // the lambdas applied BEFORE this one — node-type views register ahead
+                // of AddKernelSubHubHandlers, so their named areas are all visible.
+                layout.WithView(ctx => !layout.HasNamedRenderer(ctx.Area),
                     (host, ctx) => GetAreaStream(host.Hub.ServiceProvider)
                         .Select(a =>
                         {
@@ -82,6 +94,20 @@ public class KernelContainer(IServiceProvider serviceProvider)
                             var uiControlService = host.Hub.ServiceProvider.GetRequiredService<IUiControlService>();
                             return uiControlService.Convert(valueOrDefault);
                         })
+                        // 🚨 Emit IMMEDIATELY — this catch-all matches EVERY area on the
+                        // hub, and LayoutDefinition.Render composes the area's renderers
+                        // SEQUENTIALLY (SelectMany): a matching renderer that stays silent
+                        // dams the whole chain, so NO area on the hub ever reaches the
+                        // store. On Activity hubs (which host the kernel AND named areas
+                        // like Progress/Overview) that meant every layout-area
+                        // subscription hung forever — the code cell's output pane spun
+                        // eternally for every viewer, runner included (2026-07-03 RCA;
+                        // pinned by CodeCellOutputCaptureTest). A null renders as a
+                        // PASS-THROUGH (RenderArea: view == null ⇒ store unchanged), so
+                        // the kernel view has "no opinion" until its own area dictionary
+                        // actually owns the requested area; the script's control still
+                        // flows the moment it lands in the dictionary.
+                        .StartWith((UiControl?)null)
                 )
             )
             .WithServices(services => services.AddScoped(CreateAreaStream))

--- a/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
@@ -286,9 +286,14 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
         return Observable.Using(
             () =>
             {
+                // Both standard streams are piped into the script's ActivityLog:
+                // stdout as Information lines, stderr as Error lines — so
+                // Console.Error prints surface on the run's output (red) instead
+                // of vanishing into the host process's stderr.
                 var stdoutPipe = new LoggerTextWriter(scriptOutputLogger);
-                var capture = CapturingTextWriter.Capture(stdoutPipe);
-                return new StdoutScope(stdoutPipe, capture);
+                var stderrPipe = new LoggerTextWriter(scriptOutputLogger, LogLevel.Error);
+                var capture = CapturingTextWriter.Capture(stdoutPipe, stderrPipe);
+                return new StdoutScope(stdoutPipe, stderrPipe, capture);
             },
             // Roslyn compile+execute on the bounded Compile IoPool (see `compilePool`) —
             // NOT a bare Observable.FromAsync on the shared ThreadPool. `t` is the pool's
@@ -300,7 +305,7 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
                 .Select(state =>
                 {
                     scriptState = state;
-                    scope.StdoutPipe.Flush();
+                    scope.Flush();
                     if (state.ReturnValue is not null)
                     {
                         UpdateView(viewId, state.ReturnValue);
@@ -310,13 +315,20 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
                 }));
     }
 
-    private sealed class StdoutScope(LoggerTextWriter stdoutPipe, IDisposable capture) : IDisposable
+    private sealed class StdoutScope(LoggerTextWriter stdoutPipe, LoggerTextWriter stderrPipe, IDisposable capture) : IDisposable
     {
-        public LoggerTextWriter StdoutPipe { get; } = stdoutPipe;
+        /// <summary>Flushes any partially-buffered line on both pipes.</summary>
+        public void Flush()
+        {
+            stdoutPipe.Flush();
+            stderrPipe.Flush();
+        }
+
         public void Dispose()
         {
             capture.Dispose();
-            StdoutPipe.Dispose();
+            stdoutPipe.Dispose();
+            stderrPipe.Dispose();
         }
     }
 

--- a/src/MeshWeaver.Kernel.Hub/LoggerTextWriter.cs
+++ b/src/MeshWeaver.Kernel.Hub/LoggerTextWriter.cs
@@ -5,12 +5,14 @@ namespace MeshWeaver.Kernel.Hub;
 
 /// <summary>
 /// <see cref="TextWriter"/> that buffers per line and flushes each completed
-/// line to an <see cref="ILogger"/> as a separate <c>LogInformation</c> entry.
-/// Used by <see cref="KernelExecutor"/> to route a script's <c>Console.Write*</c>
-/// output into the script's <c>ActivityLog</c>, in line with how
-/// <c>Log.LogInformation(...)</c> calls flow.
+/// line to an <see cref="ILogger"/> as a separate log entry at
+/// <paramref name="level"/> (<see cref="LogLevel.Information"/> for the stdout
+/// pipe, <see cref="LogLevel.Error"/> for the stderr pipe). Used by
+/// <see cref="KernelExecutor"/> to route a script's <c>Console.Write*</c> /
+/// <c>Console.Error.Write*</c> output into the script's <c>ActivityLog</c>,
+/// in line with how <c>Log.LogInformation(...)</c> calls flow.
 /// </summary>
-internal sealed class LoggerTextWriter(ILogger logger) : TextWriter
+internal sealed class LoggerTextWriter(ILogger logger, LogLevel level = LogLevel.Information) : TextWriter
 {
     private readonly StringBuilder buffer = new();
     private readonly object bufferLock = new();
@@ -60,7 +62,7 @@ internal sealed class LoggerTextWriter(ILogger logger) : TextWriter
         if (buffer.Length == 0) return;
         var msg = buffer.ToString();
         buffer.Clear();
-        logger.LogInformation("{Stdout}", msg);
+        logger.Log(level, "{Stdout}", msg);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/MeshWeaver.Layout/Composition/LayoutDefinition.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutDefinition.cs
@@ -112,6 +112,19 @@ public record LayoutDefinition(IMessageHub Hub)
         };
 
     /// <summary>
+    /// True when a named renderer is registered for <paramref name="area"/>. Predicate
+    /// (catch-all) views use this to keep OFF areas that are explicitly owned: every
+    /// renderer matching an area first disposes and REMOVES that area's existing content
+    /// (<c>RenderObservable</c> → <c>DisposeExistingAreas</c>), so two renderers for the
+    /// same area are last-wins-destructive. A <c>WithView(_ =&gt; true, …)</c> that also
+    /// matched named areas silently wiped them — the kernel catch-all did exactly this on
+    /// every Activity hub, and NO named area (Progress/Overview/Thumbnail) ever rendered
+    /// there (the 2026-07-03 eternal-spinner RCA).
+    /// </summary>
+    /// <param name="area">The area name to test.</param>
+    public bool HasNamedRenderer(string area) => NamedRenderers.ContainsKey(area);
+
+    /// <summary>
     /// Renders <paramref name="context"/>'s area reactively. Composes the named
     /// renderer (if one is registered for <c>context.Area</c>) and every matching
     /// predicate renderer, accumulating their <see cref="EntityStoreAndUpdates"/> onto

--- a/src/MeshWeaver.Layout/PromptCell.cs
+++ b/src/MeshWeaver.Layout/PromptCell.cs
@@ -1,0 +1,293 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Layout.Composition;
+
+namespace MeshWeaver.Layout;
+
+/// <summary>
+/// One faked (or live) agent exchange: the code the "agent" produced and the
+/// output control to render beneath it. Simulated responders author both
+/// fields directly; the live adapter (MeshWeaver.AI's <c>TrainingSimResponder</c>)
+/// projects a real thread round into this shape.
+/// </summary>
+/// <param name="Code">The code pane's content — rendered as a fenced code block
+/// (language from <see cref="PromptCellConfig.CodeLanguage"/>).</param>
+/// <param name="Output">The result control rendered in the output pane.</param>
+public record PromptCellResponse(string Code, UiControl Output);
+
+/// <summary>
+/// Configuration for a <see cref="PromptCell"/> — the training control that
+/// MIMICS an agent exchange on course pages and exercises.
+/// <para>The MODE is the <see cref="Responder"/> you plug in:</para>
+/// <list type="bullet">
+///   <item><b>Simulated</b> — <see cref="PromptCell.Simulated"/> wraps a pure
+///   <c>prompt → (code, output)</c> function; no AI infrastructure involved.</item>
+///   <item><b>Live</b> — MeshWeaver.AI's <c>TrainingSimResponder.Live(hub, ns)</c>
+///   returns a responder that submits the prompt to a real agent thread
+///   (<c>hub.StartThread</c>, agent <c>TrainingSim</c>) and projects the reply.</item>
+/// </list>
+/// </summary>
+public record PromptCellConfig
+{
+    /// <summary>Placeholder text shown in the empty prompt composer.</summary>
+    public string? Placeholder { get; init; }
+
+    /// <summary>
+    /// The prompt the ✨ "Suggest a prompt" button fills into the composer —
+    /// the escape hatch for learners who are stuck.
+    /// </summary>
+    public string? SuggestedPrompt { get; init; }
+
+    /// <summary>
+    /// Maps the submitted prompt to the exchange to render (code pane + output
+    /// pane). The cell subscribes the first emission. See the class remarks for
+    /// the Simulated / Live factory helpers.
+    /// </summary>
+    public Func<string, IObservable<PromptCellResponse>>? Responder { get; init; }
+
+    /// <summary>
+    /// Seed folded into the deterministic pseudo-stats (see
+    /// <see cref="PromptCell.DeriveStats"/>) so two cells on one page show
+    /// different — but stable — numbers. No randomness anywhere.
+    /// </summary>
+    public int FakeStatsSeed { get; init; }
+
+    /// <summary>Language tag of the code pane's fence. Default <c>csharp</c>.</summary>
+    public string CodeLanguage { get; init; } = "csharp";
+
+    /// <summary>
+    /// Data id backing the prompt composer (bound pointer under <c>/data/…</c>).
+    /// Defaults to a fresh Guid per render; set explicitly when a page hosts a
+    /// single well-known cell (e.g. for tests).
+    /// </summary>
+    public string? DataId { get; init; }
+}
+
+/// <summary>
+/// The training "prompt in → output below" cell: a chat-composer-styled input
+/// with Send and ✨ Suggest-a-prompt buttons, and a three-pane exchange beneath
+/// it — the learner's prompt bubble, the code the (simulated or live) agent
+/// produced, and the output cell with a faked usage-stats bar. All state lives
+/// in the layout-area data stream (bound pointers / <c>host.UpdateData</c>);
+/// click actions are synchronous lambdas — nothing async, nothing hand-rolled.
+/// </summary>
+public static class PromptCell
+{
+    /// <summary>Area id of the composer bar (input + magic + send).</summary>
+    public const string ComposerArea = "Composer";
+    /// <summary>Area id of the prompt composer (TextArea).</summary>
+    public const string InputArea = "PromptInput";
+    /// <summary>Area id of the ✨ "Suggest a prompt" button.</summary>
+    public const string SuggestButtonArea = "SuggestPrompt";
+    /// <summary>Area id of the Send button.</summary>
+    public const string SendButtonArea = "SendPrompt";
+    /// <summary>Area id of the exchange pane (user bubble + code + output + stats).</summary>
+    public const string ExchangeArea = "Exchange";
+    /// <summary>Area id of the user prompt bubble inside the exchange.</summary>
+    public const string ExchangeUserArea = "UserBubble";
+    /// <summary>Area id of the agent code pane inside the exchange.</summary>
+    public const string ExchangeCodeArea = "AgentCode";
+    /// <summary>Area id of the agent output pane inside the exchange.</summary>
+    public const string ExchangeOutputArea = "AgentOutput";
+    /// <summary>Area id of the faked usage-stats bar inside the exchange.</summary>
+    public const string ExchangeStatsArea = "Stats";
+
+    /// <summary>
+    /// Wraps a pure <c>prompt → response</c> function as a Simulated-mode
+    /// responder (the common shape for course pages).
+    /// </summary>
+    public static Func<string, IObservable<PromptCellResponse>> Simulated(
+        Func<string, PromptCellResponse> respond)
+    {
+        ArgumentNullException.ThrowIfNull(respond);
+        return prompt => Observable.Defer(() => Observable.Return(respond(prompt)));
+    }
+
+    /// <summary>
+    /// Builds the prompt cell. The composer's draft is data-bound to
+    /// <c>/data/{dataId}</c>; ✨ writes <see cref="PromptCellConfig.SuggestedPrompt"/>
+    /// into that pointer; Send snapshots the draft, renders the user bubble,
+    /// invokes the responder, and renders code + output + stats reactively.
+    /// </summary>
+    public static UiControl Area(LayoutAreaHost host, PromptCellConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+        ArgumentNullException.ThrowIfNull(config);
+
+        var dataId = string.IsNullOrEmpty(config.DataId)
+            ? $"promptcell_{Guid.NewGuid():N}"
+            : config.DataId!;
+        host.UpdateData(dataId, "");
+
+        var composer = Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithStyle("display: flex; align-items: flex-end; gap: 8px; width: 100%; " +
+                       "border: 1px solid var(--neutral-stroke-rest); border-radius: 8px; " +
+                       "padding: 8px 10px; background: var(--neutral-layer-1);")
+            .WithView(new TextAreaControl(new JsonPointerReference(""))
+                    .WithPlaceholder(config.Placeholder ?? "Ask the training agent…")
+                    .WithRows(2)
+                    .WithStyle("flex: 1; width: 100%;") with
+                { DataContext = LayoutAreaReference.GetDataPointer(dataId) },
+                InputArea)
+            .WithView(Controls.Button("✨")
+                    .WithLabel("Suggest a prompt")
+                    .WithAppearance(Appearance.Neutral)
+                    .WithClickAction(ctx =>
+                    {
+                        // The magic fill: write the suggested prompt straight into
+                        // the bound pointer — the composer updates by data binding.
+                        ctx.Host.UpdateData(dataId, config.SuggestedPrompt ?? "");
+                        return Task.CompletedTask;
+                    }),
+                SuggestButtonArea)
+            .WithView(Controls.Button("Send")
+                    .WithAppearance(Appearance.Accent)
+                    .WithClickAction(ctx =>
+                    {
+                        Send(ctx, config, dataId);
+                        return Task.CompletedTask;
+                    }),
+                SendButtonArea);
+
+        return Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("display: flex; flex-direction: column; gap: 12px;")
+            .WithView(composer, ComposerArea)
+            .WithView(Controls.Body("")
+                    .WithStyle("display: none;"),
+                ExchangeArea);
+    }
+
+    /// <summary>
+    /// Send click: snapshot the bound draft (seeded, so <c>Take(1)</c> emits the
+    /// current value synchronously), render the exchange, invoke the responder,
+    /// swap in code + output + stats when it emits. Errors land in the exchange
+    /// pane — never a silent hang.
+    /// </summary>
+    private static void Send(UiActionContext ctx, PromptCellConfig config, string dataId)
+    {
+        // The exchange pane sits at the CELL root, one level above the Send
+        // button ({root}/Composer/SendPrompt → {root}/Exchange). Rendered
+        // areas carry absolute paths, so strip the two trailing segments.
+        var prefix = ctx.Area.EndsWith(SendButtonArea, StringComparison.Ordinal)
+            ? ctx.Area[..^SendButtonArea.Length]
+            : "";
+        if (prefix.EndsWith(ComposerArea + "/", StringComparison.Ordinal))
+            prefix = prefix[..^(ComposerArea.Length + 1)];
+        var exchangeArea = prefix + ExchangeArea;
+
+        ctx.Host.Stream.GetDataStream<string>(dataId)
+            .Take(1)
+            .Subscribe(draft =>
+            {
+                var prompt = draft?.Trim() ?? "";
+                if (prompt.Length == 0)
+                    return;
+
+                // Composer clears like a chat input; the prompt lives on as the
+                // user bubble in the exchange.
+                ctx.Host.UpdateData(dataId, "");
+                ctx.Host.UpdateArea(exchangeArea,
+                    BuildExchange(prompt, response: null, config));
+
+                if (config.Responder is null)
+                {
+                    ctx.Host.UpdateArea(exchangeArea, BuildExchange(prompt,
+                        new PromptCellResponse("", Controls.Markdown(
+                            "_No responder configured for this cell._")),
+                        config));
+                    return;
+                }
+
+                config.Responder(prompt)
+                    .Take(1)
+                    .Subscribe(
+                        response => ctx.Host.UpdateArea(exchangeArea,
+                            BuildExchange(prompt, response, config)),
+                        ex => ctx.Host.UpdateArea(exchangeArea, BuildExchange(prompt,
+                            new PromptCellResponse("", Controls.Markdown(
+                                $"**The training agent could not answer:** {ex.Message}")),
+                            config)));
+            });
+    }
+
+    /// <summary>
+    /// The three-pane exchange: user prompt bubble → agent code cell (fenced
+    /// markdown, same treatment as the notebook cell's code segment) → output
+    /// pane, closed by the faked stats bar. <paramref name="response"/> null
+    /// renders the waiting state (bubble + "thinking" hint).
+    /// </summary>
+    private static UiControl BuildExchange(string prompt, PromptCellResponse? response, PromptCellConfig config)
+    {
+        var exchange = Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("display: flex; flex-direction: column; gap: 8px;");
+
+        // 1 — the learner's prompt as a right-aligned chat bubble.
+        exchange = exchange.WithView(Controls.Markdown(prompt)
+                .WithStyle("align-self: flex-end; max-width: 85%; padding: 8px 14px; " +
+                           "border-radius: 14px 14px 2px 14px; background: var(--accent-fill-rest); " +
+                           "color: var(--foreground-on-accent-rest);"),
+            ExchangeUserArea);
+
+        if (response is null)
+        {
+            return exchange.WithView(Controls.Body("training-sim is thinking…")
+                    .WithStyle("display: block; font-style: italic; " +
+                               "color: var(--neutral-foreground-hint);"),
+                ExchangeStatsArea);
+        }
+
+        // 2 — the code the "agent" produced, in the notebook-cell code style.
+        if (!string.IsNullOrEmpty(response.Code))
+        {
+            exchange = exchange.WithView(
+                Controls.Markdown($"```{config.CodeLanguage}\n{response.Code}\n```")
+                    .WithStyle("width: 100%; overflow: auto; " +
+                               "border: 1px solid var(--neutral-stroke-rest); border-radius: 6px; " +
+                               "background: var(--neutral-layer-1); padding: 0 12px;"),
+                ExchangeCodeArea);
+        }
+
+        // 3 — the result cell, marked with the same left accent as a run output.
+        // (Wrapped in a Stack because the styling applies to the FRAME, not the
+        // caller's output control — whose concrete type we don't know here.)
+        exchange = exchange.WithView(Controls.Stack
+                .WithWidth("100%")
+                .WithStyle("border-left: 3px solid var(--accent-fill-rest); " +
+                           "background: var(--neutral-layer-2); padding: 10px 12px;")
+                .WithView(response.Output),
+            ExchangeOutputArea);
+
+        // 4 — the FAKED usage stats: deterministic from the prompt, no Random.
+        var (tokens, seconds) = DeriveStats(prompt, config.FakeStatsSeed);
+        return exchange.WithView(Controls.Body(
+                    $"≈ {tokens} tokens · {seconds:0.0}s · model: training-sim")
+                .WithStyle("display: block; font-size: 0.8rem; " +
+                           "color: var(--neutral-foreground-hint);"),
+            ExchangeStatsArea);
+    }
+
+    /// <summary>
+    /// Deterministic pseudo-stats for the stats bar: a stable polynomial hash of
+    /// the prompt (NOT <c>string.GetHashCode</c>, which is randomized per
+    /// process) folded with the config seed. Same prompt + seed ⇒ same numbers,
+    /// every render, every process.
+    /// </summary>
+    public static (int Tokens, double Seconds) DeriveStats(string prompt, int seed)
+    {
+        unchecked
+        {
+            var h = 17 + seed * 31;
+            foreach (var ch in prompt ?? "")
+                h = h * 31 + ch;
+            var words = string.IsNullOrWhiteSpace(prompt)
+                ? 0
+                : prompt!.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
+            var tokens = words * 4 + Math.Abs(h % 23) + 3;
+            var seconds = 0.8 + Math.Abs(h % 37) / 10.0;
+            return (tokens, seconds);
+        }
+    }
+}

--- a/test/MeshWeaver.AI.Test/CodeCellEditRightsTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellEditRightsTest.cs
@@ -1,0 +1,141 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the rights-gating of the code cell's Edit button:
+/// <list type="number">
+///   <item>A viewer WITH Update permission gets the DIRECT edit navigation
+///   (ButtonControl with <c>NavigateToHref</c> to the Edit area).</item>
+///   <item>A viewer WITHOUT Update permission (read-only Viewer role) still
+///   sees an "Edit" button — but the dialog-triggering variant (no
+///   <c>NavigateToHref</c>; its click opens the copy-to-home DialogControl).</item>
+/// </list>
+/// Uses <see cref="MonolithMeshTestBase.ConfigureMeshBase"/> (NO blanket
+/// public-admin grant) so permissions are genuinely granular: the read-only
+/// user "Bob" holds only a static Viewer assignment on the partition.
+/// </summary>
+public class CodeCellEditRightsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Partition = "rbuergi";
+    private const string ViewerUser = "Bob";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            // Static (synchronously collected) grant: Bob is a READ-ONLY Viewer
+            // on the partition — enough to subscribe + render the cell, not
+            // enough to edit it. No public-admin blanket, no grant for anyone else.
+            .AddMeshNodes(new MeshNode($"{ViewerUser}_Access", $"{Partition}/_Access")
+            {
+                NodeType = "AccessAssignment",
+                Name = $"{ViewerUser} viewer access",
+                Content = new AccessAssignment
+                {
+                    AccessObject = ViewerUser,
+                    Roles = [new RoleAssignment { Role = "Viewer" }]
+                }
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    private async Task<string> SeedExecutableCode()
+    {
+        var id = $"gated-{Guid.NewGuid():N}";
+        var path = $"{Partition}/{id}";
+        var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        await mesh.CreateNode(new MeshNode(id, Partition)
+        {
+            Name = "Rights-gated cell",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = "\"hi\"", IsExecutable = true }
+        }).Should().Within(30.Seconds()).Emit();
+        return path;
+    }
+
+    private static string FindArea(IContainerControl container, string id)
+    {
+        var match = container.Areas
+            .Select(a => a.Area?.ToString())
+            .FirstOrDefault(a => a is not null && (a == id || a.EndsWith("/" + id, StringComparison.Ordinal)));
+        match.Should().NotBeNull(
+            $"container should contain an area '{id}' — found: " +
+            $"[{string.Join(", ", container.Areas.Select(a => a.Area))}]");
+        return match!;
+    }
+
+    private async Task<ButtonControl> RenderEditButton(string codePath)
+    {
+        var workspace = GetClient().GetWorkspace();
+        var reference = new LayoutAreaReference(CodeLayoutAreas.ContentArea);
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address(codePath), reference);
+
+        var root = (StackControl)(await stream.GetControlStream(reference.Area!)
+            .Should().Within(30.Seconds()).Match(c => c is StackControl s
+                && s.Areas.Any(a => a.Area?.ToString() is { } p
+                    && (p == CodeLayoutAreas.CellArea
+                        || p.EndsWith("/" + CodeLayoutAreas.CellArea, StringComparison.Ordinal)))))!;
+        var cell = (StackControl)(await stream
+            .GetControlStream(FindArea(root, CodeLayoutAreas.CellArea))
+            .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
+        var toolbar = (StackControl)(await stream
+            .GetControlStream(FindArea(cell, CodeLayoutAreas.CellToolbarArea))
+            .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
+        var edit = await stream
+            .GetControlStream(FindArea(toolbar, CodeLayoutAreas.EditButtonArea))
+            .Should().Within(10.Seconds()).Match(c => c is ButtonControl);
+        return (ButtonControl)edit!;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Editor_Gets_Direct_Edit_Navigation()
+    {
+        // Default circuit: the DevLogin admin (claim role Admin ⇒ Update).
+        var codePath = await SeedExecutableCode();
+        var edit = await RenderEditButton(codePath);
+        edit.NavigateToHref.Should().NotBeNull(
+            "a viewer with Update permission navigates straight to the Edit area");
+        edit.NavigateToHref!.ToString().Should().Contain(CodeLayoutAreas.EditArea);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ReadOnly_Viewer_Gets_DialogTriggering_Edit()
+    {
+        var codePath = await SeedExecutableCode();
+
+        // Switch the circuit to the read-only Viewer (no Admin claim, no
+        // Update grant — only the static Viewer role on the partition).
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetCircuitContext(new AccessContext { ObjectId = ViewerUser, Name = ViewerUser });
+        try
+        {
+            var edit = await RenderEditButton(codePath);
+            edit.NavigateToHref.Should().BeNull(
+                "a read-only viewer's Edit must NOT navigate — it opens the " +
+                "copy-to-home dialog explaining the content is read-only");
+            edit.Data.Should().Be("Edit",
+                "the button is still labeled Edit so the affordance stays discoverable");
+        }
+        finally
+        {
+            accessService.SetCircuitContext(null);
+        }
+    }
+}

--- a/test/MeshWeaver.AI.Test/CodeCellLayoutTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellLayoutTest.cs
@@ -96,7 +96,8 @@ public class CodeCellLayoutTest(ITestOutputHelper output) : MonolithMeshTestBase
             .Should().Within(30.Seconds()).Match(c => c is StackControl s
                 && HasArea(s, CodeLayoutAreas.CellArea)))!;
 
-        // Cell frame: toolbar + code + output segments.
+        // Cell frame: code + output segments with the toolbar at the BOTTOM
+        // (the composer bar — 2026-07-03 UX feedback).
         var cell = (StackControl)(await stream
             .GetControlStream(FindArea(root, CodeLayoutAreas.CellArea))
             .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
@@ -104,6 +105,18 @@ public class CodeCellLayoutTest(ITestOutputHelper output) : MonolithMeshTestBase
         HasArea(cell, CodeLayoutAreas.CellCodeArea).Should().BeTrue("the code sits inside the cell frame");
         HasArea(cell, CodeLayoutAreas.CellOutputArea).Should().BeTrue(
             "an executable cell always has an output segment attached beneath the code");
+
+        // Order inside the frame: code, then output, then the toolbar LAST —
+        // the toolbar is the composer bar at the foot of the cell.
+        var areaOrder = cell.Areas.Select(a => a.Area?.ToString() ?? "").ToArray();
+        int IndexOf(string id) => Array.FindIndex(areaOrder,
+            a => a == id || a.EndsWith("/" + id, StringComparison.Ordinal));
+        IndexOf(CodeLayoutAreas.CellCodeArea).Should().BeLessThan(
+            IndexOf(CodeLayoutAreas.CellOutputArea),
+            "the output segment attaches directly beneath the code");
+        IndexOf(CodeLayoutAreas.CellOutputArea).Should().BeLessThan(
+            IndexOf(CodeLayoutAreas.CellToolbarArea),
+            "the toolbar moved to the BOTTOM of the cell, below the output segment");
 
         // (a) Toolbar contains Run (and Edit); no Cancel while nothing runs.
         var toolbarArea = FindArea(cell, CodeLayoutAreas.CellToolbarArea);
@@ -115,6 +128,16 @@ public class CodeCellLayoutTest(ITestOutputHelper output) : MonolithMeshTestBase
             "Edit moved into the cell toolbar as well");
         HasArea(toolbar, CodeLayoutAreas.CancelButtonArea).Should().BeFalse(
             "no activity is running — Cancel must not render");
+
+        // The DevLogin admin holds Update on the node — Edit is the DIRECT
+        // navigation button (rights-gated; the no-rights dialog variant is
+        // pinned by CodeCellEditRightsTest).
+        var editControl = await stream
+            .GetControlStream(FindArea(toolbar, CodeLayoutAreas.EditButtonArea))
+            .Should().Within(10.Seconds()).Match(c => c is not null);
+        editControl.Should().BeOfType<ButtonControl>()
+            .Which.NavigateToHref.Should().NotBeNull(
+                "an editor's Edit button navigates straight to the Edit area");
 
         var runControl = await stream
             .GetControlStream(FindArea(toolbar, CodeLayoutAreas.RunButtonArea))

--- a/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
@@ -1,0 +1,295 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Graph.Security;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Root-cause coverage for the "Worked Example shows an eternal spinner" class
+/// of defects — the full chain from a script's <c>Console.Write*</c> to the
+/// Progress area a VIEWER sees:
+/// <list type="number">
+///   <item><b>Capture</b>: a script's <c>Console.WriteLine</c> AND
+///   <c>Console.Error.WriteLine</c> land as ActivityLog messages (Information /
+///   Error respectively). Error capture was missing — only Console.Out was
+///   hooked; stderr prints vanished into the host process.</item>
+///   <item><b>Stamp + embed</b>: after <see cref="ExecuteScriptRequest"/> the
+///   Code node's <c>LastActivityPath</c> is stamped and the Content area's
+///   output segment embeds the Progress area of exactly THAT path.</item>
+///   <item><b>Cross-user render</b>: the Progress area of a Succeeded activity
+///   emits the output lines (not a spinner) for a DIFFERENT user than the
+///   runner — a role-less public-read viewer AND the anonymous VUser. Satellite
+///   access delegates to the activity's MainNode (the partition root), whose
+///   PublicRead policy must admit both.</item>
+///   <item><b>The rule defect</b>: <see cref="SatelliteAccessRule"/> used to
+///   hard-deny a NULL identity instead of evaluating it as Anonymous — making
+///   every satellite stricter than its MainNode (a contextless viewer could
+///   read the Code node but never its `_Activity`, so the output pane spun
+///   forever). Pinned directly against the real evaluator.</item>
+/// </list>
+/// Uses <see cref="MonolithMeshTestBase.ConfigureMeshBase"/> (no blanket
+/// public-admin) + a static PublicRead policy on the partition, so the
+/// cross-user cases exercise the REAL public-read path.
+/// </summary>
+public class CodeCellOutputCaptureTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Partition = "rbuergi";
+    private const string PublicViewer = "Bob";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            // Static PublicRead policy on the partition: EVERY user — including
+            // Anonymous — may Read the partition and (via SatelliteAccessRule's
+            // MainNode delegation) its activity satellites. No write grants.
+            .AddMeshNodes(new MeshNode("_Policy", Partition)
+            {
+                NodeType = "PartitionAccessPolicy",
+                Name = "Public read",
+                Content = new PartitionAccessPolicy { PublicRead = true }
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    private async Task<string> SeedExecutableCode(string code)
+    {
+        var id = $"capture-{Guid.NewGuid():N}";
+        var path = $"{Partition}/{id}";
+        var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        await mesh.CreateNode(new MeshNode(id, Partition)
+        {
+            Name = "Console capture cell",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = code, IsExecutable = true }
+        }).Should().Within(30.Seconds()).Emit();
+        return path;
+    }
+
+    private async Task<string> RunScript(string codePath)
+    {
+        var exec = (await Mesh.Observe(
+                new ExecuteScriptRequest(),
+                o => o.WithTarget(new Address(codePath)))
+            .Should().Within(60.Seconds()).Emit()).Message;
+        exec.Success.Should().BeTrue(exec.Error ?? "exec failed");
+        return exec.ActivityLog!;
+    }
+
+    // ── (i) console capture: Out AND Error ─────────────────────────────────
+
+    [Fact(Timeout = 120000)]
+    public async Task Script_ConsoleOut_And_ConsoleError_Land_On_ActivityLog()
+    {
+        var codePath = await SeedExecutableCode("""
+            Console.WriteLine("out-line-capture");
+            Console.Error.WriteLine("err-line-capture");
+            "done"
+            """);
+        var activityPath = await RunScript(codePath);
+
+        var workspace = GetClient().GetWorkspace();
+        var log = (await workspace.GetMeshNodeStream(activityPath)
+            .Select(n => n?.Content as ActivityLog)
+            .Should().Within(60.Seconds()).Match(l => l is not null
+                && l.Status == ActivityStatus.Succeeded
+                && l.Messages.Any(m => m.Message.Contains("out-line-capture"))
+                && l.Messages.Any(m => m.Message.Contains("err-line-capture"))))!;
+
+        log.Messages.First(m => m.Message.Contains("out-line-capture"))
+            .LogLevel.Should().Be(LogLevel.Information,
+                "stdout lines flow as Information messages");
+        log.Messages.First(m => m.Message.Contains("err-line-capture"))
+            .LogLevel.Should().Be(LogLevel.Error,
+                "stderr lines flow as Error messages — Console.Error was previously not captured at all");
+    }
+
+    // ── (ii) LastActivityPath stamp + output-segment embed ─────────────────
+
+    [Fact(Timeout = 120000)]
+    public async Task Run_Stamps_LastActivityPath_And_OutputSegment_Embeds_That_Path()
+    {
+        var codePath = await SeedExecutableCode("""
+            Console.WriteLine("stamp-check");
+            "done"
+            """);
+
+        var client = GetClient();
+        var workspace = client.GetWorkspace();
+        var reference = new LayoutAreaReference(CodeLayoutAreas.ContentArea);
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address(codePath), reference);
+
+        // Area alive before the run.
+        var root = (StackControl)(await stream.GetControlStream(reference.Area!)
+            .Should().Within(30.Seconds()).Match(c => c is StackControl))!;
+
+        var activityPath = await RunScript(codePath);
+
+        // The stamp lands on the Code node's content …
+        await workspace.GetMeshNodeStream(codePath)
+            .Select(n => n.ContentAs<CodeConfiguration>(client.JsonSerializerOptions))
+            .Should().Within(30.Seconds()).Match(c => c != null
+                && c.LastActivityPath == activityPath);
+
+        // … and the Content area's output segment embeds the Progress area of
+        // exactly THAT path (a dangling / missing stamp would leave the pane
+        // pointing nowhere — one of the eternal-spinner shapes).
+        var cellArea = root.Areas
+            .Select(a => a.Area?.ToString())
+            .First(a => a is not null
+                && (a == CodeLayoutAreas.CellArea
+                    || a.EndsWith("/" + CodeLayoutAreas.CellArea, StringComparison.Ordinal)))!;
+        var cell = (StackControl)(await stream.GetControlStream(cellArea)
+            .Should().Within(30.Seconds()).Match(c => c is StackControl))!;
+        var outputArea = cell.Areas
+            .Select(a => a.Area?.ToString())
+            .First(a => a is not null
+                && (a == CodeLayoutAreas.CellOutputArea
+                    || a.EndsWith("/" + CodeLayoutAreas.CellOutputArea, StringComparison.Ordinal)))!;
+        await stream.GetControlStream(outputArea)
+            .Should().Within(30.Seconds()).Match(c => c is LayoutAreaControl l
+                && l.Address.ToString() == activityPath
+                && l.Reference.Area == ActivityLayoutAreas.ProgressArea);
+    }
+
+    // ── (iii) Progress renders OUTPUT (not a spinner) for other viewers ────
+
+    private async Task AssertProgressShowsOutput(string activityPath, string marker)
+    {
+        var workspace = GetClient().GetWorkspace();
+        var reference = new LayoutAreaReference(ActivityLayoutAreas.ProgressArea);
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address(activityPath), reference);
+
+        // The Progress root is a Stack whose first child is the messages Html.
+        var rootControl = (StackControl)(await stream.GetControlStream(reference.Area!)
+            .Should().Within(30.Seconds()).Match(c => c is StackControl s && s.Areas.Count >= 1))!;
+        var messagesArea = rootControl.Areas.First().Area!.ToString()!;
+        await stream.GetControlStream(messagesArea)
+            .Should().Within(30.Seconds()).Match(c => c is HtmlControl h
+                && h.Data is not null
+                && h.Data.ToString()!.Contains(marker)
+                && h.Data.ToString()!.Contains("Done"));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Progress_Of_Succeeded_Activity_Renders_Output_For_PublicRead_Viewer()
+    {
+        var codePath = await SeedExecutableCode("""
+            Console.WriteLine("out-line-public");
+            "done"
+            """);
+        var activityPath = await RunScript(codePath);
+
+        // Runner (admin) waits until the activity is terminal WITH the line.
+        await GetClient().GetWorkspace().GetMeshNodeStream(activityPath)
+            .Select(n => n?.Content as ActivityLog)
+            .Should().Within(60.Seconds()).Match(l => l is not null
+                && l.Status == ActivityStatus.Succeeded
+                && l.Messages.Any(m => m.Message.Contains("out-line-public")));
+
+        // Baseline: the RUNNER can render the Progress area (bisects
+        // viewer-independent render defects from access-shaped ones).
+        await AssertProgressShowsOutput(activityPath, "out-line-public");
+
+        // A DIFFERENT, role-less user (public-read only via the partition
+        // policy) renders the Progress area: output lines, not a spinner.
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetCircuitContext(new AccessContext { ObjectId = PublicViewer, Name = PublicViewer });
+        try
+        {
+            await AssertProgressShowsOutput(activityPath, "out-line-public");
+        }
+        finally
+        {
+            accessService.SetCircuitContext(null);
+        }
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Progress_Of_Succeeded_Activity_Renders_Output_For_Anonymous_VUser()
+    {
+        var codePath = await SeedExecutableCode("""
+            Console.WriteLine("out-line-anon");
+            "done"
+            """);
+        var activityPath = await RunScript(codePath);
+
+        await GetClient().GetWorkspace().GetMeshNodeStream(activityPath)
+            .Select(n => n?.Content as ActivityLog)
+            .Should().Within(60.Seconds()).Match(l => l is not null
+                && l.Status == ActivityStatus.Succeeded
+                && l.Messages.Any(m => m.Message.Contains("out-line-anon")));
+
+        // The logged-out circuit shape (CircuitAccessHandler): the anonymous
+        // VUser — IsVirtual, ObjectId = Anonymous. PublicRead must admit it on
+        // the activity satellite exactly as it does on the Code node itself.
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetCircuitContext(new AccessContext
+        {
+            ObjectId = WellKnownUsers.Anonymous,
+            Name = "Guest",
+            IsVirtual = true
+        });
+        try
+        {
+            await AssertProgressShowsOutput(activityPath, "out-line-anon");
+        }
+        finally
+        {
+            accessService.SetCircuitContext(null);
+        }
+    }
+
+    // ── (iv) the SatelliteAccessRule defect, pinned at the rule ────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task SatelliteRule_Evaluates_Null_Identity_As_Anonymous_Not_Deny()
+    {
+        // The exact pre-fix defect: a NULL identity (no AccessContext at all —
+        // the shape a contextless delivery produces) was hard-denied, making
+        // the `_Activity` satellite stricter than its public-read MainNode.
+        // The rule must evaluate the missing identity as Anonymous: PublicRead
+        // on the MainNode grants Read; write-class operations stay denied.
+        var rule = new SatelliteAccessRule(ActivityNodeType.NodeType, Mesh);
+        var activityNode = new MeshNode($"act-{Guid.NewGuid():N}", $"{Partition}/_Activity")
+        {
+            NodeType = ActivityNodeType.NodeType,
+            MainNode = Partition,
+            Content = new ActivityLog("ScriptExecution")
+        };
+
+        await rule.HasAccess(new NodeValidationContext
+            {
+                Operation = NodeOperation.Read,
+                Node = activityNode
+            }, null)
+            .Should().Within(30.Seconds()).Match(granted => granted,
+                "a public-read partition's activity satellite must be readable without an identity");
+
+        await rule.HasAccess(new NodeValidationContext
+            {
+                Operation = NodeOperation.Update,
+                Node = activityNode
+            }, null)
+            .Should().Within(30.Seconds()).Match(granted => !granted,
+                "PublicRead grants Read only — anonymous writes stay denied");
+    }
+}

--- a/test/MeshWeaver.AI.Test/KernelStdoutCaptureTest.cs
+++ b/test/MeshWeaver.AI.Test/KernelStdoutCaptureTest.cs
@@ -23,10 +23,14 @@ public class KernelStdoutCaptureTest
     private sealed class CapturingLogger : ILogger
     {
         public List<string> Messages { get; } = new();
+        public List<LogLevel> Levels { get; } = new();
         public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullLogger.Instance.BeginScope(state)!;
         public bool IsEnabled(LogLevel logLevel) => true;
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-            => Messages.Add(formatter(state, exception));
+        {
+            Messages.Add(formatter(state, exception));
+            Levels.Add(logLevel);
+        }
     }
 
     [Fact]
@@ -104,7 +108,7 @@ public class KernelStdoutCaptureTest
 
         async Task RunCaptureAsync(StringWriter into, string label, int delayMs)
         {
-            using (CapturingTextWriter.Capture(into))
+            using (CapturingTextWriter.Capture(into, TextWriter.Null))
             {
                 Console.Write($"{label}-1");
                 await Task.Delay(delayMs);
@@ -130,7 +134,7 @@ public class KernelStdoutCaptureTest
         // We can't easily assert on the runner's Console, but we can verify
         // that a Capture scope's restorer puts the AsyncLocal back to null.
         var capture = new StringWriter();
-        using (CapturingTextWriter.Capture(capture))
+        using (CapturingTextWriter.Capture(capture, TextWriter.Null))
         {
             Console.Write("inside");
         }
@@ -139,5 +143,37 @@ public class KernelStdoutCaptureTest
         Console.Write("outside");
         capture.ToString().Length.Should().Be(beforeLength,
             "post-scope writes must not land in the no-longer-active capture");
+    }
+
+    [Fact]
+    public void LoggerTextWriter_Logs_At_Configured_Level()
+    {
+        // The stderr pipe logs each completed line at Error level — this is what
+        // turns a script's Console.Error prints red on the activity output.
+        var logger = new CapturingLogger();
+        using var writer = new LoggerTextWriter(logger, LogLevel.Error);
+
+        writer.WriteLine("boom");
+
+        logger.Messages.Should().ContainSingle().Which.Should().Contain("boom");
+        logger.Levels.Should().ContainSingle().Which.Should().Be(LogLevel.Error);
+    }
+
+    [Fact]
+    public void CapturingTextWriter_Routes_Error_Stream_To_Error_Target()
+    {
+        // Console.WriteLine → the stdout target; Console.Error.WriteLine → the
+        // stderr target. Before the two-channel capture, error prints bypassed
+        // the capture entirely and vanished into the host process's stderr.
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        using (CapturingTextWriter.Capture(stdout, stderr))
+        {
+            Console.Write("to-out");
+            Console.Error.Write("to-err");
+        }
+
+        stdout.ToString().Should().Be("to-out", "stdout capture must only see Console.Out writes");
+        stderr.ToString().Should().Be("to-err", "stderr capture must only see Console.Error writes");
     }
 }

--- a/test/MeshWeaver.AI.Test/TrainingSimResponderTest.cs
+++ b/test/MeshWeaver.AI.Test/TrainingSimResponderTest.cs
@@ -1,0 +1,123 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshThread = MeshWeaver.AI.Thread;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Coverage of the PromptCell LIVE adapter (<see cref="TrainingSimResponder"/>):
+/// <list type="number">
+///   <item><see cref="TrainingSimResponder.Project"/> splits an assistant reply
+///   into the cell's three-pane shape — first fenced code block → code pane,
+///   remainder → output markdown.</item>
+///   <item>Subscribing the LIVE responder submits the prompt through the
+///   canonical <c>hub.StartThread</c> surface: a thread node is created under
+///   the exercise namespace with <c>Composer.AgentName = TrainingSim</c> and
+///   the prompt queued as its first message. Model-less environment — the
+///   REPLY leg (a real agent round) is e2e-stack territory; this pins the
+///   submission side effect the adapter owes the cell.</item>
+/// </list>
+/// </summary>
+public class TrainingSimResponderTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string OwnerId = "Roland";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddAI().AddSampleUsers();
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddAITypes();
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    [Fact]
+    public void Project_Splits_First_Fence_Into_Code_And_Output()
+    {
+        var reply = new ThreadMessage
+        {
+            Role = "assistant",
+            Text = """
+                Here's the cell:
+
+                ```csharp
+                var totals = sales.GroupBy(s => s.Region);
+                Controls.DataGrid(totals)
+                ```
+
+                The grid shows one row per region.
+                """
+        };
+
+        var projected = TrainingSimResponder.Project(reply);
+
+        projected.Code.Should().Contain("GroupBy(s => s.Region)");
+        projected.Code.Should().NotContain("```", "the fence lines are stripped — the cell re-fences itself");
+        var outputMarkdown = projected.Output.Should().BeOfType<MarkdownControl>()
+            .Subject.Markdown!.ToString()!;
+        outputMarkdown.Should().Contain("one row per region");
+        outputMarkdown.Should().NotContain("GroupBy", "the code lives in the code pane, not the output");
+    }
+
+    [Fact]
+    public void Project_Without_Fence_Yields_Empty_Code_And_Full_Output()
+    {
+        var projected = TrainingSimResponder.Project(new ThreadMessage
+        {
+            Role = "assistant",
+            Text = "Just an explanation, no code."
+        });
+        projected.Code.Should().BeEmpty();
+        projected.Output.Should().BeOfType<MarkdownControl>()
+            .Which.Markdown!.ToString().Should().Contain("Just an explanation");
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task Live_Responder_Submits_Thread_With_TrainingSim_Agent()
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        access.SetCircuitContext(TestUsers.Admin);
+
+        var client = GetClient();
+        // Owner partition live (onboarded) — same precondition ThreadCreatableFromHomeTest pins.
+        await client.Observe(new PingRequest(), o => o.WithTarget(new Address(OwnerId)))
+            .Should().Within(30.Seconds()).Emit();
+
+        var prompt = $"training-live-{Guid.NewGuid():N}";
+        var responder = TrainingSimResponder.Live(client, OwnerId);
+
+        // Subscribe = submit. No model is configured here, so the REPLY may
+        // never complete — the assertion below is on the canonical submission
+        // side effect, not the round.
+        using var subscription = responder(prompt).Subscribe(_ => { }, _ => { });
+
+        // The thread node lands under {owner}/_Thread with the TrainingSim
+        // agent selected on its composer and our prompt as the queued/first
+        // user message.
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var thread = await meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"path:{OwnerId}/_Thread scope:children nodeType:{ThreadNodeType.NodeType}"))
+            .SelectMany(change => change.Items)
+            .Select(node => node.ContentAs<MeshThread>(Mesh.JsonSerializerOptions))
+            .Should().Within(60.Seconds()).Match(t => t is not null
+                && t.Composer != null
+                && t.Composer.AgentName == TrainingSimResponder.AgentName
+                && (t.PendingUserMessages.Values.Any(m => m.Text == prompt)
+                    || t.UserMessageIds.Count > 0));
+
+        thread!.Composer!.AgentName.Should().Be(TrainingSimResponder.AgentName,
+            "the LIVE adapter selects the dedicated training agent on the composer");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/MeshNodeImageHelperTest.cs
+++ b/test/MeshWeaver.Graph.Test/MeshNodeImageHelperTest.cs
@@ -60,4 +60,23 @@ public class MeshNodeImageHelperTest
         var node = new MeshNode("X", "ns");
         MeshNodeImageHelper.ResolveNodeIcon(node).Should().Be("/static/NodeTypeIcons/box.svg");
     }
+
+    [Fact]
+    public void SizeInlineSvg_Injects_Explicit_Size_Into_Opening_Tag()
+    {
+        // viewBox-only inline svgs have no intrinsic size; on raw-HTML surfaces
+        // (Controls.Html tiles) no scoped CSS can reach them, so the size must
+        // live in the markup — first style attribute wins in HTML parsing.
+        const string svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"M0 0h24v24\"/></svg>";
+        var sized = MeshNodeImageHelper.SizeInlineSvg(svg, 48);
+        sized.Should().StartWith("<svg style=\"width: 48px; height: 48px; display: block;\"");
+        sized.Should().Contain("viewBox=\"0 0 24 24\"");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not an svg")]
+    public void SizeInlineSvg_PassesThrough_NonSvg(string? value)
+        => MeshNodeImageHelper.SizeInlineSvg(value!, 48).Should().Be(value);
 }

--- a/test/MeshWeaver.Layout.Test/PromptCellTest.cs
+++ b/test/MeshWeaver.Layout.Test/PromptCellTest.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Data.Serialization;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Structural coverage of the training <see cref="PromptCell"/> (Simulated mode):
+/// <list type="number">
+///   <item>The cell renders a composer (bound TextArea + ✨ Suggest + Send) and
+///   an (initially empty) exchange pane.</item>
+///   <item>The ✨ magic button fills the bound prompt pointer with the
+///   configured suggestion.</item>
+///   <item>Send renders the three-pane exchange — user bubble, agent code cell,
+///   output pane — closed by the deterministic faked stats bar.</item>
+/// </list>
+/// </summary>
+public class PromptCellTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string CellView = nameof(CellView);
+    private const string PromptDataId = "training_prompt";
+    private const string Suggestion = "Show total sales by region as a column chart";
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddLayout(layout => layout
+                .WithView(CellView, (host, _) => PromptCell.Area(host, new PromptCellConfig
+                {
+                    DataId = PromptDataId,
+                    Placeholder = "Ask the training agent…",
+                    SuggestedPrompt = Suggestion,
+                    FakeStatsSeed = 7,
+                    Responder = PromptCell.Simulated(prompt => new PromptCellResponse(
+                        $"// answer for: {prompt}\nvar rows = new[] {{ 1, 2, 3 }};",
+                        Controls.Markdown($"echo: {prompt}")))
+                })));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    private static string FindArea(IContainerControl container, string id)
+    {
+        var match = container.Areas
+            .Select(a => a.Area?.ToString())
+            .FirstOrDefault(a => a is not null && (a == id || a.EndsWith("/" + id, StringComparison.Ordinal)));
+        match.Should().NotBeNull(
+            $"container should contain an area '{id}' — found: " +
+            $"[{string.Join(", ", container.Areas.Select(a => a.Area))}]");
+        return match!;
+    }
+
+    private (ISynchronizationStream<JsonElement> Stream, LayoutAreaReference Reference) OpenCell()
+    {
+        var reference = new LayoutAreaReference(CellView);
+        var stream = GetClient().GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(CreateHostAddress(), reference);
+        return (stream, reference);
+    }
+
+    [HubFact]
+    public async Task Cell_Renders_Composer_With_Input_Magic_And_Send()
+    {
+        var (stream, reference) = OpenCell();
+
+        var root = (StackControl)(await stream.GetControlStream(reference.Area!)
+            .Should().Within(10.Seconds()).Match(c => c is StackControl s
+                && s.Areas.Count >= 2))!;
+
+        var composer = (StackControl)(await stream
+            .GetControlStream(FindArea(root, PromptCell.ComposerArea))
+            .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
+
+        var input = await stream
+            .GetControlStream(FindArea(composer, PromptCell.InputArea))
+            .Should().Within(10.Seconds()).Match(c => c is not null);
+        var textArea = input.Should().BeOfType<TextAreaControl>().Subject;
+        textArea.DataContext.Should().Be(LayoutAreaReference.GetDataPointer(PromptDataId),
+            "the composer is data-bound to the prompt pointer — no hand-rolled state");
+        textArea.Placeholder.Should().Be("Ask the training agent…");
+
+        (await stream.GetControlStream(FindArea(composer, PromptCell.SuggestButtonArea))
+                .Should().Within(10.Seconds()).Match(c => c is not null))
+            .Should().BeOfType<ButtonControl>();
+        (await stream.GetControlStream(FindArea(composer, PromptCell.SendButtonArea))
+                .Should().Within(10.Seconds()).Match(c => c is not null))
+            .Should().BeOfType<ButtonControl>();
+    }
+
+    [HubFact]
+    public async Task Magic_Button_Fills_The_Bound_Prompt_Pointer()
+    {
+        var (stream, reference) = OpenCell();
+        var root = (StackControl)(await stream.GetControlStream(reference.Area!)
+            .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
+        var composer = (StackControl)(await stream
+            .GetControlStream(FindArea(root, PromptCell.ComposerArea))
+            .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
+        var suggestArea = FindArea(composer, PromptCell.SuggestButtonArea);
+        await stream.GetControlStream(suggestArea)
+            .Should().Within(10.Seconds()).Match(c => c is ButtonControl);
+
+        GetClient().Post(new ClickedEvent(suggestArea, stream.StreamId),
+            o => o.WithTarget(CreateHostAddress()));
+
+        // The suggestion lands in the DATA stream the composer is bound to.
+        await stream.GetDataStream<string>(new JsonPointerReference(
+                LayoutAreaReference.GetDataPointer(PromptDataId)))
+            .Should().Within(10.Seconds()).Match(v => v == Suggestion,
+                "✨ writes the suggested prompt into the bound pointer");
+    }
+
+    [HubFact]
+    public async Task Send_Renders_ThreePane_Exchange_With_Stats_Bar()
+    {
+        var (stream, reference) = OpenCell();
+        var root = (StackControl)(await stream.GetControlStream(reference.Area!)
+            .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
+        var composer = (StackControl)(await stream
+            .GetControlStream(FindArea(root, PromptCell.ComposerArea))
+            .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
+        var suggestArea = FindArea(composer, PromptCell.SuggestButtonArea);
+        var sendArea = FindArea(composer, PromptCell.SendButtonArea);
+        var exchangeArea = FindArea(root, PromptCell.ExchangeArea);
+        await stream.GetControlStream(sendArea)
+            .Should().Within(10.Seconds()).Match(c => c is ButtonControl);
+
+        // Fill via ✨, confirm the data landed, then Send.
+        GetClient().Post(new ClickedEvent(suggestArea, stream.StreamId),
+            o => o.WithTarget(CreateHostAddress()));
+        await stream.GetDataStream<string>(new JsonPointerReference(
+                LayoutAreaReference.GetDataPointer(PromptDataId)))
+            .Should().Within(10.Seconds()).Match(v => v == Suggestion);
+        GetClient().Post(new ClickedEvent(sendArea, stream.StreamId),
+            o => o.WithTarget(CreateHostAddress()));
+
+        // The exchange renders the three panes + stats.
+        var exchange = (StackControl)(await stream.GetControlStream(exchangeArea)
+            .Should().Within(10.Seconds()).Match(c => c is StackControl s
+                && s.Areas.Any(a => a.Area?.ToString() is { } p
+                    && p.EndsWith("/" + PromptCell.ExchangeOutputArea, StringComparison.Ordinal))))!;
+
+        // 1 — the user bubble carries the prompt.
+        var bubble = await stream
+            .GetControlStream(FindArea(exchange, PromptCell.ExchangeUserArea))
+            .Should().Within(10.Seconds()).Match(c => c is not null);
+        bubble.Should().BeOfType<MarkdownControl>()
+            .Which.Markdown!.ToString().Should().Contain(Suggestion);
+
+        // 2 — the agent code pane renders the responder's code as a fence.
+        var codePane = await stream
+            .GetControlStream(FindArea(exchange, PromptCell.ExchangeCodeArea))
+            .Should().Within(10.Seconds()).Match(c => c is not null);
+        codePane.Should().BeOfType<MarkdownControl>()
+            .Which.Markdown!.ToString().Should().Contain("```csharp")
+            .And.Contain("// answer for:");
+
+        // 3 — the output pane frames the responder's output control.
+        var outputPane = (StackControl)(await stream
+            .GetControlStream(FindArea(exchange, PromptCell.ExchangeOutputArea))
+            .Should().Within(10.Seconds()).Match(c => c is StackControl))!;
+        var outputInner = await stream
+            .GetControlStream(outputPane.Areas.First().Area!.ToString()!)
+            .Should().Within(10.Seconds()).Match(c => c is not null);
+        outputInner.Should().BeOfType<MarkdownControl>()
+            .Which.Markdown!.ToString().Should().Contain($"echo: {Suggestion}");
+
+        // 4 — the FAKED stats bar: deterministic pseudo-stats, no randomness.
+        var (tokens, seconds) = PromptCell.DeriveStats(Suggestion, 7);
+        var stats = await stream
+            .GetControlStream(FindArea(exchange, PromptCell.ExchangeStatsArea))
+            .Should().Within(10.Seconds()).Match(c => c is not null);
+        stats.Should().BeOfType<LabelControl>();
+
+        // And the derivation itself is stable + prompt-sensitive.
+        PromptCell.DeriveStats(Suggestion, 7).Should().Be((tokens, seconds));
+        PromptCell.DeriveStats(Suggestion + "!", 7).Should().NotBe((tokens, seconds));
+        $"≈ {tokens} tokens · {seconds:0.0}s · model: training-sim"
+            .Should().Contain("training-sim");
+    }
+}

--- a/test/MeshWeaver.Persistence.Test/DocExecutableBlocksTest.cs
+++ b/test/MeshWeaver.Persistence.Test/DocExecutableBlocksTest.cs
@@ -43,10 +43,10 @@ public class DocExecutableBlocksTest(ITestOutputHelper output) : MonolithMeshTes
     /// deleting a page's examples) drops the count below the ratchet and fails
     /// <see cref="Coverage_DoesNotRegress"/>. RAISE the ratchet when you add executable pages.
     /// </summary>
-    private const int MinPagesWithExecutableBlocks = 49;
+    private const int MinPagesWithExecutableBlocks = 51;
 
     /// <summary>Coverage ratchet — total executable blocks across all doc pages. See above.</summary>
-    private const int MinExecutableBlocks = 105;
+    private const int MinExecutableBlocks = 114;
 
     private static readonly Lazy<IReadOnlyDictionary<string, IReadOnlyList<SubmitCodeRequest>>> PageSubmissions =
         new(() =>


### PR DESCRIPTION
Training-driven UX batch:

- **Code cell**: toolbar at the bottom (composer bar); Edit direct only with `Permission.Update`, otherwise a copy-to-your-home dialog → NodeCopyHelper fork → redirect to the copy's editor.
- **Eternal spinner root-caused — 3 real defects fixed** (each pinned red-before/green-after): kernel catch-all view destroying every named area on kernel-hosting hubs (the actual spinner); Console.Error never captured; SatelliteAccessRule denying anonymous under public-read MainNodes.
- **PromptCell**: prompt → agent-code → output exchange with fake stats + magic suggest button; Simulated + LIVE (TrainingSim agent via StartThread) modes.
- **Docs**: ChartGallery + PivotTricks, 9 executable blocks, ratchet 51 pages/114 blocks.
- **Icons**: all icon surfaces now size inline `<svg>` (blank-box cure).

Full solution Release `-warnaserror` 0/0; new/updated test classes green (CodeCellLayoutTest, CodeCellEditRightsTest, CodeCellOutputCaptureTest, KernelStdoutCaptureTest, PromptCellTest, TrainingSimResponderTest, MeshNodeImageHelperTest, DocExecutableBlocksTest 11/11, InteractiveMarkdownExecutionTest 4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)