### PR TITLE
feat(deploy): Python gate sidecar — the trusted participant that runs `python` Code nodes

### DIFF
--- a/clients/python/meshweaver/connection.py
+++ b/clients/python/meshweaver/connection.py
@@ -56,11 +56,15 @@ class MeshConnection:
 
     async def wait_closed(self) -> None:
         """Block until the inbound stream ends — the server went away / the connection dropped.
-        A long-lived participant (e.g. the gate) awaits this to know when to reconnect."""
+        A long-lived participant (e.g. the gate) awaits this to know when to reconnect. A reader
+        exception (an RPC error on a dropped connection) IS "closed" for this purpose, so it is
+        swallowed rather than propagated; cancellation propagates normally."""
         if self._reader is not None:
             try:
                 await self._reader
             except asyncio.CancelledError:
+                raise
+            except Exception:
                 pass
 
     async def __aenter__(self) -> "MeshConnection":

--- a/clients/python/meshweaver/connection.py
+++ b/clients/python/meshweaver/connection.py
@@ -54,6 +54,15 @@ class MeshConnection:
             self._reader.cancel()
         await self._channel.close()
 
+    async def wait_closed(self) -> None:
+        """Block until the inbound stream ends — the server went away / the connection dropped.
+        A long-lived participant (e.g. the gate) awaits this to know when to reconnect."""
+        if self._reader is not None:
+            try:
+                await self._reader
+            except asyncio.CancelledError:
+                pass
+
     async def __aenter__(self) -> "MeshConnection":
         return self
 

--- a/clients/python/meshweaver/worker.py
+++ b/clients/python/meshweaver/worker.py
@@ -121,15 +121,63 @@ class CodeWorker:
         })
 
 
-async def serve(url: str, token: Optional[str] = None, address: str = DEFAULT_WORKER_ADDRESS) -> None:
-    """Connect as a stable ``py/*`` worker and run until cancelled, executing Python Code-node submissions."""
-    conn = await _connect(url, token=token, address=address)
-    CodeWorker(conn)
-    print(f"meshweaver python worker listening as {conn.address} -> {url}")
+async def serve(url: str, token: Optional[str] = None, address: str = DEFAULT_WORKER_ADDRESS,
+                *, reconnect: bool = False, retry_seconds: float = 3.0) -> None:
+    """Connect as a stable ``py/*`` worker and run until cancelled, executing Python Code-node submissions.
+
+    ``reconnect`` (the co-deployed **gate** mode): if the connection can't be established — the portal
+    isn't up yet — or it drops later — the portal restarted on a deploy / liveness probe — wait
+    ``retry_seconds`` and reconnect, instead of exiting. A gate outlives many portal restarts; the
+    default (``False``) keeps the original single-shot behaviour for scripts and tests."""
+    stop = asyncio.Event()
+    _install_stop_signals(stop)
+    while not stop.is_set():
+        try:
+            conn = await _connect(url, token=token, address=address)
+        except Exception as ex:  # connect/ack failed — portal not ready, DNS, TLS, …
+            if not reconnect:
+                raise
+            print(f"meshweaver python worker: connect to {url} failed "
+                  f"({type(ex).__name__}: {ex}); retrying in {retry_seconds}s", flush=True)
+            await _sleep_or_stop(stop, retry_seconds)
+            continue
+        CodeWorker(conn)
+        print(f"meshweaver python worker listening as {conn.address} -> {url}", flush=True)
+        try:
+            # Run until asked to stop OR the connection drops (wait_closed returns).
+            closed = asyncio.ensure_future(conn.wait_closed())
+            stopping = asyncio.ensure_future(stop.wait())
+            await asyncio.wait({closed, stopping}, return_when=asyncio.FIRST_COMPLETED)
+            for task in (closed, stopping):
+                task.cancel()
+        finally:
+            await conn.close()
+        if not reconnect:
+            break
+        if not stop.is_set():
+            print(f"meshweaver python worker: connection to {url} ended; "
+                  f"reconnecting in {retry_seconds}s", flush=True)
+            await _sleep_or_stop(stop, retry_seconds)
+
+
+def _install_stop_signals(stop: "asyncio.Event") -> None:
+    """SIGTERM / SIGINT → set the stop event, so a reconnect loop exits cleanly on pod termination.
+    Best-effort: platforms without add_signal_handler (Windows) just fall back to default handling."""
+    import signal
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, stop.set)
+        except (NotImplementedError, ValueError, RuntimeError):
+            pass
+
+
+async def _sleep_or_stop(stop: "asyncio.Event", seconds: float) -> None:
+    """Sleep ``seconds`` unless the stop event fires first (so shutdown isn't delayed by a backoff)."""
     try:
-        await asyncio.Event().wait()  # run forever; inbound requests drive the worker
-    finally:
-        await conn.close()
+        await asyncio.wait_for(stop.wait(), timeout=seconds)
+    except asyncio.TimeoutError:
+        pass
 
 
 def main() -> None:
@@ -137,8 +185,12 @@ def main() -> None:
     p.add_argument("--url", required=True, help="portal gRPC endpoint, e.g. https://atioz.meshweaver.cloud")
     p.add_argument("--token", default=None, help="MeshWeaver API token (validated server-side)")
     p.add_argument("--address", default=DEFAULT_WORKER_ADDRESS, help="stable worker address the kernel targets")
+    p.add_argument("--reconnect", action="store_true",
+                   help="reconnect on connect failure / drop (the co-deployed gate mode) instead of exiting")
+    p.add_argument("--retry-seconds", type=float, default=3.0, help="backoff between reconnects")
     args = p.parse_args()
-    asyncio.run(serve(args.url, token=args.token, address=args.address))
+    asyncio.run(serve(args.url, token=args.token, address=args.address,
+                      reconnect=args.reconnect, retry_seconds=args.retry_seconds))
 
 
 if __name__ == "__main__":

--- a/clients/python/meshweaver/worker.py
+++ b/clients/python/meshweaver/worker.py
@@ -150,6 +150,9 @@ async def serve(url: str, token: Optional[str] = None, address: str = DEFAULT_WO
             await asyncio.wait({closed, stopping}, return_when=asyncio.FIRST_COMPLETED)
             for task in (closed, stopping):
                 task.cancel()
+            # Await both so neither becomes an unobserved-exception warning (a cancelled task, or an
+            # error surfaced by wait_closed, is captured here rather than left dangling).
+            await asyncio.gather(closed, stopping, return_exceptions=True)
         finally:
             await conn.close()
         if not reconnect:

--- a/clients/python/tests/test_worker.py
+++ b/clients/python/tests/test_worker.py
@@ -1,5 +1,9 @@
 """The Python kernel worker: the pure execution core + the SubmitCodeRequest handler over a fake conn."""
+import asyncio
+import contextlib
 from typing import Any
+
+import pytest
 
 from meshweaver.envelope import Delivery
 from meshweaver.worker import CodeWorker, execute_python
@@ -118,3 +122,69 @@ async def test_handle_ignores_non_submit_requests():
     await CodeWorker(conn).handle(other)
     assert conn.posts == []
     assert conn.responses == []
+
+
+# ---- serve() reconnect resilience (the co-deployed gate mode) ---------------------------------------
+
+class _GateConn:
+    """A connected participant whose stream stays open until close() — drives serve()'s wait loop."""
+    address = "py/python-kernel"
+
+    def __init__(self):
+        self._closed = asyncio.Event()
+
+    def serve(self, handler):  # CodeWorker registers its inbound handler here
+        pass
+
+    async def wait_closed(self):
+        await self._closed.wait()
+
+    async def close(self):
+        self._closed.set()
+
+
+async def test_serve_reconnects_past_connect_failures():
+    # The gate starts before the portal binds the trusted endpoint: connect fails twice, then
+    # succeeds. reconnect=True retries instead of crashing (the crash-restart we saw in the pod).
+    import meshweaver.worker as w
+
+    attempts = {"n": 0}
+    conn = _GateConn()
+
+    async def fake_connect(url, token=None, address=None):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise ConnectionError("portal not ready")
+        return conn
+
+    orig_connect, orig_sleep = w._connect, w._sleep_or_stop
+    w._connect = fake_connect
+    w._sleep_or_stop = lambda stop, seconds: asyncio.sleep(0)  # no real backoff in the test
+    try:
+        task = asyncio.ensure_future(w.serve("http://127.0.0.1:8082", reconnect=True, retry_seconds=0))
+        for _ in range(500):  # let it retry past the two failures and reach the serving state
+            if attempts["n"] >= 3:
+                break
+            await asyncio.sleep(0)
+        assert attempts["n"] >= 3  # it did NOT crash on the failures — it retried and connected
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    finally:
+        w._connect, w._sleep_or_stop = orig_connect, orig_sleep
+
+
+async def test_serve_without_reconnect_raises_on_connect_failure():
+    # Default (script/test) behaviour is unchanged: a connect failure propagates, no retry loop.
+    import meshweaver.worker as w
+    orig = w._connect
+
+    async def boom(url, token=None, address=None):
+        raise ConnectionError("no portal")
+
+    w._connect = boom
+    try:
+        with pytest.raises(ConnectionError):
+            await w.serve("http://127.0.0.1:8082")  # reconnect defaults to False
+    finally:
+        w._connect = orig

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -92,6 +92,28 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 10
             failureThreshold: 6
+{{- if (((.Values.grpc).pythonGate).enabled) }}
+        # ---- Python gate (TRUSTED co-deployed participant — see .Values.grpc.pythonGate) ----------
+        # Same pod ⇒ shares the network namespace ⇒ reaches the portal's 127.0.0.1-bound trusted gRPC
+        # endpoint. That reachability IS the authentication (no token). Executes `python` Code nodes
+        # exactly as the in-process Roslyn kernel executes C# ones. OFF unless the image is provided.
+        - name: "python-gate"
+          image: "{{ .Values.grpc.pythonGate.image }}"
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: "MESH_GRPC_URL"
+              value: "http://127.0.0.1:{{ .Values.grpc.trustedPort }}"
+            - name: "MESH_GATE_ADDRESS"
+              value: "{{ .Values.grpc.pythonGate.address | default "py/python-kernel" }}"
+          resources:
+            requests: { cpu: "25m", memory: "64Mi" }
+            limits: { memory: "256Mi" }
+          securityContext:
+            # The image already runs as a non-root uid; harden the rest.
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities: { drop: ["ALL"] }
+{{- end }}
       volumes:
         - name: "memex-data"
 {{- if .Values.persistDataVolume }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -38,6 +38,20 @@ grpc:
   enabled: true
   port: 8081
   trustedPort: 8082
+  # ---- Python gate sidecar (executes `python` Code nodes; OFF by default) ---
+  # A trusted, co-deployed participant that runs `meshweaver.worker` as a SIDECAR in the portal pod
+  # and connects to the trusted loopback endpoint above (127.0.0.1:{trustedPort}) — reachability
+  # across the shared pod network namespace IS the authentication, no token. It is the Python
+  # counterpart of the in-process Roslyn kernel: a Code node whose Language=="python" routes to it
+  # (address `py/python-kernel`), runs, and writes its result back onto the run's Activity node.
+  #
+  # OFF by default: a deployment must (a) supply the image (built from deploy/python-gate/Dockerfile,
+  # pushed to a registry the cluster can pull) and (b) opt in — standing python execution is a
+  # deliberate capability, not a default. Enable in an overlay / --set.
+  pythonGate:
+    enabled: false
+    image: "meshweaver/python-gate:local"
+    address: "py/python-kernel"
 # ---- Portal Ingress (TLS via an ingress controller) -----------------------
 # Off by default (cloud envs wire ingress/TLS their own way). A self-host overlay
 # enables it with a hostname + a pre-created TLS secret. The proxy-*-timeout

--- a/deploy/python-gate/Dockerfile
+++ b/deploy/python-gate/Dockerfile
@@ -1,0 +1,42 @@
+# The Python gate — a TRUSTED, co-deployed MeshWeaver participant that executes `python` Code nodes.
+#
+# It runs as a SIDECAR inside the portal pod and connects to the portal's trusted loopback gRPC
+# endpoint (http://127.0.0.1:{Grpc:TrustedPort}). Reachability across the shared pod network
+# namespace IS the authentication — no API token, nothing to rotate. This is the Python counterpart
+# of the in-process Roslyn kernel: a Code node whose `Language == "python"` is routed to this gate
+# (address `py/python-kernel`), executed, and its result written back onto the run's Activity node.
+#
+# Build from the REPO ROOT (the SDK package AND the one canonical proto both live there):
+#   docker build -f deploy/python-gate/Dockerfile -t meshweaver/python-gate:local .
+
+# ---- build stage: generate the gRPC stubs from mesh.proto, then build a wheel ---------------------
+FROM python:3.12-slim AS build
+WORKDIR /w
+# The SDK package + the ONE canonical proto, kept at its repo-relative path so gen_proto.sh resolves it.
+COPY clients/python /w/clients/python
+COPY src/MeshWeaver.Hosting.Grpc/Protos/mesh.proto /w/src/MeshWeaver.Hosting.Grpc/Protos/mesh.proto
+# Generate the stubs INTO the source tree BEFORE building the wheel, so meshweaver._generated is packaged.
+RUN pip install --no-cache-dir "grpcio-tools>=1.68" \
+    && PYTHON=python bash /w/clients/python/scripts/gen_proto.sh \
+    && pip wheel --no-cache-dir --wheel-dir /wheels /w/clients/python
+
+# ---- runtime stage: just the wheel + its runtime deps (grpcio, protobuf) — no build tooling -------
+FROM python:3.12-slim
+RUN useradd --create-home --uid 10001 gate
+COPY --from=build /wheels /wheels
+RUN pip install --no-cache-dir /wheels/*.whl && rm -rf /wheels
+# Numeric uid (not the name) so Kubernetes' runAsNonRoot check can verify non-root.
+USER 10001
+
+# The trusted endpoint and the well-known kernel address the .NET side routes `python` submissions to
+# (CodeNodeType). Both overridable; the defaults match deploy/helm values.grpc.
+# PYTHONUNBUFFERED so the worker's stdout (connect line, errors) reaches the pod log immediately.
+ENV MESH_GRPC_URL=http://127.0.0.1:8082 \
+    MESH_GATE_ADDRESS=py/python-kernel \
+    PYTHONUNBUFFERED=1
+
+# `meshweaver.worker` serves SubmitCodeRequest against the trusted endpoint with NO token (the trust is
+# the loopback). --reconnect: the gate outlives portal restarts (deploys / liveness) and tolerates
+# starting before the portal has bound the endpoint — no crash-restart. exec so python is the signalled
+# process (clean SIGTERM on pod stop; the worker's signal handler stops the reconnect loop).
+CMD ["/bin/sh", "-c", "exec python -m meshweaver.worker --url \"$MESH_GRPC_URL\" --address \"$MESH_GATE_ADDRESS\" --reconnect"]

--- a/deploy/python-gate/README.md
+++ b/deploy/python-gate/README.md
@@ -1,0 +1,40 @@
+# Python gate
+
+A **trusted, co-deployed** MeshWeaver participant that executes `python` Code nodes. It runs as a
+**sidecar in the portal pod** and connects to the portal's trusted loopback gRPC endpoint
+(`http://127.0.0.1:{Grpc:TrustedPort}`, default `8082`). Reachability across the shared pod network
+namespace **is** the authentication — no API token, nothing to rotate. It is the Python counterpart of
+the in-process Roslyn kernel: a Code node whose `Language == "python"` is routed to the gate (address
+`py/python-kernel`), executed, and its result written back onto the run's Activity node — surfacing
+exactly like a C# run. Runs execute under the *requesting user's* identity (the gate echoes the
+delivery's `AccessContext`).
+
+Full architecture: `Doc/Architecture/PythonCodeNodes`. The trust model: `Doc/DataMesh/PythonStandaloneHub`
+(the trusted-gate note) and `GrpcOptions.TrustedPort`.
+
+## Build
+
+The image packs the Python SDK (`clients/python`) and the **one canonical** proto
+(`src/MeshWeaver.Hosting.Grpc/Protos/mesh.proto`), so build from the **repo root**:
+
+```bash
+docker build -f deploy/python-gate/Dockerfile -t <registry>/meshweaver/python-gate:<tag> .
+docker push <registry>/meshweaver/python-gate:<tag>
+```
+
+## Enable
+
+OFF by default (standing arbitrary-python execution is a deliberate capability, and the image must be
+provided). Turn it on in a Helm overlay / `--set`, pointing at the pushed image:
+
+```yaml
+grpc:
+  enabled: true          # the trusted endpoint the gate connects to
+  pythonGate:
+    enabled: true
+    image: <registry>/meshweaver/python-gate:<tag>
+    address: py/python-kernel
+```
+
+`MESH_GRPC_URL` and `MESH_GATE_ADDRESS` (the container's env) override the endpoint and address; the
+defaults match `deploy/helm` `values.grpc`.

--- a/src/MeshWeaver.Documentation/Data/Architecture/PythonCodeNodes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PythonCodeNodes.md
@@ -91,9 +91,35 @@ fresh namespace.
 > needs write access to where activities are stored (the runner's home partition). Use a token whose user can
 > write there — the same access model as any participant.
 
+## Ship it as a trusted sidecar (no token)
+
+The command above is the *manual* / dev shape. In a deployment the worker ships **in the portal's own pod**
+as a sidecar and connects to the portal's **trusted loopback gRPC endpoint** instead of an external URL:
+
+```bash
+# built from deploy/python-gate/Dockerfile (the SDK package + the canonical proto)
+python -m meshweaver.worker --url http://127.0.0.1:8082 --address py/python-kernel
+```
+
+There is **no `--token`**: the endpoint is bound to `127.0.0.1`, reachable only from containers in the same
+pod, so reachability *is* the authentication (see `GrpcOptions.TrustedPort` and the trusted-gate note in
+[A standalone hub in Python](/Doc/DataMesh/PythonStandaloneHub)). This is the exact parity with the in-process
+Roslyn kernel: the C# kernel runs in the portal process; the python gate runs in the portal *pod*, and a run
+executes under the requesting user's identity (the gate echoes the delivery's `AccessContext`), not a
+standing service credential — nothing to rotate.
+
+Enable it in the Helm chart (OFF by default; the deployment must supply the image):
+
+```yaml
+grpc:
+  pythonGate:
+    enabled: true
+    image: <registry>/meshweaver/python-gate:<tag>   # deploy/python-gate/Dockerfile
+```
+
 Today `python` targets the single well-known `py/python-kernel` address. A worker **pool** (lease a worker
-per run, or per partition) and other languages (`node`/`bun` → a `node/*` worker) are the natural next
-step — the routing branch is the one place that grows.
+per run, or per partition) and other languages (`node`/`bun` → a `node/*` gate) are the natural next step —
+the routing branch and the sidecar list are the two places that grow.
 
 ## Related
 


### PR DESCRIPTION
## Python gate sidecar — the shipped, trusted participant that executes `python` Code nodes

Completes the trusted-gate story from #224: that PR built the trust *mechanism* (a loopback-bound gRPC endpoint where pod-boundary reachability is the authentication); this ships the *gate that uses it*. A Code node whose `Language == "python"` now runs in a real deployment — the Python counterpart of the in-process Roslyn kernel.

### What's here (8 files, no C# changes)
- **`deploy/python-gate/Dockerfile`** — packs the Python SDK (`clients/python`) + the one canonical proto (`src/MeshWeaver.Hosting.Grpc/Protos/mesh.proto`, gen'd into the wheel), runs `meshweaver.worker` against the trusted loopback endpoint with **no token**. Multi-stage → lean runtime (grpcio/protobuf only, no build tooling), non-root numeric uid, `PYTHONUNBUFFERED`.
- **Helm chart** (`values.grpc.pythonGate`, `deployment.yaml`) — a feature-flagged sidecar container in the portal pod. Shares the pod network namespace, so it reaches `127.0.0.1:{trustedPort}`; that reachability is the auth. **OFF by default** (standing arbitrary-python execution is a deliberate capability, and the deployment must supply the image), hardened securityContext (non-root, no privilege escalation, drop ALL caps), nil-safe guard for `--reuse-values` upgrades.
- **SDK reconnect resilience** (`meshweaver.worker --reconnect`, `MeshConnection.wait_closed`) — a co-deployed gate outlives portal restarts (every deploy / liveness probe) and tolerates starting before the portal binds the endpoint, reconnecting with backoff instead of crash-restarting; clean SIGTERM shutdown. **Opt-in** — the default single-shot behaviour is unchanged for scripts/tests. Pinned by two tests.
- **Docs** — `Doc/Architecture/PythonCodeNodes` gains the "ship it as a trusted sidecar (no token)" section; `deploy/python-gate/README.md`.

### How it works
`ExecuteScriptRequest` on a `python` Code node → the Code hub creates the ActivityLog and posts `SubmitCodeRequest` to `py/python-kernel` (unchanged .NET routing, `CodeNodeType`) → the **gate** (registered there over the trusted endpoint) executes and patches the same ActivityLog → output surfaces exactly like a C# run. The gate echoes the delivery's `AccessContext`, so a run executes under the *requesting user's* identity — no standing service credential.

### Verified live on the local k3s pod (full real path)
Built the portal (with #224) + the gate image, deployed the sidecar-enabled chart, then drove a real `python` Code node end-to-end:
```
ExecuteScriptResponse: success=true, activityLog=rbuergi/_Activity/…
GATE RESULT: status=Succeeded  returnValue={"answer": 42, "runtime": "3.12.13"}
             stdout: "gate python 3.12.13 on aarch64"   ← executed IN the sidecar
```
Pod reached `2/2 Ready`; with `--reconnect` the gate rides through the startup race (portal not yet bound) with **0 restarts** — connects on retry and logs `listening as py/python-kernel`. Chart renders OFF by default (0 sidecar containers) and ON when enabled; `helm lint` clean; 58 Python tests + `DocumentationLinkIntegrityTest` green.

> Node/bun gates are the natural next step — they need their own SDK first. The routing branch (`CodeNodeType`) and the sidecar list are the two places that grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
