### PR TITLE
fix(teardown): classify disposal as cancellation at Task sinks; drain the mesh before the legacy host's container dies

### DIFF
--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -825,15 +825,40 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     /// Default cancellation = <see cref="TestContext.Current"/>'s
     /// <see cref="ITestContext.CancellationToken"/> — never pass <c>default</c>.
     /// </para>
+    /// <para>
+    /// Teardown-safety: when the hub is disposed before the response arrives,
+    /// <c>MessageHub.CancelCallbacks</c> pushes <see cref="ObjectDisposedException"/>
+    /// ("Hub … was disposed before the response arrived …") into the pending Observe
+    /// subject. If a test ABANDONED this task (an earlier assertion threw before the
+    /// await), a <em>faulted</em> task detonates at GC as an
+    /// <c>UnobservedTaskException</c> → xUnit v3 "Catastrophic failure" poisoning the
+    /// next test class (#228's capture). Rethrowing the disposal as an
+    /// <see cref="OperationCanceledException"/> makes the async state machine's task
+    /// CANCELED instead of faulted — canceled tasks never raise
+    /// UnobservedTaskException, and an awaiting test still fails loudly with the
+    /// original disposal exception attached as the cause. Real response errors
+    /// (DeliveryFailure, Timeout) keep faulting the task unchanged.
+    /// </para>
     /// </summary>
-    protected Task<IMessageDelivery<TResponse>> AwaitResponseAsync<TResponse>(
+    protected async Task<IMessageDelivery<TResponse>> AwaitResponseAsync<TResponse>(
         IRequest<TResponse> request,
         Func<PostOptions, PostOptions>? options = null,
         IMessageHub? hub = null,
         CancellationToken? ct = null)
-        => (hub ?? Mesh).Observe(request, options)
-            .FirstAsync()
-            .ToTask(ct ?? TestContext.Current.CancellationToken);
+    {
+        try
+        {
+            return await (hub ?? Mesh).Observe(request, options)
+                .FirstAsync()
+                .ToTask(ct ?? TestContext.Current.CancellationToken);
+        }
+        catch (ObjectDisposedException disposed)
+        {
+            // Hub teardown beat the response — cancellation, not failure (see remarks).
+            throw new TaskCanceledException(
+                $"Hub torn down before the response to {request.GetType().Name} arrived.", disposed);
+        }
+    }
 
     /// <summary>
     /// Canonical CQRS-correct read primitive for tests: the per-node hub's

--- a/src/MeshWeaver.Hosting/MeshHostApplicationBuilder.cs
+++ b/src/MeshWeaver.Hosting/MeshHostApplicationBuilder.cs
@@ -48,6 +48,17 @@ public record MeshHostBuilder : MeshBuilder
         this.Host = Host;
         Host.UseServiceProviderFactory(new MessageHubServiceProviderFactory(BuildHub));
         this.RegisterMeshQueryCoreOnMeshHub();
+        // Same ordered drain as MeshHostApplicationBuilder above: quiesce the mesh root hub
+        // (action blocks + IoPool + AsyncDisposeQueue) during host StopAsync, BEFORE the host
+        // disposes the root scope — which IS the hub's Autofac container. Without it, a late
+        // continuation resolves from (or begins a nested hub scope on) the already-disposed
+        // container and throws ObjectDisposedException("LifetimeScope … has already been
+        // disposed") on a pooled task nobody observes — the pre-existing "Catastrophic failure"
+        // in Orleans TestCluster teardown (this legacy IHostBuilder path builds every
+        // TestCluster silo and client via UseOrleansMeshServer/UseOrleansMeshClient).
+        // Registered FIRST so it stops LAST — after the silo and the other hosted services
+        // have stopped feeding the mesh. Pinned by MeshHostBuilderTeardownOrderingTest.
+        Host.ConfigureServices((_, services) => services.AddHostedService<MeshTeardownHostedService>());
     }
 
 

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -207,11 +207,45 @@ public sealed class MessageHub : IMessageHub
     /// <summary>
     /// Faults the <see cref="Started"/> task with <paramref name="error"/> so dependents observing
     /// startup (e.g. data-source initialization) also fault. Called when a stream errors during init.
