### PR TITLE
fix(query+ai): restore the synced-query Initial gate; truthful empty-agent-set errors

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -1123,11 +1123,22 @@ public class AgentChatClient : IAgentChat
             if (!selectionMatched)
             {
                 var requested = currentAgentPath ?? currentAgentName;
-                lastAgentCreationError =
-                    $"Selected agent '{requested}' was not found among the available agents "
-                    + $"([{string.Join(", ", loadedAgents.Select(a => a.Path ?? a.Name))}]). "
-                    + "It may have been moved, renamed, or is not available in this context — "
-                    + "pick another agent from the list.";
+                // 🚨 Truthful empty-set error (issue #201): with ZERO loaded
+                // agents the problem is never the user's selection — the agent
+                // registry returned none (the load failed or none are visible
+                // in this context). "pick another agent from the list" with an
+                // empty list misdirects the user at the selection instead of
+                // the load, so that suggestion is reserved for the non-empty
+                // case.
+                lastAgentCreationError = loadedAgents.Count == 0
+                    ? $"Selected agent '{requested}' could not be resolved. "
+                      + "No agents are available in this context — the agent registry "
+                      + "returned none (agents failed to load, or none are visible here). "
+                      + "Check the agent configuration and access rights for this space."
+                    : $"Selected agent '{requested}' was not found among the available agents "
+                      + $"([{string.Join(", ", loadedAgents.Select(a => a.Path ?? a.Name))}]). "
+                      + "It may have been moved, renamed, or is not available in this context — "
+                      + "pick another agent from the list.";
                 logger.LogWarning("[AgentChatClient] {Error}", lastAgentCreationError);
             }
             return null;
@@ -1402,6 +1413,13 @@ public class AgentChatClient : IAgentChat
                 {
                     logger.LogWarning(ex, "[AgentChatClient] Agent subscription faulted — unblocking with empty");
                     ApplyAgents(Array.Empty<AgentDisplayInfo>(), contextPath);
+                    // AFTER ApplyAgents — CreateAgentsSync resets
+                    // lastAgentCreationError at the start of each attempt, so
+                    // recording the fault first would be wiped. Surfacing the
+                    // REAL load failure here means the chat output shows why
+                    // no agents are available instead of a stale-selection
+                    // "not found" message (issue #201).
+                    lastAgentCreationError = $"Agent loading failed: {ex.Message}";
                     readinessFired = true;
                     agentsLoadedSubject.OnNext(this);
                 },

--- a/src/MeshWeaver.Graph/SyncedQueryMeshNodes.cs
+++ b/src/MeshWeaver.Graph/SyncedQueryMeshNodes.cs
@@ -198,15 +198,23 @@ public sealed record SyncedQueryMeshNodes : VirtualTypeSource<MeshNode>
     ///         <see cref="QueryResultChange{MeshNode}"/>.</item>
     ///   <item>A single <c>Scan</c> folds the deltas into
     ///         <see cref="ImmutableDictionary{TKey,TValue}"/> keyed by
-    ///         <see cref="MeshNode.Path"/> AND a per-query Initial-count
-    ///         array. <c>Initial</c>/<c>Reset</c>/<c>Added</c>/<c>Updated</c>
+    ///         <see cref="MeshNode.Path"/> plus a <c>SeenInitial</c> flag.
+    ///         <c>Initial</c>/<c>Reset</c>/<c>Added</c>/<c>Updated</c>
     ///         set/replace the dict entry; <c>Removed</c> drops it.</item>
