### PR TITLE
fix(graph): stop the per-boot stray persistence echo of static-served type-definition nodes

### DIFF
--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -593,6 +593,27 @@ public static class MeshDataSourceExtensions
     /// rapid editor-style updates collapse to one save per window, latest wins.</summary>
     private static readonly TimeSpan SaveSampleInterval = TimeSpan.FromMilliseconds(200);
 
+    /// <summary>
+    /// Resolves the static node SERVED at <paramref name="hubPath"/>: the first
+    /// non-<see cref="MeshNode.IsDefinitionOnly"/> static node across every registered
+    /// <see cref="IStaticNodeProvider"/> whose <see cref="MeshNode.Path"/> matches
+    /// (case-insensitive). Definition-only type-defs (DB-synced NodeType catalogs) are
+    /// skipped — Postgres owns the runtime node at their path
+    /// (Doc/Architecture/NodeTypeCatalogs.md).
+    ///
+    /// <para>This is the ONE resolution shared by <see cref="MeshDataSource.WithMeshNodes"/>
+    /// (which serves a matching node via <c>WithInitialData</c>, bypassing persistence
+    /// entirely) and the persistence-sampler gate in <see cref="SubscribeToOwnDeletion"/>
+    /// (which must NOT auto-persist such a node — its path routes to a partition schema
+    /// that is by design never provisioned, and a persisted echo is never served back by
+    /// this hub). Keeping both on the same lookup guarantees "served static" ⇔ "not
+    /// auto-persisted" can never drift apart.</para>
+    /// </summary>
+    internal static MeshNode? FindServedStaticNode(IServiceProvider serviceProvider, string hubPath)
+        => serviceProvider.EnumerateStaticNodes()
+            .FirstOrDefault(n => !n.IsDefinitionOnly
+                && string.Equals(n.Path, hubPath, StringComparison.OrdinalIgnoreCase));
+
     private static void SubscribeToOwnDeletion(IMessageHub hub)
     {
         var cache = hub.ServiceProvider.GetService<OwnNodeCache>();
@@ -687,9 +708,26 @@ public static class MeshDataSourceExtensions
                 return sub;
             }
 
-            var saveSub = InstallPersistenceSampler(
-                ownStream, cache, new WeakReference<IMessageHub>(hub), SaveSampleInterval);
-            hub.RegisterForDisposal(saveSub);
+            // 🚨 The sampler is ONLY for persistence-backed hubs. A hub whose own MeshNode is
+            // served from a static source (WithMeshNodes' WithInitialData branch: AddMeshNodes
+            // built-in type definitions like Code/Markdown/User, static partition definitions)
+            // has NO persistence backing — the static source wins again on every activation, so
+            // a persisted echo is never read back by this hub. Auto-persisting it anyway was the
+            // boot-time 42P01 noise on every portal start: a type-def path routes to a Postgres
+            // schema named after the lowercased type (code/markdown/user) that is BY DESIGN never
+            // provisioned (schema creation is gated to partition-owning creates — the ghost-schema
+            // invariant), so every boot logged `SaveMeshNode failed … relation "code.mesh_nodes"
+            // does not exist`. On FileSystem it littered degraded duplicates (delegate-typed
+            // HubConfiguration and default-suppressed fields are lost on serialisation) that
+            // shadow the static definition in persistence-first readers. Static definitions are
+            // never auto-persisted — Doc/Architecture/NodeTypeCatalogs.md. Same resolution as
+            // WithMeshNodes (FindServedStaticNode) so serving and persisting stay in lockstep.
+            if (FindServedStaticNode(hub.ServiceProvider, hub.Address.Path) is null)
+            {
+                var saveSub = InstallPersistenceSampler(
+                    ownStream, cache, new WeakReference<IMessageHub>(hub), SaveSampleInterval);
+                hub.RegisterForDisposal(saveSub);
+            }
 
             // Per-NodeType compile auto-watcher: fires RunCompile whenever the own
             // MeshNode emits with CompilationStatus = Pending. Replaces the legacy
