### PR TITLE
fix(routing): mesh paths with file extensions reach the node page — constrain the endpoint, never the page template

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -947,16 +947,22 @@ public static class MemexConfiguration
     }
 
     /// <summary>
-    /// Adds all MeshWeaver view assemblies (Blazor, Graph, Radzen, GoogleMaps) to the Razor components endpoint.
+    /// Adds all MeshWeaver view assemblies (Blazor, Graph, Radzen, GoogleMaps) to the Razor components endpoint,
+    /// and excludes static-asset/infrastructure prefixes (_framework, _content, favicon.ico, auth, mcp, ...)
+    /// from ApplicationPage's root catch-all endpoint so asset misses fall through to 404 instead of the
+    /// HTML shell. The page templates themselves carry NO inline constraint — the Blazor Router would
+    /// interpret ":nonfile" as the built-in dot-rejecting constraint and break every mesh path ending
+    /// in a file extension (Document nodes).
     /// </summary>
     public static RazorComponentsEndpointConventionBuilder AddMeshViews(
         this RazorComponentsEndpointConventionBuilder builder)
         => builder.AddAdditionalAssemblies(
-            typeof(ApplicationPage).Assembly,              // MeshWeaver.Blazor (includes ApplicationPage with catch-all route)
-            typeof(MeshNodeEditorView).Assembly,           // MeshWeaver.Blazor.Graph
-            typeof(RadzenChartView).Assembly,              // MeshWeaver.Blazor.Radzen
-            typeof(GoogleMapView).Assembly                 // MeshWeaver.Blazor.GoogleMaps
-        );
+                typeof(ApplicationPage).Assembly,              // MeshWeaver.Blazor (includes ApplicationPage with catch-all route)
+                typeof(MeshNodeEditorView).Assembly,           // MeshWeaver.Blazor.Graph
+                typeof(RadzenChartView).Assembly,              // MeshWeaver.Blazor.Radzen
+                typeof(GoogleMapView).Assembly                 // MeshWeaver.Blazor.GoogleMaps
+            )
+            .ExcludeStaticAssetPaths();
 }
 
 public class StylesConfiguration

--- a/src/MeshWeaver.Blazor.Portal/BlazorPortalExtensions.cs
+++ b/src/MeshWeaver.Blazor.Portal/BlazorPortalExtensions.cs
@@ -1,10 +1,8 @@
-using MeshWeaver.Blazor.Infrastructure;
 using MeshWeaver.Blazor.Portal.SidePanel;
 using MeshWeaver.Blazor.Portal.Infrastructure;
 using MeshWeaver.Blazor.Portal.Resize;
 using MeshWeaver.Blazor.Services;
 using Microsoft.AspNetCore.Components.Server;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MeshWeaver.Blazor.Portal;
@@ -18,13 +16,15 @@ public static class BlazorPortalExtensions
     /// <summary>
     /// Adds portal services including DimensionManager, CacheStorageAccessor, AppVersionService,
     /// and SidePanelStateService with persistent state support.
-    /// Also registers the "nonfile" route constraint used by ApplicationPage and AreaPage.
     /// Call this on the IServerSideBlazorBuilder returned by AddInteractiveServerComponents().
+    /// Static-asset path exclusion for the catch-all page is an endpoint convention
+    /// (NonfileRouteConstraintExtensions.ExcludeStaticAssetPaths on MapRazorComponents),
+    /// not a DI ConstraintMap registration — the Blazor Router never honors custom
+    /// inline constraints, so ":nonfile" in a page template must never come back.
     /// </summary>
     public static IServerSideBlazorBuilder AddBlazorPortalServices(this IServerSideBlazorBuilder builder)
     {
         builder.Services.AddBlazorPortalCoreServices();
-        builder.Services.AddNonfileRouteConstraint();
         builder.AddSidePanelState();
         return builder;
     }

--- a/src/MeshWeaver.Blazor/Infrastructure/NonfileRouteConstraint.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/NonfileRouteConstraint.cs
@@ -1,12 +1,24 @@
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Routing.Patterns;
 
 namespace MeshWeaver.Blazor.Infrastructure;
 
 /// <summary>
