### PR TITLE
fix(orleans): grain lifetime calls after deactivation are graceful terminals, not unobserved fatals

### DIFF
--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -69,6 +69,76 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
     private IDisposable? _activationSubscription;
 
     /// <summary>
+    /// Set at the START of <see cref="OnDeactivateAsync"/>. Grain-lifetime calls arriving
+    /// after this point (see <see cref="TryDeactivateOnIdle"/> / <see cref="TryDelayDeactivation"/>)
+    /// are graceful no-ops: reactive continuations — an activation-source emission racing
+    /// deactivation, a heartbeat, a round start, a hub disposal action — can legally fire
+    /// after the activation completed deactivation, and must never turn into a throw against
+    /// a dead activation.
+    /// </summary>
+    private volatile bool _deactivated;
+
+    /// <summary>
+    /// <see cref="Grain.DelayDeactivation"/> guarded for the mesh↔Orleans lifetime boundary.
+    /// Stragglers (sync-stream heartbeats via <c>GrainKeepAliveCallback</c>, round starts via
+    /// <c>GrainLongRunningOperationCallback</c>) run on hub/pool threads and can fire after the
+    /// activation completed deactivation; Orleans' <c>GrainRuntime.CheckRuntimeContext</c> then
+    /// THROWS <c>InvalidOperationException("Attempt to access an invalid activation…")</c>
+    /// instead of no-opping. That throw escapes RAW into whatever Rx chain / pooled task the
+    /// straggler rode (proven: the activation-source MeshQuery emission on a
+    /// <c>TaskPoolScheduler</c> work item), faults a Task nobody observes, and xUnit v3
+    /// escalates the <c>UnobservedTaskException</c> to a Catastrophic failure that poisons the
+    /// NEXT test class (CI run 28646145008 shard 2, 2026-07-03). A dead activation is a
+    /// graceful terminal here: "keep alive" is moot once the grain is gone — log the signal,
+    /// never throw. Repro: <c>OrleansGrainTeardownStragglerTest</c>.
+    /// </summary>
+    private void TryDelayDeactivation(TimeSpan delay)
+    {
+        if (_deactivated)
+            return;
+        try
+        {
+            DelayDeactivation(delay);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // The only InvalidOperationException DelayDeactivation raises is Orleans'
+            // CheckRuntimeContext invalid-activation guard — the TOCTOU window where the
+            // activation went Invalid between the _deactivated check and the call.
+            logger.LogDebug(ex,
+                "Grain {GrainId}: DelayDeactivation after the activation died — keep-alive is moot, treating as no-op",
+                this.GetPrimaryKeyString());
+        }
+    }
+
+    /// <summary>
+    /// <see cref="Grain.DeactivateOnIdle"/> guarded for the mesh↔Orleans lifetime boundary —
+    /// same rationale as <see cref="TryDelayDeactivation"/>. Callers request deactivation from
+    /// reactive continuations (activation-source terminal handlers, the NACK-fallback branch,
+    /// hub disposal via <c>RegisterForDisposal</c>, the stuck-round watchdog via
+    /// <c>GrainDeactivateCallback</c>); when the activation is already dead the requested
+    /// outcome has ALREADY happened, so the correct semantics are log-and-no-op — never a
+    /// throw that escapes into an unobserved task (the 2026-07-03 teardown-race fatal:
+    /// <c>CompleteActivation</c>'s catch block called <c>DeactivateOnIdle()</c> on an Invalid
+    /// activation and the second throw escaped the catch into the path-resolver emission).
+    /// </summary>
+    private void TryDeactivateOnIdle()
+    {
+        if (_deactivated)
+            return;
+        try
+        {
+            DeactivateOnIdle();
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogDebug(ex,
+                "Grain {GrainId}: DeactivateOnIdle after the activation died — deactivation already achieved, treating as no-op",
+                this.GetPrimaryKeyString());
+        }
+    }
+
+    /// <summary>
     /// Non-blocking activation: resolve the MeshNode (from the mesh-node cache or
     /// static providers), let <see cref="IMeshNodeHubFactory"/> hydrate the assembly
     /// bytes via <see cref="IAssemblyStore"/> and produce the HubConfiguration