-    ///   <item>Suppress emissions until every query has produced its first
-    ///         provider Initial, so the first <c>.Take(1)</c> consumer sees
-    ///         the complete path set rather than a partial one. Push the
-    ///         live path set into <see cref="_pathSet"/> for synchronous
-    ///         <see cref="Owns"/> checks by the write reducer, then emit
-    ///         <c>dict.Values</c>.</item>
+    ///   <item>🚨 INVARIANT (restored after regression a777a87bd): suppress
+    ///         ALL downstream emissions until the upstream query has produced
+    ///         its first provider <c>Initial</c>/<c>Reset</c>. The
+    ///         <see cref="_externalChanges"/> side-channel and the
+    ///         <see cref="IMeshChangeFeed"/> deletion fast-path are NOT
+    ///         filtered by the query — if either fires in the
+    ///         subscribe→Initial window, an un-gated Scan emits an EMPTY
+    ///         dictionary as its FIRST emission, which <c>Replay(1)</c>
+    ///         consumers cache and replay (issue #201: chat's agent list
+    ///         resolved to <c>[]</c>). Pre-Initial changes still fold into
+    ///         the dictionary; they are only not emitted early. Once the gate
+    ///         opens, push the live path set into <see cref="_pathSet"/> for
+    ///         synchronous <see cref="Owns"/> checks by the write reducer,
+    ///         then emit <c>dict.Values</c>.</item>
     /// </list>
     ///
     /// <para>For single-node content reads on a known path use
@@ -331,20 +339,43 @@ public sealed record SyncedQueryMeshNodes : VirtualTypeSource<MeshNode>
         // already unions across all queries, so a single Initial seeds the
         // complete snapshot; subsequent Added/Updated/Removed events apply
         // verbatim.
+        //
+        // 🚨 Initial gate — do NOT remove (regression: commit a777a87bd,
+        // 2026-05-09, deleted the per-query gate and left the side-channels
+        // un-gated). The class contract (see the type doc, "Initial gating")
+        // promises NO downstream emission until the upstream query has
+        // produced its first Initial/Reset. `externalChanges` (the
+        // NotifyDeleted side-channel) and `feedRemovals` (the process-wide
+        // IMeshChangeFeed deletions, UNFILTERED by this query) can fire in
+        // the subscribe→Initial window; without the gate the Scan's FIRST
+        // emission is an EMPTY dictionary, which Replay(1) consumers
+        // (MeshNodeStreamCache.GetQueryRaw) cache and replay — downstream
+        // symptom: "Selected agent 'X' was not found among the available
+        // agents ([])" (issue #201). Pre-Initial changes still FOLD into the
+        // dictionary — they are only not EMITTED early. SeenInitial is seeded
+        // true when there is no query core: that branch's upstream is
+        // Observable.Empty and would never emit Initial, so the side-channels
+        // must stay observable (as before) instead of wedging forever.
         return allChanges
             .Scan(
-                ImmutableDictionary<string, MeshNode>.Empty,
-                (dict, change) => change.ChangeType switch
+                (Dict: ImmutableDictionary<string, MeshNode>.Empty, SeenInitial: queryCore == null),
+                (state, change) => change.ChangeType switch
                 {
-                    QueryChangeType.Initial or QueryChangeType.Reset
-                        or QueryChangeType.Added or QueryChangeType.Updated =>
-                        change.Items.Aggregate(dict, (d, n) =>
-                            string.IsNullOrEmpty(n.Path) ? d : d.SetItem(n.Path, n)),
+                    // Only the upstream query emits Initial/Reset — this is
+                    // what flips the gate open.
+                    QueryChangeType.Initial or QueryChangeType.Reset =>
+                        (change.Items.Aggregate(state.Dict, (d, n) =>
+                            string.IsNullOrEmpty(n.Path) ? d : d.SetItem(n.Path, n)), true),
+                    QueryChangeType.Added or QueryChangeType.Updated =>
+                        (change.Items.Aggregate(state.Dict, (d, n) =>
+                            string.IsNullOrEmpty(n.Path) ? d : d.SetItem(n.Path, n)), state.SeenInitial),
                     QueryChangeType.Removed =>
-                        change.Items.Aggregate(dict, (d, n) =>
-                            string.IsNullOrEmpty(n.Path) ? d : d.Remove(n.Path)),
-                    _ => dict,
+                        (change.Items.Aggregate(state.Dict, (d, n) =>
+                            string.IsNullOrEmpty(n.Path) ? d : d.Remove(n.Path)), state.SeenInitial),
+                    _ => state,
                 })
