### PR TITLE
feat(python): live-pinned SDK wire contracts, native gRPC (HTTP/2), and trusted co-deployed gates

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -53,14 +53,50 @@ python -m meshweaver.worker --url https://atioz.meshweaver.cloud --token mw_… 
 value, REPL-style; exposes `Inputs`); `CodeWorker` is the thin mesh shell around it. Full architecture +
 how to author a Python Code node: `Doc/Architecture/PythonCodeNodes`.
 
+## Examples
+
+Each is a runnable module with a documented mesh pattern behind it (`meshweaver/examples/`):
+
+| Module | Pattern | Doc page |
+|---|---|---|
+| `pandas_node` | a stateful **backend participant**: loads a CSV file kept in mesh content into a live `pandas.DataFrame` and renders it back through the hub as a real `DataGridControl` for the C# GUI | `Doc/DataMesh/PythonPandasNode` |
+| `finetune` | **mesh-orchestrated batch work**: distill the docs into a training dataset kept in content, LoRA-fine-tune an LLM on it, stream progress back onto a run node | `Doc/DataMesh/PythonFineTuning` |
+| `standalone_hub` | a **complete hub in Python**: own address, handlers by message type, owned state; loads a namespace from the mesh, serves statistics, saves its report back | `Doc/DataMesh/PythonStandaloneHub` |
+
+All three run self-contained (`--demo`, or fake-driven tests) without a mesh; point them at a portal
+with `--url`/`--token` to go live.
+
 ## Status
 
-- **Transport / correlation / stream-demux** — complete and protocol-faithful (mirrors
-  `MeshGrpcService` + the SignalR client).
-- **Envelope wire-shape** (`envelope.py`) and **operation request types** (`mesh.py`, marked `# WIRE:`)
-  — pinned to the mesh's `IMessageDelivery` JSON. Confirm the exact `$type` token + property casing
-  against a sample captured from the C# round-trip test, then the `# WIRE:` spots are a one-line fix
-  each. Everything beneath them already works.
+**Confirmed live against a running portal (2026-07-03).**
 
-Security: the API token travels in gRPC call metadata; the server validates it and stamps every write
-with your identity. A forged client-side identity is never trusted.
+- **Transport / correlation / stream-demux** — complete and protocol-faithful (mirrors
+  `MeshGrpcService` + the SignalR client). Bidi `Open` + connect/ack + request/response correlation
+  confirmed live; the envelope `$type` is ``MessageDelivery`1[RawJson]`` (pinned from the
+  `MeshGrpcTransportTest` capture).
+- **Operations** (`mesh.py`) — two transports, both confirmed live:
+  - **REST** `POST {portal}/api/mesh/<verb>` (the portal's transport-mirror of the MCP tools):
+    `get` / `search` / `query_nodes` / `create` / `update` / `patch` / `delete` / `move` / `copy`.
+  - **gRPC sync protocol** for `watch(path)`: `SubscribeRequest(streamId, MeshNodeReference)` →
+    `DataChangedEvent` (`Full` = whole node, `Patch` = **RFC 6902 JSON-Patch op array**, deduped by
+    stream `version` — frames can arrive duplicated) → `UnsubscribeRequest` on exit. A REST patch
+    was observed live on a gRPC watch.
+- **Custom participant protocols** (e.g. the pandas node's `PandasCommand`) route by target address
+  with no server-side registration — requires the server's `RawJsonPassThrough` proxy-hub policy
+  (`GrpcConnectionRegistry`), shipped alongside this SDK.
+
+The bidi gRPC connection needs HTTP/2 end-to-end; the deployment routes `meshweaver.v1.Mesh/Open`
+natively at the ordinary portal URL (helm `values.grpc` — live on all hosted portals). For a
+self-signed local portal pass the CA via `connect(..., root_certificates=...)`.
+
+Security — two participant classes:
+
+* **External participants** authenticate with an API token (`Authorization: Bearer mw_…` in gRPC
+  call metadata); the server validates it and re-stamps every write with the validated identity.
+  A forged client-side identity is never trusted.
+* **Trusted gates** — services that ship *in the same deployment* as the portal (the co-located
+  node / bun / python gates) — connect to the trusted loopback endpoint (`http://127.0.0.1:8082`
+  inside the portal's pod). Reachability is the authentication (only same-pod containers share
+  loopback): no token, nothing to rotate. A trusted gate may carry the requesting user's
+  `accessContext` through on its deliveries (`respond` echoes it automatically), so work done on a
+  user's behalf writes under that user's identity — like the in-process C# kernel.

--- a/clients/python/meshweaver/connection.py
+++ b/clients/python/meshweaver/connection.py
@@ -114,19 +114,24 @@ class MeshConnection:
         finally:
             self._pending.pop(delivery_id, None)
 
-    async def post(self, target: str, message_type: str, message: dict[str, Any]) -> None:
-        """Fire-and-forget a message to ``target``."""
+    async def post(self, target: str, message_type: str, message: dict[str, Any],
+                   access_context: Optional[dict[str, Any]] = None) -> None:
+        """Fire-and-forget a message to ``target``. ``access_context`` carries an identity on the
+        delivery (honoured only on the trusted loopback endpoint — see :func:`envelope.build_deliver`)."""
         payload = envelope.build_deliver(
             delivery_id=uuid.uuid4().hex, sender=self.address, target=target,
-            message_type=message_type, message=message,
+            message_type=message_type, message=message, access_context=access_context,
         )
         await self._send_q.put(mesh_pb2.ClientFrame(deliver=payload))
 
     async def respond(self, to: "envelope.Delivery", message_type: str, message: dict[str, Any]) -> None:
-        """Reply to an inbound request — addressed back to its sender, correlated by its delivery id."""
+        """Reply to an inbound request — addressed back to its sender, correlated by its delivery id.
+        The inbound request's ``accessContext`` is echoed, so on a trusted connection the response
+        runs under the REQUESTER's identity (the gate acting on the user's behalf)."""
         payload = envelope.build_deliver(
             delivery_id=uuid.uuid4().hex, sender=self.address, target=to.sender or "",
             message_type=message_type, message=message, request_id=to.id,
+            access_context=to.access_context,
         )
         await self._send_q.put(mesh_pb2.ClientFrame(deliver=payload))
 
@@ -150,16 +155,26 @@ class MeshConnection:
             self._subscriptions.pop(stream_id, None)
 
 
-async def connect(url: str, token: Optional[str] = None, address: Optional[str] = None) -> MeshConnection:
+async def connect(url: str, token: Optional[str] = None, address: Optional[str] = None,
+                  root_certificates: Optional[bytes] = None) -> MeshConnection:
     """Connect a Python process to the mesh as a participant.
 
-    ``url`` is the portal gRPC endpoint, e.g. ``https://atioz.meshweaver.cloud`` (TLS) or
-    ``http://localhost:5202`` (h2c). ``token`` is a MeshWeaver API token; the server validates it and
-    stamps every write with your identity. ``address`` defaults to a fresh ``py/<uuid>`` participant.
+    ``url`` is the portal gRPC endpoint:
+
+    * ``https://memex.meshweaver.cloud`` — TLS through the portal ingress (the same-host
+      ``/meshweaver.v1.Mesh`` gRPC route). ``root_certificates`` overrides the trust roots for
+      self-signed local portals (pass the PEM bytes of the ingress cert, e.g. ``tls.crt`` from the
+      cluster's TLS secret); omit it for real certificates.
+    * ``http://127.0.0.1:8082`` — the TRUSTED loopback endpoint for gates that ship in the same
+      deployment as the portal (same pod): h2c, no token needed — reachability is the
+      authentication, and the server honours an ``accessContext`` carried on deliveries.
+
+    ``token`` is a MeshWeaver API token; the server validates it and stamps every write with your
+    identity. ``address`` defaults to a fresh ``py/<uuid>`` participant.
     """
     target = url.split("://", 1)[-1]
     if url.startswith("https://"):
-        channel = grpc.aio.secure_channel(target, grpc.ssl_channel_credentials())
+        channel = grpc.aio.secure_channel(target, grpc.ssl_channel_credentials(root_certificates))
     else:
         channel = grpc.aio.insecure_channel(target)
     conn = MeshConnection(channel, address or f"py/{uuid.uuid4().hex}", token)

--- a/clients/python/meshweaver/content.py
+++ b/clients/python/meshweaver/content.py
@@ -1,0 +1,45 @@
+"""Reading *files kept in mesh content* — the textual payload of a node, fence-aware.
+
+A "file in content" is an ordinary mesh node whose body carries the file text, typically a Markdown
+node with the data inside a fenced code block (renders readably in the portal, stays hand-editable).
+These helpers extract that text from the shapes a node read yields: a
+:class:`~meshweaver.types.MeshNode`, any object with a ``content`` attribute, or a plain node dict —
+with the content itself either a raw string or a ``MarkdownContent``-style dict.
+
+Used by the examples: the pandas node reads a CSV file (``examples/pandas_node.py``), the fine-tuning
+example reads a JSONL training set (``examples/finetune.py``).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+#: Content-dict fields that may carry the node's text, in probing order (camel + Pascal casing).
+_TEXT_FIELDS = ("content", "Content", "csv", "Csv", "text", "Text")
+
+
+def fenced_or_text(text: str) -> str:
+    """The payload inside ``text``: the first fenced code block if one is present, else the text itself.
+
+    Prose around the fence (headings, explanations) is ignored — so a node can document its own data.
+    A node that stores the bare payload with no fence works too."""
+    lines = text.splitlines()
+    start = next((i for i, line in enumerate(lines) if line.lstrip().startswith("```")), None)
+    if start is None:
+        return text.strip()
+    end = next((i for i in range(start + 1, len(lines)) if lines[i].lstrip().startswith("```")), len(lines))
+    return "\n".join(lines[start + 1:end]).strip()
+
+
+def text_from_node(node: Any) -> str:
+    """Extract the file text a mesh node keeps in its content (fence-aware).
+
+    Raises :class:`ValueError` when the node carries no textual content."""
+    content = getattr(node, "content", None) if not isinstance(node, dict) else (node.get("content") or node.get("Content"))
+    if isinstance(content, str):
+        return fenced_or_text(content)
+    if isinstance(content, dict):
+        for field in _TEXT_FIELDS:
+            text = content.get(field)
+            if isinstance(text, str):
+                return fenced_or_text(text)
+    raise ValueError("node carries no textual content")

--- a/clients/python/meshweaver/envelope.py
+++ b/clients/python/meshweaver/envelope.py
@@ -7,15 +7,18 @@ wire shape is pinned it changes here and nowhere else.
 Parsing is resilient (reads the few fields we need case-insensitively). Building is the side that must
 match the server's ``JsonSerializer.Deserialize<IMessageDelivery>`` exactly:
 
-* The delivery object needs a ``$type`` discriminator that the server's ``ITypeRegistry`` resolves to
-  the concrete ``MessageDelivery<TMessage>``; the payload under ``message`` needs its own ``$type``
-  (the registered short name of the request, e.g. ``"GetNodeRequest"``).
-* ``sender`` / ``target`` serialize as plain Address strings (``"type/id"``).
+* The delivery's ``$type`` is the RawJson-typed envelope (see ``DELIVERY_TYPE``) — the payload under
+  ``message`` carries its own ``$type`` (the registered short name of the request, e.g.
+  ``"PatchDataRequest"``), which the HANDLING hub deserializes late; an unregistered payload type
+  simply round-trips as raw JSON.
+* ``sender`` / ``target`` serialize as plain Address strings (``"type/id"``); property casing is
+  camelCase except the ``properties`` dictionary keys (verbatim, e.g. ``RequestId``).
 
-🔬 VALIDATION: the canonical sample is whatever the C# round-trip test
-(``MeshGrpcTransportTest``) logs for a real request/response. Capture it, then confirm
-``DELIVERY_TYPE`` and the property casing below. Everything else in the SDK is transport-level and
-already correct.
+Pinned against the canonical capture from ``MeshGrpcTransportTest`` (2026-07-03)::
+
+    {"$type":"MessageDelivery`1[RawJson]",
+     "message":{"$type":"EchoResponse","text":"hello mesh"},
+     "id":"…","sender":"mesh/…","target":"py/…","properties":{"RequestId":"…"}}
 """
 from __future__ import annotations
 
@@ -23,20 +26,27 @@ import json
 from dataclasses import dataclass
 from typing import Any, Optional
 