@@ -116,10 +186,10 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                         // Request deactivation NOW rather than waiting out the last DelayDeactivation
                         // window + CollectionAgeLimit. On deactivation OnDeactivateAsync disposes the hub,
                         // RegisterForDisposal fires executionCts.Cancel(), and the hung AI call is torn down.
-                        DeactivateOnIdle();
+                        TryDeactivateOnIdle();
                     }
                     else
-                        DelayDeactivation(TimeSpan.FromMinutes(10));
+                        TryDelayDeactivation(TimeSpan.FromMinutes(10));
                 }
                 return Task.CompletedTask;
             },
@@ -216,7 +286,7 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                     // Retry-on-next-access: without this the grain stays a parked
                     // corpse answering Failed until idle collection; deactivating
                     // lets the next caller re-run resolution from scratch.
-                    DeactivateOnIdle();
+                    TryDeactivateOnIdle();
                 },
                 () =>
                 {
@@ -225,7 +295,7 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                         streamId, addressPath);
                     _hubReadyRaw.OnError(new InvalidOperationException(
                         $"No MeshNode resolvable for address '{addressPath}'. Either the node does not exist or no query provider claims its partition."));
-                    DeactivateOnIdle();
+                    TryDeactivateOnIdle();
                 });
 
         return Task.CompletedTask;
@@ -241,6 +311,20 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         MeshNode node, IObservable<MeshNode> ownNodeStream)
     {
         if (_hub is not null) return;
+        // Teardown race: the activation source (path resolver / mesh-node cache) can emit
+        // AFTER deactivation began — Rx dispose of _activationSubscription cannot stop an
+        // in-flight OnNext (the 2026-07-03 CI fatal, run 28646145008 shard 2). Building a
+        // hosted hub now would leak it on a dead grain (OnDeactivateAsync already ran its
+        // hub disposal), and every grain-lifetime call below would throw against the
+        // Invalid activation. Drop the emission: DeliverMessage parkers were already
+        // failed via the ready-signal's OnCompleted, and the next access re-activates fresh.
+        if (_deactivated)
+        {
+            logger.LogDebug(
+                "[ACTIVATE] Grain {StreamId}: activation source emitted after deactivation — dropping (next access re-activates fresh)",
+                streamId);
+            return;
+        }
         try
         {
             if (node.HubConfiguration is null)
@@ -262,14 +346,14 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                     HubConfiguration = c => c.Set(
                         new UnhandledMessageNack(reason, ErrorType.NotFound, node.NodeType))
                 };
-                DeactivateOnIdle();
+                TryDeactivateOnIdle();
             }
             var hub = meshHub.GetHostedHub(address, config =>
             {
                 config = config.WithOwnNodeStream(ownNodeStream);
                 return node.HubConfiguration!(config)
                     .WithTaskScheduler(grainScheduler)
-                    .Set(new GrainKeepAliveCallback(() => DelayDeactivation(TimeSpan.FromMinutes(10))))
+                    .Set(new GrainKeepAliveCallback(() => TryDelayDeactivation(TimeSpan.FromMinutes(10))))
                     .Set(new GrainLongRunningOperationCallback(BeginLongRunningOperation))
                     // #147 escape hatch: the hub's action block runs on THIS grain's
                     // ActivationTaskScheduler (WithTaskScheduler above), so when a stuck round
@@ -287,11 +371,11 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                             "the hub's message queue (#147). Deactivating so hub disposal cancels " +
                             "the in-flight operation.",
                             this.GetPrimaryKeyString());
-                        DeactivateOnIdle();
+                        TryDeactivateOnIdle();
                     }));
             })!;
 
-            hub.RegisterForDisposal(_ => DeactivateOnIdle());
+            hub.RegisterForDisposal(_ => TryDeactivateOnIdle());
             _hub = hub;
             logger.LogDebug("[ACTIVATE] Grain {StreamId} ready", streamId);
             _hubReadyRaw.OnNext(hub);