+    /// <para>
+    /// Teardown-disposal is classified as CANCELLATION, not failure: when the cause chain
+    /// contains an <see cref="ObjectDisposedException"/> (the shape <c>CancelCallbacks</c>
+    /// pushes into pending <c>Observe</c> subjects at hub disposal — "Hub … was disposed
+    /// before the response arrived"), startup didn't fail, it will simply never happen.
+    /// A sync hub's <see cref="Started"/> task has NO awaiter at teardown, so faulting it
+    /// armed a <c>TaskScheduler.UnobservedTaskException</c> that detonated at the next GC —
+    /// xUnit v3 escalates that to a "Catastrophic failure" poisoning the next test class
+    /// (the #228 capture). A canceled task never raises UnobservedTaskException, and a live
+    /// awaiter still gets a graceful, typed <see cref="TaskCanceledException"/>
+    /// (<c>DataContext.OpenInitializationGate</c> handles <c>IsCanceled</c> explicitly).
+    /// Real startup errors keep faulting <see cref="Started"/> so dependents observe them.
+    /// Pinned by <c>FailStartupTeardownClassificationTest</c> and
+    /// <c>TeardownPendingSubscribeGracefulTest</c>.
+    /// </para>
     /// </summary>
     /// <param name="error">The exception that caused startup to fail.</param>
     public void FailStartup(Exception error)
     {
-        hasStarted.TrySetException(error);
+        if (IsTeardownDisposal(error))
+            hasStarted.TrySetCanceled();
+        else
+            hasStarted.TrySetException(error);
+    }
+
+    /// <summary>
+    /// True when <paramref name="error"/> (or any exception in its cause chain) is an
+    /// <see cref="ObjectDisposedException"/> — the benign teardown shape. Walks the chain
+    /// because the disposal error arrives both bare (the SubscribeRequest observe path) and
+    /// wrapped (e.g. <c>InvalidOperationException</c> → ODE from the DataChangeRequest
+    /// observe path in <c>JsonSynchronizationStream</c>); mirrors
+    /// <c>SynchronizationStream.IsObjectDisposed</c>.
+    /// </summary>
+    private static bool IsTeardownDisposal(Exception? error)
+    {
+        for (var e = error; e != null; e = e.InnerException)
+            if (e is ObjectDisposedException)
+                return true;
+        return false;
     }
 
     /// <summary>

