### PR TITLE
fix(mesh): ContentAs<T> recovers same-named Content from a foreign dynamically-compiled assembly — cures the empty deployed dashboards

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -262,7 +262,28 @@ public static class DataExtensions
             current = parent;
         }
         if (syncHub is null)
+        {
+            // The absent-target drop is intentional (a disconnected circuit's stream, a reaped or
+            // never-created sync hub) — but it must never be SILENT: data-sync traffic vanishing
+            // without a trace is unfindable in production (agentic-pensions#12 asked for exactly
+            // this signal). One Warning per drop, carrying the stream id + message type + hub.
+            try
+            {
+                hub.ServiceProvider.GetService<ILoggerFactory>()
+                    ?.CreateLogger(typeof(DataExtensions).FullName!)
+                    .LogWarning(
+                        "Dropping {MessageType} for stream {StreamId} on hub {Address}: no synchronization "
+                        + "hub found on this hub or any parent — the target stream is gone (disposed circuit, "
+                        + "released read stream, or never-created sync hub). Sender: {Sender}.",
+                        message.GetType().Name, streamMessage.StreamId, hub.Address, request.Sender);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Drops routinely fire while the hub is tearing down — the diagnostic must never
+                // turn a benign Ignored into a faulted delivery.
+            }
             return Observable.Return(request.Ignored());
+        }
         syncHub.DeliverMessage(request);
         return Observable.Return(request.Forwarded());
     }

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeContentExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeContentExtensions.cs
@@ -52,7 +52,12 @@ public static class MeshNodeContentExtensions
                 // assembly and the dashboard's loader dropped every one.
                 try
                 {
-                    var element = JsonSerializer.SerializeToElement(node.Content, options);
+                    // Serialize AS the concrete runtime type: the object-declared path would route
+                    // through ObjectPolymorphicConverter.GetTypeName → an UNGUARDED GetOrAddType that
+                    // adopts the foreign type into the caller's registry as a read side effect. The
+                    // concrete-type path goes through PolymorphicTypeInfoResolver, whose collectible-
+                    // assembly guard formats the discriminator WITHOUT registering.
+                    var element = JsonSerializer.SerializeToElement(node.Content, node.Content.GetType(), options);
                     var recovered = element.Deserialize<T>(options);
                     if (recovered is not null)
                     {
@@ -70,9 +75,13 @@ public static class MeshNodeContentExtensions
                 {
                     // fall through to the loud log below
                 }
+                // Assembly-qualified on purpose: dynamic node assemblies compile without namespaces,
+                // so the bare type name is identical on BOTH sides of a cross-assembly mismatch —
+                // only the assembly identity makes this diagnosable.
                 logger?.LogError(
-                    "ContentAs<{TargetType}> for {Path}: Content is {ActualType}, not convertible",
-                    typeof(T).Name, node.Path, node.Content.GetType().Name);
+                    "ContentAs<{TargetType}> for {Path}: Content is {ActualType} ({ActualAssembly}), not convertible",
+                    typeof(T).Name, node.Path, node.Content.GetType().FullName,
+                    node.Content.GetType().Assembly.GetName().Name);
                 return null;
         }
     }

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeContentExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeContentExtensions.cs
@@ -14,9 +14,10 @@ public static class MeshNodeContentExtensions
     /// <summary>
     /// Content as <typeparamref name="T"/>: already-typed → as-is; a degraded
     /// <see cref="JsonElement"/> → deserialized into <typeparamref name="T"/>;
-    /// typed with a DIFFERENT CLR type of the same shape (the same class compiled
-    /// into two dynamic node assemblies, or a same-named type resolved by another
-    /// hub's registry at the query boundary) → recovered by a JSON round-trip;
+    /// typed with a SAME-NAMED but different CLR type (the same class compiled
+    /// into two dynamic node assemblies, or resolved by another hub's registry at
+    /// the query boundary) → recovered by a JSON round-trip; typed with a
+    /// DIFFERENTLY-named type → <c>null</c> (call sites probe-dispatch on that);
     /// otherwise <c>null</c> (logged loud — never silently swallowed).
     /// </summary>
     public static T? ContentAs<T>(this MeshNode? node, JsonSerializerOptions options, ILogger? logger = null)
@@ -43,37 +44,46 @@ public static class MeshNodeContentExtensions
                     return null;
                 }
             default:
