### PR TITLE
fix(content-collections): publish written .md articles directly — don't rely on the watcher for our own writes

### DIFF
--- a/src/MeshWeaver.ContentCollections/ContentCollection.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollection.cs
@@ -137,8 +137,36 @@ public class ContentCollection : IDisposable
     /// <param name="path">The destination folder path within the collection.</param>
     /// <param name="fileName">The file name to write.</param>
     /// <param name="openReadStream">The content to persist.</param>
-    public Task SaveFileAsync(string path, string fileName, Stream openReadStream)
-        => provider.SaveFileAsync(path, fileName, openReadStream);
+    public async Task SaveFileAsync(string path, string fileName, Stream openReadStream)
+    {
+        await provider.SaveFileAsync(path, fileName, openReadStream);
+
+        // Proactively publish the markdown we just wrote into the live stream. The application
+        // knows EXACTLY what it wrote, so it must NOT depend on the FileSystemWatcher to notice
+        // its own write: the watcher's arming window and — on Linux/inotify with
+        // IncludeSubdirectories — the watch-add for a brand-new sub-folder race the very write
+        // that created the file inside it, so the change event is silently dropped on a
+        // cold/loaded box. A reactive reader (GetMarkdown → the collection-named file view) then
+        // stays stranded on absent content until a later event that never arrives — the
+        // ContentCollections cold-start hang. The watcher remains the source of truth for
+        // EXTERNAL changes; an application write publishes itself, deterministically.
+        if (MarkdownFilter(fileName))
+        {
+            var relativePath = CombineCollectionPath(path, fileName);
+            var article = await ParseArticleFromDiskAsync(relativePath, CancellationToken.None);
+            if (article is not null)
+                PublishArticle(article);
+        }
+    }
+
+    /// <summary>Joins a folder path and file name into the collection-relative path used as the
+    /// markdown-stream key (mirrors the FileSystemWatcher's <c>GetRelativePath</c> shape:
+    /// forward slashes, no leading slash).</summary>
+    private static string CombineCollectionPath(string path, string fileName)
+    {
+        var folder = path.Replace('\\', '/').Trim('/');
+        return string.IsNullOrEmpty(folder) ? fileName : $"{folder}/{fileName}";
+    }
 
     /// <summary>
     /// Streams folders + files at <paramref name="currentPath"/> as a single async enumerable.
@@ -198,35 +226,47 @@ public class ContentCollection : IDisposable
         // UpdateStreamRequest handler is await-free by contract.
         var ioPool = Hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem)
                      ?? IoPool.Unbounded;
-        ioPool.Invoke(async ct =>
-            {
-                var tuple = await provider.GetStreamWithMetadataAsync(path, ct);
-                if (tuple.Stream is null)
-                    return null;
-                return await ParseArticleAsync(tuple.Stream, tuple.Path, tuple.LastModified, ct);
-            })
+        ioPool.Invoke(ct => ParseArticleFromDiskAsync(path, ct))
             .Subscribe(
                 article =>
                 {
-                    if (article is null)
-                        return;
-                    var key = article.Path.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
-                        ? article.Path[..^3]
-                        : article.Path;
-                    markdownStream.Update(
-                        x => new ChangeItem<InstanceCollection>(x!.SetItem(key, article), markdownStream.StreamId, Hub.Version),
-                        ex =>
-                        {
-                            // The stream errors incoming pushes once it (or its hub) is disposing — typically a
-                            // FileSystemWatcher event racing collection teardown. Close the incoming stream at the
-                            // source so no further events flow into a disposed hub. See Doc/Architecture/HubDisposalModel.
-                            if (ex is ObjectDisposedException)
-                                monitorDisposable?.Dispose();
-                        });
+                    if (article is not null)
+                        PublishArticle(article);
                 },
                 ex => Hub.ServiceProvider.GetService<ILoggerFactory>()
                     ?.CreateLogger(typeof(ContentCollection))
                     .LogWarning(ex, "UpdateArticle failed reading {Path} in collection {Collection}", path, Collection));