@@ -1285,33 +1323,20 @@ public record MeshDataSource : GenericUnpartitionedDataSource<MeshDataSource>
         // for both the initial seed AND ongoing pushes into the workspace.
         var ownStream = Workspace.Hub.Configuration.Get<OwnNodeStreamHolder>()?.Stream;
 
-        // Check if this hub path corresponds to a built-in node (registered via AddMeshNodes).
-        // Built-in nodes (NodeType, Markdown, Agent, etc.) are pre-loaded — no persistence needed.
-        var builtInNode = Workspace.Hub.ServiceProvider.FindStaticNode(_hubPath);
-        // A definition-only static node (a DB-synced NodeType catalog's in-memory type-def) is NOT
-        // the runtime node at this path — Postgres owns the nodeType:NodeType partition root. Fall
-        // through to persistence so the PG root is served, never the colliding in-memory type-def.
-        // See Doc/Architecture/NodeTypeCatalogs.md.
-        if (builtInNode is { IsDefinitionOnly: true })
-            builtInNode = null;
-        if (builtInNode is not null)
-        {
-            _logger?.LogDebug("[DIAG-MeshDataSource] BUILT-IN node for hubPath='{HubPath}'", _hubPath);
-            Workspace.Hub.OpenGate(MeshNodeExtensions.MeshNodeInitGateName);
-            return WithType<MeshNode>(ts => ts
-                .WithKey(n => n.Id)
-                .WithInitialData([builtInNode]));
-        }
-
-        // Check static node providers (e.g., DocumentationNodeProvider, BuiltInAgentProvider)
-        var allStatic = Workspace.Hub.ServiceProvider.GetServices<IStaticNodeProvider>()
-            .SelectMany(p => p.GetStaticNodes()).ToList();
-        // Skip definition-only catalog type-defs here too — PG owns the runtime node at their path.
-        var staticNode = allStatic
-            .FirstOrDefault(n => !n.IsDefinitionOnly
-                && string.Equals(n.Path, _hubPath, StringComparison.OrdinalIgnoreCase));
-        _logger?.LogDebug("[DIAG-MeshDataSource] static lookup hubPath='{HubPath}', total={Total}, found={Found}",
-            _hubPath, allStatic.Count, staticNode != null);
+        // Check if this hub path is served from a static source: AddMeshNodes built-ins
+        // (NodeType, Markdown, Agent, etc.) and IStaticNodeProvider providers
+        // (DocumentationNodeProvider, DefaultPartitionProvider, …). Static-served nodes are
+        // pre-loaded — no persistence involved. Definition-only static nodes (a DB-synced
+        // NodeType catalog's in-memory type-def) are NOT the runtime node at this path —
+        // Postgres owns the nodeType:NodeType partition root, so those fall through to
+        // persistence (Doc/Architecture/NodeTypeCatalogs.md). Shares
+        // MeshDataSourceExtensions.FindServedStaticNode with the persistence-sampler gate in
+        // SubscribeToOwnDeletion: a hub served from WithInitialData below has no persistence
+        // backing, so the sampler must never post SaveMeshNodeRequest for it.
+        var staticNode = MeshDataSourceExtensions.FindServedStaticNode(
+            Workspace.Hub.ServiceProvider, _hubPath);
+        _logger?.LogDebug("[DIAG-MeshDataSource] static lookup hubPath='{HubPath}', found={Found}",
+            _hubPath, staticNode != null);
         if (staticNode != null)
         {
             Workspace.Hub.OpenGate(MeshNodeExtensions.MeshNodeInitGateName);

--- a/test/MeshWeaver.Hosting.Monolith.Test/StaticNodePersistenceEchoTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/StaticNodePersistenceEchoTest.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 Regression repro for the boot-time "SaveMeshNode failed … relation
+/// "code.mesh_nodes" does not exist" noise on every portal start (memex-cloud
+/// 2026-07-02). Built-in type-definition nodes (Code / Markdown / User, registered via
+/// <c>AddMeshNodes</c>) are STATIC-served: <c>MeshDataSource.WithMeshNodes</c> serves them
+/// through <c>WithInitialData</c>, bypassing persistence entirely, and the same static
+/// source wins again on every activation. The per-node-hub persistence sampler must
+/// therefore never post a <c>SaveMeshNodeRequest</c> for them:
+/// <list type="bullet">
+///   <item>On Postgres the type-def path routes to a schema named after the lowercased
+///     type (<c>code</c>/<c>markdown</c>/<c>user</c>) that is BY DESIGN never provisioned
+///     (schema creation is gated to partition-owning creates — the ghost-schema
+///     invariant), so the echo failed with 42P01 on every boot.</item>
+///   <item>On InMemory / FileSystem the echo "succeeds" — writing a degraded duplicate
+///     (delegate-typed <c>HubConfiguration</c> and default-suppressed fields are lost)
+///     that shadows the static definition in persistence-first readers. That silent
+///     success is what this test pins red: activating the hub must leave persistence
+///     untouched.</item>
+/// </list>
+/// See Doc/Architecture/NodeTypeCatalogs.md ("never auto-persisted to a phantom schema").
+/// </summary>
+public class StaticNodePersistenceEchoTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact(Timeout = 60000)]
+    public async Task ActivatingStaticTypeDefHubs_DoesNotEchoThemIntoPersistence()
+    {
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var paths = new[] { "Markdown", "Code", "User" };
+
+        // Capture any write echo for the static type-def paths BEFORE activating the hubs.
+        var echoes = new ConcurrentQueue<DataChangeNotification>();
+        using var echoSub = storage.Changes
+            .Where(c => paths.Contains(c.Path, StringComparer.OrdinalIgnoreCase))
+            .Subscribe(echoes.Enqueue);
+
+        // Activate each built-in type-def per-node hub — the same thing boot-time NodeType
+        // enrichment / static-repo import does in prod — and confirm the static node serves.
+        foreach (var path in paths)
+        {
+            var served = await ReadNode(path)
+                .Should().Within(30.Seconds()).Match(n => n is not null);
+            served!.Path.Should().Be(path);
+        }
+
+        // Negative assertion (sanctioned fixed wait — "confirm nothing happened"): the
+        // persistence sampler fires 200 ms after the own-stream emission; give it ample
+        // headroom, then confirm no echo write ever reached storage.
+        await Task.Delay(1500, TestContext.Current.CancellationToken);
+
+        echoes.Should().BeEmpty(
+            "static-served type definitions have no persistence backing — the per-node-hub " +
+            "sampler must not auto-persist them (on Postgres this echo is the boot-time 42P01 " +
+            "'relation \"code.mesh_nodes\" does not exist' noise)");
+
+        foreach (var path in paths)
+        {
+            var persisted = await storage.Read(path, Mesh.JsonSerializerOptions)
+                .Should().Within(10.Seconds()).Emit();
+            persisted.Should().BeNull(
+                $"the static type definition '{path}' must never be shadowed by a persisted echo");
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/BootTypeDefEchoTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/BootTypeDefEchoTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// 🚨 Regression repro for the memex-cloud boot noise (2026-07-02, image ci.211+):
+/// <c>SaveMeshNode failed for Code (version=1): relation "code.mesh_nodes" does not
+/// exist</c> (same for <c>markdown</c> / <c>user</c>) on EVERY portal boot. Built-in
+/// type-definition nodes are static-served (AddMeshNodes → <c>WithInitialData</c>, no
+/// persistence backing), yet the per-node-hub persistence sampler auto-posted a
+/// <c>SaveMeshNodeRequest</c> when boot-time enrichment activated their hubs. The PG
+/// router — correctly — refuses to conjure a schema for a type-def path (the ghost-schema
+/// invariant: schema creation is gated to partition-owning creates), so the stray write
+/// 42P01'd on every boot. The root fix removes the stray write (the sampler is gated to
+/// persistence-backed hubs); provisioning <c>code</c>/<c>markdown</c>/<c>user</c> schemas
+/// would have been the band-aid — exactly the per-type ghost schemas the router redesign
+/// eliminated.
+///
+/// <para>PG-only persistence, wired like <see cref="PgOnlyProdShapeTests"/> (the prod
+/// portal shape). Red before the fix via the captured <c>SaveMeshNodeHandler</c> warning;
+/// green after: activating the type-def hubs produces no save attempt, and no type-def
+/// schema ever exists.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class BootTypeDefEchoTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private readonly PostgreSqlFixture _fixture = fixture;
+    private readonly ConcurrentQueue<string> _saveMeshNodeWarnings = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new Npgsql.NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
+        {
+            MaxPoolSize = 16,
+            ConnectionIdleLifetime = 10
+        };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services =>
+                services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString))
+            .AddRowLevelSecurity()
+            .AddGraph()
+            .ConfigureServices(s => s.AddSingleton<ILoggerProvider>(
+                new CapturingLoggerProvider(_saveMeshNodeWarnings)));
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ActivatingStaticTypeDefHubs_NeverAttemptsA42P01Save()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var paths = new[] { "Markdown", "Code", "User" };
+
+        // Activate each built-in type-def per-node hub — what boot-time NodeType
+        // enrichment does in prod — and confirm the STATIC node serves on PG-only
+        // persistence (no echo row is needed for the type-def hub to work).
+        foreach (var path in paths)
+        {
+            var served = await ReadNode(path)
+                .Should().Within(30.Seconds()).Match(n => n is not null);
+            served!.Path.Should().Be(path);
+        }
+
+        // Negative assertion (sanctioned fixed wait — "confirm nothing happened"): the
+        // persistence sampler fired 200 ms after hub activation; give it headroom, then
+        // confirm no SaveMeshNode attempt was made for the static type-defs.
+        await Task.Delay(1500, ct);
+
+        _saveMeshNodeWarnings.Should().BeEmpty(
+            "static-served type definitions must never be auto-persisted — every warning here " +
+            "is the boot-time 42P01 noise: {0}",
+            string.Join(" | ", _saveMeshNodeWarnings));
+
+        // And the ghost-schema invariant holds: no per-type schema was ever conjured.
+        var typeSchemas = await _fixture.DataSource.ScalarLong(
+                "SELECT COUNT(*) FROM information_schema.schemata " +
+                "WHERE schema_name IN ('markdown', 'code', 'user')", ct)
+            .Should().Within(30.Seconds()).Emit();
+        typeSchemas.Should().Be(0L,
+            "type-definition paths must never materialise as partition schemas");
+    }
+
+    /// <summary>Captures warning-level messages on the SaveMeshNodeHandler channel.</summary>
+    private sealed class CapturingLoggerProvider(ConcurrentQueue<string> sink) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) =>
+            categoryName.Contains("SaveMeshNodeHandler", StringComparison.OrdinalIgnoreCase)
+                ? new CapturingLogger(sink)
+                : NullLogger.Instance;
+
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger(ConcurrentQueue<string> sink) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel >= LogLevel.Warning)
+                sink.Enqueue(formatter(state, exception)
+                    + (exception is null ? "" : $" ({exception.Message})"));
+        }
+    }
+}


### PR DESCRIPTION
Root cause of the boot-time `42P01 relation \"code/markdown/user.mesh_nodes\" does not exist` storm on every portal start: the persistence sampler was installed unconditionally, so static-served type-definition nodes echoed a stray full-node write into per-type schemas that must never exist. The write is eliminated (sampler gated on 'no static node served at this path' via a shared lookup), NOT provisioned — per the ghost-schema doctrine.

Red→green stash-verified in both an in-memory echo test and a PG-testcontainer prod-shape test that reproduces the exact production log lines. Neighbors + full-solution Release `-warnaserror` green.

Investigation also **pinned the degraded-content sibling defect** (separate follow-up): a registered-but-narrower content type + STJ silently dropping unknown members + the initial-load echo persisting the loss on pure activation — evidenced by prod data loss (Systemorph/Event/DAV2026) and by ~40 sample JSONs in local working trees losing `showChildrenInDetails`/`detailsChildrenLimit`. Recommended fix tracked separately ([JsonExtensionData] round-trip + retiring the initial-load echo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)