-/// Route constraint that excludes paths for static file prefixes used by Blazor and RCLs.
-/// Use with catch-all routes like "/{*Path:nonfile}" to prevent matching _framework, _content, etc.
+/// Route constraint that excludes paths for static file prefixes used by Blazor and RCLs,
+/// plus infrastructure endpoints (auth, dev, mcp, OAuth callbacks). Applied to the root
+/// catch-all page endpoint via <see cref="NonfileRouteConstraintExtensions.ExcludeStaticAssetPaths{TBuilder}"/>
+/// so that requests under these prefixes are never swallowed by the Blazor application page
+/// (a miss falls through to a proper 404 instead of an HTML shell).
+///
+/// 🚨 Deliberately NOT wired as an inline ":nonfile" template constraint: the Blazor Router
+/// component resolves inline constraint names against its own compiled-in map
+/// (int, bool, ..., file, nonfile) where "nonfile" is the built-in dot-rejecting
+/// NonFileNameRouteConstraint, and that map cannot be customized. An inline ":nonfile"
+/// therefore rejects every mesh path whose last segment contains a dot (all Document
+/// nodes: .pdf/.docx/.txt) in the interactive circuit — the agentic-pensions#10 regression.
+/// Constrain the endpoint, never the page template.
 /// </summary>
 public class NonfileRouteConstraint : IRouteConstraint
 {
@@ -47,19 +59,46 @@ public class NonfileRouteConstraint : IRouteConstraint
 }
 
 /// <summary>