+    }
+
+    /// <summary>Reads and parses the markdown file at <paramref name="path"/> from the backing
+    /// store, or <c>null</c> when it is absent. Shared by the change monitor
+    /// (<see cref="UpdateArticle"/>) and the proactive publish on write (<see cref="SaveFileAsync"/>).</summary>
+    private async Task<MarkdownElement?> ParseArticleFromDiskAsync(string path, CancellationToken ct)
+    {
+        var tuple = await provider.GetStreamWithMetadataAsync(path, ct);
+        if (tuple.Stream is null)
+            return null;
+        return await ParseArticleAsync(tuple.Stream, tuple.Path, tuple.LastModified, ct);
+    }
+
+    /// <summary>Merges <paramref name="article"/> into the live markdown stream under its
+    /// path-derived key (the <c>.md</c> suffix stripped), the same key <see cref="GetMarkdown"/>
+    /// reads back.</summary>
+    private void PublishArticle(MarkdownElement article)
+    {
+        var key = article.Path.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
+            ? article.Path[..^3]
+            : article.Path;
+        markdownStream.Update(
+            x => new ChangeItem<InstanceCollection>(x!.SetItem(key, article), markdownStream.StreamId, Hub.Version),
+            ex =>
+            {
+                // The stream errors incoming pushes once it (or its hub) is disposing — typically a
+                // FileSystemWatcher event racing collection teardown. Close the incoming stream at the
+                // source so no further events flow into a disposed hub. See Doc/Architecture/HubDisposalModel.
+                if (ex is ObjectDisposedException)
+                    monitorDisposable?.Dispose();
+            });
     }
 
     private async Task<MarkdownElement?> ParseArticleAsync(Stream? stream, string path, DateTime lastModified, CancellationToken ct)

--- a/src/MeshWeaver.ContentCollections/FileSystemStreamProvider.cs
+++ b/src/MeshWeaver.ContentCollections/FileSystemStreamProvider.cs
@@ -253,6 +253,18 @@ public class FileSystemStreamProvider(string basePath) : IStreamProvider
                 onChanged(Path.GetRelativePath(basePath, e.FullPath));
         };
 
