### PR TITLE
feat(gitsync): frontmatter round-trips Slide notes/background and node Order

### DIFF
--- a/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Markdig;
 using Markdig.Extensions.Yaml;
 using Markdig.Syntax;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
 using YamlDotNet.Serialization;
@@ -138,6 +139,19 @@ public partial class MarkdownFileParser : IFileFormatParser
                     frontMatter.State = v;
                 }
             }
+            if (frontMatter?.Order is null)
+            {
+                var v = RegexField("Order");
+                if (!string.IsNullOrEmpty(v) && int.TryParse(v, out var order))
+                {
+                    frontMatter ??= new MarkdownFrontMatter();
+                    frontMatter.Order = order;
+                }
+            }
+            // Notes/Background are deliberately NOT regex-recovered: Notes is
+            // typically a multi-line block scalar and Background CSS contains
+            // ` #rrggbb` — both shapes the single-line extractor would mangle.
+            // The primary YamlDotNet path handles them (quoted/block scalars).
         }
 
         // Extract markdown content (without YAML block)
@@ -169,9 +183,24 @@ public partial class MarkdownFileParser : IFileFormatParser
             Abstract = frontMatter?.Abstract
         };
 
+        var nodeType = frontMatter?.NodeType ?? "Markdown";
+
+        // A Slide file reconstructs its typed SlideContent (body + presenter notes
+        // + stage background) so a git reimport no longer downgrades Slide →
+        // MarkdownContent — the slide views read SlideContent, and a MarkdownContent
+        // payload would render an empty stage.
+        object nodeContent = nodeType == SlideNodeType.NodeType
+            ? new SlideContent
+            {
+                Content = markdownContent,
+                Notes = NullIfEmpty(frontMatter?.Notes),
+                Background = NullIfEmpty(frontMatter?.Background)
+            }
+            : markdownDocument;
+
         var node = new MeshNode(id, ns)
         {
-            NodeType = frontMatter?.NodeType ?? "Markdown",
+            NodeType = nodeType,
             Name = frontMatter?.Name ?? id,
             Category = frontMatter?.Category,
             // Surface the YAML Abstract (aka the legacy `Description:` alias) on the
@@ -181,8 +210,9 @@ public partial class MarkdownFileParser : IFileFormatParser
             // Icon: prefer Icon, then Thumbnail (fallback), resolve relative paths
             Icon = ResolveIcon(frontMatter?.Icon ?? frontMatter?.Thumbnail, ns),
             State = ParseState(frontMatter?.State),
+            Order = frontMatter?.Order,
             LastModified = lastModified,
-            Content = markdownDocument,
+            Content = nodeContent,
             PreRenderedHtml = markdownDocument.PrerenderedHtml
         };
 
@@ -197,6 +227,18 @@ public partial class MarkdownFileParser : IFileFormatParser
         // Extract MarkdownContent if available
         var mdContent = node.Content as MarkdownContent;
 
+        // Slide metadata: presenter notes + stage background live on SlideContent.
+        // On a hub with the Graph types registered the content is typed; on a hub
+        // that resolved it untyped (JSON round-trip) it is a JsonElement — handle both.
+        // Gated on the Slide shape so non-Slide nodes' emission stays byte-identical.
+        var (slideNotes, slideBackground) = node.Content switch
+        {
+            SlideContent slide => (NullIfEmpty(slide.Notes), NullIfEmpty(slide.Background)),
+            System.Text.Json.JsonElement je when node.NodeType == SlideNodeType.NodeType =>
+                (ExtractStringProperty(je, "notes"), ExtractStringProperty(je, "background")),
+            _ => (null, null)
+        };
+
         // Build YAML front matter from node properties and MarkdownContent metadata
         var frontMatter = new MarkdownFrontMatter
         {
@@ -210,7 +252,10 @@ public partial class MarkdownFileParser : IFileFormatParser
             Thumbnail = mdContent?.Thumbnail,
             // Prefer the Content abstract; fall back to the node Description so a
             // Description set directly on the node still round-trips to frontmatter.
-            Abstract = mdContent?.Abstract ?? node.Description
+            Abstract = mdContent?.Abstract ?? node.Description,
+            Order = node.Order,
+            Notes = slideNotes,
+            Background = slideBackground
         };
 
         // Only write YAML block if there's meaningful content
