### PR TITLE
feat(content): collection-named URLs, path-following chat context, opposite-panel context chip

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using MeshWeaver.AI.Persistence;
+using MeshWeaver.ContentCollections;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Layout;
@@ -538,9 +539,11 @@ public class AgentChatClient : IAgentChat
 
                         if (BinaryExtensions.Contains(ext))
                         {
-                            // Load binary from content collection on the node's hub
+                            // Load binary from the node's default content collection (the
+                            // `content:` UCR prefix addresses the default collection by design).
                             var effectivePath = nodePath ?? Context?.Path;
-                            var stream = await contentService.GetContentAsync("content", fileName).ConfigureAwait(false);
+                            var stream = await contentService.GetContentAsync(
+                                ContentCollectionsExtensions.DefaultCollectionName, fileName).ConfigureAwait(false);
                             if (stream != null)
                             {
                                 using (stream)

--- a/src/MeshWeaver.AI/Plugins/ContentCollectionPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/ContentCollectionPlugin.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Text;
+using MeshWeaver.ContentCollections;
 using MeshWeaver.Data;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.AI;
@@ -103,7 +104,7 @@ public class ContentCollectionPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
         [Description("Canonical path to the node that owns the collection — use the MeshNode's `path` property, NOT its `name`. Use @/full/path for absolute or @relative/path relative to the current context. Example: @/PartnerRe/AIConsulting or @FinalReport. If you only know the display name, call Search('name:\"...\"') first and use the path field of the match.")] string nodePath,
         [Description("File name/path within the collection (e.g., 'diagram.svg', 'images/architecture.svg')")] string filePath,
         [Description("The text content to upload (SVG markup, markdown, JSON, etc.)")] string content,
-        [Description("Collection name (default: 'content')")] string collectionName = "content",
+        [Description("Collection name (default: 'content')")] string collectionName = ContentCollectionsExtensions.DefaultCollectionName,
         CancellationToken cancellationToken = default)
     {
         var resolvedPath = MeshOperations.ResolvePath(MeshOperations.ResolveContextPath(chat, nodePath));

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -908,8 +908,9 @@ else
             @if (contextChips.Count > 0)
             {
                 <div class="thread-chat-context" style="flex: 1 1 auto; min-width: 0; overflow: hidden;">
-                    @* Context chip → peek the context object in the side panel (OnContextChipClicked),
-                       NOT navigate away (that's OnChipClicked, used by the @-reference chips above). *@
+                    @* Context chip → open the context object in the OPPOSITE panel (OnContextChipClicked):
+                       main-view chat peeks it in the side panel, side-panel chat brings it to the main
+                       view. @-reference chips above use OnChipClicked (modal preview) instead. *@
                     <ReferenceChipCollection
                         Attachments="@contextChips"
                         OnAttachmentRemoved="@OnAttachmentRemoved"

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -67,6 +67,15 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     [Inject] private IChatCompletionOrchestrator CompletionOrchestrator { get; set; } = null!;
     [Inject] private IConfiguration Configuration { get; set; } = null!;
 
+    /// <summary>
+    /// True when this chat renders inside the portal side panel (cascaded by
+    /// <c>PortalLayoutBase</c>, flowing through <c>LayoutAreaView</c>-hosted threads and the
+    /// direct new-chat composer alike). Drives the context chip's click target: a side-panel
+    /// chat opens its context in the MAIN view; a main-view chat peeks it in the side panel.
+    /// </summary>
+    [CascadingParameter(Name = "IsInSidePanel")]
+    public bool IsInSidePanel { get; set; }
+
 
     /// <summary>Stateless — single instance reused per submission.</summary>
     private static readonly ChatPreParser ChatParser = new();
@@ -2186,13 +2195,29 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         StateHasChanged();
     }
 
-    // Both chip kinds — plain @-reference chips and the context chip — open the referenced node in a
-    // modal preview LAYERED OVER the thread (issue #131), never navigating the main view away or
-    // replacing the side-panel thread. The old behaviour (NavigateTo for @-chips, OpenWithContent for
-    // context chips) left the conversation with no way back.
+    // Plain @-reference chips open the referenced node in a modal preview LAYERED OVER the thread
+    // (issue #131), never navigating the main view away or replacing the side-panel thread.
     private Task OnChipClicked(string path) => OpenNodePreviewAsync(path);
 
-    private Task OnContextChipClicked(string? path) => OpenNodePreviewAsync(path);
+    // The CONTEXT chip opens the context node in the OPPOSITE panel, so the thread and its subject
+    // are visible side by side: a main-view thread peeks the context in the side panel (the same
+    // peek ToggleSidePanel uses), a side-panel chat brings the context to the main view. Neither
+    // direction replaces the conversation — the thread stays where it is.
+    private Task OnContextChipClicked(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return Task.CompletedTask;
+
+        if (IsInSidePanel)
+        {
+            NavigationService.NavigateTo($"/{path.TrimStart('/')}");
+            return Task.CompletedTask;
+        }
+
+        SidePanelState.SetTitle(LastSegment(path));
+        SidePanelState.OpenWithContent(path);
+        return Task.CompletedTask;
+    }
 
     /// <summary>
     /// Opens <paramref name="path"/> in a modal dialog on top of the thread so the user can inspect the

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
@@ -228,18 +228,24 @@
                 <div class="side-panel-wrapper">
                     <SidePanel @key="@("side-panel-singleton")" OnCloseRequested="ToggleSidePanel">
                         <ChildContent>
-                            @if (sidePanelViewModel != null)
-                            {
-                                @* Resolved content — render via LayoutAreaView (same as main page) *@
-                                <LayoutAreaView @key="@SidePanelState.ContentPath"
-                                                ViewModel="@sidePanelViewModel"
-                                                Area="@($"sidepanel-{SidePanelState.ContentPath}")" />
-                            }
-                            else
-                            {
-                                @* New chat — no thread yet *@
-                                <ChatErrorBoundary @key="@sidePanelContentKey"><ThreadChatView @key="@sidePanelContentKey" ViewModel="@GetSidePanelControl()" /></ChatErrorBoundary>
-                            }
+                            @* IsInSidePanel lets panel-hosted views (e.g. ThreadChatView's context chip)
+                               target the OPPOSITE panel — a side-panel chat opens its context in the
+                               main view, a main-view chat peeks it here. IsFixed: the value never changes
+                               for this subtree, so descendants skip change-tracking subscriptions. *@
+                            <CascadingValue Name="IsInSidePanel" Value="@true" IsFixed="true">
+                                @if (sidePanelViewModel != null)
+                                {
+                                    @* Resolved content — render via LayoutAreaView (same as main page) *@
+                                    <LayoutAreaView @key="@SidePanelState.ContentPath"
+                                                    ViewModel="@sidePanelViewModel"
+                                                    Area="@($"sidepanel-{SidePanelState.ContentPath}")" />
+                                }
+                                else
+                                {
+                                    @* New chat — no thread yet *@
+                                    <ChatErrorBoundary @key="@sidePanelContentKey"><ThreadChatView @key="@sidePanelContentKey" ViewModel="@GetSidePanelControl()" /></ChatErrorBoundary>
+                                }
+                            </CascadingValue>
                         </ChildContent>
                     </SidePanel>
                 </div>

--- a/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor
+++ b/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor
@@ -11,7 +11,13 @@
                 <FluentBreadcrumb>
                     @{
                         var accumulatedPath = Embed ? "/" : "/collections/" + @Collection.Collection;
-                            if (Embed)
+                        var relativePath = ""; // clean collection-relative accumulator for URL-mirrored navigation
+                        var urlNav = Embed && !string.IsNullOrEmpty(UrlBasePath);
+                            if (urlNav)
+                            {
+                                <FluentBreadcrumbItem Href="@GetUrlLink(TopLevelPath)">@Root</FluentBreadcrumbItem>
+                            }
+                            else if (Embed)
                             {
                                 var topPath = string.IsNullOrEmpty(TopLevelPath) ? accumulatedPath : Path.Combine(accumulatedPath, TopLevelPath);
                                 <FluentBreadcrumbItem @onclick="@(() => ChangePath(topPath))" class="breadcrumb-clickable">@Root</FluentBreadcrumbItem>
@@ -24,9 +30,14 @@
                         @foreach (var folder in CurrentPath!.Split('/').Where(p => !string.IsNullOrEmpty(p)))
                         {
                             accumulatedPath += '/' + folder;
+                            relativePath += "/" + folder;
                             if (accumulatedPath.TrimStart('/').Length > ((TopLevelPath ?? "").TrimStart('/').Length))
                             {
-                                if (Embed)
+                                if (urlNav)
+                                {
+                                    <FluentBreadcrumbItem Href="@GetUrlLink(relativePath)">@Path.GetFileName(folder)</FluentBreadcrumbItem>
+                                }
+                                else if (Embed)
                                 {
                                     var path = accumulatedPath;
                                     <FluentBreadcrumbItem @onclick="@(() => ChangePath(path))" class="breadcrumb-clickable">@Path.GetFileName(folder)</FluentBreadcrumbItem>
@@ -89,7 +100,7 @@
             <div class="grid-item">
                 @if (context is FolderItem folder)
                 {
-                    @if (Embed)
+                    @if (Embed && string.IsNullOrEmpty(UrlBasePath))
                     {
                         <a href="javascript:void(0)" @onclick="() => ChangePath(folder.Path)" class="file-browser-link">
                             <FluentIcon Value="@(new Icons.Filled.Size20.Folder())"/>
@@ -98,7 +109,7 @@
                     }
                     else
                     {
-                        <a href="@GetLink(context)" class="file-browser-link">
+                        <a href="@(Embed ? GetUrlLink(folder.Path) : GetLink(context))" class="file-browser-link">
                             <FluentIcon Value="@(new Icons.Filled.Size20.Folder())"/>
                             <span>@context.Name</span>
                         </a>

--- a/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor.cs
+++ b/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor.cs
@@ -27,6 +27,13 @@ public partial class FileBrowser
     [Parameter] public string TopLevelPath { get; set; } = "";
     /// <summary>When true the browser renders in an embedded (compact) mode without a full-page chrome.</summary>
     [Parameter] public bool Embed { get; set; }
+    /// <summary>
+    /// Base URL the embedded browser mirrors its folder position under (e.g. <c>/{node}/Files</c>).
+    /// When set, folder rows and breadcrumbs are real links to <c>{UrlBasePath}{folderPath}</c> —
+    /// the address bar carries the full sub-folder path and deep links / refresh land in the right
+    /// folder. When null, embedded navigation stays in-place (dialogs and other URL-less hosts).
+    /// </summary>
+    [Parameter] public string? UrlBasePath { get; set; }
     /// <summary>When true, automatically creates <c>CurrentPath</c> inside the collection on initialization if it does not exist.</summary>
     [Parameter] public bool CreatePath { get; set; }
     /// <summary>When true, shows the "New Article" action in the toolbar.</summary>
@@ -167,6 +174,19 @@ public partial class FileBrowser
     {
         return $"/collections/{CollectionName}{item.Path}";
     }
+
+    /// <summary>
+    /// URL for a folder position when the embedding host mirrors navigation in the URL:
+    /// <c>{UrlBasePath}{folderPath}</c>. <paramref name="folderPath"/> is collection-relative
+    /// with a leading slash (the shape <c>FolderItem.Path</c> and the breadcrumb
+    /// accumulator produce).
+    /// </summary>
+    private string GetUrlLink(string folderPath)
+    {
+        if (string.IsNullOrEmpty(folderPath) || folderPath == Root)
+            return UrlBasePath!;
+        return folderPath.StartsWith('/') ? $"{UrlBasePath}{folderPath}" : $"{UrlBasePath}/{folderPath}";
+    }
     private string GetLink(FileItem item)
     {
         // Use full address string (e.g., "Cornerstone/Microsoft/2026") for URL generation
@@ -183,6 +203,11 @@ public partial class FileBrowser
             return $"/static/{addressString}/{encodedCollection}{item.Path}?download";
         }
 
+        // URL-mirrored host: files live in the same collection-named URL space as folders —
+        // /{node}/{collection}/{p1}/{p2}/file.ext (the collection-named layout area renders them).
+        if (!string.IsNullOrEmpty(UrlBasePath))
+            return GetUrlLink(item.Path);
+
         // Previewable files: /content/{address}/{encodedCollection}{item.Path}
         return $"/content/{addressString}/{encodedCollection}{item.Path}";
     }
@@ -191,12 +216,14 @@ public partial class FileBrowser
     /// Encodes a collection name for use in URLs by replacing '/' with '~'.
     /// This avoids issues with ASP.NET Core URL-decoding %2F before route matching.
     /// </summary>
-    private static string EncodeCollectionName(string collectionName) => collectionName.Replace("/", "~");
+    private static string EncodeCollectionName(string collectionName)
+        => ContentCollectionsExtensions.EncodeCollectionName(collectionName);
 
     /// <summary>
     /// Decodes a collection name from a URL by replacing '~' back to '/'.
     /// </summary>
-    internal static string DecodeCollectionName(string encodedName) => encodedName.Replace("~", "/");
+    internal static string DecodeCollectionName(string encodedName)
+        => ContentCollectionsExtensions.DecodeCollectionName(encodedName);
 
     private static bool ShouldDownload(string fileName)
     {

--- a/src/MeshWeaver.Blazor/FileExplorer/FileBrowserView.razor
+++ b/src/MeshWeaver.Blazor/FileExplorer/FileBrowserView.razor
@@ -3,7 +3,7 @@
 @using Microsoft.Extensions.DependencyInjection
 @inherits BlazorView<FileBrowserControl,FileBrowserView>
 
-<FileBrowser Address="Stream?.Owner" CollectionName="@Collection" CurrentPath="@Path" CreatePath="@PathCreation" TopLevelPath="@TopLevelPath" CollectionConfiguration="@CollectionConfiguration" IsReadOnly="@IsReadOnly" Embed="@true"></FileBrowser>
+<FileBrowser Address="Stream?.Owner" CollectionName="@Collection" CurrentPath="@Path" CreatePath="@PathCreation" TopLevelPath="@TopLevelPath" CollectionConfiguration="@CollectionConfiguration" IsReadOnly="@IsReadOnly" Embed="@true" UrlBasePath="@UrlBasePath"></FileBrowser>
 
 @code
 {
@@ -12,6 +12,7 @@
     private bool PathCreation;
     private string? TopLevelPath;
     private bool IsReadOnly;
+    private string? UrlBasePath;
     private ContentCollectionConfig? CollectionConfiguration;
     private string? SourceType;
     private string? CollectionBasePath;
@@ -26,6 +27,7 @@
         DataBind(ViewModel.TopLevelPath, x => x.TopLevelPath);
         DataBind(ViewModel.CollectionConfiguration, x => x.CollectionConfiguration);
         DataBind(ViewModel.ReadOnly, x => x.IsReadOnly);
+        DataBind(ViewModel.UrlBasePath, x => x.UrlBasePath);
         DataBind(ViewModel.SourceType, x => x.SourceType);
         DataBind(ViewModel.CollectionBasePath, x => x.CollectionBasePath);
         DataBind(ViewModel.CollectionSettings, x => x.CollectionSettings);

--- a/src/MeshWeaver.Blazor/Pages/ContentPage.razor.cs
+++ b/src/MeshWeaver.Blazor/Pages/ContentPage.razor.cs
@@ -291,6 +291,7 @@ public partial class ContentPage : ComponentBase, IDisposable
     /// Collection names with slashes (e.g., "Submissions@Microsoft/2026") are encoded
     /// with '~' in URLs to avoid path parsing issues.
     /// </summary>
-    private static string DecodeCollectionName(string encodedName) => encodedName.Replace("~", "/");
+    private static string DecodeCollectionName(string encodedName)
+        => ContentCollectionsExtensions.DecodeCollectionName(encodedName);
 }
 

--- a/src/MeshWeaver.ContentCollections/CollectionLayoutArea.cs
+++ b/src/MeshWeaver.ContentCollections/CollectionLayoutArea.cs
@@ -21,8 +21,8 @@ public static class CollectionLayoutArea
         if (split is null || split.Length < 1)
             return new MarkdownControl("Collection must be specified in format: Collection/Name or Collection/Name/Path");
 
-        var collection = split[0];
-        var path = split.Length > 1 ? string.Join('/', split.Skip(1)) : "/";
+        var collection = ContentCollectionsExtensions.DecodeCollectionName(split[0]);
+        var path = split.Length > 1 ? $"/{string.Join('/', split.Skip(1))}" : "/";
 
         var contentService = host.Hub.GetContentService();
         var collectionConfig = contentService.GetCollectionConfig(collection);
@@ -30,9 +30,10 @@ public static class CollectionLayoutArea
         if (collectionConfig == null)
             return new MarkdownControl($"Collection '{collection}' not found.");
 
-        var fileBrowser = new FileBrowserControl(collection);
-
-        fileBrowser = fileBrowser
+        var fileBrowser = new FileBrowserControl(collection)
+            .WithPath(path)
+            .WithUrlBasePath(
+                $"/{host.Hub.Address}/{ContentCollectionsExtensions.CollectionAreaName}/{ContentCollectionsExtensions.EncodeCollectionName(collection)}")
             .WithCollectionConfiguration(collectionConfig);
 
         return Controls.Stack

--- a/src/MeshWeaver.ContentCollections/CollectionNamedLayoutArea.cs
+++ b/src/MeshWeaver.ContentCollections/CollectionNamedLayoutArea.cs
@@ -1,0 +1,108 @@
+using System.Reactive.Linq;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.ContentCollections;
+
+/// <summary>
+/// Layout area matched by the MOUNTED collection name itself: <c>/{node}/{collection}/{path…}</c>.
+/// A collection can be mounted under any name — the URL segment IS the configured name (encoded
+/// with <see cref="ContentCollectionsExtensions.EncodeCollectionName"/>), never a hard-coded word.
+/// A folder path renders the file browser scoped to that folder (mirroring its position back into
+/// the URL); a file path renders the file's content.
+/// </summary>
+public static class CollectionNamedLayoutArea
+{
+    /// <summary>
+    /// True when <paramref name="context"/>'s area names a collection mounted on
+    /// <paramref name="hub"/>. <c>$</c>-prefixed framework areas never match. A collection
+    /// deliberately mounted under the name of a registered layout area shadows that area —
+    /// don't mount collections under area names like <c>Overview</c> or <c>Settings</c>, nor
+    /// under the reserved URL keywords (<c>area</c>/<c>data</c>/<c>schema</c>/<c>model</c>,
+    /// which the URL parser claims before area matching).
+    /// </summary>
+    public static bool IsCollectionArea(IMessageHub hub, RenderingContext context)
+    {
+        var area = context.Area;
+        if (string.IsNullOrEmpty(area) || area.StartsWith('$'))
+            return false;
+        var contentService = hub.ServiceProvider.GetService<IContentService>();
+        return contentService?.GetCollectionConfig(
+            ContentCollectionsExtensions.DecodeCollectionName(area)) is not null;
+    }
+
+    /// <summary>
+    /// Renders the collection position addressed by the area id: empty id or a folder path →
+    /// the file browser at that folder; a file path → the file's content.
+    /// </summary>
+    public static IObservable<UiControl?> Render(LayoutAreaHost host, RenderingContext context)
+        // Defer so a synchronously-throwing prologue surfaces through the rendered-error path.
+        => Observable.Defer(() => RenderCore(host, context))
+            .Catch((Exception ex) => Observable.Return<UiControl?>(
+                new MarkdownControl($"Error loading collection '{context.Area}': {ex.Message}")));
+
+    private static IObservable<UiControl?> RenderCore(LayoutAreaHost host, RenderingContext context)
+    {
+        var collectionName = ContentCollectionsExtensions.DecodeCollectionName(context.Area);
+        var idString = host.Reference.Id?.ToString() ?? "";
+        var path = idString.Split('?')[0].Trim('/');
+
+        var contentService = host.Hub.GetContentService();
+        var ioPool = ContentLayoutArea.GetIoPool(host.Hub);
+        return ioPool
+            .Invoke(ct => contentService.GetCollectionAsync(collectionName, ct))
+            .SelectMany(collection =>
+            {
+                if (collection is null)
+                    return Observable.Return<UiControl?>(
+                        new MarkdownControl($"Collection '{collectionName}' not found."));
+
+                if (path.Length == 0)
+                    return Observable.Return<UiControl?>(Browser(host, contentService, collectionName, "/"));
+
+                // Type the target by listing its parent folder — the same listing the browser
+                // itself performs — so folders and files are told apart by the provider, not by
+                // an extension heuristic.
+                var lastSlash = path.LastIndexOf('/');
+                var parent = lastSlash < 0 ? "/" : $"/{path[..lastSlash]}";
+                return ioPool
+                    .Invoke<CollectionItem?>(async ct =>
+                    {
+                        await foreach (var item in collection.GetCollectionItems(parent, ct).ConfigureAwait(false))
+                            // Item paths can carry '\' separators on Windows (FileSystem provider).
+                            if (string.Equals(item.Path.Replace('\\', '/').Trim('/'), path, StringComparison.OrdinalIgnoreCase))
+                                return item;
+                        return null;
+                    })
+                    .SelectMany(item => item switch
+                    {
+                        FolderItem => Observable.Return<UiControl?>(
+                            Browser(host, contentService, collectionName, $"/{path}")),
+                        FileItem => ContentLayoutArea.RenderFile(host, collection, collectionName, path),
+                        _ => Observable.Return<UiControl?>(
+                            new MarkdownControl($"'{path}' not found in collection '{collectionName}'.")),
+                    });
+            });
+    }
+
+    /// <summary>
+    /// The file browser scoped to <paramref name="path"/>, mirroring navigation back into this
+    /// collection's URL space (<c>/{node}/{collection}</c>).
+    /// </summary>
+    private static UiControl Browser(
+        LayoutAreaHost host, IContentService contentService, string collectionName, string path)
+    {
+        var browser = new FileBrowserControl(collectionName)
+            .WithPath(path)
+            .WithUrlBasePath(
+                $"/{host.Hub.Address}/{ContentCollectionsExtensions.EncodeCollectionName(collectionName)}");
+        var config = contentService.GetCollectionConfig(collectionName);
+        if (config is not null)
+            browser = browser
+                .WithCollectionConfiguration(config)
+                .WithCollectionInfo(config.SourceType, config.BasePath, config.Settings);
+        return browser;
+    }
+}

--- a/src/MeshWeaver.ContentCollections/ContentCollectionsExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollectionsExtensions.cs
@@ -32,8 +32,20 @@ public static class ContentCollectionsExtensions
 
     /// <summary>
     /// Default collection name used when no specific collection is configured or specified.
+    /// A collection can be mounted under ANY name — never assume a collection is called
+    /// "content"; use the configured name (or this constant only for genuine defaults).
     /// </summary>
     public const string DefaultCollectionName = "content";
+
+    /// <summary>
+    /// Encodes a collection name for use as a URL segment by replacing '/' with '~'
+    /// (a qualified name like "Submissions@Microsoft/2026" would otherwise split into
+    /// path segments; ASP.NET Core URL-decodes %2F before route matching).
+    /// </summary>
+    public static string EncodeCollectionName(string collectionName) => collectionName.Replace('/', '~');
+
+    /// <summary>Decodes a collection name from a URL segment ('~' back to '/').</summary>
+    public static string DecodeCollectionName(string encodedName) => encodedName.Replace('~', '/');
 
     /// <summary>
     /// Area name for unified content references. Uses $ prefix to avoid name collisions.
@@ -114,7 +126,14 @@ public static class ContentCollectionsExtensions
                 .AddLayout(layout => layout
                     .WithView(ContentAreaName, ContentLayoutArea.UnifiedContent)
                     .WithView(FileBrowserAreaName, FileBrowserLayoutAreas.FileBrowser)
-                    .WithView(CollectionAreaName, CollectionLayoutArea.Collection));
+                    .WithView(CollectionAreaName, CollectionLayoutArea.Collection)
+                    // Collection-named areas: /{node}/{collection}/{path…} — the URL segment is
+                    // the MOUNTED collection name (a collection can be mounted under any name;
+                    // nothing assumes "content"). A folder path renders the file browser scoped
+                    // there; a file path renders the file's content.
+                    .WithView(
+                        ctx => CollectionNamedLayoutArea.IsCollectionArea(layout.Hub, ctx),
+                        CollectionNamedLayoutArea.Render));
         }
     }
 

--- a/src/MeshWeaver.ContentCollections/ContentLayoutArea.cs
+++ b/src/MeshWeaver.ContentCollections/ContentLayoutArea.cs
@@ -54,7 +54,7 @@ public static class ContentLayoutArea
     /// reactive — no async, no Task surface (Doc/Architecture/AsynchronousCalls.md,
     /// ControlledIoPooling.md).
     /// </summary>
-    private static IIoPool GetIoPool(IMessageHub hub)
+    internal static IIoPool GetIoPool(IMessageHub hub)
         => hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem)
            ?? IoPool.Unbounded;
 
@@ -310,24 +310,55 @@ public static class ContentLayoutArea
                 if (collection is null)
                     return Observable.Return<UiControl?>(new MarkdownControl($"Collection '{collectionPart}' not found. Ensure the collection is mapped using MapContentCollection."));
 
-                var extension = Path.GetExtension(filePath).ToLowerInvariant();
-
-                // For images, get the raw content and render appropriately
-                if (IsImageFile(extension))
-                    return RenderImageContent(ioPool, collection, filePath, extension);
-
-                // For binary document formats, convert to markdown via IContentTransformer
-                if (IsDocumentFile(extension))
-                    return RenderDocumentContent(ioPool, collection, host.Hub, filePath);
-
-                // For other content types, use the existing GetMarkdown pipeline
-                var contentStream = collection.GetMarkdown(filePath);
-                if (contentStream is null)
-                    return Observable.Return<UiControl?>(new MarkdownControl($"File '{filePath}' not found in collection '{collectionPart}'."));
-
-                return contentStream.Select(content => (UiControl?)(content is null
-                    ? new MarkdownControl($"File '{filePath}' not found in collection '{collectionPart}'")
-                    : RenderContent(filePath, content, false)));
+                return RenderFile(host, collection, collectionPart, filePath);
             });
+    }
+
+    /// <summary>
+    /// Renders a single file from <paramref name="collection"/> by extension: images inline,
+    /// binary documents via <see cref="IContentTransformer"/>, PDFs embedded from the static
+    /// endpoint, everything else through the markdown pipeline. Shared by the unified
+    /// <c>$Content</c> area and the collection-named area (<see cref="CollectionNamedLayoutArea"/>).
+    /// </summary>
+    internal static IObservable<UiControl?> RenderFile(
+        LayoutAreaHost host, ContentCollection collection, string collectionName, string filePath)
+    {
+        var ioPool = GetIoPool(host.Hub);
+        var extension = Path.GetExtension(filePath).ToLowerInvariant();
+
+        // For images, get the raw content and render appropriately
+        if (IsImageFile(extension))
+            return RenderImageContent(ioPool, collection, filePath, extension);
+
+        // For binary document formats, convert to markdown via IContentTransformer
+        if (IsDocumentFile(extension))
+            return RenderDocumentContent(ioPool, collection, host.Hub, filePath);
+
+        // PDFs render embedded from the static endpoint (the markdown pipeline would read binary).
+        if (extension == ".pdf")
+            return Observable.Return<UiControl?>(RenderPdf(host, collectionName, filePath));
+
+        // For other content types, use the existing GetMarkdown pipeline
+        var contentStream = collection.GetMarkdown(filePath);
+        if (contentStream is null)
+            return Observable.Return<UiControl?>(new MarkdownControl($"File '{filePath}' not found in collection '{collectionName}'."));
+
+        return contentStream.Select(content => (UiControl?)(content is null
+            ? new MarkdownControl($"File '{filePath}' not found in collection '{collectionName}'")
+            : RenderContent(filePath, content, false)));
+    }
+
+    private static UiControl RenderPdf(LayoutAreaHost host, string collectionName, string filePath)
+    {
+        var contentUrl =
+            $"/static/{host.Hub.Address}/{ContentCollectionsExtensions.EncodeCollectionName(collectionName)}/{filePath}";
+        var fileName = Path.GetFileName(filePath);
+        return new HtmlControl(
+            $@"<div style=""width: 100%; min-height: 500px;"">
+                <iframe src=""{contentUrl}"" style=""width: 100%; height: 600px; border: 1px solid var(--neutral-stroke-rest); border-radius: 4px;"" title=""{fileName}""></iframe>
+                <div style=""margin-top: 8px;"">
+                    <a href=""{contentUrl}?download"" download=""{fileName}"">Download PDF</a>
+                </div>
+            </div>");
     }
 }

--- a/src/MeshWeaver.ContentCollections/ContentLayoutArea.cs
+++ b/src/MeshWeaver.ContentCollections/ContentLayoutArea.cs
@@ -350,14 +350,20 @@ public static class ContentLayoutArea
 
     private static UiControl RenderPdf(LayoutAreaHost host, string collectionName, string filePath)
     {
+        // The file name/path is USER content (uploads) and HtmlControl renders as raw markup:
+        // URL-encode each path segment (malformed-link safety) and HTML-encode every value
+        // interpolated into an attribute so a crafted name cannot break out of it (XSS).
+        var encodedPath = string.Join('/',
+            filePath.Split('/').Select(Uri.EscapeDataString));
         var contentUrl =
-            $"/static/{host.Hub.Address}/{ContentCollectionsExtensions.EncodeCollectionName(collectionName)}/{filePath}";
-        var fileName = Path.GetFileName(filePath);
+            $"/static/{host.Hub.Address}/{Uri.EscapeDataString(ContentCollectionsExtensions.EncodeCollectionName(collectionName))}/{encodedPath}";
+        var urlAttribute = System.Net.WebUtility.HtmlEncode(contentUrl);
+        var fileName = System.Net.WebUtility.HtmlEncode(Path.GetFileName(filePath));
         return new HtmlControl(
             $@"<div style=""width: 100%; min-height: 500px;"">
-                <iframe src=""{contentUrl}"" style=""width: 100%; height: 600px; border: 1px solid var(--neutral-stroke-rest); border-radius: 4px;"" title=""{fileName}""></iframe>
+                <iframe src=""{urlAttribute}"" style=""width: 100%; height: 600px; border: 1px solid var(--neutral-stroke-rest); border-radius: 4px;"" title=""{fileName}""></iframe>
                 <div style=""margin-top: 8px;"">
-                    <a href=""{contentUrl}?download"" download=""{fileName}"">Download PDF</a>
+                    <a href=""{urlAttribute}?download"" download=""{fileName}"">Download PDF</a>
                 </div>
             </div>");
     }

--- a/src/MeshWeaver.ContentCollections/FileBrowserLayoutAreas.cs
+++ b/src/MeshWeaver.ContentCollections/FileBrowserLayoutAreas.cs
@@ -20,20 +20,26 @@ public static class FileBrowserLayoutAreas
         if (split is null || split.Length < 1)
             return new MarkdownControl("Collection must be specified");
 
-        var collection = split[0];
-        var path = split.Length > 1 ? string.Join('/', split.Skip(1)) : "/";
+        var collection = ContentCollectionsExtensions.DecodeCollectionName(split[0]);
+        var path = split.Length > 1 ? $"/{string.Join('/', split.Skip(1))}" : "/";
 
         var contentService = host.Hub.GetContentService();
         var collectionConfig = contentService.GetCollectionConfig(collection);
 
-        var fileBrowser = new FileBrowserControl(collection);
+        var fileBrowser = new FileBrowserControl(collection)
+            .WithPath(path)
+            .WithUrlBasePath(
+                $"/{host.Hub.Address}/{ContentCollectionsExtensions.FileBrowserAreaName}/{ContentCollectionsExtensions.EncodeCollectionName(collection)}");
 
         if (collectionConfig != null)
         {
             fileBrowser = fileBrowser
                 .WithCollectionConfiguration(collectionConfig)
-                .WithCollectionInfo(collectionConfig.SourceType, collectionConfig.BasePath, collectionConfig.Settings)
-                .CreatePath();
+                .WithCollectionInfo(collectionConfig.SourceType, collectionConfig.BasePath, collectionConfig.Settings);
+            // Only auto-create the collection root — never a URL-supplied sub-path
+            // (a mistyped deep link must not create folders).
+            if (path == "/")
+                fileBrowser = fileBrowser.CreatePath();
         }
 
         return fileBrowser;

--- a/src/MeshWeaver.Documentation/DocumentationStaticRepoSource.cs
+++ b/src/MeshWeaver.Documentation/DocumentationStaticRepoSource.cs
@@ -44,7 +44,7 @@ public sealed class DocumentationStaticRepoSource(IServiceProvider serviceProvid
             NodePath: $"{Partition}/DataMesh/UnifiedPath",
             SourceCollection: "DocContent",
             SourcePath: "DataMesh/UnifiedPath",
-            TargetCollection: "content",
+            TargetCollection: MeshWeaver.ContentCollections.ContentCollectionsExtensions.DefaultCollectionName,
             TargetPath: ""),
     ];
 

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -1185,9 +1185,15 @@ public static class MeshNodeLayoutAreas
                 stack = stack.WithView(Controls.Title(col.DisplayName ?? col.Name, 3));
 
             var colConfig = col;
+            // Navigation mirrors into the collection's OWN URL space —
+            // /{node}/{collection}/{p1}/{p2} (the collection-named layout area) — so the
+            // address bar carries the full path under the MOUNTED collection name (a
+            // collection can be mounted under any name), and deep links / refresh land in
+            // the right folder. The Files tab itself always shows the collection roots.
             stack = stack.WithView(new FileBrowserControl(colConfig.Name)
                 .WithCollectionConfiguration(colConfig)
                 .WithCollectionInfo(colConfig.SourceType, colConfig.BasePath, colConfig.Settings)
+                .WithUrlBasePath(BuildUrl(hubPath, ContentCollectionsExtensions.EncodeCollectionName(colConfig.Name)))
                 .CreatePath());
         }
 
@@ -1324,9 +1330,9 @@ public static class MeshNodeLayoutAreas
 
     private static IObservable<UiControl?> RenderImageAsync(LayoutAreaHost host, string contentPath, string _)
     {
-        // Build static content URL: /static/{address}/content/{filePath}
+        // Build static content URL: /static/{address}/{defaultCollection}/{filePath}
         var address = host.Hub.Address.ToString();
-        var staticUrl = $"/static/{address}/content/{contentPath}";
+        var staticUrl = $"/static/{address}/{ContentCollectionsExtensions.DefaultCollectionName}/{contentPath}";
 
         return Observable.Return<UiControl?>(
             Controls.Html($"<img src='{staticUrl}' alt='{Path.GetFileName(contentPath)}' style='max-width: 100%;' />"));
@@ -1339,7 +1345,7 @@ public static class MeshNodeLayoutAreas
         var fileName = Path.GetFileName(contentPath);
 
         // Create a message with link to navigate to the content
-        var markdown = $"*This is text inserted from @{address}/content:{contentPath}*\n\n" +
+        var markdown = $"*This is text inserted from @{address}/{ContentCollectionsExtensions.DefaultCollectionName}:{contentPath}*\n\n" +
                        $"[Navigate to {fileName}](/{address}/$Content/{contentPath})";
 
         return Controls.Markdown(markdown);

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -335,7 +335,8 @@ public static class BlazorHostingExtensions
     /// Collection names with slashes (e.g., "Submissions@Microsoft/2026") are encoded
     /// with '~' in URLs to avoid path parsing issues.
     /// </summary>
-    private static string DecodeCollectionName(string encodedName) => encodedName.Replace("~", "/");
+    private static string DecodeCollectionName(string encodedName)
+        => ContentCollectionsExtensions.DecodeCollectionName(encodedName);
 
 }
 

--- a/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
+++ b/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
@@ -380,10 +380,14 @@ internal class NavigationService : INavigationService
         // navigation reference, node menus — then track file views; without this the literal
         // "content/…" path resolved to nothing and every file click blanked the context.
         // A GLOBAL collection (/content/{collection}/{filePath}, a portal-registered collection
-        // name) has no node address — clear the context like a page route.
-        if (route.StartsWith("content/", StringComparison.OrdinalIgnoreCase))
+        // name) has no node address — clear the context like a page route. So does BARE
+        // /content (ContentPage's catch-all matches an empty remainder) — without that case
+        // the literal route "content" fell through to mesh resolution and could synthesize a
+        // bogus partition root.
+        if (string.Equals(route, "content", StringComparison.OrdinalIgnoreCase)
+            || route.StartsWith("content/", StringComparison.OrdinalIgnoreCase))
         {
-            var contentRoute = route["content/".Length..];
+            var contentRoute = route.Length > "content".Length ? route["content/".Length..] : "";
             // '~' encodes '/' in collection names on content URLs (see ContentPage).
             var firstSegment = ContentCollectionsExtensions.DecodeCollectionName(contentRoute.Split('/')[0]);
             var contentService = _hub.ServiceProvider.GetService<IContentService>();

--- a/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
+++ b/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
@@ -3,6 +3,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
 using MeshWeaver.Blazor.Infrastructure;
+using MeshWeaver.ContentCollections;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Markdown;
@@ -81,12 +82,18 @@ internal class NavigationService : INavigationService
     private bool _isInitialized;
     private bool _disposed;
 
+    // Optional (app-level opt-in): the app's registered single-segment Blazor page routes
+    // (/login, /privacy, /search, …). See PageRouteRegistry for why the args-only heuristic
+    // is not enough. Null when the app doesn't register one — behavior then unchanged.
+    private readonly PageRouteRegistry? _pageRoutes;
+
     public NavigationService(
         NavigationManager navigationManager,
         IPathResolver pathResolver,
         IMessageHub hub,
-        ICircuitContextAccessor circuitContextAccessor)
-        : this(navigationManager, pathResolver, hub, circuitContextAccessor, DefaultRetryDelays)
+        ICircuitContextAccessor circuitContextAccessor,
+        PageRouteRegistry? pageRoutes = null)
+        : this(navigationManager, pathResolver, hub, circuitContextAccessor, DefaultRetryDelays, pageRoutes)
     {
     }
 
@@ -99,8 +106,10 @@ internal class NavigationService : INavigationService
         IPathResolver pathResolver,
         IMessageHub hub,
         ICircuitContextAccessor circuitContextAccessor,
-        int[] retryDelays)
+        int[] retryDelays,
+        PageRouteRegistry? pageRoutes = null)
     {
+        _pageRoutes = pageRoutes;
         _navigationManager = navigationManager;
         _pathResolver = pathResolver;
         _hub = hub;
@@ -344,7 +353,14 @@ internal class NavigationService : INavigationService
         // It is ALSO how `/search?q=nodeType%3AThread&…` was permission-checked as a Thread
         // node. A page route has NO node address: clear the context and stop — the page
         // (Search/Create/Login) reads its own query via [SupplyParameterFromQuery].
-        if (!string.IsNullOrEmpty(route) && !route.Contains('/') && !args.IsEmpty)
+        //
+        // 🚨 A BARE single segment matching a registered page route (/privacy, bare /login) is
+        // ALSO a page, args or not. Resolving it as a mesh path synthesizes a partition root
+        // whenever the writable provider's PartitionExists probe is indeterminate
+        // (InMemory/monolith), and the anonymous hard-gate then bounces the deliberately-PUBLIC
+        // page to /login — the /privacy regression. See PageRouteRegistry.
+        if (!string.IsNullOrEmpty(route) && !route.Contains('/')
+            && (!args.IsEmpty || _pageRoutes?.IsPageRoute(route) == true))
         {
             _resolutionSubscription?.Dispose();
             _notFoundWatchdog?.Dispose();
@@ -354,6 +370,35 @@ internal class NavigationService : INavigationService
             _status.OnNext(NavigationStatus.Idle());
             _navigationContext.OnNext(null);
             return;
+        }
+
+        // A /content/… route is the ContentPage (its own @page route — the page renders the
+        // file itself), but the navigation CONTEXT must still follow the node whose content is
+        // being viewed: /content/{address}/{collection}/{filePath} strips the page prefix and
+        // resolves {address}, leaving "{collection}/{filePath}" as the remainder (area =
+        // collection, id = file path). Context consumers — the chat context chip + agent
+        // navigation reference, node menus — then track file views; without this the literal
+        // "content/…" path resolved to nothing and every file click blanked the context.
+        // A GLOBAL collection (/content/{collection}/{filePath}, a portal-registered collection
+        // name) has no node address — clear the context like a page route.
+        if (route.StartsWith("content/", StringComparison.OrdinalIgnoreCase))
+        {
+            var contentRoute = route["content/".Length..];
+            // '~' encodes '/' in collection names on content URLs (see ContentPage).
+            var firstSegment = ContentCollectionsExtensions.DecodeCollectionName(contentRoute.Split('/')[0]);
+            var contentService = _hub.ServiceProvider.GetService<IContentService>();
+            if (!contentRoute.Contains('/') || contentService?.GetCollectionConfig(firstSegment) is not null)
+            {
+                _resolutionSubscription?.Dispose();
+                _notFoundWatchdog?.Dispose();
+                IsResolving = false;
+                Context = null;
+                CurrentNamespace = null;
+                _status.OnNext(NavigationStatus.Idle());
+                _navigationContext.OnNext(null);
+                return;
+            }
+            route = contentRoute;
         }
 
         _status.OnNext(NavigationStatus.LookingUp(route));

--- a/src/MeshWeaver.Hosting.Blazor/PageRouteRegistry.cs
+++ b/src/MeshWeaver.Hosting.Blazor/PageRouteRegistry.cs
@@ -1,0 +1,85 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.AspNetCore.Components;
+
+namespace MeshWeaver.Hosting.Blazor;
+
+/// <summary>
+/// The set of SINGLE-SEGMENT Blazor page routes (<c>/login</c>, <c>/privacy</c>, <c>/search</c>,
+/// …), derived from the same router assemblies the app's <c>Routes.razor</c> gives the Blazor
+/// <c>Router</c>. <see cref="NavigationService"/> short-circuits these BEFORE mesh path
+/// resolution.
+///
+/// <para><b>Why:</b> the navigation service's only page-route heuristic used to be "single
+/// segment WITH query args". A bare page URL (<c>/privacy</c>) fell through to
+/// <c>PathResolutionService</c>, whose partition-root synthesis treats any single segment as a
+/// potential partition root whenever the writable provider's <c>PartitionExists</c> probe is
+/// indeterminate (InMemory / monolith). The synthetic resolution then hit the anonymous
+/// hard-gate, bouncing the deliberately-PUBLIC page to <c>/login</c>. Registering the app's
+/// actual page routes makes the decision exact instead of heuristic.</para>
+///
+/// <para>Only templates that are exactly ONE fixed segment are registered: multi-segment page
+/// routes cannot be mistaken for partition roots (synthesis requires a single segment), and
+/// registering their first segments could shadow real mesh paths (e.g. a page under
+/// <c>/admin/…</c> must not shadow the <c>Admin</c> partition).</para>
+///
+/// <para>Register as a DI singleton (app-level opt-in); when absent, the navigation service
+/// falls back to the args-only heuristic. Instance state on a mesh-scoped singleton — never
+/// static (see NoStaticState.md).</para>
+/// </summary>
+public sealed class PageRouteRegistry
+{
+    private readonly ConcurrentDictionary<string, byte> _segments = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Builds the registry from the given router assemblies — pass the SAME assemblies
+    /// the app's <c>Routes.razor</c> passes to the Blazor <c>Router</c>.</summary>
+    public PageRouteRegistry(params Assembly[] routerAssemblies)
+    {
+        foreach (var assembly in routerAssemblies)
+            Register(assembly);
+    }
+
+    /// <summary>Registers every single-fixed-segment <see cref="RouteAttribute"/> template
+    /// found on the assembly's component types.</summary>
+    public void Register(Assembly assembly)
+    {
+        Type[] types;
+        try
+        {
+            types = assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types.Where(t => t is not null).Cast<Type>().ToArray();
+        }
+
+        foreach (var type in types)
+        {
+            if (!typeof(IComponent).IsAssignableFrom(type))
+                continue;
+            foreach (var route in type.GetCustomAttributes<RouteAttribute>())
+            {
+                var template = route.Template.Trim().TrimStart('/');
+                if (template.Length == 0 || template.Contains('/') || template.StartsWith('{'))
+                    continue;
+                _segments.TryAdd(template, 0);
+            }
+        }
+    }
+
+    /// <summary>Registers explicit route segments (tests / routes not discoverable by
+    /// reflection).</summary>
+    public void Register(params string[] segments)
+    {
+        foreach (var segment in segments)
+        {
+            var trimmed = segment.Trim().TrimStart('/');
+            if (trimmed.Length > 0 && !trimmed.Contains('/'))
+                _segments.TryAdd(trimmed, 0);
+        }
+    }
+
+    /// <summary>True when <paramref name="route"/> is a registered single-segment page route.</summary>
+    public bool IsPageRoute(string? route) =>
+        !string.IsNullOrEmpty(route) && _segments.ContainsKey(route);
+}

--- a/src/MeshWeaver.Layout/FileBrowserControl.cs
+++ b/src/MeshWeaver.Layout/FileBrowserControl.cs
@@ -44,6 +44,24 @@
         public FileBrowserControl CreatePath()
             => this with { PathCreation = true };
 
+        /// <summary>Returns a copy with <paramref name="path"/> as the folder the browser opens on.</summary>
+        /// <param name="path">The collection-relative folder path (leading slash), e.g. <c>/p1/p2</c>.</param>
+        public FileBrowserControl WithPath(string path)
+            => this with { Path = path };
+
+        /// <summary>Returns a copy with <paramref name="urlBasePath"/> as the URL the browser mirrors its folder position under.</summary>
+        /// <param name="urlBasePath">The base URL of the embedding area (e.g. <c>/{node}/Files</c>); folder navigation appends the folder path to it.</param>
+        public FileBrowserControl WithUrlBasePath(string urlBasePath)
+            => this with { UrlBasePath = urlBasePath };
+
+        /// <summary>
+        /// When set, the embedded browser navigates folders THROUGH THE URL: folder rows and
+        /// breadcrumbs are links to <c>{UrlBasePath}{folderPath}</c>, so the address bar always
+        /// carries the full sub-folder path (deep-linkable, refresh-safe). When null, embedded
+        /// folder navigation stays in-place (dialogs and other URL-less hosts).
+        /// </summary>
+        public string? UrlBasePath { get; init; }
+
         /// <summary>Returns a copy with <paramref name="path"/> as the top-level path the browser is restricted to.</summary>
         /// <param name="path">The top-level mesh or file-system path; the browser cannot navigate above this.</param>
         public FileBrowserControl WithTopLevel(string path)

--- a/src/MeshWeaver.Markdown.Export/Configuration/MarkdownExportConfig.cs
+++ b/src/MeshWeaver.Markdown.Export/Configuration/MarkdownExportConfig.cs
@@ -10,7 +10,7 @@ public class MarkdownExportConfig
     /// Name of the content collection to write exports into. Defaults to <c>content</c>
     /// — the single editable collection every node hub has by default.
     /// </summary>
-    public string CollectionName { get; set; } = "content";
+    public string CollectionName { get; set; } = MeshWeaver.ContentCollections.ContentCollectionsExtensions.DefaultCollectionName;
 
     /// <summary>
     /// Sub-directory within the collection (relative to the collection root) where

--- a/test/MeshWeaver.ContentCollections.Test/DocxConversionTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/DocxConversionTest.cs
@@ -23,17 +23,26 @@ namespace MeshWeaver.ContentCollections.Test;
 /// Tests for docx → markdown conversion via IContentTransformer,
 /// content autocomplete for document files, and agent content access.
 /// </summary>
-public class DocxConversionTest(ITestOutputHelper output) : HubTestBase(output)
+public class DocxConversionTest : HubTestBase
 {
     private readonly string _contentBasePath = Path.Combine(AppContext.BaseDirectory, "Files", "DocxTest");
 
-    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    public DocxConversionTest(ITestOutputHelper output) : base(output)
     {
+        // The fixtures are read BOTH through the client hub's collection AND directly from
+        // disk (DocSharpContentTransformer_Converts_Docx_To_Markdown never builds a hub) —
+        // create them in the ctor, not in ConfigureClient, so they exist regardless of
+        // whether (and in which order) a test calls GetClient(). Creating them in
+        // ConfigureClient made the direct-read test order-dependent: green on a warm bin
+        // (residue from earlier runs), DirectoryNotFoundException on a clean checkout.
         Directory.CreateDirectory(_contentBasePath);
         CreateTestDocx(Path.Combine(_contentBasePath, "sample.docx"), "Hello World", "This is a test document.");
         // Also create a plain text file for comparison
         File.WriteAllText(Path.Combine(_contentBasePath, "readme.md"), "# Readme\nSome text.");
+    }
 
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
         return base.ConfigureClient(configuration)
             .AddContentCollection(_ => new ContentCollectionConfig
             {

--- a/test/MeshWeaver.ContentCollections.Test/NodeHubContentCollectionTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/NodeHubContentCollectionTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using MeshWeaver.Data;
 using MeshWeaver.Fixture;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Client;
@@ -39,6 +40,8 @@ public class NodeHubContentCollectionTest(ITestOutputHelper output) : HubTestBas
         Directory.CreateDirectory(contentPath);
 
         return base.ConfigureClient(configuration)
+            // Layout areas ($Content, $FileBrowser, $Collection, and the collection-named area)
+            .AddContentCollections()
             .AddContentCollection(_ => new ContentCollectionConfig
             {
                 Name = "content",
@@ -137,5 +140,59 @@ public class NodeHubContentCollectionTest(ITestOutputHelper output) : HubTestBas
         // But GetCollectionConfig should still find "storage" (for internal use)
         var storageConfig = contentService.GetCollectionConfig("storage");
         storageConfig.Should().NotBeNull("storage should still be resolvable directly");
+    }
+
+    /// <summary>
+    /// The collection-named layout area serves the collection's OWN URL space —
+    /// <c>/{node}/{collection}/{path…}</c>, where the segment is the MOUNTED collection name
+    /// (a collection can be mounted under any name; nothing assumes "content"): a folder path
+    /// renders the file browser scoped to that folder with the URL base reflecting the
+    /// collection name, a file path renders the file's content.
+    /// </summary>
+    [Fact]
+    public async Task CollectionNamedArea_RendersBrowserForFolder_AndContentForFile()
+    {
+        var client = GetClient();
+        var contentService = client.ServiceProvider.GetRequiredService<IContentService>();
+        var ct = TestContext.Current.CancellationToken;
+        var collection = await contentService.GetCollectionAsync("content", ct);
+        collection.Should().NotBeNull();
+
+        // A nested file so folder and file rendering are distinguishable.
+        var bytes = "# Hello from the collection area"u8.ToArray();
+        using (var stream = new MemoryStream(bytes))
+            await collection!.SaveFileAsync("/sub", "hello.md", stream);
+
+        try
+        {
+            // Subscribe from the HOST hub — a hub cannot GetRemoteStream its own address.
+            var workspace = GetHost().GetWorkspace();
+
+            // Folder → the file browser scoped to /sub, mirroring the collection-named URL space.
+            var folderControl = await workspace
+                .GetRemoteStream<System.Text.Json.JsonElement, LayoutAreaReference>(
+                    client.Address, new LayoutAreaReference("content") { Id = "sub" })
+                .GetControlStream("content")
+                .Should().Within(30.Seconds()).Match(c => c != null);
+            var folderJson = folderControl!.ToString()!;
+            folderJson.Should().Contain("FileBrowser", "a folder path renders the browser");
+            folderJson.Should().Contain("/sub", "the browser is scoped to the folder");
+            folderJson.Should().Contain($"/{client.Address}/content",
+                "navigation mirrors into the collection-named URL space");
+
+            // File → the file's rendered content, not a browser.
+            var fileControl = await workspace
+                .GetRemoteStream<System.Text.Json.JsonElement, LayoutAreaReference>(
+                    client.Address, new LayoutAreaReference("content") { Id = "sub/hello.md" })
+                .GetControlStream("content")
+                .Should().Within(30.Seconds())
+                .Match(c => c != null && c.ToString()!.Contains("Hello from the collection area"));
+            fileControl!.ToString().Should().NotContain("FileBrowser",
+                "a file path renders content, not a browser");
+        }
+        finally
+        {
+            await collection!.DeleteFileAsync("/sub/hello.md");
+        }
     }
 }

--- a/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
@@ -291,6 +291,111 @@ public class NavigationServiceTest
 
     #endregion
 
+    #region Page Route Tests
+
+    /// <summary>
+    /// A bare single-segment URL matching a REGISTERED page route (/privacy) must
+    /// short-circuit BEFORE mesh path resolution: no ResolveNavigationPath call and no
+    /// anonymous-gate /login redirect — the deliberately-PUBLIC page renders for a
+    /// logged-out visitor. Without the registry, partition-root synthesis resolved the
+    /// bare segment on indeterminate providers (InMemory/monolith) and the anonymous
+    /// gate bounced the page to /login.
+    /// </summary>
+    [Fact]
+    public async Task AnonymousVisitor_RegisteredPageRoute_ShortCircuits_NoLoginRedirect()
+    {
+        MakeVisitorAnonymous();
+        var registry = new PageRouteRegistry();
+        registry.Register("privacy");
+        var service = new NavigationService(
+            _navigationManager, _pathResolver, _hub, _circuitContextAccessor, registry);
+        // If the short-circuit failed, this resolution would fire the anonymous gate.
+        _pathResolver.ResolveNavigationPath(Arg.Any<string>())
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("privacy", "")));
+
+        service.Initialize();
+        _navigationManager.SimulateLocationChanged("http://localhost/privacy");
+
+        // Negative test: give any (wrong) resolution path a moment to run, then assert
+        // nothing resolved and nothing redirected.
+        await Task.Delay(200);
+        _navigationManager.Uri.Should().NotContain("/login");
+        _ = _pathResolver.DidNotReceive().ResolveNavigationPath(Arg.Any<string>());
+    }
+
+    /// <summary>
+    /// Reflection-derived registry: single-fixed-segment @page templates register;
+    /// multi-segment and parameterized templates do not.
+    /// </summary>
+    [Fact]
+    public void PageRouteRegistry_ReflectsSingleSegmentTemplates()
+    {
+        var registry = new PageRouteRegistry(typeof(TestPrivacyPage).Assembly);
+        registry.IsPageRoute("test-privacy").Should().BeTrue();
+        registry.IsPageRoute("TEST-PRIVACY").Should().BeTrue(); // case-insensitive
+        registry.IsPageRoute("multi").Should().BeFalse();       // multi-segment template
+        registry.IsPageRoute("nonexistent").Should().BeFalse();
+    }
+
+    [Microsoft.AspNetCore.Components.Route("/test-privacy")]
+    private sealed class TestPrivacyPage : IComponent
+    {
+        public void Attach(RenderHandle renderHandle) { }
+        public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+    }
+
+    [Microsoft.AspNetCore.Components.Route("/multi/segment")]
+    private sealed class TestMultiSegmentPage : IComponent
+    {
+        public void Attach(RenderHandle renderHandle) { }
+        public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+    }
+
+    #endregion
+
+    #region Content Route Context Tests
+
+    /// <summary>
+    /// A /content/{address}/{collection}/{filePath} URL is the ContentPage (its own @page route —
+    /// the page renders the file itself), but the navigation CONTEXT must follow the node whose
+    /// content is being viewed: the "content/" page prefix is stripped, the {address} part
+    /// resolves, and the remainder carries area = {collection}, id = {filePath}. This keeps the
+    /// chat context chip + agent navigation reference (and the node menus) tracking file views;
+    /// before, the literal "content/…" path resolved to nothing and every file click blanked the
+    /// context.
+    /// </summary>
+    [Fact]
+    public async Task OnLocationChanged_ContentRoute_ResolvesNodeContext_WithCollectionAreaAndFilePath()
+    {
+        var service = CreateService();
+        _pathResolver.ResolveNavigationPath(Arg.Any<string>())
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("ACME", null)));
+        service.Initialize();
+
+        _pathResolver.ResolveNavigationPath("ACME/Project/content/p1/p2/file.cs")
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("ACME/Project", "content/p1/p2/file.cs")));
+
+        // Act — the browser is on the ContentPage URL (page prefix "content/").
+        _navigationManager.SimulateLocationChanged(
+            "http://localhost/content/ACME/Project/content/p1/p2/file.cs");
+        await service.NavigationContext.Should().Within(WaitTimeout)
+            .Match(ctx => ctx?.Namespace == "ACME/Project");
+
+        // Assert — the context is the owning node with the file carried as area reference.
+        service.Context.Should().NotBeNull();
+        service.Context!.Namespace.Should().Be("ACME/Project");
+        service.Context.Area.Should().Be("content");
+        service.Context.Id.Should().Be("p1/p2/file.cs");
+        // The literal page route (with the /content/ prefix) is never fed to the resolver.
+        _ = _pathResolver.DidNotReceive()
+            .ResolveNavigationPath("content/ACME/Project/content/p1/p2/file.cs");
+    }
+
+    #endregion
+
     #region InitializeAsync Tests
 
     [Fact]