@@ -302,7 +386,12 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
             _hubReadyRaw.OnError(ex);
             // Same retry-on-next-access semantics as the activation-fault path:
             // a grain whose hub construction threw must not linger as a corpse.
-            DeactivateOnIdle();
+            // 🚨 MUST be the guarded variant: this catch runs inside the activation
+            // source's Rx chain (a TaskPool work item). The 2026-07-03 CI fatal was the
+            // raw DeactivateOnIdle() here throwing invalid-activation as the SECOND
+            // exception, escaping this catch into the chain, and surfacing as an
+            // unobserved-task Catastrophic failure that poisoned the next test class.
+            TryDeactivateOnIdle();
         }
     }
 
@@ -372,8 +461,9 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         // bound it (see MaxLongRunningOperationDuration / #147).
         if (Interlocked.Increment(ref _activeOperations) == 1)
             Volatile.Write(ref _longRunningStartedTicks, DateTime.UtcNow.Ticks);
-        // DelayDeactivation is thread-safe in Orleans
-        DelayDeactivation(TimeSpan.FromMinutes(10));
+        // DelayDeactivation is thread-safe in Orleans; guarded because a round can start
+        // on a pool thread after the activation already died (teardown race).
+        TryDelayDeactivation(TimeSpan.FromMinutes(10));
         logger.LogInformation("Grain {GrainId}: long-running operation started (active={Count})",
             this.GetPrimaryKeyString(), Volatile.Read(ref _activeOperations));
 
@@ -436,15 +526,29 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         var grainId = this.GetPrimaryKeyString();
         logger.LogInformation("Grain {GrainId} deactivating: reason={Reason}", grainId, reason.ReasonCode);
 
+        // FIRST: flip the lifetime flag so every straggler (activation-source emission,
+        // heartbeat KeepAlive, round BeginOperation, disposal action) that fires from here
+        // on takes the graceful no-op path in TryDeactivateOnIdle / TryDelayDeactivation
+        // instead of throwing against a soon-to-be-Invalid activation.
+        _deactivated = true;
+
         // Tear down activation subscription so any in-flight emission can't try to
-        // instantiate the hub after deactivation began.
+        // instantiate the hub after deactivation began. (Rx dispose cannot stop an
+        // ALREADY-in-flight OnNext — CompleteActivation's _deactivated guard covers that.)
         _activationSubscription?.Dispose();
         _activationSubscription = null;
 
         // Complete the ready-signal so any pending DeliverMessage subscribers wake up
         // with OnCompleted and fail-fast with DeliveryFailure.
+        //
+        // 🚨 Deliberately NOT disposed. An in-flight activation emission racing this
+        // deactivation may still call OnNext/OnError on the subject; after OnCompleted
+        // those are safe no-ops by the Rx subject contract, but after Dispose they throw
+        // ObjectDisposedException — straight into the activation source's TaskPool work
+        // item, i.e. the same unobserved-fatal channel as the invalid-activation throw
+        // (2026-07-03 teardown race). The subject holds one buffered hub reference at
+        // most and dies with the grain — GC covers it.
         try { _hubReadyRaw.OnCompleted(); } catch { /* already terminated */ }
