### PR TITLE
fix(migration): always-runs partition-access reconcile — drift self-heals every roll

### DIFF
--- a/memex/aspire/Memex.Database.Migration/Migrations/PartitionAccessReconcile.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/PartitionAccessReconcile.cs
@@ -48,13 +48,17 @@ public static class PartitionAccessReconcile
 
         foreach (var schema in schemas)
         {
+            // Quoted-identifier escaping: schema names come from information_schema but can
+            // legally contain double quotes (and prod carries junk schemas from URL fragments)
+            // — double any embedded quote so the interpolated identifier stays valid SQL.
+            var ident = schema.Replace("\"", "\"\"");
             // Drift detection BEFORE the heal: assignments present but materialization empty is
             // the silent permission wedge — surface it loudly so recurrences are diagnosable.
             try
             {
                 await using var driftCmd = dataSource.CreateCommand($"""
-                    SELECT (SELECT count(*) FROM "{schema}".access),
-                           (SELECT count(*) FROM "{schema}".user_effective_permissions)
+                    SELECT (SELECT count(*) FROM "{ident}".access),
+                           (SELECT count(*) FROM "{ident}".user_effective_permissions)
                     """);
                 await using var rdr = await driftCmd.ExecuteReaderAsync();
                 if (await rdr.ReadAsync())
@@ -97,7 +101,7 @@ public static class PartitionAccessReconcile
             try
             {
                 await using var rebuildCmd = dataSource.CreateCommand(
-                    $"SELECT \"{schema}\".rebuild_user_effective_permissions()");
+                    $"SELECT \"{ident}\".rebuild_user_effective_permissions()");
                 await rebuildCmd.ExecuteNonQueryAsync();
             }
             catch (Exception ex)

--- a/memex/aspire/Memex.Database.Migration/Migrations/PartitionAccessReconcile.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/PartitionAccessReconcile.cs
@@ -1,0 +1,113 @@
+using MeshWeaver.Hosting.PostgreSql;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace Memex.Database.Migration.Migrations;
+
+/// <summary>
+/// The partition-access reconcile: re-applies the current per-partition permission functions and
+/// rebuilds <c>{schema}.user_effective_permissions</c> + <c>public.partition_access</c> from the
+/// <c>access</c> satellites — the single implementation behind BOTH
+/// <see cref="V35_ReconcilePartitionAccessIndex"/> (the one-shot versioned heal) and the
+/// ALWAYS-RUNS migration phase in <c>Program.cs</c>.
+///
+/// <para><b>Why always-runs.</b> V35 healed this drift once, but it RECURRED on a database
+/// already past v35 (memex.local, 2026-07-03: every partition's
+/// <c>user_effective_permissions</c> empty while the <c>access</c> tables held valid Admin
+/// assignments — grants invisible to the permission evaluator because the synced queries run
+/// under RLS, which depends on <c>partition_access</c>; menus silently degrade and the user's
+/// own spaces vanish from search, with no error anywhere). A versioned one-shot cannot heal a
+/// recurrence, so the reconcile now runs on EVERY migration pass, like the doc-mirror phase:
+/// idempotent, one function call per schema, and any future drift self-heals on the next roll
+/// instead of wedging permissions until someone hand-runs SQL.</para>
+///
+/// <para><b>Drift detection.</b> Before rebuilding, each schema with AccessAssignment rows but an
+/// EMPTY materialization is logged at Warning — the recurrence's root cause (what wipes the
+/// tables) is still unidentified, and these log lines are the evidence trail that will pin it.</para>
+/// </summary>
+public static class PartitionAccessReconcile
+{
+    /// <summary>Runs the reconcile across every partition schema (those with an <c>access</c> table).</summary>
+    /// <param name="dataSource">The database to reconcile.</param>
+    /// <param name="vectorDimensions">Embedding dimension for the provisioning proc script.</param>
+    /// <param name="logger">Migration logger.</param>
+    /// <param name="phase">Log prefix identifying the caller ("v35" or "always-on").</param>
+    public static async Task RunAsync(
+        NpgsqlDataSource dataSource, int vectorDimensions, ILogger logger, string phase)
+    {
+        // 1. (Re)install the single-source-of-truth provisioning proc so its body carries the
+        //    CURRENT versioned DDL (the rebuild functions with the partition_access sync). Pure
+        //    CREATE OR REPLACE FUNCTION — idempotent.
+        await using (var procCmd = dataSource.CreateCommand(
+            PostgreSqlSchemaInitializer.GetEnsurePartitionSchemaProcScript(vectorDimensions)))
+        {
+            await procCmd.ExecuteNonQueryAsync();
+        }
+
+        var schemas = await SchemaHelpers.DiscoverAccessSchemasAsync(dataSource);
+
+        foreach (var schema in schemas)
+        {
+            // Drift detection BEFORE the heal: assignments present but materialization empty is
+            // the silent permission wedge — surface it loudly so recurrences are diagnosable.
+            try
+            {
+                await using var driftCmd = dataSource.CreateCommand($"""
+                    SELECT (SELECT count(*) FROM "{schema}".access),
+                           (SELECT count(*) FROM "{schema}".user_effective_permissions)
+                    """);
+                await using var rdr = await driftCmd.ExecuteReaderAsync();
+                if (await rdr.ReadAsync())
+                {
+                    var accessRows = rdr.GetInt64(0);
+                    var uepRows = rdr.GetInt64(1);
+                    if (accessRows > 0 && uepRows == 0)
+                        logger.LogWarning(
+                            "Reconcile {Phase}: DRIFT in \"{Schema}\" — {AccessRows} access assignment(s) but an EMPTY "
+                            + "user_effective_permissions (grants invisible to RLS/permissions until this heal). "
+                            + "Something wiped or bypassed the materialization — investigate what ran before this.",
+                            phase, schema, accessRows);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Reconcile {Phase}: drift probe failed for \"{Schema}\"", phase, schema);
+            }
+
+            // 2a. Re-apply the current per-partition DDL (CREATE OR REPLACE the rebuild functions
+            //     etc.) via the single-source-of-truth proc — cures any stale function body.
+            try
+            {
+                await using var ensureCmd = dataSource.CreateCommand(
+                    "SELECT public.ensure_partition_schema(@p)");
+                ensureCmd.Parameters.AddWithValue("@p", schema);
+                await ensureCmd.ExecuteNonQueryAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Reconcile {Phase}: \"{Schema}\" — ensure_partition_schema failed; skipping", phase, schema);
+                continue;
+            }
+
+            // 2b. Full schema-level reconcile: rebuild user_effective_permissions AND re-sync
+            //     public.partition_access (upserts every user with Read, deletes the revoked) —
+            //     heals the drift whether it came from a stale function, a trigger-bypassing
+            //     write, or a wiped table.
+            try
+            {
+                await using var rebuildCmd = dataSource.CreateCommand(
+                    $"SELECT \"{schema}\".rebuild_user_effective_permissions()");
+                await rebuildCmd.ExecuteNonQueryAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Reconcile {Phase}: rebuild_user_effective_permissions failed for \"{Schema}\"", phase, schema);
+            }
+        }
+
+        logger.LogInformation(
+            "Reconcile {Phase}: partition-access reconciled across {Count} schema(s)", phase, schemas.Count);
+    }
+}