-# $type token the server uses for the concrete delivery envelope. Confirm against a captured sample.
-DELIVERY_TYPE = "MessageDelivery"
+# $type of the delivery envelope. The server serializes deliveries whose payload travelled the mesh
+# as MessageDelivery`1[RawJson]; a client-built delivery uses the same envelope and the receiving
+# hub late-deserializes `message` by ITS $type. (Backtick-1 = the CLR constructed-generic name.)
+DELIVERY_TYPE = "MessageDelivery`1[RawJson]"
 TYPE_KEY = "$type"
 REQUEST_ID = "RequestId"
 
 
 def build_deliver(
     *, delivery_id: str, sender: str, target: str, message_type: str, message: dict[str, Any],
-    request_id: Optional[str] = None,
+    request_id: Optional[str] = None, access_context: Optional[dict[str, Any]] = None,
 ) -> str:
     """Serialize a participant->mesh delivery to the JSON the server deserializes.
 
     ``request_id`` set => this is a RESPONSE: the server correlates it back to the original request by
-    ``properties.RequestId`` (the same key ``observe`` keys responses on)."""
+    ``properties.RequestId`` (the same key ``observe`` keys responses on).
+
+    ``access_context`` carries an identity on the delivery. Only meaningful on the TRUSTED loopback
+    endpoint, where the server passes it through — a gate executing a user's request echoes the
+    requester's context so its write-backs run under that user's identity. On token-authenticated
+    connections the server re-stamps regardless (a forged identity is never trusted)."""
     envelope = {
         TYPE_KEY: DELIVERY_TYPE,
         "id": delivery_id,
@@ -45,6 +55,8 @@ def build_deliver(
         "message": {TYPE_KEY: message_type, **message},
         "properties": {REQUEST_ID: request_id} if request_id else {},
     }
+    if access_context:
+        envelope["accessContext"] = access_context
     return json.dumps(envelope)
 
 
@@ -59,6 +71,7 @@ class Delivery:
     message_type: Optional[str]
     message: dict[str, Any]
     raw: dict[str, Any]
+    access_context: Optional[dict[str, Any]] = None
 
 
 def parse_delivery(payload: str) -> Delivery:
@@ -66,6 +79,7 @@ def parse_delivery(payload: str) -> Delivery:
     root = json.loads(payload)
     props = _get(root, "properties") or {}
     message = _get(root, "message") or {}
+    context = _get(root, "accessContext")
     return Delivery(
         id=_get(root, "id"),
         sender=_get(root, "sender"),
@@ -74,6 +88,7 @@ def parse_delivery(payload: str) -> Delivery:
         message_type=message.get(TYPE_KEY) if isinstance(message, dict) else None,
         message=message if isinstance(message, dict) else {},
         raw=root,
+        access_context=context if isinstance(context, dict) else None,
     )
 
 

--- a/clients/python/meshweaver/examples/finetune.py
+++ b/clients/python/meshweaver/examples/finetune.py
@@ -1,0 +1,310 @@
+"""Fine-tune a language model on MeshWeaver's own documentation — the dataset lives IN the mesh.
+
+The full loop, each leg a mesh round trip (see ``Doc/DataMesh/PythonFineTuning``):
+
+1. ``collect`` — **mesh → Python → mesh**: query the documentation nodes, distill every page into
+   chat-format instruction records ("teach the model MeshWeaver"), and write the JSONL back to the
+   mesh as **a file kept in content** (``PythonDemo/FineTune/TrainingData``) — reviewable, versioned,
+   hand-editable like any node.
+2. ``train`` — **mesh → Python → mesh**: pull that training file from the mesh, LoRA-fine-tune a
+   causal LM (``transformers`` + ``peft``, the optional ``[finetune]`` extras), and stream per-step
+   progress back onto a run node — so the portal watches the training live, exactly like any other
+   activity.
+
+Run it::
+
+    pip install -e ".[finetune]"
+    python -m meshweaver.examples.finetune collect --url https://memex.meshweaver.cloud --token mw_…
+    python -m meshweaver.examples.finetune train   --url https://memex.meshweaver.cloud --token mw_…
+
+Everything except :func:`lora_fine_tune` is dependency-free and unit-tested
+(``tests/test_finetune.py``); the heavy trainer is injectable so the mesh orchestration is testable
+without ``torch``.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import time
+from typing import Any, Callable, Iterable, Optional
+
+from ..content import text_from_node
+from ..mesh import Mesh
+
+DEFAULT_QUERY = "namespace:Doc nodeType:Markdown"
+DEFAULT_DATA_PATH = "PythonDemo/FineTune/TrainingData"
+DEFAULT_MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+
+SYSTEM_PROMPT = (
+    "You are the MeshWeaver assistant. Answer questions about the MeshWeaver data mesh "
+    "platform precisely, grounded in its documentation."
+)
+
+#: Cap per-answer length so one giant page doesn't dominate the dataset (cut at a paragraph edge).
+MAX_ANSWER_CHARS = 4000
+
+
+# --- docs -> training records (pure, tested) --------------------------------------------------------
+
+def training_records(nodes: Iterable[Any]) -> list[dict[str, Any]]:
+    """Distill documentation nodes into chat-format instruction records.
+
+    Deterministic — no generator model in the loop: each page yields one "explain the page" record,
+    plus one record per ``##`` section ("how does <section> work?"). The assistant turn is the
+    documentation text itself, so the tuned model learns to answer the way the docs do."""
+    records: list[dict[str, Any]] = []
+    for node in nodes:
+        title, text = _title_and_text(node)
+        if not title or not text:
+            continue
+        records.append(_chat(f"Explain {title} in MeshWeaver.", _truncate(text)))
+        for heading, body in _sections(text):
+            records.append(_chat(f"In MeshWeaver's {title}: how does {heading} work?", _truncate(body)))
+    return records
+
+
+def _title_and_text(node: Any) -> tuple[Optional[str], Optional[str]]:
+    """A doc node's display title and markdown body, tolerant of MeshNode / dict shapes."""
+    content = getattr(node, "content", None) if not isinstance(node, dict) else (node.get("content") or node.get("Content"))
+    name = getattr(node, "name", None) if not isinstance(node, dict) else (node.get("name") or node.get("Name"))
+    if isinstance(content, dict):
+        title = content.get("title") or content.get("Title") or name
+        text = content.get("content") or content.get("Content")
+        return title, text if isinstance(text, str) else None
+    return name, content if isinstance(content, str) else None
+
+
+def _sections(markdown: str) -> list[tuple[str, str]]:
+    """(heading, body) per ``##`` section — skips bodies too short to teach anything."""
+    sections: list[tuple[str, str]] = []
+    heading: Optional[str] = None
+    body: list[str] = []
+    for line in markdown.splitlines() + ["## "]:  # sentinel flushes the last section
+        if line.startswith("## "):
+            text = "\n".join(body).strip()
+            if heading and len(text) >= 80:
+                sections.append((heading, text))
+            heading, body = line[3:].strip() or None, []
+        else:
+            body.append(line)
+    return sections
+
+
+def _chat(question: str, answer: str) -> dict[str, Any]:
+    return {"messages": [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": question},
+        {"role": "assistant", "content": answer},
+    ]}
+
+
+def _truncate(text: str, limit: int = MAX_ANSWER_CHARS) -> str:
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    cut = text.rfind("\n\n", 0, limit)
+    return text[: cut if cut > 0 else limit].strip()
+
+
+def to_jsonl(records: Iterable[dict[str, Any]]) -> str:
+    return "\n".join(json.dumps(r, ensure_ascii=False) for r in records)
+
+
+def from_jsonl(text: str) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+# --- the training file kept in content --------------------------------------------------------------
+
+def training_data_node(path: str, jsonl: str, query: str, count: int) -> dict[str, Any]:
+    """The mesh node that KEEPS the training set in content: a Markdown node documenting itself,
+    with the JSONL in a fenced block (``text_from_node`` reads it back out)."""
+    namespace, _, node_id = path.rpartition("/")
+    body = (
+        f"# {node_id}\n\n"
+        f"Instruction-tuning dataset distilled from the MeshWeaver documentation "
+        f"(query: `{query}`) — **{count} chat-format records**, consumed by "
+        f"`python -m meshweaver.examples.finetune train`.\n\n"
+        f"```jsonl\n{jsonl}\n```\n"
+    )
+    return {
+        "id": node_id,
+        "namespace": namespace,
+        "name": "MeshWeaver training data",
+        "nodeType": "Markdown",
+        "description": f"Fine-tuning dataset built from the docs ({count} records).",
+        # MarkdownContent is the Markdown NodeType's registered content shape (the portal rejects
+        # unregistered $type discriminators — they would persist as untyped blobs).
+        "content": {"$type": "MarkdownContent", "content": body},
+    }
+
+
+def run_node(path: str, data_path: str, model: str, count: int) -> dict[str, Any]:
+    """The run node the trainer streams progress onto — watch it live in the portal."""
+    namespace, _, node_id = path.rpartition("/")
+    return {
+        "id": node_id,
+        "namespace": namespace,
+        "name": f"Fine-tune {node_id}",
+        "nodeType": "Markdown",
+        "description": f"LoRA fine-tune of {model} on {data_path} ({count} records).",
+        "content": {"$type": "MarkdownContent", "content": ""},
+    }
+
+
+# --- collect: docs -> dataset -> a file in content --------------------------------------------------
+
+async def collect(mesh: Any, query: str = DEFAULT_QUERY, target: str = DEFAULT_DATA_PATH,
+                  limit: int = 200) -> dict[str, Any]:
+    """mesh → Python → mesh: build the training set from the docs and keep it in content."""
+    hits = await mesh.search(query, limit=limit)
+    nodes = []
+    for hit in hits:
+        path = hit.get("path") or hit.get("Path")
+        if path:
+            nodes.append(await mesh.get(path))  # full content — search hits are summaries
+    records = training_records(nodes)
+    if not records:
+        raise RuntimeError(f"query {query!r} yielded no usable documentation pages")
+    await mesh.create_or_update(training_data_node(target, to_jsonl(records), query, len(records)))
+    return {"documents": len(nodes), "records": len(records), "path": target}
+
+
+# --- train: the file in content -> LoRA -> progress back onto the mesh ------------------------------
+
+async def train(mesh: Any, data_path: str = DEFAULT_DATA_PATH, run_path: Optional[str] = None,
+                model: str = DEFAULT_MODEL, epochs: int = 3, learning_rate: float = 2e-4,
+                output_dir: str = "./meshweaver-lora",
+                tuner: Optional[Callable[..., dict[str, Any]]] = None) -> dict[str, Any]:
+    """Pull the training file from the mesh, fine-tune, and stream progress back to a run node.
+
+    ``tuner`` defaults to :func:`lora_fine_tune`; tests inject a stub so the mesh orchestration is
+    provable without torch. The tuner runs on a worker thread (it blocks for minutes); progress
+    callbacks marshal back onto the event loop to patch the run node."""
+    run_path = run_path or f"PythonDemo/FineTune/Runs/{time.strftime('%Y%m%d-%H%M%S')}"
+    node = await mesh.get(data_path)
+    records = from_jsonl(text_from_node(node))
+
+    await mesh.create_or_update(run_node(run_path, data_path, model, len(records)))
+    lines = [
+        "# Fine-tune run", "",
+        f"- **Data:** `{data_path}` — {len(records)} records",
+        f"- **Model:** `{model}` (LoRA)",
+        f"- **Status:** Running", "",
+        "## Progress", "",
+    ]
+
+    async def report(line: str) -> None:
+        lines.append(line)
+        await mesh.patch(run_path, {"content": {"content": "\n".join(lines)}})
+
+    loop = asyncio.get_running_loop()
+
+    def on_progress(line: str) -> None:  # called from the trainer thread
+        asyncio.run_coroutine_threadsafe(report(f"- {line}"), loop).result()
+
+    tune = tuner or lora_fine_tune
+    try:
+        metrics = await asyncio.to_thread(
+            tune, records, model=model, epochs=epochs, learning_rate=learning_rate,
+            output_dir=output_dir, on_progress=on_progress)
+    except Exception as ex:
+        await report(f"\n**Failed:** {ex}")
+        raise
+
+    await report(f"\n**Succeeded** — final training loss `{metrics['train_loss']:.4f}` "
+                 f"over {metrics['steps']} steps; adapter saved to `{metrics['output_dir']}`.")
+    return {**metrics, "run_path": run_path}
+
+
+def lora_fine_tune(records: list[dict[str, Any]], *, model: str = DEFAULT_MODEL, epochs: int = 3,
+                   learning_rate: float = 2e-4, output_dir: str = "./meshweaver-lora",
+                   on_progress: Callable[[str], None] = lambda line: None) -> dict[str, Any]:
+    """LoRA fine-tuning of a causal LM on the chat records — the only function needing the heavy deps."""
+    try:
+        from datasets import Dataset
+        from peft import LoraConfig, get_peft_model
+        from transformers import (AutoModelForCausalLM, AutoTokenizer, DataCollatorForLanguageModeling,
+                                  Trainer, TrainerCallback, TrainingArguments)
+    except ImportError as ex:  # keep the mesh loop importable without torch
+        raise RuntimeError(
+            'fine-tuning needs the optional extras: pip install -e ".[finetune]"') from ex
+
+    tokenizer = AutoTokenizer.from_pretrained(model)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    texts = [_render_chat(tokenizer, r["messages"]) for r in records]
+    dataset = Dataset.from_dict({"text": texts}).map(
+        lambda batch: tokenizer(batch["text"], truncation=True, max_length=1024),
+        batched=True, remove_columns=["text"])
+
+    lm = get_peft_model(
+        AutoModelForCausalLM.from_pretrained(model),
+        LoraConfig(task_type="CAUSAL_LM", r=16, lora_alpha=32, target_modules="all-linear"))
+
+    class Report(TrainerCallback):
+        def on_log(self, args: Any, state: Any, control: Any, logs: Any = None, **kw: Any) -> None:
+            if logs and "loss" in logs:
+                on_progress(f"step {state.global_step}: loss {logs['loss']:.4f}")
+
+    trainer = Trainer(
+        model=lm,
+        args=TrainingArguments(output_dir=output_dir, num_train_epochs=epochs,
+                               learning_rate=learning_rate, per_device_train_batch_size=2,
+                               logging_steps=10, save_strategy="no", report_to=[]),
+        train_dataset=dataset,
+        data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False),
+        callbacks=[Report()])
+    outcome = trainer.train()
+    lm.save_pretrained(output_dir)
+    tokenizer.save_pretrained(output_dir)
+    return {"train_loss": float(outcome.training_loss), "steps": int(outcome.global_step),
+            "output_dir": output_dir}
+
+
+def _render_chat(tokenizer: Any, messages: list[dict[str, str]]) -> str:
+    if getattr(tokenizer, "chat_template", None):
+        return tokenizer.apply_chat_template(messages, tokenize=False)
+    return "\n".join(f"<|{m['role']}|>\n{m['content']}" for m in messages) + (tokenizer.eos_token or "")
+
+
+# --- CLI ---------------------------------------------------------------------------------------------
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="meshweaver.examples.finetune",
+                                description="Fine-tune a model on MeshWeaver docs kept in the mesh.")
+    sub = p.add_subparsers(dest="mode", required=True)
+
+    c = sub.add_parser("collect", help="docs -> chat-format JSONL -> a file kept in content")
+    c.add_argument("--url", required=True)
+    c.add_argument("--token", default=None)
+    c.add_argument("--query", default=DEFAULT_QUERY)
+    c.add_argument("--target", default=DEFAULT_DATA_PATH)
+    c.add_argument("--limit", type=int, default=200)
+
+    t = sub.add_parser("train", help="the file in content -> LoRA fine-tune -> progress on a run node")
+    t.add_argument("--url", required=True)
+    t.add_argument("--token", default=None)
+    t.add_argument("--data", default=DEFAULT_DATA_PATH)
+    t.add_argument("--run", default=None, help="run-node path (default PythonDemo/FineTune/Runs/<stamp>)")
+    t.add_argument("--model", default=DEFAULT_MODEL)
+    t.add_argument("--epochs", type=int, default=3)
+    t.add_argument("--learning-rate", type=float, default=2e-4)
+    t.add_argument("--output-dir", default="./meshweaver-lora")
+
+    args = p.parse_args()
+
+    async def run() -> dict[str, Any]:
+        async with await Mesh.connect(args.url, token=args.token) as mesh:
+            if args.mode == "collect":
+                return await collect(mesh, query=args.query, target=args.target, limit=args.limit)
+            return await train(mesh, data_path=args.data, run_path=args.run, model=args.model,
+                               epochs=args.epochs, learning_rate=args.learning_rate,
+                               output_dir=args.output_dir)
+
+    print(json.dumps(asyncio.run(run()), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/meshweaver/examples/pandas_node.py
+++ b/clients/python/meshweaver/examples/pandas_node.py
@@ -22,6 +22,11 @@ Two interaction surfaces, both against the SAME live frame:
    ``df["margin"] = df["sales"] - df["cost"]`` in one submission is visible to the next. That persistent
    ``df`` IS "an object created and controlled in Python".
 
+The canonical data source is **a file kept in mesh content**: a ``load`` command carrying a ``path``
+(e.g. ``PythonDemo/SalesData``) makes the participant read that node over the mesh, parse the CSV it
+holds with :func:`pandas.read_csv`, and replace the held frame — mesh → Python. Every analytical view
+then flows back through the hub as a ``DataGridControl`` — Python → mesh → C# GUI.
+
 Run the self-contained showcase (no mesh needed) — prints the DataGrid JSON the GUI would render::
 
     python -m meshweaver.examples.pandas_node --demo
@@ -46,6 +51,8 @@ import pandas.api.types as pdt
 
 from .. import envelope
 from ..connection import connect as _connect
+from ..content import fenced_or_text, text_from_node
+from ..mesh import Mesh
 from ..worker import _jsonable
 
 DEFAULT_ADDRESS = "py/pandas"
@@ -105,6 +112,30 @@ def frame_to_datagrid(df: pd.DataFrame) -> dict[str, Any]:
     return {"data": data, "columns": columns}
 
 
+# --- a file kept in content -> DataFrame (mesh -> Python) ------------------------------------------
+
+def csv_from_markdown(text: str) -> str:
+    """The CSV inside ``text``: the first fenced code block if one is present, else the text itself.
+
+    A CSV file kept in content is typically a Markdown node whose body wraps the data in a
+    ```` ```csv ```` fence (renders as a code block in the portal, stays hand-editable). Prose around
+    the fence is ignored; a node that stores the bare CSV works too."""
+    return fenced_or_text(text)
+
+
+def csv_from_node(node: Any) -> str:
+    """Extract the CSV text a mesh node keeps in its content — see :func:`meshweaver.content.text_from_node`."""
+    try:
+        return text_from_node(node)
+    except ValueError:
+        raise ValueError("node carries no textual content to read CSV from") from None
+
+
+def frame_from_node(node: Any) -> pd.DataFrame:
+    """Parse the CSV a node keeps in content into a DataFrame — the mesh → pandas edge."""
+    return pd.read_csv(io.StringIO(csv_from_node(node)))
+
+
 # --- the participant that owns the frame -----------------------------------------------------------
 
 class PandasNode:
@@ -112,12 +143,19 @@ class PandasNode:
 
     Construct with a connected :class:`MeshConnection` (or any object exposing ``serve`` / ``respond`` /
     ``post`` — that's what the tests and the ``--demo`` driver pass). The frame is real Python state on
-    ``self``; :meth:`handle` reacts to inbound deliveries and mutates / queries / renders it."""
+    ``self``; :meth:`handle` reacts to inbound deliveries and mutates / queries / renders it.
 
-    def __init__(self, connection: Any, frame: Optional[pd.DataFrame] = None):
+    ``node_reader`` is the mesh-read edge for ``load`` commands that carry a ``path`` (a file kept in
+    content): an async callable ``path -> node``. On a real :class:`MeshConnection` it defaults to
+    :meth:`meshweaver.mesh.Mesh.get`; tests inject a fake."""
+
+    def __init__(self, connection: Any, frame: Optional[pd.DataFrame] = None, node_reader: Any = None):
         self._c = connection
         self._df = pd.DataFrame() if frame is None else frame.copy()
         self._ns: dict[str, Any] = {"pd": pd}  # persistent namespace for the SubmitCodeRequest surface
+        if node_reader is None and hasattr(connection, "subscribe"):
+            node_reader = Mesh(connection).get  # a real participant reads nodes off their live streams
+        self._read_node = node_reader
         connection.serve(self.handle)
 
     @property
@@ -138,12 +176,24 @@ class PandasNode:
     async def _handle_command(self, delivery: "envelope.Delivery") -> None:
         msg = delivery.message
         command = str(msg.get("command") or msg.get("Command") or "").lower()
+        path = msg.get("path") or msg.get("Path")
         try:
-            kind, payload = self._apply(command, msg)
+            if command == "load" and path:
+                kind, payload = "ack", await self._load_from_content(str(path))
+            else:
+                kind, payload = self._apply(command, msg)
         except Exception as ex:  # a bad command never wedges the node — it replies with an error
             await self._c.respond(delivery, ERROR_TYPE, {"command": command, "error": f"{type(ex).__name__}: {ex}"})
             return
         await self._c.respond(delivery, GRID_TYPE if kind == "grid" else ACK_TYPE, payload)
+
+    async def _load_from_content(self, path: str) -> dict[str, Any]:
+        """mesh → Python: read the CSV file kept in content at ``path``, replace the held frame with it."""
+        if self._read_node is None:
+            raise RuntimeError("this node has no mesh connection to read content nodes from")
+        node = await self._read_node(path)
+        self._df = frame_from_node(node)
+        return {**self._summary(), "source": path}
 
     def _apply(self, command: str, msg: dict[str, Any]) -> tuple[str, dict[str, Any]]:
         """Apply one command to the held frame, returning ``("grid"|"ack", payload)``.
@@ -196,12 +246,15 @@ class PandasNode:
         status = "Succeeded" if result["error"] is None else "Failed"
         if activity_path:
             messages = [{"message": m} for m in (result["output"], result["error"]) if m]
+            # PatchDataRequest = (reference, patch) targeted at the node's own hub (PatchDataRequest.cs);
+            # the requester's context is echoed (honoured on the trusted endpoint).
             await self._c.post(
                 target=activity_path,
                 message_type="PatchDataRequest",
-                message={"path": activity_path, "change": {"content": {
+                message={"reference": {"$type": "MeshNodeReference"}, "patch": {"content": {
                     "status": status, "messages": messages, "returnValue": result["returnValue"],
                 }}},
+                access_context=delivery.access_context,
             )
         await self._c.respond(delivery, "SubmitCodeResponse", {
             "status": status, "returnValue": result["returnValue"], "output": result["output"],
@@ -259,7 +312,7 @@ class RecordingConnection:
     async def respond(self, to: Any, message_type: str, message: dict[str, Any]) -> None:
         self.responses.append((message_type, message))
 
-    async def post(self, target: str, message_type: str, message: dict[str, Any]) -> None:
+    async def post(self, target: str, message_type: str, message: dict[str, Any], access_context: Any = None) -> None:
         self.posts.append((target, message_type, message))
 
     async def send_command(self, node: "PandasNode", command: str, **fields: Any) -> tuple[str, dict[str, Any]]:

--- a/clients/python/meshweaver/examples/standalone_hub.py
+++ b/clients/python/meshweaver/examples/standalone_hub.py
@@ -1,0 +1,265 @@
+"""A full MeshWeaver hub programmed in Python — standalone, no .NET code anywhere in its loop.
+
+A hub on the mesh is three things: an **address** deliveries route to, a set of **message handlers**
+keyed by message type, and **state** the handlers own. :class:`PyHub` is exactly that, in Python —
+the in-language mirror of the C# ``MessageHubConfiguration.WithHandler<T>(...)`` model:
+
+* ``hub.register("SomeRequest", handler)`` — one handler per message type (C#: ``WithHandler<T>``),
+* a handler returns ``(response_type, payload)`` and the hub responds, correlated, to the sender
+  (C#: ``hub.Post(response, o => o.ResponseFor(request))``),
+* a raising handler answers with an ``ErrorResponse`` instead of wedging — errors always propagate
+  to the caller, never into silence,
+* inbound dispatch is serialised by the connection's read loop; outbound requests go through
+  ``observe`` (request/response) and ``post`` (fire-and-forget), exactly like any C# hub.
+
+:class:`NamespaceStatsHub` is the working example on top: on start it **loads info from the mesh**
+(every node in a namespace), serves statistics about them to any participant that asks, and **saves
+its report back to the mesh** as a Markdown node — read, compute, write, all from Python.
+
+Run the self-contained showcase (no mesh needed)::
+
+    python -m meshweaver.examples.standalone_hub --demo
+
+Or attach the hub to a live mesh::
+
+    python -m meshweaver.examples.standalone_hub --url https://memex.meshweaver.cloud \
+        --token mw_… --namespace PythonDemo --address py/stats
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from typing import Any, Awaitable, Callable, Optional
+
+from .. import envelope
+from ..connection import connect as _connect
+from ..mesh import Mesh
+
+DEFAULT_ADDRESS = "py/stats"
+
+#: A handler takes the inbound delivery and returns ``(response_type, payload)`` or ``None``.
+Handler = Callable[["envelope.Delivery"], Awaitable[Optional[tuple[str, dict[str, Any]]]]]
+
+
+class PyHub:
+    """The hub programming model, in Python: an address, handlers by message type, owned state.
+
+    Construct with a connected :class:`~meshweaver.connection.MeshConnection` (or any object exposing
+    ``serve`` / ``respond`` — the tests pass a recording fake). Handlers registered via
+    :meth:`register` receive every delivery of their message type addressed to this hub."""
+
+    def __init__(self, connection: Any):
+        self._c = connection
+        self._handlers: dict[str, Handler] = {}
+        connection.serve(self.handle)
+
+    def register(self, message_type: str, handler: Handler) -> "PyHub":
+        """Register the handler for ``message_type`` — the C# ``WithHandler<T>`` of this hub."""
+        self._handlers[message_type] = handler
+        return self
+
+    async def handle(self, delivery: "envelope.Delivery") -> None:
+        """Dispatch one inbound delivery. Unknown types are ignored (another participant's traffic);
+        a raising handler answers with an ``ErrorResponse`` — the hub never wedges, the caller
+        always learns what happened."""
+        handler = self._handlers.get(delivery.message_type)
+        if handler is None:
+            return
+        try:
+            reply = await handler(delivery)
+        except Exception as ex:
+            await self._c.respond(delivery, "ErrorResponse",
+                                  {"error": f"{type(ex).__name__}: {ex}"})
+            return
+        if reply is not None:
+            response_type, payload = reply
+            await self._c.respond(delivery, response_type, payload)
+
+
+# --- the working hub: load from the mesh, serve, save back ------------------------------------------
+
+class NamespaceStatsHub(PyHub):
+    """A standalone Python hub that knows one namespace of the mesh.
+
+    * :meth:`load` — mesh → Python: reads every node in the namespace into hub state,
+    * ``NamespaceStatsRequest`` → ``NamespaceStatsResponse`` — serves statistics over that state,
+    * ``ReloadRequest`` — re-reads the namespace, then answers with fresh statistics,
+    * :meth:`save_report` — Python → mesh: writes the statistics back as a Markdown node
+      (``{namespace}/PythonHubReport``), so the hub's knowledge is itself mesh content."""
+
+    def __init__(self, connection: Any, mesh: Any, namespace: str):
+        super().__init__(connection)
+        self._mesh = mesh
+        self.namespace = namespace
+        self.nodes: list[Any] = []
+        self.register("NamespaceStatsRequest", self._on_stats)
+        self.register("ReloadRequest", self._on_reload)
+
+    # ---- mesh -> Python: the hub's state is loaded from the mesh -----------------------------------
+
+    async def load(self) -> dict[str, Any]:
+        """Read every node in the namespace into hub state and return the statistics."""
+        hits = await self._mesh.search(f"namespace:{self.namespace}", limit=500)
+        self.nodes = []
+        for hit in hits:
+            path = hit.get("path") or hit.get("Path")
+            if path:
+                self.nodes.append(await self._mesh.get(path))
+        return self.stats()
+
+    def stats(self) -> dict[str, Any]:
+        """Statistics over the held state: node count, per-nodeType counts, total words of content."""
+        by_type: dict[str, int] = {}
+        words = 0
+        for node in self.nodes:
+            node_type = self._field(node, "nodeType", "NodeType", "node_type") or "?"
+            by_type[node_type] = by_type.get(node_type, 0) + 1
+            content = self._field(node, "content", "Content")
+            if isinstance(content, dict):
+                text = content.get("content") or content.get("Content")
+                if isinstance(text, str):
+                    words += len(text.split())
+        return {"namespace": self.namespace, "nodeCount": len(self.nodes),
+                "byNodeType": by_type, "contentWords": words}
+
+    @staticmethod
+    def _field(node: Any, *names: str) -> Any:
+        for name in names:
+            value = node.get(name) if isinstance(node, dict) else getattr(node, name, None)
+            if value is not None:
+                return value
+        return None
+
+    # ---- the served surface -------------------------------------------------------------------------
+
+    async def _on_stats(self, delivery: "envelope.Delivery") -> tuple[str, dict[str, Any]]:
+        return "NamespaceStatsResponse", self.stats()
+
+    async def _on_reload(self, delivery: "envelope.Delivery") -> tuple[str, dict[str, Any]]:
+        return "NamespaceStatsResponse", await self.load()
+
+    # ---- Python -> mesh: the hub's knowledge becomes mesh content ----------------------------------
+
+    async def save_report(self) -> str:
+        """Write the statistics back to the mesh as a readable Markdown node; returns its path."""
+        stats = self.stats()
+        path = f"{self.namespace}/PythonHubReport"
+        rows = "\n".join(f"| {t} | {n} |" for t, n in sorted(stats["byNodeType"].items()))
+        body = (
+            f"# Namespace report: {self.namespace}\n\n"
+            f"Written by the standalone Python hub (`{DEFAULT_ADDRESS}`, "
+            f"`meshweaver.examples.standalone_hub`).\n\n"
+            f"- **Nodes:** {stats['nodeCount']}\n"
+            f"- **Words of content:** {stats['contentWords']}\n\n"
+            f"| Node type | Count |\n|---|---|\n{rows}\n"
+        )
+        await self._mesh.create_or_update({
+            "id": "PythonHubReport",
+            "namespace": self.namespace,
+            "name": f"Python hub report — {self.namespace}",
+            "nodeType": "Markdown",
+            "description": f"Namespace statistics computed by the standalone Python hub ({stats['nodeCount']} nodes).",
+            "content": {"$type": "MarkdownContent", "content": body},
+        })
+        return path
+
+
+# --- run it -------------------------------------------------------------------------------------------
+
+async def serve(url: str, token: Optional[str] = None, namespace: str = "PythonDemo",
+                address: str = DEFAULT_ADDRESS) -> None:
+    """Attach the hub to a live mesh: load the namespace, publish the report, serve until cancelled."""
+    conn = await _connect(url, token=token, address=address)
+    mesh = Mesh(conn, url=url, token=token)   # gRPC participant + the portal's REST verbs
+    hub = NamespaceStatsHub(conn, mesh, namespace)
+    stats = await hub.load()
+    report_path = await hub.save_report()
+    print(f"python hub serving as {conn.address} -> {url}")
+    print(f"loaded {stats['nodeCount']} nodes from {namespace}; report saved to {report_path}")
+    try:
+        await asyncio.Event().wait()  # inbound NamespaceStatsRequest / ReloadRequest drive the hub
+    finally:
+        await conn.close()
+
+
+class RecordingConnection:
+    """In-process stand-in for a MeshConnection — records what the hub would send (the demo/tests)."""
+
+    def __init__(self) -> None:
+        self.responses: list[tuple[str, dict[str, Any]]] = []
+        self._handler: Any = None
+
+    def serve(self, handler: Any) -> None:
+        self._handler = handler
+
+    async def respond(self, to: Any, message_type: str, message: dict[str, Any]) -> None:
+        self.responses.append((message_type, message))
+
+    async def deliver(self, message_type: str, message: Optional[dict[str, Any]] = None) -> tuple[str, dict[str, Any]]:
+        """Route a delivery to the hub the way the mesh would, and return its response."""
+        delivery = envelope.Delivery(
+            id="demo", sender="py/demo-driver", target=DEFAULT_ADDRESS, request_id=None,
+            message_type=message_type, message={"$type": message_type, **(message or {})}, raw={},
+        )
+        await self._handler(delivery)
+        return self.responses[-1]
+
+
+class DemoMesh:
+    """A tiny in-memory namespace, standing in for the live mesh in ``--demo`` mode."""
+
+    def __init__(self) -> None:
+        self.nodes = {
+            "PythonDemo/SalesData": {"path": "PythonDemo/SalesData", "nodeType": "Markdown",
+                                     "content": {"content": "month,region,sales,units " * 9}},
+            "PythonDemo/PandasExplorer": {"path": "PythonDemo/PandasExplorer", "nodeType": "NodeType",
+                                          "content": {"content": "an interactive pandas frontend"}},
+            "PythonDemo/PrimeReport": {"path": "PythonDemo/PrimeReport", "nodeType": "NodeType",
+                                       "content": {"content": "primes computed by python"}},
+        }
+        self.upserts: list[dict[str, Any]] = []
+
+    async def search(self, query: str, limit: int = 500) -> list[dict[str, Any]]:
+        return [{"path": p} for p in self.nodes]
+
+    async def get(self, path: str) -> dict[str, Any]:
+        return self.nodes[path]
+
+    async def create_or_update(self, node: dict[str, Any]) -> dict[str, Any]:
+        self.upserts.append(node)
+        return {"status": "ok"}
+
+
+async def run_demo() -> dict[str, Any]:
+    """Scripted end-to-end without a mesh: load → serve a stats request → save the report."""
+    conn = RecordingConnection()
+    mesh = DemoMesh()
+    hub = NamespaceStatsHub(conn, mesh, "PythonDemo")
+    await hub.load()
+    _, stats = await conn.deliver("NamespaceStatsRequest")
+    report_path = await hub.save_report()
+    return {"stats": stats, "report_path": report_path, "report": mesh.upserts[-1]}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(prog="meshweaver.examples.standalone_hub",
+                                description="A full MeshWeaver hub programmed in Python.")
+    p.add_argument("--demo", action="store_true", help="run the self-contained showcase (no mesh)")
+    p.add_argument("--url", default=None, help="portal gRPC endpoint, e.g. https://memex.meshweaver.cloud")
+    p.add_argument("--token", default=None, help="MeshWeaver API token (validated server-side)")
+    p.add_argument("--namespace", default="PythonDemo", help="the namespace this hub loads and reports on")
+    p.add_argument("--address", default=DEFAULT_ADDRESS, help="stable participant address of this hub")
+    args = p.parse_args()
+
+    if args.demo or not args.url:
+        result = asyncio.run(run_demo())
+        print(json.dumps(result["stats"], indent=2))
+        print(f"\n# report node written to {result['report_path']}")
+        return
+
+    asyncio.run(serve(args.url, token=args.token, namespace=args.namespace, address=args.address))
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/meshweaver/mesh.py
+++ b/clients/python/meshweaver/mesh.py
@@ -1,12 +1,27 @@
 """Ergonomic mesh operations — the in-language port of ``MeshWeaver.AI.MeshOperations``.
 
-Each method is a thin composition of the :class:`MeshConnection` primitives (``observe`` / ``post`` /
-``subscribe``). The request *type names* and *target addresses* below are the mesh's own message
-contracts; they are annotated ``# WIRE:`` where they must be confirmed against the running mesh
-(capture a sample from the C# round-trip test). The transport underneath is already correct.
+Two transports, matching what the portal actually offers a remote participant:
+
+* **REST** (``POST {portal}/api/mesh/<verb>``, ``Authorization: Bearer mw_…``) — the portal's
+  transport-mirror of the MCP tools (``MeshApiEndpoints`` → ``MeshOperations``): ``get`` / ``search``
+  / ``query_nodes`` / ``create`` / ``update`` / ``patch`` / ``delete`` / ``move`` / ``copy``. One
+  shared core backs REST, MCP and this SDK, so the semantics cannot drift.
+* **gRPC** (the participant connection) — what REST cannot do: being addressable on the mesh, and
+  **live node streams**: ``watch(path)`` speaks the synchronization protocol (``SubscribeRequest`` →
+  ``DataChangedEvent`` Full + RFC 7396 merge patches → ``UnsubscribeRequest``), the same wire the
+  Blazor / MAUI clients bind to.
+
+Shapes are pinned against the C# contracts (``Messages.cs``, ``PatchDataRequest.cs``,
+``MeshApiEndpoints.cs``) and confirmed live against a running portal — see ``tests/test_mesh.py``.
 """
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import json
+import ssl
+import urllib.error
+import urllib.request
 import uuid
 from typing import Any, AsyncIterator, Optional
 
@@ -14,19 +29,115 @@ from .connection import MeshConnection, connect as _connect
 from .types import MeshNode
 
 
-class Mesh:
-    """High-level mesh handle. Wraps a :class:`MeshConnection`."""
+class MeshError(RuntimeError):
+    """An operation the portal answered with an ``Error: …`` / ``Not found: …`` sentinel."""
 
-    def __init__(self, connection: MeshConnection, mesh_address: str = "mesh/main"):
+
+def merge_patch(target: Any, patch: Any) -> Any:
+    """RFC 7396 JSON merge patch — the shape ``PatchDataRequest`` writes travel as."""
+    if not isinstance(patch, dict):
+        return patch
+    result = dict(target) if isinstance(target, dict) else {}
+    for key, value in patch.items():
+        if value is None:
+            result.pop(key, None)
+        else:
+            result[key] = merge_patch(result.get(key), value)
+    return result
+
+
+def apply_json_patch(target: Any, ops: list[dict[str, Any]]) -> Any:
+    """RFC 6902 JSON Patch — the client-side fold for ``DataChangedEvent`` Patch frames.
+
+    The sync protocol's incremental changes are op ARRAYS (``[{"op":"replace","path":"/content/…",…}]``
+    — confirmed on the live wire), not merge objects. Supports the ops the owner emits
+    (add / replace / remove) over object paths; list indices are handled for completeness."""
+    import copy
+
+    result = copy.deepcopy(target) if isinstance(target, (dict, list)) else {}
+    for op in ops:
+        kind = op.get("op")
+        pointer = [p.replace("~1", "/").replace("~0", "~") for p in str(op.get("path", "")).split("/")[1:]]
+        if not pointer:
+            if kind in ("add", "replace"):
+                result = op.get("value")
+            continue
+        parent = result
+        for key in pointer[:-1]:
+            if isinstance(parent, list):
+                parent = parent[int(key)]
+            elif isinstance(parent, dict):
+                parent = parent.setdefault(key, {})
+        leaf = pointer[-1]
+        if isinstance(parent, list):
+            index = len(parent) if leaf == "-" else int(leaf)
+            if kind == "remove":
+                del parent[index]
+            elif kind == "add":
+                parent.insert(index, op.get("value"))
+            else:
+                parent[index] = op.get("value")
+        elif isinstance(parent, dict):
+            if kind == "remove":
+                parent.pop(leaf, None)
+            else:
+                parent[leaf] = op.get("value")
+    return result
+
+
+class RestClient:
+    """Thin async client for the portal's ``/api/mesh`` verb endpoints (stdlib-only)."""
+
+    def __init__(self, url: str, token: Optional[str] = None, insecure: bool = False):
+        self._base = url.rstrip("/") + "/api/mesh"
+        self._token = token
+        self._ssl = ssl._create_unverified_context() if insecure else None  # noqa: S323 — local/dev portals
+
+    async def post(self, verb: str, body: dict[str, Any]) -> str:
+        return await asyncio.to_thread(self._post_sync, verb, body)
+
+    def _post_sync(self, verb: str, body: dict[str, Any]) -> str:
+        headers = {"Content-Type": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        request = urllib.request.Request(f"{self._base}/{verb}", data=json.dumps(body).encode(), headers=headers)
+        try:
+            with urllib.request.urlopen(request, context=self._ssl) as response:  # noqa: S310 — caller-supplied portal URL
+                return response.read().decode()
+        except urllib.error.HTTPError as ex:
+            raise MeshError(f"{verb} -> HTTP {ex.code}: {ex.read().decode(errors='replace')[:500]}") from None
+
+
+def _checked(result: str) -> str:
+    """Raise :class:`MeshError` on the MeshOperations error sentinels (``Error: …``,
+    ``Error creating node: …``, ``Not found: …``, ``Invalid JSON: …``)."""
+    if result.startswith(("Error", "Not found:", "Invalid JSON")):
+        raise MeshError(result)
+    return result
+
+
+class Mesh:
+    """High-level mesh handle: REST ops + (optionally) the gRPC participant connection."""
+
+    def __init__(self, connection: Optional[Any] = None, url: Optional[str] = None,
+                 token: Optional[str] = None, rest: Optional[Any] = None, insecure: bool = False):
         self._c = connection
-        self._mesh = mesh_address  # WIRE: confirm the portal's mesh-service address
+        self._rest = rest or (RestClient(url, token, insecure=insecure) if url else None)
 
     @classmethod
-    async def connect(cls, url: str, token: Optional[str] = None, **kw: Any) -> "Mesh":
-        return cls(await _connect(url, token=token), **kw)
+    async def connect(cls, url: str, token: Optional[str] = None, address: Optional[str] = None,
+                      grpc_url: Optional[str] = None, insecure: bool = False,
+                      root_certificates: Optional[bytes] = None) -> "Mesh":
+        """Connect both transports: REST at ``url`` and the gRPC participant at ``grpc_url``
+        (defaults to ``url`` — the portal ingress routes ``meshweaver.v1.Mesh/Open`` natively).
+        ``root_certificates`` overrides the gRPC trust roots for self-signed local portals."""
+        return cls(await _connect(grpc_url or url, token=token, address=address,
+                                  root_certificates=root_certificates),
+                   url=url, token=token, insecure=insecure)
 
     async def close(self) -> None:
-        await self._c.close()
+        if self._c is not None:
+            await self._c.close()
 
     async def __aenter__(self) -> "Mesh":
         return self
@@ -34,64 +145,117 @@ class Mesh:
     async def __aexit__(self, *exc: Any) -> None:
         await self.close()
 
+    def _require_rest(self) -> Any:
+        if self._rest is None:
+            raise MeshError("this operation needs the REST transport — construct Mesh with url=/token=")
+        return self._rest
+
     # ---- reads -----------------------------------------------------------
 
     async def search(self, query: str, base_path: Optional[str] = None, limit: int = 50) -> list[dict[str, Any]]:
-        """Free-text / structured mesh query (routes to vector or SQL server-side)."""
-        resp = await self._c.observe(
-            self._mesh,
-            "QueryRequest",  # WIRE: confirm IMeshService query request type
-            {"query": query, "basePath": base_path, "limit": limit},
-        )
-        return resp.message.get("results") or resp.message.get("Results") or []
+        """Free-text / structured mesh query → summary hits ``[{path, name, nodeType}, …]``."""
+        result = _checked(await self._require_rest().post(
+            "search", {"query": query, "basePath": base_path, "limit": limit}))
+        return json.loads(result).get("results") or []
+
+    async def query_nodes(self, query: str, limit: int = 50) -> list[dict[str, Any]]:
+        """Mesh query → FULL node payloads (content included) — one round trip, no per-hit get."""
+        result = _checked(await self._require_rest().post("query-nodes", {"query": query, "limit": limit}))
+        return json.loads(result).get("results") or []
 
     async def get(self, path: str) -> MeshNode:
-        """Read a single node's current state (one snapshot off its live stream)."""
-        async for node in self.watch(path):  # watch() already yields MeshNode (applies from_change)
-            return node
-        raise RuntimeError("stream closed before first state")
+        """Read a single node. REST when configured; otherwise one snapshot off the node's live
+        stream over the participant connection (:meth:`watch`)."""
+        if self._rest is not None:
+            result = _checked(await self._require_rest().post("get", {"path": path}))
+            return MeshNode.from_change(json.loads(result))
+        # aclosing is mandatory: returning out of a bare `async for` leaves the generator open,
+        # so watch's finally (the UnsubscribeRequest) would never run — a leaked owner subscription.
+        async with contextlib.aclosing(self.watch(path)) as stream:
+            async for node in stream:
+                return node
+        raise MeshError(f"stream for {path} closed before first state")
 
     async def watch(self, path: str) -> AsyncIterator[MeshNode]:
-        """Subscribe to a node's live state — yields on every change (Full, then merge-patches)."""
+        """Subscribe to a node's LIVE state over the participant connection — yields the current
+        node on every change. Wire (confirmed live): post ``SubscribeRequest(streamId,
+        MeshNodeReference)`` to the node's own address; the owner streams ``DataChangedEvent``\\ s —
+        ``Full`` carries the whole node, ``Patch`` carries an RFC 6902 JSON-Patch op array — each
+        stamped with a monotonically increasing ``version`` (frames can arrive duplicated; the
+        version dedups). ``UnsubscribeRequest`` on exit releases the owner's subscription."""
+        if self._c is None:
+            raise MeshError("watch needs the gRPC participant connection — use Mesh.connect(...)")
         stream_id = uuid.uuid4().hex
-        async for delivery in self._c.subscribe(
-            target=path,
-            stream_id=stream_id,
-            subscribe_type="SubscribeRequest",  # WIRE: confirm reference shape for a node path
-            subscribe_msg={"reference": {"path": path}},
-        ):
-            yield MeshNode.from_change(delivery.message)
+        state: Any = None
+        last_version = -1
+        try:
+            async for delivery in self._c.subscribe(
+                target=path,
+                stream_id=stream_id,
+                subscribe_type="SubscribeRequest",
+                subscribe_msg={
+                    "reference": {"$type": "MeshNodeReference"},   # the target hub IS the node
+                    "subscriber": self._c.address,                 # Address serializes as its path string
+                },
+            ):
+                if delivery.message_type != "DataChangedEvent":
+                    continue
+                version = int(delivery.message.get("version") or 0)
+                if version <= last_version:
+                    continue                                        # duplicate / out-of-order frame
+                last_version = version
+                change = delivery.message.get("change")
+                change_type = str(delivery.message.get("changeType") or "").lower()
+                if change_type == "full":
+                    state = change
+                elif isinstance(change, list):
+                    state = apply_json_patch(state, change)
+                else:
+                    state = merge_patch(state, change)
+                if isinstance(state, dict):
+                    yield MeshNode.from_change(state)
+        finally:
+            await self._c.post(path, "UnsubscribeRequest", {"streamId": stream_id})
 
-    # ---- writes (carry the caller's identity, server-stamped) ------------
+    # ---- writes (REST; the caller's token identity is server-stamped) ----
 
-    async def patch(self, path: str, fields: dict[str, Any]) -> None:
+    async def patch(self, path: str, fields: dict[str, Any]) -> str:
         """Field-level partial update (content deep-merges, RFC 7396) — the canonical mutation."""
-        await self._c.post(
-            target=path,
-            message_type="PatchDataRequest",  # WIRE: confirm partial-update request type
-            message={"path": path, "change": fields},
-        )
+        return _checked(await self._require_rest().post(
+            "patch", {"path": path, "fields": json.dumps(fields)}))
 
-    # ---- node lifecycle (routes through the mesh hub) --------------------
+    async def create(self, node: dict[str, Any]) -> str:
+        """Create a node (first writer wins — an existing node is reported, not overwritten)."""
+        return _checked(await self._require_rest().post("create", {"node": json.dumps(node)}))
 
-    async def create(self, node: dict[str, Any]) -> dict[str, Any]:
-        """Create a node (node-lifecycle on the mesh hub — routes, doesn't mutate)."""
-        resp = await self._c.observe(self._mesh, "CreateNodeRequest", {"node": node})  # WIRE: create request shape
-        return resp.message
+    async def update(self, nodes: list[dict[str, Any]]) -> str:
+        """Full-replacement update of one or more EXISTING nodes."""
+        return _checked(await self._require_rest().post("update", {"nodes": json.dumps(nodes)}))
 
-    async def delete(self, path: str) -> None:
-        """Delete a node by path."""
-        await self._c.observe(self._mesh, "DeleteNodeRequest", {"path": path})  # WIRE: delete request shape
+    async def create_or_update(self, node: dict[str, Any]) -> str:
+        """Idempotent upsert: create, falling back to full-replacement update when it already exists."""
+        try:
+            return await self.create(node)
+        except MeshError as ex:
+            if "already exists" not in str(ex).lower():
+                raise
+            return await self.update([node])
 
-    async def move(self, source: str, target: str) -> None:
+    async def delete(self, *paths: str) -> str:
+        """Delete one or more nodes (and their descendants). The verb takes a JSON ARRAY of paths."""
+        return _checked(await self._require_rest().post("delete", {"paths": json.dumps(list(paths))}))
+
+    async def move(self, source: str, target: str) -> str:
         """Move a node (and its satellites) from one path to another."""
-        await self._c.observe(self._mesh, "MoveNodeRequest", {"source": source, "target": target})  # WIRE: MoveNodeRequest fields
+        return _checked(await self._require_rest().post(
+            "move", {"sourcePath": source, "targetPath": target}))
 
-    async def copy(self, source: str, target: str) -> None:
-        """Copy a node to a new path."""
-        await self._c.observe(self._mesh, "CopyNodeRequest", {"source": source, "target": target})  # WIRE: CopyNodeRequest fields
+    async def copy(self, source: str, target_namespace: str) -> str:
+        """Copy a node into another namespace."""
+        return _checked(await self._require_rest().post(
+            "copy", {"sourcePath": source, "targetNamespace": target_namespace}))
 
-    async def execute(self, path: str) -> None:
+    async def execute(self, path: str) -> str:
         """Run an executable Code/activity node by flipping its control-plane trigger to Running
         (operations-as-scripts — the owning hub's watcher reacts). Use ``watch(path)`` to follow Status."""
-        await self.patch(path, {"requestedStatus": "Running"})  # WIRE: confirm the activity control-plane field
+        return await self.patch(path, {"content": {"requestedStatus": "Running"}})

--- a/clients/python/meshweaver/worker.py
+++ b/clients/python/meshweaver/worker.py
@@ -102,13 +102,18 @@ class CodeWorker:
         status = "Succeeded" if result.ok else "Failed"
         messages = [{"message": m} for m in (result.stdout, result.error) if m]  # WIRE: LogMessage shape
         # Mesh-native: patch the Activity node subscribers already watch (same surface as the C# kernel).
+        # PatchDataRequest is (reference, patch): a MeshNodeReference targeted at the node's own hub,
+        # with the RFC 7396 merge patch under `patch` (the pinned C# contract — PatchDataRequest.cs).
+        # The requester's accessContext is echoed so, on the trusted endpoint, the write runs under
+        # the identity of the user whose Code node this run is — like the in-process C# kernel.
         if activity_path:
             await self._c.post(
                 target=activity_path,
-                message_type="PatchDataRequest",  # WIRE: confirm partial-update request type
-                message={"path": activity_path, "change": {"content": {
+                message_type="PatchDataRequest",
+                message={"reference": {"$type": "MeshNodeReference"}, "patch": {"content": {
                     "status": status, "messages": messages, "returnValue": result.return_value,  # WIRE: ActivityLog fields
                 }}},
+                access_context=delivery.access_context,
             )
         # And reply to the requester for request/response callers (e.g. the .NET dispatch awaiting a result).
         await self._c.respond(delivery, "SubmitCodeResponse", {  # WIRE: SubmitCodeResponse shape

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -14,6 +14,14 @@ dependencies = [
 examples = [
     "pandas>=2.0",
 ]
+# The fine-tuning example (meshweaver.examples.finetune) — heavy; only the `train` step needs these.
+finetune = [
+    "torch>=2.4",
+    "transformers>=4.45",
+    "peft>=0.13",
+    "datasets>=3.0",
+    "accelerate>=1.0",
+]
 dev = [
     "grpcio-tools>=1.68",
     "pytest>=8",

--- a/clients/python/tests/test_envelope.py
+++ b/clients/python/tests/test_envelope.py
@@ -37,3 +37,15 @@ def test_extracts_request_id_and_is_casing_resilient():
     assert d.sender == "p"
     assert d.request_id == "r"
     assert d.message_type == "M"
+
+
+def test_access_context_round_trips():
+    ctx = {"$type": "AccessContext", "objectId": "alice", "name": "Alice"}
+    built = e.build_deliver(delivery_id="d3", sender="s", target="t",
+                            message_type="Ping", message={}, access_context=ctx)
+    assert json.loads(built)["accessContext"] == ctx     # carried on the envelope, camelCase
+    assert e.parse_delivery(built).access_context == ctx
+    # Absent context stays absent — never an empty object the server would misread.
+    plain = e.build_deliver(delivery_id="d4", sender="s", target="t", message_type="Ping", message={})
+    assert "accessContext" not in json.loads(plain)
+    assert e.parse_delivery(plain).access_context is None

--- a/clients/python/tests/test_finetune.py
+++ b/clients/python/tests/test_finetune.py
@@ -1,0 +1,143 @@
+"""The fine-tuning loop: docs → chat-format records → a file kept in content → train with progress
+streamed back onto a run node. The heavy LoRA trainer is injected as a stub, so these pin the whole
+mesh orchestration without torch — the same duck-typing test_mesh uses."""
+from typing import Any
+
+import pytest
+
+from meshweaver.content import text_from_node
+from meshweaver.examples.finetune import (
+    SYSTEM_PROMPT,
+    collect,
+    from_jsonl,
+    to_jsonl,
+    train,
+    training_data_node,
+    training_records,
+)
+
+DOC_BODY = (
+    "MeshWeaver is an actor-model data mesh.\n\n"
+    "## Message routing\n\n"
+    "Every hub has an address; deliveries route by target. " + "Routing detail. " * 10 + "\n\n"
+    "## Layout areas\n\n"
+    "Views are reactive UiControl trees rendered in Blazor. " + "Layout detail. " * 10 + "\n"
+)
+
+
+def _doc(path: str, title: str, body: str = DOC_BODY) -> dict[str, Any]:
+    return {"path": path, "name": title,
+            "content": {"$type": "MarkdownContent", "title": title, "content": body}}
+
+
+class FakeMesh:
+    """Answers search/get and records every write — the mesh side of the loop."""
+
+    def __init__(self, nodes: dict[str, dict[str, Any]]):
+        self.nodes = nodes
+        self.upserts: list[dict[str, Any]] = []
+        self.patches: list[tuple[str, dict[str, Any]]] = []
+
+    async def search(self, query: str, limit: int = 50) -> list[dict[str, Any]]:
+        return [{"path": p} for p in self.nodes]
+
+    async def get(self, path: str) -> dict[str, Any]:
+        return self.nodes[path]
+
+    async def create_or_update(self, node: dict[str, Any]) -> dict[str, Any]:
+        self.upserts.append(node)
+        return {"status": "ok"}
+
+    async def patch(self, path: str, fields: dict[str, Any]) -> None:
+        self.patches.append((path, fields))
+
+
+# ---- docs -> records (pure) ------------------------------------------------------------------------
+
+def test_training_records_distill_page_and_sections():
+    records = training_records([_doc("Doc/Routing", "Message Routing")])
+    questions = [r["messages"][1]["content"] for r in records]
+    assert "Explain Message Routing in MeshWeaver." in questions
+    assert any("Message routing" in q for q in questions)      # one record per ## section
+    assert any("Layout areas" in q for q in questions)
+    for r in records:
+        roles = [m["role"] for m in r["messages"]]
+        assert roles == ["system", "user", "assistant"]
+        assert r["messages"][0]["content"] == SYSTEM_PROMPT
+        assert r["messages"][2]["content"]                     # the docs text is the answer
+
+
+def test_training_records_skip_nodes_without_text():
+    assert training_records([{"path": "Doc/Empty", "name": "Empty", "content": {}}]) == []
+
+
+def test_jsonl_round_trips_through_the_content_node():
+    records = training_records([_doc("Doc/Routing", "Message Routing")])
+    node = training_data_node("PythonDemo/FineTune/TrainingData", to_jsonl(records),
+                              "namespace:Doc", len(records))
+    assert node["namespace"] == "PythonDemo/FineTune"
+    assert node["id"] == "TrainingData"
+    # The JSONL survives the trip INTO the markdown fence and back out.
+    assert from_jsonl(text_from_node(node)) == records
+
+
+# ---- collect: mesh -> records -> a file kept in content --------------------------------------------
+
+async def test_collect_reads_docs_and_upserts_the_training_file():
+    mesh = FakeMesh({"Doc/Routing": _doc("Doc/Routing", "Message Routing"),
+                     "Doc/Layout": _doc("Doc/Layout", "Layout Areas")})
+    result = await collect(mesh, query="namespace:Doc", target="PythonDemo/FineTune/TrainingData")
+    assert result["documents"] == 2
+    assert result["records"] >= 4                              # 1 page + 2 sections per doc
+    (node,) = mesh.upserts
+    assert node["namespace"] + "/" + node["id"] == "PythonDemo/FineTune/TrainingData"
+    assert len(from_jsonl(text_from_node(node))) == result["records"]
+
+
+async def test_collect_with_no_usable_docs_raises():
+    mesh = FakeMesh({"Doc/Empty": {"path": "Doc/Empty", "name": "Empty", "content": {}}})
+    with pytest.raises(RuntimeError):
+        await collect(mesh, query="namespace:Doc")
+
+
+# ---- train: the file in content -> tuner -> progress back onto the run node ------------------------
+
+async def test_train_pulls_the_file_streams_progress_and_reports_success():
+    records = training_records([_doc("Doc/Routing", "Message Routing")])
+    data = training_data_node("PythonDemo/FineTune/TrainingData", to_jsonl(records),
+                              "namespace:Doc", len(records))
+    mesh = FakeMesh({"PythonDemo/FineTune/TrainingData": data})
+    seen: dict[str, Any] = {}
+
+    def fake_tuner(recs: list[dict[str, Any]], *, on_progress: Any, **hp: Any) -> dict[str, Any]:
+        seen["records"] = recs
+        seen["hp"] = hp
+        on_progress("step 10: loss 2.5000")                    # from the trainer thread
+        on_progress("step 20: loss 1.2500")
+        return {"train_loss": 1.25, "steps": 20, "output_dir": hp["output_dir"]}
+
+    result = await train(mesh, run_path="PythonDemo/FineTune/Runs/test", tuner=fake_tuner)
+
+    assert seen["records"] == records                          # decoded from the content file
+    assert seen["hp"]["model"]
+    assert result["run_path"] == "PythonDemo/FineTune/Runs/test"
+    (run,) = mesh.upserts                                      # the run node was created first
+    assert run["namespace"] + "/" + run["id"] == "PythonDemo/FineTune/Runs/test"
+    # Progress and the final verdict were streamed onto the run node (python -> mesh).
+    bodies = [f["content"]["content"] for p, f in mesh.patches if p == "PythonDemo/FineTune/Runs/test"]
+    assert any("step 10: loss 2.5000" in b for b in bodies)
+    assert "Succeeded" in bodies[-1] and "1.2500" in bodies[-1]
+
+
+async def test_train_failure_lands_on_the_run_node_and_raises():
+    records = training_records([_doc("Doc/Routing", "Message Routing")])
+    data = training_data_node("PythonDemo/FineTune/TrainingData", to_jsonl(records),
+                              "namespace:Doc", len(records))
+    mesh = FakeMesh({"PythonDemo/FineTune/TrainingData": data})
+
+    def broken_tuner(recs: list[dict[str, Any]], **hp: Any) -> dict[str, Any]:
+        raise RuntimeError("CUDA out of memory")
+
+    with pytest.raises(RuntimeError, match="CUDA out of memory"):
+        await train(mesh, run_path="PythonDemo/FineTune/Runs/test", tuner=broken_tuner)
+    assert "Failed" in mesh.patches[-1][1]["content"]["content"]

--- a/clients/python/tests/test_mesh.py
+++ b/clients/python/tests/test_mesh.py
@@ -1,74 +1,198 @@
-"""Mesh ops compose correctly over the connection primitives — driven by a duck-typed fake connection
-(no gRPC channel needed), the Python analog of the web client's in-memory-transport tests."""
+"""Mesh ops against the PINNED portal contracts: the REST verb surface (``/api/mesh/*`` — the
+transport-mirror of MeshOperations) and the gRPC synchronization protocol for live node streams
+(SubscribeRequest → DataChangedEvent Full/Patch → UnsubscribeRequest). Driven by duck-typed fakes;
+the same shapes are confirmed live in the portal smoke run (see README status)."""
+import json
 from typing import Any, AsyncIterator
 
+import pytest
+
 from meshweaver.envelope import Delivery
-from meshweaver.mesh import Mesh
+from meshweaver.mesh import Mesh, MeshError, apply_json_patch, merge_patch
 
 
-def _delivery(message_type: str, message: dict[str, Any]) -> Delivery:
-    return Delivery(id=None, sender=None, target=None, request_id=None, message_type=message_type, message=message, raw={})
+class FakeRest:
+    """Records every verb call and answers with canned portal responses."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.responses: dict[str, str] = {}
+
+    async def post(self, verb: str, body: dict[str, Any]) -> str:
+        self.calls.append((verb, body))
+        return self.responses.get(verb, '{"status":"ok"}')
 
 
 class FakeConn:
-    """Records observe/post calls and answers them the way the mesh hub would."""
+    """The gRPC-connection half: yields a scripted change stream, records posts."""
 
-    def __init__(self) -> None:
-        self.observed: list[tuple[str, str, dict[str, Any]]] = []
+    address = "py/test"
+
+    def __init__(self, deliveries: list[Delivery]) -> None:
+        self.deliveries = deliveries
         self.posted: list[tuple[str, str, dict[str, Any]]] = []
+        self.subscribed: list[tuple[str, str, dict[str, Any]]] = []
 
-    async def observe(self, target: str, message_type: str, message: dict[str, Any], *args: Any, **kw: Any) -> Delivery:
-        self.observed.append((target, message_type, message))
-        if message_type == "QueryRequest":
-            return _delivery("QueryResponse", {"results": [{"path": "ACME/Stories/1", "name": "S1"}]})
-        if message_type == "CreateNodeRequest":
-            return _delivery("CreateNodeResponse", {"path": message["node"].get("path")})
-        return _delivery(message_type.replace("Request", "Response"), {"status": "ok"})
-
-    async def post(self, *, target: str, message_type: str, message: dict[str, Any]) -> None:
+    async def post(self, target: str, message_type: str, message: dict[str, Any], access_context: Any = None) -> None:
         self.posted.append((target, message_type, message))
 
-    async def subscribe(self, *, target: str, stream_id: str, subscribe_type: str, subscribe_msg: dict[str, Any]) -> AsyncIterator[Delivery]:
-        path = subscribe_msg["reference"]["path"]
-        yield _delivery("DataChangedEvent", {"path": path, "content": {"done": False}})
+    async def subscribe(self, *, target: str, stream_id: str, subscribe_type: str,
+                        subscribe_msg: dict[str, Any]) -> AsyncIterator[Delivery]:
+        self.subscribed.append((target, subscribe_type, {**subscribe_msg, "streamId": stream_id}))
+        for d in self.deliveries:
+            yield d
+
+    async def close(self) -> None:
+        pass
 
 
-async def test_search_returns_results():
-    mesh = Mesh(FakeConn())
-    results = await mesh.search("nodeType:Story namespace:ACME")
+def _change(change_type: str, change: Any, version: int = 1, stream_id: str = "s1") -> Delivery:
+    return Delivery(
+        id="d1", sender="ACME/X", target="py/test", request_id=None,
+        message_type="DataChangedEvent",
+        message={"$type": "DataChangedEvent", "streamId": stream_id, "version": version,
+                 "change": change, "changeType": change_type, "changedBy": None},
+        raw={})
+
+
+# ---- the client-side folds --------------------------------------------------------------------------
+
+def test_merge_patch_is_rfc7396():
+    base = {"a": 1, "b": {"x": 1, "y": 2}, "c": 3}
+    assert merge_patch(base, {"b": {"y": None, "z": 9}, "c": 4}) == {"a": 1, "b": {"x": 1, "z": 9}, "c": 4}
+    assert merge_patch(base, "scalar") == "scalar"
+
+
+def test_apply_json_patch_is_rfc6902():
+    base = {"content": {"content": "old", "keep": 1}, "version": 5}
+    # The exact op shape captured on the live wire (2026-07-03).
+    ops = [{"op": "replace", "path": "/content/content", "value": "new"},
+           {"op": "replace", "path": "/version", "value": 6},
+           {"op": "add", "path": "/description", "value": "d"},
+           {"op": "remove", "path": "/content/keep"}]
+    assert apply_json_patch(base, ops) == {
+        "content": {"content": "new"}, "version": 6, "description": "d"}
+    # The input is NOT mutated (folds must be pure — the previous state may still be referenced).
+    assert base["content"]["keep"] == 1
+
+
+# ---- REST verbs (the /api/mesh surface) -------------------------------------------------------------
+
+async def test_search_posts_the_search_verb_and_unwraps_results():
+    rest = FakeRest()
+    rest.responses["search"] = json.dumps(
+        {"count": 1, "limit": 50, "truncated": False,
+         "results": [{"path": "ACME/Stories/1", "name": "S1", "nodeType": "Story"}]})
+    results = await Mesh(rest=rest).search("nodeType:Story", base_path="ACME")
     assert results[0]["path"] == "ACME/Stories/1"
+    verb, body = rest.calls[0]
+    assert verb == "search"
+    assert body == {"query": "nodeType:Story", "basePath": "ACME", "limit": 50}
 
 
-async def test_get_reads_first_node_state():
-    node = await Mesh(FakeConn()).get("ACME/Stories/42")
-    assert node.path == "ACME/Stories/42"
+async def test_query_nodes_returns_full_payloads():
+    rest = FakeRest()
+    rest.responses["query-nodes"] = json.dumps(
+        {"count": 1, "results": [{"path": "ACME/X", "content": {"done": False}}]})
+    results = await Mesh(rest=rest).query_nodes("path:ACME/*")
+    assert results[0]["content"] == {"done": False}
+
+
+async def test_get_uses_rest_when_configured():
+    rest = FakeRest()
+    rest.responses["get"] = json.dumps({"path": "ACME/X", "name": "X", "content": {"done": False}})
+    node = await Mesh(rest=rest).get("ACME/X")
+    assert node.path == "ACME/X"
     assert node.content["done"] is False
 
 
-async def test_patch_posts_partial_update():
-    conn = FakeConn()
-    await Mesh(conn).patch("ACME/X", {"content": {"done": True}})
-    target, message_type, message = conn.posted[0]
-    assert target == "ACME/X"
-    assert message_type == "PatchDataRequest"
-    assert message["change"] == {"content": {"done": True}}
+async def test_patch_serializes_fields_as_a_json_string():
+    rest = FakeRest()
+    await Mesh(rest=rest).patch("ACME/X", {"content": {"done": True}})
+    verb, body = rest.calls[0]
+    assert verb == "patch"
+    assert body["path"] == "ACME/X"
+    assert json.loads(body["fields"]) == {"content": {"done": True}}
 
 
-async def test_create_returns_response_and_lifecycle_ops_route_to_mesh():
-    conn = FakeConn()
-    mesh = Mesh(conn)
-    resp = await mesh.create({"path": "ACME/New", "nodeType": "Story"})
-    assert resp["path"] == "ACME/New"
+async def test_lifecycle_verbs_route_to_their_endpoints():
+    rest = FakeRest()
+    mesh = Mesh(rest=rest)
+    await mesh.create({"path": "ACME/New"})
+    await mesh.update([{"path": "ACME/New"}])
     await mesh.delete("ACME/Old")
     await mesh.move("ACME/A", "ACME/B")
-    await mesh.copy("ACME/A", "ACME/C")
-    types = [mt for _, mt, _ in conn.observed]
-    assert {"CreateNodeRequest", "DeleteNodeRequest", "MoveNodeRequest", "CopyNodeRequest"} <= set(types)
+    await mesh.copy("ACME/A", "Elsewhere")
+    verbs = [v for v, _ in rest.calls]
+    assert verbs == ["create", "update", "delete", "move", "copy"]
+    assert json.loads(rest.calls[2][1]["paths"]) == ["ACME/Old"]   # delete takes a JSON array
+    assert rest.calls[3][1] == {"sourcePath": "ACME/A", "targetPath": "ACME/B"}
+    assert rest.calls[4][1] == {"sourcePath": "ACME/A", "targetNamespace": "Elsewhere"}
 
 
-async def test_execute_flips_requested_status():
-    conn = FakeConn()
-    await Mesh(conn).execute("ACME/Jobs/import")
-    target, message_type, message = conn.posted[0]
-    assert message_type == "PatchDataRequest"
-    assert message["change"]["requestedStatus"] == "Running"
+async def test_create_or_update_falls_back_to_update_on_already_exists():
+    class ExistsRest(FakeRest):
+        async def post(self, verb: str, body: dict[str, Any]) -> str:
+            await super().post(verb, body)
+            if verb == "create":
+                return "Error: node at ACME/X already exists."
+            return "Updated ACME/X"
+
+    rest = ExistsRest()
+    result = await Mesh(rest=rest).create_or_update({"path": "ACME/X"})
+    assert result == "Updated ACME/X"
+    assert [v for v, _ in rest.calls] == ["create", "update"]
+
+
+async def test_error_sentinels_raise_mesh_error():
+    rest = FakeRest()
+    rest.responses["get"] = "Not found: ACME/Missing"
+    with pytest.raises(MeshError, match="Not found"):
+        await Mesh(rest=rest).get("ACME/Missing")
+
+
+async def test_execute_flips_the_control_plane_trigger():
+    rest = FakeRest()
+    await Mesh(rest=rest).execute("ACME/Jobs/import")
+    verb, body = rest.calls[0]
+    assert verb == "patch"
+    assert json.loads(body["fields"]) == {"content": {"requestedStatus": "Running"}}
+
+
+# ---- watch: the synchronization protocol over the participant connection ----------------------------
+
+async def test_watch_speaks_the_sync_protocol_and_folds_changes():
+    conn = FakeConn([
+        _change("Full", {"path": "ACME/X", "name": "X", "content": {"done": False, "n": 1}}, version=1),
+        _change("Full", {"path": "ACME/X", "name": "X", "content": {"done": False, "n": 1}}, version=1),
+        # Patch frames are RFC 6902 op arrays on the live wire; duplicates share the version.
+        _change("Patch", [{"op": "replace", "path": "/content/done", "value": True}], version=2),
+        _change("Patch", [{"op": "replace", "path": "/content/done", "value": True}], version=2),
+    ])
+    seen = []
+    async for node in Mesh(conn).watch("ACME/X"):
+        seen.append(node)
+
+    # SubscribeRequest went to the node's own address with a MeshNodeReference + our subscriber address.
+    target, subscribe_type, msg = conn.subscribed[0]
+    assert target == "ACME/X"
+    assert subscribe_type == "SubscribeRequest"
+    assert msg["reference"] == {"$type": "MeshNodeReference"}
+    assert msg["subscriber"] == "py/test"
+    assert msg["streamId"]
+
+    # Full replaces, Patch op-folds — content.n survives; duplicated frames dedup by version.
+    assert [n.content for n in seen] == [{"done": False, "n": 1}, {"done": True, "n": 1}]
+
+    # The stream is released on exit.
+    target, message_type, message = conn.posted[-1]
+    assert (target, message_type) == ("ACME/X", "UnsubscribeRequest")
+    assert message["streamId"] == msg["streamId"]
+
+
+async def test_get_without_rest_takes_one_snapshot_off_the_stream():
+    conn = FakeConn([_change("Full", {"path": "ACME/X", "content": {"done": False}})])
+    node = await Mesh(conn).get("ACME/X")
+    assert node.path == "ACME/X"
+    # Even a single-snapshot get unsubscribes cleanly.
+    assert conn.posted[-1][1] == "UnsubscribeRequest"

--- a/clients/python/tests/test_pandas_node.py
+++ b/clients/python/tests/test_pandas_node.py
@@ -11,6 +11,8 @@ from meshweaver.examples.pandas_node import (
     GRID_TYPE,
     PandasNode,
     RecordingConnection,
+    csv_from_markdown,
+    csv_from_node,
     frame_to_datagrid,
     run_demo,
     sample_sales_frame,
@@ -113,6 +115,58 @@ async def test_unknown_command_replies_error_never_raises():
     assert "unknown command" in payload["error"]
 
 
+# ---- a file kept in content: `load path=…` reads the CSV node over the mesh -----------------------
+
+SALES_MARKDOWN = (
+    "# Sales Data\n\nMonthly sales by region — a file kept in content.\n\n"
+    "```csv\nmonth,region,sales,units\nJan,EMEA,120.0,12\nFeb,APAC,98.0,9\n```\n"
+)
+
+
+def test_csv_from_markdown_extracts_the_fenced_block():
+    csv = csv_from_markdown(SALES_MARKDOWN)
+    assert csv.startswith("month,region,sales,units")
+    assert csv.endswith("Feb,APAC,98.0,9")
+    # A node storing the bare CSV (no fence, no prose) works too.
+    assert csv_from_markdown("a,b\n1,2\n") == "a,b\n1,2"
+
+
+def test_csv_from_node_handles_markdown_document_and_raw_string_content():
+    doc_node = {"path": "PythonDemo/SalesData",
+                "content": {"$type": "MarkdownContent", "content": SALES_MARKDOWN}}
+    assert csv_from_node(doc_node).startswith("month,region")
+    assert csv_from_node({"content": "a,b\n1,2"}) == "a,b\n1,2"
+    with pytest.raises(ValueError):
+        csv_from_node({"content": None})
+
+
+async def test_load_with_path_reads_the_content_file_over_the_mesh():
+    conn = RecordingConnection()
+    reads: list[str] = []
+
+    async def read_node(path: str) -> dict:
+        reads.append(path)
+        return {"path": path, "content": {"$type": "MarkdownContent", "content": SALES_MARKDOWN}}
+
+    node = PandasNode(conn, node_reader=read_node)
+    mtype, ack = await conn.send_command(node, "load", path="PythonDemo/SalesData")
+    assert mtype == "PandasAck"
+    assert reads == ["PythonDemo/SalesData"]        # the participant fetched the node itself
+    assert ack["source"] == "PythonDemo/SalesData"
+    assert ack["rowCount"] == 2
+    # read_csv parsed real dtypes: floats stay numeric, so groupby/rolling work downstream.
+    assert list(node.dataframe["region"]) == ["EMEA", "APAC"]
+    assert float(node.dataframe["sales"].sum()) == 120.0 + 98.0
+
+
+async def test_load_with_path_without_mesh_connection_replies_error():
+    conn = RecordingConnection()                    # no `subscribe` -> no node reader
+    node = PandasNode(conn)
+    mtype, payload = await conn.send_command(node, "load", path="PythonDemo/SalesData")
+    assert mtype == "PandasError"
+    assert "no mesh connection" in payload["error"]
+
+
 # ---- the code surface: the frame persists across SubmitCodeRequests -------------------------------
 
 async def test_submit_code_persists_frame_state_across_calls():
@@ -136,7 +190,8 @@ async def test_submit_code_writes_back_to_activity_node():
     target, mtype, message = conn.posts[0]
     assert target == "ACME/_Activity/1"
     assert mtype == "PatchDataRequest"
-    content = message["change"]["content"]
+    assert message["reference"] == {"$type": "MeshNodeReference"}
+    content = message["patch"]["content"]
     assert content["status"] == "Succeeded"
     assert content["returnValue"] == 6
     assert any("rows: 6" in m["message"] for m in content["messages"])

--- a/clients/python/tests/test_standalone_hub.py
+++ b/clients/python/tests/test_standalone_hub.py
@@ -1,0 +1,105 @@
+"""The standalone Python hub: handler dispatch by message type (the C# WithHandler<T> mirror),
+error propagation instead of wedging, and the load-from-mesh / save-back-to-mesh loop — all driven
+through recording fakes, the same duck-typing the other example tests use."""
+from typing import Any
+
+from meshweaver.envelope import Delivery
+from meshweaver.examples.standalone_hub import (
+    DemoMesh,
+    NamespaceStatsHub,
+    PyHub,
+    RecordingConnection,
+    run_demo,
+)
+
+
+def _delivery(message_type: str, message: dict[str, Any] | None = None) -> Delivery:
+    return Delivery(id="d1", sender="py/caller", target="py/stats", request_id=None,
+                    message_type=message_type, message={"$type": message_type, **(message or {})}, raw={})
+
+
+# ---- PyHub: the hub programming model ---------------------------------------------------------------
+
+async def test_registered_handler_answers_with_a_correlated_response():
+    conn = RecordingConnection()
+    hub = PyHub(conn)
+
+    async def on_ping(delivery: Delivery):
+        return "PongResponse", {"echo": delivery.message.get("text")}
+
+    hub.register("PingRequest", on_ping)
+    await hub.handle(_delivery("PingRequest", {"text": "hello"}))
+    assert conn.responses == [("PongResponse", {"echo": "hello"})]
+
+
+async def test_unregistered_message_types_are_ignored():
+    conn = RecordingConnection()
+    PyHub(conn)
+    await conn._handler(_delivery("SomeoneElsesRequest"))
+    assert conn.responses == []
+
+
+async def test_raising_handler_answers_error_response_never_wedges():
+    conn = RecordingConnection()
+    hub = PyHub(conn)
+
+    async def broken(delivery: Delivery):
+        raise ValueError("bad input")
+
+    hub.register("PingRequest", broken)
+    await hub.handle(_delivery("PingRequest"))
+    message_type, payload = conn.responses[0]
+    assert message_type == "ErrorResponse"
+    assert "ValueError: bad input" in payload["error"]
+
+
+# ---- NamespaceStatsHub: load from the mesh, serve, save back ----------------------------------------
+
+async def test_load_reads_the_namespace_into_hub_state_and_stats_summarise_it():
+    hub = NamespaceStatsHub(RecordingConnection(), DemoMesh(), "PythonDemo")
+    stats = await hub.load()
+    assert stats["nodeCount"] == 3
+    assert stats["byNodeType"] == {"Markdown": 1, "NodeType": 2}
+    assert stats["contentWords"] > 0
+
+
+async def test_stats_request_is_served_from_held_state():
+    conn = RecordingConnection()
+    hub = NamespaceStatsHub(conn, DemoMesh(), "PythonDemo")
+    await hub.load()
+    message_type, stats = await conn.deliver("NamespaceStatsRequest")
+    assert message_type == "NamespaceStatsResponse"
+    assert stats["namespace"] == "PythonDemo"
+    assert stats["nodeCount"] == 3
+
+
+async def test_reload_rereads_the_mesh():
+    conn = RecordingConnection()
+    mesh = DemoMesh()
+    hub = NamespaceStatsHub(conn, mesh, "PythonDemo")
+    await hub.load()
+    mesh.nodes["PythonDemo/New"] = {"path": "PythonDemo/New", "nodeType": "Markdown",
+                                    "content": {"content": "fresh"}}
+    _, stats = await conn.deliver("ReloadRequest")
+    assert stats["nodeCount"] == 4
+
+
+async def test_save_report_writes_the_knowledge_back_to_the_mesh():
+    mesh = DemoMesh()
+    hub = NamespaceStatsHub(RecordingConnection(), mesh, "PythonDemo")
+    await hub.load()
+    path = await hub.save_report()
+    assert path == "PythonDemo/PythonHubReport"
+    (report,) = mesh.upserts
+    assert report["namespace"] == "PythonDemo"
+    assert report["id"] == "PythonHubReport"
+    body = report["content"]["content"]
+    assert "**Nodes:** 3" in body
+    assert "| Markdown | 1 |" in body
+
+
+async def test_run_demo_is_the_full_loop():
+    result = await run_demo()
+    assert result["stats"]["nodeCount"] == 3
+    assert result["report_path"] == "PythonDemo/PythonHubReport"
+    assert result["report"]["nodeType"] == "Markdown"

--- a/clients/python/tests/test_worker.py
+++ b/clients/python/tests/test_worker.py
@@ -43,25 +43,28 @@ def test_error_is_captured_not_raised():
 class FakeConn:
     def __init__(self) -> None:
         self.posts: list[tuple[str, str, dict[str, Any]]] = []
+        self.post_contexts: list[Any] = []
         self.responses: list[tuple[Delivery, str, dict[str, Any]]] = []
         self.handler = None
 
     def serve(self, handler) -> None:
         self.handler = handler
 
-    async def post(self, target: str, message_type: str, message: dict[str, Any]) -> None:
+    async def post(self, target: str, message_type: str, message: dict[str, Any], access_context: Any = None) -> None:
         self.posts.append((target, message_type, message))
+        self.post_contexts.append(access_context)
 
     async def respond(self, to: Delivery, message_type: str, message: dict[str, Any]) -> None:
         self.responses.append((to, message_type, message))
 
 
-def _submit(code: str, activity: str = "ACME/_Activity/1") -> Delivery:
+def _submit(code: str, activity: str = "ACME/_Activity/1", access_context: Any = None) -> Delivery:
     return Delivery(
         id="req-1", sender="@code/ACME/Source/1", target="py/python-kernel", request_id=None,
         message_type="SubmitCodeRequest",
         message={"$type": "SubmitCodeRequest", "code": code, "activityLogPath": activity},
         raw={},
+        access_context=access_context,
     )
 
 
@@ -79,7 +82,8 @@ async def test_handle_executes_and_writes_back_to_activity():
     target, message_type, message = conn.posts[0]
     assert target == "ACME/_Activity/1"
     assert message_type == "PatchDataRequest"
-    content = message["change"]["content"]
+    assert message["reference"] == {"$type": "MeshNodeReference"}
+    content = message["patch"]["content"]
     assert content["status"] == "Succeeded"
     assert content["returnValue"] == 42
     assert any("hi" in m["message"] for m in content["messages"])
@@ -92,9 +96,19 @@ async def test_handle_executes_and_writes_back_to_activity():
 async def test_handle_reports_failure_status():
     conn = FakeConn()
     await CodeWorker(conn).handle(_submit("raise ValueError('boom')"))
-    content = conn.posts[0][2]["change"]["content"]
+    content = conn.posts[0][2]["patch"]["content"]
     assert content["status"] == "Failed"
     assert any("ValueError" in m["message"] for m in content["messages"])
+
+
+async def test_write_back_echoes_the_requesters_access_context():
+    # On the TRUSTED loopback endpoint the server passes a carried accessContext through, so the
+    # gate's activity write-back must echo the identity of the user whose Code node this run is —
+    # the worker acts on the user's behalf, like the in-process C# kernel.
+    conn = FakeConn()
+    requester = {"$type": "AccessContext", "objectId": "alice", "name": "Alice"}
+    await CodeWorker(conn).handle(_submit("1 + 1", access_context=requester))
+    assert conn.post_contexts == [requester]
 
 
 async def test_handle_ignores_non_submit_requests():

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -14,6 +14,21 @@ data:
   MEMEX_JDBCCONNECTIONSTRING: "{{ .Values.config.memex_portal.MEMEX_JDBCCONNECTIONSTRING }}"
   MEMEX_DATABASENAME: "{{ .Values.config.memex_portal.MEMEX_DATABASENAME }}"
   ASPNETCORE_HTTP_PORTS: "{{ .Values.config.memex_portal.ASPNETCORE_HTTP_PORTS }}"
+{{- if (.Values.grpc).enabled }}
+  # ---- Native gRPC (HTTP/2) — see .Values.grpc ------------------------------
+  # Explicit Kestrel endpoints (these OVERRIDE ASPNETCORE_HTTP_PORTS, so the web port is
+  # restated): the web port stays HTTP/1.1+2 defaults; the gRPC port is h2c (Http2-only —
+  # cleartext HTTP/2 needs prior knowledge, which requires a dedicated endpoint); the trusted
+  # port binds loopback so ONLY same-pod containers (the shipped gates) can reach it.
+  ASPNETCORE_Kestrel__Endpoints__Http__Url: "http://0.0.0.0:{{ .Values.config.memex_portal.ASPNETCORE_HTTP_PORTS | default 8080 }}"
+  ASPNETCORE_Kestrel__Endpoints__Grpc__Url: "http://0.0.0.0:{{ .Values.grpc.port }}"
+  ASPNETCORE_Kestrel__Endpoints__Grpc__Protocols: "Http2"
+  ASPNETCORE_Kestrel__Endpoints__GrpcTrusted__Url: "http://127.0.0.1:{{ .Values.grpc.trustedPort }}"
+  ASPNETCORE_Kestrel__Endpoints__GrpcTrusted__Protocols: "Http2"
+  # The server-side trust discriminator (GrpcOptions): a connection whose local port is this one
+  # authenticates as a trusted co-deployed service.
+  Grpc__TrustedPort: "{{ .Values.grpc.trustedPort }}"
+{{- end }}
   Deployment__Backend: "{{ .Values.config.memex_portal.Deployment__Backend }}"
   Deployment__DataRoot: "{{ .Values.config.memex_portal.Deployment__DataRoot }}"
   Deployment__Orleans__Clustering: "{{ .Values.config.memex_portal.Deployment__Orleans__Clustering }}"
@@ -30,7 +45,7 @@ data:
   # InstanceColor is the badge fill (hex, e.g. "#f59e0b"); empty = amber default.
   Portal__InstanceName: "{{ .Values.config.memex_portal.Portal__InstanceName | default "" }}"
   Portal__InstanceColor: "{{ .Values.config.memex_portal.Portal__InstanceColor | default "" }}"
-{{- if .Values.portalNext.enabled }}
+{{- if (.Values.portalNext).enabled }}
   # ---- Next.js React frontend (FEATURE-FLAGGED — see .Values.portalNext) -----
   # Non-empty ReactAppUrl is what enables FrontendSelection: it shows the user
   # menu's "Try the new frontend" entry, activates the /frontend/{react|blazor}

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -56,6 +56,12 @@ spec:
             - name: "http"
               protocol: "TCP"
               containerPort: 8080
+{{- if (.Values.grpc).enabled }}
+            # Public h2c gRPC (the trusted port binds 127.0.0.1 and is same-pod only — not listed).
+            - name: "grpc"
+              protocol: "TCP"
+              containerPort: {{ .Values.grpc.port }}
+{{- end }}
           volumeMounts:
             - name: "memex-data"
               mountPath: "/data"

--- a/deploy/helm/templates/memex-portal/ingress.yaml
+++ b/deploy/helm/templates/memex-portal/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
-{{- if .Values.portalNext.enabled }}
+{{- if (.Values.portalNext).enabled }}
           # ---- Next.js React GUI (FEATURE-FLAGGED — see .Values.portalNext) ---
           # nginx matches the LONGEST prefix first regardless of order, so /next/*
           # (the app + its /next/_next assets) hits portal-next while everything
@@ -50,4 +50,45 @@ spec:
                 name: "memex-portal-service"
                 port:
                   number: {{ .Values.config.memex_portal.ASPNETCORE_HTTP_PORTS | default 8080 }}
+{{- if (.Values.grpc).enabled }}
+# ---- Native gRPC on the SAME host (backend-protocol is per-Ingress-resource) ----
+# ONLY the bidi participant connection (meshweaver.v1.Mesh/Open) is native gRPC — a second Ingress
+# on the same host routes exactly that method to the portal's h2c gRPC port with backend-protocol
+# GRPC, so participants connect to the ordinary portal URL over TLS (nginx serves HTTP/2 on 443),
+# no extra DNS or certs. 🚨 Deliberately NOT the whole /meshweaver.v1.Mesh prefix: the gRPC-WEB
+# split (Connect + Deliver — the React GUI's browser transport) shares that prefix but is
+# HTTP/1.1, and grpc_pass would break it; it keeps falling through to the web ingress above.
+---
+apiVersion: "networking.k8s.io/v1"
+kind: "Ingress"
+metadata:
+  name: "memex-portal-grpc-ingress"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "memex-portal"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    # Long-lived bidi streams (the participant connection IS one Open stream) — keep the proxy
+    # from idling them out.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+spec:
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tlsSecret | quote }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: "/meshweaver.v1.Mesh/Open"
+            pathType: "Exact"
+            backend:
+              service:
+                name: "memex-portal-service"
+                port:
+                  number: {{ .Values.grpc.port }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/templates/memex-portal/portal-next.yaml
+++ b/deploy/helm/templates/memex-portal/portal-next.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.portalNext.enabled }}
+{{- if (.Values.portalNext).enabled }}
 # ---- Next.js React portal (FEATURE-FLAGGED frontend) -----------------------
 # A Next.js streaming-SSR build of clients/portal-next, served at /next beside the
 # Blazor portal (the portal ingress routes /next → this Service; see ingress.yaml).

--- a/deploy/helm/templates/memex-portal/service.yaml
+++ b/deploy/helm/templates/memex-portal/service.yaml
@@ -18,3 +18,11 @@ spec:
       protocol: "TCP"
       port: 8080
       targetPort: 8080
+{{- if (.Values.grpc).enabled }}
+    # Native gRPC (h2c) for foreign-language participants — see .Values.grpc. The trusted
+    # loopback port (grpc.trustedPort) is deliberately NOT exposed here: it is same-pod only.
+    - name: "grpc"
+      protocol: "TCP"
+      port: {{ .Values.grpc.port }}
+      targetPort: {{ .Values.grpc.port }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -23,6 +23,21 @@ ollama:
     enabled: false
     host: ""        # cluster host-gateway IP of the host running Ollama
     port: 11434
+# ---- Native gRPC (HTTP/2) for foreign-language participants ---------------
+# The mesh gRPC service (meshweaver.v1.Mesh/Open — the bidi participant connection the Python /
+# Node SDKs use) needs real HTTP/2 end-to-end; the browser path (HTTP/1.1 + gRPC-web) is not
+# enough. Enabled: Kestrel gets TWO extra endpoints beside the 8080 web port —
+#   * port (8081): PUBLIC h2c gRPC, exposed via the service and (when ingress.enabled) a same-host
+#     ingress whose /meshweaver.v1.Mesh path proxies with backend-protocol GRPC — so participants
+#     connect to the ordinary portal URL over TLS, no extra DNS or certs.
+#   * trustedPort (8082): TRUSTED endpoint bound to 127.0.0.1 — reachable ONLY from containers in
+#     the portal's own pod (the shipped node / bun / python gates). Reachability IS the
+#     authentication: no API token, nothing to rotate; deliveries may carry through the requesting
+#     user's AccessContext (see GrpcOptions.TrustedPort).
+grpc:
+  enabled: true
+  port: 8081
+  trustedPort: 8082
 # ---- Portal Ingress (TLS via an ingress controller) -----------------------
 # Off by default (cloud envs wire ingress/TLS their own way). A self-host overlay
 # enables it with a hostname + a pre-created TLS secret. The proxy-*-timeout

--- a/samples/Graph/Data/PythonDemo/PandasExplorer/LiveFrame.json
+++ b/samples/Graph/Data/PythonDemo/PandasExplorer/LiveFrame.json
@@ -8,6 +8,7 @@
   "content": {
     "$type": "PandasExplorer",
     "name": "Live sales frame",
-    "description": "Monthly sales by region, held live in a Python pandas DataFrame."
+    "description": "Monthly sales by region, held live in a Python pandas DataFrame.",
+    "sourcePath": "PythonDemo/SalesData"
   }
 }

--- a/samples/Graph/Data/PythonDemo/PandasExplorer/Source/PandasExplorer.cs
+++ b/samples/Graph/Data/PythonDemo/PandasExplorer/Source/PandasExplorer.cs
@@ -14,11 +14,14 @@ using MeshWeaver.Messaging;
 /// Content of a <c>PandasExplorer</c> node — the marker record for the interactive frontend
 /// (<see cref="PandasExplorerLayoutAreas"/>) that DRIVES the Python <c>py/pandas</c> participant
 /// (<c>clients/python/meshweaver/examples/pandas_node.py</c>). The node holds no data itself; the
-/// live <c>pandas.DataFrame</c> lives in the Python process. This record only carries the display
-/// name so the node is addressable and browsable.
+/// live <c>pandas.DataFrame</c> lives in the Python process and is fed from
+/// <see cref="SourcePath"/> — a CSV file kept in mesh content.
 /// </summary>
 public record PandasExplorer
 {
+    /// <summary>The CSV file kept in content that feeds the frame when no per-node override is set.</summary>
+    public const string DefaultSourcePath = "PythonDemo/SalesData";
+
     /// <summary>Display name of the explorer node (mirrored onto <see cref="MeshNode.Name"/>).</summary>
     [Required]
     [MeshNodeProperty(nameof(MeshNode.Name))]
@@ -26,6 +29,13 @@ public record PandasExplorer
 
     /// <summary>Optional blurb rendered above the interactive controls.</summary>
     public string? Description { get; init; }
+
+    /// <summary>
+    /// Mesh path of the CSV file kept in content that the <em>Load</em> button feeds to the Python
+    /// participant (which reads the node over the mesh and parses it with <c>pandas.read_csv</c>).
+    /// Point different explorer instances at different data files.
+    /// </summary>
+    public string SourcePath { get; init; } = DefaultSourcePath;
 }
 
 /// <summary>
@@ -40,6 +50,13 @@ public record PandasCommand : IRequest<DataGridControl>
 {
     /// <summary>Command verb: <c>load</c>, <c>append</c>, <c>reset</c>, <c>render</c>, <c>groupby</c>, <c>rolling</c> or <c>describe</c>.</summary>
     public string Command { get; init; } = "render";
+
+    /// <summary>
+    /// For <c>load</c>: mesh path of a CSV file kept in content. The participant reads that node over
+    /// the mesh (mesh → Python) and replaces the held frame with the parsed CSV. Takes precedence
+    /// over inline <see cref="Data"/>.
+    /// </summary>
+    public string? Path { get; init; }
 
     /// <summary>Group-by column for <c>groupby</c>.</summary>
     public string? By { get; init; }
@@ -59,28 +76,20 @@ public record PandasCommand : IRequest<DataGridControl>
     /// <summary>Records to replace the frame with for <c>load</c>.</summary>
     public object[]? Data { get; init; }
 
-    /// <summary>A monthly sales frame across two regions — the same showcase dataset the Python demo seeds.</summary>
-    public static object[] SampleSales() =>
-    [
-        new { month = "Jan", region = "EMEA", sales = 120.0, units = 12 },
-        new { month = "Feb", region = "EMEA", sales = 135.5, units = 14 },
-        new { month = "Mar", region = "EMEA", sales = 128.0, units = 13 },
-        new { month = "Apr", region = "APAC", sales = 98.0, units = 9 },
-        new { month = "May", region = "APAC", sales = 143.0, units = 15 },
-        new { month = "Jun", region = "APAC", sales = 150.0, units = 16 },
-    ];
+    /// <summary>
+    /// Replace the held frame with a CSV file kept in mesh content: the participant reads the node at
+    /// <paramref name="path"/> and parses its CSV — the data never travels through the frontend.
+    /// </summary>
+    public static PandasCommand LoadFrom(string path) => new() { Command = "load", Path = path };
 
-    /// <summary>Replace the held frame with the sample sales data.</summary>
-    public static PandasCommand LoadSample() => new() { Command = "load", Data = SampleSales() };
-
-    /// <summary>Append two more months over the mesh — mutates the held frame.</summary>
+    /// <summary>Append two more months over the mesh — mutates the held frame (the CSV file keeps Jan–Aug).</summary>
     public static PandasCommand AppendTwo() => new()
     {
         Command = "append",
         Rows =
         [
-            new { month = "Jul", region = "APAC", sales = 161.0, units = 17 },
-            new { month = "Aug", region = "EMEA", sales = 152.0, units = 15 },
+            new { month = "Sep", region = "APAC", sales = 161.0, units = 17 },
+            new { month = "Oct", region = "EMEA", sales = 152.0, units = 15 },
         ],
     };
 

--- a/samples/Graph/Data/PythonDemo/PandasExplorer/Source/PandasExplorerLayoutAreas.cs
+++ b/samples/Graph/Data/PythonDemo/PandasExplorer/Source/PandasExplorerLayoutAreas.cs
@@ -4,20 +4,23 @@
 // </meshweaver>
 
 using System;
+using System.Linq;
 using System.Reactive.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Layout.DataGrid;
+using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 
 /// <summary>
 /// The INTERACTIVE frontend for the Python <c>py/pandas</c> participant
 /// (<c>clients/python/meshweaver/examples/pandas_node.py</c>). A toolbar of real framework buttons +
-/// a text input DRIVE a live <c>pandas.DataFrame</c> that lives in a Python process, and the grid
-/// below shows the frame's current state as a genuine <see cref="DataGridControl"/> — never markdown
-/// or an HTML string.
+/// a text input DRIVE a live <c>pandas.DataFrame</c> that lives in a Python process — fed from a CSV
+/// file kept in mesh content (<see cref="PandasExplorer.SourcePath"/>) — and the grid below shows the
+/// frame's current state as a genuine <see cref="DataGridControl"/> — never markdown or an HTML string.
 /// <para>
 /// Everything is reactive end-to-end: a button flips a trigger in the layout-area data store, the
 /// grid sub-area re-observes it and POSTS the matching <see cref="PandasCommand"/> to <c>py/pandas</c>,
@@ -45,8 +48,10 @@ public static class PandasExplorerLayoutAreas
 
     private const string Intro =
         "This grid is rendered by a **Python** process — a `pandas.DataFrame` held live in the "
-        + "`py/pandas` mesh participant. The buttons below post `PandasCommand` messages that mutate "
-        + "and analyse that frame; the grid re-renders from whatever the Python node returns.";
+        + "`py/pandas` mesh participant, fed from a **CSV file kept in mesh content** "
+        + "(`PythonDemo/SalesData` by default). *Load* makes the participant read that node over the "
+        + "mesh and parse it with `pandas.read_csv`; the other buttons post `PandasCommand` messages "
+        + "that mutate and analyse the frame, and the grid re-renders from whatever Python returns.";
 
     private const string NoNodeText =
         "**No Python pandas node attached.**\n\n"
@@ -142,8 +147,8 @@ public static class PandasExplorerLayoutAreas
             .WithOrientation(Orientation.Horizontal)
             .WithStyle("display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin: 8px 0 16px 0;")
             // load / append MUTATE the held frame, then refresh the grid.
-            .WithView(Button("Load sample sales", Appearance.Accent,
-                ctx => Mutate(ctx.Host, PandasCommand.LoadSample())), "load")
+            .WithView(Button("Load sales CSV", Appearance.Accent,
+                ctx => LoadFromContent(ctx.Host)), "load")
             .WithView(Button("Append 2 rows", Appearance.Neutral,
                 ctx => Mutate(ctx.Host, PandasCommand.AppendTwo())), "append")
             // group-by reads the text input, then renders a grouped view.
@@ -172,6 +177,61 @@ public static class PandasExplorerLayoutAreas
     /// <summary>Flip the trigger to a new read-only view — the grid sub-area re-renders it.</summary>
     private static void View(LayoutAreaHost host, PandasViewCommand view) =>
         host.UpdateData(TriggerId, view);
+
+    /// <summary>
+    /// Load the CSV file kept in mesh content into the Python-held frame: resolve the source path from
+    /// the explorer node's content (<see cref="PandasExplorer.SourcePath"/>), then post a <c>load</c>
+    /// command carrying only the PATH — the participant reads the node over the mesh itself, so the
+    /// data never travels through the frontend.
+    /// </summary>
+    private static void LoadFromContent(LayoutAreaHost host) =>
+        SourcePath(host).Subscribe(path => Mutate(host, PandasCommand.LoadFrom(path)));
+
+    /// <summary>
+    /// The explorer node's <see cref="PandasExplorer.SourcePath"/> — one snapshot off the per-node
+    /// hub's own node stream (the same read the framework's default node areas use). Falls back to
+    /// <see cref="PandasExplorer.DefaultSourcePath"/> when the area is hosted without a node (tests,
+    /// ad-hoc layout hosts) so the button stays functional everywhere.
+    /// </summary>
+    private static IObservable<string> SourcePath(LayoutAreaHost host)
+    {
+        var nodeStream = host.Workspace.GetStream<MeshNode>();
+        if (nodeStream is null)
+            return Observable.Return(PandasExplorer.DefaultSourcePath);
+
+        var hubPath = host.Hub.Address.ToString();
+        return nodeStream
+            .Select(nodes => ExtractExplorer(nodes?.FirstOrDefault(n => n.Path == hubPath))?.SourcePath)
+            .Select(path => string.IsNullOrWhiteSpace(path) ? PandasExplorer.DefaultSourcePath : path!)
+            .Take(1)
+            .Timeout(BackendTimeout)
+            .Catch((Exception _) => Observable.Return(PandasExplorer.DefaultSourcePath));
+    }
+
+    /// <summary>
+    /// Extracts the typed content from the MeshNode, handling both the typed record and the raw
+    /// JsonElement shape (content arrives as JSON before the type is bound).
+    /// </summary>
+    private static PandasExplorer? ExtractExplorer(MeshNode? node)
+    {
+        if (node?.Content is PandasExplorer explorer)
+            return explorer;
+
+        if (node?.Content is JsonElement json)
+        {
+            try
+            {
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                return JsonSerializer.Deserialize<PandasExplorer>(json.GetRawText(), options);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
 
     /// <summary>Read the current group-by column from the input, then render the grouped view.</summary>
     private static void GroupBy(LayoutAreaHost host) =>

--- a/samples/Graph/Data/PythonDemo/SalesData.json
+++ b/samples/Graph/Data/PythonDemo/SalesData.json
@@ -1,0 +1,12 @@
+{
+  "id": "SalesData",
+  "namespace": "PythonDemo",
+  "name": "Sales Data (CSV)",
+  "nodeType": "Markdown",
+  "description": "A CSV file kept in mesh content — the data source the Python pandas participant loads over the mesh. Edit it here and reload the Pandas Explorer to see the new data.",
+  "isPersistent": true,
+  "content": {
+    "$type": "MarkdownContent",
+    "content": "# Sales Data\n\nMonthly sales by region — **a file kept in content**. The `py/pandas` participant reads this node over the mesh, parses the CSV below with `pandas.read_csv`, and serves the resulting DataFrame back to the [Pandas Explorer](@/PythonDemo/PandasExplorer/LiveFrame) as a live DataGrid.\n\n```csv\nmonth,region,sales,units\nJan,EMEA,120.0,12\nFeb,EMEA,135.5,14\nMar,EMEA,128.0,13\nApr,APAC,98.0,9\nMay,APAC,143.0,15\nJun,APAC,150.0,16\nJul,APAC,161.0,17\nAug,EMEA,152.0,15\n```\n"
+  }
+}

--- a/src/MeshWeaver.Documentation/Data/DataMesh/NodeTypes.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/NodeTypes.md
@@ -115,7 +115,15 @@ Compute a layout area's content in an external `python3` process through the bou
 
 ### [A pandas node in Python](/Doc/DataMesh/PythonPandasNode)
 
-Connect a Python process to the mesh as a participant, hold a live `pandas.DataFrame` inside it, control that object over the mesh, and render its state back as a real `DataGridControl`.
+Connect a Python process to the mesh as a participant, load a CSV file kept in mesh content into a live `pandas.DataFrame`, control that object over the mesh, and render its state back as a real `DataGridControl` — GUI in C#, backend in Python.
+
+### [A standalone hub in Python](/Doc/DataMesh/PythonStandaloneHub)
+
+Program a complete MeshWeaver hub in Python — its own address, message handlers, owned state — connect it to the mesh, load information from the mesh and save results back.
+
+### [Fine-tuning an LLM on mesh content](/Doc/DataMesh/PythonFineTuning)
+
+Distill the documentation into a training dataset kept in mesh content, fine-tune a language model on it in Python, and stream training progress live back onto a mesh node.
 
 ### [Testing Node Types](/Doc/DataMesh/NodeTypes/Testing)
 

--- a/src/MeshWeaver.Documentation/Data/DataMesh/PythonFineTuning.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/PythonFineTuning.md
@@ -1,0 +1,96 @@
+---
+Name: Fine-tuning an LLM on mesh content
+Category: Documentation
+Description: Distill the MeshWeaver documentation into a training dataset kept in mesh content, then fine-tune a language model in Python — with training progress streamed live back onto a mesh node.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a4 4 0 0 1 4 4c0 1.1-.45 2.1-1.17 2.83L12 12l-2.83-3.17A4 4 0 0 1 12 2z"/><path d="M5 22v-5l7-5 7 5v5"/><path d="M9 22v-3h6v3"/></svg>
+---
+
+# Fine-tuning an LLM on mesh content
+
+The mesh is not just where data lives — it is where **training data** lives. This example teaches a language model MeshWeaver by fine-tuning it on MeshWeaver's own documentation, and every artifact of the loop is a mesh node:
+
+1. **Collect** — a Python participant queries the documentation pages over the mesh, distills each page into chat-format instruction records, and writes the JSONL back to the mesh as **a file kept in content**: `PythonDemo/FineTune/TrainingData`. The dataset is reviewable, hand-editable and versioned like any other node.
+2. **Train** — Python pulls that training file from the mesh, runs a LoRA fine-tune (`transformers` + `peft`), and **streams per-step progress back onto a run node** — open it in the portal and watch the loss fall, live.
+
+```mermaid
+graph LR
+    D[(Doc partition<br/>documentation nodes)] -- search + get --> C[collect<br/>Python]
+    C -- create_or_update --> T[(PythonDemo/FineTune/TrainingData<br/>JSONL kept in content)]
+    T -- get --> R[train<br/>LoRA via transformers + peft]
+    R -- patch per step --> P[(PythonDemo/FineTune/Runs/…<br/>live progress node)]
+    R --> A[/LoRA adapter on disk/]
+```
+
+The working code is `clients/python/meshweaver/examples/finetune.py`; every mesh-facing step is pinned by `clients/python/tests/test_finetune.py` (the heavy trainer is injectable, so the orchestration is tested without `torch`).
+
+## 1 — Collect: the docs become a dataset in content
+
+```bash
+cd clients/python
+pip install -e ".[dev]"
+python -m meshweaver.examples.finetune collect \
+    --url https://memex.meshweaver.cloud --token mw_… \
+    --query "namespace:Doc nodeType:Markdown" \
+    --target PythonDemo/FineTune/TrainingData
+```
+
+`collect` runs `mesh.search(query)`, reads each hit's **full** content with `mesh.get` (search hits are summaries), and distills deterministically — no generator model in the loop:
+
+- one record per page: *“Explain \<title> in MeshWeaver.”* → the page text,
+- one record per `##` section: *“In MeshWeaver's \<title>: how does \<section> work?”* → the section text.
+
+Each record is standard chat format, so any chat-template-aware trainer consumes it directly:
+
+```json
+{"messages": [
+  {"role": "system", "content": "You are the MeshWeaver assistant. …"},
+  {"role": "user", "content": "In MeshWeaver's Message Routing: how does address partitioning work?"},
+  {"role": "assistant", "content": "Every hub has an address; deliveries route by target…"}
+]}
+```
+
+The result is written with `mesh.create_or_update` as a Markdown node whose body carries the JSONL in a fenced block — the same *file kept in content* convention the [pandas node](../PythonPandasNode) uses for its CSV. Open `PythonDemo/FineTune/TrainingData` in the portal to review (or prune) the dataset before training on it.
+
+## 2 — Train: pull from the mesh, stream progress back
+
+```bash
+pip install -e ".[finetune]"          # torch + transformers + peft + datasets (heavy, train-only)
+python -m meshweaver.examples.finetune train \
+    --url https://memex.meshweaver.cloud --token mw_… \
+    --data PythonDemo/FineTune/TrainingData \
+    --model Qwen/Qwen2.5-0.5B-Instruct --epochs 3
+```
+
+`train` reads the training file back off its node (`text_from_node` extracts the fenced JSONL), then LoRA-fine-tunes the base model. Two things are worth copying into your own jobs:
+
+- **The trainer never blocks the mesh connection.** `Trainer.train()` blocks for minutes, so it runs on a worker thread (`asyncio.to_thread`); the gRPC participant connection stays responsive on the event loop.
+- **Progress is a mesh write, not a log file.** A `TrainerCallback` forwards every logged step to the event loop, which patches the run node:
+
+```python
+async def report(line):
+    lines.append(line)
+    await mesh.patch(run_path, {"content": {"content": "\n".join(lines)}})
+
+def on_progress(line):                      # called from the trainer thread
+    asyncio.run_coroutine_threadsafe(report(f"- {line}"), loop).result()
+```
+
+The run node `PythonDemo/FineTune/Runs/<stamp>` fills up live — data + model header, one line per logged step, and a final **Succeeded** (loss, step count, adapter path) or **Failed** (the exception) verdict. Anyone watching the node in the portal sees the training as it happens; nothing is hidden in a terminal.
+
+The adapter lands in `--output-dir` (default `./meshweaver-lora`) — load it with `peft`'s `PeftModel.from_pretrained` on top of the base model.
+
+## Why the dataset lives in the mesh
+
+| Property | What it buys |
+|---|---|
+| Reviewable | open the node, read the records, delete bad ones in the editor |
+| Reproducible | the run node records exactly which data node the adapter came from |
+| Shared | agents and colleagues query it like any node (`path:PythonDemo/FineTune/*`) |
+| Composable | re-run `collect` after doc changes — `create_or_update` refreshes in place |
+
+## Related
+
+- [A pandas node in Python](../PythonPandasNode) — the same *file kept in content* convention, feeding a live DataFrame.
+- [A standalone hub in Python](../PythonStandaloneHub) — the participant model this example's mesh I/O builds on.
+- [Calling Python](../CallingPython) — the stateless subprocess pattern.
+- [Query Syntax](../QuerySyntax) — the `--query` language `collect` uses to select the docs.

--- a/src/MeshWeaver.Documentation/Data/DataMesh/PythonPandasNode.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/PythonPandasNode.md
@@ -1,32 +1,63 @@
 ---
 Name: A pandas node in Python
 Category: Documentation
-Description: Hold a live pandas DataFrame inside a Python mesh participant, control it over the mesh, and render its state back as a real DataGrid control — not markdown.
+Description: Load a CSV file kept in mesh content into a live pandas DataFrame held by a Python mesh participant, and render every analysis back through the hub as a real DataGrid — GUI in C#, backend in Python.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18M9 3v18M15 3v18"/></svg>
 ---
 
 # A pandas node in Python
 
-[Calling Python](../CallingPython) runs `python3` as a **stateless external process**: the mesh shells out, Python prints, the process dies. This page is the interactive counterpart. Here a Python process **connects to the mesh as a participant** (over gRPC, exactly like the MAUI / Blazor-WASM clients) and **owns a live object** — a `pandas.DataFrame` — that the mesh can drive over many round trips. The frame is real, long-lived Python state; the mesh creates it, mutates it, queries it, and renders its **current** state back as a genuine `DataGridControl`.
+[Calling Python](../CallingPython) runs `python3` as a **stateless external process**: the mesh shells out, Python prints, the process dies. This page is the interactive counterpart — **GUI in C#, backend in Python**. A Python process **connects to the mesh as a participant** (over gRPC, exactly like the MAUI / Blazor-WASM clients) and **owns a live object** — a `pandas.DataFrame` — fed from **a CSV file kept in mesh content**. The C# frontend never touches the data: it posts commands through the hub, Python reads the file node over the mesh, does the pandas work, and every result flows back through the hub as a genuine `DataGridControl` the GUI renders.
 
 | | [Calling Python](../CallingPython) | This page |
 |---|---|---|
 | Python is a… | short-lived process | connected mesh **participant** (`py/pandas`) |
+| Data source | inline in the script | a **CSV file kept in content** (`PythonDemo/SalesData`) |
 | State | none (fresh each call) | a **live DataFrame held in the participant** |
 | Output | markdown text | a real **`DataGridControl`** (sortable, formatted) |
 
 The working code lives in the Python client package: `clients/python/meshweaver/examples/pandas_node.py` (tests: `clients/python/tests/test_pandas_node.py`). The participant model itself is in `clients/python/README.md`.
 
+## The file kept in content
+
+The data source is an ordinary mesh node, `PythonDemo/SalesData` — a Markdown node whose body carries the CSV in a fenced block, so it renders as a readable table-of-text in the portal and stays **hand-editable** like any other content:
+
+````markdown
+# Sales Data
+
+Monthly sales by region — **a file kept in content**.
+
+```csv
+month,region,sales,units
+Jan,EMEA,120.0,12
+Feb,EMEA,135.5,14
+…
+Aug,EMEA,152.0,15
+```
+````
+
+When the frontend asks for a load, it sends **only the path**. The participant reads the node itself — `Mesh.get(path)` (one snapshot off the node's live stream, the Python analog of `GetMeshNodeStream`), extracts the fenced CSV, and parses it:
+
+```python
+async def _load_from_content(self, path: str):
+    node = await self._read_node(path)            # mesh → Python: read the content node
+    self._df = pd.read_csv(io.StringIO(csv_from_node(node)))
+    return {**self._summary(), "source": path}
+```
+
+Edit the CSV in the portal, press *Load sales CSV* again, and the new data is live — the mesh content is the single source of truth for the file.
+
 ## Two ways to control the frame
 
 Both surfaces act on the **same** held DataFrame:
 
-1. **Typed `PandasCommand` messages** — `load` / `append` / `reset` (mutate), `render` / `groupby` / `describe` / `rolling` (analyse). The mesh routes them to the participant's address by *target*; the message type is opaque to the mesh (it round-trips as `RawJson`), so nothing needs server-side registration.
+1. **Typed `PandasCommand` messages** — `load` (with a `path` to a content file, or inline `data`) / `append` / `reset` (mutate), `render` / `groupby` / `describe` / `rolling` (analyse). The mesh routes them to the participant's address by *target*; the message type is opaque to the mesh (it round-trips as `RawJson`), so nothing needs server-side registration.
 2. **`SubmitCodeRequest`** — pandas code run against a **persistent** namespace where the frame lives as `df`. Unlike the stateless kernel worker (`meshweaver.worker.execute_python`, a fresh namespace per call), this namespace *survives* across calls, so `df["margin"] = df["sales"] - df["units"]` in one submission is visible to the next. That persistent `df` **is** "an object created and controlled in Python".
 
 ```mermaid
 graph LR
-    A[mesh participant / agent] -- PandasCommand / SubmitCode --> B[py/pandas participant]
+    S[(PythonDemo/SalesData<br/>CSV file in content)] -- Mesh.get --> B[py/pandas participant]
+    A[C# frontend / agent] -- PandasCommand / SubmitCode --> B
     B -- holds --> D[(live pandas DataFrame)]
     B -- render --> G[DataGridControl JSON]
     G -- deserialises to --> H[typed DataGridControl<br/>GUI renders a real grid]
@@ -88,12 +119,13 @@ A `render` (or any analytical command) replies with the grid **as a `DataGridCon
 
 ## The interactive frontend — the `PandasExplorer` node
 
-The Python participant is the backend. **A .NET NodeType is the frontend that drives it.** `PandasExplorer` (`samples/Graph/Data/PythonDemo/PandasExplorer/`) is an ordinary mesh NodeType whose layout area (`PandasExplorerLayoutAreas.Explorer`) is a toolbar of **real framework controls** above a **live `DataGridControl`** — no hand-rolled HTML, no markdown for the data.
+The Python participant is the backend. **A .NET NodeType is the frontend that drives it.** `PandasExplorer` (`samples/Graph/Data/PythonDemo/PandasExplorer/`) is an ordinary mesh NodeType whose layout area (`PandasExplorerLayoutAreas.Explorer`) is a toolbar of **real framework controls** above a **live `DataGridControl`** — no hand-rolled HTML, no markdown for the data. Its content record carries `SourcePath` — the mesh path of the CSV file in content — so different explorer instances can point at different data files.
 
 ```mermaid
 graph LR
     U[user] -- clicks a button --> F[PandasExplorer layout area]
     F -- PandasCommand --> P[py/pandas participant]
+    S[(SalesData CSV<br/>in content)] -- Mesh.get --> P
     P -- holds --> D[(live DataFrame)]
     P -- DataGridControl --> F
     F -- renders --> G[real DataGrid]
@@ -103,13 +135,15 @@ Every control maps to one `PandasCommand` posted to `py/pandas`; the grid then r
 
 | Control | Posts | Effect |
 |---|---|---|
-| **Load sample sales** | `load` (6 rows) | replaces the held frame, then re-renders |
+| **Load sales CSV** | `load` with `path` = the node's `SourcePath` | the participant reads the file node over the mesh, `read_csv`s it into the frame, then re-renders |
 | **Append 2 rows** | `append` | grows the held frame, then re-renders |
 | **Group by** + text input | `groupby` (by = the typed column, default `region`) | grouped sum view |
 | **Rolling mean (3)** | `rolling` (column `sales`, window 3) | adds a rolling-mean column |
 | **Describe** | `describe` | descriptive statistics |
 | **Refresh** | `render` | re-renders the current frame |
 | **Reset** | `reset` | clears the held frame |
+
+Note what travels over the wire on a load: **the path, not the data**. The GUI in C# stays a thin reactive shell; the file read and every pandas computation happen in the Python backend, and only the rendered `DataGridControl` comes back through the hub.
 
 The whole flow is **reactive, never `async`** (a rule of the actor-model mesh): a click flips a trigger in the layout-area data store, the grid sub-area re-observes it, `Hub.Post(command, o => o.WithTarget("py/pandas"))` fires and `Hub.Observe(delivery)` awaits the reply — composed with `Timeout` + `Catch`, so the grid degrades gracefully instead of hanging. Mutations (`load`/`append`/`reset`) chain their re-render off the participant's ack, so the grid always reflects the new frame state (race-free).
 
@@ -138,6 +172,10 @@ Serve as a real participant other participants / agents drive over gRPC:
 python -m meshweaver.examples.pandas_node --url https://memex.meshweaver.cloud --token mw_… --address py/pandas
 ```
 
+The bidi participant connection is native gRPC at the ordinary portal URL (the deployment routes `meshweaver.v1.Mesh/Open` to a dedicated HTTP/2 port — see the transport note in [A standalone hub in Python](../PythonStandaloneHub)); a gate shipping in the portal's own pod uses the trusted loopback endpoint instead, with no token at all. The `PandasCommand` protocol itself needs **no server-side registration**: the participant's proxy hub forwards unregistered types verbatim (`RawJsonPassThrough`).
+
+Then open the `PythonDemo/PandasExplorer/LiveFrame` node in the portal and press **Load sales CSV**: the participant reads `PythonDemo/SalesData` over the mesh, parses it, and the grid renders the file's contents. Edit the CSV node and load again to see the change flow through.
+
 ## Proof it's a real grid, not markdown
 
 The bytes `--demo` emits are checked end to end:
@@ -147,6 +185,8 @@ The bytes `--demo` emits are checked end to end:
 
 ## Related
 
+- [A standalone hub in Python](../PythonStandaloneHub) — the full hub programming model this participant is a special case of.
+- [Fine-tuning an LLM on mesh content](../PythonFineTuning) — the same *file kept in content* convention feeding a training job.
 - [Calling Python](../CallingPython) — the stateless process pattern (a layout area shells out to `python3`).
 - [Controlled I/O Pooling](/Doc/Architecture/ControlledIoPooling) — why the C# side bridges every async/blocking edge through `IIoPool`.
 - [Query Syntax](../QuerySyntax) — the query language a participant uses to find nodes to feed a frame.

--- a/src/MeshWeaver.Documentation/Data/DataMesh/PythonStandaloneHub.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/PythonStandaloneHub.md
@@ -1,0 +1,145 @@
+---
+Name: A standalone hub in Python
+Category: Documentation
+Description: Program a complete MeshWeaver hub in Python — its own address, message handlers, owned state — connect it to the mesh, load information from the mesh and save results back.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><circle cx="4" cy="6" r="2"/><circle cx="20" cy="6" r="2"/><circle cx="4" cy="18" r="2"/><circle cx="20" cy="18" r="2"/><path d="M6 7l4 3M18 7l-4 3M6 17l4-3M18 17l-4-3"/></svg>
+---
+
+# A standalone hub in Python
+
+A hub on the mesh is three things: an **address** deliveries route to, **message handlers** keyed by message type, and **state** the handlers own. None of that is .NET-specific — this page programs a complete hub in Python, connects it to the mesh over gRPC, and runs the full read–compute–serve–write loop from there. There is no C# in this example at all.
+
+The working code is `clients/python/meshweaver/examples/standalone_hub.py` (tests: `clients/python/tests/test_standalone_hub.py`).
+
+## The hub programming model, in Python
+
+`PyHub` is the in-language mirror of the C# `MessageHubConfiguration`:
+
+| C# hub | Python hub |
+|---|---|
+| `WithHandler<TRequest>((hub, req) => …)` | `hub.register("TRequest", handler)` |
+| `hub.Post(response, o => o.ResponseFor(request))` | return `("TResponse", payload)` from the handler |
+| `hub.Observe<TResponse>(request, o => o.WithTarget(addr))` | `await connection.observe(addr, "TRequest", {...})` |
+| `hub.Post(message, o => o.WithTarget(addr))` | `await connection.post(addr, "TMessage", {...})` |
+| single-threaded action block | the connection's read loop serialises dispatch |
+| errors forward to the caller, never wedge | a raising handler answers `ErrorResponse` |
+
+```python
+class PyHub:
+    def __init__(self, connection):
+        self._c = connection
+        self._handlers = {}
+        connection.serve(self.handle)              # register as the inbound dispatcher
+
+    def register(self, message_type, handler):     # the C# WithHandler<T>
+        self._handlers[message_type] = handler
+        return self
+
+    async def handle(self, delivery):
+        handler = self._handlers.get(delivery.message_type)
+        if handler is None:
+            return                                  # not ours — ignore quietly
+        try:
+            reply = await handler(delivery)
+        except Exception as ex:                     # errors PROPAGATE — the hub never wedges
+            await self._c.respond(delivery, "ErrorResponse", {"error": f"{type(ex).__name__}: {ex}"})
+            return
+        if reply is not None:
+            await self._c.respond(delivery, *reply) # correlated response to the sender
+```
+
+The message types are the hub's own protocol — unregistered on the mesh, they round-trip as `RawJson` and route purely by target address, so a Python hub needs **no server-side registration** to define its surface.
+
+## The working hub: load → serve → save
+
+`NamespaceStatsHub` puts state and mesh I/O on that skeleton. It owns one namespace's worth of knowledge:
+
+```mermaid
+graph LR
+    M[(mesh<br/>namespace nodes)] -- "1 load: search + get" --> H[py/stats hub<br/>held state]
+    C[any participant] -- "2 NamespaceStatsRequest" --> H
+    H -- NamespaceStatsResponse --> C
+    H -- "3 save_report: create_or_update" --> R[(PythonDemo/PythonHubReport<br/>Markdown node)]
+```
+
+1. **Load info from the mesh** — on start the hub reads every node of its namespace into hub state: `mesh.search(f"namespace:{ns}")`, then `mesh.get(path)` per hit for full content.
+2. **Serve** — `NamespaceStatsRequest` answers with statistics over the held state (node count, per-nodeType counts, words of content); `ReloadRequest` re-reads the namespace first. Any mesh participant — a C# hub, an agent, another Python process — can `observe` these.
+3. **Save info back to the mesh** — `save_report()` writes the computed statistics as a readable Markdown node, `{namespace}/PythonHubReport`, via `mesh.create_or_update`. The hub's knowledge is itself mesh content, browsable in the portal.
+
+```python
+class NamespaceStatsHub(PyHub):
+    def __init__(self, connection, mesh, namespace):
+        super().__init__(connection)
+        self._mesh, self.namespace, self.nodes = mesh, namespace, []
+        self.register("NamespaceStatsRequest", self._on_stats)
+        self.register("ReloadRequest", self._on_reload)
+
+    async def load(self):                                   # mesh -> Python
+        hits = await self._mesh.search(f"namespace:{self.namespace}", limit=500)
+        self.nodes = [await self._mesh.get(h["path"]) for h in hits]
+        return self.stats()
+
+    async def _on_stats(self, delivery):                    # the served surface
+        return "NamespaceStatsResponse", self.stats()
+
+    async def save_report(self):                            # Python -> mesh
+        await self._mesh.create_or_update({... "nodeType": "Markdown", ...})
+```
+
+## Run it
+
+Self-contained showcase (no mesh needed — an in-memory namespace stands in):
+
+```bash
+cd clients/python
+pip install -e ".[dev]"
+scripts/gen_proto.sh
+python -m meshweaver.examples.standalone_hub --demo
+```
+
+Attach to a live mesh:
+
+```bash
+python -m meshweaver.examples.standalone_hub \
+    --url https://memex.meshweaver.cloud --token mw_… \
+    --namespace PythonDemo --address py/stats
+```
+
+> **Transport note.** The participant connection is bidirectional gRPC (HTTP/2) at the ordinary
+> portal URL — the deployment routes `meshweaver.v1.Mesh/Open` natively (helm `values.grpc`; a
+> same-host ingress path proxies it to the portal's dedicated h2c port with `backend-protocol:
+> GRPC`, so no extra DNS or certs). All three hosted portals serve it. For a self-signed local
+> portal pass the CA to `connect(..., root_certificates=...)`.
+>
+> **Trusted gates.** A service that ships *in the same deployment* as the portal (the co-located
+> node / bun / python gates) connects to the **trusted loopback endpoint** instead —
+> `http://127.0.0.1:8082` inside the pod. Reachability is the authentication (only same-pod
+> containers share loopback): no API token, nothing to rotate. Deliveries from a trusted gate may
+> carry the requesting user's `AccessContext` through (the SDK's `respond`/`post` echo it), so the
+> gate acts under that user's identity — exactly like the in-process C# kernel. External
+> participants keep using API tokens and are always re-stamped server-side.
+
+The hub loads the namespace, writes `PythonDemo/PythonHubReport` (open it in the portal), and then serves requests until stopped. Drive it from any other participant:
+
+```python
+resp = await connection.observe("py/stats", "NamespaceStatsRequest", {})
+print(resp.message["nodeCount"])
+```
+
+Identity works like every participant: the API token is validated server-side and every write the hub makes is stamped with that identity — a Python hub is subject to exactly the same access control as any user or C# hub.
+
+## Where the other Python patterns fit
+
+| Pattern | What Python is | Page |
+|---|---|---|
+| Shell out to `python3` from a layout area | a short-lived subprocess | [Calling Python](../CallingPython) |
+| Python worker executing `python` Code nodes | the mesh kernel's Python half | `Doc/Architecture/PythonCodeNodes` |
+| Live pandas DataFrame behind a C# GUI | a stateful backend participant | [A pandas node in Python](../PythonPandasNode) |
+| Fine-tune an LLM on mesh content | a batch job with mesh-visible progress | [Fine-tuning an LLM on mesh content](../PythonFineTuning) |
+| **A complete hub — this page** | **a first-class mesh hub** | — |
+
+## Related
+
+- [A pandas node in Python](../PythonPandasNode) — a Python participant behind a C# frontend.
+- [Fine-tuning an LLM on mesh content](../PythonFineTuning) — mesh-orchestrated Python batch work.
+- [Query Syntax](../QuerySyntax) — the query language `load()` uses.

--- a/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
@@ -193,7 +193,9 @@ public sealed class GrpcConnectionRegistry : IDisposable
     public void Deliver(string connectionId, IMessageDelivery delivery)
     {
         var state = connections.TryGetValue(connectionId, out var s) ? s : null;
-        var user = state?.Trusted == true && delivery.AccessContext is not null
+        // Pass-through requires a REAL carried identity — an empty AccessContext object (no
+        // ObjectId) falls back to the trusted default (System), never an empty principal.
+        var user = state?.Trusted == true && delivery.AccessContext is { ObjectId.Length: > 0 }
             ? delivery.AccessContext
             : state?.User ?? Anonymous;
         using (accessService.SwitchAccessContext(user))

--- a/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
@@ -56,9 +56,19 @@ public sealed class GrpcConnectionRegistry : IDisposable
         Name = WellKnownUsers.Anonymous,
     };
 
+    // Default identity of a TRUSTED connection (a co-deployed gate on the loopback endpoint) when
+    // an injected delivery carries no AccessContext of its own — the same well-known System
+    // principal the in-process infrastructure impersonates (Permission.All, RLS-bypassing).
+    private static readonly AccessContext TrustedService = new()
+    {
+        ObjectId = WellKnownUsers.System,
+        Name = WellKnownUsers.System,
+    };
+
     private sealed record ConnectionState(
         AccessContext User,
         ChannelWriter<ServerFrame> Outbound,
+        bool Trusted = false,
         IDisposable? Route = null,
         IMessageHub? ParticipantHub = null);
     private readonly ConcurrentDictionary<string, ConnectionState> connections = new();
@@ -68,9 +78,23 @@ public sealed class GrpcConnectionRegistry : IDisposable
     public void Begin(string connectionId, ChannelWriter<ServerFrame> outbound) =>
         connections[connectionId] = new ConnectionState(Anonymous, outbound);
 
-    /// <summary>Validate the connection's Bearer token (if any) → remember the user for this connection.</summary>
-    public IObservable<Unit> Authenticate(string connectionId, string? rawToken)
+    /// <summary>
+    /// Validate the connection's Bearer token (if any) → remember the user for this connection.
+    /// <paramref name="trusted"/> marks a connection that arrived on the TRUSTED loopback endpoint
+    /// (<see cref="GrpcOptions.TrustedPort"/> — reachable only from the portal's own pod): it needs
+    /// no token, defaults to the well-known System identity, and its injected deliveries keep an
+    /// <c>AccessContext</c> they already carry (see <see cref="Deliver"/>).
+    /// </summary>
+    public IObservable<Unit> Authenticate(string connectionId, string? rawToken, bool trusted = false)
     {
+        if (trusted)
+        {
+            connections.AddOrUpdate(connectionId,
+                _ => new ConnectionState(TrustedService, Channel.CreateUnbounded<ServerFrame>().Writer, Trusted: true),
+                (_, s) => s with { User = TrustedService, Trusted = true });
+            return Observable.Return(Unit.Default);
+        }
+
         if (string.IsNullOrWhiteSpace(rawToken)
             || !rawToken.StartsWith(ValidateTokenRequest.TokenPrefix, StringComparison.Ordinal))
         {
@@ -126,7 +150,10 @@ public sealed class GrpcConnectionRegistry : IDisposable
     {
         var route = routingService.RegisterStream(address, (delivery, ct) => PushToClient(connectionId, delivery, ct));
         var participantHub = hub.GetHostedHub(address, config =>
-            config.WithRoutes(routes =>
+            // The proxy hub only FORWARDS — a participant's own protocol types (registered nowhere
+            // on the server) must pass through as RawJson instead of failing deserialization.
+            config.Set(new RawJsonPassThrough())
+                .WithRoutes(routes =>
                 routes.WithHandler((delivery, ct) =>
                     // Forward messages addressed to the participant FROM elsewhere (responses, stream
                     // changes). Leave the proxy hub's own self/lifecycle messages (InitializeHubRequest,
@@ -145,7 +172,8 @@ public sealed class GrpcConnectionRegistry : IDisposable
                         : ForwardToClientSync(connectionId, delivery))));
         connections.AddOrUpdate(connectionId,
             // Begin() always runs first, so the "add" branch is a defensive fallback only.
-            _ => new ConnectionState(Anonymous, Channel.CreateUnbounded<ServerFrame>().Writer, route, participantHub),
+            _ => new ConnectionState(Anonymous, Channel.CreateUnbounded<ServerFrame>().Writer,
+                Route: route, ParticipantHub: participantHub),
             (_, s) =>
             {
                 s.Route?.Dispose();
@@ -154,10 +182,20 @@ public sealed class GrpcConnectionRegistry : IDisposable
             });
     }
 
-    /// <summary>Inject a participant message into the mesh, stamped with the connection's validated identity.</summary>
+    /// <summary>
+    /// Inject a participant message into the mesh, stamped with the connection's validated identity.
+    /// A TRUSTED connection (co-deployed gate on the loopback endpoint) may instead carry through an
+    /// <c>AccessContext</c> already on the delivery — a gate executing a user's request (e.g. the
+    /// python kernel running a Code node) echoes the requester's context onto its write-backs so
+    /// they run under that user's identity, exactly like the in-process C# kernel. Untrusted
+    /// connections are ALWAYS re-stamped; a forged client-side identity is never trusted.
+    /// </summary>
     public void Deliver(string connectionId, IMessageDelivery delivery)
     {
-        var user = connections.TryGetValue(connectionId, out var s) ? s.User : Anonymous;
+        var state = connections.TryGetValue(connectionId, out var s) ? s : null;
+        var user = state?.Trusted == true && delivery.AccessContext is not null
+            ? delivery.AccessContext
+            : state?.User ?? Anonymous;
         using (accessService.SwitchAccessContext(user))
             hub.DeliverMessage(delivery.SetAccessContext(user));
     }

--- a/src/MeshWeaver.Hosting.Grpc/GrpcHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcHostingExtensions.cs
@@ -41,6 +41,8 @@ public static class GrpcHostingExtensions
     {
         services.AddGrpc();
         services.AddSingleton<GrpcConnectionRegistry>();
+        // Grpc:TrustedPort — the loopback endpoint co-deployed gates authenticate on (GrpcOptions).
+        services.AddOptions<GrpcOptions>().BindConfiguration(GrpcOptions.SectionName);
         return services;
     }
 

--- a/src/MeshWeaver.Hosting.Grpc/GrpcOptions.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcOptions.cs
@@ -1,0 +1,28 @@
+namespace MeshWeaver.Hosting.Grpc;
+
+/// <summary>
+/// Options for the gRPC mesh transport, bound from the <c>Grpc</c> configuration section.
+/// </summary>
+public class GrpcOptions
+{
+    /// <summary>The configuration section the options bind from.</summary>
+    public const string SectionName = "Grpc";
+
+    /// <summary>
+    /// Local port of the <b>trusted</b> gRPC endpoint — the loopback-bound Kestrel endpoint
+    /// (<c>http://127.0.0.1:{TrustedPort}</c>) reserved for services that ship <em>in the same
+    /// deployment</em> as the portal: the co-located node / bun / python gates. Only containers in
+    /// the same pod share the loopback network namespace, so reachability of this port <b>is</b> the
+    /// trust boundary — kernel-enforced, no shared secret, nothing to rotate.
+    ///
+    /// <para>A connection arriving on this port authenticates as a trusted service: no Bearer token
+    /// is required, its default identity is the well-known System principal, and an
+    /// <c>AccessContext</c> already carried on an injected delivery is <b>passed through</b> instead
+    /// of re-stamped — so a gate executing a user's request writes back under that user's identity,
+    /// exactly like the in-process C# kernel does (see AccessContextPropagation.md).</para>
+    ///
+    /// <para><c>null</c> (default) disables the trusted path entirely: every connection
+    /// authenticates via API token and is re-stamped with the validated identity.</para>
+    /// </summary>
+    public int? TrustedPort { get; set; }
+}

--- a/src/MeshWeaver.Hosting.Grpc/MeshGrpcService.cs
+++ b/src/MeshWeaver.Hosting.Grpc/MeshGrpcService.cs
@@ -5,6 +5,8 @@ using System.Threading.Channels;
 using Grpc.Core;
 using MeshWeaver.Hosting.Grpc.Protocol;
 using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace MeshWeaver.Hosting.Grpc;
 
@@ -22,10 +24,36 @@ namespace MeshWeaver.Hosting.Grpc;
 /// outbound frame — the connect ack AND mesh deliveries — funnels through one pump draining the
 /// connection's <see cref="Channel{T}"/>.</para>
 /// </summary>
-public sealed class MeshGrpcService(IMessageHub hub, GrpcConnectionRegistry registry) : Protocol.Mesh.MeshBase
+public sealed class MeshGrpcService(IMessageHub hub, GrpcConnectionRegistry registry, IOptions<GrpcOptions>? options = null)
+    : Protocol.Mesh.MeshBase
 {
     /// <summary>The fully-qualified gRPC service name the endpoint is mapped at.</summary>
     public const string ServiceName = "meshweaver.v1.Mesh";
+
+    /// <summary>
+    /// Whether this call arrived on the TRUSTED loopback endpoint (<see cref="GrpcOptions.TrustedPort"/>).
+    /// The trust boundary is the pod: only same-pod containers (the shipped node / bun / python gates)
+    /// can reach a <c>127.0.0.1</c>-bound port, so the local port of the accepted connection IS the
+    /// authentication. No configured trusted port ⇒ never trusted.
+    /// </summary>
+    private bool IsTrusted(ServerCallContext context)
+    {
+        if (options?.Value.TrustedPort is not int trustedPort)
+            return false;
+        try
+        {
+            // The official accessor: on real Kestrel the context IS an HttpContextServerCallContext
+            // (a UserState probe does NOT work there — "__HttpContext" is only its legacy fallback,
+            // which the in-memory transport tests use).
+            return context.GetHttpContext().Connection.LocalPort == trustedPort;
+        }
+        catch (InvalidOperationException)
+        {
+            // Not an AspNetCore-hosted call (e.g. an in-memory context without the fallback entry) —
+            // no HttpContext means no trusted-port evidence.
+            return false;
+        }
+    }
 
     /// <inheritdoc />
     public override async Task Open(
@@ -43,7 +71,8 @@ public sealed class MeshGrpcService(IMessageHub hub, GrpcConnectionRegistry regi
         try
         {
             // Boundary bridge: validate the Bearer token (gRPC call metadata) once per connection.
-            await registry.Authenticate(connectionId, ExtractBearerToken(context))
+            // A call on the trusted loopback endpoint authenticates by reachability instead.
+            await registry.Authenticate(connectionId, ExtractBearerToken(context), IsTrusted(context))
                 .FirstAsync().ToTask(context.CancellationToken);
 
             await foreach (var frame in requestStream.ReadAllAsync(context.CancellationToken))
@@ -95,7 +124,7 @@ public sealed class MeshGrpcService(IMessageHub hub, GrpcConnectionRegistry regi
         var pump = WritePumpAsync(outbound.Reader, responseStream);
         try
         {
-            await registry.Authenticate(connectionId, ExtractBearerToken(context))
+            await registry.Authenticate(connectionId, ExtractBearerToken(context), IsTrusted(context))
                 .FirstAsync().ToTask(context.CancellationToken);
             var address = JsonSerializer.Deserialize<Address>(request.Address, hub.JsonSerializerOptions)
                 ?? throw new RpcException(new Status(StatusCode.InvalidArgument, "Address did not deserialize."));

--- a/src/MeshWeaver.Messaging.Contract/Events.cs
+++ b/src/MeshWeaver.Messaging.Contract/Events.cs
@@ -105,6 +105,23 @@ public record UnhandledMessageNack(
     string? NodeTypePath = null);
 
 /// <summary>
+/// Hub-level "forward, don't deserialize" policy for PROXY hubs that stand in for a remote
+/// participant (the gRPC connection registry's hosted hub is the canonical case). Such a hub is the
+/// delivery <em>target</em> only nominally — its catch-all route re-serializes every delivery onto
+/// the participant's wire, so inbound payloads whose <c>$type</c> is not in the server's
+/// TypeRegistry (a participant's own protocol, e.g. the Python pandas node's <c>PandasCommand</c>)
+/// must stay <c>RawJson</c> and forward verbatim instead of failing with
+/// "type not registered in this hub's TypeRegistry".
+///
+/// <para>Set on the proxy hub via <c>MessageHubConfiguration.Set(new RawJsonPassThrough())</c>.
+/// Registered types still deserialize normally; only the unregistered-type fallback changes from
+/// fail-the-delivery to pass-through. Do NOT set this on hubs that dispatch to typed handlers —
+/// there the fail-fast is what keeps callers from parking forever (see
+/// <see cref="UnhandledMessageNack"/>).</para>
+/// </summary>
+public record RawJsonPassThrough;
+
+/// <summary>
 /// Classifies why a message delivery failed, carried on a <see cref="DeliveryFailure"/>.
 /// </summary>
 public enum ErrorType

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -977,6 +977,12 @@ public class MessageService : IMessageService
         // posts a DeliveryFailure back to the sender with a clear hint.
         if (deserializedMessage is JsonElement)
         {
+            // Participant-proxy hubs forward every delivery verbatim (their catch-all route
+            // re-serializes it onto the remote wire), so a participant's own protocol types —
+            // registered nowhere on the server — must stay RawJson and pass through.
+            if (hub.Configuration.Get<RawJsonPassThrough>() is not null)
+                return delivery;
+
             var jsonType = ExtractJsonType(rawJson.Content);
             var failureMessage = $"Could not deserialize message in hub {Address} — " +
                 $"type '{jsonType}' is not registered in this hub's TypeRegistry.";

--- a/test/MeshWeaver.Hosting.Grpc.Test/MeshGrpcTransportTest.cs
+++ b/test/MeshWeaver.Hosting.Grpc.Test/MeshGrpcTransportTest.cs
@@ -150,6 +150,10 @@ public class MeshGrpcTransportTest(ITestOutputHelper output) : MonolithMeshTestB
         Assert.Equal("alice", await WhoAmI(service, cts.Token, trusted,
             new AccessContext { ObjectId = "alice", Name = "Alice" }));
         Assert.Equal(WellKnownUsers.System, await WhoAmI(service, cts.Token, trusted, null));
+        // An EMPTY carried context (no ObjectId) is not an identity — falls back to System,
+        // never an empty principal.
+        Assert.Equal(WellKnownUsers.System, await WhoAmI(service, cts.Token, trusted,
+            new AccessContext { ObjectId = "", Name = "" }));
 
         var untrusted = new DefaultHttpContext();
         untrusted.Connection.LocalPort = 8081;

--- a/test/MeshWeaver.Hosting.Grpc.Test/MeshGrpcTransportTest.cs
+++ b/test/MeshWeaver.Hosting.Grpc.Test/MeshGrpcTransportTest.cs
@@ -9,8 +9,11 @@ using MeshWeaver.Hosting.Grpc;
 using MeshWeaver.Hosting.Grpc.Protocol;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace MeshWeaver.Hosting.Grpc.Test;
@@ -33,6 +36,10 @@ public class MeshGrpcTransportTest(ITestOutputHelper output) : MonolithMeshTestB
     public record EchoRequest(string Text) : IRequest<EchoResponse>;
     public record EchoResponse(string Text);
 
+    /// <summary>Answers with the identity the delivery arrived under — pins the trust semantics.</summary>
+    public record WhoAmIRequest : IRequest<WhoAmIResponse>;
+    public record WhoAmIResponse(string ObjectId);
+
     // Fires when the echo handler actually runs — lets the test tell "request never reached the
     // handler" apart from "handler ran but the response didn't route back".
     private readonly TaskCompletionSource<string> handlerHit =
@@ -46,12 +53,20 @@ public class MeshGrpcTransportTest(ITestOutputHelper output) : MonolithMeshTestB
             {
                 config.TypeRegistry.WithType(typeof(EchoRequest), nameof(EchoRequest));
                 config.TypeRegistry.WithType(typeof(EchoResponse), nameof(EchoResponse));
+                config.TypeRegistry.WithType(typeof(WhoAmIRequest), nameof(WhoAmIRequest));
+                config.TypeRegistry.WithType(typeof(WhoAmIResponse), nameof(WhoAmIResponse));
                 return config.WithHandler<EchoRequest>((hub, request) =>
-                {
-                    handlerHit.TrySetResult(request.Message.Text);
-                    hub.Post(new EchoResponse(request.Message.Text), o => o.ResponseFor(request));
-                    return request.Processed();
-                });
+                    {
+                        handlerHit.TrySetResult(request.Message.Text);
+                        hub.Post(new EchoResponse(request.Message.Text), o => o.ResponseFor(request));
+                        return request.Processed();
+                    })
+                    .WithHandler<WhoAmIRequest>((hub, request) =>
+                    {
+                        hub.Post(new WhoAmIResponse(request.AccessContext?.ObjectId ?? "<none>"),
+                            o => o.ResponseFor(request));
+                        return request.Processed();
+                    });
             });
 
     [Fact]
@@ -112,6 +127,136 @@ public class MeshGrpcTransportTest(ITestOutputHelper output) : MonolithMeshTestB
 
         inbound.Writer.Complete();
         await open;
+    }
+
+    [Fact]
+    public async Task Trusted_endpoint_identity_semantics()
+    {
+        // The trust boundary is the POD: only same-pod containers (the shipped node / bun / python
+        // gates) can reach the loopback-bound trusted port, so arriving on it IS the authentication —
+        // no token, nothing to rotate. Three semantics pinned here:
+        //   1. trusted + carried AccessContext → passes through (a gate executing a user's request
+        //      writes back under that user's identity, like the in-process C# kernel),
+        //   2. trusted + no context → the well-known System principal,
+        //   3. UNTRUSTED + forged context → re-stamped to the connection's own (Anonymous) identity.
+        var hub = Mesh;
+        var registry = hub.ServiceProvider.GetRequiredService<GrpcConnectionRegistry>();
+        var service = new MeshGrpcService(hub, registry,
+            Options.Create(new GrpcOptions { TrustedPort = 8082 }));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var trusted = new DefaultHttpContext();
+        trusted.Connection.LocalPort = 8082;
+        Assert.Equal("alice", await WhoAmI(service, cts.Token, trusted,
+            new AccessContext { ObjectId = "alice", Name = "Alice" }));
+        Assert.Equal(WellKnownUsers.System, await WhoAmI(service, cts.Token, trusted, null));
+
+        var untrusted = new DefaultHttpContext();
+        untrusted.Connection.LocalPort = 8081;
+        Assert.Equal(WellKnownUsers.Anonymous, await WhoAmI(service, cts.Token, untrusted,
+            new AccessContext { ObjectId = "alice", Name = "Alice" }));
+    }
+
+    private async Task<string> WhoAmI(
+        MeshGrpcService service, CancellationToken ct, HttpContext http, AccessContext? carried)
+    {
+        var hub = Mesh;
+        var participant = new Address(GrpcHostingExtensions.PythonAddressType, Guid.NewGuid().ToString("N"));
+        var inbound = Channel.CreateUnbounded<ClientFrame>();
+        var writer = new CapturingStreamWriter<ServerFrame>();
+        var open = service.Open(new ChannelStreamReader<ClientFrame>(inbound.Reader), writer,
+            new FakeServerCallContext(new Metadata(), ct, http));
+        await inbound.Writer.WriteAsync(new ClientFrame
+        {
+            Connect = JsonSerializer.Serialize(participant, hub.JsonSerializerOptions)
+        }, ct);
+        var ack = await NextFrame(writer, "connect ack", TimeSpan.FromSeconds(10));
+        Assert.Equal(ServerFrame.KindOneofCase.Ack, ack.KindCase);
+
+        IMessageDelivery delivery = new MessageDelivery<WhoAmIRequest>(
+            participant, hub.Address, new WhoAmIRequest(), hub.JsonSerializerOptions);
+        if (carried is not null)
+            delivery = delivery.SetAccessContext(carried);
+        await inbound.Writer.WriteAsync(new ClientFrame
+        {
+            Deliver = JsonSerializer.Serialize(delivery, hub.JsonSerializerOptions)
+        }, ct);
+
+        for (var i = 0; i < 20; i++)
+        {
+            var f = await NextFrame(writer, "whoami response", TimeSpan.FromSeconds(10));
+            if (f.KindCase != ServerFrame.KindOneofCase.Receive || !f.Receive.Contains(nameof(WhoAmIResponse)))
+                continue;
+            inbound.Writer.Complete();
+            await open;
+            using var doc = JsonDocument.Parse(f.Receive);
+            return doc.RootElement.GetProperty("message").GetProperty("objectId").GetString()!;
+        }
+        throw new TimeoutException("no WhoAmIResponse frame");
+    }
+
+    [Fact]
+    public async Task Unregistered_message_type_forwards_between_participants_as_raw_json()
+    {
+        // The participant contract: a custom protocol type (e.g. the Python pandas node's
+        // PandasCommand) is OPAQUE to the mesh — it routes by target address and round-trips as
+        // RawJson, needing NO server-side registration. The defect this pins: the participant's
+        // hosted proxy hub is the delivery TARGET, so UnpackIfNecessary ran there and failed the
+        // delivery ("type not registered in this hub's TypeRegistry") instead of forwarding it.
+        var hub = Mesh;
+        var registry = hub.ServiceProvider.GetRequiredService<GrpcConnectionRegistry>();
+        var service = new MeshGrpcService(hub, registry);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        // Two foreign participants, A and B, each on its own bidi stream.
+        var (participantA, inboundA, writerA, openA) = await OpenParticipant(service, cts.Token);
+        var (participantB, inboundB, writerB, openB) = await OpenParticipant(service, cts.Token);
+
+        // A -> B: a message whose $type is registered NOWHERE on the server.
+        var payload = """{"$type":"TotallyCustomCommand","command":"load","path":"PythonDemo/SalesData"}""";
+        var delivery = new MessageDelivery<RawJson>(participantA, participantB, new RawJson(payload), hub.JsonSerializerOptions);
+        await inboundA.Writer.WriteAsync(new ClientFrame
+        {
+            Deliver = JsonSerializer.Serialize<IMessageDelivery>(delivery, hub.JsonSerializerOptions)
+        });
+
+        // B receives it verbatim as a receive frame — the custom protocol survived the proxy hub.
+        string? received = null;
+        for (var i = 0; i < 20 && received is null; i++)
+        {
+            var f = await NextFrame(writerB, "forwarded custom command", TimeSpan.FromSeconds(10));
+            if (f.KindCase == ServerFrame.KindOneofCase.Receive && f.Receive.Contains("TotallyCustomCommand"))
+                received = f.Receive;
+        }
+        Assert.NotNull(received);
+        Assert.Contains("PythonDemo/SalesData", received!);
+
+        // And A got no DeliveryFailure for it.
+        while (writerA.Output.TryRead(out var frame))
+            Assert.DoesNotContain(nameof(DeliveryFailure), frame.Receive ?? "");
+
+        inboundA.Writer.Complete();
+        inboundB.Writer.Complete();
+        await Task.WhenAll(openA, openB);
+    }
+
+    private async Task<(Address Participant, Channel<ClientFrame> Inbound, CapturingStreamWriter<ServerFrame> Writer, Task Open)>
+        OpenParticipant(MeshGrpcService service, CancellationToken ct)
+    {
+        var hub = Mesh;
+        var participant = new Address(GrpcHostingExtensions.PythonAddressType, Guid.NewGuid().ToString("N"));
+        var inbound = Channel.CreateUnbounded<ClientFrame>();
+        var writer = new CapturingStreamWriter<ServerFrame>();
+        var open = service.Open(new ChannelStreamReader<ClientFrame>(inbound.Reader), writer,
+            new FakeServerCallContext(new Metadata(), ct));
+        await inbound.Writer.WriteAsync(new ClientFrame
+        {
+            Connect = JsonSerializer.Serialize(participant, hub.JsonSerializerOptions)
+        }, ct);
+        // Wait for the ack so the participant's route + proxy hub are registered before use.
+        var ack = await NextFrame(writer, "connect ack", TimeSpan.FromSeconds(10));
+        Assert.Equal(ServerFrame.KindOneofCase.Ack, ack.KindCase);
+        return (participant, inbound, writer, open);
     }
 
     [Fact]
@@ -207,9 +352,17 @@ public class MeshGrpcTransportTest(ITestOutputHelper output) : MonolithMeshTestB
         }
     }
 
-    // Minimal ServerCallContext — MeshGrpcService.Open only reads RequestHeaders + CancellationToken.
-    private sealed class FakeServerCallContext(Metadata headers, CancellationToken ct) : ServerCallContext
+    // Minimal ServerCallContext — MeshGrpcService.Open reads RequestHeaders + CancellationToken +
+    // UserState (the AspNetCore HttpContext slot, used for the trusted-endpoint local-port check).
+    private sealed class FakeServerCallContext(Metadata headers, CancellationToken ct, HttpContext? httpContext = null)
+        : ServerCallContext
     {
+        private readonly Dictionary<object, object> userState = httpContext is null
+            ? new Dictionary<object, object>()
+            : new Dictionary<object, object> { ["__HttpContext"] = httpContext };
+
+        protected override IDictionary<object, object> UserStateCore => userState;
+
         protected override string MethodCore => MeshGrpcService.ServiceName + "/Open";
         protected override string HostCore => "localhost";
         protected override string PeerCore => "ipv4:127.0.0.1:0";

--- a/test/MeshWeaver.Hosting.Grpc.Test/MeshGrpcTrustedKestrelTest.cs
+++ b/test/MeshWeaver.Hosting.Grpc.Test/MeshGrpcTrustedKestrelTest.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Net.Client;
+using MeshWeaver.Hosting.Grpc;
+using MeshWeaver.Hosting.Grpc.Protocol;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Grpc.Test;
+
+/// <summary>
+/// The trusted-endpoint semantics over a REAL Kestrel server and real gRPC channels — the two seams
+/// the in-memory transport test cannot cover: <c>Grpc:TrustedPort</c> bound from configuration (the
+/// chart injects it as the <c>Grpc__TrustedPort</c> env var) and the accepted connection's actual
+/// <c>Connection.LocalPort</c> as the trust discriminator. Two h2c endpoints stand in for the
+/// deployment's public (8081) and trusted-loopback (8082) ports.
+/// </summary>
+public class MeshGrpcTrustedKestrelTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    public record WhoAmIRequest : IRequest<WhoAmIResponse>;
+    public record WhoAmIResponse(string ObjectId);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddGrpcHub()
+            .ConfigureHub(config =>
+            {
+                config.TypeRegistry.WithType(typeof(WhoAmIRequest), nameof(WhoAmIRequest));
+                config.TypeRegistry.WithType(typeof(WhoAmIResponse), nameof(WhoAmIResponse));
+                return config.WithHandler<WhoAmIRequest>((hub, request) =>
+                {
+                    hub.Post(new WhoAmIResponse(request.AccessContext?.ObjectId ?? "<none>"),
+                        o => o.ResponseFor(request));
+                    return request.Processed();
+                });
+            });
+
+    [Fact]
+    public async Task Trusted_port_is_detected_on_real_kestrel_with_config_bound_options()
+    {
+        var publicPort = FreePort();
+        var trustedPort = FreePort();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        // The exact shape the helm chart injects: Grpc__TrustedPort → Grpc:TrustedPort.
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Grpc:TrustedPort"] = trustedPort.ToString(),
+        });
+        builder.Services.AddGrpc();
+        builder.Services.AddOptions<GrpcOptions>().BindConfiguration(GrpcOptions.SectionName);
+        // The gRPC service resolves the MESH's hub + registry (the app is just the transport shell).
+        builder.Services.AddSingleton(Mesh);
+        builder.Services.AddSingleton(Mesh.ServiceProvider.GetRequiredService<GrpcConnectionRegistry>());
+        builder.WebHost.ConfigureKestrel(kestrel =>
+        {
+            // h2c needs a dedicated Http2 endpoint — the same layout the chart configures.
+            kestrel.ListenLocalhost(publicPort, l => l.Protocols = HttpProtocols.Http2);
+            kestrel.ListenLocalhost(trustedPort, l => l.Protocols = HttpProtocols.Http2);
+        });
+
+        await using var app = builder.Build();
+        app.MapMeshWeaverGrpc();
+        await app.StartAsync();
+        try
+        {
+            // 1) trusted + carried context → passes through (the gate acts as the requesting user).
+            Assert.Equal("alice", await WhoAmIOver($"http://localhost:{trustedPort}",
+                new AccessContext { ObjectId = "alice", Name = "Alice" }));
+
+            // 2) trusted + no context → the well-known System principal.
+            Assert.Equal(WellKnownUsers.System, await WhoAmIOver($"http://localhost:{trustedPort}", null));
+
+            // 3) public port + forged context → re-stamped to the connection's (Anonymous) identity.
+            Assert.Equal(WellKnownUsers.Anonymous, await WhoAmIOver($"http://localhost:{publicPort}",
+                new AccessContext { ObjectId = "alice", Name = "Alice" }));
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    private async Task<string> WhoAmIOver(string url, AccessContext? carried)
+    {
+        var hub = Mesh;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var channel = GrpcChannel.ForAddress(url);
+        var client = new Protocol.Mesh.MeshClient(channel);
+        using var call = client.Open(cancellationToken: cts.Token);
+
+        var participant = new Address(GrpcHostingExtensions.PythonAddressType, Guid.NewGuid().ToString("N"));
+        await call.RequestStream.WriteAsync(new ClientFrame
+        {
+            Connect = JsonSerializer.Serialize(participant, hub.JsonSerializerOptions)
+        }, cts.Token);
+        Assert.True(await call.ResponseStream.MoveNext(cts.Token));
+        Assert.Equal(ServerFrame.KindOneofCase.Ack, call.ResponseStream.Current.KindCase);
+
+        IMessageDelivery delivery = new MessageDelivery<WhoAmIRequest>(
+            participant, hub.Address, new WhoAmIRequest(), hub.JsonSerializerOptions);
+        if (carried is not null)
+            delivery = delivery.SetAccessContext(carried);
+        await call.RequestStream.WriteAsync(new ClientFrame
+        {
+            Deliver = JsonSerializer.Serialize(delivery, hub.JsonSerializerOptions)
+        }, cts.Token);
+
+        while (await call.ResponseStream.MoveNext(cts.Token))
+        {
+            var frame = call.ResponseStream.Current;
+            if (frame.KindCase != ServerFrame.KindOneofCase.Receive
+                || !frame.Receive.Contains(nameof(WhoAmIResponse)))
+                continue;
+            await call.RequestStream.CompleteAsync();
+            using var doc = JsonDocument.Parse(frame.Receive);
+            return doc.RootElement.GetProperty("message").GetProperty("objectId").GetString()!;
+        }
+        throw new TimeoutException("no WhoAmIResponse frame received");
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/test/MeshWeaver.Layout.Test/PandasExplorerAreaTest.cs
+++ b/test/MeshWeaver.Layout.Test/PandasExplorerAreaTest.cs
@@ -109,6 +109,30 @@ public class PandasExplorerAreaTest : HubTestBase
     }
 
     [HubFact]
+    public async Task Load_button_posts_load_with_the_content_file_path()
+    {
+        var reference = new LayoutAreaReference(Area);
+        var client = GetClient();
+        var stream = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(CreateHostAddress(), reference);
+
+        await stream.GetControlStream($"{Area}/toolbar/load")
+            .Where(c => c is not null).FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+
+        var recorder = ServiceProvider.GetRequiredService<PandasCommandRecorder>();
+        client.Post(new ClickedEvent($"{Area}/toolbar/load", stream.StreamId),
+            o => o.WithTarget(CreateHostAddress()));
+
+        // The click posts `load` carrying the PATH of the CSV file kept in content — never the data
+        // itself; the participant reads the node over the mesh. Hosted without a node instance, the
+        // area falls back to the default source path.
+        var load = await recorder.Commands.Where(c => c.Command == "load")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(20)).ToTask();
+        Assert.Equal(PandasExplorer.DefaultSourcePath, load.Path);
+        Assert.Null(load.Data);
+    }
+
+    [HubFact]
     public async Task GroupBy_button_posts_a_groupby_PandasCommand_to_py_pandas()
     {
         var reference = new LayoutAreaReference(Area);


### PR DESCRIPTION
## Python SDK live-pinned wire contracts, native gRPC (HTTP/2) everywhere, and trusted co-deployed gates

Confirmed live end-to-end against the local k3s portal AND the three hosted portals (native gRPC is already enabled on atioz / memex / memex-cloud via kubectl-level deltas matching this chart).

### Python SDK (`clients/python`) — wire shapes pinned live
- Envelope `$type` is ``MessageDelivery`1[RawJson]`` (pinned from the `MeshGrpcTransportTest` capture).
- Ops moved to the portal's REST verb surface (`POST /api/mesh/*` — the MCP transport-mirror): `get` / `search` / `query_nodes` / `create` / `update` / `patch` / `delete` (JSON array) / `move` / `copy`, with the MeshOperations error sentinels surfaced as `MeshError`.
- `watch(path)` speaks the real sync protocol: `SubscribeRequest(streamId, MeshNodeReference)` → `DataChangedEvent` where **Patch frames are RFC 6902 op arrays** (not merge patches), deduped by stream `version` (frames arrive duplicated); `UnsubscribeRequest` on exit (incl. `aclosing` on early-exit `get` so the owner subscription is never leaked).
- TLS: `connect(..., root_certificates=...)` for self-signed local portals; real certs need nothing.
- New examples with docs (`Doc/DataMesh/PythonPandasNode|PythonFineTuning|PythonStandaloneHub`): pandas on a CSV file kept in content (path travels, not data), LLM fine-tuning on a docs-derived dataset kept in content with live progress on a run node, and a complete standalone hub in Python. 56 tests.

### `RawJsonPassThrough` (src/Messaging + Hosting.Grpc)
The participant proxy hub failed unregistered custom protocol types ("not registered in this hub's TypeRegistry") instead of forwarding them — breaking the documented "participant protocols need no server-side registration" contract. New marker policy on the proxy hub keeps unregistered payloads as `RawJson` and forwards verbatim. Pinned by a transport test that failed before the fix.

### Trusted co-deployed gates (`GrpcOptions.TrustedPort`)
Services that ship in the same deployment as the portal (the node / bun / python gates) authenticate by **pod-boundary reachability**: a loopback-bound Kestrel endpoint (`127.0.0.1:8082`) only same-pod containers can reach — no API token, nothing to rotate. Semantics (pinned by an in-memory test AND a real-Kestrel integration test, and live-verified on a pod):
- trusted + carried `AccessContext` → passed through (a gate executing a user's request writes back under that user's identity, like the in-process C# kernel; the SDK echoes the context automatically),
- trusted + no context → the well-known System principal,
- untrusted + forged context → re-stamped to the connection's validated identity.

The real-Kestrel test caught a real defect the in-memory test missed: `UserState["__HttpContext"]` is only grpc-dotnet's legacy fallback — the official `GetHttpContext()` accessor is required on real Kestrel.

### Helm chart (`values.grpc`, default on)
- Kestrel endpoints: web 8080 + public h2c gRPC 8081 + trusted loopback 8082 (+ `Grpc__TrustedPort`).
- Service port + a second same-host ingress routing **exactly** `/meshweaver.v1.Mesh/Open` with `backend-protocol: GRPC` — participants connect at the ordinary portal URL over TLS, no extra DNS/certs. Deliberately NOT the whole prefix: gRPC-WEB (`Connect`/`Deliver`, the React GUI's HTTP/1.1 transport) shares it and must keep falling through to the web ingress.
- Templates nil-safe (`(.Values.grpc).enabled`, `(.Values.portalNext).enabled`) so `--reuse-values` upgrades from older value sets don't break.

### Verification
- 6 `MeshWeaver.Hosting.Grpc.Test` tests (incl. the new unregistered-type forward + trusted-semantics + real-Kestrel tests), 6 `MeshWeaver.Layout.Test` Pandas tests, 56 Python tests, `DocumentationLinkIntegrityTest`, helm lint, and a clean-worktree `-warnaserror -p:CIRun=true` solution build.
- Live: full REST + gRPC smoke suites (8/8 + 4/4) through the local TLS ingress; the pandas example end-to-end (content CSV → participant → DataGridControl with correct groupby sums); trusted-endpoint identity probes on a pod; native gRPC connect/ack on all three hosted portals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
