### PR TITLE
fix(ai): empty agent catalog reports the truthful condition — not 'moved or renamed, pick another' (#201)

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -1135,12 +1135,13 @@ public class AgentChatClient : IAgentChat
                 // once the catalog emits. The stale-selection wording stays reserved for
                 // the non-empty case, where picking another agent is real advice.
                 lastAgentCreationError = loadedAgents.Count == 0
-                    ? $"Selected agent '{requested}' could not be validated: NO agents are "
-                      + "loaded in this context (the agent catalog is empty). Either the "
-                      + "agent query has not emitted yet (cold start — retry the message) "
-                      + "or no agents are visible to this identity/context. If this "
-                      + "persists, verify agents exist under the user/space/global Agent "
-                      + "namespaces and are readable in this context."
+                    ? $"Selected agent '{requested}' could not be validated: the agent "
+                      + "catalog is empty — no agents are loaded in this context. Either "
+                      + "the agent query has not emitted yet (cold start — retry the "
+                      + "message) or no agents are visible to this identity/context. If "
+                      + "this persists, verify agents exist under the 'Agent', "
+                      + "'{space}/Agent' or '{user}/Agent' namespaces and are readable "
+                      + "in this context."
                     : $"Selected agent '{requested}' was not found among the available agents "
                       + $"([{string.Join(", ", loadedAgents.Select(a => a.Path ?? a.Name))}]). "
                       + "It may have been moved, renamed, or is not available in this context — "

--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -1126,11 +1126,25 @@ public class AgentChatClient : IAgentChat
             if (!selectionMatched)
             {
                 var requested = currentAgentPath ?? currentAgentName;
-                lastAgentCreationError =
-                    $"Selected agent '{requested}' was not found among the available agents "
-                    + $"([{string.Join(", ", loadedAgents.Select(a => a.Path ?? a.Name))}]). "
-                    + "It may have been moved, renamed, or is not available in this context — "
-                    + "pick another agent from the list.";
+                // 🚨 Distinguish "stale selection" from "EMPTY catalog" (#201). With zero
+                // loaded agents there is nothing to "pick from the list" — blaming the
+                // selection ("moved or renamed — pick another") dead-ends the user. An
+                // empty catalog means the agent query returned nothing for THIS hub's
+                // identity/context (still converging on a cold start, or agents not
+                // visible to this principal) — say that, and that a retry can succeed
+                // once the catalog emits. The stale-selection wording stays reserved for
+                // the non-empty case, where picking another agent is real advice.
+                lastAgentCreationError = loadedAgents.Count == 0
+                    ? $"Selected agent '{requested}' could not be validated: NO agents are "
+                      + "loaded in this context (the agent catalog is empty). Either the "
+                      + "agent query has not emitted yet (cold start — retry the message) "
+                      + "or no agents are visible to this identity/context. If this "
+                      + "persists, verify agents exist under the user/space/global Agent "
+                      + "namespaces and are readable in this context."
+                    : $"Selected agent '{requested}' was not found among the available agents "
+                      + $"([{string.Join(", ", loadedAgents.Select(a => a.Path ?? a.Name))}]). "
+                      + "It may have been moved, renamed, or is not available in this context — "
+                      + "pick another agent from the list.";
                 logger.LogWarning("[AgentChatClient] {Error}", lastAgentCreationError);
             }
             return null;

--- a/test/MeshWeaver.AI.Test/AgentSelectionPathResolutionTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentSelectionPathResolutionTest.cs
@@ -197,7 +197,7 @@ public class AgentSelectionPathResolutionTest : AITestBase
 
         response.Should().Contain("Agent/Assistant",
             "the message should name the agent the user asked for");
-        response.Should().Contain("NO agents are loaded",
+        response.Should().Contain("agent catalog is empty",
             "an empty catalog is a load/visibility condition, not a stale selection");
         response.Should().NotContain("pick another agent from the list",
             "there is nothing to pick from — the stale-selection advice is a dead end");

--- a/test/MeshWeaver.AI.Test/AgentSelectionPathResolutionTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentSelectionPathResolutionTest.cs
@@ -176,6 +176,34 @@ public class AgentSelectionPathResolutionTest : AITestBase
         response.Should().Contain("was not found among the available agents",
             "a genuinely unmatched selection IS an agent-not-found failure");
     }
+
+    /// <summary>
+    /// #201: with an EMPTY agent catalog the failure is "no agents loaded in this
+    /// context", never "your selection was moved or renamed — pick another from the
+    /// list": there is no list. The stale-selection wording dead-ended users on the
+    /// deployed portal ("available agents ([])" with nothing to pick); the empty-set
+    /// message must name the real condition (catalog not emitted / not visible) and
+    /// the recovery (retry; check agent visibility).
+    /// </summary>
+    [Fact]
+    public async Task SelectAgent_WithEmptyCatalog_ReportsEmptyCatalog_NotStaleSelection()
+    {
+        var client = new AgentChatClient(Mesh.ServiceProvider);
+        client.ApplyAgents(Array.Empty<AgentDisplayInfo>(), contextPath: null);
+
+        client.SetSelectedAgent("Agent/Assistant");
+
+        var response = await RunAndCaptureAsync(client);
+
+        response.Should().Contain("Agent/Assistant",
+            "the message should name the agent the user asked for");
+        response.Should().Contain("NO agents are loaded",
+            "an empty catalog is a load/visibility condition, not a stale selection");
+        response.Should().NotContain("pick another agent from the list",
+            "there is nothing to pick from — the stale-selection advice is a dead end");
+        response.Should().NotContain("may have been moved, renamed",
+            "blaming the selection is wrong when zero agents resolved");
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Fixes the empty-set half of #201: when an explicit agent selection fails to resolve **and zero agents are loaded**, the error blamed the selection (*"may have been moved, renamed … pick another agent from the list ([])"*) — a dead end, since there is nothing to pick. An empty catalog is a different condition: the synced agent query hasn't emitted for this hub's identity/context yet (cold start), or agents aren't visible to this principal. The message now names that condition and the recovery (retry once the catalog emits; check agent visibility if it persists).

Unchanged by design:
- the stale-selection wording for the **non-empty** case (picking another agent is real advice there);
- the deliberate no-silent-fallback contract for explicit selections (an unresolvable explicit pick never silently routes to a different agent).

Whether the deployed round's catalog was legitimately empty (visibility/RLS) or a cold-start race is environment-specific — left open on #201 with this PR removing the misleading dead-end in either case.

## Tests

`SelectAgent_WithEmptyCatalog_ReportsEmptyCatalog_NotStaleSelection` (new); AgentSelection* 6/6 green; MeshWeaver.AI Release `-warnaserror` clean.

Refs #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)