### PR TITLE
fix(persistence): content narrowing is lossless — unknown members round-trip, initial-load echo retired

### DIFF
--- a/src/MeshWeaver.AI/Thread.cs
+++ b/src/MeshWeaver.AI/Thread.cs
@@ -360,6 +360,20 @@ public record Thread
     public ImmutableList<ToolCallEntry>? StreamingToolCalls { get; init; }
 
     /// <summary>
+    /// 🚨 Round-trip buffer for content members this compiled shape does not declare
+    /// (schema evolution: written by a newer build, or removed since the JSON was
+    /// persisted — the mixed-version-silo case during rolling updates).
+    /// <c>[JsonExtensionData]</c> captures them on read and re-emits them on write, and
+    /// rides record <c>with</c>-copies — so neither the persistence echo nor an edit
+    /// through a narrower shape can silently drop them (the content-narrowing
+    /// silent-data-loss class; see <c>NodeTypeDefinition.UnknownMembers</c>). Never read
+    /// programmatically. <c>[Browsable(false)]</c> keeps it out of reflected editors.
+    /// </summary>
+    [System.ComponentModel.Browsable(false)]
+    [JsonExtensionData]
+    public IDictionary<string, JsonElement>? UnknownMembers { get; init; }
+
+    /// <summary>
     /// Brings the thread to REST — the single canonical reset of transient execution state. Sets
     /// <c>Status = Idle</c> and clears the active-round handle, streaming buffers, and the
     /// control-plane request, while PRESERVING the conversation
@@ -556,4 +570,18 @@ public record ThreadMessage
     /// streaming. <c>CompletedAt - Timestamp</c> is the per-message duration.
     /// </summary>
     public DateTime? CompletedAt { get; init; }
+
+    /// <summary>
+    /// 🚨 Round-trip buffer for content members this compiled shape does not declare
+    /// (schema evolution: written by a newer build, or removed since the JSON was
+    /// persisted — the mixed-version-silo case during rolling updates).
+    /// <c>[JsonExtensionData]</c> captures them on read and re-emits them on write, and
+    /// rides record <c>with</c>-copies — so neither the persistence echo nor an edit
+    /// through a narrower shape can silently drop them (the content-narrowing
+    /// silent-data-loss class; see <c>NodeTypeDefinition.UnknownMembers</c>). Never read
+    /// programmatically. <c>[Browsable(false)]</c> keeps it out of reflected editors.
+    /// </summary>
+    [System.ComponentModel.Browsable(false)]
+    [JsonExtensionData]
+    public IDictionary<string, JsonElement>? UnknownMembers { get; init; }
 }

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
@@ -505,4 +505,24 @@ public record NodeTypeDefinition
     /// <para><c>null</c> until the first successful compile completes.</para>
     /// </summary>
     public string? CompiledFrameworkVersion { get; init; }
+
+    /// <summary>
+    /// 🚨 Round-trip buffer for content members this compiled shape does not declare —
+    /// schema evolution: a property written by a NEWER build, or one removed since the
+    /// JSON was persisted. Without this, System.Text.Json silently DROPS such members on
+    /// typed materialization (no exception, so the preserve-raw fallback in
+    /// <c>ObjectPolymorphicConverter</c> never fires) and the per-node hub's persistence
+    /// echo then persists the loss on pure activation — the content-narrowing
+    /// silent-data-loss class (prod <c>Systemorph/Event/DAV2026</c> stripped to defaults;
+    /// ~40 <c>samples/Graph/Data</c> NodeType files losing
+    /// <c>showChildrenInDetails</c>/<c>detailsChildrenLimit</c>).
+    /// <para><c>[JsonExtensionData]</c> captures the unknown members on read and re-emits
+    /// them on write — and, being a real record property, it rides every <c>with</c>-copy,
+    /// so edits made through the narrower shape keep them too. Never read this
+    /// programmatically; it exists solely so unknown JSON survives the round-trip.
+    /// <c>[Browsable(false)]</c> keeps it out of reflected content editors.</para>
+    /// </summary>
+    [System.ComponentModel.Browsable(false)]
+    [System.Text.Json.Serialization.JsonExtensionData]
+    public IDictionary<string, System.Text.Json.JsonElement>? UnknownMembers { get; init; }
 }

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -419,6 +419,26 @@ public static class MeshDataSourceExtensions
         public volatile MeshNode? Current;
         /// <summary>Whether the cached node has been deleted.</summary>
         public volatile bool IsDeleted;