-                // Content is a typed object, but not OUR T: the same class compiled into a different
-                // dynamic node assembly (@@-included copies), or a same-short-named type another hub's
-                // registry resolved when the node crossed the query/message boundary. The VALUE is
-                // perfectly recoverable — round-trip through JSON and bind into the caller's T. The
-                // silent null here was the atioz "BalanceSheet dashboards render empty" outage
-                // (agentic-pensions#12): 200 fact nodes arrived typed with the fact NodeType's own
-                // assembly and the dashboard's loader dropped every one.
-                try
+                // Content is a typed object, but not OUR T. Recover ONLY when the runtime type has the
+                // SAME short name as T: the same class compiled into a different dynamic node assembly
+                // (@@-included copies), or a same-short-named type another hub's registry resolved when
+                // the node crossed the query/message boundary. The silent null here was the atioz
+                // "BalanceSheet dashboards render empty" outage (agentic-pensions#12): 200 fact nodes
+                // arrived typed with the fact NodeType's own assembly and the dashboard's loader
+                // dropped every one.
+                //
+                // A DIFFERENTLY-named type must stay null: call sites probe-dispatch on it — e.g. the
+                // token validator's `ContentAs<ApiTokenIndex>() ?? treat node as the token itself`.
+                // Shape-recovering ApiToken→ApiTokenIndex there (both carry TokenHash) yields a
+                // half-populated index with a null TokenPath and every login fails "Token not found"
+                // (the McpAccessControlTests regression that reverted the first cut of this recovery).
+                if (node.Content.GetType().Name == typeof(T).Name)
                 {
-                    // Serialize AS the concrete runtime type: the object-declared path would route
-                    // through ObjectPolymorphicConverter.GetTypeName → an UNGUARDED GetOrAddType that
-                    // adopts the foreign type into the caller's registry as a read side effect. The
-                    // concrete-type path goes through PolymorphicTypeInfoResolver, whose collectible-
-                    // assembly guard formats the discriminator WITHOUT registering.
-                    var element = JsonSerializer.SerializeToElement(node.Content, node.Content.GetType(), options);
-                    var recovered = element.Deserialize<T>(options);
-                    if (recovered is not null)
+                    try
                     {
-                        // Debug, not Warning: this fires per node per read on the cross-assembly path
-                        // (a healthy, recoverable shape) — Warning would storm at snapshot size × emission.
-                        logger?.LogDebug(
-                            "ContentAs<{TargetType}> for {Path}: recovered Content typed as foreign {ActualType} "
-                            + "({ActualAssembly}) via JSON round-trip",
-                            typeof(T).Name, node.Path, node.Content.GetType().Name,
-                            node.Content.GetType().Assembly.GetName().Name);
-                        return recovered;
+                        // Serialize AS the concrete runtime type: the object-declared path would route
+                        // through ObjectPolymorphicConverter.GetTypeName → an UNGUARDED GetOrAddType that
+                        // adopts the foreign type into the caller's registry as a read side effect. The
+                        // concrete-type path goes through PolymorphicTypeInfoResolver, whose collectible-
+                        // assembly guard formats the discriminator WITHOUT registering.
+                        var element = JsonSerializer.SerializeToElement(node.Content, node.Content.GetType(), options);
+                        var recovered = element.Deserialize<T>(options);
+                        if (recovered is not null)
+                        {
+                            // Debug, not Warning: this fires per node per read on the cross-assembly path
+                            // (a healthy, recoverable shape) — Warning would storm at snapshot size × emission.
+                            logger?.LogDebug(
+                                "ContentAs<{TargetType}> for {Path}: recovered Content typed as foreign {ActualType} "
+                                + "({ActualAssembly}) via JSON round-trip",
+                                typeof(T).Name, node.Path, node.Content.GetType().Name,
+                                node.Content.GetType().Assembly.GetName().Name);
+                            return recovered;
+                        }
                     }
-                }
-                catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
-                {
-                    // fall through to the loud log below
+                    catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
+                    {
+                        // fall through to the loud log below
+                    }
                 }
                 // Assembly-qualified on purpose: dynamic node assemblies compile without namespaces,
                 // so the bare type name is identical on BOTH sides of a cross-assembly mismatch —

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeContentExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeContentExtensions.cs
@@ -14,6 +14,9 @@ public static class MeshNodeContentExtensions
     /// <summary>
     /// Content as <typeparamref name="T"/>: already-typed → as-is; a degraded
     /// <see cref="JsonElement"/> → deserialized into <typeparamref name="T"/>;
+    /// typed with a DIFFERENT CLR type of the same shape (the same class compiled
+    /// into two dynamic node assemblies, or a same-named type resolved by another
+    /// hub's registry at the query boundary) → recovered by a JSON round-trip;
     /// otherwise <c>null</c> (logged loud — never silently swallowed).
     /// </summary>
     public static T? ContentAs<T>(this MeshNode? node, JsonSerializerOptions options, ILogger? logger = null)
@@ -40,6 +43,33 @@ public static class MeshNodeContentExtensions
                     return null;
                 }
             default:
+                // Content is a typed object, but not OUR T: the same class compiled into a different
+                // dynamic node assembly (@@-included copies), or a same-short-named type another hub's
+                // registry resolved when the node crossed the query/message boundary. The VALUE is
+                // perfectly recoverable — round-trip through JSON and bind into the caller's T. The
+                // silent null here was the atioz "BalanceSheet dashboards render empty" outage
+                // (agentic-pensions#12): 200 fact nodes arrived typed with the fact NodeType's own
+                // assembly and the dashboard's loader dropped every one.
+                try
+                {
+                    var element = JsonSerializer.SerializeToElement(node.Content, options);
+                    var recovered = element.Deserialize<T>(options);
+                    if (recovered is not null)
+                    {
+                        // Debug, not Warning: this fires per node per read on the cross-assembly path
+                        // (a healthy, recoverable shape) — Warning would storm at snapshot size × emission.
+                        logger?.LogDebug(
+                            "ContentAs<{TargetType}> for {Path}: recovered Content typed as foreign {ActualType} "
+                            + "({ActualAssembly}) via JSON round-trip",
+                            typeof(T).Name, node.Path, node.Content.GetType().Name,
+                            node.Content.GetType().Assembly.GetName().Name);
+                        return recovered;
+                    }
+                }
+                catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
+                {
+                    // fall through to the loud log below
+                }
                 logger?.LogError(
                     "ContentAs<{TargetType}> for {Path}: Content is {ActualType}, not convertible",
                     typeof(T).Name, node.Path, node.Content.GetType().Name);

