### PR TITLE
fix(mcp): wire the documented layoutAreas/ and area/ read routes

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -234,6 +234,15 @@ public class MeshOperations
                 });
         }
 
+        // MCP-documented AREA-READ route `{path}/area/{Name[/Id]}` (McpMeshPlugin.Get docs).
+        // Routed through the same one-shot client-hub subscription RenderArea uses
+        // (GetRemoteStream + materialised-frame wait + Finally-dispose), so the payload is
+        // the SETTLED control tree — never the base-frame shell a raw first emission
+        // carries. Before this route existed, the path fell through to FetchNode on the
+        // full "{path}/area/Name" string and always returned "Not found: …".
+        if (TryParseAreaRoute(resolvedPath, out var areaNodePath, out var routeArea, out var routeAreaId))
+            return GetAreaRoute(resolvedPath, areaNodePath, routeArea, routeAreaId);
+
         // Single-node content read via GetDataRequest + MeshNodeReference + RegisterCallback.
         // See Doc/Architecture/CqrsAndContentAccess.md — queries are for sets only.
         return TryResolveUnifiedPath(resolvedPath)
@@ -453,6 +462,67 @@ public class MeshOperations
                 .Finally(stream.Dispose);
         });
     }
+
+    /// <summary>
+    /// Parses the MCP-documented area-read route <c>{nodePath}/area/{Name[/Id]}</c>.
+    /// The marker is the LAST exact <c>area</c> segment (ordinal, the documented casing) so
+    /// a node path that itself contains an <c>area</c> segment still yields the deepest —
+    /// i.e. correct — node-path/area split. The legacy colon form <c>{path}/area:Name</c> is
+    /// deliberately NOT parsed here: it keeps flowing through <see cref="TryResolveUnifiedPath"/>
+    /// unchanged (it supports UCR-special forms like <c>area:content:file</c> that map to
+    /// <c>$Content</c> areas downstream).
+    /// </summary>
+    private static bool TryParseAreaRoute(
+        string resolvedPath, out string nodePath, out string? area, out string? id)
+    {
+        nodePath = string.Empty;
+        area = null;
+        id = null;
+
+        if (resolvedPath.Contains(':'))
+            return false; // legacy colon form — handled by TryResolveUnifiedPath
+
+        var segments = resolvedPath.Split('/');
+        for (var i = segments.Length - 1; i > 0; i--)
+        {
+            if (!string.Equals(segments[i], "area", StringComparison.Ordinal))
+                continue;
+
+            nodePath = string.Join('/', segments.Take(i));
+            if (string.IsNullOrEmpty(nodePath.Trim('/')))
+                return false; // no node path before the marker — not the area route
+
+            var rest = segments.Skip(i + 1).ToImmutableList();
+            area = rest.Count > 0 && rest[0].Length > 0 ? rest[0] : null;
+            var restId = rest.Count > 1 ? string.Join('/', rest.Skip(1)).Trim('/') : string.Empty;
+            id = restId.Length > 0 ? restId : null;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Serves the MCP <c>get {path}/area/{Name}</c> route: renders through the settled
+    /// <see cref="RenderArea"/> pipeline, mapping a fault (incl. the timeout) onto the Get
+    /// contract's <c>"Error: …"</c> string. When the area interpretation fails, a REAL node
+    /// at the FULL path is authoritative and wins (the same interior-keyword-shadowing rule
+    /// the UCR <c>content</c> fallback applies — see <c>DocumentNodeGetTest</c>); the area
+    /// error surfaces only when no such node exists.
+    /// </summary>
+    private IObservable<string> GetAreaRoute(
+        string fullPath, string nodePath, string? area, string? id) =>
+        RenderArea(nodePath, area, id)
+            .Catch((Exception ex) => Observable.Return($"Error: {ex.Message}"))
+            .SelectMany(result =>
+            {
+                if (!result.StartsWith("Not found:", StringComparison.Ordinal)
+                    && !result.StartsWith("Error:", StringComparison.Ordinal))
+                    return Observable.Return(result);
+                return FetchNode(fullPath).Select(node => node is null
+                    ? result
+                    : JsonSerializer.Serialize(node, hub.JsonSerializerOptions));
+            });
 
     /// <summary>
     /// Splits a path-resolution remainder into <c>(area, id)</c> — the same
@@ -704,13 +774,19 @@ public class MeshOperations
             }
         }
 