-/// Extension methods for registering the nonfile route constraint.
+/// Extension methods for applying <see cref="NonfileRouteConstraint"/> to razor-component endpoints.
 /// </summary>
 public static class NonfileRouteConstraintExtensions
 {
     /// <summary>
-    /// Registers the "nonfile" route constraint that excludes static file paths.
+    /// Applies <see cref="NonfileRouteConstraint"/> to the root catch-all page endpoint
+    /// (ApplicationPage's <c>/{**Path}</c>) so static-asset and infrastructure prefixes
+    /// (<c>_framework</c>, <c>_content</c>, <c>favicon.ico</c>, <c>auth</c>, <c>mcp</c>, ...)
+    /// are not swallowed by the Blazor application page: a request under those prefixes that
+    /// no static file or explicit endpoint handles falls through to 404 instead of rendering
+    /// the HTML shell. Chain on the builder returned by <c>MapRazorComponents</c>.
+    ///
+    /// This is an endpoint convention, NOT an inline template constraint, because only the
+    /// ASP.NET endpoint layer honors custom constraints — the Blazor Router's inline-constraint
+    /// map is compiled-in and would interpret ":nonfile" as the built-in dot-rejecting
+    /// constraint, breaking every mesh path that ends in a file extension.
     /// </summary>
-    public static IServiceCollection AddNonfileRouteConstraint(this IServiceCollection services)
+    public static TBuilder ExcludeStaticAssetPaths<TBuilder>(this TBuilder builder)
+        where TBuilder : IEndpointConventionBuilder
     {
-        services.AddRouting(options =>
+        builder.Add(endpointBuilder =>
         {
-            options.ConstraintMap["nonfile"] = typeof(NonfileRouteConstraint);
+            if (endpointBuilder is not RouteEndpointBuilder routeEndpointBuilder)
+                return;
+
+            // Target only the root catch-all page ("/{**Path}"): excluded prefixes are
+            // root-anchored, so sub-path catch-alls (/area, /article, /content, ...) can
+            // never collide with static assets and stay unconstrained.
+            var pattern = routeEndpointBuilder.RoutePattern;
+            if (pattern.RawText is not { } rawText
+                || pattern.PathSegments.Count != 1
+                || pattern.PathSegments[0].Parts.Count != 1
+                || pattern.PathSegments[0].Parts[0] is not RoutePatternParameterPart { IsCatchAll: true } parameter)
+                return;
+
+            routeEndpointBuilder.RoutePattern = RoutePatternFactory.Parse(
+                rawText,
+                defaults: null,
+                parameterPolicies: new RouteValueDictionary { [parameter.Name] = new NonfileRouteConstraint() });
         });
-        return services;
+        return builder;
     }
 }

--- a/src/MeshWeaver.Blazor/Pages/ApplicationPage.razor
+++ b/src/MeshWeaver.Blazor/Pages/ApplicationPage.razor
@@ -1,6 +1,10 @@
-@* Routes for application pages - entire path is matched against registered namespace patterns *@
-@* The :nonfile constraint prevents matching static file paths like _content, _framework, etc. *@
-@page "/{*Path:nonfile}"
+@* Routes for application pages - entire path is matched against registered namespace patterns.
+   NO inline route constraint here: the Blazor Router resolves inline constraints against its own
+   compiled-in map where "nonfile" is the built-in dot-rejecting NonFileNameRouteConstraint, which
+   made every mesh path ending in a file extension (Document nodes: .pdf/.docx/...) unroutable in
+   the interactive circuit. Static-asset prefixes (_framework, _content, ...) are excluded at the
+   endpoint layer instead — see NonfileRouteConstraintExtensions.ExcludeStaticAssetPaths. *@
+@page "/{**Path}"
 @using MeshWeaver.Blazor.Components
 @using MeshWeaver.Mesh.Services
 @using MeshWeaver.Messaging

--- a/src/MeshWeaver.Blazor/Pages/AreaPage.razor
+++ b/src/MeshWeaver.Blazor/Pages/AreaPage.razor
@@ -1,6 +1,7 @@
-@* Routes for area pages - entire path is matched against registered namespace patterns *@
-@* The :nonfile constraint prevents matching static file paths like _content, _framework, etc. *@
-@page "/area/{*Path:nonfile}"
+@* Routes for area pages - entire path is matched against registered namespace patterns.
+   NO inline route constraint (see ApplicationPage.razor): mesh paths may end in file extensions,
+   and static assets never live under /area/ — like /article and /content this is a plain catch-all. *@
+@page "/area/{**Path}"
 @using MeshWeaver.Blazor.Layouts
 @layout EmptyLayout
 

--- a/test/MeshWeaver.Hosting.Blazor.Test/CatchAllPageRoutingTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/CatchAllPageRoutingTest.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using MeshWeaver.Blazor.Infrastructure;
+using MeshWeaver.Blazor.Pages;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// End-to-end regression pin for mesh-path routing through BOTH routing layers:
+/// ASP.NET endpoint routing (which selects the razor-component endpoint) AND the
+/// Blazor Router component (which picks the page during SSR and on every
+/// interactive navigation).
+///
+/// Regression under test (Systemorph/agentic-pensions#10): a Document node URL whose
+/// mesh path ends in a file extension (e.g. AgenticPension/content/_Documents/PKG_2026.pdf)
+/// rendered "Sorry, there's nothing at this address". Root cause: the inline
+/// ":nonfile" constraint in ApplicationPage's @page template was resolved by the
+/// Blazor Router component against its FIXED, compiled-in constraint map
+/// (int, bool, ..., file, nonfile) where "nonfile" is the built-in dot-rejecting
+/// NonFileNameRouteConstraint. The DI ConstraintMap registration (which mapped
+/// "nonfile" to the prefix-based MeshWeaver constraint) only ever reached the
+/// endpoint-routing layer — the Router component cannot be customized, so every
+/// path whose last segment contained a dot was rejected by the Router even though
+/// the endpoint matched.
+///
+/// The fix removes the inline constraint from the page templates (the Router now
+/// matches every mesh path) and re-applies the prefix-based static-asset exclusion
+/// where it belongs and is customizable: as an endpoint convention
+/// (ExcludeStaticAssetPaths) on the root catch-all endpoint, so requests under
+/// _framework/, _content/ etc. still fall through to the static-file pipeline / 404
+/// instead of being swallowed by the Blazor page.
+/// </summary>
+public class CatchAllPageRoutingTest : IAsyncLifetime
+{
+    private WebApplication? app;
+    private HttpClient client = null!;
+    private string webRoot = null!;
+
+    private const string StaticAssetContent = "/* probe asset */";
+
+    public async ValueTask InitializeAsync()
+    {
+        // A real webroot with a real asset, to pin that genuine static files keep
+        // being served by the static-file middleware ahead of the Blazor catch-all.
+        webRoot = Path.Combine(AppContext.BaseDirectory, "catchall-routing-webroot");
+        Directory.CreateDirectory(webRoot);
+        await File.WriteAllTextAsync(Path.Combine(webRoot, "probe-asset.css"), StaticAssetContent);
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            WebRootPath = webRoot,
+        });
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        builder.Services.AddRazorComponents();
+
+        var webApp = builder.Build();
+
+        // Mirrors the portal pipeline (MemexConfiguration.StartPortalApplication):
+        // static files BEFORE routing, then the razor-component endpoints with the
+        // static-asset exclusion applied to the root catch-all page endpoint.
+        webApp.UseStaticFiles();
+        webApp.UseRouting();
+        webApp.UseAntiforgery();
+        webApp.MapRazorComponents<RouterProbeApp>()
+            .AddAdditionalAssemblies(typeof(ApplicationPage).Assembly)
+            .ExcludeStaticAssetPaths();
+
+        await webApp.StartAsync(TestContext.Current.CancellationToken);
+        app = webApp;
+        client = webApp.GetTestClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        client?.Dispose();
+        if (app is not null)
+            await app.DisposeAsync();
+    }
+
+    private async Task<(HttpStatusCode Status, string Body)> GetAsync(string path)
+    {
+        var response = await client.GetAsync(path, TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        return (response.StatusCode, body);
+    }
+
+    [Fact]
+    public async Task DocumentPath_WithFileExtension_RoutesToApplicationPage()
+    {
+        // The exact URL shape from the issue: a Document node under a content
+        // collection, whose slug ends in ".pdf".
+        var (_, body) = await GetAsync("/AgenticPension/content/_Documents/PKG_2026.pdf");
+
+        body.Should().NotContain(RouterProbeApp.NotFoundMarker,
+            because: "a mesh-node path ending in a file extension must not be rejected by the Blazor Router");
+        body.Should().Contain($"{RouterProbeApp.FoundMarker}{nameof(ApplicationPage)}",
+            because: "document node URLs are mesh paths and must reach the catch-all application page");
+    }
+
+    [Fact]
+    public async Task AreaPath_WithFileExtension_RoutesToAreaPage()
+    {
+        var (_, body) = await GetAsync("/area/AgenticPension/content/_Documents/PKG_2026.pdf");
+
+        body.Should().Contain($"{RouterProbeApp.FoundMarker}{nameof(AreaPage)}",
+            because: "area routes address mesh paths too and must allow file extensions");
+    }
+
+    [Fact]
+    public async Task PlainApplicationPath_RoutesToApplicationPage()
+    {
+        var (_, body) = await GetAsync("/ACME/Overview");
+
+        body.Should().Contain($"{RouterProbeApp.FoundMarker}{nameof(ApplicationPage)}");
+    }
+
+    [Theory]
+    [InlineData("/_framework/does-not-exist.js")]
+    [InlineData("/_content/Some.Lib/missing.css")]
+    [InlineData("/favicon.ico")]
+    [InlineData("/auth/login")]
+    [InlineData("/signin-microsoft")]
+    public async Task StaticAndInfrastructurePrefixes_AreNotSwallowedByCatchAllPage(string path)
+    {
+        var (status, body) = await GetAsync(path);
+
+        body.Should().NotContain(RouterProbeApp.FoundMarker,
+            because: $"'{path}' must not be swallowed by the Blazor catch-all page");
+        status.Should().Be(HttpStatusCode.NotFound,
+            because: $"'{path}' has no endpoint and no physical file, so it must fall through to 404");
+    }
+
+    [Fact]
+    public async Task RealStaticAsset_IsServedByStaticFileMiddleware()
+    {
+        var (status, body) = await GetAsync("/probe-asset.css");
+
+        status.Should().Be(HttpStatusCode.OK);
+        body.Should().Be(StaticAssetContent,
+            because: "physical static assets are served by the static-file middleware ahead of routing");
+    }
+
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/InteractiveRouterMeshPathTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/InteractiveRouterMeshPathTest.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Threading.Tasks;
+using MeshWeaver.Blazor.Pages;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// Regression pin for Systemorph/agentic-pensions#10 at the layer where the bug lives:
+/// the Blazor Router component's OWN route matching.
+///
+/// The portal renders &lt;Routes @rendermode="InteractiveServer" /&gt;. Inside the
+/// interactive circuit (hydration and every subsequent navigation) there is no
+/// endpoint-routing RouteData to fall back on, so the Router matches the URI against
+/// its own route table, built by the Components-internal template parser. That parser
+/// has a FIXED, compiled-in constraint map (int, bool, ..., file, nonfile) in which
+/// "nonfile" is the built-in dot-rejecting NonFileNameRouteConstraint — the app-level
+/// ConstraintMap registration that maps ":nonfile" to MeshWeaver's prefix-based
+/// constraint NEVER reaches it. With ":nonfile" inline in ApplicationPage's @page
+/// template, every mesh path whose last segment contains a dot (all Document nodes:
+/// .pdf/.docx/.txt) was rejected by the Router and rendered
+/// "Sorry, there's nothing at this address."
+///
+/// This harness renders the real Router through HtmlRenderer WITHOUT endpoint routing —
+/// exactly the interactive router's matching path — so these tests fail (red) while the
+/// inline ":nonfile" is in the template and pass once the templates carry no constraint.
+/// </summary>
+public class InteractiveRouterMeshPathTest
+{
+    private static async Task<string> RenderRouterAsync(string relativeUri)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<NavigationManager>(new StaticNavigationManager(
+            "https://portal.test/", "https://portal.test/" + relativeUri));
+        services.AddSingleton<INavigationInterception, NoopNavigationInterception>();
+        services.AddSingleton<IScrollToLocationHash, NoopScrollToLocationHash>();
+        var provider = services.BuildServiceProvider();
+        await using (provider)
+        {
+            var htmlRenderer = new HtmlRenderer(provider, provider.GetRequiredService<ILoggerFactory>());
+            await using (htmlRenderer)
+            {
+                return await htmlRenderer.Dispatcher.InvokeAsync(async () =>
+                {
+                    var output = await htmlRenderer.RenderComponentAsync<RouterProbeApp>();
+                    return output.ToHtmlString();
+                });
+            }
+        }
+    }
+
+    [Fact]
+    public async Task DocumentPath_WithFileExtension_IsRoutedToApplicationPage()
+    {
+        // The exact URL shape from the issue: a Document node under a content
+        // collection, whose slug ends in ".pdf".
+        var html = await RenderRouterAsync("AgenticPension/content/_Documents/PKG_2026.pdf");
+
+        html.Should().NotContain(RouterProbeApp.NotFoundMarker,
+            because: "a mesh-node path ending in a file extension must not be rejected by the interactive router");
+        html.Should().Contain($"{RouterProbeApp.FoundMarker}{nameof(ApplicationPage)}",
+            because: "document node URLs are mesh paths and must reach the catch-all application page");
+    }
+
+    [Fact]
+    public async Task AreaPath_WithFileExtension_IsRoutedToAreaPage()
+    {
+        var html = await RenderRouterAsync("area/AgenticPension/content/_Documents/PKG_2026.pdf");
+
+        html.Should().Contain($"{RouterProbeApp.FoundMarker}{nameof(AreaPage)}",
+            because: "area routes address mesh paths too and must allow file extensions");
+    }
+
+    [Fact]
+    public async Task PlainMeshPath_IsRoutedToApplicationPage()
+    {
+        var html = await RenderRouterAsync("ACME/Overview");
+
+        html.Should().Contain($"{RouterProbeApp.FoundMarker}{nameof(ApplicationPage)}");
+    }
+
+    private sealed class StaticNavigationManager : NavigationManager
+    {
+        public StaticNavigationManager(string baseUri, string uri) => Initialize(baseUri, uri);
+
+        protected override void NavigateToCore(string uri, NavigationOptions options)
+        {
+        }
+    }
+
+    private sealed class NoopNavigationInterception : INavigationInterception
+    {
+        public Task EnableNavigationInterceptionAsync() => Task.CompletedTask;
+    }
+
+    private sealed class NoopScrollToLocationHash : IScrollToLocationHash
+    {
+        public Task RefreshScrollPositionForHash(string locationAbsolute) => Task.CompletedTask;
+    }
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/MeshWeaver.Hosting.Blazor.Test.csproj
+++ b/test/MeshWeaver.Hosting.Blazor.Test/MeshWeaver.Hosting.Blazor.Test.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Blazor\MeshWeaver.Hosting.Blazor.csproj" />

--- a/test/MeshWeaver.Hosting.Blazor.Test/NonfileRouteConstraintTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/NonfileRouteConstraintTest.cs
@@ -55,6 +55,19 @@ public class NonfileRouteConstraintTest
         Match(path).Should().BeTrue(because: $"'{path}' is a normal route and should pass through");
     }
 
