### PR TITLE
fix(serialization): cycles throw a descriptive JsonException instead of killing the process

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/Serialization/ImmutableDictionaryConverter.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/ImmutableDictionaryConverter.cs
@@ -11,8 +11,16 @@ namespace MeshWeaver.Messaging.Serialization;
 /// arbitrary object values, mapping a JSON object to/from the immutable dictionary and
 /// deserializing each value loosely as <see cref="object"/>.
 /// </summary>
-public class ImmutableDictionaryOfStringObjectConverter : JsonConverter<ImmutableDictionary<string, object?>>
+public class ImmutableDictionaryOfStringObjectConverter(SerializationDepthGuard? depthGuard = null)
+    : JsonConverter<ImmutableDictionary<string, object?>>
 {
+    // Depth accounting across the nested SerializeToNode sessions this converter spawns per value
+    // (fresh writer per session → depth restarts at 0). Without it a cyclic graph threading through
+    // a dictionary value recurses per edge until the native stack dies (SIGABRT) — see
+    // SerializationDepthGuard. Shared with the other session-spawning standard converters of the
+    // same options; instance state, dies with the hub.
+    private readonly SerializationDepthGuard depthGuard = depthGuard ?? new();
+
     /// <summary>
     /// Reads a JSON object into an immutable string-to-object dictionary; an empty/null
     /// payload yields an empty dictionary.
@@ -36,7 +44,12 @@ public class ImmutableDictionaryOfStringObjectConverter : JsonConverter<Immutabl
     /// <param name="value">The dictionary to serialize.</param>
     /// <param name="options">The active serializer options used to serialize values.</param>
     public override void Write(Utf8JsonWriter writer, ImmutableDictionary<string, object?> value, JsonSerializerOptions options)
-        => Serialize(value, options).WriteTo(writer);
+    {
+        JsonObject node;
+        using (depthGuard.Enter(writer, options, value.GetType()))
+            node = Serialize(value, options);
+        node.WriteTo(writer);
+    }
 
     private static JsonObject Serialize(ImmutableDictionary<string, object?> value, JsonSerializerOptions options)
     {

--- a/src/MeshWeaver.Messaging.Hub/Serialization/ObjectPolymorphicConverter.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/ObjectPolymorphicConverter.cs
@@ -9,8 +9,18 @@ namespace MeshWeaver.Messaging.Serialization;
 /// Custom converter for object types that handles polymorphic serialization/deserialization
 /// using the type registry and $type discriminator.
 /// </summary>
-public class ObjectPolymorphicConverter(ITypeRegistry typeRegistry, ILogger? logger = null) : JsonConverter<object>
+public class ObjectPolymorphicConverter(
+    ITypeRegistry typeRegistry,
+    ILogger? logger = null,
+    SerializationDepthGuard? depthGuard = null) : JsonConverter<object>
 {
+    // Depth accounting across the NESTED serializer sessions this converter spawns (see
+    // SerializationDepthGuard): without it a self-referencing graph recurses one C# stack level
+    // per edge while every fresh session resets writer depth to 0 — MaxDepth never trips and the
+    // process dies of native stack exhaustion (SIGABRT). Shared with the other session-spawning
+    // standard converters of the same options; instance state, dies with the hub.
+    private readonly SerializationDepthGuard depthGuard = depthGuard ?? new();
+
     // Warn at most once per unregistered $type (per hub/options instance) so the receiving-hub diagnostic
     // can never become a log storm. Instance field — dies with the hub's serializer options (no static state).
     // Bounded: '$type' is payload-controlled, so the dedup set is capped (adversarial junk types stop being
@@ -253,7 +263,12 @@ public class ObjectPolymorphicConverter(ITypeRegistry typeRegistry, ILogger? log
             {
                 // Register the ValueTuple type and serialize with type information
                 var typeName = typeRegistry.GetOrAddType(valueType);
-                var json = JsonSerializer.Serialize(value, valueType, options);
+                // Nested serializer session: its fresh writer restarts depth at 0, so account the
+                // depth consumed so far via the guard — otherwise a cyclic graph recurses past every
+                // MaxDepth check and exhausts the native stack (SIGABRT).
+                string json;
+                using (depthGuard.Enter(writer, options, valueType))
+                    json = JsonSerializer.Serialize(value, valueType, options);
                 using var doc = JsonDocument.Parse(json);
 
                 writer.WriteStartObject();
@@ -288,8 +303,13 @@ public class ObjectPolymorphicConverter(ITypeRegistry typeRegistry, ILogger? log
             // For complex types, serialize with type information if registered
             else if (typeRegistry.TryGetCollectionName(valueType, out var typeName))
             {
-                // Create a wrapper object with type discriminator
-                var json = JsonSerializer.Serialize(value, valueType, options);
+                // Create a wrapper object with type discriminator.
+                // Nested serializer session (fresh writer, depth restarts at 0): account the depth
+                // consumed so far via the guard so a self-referencing graph trips MaxDepth as a
+                // JsonException instead of recursing per edge until the native stack dies (SIGABRT).
+                string json;
+                using (depthGuard.Enter(writer, options, valueType))
+                    json = JsonSerializer.Serialize(value, valueType, options);
                 using var doc = JsonDocument.Parse(json);
 
                 if (doc.RootElement.ValueKind == JsonValueKind.Object)

--- a/src/MeshWeaver.Messaging.Hub/Serialization/SerializationDepthGuard.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/SerializationDepthGuard.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+
+namespace MeshWeaver.Messaging.Serialization;
+
+/// <summary>
+/// Carries JSON serialization depth across the NESTED serializer sessions the mesh's converter
+/// chain spawns, so <see cref="JsonSerializerOptions.MaxDepth"/> semantics hold for the whole
+/// object graph.
+///
+/// <para><b>Why this exists.</b> <see cref="ObjectPolymorphicConverter"/> (to inject the $type
+/// discriminator) and <see cref="ImmutableDictionaryOfStringObjectConverter"/> (to serialize values
+/// by runtime type) serialize sub-values through a fresh session
+/// (<c>JsonSerializer.Serialize(value → string)</c> / <c>SerializeToNode</c>). Every fresh session
+/// creates a fresh <see cref="Utf8JsonWriter"/> whose <see cref="Utf8JsonWriter.CurrentDepth"/>
+/// restarts at 0, so no single writer ever approaches MaxDepth while the C# call stack grows by one
+/// converter frame per object-graph edge. For a SELF-REFERENCING graph that recursion is unbounded:
+/// the native stack exhausts before any depth guard trips, and the resulting StackOverflow kills
+/// the whole process (SIGABRT / exit 134) — uncatchable by any try/catch. This guard restores the
+/// invariant the per-session writers lost: the ACCUMULATED depth (all outer sessions + the current
+/// writer) is checked before each nested session, and exceeding the effective MaxDepth throws a
+/// diagnosable <see cref="JsonException"/> naming the type, exactly what MaxDepth is for.</para>
+///
+/// <para><b>Lifetime / state.</b> One instance is shared by the standard converters of ONE hub's
+/// <see cref="JsonSerializerOptions"/> (created in <c>GetStandardConverters</c>) — instance state
+/// that dies with the hub, never static. The counter is a <see cref="ThreadLocal{T}"/> because
+/// serialization depth is a property of the current thread's call stack: the nested sessions run
+/// synchronously on the caller's thread, and concurrent serializations on other threads must not
+/// observe each other's depth.</para>
+/// </summary>
+public sealed class SerializationDepthGuard
+{
+    /// <summary>
+    /// The effective depth limit when <see cref="JsonSerializerOptions.MaxDepth"/> is 0
+    /// (System.Text.Json's documented default).
+    /// </summary>
+    public const int DefaultMaxDepth = 64;
+
+    private readonly ThreadLocal<int> accumulatedDepth = new();
+
+    /// <summary>
+    /// Accounts for the depth already consumed by the current writer (plus the wrapper object the
+    /// caller is about to emit) before a nested serializer session runs, throwing when the
+    /// accumulated depth exceeds the options' effective MaxDepth. Dispose the returned scope when
+    /// the nested session completes.
+    /// </summary>
+    /// <param name="writer">The writer of the CURRENT session, whose <see cref="Utf8JsonWriter.CurrentDepth"/>
+    /// contributes the depth consumed since this session started.</param>
+    /// <param name="options">The serializer options in effect; source of MaxDepth.</param>
+    /// <param name="valueType">The type about to be serialized in the nested session — named in the
+    /// error so a cycle is diagnosable.</param>
+    /// <returns>A scope that restores the previous accumulated depth on dispose.</returns>
+    /// <exception cref="JsonException">The accumulated depth exceeds the effective MaxDepth —
+    /// the object graph is self-referencing (a cycle) or nested too deeply.</exception>
+    public Scope Enter(Utf8JsonWriter writer, JsonSerializerOptions options, Type valueType)
+    {
+        var effectiveMaxDepth = options.MaxDepth > 0 ? options.MaxDepth : DefaultMaxDepth;
+        var previous = accumulatedDepth.Value;
+        var depth = previous + writer.CurrentDepth + 1;
+        if (depth > effectiveMaxDepth)
+            throw new JsonException(
+                $"Serialization depth {depth} exceeds MaxDepth {effectiveMaxDepth} while serializing "
+                + $"'{valueType}' — the object graph is self-referencing (a cycle) or nested too deeply. "
+                + "The mesh wire format does not support cyclic object graphs; break the cycle, e.g. by "
+                + "referencing a path/id instead of embedding the object.");
+        accumulatedDepth.Value = depth;
+        return new Scope(this, previous);
+    }
+
+    /// <summary>
+    /// Restores the accumulated depth recorded at <see cref="Enter"/> when disposed.
+    /// </summary>
+    public readonly struct Scope(SerializationDepthGuard guard, int previous) : IDisposable
+    {
+        /// <summary>Restores the accumulated depth of the owning guard.</summary>
+        public void Dispose() => guard.accumulatedDepth.Value = previous;
+    }
+}

--- a/src/MeshWeaver.Messaging.Hub/SerializationExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/SerializationExtensions.cs
@@ -112,13 +112,20 @@ public static class SerializationExtensions
 
     private static IEnumerable<JsonConverter> GetStandardConverters(IMessageHub hub)
     {
+        // One depth guard per hub's options, shared by every standard converter that spawns
+        // NESTED serializer sessions (serialize-to-string / SerializeToNode per polymorphic edge).
+        // It carries accumulated depth across those sessions so a self-referencing object graph
+        // trips MaxDepth as a catchable JsonException instead of recursing per edge until the
+        // native stack is exhausted (StackOverflow → SIGABRT — uncatchable, kills the process).
+        var depthGuard = new SerializationDepthGuard();
         yield return new AddressConverter();
         yield return new ObjectPolymorphicConverter(hub.TypeRegistry,
-            hub.ServiceProvider.GetService<ILogger<ObjectPolymorphicConverter>>());
+            hub.ServiceProvider.GetService<ILogger<ObjectPolymorphicConverter>>(),
+            depthGuard);
         yield return new MessageDeliveryConverter(hub.TypeRegistry);
         yield return new ReadOnlyCollectionConverterFactory();
         yield return new JsonNodeConverter();
-        yield return new ImmutableDictionaryOfStringObjectConverter();
+        yield return new ImmutableDictionaryOfStringObjectConverter(depthGuard);
         yield return new RawJsonConverter();
     }
     private static SerializationConfiguration CreateSerializationConfiguration(IMessageHub hub)

--- a/test/MeshWeaver.Serialization.Test/SerializerSelfReferenceTest.cs
+++ b/test/MeshWeaver.Serialization.Test/SerializerSelfReferenceTest.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Serialization.Test;
+
+/// <summary>
+/// Test type for cyclic / deep object graphs. <see cref="Self"/> is typed <see langword="object"/>
+/// so serialization routes through the hub's polymorphic chain (ObjectPolymorphicConverter).
+/// </summary>
+public record SelfReferencing(string Name)
+{
+    /// <summary>The link that closes the cycle / builds the chain.</summary>
+    public object? Self { get; set; }
+}
+
+/// <summary>
+/// Pins the serializer self-reference defect: serializing a SELF-REFERENCING object through the
+/// hub's real <see cref="JsonSerializerOptions"/> must surface a catchable <see cref="JsonException"/>
+/// naming the type — never unbounded recursion that exhausts the native stack and kills the process
+/// (exit 134 / SIGABRT). Root cause: ObjectPolymorphicConverter (and the ImmutableDictionary
+/// converter) recursed per object-graph edge through FRESH serializer sessions
+/// (<c>JsonSerializer.Serialize(value → string)</c> / <c>SerializeToNode</c>), each of which resets
+/// <c>Utf8JsonWriter.CurrentDepth</c> to 0 — so the MaxDepth(64) guard never tripped while the C#
+/// call stack grew per edge. The fix (SerializationDepthGuard) carries accumulated depth across
+/// those nested sessions so MaxDepth semantics hold again.
+/// </summary>
+public class SerializerSelfReferenceTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    internal const string ProbeEnvVar = "MW_SERIALIZER_CYCLE_PROBE";
+    internal const string ProbeOutEnvVar = "MW_SERIALIZER_CYCLE_PROBE_OUT";
+    private const string JsonExceptionMarker = "JSON_EXCEPTION:";
+    private const string NoExceptionMarker = "NO_EXCEPTION:";
+
+    /// <inheritdoc />
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration).WithTypes(typeof(SelfReferencing));
+
+    /// <summary>
+    /// A DEEP (non-cyclic, finite) chain of object-typed edges must be rejected with a
+    /// <see cref="JsonException"/> that names the offending type once accumulated depth exceeds
+    /// MaxDepth — the same guard that turns a true cycle into an error instead of a SIGABRT.
+    /// This variant is host-safe in both red and green states (the chain is finite), so it can
+    /// run in-suite; the true-cycle case runs in a child process below.
+    /// Runs on a dedicated wide-stack thread so the pre-fix red state (recursion one C# stack
+    /// level per edge) is a clean assertion failure rather than a stack-size gamble.
+    /// </summary>
+    [Fact]
+    public void DeepObjectGraph_ThrowsJsonExceptionNamingTheType()
+    {
+        var host = GetHost();
+        object chain = new SelfReferencing("leaf");
+        for (var i = 0; i < 100; i++)
+            chain = new SelfReferencing($"level{i}") { Self = chain };
+
+        Exception? caught = null;
+        var thread = new Thread(
+            () =>
+            {
+                try
+                {
+                    JsonSerializer.Serialize(chain, host.JsonSerializerOptions);
+                }
+                catch (Exception ex)
+                {
+                    caught = ex;
+                }
+            },
+            maxStackSize: 16 * 1024 * 1024);
+        thread.Start();
+        thread.Join(TimeSpan.FromSeconds(30)).Should().BeTrue("serialization of a depth-101 chain must terminate");
+
+        caught.Should().NotBeNull("a graph nested beyond MaxDepth must be rejected, not serialized by resetting writer depth per level");
+        caught.Should().BeOfType<JsonException>();
+        caught!.Message.Should().Contain(nameof(SelfReferencing),
+            "the depth-guard error must name the offending type so a cycle is diagnosable");
+        caught.Message.Should().Contain("MaxDepth");
+    }
+
+    /// <summary>
+    /// Child-process payload for <see cref="SelfReferencingObject_SurfacesJsonException_InsteadOfKillingTheProcess"/>.
+    /// No-op unless <see cref="ProbeEnvVar"/> is set: pre-fix, serializing a true cycle exhausts the
+    /// native stack and SIGABRTs the whole process — uncatchable — so it must only ever run in a
+    /// disposable child process, never in the shared test host.
+    /// </summary>
+    [Fact]
+    public void CycleProbe()
+    {
+        if (Environment.GetEnvironmentVariable(ProbeEnvVar) != "1")
+            return; // only meaningful when driven by the parent test in a child process
+
+        var host = GetHost();
+        var cyclic = new SelfReferencing("root");
+        cyclic.Self = cyclic; // the cycle
+
+        string result;
+        try
+        {
+            var json = JsonSerializer.Serialize(cyclic, host.JsonSerializerOptions);
+            result = NoExceptionMarker + json[..Math.Min(200, json.Length)];
+        }
+        catch (JsonException ex)
+        {
+            result = JsonExceptionMarker + ex.Message;
+        }
+
+        var outFile = Environment.GetEnvironmentVariable(ProbeOutEnvVar);
+        if (outFile is not null)
+            File.WriteAllText(outFile, result);
+    }
+
+    /// <summary>
+    /// THE repro for the SIGABRT defect, host-protected: runs <see cref="CycleProbe"/> (a true
+    /// self-reference serialized with the hub's real options) in a CHILD process — this same
+    /// xunit.v3 executable filtered to that one method — so the red state is an assertable exit
+    /// code (134 = SIGABRT, native stack exhausted), not a dead test host. Green: the child
+    /// survives and reports a catchable <see cref="JsonException"/> naming the type.
+    /// </summary>
+    [Fact]
+    public async Task SelfReferencingObject_SurfacesJsonException_InsteadOfKillingTheProcess()
+    {
+        var assemblyPath = typeof(SerializerSelfReferenceTest).Assembly.Location;
+        var resultFile = Path.Combine(Path.GetTempPath(), $"mw-cycle-probe-{Guid.NewGuid():N}.txt");
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        psi.ArgumentList.Add("exec");
+        psi.ArgumentList.Add(assemblyPath);
+        psi.ArgumentList.Add("-method");
+        psi.ArgumentList.Add($"{typeof(SerializerSelfReferenceTest).FullName}.{nameof(CycleProbe)}");
+        psi.Environment[ProbeEnvVar] = "1";
+        psi.Environment[ProbeOutEnvVar] = resultFile;
+
+        try
+        {
+            using var probe = Process.Start(psi)!;
+            var stdoutTask = probe.StandardOutput.ReadToEndAsync();
+            var stderrTask = probe.StandardError.ReadToEndAsync();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(45));
+            try
+            {
+                await probe.WaitForExitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                probe.Kill(entireProcessTree: true);
+                throw new TimeoutException("Cycle probe child process did not exit within 45s.");
+            }
+
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
+            Output.WriteLine($"probe exit code: {probe.ExitCode}");
+            Output.WriteLine($"probe stdout:\n{stdout}");
+            Output.WriteLine($"probe stderr:\n{stderr}");
+
+            File.Exists(resultFile).Should().BeTrue(
+                $"the probe child must SURVIVE serializing a self-referencing object and record an outcome "
+                + $"(exit code {probe.ExitCode}; 134 = SIGABRT — the converter chain recursed per graph edge "
+                + "without consuming serializer depth and exhausted the native stack)");
+            var result = await File.ReadAllTextAsync(resultFile, TestContext.Current.CancellationToken);
+            Output.WriteLine($"probe result: {result}");
+            result.Should().StartWith(JsonExceptionMarker,
+                "a cycle must surface as a catchable JsonException — never serialize 'successfully' and never crash");
+            result.Should().Contain(nameof(SelfReferencing), "the error must name the offending type");
+            probe.ExitCode.Should().Be(0, "the probe test itself must pass in the child");
+        }
+        finally
+        {
+            if (File.Exists(resultFile))
+                File.Delete(resultFile);
+        }
+    }
+}


### PR DESCRIPTION
A self-referencing object serialized through the hub's options killed the whole process (SIGABRT): the $type-injecting converters spawn a FRESH serializer session per nesting level, so every writer stays at depth ~2 and MaxDepth never trips while the C# stack grows per graph edge — StackOverflow, uncatchable.

Fix: a per-hub SerializationDepthGuard accumulating depth across nested sessions (ThreadLocal — depth belongs to the thread's call stack); past MaxDepth it throws a JsonException naming the type. Wire shape for legal graphs unchanged (PackageWireShapeTest green).

Repro is child-process-protected: pre-fix asserts the child's exit 134; post-fix asserts the clean JsonException. 363 tests green across the serialization-consuming suites; Release `-warnaserror` 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)