--- a/src/MeshWeaver.Messaging.Hub/Serialization/PolymorphicTypeInfoResolver.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/PolymorphicTypeInfoResolver.cs
@@ -83,14 +83,40 @@ public class PolymorphicTypeInfoResolver(ITypeRegistry typeRegistry, string? own
         if (!baseType.IsAbstract && !baseType.IsInterface)
         {
             // A type that is registered in THIS hub's registry resolves to its short collection name;
-            // an UNregistered type falls back to GetOrAddType → FormatType → the namespace-qualified
-            // full name. Probe registration BEFORE the auto-add so we can tell the two apart (generic
+            // an UNregistered type falls back to GetOrAddType → FormatType → the short type name.
+            // Probe registration BEFORE the auto-add so we can tell the two apart (generic
             // names legitimately contain '.', so a naive '.'-scan would false-positive).
-            var wasRegistered = typeRegistry.TryGetCollectionName(baseType, out _);
-            // Automatically register the type in the registry if not already present
-            var typeName = typeRegistry.GetOrAddType(baseType);
-            if (!wasRegistered)
+            var wasRegistered = typeRegistry.TryGetCollectionName(baseType, out var registeredName);
+            string typeName;
+            if (wasRegistered)
+            {
+                typeName = registeredName!;
+            }
+            else if (baseType.Assembly.IsCollectible)
+            {
+                // 🚨 NEVER auto-register a type from a COLLECTIBLE assembly (dynamic node / kernel-script
+                // compilations — every recompile is a NEW assembly with a NEW CLR identity for the "same"
+                // class). Adopting such a type into a long-lived hub's registry as a serialization side
+                // effect poisons that hub for the rest of the process: every later $type resolution on the
+                // hub (e.g. mesh-query row deserialization) then yields THAT foreign/stale CLR type, and a
+                // consumer holding its OWN compilation of the class (`Content is T` / `ContentAs<T>`) reads
+                // null — the atioz "BalanceSheet dashboards render empty" outage (agentic-pensions#12). It
+                // also pins the collectible assembly, defeating unload. Format the discriminator WITHOUT
+                // registering: THIS serialization still writes the short-name $type; deserialization on
+                // this hub politely degrades to JsonElement, which ContentAs<T> recovers at the consumer.
+                // Hubs that legitimately OWN the type register it explicitly (WithType / WithContentType /
+                // GetTypeDefinition) — those paths are unaffected.
+                typeName = typeRegistry is TypeRegistry concreteRegistry
+                    ? concreteRegistry.FormatType(baseType)
+                    : baseType.Name;
+                WarnCollectibleSerialization(baseType, typeName);
+            }
+            else
+            {
+                // Automatically register the type in the registry if not already present
+                typeName = typeRegistry.GetOrAddType(baseType);
                 WarnUnregisteredSerialization(baseType, typeName);
+            }
             derivedTypes.Add(new JsonDerivedType(baseType, typeName));
         }
 
@@ -115,8 +141,10 @@ public class PolymorphicTypeInfoResolver(ITypeRegistry typeRegistry, string? own
                 {
                     derivedTypes.Add(new JsonDerivedType(attr.DerivedType, typeDiscriminator));
 
-                    // Also register in the type registry for consistency
-                    typeRegistry.GetOrAddType(attr.DerivedType);
+                    // Also register in the type registry for consistency — but never adopt a
+                    // collectible-assembly type as a side effect (see the guard above).
+                    if (!attr.DerivedType.Assembly.IsCollectible)
+                        typeRegistry.GetOrAddType(attr.DerivedType);
                 }
             }
         }
@@ -194,6 +222,28 @@ public class PolymorphicTypeInfoResolver(ITypeRegistry typeRegistry, string? own
             + "where this hub is configured — explicit registration avoids short-name collisions across "
             + "namespaces and documents the contract.",
             type.FullName, owner ?? "(unknown)", discriminator);
+    }
+
+    /// <summary>
+    /// A type from a COLLECTIBLE assembly (dynamic node compilation, kernel script) was serialised on a
+    /// hub that has not explicitly registered it. The discriminator is formatted but the type is NOT
+    /// adopted into the registry — a per-compile CLR identity in a long-lived registry would make every
+    /// later $type resolution on this hub yield the foreign/stale type (consumers holding their own
+    /// compilation read null) and would pin the collectible assembly. Deduped per type; Debug level —
+    /// this is the EXPECTED shape whenever a shared hub relays dynamic-node content it does not own.
+    /// </summary>
+    private void WarnCollectibleSerialization(Type type, string discriminator)
+    {
+        if (logger is null || !warnedUnregistered.TryAdd(type, 0))
+            return;
+        logger.LogDebug(
+            "Type {Type} from collectible assembly {Assembly} serialised on hub {Hub} with $type='{Discriminator}' "
+            + "WITHOUT registering it: adopting a per-compile CLR identity into this hub's TypeRegistry would make "
+            + "every later $type resolution here yield the foreign/stale type (consumers holding their own "
+            + "compilation of the class read Content as null) and would pin the collectible assembly. Reads on "
+            + "this hub degrade to JsonElement, which ContentAs<T> recovers at the consumer. If this hub OWNS the "
+            + "type, register it explicitly via WithType/WithContentType.",
+            type.FullName, type.Assembly.GetName().Name, owner ?? "(unknown)", discriminator);
     }
 
     private static bool IsValidDerivedTypeForBase(Type baseType, Type derivedType)

--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("agent", "code", "create-space", "harness", "layout-area", "maui", "model", "provider-keys");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-space", "harness", "layout-area", "maui", "model", "provider-keys");
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -29,7 +29,7 @@ public class SkillNodeTypeTest
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
         skills.Should().OnlyContain(n => n.Namespace == SkillNodeType.RootNamespace);
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("agent", "code", "create-space", "harness", "layout-area", "maui", "model", "provider-keys");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-space", "harness", "layout-area", "maui", "model", "provider-keys");
 
         var def = (SkillDefinition)skills.Single(n => n.Id == "model").Content!;
         def.Action!.Kind.Should().Be(SkillActionKind.Pick);