+            .Where(state => state.SeenInitial)
+            .Select(state => state.Dict)
             .Do(dict => diagLogger?.LogDebug(
                 "[SyncedQuery] snapshot hub={HubAddress} count={Count} keys=[{Keys}]",
                 workspace.Hub.Address, dict.Count,

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshQueryCore.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshQueryCore.cs
@@ -7,6 +7,9 @@ using System.Text.Json;
 [assembly: InternalsVisibleTo("MeshWeaver.Graph")]
 [assembly: InternalsVisibleTo("MeshWeaver.AI")]
 [assembly: InternalsVisibleTo("Memex.Portal.Shared")]
+// SyncedQueryInitialGateTest decorates the REAL IMeshQueryCore with a
+// subscription-delaying wrapper to pin the pre-Initial emission gate.
+[assembly: InternalsVisibleTo("MeshWeaver.Query.Test")]
 // Castle.DynamicProxy (used by NSubstitute) generates proxies in this assembly;
 // without InternalsVisibleTo it can't implement the internal IMeshQueryCore.
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/test/MeshWeaver.AI.Test/AgentSelectionPathResolutionTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentSelectionPathResolutionTest.cs
@@ -176,6 +176,38 @@ public class AgentSelectionPathResolutionTest : AITestBase
         response.Should().Contain("was not found among the available agents",
             "a genuinely unmatched selection IS an agent-not-found failure");
     }
+
+    /// <summary>
+    /// Issue #201's downstream symptom surface: an EMPTY agent set (the synced agent
+    /// query emitted an empty snapshot — pre-Initial-gate regression, or genuinely no
+    /// agents visible) combined with an explicit selection must report the TRUTHFUL
+    /// failure — no agents are available in this context — and must NOT tell the user
+    /// to "pick another agent from the list" when the list is empty. (The explicit
+    /// selection still does NOT fall through to another agent — there is none — and
+    /// the non-empty case keeps the existing "was not found among the available
+    /// agents ([…]) … pick another agent" message, pinned by
+    /// <see cref="SelectUnknownAgentPath_DegradesGracefully_DoesNotSilentlyPickAnotherAgent"/>.)
+    /// </summary>
+    [Fact]
+    public async Task EmptyAgentSet_ExplicitSelection_ReportsNoAgentsAvailable_NotPickAnother()
+    {
+        var client = new AgentChatClient(Mesh.ServiceProvider);
+        // The empty-snapshot state: the synced-query Subscribe callback applied
+        // an empty agent list (the exact production path of issue #201).
+        client.ApplyAgents(Array.Empty<AgentDisplayInfo>(), contextPath: null);
+
+        // The composer's picker carries a persisted selection from before the list emptied.
+        client.SetSelectedAgent("Agent/Assistant");
+
+        var response = await RunAndCaptureAsync(client);
+
+        response.Should().Contain("No agents are available",
+            "with zero loaded agents the truthful failure is the agent LOAD (registry returned "
+            + "none — failed to load or none visible), not the user's selection");
+        response.Should().NotContain("pick another agent from the list",
+            "there is no list to pick from — that suggestion misdirects the user at the "
+            + "selection instead of the load");
+    }
 }
 
 /// <summary>