+
+        /// <summary>
+        /// 🚨 The latest own-node instance that is KNOWN to be already persisted — stamped by
+        /// <c>MeshNodeTypeSource.BuildInstanceCollection</c> for every state that ARRIVED from
+        /// persistence or from the routing-supplied own-node stream (both are, by construction,
+        /// already-durable: the fallback read comes straight from storage, and the routing
+        /// stream is fed by the storage/catalog change feed). The persistence sampler skips
+        /// emissions that are reference-identical to this snapshot: a load is a READ, and
+        /// echoing it back to storage is at best a redundant rewrite on every activation
+        /// (file/mtime churn — the perpetually-git-dirty <c>samples/Graph/Data</c> trees) and
+        /// was, before persisted content types carried their <c>[JsonExtensionData]</c>
+        /// buffers, the write that persisted the content-narrowing loss on pure activation
+        /// (prod <c>Systemorph/Event/DAV2026</c>).
+        /// <para>Reference identity — not value equality — keeps this fail-open: every state a
+        /// LOCAL write produces is a fresh <c>with</c>-copy (<c>UpdateImpl</c> stamps a new
+        /// instance; the cross-hub patch path deserializes one), so a genuine write can never
+        /// be suppressed. An identity-breaking hop merely degrades to the old behaviour — a
+        /// redundant (now lossless) echo.</para>
+        /// </summary>
+        public volatile MeshNode? PersistedSnapshot;
     }
 
     /// <summary>