--- a/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
@@ -394,6 +394,24 @@ public class NavigationServiceTest
             .ResolveNavigationPath("content/ACME/Project/content/p1/p2/file.cs");
     }
 
+    /// <summary>
+    /// Bare /content (ContentPage's catch-all matches an empty remainder) is a page route with
+    /// no node address: the context clears and the literal "content" is never fed to the mesh
+    /// resolver (which could synthesize a bogus partition root).
+    /// </summary>
+    [Fact]
+    public async Task OnLocationChanged_BareContentRoute_ClearsContext_WithoutResolving()
+    {
+        var service = CreateService();
+        service.Initialize();
+
+        _navigationManager.SimulateLocationChanged("http://localhost/content");
+        await service.NavigationContext.Should().Within(WaitTimeout).Match(ctx => ctx == null);
+
+        service.Context.Should().BeNull();
+        _ = _pathResolver.DidNotReceive().ResolveNavigationPath(Arg.Any<string>());
+    }
+
     #endregion
 
     #region InitializeAsync Tests


### PR DESCRIPTION
## What

Content collections get their own URL space named by the **mounted collection**: `/{node}/{collection}/{p1}/{p2}[/file.ext]` — the segment is whatever name the collection is mounted under, never a hard-coded word.

- **`CollectionNamedLayoutArea`** (new, registered by `AddContentCollections` as a predicate view): matches any area naming a mounted collection; asks the provider whether the path is a folder or file — folders render the `FileBrowserControl` scoped there, files render via the shared `ContentLayoutArea.RenderFile` (markdown, code, images, docx, new PDF embed).
- **`FileBrowser` URL mirroring** (`UrlBasePath`): folder rows, breadcrumbs, and previewable-file links become real hrefs under the collection's URL base — the address bar carries the full sub-folder path; deep links and refresh land in the right folder. URL-less hosts (dialogs) keep in-place navigation. The Files tab mirrors each collection's browser into its own URL space; `$Collection`/`$FileBrowser` now honor their (previously parsed-but-ignored) sub-path id.
- **Chat context follows the viewed path**: legacy `/content/{address}/{collection}/{path}` ContentPage URLs now resolve a navigation context for the owning node (area = collection, id = file path) instead of blanking it; collection-named URLs carry area/id natively. The composer chip + agent navigation reference update reactively.
- **Context chip → opposite panel**: a main-view thread peeks its context in the side panel; a side-panel chat (new `IsInSidePanel` cascading value) brings it to the main view. `@`-reference chips keep the modal preview (#131).
- **Hard-coded `"content"` sweep**: `MeshNodeLayoutAreas`, `AgentChatClient`, `ContentCollectionPlugin`, `MarkdownExportConfig`, `DocumentationStaticRepoSource` now use the configured name / `DefaultCollectionName`; `~` encode/decode helpers unified on `ContentCollectionsExtensions`. UCR keywords and fixed page/API routes deliberately unchanged.

## Also included

- **`PageRouteRegistry` groundwork** (registered page routes short-circuit mesh resolution): its `NavigationService` hunks are entangled with the content-route change; inert until a portal registers the registry (that registration + privacy page stays in a follow-up).
- **`DocxConversionTest` fixture fix**: fixtures were created in `ConfigureClient` (only runs on `GetClient()`), making the direct-disk-read test order-dependent — green on a warm bin, `DirectoryNotFoundException` on a clean checkout. Fixtures now created in the ctor.

## Tests

- `NavigationServiceTest.OnLocationChanged_ContentRoute_ResolvesNodeContext_WithCollectionAreaAndFilePath` — content-route context resolution.
- `NodeHubContentCollectionTest.CollectionNamedArea_RendersBrowserForFolder_AndContentForFile` — folder-vs-file rendering of the collection-named area.
- Clean-worktree pre-flight: `Release -p:CIRun=true -warnaserror` build green; ContentCollections 15/15 (clean bin fixtures), Hosting.Blazor 120/120.

## Caveat

A collection mounted under a registered area name (`Overview`, `Settings`) or reserved URL keyword (`area`/`data`/`schema`/`model`) shadows it — documented on the predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)