--- a/test/MeshWeaver.Data.Test/TeardownPendingSubscribeGracefulTest.cs
+++ b/test/MeshWeaver.Data.Test/TeardownPendingSubscribeGracefulTest.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Deterministic repro for the TEARDOWN STRAGGLER left open by #228 (task #18, defect 1):
+/// at hub disposal, <c>MessageHub.CancelCallbacks</c> pushes
+/// <see cref="ObjectDisposedException"/> ("Hub … was disposed before the response arrived
+/// (request type SubscribeRequest …)") into every pending <c>hub.Observe</c> subject. For a
+/// remote sync subscription whose owner never answered, that error is routed by
+/// <c>JsonSynchronizationStream</c> into <c>reduced.OnError</c> →
+/// <c>SynchronizationStream.OnError</c> → <c>Hub.FailStartup(error)</c> on the INNER sync hub
+/// (<c>sync/{streamId}</c>) — whose <c>Started</c> gate is still closed because the initial
+/// <c>DataChangedEvent</c> never arrived.
+///
+/// <para><b>The defect:</b> <c>FailStartup</c> faulted the <c>hasStarted</c>
+/// <c>TaskCompletionSource</c> with the teardown <see cref="ObjectDisposedException"/>. A
+/// sync hub's <c>Started</c> task has NO awaiter at teardown (the only frameworks awaiting
+/// <c>Started</c> — the DataContext init gate — cover data-source streams, not ad-hoc remote
+/// streams), so the fault sat in an unreferenced Task until GC finalized it and raised
+/// <c>TaskScheduler.UnobservedTaskException</c> — which xUnit v3 escalates to a
+/// "Catastrophic failure" that poisons whichever test class runs next (#228's capture).</para>
+///
+/// <para><b>The contract under test:</b> teardown-disposal is a CANCELLATION of startup, not
+/// a startup failure — the hub will simply never start. <c>FailStartup</c> must transition
+/// <c>Started</c> to Canceled (a canceled Task never raises UnobservedTaskException; a live
+/// awaiter still gets a graceful, typed <see cref="TaskCanceledException"/>). A REAL startup
+/// error must still fault <c>Started</c> — that path is pinned by
+/// <c>FailStartupTeardownClassificationTest</c> in Messaging.Hub.Test.</para>
+/// </summary>
+public class TeardownPendingSubscribeGracefulTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>
+    /// Signals each <see cref="SubscribeRequest"/> the host swallows. Instance state —
+    /// never static (no cross-test bleed); completes with the stream id of the request.
+    /// </summary>
+    private readonly ReplaySubject<string> subscribeReceived = new();
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            // The owner SWALLOWS every SubscribeRequest — no ack, no DataChangedEvent, no
+            // failure. This pins the client's pending-callback state: the SubscribeRequest
+            // stays in the client hub's responseSubjects until disposal cancels it.
+            .WithHandler<SubscribeRequest>((_, delivery) =>
+            {
+                subscribeReceived.OnNext(delivery.Message.StreamId);
+                return delivery.Processed();
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            // Workspace only — no data sources. The stream under test is the AD-HOC remote
+            // stream (GetRemoteStream), whose inner sync hub's Started task has no awaiter —
+            // exactly the shape (mesh-node/user-driven subscriptions) that fataled in CI.
+            .AddData();
+
+    [HubFact]
+    public async Task DisposingHubWithPendingSubscribe_CancelsSyncHubStartup_InsteadOfFaultingIt()
+    {
+        GetHost(); // activate the swallowing owner
+        var client = GetClient();
+        var workspace = client.ServiceProvider.GetRequiredService<IWorkspace>();
+
+        // Capture unobserved task faults of the incident's exact shape. Registered BEFORE
+        // the stream is opened so nothing can slip past; filtered so unrelated teardown
+        // noise from parallel infrastructure can never fail this test.
+        var unobservedFatals = new ConcurrentBag<Exception>();
+        EventHandler<UnobservedTaskExceptionEventArgs> onUnobserved = (_, e) =>
+        {
+            var matches = e.Exception?.Flatten().InnerExceptions
+                .Where(ex => ex is ObjectDisposedException
+                             && ex.Message.Contains("disposed before the response arrived"))
+                .ToArray();
+            if (matches is { Length: > 0 })
+            {
+                foreach (var ex in matches)
+                    unobservedFatals.Add(ex);
+                e.SetObserved(); // keep the repro's own fatal from poisoning sibling tests
+            }
+        };
+        TaskScheduler.UnobservedTaskException += onUnobserved;
+        try
+        {
+            // Open the remote stream: posts SubscribeRequest to the owner and spins up the
+            // inner sync hub, whose SynchronizationGate stays closed until the initial
+            // DataChangedEvent (which never comes).
+            var stream = workspace.GetRemoteStream<EntityStore, CollectionsReference>(
+                CreateHostAddress(), new CollectionsReference("ghost"));
+            var syncHub = stream.Hub;
+
+            // Wait on the actual condition: the owner HAS the SubscribeRequest (so the
+            // pending callback exists in the client hub) — no sleeps.
+            await subscribeReceived
+                .Where(id => id == stream.StreamId)
+                .FirstAsync()
+                .Timeout(10.Seconds())
+                .ToTask();
+
+            // Precondition that makes the seam live: the sync hub never started (its
+            // initialization gate is still waiting on the initial state).
+            syncHub.Started.IsCompleted.Should().BeFalse(
+                "the owner never sent the initial DataChangedEvent, so the sync hub's startup gate must still be closed");
+
+            // THE RACE, DISTILLED: dispose the client while the SubscribeRequest is pending.
+            // CancelCallbacks pushes the ObjectDisposedException; the sync stream routes it
+            // into FailStartup on the never-started sync hub.
+            client.Dispose();
+            await client.DisposalCompleted
+                .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
+                .FirstOrDefaultAsync()
+                .ToTask()
+                .WaitAsync(30.Seconds());
+
+            // The seam contract. Pre-fix: IsFaulted == true (the unobserved fatal armed and
+            // waiting for GC). Post-fix: startup is CANCELED — graceful for live awaiters,
+            // benign for abandoned ones.
+            syncHub.Started.IsFaulted.Should().BeFalse(
+                "teardown-disposal must never fault the sync hub's Started task — a faulted Started with no awaiter "
+                + "is exactly the unobserved-task fatal that poisoned CI (#228 capture)");
+            syncHub.Started.IsCanceled.Should().BeTrue(
+                "disposal before the initial state is a graceful CANCELLATION of startup — the hub will simply never start");
+
+            // Incident-shaped proof: release every reference to the sync hub's task graph and
+            // force finalization — no unobserved fatal of the captured shape may surface.
+            stream = null!;
+            syncHub = null!;
+        }
+        finally
+        {
+            // The GC sweep runs with the handler still attached, then detaches it.
+            for (var i = 0; i < 3; i++)
+            {
+                GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+                GC.WaitForPendingFinalizers();
+            }
+            TaskScheduler.UnobservedTaskException -= onUnobserved;
+        }
+
+        unobservedFatals.Should().BeEmpty(
+            "no teardown-disposal may ever surface as an unobserved task fault (the CI-poisoning catastrophic)");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/MeshHostBuilderTeardownOrderingTest.cs
+++ b/test/MeshWeaver.Hosting.Test/MeshHostBuilderTeardownOrderingTest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading.Tasks;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Deterministic repro for the Autofac "LifetimeScope … has already been disposed"
+/// CATASTROPHICS during Orleans TestCluster / silo teardown (task #18, defect 2 — the
+/// second straggler adjacent to #228).
+///
+/// <para><b>The disposal-ordering defect.</b> A host built through the legacy
+/// <see cref="MeshHostBuilder"/> (the <c>IHostBuilder</c> path — used by
+/// <c>UseOrleansMeshServer(this IHostBuilder)</c> / <c>UseOrleansMeshClient</c>, i.e. every
+/// Orleans TestCluster silo and client, and any prod silo on the legacy builder) had NO
+/// ordered mesh drain on shutdown: <c>host.StopAsync()</c> stopped the hosted services and
+/// then <c>host.Dispose()</c> disposed the root <c>IServiceProvider</c> — which IS the mesh
+/// root hub's Autofac container (<see cref="MessageHubServiceProviderFactory"/>) — while the
+/// hub's action blocks, offloaded <c>IIoPool</c> work and the <c>AsyncDisposeQueue</c> were
+/// still draining. A late continuation then resolves a service (or begins a nested hub
+/// scope) from the disposed container → <see cref="ObjectDisposedException"/>
+/// ("Instances cannot be resolved and nested lifetimes cannot be created from this
+/// LifetimeScope …") on a pooled task nobody observes → xUnit v3 escalates the
+/// UnobservedTaskException to a "Catastrophic failure" (the pre-existing FATAL in CI run
+/// 28646145008 shard 2 that <c>OrleansShutdownRaceSuppressor.SetObserved()</c> cannot
+/// beat xUnit's reporter to).</para>
+///
+/// <para><b>The contract under test</b> — dispose the USERS before the SCOPE: by the time
+/// <c>StopAsync</c> returns (i.e. BEFORE the host disposes the container), the mesh root
+/// hub must be fully drained. <see cref="MeshHostApplicationBuilder"/> (the
+/// <c>IHostApplicationBuilder</c> path) has carried exactly this guarantee via
+/// <see cref="MeshTeardownHostedService"/> since it was introduced; this test pins the
+/// SAME guarantee onto <see cref="MeshHostBuilder"/>. RED before the fix: the hub is
+/// still fully alive (<c>RunLevel == Started</c>) when <c>StopAsync</c> returns.</para>
+/// </summary>
+public class MeshHostBuilderTeardownOrderingTest
+{
+    [Fact(Timeout = 60000)]
+    public async Task StopAsync_DrainsTheMeshRootHub_BeforeTheHostDisposesItsAutofacScope()
+    {
+        var hostBuilder = new HostBuilder();
+        _ = new MeshHostBuilder(hostBuilder, new Address("mesh", "teardown-ordering"));
+        using var host = hostBuilder.Build();
+        await host.StartAsync();
+
+        var mesh = host.Services.GetRequiredService<IMessageHub>();
+        mesh.IsDisposing.Should().BeFalse("the mesh must be alive while the host runs");
+
+        await host.StopAsync();
+
+        // The ordering contract: StopAsync (which runs every IHostedService.StopAsync,
+        // including the mesh drain) must have FULLY drained the mesh root hub before the
+        // caller goes on to dispose the host — because host.Dispose() tears down the
+        // Autofac container the hub's continuations resolve from. A hub still running
+        // here is the armed LifetimeScope catastrophic.
+        mesh.IsDisposing.Should().BeTrue(
+            "host shutdown must dispose the mesh root hub BEFORE the Autofac scope goes away — "
+            + "otherwise late continuations resolve from a disposed LifetimeScope (the CI catastrophic)");
+        mesh.RunLevel.Should().Be(MessageHubRunLevel.Dead,
+            "the drain must be COMPLETE (action blocks + IoPool + AsyncDisposeQueue) when StopAsync returns, "
+            + "not merely started — the container disposal follows immediately");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/MeshWeaver.Hosting.Test.csproj
+++ b/test/MeshWeaver.Hosting.Test/MeshWeaver.Hosting.Test.csproj
@@ -6,4 +6,9 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Concrete HostBuilder for MeshHostBuilderTeardownOrderingTest (the legacy
+         IHostBuilder path the Orleans TestCluster silos/clients are built on). -->
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
 </Project>

--- a/test/MeshWeaver.Messaging.Hub.Test/FailStartupTeardownClassificationTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/FailStartupTeardownClassificationTest.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Seam contract for <see cref="IMessageHub.FailStartup"/> (task #18, defect 1 — the
+/// TEARDOWN STRAGGLER adjacent to #228):
+///
+/// <para><b>Teardown-disposal is a CANCELLATION of startup, not a startup failure.</b>
+/// At hub disposal, <c>MessageHub.CancelCallbacks</c> pushes
+/// <see cref="ObjectDisposedException"/> ("Hub … was disposed before the response arrived
+/// …") into every pending <c>Observe</c> subject; <c>SynchronizationStream.OnError</c>
+/// forwards that into <c>Hub.FailStartup</c> on its inner sync hub. Faulting the
+/// <c>Started</c> <c>TaskCompletionSource</c> with it armed an unobserved-task fatal:
+/// a sync hub's <c>Started</c> has NO awaiter at teardown, so the fault detonated at GC as
+/// <c>TaskScheduler.UnobservedTaskException</c> → xUnit v3 "Catastrophic failure" (#228's
+/// capture). A CANCELED task, by contrast, never raises UnobservedTaskException — and a
+/// live awaiter still gets a graceful, typed <see cref="TaskCanceledException"/>.</para>
+///
+/// <para><b>A REAL startup error must still FAULT <c>Started</c></b> — dependents awaiting
+/// startup (the DataContext init gate) must observe the actual exception. Only the
+/// disposal shape (an <see cref="ObjectDisposedException"/> anywhere in the cause chain,
+/// matching <c>SynchronizationStream.IsObjectDisposed</c>) is classified as cancellation.</para>
+///
+/// <para>End-to-end repro of the incident chain (pending SubscribeRequest → dispose →
+/// sync hub startup canceled, no unobserved fatal):
+/// <c>MeshWeaver.Data.Test.TeardownPendingSubscribeGracefulTest</c>.</para>
+/// </summary>
+public class FailStartupTeardownClassificationTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>
+    /// Creates a client hub whose initialization never completes on its own (the init
+    /// observable is gated on a subject this test controls), so <c>Started</c> is still
+    /// pending when <c>FailStartup</c> is invoked — the exact state of a sync hub whose
+    /// initial DataChangedEvent never arrived.
+    /// </summary>
+    private IMessageHub CreateUnstartedHub(out AsyncSubject<Unit> releaseInit)
+    {
+        var gate = new AsyncSubject<Unit>();
+        releaseInit = gate;
+        return GetClient(c => c
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithInitialization(_ => gate.AsObservable()));
+    }
+
+    private static void Release(AsyncSubject<Unit> gate)
+    {
+        gate.OnNext(Unit.Default);
+        gate.OnCompleted();
+    }
+
+    [Fact(Timeout = 30000)]
+    public void FailStartup_WithTeardownDisposal_CancelsStarted_InsteadOfFaultingIt()
+    {
+        var hub = CreateUnstartedHub(out var gate);
+        try
+        {
+            hub.Started.IsCompleted.Should().BeFalse("the init gate is still closed");
+
+            // The exact shape CancelCallbacks pushes at teardown.
+            hub.FailStartup(new ObjectDisposedException(nameof(MessageHub),
+                $"Hub {hub.Address} was disposed before the response arrived (request type SubscribeRequest, target host/1)."));
+
+            hub.Started.IsCanceled.Should().BeTrue(
+                "disposal before startup is a graceful cancellation — the hub will simply never start");
+            hub.Started.IsFaulted.Should().BeFalse(
+                "a faulted Started with no awaiter is an unobserved-task fatal armed for the next GC (the #228 catastrophic)");
+        }
+        finally
+        {
+            Release(gate);
+        }
+    }
+
+    [Fact(Timeout = 30000)]
+    public void FailStartup_WithWrappedDisposal_IsAlsoClassifiedAsCancellation()
+    {
+        var hub = CreateUnstartedHub(out var gate);
+        try
+        {
+            // The JsonSynchronizationStream DataChangeRequest error shape: the teardown
+            // ObjectDisposedException arrives WRAPPED (InvalidOperationException → ODE).
+            // Classification must walk the cause chain, mirroring
+            // SynchronizationStream.IsObjectDisposed.
+            hub.FailStartup(new InvalidOperationException(
+                "DataChangeRequest failed for stream sync-1",
+                new ObjectDisposedException(nameof(MessageHub), "Hub client/1 was disposed before the response arrived.")));
+
+            hub.Started.IsCanceled.Should().BeTrue("the disposal cause must be recognised anywhere in the chain");
+            hub.Started.IsFaulted.Should().BeFalse();
+        }
+        finally
+        {
+            Release(gate);
+        }
+    }
+
+    [Fact(Timeout = 30000)]
+    public void FailStartup_WithRealError_StillFaultsStarted_ForDependentsToObserve()
+    {
+        var hub = CreateUnstartedHub(out var gate);
+        try
+        {
+            var error = new InvalidOperationException("schema load failed: column mismatch");
+            hub.FailStartup(error);
+
+            hub.Started.IsFaulted.Should().BeTrue(
+                "a genuine startup failure must fault Started so dependents (the DataContext init gate) observe the real error");
+            hub.Started.Exception!.InnerExceptions.Should().Contain(error);
+
+            // Observe the fault here so this test's own assertion never becomes
+            // the unobserved fatal it is guarding against.
+            _ = hub.Started.Exception;
+        }
+        finally
+        {
+            Release(gate);
+        }
+    }
+}


### PR DESCRIPTION
Closes the two remaining teardown-straggler seams from the #228 investigation:

1. **Unobserved fatal** wasn't an Rx bridge — it was the `hasStarted` TCS faulting at teardown with no awaiter. Disposal now classifies as **cancellation** at the Task sinks (FailStartup + test-base bridge); real errors still fault loudly; CancelCallbacks' OnError contract unchanged (consumers pinned).
2. **Autofac LifetimeScope catastrophics**: the legacy `MeshHostBuilder` (TestCluster silo/client hosts) never registered `MeshTeardownHostedService` — the container died while the mesh was still draining. Now registered first (stops last), matching the modern path.

Red→green ×3; Orleans 123/123 @ 2 cores with **zero** Catastrophic/FATAL lines; 544 neighbor tests green; Release `-warnaserror` 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)