--- a/memex/aspire/Memex.Database.Migration/Migrations/V35_ReconcilePartitionAccessIndex.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V35_ReconcilePartitionAccessIndex.cs
@@ -50,58 +50,10 @@ public sealed class V35_ReconcilePartitionAccessIndex : IMigration
     public string Description =>
         "Re-apply per-partition permission functions and reconcile public.partition_access for every schema";
 
-    public async Task RunAsync(MigrationContext ctx)
-    {
-        // 1. (Re)install the single-source-of-truth provisioning proc so its body carries the
-        //    CURRENT versioned DDL (the rebuild functions with the partition_access sync). Pure
-        //    CREATE OR REPLACE FUNCTION — idempotent.
-        await using (var procCmd = ctx.DataSource.CreateCommand(
-            PostgreSqlSchemaInitializer.GetEnsurePartitionSchemaProcScript(ctx.Options.VectorDimensions)))
-        {
-            await procCmd.ExecuteNonQueryAsync();
-        }
-
-        // 2. Re-apply the functions per schema, then reconcile uep + partition_access.
-        var schemas = await SchemaHelpers.DiscoverAccessSchemasAsync(ctx.DataSource);
-
-        foreach (var schema in schemas)
-        {
-            // 2a. Re-apply the current per-partition DDL (CREATE OR REPLACE the rebuild functions
-            //     etc.) via the single-source-of-truth proc. This cures a stale
-            //     rebuild_user_permissions_for that never synced partition_access.
-            try
-            {
-                await using var ensureCmd = ctx.DataSource.CreateCommand(
-                    "SELECT public.ensure_partition_schema(@p)");
-                ensureCmd.Parameters.AddWithValue("@p", schema);
-                await ensureCmd.ExecuteNonQueryAsync();
-                ctx.Logger.LogInformation(
-                    "Repair v35: \"{Schema}\" — per-partition functions re-applied", schema);
-            }
-            catch (Exception ex)
-            {
-                ctx.Logger.LogWarning(ex,
-                    "Repair v35: \"{Schema}\" — ensure_partition_schema failed; skipping", schema);
-                continue;
-            }
-
-            // 2b. Full schema-level reconcile: rebuild user_effective_permissions AND re-sync
-            //     public.partition_access for every user with Read in this partition. Heals the
-            //     drift whether it came from a stale function or a trigger-bypassing write.
-            try
-            {
-                await using var rebuildCmd = ctx.DataSource.CreateCommand(
-                    $"SELECT \"{schema}\".rebuild_user_effective_permissions()");
-                await rebuildCmd.ExecuteNonQueryAsync();
-                ctx.Logger.LogInformation(
-                    "Repair v35: \"{Schema}\".rebuild_user_effective_permissions() OK — partition_access reconciled",
-                    schema);
-            }
-            catch (Exception ex)
-            {
-                ctx.Logger.LogWarning(ex,
-                    "Repair v35: rebuild_user_effective_permissions failed for \"{Schema}\"", schema);
-            }
-        }
-    }
+    public Task RunAsync(MigrationContext ctx)
+        // Single implementation shared with the ALWAYS-RUNS phase in Program.cs — the drift
+        // this migration healed once RECURRED on databases already past v35, so the reconcile
+        // now also runs on every migration pass; see PartitionAccessReconcile.
+        => PartitionAccessReconcile.RunAsync(
+            ctx.DataSource, ctx.Options.VectorDimensions, ctx.Logger, phase: "v35");
 }

