### PR TITLE
fix(access): canonical subject-picker queries + diacritic-insensitive matching (#213)

### DIFF
--- a/memex/Memex.Portal.Shared/Pages/DevLogin.razor
+++ b/memex/Memex.Portal.Shared/Pages/DevLogin.razor
@@ -86,8 +86,10 @@
 
     protected override void OnInitialized()
     {
+        // Canonical users query — the legacy "namespace:User" shape targets the pre-V27
+        // `user` schema, which no longer exists, and silently returns zero users.
         _personsSubscription = MeshQuery
-            .Query<MeshNode>(MeshQueryRequest.FromQuery("nodeType:User namespace:User"))
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWeaver.Mesh.Security.AccessSubjectQueries.Users))
             .Subscribe(
                 change =>
                 {

--- a/src/MeshWeaver.AI/Data/Skill/access.md
+++ b/src/MeshWeaver.AI/Data/Skill/access.md
@@ -1,0 +1,131 @@
+---
+nodeType: Skill
+name: /access
+description: Hand out access rights to mesh nodes — create the AccessAssignment the framework way (right namespace, right mainNode), pick the correct role and scope, grant platform admin correctly, and verify the grant took effect. Covers the Access Control UI, MCP recipes, and the pitfalls that make a grant silently do nothing.
+icon: LockClosed
+category: Skills
+order: 11
+---
+
+You are handing out **access rights to mesh nodes**. Permissions in MeshWeaver are **data**:
+an `AccessAssignment` MeshNode inside a `_Access` satellite namespace. There is no separate
+ACL store — you grant access by creating a node with the right **placement** and **content**,
+and the reactive `PermissionEvaluator` picks it up within ~1 second. Get the placement wrong
+and the grant is **silently ignored** — the node exists, permissions don't change.
+
+# The model — one node per subject per scope
+
+```
+path:        {scope}/_Access/{subject}_Access      ← MUST contain the /_Access/ segment
+mainNode:    {scope}                                ← MUST equal the scope the path lives under
+nodeType:    AccessAssignment
+content:     { accessObject, displayName, roles: [ { role, denied? } ] }
+```
+
+- **`{scope}`** is the node/partition the grant covers: a partition root (`rbuergi`), a space
+  (`ACME`), or any subtree (`ACME/Projects`). Grants **inherit downward** — a grant at `ACME`
+  covers every node under `ACME/…`.
+- **`accessObject`** is the subject's userId (matched against the login identity) or a Group id.
+- **`roles[].role`**: `Admin` (all), `Editor` (read/create/update/comment), `Viewer` (read),
+  `Commenter` (read/comment), or a custom `Role` node's id. `denied: true` turns a grant into
+  a deny for that role at that scope (closest scope wins).
+- **Satellites never get their own grants.** `_Thread`, `_Comment`, `_Activity`, … inherit from
+  their `mainNode` automatically. Grant on the main node, never on a satellite path.
+
+# Recipe 1 — grant a user a role on a node / space
+
+Example: give `alice` Editor on the `ACME` space (works the same for any subtree path):
+
+```bash
+mcp create --node '{
+  "id": "alice_Access",
+  "namespace": "ACME/_Access",
+  "name": "alice Access (Editor)",
+  "nodeType": "AccessAssignment",
+  "mainNode": "ACME",
+  "content": {
+    "$type": "AccessAssignment",
+    "accessObject": "alice",
+    "displayName": "Alice",
+    "roles": [ { "$type": "RoleAssignment", "role": "Editor" } ]
+  }
+}'
+```
+
+If the subject already has an assignment at that scope, **update the existing node's `roles`**
+instead of creating a second one — the convention is one node per subject per scope.
+
+**GUI equivalent:** open the node → **Settings → Access Control** → *Add* row (or *Add
+Assignment* dialog) → pick the subject in the **Subject (User or Group)** picker → pick the
+role. The picker binds the canonical `AccessSubjectQueries` (users at the root namespace via
+the `auth` mirror + groups in the scope's partition subtree) and filters in-memory,
+diacritic-insensitively — "Burgi" finds "Bürgi". A person who has never logged in has no
+`User` node yet and cannot be picked — see §not-yet-provisioned below.
+
+# Recipe 2 — platform (global) admin: Admin partition, NEVER root
+
+"Global admin" has exactly one shape: the `Admin` role **in the `Admin/_Access` namespace**
+(`mainNode` empty). This makes the user a **platform admin** (invites, deletes, config —
+checked via `hub.IsGlobalAdmin()`), NOT a data superuser:
+
+```bash
+mcp create --node '{
+  "id": "alice_Access",
+  "namespace": "Admin/_Access",
+  "name": "alice — Admin",
+  "nodeType": "AccessAssignment",
+  "mainNode": "",
+  "content": {
+    "$type": "AccessAssignment",
+    "accessObject": "alice",
+    "displayName": "Alice",
+    "roles": [ { "$type": "RoleAssignment", "role": "Admin" } ]
+  }
+}'
+```
+
+🚨 **Never create a grant in the root `_Access` namespace.** That is the data-superuser shape —
+standing `Permission.All` over every partition — and is deliberately not how admins are
+provisioned. Emergency cross-partition data access is an explicit break-glass elevation,
+never a standing grant.
+
+# Recipe 3 — public / anonymous read
+
+- **All authenticated users**: `accessObject: "Public"` in `{scope}/_Access` (usually `Viewer`).
+- **Not-logged-in visitors**: `accessObject: "Anonymous"`.
+- **Whole-partition defaults** are better expressed as a `PartitionAccessPolicy` `_Policy` node
+  (`publicRead: true` + write caps) than as Public grants on every subtree.
+
+# Not-yet-provisioned users
+
+A `User` node is created on first login/onboarding. If the person you want to grant to has no
+`User` node yet, the subject picker cannot offer them. Options, in order:
+
+1. **Invite them** (platform admin → Invitations) so onboarding creates the `User` node, then grant.
+2. **Grant by principal anyway** via MCP (Recipe 1) — `accessObject` matches the userId at login
+   time; the assignment simply lies dormant until they exist. Make sure the id you write is the
+   exact login userId (email-derived), not a guessed display name.
+
+# Verify — never declare a grant done without this
+
+1. `mcp get @{scope}/_Access/{subject}_Access` → confirm the node exists AND `mainNode` == `{scope}`.
+2. Confirm effect: have the user (or `search` under their identity) read a node under `{scope}` —
+   the `Access denied` banner must be gone. Propagation is ~1 s; no restart, no cache flush.
+3. For platform admin: the Global Administration tab appears on the user's profile.
+
+# Pitfalls — each of these makes a grant silently do nothing
+
+| Symptom | Cause |
+|---|---|
+| Assignment exists, still `Access denied` | `mainNode` empty (non-global grant) — the evaluator ignores it |
+| Edited assignment has no effect | `mcp patch` does NOT write `mainNode` (indexed column) — use full `update` |
+| Node created but never enforced | namespace doesn't end in `/_Access` — landed outside the security pipeline |
+| Grant on a thread/comment has no effect | satellites inherit from `mainNode` — grant on the main node instead |
+| "Global admin" can't see admin tabs | grant written to root `_Access` instead of `Admin/_Access` |
+| User can't be picked in the GUI | no `User` node yet (never logged in) — invite first or grant by principal via MCP |
+
+# Related
+
+- [Granting Access via AccessAssignments](/Doc/Architecture/GrantingAccess) — field anatomy + full recipes
+- [Access Control Architecture](/Doc/Architecture/AccessControl) — evaluator internals, roles, deny semantics
+- [Access Context Propagation](/Doc/Architecture/AccessContextPropagation) — who a write runs as

--- a/src/MeshWeaver.Blazor/Components/MeshNodePickerView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshNodePickerView.razor.cs
@@ -53,6 +53,17 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
     // SearchText.Matches — server-side ILIKE would miss "Burgi" → "Bürgi" (issue #213).
     private bool UseClientFilter => HasItems || ViewModel?.FilterInMemory == true;
 
+    // The FilterInMemory base load is CAPPED so a large installation can't pull the whole
+    // node set into the circuit. When the cap is hit (_cacheAtCap), typed text falls back to
+    // the normal server-side search and the dropdown shows the union of the client-filtered
+    // cache and the server matches — the tail beyond the cap stays findable.
+    private const int ClientFilterLoadLimit = 500;
+    private bool _cacheAtCap;
+
+    // At-cap + non-empty text → the cheap cached path is NOT sufficient; go to the server.
+    private bool CanServeFromCache(string searchText)
+        => UseClientFilter && _cachedResults != null && !(_cacheAtCap && searchText.Length > 0);
+
     // Compact "thin" rendering + open-upward dropdown, driven by the control's Layout/Open.
     private bool IsThin => ViewModel?.Layout == MeshNodePickerLayout.Thin;
     private bool OpensUp => ViewModel?.Open == MeshNodePickerOpenDirection.Up;
@@ -204,7 +215,7 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
         _isSearchOpen = true;
 
         // In-memory filter path — cheap, no debounce.
-        if (UseClientFilter && _cachedResults != null)
+        if (CanServeFromCache(_searchText.Trim()))
         {
             _results = FilterCached(_searchText.Trim());
             _highlightedIndex = 0;
@@ -225,7 +236,7 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
     private void LoadResultsAsync()
     {
         // When the cached client-filter set is already loaded, filter in-memory
-        if (UseClientFilter && _cachedResults != null)
+        if (CanServeFromCache(_searchText.Trim()))
         {
             _results = FilterCached(_searchText.Trim());
             _highlightedIndex = 0;
@@ -255,13 +266,17 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
         }
 
         var userText = _searchText.Trim();
+        // Client-filter mode appends the typed text ONLY when the capped cache can't answer
+        // (at cap): then the server search covers the tail beyond the cap.
+        var appendText = !string.IsNullOrEmpty(userText) && (!UseClientFilter || _cacheAtCap);
         var observables = queries.Select(baseQuery =>
         {
-            var fullQuery = UseClientFilter || string.IsNullOrEmpty(userText)
-                ? baseQuery
-                : $"{baseQuery} {userText}";
+            var fullQuery = appendText ? $"{baseQuery} {userText}" : baseQuery;
+            var request = MeshQueryRequest.FromQuery(fullQuery);
+            if (UseClientFilter)
+                request = request with { Limit = ClientFilterLoadLimit };
             return MeshQuery
-                .Query<MeshNode>(MeshQueryRequest.FromQuery(fullQuery))
+                .Query<MeshNode>(request)
                 .Take(1)
                 .Select(c => (IReadOnlyList<MeshNode>)c.Items)
                 .Catch<IReadOnlyList<MeshNode>, Exception>(
@@ -297,9 +312,26 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
 
             if (UseClientFilter)
             {
-                // Cache for in-memory filtering
-                _cachedResults = merged;
-                _results = FilterCached(_searchText.Trim());
+                var searchText = _searchText.Trim();
+                if (_cachedResults == null || searchText.Length == 0)
+                {
+                    // Base load (no typed text appended): (re)establish the cache. At-cap
+                    // detection keys the server-search fallback for later keystrokes.
+                    _cachedResults = merged;
+                    _cacheAtCap = queryResults.Count >= ClientFilterLoadLimit;
+                    _results = FilterCached(searchText);
+                }
+                else
+                {
+                    // At-cap text search: union the diacritic-filtered cache with the
+                    // server-side text matches (dedup by Path; cache entries win). The
+                    // cache itself stays the base set — never poison it with a filtered load.
+                    _results = FilterCached(searchText)
+                        .Concat(merged)
+                        .GroupBy(n => n.Path, StringComparer.OrdinalIgnoreCase)
+                        .Select(g => g.First())
+                        .ToList();
+                }
             }
             else
             {

--- a/src/MeshWeaver.Blazor/Components/MeshNodePickerView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshNodePickerView.razor.cs
@@ -47,6 +47,12 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
     private MeshNode[]? BoundItems { get; set; }
     private bool HasItems => BoundItems is { Length: > 0 };
 
+    // Client-side filtering: pre-loaded Items OR an explicit FilterInMemory opt-in on the
+    // control (bounded sets like the access-subject picker). The base queries load once
+    // WITHOUT the typed text; keystrokes filter the cached set diacritic-insensitively via
+    // SearchText.Matches — server-side ILIKE would miss "Burgi" → "Bürgi" (issue #213).
+    private bool UseClientFilter => HasItems || ViewModel?.FilterInMemory == true;
+
     // Compact "thin" rendering + open-upward dropdown, driven by the control's Layout/Open.
     private bool IsThin => ViewModel?.Layout == MeshNodePickerLayout.Thin;
     private bool OpensUp => ViewModel?.Open == MeshNodePickerOpenDirection.Up;
@@ -198,7 +204,7 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
         _isSearchOpen = true;
 
         // In-memory filter path — cheap, no debounce.
-        if (HasItems && _cachedResults != null)
+        if (UseClientFilter && _cachedResults != null)
         {
             _results = FilterCached(_searchText.Trim());
             _highlightedIndex = 0;
@@ -218,8 +224,8 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
 
     private void LoadResultsAsync()
     {
-        // When Items are provided and already cached, filter in-memory
-        if (HasItems && _cachedResults != null)
+        // When the cached client-filter set is already loaded, filter in-memory
+        if (UseClientFilter && _cachedResults != null)
         {
             _results = FilterCached(_searchText.Trim());
             _highlightedIndex = 0;
@@ -251,7 +257,7 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
         var userText = _searchText.Trim();
         var observables = queries.Select(baseQuery =>
         {
-            var fullQuery = HasItems || string.IsNullOrEmpty(userText)
+            var fullQuery = UseClientFilter || string.IsNullOrEmpty(userText)
                 ? baseQuery
                 : $"{baseQuery} {userText}";
             return MeshQuery
@@ -289,7 +295,7 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
                 .Select(g => g.First())
                 .ToList();
 
-            if (HasItems)
+            if (UseClientFilter)
             {
                 // Cache for in-memory filtering
                 _cachedResults = merged;
@@ -333,12 +339,9 @@ public partial class MeshNodePickerView : FormComponentBase<MeshNodePickerContro
         if (_cachedResults == null) return new List<MeshNode>();
         if (string.IsNullOrEmpty(searchText)) return _cachedResults;
 
+        // Diacritic- AND case-insensitive: "Burgi" matches "Bürgi" (SearchText.Fold).
         return _cachedResults
-            .Where(n =>
-                (n.Name ?? "").Contains(searchText, StringComparison.OrdinalIgnoreCase)
-                || (n.Path ?? "").Contains(searchText, StringComparison.OrdinalIgnoreCase)
-                || (n.NodeType ?? "").Contains(searchText, StringComparison.OrdinalIgnoreCase)
-                || (n.Id ?? "").Contains(searchText, StringComparison.OrdinalIgnoreCase))
+            .Where(n => SearchText.Matches(searchText, n.Name, n.Path, n.NodeType, n.Id))
             .ToList();
     }
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -557,7 +557,7 @@ The Access Control layout area (`AccessControlLayoutArea`, Settings → Access C
 3. **Add row / Add Assignment dialog** (admin-only) — subject picker + role select that creates the AccessAssignment node.
 4. **Advanced** — the partition policy (`PartitionAccessPolicy`) capping permissions for everyone at this scope and below.
 
-The subject picker binds the canonical queries from **`AccessSubjectQueries`** (`MeshWeaver.Mesh.Contract`): users at the root namespace (served by the `auth` lookup mirror via `UserNodeType`'s routing rule) plus groups in the scope's partition subtree. It filters the bounded subject set in-memory, diacritic-insensitively (`SearchText`). Hand-rolled subject queries are forbidden — the legacy `namespace:User` / `namespace:Group` shapes target dropped schemas and silently return zero rows (issue #213). See [Granting Access](/Doc/Architecture/GrantingAccess) for the UI walkthrough and MCP recipes.
+The subject picker binds the canonical queries from **`AccessSubjectQueries`** (`MeshWeaver.Mesh.Contract`): users at the root namespace (served by the `auth` lookup mirror via `UserNodeType`'s routing rule) plus groups in the scope's partition subtree. It loads the subject set once (capped at 500) and filters it in-memory, diacritic-insensitively (`SearchText`); beyond the cap, typed text falls back to the server-side search and the union is shown. Hand-rolled subject queries are forbidden — the legacy `namespace:User` / `namespace:Group` shapes target dropped schemas and silently return zero rows (issue #213). See [Granting Access](/Doc/Architecture/GrantingAccess) for the UI walkthrough and MCP recipes.
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -550,11 +550,14 @@ flowchart TB
 
 # Access Control UI
 
-The Access Control layout area (`AccessControlArea`) provides three panels:
+The Access Control layout area (`AccessControlLayoutArea`, Settings → Access Control) provides:
 
-1. **Inherited Permissions** (read-only markdown table) — shows AccessAssignment nodes from ancestor scopes, displaying Subject, Role, Source path, and Allow/Deny status.
-2. **Local Assignments** (editable) — shows AccessAssignment nodes that are direct children of the current node. Admins can toggle Allow/Deny and delete assignments.
-3. **Add Assignment** (admin-only) — dialog with autocompleting comboboxes for Subject (User/Group search via `IMeshService`) and Role selection.
+1. **Parent scope** (read-only) — the AccessAssignment nodes inherited from the parent scope, rendered via the AccessAssignment Thumbnail area.
+2. **Current scope** (editable, admin-only) — the assignments at this node; role dropdown + Deny toggle bind directly to each assignment's node stream.
+3. **Add row / Add Assignment dialog** (admin-only) — subject picker + role select that creates the AccessAssignment node.
+4. **Advanced** — the partition policy (`PartitionAccessPolicy`) capping permissions for everyone at this scope and below.
+
+The subject picker binds the canonical queries from **`AccessSubjectQueries`** (`MeshWeaver.Mesh.Contract`): users at the root namespace (served by the `auth` lookup mirror via `UserNodeType`'s routing rule) plus groups in the scope's partition subtree. It filters the bounded subject set in-memory, diacritic-insensitively (`SearchText`). Hand-rolled subject queries are forbidden — the legacy `namespace:User` / `namespace:Group` shapes target dropped schemas and silently return zero rows (issue #213). See [Granting Access](/Doc/Architecture/GrantingAccess) for the UI walkthrough and MCP recipes.
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/GrantingAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GrantingAccess.md
@@ -65,7 +65,7 @@ The **Subject (User or Group)** picker is bound to the canonical queries in `Acc
 - **Users** — `nodeType:User namespace:""`. Users live at the ROOT namespace (path = userId); the path-less query is pinned to the central `auth` lookup mirror by `UserNodeType`'s routing rule, so one query covers every user in the mesh. 🚨 The legacy `namespace:User` shape targets the pre-V27 `user` schema, which no longer exists — it silently returns **zero** rows. Never hand-roll subject queries; reference `AccessSubjectQueries`.
 - **Groups** — `nodeType:Group namespace:{partition} scope:subtree`: every group defined in the scope's partition.
 
-The picker loads the (bounded) subject set once and filters **in-memory, diacritic- and case-insensitively** (`SearchText.Fold`): typing "Burgi" finds "Bürgi".
+The picker loads the subject set once (capped at 500 nodes) and filters **in-memory, diacritic- and case-insensitively** (`SearchText.Fold`): typing "Burgi" finds "Bürgi". On installations with more subjects than the cap, typed text additionally runs the normal server-side search and the union is shown, so users beyond the cap remain findable (that path matches by substring, without diacritic folding).
 
 **Limitation — not-yet-provisioned users.** A `User` node is created at first login/onboarding, so a person who has never logged in cannot be picked. Either invite them first (platform admin → Invitations), or grant by principal via MCP (Recipe 3 below with the exact login userId) — the assignment lies dormant until they exist.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/GrantingAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GrantingAccess.md
@@ -6,9 +6,9 @@ Description: "Grant user permissions in MeshWeaver by creating AccessAssignment 
 
 # Granting Access via AccessAssignments
 
-Permissions in MeshWeaver are **data** — they live as `AccessAssignment` MeshNodes inside `_Access` satellite namespaces. There is no dedicated admin UI. You grant access by creating an `AccessAssignment` node via MCP, a hub message, or the migration runner, and the `PermissionEvaluator` picks it up automatically via its synced query.
+Permissions in MeshWeaver are **data** — they live as `AccessAssignment` MeshNodes inside `_Access` satellite namespaces. You grant access either through the **Access Control UI** (Settings → Access Control on any node you administer) or by creating an `AccessAssignment` node via MCP, a hub message, or the migration runner. Either way, the `PermissionEvaluator` picks the node up automatically via its synced query — the UI is just a convenient writer of the same data.
 
-This page walks through the field anatomy and provides copy-paste recipes for the most common scenarios.
+This page walks through the UI, the field anatomy, and copy-paste recipes for the most common scenarios.
 
 <svg viewBox="0 0 760 320" xmlns="http://www.w3.org/2000/svg" style="width:100%;max-width:760px;height:auto;display:block;margin:20px auto;" font-family="sans-serif" font-size="13">
   <defs>
@@ -53,6 +53,21 @@ This page walks through the field anatomy and provides copy-paste recipes for th
 </svg>
 
 *AccessAssignment nodes live in `_Access` satellite namespaces; `PermissionEvaluator` picks them up via a synced query and Postgres triggers rebuild effective permissions automatically.*
+
+---
+
+## The Access Control UI
+
+Open a node you administer → **Settings → Access Control**. The page shows the assignments inherited from the parent scope (read-only), the editable assignments at the current scope, an inline **Add** row, and a collapsed **Advanced** section for the partition policy.
+
+The **Subject (User or Group)** picker is bound to the canonical queries in `AccessSubjectQueries` (`src/MeshWeaver.Mesh.Contract/Security/AccessSubjectQueries.cs`):
+
+- **Users** — `nodeType:User namespace:""`. Users live at the ROOT namespace (path = userId); the path-less query is pinned to the central `auth` lookup mirror by `UserNodeType`'s routing rule, so one query covers every user in the mesh. 🚨 The legacy `namespace:User` shape targets the pre-V27 `user` schema, which no longer exists — it silently returns **zero** rows. Never hand-roll subject queries; reference `AccessSubjectQueries`.
+- **Groups** — `nodeType:Group namespace:{partition} scope:subtree`: every group defined in the scope's partition.
+
+The picker loads the (bounded) subject set once and filters **in-memory, diacritic- and case-insensitively** (`SearchText.Fold`): typing "Burgi" finds "Bürgi".
+
+**Limitation — not-yet-provisioned users.** A `User` node is created at first login/onboarding, so a person who has never logged in cannot be picked. Either invite them first (platform admin → Invitations), or grant by principal via MCP (Recipe 3 below with the exact login userId) — the assignment lies dormant until they exist.
 
 ---
 

--- a/src/MeshWeaver.Graph/AccessAssignmentLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/AccessAssignmentLayoutAreas.cs
@@ -286,17 +286,17 @@ public static class AccessAssignmentLayoutAreas
         var formId = $"change_subject_{Guid.NewGuid().AsString()}";
         ctx.Host.UpdateData(formId, new Dictionary<string, object?> { ["accessObject"] = "" });
 
-        // Users live at the root namespace; groups in the partition subtree.
-        var subjectQueries = new[]
-        {
-            "namespace:\"\" nodeType:User",
-            "namespace:Group nodeType:Group"
-        };
+        // Canonical subject queries for the assignment's SCOPE (the path prefix before
+        // /_Access). The previous hand-rolled pair searched the legacy "Group" partition,
+        // whose schema no longer exists — the group half always came back empty (issue #213).
+        var subjectQueries = AccessSubjectQueries.ForScope(
+            AccessSubjectQueries.ScopeOfAssignment(nodePath));
 
         var formContent = Controls.Stack.WithStyle("gap: 16px; padding: 16px;")
             .WithView(new MeshNodePickerControl(new JsonPointerReference("accessObject"))
             {
                 Queries = subjectQueries,
+                FilterInMemory = true,
                 Label = "Subject (User or Group)",
                 Required = true,
                 DataContext = LayoutAreaReference.GetDataPointer(formId)

--- a/src/MeshWeaver.Graph/AccessControlLayoutArea.cs
+++ b/src/MeshWeaver.Graph/AccessControlLayoutArea.cs
@@ -155,8 +155,9 @@ public static class AccessControlLayoutArea
 
         var userPicker = new MeshNodePickerControl(new JsonPointerReference("accessObject"))
         {
-            Queries = ["namespace:\"\" nodeType:User"],
-            Label = "Add user",
+            Queries = AccessSubjectQueries.ForScope(nodePath),
+            FilterInMemory = true,
+            Label = "Add user or group",
             DataContext = dataContext
         }.WithStyle("flex: 1; min-width: 220px;");
 
@@ -278,10 +279,11 @@ public static class AccessControlLayoutArea
             ["role"] = ""
         });
 
-        // Resolve queries for AccessObject from [MeshNode] attribute
-        var meshNodeAttr = typeof(AccessAssignment).GetProperty(nameof(AccessAssignment.AccessObject))!
-            .GetCustomAttributes(typeof(MeshNodeAttribute), false).OfType<MeshNodeAttribute>().First();
-        var subjectQueries = MeshNodeAttribute.ResolveQueries(meshNodeAttr.Queries, nodePath, nodePath);
+        // Canonical subject queries (users at root via the auth mirror + groups in the
+        // partition subtree) — never resolve the attribute template with a PATH here: the
+        // previous ResolveQueries(queries, nodePath, nodePath) substituted the node's path
+        // into {node.namespace}, scoping the group search to the node instead of its partition.
+        var subjectQueries = AccessSubjectQueries.ForScope(nodePath);
 
         // Resolve queries for Role from [MeshNodeCollection] attribute
         var rolesAttr = typeof(AccessAssignment).GetProperty(nameof(AccessAssignment.Roles))!
@@ -293,6 +295,7 @@ public static class AccessControlLayoutArea
             .WithView(new MeshNodePickerControl(new JsonPointerReference("accessObject"))
             {
                 Queries = subjectQueries,
+                FilterInMemory = true,
                 Label = "Subject (User or Group)",
                 Required = true,
                 DataContext = LayoutAreaReference.GetDataPointer(formId)

--- a/src/MeshWeaver.Layout/MeshNodePickerControl.cs
+++ b/src/MeshWeaver.Layout/MeshNodePickerControl.cs
@@ -91,10 +91,13 @@ public record MeshNodePickerControl(object Data)
     public bool DefaultToFirst { get; init; }
 
     /// <summary>
-    /// When true, the queries load ONCE without the typed text and the view filters the
-    /// cached result set in-memory (diacritic- and case-insensitive — "Burgi" finds "Bürgi").
-    /// Use for bounded result sets (users, groups, roles) where server-side substring search
-    /// would miss accented matches; leave false for large/open sets that need server search.
+    /// When true, the queries load ONCE without the typed text — capped at 500 nodes — and
+    /// the view filters the cached set in-memory (diacritic- and case-insensitive — "Burgi"
+    /// finds "Bürgi"). If the cap is hit, typed text ADDITIONALLY runs the normal server-side
+    /// search and the union is shown, so installations larger than the cap still find the
+    /// tail (server matching there is substring-based, not diacritic-folded). Use for
+    /// typically-small sets (users, groups, roles); leave false for large/open sets that
+    /// should always search server-side.
     /// </summary>
     public bool FilterInMemory { get; init; }
 

--- a/src/MeshWeaver.Layout/MeshNodePickerControl.cs
+++ b/src/MeshWeaver.Layout/MeshNodePickerControl.cs
@@ -90,6 +90,14 @@ public record MeshNodePickerControl(object Data)
     /// </summary>
     public bool DefaultToFirst { get; init; }
 
+    /// <summary>
+    /// When true, the queries load ONCE without the typed text and the view filters the
+    /// cached result set in-memory (diacritic- and case-insensitive — "Burgi" finds "Bürgi").
+    /// Use for bounded result sets (users, groups, roles) where server-side substring search
+    /// would miss accented matches; leave false for large/open sets that need server search.
+    /// </summary>
+    public bool FilterInMemory { get; init; }
+
     /// <summary>Returns a copy with <paramref name="layout"/> controlling the visual density of picker results.</summary>
     /// <param name="layout">The desired layout variant (e.g. compact or full card).</param>
     public MeshNodePickerControl WithLayout(MeshNodePickerLayout layout)

--- a/src/MeshWeaver.Mesh.Contract/SearchText.cs
+++ b/src/MeshWeaver.Mesh.Contract/SearchText.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+using System.Text;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// Diacritic-insensitive, case-insensitive text matching for in-process search filtering —
+/// the matcher behind <c>MeshNodePickerView</c>'s client-side filter. Folds combining marks
+/// (ü→u, é→e) plus the common Latin ligatures/specials FormD does not decompose (ß→ss, æ→ae,
+/// œ→oe, ø→o, đ→d, ł→l), so "Burgi" finds "Bürgi" and vice versa.
+/// </summary>
+public static class SearchText
+{
+    /// <summary>
+    /// Folds <paramref name="text"/> to its lower-case, diacritic-free comparison form.
+    /// Null/empty input folds to <c>""</c>.
+    /// </summary>
+    public static string Fold(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return "";
+        var normalized = text.Normalize(NormalizationForm.FormD);
+        var sb = new StringBuilder(normalized.Length);
+        foreach (var c in normalized)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.NonSpacingMark)
+                continue;
+            switch (char.ToLowerInvariant(c))
+            {
+                case 'ß': sb.Append("ss"); break;
+                case 'æ': sb.Append("ae"); break;
+                case 'œ': sb.Append("oe"); break;
+                case 'ø': sb.Append('o'); break;
+                case 'đ': sb.Append('d'); break;
+                case 'ł': sb.Append('l'); break;
+                default: sb.Append(char.ToLowerInvariant(c)); break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// True when the folded <paramref name="searchText"/> is a substring of any folded
+    /// <paramref name="fields"/> entry. An empty search text matches everything.
+    /// </summary>
+    public static bool Matches(string? searchText, params string?[] fields)
+    {
+        var needle = Fold(searchText);
+        if (needle.Length == 0) return true;
+        foreach (var field in fields)
+        {
+            if (!string.IsNullOrEmpty(field) && Fold(field).Contains(needle, StringComparison.Ordinal))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/Security/AccessAssignment.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/AccessAssignment.cs
@@ -12,7 +12,7 @@ namespace MeshWeaver.Mesh.Security;
 public record AccessAssignment
 {
     /// <summary>Subject identifier (User or Group path) for this assignment.</summary>
-    [MeshNode("nodeType:User namespace:\"\"", "nodeType:Group namespace:{node.namespace} scope:subtree")]
+    [MeshNode(AccessSubjectQueries.Users, AccessSubjectQueries.GroupsTemplate)]
     public string AccessObject { get; init; } = "";
 
     /// <summary>Optional display name for the subject.</summary>

--- a/src/MeshWeaver.Mesh.Contract/Security/AccessSubjectQueries.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/AccessSubjectQueries.cs
@@ -1,0 +1,81 @@
+namespace MeshWeaver.Mesh.Security;
+
+/// <summary>
+/// The ONE source of truth for the mesh queries that find access <b>subjects</b> (users and
+/// groups) — used by the <c>[MeshNode]</c> attributes on <see cref="AccessAssignment.AccessObject"/> /
+/// <see cref="GroupMembership.Member"/> and by every Access Control picker in the GUI.
+///
+/// <para>Users live at the ROOT namespace (path = userId, namespace = "") — the post-v10
+/// placement. A path-less <c>nodeType:User</c> query is pinned to the central <c>auth</c>
+/// lookup mirror by <c>UserNodeType</c>'s query-routing rule, so one query covers every user
+/// in the mesh. The legacy <c>namespace:User</c> shape targets the pre-V27 <c>user</c> schema,
+/// which no longer exists — it silently returns ZERO rows (the 2026-07 "cannot select a user
+/// in the Subject dropdown" bug, issue #213). Never hand-roll these queries again; reference
+/// the members of this class.</para>
+/// </summary>
+public static class AccessSubjectQueries
+{
+    /// <summary>
+    /// All users in the mesh: root-namespace <c>User</c> nodes, served by the <c>auth</c>
+    /// lookup mirror via <c>UserNodeType</c>'s routing rule. Usable in attributes (const).
+    /// </summary>
+    public const string Users = "nodeType:User namespace:\"\"";
+
+    /// <summary>
+    /// Template form of the groups query for <c>[MeshNode]</c> attributes —
+    /// <c>{node.namespace}</c> is substituted by the generic property editor at render time.
+    /// Code that knows the scope path calls <see cref="Groups"/> instead.
+    /// </summary>
+    public const string GroupsTemplate = "nodeType:Group namespace:{node.namespace} scope:subtree";
+
+    /// <summary>
+    /// Groups eligible as subjects when granting at <paramref name="scopePath"/>: every
+    /// <c>Group</c> node in the scope's PARTITION subtree (first path segment — groups defined
+    /// anywhere in the space/user partition are grantable on any node inside it). At the root
+    /// scope the query is unscoped and fans out across partitions, access-filtered.
+    /// </summary>
+    public static string Groups(string? scopePath)
+    {
+        var partition = Partition(scopePath);
+        return string.IsNullOrEmpty(partition)
+            ? "nodeType:Group"
+            : $"nodeType:Group namespace:{partition} scope:subtree";
+    }
+
+    /// <summary>
+    /// The subject-picker queries (users + groups) for granting access at
+    /// <paramref name="scopePath"/> — what every Access Control picker binds to.
+    /// </summary>
+    public static string[] ForScope(string? scopePath) => [Users, Groups(scopePath)];
+
+    /// <summary>
+    /// The scope a satellite node governs: the path prefix before its satellite segment
+    /// (e.g. <c>rsalzmann/Games/Lolo/_Access/alice_Access</c> → <c>rsalzmann/Games/Lolo</c>;
+    /// a root-level <c>_Access/x</c> → <c>""</c>). A path without an <c>_Access</c> segment
+    /// is returned unchanged (it IS the scope).
+    /// </summary>
+    public static string ScopeOfAssignment(string? assignmentPath)
+    {
+        if (string.IsNullOrEmpty(assignmentPath)) return "";
+        var idx = assignmentPath.IndexOf("_Access", StringComparison.Ordinal);
+        while (idx >= 0)
+        {
+            var atStart = idx == 0 || assignmentPath[idx - 1] == '/';
+            var end = idx + "_Access".Length;
+            var atEnd = end == assignmentPath.Length || assignmentPath[end] == '/';
+            if (atStart && atEnd)
+                return idx == 0 ? "" : assignmentPath[..(idx - 1)];
+            idx = assignmentPath.IndexOf("_Access", idx + 1, StringComparison.Ordinal);
+        }
+        return assignmentPath;
+    }
+
+    /// <summary>The partition (first path segment) of <paramref name="path"/>, or <c>""</c> for root.</summary>
+    public static string Partition(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return "";
+        var trimmed = path.Trim('/');
+        var slash = trimmed.IndexOf('/');
+        return slash < 0 ? trimmed : trimmed[..slash];
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/Security/GroupMembership.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/GroupMembership.cs
@@ -11,7 +11,7 @@ namespace MeshWeaver.Mesh.Security;
 public record GroupMembership
 {
     /// <summary>Member identifier (User or Group path) for this membership.</summary>
-    [MeshNode("namespace:User nodeType:User", "namespace:{node.namespace} nodeType:Group scope:selfAndAncestors")]
+    [MeshNode(AccessSubjectQueries.Users, "namespace:{node.namespace} nodeType:Group scope:selfAndAncestors")]
     public string Member { get; init; } = "";
 
     /// <summary>Optional display name for the member.</summary>

--- a/test/MeshWeaver.Security.Test/AccessControlLayoutAreaTest.cs
+++ b/test/MeshWeaver.Security.Test/AccessControlLayoutAreaTest.cs
@@ -301,12 +301,12 @@ public class AccessControlLayoutAreaTest(ITestOutputHelper output) : MonolithMes
         var rootControl = (await stream.GetControlStream(reference.Area!)
             .Should().Within(15.Seconds()).Match(c => c is StackControl s && s.Areas?.Count >= 4))!;
 
-        // The inline add row renders a user picker scoped to root-namespace users…
+        // The inline add row renders a subject picker bound to the canonical users query…
         var pickers = await CollectControls<MeshNodePickerControl>(stream, rootControl, reference.Area!);
         var userPicker = pickers.Select(p => p.Control)
-            .FirstOrDefault(p => p.Queries?.Contains("namespace:\"\" nodeType:User") == true);
+            .FirstOrDefault(p => p.Queries?.Contains(AccessSubjectQueries.Users) == true);
         userPicker.Should().NotBeNull(
-            "the inline add row must render a user picker — broken if hub.CheckPermission(path, Permission.Delete) didn't surface the admin assignment");
+            "the inline add row must render a subject picker — broken if hub.CheckPermission(path, Permission.Delete) didn't surface the admin assignment");
 
         // …and a + Add button.
         var buttons = await CollectControls<ButtonControl>(stream, rootControl, reference.Area!);
@@ -342,11 +342,12 @@ public class AccessControlLayoutAreaTest(ITestOutputHelper output) : MonolithMes
 
         var pickers = await CollectControls<MeshNodePickerControl>(stream, rootControl, reference.Area!);
         var userPicker = pickers.Select(p => p.Control)
-            .FirstOrDefault(p => string.Equals(p.Label?.ToString(), "Add user", StringComparison.Ordinal));
-        userPicker.Should().NotBeNull("the inline add row must render an 'Add user' picker");
+            .FirstOrDefault(p => string.Equals(p.Label?.ToString(), "Add user or group", StringComparison.Ordinal));
+        userPicker.Should().NotBeNull("the inline add row must render an 'Add user or group' picker");
         userPicker!.Queries.Should().NotBeNull();
-        userPicker.Queries!.Should().Contain("namespace:\"\" nodeType:User",
-            "users live at the root namespace, so the add field must scope to namespace:\"\"");
+        userPicker.Queries!.Should().Contain(AccessSubjectQueries.Users,
+            "the add field must bind the canonical AccessSubjectQueries.Users query "
+            + "(users live at the root namespace, served by the auth mirror)");
 
         var selects = await CollectControls<SelectControl>(stream, rootControl, reference.Area!);
         var roleSelect = selects.Select(s => s.Control)

--- a/test/MeshWeaver.Security.Test/AccessSubjectQueriesTests.cs
+++ b/test/MeshWeaver.Security.Test/AccessSubjectQueriesTests.cs
@@ -1,0 +1,125 @@
+using MeshWeaver.Domain;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// Unit tests for <see cref="AccessSubjectQueries"/> — the single source of truth for the
+/// subject-picker queries used by the Access Control UI and the <c>[MeshNode]</c> attributes
+/// on <see cref="AccessAssignment.AccessObject"/> / <see cref="GroupMembership.Member"/> —
+/// and for <see cref="SearchText"/>, the diacritic-insensitive in-memory matcher the picker
+/// filters with (issue #213: "Burgi" must find "Bürgi").
+/// </summary>
+public class AccessSubjectQueriesTests
+{
+    [Fact]
+    public void UsersQuery_TargetsRootNamespace_NotLegacyUserPartition()
+    {
+        // The legacy "namespace:User" shape targets the pre-V27 `user` schema (dropped) and
+        // silently returns zero rows — the root cause of issue #213's empty subject picker.
+        AccessSubjectQueries.Users.Should().Be("nodeType:User namespace:\"\"");
+        AccessSubjectQueries.Users.Should().NotContain("namespace:User");
+    }
+
+    [Theory]
+    [InlineData("rsalzmann/Games/Lolo", "nodeType:Group namespace:rsalzmann scope:subtree")]
+    [InlineData("ACME", "nodeType:Group namespace:ACME scope:subtree")]
+    [InlineData("", "nodeType:Group")]
+    [InlineData(null, "nodeType:Group")]
+    public void GroupsQuery_ScopesToPartition(string? scopePath, string expected)
+        => AccessSubjectQueries.Groups(scopePath).Should().Be(expected);
+
+    [Fact]
+    public void ForScope_ReturnsUsersAndPartitionGroups()
+        => AccessSubjectQueries.ForScope("ACME/Projects/X").Should().Equal(
+            AccessSubjectQueries.Users,
+            "nodeType:Group namespace:ACME scope:subtree");
+
+    [Theory]
+    [InlineData("rsalzmann/Games/Lolo/_Access/alice_Access", "rsalzmann/Games/Lolo")]
+    [InlineData("ACME/_Access/bob_Access", "ACME")]
+    [InlineData("_Access/root_Access", "")]
+    [InlineData("Admin/_Access", "Admin")]
+    [InlineData("ACME/Projects/X", "ACME/Projects/X")] // no _Access segment → path IS the scope
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void ScopeOfAssignment_StripsAccessSatelliteSuffix(string? assignmentPath, string expected)
+        => AccessSubjectQueries.ScopeOfAssignment(assignmentPath).Should().Be(expected);
+
+    [Fact]
+    public void ScopeOfAssignment_IgnoresNonSegmentOccurrences()
+        // "_AccessLog" is not the "_Access" satellite segment — must not be treated as one.
+        => AccessSubjectQueries.ScopeOfAssignment("ACME/_AccessLog/x").Should().Be("ACME/_AccessLog/x");
+
+    [Theory]
+    [InlineData("ACME/Projects/X", "ACME")]
+    [InlineData("rbuergi", "rbuergi")]
+    [InlineData("/rbuergi/", "rbuergi")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void Partition_IsFirstSegment(string? path, string expected)
+        => AccessSubjectQueries.Partition(path).Should().Be(expected);
+
+    [Fact]
+    public void AccessAssignmentAttribute_UsesCanonicalQueries()
+    {
+        // Pin the [MeshNode] attribute on AccessAssignment.AccessObject to the canonical
+        // constants — a drift back to a hand-rolled query re-opens issue #213.
+        var attr = typeof(AccessAssignment).GetProperty(nameof(AccessAssignment.AccessObject))!
+            .GetCustomAttributes(typeof(MeshNodeAttribute), false)
+            .OfType<MeshNodeAttribute>().Single();
+        attr.Queries.Should().Equal(AccessSubjectQueries.Users, AccessSubjectQueries.GroupsTemplate);
+    }
+
+    [Fact]
+    public void GroupMembershipAttribute_UsesCanonicalUsersQuery()
+    {
+        var attr = typeof(GroupMembership).GetProperty(nameof(GroupMembership.Member))!
+            .GetCustomAttributes(typeof(MeshNodeAttribute), false)
+            .OfType<MeshNodeAttribute>().Single();
+        attr.Queries[0].Should().Be(AccessSubjectQueries.Users);
+    }
+}
+
+/// <summary>
+/// Unit tests for <see cref="SearchText"/> — diacritic folding and matching.
+/// </summary>
+public class SearchTextTests
+{
+    [Theory]
+    [InlineData("Bürgi", "burgi")]
+    [InlineData("BÜRGI", "burgi")]
+    [InlineData("Müller-Straße", "muller-strasse")]
+    [InlineData("Ærø", "aero")]
+    [InlineData("Łódź", "lodz")]
+    [InlineData("café", "cafe")]
+    [InlineData("plain", "plain")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void Fold_RemovesDiacriticsAndCase(string? input, string expected)
+        => SearchText.Fold(input).Should().Be(expected);
+
+    [Theory]
+    [InlineData("Burgi", "Roland Bürgi")]   // unaccented query finds accented name
+    [InlineData("Bürgi", "Roland Burgi")]   // accented query finds unaccented name
+    [InlineData("bürgi", "Roland BÜRGI")]
+    [InlineData("roland b", "Roland Bürgi")]
+    [InlineData("", "anything")]            // empty search matches everything
+    public void Matches_IsDiacriticAndCaseInsensitive(string search, string name)
+        => SearchText.Matches(search, name).Should().BeTrue();
+
+    [Theory]
+    [InlineData("Bürge", "Roland Bürgi")]   // different letters stay different (e ≠ i)
+    [InlineData("xyz", "Roland Bürgi")]
+    public void Matches_RejectsNonMatches(string search, string name)
+        => SearchText.Matches(search, name).Should().BeFalse();
+
+    [Fact]
+    public void Matches_ChecksEveryField()
+    {
+        SearchText.Matches("bürgi", null, "path/rburgi", null).Should().BeTrue();
+        SearchText.Matches("bürgi", null, null, "User").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Fixes the Access Control "cannot select a user in the Subject dropdown" bug (#213) at the root, factors the subject-query logic into a backend static class with unit tests, adds the `/access` skill, and refreshes the access docs.

## Root causes (verified live on memex)

1. **Dead legacy queries.** The subject pickers hand-rolled their queries in three places; `namespace:Group` targets the dropped `group` schema and `namespace:User` (GroupMembership member picker, DevLogin) targets the pre-V27 `user` schema — both silently return **zero rows** on partitioned Postgres (`namespace:User nodeType:User` → 0 results, reproduced via MCP).
2. **Diacritic-sensitive matching.** The picker appended the typed text to the server query; ILIKE substring matching misses accented names — `nodeType:User namespace:"" Burgi` → 0 results even though "Roland Bürgi" exists.

## Changes

- **`AccessSubjectQueries`** (new, `MeshWeaver.Mesh.Contract/Security`) — the one source of truth for subject queries: users at the root namespace (auth mirror via `UserNodeType`'s routing rule) + groups in the scope's partition subtree. Referenced by the `[MeshNode]` attributes on `AccessAssignment.AccessObject` / `GroupMembership.Member` and every Access Control picker. Includes `ScopeOfAssignment` / `Partition` helpers.
- **`SearchText`** (new, `MeshWeaver.Mesh.Contract`) — diacritic-/case-insensitive fold + match ("Burgi" ⇄ "Bürgi", ß→ss, æ→ae…).
- **`MeshNodePickerControl.FilterInMemory`** — bounded subject sets load once and filter client-side through `SearchText`; the view's cached filter is now diacritic-insensitive for all pickers.
- **Access Control UI** — inline add row now offers groups; add row + Add Assignment dialog + Change Subject dialog all bind `AccessSubjectQueries.ForScope` (the dialog previously substituted the node *path* into the `{node.namespace}` template; the Change Subject dialog used the dead `namespace:Group` shape).
- **DevLogin** person list — canonical users query.
- **`/access` skill** (`MeshWeaver.AI/Data/Skill/access.md`) — teaching agents how to hand out access rights: assignment shape, recipes (partition role, platform admin, public/anonymous), not-yet-provisioned users, verification, pitfalls.
- **Docs** — `GrantingAccess.md` gains an Access Control UI section (its "no dedicated admin UI" claim was stale); `AccessControl.md` UI section updated to the current layout + canonical query contract.

## Tests

- New `AccessSubjectQueriesTests` + `SearchTextTests` (38 facts) — query shapes, scope/partition helpers, attribute pinning (drift back to hand-rolled queries fails the build), folding/matching incl. the "Bürge ≠ Bürgi" non-match.
- `AccessControlLayoutAreaTest` updated to the canonical contract (8/8 green).
- `DocumentationLinkIntegrityTest` green.
- Release `-warnaserror` build green for all touched projects.

## Out of scope (follow-up in #213)

Invite-by-email path for granting to a person who has never logged in (no `User` node yet) — the picker can only offer provisioned subjects; the skill and docs document the MCP grant-by-principal workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)