+    [Theory]
+    [InlineData("AgenticPension/content/_Documents/PKG_2026.pdf")]
+    [InlineData("AgenticPension/content/_Documents/contract_motor_2026.docx")]
+    [InlineData("Doc/notes.txt")]
+    [InlineData("robots.txt")]
+    public void MeshPathsWithFileExtensions_PassThrough(string path)
+    {
+        // Regression pin for agentic-pensions#10: this constraint excludes by PREFIX only.
+        // It must never reject a path because its last segment contains a dot — Document
+        // node slugs legitimately end in file extensions and must reach ApplicationPage.
+        Match(path).Should().BeTrue(because: $"'{path}' is a mesh path, not a static asset — extensions are legitimate");
+    }
+
     [Fact]
     public void EmptyPath_ReturnsTrue()
     {

--- a/test/MeshWeaver.Hosting.Blazor.Test/RouterProbeApp.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/RouterProbeApp.cs
@@ -1,0 +1,39 @@
+using MeshWeaver.Blazor.Pages;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Routing;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// Root component hosting the real Blazor Router over the MeshWeaver.Blazor page
+/// assembly. Found/NotFound render plain text markers instead of RouteView, so tests
+/// observe the ROUTING decision without instantiating the matched page
+/// (ApplicationPage needs the full portal DI graph to render).
+/// </summary>
+public sealed class RouterProbeApp : ComponentBase
+{
+    /// <summary>Marker emitted when the Router matched a page; followed by the page type name.</summary>
+    public const string FoundMarker = "ROUTED-TO:";
+
+    /// <summary>Marker emitted when the Router rendered its NotFound content.</summary>
+    public const string NotFoundMarker = "ROUTER-NOT-FOUND";
+
+    /// <inheritdoc />
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenComponent<Router>(0);
+        builder.AddComponentParameter(1, nameof(Router.AppAssembly), typeof(ApplicationPage).Assembly);
+        builder.AddComponentParameter(2, nameof(Router.Found),
+            (RenderFragment<RouteData>)(routeData => b => b.AddContent(0, $"{FoundMarker}{routeData.PageType.Name}")));
+        // Router.NotFound is obsolete in .NET 10 in favor of NotFoundPage, but the
+        // portal's Routes.razor still renders its "Sorry, there's nothing at this
+        // address." message through NotFound — the probe mirrors that exact surface
+        // so the tests observe the same not-found decision the portal shows.
+#pragma warning disable CS0618
+        builder.AddComponentParameter(3, nameof(Router.NotFound),
+            (RenderFragment)(b => b.AddContent(0, NotFoundMarker)));
+#pragma warning restore CS0618
+        builder.CloseComponent();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Systemorph/agentic-pensions#10: Document node URLs whose mesh path ends in a file extension (e.g. `/AgenticPension/content/_Documents/PKG_2026.pdf`) rendered "Sorry, there's nothing at this address" even though the node exists.

## Root cause

Two routing engines read the same `@page` template — and only one is customizable. `ApplicationPage`/`AreaPage` declared `@page "/{*Path:nonfile}"`; the DI `ConstraintMap["nonfile"]` override (prefix-based `NonfileRouteConstraint`, 7f5537454) only reaches **ASP.NET endpoint routing**. The **Blazor Router component** parses the same template against its own compiled-in constraint map, where `nonfile` is the built-in **dot-rejecting** `NonFileNameRouteConstraint` — and that map cannot be customized. The endpoint matched, the shell SSR'd, then the interactive Router re-matched the URI and rejected any last segment containing a dot → `<NotFound>`. `DocumentPaths.Slug()` keeps extensions, so every Document URL was unreachable.

## Fix

Constrain the **endpoint**, never the page template:
- Page templates become plain catch-alls (`/{**Path}`, `/area/{**Path}`) — the Router matches every mesh path (`{baseUrl}/{meshpath}` contract).
- New endpoint convention `ExcludeStaticAssetPaths` re-attaches the prefix-based constraint to the ROOT catch-all endpoint only (`_framework`/`_content`/`favicon.ico`/`auth`/`dev`/`mcp`/`signin-*` misses still 404 instead of being swallowed by the HTML shell). Wired in `MemexConfiguration.AddMeshViews`.
- `AddNonfileRouteConstraint` (ConstraintMap registration) deleted — it can never reach the Blazor Router and invites re-adding `:nonfile` to a template.

Rejected alternative (issue's Option A — de-dotting `Slug()`): re-slugs existing data, breaks stored links, and leaves any dotted mesh path unroutable.

## Tests (red → green)

- `InteractiveRouterMeshPathTest` (real Router via HtmlRenderer — the interactive circuit's matching path): dotted document + area paths RED pre-fix, GREEN post-fix; plain-path control green throughout.
- `CatchAllPageRoutingTest` (TestServer end-to-end): document URL reaches ApplicationPage; excluded-prefix misses stay 404; real webroot asset served by static files ahead of the catch-all.
- `NonfileRouteConstraintTest` theory pins prefix-only semantics.
- MeshWeaver.Hosting.Blazor.Test 137/137; full solution Release `-warnaserror` clean.

Fixes Systemorph/agentic-pensions#10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)