-        _hubReadyRaw.Dispose();
 
         var hub = _hub;
         if (hub != null)

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansGrainTeardownStragglerTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansGrainTeardownStragglerTest.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Hosting;
+using Orleans.Runtime;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Deterministic repro for the ORLEANS TEARDOWN RACE (CI run 28646145008 shard 2):
+/// during test-class teardown a straggler (a change-feed / activation-source emission,
+/// a heartbeat, a round start, a disposal action) still reaches the per-node
+/// <see cref="MessageHubGrain"/> AFTER its activation completed deactivation
+/// (<c>State=Invalid</c>). The grain-lifetime calls those stragglers make —
+/// <c>Grain.DelayDeactivation</c> (via <c>GrainKeepAliveCallback</c> /
+/// <c>GrainLongRunningOperationCallback</c>) and <c>Grain.DeactivateOnIdle</c> (via
+/// <c>GrainDeactivateCallback</c> / <c>RegisterForDisposal</c> / the activation-source
+/// terminal handlers) — then hit Orleans'
+/// <c>GrainRuntime.CheckRuntimeContext</c>, which THROWS
+/// <c>InvalidOperationException("Attempt to access an invalid activation: …")</c> instead
+/// of no-opping. On the real teardown path that throw escapes RAW into the activation
+/// source's Rx chain (proven stack: <c>MessageHubGrain.CompleteActivation</c> →
+/// <c>DeactivateOnIdle</c> inside its own catch block → the path-resolver
+/// <c>MeshQuery</c> emission → <c>TaskPoolScheduler.ScheduledWorkItem</c>), faults a
+/// ThreadPool task nobody observes, and xUnit v3 escalates the
+/// <c>UnobservedTaskException</c> to a Catastrophic failure that poisons the NEXT test
+/// class (OrleansSubThreadRoutingTest died as collateral in the incident).
+///
+/// <para>This test distills the race deterministically: activate a per-thread grain,
+/// capture the grain-lifetime callbacks it hands to hub code, drive the activation to
+/// FULL deactivation (gone from the silo catalog ⇒ <c>State=Invalid</c>), then invoke the
+/// callbacks the way a straggler would. Contract under test: a dead activation is a
+/// GRACEFUL TERMINAL for grain-lifetime calls — "deactivate" is already achieved and
+/// "keep alive" is moot — so the callbacks must log-and-no-op, never throw. Pre-fix this
+/// fails with the exact incident exception.</para>
+/// </summary>
+public class OrleansGrainTeardownStragglerTest(ITestOutputHelper output) : OrleansSharedTestBase(output)
+{
+    [Fact(Timeout = 60000)]
+    public async Task GrainLifetimeCallbacks_AfterActivationIsInvalid_AreGracefulNoOps_NotThrows()
+    {
+        var ct = new CancellationTokenSource(55.Seconds()).Token;
+        var suffix = Guid.NewGuid().ToString("N")[..6];
+        var client = GetClient($"straggler-{suffix}");
+
+        // 1. Create a thread node — the incident's grain shape (every fataled grain was
+        //    a TestUser/_Thread/... MessageHubGrain).
+        var threadNode = ThreadNodeType.BuildThreadNode("TestUser", $"Teardown straggler {suffix}", "TestUser");
+        var createResp = await client.Observe(new CreateNodeRequest(threadNode), o => o.WithTarget(new Address("TestUser")))
+            .FirstAsync().ToTask(ct);
+        createResp.Message.Success.Should().BeTrue(createResp.Message.Error ?? "");
+        var threadPath = createResp.Message.Node!.Path!;
+        Output.WriteLine($"Thread: {threadPath}");
+
+        // 2. Activate the grain by routing a read to it (grain activation → hub build →
+        //    CompleteActivation stamps the lifetime callbacks on the hub configuration).
+        var getResp = await client.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(threadPath)))
+            .FirstAsync().ToTask(ct);
+        getResp.Message.Data.Should().NotBeNull("the grain must have activated and served its node");
+
+        // 3. Reach the silo-side grain-hosted hub and capture the callbacks the grain
+        //    hands out to hub code (heartbeats → KeepAlive, rounds → BeginOperation,
+        //    stuck-round watchdog → Invoke). These are exactly what stragglers call.
+        var hub = FindSiloHostedHub(threadPath);
+        hub.Should().NotBeNull($"the grain-hosted hub for {threadPath} must exist on the silo");
+        var keepAlive = hub!.Configuration.Get<GrainKeepAliveCallback>();
+        var longRunning = hub.Configuration.Get<GrainLongRunningOperationCallback>();
+        var deactivate = hub.Configuration.Get<GrainDeactivateCallback>();
+        keepAlive.Should().NotBeNull();
+        longRunning.Should().NotBeNull();
+        deactivate.Should().NotBeNull();
+
+        // 4. Deactivate while ALIVE (legal — the #147 escape hatch) and wait for the
+        //    activation to be FULLY gone: first the hub's own disposal completes
+        //    (OnDeactivateAsync), then the activation disappears from the silo catalog,
+        //    which happens only after ActivationData.FinishDeactivating set
+        //    State=Invalid. No sleeps — both waits are on the actual condition.
+        deactivate!.Invoke();
+        await hub.DisposalCompleted
+            .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
+            .FirstOrDefaultAsync()
+            .ToTask(ct);
+        Output.WriteLine("Hub disposal completed — waiting for the activation to leave the catalog...");
+
+        var grainId = $"messagehub/{threadPath}";
+        var mgmt = Fixture.Cluster.Client.GetGrain<IManagementGrain>(0);
+        await Observable.Interval(TimeSpan.FromMilliseconds(100))
+            .StartWith(0L)
+            .SelectMany(_ => mgmt.GetDetailedGrainStatistics().ToObservable())
+            .Where(stats => stats.All(s => !string.Equals(s.GrainId.ToString(), grainId, StringComparison.OrdinalIgnoreCase)))
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(ct);
+        Output.WriteLine("Activation is gone from the catalog (State=Invalid). Now the stragglers fire.");
+
+        // 5. THE RACE, DISTILLED. Pre-fix each of these throws
+        //    InvalidOperationException("Attempt to access an invalid activation: …") —
+        //    the exact exception that escaped as the unobserved FATAL in CI. The
+        //    contract: a dead activation is a graceful terminal — log-and-no-op.
+        Record.Exception(() => keepAlive!.KeepAlive())
+            .Should().BeNull("a heartbeat keep-alive after the activation died is moot — graceful no-op, never a throw");
+        Record.Exception(() => longRunning!.BeginOperation().Dispose())
+            .Should().BeNull("a round starting against a dead activation must not blow up the pooled task with an unobservable throw");
+        Record.Exception(() => deactivate.Invoke())
+            .Should().BeNull("requesting deactivation of an already-dead activation is the requested outcome — graceful no-op");
+    }
+
+    /// <summary>
+    /// Finds the grain-hosted hub for <paramref name="path"/> on the silo mesh hub
+    /// (test-only reflection, same approach as
+    /// <see cref="SharedOrleansFixture.CleanupSiloHubsWithPrefix"/>).
+    /// </summary>
+    private IMessageHub? FindSiloHostedHub(string path)
+    {
+        foreach (var siloHandle in Fixture.Cluster.Silos)
+        {
+            var siloHost = siloHandle.GetType().GetProperty("SiloHost")?.GetValue(siloHandle) as IHost;
+            var meshHub = siloHost?.Services.GetService(typeof(IMessageHub)) as IMessageHub;
+            if (meshHub is null) continue;
+
+            var field = meshHub.GetType().GetField("hostedHubs", BindingFlags.Instance | BindingFlags.NonPublic);
+            var hosted = field?.GetValue(meshHub) as HostedHubsCollection;
+            if (hosted is null) continue;
+
+            var hub = hosted.Hubs.FirstOrDefault(h => h.Address.ToString() == path);
+            if (hub is not null)
+                return hub;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Root cause of the CI shard-poisoning FATALs (task from the #214 incident): in-flight activation-source emissions land after deactivation, and `MessageHubGrain`'s raw `DeactivateOnIdle`/`DelayDeactivation` calls throw on the dead activation — the second throw escaping from inside a catch into an unobserved pooled task. xUnit v3 escalates it and kills the next test class.

Fix: the grain is the mesh↔Orleans lifetime boundary — dead activation is a graceful, logged terminal (`_deactivated` flag + Try-wrappers on all ten call sites; no hosted hub built post-deactivation; ready-subject completed but not disposed). Complementary to 1429e6e72 (caller-side retry, which actually widens this window during shutdown).

Deterministic repro red (~1s, exact incident exception) → green; 2-core harness catastrophics 3 → 0; Orleans tests 123/123; Release `-warnaserror` 0/0; private members only, no public-surface change.

Adjacent findings (not fixed here, noted in the report): MessageHub.CancelCallbacks pushes an unobserved OnError at teardown via a .ToTask bridge; the Autofac LifetimeScope catastrophics are pre-existing and the shutdown suppressor can't beat xUnit's reporter to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)