### PR TITLE
fix(content): ingest a collection's own write immediately — kill the CI-only file-render flake

### DIFF
--- a/src/MeshWeaver.ContentCollections/ContentCollection.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollection.cs
@@ -137,8 +137,25 @@ public class ContentCollection : IDisposable
     /// <param name="path">The destination folder path within the collection.</param>
     /// <param name="fileName">The file name to write.</param>
     /// <param name="openReadStream">The content to persist.</param>
-    public Task SaveFileAsync(string path, string fileName, Stream openReadStream)
-        => provider.SaveFileAsync(path, fileName, openReadStream);
+    public async Task SaveFileAsync(string path, string fileName, Stream openReadStream)
+    {
+        await provider.SaveFileAsync(path, fileName, openReadStream);
+
+        // 🚨 Read-after-write for the collection's OWN writes must NOT depend on the file-system
+        // watcher. The watcher (AttachMonitor) is the only thing that feeds a post-init write into
+        // markdownStream — but on Linux inotify DROPS the event for a file written into a
+        // just-created subdirectory (the recursive watch on the new dir isn't registered before the
+        // write), so the article never lands and a content render stays "not found" until the
+        // collection re-initializes. That is the CI-only CollectionNamedArea flake AND the prod
+        // "upload a file then open it → shows nothing" bug this test class was written for. macOS
+        // FSEvents watches the whole tree so it never misses — which is why it only ever flaked on
+        // the Linux runner. Ingest our own write directly; the watcher remains for EXTERNAL changes.
+        if (fileName.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+        {
+            var folder = path.Trim('/');
+            UpdateArticle(folder.Length == 0 ? fileName : $"{folder}/{fileName}");
+        }
+    }
 
     /// <summary>
     /// Streams folders + files at <paramref name="currentPath"/> as a single async enumerable.

--- a/src/MeshWeaver.ContentCollections/FileSystemStreamProvider.cs
+++ b/src/MeshWeaver.ContentCollections/FileSystemStreamProvider.cs
@@ -253,21 +253,18 @@ public class FileSystemStreamProvider(string basePath) : IStreamProvider
         // idempotent, so a file that raises both Created and Changed is merged once per event
         // harmlessly. (In-process writes no longer depend on this at all — see
         // ContentCollection.SaveFileAsync's proactive ingest.)
-        FileSystemEventHandler ingest = (sender, e) =>
+        // Case-insensitive `.md` (an upload named `.MD`/`.Md` is still markdown) and forward-slash
+        // relative paths — the article key must match what GetMarkdown reduces on, which uses `/`;
+        // Path.GetRelativePath yields `\` on Windows, so normalize (no-op on Linux/macOS).
+        void Ingest(string fullPath)
         {
             if (handle.Stopped) return;
-            if (Path.GetExtension(e.FullPath) == ".md")
-                onChanged(Path.GetRelativePath(basePath, e.FullPath));
-        };
-        w.Created += ingest;
-        w.Changed += ingest;
-
-        w.Renamed += (sender, e) =>
-        {
-            if (handle.Stopped) return;
-            if (Path.GetExtension(e.FullPath) == ".md")
-                onChanged(Path.GetRelativePath(basePath, e.FullPath));
-        };
+            if (string.Equals(Path.GetExtension(fullPath), ".md", StringComparison.OrdinalIgnoreCase))
+                onChanged(Path.GetRelativePath(basePath, fullPath).Replace('\\', '/'));
+        }
+        w.Created += (_, e) => Ingest(e.FullPath);
+        w.Changed += (_, e) => Ingest(e.FullPath);
+        w.Renamed += (_, e) => Ingest(e.FullPath);
 
         w.EnableRaisingEvents = true;
         return handle;

--- a/src/MeshWeaver.ContentCollections/FileSystemStreamProvider.cs
+++ b/src/MeshWeaver.ContentCollections/FileSystemStreamProvider.cs
@@ -246,12 +246,21 @@ public class FileSystemStreamProvider(string basePath) : IStreamProvider
         // drive stream.Update into a disposed hub. See Doc/Architecture/HubDisposalModel.
         var handle = new WatcherHandle(w);
 