-        // Try new slash format: address/prefix/path where prefix is a known UCR keyword
+        // Try new slash format: address/prefix/path where prefix is a known UCR keyword.
+        // `layoutAreas` is the MCP-documented listing route (`{path}/layoutAreas/`): it is
+        // not in the UCR prefix map (it maps to no $-area), but the per-node hub answers
+        // GetDataRequest(UnifiedReference("layoutAreas…")) directly via the layout plugin's
+        // HandleLayoutAreasRequest — so route it like any unified segment. Without this the
+        // path fell through to FetchNode("{path}/layoutAreas") → always "Not found: …".
         if (addressPart == null)
         {
             var segments = resolvedPath.Split('/');
             for (var i = 0; i < segments.Length; i++)
             {
-                if (UcrPrefixResolver.PrefixToAreaMap.ContainsKey(segments[i]))
+                if (UcrPrefixResolver.PrefixToAreaMap.ContainsKey(segments[i])
+                    || string.Equals(segments[i], "layoutAreas", StringComparison.Ordinal))
                 {
                     if (i > 0)
                     {

--- a/test/MeshWeaver.AI.Test/RenderAreaOperationTest.cs
+++ b/test/MeshWeaver.AI.Test/RenderAreaOperationTest.cs
@@ -27,6 +27,12 @@ namespace MeshWeaver.AI.Test;
 /// <item>an unknown path returns the clean <c>"Not found: …"</c> sentinel;</item>
 /// <item>a timeout faults with <see cref="TimeoutException"/> (the REST layer maps it to 504).</item>
 /// </list>
+/// It ALSO pins the MCP <c>get</c> AREA-READ path shapes documented on the tool
+/// (<c>{path}/layoutAreas/</c> and <c>{path}/area/{Name}</c> — <c>McpMeshPlugin.Get</c>):
+/// both routed through <see cref="MeshOperations.Get"/>, which must dispatch them to the
+/// node hub's layoutAreas listing and to the same settled RenderArea pipeline respectively
+/// (live defect: both returned "Not found: …" for every node — the router never recognised
+/// the documented segments).
 /// Leak coverage: <see cref="MonolithMeshTestBase.DisposeAsync"/> fails any test in this class
 /// that leaves the render subscription (or its SubscribeRequest callback) pending past the
 /// quiescing budget — RenderArea's <c>Finally(stream.Dispose)</c> is what keeps that green.
@@ -128,6 +134,97 @@ public class RenderAreaOperationTest(ITestOutputHelper output) : MonolithMeshTes
         result.Should().NotStartWith("Error");
         result.Should().Contain("Area not found",
             "an unknown area renders the framework's visible placeholder — portal-URL parity");
+    }
+
+    /// <summary>
+    /// MCP `get {path}/layoutAreas/` — the documented listing of layout areas on the node —
+    /// must return the area definitions declared on the node's hub configuration (a Markdown
+    /// node declares Overview/Edit/… via <c>AddMarkdownViews</c>), not "Not found".
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task Get_LayoutAreasRoute_ReturnsDeclaredAreaNames()
+    {
+        var path = await SeedMarkdownNodeAsync("layoutareas-route");
+
+        var result = await new MeshOperations(Mesh).Get($"@{path}/layoutAreas/")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+
+        result.Should().NotStartWith("Not found").And.NotStartWith("Error");
+        using var doc = JsonDocument.Parse(result);
+        doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array,
+            "the layoutAreas listing is a JSON array of LayoutAreaDefinition");
+        var areaNames = doc.RootElement.EnumerateArray()
+            .Select(e => (e.TryGetProperty("area", out var a) ? a : e.GetProperty("Area")).GetString())
+            .ToList();
+        areaNames.Should().Contain("Overview").And.Contain("Edit",
+            because: "the listing must come from the node hub's declared area definitions");
+    }
+
+    /// <summary>The docs show a trailing slash, but the bare form must route identically.</summary>
+    [Fact(Timeout = 60000)]
+    public async Task Get_LayoutAreasRoute_NoTrailingSlash_RoutesIdentically()
+    {
+        var path = await SeedMarkdownNodeAsync("layoutareas-bare");
+
+        var result = await new MeshOperations(Mesh).Get($"@{path}/layoutAreas")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+
+        result.Should().NotStartWith("Not found").And.NotStartWith("Error");
+        using var doc = JsonDocument.Parse(result);
+        doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    /// <summary>
+    /// MCP `get {path}/area/{Name}` — the documented rendered-payload read — must return the
+    /// SETTLED wire frame (same materialised-control wait as RenderArea, never the base-frame
+    /// shell), not "Not found".
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task Get_AreaRoute_ReturnsMaterializedControlPayload()
+    {
+        var path = await SeedMarkdownNodeAsync("area-route");
+
+        var result = await new MeshOperations(Mesh).Get($"@{path}/area/Overview")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+
+        result.Should().NotStartWith("Not found").And.NotStartWith("Error");
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        root.TryGetProperty("areas", out var areas).Should().BeTrue(
+            "the area payload must be the wire {areas,data} frame");
+        areas.TryGetProperty("\"Overview\"", out var overview).Should().BeTrue(
+            "the requested area's control must have materialised (no base-frame shell)");
+        overview.TryGetProperty("$type", out _).Should().BeTrue(
+            "controls keep their $type discriminator on the wire");
+    }
+
+    /// <summary>
+    /// The pre-existing `get` path shapes must keep working around the new area routes:
+    /// the node itself, children (`/*`), `data/` (default data reference = the node), and
+    /// `schema/`.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task Get_ExistingPathShapes_KeepWorking()
+    {
+        var path = await SeedMarkdownNodeAsync("regression-shapes");
+        var ops = new MeshOperations(Mesh);
+
+        var node = await ops.Get($"@{path}")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+        node.Should().Contain("\"nodeType\":\"Markdown\"", "the plain node read must return the node");
+
+        var children = await ops.Get($"@{TestPartition}/*")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+        using (var childrenDoc = JsonDocument.Parse(children))
+            childrenDoc.RootElement.ValueKind.Should().Be(JsonValueKind.Array, "children listing stays an array");
+
+        var data = await ops.Get($"@{path}/data/")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+        data.Should().NotStartWith("Not found").And.NotStartWith("Error");
+
+        var schema = await ops.Get($"@{path}/schema/")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+        schema.Should().NotStartWith("Not found").And.NotStartWith("Error");
     }
 
     [Fact(Timeout = 60000)]


### PR DESCRIPTION
The MCP `get` tool documented `{path}/layoutAreas/` and `{path}/area/{Name}` but the router's slash-segment scan never included them — both fell through to a full-path node lookup → 'Not found' for every node on every deployment. The downstream capability (layout plugin's UnifiedReference handler + the settled RenderArea client-hub read) existed all along, unreachable.

Fix wires both routes to those existing pipelines; one fix point covers MCP, agent tools, and REST. Red→green (3 facts reproducing the exact live sentinel), RenderAreaOperationTest 9/9, adjacent sweep 112/112, Release `-warnaserror` 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)