### PR TITLE
fix(monaco): dark-mode composer no longer renders black-on-dark

### DIFF
--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -277,12 +277,16 @@ export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = fals
     // Add placeholder styling
     updatePlaceholder(editorId, placeholder, showLineNumbers);
 
-    // Apply theme immediately to this editor instance to ensure correct colors
-    // This is needed because the editor may be created before the global theme sync runs
-    if (editorInstance) {
+    // Apply the CURRENT app theme immediately and UNCONDITIONALLY. monaco.editor.setTheme is
+    // GLOBAL (not per-instance), so it must run even when this editor isn't in BlazorMonaco's
+    // registry yet (getEditor returned null). Gating it on `editorInstance` (the content-change
+    // rewiring) meant a composer mounted AFTER the first editor — e.g. the chat composer inside
+    // the user-activity area — kept Monaco's default 'vs' (light) theme, so its glyphs rendered
+    // BLACK on the transparent-over-dark composer background (unreadable in dark mode). Re-syncing
+    // the global theme on every mount also heals a stale theme set before the app flipped to dark.
+    if (typeof monaco !== 'undefined' && monaco.editor) {
         const currentTheme = detectThemeFromDOM();
-        const monacoTheme = currentTheme === 'dark' ? 'vs-dark' : 'vs';
-        monaco.editor.setTheme(monacoTheme);
+        monaco.editor.setTheme(currentTheme === 'dark' ? 'vs-dark' : 'vs');
     }
     if (editorInstance) {
         // Handle content changes for placeholder AND push the value back to C#.


### PR DESCRIPTION
The chat composer's Monaco editor (e.g. embedded in the user-activity area) rendered **black glyphs on the dark background** in dark mode — unreadable.

**Root cause:** `initEditor` applied the Monaco theme only inside `if (editorInstance)`, but `editorInstance = blazorMonaco.editor.getEditor(editorId)` is frequently `null` at init (the BlazorMonaco registry hasn't registered the editor yet). `monaco.editor.setTheme` is **global** and never needed the instance. So an editor mounted *after* the first one kept Monaco's default `vs` (light) theme; combined with the composer CSS forcing `background: transparent` over the dark container, its text rendered black on dark.

**Fix:** ungate the `setTheme` (guard only on `monaco` being loaded) and re-sync the global theme on every mount — which also heals a stale global theme set before the app flipped to dark. One-file change to `MonacoEditorView.razor.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)