### PR TITLE
feat(sync): bi-directional space replication between MeshWeaver instances

### DIFF
--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -83,6 +83,7 @@
     <Project Path="src/MeshWeaver.GoogleMaps/MeshWeaver.GoogleMaps.csproj" />
     <Project Path="src/MeshWeaver.Graph/MeshWeaver.Graph.csproj" />
     <Project Path="src/MeshWeaver.GitSync/MeshWeaver.GitSync.csproj" />
+    <Project Path="src/MeshWeaver.InstanceSync/MeshWeaver.InstanceSync.csproj" />
     <Project Path="src/MeshWeaver.GridModel/MeshWeaver.GridModel.csproj" />
     <Project Path="src/MeshWeaver.Hosting.AzureBlob/MeshWeaver.Hosting.AzureBlob.csproj" />
     <Project Path="src/MeshWeaver.Hosting.Blazor/MeshWeaver.Hosting.Blazor.csproj" />
@@ -153,6 +154,7 @@
     <Project Path="test/MeshWeaver.TestDomain/MeshWeaver.TestDomain.csproj" />
     <Project Path="test/MeshWeaver.Graph.Test/MeshWeaver.Graph.Test.csproj" />
     <Project Path="test/MeshWeaver.GitSync.Test/MeshWeaver.GitSync.Test.csproj" />
+    <Project Path="test/MeshWeaver.InstanceSync.Test/MeshWeaver.InstanceSync.Test.csproj" />
     <Project Path="test/MeshWeaver.Hosting.Blazor.Test/MeshWeaver.Hosting.Blazor.Test.csproj" />
     <Project Path="test/MeshWeaver.Hosting.Test/MeshWeaver.Hosting.Test.csproj" />
     <Project Path="test/MeshWeaver.Hub.Fixture/MeshWeaver.Hub.Fixture.csproj" />

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Grpc\MeshWeaver.Hosting.Grpc.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.InstanceSync\MeshWeaver.InstanceSync.csproj" />
     <!-- Content → vector index (core tech): chunk/embed/store on a separate Postgres vector DB,
          per-file Document nodes, chunk-search autocomplete. Inert unless ConnectionStrings:contentindex
          + embeddings are configured (so the monolith compiles it but never activates it). -->

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -32,6 +32,7 @@ using MeshWeaver.GoogleMaps;
 using MeshWeaver.Data;
 using MeshWeaver.GitSync;
 using MeshWeaver.Graph;
+using MeshWeaver.InstanceSync;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Markdown.Export.Configuration;
 using MeshWeaver.Hosting.Activity;
@@ -257,6 +258,11 @@ public static class MemexConfiguration
         // absent a client id the Connect flow is gracefully disabled.
         services.AddGitHubSyncServices();
         services.Configure<GitHubOAuthOptions>(builder.Configuration.GetSection("GitHub:OAuth"));
+
+        // Instance sync — bidirectional Space replication to another MeshWeaver instance
+        // (per-space registry at {space}/_Sync; offline changes accumulate in the durable
+        // manifest and drain when the remote is reachable again).
+        services.AddInstanceSyncServices();
 
         // Per-user CLI Connect (Settings → Models, CLI providers). The
         // ConnectSessionManager is a mesh-scoped singleton holding the live
@@ -509,6 +515,9 @@ public static class MemexConfiguration
                 // Register GitHub-sync content types (GitHubCredential / GitHubSyncConfig)
                 // on the mesh + per-node hubs so their config nodes (de)serialize.
                 .AddGitHubSyncTypes()
+                // Register the instance-sync content type ({space}/_Sync/{sourceId} config
+                // nodes) on the mesh + per-node hubs so they (de)serialize.
+                .AddInstanceSyncTypes()
                 // Seed root-scope Admin AccessAssignments for users listed under
                 // `Auth:GlobalAdmins` so configured admins bypass per-partition
                 // RLS for cross-partition operations (list Spaces, create
@@ -688,6 +697,9 @@ public static class MemexConfiguration
                         .AddTokenUsageSettingsTab()
                         // GitHub Sync tab — shows only on Space nodes (self-filtered).
                         .AddGitHubSyncSettingsTab()
+                        // Instance Sync tab — replicate the Space to another MeshWeaver
+                        // instance (self-filtered to Spaces, like the GitHub Sync tab).
+                        .AddInstanceSyncSettingsTab()
                         // Code workspace tab — on-disk working-tree editor (checkout/edit/commit/push).
                         .AddWorkingTreeTab()
                         // Git history tab — read-only git browser (commit log + changes + diffs) over the same working tree.

--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -798,7 +798,8 @@ public class MeshOperations
     }
 
     /// <summary>
-    /// Runs a mesh query and returns a JSON envelope <c>{count, limit, truncated, results:[{path,name,nodeType}]}</c>.
+    /// Runs a mesh query and returns a JSON envelope
+    /// <c>{count, limit, truncated, results:[{path,name,nodeType,version,lastModified}]}</c>.
     /// When <paramref name="basePath"/> is set the query is scoped to that namespace; <c>truncated</c> flags that
     /// more matches exist than were returned.
     /// </summary>
