### PR TITLE
fix(chat): harden the composer hit-target + focus path

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -860,7 +860,13 @@ else
            Submit isn't pushed below the fold. *@
         @if (_connectProvider is null)
         {
-        <div class="input-container" @onkeydown="@OnInputKeyDown">
+        @* @onclick FocusComposerAsync: any click in the composer region focuses the
+           editor. Defuses the thread-nav-shell amplifier (issue #199): the shell is
+           tabindex="0" with outline:none for Alt-Tab thread cycling, so a click that
+           misses Monaco's hit-target would otherwise focus the shell and every
+           printable keystroke would be silently discarded while the input LOOKS
+           active. Focusing an already-focused editor is a no-op. *@
+        <div class="input-container" @onkeydown="@OnInputKeyDown" @onclick="@FocusComposerAsync">
             @* AutoGrow: the composer expands with the content from 80px up to the adaptive
                max (mirrors the command palette's min(440px, calc(100vh - 180px)) pattern),
                then scrolls internally — no more invisible scrolling in a fixed 80px box. *@

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1940,6 +1940,27 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         }
     }
 
+    /// <summary>
+    /// Click anywhere in the composer region focuses the editor (issue #199). The
+    /// surrounding thread-nav-shell is <c>tabindex="0"</c> with a suppressed outline
+    /// (for Alt-Tab thread cycling), so a click that misses Monaco's hit-target would
+    /// otherwise focus the shell and every printable keystroke would be silently
+    /// discarded while the input looks active. Focusing an already-focused editor is
+    /// a no-op; failures are debug-logged (a disposed editor mid-teardown).
+    /// </summary>
+    private async Task FocusComposerAsync()
+    {
+        try
+        {
+            if (monacoEditor != null)
+                await monacoEditor.FocusAsync();
+        }
+        catch (Exception ex) when (!_isDisposed)
+        {
+            Logger.LogDebug(ex, "[ThreadChat:{InstanceId}] Failed to focus Monaco editor", _instanceId);
+        }
+    }
+
     private void CancelSubmission()
     {
         if (submissionHandler.IsInputEnabled || isCancelling)

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor
@@ -141,7 +141,15 @@
 
     private string ContainerStyle => AutoGrow
         // Auto-grow: JS drives the height from the content size; CSS clamps the range.
-        ? $"max-height: {MaxHeight}; min-height: {Height};"
+        // 🚨 The explicit initial height is LOAD-BEARING (issue #199): the inner
+        // .monaco-editor-view is pinned to `height: 100% !important`, so with an
+        // auto-height container the whole chain resolves to 0 until the first
+        // debounced onDidContentSizeChange lands — Monaco's hit-target collapses to
+        // ~one text line while the box still LOOKS like an input, and clicks land on
+        // whatever focusable ancestor sits behind it (the #188 dead-keyboard
+        // regression). Geometry must never depend on a JS event: start at Height,
+        // let the JS grow-write overwrite the inline value from there.
+        ? $"height: {Height}; max-height: {MaxHeight}; min-height: {Height};"
         : $"height: {Height}; max-height: {MaxHeight}; min-height: 40px;";
 
     private string GetMonacoTheme() => isDarkMode ? "vs-dark" : "vs";

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -352,9 +352,15 @@ export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = fals
                     // rendered yet. Typing "/model" and pressing Enter inside the completion
                     // debounce therefore swallowed the first Enter with no visible widget
                     // (issue #174: commands need multiple attempts). The rendered widget adds
-                    // .suggest-widget.visible to the editor DOM — check that instead: it is
-                    // exactly what the user sees, and version-stable across Monaco builds.
-                    const suggestWidget = editorInstance.getDomNode()?.querySelector('.suggest-widget');
+                    // .suggest-widget.visible — but with FixedOverflowWidgets (our config) the
+                    // widget is hosted OUTSIDE the editor node in the document-level
+                    // .overflowingContentWidgets container (same reason isAutocompleteVisible
+                    // below searches document-wide), so check the editor DOM first and fall
+                    // back to the overflow container. A visible suggest widget can only belong
+                    // to the focused editor — the one receiving this keydown — so the
+                    // document-wide fallback cannot misattribute across editors.
+                    const suggestWidget = editorInstance.getDomNode()?.querySelector('.suggest-widget')
+                        ?? document.querySelector('.overflowingContentWidgets .suggest-widget');
                     const isSuggestVisible = !!suggestWidget && suggestWidget.classList.contains('visible');
 
                     if (!isSuggestVisible) {

--- a/test/MeshWeaver.Portal.E2E.Test/ChatComposerRefocusTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/ChatComposerRefocusTest.cs
@@ -1,0 +1,63 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// Regression test for issue #199: the side-chat composer must keep accepting keyboard
+/// input after the user clicks away into the main content area and back. The pre-fix
+/// failure mode: the AutoGrow container had no initial height, the inner
+/// <c>height: 100% !important</c> chain collapsed Monaco's hit-target to ~one text line,
+/// and a click at the visual CENTER of the input box landed on the <c>thread-nav-shell</c>
+/// (<c>tabindex="0"</c>, outline suppressed) which silently swallowed every printable
+/// keystroke — the input looked active but nothing typed.
+///
+/// <para>Deliberately clicks the composer's <c>.input-container</c> CENTER (the
+/// previously dead zone) — NOT <c>.view-lines</c>, which the other chat tests target and
+/// which sat inside the one live band and therefore never caught this. No model round is
+/// needed; typing alone exercises the defect. Runs against the DevLogin e2e portal:
+/// <c>memex-local e2e up &amp;&amp; memex-local e2e test ChatComposerRefocus</c>.</para>
+/// </summary>
+[Collection("portal-e2e")]
+public class ChatComposerRefocusTest(PortalFixture fixture)
+{
+    [Fact(Timeout = 180_000)]
+    public async Task Composer_AcceptsTyping_AfterClickingAwayAndBack()
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+
+        await using var context = await fixture.NewAuthenticatedContextAsync();
+        var page = await context.NewPageAsync();
+        await page.SetViewportSizeAsync(1400, 950);
+        await page.GotoAsync($"{fixture.BaseUrl}/User/Roland",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // Open the side-panel chat.
+        var chatToggle = page.Locator(".side-panel-toggle button, .side-panel-toggle fluent-button").First;
+        await chatToggle.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+        await chatToggle.ClickAsync();
+
+        var inputContainer = page.Locator(".thread-chat-footer .input-container").Last;
+        await inputContainer.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+        var viewLines = page.Locator(".thread-chat-footer .monaco-editor .view-lines").Last;
+
+        // 1. Baseline: click the container CENTER (not .view-lines) and type — must land.
+        await inputContainer.ClickAsync();
+        await page.Keyboard.TypeAsync("hello");
+        await Assertions.Expect(viewLines).ToContainTextAsync("hello",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+
+        // 2. Click away into the MAIN content area (left of the side panel) — the exact
+        //    step of the report ("click a citation / open a node / scroll the dashboard").
+        await page.Mouse.ClickAsync(300, 400);
+
+        // 3. Click BACK into the composer at its CENTER — the pre-fix dead zone — and type.
+        await inputContainer.ClickAsync();
+        await page.Keyboard.TypeAsync(" again");
+
+        // 4. The keystrokes must appear; pre-fix they were silently swallowed by the
+        //    focused nav shell while the input looked active.
+        await Assertions.Expect(viewLines).ToContainTextAsync("again",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+    }
+}


### PR DESCRIPTION
Closes #199.

## What happened (full analysis on the issue)
#199 was a regression from #188 (my change), browser-reproduced with the real CSS: AutoGrow removed the container's fixed height while `.monaco-editor-view` is pinned `height:100% !important`, so until the first debounced `onDidContentSizeChange` the chain resolved to 0 — Monaco's hit-target collapsed to ~one text line (7 of 9 click offsets dead, including the visual center) and clicks landed on the `tabindex="0"` `thread-nav-shell` (outline suppressed, keydown only handles Alt-Tab), which silently swallowed every keystroke. #207 later moved the grow-write to the outer container and **incidentally** restored the geometry (9/9 offsets work at HEAD). This PR makes the fix deliberate and removes the remaining exposure:

## Changes
1. **`MonacoEditorView` ContainerStyle (AutoGrow)**: explicit initial inline `height: {Height}` — the hit-target never depends on a debounced JS event again (load-bearing comment added so it isn't "simplified" away).
2. **Composer click-to-focus**: any click in `.input-container` calls `FocusAsync()` on the editor — defuses the nav-shell keystroke-swallowing amplifier for the composer region without touching Alt-Tab thread cycling (focusing an already-focused editor is a no-op).
3. **Enter gate follow-up (#174/#188 defect found during the investigation)**: with `FixedOverflowWidgets` (our config) the suggest widget can be hosted document-wide in `.overflowingContentWidgets`, not inside the editor node — the visibility check now falls back there, matching the module's own `isAutocompleteVisible`. Without this, Enter with a visible suggestion list could submit instead of accepting. A visible suggest widget can only belong to the focused editor (the one receiving the keydown), so the fallback cannot misattribute across editors.
4. **New E2E `ChatComposerRefocusTest`**: clicks the composer **center** (the pre-fix dead zone — existing chat tests dodge it by targeting `.view-lines`), clicks away into the main area, clicks back, types — asserts keystrokes land. Skips when the portal fixture is unavailable, like the rest of the suite.

## Verification
- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Blazor.Portal` (pulls Blazor) and the E2E test project.
- Mechanism evidence: headless-Chrome repro measured 9/9 offsets pre-#188, 7/9 dead on the code live when #199 was filed, 9/9 at HEAD — details in the issue comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)