--- a/test/MeshWeaver.Hosting.Test/ContentAsForeignAssemblyContentTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ContentAsForeignAssemblyContentTest.cs
@@ -1,0 +1,163 @@
+using System.Text.Json;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins the cure for agentic-pensions#12 ("virtual-data-source workspaces stay empty on the
+/// deployed portal"): <see cref="MeshNodeContentExtensions.ContentAs{T}"/> must recover
+/// <see cref="MeshNode.Content"/> that was materialized as a SAME-NAMED type from a DIFFERENT
+/// assembly.
+///
+/// <para>The production chain this reproduces: every dynamically compiled NodeType assembly
+/// carries its own copy of shared records (<c>@@</c>-included sources), so CLR identity across
+/// those assemblies never matches. The query layer (<c>IMeshService.Query&lt;MeshNode&gt;</c>)
+/// deserializes rows with the ROOT hub's options; the root registry auto-learns the short-name
+/// <c>$type</c> the first time such content is SERIALIZED at root level (persistence writes —
+/// <c>PolymorphicTypeInfoResolver.ComputeDerivedTypes</c> → <c>GetOrAddType</c>), and from then
+/// on every query result's Content arrives as the OWNING NodeType assembly's CLR type. A consumer
+/// hub's <c>ContentAs&lt;T&gt;</c> — where <c>T</c> is its OWN compiled copy — then hit the
+/// <c>default:</c> branch (not <c>T</c>, not <see cref="JsonElement"/>) and silently returned
+/// null: every content-filtered loader row vanished and the dashboards rendered their empty
+/// state (atioz: <c>AgenticPension/Dashboard</c> EntryNode = 0 of 200, ExtraktionsReview
+/// "Noch keine Bilanzwerte geladen"), while metadata-only collections kept working.</para>
+///
+/// <para>The contract (per the ContentAs xmldoc): the read site owns recovery into its target
+/// type. A same-shaped foreign-assembly instance carries the authoritative JSON shape — recover
+/// it by round-tripping through JSON, exactly like the degraded-JsonElement path.</para>
+/// </summary>
+public class ContentAsForeignAssemblyContentTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>
+    /// The "query layer's" MeshNode: Content serialized and rehydrated through the HOST hub's
+    /// options. Serializing auto-registers the short-name $type in the host registry (the exact
+    /// write-side pollution), so the rehydrate materializes Content as
+    /// <see cref="QueryLayerModel.BalanceEntry"/> — the foreign type every consumer receives.
+    /// </summary>
+    private MeshNode MaterializeThroughHost(out JsonSerializerOptions hostOptions)
+    {
+        var host = GetHost();
+        hostOptions = host.JsonSerializerOptions;
+
+        var typedNode = MeshNode.FromPath("pension/Entry/e1") with
+        {
+            Name = "Aktien 2024",
+            NodeType = "pension/Entry",
+            Content = new QueryLayerModel.BalanceEntry
+            {
+                Position = "pension/Position/Equities",
+                Year = "pension/Year/2024",
+                Amount = 16091.584,
+                Konfidenz = QueryLayerModel.Confidence.Mittel,
+            },
+        };
+
+        var json = JsonSerializer.Serialize(typedNode, hostOptions);
+        var node = JsonSerializer.Deserialize<MeshNode>(json, hostOptions);
+        node.Should().NotBeNull();
+        return node!;
+    }
+
+    [Fact]
+    public void ContentAs_SameNamedTypeFromForeignAssembly_RecoversViaJsonRoundTrip()
+    {
+        var node = MaterializeThroughHost(out _);
+
+        // Premise of the repro: the query layer hands consumers Content ALREADY MATERIALIZED
+        // as the foreign CLR type (not a JsonElement). If this ever degrades to JsonElement
+        // the test no longer exercises the defect — fail loudly so it gets rebuilt.
+        node.Content.Should().BeOfType<QueryLayerModel.BalanceEntry>(
+            "the host-side rehydrate must reproduce the query layer's typed materialization");
+
+        // The consumer hub types the content with ITS OWN copy of the record — same short
+        // name, different CLR type (prod: a different DynamicNode_* assembly).
+        var client = GetClient();
+        var typed = node.ContentAs<ConsumerModel.BalanceEntry>(client.JsonSerializerOptions);
+
+        typed.Should().NotBeNull(
+            "ContentAs must recover a same-shaped foreign-assembly Content instead of silently dropping it");
+        typed!.Position.Should().Be("pension/Position/Equities");
+        typed.Year.Should().Be("pension/Year/2024");
+        typed.Amount.Should().Be(16091.584);
+        typed.Konfidenz.Should().Be(ConsumerModel.Confidence.Mittel);
+    }
+
+    [Fact]
+    public void ContentAs_DifferentlyNamedTargetType_BindsByShapeLikeTheJsonElementPath()
+    {
+        var node = MaterializeThroughHost(out _);
+        node.Content.Should().BeOfType<QueryLayerModel.BalanceEntry>();
+
+        // Parity with the degraded-JsonElement recovery: a $type the target doesn't recognise
+        // is just an ignored member — the fields still bind by shape (the rbuergi/EntryProbe
+        // diagnostic on atioz exercised exactly this: ContentAs<ProbeEntry> over
+        // "$type":"BalanceSheetEntry" content).
+        var client = GetClient();
+        var typed = node.ContentAs<ConsumerModel.RenamedEntry>(client.JsonSerializerOptions);
+
+        typed.Should().NotBeNull();
+        typed!.Position.Should().Be("pension/Position/Equities");
+        typed.Year.Should().Be("pension/Year/2024");
+    }
+
+    [Fact]
+    public void ContentAs_ForeignRecovery_DoesNotBreakTheConsumersOwnRegistrations()
+    {
+        var node = MaterializeThroughHost(out _);
+        var client = GetClient();
+
+        // Recover the foreign content (this may auto-register names in the client registry) …
+        node.ContentAs<ConsumerModel.BalanceEntry>(client.JsonSerializerOptions).Should().NotBeNull();
+
+        // … and the client's OWN type must still round-trip through the client's options
+        // afterwards: the recovery must not clobber the consumer's name→type resolution.
+        var own = new ConsumerModel.BalanceEntry
+        {
+            Position = "pension/Position/Cash",
+            Year = "pension/Year/2025",
+            Amount = 1.0,
+        };
+        var json = JsonSerializer.Serialize<object>(own, client.JsonSerializerOptions);
+        var back = JsonSerializer.Deserialize<object>(json, client.JsonSerializerOptions);
+        back.Should().BeOfType<ConsumerModel.BalanceEntry>(
+            "the consumer's own registration must survive the foreign-content recovery");
+    }
+}
+
+/// <summary>The record shape as compiled into the OWNING NodeType's assembly (the type the
+/// root-registry materialization produces).</summary>
+internal static class QueryLayerModel
+{
+    public enum Confidence { Hoch, Mittel, Niedrig }
+
+    public record BalanceEntry
+    {
+        public string Position { get; init; } = string.Empty;
+        public string Year { get; init; } = string.Empty;
+        public double Amount { get; init; }
+        public Confidence? Konfidenz { get; init; }
+    }
+}
+
+/// <summary>The SAME record shape as compiled into a CONSUMING NodeType's assembly (an
+/// <c>@@</c>-included copy) — same short names, different CLR identity.</summary>
+internal static class ConsumerModel
+{
+    public enum Confidence { Hoch, Mittel, Niedrig }
+
+    public record BalanceEntry
+    {
+        public string Position { get; init; } = string.Empty;
+        public string Year { get; init; } = string.Empty;
+        public double Amount { get; init; }
+        public Confidence? Konfidenz { get; init; }
+    }
+
+    public record RenamedEntry
+    {
+        public string Position { get; init; } = string.Empty;
+        public string Year { get; init; } = string.Empty;
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/ContentAsForeignAssemblyContentTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ContentAsForeignAssemblyContentTest.cs
@@ -85,21 +85,24 @@ public class ContentAsForeignAssemblyContentTest(ITestOutputHelper output) : Hub
     }
 
     [Fact]
-    public void ContentAs_DifferentlyNamedTargetType_BindsByShapeLikeTheJsonElementPath()
+    public void ContentAs_DifferentlyNamedTypedContent_StaysNull_PreservingProbeDispatch()
     {
         var node = MaterializeThroughHost(out _);
         node.Content.Should().BeOfType<QueryLayerModel.BalanceEntry>();
 
-        // Parity with the degraded-JsonElement recovery: a $type the target doesn't recognise
-        // is just an ignored member — the fields still bind by shape (the rbuergi/EntryProbe
-        // diagnostic on atioz exercised exactly this: ContentAs<ProbeEntry> over
-        // "$type":"BalanceSheetEntry" content).
+        // A DIFFERENTLY-named typed content is a legitimate "this is another domain type" answer,
+        // and call sites probe-dispatch on it: the token validator does
+        // `ContentAs<ApiTokenIndex>() ?? treat the node as the token itself` — shape-recovering
+        // ApiToken→ApiTokenIndex (both carry TokenHash) yields a half-populated index with a null
+        // TokenPath and every login fails "Token not found" (McpAccessControlTests, shard 0).
+        // Recovery is strictly for the SAME-named cross-assembly identity; by-shape binding of
+        // differently-named types remains the degraded-JsonElement path's job (untyped content).
         var client = GetClient();
         var typed = node.ContentAs<ConsumerModel.RenamedEntry>(client.JsonSerializerOptions);
 
-        typed.Should().NotBeNull();
-        typed!.Position.Should().Be("pension/Position/Equities");
-        typed.Year.Should().Be("pension/Year/2024");
+        typed.Should().BeNull(
+            "a typed content of a DIFFERENT name must not be shape-recovered — probe-dispatch "
+            + "call sites rely on the null to fall back to their next interpretation");
     }
 
     [Fact]

--- a/test/MeshWeaver.Hosting.Test/MeshNodeContentAsTest.cs
+++ b/test/MeshWeaver.Hosting.Test/MeshNodeContentAsTest.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using Xunit;
+
+// Two compilations of "the same" content class — the @@-include shape from agentic-pensions#12:
+// the fact NodeType's own assembly vs the dashboard's included copy. Same short name, same JSON
+// shape, DIFFERENT CLR identity. (Different namespaces model different dynamic assemblies without
+// needing Roslyn in this test project — the CLR-identity mismatch is identical.)
+namespace MeshWeaver.Hosting.Test.OwnerCopy
+{
+    public record SharedEntry
+    {
+        public string Position { get; init; } = string.Empty;
+        public string Year { get; init; } = string.Empty;
+        public double Amount { get; init; }
+    }
+}
+
+namespace MeshWeaver.Hosting.Test.ConsumerCopy
+{
+    public record SharedEntry
+    {
+        public string Position { get; init; } = string.Empty;
+        public string Year { get; init; } = string.Empty;
+        public double Amount { get; init; }
+    }
+}
+
+namespace MeshWeaver.Hosting.Test
+{
+    /// <summary>
+    /// Pins the <see cref="MeshNodeContentExtensions.ContentAs{T}"/> recovery contract for Content that
+    /// arrives TYPED with a different CLR type of the same shape — the same class compiled into two
+    /// dynamic node assemblies, or a same-short-named type resolved by another hub's registry at the
+    /// query boundary. Pre-fix the default branch returned a SILENT null, so every projection filtering
+    /// on <c>Content is not null</c> dropped the whole result set: the atioz "BalanceSheet dashboards
+    /// render empty" outage (agentic-pensions#12) — 200 fact nodes arrived typed with the fact
+    /// NodeType's own assembly and the dashboard's loader (holding its @@-included copy) kept none.
+    /// </summary>
+    public class MeshNodeContentAsTest
+    {
+        private static readonly JsonSerializerOptions Options = new();
+
+        private static MeshNode NodeWith(object content) =>
+            new("entry", "Test/Entries") { Name = "Entry", NodeType = "Test/Entry", Content = content };
+
+        [Fact]
+        public void TypedForeignContent_SameShape_IsRecovered()
+        {
+            var node = NodeWith(new OwnerCopy.SharedEntry
+            {
+                Position = "Test/Position/FreeFunds",
+                Year = "Test/Year/2025",
+                Amount = 10.5,
+            });
+
+            var recovered = node.ContentAs<ConsumerCopy.SharedEntry>(Options);
+
+            recovered.Should().NotBeNull(
+                "a same-shaped foreign CLR type is recoverable via JSON round-trip — silent null "
+                + "drops the whole collection at every 'Content is not null' projection");
+            recovered!.Position.Should().Be("Test/Position/FreeFunds");
+            recovered.Year.Should().Be("Test/Year/2025");
+            recovered.Amount.Should().Be(10.5);
+        }
+
+        [Fact]
+        public void TypedSameClrContent_IsReturnedAsIs()
+        {
+            var content = new ConsumerCopy.SharedEntry { Position = "p", Year = "y", Amount = 1 };
+            NodeWith(content).ContentAs<ConsumerCopy.SharedEntry>(Options).Should().BeSameAs(content);
+        }
+
+        [Fact]
+        public void JsonElementContent_IsDeserialized()
+        {
+            var element = JsonSerializer.SerializeToElement(
+                new ConsumerCopy.SharedEntry { Position = "p", Year = "y", Amount = 2 }, Options);
+            var recovered = NodeWith(element).ContentAs<ConsumerCopy.SharedEntry>(Options);
+            recovered.Should().NotBeNull();
+            recovered!.Amount.Should().Be(2);
+        }
+
+        [Fact]
+        public void UnrecoverableContent_ReturnsNull_WithoutThrowing()
+        {
+            // A string cannot bind into an object shape — the read must degrade to null, never throw
+            // (a throw on read faults the node).
+            NodeWith("just a string").ContentAs<ConsumerCopy.SharedEntry>(Options).Should().BeNull();
+        }
+
+        [Fact]
+        public void NullContent_ReturnsNull()
+        {
+            NodeWith(null!).ContentAs<ConsumerCopy.SharedEntry>(Options).Should().BeNull();
+        }
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/TypeRegistryTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/TypeRegistryTest.cs
@@ -138,6 +138,91 @@ public class TypeRegistryTest(ITestOutputHelper output) : HubTestBase(output)
         writeName.Should().Be(nameof(AliasedContent));
     }
 
+    /// <summary>
+    /// Serializing a type from a COLLECTIBLE assembly (a dynamic node / kernel-script compilation —
+    /// per-compile CLR identity) must NOT adopt the type into the hub's TypeRegistry. Pre-fix, the
+    /// resolver's auto-registration poisoned the shared hub for the pod's lifetime: every later $type
+    /// resolution (e.g. mesh-query row deserialization) yielded THAT foreign CLR type, and consumers
+    /// holding their OWN compilation of the class read Content as null — the atioz "BalanceSheet
+    /// dashboards render empty" outage (agentic-pensions#12). The wire shape must be unchanged (short-name
+    /// $type still written); reads on this hub degrade politely to JsonElement, which the consumer recovers.
+    /// </summary>
+    [Fact]
+    public void SerializingCollectibleType_DoesNotPoisonRegistry_AndDegradesReadsToJsonElement()
+    {
+        var host = GetHost();
+        var typeRegistry = host.ServiceProvider.GetRequiredService<ITypeRegistry>();
+        var collectibleType = EmitCollectibleType("SharedEntry", "Position");
+        collectibleType.Assembly.IsCollectible.Should().BeTrue(
+            "the emitted assembly must model a dynamic node compilation (loaded collectible)");
+
+        var captured = new ConcurrentQueue<string>();
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new ObjectPolymorphicConverter(typeRegistry));
+        options.TypeInfoResolver = new PolymorphicTypeInfoResolver(
+            typeRegistry, owner: "mesh/shared-hub", logger: new CapturingLogger(captured));
+
+        var instance = Activator.CreateInstance(collectibleType)!;
+        collectibleType.GetProperty("Position")!.SetValue(instance, "Assets");
+        var json = JsonSerializer.Serialize(instance, typeof(object), options);
+
+        // Wire shape unchanged: the short-name $type is still written, so hubs that DO own the type
+        // (explicit WithType/WithContentType registration) resolve it exactly as before.
+        json.Should().Contain("\"SharedEntry\"",
+            "serialization must still stamp the short-name $type discriminator");
+        json.Should().Contain("Assets", "the payload properties must serialize normally");
+
+        // The poisoning is gone: the registry must NOT have adopted the per-compile CLR identity.
+        typeRegistry.TryGetType("SharedEntry", out _).Should().BeFalse(
+            "a collectible-assembly type must never be auto-registered by serialization — it would make "
+            + "every later $type resolution on this hub yield the foreign/stale CLR type");
+        typeRegistry.TryGetCollectionName(collectibleType, out _).Should().BeFalse();
+
+        // Reads on THIS hub degrade politely to JsonElement (recoverable via ContentAs<T> at the
+        // consumer) instead of resolving to the foreign type.
+        var back = JsonSerializer.Deserialize<object>(json, options);
+        back.Should().BeOfType<JsonElement>();
+    }
+
+    /// <summary>
+    /// Emits a minimal public class with one string property into a COLLECTIBLE dynamic assembly —
+    /// the CLR shape of a compiled dynamic-node type (see CompilationCacheService: collectible ALC,
+    /// "DynamicNode_*" naming) without dragging Roslyn into this test project.
+    /// </summary>
+    private static Type EmitCollectibleType(string typeName, string propertyName)
+    {
+        var assemblyBuilder = System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(
+            new System.Reflection.AssemblyName("DynamicNode_CollectibleTest"),
+            System.Reflection.Emit.AssemblyBuilderAccess.RunAndCollect);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("main");
+        var typeBuilder = moduleBuilder.DefineType(
+            typeName, System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        var field = typeBuilder.DefineField(
+            $"_{propertyName}", typeof(string), System.Reflection.FieldAttributes.Private);
+        var property = typeBuilder.DefineProperty(
+            propertyName, System.Reflection.PropertyAttributes.None, typeof(string), null);
+        const System.Reflection.MethodAttributes accessorAttributes =
+            System.Reflection.MethodAttributes.Public
+            | System.Reflection.MethodAttributes.SpecialName
+            | System.Reflection.MethodAttributes.HideBySig;
+        var getter = typeBuilder.DefineMethod(
+            $"get_{propertyName}", accessorAttributes, typeof(string), Type.EmptyTypes);
+        var getterIl = getter.GetILGenerator();
+        getterIl.Emit(System.Reflection.Emit.OpCodes.Ldarg_0);
+        getterIl.Emit(System.Reflection.Emit.OpCodes.Ldfld, field);
+        getterIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        var setter = typeBuilder.DefineMethod(
+            $"set_{propertyName}", accessorAttributes, null, new[] { typeof(string) });
+        var setterIl = setter.GetILGenerator();
+        setterIl.Emit(System.Reflection.Emit.OpCodes.Ldarg_0);
+        setterIl.Emit(System.Reflection.Emit.OpCodes.Ldarg_1);
+        setterIl.Emit(System.Reflection.Emit.OpCodes.Stfld, field);
+        setterIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        property.SetGetMethod(getter);
+        property.SetSetMethod(setter);
+        return typeBuilder.CreateType()!;
+    }
+
     private sealed class CapturingLogger(ConcurrentQueue<string> sink) : ILogger
     {
         public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;

--- a/test/MeshWeaver.Query.Test/VirtualDataSourceContentTypeTest.cs
+++ b/test/MeshWeaver.Query.Test/VirtualDataSourceContentTypeTest.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+// Two compilations of "the same" content class — the @@-include shape from agentic-pensions#12: the
+// fact NodeType's own assembly vs the dashboard's included copy. Same short name, same JSON shape,
+// DIFFERENT CLR identity (different namespaces model different dynamic assemblies).
+namespace MeshWeaver.Query.Test.OwnerCopy
+{
+    public record SharedEntry
+    {
+        public string Position { get; init; } = string.Empty;
+        public double Amount { get; init; }
+    }
+}
+
+namespace MeshWeaver.Query.Test.ConsumerCopy
+{
+    public record SharedEntry
+    {
+        public string Position { get; init; } = string.Empty;
+        public double Amount { get; init; }
+    }
+}
+
+namespace MeshWeaver.Query.Test
+{
+    /// <summary>
+    /// End-to-end regression for the atioz "BalanceSheet dashboards render empty" outage
+    /// (agentic-pensions#12). The production corridor: fact nodes flow through the shared query
+    /// pipeline with their Content TYPED as the fact NodeType's own compilation of the content class;
+    /// the consuming NodeType's virtual-data-source loader projects them via
+    /// <c>ContentAs&lt;T&gt;</c> against its OWN @@-included compilation — a different CLR type.
+    /// Pre-fix, <c>ContentAs</c> silently returned null for every node and the loader's
+    /// <c>Content is not null</c> filter emptied the whole collection; the store still initialized
+    /// "successfully", so the dashboard rendered its empty state with zero errors anywhere.
+    ///
+    /// <para>Setup mirrors <see cref="SyncedQueryDataSourceTest"/>: a static Subscriber node whose
+    /// <c>HubConfiguration</c> registers the virtual data source exactly the way the production
+    /// NodeType (BalanceSheetConfig.ConfigureBalanceSheet) does, with the loader shape of
+    /// BalanceSheetData.LoadEntries.</para>
+    /// </summary>
+    public class VirtualDataSourceContentTypeTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+    {
+        private const string SubscriberPath = $"{TestPartition}/EntrySubscriber";
+        private const string EntriesNamespace = $"{TestPartition}/Entries";
+        private const string EntryCollection = nameof(EntryProjection);
+
+        /// <summary>Workspace projection of a fact node — the EntryNode shape from the outage.</summary>
+        public record EntryProjection
+        {
+            [Key]
+            public string Path { get; init; } = string.Empty;
+            public ConsumerCopy.SharedEntry Content { get; init; } = null!;
+        }
+
+        protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+            => base.ConfigureMesh(builder)
+                .AddMeshNodes(new MeshNode("EntrySubscriber", TestPartition)
+                {
+                    Name = "Entry Subscriber",
+                    NodeType = "Markdown",
+                    State = MeshNodeState.Active,
+                    HubConfiguration = config => config
+                        .AddData(data => data.WithVirtualDataSource("$entries",
+                            vs => vs.WithVirtualType<EntryProjection>(LoadEntries)))
+                });
+
+        /// <summary>The exact loader shape of BalanceSheetData.LoadEntries (agentic-pensions).</summary>
+        private static IObservable<IEnumerable<EntryProjection>> LoadEntries(IWorkspace workspace)
+            => workspace.Hub.ServiceProvider.GetRequiredService<IMeshService>()
+                .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                    $"namespace:{EntriesNamespace} nodeType:Markdown state:Active"))
+                .Select(change => change.Items
+                    .Select(n => new EntryProjection
+                    {
+                        Path = n.Path,
+                        Content = n.ContentAs<ConsumerCopy.SharedEntry>(workspace.Hub.JsonSerializerOptions)!,
+                    })
+                    .Where(x => x.Content is not null && x.Content.Position.Length > 0)
+                    .ToImmutableList()
+                    .AsEnumerable());
+
+        /// <summary>
+        /// Fact nodes whose Content is typed with the OWNER's compilation must still populate the
+        /// consumer's virtual collection. Pre-fix this stayed empty forever — the read below is the
+        /// same grain-workspace read (<c>GetDataRequest</c> + <c>CollectionReference</c>) that showed
+        /// EntryNode at 0 of 200 on atioz while every query and probe reported healthy data.
+        /// </summary>
+        [Fact]
+        public async Task TypedForeignContent_StillPopulatesVirtualCollection()
+        {
+            foreach (var i in Enumerable.Range(0, 3))
+                await NodeFactory.CreateNode(new MeshNode($"entry-{i}", EntriesNamespace)
+                {
+                    Name = $"Entry {i}",
+                    NodeType = "Markdown",
+                    State = MeshNodeState.Active,
+                    Content = new OwnerCopy.SharedEntry { Position = $"Position/P{i}", Amount = i * 10.0 },
+                }).Should().Emit();
+
+            var client = GetClient();
+
+            // The subscriber activates on first request; its virtual data source may see the creates in
+            // its Initial or as later change-feed updates — re-read until the collection converges. The
+            // response Data crosses back serialized, so it lands as a JsonElement keyed by entry path.
+            var collection = await Observable.Interval(TimeSpan.FromMilliseconds(200))
+                .StartWith(0L)
+                .SelectMany(_ => client
+                    .Observe<GetDataResponse>(
+                        new GetDataRequest(new CollectionReference(EntryCollection)),
+                        o => o.WithTarget(new Address(SubscriberPath)))
+                    .Take(1))
+                .Select(d => d.Message.Data is JsonElement { ValueKind: JsonValueKind.Object } je
+                    ? je
+                    : (JsonElement?)null)
+                .Should().Within(TimeSpan.FromSeconds(30))
+                .Match(je => je != null && Entries(je.Value).Count == 3);
+
+            var entries = Entries(collection!.Value);
+            entries.Should().HaveCount(3,
+                "every fact node's typed-foreign Content must be recovered into the consumer's copy");
+            entries.Select(e => e.GetProperty("content").GetProperty("position").GetString())
+                .OrderBy(p => p).Should()
+                .Equal("Position/P0", "Position/P1", "Position/P2");
+            entries.Sum(e => e.GetProperty("content").TryGetProperty("amount", out var amount)
+                    ? amount.GetDouble()
+                    : 0.0)
+                .Should().Be(30.0);
+        }
+
+        /// <summary>The instances of a serialized InstanceCollection payload (path-keyed; $type stripped).</summary>
+        private static List<JsonElement> Entries(JsonElement collection)
+            => collection.EnumerateObject()
+                .Where(p => p.Name != "$type")
+                .Select(p => p.Value)
+                .ToList();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Systemorph/agentic-pensions#12 — on the deployed portal, every virtual-data-source collection whose loader filters on **content fields** stayed empty forever (`AgenticPension/Dashboard` EntryNode = 0 of 200, `/AgenticPension/ExtraktionsReview` stuck on "Noch keine Bilanzwerte geladen"), while metadata-only collections populated.

## Root cause (NOT the suspected stream drop)

The issue's working theory (large snapshot silently dropped by the RouteStreamMessage `Ignored()` + idle-release race) is falsified: a diagnostic NodeType run **in-grain on atioz** showed the 200-item `Query<MeshNode>` result arriving completely — but `Content.GetType()` on every row was `BalanceSheetEntry @ DynamicNode_AgenticPension_BalanceSheetEntry`, and `ContentAs<BalanceSheetEntry>` returned **null for every row, silently**.

The chain:

1. Serialize-time auto-registration (`PolymorphicTypeInfoResolver.ComputeDerivedTypes` → `GetOrAddType`) teaches the **root** registry a short-name `$type` → the owning NodeType assembly's CLR type, the first time such content is serialized at root level (persistence writes).
2. The query layer (`MeshQuery.Options` = root hub options) then materializes every result row's Content as that CLR type.
3. Consumer NodeType hubs compile their **own copy** of the shared record (`@@`-included sources) — same short name, different assembly — so `ContentAs<T>`'s `default:` branch (not `T`, not `JsonElement`) returned null, and the loaders' `.Where(Content is not null …)` filtered every row.

This is order/restart-dependent (the registry learns on the first root-level serialize), which is why A/B revert experiments misattributed it to the framework build diff, and why "small collections work" (their loaders never touch Content, or filter only on non-null) masqueraded as a size-dependent stream bug.

## Fix (three layers — read-site recovery + the arming root-fix + observability)

1. **`PolymorphicTypeInfoResolver` never auto-registers collectible-assembly types** (`Assembly.IsCollectible` guard). Dynamic node / kernel-script compilations produce a NEW CLR identity per recompile; adopting one into a long-lived hub's registry as a *serialization side effect* is what armed the outage — and it also pins the collectible assembly, defeating unload. The `$type` discriminator is still formatted and written; reads on non-owning hubs degrade to `JsonElement`. This kills the poisoning at its source.
2. **`MeshNodeContentExtensions.ContentAs<T>`**: the `default:` branch now recovers any foreign materialized shape by a JSON round-trip (`SerializeToElement(content, content.GetType(), options)` → `Deserialize<T>`), symmetric with the existing degraded-`JsonElement` recovery — serialized AS the concrete runtime type so it routes through the guarded resolver, not `ObjectPolymorphicConverter`'s unguarded `GetOrAddType` (per Copilot review). Recovery logs at Debug (healthy per-row path); unrecoverable shapes return null with an **assembly-qualified** error (dynamic types have no namespace — the bare name is identical on both sides of the mismatch).
3. **`RouteStreamMessage`'s absent-sync-hub drop logs one Warning** (StreamId + message type + hub) instead of a fully silent `Ignored()` — the issue's explicit observability ask.

This PR reconciles two independent investigations that converged on the same RCA (see the coordination trail in the commits).

## Tests

- `TypeRegistryTest` collectible-assembly facts (against a REAL emitted collectible assembly): serializing never poisons the registry.
- `ContentAsForeignAssemblyContentTest` (red→green): the full pollute → materialize → consume chain through real hub options, incl. registry-survival of the consumer's own registrations.
- `MeshNodeContentAsTest`: the plain `ContentAs` contract facts (typed / JsonElement / foreign-typed).
- `VirtualDataSourceContentTypeTest` (Query.Test): the full virtual-data-source loader corridor.
- Suites green: Messaging.Hub 81, Hosting.Test 61, Data.Test 274, Query.Test 343; solution Release `-warnaserror` clean.

## Notes

- `MeshNodeStreamCache.DeserializeContent` has the mirror gap (returns the node unchanged when Content is already foreign-typed) — benign today because the cache hub's registry only knows framework types; noted as follow-up.
- Once this merges and the portals self-update, atioz's dashboards and the ExtraktionsReview table populate without any change to the customer's node code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