+        // A brand-new file is signalled by Created; its content write then fires Changed. Handle
+        // BOTH: relying on Changed alone drops externally-created markdown whose Created arrives
+        // but whose Changed is coalesced/lost (e.g. an atomic write, or the inotify watch for a
+        // just-made sub-folder being added only after the file inside it was already written).
+        // onChanged re-reads + re-parses, so a double-fire (Created + Changed) is idempotent.
+        w.Created += (sender, e) =>
+        {
+            if (handle.Stopped) return;
+            if (Path.GetExtension(e.FullPath) == ".md")
+                onChanged(Path.GetRelativePath(basePath, e.FullPath));
+        };
+
         w.Renamed += (sender, e) =>
         {
             if (handle.Stopped) return;

--- a/test/MeshWeaver.ContentCollections.Test/NodeHubContentCollectionTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/NodeHubContentCollectionTest.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Fixture;
@@ -194,5 +197,96 @@ public class NodeHubContentCollectionTest(ITestOutputHelper output) : HubTestBas
         {
             await collection!.DeleteFileAsync("/sub/hello.md");
         }
+    }
+}
+
+/// <summary>
+/// Pins the ContentCollections cold-start race that timed out
+/// <see cref="NodeHubContentCollectionTest.CollectionNamedArea_RendersBrowserForFolder_AndContentForFile"/>
+/// on CI. The collection-named FILE view reads content from the collection's live markdown stream,
+/// which was historically populated ONLY by the <see cref="System.IO.FileSystemWatcher"/>. On a
+/// cold/loaded box that change event is unreliable — most sharply on Linux/inotify, where a
+/// <c>SaveFileAsync</c> into a brand-new sub-folder creates the folder and writes the file inside it
+/// in immediate succession, and the inotify watch for the new folder is added only AFTER the file's
+/// write events already fired (with <c>IncludeSubdirectories = true</c>). The events are then dropped,
+/// so a reactive reader (<c>GetMarkdown</c>) stays stranded on absent content until an event that
+/// never arrives — the observable "never emits" → 30s render timeout.
+/// <para>
+/// This test makes the failure DETERMINISTIC by pairing the collection with a provider whose monitor
+/// NEVER delivers (<c>AttachMonitor</c> → null) — the exact stand-in for a dropped watcher event —
+/// and asserts the write still publishes its own article into the stream. It fails (10s timeout)
+/// against the pre-fix code where the write did not publish, and passes once <c>SaveFileAsync</c>
+/// publishes proactively.
+/// </para>
+/// </summary>
+public class ContentCollectionWriteIsWatcherIndependentTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    [Fact]
+    public async Task SaveFile_PublishesToMarkdownStream_WithoutTheFileSystemWatcher()
+    {
+        var hub = GetClient();
+        var ct = TestContext.Current.CancellationToken;
+        var basePath = Path.Combine(
+            AppContext.BaseDirectory, "Files", "WatcherIndependent", Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(basePath);
+
+        var config = new ContentCollectionConfig
+        {
+            Name = "content",
+            SourceType = "FileSystem",
+            IsEditable = true,
+            BasePath = basePath,
+            Settings = new Dictionary<string, string> { ["BasePath"] = basePath }
+        };
+
+        // A provider whose monitor NEVER fires — the deterministic stand-in for a FileSystemWatcher
+        // whose event is dropped under CI cold-start load.
+        var provider = new MonitorlessFileSystemProvider(basePath);
+        using var collection = new ContentCollection(config, provider, hub);
+        await collection.InitializeAsync(ct);
+
+        var bytes = "# Hello from the collection area"u8.ToArray();
+        using (var stream = new MemoryStream(bytes))
+            // Write into a brand-new sub-folder, exactly like the failing test.
+            await collection.SaveFileAsync("/sub", "hello.md", stream);
+
+        // With the watcher permanently silent, the ONLY way the article reaches the stream is the
+        // proactive publish on write. GetMarkdown must therefore still emit it. (It is already
+        // present, so this resolves immediately; the bound only fences a regression as a timeout.)
+        var content = await collection.GetMarkdown("sub/hello.md")
+            .Should().Within(TimeSpan.FromSeconds(10))
+            .Match(x => x is MarkdownElement me && me.Content.Contains("Hello from the collection area"));
+
+        content.Should().NotBeNull();
+    }
+
+    /// <summary>Delegates every I/O op to a real <see cref="FileSystemStreamProvider"/> but returns
+    /// a null monitor, so the live stream is fed ONLY by the write path — never by a watcher.</summary>
+    private sealed class MonitorlessFileSystemProvider(string basePath) : IStreamProvider
+    {
+        private readonly FileSystemStreamProvider _inner = new(basePath);
+
+        public string ProviderType => _inner.ProviderType;
+        public Task<Stream?> GetStreamAsync(string reference, CancellationToken ct = default)
+            => _inner.GetStreamAsync(reference, ct);
+        public Task<(Stream? Stream, string Path, DateTime LastModified)> GetStreamWithMetadataAsync(string path, CancellationToken ct = default)
+            => _inner.GetStreamWithMetadataAsync(path, ct);
+        public Task WriteStreamAsync(string reference, Stream content, CancellationToken ct = default)
+            => _inner.WriteStreamAsync(reference, content, ct);
+        public IAsyncEnumerable<(Stream? Stream, string Path, DateTime LastModified)> GetStreamsAsync(Func<string, bool> filter, CancellationToken ct = default)
+            => _inner.GetStreamsAsync(filter, ct);
+        public IAsyncEnumerable<FolderItem> GetFolders(string path, CancellationToken ct = default)
+            => _inner.GetFolders(path, ct);
+        public IAsyncEnumerable<FileItem> GetFiles(string path, CancellationToken ct = default)
+            => _inner.GetFiles(path, ct);
+        public Task SaveFileAsync(string path, string fileName, Stream content, CancellationToken ct = default)
+            => _inner.SaveFileAsync(path, fileName, content, ct);
+        public Task CreateFolderAsync(string folderPath) => _inner.CreateFolderAsync(folderPath);
+        public Task DeleteFolderAsync(string folderPath) => _inner.DeleteFolderAsync(folderPath);
+        public Task DeleteFileAsync(string filePath) => _inner.DeleteFileAsync(filePath);
+        // The point of the test: the monitor NEVER delivers a change.
+        public IDisposable? AttachMonitor(Action<string> onChanged) => null;
+        public Task<ImmutableDictionary<string, Author>> LoadAuthorsAsync(CancellationToken ct = default)
+            => _inner.LoadAuthorsAsync(ct);
     }
 }


### PR DESCRIPTION
Root cause of the twice-observed CI cold-start hang (NodeHubContentCollectionTest, 30s timeout, Linux-only): the file render read from a stream populated only by the FileSystemWatcher, and `SaveFileAsync` relied on the watcher to notice a file it wrote itself. On inotify, a write into a just-created subdirectory races the (subdir-scoped) watch registration and is silently dropped under cold/2-core load — the article never publishes, the view never emits.

Fix: `SaveFileAsync` publishes the written article directly (watcher stays authoritative for external changes only) + the missing `.md` Created handler. No timeout widening, no retry.

Deterministic repro (monitor-less provider): 10s hang with the exact CI signature without the fix, 258ms with it. 16/16 + cold-first @2-core 8/8 + 20/20 under load; Release `-warnaserror` 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)