@@ -831,8 +832,10 @@ public class MeshOperations
             .Take(1)
             .Select(change =>
             {
+                // Version + LastModified ride along so remote consumers (the instance-sync
+                // pull sweep) can detect changed nodes from the listing alone.
                 var list = change.Items
-                    .Select(node => (object)new { node.Path, node.Name, node.NodeType })
+                    .Select(node => (object)new { node.Path, node.Name, node.NodeType, node.Version, node.LastModified })
                     .ToImmutableList();
                 // Envelope instead of a bare array so truncation is VISIBLE: a result
                 // set that silently stops at the limit reads as "that's everything"

--- a/src/MeshWeaver.Blazor.AI/McpMeshPlugin.cs
+++ b/src/MeshWeaver.Blazor.AI/McpMeshPlugin.cs
@@ -167,7 +167,7 @@ The target collection must exist on the node and be editable (`IsEditable=true`)
     /// <param name="limit">Maximum number of results to return (default 50, max 200).</param>
     /// <returns>A JSON envelope <c>{count, limit, truncated, results}</c> as a string.</returns>
     [McpServerTool(Title = "Search the mesh", ReadOnly = true, Idempotent = true, OpenWorld = false)]
-    [Description(@"Searches the mesh using GitHub-style query syntax. Returns {count, limit, truncated, results:[{path,name,nodeType}]} — when 'truncated' is true there are more matches than returned; narrow the query or raise 'limit'.
+    [Description(@"Searches the mesh using GitHub-style query syntax. Returns {count, limit, truncated, results:[{path,name,nodeType,version,lastModified}]} — when 'truncated' is true there are more matches than returned; narrow the query or raise 'limit'.
 
 Query terms (space-separated, all case-insensitive):
   • field filters: nodeType:Agent, name:Acme, name:*sales* (wildcards), -status:Archived (negation), price:>100

--- a/src/MeshWeaver.Documentation/Data/Architecture/InstanceSync.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InstanceSync.md
@@ -60,7 +60,7 @@ IMeshChangeFeed ──► InstanceSyncCoordinator (IHostedService, one per proce
                        ▼
                 InstanceSyncWorker (one per registration)
                   PUSH: coalesce into PendingChanges manifest (stream.Update, durable)
-                        └─ drain pipeline (Subject → Throttle → Concat, serialized)
+                        └─ drain pipeline (Subject → Sample → Concat, serialized)
                             └─ per node: Get remote → equal? skip : Create/Update/Delete
                   PULL: periodic sweep — search hits carry version + lastModified,
                         Get only changed nodes, newest-writer-wins, apply as system

--- a/src/MeshWeaver.Documentation/Data/Architecture/InstanceSync.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InstanceSync.md
@@ -1,0 +1,116 @@
+---
+NodeType: Markdown
+Name: "Instance Sync — bi-directional space replication between MeshWeaver instances"
+Abstract: "Replicate a Space to another MeshWeaver instance and keep syncing changes as they happen, SharePoint-style. The sync registry lives at {space}/_Sync/{sourceId}; each registration carries a durable change manifest that accumulates while the remote is unreachable and drains on reconnect. The registering instance is the sync CLIENT for both directions — push (change feed → manifest → remote MCP surface) and pull (periodic reconciliation sweep) — so the remote stays passive."
+Icon: "<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><rect width='24' height='24' rx='4' fill='#1565c0'/><path d='M7 9a5 5 0 0 1 9.6-1.5M17 15a5 5 0 0 1-9.6 1.5' stroke='white' stroke-width='2' fill='none' stroke-linecap='round'/><path d='M16.5 4v3.5H13M7.5 20v-3.5H11' stroke='white' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>"
+Authors:
+  - "Roland Buergi"
+Tags:
+  - "Architecture"
+  - "Sync"
+  - "Replication"
+  - "Federation"
+---
+
+> **Read first:** [Asynchronous Calls](/Doc/Architecture/AsynchronousCalls) (everything here is reactive, IoPool-bounded) and [Access Context Propagation](/Doc/Architecture/AccessContextPropagation) (worker writes run as system). The GitHub counterpart of this feature is the GitSync engine; instance sync reuses its config-satellite and settings-tab shape.
+
+## What it does
+
+From any Space's **Settings → Instance Sync** tab, a Space admin adds a *syncing party*: the URL
+of another MeshWeaver instance plus an ApiToken issued there. The Space is replicated to the
+remote instance, and from then on changes keep syncing as they happen — like syncing a
+SharePoint library. If the other instance is down, changes **accumulate** in a durable manifest
+and are applied when it can be reached again. The tab lists every syncing party with its live
+status, and each party can be paused (`Active` off), poked (`Sync now`) or removed (cancel).
+The same sources also appear on the platform-admin **Partitions** page through the
+`IPartitionSyncSourceProvider` seam (kind: *Remote Instance*).
+
+## The registry: `{space}/_Sync/{sourceId}`
+
+Each syncing party is one MeshNode at `{space}/_Sync/{sourceId}` with content
+`InstanceSyncConfig` (project `MeshWeaver.InstanceSync`):
+
+| Field | Meaning |
+|---|---|
+| `RemoteUrl`, `RemoteToken` | The remote portal and the ApiToken issued **by that remote** |
+| `RemoteSpace` | Space id on the remote (blank = same id) |
+| `Direction` | `Bidirectional` (default) / `PushOnly` / `PullOnly` |
+| `Active` | Uncheck to pause — changes still accumulate, nothing transfers |
+| `SyncRequestedAt` | Control-plane trigger stamped by "Sync now" (the Requested-field pattern) |
+| `Status`, `LastSyncedAt`, `LastError` | Worker-written, read-only in the GUI |
+| `PendingChanges` | **The durable change manifest** (see below) |
+
+`_Sync` is a `_`-prefixed satellite segment, so every content filter (the GitHub export filter
+and the instance-sync push filter itself) excludes it: the registry — including the token —
+never replicates anywhere, and the worker's own status/manifest writes never re-enter the sync
+loop. The GUI edits the config through the standard node-content editor bound directly to the
+node stream; there is no hand-rolled form or replica.
+
+## Architecture: the registering instance is the sync client
+
+The remote instance needs nothing but its existing MCP surface (`get` / `create` / `update` /
+`delete` / `search`, reached through `McpRemoteMeshClient` with `Authorization: Bearer` — the
+same client the mirror feature uses). All sync logic runs on the instance that holds the
+registration, exactly like a SharePoint/OneDrive sync client:
+
+```
+IMeshChangeFeed ──► InstanceSyncCoordinator (IHostedService, one per process)
+                       │  config-node events ⇒ start/stop/poke workers
+                       │  content events     ⇒ offer to each worker
+                       ▼
+                InstanceSyncWorker (one per registration)
+                  PUSH: coalesce into PendingChanges manifest (stream.Update, durable)
+                        └─ drain pipeline (Subject → Throttle → Concat, serialized)
+                            └─ per node: Get remote → equal? skip : Create/Update/Delete
+                  PULL: periodic sweep — search hits carry version + lastModified,
+                        Get only changed nodes, newest-writer-wins, apply as system
+```
+
+- **Initial replication** — first drain pushes the whole filtered subtree (root first, so the
+  remote provisions the Space partition), then stamps `InitialSyncAt`.
+- **Offline accumulation** — a transport failure flips the source to `Offline`, keeps the
+  manifest (it lives on the config node, so it survives restarts) and starts a reconnect probe
+  with backoff (5s → 60s cap). The probe **is** the feature — "changes accumulate until the
+  other instance can be reached again" — not a recovery watchdog for a defect. Entries coalesce
+  per path: the drain pushes each node's *current* content, so only the latest pending state
+  matters.
+- **Restart resume** — the coordinator's boot discovery (one system-identity query for
+  `nodeType:InstanceSyncConfig`) restarts every worker; pending manifests drain immediately.
+- **Errors are never swallowed** — a remote-rejected node stays in the manifest with
+  `Status=Error` + `LastError` on the node (visible in the GUI); a transport failure surfaces
+  as `Offline`. Wedges-to-zero: every failure lands on the registration node.
+
+## Loop prevention (the echo problem)
+
+Applying a pulled change locally fires the local change feed, which would re-enter the manifest
+and push the change straight back — an infinite ping-pong. Two independent layers stop it:
+
+1. **Consume-once suppression** — the pull-apply registers the local path in an instance-scoped
+   registry *before* writing; the very next feed event for that path is swallowed exactly once.
+2. **Value-equality convergence guard** — every push and pull first compares content
+   (name/type/state + canonical JSON) and drops value-equal writes. Any echo that slips past
+   layer 1 terminates after one hop instead of oscillating.
+
+Conflicts resolve **newest-writer-wins** by `LastModified` (ties keep the local side). This is
+last-write-wins at node granularity — concurrent edits to the *same node* on both instances
+within one sweep interval resolve to the newer stamp, not a field merge.
+
+## Known limitations (v1)
+
+- **Remote deletes don't propagate on pull** — only local deletes push. In a symmetric setup
+  (a registration on each side) deletes propagate both ways via each side's push.
+- **Clock skew** between instances shifts newest-writer-wins fairness; stamps come from each
+  instance's own clock.
+- **One coordinator per process** — multi-replica portals would run duplicate workers. The
+  equality guard makes duplicate pushes converge, but the intended deployment is the standard
+  single-replica portal; a single-activation grain is the follow-up for scale-out.
+- The pull sweep enumerates via the remote `search` envelope (now carrying `version` +
+  `lastModified` per hit); listings beyond the per-level search cap are walked per-namespace
+  and logged loudly when still truncated — never silently dropped.
+
+## Testing
+
+`test/MeshWeaver.InstanceSync.Test` runs the full loop against an in-memory
+`IRemoteMeshClient` fake (the interface's sanctioned test seam) with tight intervals:
+initial replication, incremental push, offline accumulation → reconnect drain, restart resume,
+pull, echo suppression, and direction gating.

--- a/src/MeshWeaver.Hosting/Persistence/Http/IRemoteMeshClient.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Http/IRemoteMeshClient.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Linq;
 using MeshWeaver.Mesh;
 
 namespace MeshWeaver.Hosting.Persistence.Http;
@@ -59,4 +60,25 @@ public interface IRemoteMeshClient
     /// is left to the adapter when it matters.
     /// </summary>
     IObservable<IReadOnlyList<string>> SearchPaths(string query);
+
+    /// <summary>
+    /// Run a MeshWeaver search query and emit the full hit envelope: per-hit path /
+    /// nodeType / version / lastModified plus the truncation flag. This is the instance-sync
+    /// pull sweep's primitive — the version + lastModified stamps let the sweep fetch only
+    /// nodes that actually changed. Default falls back to <see cref="SearchPaths"/> with empty
+    /// stamps (a remote older than the enriched search envelope), which forces a per-node Get.
+    /// </summary>
+    IObservable<RemoteSearchResult> Search(string query, int limit = 50) =>
+        SearchPaths(query).Select(paths => new RemoteSearchResult(
+            paths.Select(p => new RemoteSearchHit(p, null, 0, null)).ToList(),
+            Truncated: paths.Count >= limit));
 }
+
+/// <summary>One remote search hit. <see cref="Version"/>/<see cref="LastModified"/> are the
+/// remote node's change stamps when the remote returns them (0/null from older remotes —
+/// treat as "changed" and Get the node).</summary>
+public record RemoteSearchHit(string Path, string? NodeType, long Version, DateTimeOffset? LastModified);
+
+/// <summary>A remote search result page. <see cref="Truncated"/> mirrors the portal envelope's
+/// flag — more matches exist than were returned.</summary>
+public record RemoteSearchResult(IReadOnlyList<RemoteSearchHit> Hits, bool Truncated);

--- a/src/MeshWeaver.Hosting/Persistence/Http/McpRemoteMeshClient.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Http/McpRemoteMeshClient.cs
@@ -149,26 +149,46 @@ public sealed class McpRemoteMeshClient : IRemoteMeshClient, IAsyncDisposable
 
     /// <inheritdoc />
     public IObservable<IReadOnlyList<string>> SearchPaths(string query) =>
+        Search(query).Select(result => (IReadOnlyList<string>)result.Hits.Select(h => h.Path).ToList());
+
+    /// <inheritdoc />
+    public IObservable<RemoteSearchResult> Search(string query, int limit = 50) =>
         Connect().SelectMany(client =>
             _pool.Invoke(async ct =>
             {
                 var result = await client.CallToolAsync(
                     "search",
-                    new Dictionary<string, object?> { ["query"] = query }!,
+                    new Dictionary<string, object?> { ["query"] = query, ["limit"] = limit }!,
                     progress: null, options: null, cancellationToken: ct).ConfigureAwait(false);
                 var text = ExtractText(result);
-                if (string.IsNullOrEmpty(text)) return (IReadOnlyList<string>)Array.Empty<string>();
+                if (string.IsNullOrEmpty(text)) return new RemoteSearchResult([], Truncated: false);
 
-                // Search returns a JSON array of anonymous objects each with a `path` field.
+                // The search tool returns the envelope {count, limit, truncated, results:[...]}
+                // (MeshOperations.Search); a bare array is tolerated for older remotes.
                 var jsonNode = JsonNode.Parse(text);
-                if (jsonNode is not JsonArray arr) return Array.Empty<string>();
-                var paths = new List<string>(arr.Count);
-                foreach (var item in arr)
+                var (items, truncated) = jsonNode switch
                 {
-                    if (item is JsonObject obj && obj["path"]?.GetValue<string>() is { Length: > 0 } p)
-                        paths.Add(p);
+                    JsonObject envelope => (
+                        envelope["results"] as JsonArray,
+                        envelope["truncated"]?.GetValue<bool>() ?? false),
+                    JsonArray bare => (bare, false),
+                    _ => (null, false),
+                };
+                if (items is null) return new RemoteSearchResult([], Truncated: truncated);
+
+                var hits = new List<RemoteSearchHit>(items.Count);
+                foreach (var item in items)
+                {
+                    if (item is not JsonObject obj
+                        || obj["path"]?.GetValue<string>() is not { Length: > 0 } path)
+                        continue;
+                    hits.Add(new RemoteSearchHit(
+                        path,
+                        obj["nodeType"]?.GetValue<string>(),
+                        obj["version"]?.GetValue<long>() ?? 0,
+                        obj["lastModified"]?.GetValue<DateTimeOffset>()));
                 }
-                return (IReadOnlyList<string>)paths;
+                return new RemoteSearchResult(hits, truncated);
             }));
 
     /// <summary>

--- a/src/MeshWeaver.InstanceSync/InstanceSyncConfig.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncConfig.cs
@@ -140,7 +140,10 @@ public record InstanceSyncConfig
     [Browsable(false)]
     public ImmutableList<PendingChange> PendingChanges { get; init; } = [];
 
-    /// <summary>Whether the connection settings are complete enough to sync.</summary>
+    /// <summary>Whether the connection settings are complete enough to sync (derived — hidden
+    /// from the generated editor).</summary>
+    [Browsable(false)]
+    [JsonIgnore]
     public bool IsConfigured =>
         !string.IsNullOrWhiteSpace(RemoteUrl) && !string.IsNullOrWhiteSpace(RemoteToken);
 }

--- a/src/MeshWeaver.InstanceSync/InstanceSyncConfig.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncConfig.cs
@@ -1,0 +1,146 @@
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using MeshWeaver.Mesh.Services;
+
+namespace MeshWeaver.InstanceSync;
+
+/// <summary>
+/// The direction a remote-instance sync source is allowed to sync in. Push = this instance →
+/// the remote; pull = the remote → this instance. Enforced by <see cref="InstanceSyncWorker"/>
+/// on every operation.
+/// </summary>
+public enum InstanceSyncDirection
+{
+    /// <summary>Default. Local changes push to the remote AND remote changes pull back — the
+    /// full bi-directional replication.</summary>
+    Bidirectional = 0,
+
+    /// <summary>Unidirectional local → remote. Remote-side edits are never pulled back.</summary>
+    PushOnly,
+
+    /// <summary>Unidirectional remote → local. Local edits are never pushed out.</summary>
+    PullOnly,
+}
+
+/// <summary>The lifecycle state of one remote-instance sync source, written by the
+/// <see cref="InstanceSyncWorker"/> and displayed read-only in the GUI.</summary>
+public enum InstanceSyncStatus
+{
+    /// <summary>The source exists but its remote URL / token are not filled in yet.</summary>
+    NotConfigured = 0,
+
+    /// <summary>The initial full replication of the space to the remote is running.</summary>
+    Initializing,
+
+    /// <summary>Connected — changes flow as they happen.</summary>
+    Syncing,
+
+    /// <summary>The remote cannot be reached. Local changes accumulate in
+    /// <see cref="InstanceSyncConfig.PendingChanges"/> and drain on the next successful
+    /// reconnect (the retry loop keeps probing with backoff).</summary>
+    Offline,
+
+    /// <summary>Paused by the user (<see cref="InstanceSyncConfig.Active"/> = false).
+    /// Changes still accumulate; nothing is transferred.</summary>
+    Paused,
+
+    /// <summary>The last operation failed for a non-connectivity reason — see
+    /// <see cref="InstanceSyncConfig.LastError"/>.</summary>
+    Error,
+}
+
+/// <summary>
+/// One entry of the durable change manifest: a local mesh mutation under the synced space that
+/// still has to be applied to the remote instance. Kept on the config node's content
+/// (<see cref="InstanceSyncConfig.PendingChanges"/>) so accumulation survives restarts and an
+/// unreachable remote. Entries are coalesced per <see cref="Path"/> — only the LATEST pending
+/// state of a node matters, because the drain pushes the node's CURRENT content, not a diff.
+/// </summary>
+/// <param name="Path">The absolute local path of the changed node.</param>
+/// <param name="Kind">Created / Updated / Deleted.</param>
+/// <param name="Version">The node's version at change time (drain removes entries up to the
+/// drained version, so a write racing the drain is never lost).</param>
+/// <param name="Timestamp">When the change was observed.</param>
+public record PendingChange(string Path, MeshChangeKind Kind, long Version, DateTimeOffset Timestamp);
+
+/// <summary>
+/// One remote-instance sync source of a Space, stored as a MeshNode at
+/// <c>{spaceId}/_Sync/{sourceId}</c>. Pairs the space with one remote MeshWeaver instance
+/// (URL + ApiToken issued by that remote) and gates the allowed <see cref="Direction"/>.
+///
+/// <para>This record IS the editor: the Instance Sync settings tab renders it through the
+/// standard mesh-node editor (data-bound, <c>stream.Update</c>-persisting), so the attributes
+/// drive the generated controls. The status/manifest fields are written by the
+/// <see cref="InstanceSyncWorker"/> and shown read-only — <see cref="BrowsableAttribute"/>
+/// hides them from the editable form.</para>
+///
+/// <para>The <see cref="RemoteToken"/> stays on this instance: <c>_Sync</c> is a
+/// <c>_</c>-prefixed satellite segment, which every export/sync filter (GitHub sync and the
+/// instance-sync push itself) excludes — the token is never replicated anywhere; it only rides
+/// the <c>Authorization</c> header toward the remote it belongs to.</para>
+/// </summary>
+public record InstanceSyncConfig
+{
+    /// <summary>Base URL of the remote MeshWeaver instance, e.g. <c>https://memex.meshweaver.cloud</c>.</summary>
+    [Description("Remote instance URL (e.g. https://memex.meshweaver.cloud)")]
+    public string? RemoteUrl { get; init; }
+
+    /// <summary>API token issued by the remote instance (<c>mw_…</c>) — authenticates every push/pull.</summary>
+    [Description("API token issued by the remote instance (mw_…)")]
+    public string? RemoteToken { get; init; }
+
+    /// <summary>The space id on the remote to replicate into. Blank = same id as the local space.</summary>
+    [Description("Space id on the remote (blank = same id as this space)")]
+    public string? RemoteSpace { get; init; }
+
+    /// <summary>The allowed sync direction — bi-directional (default), push-only, or pull-only.</summary>
+    [Description("Sync direction")]
+    public InstanceSyncDirection Direction { get; init; } = InstanceSyncDirection.Bidirectional;
+
+    /// <summary>
+    /// Uncheck to pause syncing — changes keep accumulating, nothing is transferred.
+    /// 🚨 Serialized unconditionally: the hub options suppress CLR-default values, and a bool
+    /// whose initializer (true) differs from its CLR default (false) would otherwise lose every
+    /// true→false write — the merge patch never carries the omitted field and deserialization
+    /// re-materializes the initializer. Pinned by the pause test.
+    /// </summary>
+    [Description("Active — uncheck to pause syncing")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    public bool Active { get; init; } = true;
+
+    /// <summary>
+    /// Control-plane trigger ("Sync now"): the GUI stamps this via <c>stream.Update</c>; the
+    /// coordinator reacts to the config change event and pokes the worker — the standard
+    /// Requested-field pattern, working from any process that renders the view.
+    /// </summary>
+    [Browsable(false)]
+    public DateTimeOffset? SyncRequestedAt { get; init; }
+
+    /// <summary>Current worker status. Written by the sync worker; not user-editable.</summary>
+    [Browsable(false)]
+    public InstanceSyncStatus Status { get; init; }
+
+    /// <summary>When the initial full replication completed. Null until it ran once.</summary>
+    [Browsable(false)]
+    public DateTimeOffset? InitialSyncAt { get; init; }
+
+    /// <summary>When changes last transferred successfully (either direction).</summary>
+    [Browsable(false)]
+    public DateTimeOffset? LastSyncedAt { get; init; }
+
+    /// <summary>The last failure, shown in the GUI; cleared on the next success.</summary>
+    [Browsable(false)]
+    public string? LastError { get; init; }
+
+    /// <summary>
+    /// The durable change manifest: local changes observed while the remote was unreachable
+    /// (or not yet drained), coalesced by path. Drained in order on every successful connect.
+    /// </summary>
+    [Browsable(false)]
+    public ImmutableList<PendingChange> PendingChanges { get; init; } = [];
+
+    /// <summary>Whether the connection settings are complete enough to sync.</summary>
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(RemoteUrl) && !string.IsNullOrWhiteSpace(RemoteToken);
+}

--- a/src/MeshWeaver.InstanceSync/InstanceSyncConfiguration.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncConfiguration.cs
@@ -1,0 +1,66 @@
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Persistence.Http;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace MeshWeaver.InstanceSync;
+
+/// <summary>
+/// Wiring for the remote-instance sync feature (mirrors <c>GitHubSyncConfiguration</c>).
+/// Three entry points the host composes:
+/// <list type="bullet">
+///   <item><see cref="AddInstanceSyncServices"/> — DI (config service, coordinator hosted
+///     service, admin-page provider) on the app service collection;</item>
+///   <item><see cref="AddInstanceSyncTypes{TBuilder}"/> — registers the
+///     <see cref="InstanceSyncConfig"/> content type on the mesh hub + every per-node hub so
+///     the <c>{space}/_Sync/{sourceId}</c> nodes (de)serialize;</item>
+///   <item><see cref="InstanceSyncSettingsTab.AddInstanceSyncSettingsTab"/> — the Space-settings GUI tab.</item>
+/// </list>
+/// </summary>
+public static class InstanceSyncConfiguration
+{
+    /// <summary>Registers the instance-sync services as mesh-scoped singletons plus the
+    /// coordinator hosted service that runs the sync workers.</summary>
+    public static IServiceCollection AddInstanceSyncServices(this IServiceCollection services)
+    {
+        services.AddSingleton(new InstanceSyncOptions());
+        // The MCP-over-HTTP client toward the remote instance (IoPool-bounded). TryAdd so a
+        // host (or test) that registered its own factory wins.
+        services.TryAddSingleton<IRemoteMeshClientFactory, McpRemoteMeshClientFactory>();
+        services.AddSingleton<InstanceSyncService>();
+        services.AddSingleton<InstanceSyncCoordinator>();
+        services.AddHostedService(sp => sp.GetRequiredService<InstanceSyncCoordinator>());
+        // Surfaces the per-space remote-instance sync sources on the partition administration
+        // page (PartitionSyncAdminLayoutArea resolves all IPartitionSyncSourceProvider from DI).
+        services.AddSingleton<IPartitionSyncSourceProvider>(sp => new InstanceSyncPartitionSyncSourceProvider(
+            sp.GetRequiredService<InstanceSyncService>()));
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the instance-sync content type on the mesh hub AND every per-node hub so the
+    /// <c>{spaceId}/_Sync/{sourceId}</c> config nodes (de)serialize with a resolvable
+    /// <c>$type</c> (avoids the content-discriminator reject + JsonElement degradation).
+    /// </summary>
+    public static TBuilder AddInstanceSyncTypes<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(
+            new MeshNode(InstanceSyncService.ConfigNodeType)
+            {
+                Name = "Instance Sync Config",
+                IsSatelliteType = false,
+                ExcludeFromContext = new HashSet<string> { "search", "create" },
+                HubConfiguration = config => config
+                    .AddMeshDataSource(source => source.WithContentType<InstanceSyncConfig>()),
+            });
+
+        builder.ConfigureHub(c => c
+            .WithType<InstanceSyncConfig>(nameof(InstanceSyncConfig))
+            .WithType<PendingChange>(nameof(PendingChange)));
+        builder.ConfigureDefaultNodeHub(c => c
+            .WithType<InstanceSyncConfig>(nameof(InstanceSyncConfig))
+            .WithType<PendingChange>(nameof(PendingChange)));
+        return builder;
+    }
+}

--- a/src/MeshWeaver.InstanceSync/InstanceSyncCoordinator.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncCoordinator.cs
@@ -1,0 +1,144 @@
+using System.Collections.Concurrent;
+using System.Reactive.Linq;
+using MeshWeaver.Hosting.Persistence.Http;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.InstanceSync;
+
+/// <summary>
+/// Owns the <see cref="InstanceSyncWorker"/> lifecycle. One global
+/// <see cref="IMeshChangeFeed"/> subscription does double duty:
+/// <list type="bullet">
+///   <item>events for <c>InstanceSyncConfig</c> nodes reconcile the worker set — a created
+///     config starts a worker, a deleted one stops it (that IS the "cancel sync" path), an
+///     edited one pokes the worker to re-read its settings;</item>
+///   <item>every other event is offered to each worker, which filters to its own space and
+///     accumulates the change in its durable manifest.</item>
+/// </list>
+/// On host start, existing registrations are discovered with one system-identity query so
+/// syncing resumes across restarts (pending manifests drain immediately). Runs as an
+/// <see cref="IHostedService"/> bound to the host lifecycle — the same shape as
+/// <c>ApprovalToPublishHandler</c>.
+/// </summary>
+public sealed class InstanceSyncCoordinator(
+    IMessageHub hub,
+    IMeshService meshService,
+    IMeshChangeFeed feed,
+    InstanceSyncService service,
+    IRemoteMeshClientFactory clientFactory,
+    InstanceSyncOptions options,
+    ILogger<InstanceSyncCoordinator>? logger = null) : IHostedService, IDisposable
+{
+    // Instance state on a mesh-scoped singleton (never static) — dies with the mesh.
+    private readonly ConcurrentDictionary<string, InstanceSyncWorker> workers = new(StringComparer.Ordinal);
+    private IDisposable? feedSubscription;
+
+    /// <summary>Subscribes the change feed and discovers existing sync registrations.</summary>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        feedSubscription = feed.Subscribe(OnChange);
+
+        // Boot discovery: resume every existing registration. System identity — this is
+        // infrastructure enumeration across partitions, not a user read.
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        Observable.Using(
+                () => accessService.ImpersonateAsSystem(),
+                _ => meshService
+                    .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{InstanceSyncService.ConfigNodeType}"))
+                    .Where(change => change.ChangeType == QueryChangeType.Initial)
+                    .Take(1))
+            .Timeout(TimeSpan.FromSeconds(30))
+            .Subscribe(
+                change =>
+                {
+                    foreach (var node in change.Items)
+                        EnsureWorker(node.Path);
+                    logger?.LogInformation("Instance sync resumed {Count} registration(s)", change.Items.Count);
+                },
+                ex => logger?.LogWarning(ex,
+                    "Instance sync boot discovery failed — registrations resume on their next change event"));
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Stops every worker and the feed subscription.</summary>
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>The currently active workers (exposed for tests/diagnostics).</summary>
+    public IReadOnlyCollection<InstanceSyncWorker> Workers => workers.Values.ToArray();
+
+    private void OnChange(MeshChangeEvent evt)
+    {
+        // Deleted events do not reliably carry NodeType (several publish paths pass null) —
+        // a removed registration is recognized by its path instead.
+        if (evt.Kind == MeshChangeKind.Deleted && workers.ContainsKey(evt.Path))
+        {
+            StopWorker(evt.Path);
+            return;
+        }
+
+        if (string.Equals(evt.NodeType, InstanceSyncService.ConfigNodeType, StringComparison.Ordinal))
+        {
+            if (evt.Kind != MeshChangeKind.Deleted)
+                EnsureWorker(evt.Path)?.OnConfigChanged();
+            return;
+        }
+
+        // Content events: each worker filters to its own space (few workers, cheap filter).
+        foreach (var worker in workers.Values)
+            worker.OnLocalChange(evt);
+    }
+
+    private InstanceSyncWorker? EnsureWorker(string configPath)
+    {
+        if (workers.TryGetValue(configPath, out var existing))
+            return existing;
+
+        // {space}/_Sync/{sourceId} — anything else is not a registration path.
+        var segments = configPath.Split('/');
+        if (segments.Length != 3 || !string.Equals(segments[1], InstanceSyncService.ConfigId, StringComparison.Ordinal))
+        {
+            logger?.LogWarning("Ignoring InstanceSyncConfig at unexpected path {Path}", configPath);
+            return null;
+        }
+
+        var created = new InstanceSyncWorker(
+            hub, service, clientFactory, options, segments[0], segments[2],
+            logger: hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger<InstanceSyncWorker>());
+        if (!workers.TryAdd(configPath, created))
+        {
+            created.Dispose(); // concurrent registration won the race
+            return workers.TryGetValue(configPath, out var winner) ? winner : null;
+        }
+        logger?.LogInformation("Instance sync worker started for {Config}", configPath);
+        created.Start();
+        return created;
+    }
+
+    private void StopWorker(string configPath)
+    {
+        if (workers.TryRemove(configPath, out var worker))
+        {
+            worker.Dispose();
+            logger?.LogInformation("Instance sync worker stopped for {Config} (registration removed)", configPath);
+        }
+    }
+
+    /// <summary>Disposes the feed subscription and every worker.</summary>
+    public void Dispose()
+    {
+        feedSubscription?.Dispose();
+        feedSubscription = null;
+        foreach (var path in workers.Keys.ToArray())
+            StopWorker(path);
+    }
+}

--- a/src/MeshWeaver.InstanceSync/InstanceSyncOptions.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncOptions.cs
@@ -1,0 +1,26 @@
+namespace MeshWeaver.InstanceSync;
+
+/// <summary>
+/// Tuning knobs for the instance-sync workers. Registered as a mesh-scoped singleton with these
+/// defaults; tests override the registration with tight intervals so sync round-trips complete
+/// in milliseconds instead of the production cadence.
+/// </summary>
+public record InstanceSyncOptions
+{
+    /// <summary>Quiet period that coalesces a burst of local changes into one drain pass.</summary>
+    public TimeSpan DrainDebounce { get; init; } = TimeSpan.FromMilliseconds(300);
+
+    /// <summary>How often the pull sweep reconciles remote changes back into this instance.</summary>
+    public TimeSpan PullInterval { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>First reconnect probe delay after the remote turns out to be unreachable.</summary>
+    public TimeSpan RetryInitial { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>Reconnect probe backoff cap. The probe keeps firing at this cadence for as long
+    /// as the remote stays down — that IS the offline-accumulation feature (changes pile up in
+    /// the manifest and drain on the first successful probe), not a recovery watchdog.</summary>
+    public TimeSpan RetryMax { get; init; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>Concurrent remote upserts during the initial full replication.</summary>
+    public int PushConcurrency { get; init; } = 4;
+}

--- a/src/MeshWeaver.InstanceSync/InstanceSyncPartitionSyncSourceProvider.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncPartitionSyncSourceProvider.cs
@@ -1,0 +1,48 @@
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.InstanceSync;
+
+/// <summary>
+/// Exposes a Space's remote-instance sync sources (<c>{space}/_Sync/{sourceId}</c>, content
+/// <see cref="InstanceSyncConfig"/>) to the partition administration GUI through the
+/// <see cref="IPartitionSyncSourceProvider"/> seam — a thin delegate onto
+/// <see cref="InstanceSyncService"/>. All sources are removable (removal = cancel the sync).
+/// </summary>
+public sealed class InstanceSyncPartitionSyncSourceProvider(InstanceSyncService sync)
+    : IPartitionSyncSourceProvider
+{
+    /// <inheritdoc />
+    public string Kind => "Remote Instance";
+
+    /// <inheritdoc />
+    public Type ConfigContentType => typeof(InstanceSyncConfig);
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<MeshNode>> WatchSyncSources(string partition)
+        => sync.WatchConfigNodes(partition);
+
+    /// <inheritdoc />
+    public string Describe(MeshNode source) => Describe(sync.Extract(source));
+
+    /// <summary>One-line status summary for a config, shared with the settings tab.</summary>
+    public static string Describe(InstanceSyncConfig? config)
+    {
+        if (config?.RemoteUrl is not { Length: > 0 } url)
+            return "not configured";
+        var target = string.IsNullOrWhiteSpace(config.RemoteSpace) ? "" : $" → {config.RemoteSpace}";
+        var pending = config.PendingChanges.Count > 0 ? $", {config.PendingChanges.Count} pending" : "";
+        return $"{url}{target} ({config.Direction}, {config.Status}{pending})";
+    }
+
+    /// <inheritdoc />
+    public bool CanRemove(string partition, MeshNode source) => true;
+
+    /// <inheritdoc />
+    public IObservable<MeshNode> AddSyncSource(string partition, string name)
+        => sync.AddSyncSource(partition, name);
+
+    /// <inheritdoc />
+    public IObservable<bool> RemoveSyncSource(string partition, MeshNode source)
+        => sync.RemoveSyncSource(partition, source.Id);
+}

--- a/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
@@ -1,0 +1,310 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.InstanceSync;
+
+/// <summary>
+/// Config store + shared helpers for the remote-instance sync feature. A Space's sync sources
+/// live at <c>{space}/_Sync/{sourceId}</c> (content <see cref="InstanceSyncConfig"/>); this
+/// service owns their lifecycle (add / watch / remove) and the read-modify-write status +
+/// manifest updates the <see cref="InstanceSyncWorker"/> performs. Mirrors
+/// <c>GitHubSyncService</c>'s config section — the GUI binds the standard node-content editor
+/// directly to each config node's stream; nothing here replicates node state.
+///
+/// <para>🚨 Reactive end-to-end (no <c>async</c>/<c>await</c>/<c>Task</c> in any signature);
+/// all remote I/O lives behind <c>IRemoteMeshClient</c> (IoPool-bounded).</para>
+/// </summary>
+public sealed class InstanceSyncService(
+    IMessageHub hub,
+    IMeshService meshService,
+    ILogger<InstanceSyncService>? logger = null)
+{
+    /// <summary>The satellite segment holding a Space's sync registry: <c>{space}/_Sync</c>.</summary>
+    public const string ConfigId = "_Sync";
+
+    /// <summary>The <see cref="MeshNode.NodeType"/> of a sync-source config node.</summary>
+    public const string ConfigNodeType = "InstanceSyncConfig";
+
+    /// <summary>The <see cref="MeshNode.NodeType"/> identifying a Space (the unit instance sync acts on).</summary>
+    public const string SpaceNodeType = "Space";
+
+    /// <summary>The sync-source config path: <c>{spacePath}/_Sync/{sourceId}</c>.</summary>
+    public static string ConfigPath(string spacePath, string sourceId) =>
+        $"{spacePath}/{ConfigId}/{sourceId}";
+
+    /// <summary>The namespace all of a space's sync sources share: <c>{spacePath}/_Sync</c>.</summary>
+    public static string ConfigNamespace(string spacePath) => $"{spacePath}/{ConfigId}";
+
+    /// <summary>The containing space of a config path (its first segment — spaces are top-level).</summary>
+    public static string SpaceOf(string configPath) => configPath.Split('/', 2)[0];
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Config lifecycle
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Live stream of ALL of the space's sync-source config nodes, ordered by source id.
+    /// Re-emits when a source is added, removed, or edited — the synced <c>GetQuery</c> over
+    /// the <c>_Sync</c> namespace (same pattern as <c>GitHubSyncService.WatchConfigNodes</c>).
+    /// </summary>
+    public IObservable<IReadOnlyList<MeshNode>> WatchConfigNodes(string spacePath)
+    {
+        var ns = ConfigNamespace(spacePath);
+        return hub.GetWorkspace()
+            .GetQuery($"instsync-cfgs:{spacePath}", $"namespace:{ns} nodeType:{ConfigNodeType}")
+            .Select(nodes => (IReadOnlyList<MeshNode>)(nodes ?? [])
+                .Where(n => string.Equals(n.Namespace, ns, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(n => n.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList());
+    }
+
+    /// <summary>Live stream of one sync-source config node (or null when absent).</summary>
+    public IObservable<MeshNode?> WatchConfigNode(string spacePath, string sourceId)
+    {
+        var path = ConfigPath(spacePath, sourceId);
+        return hub.GetWorkspace()
+            .GetQuery($"instsync-cfg:{path}", $"path:{path}")
+            .Select(nodes => nodes?.FirstOrDefault(n =>
+                string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    /// <summary>One-shot typed config read off the synced query (null when the node is absent
+    /// or degraded). Eventually consistent — fine for GUI/list reads and test polling.</summary>
+    public IObservable<InstanceSyncConfig?> ReadConfig(string spacePath, string sourceId) =>
+        WatchConfigNode(spacePath, sourceId).Take(1).Select(Extract);
+
+    /// <summary>
+    /// AUTHORITATIVE one-shot config read — the owning hub's current state via the node stream,
+    /// never the (lagged) query index. The worker MUST use this: a drain poked by a config
+    /// change event would otherwise race the index and act on the pre-change snapshot (e.g.
+    /// read Active=true right after the user paused) with no second poke coming. CQRS rule:
+    /// never query for a single node's content you're about to act on.
+    /// </summary>
+    public IObservable<InstanceSyncConfig?> ReadConfigAuthoritative(string spacePath, string sourceId) =>
+        hub.GetMeshNode(ConfigPath(spacePath, sourceId), TimeSpan.FromSeconds(15))
+            .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null))
+            .Select(Extract);
+
+    /// <summary>
+    /// Adds a sync source to the space: creates <c>{space}/_Sync/{sourceId}</c> (defaults, id =
+    /// sanitized name). Create-on-absent — adding an existing id returns the node untouched.
+    /// The remote URL / token are filled in afterwards through the standard node editor bound
+    /// to the returned node's path.
+    /// </summary>
+    public IObservable<MeshNode> AddSyncSource(string spacePath, string name)
+    {
+        var sourceId = SanitizeSourceId(name);
+        if (string.IsNullOrEmpty(sourceId))
+            return Observable.Throw<MeshNode>(new ArgumentException(
+                "The sync-source name must contain at least one letter or digit.", nameof(name)));
+
+        // Capture identity synchronously BEFORE the async existence-read hop — the SelectMany
+        // continuation can run without the AsyncLocal AccessContext, and CreateNode captures the
+        // context at its call. Same async-boundary fix as GitHubSyncService.EnsureConfigNode.
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var ctx = accessService?.Context ?? accessService?.CircuitContext;
+        return WatchConfigNode(spacePath, sourceId).Take(1).SelectMany(existing =>
+        {
+            if (existing is not null) return Observable.Return(existing);
+            var node = new MeshNode(sourceId, ConfigNamespace(spacePath))
+            {
+                NodeType = ConfigNodeType,
+                Name = name,
+                State = MeshNodeState.Active,
+                MainNode = spacePath,
+                Content = new InstanceSyncConfig(),
+            };
+            var create = accessService is null || ctx is null
+                ? meshService.CreateNode(node)
+                : Observable.Using(() => accessService.SwitchAccessContext(ctx), _ => meshService.CreateNode(node));
+            // A concurrent caller may win the create race — fall back to reading the node.
+            return create.Catch<MeshNode, Exception>(_ =>
+                WatchConfigNode(spacePath, sourceId).Where(n => n is not null).Select(n => n!).Take(1));
+        });
+    }
+
+    /// <summary>Removes (cancels) a sync source — deletes its config node; the coordinator
+    /// stops the worker on the resulting change-feed event.</summary>
+    public IObservable<bool> RemoveSyncSource(string spacePath, string sourceId) =>
+        meshService.DeleteNode(ConfigPath(spacePath, sourceId));
+
+    /// <summary>Sanitizes a display name into a node id: letters/digits/dash/underscore only.</summary>
+    private static string SanitizeSourceId(string name) =>
+        new string(name.Trim()
+            .Select(c => char.IsLetterOrDigit(c) ? c : '-')
+            .ToArray()).Trim('-');
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Status + manifest updates (read-modify-write via stream.Update)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Read-modify-write of the config content via <c>GetMeshNodeStream(path).Update</c> — the
+    /// owning hub serialises writers, so worker status stamps never clobber a concurrent GUI
+    /// edit of the connection fields. Cold; the caller subscribes.
+    /// </summary>
+    public IObservable<MeshNode> UpdateConfig(string configPath, Func<InstanceSyncConfig, InstanceSyncConfig> update) =>
+        hub.GetWorkspace().GetMeshNodeStream(configPath).Update(node =>
+        {
+            var current = Extract(node) ?? new InstanceSyncConfig();
+            return node with { Content = update(current) };
+        });
+
+    /// <summary>
+    /// Appends a local change to the durable manifest, coalescing by path: only the LATEST
+    /// pending state of a node matters because the drain pushes CURRENT content. Ordering of
+    /// first-appearance is preserved so the drain replays roughly in change order.
+    /// </summary>
+    public IObservable<MeshNode> AppendPending(string configPath, PendingChange change) =>
+        UpdateConfig(configPath, cfg => cfg with
+        {
+            PendingChanges = Coalesce(cfg.PendingChanges, change),
+        });
+
+    /// <summary>
+    /// Removes drained entries from the manifest — only entries whose version is ≤ the drained
+    /// version, so a write racing the drain stays pending and is pushed on the next pass.
+    /// </summary>
+    public IObservable<MeshNode> RemoveDrained(string configPath, IReadOnlyCollection<PendingChange> drained) =>
+        UpdateConfig(configPath, cfg => cfg with
+        {
+            PendingChanges = cfg.PendingChanges
+                .Where(p => !drained.Any(d =>
+                    string.Equals(d.Path, p.Path, StringComparison.Ordinal) && p.Version <= d.Version))
+                .ToImmutableList(),
+        });
+
+    private static ImmutableList<PendingChange> Coalesce(ImmutableList<PendingChange> pending, PendingChange change)
+    {
+        var index = pending.FindIndex(p => string.Equals(p.Path, change.Path, StringComparison.Ordinal));
+        return index < 0 ? pending.Add(change) : pending.SetItem(index, change);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Shared helpers (snapshot, filtering, remapping, equality)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Snapshot of the space's syncable nodes: root + descendants, minus satellite/governance
+    /// subtrees (any <c>_</c>-prefixed segment after the root — including <c>_Sync</c> itself,
+    /// so the sync registry and its tokens never replicate) and minus
+    /// <see cref="SyncBehavior"/>-excluded nodes. Ordered parents-first (path depth) so the
+    /// space root lands on the remote before its children.
+    /// </summary>
+    public IObservable<IReadOnlyList<MeshNode>> SnapshotSpaceNodes(string spacePath)
+    {
+        var root = hub.GetWorkspace().GetMeshNodeStream(spacePath)
+            .Where(n => n is not null).Take(1).Timeout(TimeSpan.FromSeconds(30));
+        var descendants = meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{spacePath} scope:descendants"))
+            .Take(1).Select(c => (IEnumerable<MeshNode>)c.Items);
+        return root.CombineLatest(descendants, (r, desc) =>
+        {
+            var all = new List<MeshNode>();
+            if (r is not null) all.Add(r);
+            all.AddRange(desc);
+            return FilterSyncable(all, spacePath);
+        });
+    }
+
+    /// <summary>Content-node filter — same semantics as GitHub sync's export filter.</summary>
+    public static IReadOnlyList<MeshNode> FilterSyncable(List<MeshNode> all, string partition)
+    {
+        var excludedRoots = all
+            .Where(n => n.SyncBehavior == SyncBehavior.ExcludeThisAndChildren)
+            .Select(n => n.Path)
+            .ToArray();
+        bool UnderExcluded(string p) =>
+            excludedRoots.Any(r => p.StartsWith(r + "/", StringComparison.Ordinal));
+
+        return all
+            .Where(n => !string.IsNullOrEmpty(n.Path)
+                        && !n.Segments.Skip(1).Any(s => s.StartsWith('_'))
+                        && n.SyncBehavior == SyncBehavior.Include
+                        && !UnderExcluded(n.Path))
+            .GroupBy(n => n.Path, StringComparer.Ordinal)
+            .Select(g => g.First())
+            .OrderBy(n => n.Segments.Count)
+            .ThenBy(n => n.Path, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>Whether a local path is inside the synced space AND syncable (no satellite
+    /// segments — which also keeps the sync's own config/manifest writes out of the loop).</summary>
+    public static bool IsSyncablePath(string path, string spacePath)
+    {
+        if (!string.Equals(path, spacePath, StringComparison.Ordinal)
+            && !path.StartsWith(spacePath + "/", StringComparison.Ordinal))
+            return false;
+        var segments = path.Split('/');
+        return !segments.Skip(1).Any(s => s.StartsWith('_'));
+    }
+
+    /// <summary>Maps a local path inside the space to its path on the remote space (and back —
+    /// the mapping is symmetric).</summary>
+    public static string RemapPath(string path, string fromSpace, string toSpace) =>
+        string.Equals(path, fromSpace, StringComparison.Ordinal)
+            ? toSpace
+            : toSpace + path[fromSpace.Length..];
+
+    /// <summary>
+    /// Rebases a node onto a target path, dropping instance-local bookkeeping (version and
+    /// audit stamps — the receiving instance stamps its own) so the payload is pure content.
+    /// </summary>
+    public static MeshNode RebaseNode(MeshNode node, string targetPath) =>
+        MeshNode.FromPath(targetPath) with
+        {
+            Name = node.Name,
+            Description = node.Description,
+            NodeType = node.NodeType,
+            Category = node.Category,
+            Icon = node.Icon,
+            Order = node.Order,
+            State = node.State,
+            Content = node.Content,
+            SyncBehavior = node.SyncBehavior,
+        };
+
+    /// <summary>
+    /// Content-level equality of two nodes (name, type, state, content as canonical JSON) — the
+    /// convergence guard that terminates the push/pull echo: a change that round-trips back
+    /// value-equal is dropped instead of re-written.
+    /// </summary>
+    public bool ContentEquals(MeshNode? a, MeshNode? b)
+    {
+        if (a is null || b is null) return a is null && b is null;
+        if (!string.Equals(a.Name, b.Name, StringComparison.Ordinal)
+            || !string.Equals(a.NodeType, b.NodeType, StringComparison.Ordinal)
+            || a.State != b.State)
+            return false;
+        return JsonNode.DeepEquals(
+            JsonSerializer.SerializeToNode(a.Content, hub.JsonSerializerOptions),
+            JsonSerializer.SerializeToNode(b.Content, hub.JsonSerializerOptions));
+    }
+
+    /// <summary>Typed content extraction — tolerant of degraded JsonElement content, loud on failure.</summary>
+    public InstanceSyncConfig? Extract(MeshNode? node) =>
+        node.ContentAs<InstanceSyncConfig>(hub.JsonSerializerOptions, logger);
+
+    /// <summary>
+    /// Runs an operation under the system identity — for worker-originated writes (feed
+    /// callbacks, drain/retry timers) that have NO ambient AccessContext; PostPipeline fails
+    /// closed without one. Status/manifest stamps on the sync registry are infrastructure
+    /// writes, the same identity model as <c>StaticRepoImporter</c>. GUI-originated calls keep
+    /// the user's own context and never go through here.
+    /// </summary>
+    public IObservable<T> AsSystem<T>(Func<IObservable<T>> operation)
+    {
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        return Observable.Using(() => accessService.ImpersonateAsSystem(), _ => operation());
+    }
+}

--- a/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
@@ -174,14 +174,20 @@ public sealed class InstanceSyncService(
     /// Removes drained entries from the manifest — only entries whose version is ≤ the drained
     /// version, so a write racing the drain stays pending and is pushed on the next pass.
     /// </summary>
-    public IObservable<MeshNode> RemoveDrained(string configPath, IReadOnlyCollection<PendingChange> drained) =>
-        UpdateConfig(configPath, cfg => cfg with
+    public IObservable<MeshNode> RemoveDrained(string configPath, IReadOnlyCollection<PendingChange> drained)
+    {
+        // Path → highest drained version, so the filter is O(pending) even after a long
+        // offline accumulation.
+        var drainedByPath = drained
+            .GroupBy(d => d.Path, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Max(d => d.Version), StringComparer.Ordinal);
+        return UpdateConfig(configPath, cfg => cfg with
         {
             PendingChanges = cfg.PendingChanges
-                .Where(p => !drained.Any(d =>
-                    string.Equals(d.Path, p.Path, StringComparison.Ordinal) && p.Version <= d.Version))
+                .Where(p => !(drainedByPath.TryGetValue(p.Path, out var v) && p.Version <= v))
                 .ToImmutableList(),
         });
+    }
 
     private static ImmutableList<PendingChange> Coalesce(ImmutableList<PendingChange> pending, PendingChange change)
     {

--- a/src/MeshWeaver.InstanceSync/InstanceSyncSettingsTab.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncSettingsTab.cs
@@ -1,0 +1,216 @@
+using System.Reactive.Linq;
+using MeshWeaver.Application.Styles;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.InstanceSync;
+
+/// <summary>
+/// The "Instance Sync" settings tab — the GUI for syncing a Space with another MeshWeaver
+/// instance. Appears on the Settings page of every node within a Space (always acting on the
+/// containing Space, exactly like the GitHub Sync tab) for users with Update on the Space.
+/// Lists every syncing party live (status, pending changes, last sync), binds the standard
+/// node-content editor to each registration's config node (remote URL / token / target space /
+/// direction / active — data-bound, <c>stream.Update</c>-persisting, nothing hand-rolled),
+/// and offers Sync now / Remove per party plus the add-party form.
+/// </summary>
+public static class InstanceSyncSettingsTab
+{
+    /// <summary>The settings-menu item id for the Instance Sync tab.</summary>
+    public const string TabId = "InstanceSync";
+
+    private const string AddSourceFormId = "instanceSyncAddSource";
+
+    /// <summary>Registers the Instance Sync settings tab provider (shown on any node within a Space).</summary>
+    public static MessageHubConfiguration AddInstanceSyncSettingsTab(this MessageHubConfiguration config)
+        => config.AddSettingsMenuItems(new SettingsMenuItemProvider(GetTab));
+
+    private static IObservable<IReadOnlyList<SettingsMenuItemDefinition>> GetTab(
+        LayoutAreaHost host, RenderingContext ctx)
+    {
+        IReadOnlyList<SettingsMenuItemDefinition> none = Array.Empty<SettingsMenuItemDefinition>();
+        var tab = new SettingsMenuItemDefinition(
+            Id: TabId,
+            Label: "Instance Sync",
+            ContentBuilder: BuildContent,
+            Group: "Integration",
+            Icon: FluentIcons.ArrowSync(),
+            GroupIcon: FluentIcons.Document(),
+            Order: 255,
+            Keywords: ["instance sync", "sync", "remote instance", "replicate", "replication",
+                "mirror", "bidirectional", "federation", "share", "memex"],
+            // Visibility + the Update check are gated on the CONTAINING SPACE below, same as
+            // the GitHub Sync tab — the feature replicates the whole Space.
+            RequiredPermission: Permission.None);
+
+        var spaceRoot = SpaceRootPath(host.Hub.Address.ToString());
+        if (string.IsNullOrEmpty(spaceRoot))
+            return Observable.Return(none);
+
+        return host.Workspace.GetMeshNodeStream(spaceRoot)
+            .Select(node => string.Equals(node?.NodeType, InstanceSyncService.SpaceNodeType, StringComparison.Ordinal))
+            .CombineLatest(
+                host.Hub.GetEffectivePermissions(spaceRoot),
+                (isSpace, perms) => isSpace && perms.HasFlag(Permission.Update))
+            .DistinctUntilChanged()
+            .Select(show => show ? (IReadOnlyList<SettingsMenuItemDefinition>)new[] { tab } : none)
+            .Catch<IReadOnlyList<SettingsMenuItemDefinition>, Exception>(_ => Observable.Return(none))
+            .StartWith(none);
+    }
+
+    /// <summary>The partition root for a node path — its first segment (spaces are top-level).</summary>
+    private static string SpaceRootPath(string? path) =>
+        string.IsNullOrEmpty(path) ? "" : path.Split('/', 2)[0];
+
+    internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack, MeshNode? node)
+    {
+        var sp = host.Hub.ServiceProvider;
+        var sync = sp.GetRequiredService<InstanceSyncService>();
+        var logger = sp.GetService<ILoggerFactory>()?.CreateLogger(typeof(InstanceSyncSettingsTab));
+        var spacePath = SpaceRootPath(node?.Path ?? "");
+
+        if (string.IsNullOrEmpty(spacePath))
+            return stack.WithView(Controls.Markdown("*Instance Sync is available inside a Space.*"));
+
+        stack = stack.WithView(Controls.H2("Instance Sync").WithStyle("margin: 0 0 8px 0;"));
+        stack = stack.WithView(Controls.Markdown(
+            "Replicate this Space to another MeshWeaver instance and keep syncing changes as they "
+            + "happen — like syncing a SharePoint library. Enter the remote instance's URL and an "
+            + "API token issued there; the initial replication runs automatically, then changes flow "
+            + "in the configured direction. If the remote is unreachable, changes accumulate and "
+            + "sync as soon as it can be reached again."));
+
+        // The live parties list: re-renders on add / remove / any config or status change.
+        stack = stack.WithView((h, _) => sync.WatchConfigNodes(spacePath)
+            .Select(sources => (UiControl?)BuildPartiesView(h, sync, spacePath, sources, logger))
+            .StartWith((UiControl?)Controls.Markdown("*Loading sync parties…*")));
+
+        return stack;
+    }
+
+    private static UiControl BuildPartiesView(
+        LayoutAreaHost host, InstanceSyncService sync, string spacePath,
+        IReadOnlyList<MeshNode> sources, ILogger? logger)
+    {
+        var stack = Controls.Stack.WithWidth("100%").WithStyle("gap: 12px;");
+        stack = stack.WithView(Controls.Title("Syncing parties", 3));
+
+        if (sources.Count == 0)
+            stack = stack.WithView(Controls.Markdown("*No syncing parties yet — add one below.*"));
+
+        foreach (var source in sources)
+            stack = stack.WithView(BuildPartyCard(sync, spacePath, source, logger));
+
+        stack = stack.WithView(BuildAddForm(sync, spacePath, logger));
+        return stack;
+    }
+
+    private static UiControl BuildPartyCard(
+        InstanceSyncService sync, string spacePath, MeshNode source, ILogger? logger)
+    {
+        var config = sync.Extract(source) ?? new InstanceSyncConfig();
+        var card = Controls.Stack.WithWidth("100%")
+            .WithStyle("padding: 12px; background: var(--neutral-layer-2); border-radius: 8px; gap: 8px;");
+
+        card = card.WithView(Controls.Markdown(
+            $"**{source.Name ?? source.Id}** — {InstanceSyncPartitionSyncSourceProvider.Describe(config)}"));
+        card = card.WithView(Controls.Markdown(StatusLine(config)));
+
+        // The connection settings — the STANDARD node-content editor bound directly to the
+        // config node's stream (per-field auto-persisting; no replica, no save subscription).
+        card = card.WithView(MeshNodeContentEditorControl.ForType(source.Path, typeof(InstanceSyncConfig)));
+
+        var actions = Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithHorizontalGap(8)
+            .WithStyle("flex-wrap: wrap;");
+
+        // "Sync now" stamps the SyncRequestedAt control-plane field: the coordinator reacts to
+        // the config change event and pokes the worker — works regardless of which process
+        // renders this view (the standard Requested-field pattern).
+        var sourcePath = source.Path;
+        actions = actions.WithView(Controls.Button("Sync now")
+            .WithAppearance(Appearance.Accent)
+            .WithIconStart(FluentIcons.ArrowSync())
+            .WithClickAction(ctx =>
+            {
+                sync.UpdateConfig(sourcePath, c => c with { SyncRequestedAt = DateTimeOffset.UtcNow })
+                    .Subscribe(_ => { },
+                        ex => logger?.LogWarning(ex, "Sync-now request failed for {Path}", sourcePath));
+                return Task.CompletedTask;
+            }));
+
+        actions = actions.WithView(Controls.Button("Remove (stop syncing)")
+            .WithAppearance(Appearance.Outline)
+            .WithIconStart(FluentIcons.Delete())
+            .WithStyle("color: var(--error, #d32f2f);")
+            .WithClickAction(ctx =>
+            {
+                // The parties list live-binds to WatchSyncSources — the delete re-emits and the
+                // card disappears; the coordinator stops the worker on the same event.
+                sync.RemoveSyncSource(spacePath, sourcePath.Split('/')[^1])
+                    .Subscribe(_ => { },
+                        ex => logger?.LogWarning(ex, "Removing sync party {Path} failed", sourcePath));
+                return Task.CompletedTask;
+            }));
+
+        return card.WithView(actions);
+    }
+
+    private static string StatusLine(InstanceSyncConfig config)
+    {
+        var parts = new List<string> { $"- **Status:** {config.Status}" };
+        if (config.PendingChanges.Count > 0)
+            parts.Add($"- **Pending changes:** {config.PendingChanges.Count} (accumulate until the remote is reachable)");
+        if (config.InitialSyncAt is { } initial)
+            parts.Add($"- **Initial replication:** {initial:yyyy-MM-dd HH:mm} UTC");
+        if (config.LastSyncedAt is { } last)
+            parts.Add($"- **Last synced:** {last:yyyy-MM-dd HH:mm:ss} UTC");
+        if (!string.IsNullOrEmpty(config.LastError))
+            parts.Add($"- **Last error:** {config.LastError}");
+        return string.Join("\n", parts);
+    }
+
+    private static UiControl BuildAddForm(InstanceSyncService sync, string spacePath, ILogger? logger)
+    {
+        var row = Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithHorizontalGap(8)
+            .WithStyle("align-items: flex-end;");
+        row = row.WithView(new TextFieldControl(new JsonPointerReference("name"))
+        {
+            Label = "New syncing party",
+            Placeholder = "e.g. prod, backup, partner-instance",
+            DataContext = LayoutAreaReference.GetDataPointer(AddSourceFormId),
+        }.WithWidth("280px"));
+        row = row.WithView(Controls.Button("Add syncing party")
+            .WithAppearance(Appearance.Outline)
+            .WithIconStart(FluentIcons.Add())
+            .WithClickAction(ctx =>
+            {
+                ctx.Host.Stream.GetDataStream<Dictionary<string, object?>>(AddSourceFormId)
+                    .Take(1)
+                    .Subscribe(form =>
+                    {
+                        var name = form.GetValueOrDefault("name") is { } v ? v.ToString()?.Trim() : null;
+                        if (string.IsNullOrEmpty(name))
+                            return;
+                        sync.AddSyncSource(spacePath, name)
+                            .Subscribe(_ => ctx.Host.UpdateData(AddSourceFormId,
+                                    new Dictionary<string, object?> { ["name"] = "" }),
+                                ex => logger?.LogWarning(ex,
+                                    "Adding sync party '{Name}' to {Space} failed", name, spacePath));
+                    });
+                return Task.CompletedTask;
+            }));
+        return row;
+    }
+}

--- a/src/MeshWeaver.InstanceSync/InstanceSyncSettingsTab.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncSettingsTab.cs
@@ -154,7 +154,7 @@ public static class InstanceSyncSettingsTab
             {
                 // The parties list live-binds to WatchSyncSources — the delete re-emits and the
                 // card disappears; the coordinator stops the worker on the same event.
-                sync.RemoveSyncSource(spacePath, sourcePath.Split('/')[^1])
+                sync.RemoveSyncSource(spacePath, source.Id)
                     .Subscribe(_ => { },
                         ex => logger?.LogWarning(ex, "Removing sync party {Path} failed", sourcePath));
                 return Task.CompletedTask;

--- a/src/MeshWeaver.InstanceSync/InstanceSyncSettingsTab.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncSettingsTab.cs
@@ -27,8 +27,6 @@ public static class InstanceSyncSettingsTab
     /// <summary>The settings-menu item id for the Instance Sync tab.</summary>
     public const string TabId = "InstanceSync";
 
-    private const string AddSourceFormId = "instanceSyncAddSource";
-
     /// <summary>Registers the Instance Sync settings tab provider (shown on any node within a Space).</summary>
     public static MessageHubConfiguration AddInstanceSyncSettingsTab(this MessageHubConfiguration config)
         => config.AddSettingsMenuItems(new SettingsMenuItemProvider(GetTab));
@@ -109,7 +107,7 @@ public static class InstanceSyncSettingsTab
         foreach (var source in sources)
             stack = stack.WithView(BuildPartyCard(sync, spacePath, source, logger));
 
-        stack = stack.WithView(BuildAddForm(sync, spacePath, logger));
+        stack = stack.WithView(BuildAddButton(sync, spacePath, sources, logger));
         return stack;
     }
 
@@ -179,38 +177,37 @@ public static class InstanceSyncSettingsTab
         return string.Join("\n", parts);
     }
 
-    private static UiControl BuildAddForm(InstanceSyncService sync, string spacePath, ILogger? logger)
+    /// <summary>
+    /// One-click add: creates the registration under a generated unique id — the connection
+    /// (URL, token, target space, direction) is then filled in through the standard node
+    /// editor on the new card. No hand-rolled form state.
+    /// </summary>
+    private static UiControl BuildAddButton(
+        InstanceSyncService sync, string spacePath, IReadOnlyList<MeshNode> sources, ILogger? logger)
     {
-        var row = Controls.Stack
-            .WithOrientation(Orientation.Horizontal)
-            .WithHorizontalGap(8)
-            .WithStyle("align-items: flex-end;");
-        row = row.WithView(new TextFieldControl(new JsonPointerReference("name"))
-        {
-            Label = "New syncing party",
-            Placeholder = "e.g. prod, backup, partner-instance",
-            DataContext = LayoutAreaReference.GetDataPointer(AddSourceFormId),
-        }.WithWidth("280px"));
-        row = row.WithView(Controls.Button("Add syncing party")
+        var name = NextPartyName(sources);
+        return Controls.Button("Add syncing party")
             .WithAppearance(Appearance.Outline)
             .WithIconStart(FluentIcons.Add())
             .WithClickAction(ctx =>
             {
-                ctx.Host.Stream.GetDataStream<Dictionary<string, object?>>(AddSourceFormId)
-                    .Take(1)
-                    .Subscribe(form =>
-                    {
-                        var name = form.GetValueOrDefault("name") is { } v ? v.ToString()?.Trim() : null;
-                        if (string.IsNullOrEmpty(name))
-                            return;
-                        sync.AddSyncSource(spacePath, name)
-                            .Subscribe(_ => ctx.Host.UpdateData(AddSourceFormId,
-                                    new Dictionary<string, object?> { ["name"] = "" }),
-                                ex => logger?.LogWarning(ex,
-                                    "Adding sync party '{Name}' to {Space} failed", name, spacePath));
-                    });
+                // The parties list live-binds to WatchSyncSources; the create re-emits and the
+                // new card (with its editor) appears on its own.
+                sync.AddSyncSource(spacePath, name)
+                    .Subscribe(_ => { },
+                        ex => logger?.LogWarning(ex,
+                            "Adding sync party '{Name}' to {Space} failed", name, spacePath));
                 return Task.CompletedTask;
-            }));
-        return row;
+            });
+    }
+
+    /// <summary>First free "party-N" id given the existing sources.</summary>
+    private static string NextPartyName(IReadOnlyList<MeshNode> sources)
+    {
+        var existing = sources.Select(s => s.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var n = 1;
+        while (existing.Contains($"party-{n}"))
+            n++;
+        return $"party-{n}";
     }
 }

--- a/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
@@ -39,7 +39,7 @@ namespace MeshWeaver.InstanceSync;
 /// any echo that slips through converges after one hop instead of ping-ponging.</para>
 ///
 /// <para>🚨 Reactive end-to-end; the only asynchrony lives inside <see cref="IRemoteMeshClient"/>
-/// (IoPool-bounded). Drains are serialised by a Subject → Throttle → Concat pipeline (never a
+/// (IoPool-bounded). Drains are serialised by a Subject → Sample → Concat pipeline (never a
 /// lock/semaphore); config/manifest writes go through <c>stream.Update</c> on the owning hub.</para>
 /// </summary>
 public sealed class InstanceSyncWorker : IDisposable
@@ -110,10 +110,11 @@ public sealed class InstanceSyncWorker : IDisposable
     {
         disposables.Add(retryProbe);
 
-        // Serialised drain pipeline: bursts coalesce (Throttle), passes never overlap (Concat),
-        // failures are handled inside RunDrain so the pipeline itself never terminates.
+        // Serialised drain pipeline: bursts coalesce (Sample — unlike Throttle it cannot starve
+        // under a sustained change stream), passes never overlap (Concat), failures are handled
+        // inside RunDrain so the pipeline itself never terminates.
         disposables.Add(drainRequests
-            .Throttle(options.DrainDebounce)
+            .Sample(options.DrainDebounce)
             .Select(_ => RunDrain()
                 .Catch<Unit, Exception>(ex =>
                 {
@@ -126,7 +127,7 @@ public sealed class InstanceSyncWorker : IDisposable
                 ex => logger?.LogError(ex, "Instance sync drain pipeline terminated for {Config}", ConfigPath)));
 
         // Pull-sweep loop: the next tick is scheduled only after the previous sweep completed
-        // (recursive Defer + Concat), so sweeps never overlap and a slow remote never queues up.
+        // (Defer + Repeat), so sweeps never overlap and a slow remote never queues up.
         disposables.Add(PullLoop().Subscribe(
             _ => { },
             ex => logger?.LogError(ex, "Instance sync pull loop terminated for {Config}", ConfigPath)));
@@ -134,7 +135,7 @@ public sealed class InstanceSyncWorker : IDisposable
         RequestDrain();
     }
 
-    /// <summary>Signals the drain pipeline (idempotent; coalesced by the Throttle).</summary>
+    /// <summary>Signals the drain pipeline (idempotent; coalesced by the Sample window).</summary>
     public void RequestDrain()
     {
         if (!disposed)
@@ -314,14 +315,13 @@ public sealed class InstanceSyncWorker : IDisposable
     // ══════════════════════════════════════════════════════════════════════════
 
     private IObservable<Unit> PullLoop() =>
-        Observable.Timer(options.PullInterval)
-            .SelectMany(_ => RunPullSweep().Catch<Unit, Exception>(ex =>
-            {
-                logger?.LogWarning(ex, "Instance sync pull sweep failed for {Config}", ConfigPath);
-                return Observable.Return(Unit.Default);
-            }))
-            .IgnoreElements()
-            .Concat(Observable.Defer(PullLoop));
+        Observable.Defer(() => Observable.Timer(options.PullInterval)
+                .SelectMany(_ => RunPullSweep().Catch<Unit, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex, "Instance sync pull sweep failed for {Config}", ConfigPath);
+                    return Observable.Return(Unit.Default);
+                })))
+            .Repeat(); // next tick scheduled only after the previous sweep completed — no overlap
 
     private IObservable<Unit> RunPullSweep() =>
         service.AsSystem(() => service.ReadConfigAuthoritative(SpacePath, SourceId)).SelectMany(cfg =>

--- a/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
@@ -1,0 +1,561 @@
+using System.Collections.Concurrent;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Hosting.Persistence.Http;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.InstanceSync;
+
+/// <summary>
+/// The sync engine for ONE sync source (<c>{space}/_Sync/{sourceId}</c>) — the client side of
+/// the bi-directional replication; the remote instance stays passive (just its MCP surface).
+///
+/// <para><b>Push</b>: the coordinator forwards every local change under the space; the worker
+/// coalesces them into the durable <see cref="InstanceSyncConfig.PendingChanges"/> manifest
+/// (written to the config node, so accumulation survives restarts AND an unreachable remote)
+/// and drains the manifest to the remote whenever it is reachable. An unreachable remote flips
+/// the source to <see cref="InstanceSyncStatus.Offline"/> and starts the reconnect probe
+/// (backoff up to <see cref="InstanceSyncOptions.RetryMax"/>) — that probe IS the documented
+/// offline-accumulation feature ("changes accumulate until the other instance can be reached
+/// again"), not a recovery watchdog for a defect.</para>
+///
+/// <para><b>Pull</b>: a periodic reconciliation sweep lists the remote space (search hits carry
+/// version + lastModified), fetches nodes that changed since the last sweep, and applies the
+/// newer ones locally under the system identity (infrastructure write, like
+/// <c>StaticRepoImporter</c>).</para>
+///
+/// <para><b>Echo/loop prevention</b>, two independent layers: (1) a pull-apply registers the
+/// local path in a consume-once suppression registry BEFORE writing, so the resulting change-feed
+/// event is swallowed instead of re-entering the manifest; (2) every push/pull first compares
+/// content (<see cref="InstanceSyncService.ContentEquals"/>) and drops value-equal writes, so
+/// any echo that slips through converges after one hop instead of ping-ponging.</para>
+///
+/// <para>🚨 Reactive end-to-end; the only asynchrony lives inside <see cref="IRemoteMeshClient"/>
+/// (IoPool-bounded). Drains are serialised by a Subject → Throttle → Concat pipeline (never a
+/// lock/semaphore); config/manifest writes go through <c>stream.Update</c> on the owning hub.</para>
+/// </summary>
+public sealed class InstanceSyncWorker : IDisposable
+{
+    private readonly IMessageHub hub;
+    private readonly InstanceSyncService service;
+    private readonly IRemoteMeshClientFactory clientFactory;
+    private readonly InstanceSyncOptions options;
+    private readonly ILogger? logger;
+
+    /// <summary>The space this worker replicates.</summary>
+    public string SpacePath { get; }
+
+    /// <summary>The sync-source id under <c>{space}/_Sync</c>.</summary>
+    public string SourceId { get; }
+
+    private string ConfigPath => InstanceSyncService.ConfigPath(SpacePath, SourceId);
+
+    private readonly CompositeDisposable disposables = new();
+    private readonly Subject<Unit> drainRequests = new();
+
+    // Consume-once echo suppression: paths this worker just wrote locally from a pull-apply.
+    // The very next change-feed event for the path is the echo of that write — swallow exactly
+    // one. Instance state on a mesh-scoped worker (never static).
+    private readonly ConcurrentDictionary<string, byte> appliedInbound = new();
+
+    // Last remote (version, lastModified) seen per remote path — the pull sweep re-fetches a
+    // node only when its stamp moved, so steady-state sweeps are one listing round-trip.
+    private readonly ConcurrentDictionary<string, (long Version, DateTimeOffset LastModified)> lastSeenRemote = new();
+
+    // The remote client, recreated whenever the URL/token change or a connect failure poisons
+    // the cached connect promise (McpRemoteMeshClient replays a failed handshake forever).
+    // Plain lock for a synchronous field swap only — never held across an await/subscribe.
+    private readonly object clientLock = new();
+    private IRemoteMeshClient? client;
+    private (string Url, string Token)? clientKey;
+
+    private readonly SerialDisposable retryProbe = new();
+    private TimeSpan retryDelay;
+    private volatile InstanceSyncConfig? lastKnownConfig;
+    private volatile bool disposed;
+
+    /// <summary>Creates the worker for one sync source; call <see cref="Start"/> to activate it.</summary>
+    public InstanceSyncWorker(
+        IMessageHub hub,
+        InstanceSyncService service,
+        IRemoteMeshClientFactory clientFactory,
+        InstanceSyncOptions options,
+        string spacePath,
+        string sourceId,
+        ILogger? logger = null)
+    {
+        this.hub = hub;
+        this.service = service;
+        this.clientFactory = clientFactory;
+        this.options = options;
+        this.logger = logger;
+        SpacePath = spacePath;
+        SourceId = sourceId;
+        retryDelay = options.RetryInitial;
+    }
+
+    /// <summary>
+    /// Activates the worker: the serialised drain pipeline, the pull-sweep loop, and an initial
+    /// drain kick (which also runs the initial full replication when it hasn't happened yet).
+    /// </summary>
+    public void Start()
+    {
+        disposables.Add(retryProbe);
+
+        // Serialised drain pipeline: bursts coalesce (Throttle), passes never overlap (Concat),
+        // failures are handled inside RunDrain so the pipeline itself never terminates.
+        disposables.Add(drainRequests
+            .Throttle(options.DrainDebounce)
+            .Select(_ => RunDrain()
+                .Catch<Unit, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex, "Instance sync drain failed for {Config}", ConfigPath);
+                    return Observable.Return(Unit.Default);
+                }))
+            .Concat()
+            .Subscribe(
+                _ => { },
+                ex => logger?.LogError(ex, "Instance sync drain pipeline terminated for {Config}", ConfigPath)));
+
+        // Pull-sweep loop: the next tick is scheduled only after the previous sweep completed
+        // (recursive Defer + Concat), so sweeps never overlap and a slow remote never queues up.
+        disposables.Add(PullLoop().Subscribe(
+            _ => { },
+            ex => logger?.LogError(ex, "Instance sync pull loop terminated for {Config}", ConfigPath)));
+
+        RequestDrain();
+    }
+
+    /// <summary>Signals the drain pipeline (idempotent; coalesced by the Throttle).</summary>
+    public void RequestDrain()
+    {
+        if (!disposed)
+            drainRequests.OnNext(Unit.Default);
+    }
+
+    /// <summary>Called by the coordinator when the config node was created/edited — re-reads the
+    /// config on the next drain (which also picks up URL/token changes via the client cache).</summary>
+    public void OnConfigChanged() => RequestDrain();
+
+    /// <summary>
+    /// Called by the coordinator for every mesh change. Filters to syncable paths under the
+    /// space, swallows the one echo of a pull-apply, appends to the durable manifest, and
+    /// requests a drain.
+    /// </summary>
+    public void OnLocalChange(MeshChangeEvent evt)
+    {
+        if (disposed) return;
+        if (!InstanceSyncService.IsSyncablePath(evt.Path, SpacePath)) return;
+        if (appliedInbound.TryRemove(evt.Path, out _)) return;
+        if (lastKnownConfig is { Direction: InstanceSyncDirection.PullOnly }) return;
+
+        // System scope: feed callbacks carry no ambient AccessContext (fails closed otherwise).
+        service.AsSystem(() => service.AppendPending(
+                ConfigPath, new PendingChange(evt.Path, evt.Kind, evt.Version, evt.Timestamp)))
+            .Subscribe(
+                _ => RequestDrain(),
+                ex => logger?.LogWarning(ex, "Failed to record pending change {Path} for {Config}", evt.Path, ConfigPath));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Drain (push direction)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    private IObservable<Unit> RunDrain() =>
+        service.AsSystem(() => service.ReadConfigAuthoritative(SpacePath, SourceId)).SelectMany(cfg =>
+        {
+            lastKnownConfig = cfg;
+            if (cfg is null || disposed) return Observable.Return(Unit.Default);
+            if (!cfg.Active) return SetStatus(cfg, InstanceSyncStatus.Paused);
+            if (!cfg.IsConfigured) return SetStatus(cfg, InstanceSyncStatus.NotConfigured);
+            if (cfg.Direction == InstanceSyncDirection.PullOnly)
+            {
+                // Pull-only sources push nothing: settle the status and drop anything a
+                // config-read race appended to the manifest before the direction was known.
+                if (cfg.PendingChanges.IsEmpty && cfg.Status == InstanceSyncStatus.Syncing)
+                    return Observable.Return(Unit.Default);
+                return UpdateConfigAsSystem(c => c with
+                {
+                    Status = InstanceSyncStatus.Syncing,
+                    LastError = null,
+                    PendingChanges = [],
+                }).Select(_ => Unit.Default);
+            }
+
+            var remote = GetClient(cfg);
+            var initial = cfg.InitialSyncAt is null
+                ? RunInitialReplication(remote, cfg)
+                : Observable.Return(Unit.Default);
+            return initial
+                .SelectMany(_ => DrainPending(remote, cfg))
+                .Catch<Unit, Exception>(ex => OnSyncFailure(ex));
+        });
+
+    /// <summary>
+    /// The initial full replication: pushes the space root first (creating the Space on the
+    /// remote provisions its partition), then the remaining subtree with bounded concurrency,
+    /// then stamps <see cref="InstanceSyncConfig.InitialSyncAt"/>.
+    /// </summary>
+    private IObservable<Unit> RunInitialReplication(IRemoteMeshClient remote, InstanceSyncConfig cfg)
+    {
+        var remoteSpace = RemoteSpaceOf(cfg);
+        logger?.LogInformation("Initial replication of {Space} → {Url} ({RemoteSpace}) starting",
+            SpacePath, cfg.RemoteUrl, remoteSpace);
+        return SetStatus(cfg, InstanceSyncStatus.Initializing)
+            .SelectMany(_ => service.AsSystem(() => service.SnapshotSpaceNodes(SpacePath)))
+            .SelectMany(nodes =>
+            {
+                var root = nodes.Where(n => string.Equals(n.Path, SpacePath, StringComparison.Ordinal)).ToList();
+                var rest = nodes.Where(n => !string.Equals(n.Path, SpacePath, StringComparison.Ordinal)).ToList();
+                var pushRoot = root.Select(n => PushNode(remote, cfg, n)).Concat().DefaultIfEmpty(Unit.Default);
+                var pushRest = rest.Select(n => PushNode(remote, cfg, n)).Merge(options.PushConcurrency).DefaultIfEmpty(Unit.Default);
+                return pushRoot.LastAsync().SelectMany(_ => pushRest.LastAsync())
+                    .Do(_ => logger?.LogInformation(
+                        "Initial replication of {Space} → {Url} pushed {Count} node(s)",
+                        SpacePath, cfg.RemoteUrl, nodes.Count));
+            })
+            .SelectMany(_ => UpdateConfigAsSystem(c => c with
+            {
+                InitialSyncAt = DateTimeOffset.UtcNow,
+                LastSyncedAt = DateTimeOffset.UtcNow,
+                Status = InstanceSyncStatus.Syncing,
+                LastError = null,
+            }))
+            .Select(_ => Unit.Default);
+    }
+
+    /// <summary>Config write from worker context — always under the system identity, with the
+    /// impersonation scope opened at THIS segment's subscribe so the capture-at-call never
+    /// depends on an AsyncLocal surviving earlier pool hops.</summary>
+    private IObservable<MeshNode> UpdateConfigAsSystem(Func<InstanceSyncConfig, InstanceSyncConfig> update) =>
+        service.AsSystem(() => service.UpdateConfig(ConfigPath, update));
+
+    /// <summary>
+    /// Drains the manifest sequentially. Per-entry application failures keep the entry pending
+    /// (visible via <see cref="InstanceSyncStatus.Error"/> + LastError — never silently dropped);
+    /// a connectivity failure aborts the pass and is classified by <see cref="OnSyncFailure"/>.
+    /// </summary>
+    private IObservable<Unit> DrainPending(IRemoteMeshClient remote, InstanceSyncConfig cfg)
+    {
+        var pending = cfg.PendingChanges;
+        if (pending.IsEmpty)
+            return SetStatus(cfg, InstanceSyncStatus.Syncing);
+
+        return pending
+            .Select(p => DrainOne(remote, cfg, p).Select(ok => (Change: p, Ok: ok, Error: (string?)null))
+                .Catch<(PendingChange Change, bool Ok, string? Error), Exception>(ex =>
+                    IsConnectivityError(ex)
+                        ? Observable.Throw<(PendingChange Change, bool Ok, string? Error)>(ex)
+                        : Observable.Return((Change: p, Ok: false, Error: (string?)ex.Message))))
+            .Concat()
+            .ToList()
+            .SelectMany(results =>
+            {
+                var drained = results.Where(r => r.Ok).Select(r => r.Change).ToList();
+                var firstError = results.FirstOrDefault(r => !r.Ok).Error;
+                if (firstError is not null)
+                    logger?.LogWarning("Instance sync {Config}: {Failed} change(s) rejected by remote: {Error}",
+                        ConfigPath, results.Count(r => !r.Ok), firstError);
+                ResetRetry();
+                return service.AsSystem(() => service.RemoveDrained(ConfigPath, drained))
+                    .SelectMany(_ => UpdateConfigAsSystem(c => c with
+                    {
+                        Status = firstError is null ? InstanceSyncStatus.Syncing : InstanceSyncStatus.Error,
+                        LastSyncedAt = drained.Count > 0 ? DateTimeOffset.UtcNow : c.LastSyncedAt,
+                        LastError = firstError,
+                    }))
+                    .Select(_ => Unit.Default);
+            });
+    }
+
+    private IObservable<bool> DrainOne(IRemoteMeshClient remote, InstanceSyncConfig cfg, PendingChange change)
+    {
+        var remotePath = InstanceSyncService.RemapPath(change.Path, SpacePath, RemoteSpaceOf(cfg));
+        if (change.Kind == MeshChangeKind.Deleted)
+            return DeleteRemote(remote, remotePath);
+
+        // Push the node's CURRENT content; a node deleted since the change was observed
+        // degrades to a delete.
+        return hub.GetMeshNode(change.Path, TimeSpan.FromSeconds(15))
+            .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null))
+            .SelectMany(local => local is null
+                ? DeleteRemote(remote, remotePath)
+                : PushNode(remote, cfg, local).Select(_ => true));
+    }
+
+    private static IObservable<bool> DeleteRemote(IRemoteMeshClient remote, string remotePath) =>
+        remote.Get(remotePath).SelectMany(existing => existing is null
+            ? Observable.Return(true)
+            : remote.Delete(remotePath).Select(_ => true));
+
+    /// <summary>Upsert with the convergence guard: value-equal remote content is left untouched.</summary>
+    private IObservable<Unit> PushNode(IRemoteMeshClient remote, InstanceSyncConfig cfg, MeshNode local)
+    {
+        var remotePath = InstanceSyncService.RemapPath(local.Path, SpacePath, RemoteSpaceOf(cfg));
+        var payload = InstanceSyncService.RebaseNode(local, remotePath);
+        return remote.Get(remotePath).SelectMany(existing =>
+        {
+            if (existing is not null && service.ContentEquals(payload, existing))
+                return Observable.Return(Unit.Default);
+            return existing is null ? remote.Create(payload) : remote.Update(payload);
+        });
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Pull sweep (remote → local)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    private IObservable<Unit> PullLoop() =>
+        Observable.Timer(options.PullInterval)
+            .SelectMany(_ => RunPullSweep().Catch<Unit, Exception>(ex =>
+            {
+                logger?.LogWarning(ex, "Instance sync pull sweep failed for {Config}", ConfigPath);
+                return Observable.Return(Unit.Default);
+            }))
+            .IgnoreElements()
+            .Concat(Observable.Defer(PullLoop));
+
+    private IObservable<Unit> RunPullSweep() =>
+        service.AsSystem(() => service.ReadConfigAuthoritative(SpacePath, SourceId)).SelectMany(cfg =>
+        {
+            lastKnownConfig = cfg;
+            // Bidirectional pulls only after the initial push established the remote baseline;
+            // pull-only sources have no push phase and sweep immediately.
+            if (cfg is null || disposed || !cfg.Active || !cfg.IsConfigured
+                || cfg.Direction == InstanceSyncDirection.PushOnly
+                || (cfg.InitialSyncAt is null && cfg.Direction == InstanceSyncDirection.Bidirectional))
+                return Observable.Return(Unit.Default);
+
+            var remote = GetClient(cfg);
+            var remoteSpace = RemoteSpaceOf(cfg);
+            return ListRemote(remote, remoteSpace)
+                .SelectMany(hits => hits
+                    .Where(h => InstanceSyncService.IsSyncablePath(h.Path, remoteSpace))
+                    .Where(HasRemoteStampMoved)
+                    .Select(h => PullOne(remote, cfg, h))
+                    .Merge(options.PushConcurrency)
+                    .ToList())
+                .SelectMany(applied =>
+                {
+                    ResetRetry();
+                    var pulled = applied.Count(x => x);
+                    return pulled == 0
+                        ? Observable.Return(Unit.Default)
+                        : UpdateConfigAsSystem(c => c with
+                        {
+                            LastSyncedAt = DateTimeOffset.UtcNow,
+                            Status = c.Status == InstanceSyncStatus.Offline ? InstanceSyncStatus.Syncing : c.Status,
+                            LastError = null,
+                        }).Select(_ => Unit.Default);
+                })
+                .Catch<Unit, Exception>(ex => OnSyncFailure(ex));
+        });
+
+    /// <summary>
+    /// Lists the remote space subtree (root + descendants). When the flat descendants listing
+    /// is truncated at the search cap, falls back to a per-namespace recursive walk so large
+    /// spaces are still fully enumerated; any level that STILL truncates is logged loudly —
+    /// never a silent cap.
+    /// </summary>
+    private IObservable<IReadOnlyList<RemoteSearchHit>> ListRemote(IRemoteMeshClient remote, string remoteSpace)
+    {
+        var root = remote.Get(remoteSpace)
+            .Select(n => n is null
+                ? []
+                : new[] { new RemoteSearchHit(remoteSpace, n.NodeType, n.Version, n.LastModified) }.ToList());
+        var descendants = remote.Search($"path:{remoteSpace} scope:descendants", 200)
+            .SelectMany(result => result.Truncated
+                ? WalkRemoteNamespace(remote, remoteSpace)
+                : Observable.Return(result.Hits));
+        return root.CombineLatest(descendants,
+            (r, d) => (IReadOnlyList<RemoteSearchHit>)r.Concat(d).ToList());
+    }
+
+    private IObservable<IReadOnlyList<RemoteSearchHit>> WalkRemoteNamespace(IRemoteMeshClient remote, string ns) =>
+        remote.Search($"path:{ns} scope:children", 200).SelectMany(result =>
+        {
+            if (result.Truncated)
+                logger?.LogWarning(
+                    "Instance sync {Config}: remote namespace {Namespace} exceeds the search cap even per-level — "
+                    + "some remote nodes were not swept this pass", ConfigPath, ns);
+            var children = result.Hits;
+            if (children.Count == 0)
+                return Observable.Return((IReadOnlyList<RemoteSearchHit>)children);
+            return children
+                .Select(h => WalkRemoteNamespace(remote, h.Path))
+                .Merge(options.PushConcurrency)
+                .ToList()
+                .Select(nested => (IReadOnlyList<RemoteSearchHit>)children.Concat(nested.SelectMany(x => x)).ToList());
+        });
+
+    private bool HasRemoteStampMoved(RemoteSearchHit hit) =>
+        !lastSeenRemote.TryGetValue(hit.Path, out var seen)
+        || seen.Version != hit.Version
+        || seen.LastModified != hit.LastModified;
+
+    /// <summary>
+    /// Applies one remote change locally: newest-writer-wins by LastModified, value-equal
+    /// content is dropped (convergence guard), and the local write registers the path in the
+    /// consume-once suppression registry FIRST so its own change-feed echo never re-enters the
+    /// manifest. Emits whether a local write happened.
+    /// </summary>
+    private IObservable<bool> PullOne(IRemoteMeshClient remote, InstanceSyncConfig cfg, RemoteSearchHit hit) =>
+        remote.Get(hit.Path).SelectMany(remoteNode =>
+        {
+            if (remoteNode is null)
+            {
+                lastSeenRemote.TryRemove(hit.Path, out _);
+                return Observable.Return(false);
+            }
+            lastSeenRemote[hit.Path] = (remoteNode.Version, remoteNode.LastModified);
+            var localPath = InstanceSyncService.RemapPath(hit.Path, RemoteSpaceOf(cfg), SpacePath);
+            return hub.GetMeshNode(localPath, TimeSpan.FromSeconds(15))
+                .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null))
+                .SelectMany(local =>
+                {
+                    if (local is not null && service.ContentEquals(local, remoteNode))
+                        return Observable.Return(false);
+                    // Newest writer wins; ties keep the local side (the push direction owns it).
+                    if (local is not null && local.LastModified >= remoteNode.LastModified)
+                        return Observable.Return(false);
+                    var payload = InstanceSyncService.RebaseNode(remoteNode, localPath);
+                    appliedInbound[localPath] = 1;
+                    return ApplyLocal(payload)
+                        .Do(_ => logger?.LogDebug("Instance sync pulled {Path} from {Url}", localPath, cfg.RemoteUrl))
+                        .Select(_ => true)
+                        .Do(_ => { }, ex => appliedInbound.TryRemove(localPath, out _));
+                });
+        });
+
+    /// <summary>Applies a pulled node under the system identity — an infrastructure write, the
+    /// same identity model as <c>StaticRepoImporter</c>. The suppression entry is registered by
+    /// the caller before subscribing.</summary>
+    private IObservable<MeshNode> ApplyLocal(MeshNode payload)
+    {
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        return Observable.Using(
+                () => accessService.ImpersonateAsSystem(),
+                _ => hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(payload)).FirstAsync())
+            .SelectMany(d => d.Message.Success
+                ? Observable.Return(d.Message.Node!)
+                : Observable.Throw<MeshNode>(new InvalidOperationException(
+                    $"Applying pulled node {payload.Path} failed: {d.Message.Error}")));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Failure classification + reconnect probe
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Connectivity failures flip the source Offline, drop the (poisoned) client so the next
+    /// attempt reconnects fresh, and schedule the reconnect probe with backoff — the manifest
+    /// keeps accumulating meanwhile. Anything else is a real error: surfaced on the node
+    /// (Status=Error + LastError), never swallowed.
+    /// </summary>
+    private IObservable<Unit> OnSyncFailure(Exception ex)
+    {
+        if (IsConnectivityError(ex))
+        {
+            logger?.LogWarning("Instance sync {Config}: remote unreachable ({Error}) — accumulating; next probe in {Delay}",
+                ConfigPath, ex.Message, retryDelay);
+            DropClient();
+            var delay = retryDelay;
+            retryDelay = TimeSpan.FromTicks(Math.Min(retryDelay.Ticks * 2, options.RetryMax.Ticks));
+            retryProbe.Disposable = Observable.Timer(delay).Subscribe(_ => RequestDrain());
+            return UpdateConfigAsSystem(c => c with
+            {
+                Status = InstanceSyncStatus.Offline,
+                LastError = ex.Message,
+            }).Select(_ => Unit.Default);
+        }
+
+        logger?.LogWarning(ex, "Instance sync {Config} failed", ConfigPath);
+        return UpdateConfigAsSystem(c => c with
+        {
+            Status = InstanceSyncStatus.Error,
+            LastError = ex.Message,
+        }).Select(_ => Unit.Default);
+    }
+
+    private void ResetRetry()
+    {
+        retryDelay = options.RetryInitial;
+        retryProbe.Disposable = Disposable.Empty;
+    }
+
+    /// <summary>Transport-level failures (remote down / DNS / timeout) anywhere in the chain.</summary>
+    internal static bool IsConnectivityError(Exception? ex)
+    {
+        for (var e = ex; e is not null; e = e.InnerException)
+        {
+            if (e is HttpRequestException or SocketException or TimeoutException
+                or TaskCanceledException or OperationCanceledException
+                or System.IO.IOException)
+                return true;
+            if (e is AggregateException agg && agg.InnerExceptions.Any(i => IsConnectivityError(i)))
+                return true;
+        }
+        return false;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Client cache + misc
+    // ══════════════════════════════════════════════════════════════════════════
+
+    private string RemoteSpaceOf(InstanceSyncConfig cfg) =>
+        string.IsNullOrWhiteSpace(cfg.RemoteSpace) ? SpacePath : cfg.RemoteSpace.Trim().Trim('/');
+
+    private IRemoteMeshClient GetClient(InstanceSyncConfig cfg)
+    {
+        var key = (Url: cfg.RemoteUrl!.Trim(), Token: cfg.RemoteToken!.Trim());
+        lock (clientLock)
+        {
+            if (client is not null && clientKey == key) return client;
+            DisposeClientLocked();
+            client = clientFactory.Create(key.Url, key.Token);
+            clientKey = key;
+            return client;
+        }
+    }
+
+    private void DropClient()
+    {
+        lock (clientLock)
+            DisposeClientLocked();
+    }
+
+    private void DisposeClientLocked()
+    {
+        if (client is IAsyncDisposable disposable)
+            _ = disposable.DisposeAsync(); // best-effort; McpRemoteMeshClient's dispose never faults
+        client = null;
+        clientKey = null;
+    }
+
+    private IObservable<Unit> SetStatus(InstanceSyncConfig cfg, InstanceSyncStatus status)
+    {
+        if (cfg.Status == status && cfg.LastError is null)
+            return Observable.Return(Unit.Default);
+        return UpdateConfigAsSystem(c => c with { Status = status, LastError = null })
+            .Select(_ => Unit.Default);
+    }
+
+    /// <summary>Stops the worker: drains no more, probes no more, drops the remote client.</summary>
+    public void Dispose()
+    {
+        if (disposed) return;
+        disposed = true;
+        drainRequests.OnCompleted();
+        drainRequests.Dispose();
+        disposables.Dispose();
+        DropClient();
+    }
+}

--- a/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
@@ -462,6 +462,10 @@ public sealed class InstanceSyncWorker : IDisposable
     /// </summary>
     private IObservable<Unit> OnSyncFailure(Exception ex)
     {
+        // A failure surfacing after disposal (an in-flight remote call cancelled by shutdown)
+        // must not stamp the node or schedule a probe — the worker is already gone.
+        if (disposed)
+            return Observable.Return(Unit.Default);
         if (IsConnectivityError(ex))
         {
             logger?.LogWarning("Instance sync {Config}: remote unreachable ({Error}) — accumulating; next probe in {Delay}",

--- a/src/MeshWeaver.InstanceSync/MeshWeaver.InstanceSync.csproj
+++ b/src/MeshWeaver.InstanceSync/MeshWeaver.InstanceSync.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{a2e5d7c9-4f1b-4a8e-9c3d-7b6a0e2f8d15}</ProjectGuid>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="System.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The settings-tab layout area is internal; the test project renders it directly. -->
+    <InternalsVisibleTo Include="MeshWeaver.InstanceSync.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
+    <ProjectReference Include="..\MeshWeaver.Messaging.Hub\MeshWeaver.Messaging.Hub.csproj" />
+    <ProjectReference Include="..\MeshWeaver.Data\MeshWeaver.Data.csproj" />
+    <ProjectReference Include="..\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
+    <ProjectReference Include="..\MeshWeaver.Application.Styles\MeshWeaver.Application.Styles.csproj" />
+    <ProjectReference Include="..\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
+    <ProjectReference Include="..\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/MeshWeaver.InstanceSync.Test/FakeRemoteMesh.cs
+++ b/test/MeshWeaver.InstanceSync.Test/FakeRemoteMesh.cs
@@ -1,0 +1,138 @@
+using System.Collections.Concurrent;
+using System.Net.Http;
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Hosting.Persistence.Http;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.InstanceSync.Test;
+
+/// <summary>
+/// In-memory stand-in for a remote MeshWeaver instance behind <see cref="IRemoteMeshClient"/> —
+/// the sanctioned test seam (see the interface docs: "Tests inject a stub"). One node store per
+/// fake (shared by every client the factory hands out), an <see cref="Unreachable"/> toggle that
+/// makes every call throw <see cref="HttpRequestException"/> (the offline scenario), and a full
+/// call log so tests can assert exactly what reached the remote (e.g. that a pulled change is
+/// never echoed back). Write stamps (Version / LastModified) are assigned the way a real remote
+/// would assign its own.
+/// </summary>
+public sealed class FakeRemoteMesh : IRemoteMeshClientFactory
+{
+    private readonly ConcurrentDictionary<string, MeshNode> store = new(StringComparer.Ordinal);
+    private readonly ConcurrentQueue<(string Op, string Path)> calls = new();
+    private long version;
+
+    /// <summary>When true, every remote call throws <see cref="HttpRequestException"/>.</summary>
+    public volatile bool Unreachable;
+
+    /// <summary>Every remote call in order: (operation, path).</summary>
+    public IReadOnlyList<(string Op, string Path)> Calls => calls.ToArray();
+
+    /// <summary>The (url, token) pairs clients were created for.</summary>
+    public ConcurrentQueue<(string Url, string Token)> CreatedClients { get; } = new();
+
+    /// <summary>Snapshot of the remote store keyed by path.</summary>
+    public IReadOnlyDictionary<string, MeshNode> Store => store;
+
+    /// <summary>The write calls (create/update/delete) recorded for <paramref name="path"/>.</summary>
+    public int WriteCount(string path) =>
+        calls.Count(c => c.Path == path && c.Op is "create" or "update" or "delete");
+
+    /// <summary>Reads a stored node (null when absent).</summary>
+    public MeshNode? Node(string path) => store.GetValueOrDefault(path);
+
+    /// <summary>Seeds a node as if a remote user had written it (own stamps).</summary>
+    public void Seed(MeshNode node, DateTimeOffset? lastModified = null) =>
+        store[node.Path] = node with
+        {
+            Version = Interlocked.Increment(ref version),
+            LastModified = lastModified ?? DateTimeOffset.UtcNow,
+        };
+
+    /// <inheritdoc />
+    public IRemoteMeshClient Create(string remoteBaseUrl, string remoteToken)
+    {
+        CreatedClients.Enqueue((remoteBaseUrl, remoteToken));
+        return new Client(this);
+    }
+
+    private void ThrowIfUnreachable()
+    {
+        if (Unreachable)
+            throw new HttpRequestException("Connection refused (fake remote is unreachable)");
+    }
+
+    private void Record(string op, string path) => calls.Enqueue((op, path));
+
+    private sealed class Client(FakeRemoteMesh owner) : IRemoteMeshClient
+    {
+        public IObservable<MeshNode?> Get(string path) => Observable.Defer(() =>
+        {
+            owner.ThrowIfUnreachable();
+            owner.Record("get", path);
+            return Observable.Return(owner.store.GetValueOrDefault(path));
+        });
+
+        public IObservable<Unit> Create(MeshNode node) => Observable.Defer(() =>
+        {
+            owner.ThrowIfUnreachable();
+            owner.Record("create", node.Path);
+            var stamped = node with
+            {
+                Version = Interlocked.Increment(ref owner.version),
+                LastModified = DateTimeOffset.UtcNow,
+            };
+            if (!owner.store.TryAdd(node.Path, stamped))
+                throw new InvalidOperationException($"Node already exists: {node.Path}");
+            return Observable.Return(Unit.Default);
+        });
+
+        public IObservable<Unit> Update(MeshNode node) => Observable.Defer(() =>
+        {
+            owner.ThrowIfUnreachable();
+            owner.Record("update", node.Path);
+            if (!owner.store.ContainsKey(node.Path))
+                throw new InvalidOperationException($"Node does not exist: {node.Path}");
+            owner.store[node.Path] = node with
+            {
+                Version = Interlocked.Increment(ref owner.version),
+                LastModified = DateTimeOffset.UtcNow,
+            };
+            return Observable.Return(Unit.Default);
+        });
+
+        public IObservable<Unit> Delete(string path) => Observable.Defer(() =>
+        {
+            owner.ThrowIfUnreachable();
+            owner.Record("delete", path);
+            owner.store.TryRemove(path, out _);
+            return Observable.Return(Unit.Default);
+        });
+
+        public IObservable<IReadOnlyList<string>> SearchPaths(string query) =>
+            Search(query).Select(r => (IReadOnlyList<string>)r.Hits.Select(h => h.Path).ToList());
+
+        /// <summary>Supports the two query shapes the sync worker emits:
+        /// <c>path:{p} scope:descendants</c> and <c>path:{p} scope:children</c>.</summary>
+        public IObservable<RemoteSearchResult> Search(string query, int limit = 50) => Observable.Defer(() =>
+        {
+            owner.ThrowIfUnreachable();
+            owner.Record("search", query);
+            var parts = query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var path = parts.FirstOrDefault(p => p.StartsWith("path:", StringComparison.Ordinal))?["path:".Length..]
+                       ?? throw new InvalidOperationException($"Fake remote cannot parse query: {query}");
+            var scope = parts.FirstOrDefault(p => p.StartsWith("scope:", StringComparison.Ordinal))?["scope:".Length..]
+                        ?? "children";
+            var prefix = path + "/";
+            var matches = owner.store.Values
+                .Where(n => n.Path.StartsWith(prefix, StringComparison.Ordinal))
+                .Where(n => scope != "children" || !n.Path[prefix.Length..].Contains('/'))
+                .OrderBy(n => n.Path, StringComparer.Ordinal)
+                .ToList();
+            var hits = matches.Take(limit)
+                .Select(n => new RemoteSearchHit(n.Path, n.NodeType, n.Version, n.LastModified))
+                .ToList();
+            return Observable.Return(new RemoteSearchResult(hits, Truncated: matches.Count > limit));
+        });
+    }
+}

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncPullTest.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncPullTest.cs
@@ -1,0 +1,125 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.InstanceSync.Test;
+
+/// <summary>
+/// The pull direction: the reconciliation sweep applies remote changes locally, never echoes a
+/// pulled change back to the remote (the loop-prevention core), and respects the direction
+/// gating (PushOnly never pulls, PullOnly never pushes).
+/// </summary>
+public class InstanceSyncPullTest(ITestOutputHelper output) : InstanceSyncTestBase(output)
+{
+    [Fact]
+    public async Task Remote_change_is_pulled_into_the_local_space()
+    {
+        await CreateSpace("pull1");
+        await AddConfiguredSource("pull1");
+        await WaitForConfig("pull1", "partner", c => c.InitialSyncAt is not null);
+
+        // A remote-side user adds a node (newer than anything local at that path).
+        Remote.Seed(MeshNode.FromPath("pull1/remote-doc") with
+        {
+            NodeType = "Markdown",
+            Name = "Remote Doc",
+            State = MeshNodeState.Active,
+            Content = new MarkdownContent { Content = "written remotely" },
+        });
+
+        var local = await WaitForNode("pull1/remote-doc");
+        MarkdownBody(local).Should().Be("written remotely");
+    }
+
+    [Fact]
+    public async Task Pulled_change_is_never_echoed_back_to_the_remote()
+    {
+        await CreateSpace("pull2");
+        await AddConfiguredSource("pull2");
+        await WaitForConfig("pull2", "partner", c => c.InitialSyncAt is not null);
+
+        Remote.Seed(MeshNode.FromPath("pull2/echo-check") with
+        {
+            NodeType = "Markdown",
+            Name = "Echo Check",
+            State = MeshNodeState.Active,
+            Content = new MarkdownContent { Content = "remote origin" },
+        });
+        await WaitForNode("pull2/echo-check");
+
+        // Negative assertion: give the (tight, 50ms-debounce) drain ample time to misbehave,
+        // then check the pulled path never came back as a remote write. Sanctioned fixed wait —
+        // there is no positive signal for "nothing happened".
+        await Task.Delay(1500, TestContext.Current.CancellationToken);
+        Remote.WriteCount("pull2/echo-check").Should().Be(0,
+            "a pulled change is suppressed from the manifest and must not ping-pong");
+        var cfg = await Sync.ReadConfig("pull2", "partner").Timeout(10.Seconds()).ToTask();
+        cfg!.PendingChanges.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Remote_update_wins_only_when_newer()
+    {
+        await CreateSpace("pull3");
+        await CreateMarkdown("pull3/doc", "Doc", "local v1");
+        await AddConfiguredSource("pull3");
+        await WaitForConfig("pull3", "partner", c => c.InitialSyncAt is not null);
+
+        // Remote edit with a NEWER stamp than the replicated copy → pulled over the local one.
+        Remote.Seed(Remote.Node("pull3/doc")! with
+        {
+            Content = new MarkdownContent { Content = "remote v2" },
+        }, DateTimeOffset.UtcNow.AddMinutes(1));
+
+        await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => ReadNode("pull3/doc"))
+            .Where(n => MarkdownBody(n) == "remote v2")
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+
+        // An OLDER remote stamp must never overwrite the (newer) local content.
+        Remote.Seed(Remote.Node("pull3/doc")! with
+        {
+            Content = new MarkdownContent { Content = "remote stale" },
+        }, DateTimeOffset.UtcNow.AddMinutes(-30));
+
+        await Task.Delay(1000, TestContext.Current.CancellationToken);
+        MarkdownBody(await ReadNode("pull3/doc").Timeout(10.Seconds()).ToTask())
+            .Should().Be("remote v2", "an older remote stamp never overwrites newer local content");
+    }
+
+    [Fact]
+    public async Task PushOnly_direction_never_pulls()
+    {
+        await CreateSpace("pull4");
+        await AddConfiguredSource("pull4", direction: InstanceSyncDirection.PushOnly);
+        await WaitForConfig("pull4", "partner", c => c.InitialSyncAt is not null);
+
+        Remote.Seed(MeshNode.FromPath("pull4/remote-only") with
+        {
+            NodeType = "Markdown",
+            Name = "Remote Only",
+            State = MeshNodeState.Active,
+            Content = new MarkdownContent { Content = "must stay remote" },
+        });
+
+        await Task.Delay(1000, TestContext.Current.CancellationToken);
+        (await ReadNode("pull4/remote-only").Timeout(10.Seconds()).ToTask())
+            .Should().BeNull("PushOnly sources must not pull remote changes");
+    }
+
+    [Fact]
+    public async Task PullOnly_direction_never_pushes_local_changes()
+    {
+        await CreateSpace("pull5");
+        await AddConfiguredSource("pull5", direction: InstanceSyncDirection.PullOnly);
+
+        await CreateMarkdown("pull5/local-only", "Local Only", "must stay local");
+
+        await Task.Delay(1000, TestContext.Current.CancellationToken);
+        Remote.Node("pull5/local-only").Should().BeNull("PullOnly sources must not push");
+        var cfg = await Sync.ReadConfig("pull5", "partner").Timeout(10.Seconds()).ToTask();
+        cfg!.PendingChanges.Should().BeEmpty("PullOnly sources do not accumulate a push manifest");
+    }
+}

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncPushTest.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncPushTest.cs
@@ -1,0 +1,165 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.InstanceSync.Test;
+
+/// <summary>
+/// The push direction end-to-end: initial full replication, incremental change propagation,
+/// path remapping onto a differently-named remote space, delete propagation, and the core
+/// offline story — changes accumulate in the durable manifest while the remote is unreachable
+/// and drain on the first successful reconnect probe.
+/// </summary>
+public class InstanceSyncPushTest(ITestOutputHelper output) : InstanceSyncTestBase(output)
+{
+    [Fact]
+    public async Task Initial_replication_pushes_space_subtree_to_remote()
+    {
+        await CreateSpace("alpha", "Alpha");
+        await CreateMarkdown("alpha/notes", "Notes", "hello world");
+
+        await AddConfiguredSource("alpha");
+
+        var cfg = await WaitForConfig("alpha", "partner",
+            c => c.InitialSyncAt is not null && c.Status == InstanceSyncStatus.Syncing);
+        cfg.LastSyncedAt.Should().NotBeNull();
+        cfg.LastError.Should().BeNull();
+
+        Remote.Node("alpha").Should().NotBeNull("the space root replicates first");
+        Remote.Node("alpha")!.NodeType.Should().Be("Space");
+        Remote.Node("alpha/notes").Should().NotBeNull();
+        MarkdownBody(Remote.Node("alpha/notes")).Should().Be("hello world");
+        // The sync registry itself must never replicate (it holds the remote token).
+        Remote.Store.Keys.Should().NotContain(k => k.Contains("/_Sync"));
+    }
+
+    [Fact]
+    public async Task Local_changes_push_incrementally_after_initial_sync()
+    {
+        await CreateSpace("beta");
+        await AddConfiguredSource("beta");
+        await WaitForConfig("beta", "partner", c => c.InitialSyncAt is not null);
+
+        await CreateMarkdown("beta/doc1", "Doc 1", "v1");
+        await WaitForRemote(r => r.Node("beta/doc1") is not null);
+
+        await Mesh.GetWorkspace().GetMeshNodeStream("beta/doc1")
+            .Update(n => n with { Content = new MarkdownContent { Content = "v2" } })
+            .Timeout(30.Seconds()).ToTask();
+        await WaitForRemote(r => MarkdownBody(r.Node("beta/doc1")) == "v2");
+
+        var cfg = await WaitForConfig("beta", "partner", c => c.PendingChanges.IsEmpty);
+        cfg.Status.Should().Be(InstanceSyncStatus.Syncing);
+    }
+
+    [Fact]
+    public async Task Remote_space_name_remaps_the_whole_subtree()
+    {
+        await CreateSpace("gamma");
+        await CreateMarkdown("gamma/page", "Page", "content");
+
+        await AddConfiguredSource("gamma", remoteSpace: "mirror");
+        await WaitForConfig("gamma", "partner", c => c.InitialSyncAt is not null);
+
+        Remote.Node("mirror").Should().NotBeNull();
+        Remote.Node("mirror/page").Should().NotBeNull();
+        Remote.Store.Keys.Should().NotContain("gamma");
+    }
+
+    [Fact]
+    public async Task Local_delete_propagates_to_remote()
+    {
+        await CreateSpace("delta");
+        await CreateMarkdown("delta/temp", "Temp", "to be removed");
+        await AddConfiguredSource("delta");
+        await WaitForConfig("delta", "partner", c => c.InitialSyncAt is not null);
+        await WaitForRemote(r => r.Node("delta/temp") is not null);
+
+        await NodeFactory.DeleteNode("delta/temp").Timeout(30.Seconds()).ToTask();
+
+        await WaitForRemote(r => r.Node("delta/temp") is null);
+    }
+
+    [Fact]
+    public async Task Unreachable_remote_accumulates_changes_and_drains_on_reconnect()
+    {
+        await CreateSpace("epsilon");
+        await AddConfiguredSource("epsilon");
+        await WaitForConfig("epsilon", "partner", c => c.InitialSyncAt is not null);
+
+        Remote.Unreachable = true;
+
+        await CreateMarkdown("epsilon/a", "A", "a1");
+        await CreateMarkdown("epsilon/b", "B", "b1");
+        // Two writes to the same path coalesce to ONE manifest entry (latest state wins).
+        await Mesh.GetWorkspace().GetMeshNodeStream("epsilon/a")
+            .Update(n => n with { Content = new MarkdownContent { Content = "a2" } })
+            .Timeout(30.Seconds()).ToTask();
+
+        // Offline: the manifest holds exactly the two touched paths, durably on the node.
+        var offline = await WaitForConfig("epsilon", "partner",
+            c => c.Status == InstanceSyncStatus.Offline && c.PendingChanges.Count == 2);
+        offline.PendingChanges.Select(p => p.Path).OrderBy(p => p, StringComparer.Ordinal)
+            .Should().Equal("epsilon/a", "epsilon/b");
+        offline.LastError.Should().NotBeNullOrEmpty();
+        Remote.Node("epsilon/a").Should().BeNull("nothing reaches an unreachable remote");
+
+        // Reconnect: the retry probe drains the manifest without any new local change.
+        Remote.Unreachable = false;
+
+        var synced = await WaitForConfig("epsilon", "partner",
+            c => c.Status == InstanceSyncStatus.Syncing && c.PendingChanges.IsEmpty);
+        synced.LastError.Should().BeNull();
+        MarkdownBody(Remote.Node("epsilon/a")).Should().Be("a2", "the drain pushes the LATEST content");
+        MarkdownBody(Remote.Node("epsilon/b")).Should().Be("b1");
+    }
+
+    [Fact]
+    public async Task Pending_manifest_survives_restart_and_drains_on_startup()
+    {
+        await CreateSpace("eta");
+        await AddConfiguredSource("eta");
+        await WaitForConfig("eta", "partner", c => c.InitialSyncAt is not null);
+
+        Remote.Unreachable = true;
+        await CreateMarkdown("eta/offline-doc", "Offline Doc", "written while down");
+        await WaitForConfig("eta", "partner", c => c.PendingChanges.Count == 1);
+
+        // "Restart": stop the coordinator (its workers die with it), reconnect the remote,
+        // start again — the manifest lives on the config NODE, not in worker memory.
+        await Coordinator.StopAsync(TestContext.Current.CancellationToken);
+        Remote.Unreachable = false;
+        await Coordinator.StartAsync(TestContext.Current.CancellationToken);
+
+        // Boot discovery resumes the registration and drains the persisted manifest.
+        await WaitForRemote(r => r.Node("eta/offline-doc") is not null);
+        await WaitForConfig("eta", "partner",
+            c => c.PendingChanges.IsEmpty && c.Status == InstanceSyncStatus.Syncing);
+    }
+
+    [Fact]
+    public async Task Paused_source_accumulates_but_transfers_nothing()
+    {
+        await CreateSpace("zeta");
+        await AddConfiguredSource("zeta");
+        await WaitForConfig("zeta", "partner", c => c.InitialSyncAt is not null);
+
+        await Sync.UpdateConfig("zeta/_Sync/partner", c => c with { Active = false })
+            .Timeout(30.Seconds()).ToTask();
+        await WaitForConfig("zeta", "partner", c => c.Status == InstanceSyncStatus.Paused);
+
+        await CreateMarkdown("zeta/held", "Held", "while paused");
+        await WaitForConfig("zeta", "partner", c => c.PendingChanges.Count == 1);
+        Remote.Node("zeta/held").Should().BeNull("paused sources transfer nothing");
+
+        // Resume: the accumulated change drains.
+        await Sync.UpdateConfig("zeta/_Sync/partner", c => c with { Active = true })
+            .Timeout(30.Seconds()).ToTask();
+        await WaitForRemote(r => r.Node("zeta/held") is not null);
+        await WaitForConfig("zeta", "partner",
+            c => c.Status == InstanceSyncStatus.Syncing && c.PendingChanges.IsEmpty);
+    }
+}

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncRegistryTest.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncRegistryTest.cs
@@ -1,0 +1,111 @@
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.InstanceSync.Test;
+
+/// <summary>
+/// The sync registry lifecycle: adding a syncing party materializes its config node under
+/// <c>{space}/_Sync</c>, the coordinator starts/stops workers on registry events, and the
+/// partition-admin provider describes sources. Plus the pure path/filter helpers.
+/// </summary>
+public class InstanceSyncRegistryTest(ITestOutputHelper output) : InstanceSyncTestBase(output)
+{
+    [Fact]
+    public async Task AddSyncSource_creates_registry_node_and_starts_worker()
+    {
+        await CreateSpace("regspace");
+
+        var node = await Sync.AddSyncSource("regspace", "partner").Timeout(30.Seconds()).ToTask();
+        node.Path.Should().Be("regspace/_Sync/partner");
+        node.NodeType.Should().Be(InstanceSyncService.ConfigNodeType);
+
+        var listed = await Sync.WatchConfigNodes("regspace")
+            .Where(nodes => nodes.Count == 1)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+        listed[0].Path.Should().Be("regspace/_Sync/partner");
+
+        // The coordinator reacts to the registry create event and starts the worker.
+        await Observable.Interval(50.Milliseconds()).StartWith(0L)
+            .Where(_ => Coordinator.Workers.Any(w =>
+                w.SpacePath == "regspace" && w.SourceId == "partner"))
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+
+        // Unconfigured source settles on NotConfigured — visible in the GUI.
+        var cfg = await WaitForConfig("regspace", "partner",
+            c => c.Status == InstanceSyncStatus.NotConfigured);
+        cfg.IsConfigured.Should().BeFalse();
+
+        var provider = new InstanceSyncPartitionSyncSourceProvider(Sync);
+        provider.Describe(listed[0]).Should().Be("not configured");
+        provider.CanRemove("regspace", listed[0]).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RemoveSyncSource_deletes_registration_and_stops_worker()
+    {
+        await CreateSpace("rmspace");
+        await Sync.AddSyncSource("rmspace", "partner").Timeout(30.Seconds()).ToTask();
+        await Observable.Interval(50.Milliseconds()).StartWith(0L)
+            .Where(_ => Coordinator.Workers.Any(w => w.SpacePath == "rmspace"))
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+
+        await Sync.RemoveSyncSource("rmspace", "partner").Timeout(30.Seconds()).ToTask();
+
+        // The delete event stops (cancels) the worker and the registry lists empty.
+        await Observable.Interval(50.Milliseconds()).StartWith(0L)
+            .Where(_ => Coordinator.Workers.All(w => w.SpacePath != "rmspace"))
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+        var listed = await Sync.WatchConfigNodes("rmspace").FirstAsync().Timeout(30.Seconds()).ToTask();
+        listed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RemapPath_maps_root_and_children_symmetrically()
+    {
+        InstanceSyncService.RemapPath("alpha", "alpha", "beta").Should().Be("beta");
+        InstanceSyncService.RemapPath("alpha/doc/x", "alpha", "beta").Should().Be("beta/doc/x");
+        InstanceSyncService.RemapPath("beta/doc/x", "beta", "alpha").Should().Be("alpha/doc/x");
+    }
+
+    [Fact]
+    public void IsSyncablePath_excludes_satellites_and_foreign_paths()
+    {
+        InstanceSyncService.IsSyncablePath("alpha", "alpha").Should().BeTrue();
+        InstanceSyncService.IsSyncablePath("alpha/doc", "alpha").Should().BeTrue();
+        InstanceSyncService.IsSyncablePath("alpha/_Sync/p", "alpha").Should().BeFalse();
+        InstanceSyncService.IsSyncablePath("alpha/doc/_Comment/1", "alpha").Should().BeFalse();
+        InstanceSyncService.IsSyncablePath("other/doc", "alpha").Should().BeFalse();
+        InstanceSyncService.IsSyncablePath("alphaville/doc", "alpha").Should().BeFalse();
+    }
+
+    [Fact]
+    public void FilterSyncable_orders_parents_first_and_honours_sync_behavior()
+    {
+        var nodes = new List<MeshNode>
+        {
+            MeshNode.FromPath("s/a/deep"),
+            MeshNode.FromPath("s"),
+            MeshNode.FromPath("s/a"),
+            MeshNode.FromPath("s/_Sync/cfg"),
+            MeshNode.FromPath("s/excluded") with { SyncBehavior = SyncBehavior.ExcludeThisAndChildren },
+            MeshNode.FromPath("s/excluded/child"),
+        };
+        var filtered = InstanceSyncService.FilterSyncable(nodes, "s");
+        filtered.Select(n => n.Path).Should().Equal("s", "s/a", "s/a/deep");
+    }
+
+    [Fact]
+    public void IsConnectivityError_classifies_transport_failures_only()
+    {
+        InstanceSyncWorker.IsConnectivityError(new HttpRequestException("refused")).Should().BeTrue();
+        InstanceSyncWorker.IsConnectivityError(
+            new InvalidOperationException("outer", new SocketException())).Should().BeTrue();
+        InstanceSyncWorker.IsConnectivityError(new TimeoutException()).Should().BeTrue();
+        InstanceSyncWorker.IsConnectivityError(new InvalidOperationException("node rejected")).Should().BeFalse();
+        InstanceSyncWorker.IsConnectivityError(null).Should().BeFalse();
+    }
+}

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncTestBase.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncTestBase.cs
@@ -1,0 +1,119 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence.Http;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.InstanceSync.Test;
+
+/// <summary>
+/// Base for instance-sync integration tests: wires the instance-sync types + services with
+/// tight test intervals and the in-memory <see cref="FakeRemoteMesh"/> standing in for the
+/// remote instance, so the full replicate / accumulate / drain / pull loop runs offline.
+/// </summary>
+public abstract class InstanceSyncTestBase(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected readonly FakeRemoteMesh Remote = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddInstanceSyncTypes()
+            .ConfigureServices(s =>
+            {
+                s.AddInstanceSyncServices();
+                // Tight intervals so accumulate → probe → drain round-trips run in
+                // milliseconds (last registration wins over the production defaults).
+                s.AddSingleton(new InstanceSyncOptions
+                {
+                    DrainDebounce = TimeSpan.FromMilliseconds(50),
+                    PullInterval = TimeSpan.FromMilliseconds(200),
+                    RetryInitial = TimeSpan.FromMilliseconds(100),
+                    RetryMax = TimeSpan.FromMilliseconds(400),
+                });
+                // The remote instance is the in-memory fake (last registration wins).
+                s.AddSingleton<IRemoteMeshClientFactory>(Remote);
+                return s;
+            });
+
+    protected InstanceSyncService Sync => Mesh.ServiceProvider.GetRequiredService<InstanceSyncService>();
+    protected InstanceSyncCoordinator Coordinator => Mesh.ServiceProvider.GetRequiredService<InstanceSyncCoordinator>();
+
+    protected async Task<MeshNode> CreateSpace(string id, string? name = null) =>
+        await NodeFactory.CreateNode(new MeshNode(id)
+        {
+            NodeType = "Space",
+            Name = name ?? id,
+            State = MeshNodeState.Active,
+            Content = new Space { Name = name ?? id },
+        }).Timeout(60.Seconds()).ToTask();
+
+    protected async Task<MeshNode> CreateMarkdown(string path, string name, string body)
+    {
+        var seed = MeshNode.FromPath(path);
+        return await NodeFactory.CreateNode(seed with
+        {
+            NodeType = "Markdown",
+            Name = name,
+            State = MeshNodeState.Active,
+            Content = new MarkdownContent { Content = body },
+        }).Timeout(60.Seconds()).ToTask();
+    }
+
+    /// <summary>Adds a sync source and configures its connection in one go.</summary>
+    protected async Task<string> AddConfiguredSource(
+        string spacePath, string name = "partner",
+        InstanceSyncDirection direction = InstanceSyncDirection.Bidirectional,
+        string? remoteSpace = null)
+    {
+        var node = await Sync.AddSyncSource(spacePath, name).Timeout(30.Seconds()).ToTask();
+        await Sync.UpdateConfig(node.Path, c => c with
+        {
+            RemoteUrl = "https://remote.example",
+            RemoteToken = "mw_test_token",
+            RemoteSpace = remoteSpace,
+            Direction = direction,
+        }).Timeout(30.Seconds()).ToTask();
+        return node.Path;
+    }
+
+    /// <summary>Polls the source's config until it satisfies <paramref name="predicate"/>.</summary>
+    protected async Task<InstanceSyncConfig> WaitForConfig(
+        string spacePath, string sourceId, Func<InstanceSyncConfig, bool> predicate,
+        TimeSpan? timeout = null) =>
+        await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => Sync.ReadConfig(spacePath, sourceId))
+            .Where(c => c is not null && predicate(c))
+            .Select(c => c!)
+            .FirstAsync()
+            .Timeout(timeout ?? 30.Seconds())
+            .ToTask();
+
+    /// <summary>Polls the fake remote until <paramref name="predicate"/> holds.</summary>
+    protected async Task WaitForRemote(Func<FakeRemoteMesh, bool> predicate, TimeSpan? timeout = null) =>
+        await Observable.Interval(50.Milliseconds()).StartWith(0L)
+            .Where(_ => predicate(Remote))
+            .FirstAsync()
+            .Timeout(timeout ?? 30.Seconds())
+            .ToTask();
+
+    /// <summary>Polls until a local node is readable at <paramref name="path"/>.</summary>
+    protected async Task<MeshNode> WaitForNode(string path) =>
+        (await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => ReadNode(path))
+            .Where(n => n is not null)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask())!;
+
+    protected static string MarkdownBody(MeshNode? node) => node?.Content switch
+    {
+        MarkdownContent mc => mc.Content,
+        string s => s,
+        _ => "",
+    };
+}

--- a/test/MeshWeaver.InstanceSync.Test/MeshWeaver.InstanceSync.Test.csproj
+++ b/test/MeshWeaver.InstanceSync.Test/MeshWeaver.InstanceSync.Test.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{c8f5e2b3-4d9a-4b01-8e32-6f7a8b9c0d12}</ProjectGuid>
+  </PropertyGroup>
+  <!-- xUnit v3, Reactive.Assertions, and test props come from test/Directory.Build.props. -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MeshWeaver.InstanceSync\MeshWeaver.InstanceSync.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/MeshWeaver.Portal.E2E.Test/InstanceSyncE2ETest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/InstanceSyncE2ETest.cs
@@ -52,6 +52,32 @@ public class InstanceSyncE2ETest(PortalFixture fixture)
             {
                 // Persisted from a prior run — fine.
             }
+            // A token-created Space grants its creator under the TOKEN identity (the lowercase
+            // partition key, e.g. "roland"), while the browser circuit authenticates as the
+            // DevLogin ObjectId (e.g. "Roland") — so the circuit would be denied on the fresh
+            // space. Grant the circuit identity explicitly (the token user is the space admin
+            // and may write _Access), mirroring what the UI's share flow would do.
+            try
+            {
+                await fixture.CreateNodeAsync(context, token, $$"""
+                    {
+                      "id": "{{fixture.UserId}}_CircuitAccess",
+                      "namespace": "{{Space}}/_Access",
+                      "name": "{{fixture.UserId}} Access",
+                      "nodeType": "AccessAssignment",
+                      "mainNode": "{{Space}}",
+                      "content": {
+                        "$type": "AccessAssignment",
+                        "accessObject": "{{fixture.UserId}}",
+                        "displayName": "{{fixture.UserId}}",
+                        "roles": [ { "$type": "RoleAssignment", "role": "Admin" } ]
+                      }
+                    }
+                    """);
+            }
+            catch (InvalidOperationException)
+            {
+            }
             try
             {
                 await fixture.CreateNodeAsync(context, token, $$"""
@@ -74,15 +100,35 @@ public class InstanceSyncE2ETest(PortalFixture fixture)
             await page.SetViewportSizeAsync(1600, 1000);
 
             // ── The Instance Sync tab on the Space's settings page ─────────────
-            await page.GotoAsync($"{fixture.BaseUrl}/{Space}/Settings/InstanceSync",
-                new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 90_000 });
-            await page.GetByText("Instance Sync").First.WaitForAsync(
-                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 90_000 });
+            // The creator-admin grant on a fresh space propagates eventually; a circuit that
+            // subscribes before it lands is denied and keeps last-good display without
+            // retrying — so retry the navigation (each reload is a fresh subscription), the
+            // same "wait for the grant BEFORE driving the UI" rule the other E2E tests follow.
+            var tabVisible = false;
+            for (var attempt = 0; attempt < 8 && !tabVisible; attempt++)
+            {
+                await page.GotoAsync($"{fixture.BaseUrl}/{Space}/Settings/InstanceSync",
+                    new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 90_000 });
+                try
+                {
+                    await page.GetByText("Instance Sync").First.WaitForAsync(
+                        new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 15_000 });
+                    tabVisible = true;
+                }
+                catch (TimeoutException)
+                {
+                    // grant not propagated to the circuit yet — reload
+                }
+                catch (PlaywrightException)
+                {
+                    // grant not propagated to the circuit yet — reload
+                }
+            }
+            tabVisible.Should().BeTrue("the Instance Sync tab must render once the creator grant propagated");
             await page.GetByText("No syncing parties yet", new() { Exact = false }).First.WaitForAsync(
                 new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
 
-            // ── Add a syncing party through the UI form ────────────────────────
-            await page.GetByLabel("New syncing party").FillAsync("loopback");
+            // ── Add a syncing party through the UI (one-click, auto-named party-1) ──
             await page.GetByText("Add syncing party", new() { Exact = true }).ClickAsync();
 
             // The parties list live-binds — the new card appears with its editor.
@@ -90,7 +136,7 @@ public class InstanceSyncE2ETest(PortalFixture fixture)
                 new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
 
             // ── Configure the connection (merge patch onto the registry node) ──
-            await fixture.PatchNodeAsync(context, token, $"{Space}/_Sync/loopback", $$"""
+            await fixture.PatchNodeAsync(context, token, $"{Space}/_Sync/party-1", $$"""
                 {
                   "content": {
                     "remoteUrl": "{{LoopbackUrl}}",
@@ -124,7 +170,7 @@ public class InstanceSyncE2ETest(PortalFixture fixture)
         finally
         {
             // Best-effort cleanup so reruns start clean.
-            await fixture.DeleteNodeAsync(context, token, $"{Space}/_Sync/loopback");
+            await fixture.DeleteNodeAsync(context, token, $"{Space}/_Sync/party-1");
             await fixture.DeleteNodeAsync(context, token, MirrorSpace);
             await fixture.DeleteNodeAsync(context, token, Space);
         }

--- a/test/MeshWeaver.Portal.E2E.Test/InstanceSyncE2ETest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/InstanceSyncE2ETest.cs
@@ -1,0 +1,132 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// End-to-end instance sync through the REAL portal: a Space is synced to "another instance"
+/// which is the portal ITSELF (pod-internal loopback URL + a freshly minted ApiToken), so the
+/// whole chain runs live — the Instance Sync settings tab, the sync worker, the MCP-over-HTTP
+/// remote client (Bearer auth, search envelope), initial replication, and cancel:
+/// <list type="number">
+///   <item>add a syncing party on the Space's Settings → Instance Sync tab (the UI form);</item>
+///   <item>configure the connection (loopback URL, minted token, a different target space);</item>
+///   <item>the initial replication materializes the target space + child on the "remote";</item>
+///   <item>the party card shows the live Syncing status;</item>
+///   <item>Remove (cancel) deletes the registration and the list empties.</item>
+/// </list>
+/// </summary>
+[Collection("portal-e2e")]
+public class InstanceSyncE2ETest(PortalFixture fixture)
+{
+    // The worker runs inside the portal pod; the "remote" must be reachable from THERE —
+    // the pod's own Kestrel endpoint, not the host-side ingress port-forward.
+    private const string LoopbackUrl = "http://localhost:8080";
+
+    private const string Space = "synce2e";
+    private const string MirrorSpace = "synce2e-mirror";
+
+    [Fact(Timeout = 300_000)]
+    public async Task Space_syncs_to_remote_instance_and_cancel_stops_it()
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+
+        await using var context = await fixture.NewAuthenticatedContextAsync();
+        var token = await fixture.MintTokenAsync(context);
+
+        try
+        {
+            // ── Seed: a Space with one content node ────────────────────────────
+            try
+            {
+                await fixture.CreateNodeAsync(context, token, $$"""
+                    {
+                      "id": "{{Space}}",
+                      "name": "Sync E2E",
+                      "nodeType": "Space",
+                      "content": { "$type": "Space", "name": "Sync E2E" }
+                    }
+                    """);
+            }
+            catch (InvalidOperationException)
+            {
+                // Persisted from a prior run — fine.
+            }
+            try
+            {
+                await fixture.CreateNodeAsync(context, token, $$"""
+                    {
+                      "id": "hello",
+                      "namespace": "{{Space}}",
+                      "name": "Hello",
+                      "nodeType": "Markdown",
+                      "content": { "$type": "MarkdownContent", "content": "sync me across instances" }
+                    }
+                    """);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+            (await fixture.WaitUntilReadableAsync(context, token, $"{Space}/hello", TimeSpan.FromSeconds(60)))
+                .Should().BeTrue("the seeded space must be readable before driving the UI");
+
+            var page = await context.NewPageAsync();
+            await page.SetViewportSizeAsync(1600, 1000);
+
+            // ── The Instance Sync tab on the Space's settings page ─────────────
+            await page.GotoAsync($"{fixture.BaseUrl}/{Space}/Settings/InstanceSync",
+                new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 90_000 });
+            await page.GetByText("Instance Sync").First.WaitForAsync(
+                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 90_000 });
+            await page.GetByText("No syncing parties yet", new() { Exact = false }).First.WaitForAsync(
+                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+
+            // ── Add a syncing party through the UI form ────────────────────────
+            await page.GetByLabel("New syncing party").FillAsync("loopback");
+            await page.GetByText("Add syncing party", new() { Exact = true }).ClickAsync();
+
+            // The parties list live-binds — the new card appears with its editor.
+            await page.GetByText("not configured", new() { Exact = false }).First.WaitForAsync(
+                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+
+            // ── Configure the connection (merge patch onto the registry node) ──
+            await fixture.PatchNodeAsync(context, token, $"{Space}/_Sync/loopback", $$"""
+                {
+                  "content": {
+                    "remoteUrl": "{{LoopbackUrl}}",
+                    "remoteToken": "{{token}}",
+                    "remoteSpace": "{{MirrorSpace}}"
+                  }
+                }
+                """);
+
+            // ── The initial replication runs through the REAL loopback MCP ─────
+            (await fixture.WaitUntilReadableAsync(context, token, MirrorSpace, TimeSpan.FromMinutes(2)))
+                .Should().BeTrue("initial replication must create the target space on the 'remote'");
+            (await fixture.WaitUntilReadableAsync(context, token, $"{MirrorSpace}/hello", TimeSpan.FromMinutes(2)))
+                .Should().BeTrue("initial replication must copy the space's content nodes");
+
+            // The party card reflects the live status (WatchConfigNodes re-renders the list).
+            await page.GetByText("Status:", new() { Exact = false }).First.WaitForAsync(
+                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+            await page.GetByText("Syncing", new() { Exact = false }).First.WaitForAsync(
+                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 120_000 });
+            await page.ScreenshotAsync(new PageScreenshotOptions
+                { Path = "/tmp/instance-sync-syncing.png", FullPage = true });
+
+            // ── Cancel: Remove stops the sync and empties the list ─────────────
+            await page.GetByText("Remove (stop syncing)", new() { Exact = false }).First.ClickAsync();
+            await page.GetByText("No syncing parties yet", new() { Exact = false }).First.WaitForAsync(
+                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+            await page.ScreenshotAsync(new PageScreenshotOptions
+                { Path = "/tmp/instance-sync-cancelled.png", FullPage = true });
+        }
+        finally
+        {
+            // Best-effort cleanup so reruns start clean.
+            await fixture.DeleteNodeAsync(context, token, $"{Space}/_Sync/loopback");
+            await fixture.DeleteNodeAsync(context, token, MirrorSpace);
+            await fixture.DeleteNodeAsync(context, token, Space);
+        }
+    }
+}


### PR DESCRIPTION
## What

SharePoint-style **instance sync**: on any Space, add a *syncing party* (remote MeshWeaver instance URL + an ApiToken issued there) — the space replicates to the remote and changes keep syncing both ways as they happen. If the remote is down, changes **accumulate in a durable manifest** and drain on the first successful reconnect probe.

## How

New project `MeshWeaver.InstanceSync` (mirrors the GitSync layering):

- **Registry**: `{space}/_Sync/{sourceId}` nodes (`InstanceSyncConfig`: URL, token, target space, direction, Active) with the **`PendingChanges` manifest on the node content** — offline accumulation survives restarts. `_Sync` is a `_`-satellite segment, so the registry (and its token) is excluded from every sync/export filter.
- **Worker per registration** (`InstanceSyncWorker`) — the registering instance is the sync *client*; the remote stays passive (its existing MCP surface via `McpRemoteMeshClient`, Bearer-authenticated, IoPool-bounded):
  - *Push*: change feed → coalesced manifest (`stream.Update`) → serialised drain (Subject → Sample → Concat); unreachable remote ⇒ `Offline` + backoff reconnect probe (that probe IS the offline-accumulation feature).
  - *Pull*: periodic reconciliation sweep — search hits now carry `version`/`lastModified`, only changed nodes are fetched; newest-writer-wins; applied under the system identity.
  - *Loop prevention*: consume-once suppression registry + value-equality convergence guard (echoes die after one hop).
- **Coordinator** (`IHostedService`): one change-feed subscription drives worker lifecycle + change dispatch; boot discovery resumes registrations (pending manifests drain at startup). Deleting the registration cancels the sync.
- **UI**: "Instance Sync" Space-settings tab — live list of syncing parties (status, pending count, last sync), standard node-bound editor per party, one-click add, **Sync now** (via the `SyncRequestedAt` control-plane field), pause (Active), **Remove (stop syncing)**. Parties also appear on the admin Partitions page via `IPartitionSyncSourceProvider`.
- **Enablers**: search envelope carries `version`/`lastModified` per hit; `McpRemoteMeshClient.SearchPaths` fixed for the `{results:[…]}` envelope (was parsing a bare array → always empty) + rich `Search(query, limit)`; `InstanceSyncConfig.Active` serialized unconditionally (a `true`-initialized bool would lose every `true→false` write under default-value suppression — pinned by the pause test).

## Tests

- `test/MeshWeaver.InstanceSync.Test` — **18 tests green**: initial replication, incremental push, delete propagation, offline accumulate → reconnect drain, restart resume, pause/resume, pull, echo suppression, direction gating, registry lifecycle + pure helpers (against an in-memory `IRemoteMeshClient` fake, the interface's sanctioned test seam).
- **Playwright E2E green** (`InstanceSyncE2ETest`, via `memex-local e2e`): the live portal syncs a space to *itself* (pod-internal URL + minted ApiToken) — tab UI, one-click add, real MCP loopback replication, live Syncing status, cancel.
- `DocumentationLinkIntegrityTest` green (new doc `Doc/Architecture/InstanceSync`).
- Full-solution `Release -warnaserror -p:CIRun=true` build: 0 warnings, on the branch merged with current main.

## Known v1 limitations (documented in the architecture doc)

Remote deletes don't propagate on pull (symmetric registrations cover it); newest-writer-wins is clock-based; one coordinator per process (single-replica portals — the equality guard makes duplicate pushes converge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)