@@ -222,7 +267,10 @@ public partial class MarkdownFileParser : IFileFormatParser
                             frontMatter.Authors?.Count > 0 ||
                             frontMatter.Tags?.Count > 0 ||
                             frontMatter.Thumbnail != null ||
-                            frontMatter.Abstract != null;
+                            frontMatter.Abstract != null ||
+                            frontMatter.Order != null ||
+                            frontMatter.Notes != null ||
+                            frontMatter.Background != null;
 
         if (hasYamlContent)
         {
@@ -238,6 +286,7 @@ public partial class MarkdownFileParser : IFileFormatParser
         var markdownText = node.Content switch
         {
             MarkdownContent doc => doc.Content,
+            SlideContent slide => slide.Content,
             string str => str,
             System.Text.Json.JsonElement jsonElement => ExtractContentFromJsonElement(jsonElement),
             _ => null
@@ -255,9 +304,12 @@ public partial class MarkdownFileParser : IFileFormatParser
     public bool CanSerialize(MeshNode node)
     {
         // Handle nodes with NodeType "Markdown", MarkdownContent content, string content,
-        // or JsonElement content (from JSON round-trip where type info was lost)
+        // typed SlideContent (the canonical .md form for slides — frontmatter carries
+        // Notes/Background), or JsonElement content (from JSON round-trip where type
+        // info was lost; a JsonElement SlideContent qualifies via its `content` string).
         return node.NodeType == "Markdown"
             || node.Content is MarkdownContent
+            || node.Content is SlideContent
             || node.Content is string
             || (node.Content is System.Text.Json.JsonElement je && HasMarkdownContent(je));
     }
@@ -281,6 +333,20 @@ public partial class MarkdownFileParser : IFileFormatParser
 
         return null;
     }
+
+    /// <summary>
+    /// Reads a non-empty string property off a JsonElement object (camelCase wire
+    /// shape), or null when absent/empty/not a string.
+    /// </summary>
+    private static string? ExtractStringProperty(System.Text.Json.JsonElement element, string propertyName) =>
+        element.ValueKind == System.Text.Json.JsonValueKind.Object
+        && element.TryGetProperty(propertyName, out var prop)
+        && prop.ValueKind == System.Text.Json.JsonValueKind.String
+        && prop.GetString() is { Length: > 0 } value
+            ? value
+            : null;
+
+    private static string? NullIfEmpty(string? value) => string.IsNullOrEmpty(value) ? null : value;
 
     /// <summary>
     /// Checks if a JsonElement looks like it contains markdown content.
@@ -433,6 +499,20 @@ public partial class MarkdownFileParser : IFileFormatParser
         public List<string>? Tags { get; set; }
         public string? Thumbnail { get; set; }
         public string? Abstract { get; set; }
+
+        // Node ordering + Slide metadata. Declared AFTER the original keys so files
+        // that don't carry them serialize with the exact same key order (and bytes)
+        // as before these fields existed — no diff churn on existing git mirrors
+        // (the YAML serializer omits nulls and emits keys in declaration order).
+        // Order round-trips MeshNode.Order for ANY node type (slide/lesson/module
+        // ordering); Notes/Background round-trip SlideContent.Notes/.Background and
+        // are only emitted for Slide nodes. On parse, stray Notes/Background keys on
+        // a NON-Slide file are ignored: MarkdownContent has no such fields, and
+        // inventing a JsonElement content to carry them would downgrade the node's
+        // content type — the platform reads them from SlideContent only.
+        public int? Order { get; set; }
+        public string? Notes { get; set; }
+        public string? Background { get; set; }
 
         // Legacy aliases. YamlDotNet doesn't follow C# property hierarchy, so we
         // expose them as plain settable properties and fold them in below

--- a/test/MeshWeaver.Content.Test/MarkdownFileParserTest.cs
+++ b/test/MeshWeaver.Content.Test/MarkdownFileParserTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Persistence.Parsers;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
@@ -421,6 +422,214 @@ public class MarkdownFileParserTest
 
     #endregion
 
+    #region Slide + Order Frontmatter (Notes / Background / Order)
+
+    [Fact(Timeout = 20000)]
+    public void RoundTrip_SlideNode_PreservesNotesBackgroundAndOrder()
+    {
+        // Arrange - a typed Slide node as the mesh holds it (framework SlideContent)
+        var node = new MeshNode("S01", "deck")
+        {
+            NodeType = "Slide",
+            Name = "Opening",
+            Order = 1,
+            Content = new SlideContent
+            {
+                Content = "# Opening\n\nWelcome to the deck.",
+                Notes = "Speak slowly.\nPause after the title.",
+                Background = "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
+            }
+        };
+
+        // Act - serialize to canonical .md, then parse back
+        var serialized = _parser.Serialize(node);
+        var reparsed = _parser.Parse("/root/deck/S01.md", serialized, "deck/S01.md");
+
+        // Assert - the .md carries everything in frontmatter + body
+        serialized.Should().Contain("NodeType: Slide");
+        serialized.Should().Contain("Order: 1");
+        serialized.Should().Contain("# Opening");
+
+        // ... and a git reimport no longer downgrades Slide → Markdown
+        reparsed.Should().NotBeNull();
+        reparsed!.NodeType.Should().Be("Slide");
+        reparsed.Name.Should().Be("Opening");
+        reparsed.Order.Should().Be(1);
+        var slide = reparsed.Content.Should().BeOfType<SlideContent>().Subject;
+        slide.Content.Should().Be("# Opening\n\nWelcome to the deck.");
+        slide.Notes.Should().Be("Speak slowly.\nPause after the title.");
+        slide.Background.Should().Be("linear-gradient(135deg, #667eea 0%, #764ba2 100%)");
+    }
+
+    [Fact(Timeout = 20000)]
+    public void Serialize_SlideNode_WithJsonElementContent_EmitsNotesBackgroundAndBody()
+    {
+        // Arrange - the untyped wire form a hub without the typed registry resolves
+        var json = """
+            {"$type":"SlideContent","content":"# Body slide","notes":"Presenter note.","background":"#123456"}
+            """;
+        var node = new MeshNode("S02", "deck")
+        {
+            NodeType = "Slide",
+            Name = "S02",
+            Order = 2,
+            Content = System.Text.Json.JsonDocument.Parse(json).RootElement
+        };
+
+        // Act
+        var serialized = _parser.Serialize(node);
+        var reparsed = _parser.Parse("/root/deck/S02.md", serialized, "deck/S02.md");
+
+        // Assert
+        serialized.Should().Contain("NodeType: Slide");
+        serialized.Should().Contain("Order: 2");
+        serialized.Should().Contain("Presenter note.");
+        serialized.Should().Contain("# Body slide");
+
+        reparsed!.NodeType.Should().Be("Slide");
+        reparsed.Order.Should().Be(2);
+        var slide = reparsed.Content.Should().BeOfType<SlideContent>().Subject;
+        slide.Content.Should().Be("# Body slide");
+        slide.Notes.Should().Be("Presenter note.");
+        slide.Background.Should().Be("#123456");
+    }
+
+    [Fact(Timeout = 20000)]
+    public void RoundTrip_OrderedMarkdownNode_PreservesOrder()
+    {
+        // Arrange - Order applies to ANY node type (lesson/module ordering)
+        var node = new MeshNode("L05", "course")
+        {
+            Name = "Lesson Five",
+            Order = 5,
+            Content = new MarkdownContent { Content = "# Lesson 5" }
+        };
+
+        // Act
+        var serialized = _parser.Serialize(node);
+        var reparsed = _parser.Parse("/root/course/L05.md", serialized, "course/L05.md");
+
+        // Assert - Order round-trips; content stays MarkdownContent
+        serialized.Should().Contain("Order: 5");
+        reparsed!.Order.Should().Be(5);
+        reparsed.NodeType.Should().Be("Markdown");
+        reparsed.Content.Should().BeOfType<MarkdownContent>();
+    }
+
+    [Fact(Timeout = 20000)]
+    public void Serialize_NodeWithoutNewKeys_EmissionIsByteIdenticalToLegacyFormat()
+    {
+        // Arrange - a node carrying none of Order/Notes/Background. Its emission is
+        // pinned byte-for-byte: the new frontmatter keys are OmitNull and declared
+        // AFTER the legacy keys, so existing git mirrors see zero diff churn.
+        var node = new MeshNode("doc", "test")
+        {
+            NodeType = "Article",
+            Name = "My Doc",
+            Category = "Docs",
+            Content = new MarkdownContent
+            {
+                Content = "# Body\n\nText.",
+                Abstract = "Summary"
+            }
+        };
+
+        var nl = Environment.NewLine;
+        var expected =
+            "---" + nl +
+            "NodeType: Article" + nl +
+            "Name: My Doc" + nl +
+            "Category: Docs" + nl +
+            "Abstract: Summary" + nl +
+            "---" + nl +
+            nl +
+            "# Body\n\nText.";
+
+        // Act
+        var serialized = _parser.Serialize(node);
+
+        // Assert
+        serialized.Should().Be(expected);
+    }
+
+    [Fact(Timeout = 20000)]
+    public void Parse_LegacyFileWithoutNewKeys_ParsesUnchanged()
+    {
+        // Arrange - a pre-existing mirror file that never carried the new keys
+        var content = """
+            ---
+            NodeType: Article
+            Name: Legacy File
+            ---
+
+            # Legacy
+
+            Body.
+            """;
+
+        // Act
+        var node = _parser.Parse("/test/legacy.md", content, "test/legacy.md");
+
+        // Assert - no Order, regular MarkdownContent, nothing invented
+        node.Should().NotBeNull();
+        node!.NodeType.Should().Be("Article");
+        node.Order.Should().BeNull();
+        node.Content.Should().BeOfType<MarkdownContent>();
+    }
+
+    [Fact(Timeout = 20000)]
+    public void Parse_LegacySlideFileWithoutNotesOrBackground_ReconstructsSlideContent()
+    {
+        // Arrange - a Slide exported before the frontmatter carried Notes/Background
+        var content = """
+            ---
+            NodeType: Slide
+            Name: Old Slide
+            ---
+
+            # Old slide body
+            """;
+
+        // Act
+        var node = _parser.Parse("/deck/old.md", content, "deck/old.md");
+
+        // Assert - Slide is reconstructed typed (no downgrade to Markdown), extras null
+        node.Should().NotBeNull();
+        node!.NodeType.Should().Be("Slide");
+        var slide = node.Content.Should().BeOfType<SlideContent>().Subject;
+        slide.Content.Should().Contain("# Old slide body");
+        slide.Notes.Should().BeNull();
+        slide.Background.Should().BeNull();
+    }
+
+    [Fact(Timeout = 20000)]
+    public void Parse_NonSlideFileWithStrayNotes_IgnoresThem()
+    {
+        // Arrange - Notes/Background only mean something on a Slide; on any other
+        // node type they are ignored (MarkdownContent has no such fields, and
+        // inventing an untyped content to carry them would downgrade the node).
+        var content = """
+            ---
+            Name: Not A Slide
+            Notes: stray presenter notes
+            Background: red
+            ---
+
+            Body.
+            """;
+
+        // Act
+        var node = _parser.Parse("/test/plain.md", content, "test/plain.md");
+        var reserialized = _parser.Serialize(node!);
+
+        // Assert
+        node!.Content.Should().BeOfType<MarkdownContent>();
+        reserialized.Should().NotContain("Notes:");
+        reserialized.Should().NotContain("Background:");
+    }
+
+    #endregion
+
     #region CanSerialize Tests
 
     [Fact(Timeout = 20000)]
@@ -441,6 +650,15 @@ public class MarkdownFileParserTest
     public void CanSerialize_WithStringContent_ReturnsTrue()
     {
         var node = new MeshNode("doc") { Content = "# Markdown string" };
+        _parser.CanSerialize(node).Should().BeTrue();
+    }
+
+    [Fact(Timeout = 20000)]
+    public void CanSerialize_WithTypedSlideContent_ReturnsTrue()
+    {
+        // Typed SlideContent serializes as canonical .md (frontmatter carries
+        // Notes/Background) — not as a .json fallback.
+        var node = new MeshNode("S01") { NodeType = "Slide", Content = new SlideContent { Content = "# Slide" } };
         _parser.CanSerialize(node).Should().BeTrue();
     }
 

--- a/test/MeshWeaver.GitSync.Test/GitHubExportImportTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubExportImportTest.cs
@@ -1,6 +1,8 @@
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
 using Xunit;
 
 namespace MeshWeaver.GitSync.Test;
@@ -47,6 +49,54 @@ public class GitHubExportImportTest(ITestOutputHelper output) : GitHubSyncTestBa
         Assert.Contains("Section.", MarkdownBody(await WaitForNode($"{b}/Docs")));
         // README.md is a display file — import must NOT create a stray node for it.
         Assert.True(await IsAbsent($"{b}/README"));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Export_Then_Import_RoundTripsSlideNotesBackgroundAndOrder()
+    {
+        await Connect();
+        var a = "GhD" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(a, "Deck A");
+        await NodeFactory.CreateNode(MeshNode.FromPath($"{a}/S01") with
+        {
+            NodeType = "Slide",
+            Name = "Opening",
+            Order = 1,
+            State = MeshNodeState.Active,
+            Content = new SlideContent
+            {
+                Content = "# Opening\n\nWelcome to the deck.",
+                Notes = "Speak slowly.",
+                Background = "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
+            },
+        }).Timeout(60.Seconds()).ToTask();
+
+        var repo = "https://github.com/test/deck-a";
+        await Sync.SaveConfig(a, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+        await Sync.SyncToGitHub(a, UserId).Timeout(60.Seconds()).ToTask();
+
+        // The slide mirrors as canonical .md whose frontmatter carries the slide metadata.
+        var file = Fake.Tree(repo).FirstOrDefault(f => f.Path == "S01.md");
+        Assert.NotNull(file);
+        Assert.Contains("NodeType: Slide", file!.Content);
+        Assert.Contains("Order: 1", file.Content);
+        Assert.Contains("Speak slowly.", file.Content);
+        Assert.Contains("667eea", file.Content);
+        Assert.Contains("# Opening", file.Content);
+
+        // Import into a fresh Space — the Slide must round-trip typed, not downgrade to Markdown.
+        var b = "GhE" + Guid.NewGuid().ToString("N")[..8];
+        await Sync.ImportFromGitHub(repo, "main", b, "Deck B", subdirectory: null, UserId)
+            .Timeout(90.Seconds()).ToTask();
+
+        var slideNode = await WaitForNode($"{b}/S01");
+        Assert.Equal("Slide", slideNode.NodeType);
+        Assert.Equal(1, slideNode.Order);
+        var slide = slideNode.ContentAs<SlideContent>(Mesh.JsonSerializerOptions);
+        Assert.NotNull(slide);
+        Assert.Contains("Welcome to the deck.", slide!.Content);
+        Assert.Equal("Speak slowly.", slide.Notes);
+        Assert.Equal("linear-gradient(135deg, #667eea 0%, #764ba2 100%)", slide.Background);
     }
 
     [Fact(Timeout = 120000)]


### PR DESCRIPTION
# GitSync .md frontmatter round-trips Slide notes/background and node Order

## The mirror gap

The canonical GitSync `.md` format (`MarkdownFileParser`) could not represent three things, proven during the Systemorph/AgenticEngineering export:

- **`SlideContent.Notes`** — presenter notes (11 slides on memex carry them) were silently dropped in the git mirror.
- **`SlideContent.Background`** — per-slide CSS background (7 slides), also dropped.
- **`MeshNode.Order`** — platform-wide ordering (slides S01..S20, lessons L01..L18, modules) survived only via alphabetical ids.

Worse, a git **reimport downgraded Slide → plain Markdown**: the parser always reconstructed `MarkdownContent`, so a round-tripped slide rendered an empty stage (the slide views read `SlideContent`).

## The format extension

`MarkdownFrontMatter` gains three keys — `Order` (any node type), `Notes` and `Background` (Slide only):

```yaml
---
NodeType: Slide
Name: Opening
Order: 1
Notes: Speak slowly.
Background: linear-gradient(135deg, #667eea 0%, #764ba2 100%)
---

# Opening

Welcome to the deck.
```

- **Serialize**: `Order` is emitted whenever `MeshNode.Order` is non-null. `Notes`/`Background` are emitted when the content carries them — handling **both** the typed `SlideContent` (hubs with the Graph registry, since PR #205 made Slide a framework type) and the untyped `JsonElement` wire form. Typed `SlideContent` is now claimed by `CanSerialize`, so slides mirror as canonical `.md` instead of falling back to `.json`.
- **Parse**: `Order` → `MeshNode.Order` for any node. `NodeType: Slide` files reconstruct a **typed `SlideContent`** (body + notes + background) — reimport no longer downgrades Slide → Markdown. Stray `Notes`/`Background` on a non-Slide file are ignored (documented): `MarkdownContent` has no such fields, and inventing an untyped content to carry them would downgrade the node's content type.

## Emission stability

The new keys are `OmitNull` and declared **after** the existing frontmatter keys, so every node that doesn't carry them emits **byte-identically** to before — zero diff churn on existing git mirrors. Pinned by `Serialize_NodeWithoutNewKeys_EmissionIsByteIdenticalToLegacyFormat` (exact fixture-string assertion).

## Tests

- `RoundTrip_SlideNode_PreservesNotesBackgroundAndOrder` — typed slide → .md → parse: everything preserved, `NodeType: Slide`, typed `SlideContent` back.
- `Serialize_SlideNode_WithJsonElementContent_EmitsNotesBackgroundAndBody` — untyped wire form.
- `RoundTrip_OrderedMarkdownNode_PreservesOrder` — Order on a plain Markdown node.
- `Serialize_NodeWithoutNewKeys_EmissionIsByteIdenticalToLegacyFormat` — byte-stability pin.
- `Parse_LegacyFileWithoutNewKeys_ParsesUnchanged` / `Parse_LegacySlideFileWithoutNotesOrBackground_ReconstructsSlideContent` / `Parse_NonSlideFileWithStrayNotes_IgnoresThem` — legacy-file behavior.
- `Export_Then_Import_RoundTripsSlideNotesBackgroundAndOrder` (GitSync integration) — full export → fake repo → import loop: the mirrored `S01.md` carries the metadata and the reimported node is a typed Slide with notes/background/order intact.

Notes: `SlideContent.Transition` (reserved, never written anywhere) is deliberately not in the format yet; the defensive regex frontmatter extractor recovers `Order` but not `Notes`/`Background` (multi-line block scalars and ` #rrggbb` CSS would be mangled by a single-line regex — the primary YamlDotNet path handles them).

Gate: `MeshWeaver.Content.Test` MarkdownFileParserTest 30/30, `MeshWeaver.GitSync.Test` 59/59, full-solution `Release -p:CIRun=true -warnaserror` 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