@@ -686,7 +706,19 @@ public static class MeshDataSourceExtensions
             {
                 var sub = new System.Reactive.Disposables.SingleAssignmentDisposable();
                 sub.Disposable = own
-                    .Where(n => n != null && !nodeCache.IsDeleted)
+                    // 🚨 Initial-load echo suppression: a state that ARRIVED from
+                    // persistence/routing (reference-identical to PersistedSnapshot,
+                    // stamped by MeshNodeTypeSource.BuildInstanceCollection) is already
+                    // durable — a load is a READ and must not write storage. Before this
+                    // gate, pure activation re-saved the just-loaded node 200 ms later,
+                    // which both churned every FS-persisted file on activation and
+                    // persisted the content-narrowing loss when the content had
+                    // materialized through a narrower registered type. Local writes are
+                    // fresh instances (UpdateImpl `with`-stamps; patches deserialize),
+                    // so they always pass; an identity-breaking hop fails open to a
+                    // redundant (lossless) echo. See OwnNodeCache.PersistedSnapshot.
+                    .Where(n => n != null && !nodeCache.IsDeleted
+                        && !ReferenceEquals(n, nodeCache.PersistedSnapshot))
                     .DistinctUntilChanged()
                     .Sample(interval)
                     .Subscribe(node =>

--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -33,6 +33,7 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
     private readonly IWorkspace _workspace;
     private readonly ILogger? _logger;
     private readonly IObservable<MeshNode?>? _ownNodeStream;
+    private readonly MeshDataSourceExtensions.OwnNodeCache? _ownNodeCache;
     private InstanceCollection _lastSaved = new();
 
     // Pending create / delete buffer. UpdateImpl enqueues here; a debounce
@@ -86,6 +87,8 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
             .DistinctUntilChanged()
             .Replay(1).RefCount();
         _logger = workspace.Hub.ServiceProvider.GetService<ILogger<MeshNodeTypeSource>>();
+        _ownNodeCache = workspace.Hub.ServiceProvider
+            .GetService<MeshDataSourceExtensions.OwnNodeCache>();
         _logger?.LogDebug("MeshNodeTypeSource: Created for hubPath={HubPath} (routingSuppliedStream={Supplied})",
             hubPath, ownNodeStream != null);
 
@@ -484,6 +487,18 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
     private InstanceCollection BuildInstanceCollection(MeshNode? rawNode)
     {
         var ownNode = rawNode != null ? ResolveJsonElementContent(rawNode) : null;
+
+        // 🚨 Stamp this instance as ALREADY PERSISTED before it enters the workspace:
+        // every state flowing through here arrived from persistence (the fallback
+        // one-shot read) or from the routing-supplied own-node stream (fed by the
+        // storage/catalog change feed) — both durable by construction. The persistence
+        // sampler (MeshDataSourceExtensions.SubscribeToOwnDeletion) skips emissions
+        // reference-identical to this snapshot so a pure load never writes storage
+        // back (the initial-load echo that rewrote every FS file on activation and
+        // persisted content-narrowing losses). Set BEFORE the collection is returned
+        // so the stamp is in place when the workspace emits it to the sampler.
+        if (_ownNodeCache != null)
+            _ownNodeCache.PersistedSnapshot = ownNode;
 
         // 🚨 LEAVE BOTH CLOCKS ALONE on load — never touch Hub.Version, never re-stamp the node.
         // Hub.Version is already strictly monotonic on its own (++ per message in

--- a/src/MeshWeaver.Markdown/MarkdownContent.cs
+++ b/src/MeshWeaver.Markdown/MarkdownContent.cs
@@ -48,6 +48,19 @@ public record MarkdownContent
     public string? Abstract { get; init; }
 
     /// <summary>
+    /// 🚨 Round-trip buffer for content members this compiled shape does not declare
+    /// (schema evolution: written by a newer build, or removed since the JSON was
+    /// persisted). <c>[JsonExtensionData]</c> captures them on read and re-emits them on
+    /// write, and rides record <c>with</c>-copies — so neither the persistence echo nor
+    /// an edit through a narrower shape can silently drop them (the content-narrowing
+    /// silent-data-loss class; see <c>NodeTypeDefinition.UnknownMembers</c>). Never read
+    /// programmatically. <c>[Browsable(false)]</c> keeps it out of reflected editors.
+    /// </summary>
+    [System.ComponentModel.Browsable(false)]
+    [System.Text.Json.Serialization.JsonExtensionData]
+    public IDictionary<string, System.Text.Json.JsonElement>? UnknownMembers { get; init; }
+
+    /// <summary>
     /// Creates a MarkdownContent from raw content by parsing and rendering.
     /// </summary>
     /// <param name="content">The raw markdown content (without YAML front matter).</param>

--- a/src/MeshWeaver.Mesh.Contract/CodeConfiguration.cs
+++ b/src/MeshWeaver.Mesh.Contract/CodeConfiguration.cs
@@ -66,4 +66,17 @@ public record CodeConfiguration
     /// the doc partition's).</para>
     /// </summary>
     public string? ActivityParentPath { get; init; }
+
+    /// <summary>
+    /// 🚨 Round-trip buffer for content members this compiled shape does not declare
+    /// (schema evolution: written by a newer build, or removed since the JSON was
+    /// persisted). <c>[JsonExtensionData]</c> captures them on read and re-emits them on
+    /// write, and rides record <c>with</c>-copies — so neither the persistence echo nor
+    /// an edit through a narrower shape can silently drop them (the content-narrowing
+    /// silent-data-loss class; see <c>NodeTypeDefinition.UnknownMembers</c>). Never read
+    /// programmatically. <c>[Browsable(false)]</c> keeps it out of reflected editors.
+    /// </summary>
+    [System.ComponentModel.Browsable(false)]
+    [System.Text.Json.Serialization.JsonExtensionData]
+    public IDictionary<string, System.Text.Json.JsonElement>? UnknownMembers { get; init; }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/ContentNarrowingPersistenceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ContentNarrowingPersistenceTest.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 Regression repro for CONTENT-NARROWING SILENT DATA LOSS: when a persisted node's
+/// content deserializes through a REGISTERED-but-NARROWER type (an older compiled shape —
+/// properties since removed or not yet added), System.Text.Json silently drops the unknown
+/// members (no exception, so the preserve-raw fallback in <c>ObjectPolymorphicConverter</c>
+/// never fires) and the per-node hub's persistence sampler then ECHOES the narrowed state
+/// back to storage on pure activation — no user edit, no version bump. Live artifacts:
+/// prod <c>Systemorph/Event/DAV2026</c> stripped to defaults; ~40
+/// <c>samples/Graph/Data/*.json</c> NodeType files losing
+/// <c>showChildrenInDetails</c>/<c>detailsChildrenLimit</c> in local trees.
+/// The fix is two-sided:
+/// <list type="bullet">
+///   <item><b>Lossless round-trip</b> — persisted content types carry a
+///     <c>[JsonExtensionData]</c> buffer so unknown members survive typed
+///     materialization and re-serialization (and record <c>with</c>-copies, so
+///     edits through the narrower shape keep them too).</item>
+///   <item><b>No initial-load echo</b> — a state that ARRIVED from persistence/routing
+///     is by construction already persisted; the sampler must not write it back
+///     (a load is a READ). Local writes (create + update) still persist.</item>
+/// </list>
+/// </summary>
+public class ContentNarrowingPersistenceTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private string? _tempDir;
+
+    private string GetTempDir()
+    {
+        if (_tempDir != null) return _tempDir;
+        _tempDir = Path.Combine(Path.GetTempPath(), "MeshWeaverNarrowingRepro", $"t_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        return _tempDir;
+    }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddFileSystemPersistence(GetTempDir());
+
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
+        if (_tempDir != null && Directory.Exists(_tempDir))
+        {
+            try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Seeds a persisted NodeType node whose content carries members the CURRENT
+    /// <see cref="NodeTypeDefinition"/> does not have (they existed in an older build) —
+    /// the exact shape of the stripped samples/Graph/Data NodeType files.
+    /// </summary>
+    private async Task<string> SeedNarrowedNodeFile(string id)
+    {
+        var dir = Path.Combine(GetTempDir(), "TestData");
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, $"{id}.json");
+        var seeded =
+            $"{{\"$type\":\"MeshNode\",\"id\":\"{id}\",\"namespace\":\"TestData\"," +
+            $"\"path\":\"TestData/{id}\",\"mainNode\":\"TestData/{id}\",\"name\":\"{id}\"," +
+            "\"nodeType\":\"NodeType\",\"version\":3,\"state\":\"Active\"," +
+            "\"content\":{\"$type\":\"NodeTypeDefinition\",\"description\":\"repro\"," +
+            "\"showChildrenInDetails\":true,\"detailsChildrenLimit\":10}}";
+        await File.WriteAllTextAsync(file, seeded, TestContext.Current.CancellationToken);
+        return file;
+    }
+
+    /// <summary>
+    /// Pure activation (a READ) must never destroy stored content members the current
+    /// compiled type doesn't know. Pre-fix, the persistence sampler's initial-load echo
+    /// rewrote the file from the narrowed typed materialization, silently dropping them.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task ActivationEcho_MustNotDropUnknownContentMembers()
+    {
+        var file = await SeedNarrowedNodeFile("MyType");
+
+        // Activate the per-node hub (deserializes content into the current, narrower type).
+        var node = await ReadNode("TestData/MyType")
+            .Should().Within(30.Seconds()).Match(n => n is not null);
+        node!.Path.Should().Be("TestData/MyType");
+
+        // Sanctioned fixed wait ("confirm nothing bad happened"): the persistence sampler
+        // fires 200 ms after the own-stream emission; give it ample headroom.
+        await Task.Delay(1500, TestContext.Current.CancellationToken);
+
+        var persisted = await File.ReadAllTextAsync(file, TestContext.Current.CancellationToken);
+        persisted.Should().Contain("showChildrenInDetails",
+            "loading a node must never destroy stored content members the current type doesn't know");
+        persisted.Should().Contain("detailsChildrenLimit",
+            "loading a node must never destroy stored content members the current type doesn't know");
+    }
+
+    /// <summary>
+    /// The serializer-level half of the defect, pinned through the HUB's options (the
+    /// exact chain storage writes use: <c>ObjectPolymorphicConverter</c> + the polymorphic
+    /// type-info resolver): materializing content into a registered-but-narrower type and
+    /// re-serializing must round-trip unknown members instead of silently dropping them.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task HubOptions_RoundTrip_PreservesUnknownContentMembers()
+    {
+        const string stored =
+            "{\"$type\":\"MeshNode\",\"id\":\"RT\",\"namespace\":\"TestData\"," +
+            "\"path\":\"TestData/RT\",\"mainNode\":\"TestData/RT\",\"name\":\"RT\"," +
+            "\"nodeType\":\"NodeType\",\"version\":3,\"state\":\"Active\"," +
+            "\"content\":{\"$type\":\"NodeTypeDefinition\",\"description\":\"repro\"," +
+            "\"showChildrenInDetails\":true,\"detailsChildrenLimit\":10}}";
+
+        var node = JsonSerializer.Deserialize<MeshNode>(stored, Mesh.JsonSerializerOptions);
+
+        // The defect only exists when the content MATERIALIZES into the registered narrower
+        // type (an untyped JsonElement would round-trip trivially) — assert the premise.
+        node!.Content.Should().BeOfType<NodeTypeDefinition>(
+            "the $type is registered on the hub, so content materializes typed");
+        ((NodeTypeDefinition)node.Content!).Description.Should().Be("repro");
+
+        var roundTripped = JsonSerializer.Serialize(node, Mesh.JsonSerializerOptions);
+        roundTripped.Should().Contain("showChildrenInDetails",
+            "unknown members must survive typed materialization through the hub's serializer chain");
+        roundTripped.Should().Contain("detailsChildrenLimit",
+            "unknown members must survive typed materialization through the hub's serializer chain");
+
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// A REAL edit made through the narrower compiled shape must persist the edit AND keep
+    /// the unknown members (the extension-data buffer rides the record <c>with</c>-copy).
+    /// This is the flow that would still lose data if only the echo were suppressed.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task EditThroughNarrowerType_PersistsEditAndKeepsUnknownMembers()
+    {
+        var file = await SeedNarrowedNodeFile("Edited");
+
+        var node = await ReadNode("TestData/Edited")
+            .Should().Within(30.Seconds()).Match(n => n is not null);
+        node!.Path.Should().Be("TestData/Edited");
+
+        var options = Mesh.JsonSerializerOptions;
+        Mesh.GetWorkspace().GetMeshNodeStream("TestData/Edited")
+            .Update(current =>
+            {
+                var def = current!.ContentAs<NodeTypeDefinition>(options)
+                          ?? new NodeTypeDefinition();
+                return current with { Content = def with { Description = "edited-through-narrow-shape" } };
+            })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"Update failed: {ex}"));
+
+        // Wait on the actual condition: the edited description landing in the file.
+        var persisted = await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .Select(_ => File.Exists(file) ? File.ReadAllText(file) : null)
+            .Should().Within(30.Seconds())
+            .Match(txt => txt != null && txt.Contains("edited-through-narrow-shape"));
+
+        persisted.Should().Contain("showChildrenInDetails",
+            "an edit through the narrower shape must not clobber members it doesn't know");
+        persisted.Should().Contain("detailsChildrenLimit",
+            "an edit through the narrower shape must not clobber members it doesn't know");
+    }
+
+    /// <summary>
+    /// The echo side, pinned hard: pure activation of a persistence-backed node is a READ —
+    /// it must not touch storage AT ALL. The state arrived FROM persistence, so writing it
+    /// back is at best file/mtime churn on every activation (the perpetually-git-dirty
+    /// samples/Graph/Data trees) and was, pre-fix, the write that persisted the
+    /// content-narrowing loss. Mirrors #227's StaticNodePersistenceEchoTest for
+    /// persistence-backed (not static-served) nodes.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task PureActivation_DoesNotWriteStorageAtAll()
+    {
+        var file = await SeedNarrowedNodeFile("Untouched");
+        var before = await File.ReadAllTextAsync(file, TestContext.Current.CancellationToken);
+
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var echoes = new ConcurrentQueue<DataChangeNotification>();
+        using var echoSub = storage.Changes
+            .Where(c => string.Equals(c.Path, "TestData/Untouched", StringComparison.OrdinalIgnoreCase))
+            .Subscribe(echoes.Enqueue);
+
+        var node = await ReadNode("TestData/Untouched")
+            .Should().Within(30.Seconds()).Match(n => n is not null);
+        node!.Path.Should().Be("TestData/Untouched");
+
+        // Sanctioned fixed wait (negative test — "confirm nothing happened"): the sampler
+        // fires 200 ms after the own-stream emission; give it ample headroom.
+        await Task.Delay(1500, TestContext.Current.CancellationToken);
+
+        echoes.Should().BeEmpty(
+            "a state loaded FROM persistence is already durable — activating its hub must not echo it back");
+        var after = await File.ReadAllTextAsync(file, TestContext.Current.CancellationToken);
+        after.Should().Be(before, "pure activation must leave the persisted bytes untouched");
+    }
+
+    /// <summary>
+    /// Guards the initial-load-echo suppression: creates and subsequent updates must
+    /// persist WITHOUT relying on the activation echo. The create is insta-written by
+    /// <c>MeshNodeTypeSource.UpdateImpl</c>'s add path; updates ride the sampler. If the
+    /// suppression ever over-reached into these local-write paths, this pins it red.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task CreateThenUpdate_PersistsWithoutRelyingOnActivationEcho()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var created = MeshNode.FromPath("TestData/Created") with
+        {
+            Name = "Created",
+            NodeType = "NodeType",
+            Content = new NodeTypeDefinition { Description = "created-content" }
+        };
+
+        await meshService.CreateNode(created).Should().Within(30.Seconds()).Emit();
+
+        var file = Path.Combine(GetTempDir(), "TestData", "Created.json");
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .Select(_ => File.Exists(file) ? File.ReadAllText(file) : null)
+            .Should().Within(30.Seconds())
+            .Match(txt => txt != null && txt.Contains("created-content"));
+
+        var options = Mesh.JsonSerializerOptions;
+        Mesh.GetWorkspace().GetMeshNodeStream("TestData/Created")
+            .Update(current =>
+            {
+                var def = current!.ContentAs<NodeTypeDefinition>(options)
+                          ?? new NodeTypeDefinition();
+                return current with { Content = def with { Description = "updated-content" } };
+            })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"Update failed: {ex}"));
+
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .Select(_ => File.Exists(file) ? File.ReadAllText(file) : null)
+            .Should().Within(30.Seconds())
+            .Match(txt => txt != null && txt.Contains("updated-content"));
+    }
+}


### PR DESCRIPTION
Root fix for the silent data loss pinned during #227 (prod `Systemorph/Event/DAV2026` stripped; ~40 sample JSONs losing fields on pure activation):

1. **`[JsonExtensionData]` buffer** on the persisted, evolving content records (NodeTypeDefinition, CodeConfiguration, MarkdownContent, Thread, ThreadMessage) — unknown members survive typed materialization, `with`-copies, and the polymorphic write path.
2. **Initial-load echo retired** for persistence-backed nodes (persisted-snapshot reference identity, fail-open; creates pinned independent of the echo). Pure activation no longer writes storage at all — ends the perpetually-dirty `samples/Graph/Data` churn.

Red→green ×3 + two guard pins; ~1,380 neighbor tests green incl. a real PG container; full solution Release `-warnaserror` 0/0.

Residuals noted in the report: dynamically-compiled user records can still narrow on *genuine edits* through a stale shape (docs note recommended); the MeshNode envelope itself has no buffer (possible follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)