-        w.Changed += (sender, e) =>
+        // A brand-new file often surfaces ONLY as Created (not Changed) — notably an external
+        // writer (git sync, another process) creating a .md file, and on Linux a create+write into
+        // a newly-created subdirectory. Handle Created as well as Changed so those files ingest
+        // instead of staying invisible until the collection re-initializes. UpdateArticle is
+        // idempotent, so a file that raises both Created and Changed is merged once per event
+        // harmlessly. (In-process writes no longer depend on this at all — see
+        // ContentCollection.SaveFileAsync's proactive ingest.)
+        FileSystemEventHandler ingest = (sender, e) =>
         {
             if (handle.Stopped) return;
             if (Path.GetExtension(e.FullPath) == ".md")
                 onChanged(Path.GetRelativePath(basePath, e.FullPath));
         };
+        w.Created += ingest;
+        w.Changed += ingest;
 
         w.Renamed += (sender, e) =>
         {

--- a/test/MeshWeaver.ContentCollections.Test/ContentCollectionWriteIngestTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/ContentCollectionWriteIngestTest.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Test;
+
+/// <summary>
+/// Pins the root cause of the CI-only <c>CollectionNamedArea_RendersBrowserForFolder_AndContentForFile</c>
+/// flake (a 30s timeout on the FILE-content render while the folder render passed): a markdown file
+/// written THROUGH the collection must be readable immediately, WITHOUT depending on the file-system
+/// watcher.
+///
+/// <para>The watcher is the only thing that fed a post-init write into <c>markdownStream</c> (the
+/// content read path), but on Linux inotify drops the event for a file created in a just-made
+/// subdirectory — so the content render stayed "not found" until re-init. macOS FSEvents never
+/// misses, so it only ever flaked on the Linux runner and never reproduced locally.</para>
+///
+/// <para>Here the watcher is NEUTERED (<see cref="NoMonitorProvider"/> never fires
+/// <c>onChanged</c>), so the article can only reach <c>markdownStream</c> via
+/// <see cref="ContentCollection.SaveFileAsync"/>'s proactive ingest. This makes the guarantee
+/// deterministic and OS-independent: without the ingest the read never resolves (fails fast at the
+/// 10s timeout instead of flaking); with it the article is readable at once.</para>
+/// </summary>
+public class ContentCollectionWriteIngestTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration).AddContentCollections();
+
+    [Fact]
+    public async Task SaveFileAsync_ingests_the_article_without_the_watcher()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var dir = Path.Combine(AppContext.BaseDirectory, "Files", "WriteIngest", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        var collection = new ContentCollection(
+            new ContentCollectionConfig
+            {
+                Name = "content",
+                SourceType = "FileSystem",
+                IsEditable = true,
+                BasePath = dir,
+            },
+            new NoMonitorProvider(new FileSystemStreamProvider(dir)),
+            GetHost());
+        await collection.InitializeAsync(ct);
+
+        // Write into a NESTED, freshly-created subdirectory — the exact shape whose inotify event
+        // the Linux runner dropped. With the watcher neutered this can ONLY resolve via the
+        // collection's own proactive ingest on write.
+        using (var stream = new MemoryStream("# Hello ingest"u8.ToArray()))
+            await collection.SaveFileAsync("/sub", "hello.md", stream);
+
+        // GetMarkdown is the SAME content read the file render uses (ContentLayoutArea.RenderFile).
+        // Without the fix this stays null (the watcher never fires) and the wait times out — the
+        // deterministic stand-in for the 30s CI flake.
+        var article = await collection.GetMarkdown("sub/hello.md")
+            .Where(x => x is not null)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(10))
+            .ToTask(ct);
+
+        article.Should().NotBeNull(
+            "SaveFileAsync must ingest its own write into markdownStream — the content render must "
+            + "not wait on the file-system watcher (which drops the event on Linux)");
+    }
+
+    /// <summary>
+    /// Delegates every operation to a real provider but NEVER fires change notifications
+    /// (<see cref="AttachMonitor"/> returns an inert handle), so a read after a write can only
+    /// succeed through the collection's proactive ingest — never the watcher.
+    /// </summary>
+    private sealed class NoMonitorProvider(IStreamProvider inner) : IStreamProvider
+    {
+        public string ProviderType => inner.ProviderType;
+
+        // The whole point: the monitor is inert.
+        public IDisposable? AttachMonitor(Action<string> onChanged) => Disposable.Empty;
+
+        public Task<Stream?> GetStreamAsync(string reference, CancellationToken ct = default)
+            => inner.GetStreamAsync(reference, ct);
+        public Task<(Stream? Stream, string Path, DateTime LastModified)> GetStreamWithMetadataAsync(
+            string path, CancellationToken ct = default) => inner.GetStreamWithMetadataAsync(path, ct);
+        public Task WriteStreamAsync(string reference, Stream content, CancellationToken ct = default)
+            => inner.WriteStreamAsync(reference, content, ct);
+        public IAsyncEnumerable<(Stream? Stream, string Path, DateTime LastModified)> GetStreamsAsync(
+            Func<string, bool> filter, CancellationToken ct = default) => inner.GetStreamsAsync(filter, ct);
+        public IAsyncEnumerable<FolderItem> GetFolders(string path, CancellationToken ct = default)
+            => inner.GetFolders(path, ct);
+        public IAsyncEnumerable<FileItem> GetFiles(string path, CancellationToken ct = default)
+            => inner.GetFiles(path, ct);
+        public Task SaveFileAsync(string path, string fileName, Stream content, CancellationToken ct = default)
+            => inner.SaveFileAsync(path, fileName, content, ct);
+        public Task CreateFolderAsync(string folderPath) => inner.CreateFolderAsync(folderPath);
+        public Task DeleteFolderAsync(string folderPath) => inner.DeleteFolderAsync(folderPath);
+        public Task DeleteFileAsync(string filePath) => inner.DeleteFileAsync(filePath);
+        public Task<ImmutableDictionary<string, Author>> LoadAuthorsAsync(CancellationToken ct = default)
+            => inner.LoadAuthorsAsync(ct);
+    }
+}