--- a/memex/aspire/Memex.Database.Migration/Program.cs
+++ b/memex/aspire/Memex.Database.Migration/Program.cs
@@ -156,6 +156,16 @@ var ctx = new MigrationContext(dataSource, connectionString, options, logger, in
 var runner = new MigrationRunner(migrations);
 var finalVersion = await runner.RunAsync(ctx);
 
+// ── Partition-access reconcile (always runs): rebuild {schema}.user_effective_permissions +
+// public.partition_access from the access satellites across every partition schema. The V35
+// one-shot healed this drift once, but it RECURRED on databases already past v35 (memex.local +
+// atioz, 2026-07-03: grants present, materialization empty → permissions silently wedge and
+// spaces vanish from search, no error anywhere). Idempotent and cheap (one function call per
+// schema); any future drift self-heals on the next roll, and detected drift is logged at
+// Warning as the evidence trail for the still-unidentified wiper. Runs AFTER the versioned
+// migrations (schema moves/drops done) and BEFORE the searchable-schemas refresh.
+await PartitionAccessReconcile.RunAsync(dataSource, options.VectorDimensions, logger, phase: "always-on");
+
 // ── Doc search index (always runs): mirror the embedded documentation into the `doc`
 // schema so it surfaces in the main search bar (full-text + vector). Runs BEFORE Phase 3
 // so the searchable-schemas refresh picks up `doc`. Full replace + incremental embedding.


### PR DESCRIPTION
## Why

The `user_effective_permissions` / `public.partition_access` drift that migration **V35** healed once **recurred on databases already past v35**. Found 2026-07-03 on **memex.local (portal-wide)** and **all three prod portals** (atioz: 8 partitions incl. customer spaces `dokumentenpruefung`/`provider`; memex: 4; memex-cloud: 1) — `access` satellites held valid Admin assignments while the materialization was empty.

The failure is a **silent permission wedge**: the synced permission queries run under RLS, which depends on `partition_access` — so a wiped materialization makes the user's **own grants invisible**. Menu items (e.g. Delete) disappear and their spaces vanish from search, with no error anywhere. A versioned one-shot cannot heal a recurrence.

## What

- Extract V35's reconcile into `PartitionAccessReconcile` (V35 delegates to it — version history unchanged).
- Run it as an **always-runs migration phase** (same shape as the doc-mirror phase): idempotent, one `rebuild_user_effective_permissions()` call per schema, after the versioned migrations, before the searchable-schemas refresh. Any future drift self-heals on the next roll.
- **Drift detection**: schemas with assignments but an empty materialization are logged at **Warning before the heal** — the evidence trail for the still-unidentified wiper (drifted schemas skew toward script-created spaces, consistent with writes bypassing the `access_changed` trigger).

## Ops note

All four affected environments were healed by hand today with the same rebuild call; this PR makes the heal structural.

Full-solution `Release -warnaserror -p:CIRun=true` build green locally on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)