--- a/test/MeshWeaver.Query.Test/SyncedQueryInitialGateTest.cs
+++ b/test/MeshWeaver.Query.Test/SyncedQueryInitialGateTest.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace MeshWeaver.Query.Test;
+
+/// <summary>
+/// Pins the <b>Initial gate</b> of <see cref="SyncedQueryMeshNodes"/> (issue #201,
+/// regression a777a87bd): the class contract promises NO downstream emission until the
+/// upstream query has produced its first <c>Initial</c>/<c>Reset</c>. Two side-channels
+/// are merged into the pipeline UNFILTERED by the query — the
+/// <see cref="SyncedQueryMeshNodes.NotifyDeleted"/> subject and the process-wide
+/// <see cref="IMeshChangeFeed"/> deletion fast-path. If either fires in the
+/// subscribe→Initial window, an un-gated Scan emits an EMPTY dictionary as its FIRST
+/// emission, which <c>Replay(1)</c> consumers (<c>MeshNodeStreamCache.GetQueryRaw</c>,
+/// <c>AgentChatClient</c>'s agent dropdown) cache and replay — the production symptom
+/// was "Selected agent 'X' was not found among the available agents ([])".
+///
+/// <para><b>Determinism:</b> the subscribe→Initial race is made deterministic by a
+/// delaying DECORATOR over the REAL <see cref="IMeshQueryCore"/> (no mock): it defers
+/// the inner <c>Query</c> subscription for exactly the gated query string until the
+/// test fires <see cref="initialGate"/>. Both side-channels deliver synchronously
+/// (Rx <c>Subject</c> / in-process change feed), so "fire the side-channel while
+/// Initial is held" is exact, not timing-dependent.</para>
+/// </summary>
+public class SyncedQueryInitialGateTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string SubjectsNamespace = $"{TestPartition}/InitialGateSubjects";
+
+    /// <summary>
+    /// The exact query string of the gated synced query. The decorator delays ONLY
+    /// requests carrying this exact string, so framework synced queries (SecurityService
+    /// _Access walks, …) and this test's un-gated probe query (which appends
+    /// <c>state:Active</c>) flow through undisturbed.
+    /// </summary>
+    private const string GatedQuery = $"namespace:{SubjectsNamespace} scope:subtree nodeType:Markdown";
+
+    /// <summary>
+    /// Test-controlled release for the held Initial. The decorator subscribes the
+    /// REAL query only after this fires.
+    /// </summary>
+    private readonly Subject<Unit> initialGate = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+            {
+                // Decorate the REAL IMeshQueryCore registered by the persistence
+                // layer — wrap its factory, don't mock the interface.
+                var innerDescriptor = services.LastOrDefault(d => d.ServiceType == typeof(IMeshQueryCore))
+                    ?? throw new InvalidOperationException(
+                        "IMeshQueryCore must already be registered by the persistence layer "
+                        + "before the delaying decorator can wrap it.");
+                var innerFactory = innerDescriptor.ImplementationFactory
+                    ?? throw new InvalidOperationException(
+                        "Expected a factory-based IMeshQueryCore registration to decorate.");
+                services.RemoveAll<IMeshQueryCore>();
+                services.AddSingleton<IMeshQueryCore>(sp => new DelayingQueryCore(
+                    (IMeshQueryCore)innerFactory(sp),
+                    initialGate,
+                    request => request.EffectiveQueries.Any(q => q == GatedQuery)));
+                return services;
+            });
+
+    /// <summary>
+    /// Decorator over the real <see cref="IMeshQueryCore"/>: for requests matching
+    /// <paramref name="shouldDelay"/>, the inner <c>Query</c> subscription is deferred
+    /// until <paramref name="gate"/> emits — holding the upstream Initial open while the
+    /// test fires the un-gated side-channels. Everything else passes straight through.
+    /// </summary>
+    private sealed class DelayingQueryCore(
+        IMeshQueryCore inner,
+        IObservable<Unit> gate,
+        Func<MeshQueryRequest, bool> shouldDelay) : IMeshQueryCore
+    {
+        public IObservable<QueryResultChange<T>> Query<T>(
+            MeshQueryRequest request,
+            JsonSerializerOptions options)
+            => shouldDelay(request)
+                ? gate.Take(1).SelectMany(_ => inner.Query<T>(request, options))
+                : inner.Query<T>(request, options);
+    }
+
+    private static MeshNode MakeSubject(string id)
+        => new(id, SubjectsNamespace)
+        {
+            Name = id,
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        };
+
+    /// <summary>
+    /// Seeds one matching node and PROVES it is visible on the query surface via an
+    /// un-gated probe query (exact-string delay predicate ⇒ the probe passes through),
+    /// so the gated query's Initial — computed when the gate releases — deterministically
+    /// contains the seed. Guards the assertions below against the create→index lag noted
+    /// in <see cref="SyncedQueryTest"/>.
+    /// </summary>
+    private async Task<MeshNode> SeedAndProveVisible(string id, object probeId)
+    {
+        var seed = MakeSubject(id);
+        await NodeFactory.CreateNode(seed).Should().Emit();
+
+        var probe = Mesh.GetWorkspace().GetQuery(probeId, $"{GatedQuery} state:Active");
+        await probe
+            .Where(nodes => nodes.Any(n => n.Path == seed.Path))
+            .Should().Within(15.Seconds()).Emit();
+        return seed;
+    }
+
+    private static (IDisposable Recorder, Func<MeshNode[][]> Snapshot) Record(
+        IObservable<IEnumerable<MeshNode>> stream)
+    {
+        var emissions = new List<MeshNode[]>();
+        var recorder = stream.Subscribe(nodes =>
+        {
+            lock (emissions)
+                emissions.Add(nodes.ToArray());
+        });
+        return (recorder, () =>
+        {
+            lock (emissions)
+                return emissions.ToArray();
+        });
+    }
+
+    private static void AssertNoEmptyFirstEmission(MeshNode[][] recorded, string seedPath)
+    {
+        recorded.Should().NotBeEmpty("the released Initial must reach the subscriber");
+        recorded.Should().OnlyContain(e => e.Length > 0,
+            "no emission may precede the upstream Initial — an empty pre-Initial snapshot "
+            + "is exactly the issue-#201 bug (Replay(1) consumers cache and serve it)");
+        recorded[0].Should().Contain(n => n.Path == seedPath,
+            "the FIRST emission must be the complete Initial snapshot, never a "
+            + "side-channel-fabricated empty dictionary");
+    }
+
+    /// <summary>
+    /// The <see cref="SyncedQueryMeshNodes.NotifyDeleted"/> side-channel leg: a synthetic
+    /// Removed for an UNRELATED path pushed while the upstream Initial is held must NOT
+    /// produce an empty first emission. RED before the fix (the un-gated Scan emitted the
+    /// empty dictionary synchronously); GREEN with the restored Initial gate.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task NotifyDeleted_BeforeInitial_DoesNotEmitEmptySnapshot()
+    {
+        var seed = await SeedAndProveVisible("seed-external", "$initial-gate-probe-external");
+
+        var synced = new SyncedQueryMeshNodes(
+            Mesh.GetWorkspace(),
+            "$initial-gate-external",
+            GatedQuery);
+
+        var (recorder, snapshot) = Record(synced.StreamUpdates());
+        using (recorder)
+        {
+            // While Initial is HELD by the decorator, fire the NotifyDeleted
+            // side-channel for a path that was never in the result set —
+            // delivered synchronously into the Scan on this thread.
+            synced.NotifyDeleted("Unrelated/Path");
+
+            // Release the gate → the REAL query subscribes and emits Initial.
+            initialGate.OnNext(Unit.Default);
+
+            await synced.StreamUpdates()
+                .Where(nodes => nodes.Any(n => n.Path == seed.Path))
+                .Should().Within(15.Seconds()).Emit();
+
+            AssertNoEmptyFirstEmission(snapshot(), seed.Path);
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IMeshChangeFeed"/> deletion fast-path leg: the feed subscription in
+    /// <c>BuildReadStreamCore</c> is process-wide and UNFILTERED by the query, so ANY
+    /// hub's delete lands in EVERY synced query's pipeline. A Deleted event published
+    /// while the upstream Initial is held must NOT produce an empty first emission.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task ChangeFeedDeletion_BeforeInitial_DoesNotEmitEmptySnapshot()
+    {
+        var seed = await SeedAndProveVisible("seed-feed", "$initial-gate-probe-feed");
+
+        var synced = new SyncedQueryMeshNodes(
+            Mesh.GetWorkspace(),
+            "$initial-gate-feed",
+            GatedQuery);
+
+        var (recorder, snapshot) = Record(synced.StreamUpdates());
+        using (recorder)
+        {
+            // While Initial is HELD, publish a Deleted change-feed event for an
+            // unrelated path — the in-process feed delivers synchronously.
+            var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+            changeFeed.Publish(MeshChangeEvent.Deleted("Unrelated/FeedPath"));
+
+            initialGate.OnNext(Unit.Default);
+
+            await synced.StreamUpdates()
+                .Where(nodes => nodes.Any(n => n.Path == seed.Path))
+                .Should().Within(15.Seconds()).Emit();
+
+            AssertNoEmptyFirstEmission(snapshot(), seed.Path);
+        }
+    }
+}


### PR DESCRIPTION
Closes #201.

## Root cause (investigation on the issue): a May regression in the synced-query layer
`SyncedQueryMeshNodes.BuildReadStreamCore` merges the upstream query with two side-channels — the `NotifyDeleted` channel and the **process-wide** `IMeshChangeFeed` Deleted feed (unfiltered by the query) — into a `Scan` that had **no Initial gate**: commit `a777a87bd` (2026-05-09, multi-query union) deleted the per-query gate and left the side-channels un-gated, while the class docstring still promised "suppresses emissions until Initial". Any node deletion anywhere in the mesh during the subscribe→Initial window produced an **empty first emission**, which `MeshNodeStreamCache`'s `Replay(1)` cached and replayed. Downstream, `AgentChatClient`'s readiness gate fires on *any* first emission → agent validation ran against an empty set → *"Selected agent 'Agent/Assistant' was not found among the available agents (**[]**) … pick another agent from the list"* with nothing to pick.

## Fixes
1. **Initial gate restored** (`SyncedQueryMeshNodes`): the `Scan` state carries `SeenInitial` (flips on `Initial`/`Reset`, which only the upstream emits); emissions are suppressed until then; pre-Initial removals still fold into the state. Seeded true for the no-core branch so it can't wedge. Docs state the invariant and cite the regression commit so the gate isn't deleted again. This heals every synced-query consumer (agent picker, model picker, security walks), not just agents.
2. **Truthful empty-set error** (`AgentChatClient`): an unmatched explicit selection against an EMPTY set now reports that no agents are available in this context (registry returned none) — never "pick another agent from the list". Non-empty keeps the existing message verbatim (pinned by an existing test).
3. **Faulted agent subscription surfaces its reason**: the OnError path sets `lastAgentCreationError = "Agent loading failed: …"` (ordered after `ApplyAgents`, which resets the field) instead of leaving the stale-selection lie.

**Deliberately NO fallback-to-another-agent** when the persisted selection is missing but others exist — that silent-fallback shape caused the earlier wrong-agent prod confusion and is pinned by `SelectUnknownAgentPath_DegradesGracefully_DoesNotSilentlyPickAnotherAgent`.

## Red-first evidence
- `SyncedQueryInitialGateTest` (new, deterministic — a delaying decorator over the REAL `IMeshQueryCore` holds the upstream Initial while the side-channels fire; no `Task.Delay`, no mocks of core interfaces): both legs (NotifyDeleted + change-feed Deleted) **red pre-fix** with an empty first emission, green post-fix.
- `EmptyAgentSet_ExplicitSelection_ReportsNoAgentsAvailable_NotPickAnother` (new): **red pre-fix** reproducing the exact production message, green post-fix.

## Regression matrix (all green, run individually)
SyncedQueryTest 13/13 · SyncedQueryFreshnessContractTest 2/2 · all three AgentSelection* classes 5/5 (incl. the pinning tests) · AgentChatClientNoSuitableAgentTest · LanguageModelSyncedQueryTest 2/2 (synced-query consumer integration). Zero consumer depended on early-empty emissions. `dotnet build -c Release -warnaserror` clean for Graph, AI, and all three test projects. (`IMeshQueryCore.cs` gains `InternalsVisibleTo("MeshWeaver.Query.Test")` — precedent: `IMeshNodeStreamCache` already grants it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)