--- a/test/MeshWeaver.ContentCollections.Test/ContentCollectionWriteIngestTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/ContentCollectionWriteIngestTest.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
-using System.Threading;
-using System.Threading.Tasks;
 using MeshWeaver.Fixture;
 using MeshWeaver.Messaging;
 using Xunit;


### PR DESCRIPTION
## The flake

`NodeHubContentCollectionTest.CollectionNamedArea_RendersBrowserForFolder_AndContentForFile` intermittently timed out on the Linux CI shard (30.3s, at the **file-content** assertion — the folder assertion passed), and never reproduced locally. The trx confirmed a pure timeout: *"Expected the observable to emit a value matching the predicate within 30s, but it did not."*

## Root cause

- The **folder / listing** path reads the live directory (`provider.GetFolders/GetFiles`) → immediate.
- The **file-content** path (`GetMarkdown`) is served only from `markdownStream`, populated by `InitializeAsync` (files present at init) and thereafter **only by the `FileSystemWatcher`** (`AttachMonitor → UpdateArticle`).

So a file written *after* init reaches content solely via the watcher. On Linux, inotify **drops the event for a file created in a just-made subdirectory** (the recursive watch on the new dir isn't registered before the write) — so the article never lands and the render stays "not found" until re-init. That is both this flake **and** the prod *"upload a file then open it → shows nothing"* bug this test class was written for. macOS FSEvents watches the whole tree and never misses — which is exactly why it only ever flaked on the Linux runner.

## Fix (root cause, not the timeout)

- `ContentCollection.SaveFileAsync` ingests its own markdown write into `markdownStream` directly (`UpdateArticle`) after the provider write — read-after-write for the collection's **own** writes no longer depends on the watcher. The watcher remains for **external** changes only.
- `FileSystemStreamProvider.AttachMonitor` also handles **`Created`** (not just `Changed`/`Renamed`), so an external new `.md` file — which often surfaces only as `Created` — is ingested instead of staying invisible until re-init.

## Deterministic, OS-independent pin

`ContentCollectionWriteIngestTest` uses a `NoMonitorProvider` that neuters the watcher, so read-after-write can succeed **only** via the proactive ingest. Verified it **FAILS (10s timeout) on the pre-fix code** and **PASSES (376ms) with the fix** — the exact edge the CI flake hit, made deterministic and reproducible on any OS.

Full ContentCollections.Test project green (16 tests). CI-parity `Release -warnaserror -p:CIRun=true` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)