### PR TITLE
fix(portal): identity-casing home bug, Blazor kernel-leak wedge, doc-example E2E sweeps

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -500,6 +500,7 @@ verify_endpoint() {
 # ---------------------------------------------------------------------------
 readonly E2E_DB="memex_e2e"
 readonly E2E_APP="memex-e2e-portal"
+readonly E2E_NEXT_APP="memex-e2e-portal-next"
 readonly E2E_MIG_JOB="memex-e2e-migration"
 readonly E2E_HOST="e2e.${HOSTNAME_LOCAL}"            # covered by the *.memex.localhost cert
 readonly E2E_PORT="${MEMEX_E2E_PORT:-8444}"
@@ -563,7 +564,11 @@ spec:
           env:
             - { name: ConnectionStrings__memex, value: "$(e2e_conn)" }
 YAML
-  kubectl -n "$NAMESPACE" wait --for=condition=complete "job/$E2E_MIG_JOB" --timeout=300s \
+  # 900s (was 300s): a FRESH memex_e2e runs the full first-boot EmbeddingBackfill (embed every
+  # imported doc + sample node at 1024-dim through host Ollama) — several minutes, and a migration
+  # that is making steady progress must never be killed by a short wait (that's a false-wedge).
+  # A genuinely stuck migration still fails at 900s; check job completion, not just wall-clock.
+  kubectl -n "$NAMESPACE" wait --for=condition=complete "job/$E2E_MIG_JOB" --timeout=900s \
     || { kubectl -n "$NAMESPACE" logs "job/$E2E_MIG_JOB" --tail=50 2>/dev/null || true; die "e2e migration failed"; }
   ok "migration complete"
 }
@@ -589,9 +594,13 @@ spec:
           # to stay small), pushing the Colima VM to ~86% and risking an OOM of the
           # real memex portal. With a memory LIMIT, .NET reads the cgroup cap and
           # holds its GC heap under it — bounded AND leaner at steady state.
+          # 3cpu/6Gi (was 2cpu/4Gi): the full doc-example E2E SWEEP compiles ~50 Roslyn
+          # cells; at 2 CPUs the pod CPU-saturated, /healthz blew past the probe timeout,
+          # readiness flapped, and the Service pulled the pod mid-run (every test then got
+          # connection-refused). This headroom keeps /healthz answering during a compile burst.
           resources:
-            requests: { cpu: "250m", memory: "1Gi" }
-            limits:   { cpu: "2",    memory: "4Gi" }
+            requests: { cpu: "500m", memory: "2Gi" }
+            limits:   { cpu: "3",    memory: "6Gi" }
           ports: [ { containerPort: 8080 } ]
           envFrom:
             - configMapRef: { name: memex-portal-config }
@@ -610,6 +619,11 @@ spec:
             httpGet: { path: /healthz, port: 8080 }
             initialDelaySeconds: 10
             periodSeconds: 5
+            # 5s (k8s default is 1s): /healthz short-circuits before identity/mesh/renderer, so it
+            # only ever exceeds 1s when the pod is CPU-saturated (a doc-sweep compile burst). A 1s
+            # timeout flapped readiness under that load and the Service pulled the pod mid-run.
+            # Matches the production helm probe (deployment.yaml timeoutSeconds: 5).
+            timeoutSeconds: 5
             failureThreshold: 60
           volumeMounts:
             # The reused config's Deployment:DataRoot is /data (assembly/nuget/dataprotection
@@ -652,6 +666,62 @@ YAML
   kubectl -n "$NAMESPACE" rollout status "deploy/$E2E_APP" --timeout=300s \
     || { kubectl -n "$NAMESPACE" logs "deploy/$E2E_APP" --tail=60 2>/dev/null || true; die "e2e portal did not become ready"; }
   ok "e2e portal ready"
+
+  e2e_deploy_portal_next
+}
+
+# The Next.js React GUI beside the e2e portal — same shape as the chart's portal-next.yaml, so
+# Playwright can drive /next with DevLogin (the parity suite). Gated on the image being present
+# (built by 'up'; '--skip-build' reuses it). SSR talks to the e2e portal Service directly
+# (PORTAL_ORIGIN); the BROWSER stays same-origin through the ingress — exactly the deployed shape.
+e2e_deploy_portal_next() {
+  if ! docker image inspect "$PORTAL_NEXT_IMAGE" >/dev/null 2>&1; then
+    info "portal-next image not present → e2e is Blazor-only (build it with 'memex-local update' or 'up')"
+    return 0
+  fi
+  step "Deploying e2e portal-next ($E2E_NEXT_APP) at /next"
+  kubectl -n "$NAMESPACE" apply -f - <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: $E2E_NEXT_APP, labels: { app: $E2E_NEXT_APP } }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: $E2E_NEXT_APP } }
+  template:
+    metadata: { labels: { app: $E2E_NEXT_APP } }
+    spec:
+      containers:
+        - name: portal-next
+          image: $PORTAL_NEXT_IMAGE
+          imagePullPolicy: IfNotPresent
+          ports: [ { containerPort: 3000 } ]
+          env:
+            - { name: PORTAL_ORIGIN, value: "http://$E2E_APP:8080" }
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits:   { memory: 512Mi }
+          readinessProbe:
+            httpGet: { path: /next, port: 3000 }
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata: { name: $E2E_NEXT_APP }
+spec:
+  selector: { app: $E2E_NEXT_APP }
+  ports: [ { port: 3000, targetPort: 3000 } ]
+YAML
+  # Add the /next path to the e2e ingress (idempotent JSON patch — apply above owns the base rule).
+  kubectl -n "$NAMESPACE" patch ingress "$E2E_APP" --type=json -p "[
+    {\"op\": \"add\", \"path\": \"/spec/rules/0/http/paths/0\", \"value\": {
+      \"path\": \"/next\", \"pathType\": \"Prefix\",
+      \"backend\": { \"service\": { \"name\": \"$E2E_NEXT_APP\", \"port\": { \"number\": 3000 } } } } }
+  ]" >/dev/null 2>&1 || warn "could not patch /next into the e2e ingress (already present?)"
+  kubectl -n "$NAMESPACE" rollout restart "deploy/$E2E_NEXT_APP" >/dev/null 2>&1 || true
+  kubectl -n "$NAMESPACE" rollout status "deploy/$E2E_NEXT_APP" --timeout=180s \
+    || { kubectl -n "$NAMESPACE" logs "deploy/$E2E_NEXT_APP" --tail=40 2>/dev/null || true; die "e2e portal-next did not become ready"; }
+  ok "e2e portal-next ready at https://$E2E_HOST:$E2E_PORT/next"
 }
 
 e2e_forward_stop() {
@@ -710,7 +780,7 @@ cmd_e2e() {
       [ "${1:-}" = "--skip-build" ] && skip_build="yes"
       preflight
       e2e_require_stack
-      [ "$skip_build" = "yes" ] || image_build_local      # §3 Option B — current working tree
+      [ "$skip_build" = "yes" ] || { image_build_local; portal_next_build_local; }  # §3 Option B — current working tree
       e2e_ensure_db
       e2e_migrate
       e2e_deploy
@@ -749,6 +819,7 @@ cmd_e2e() {
       e2e_forward_stop
       step "Deleting e2e portal/service/ingress/job"
       kubectl -n "$NAMESPACE" delete deployment,service,ingress "$E2E_APP" --ignore-not-found
+      kubectl -n "$NAMESPACE" delete deployment,service "$E2E_NEXT_APP" --ignore-not-found
       kubectl -n "$NAMESPACE" delete job "$E2E_MIG_JOB" --ignore-not-found
       if [ "$keep_db" = "no" ]; then
         step "Dropping database '$E2E_DB'"
@@ -945,6 +1016,17 @@ cmd_update() {
   kubectl rollout restart deploy/memex-portal-deployment -n "$NAMESPACE"
   apply_logging
   kubectl rollout status deploy/memex-portal-deployment -n "$NAMESPACE" --timeout=300s
+
+  # portal-next has the SAME unchanged-tag problem (:local + IfNotPresent): a rebuilt image never
+  # reaches the running pod without a restart. Without this, /next silently serves the previous
+  # build forever — the exact "full portal is not deployed" trap. Only when the deployment exists
+  # (the feature flag was on).
+  if [ "$image_source" = "build" ] \
+      && kubectl get deploy/portal-next-deployment -n "$NAMESPACE" >/dev/null 2>&1; then
+    step "Forcing a fresh portal-next pod (:local tag unchanged → rollout restart picks up the rebuilt image)"
+    kubectl rollout restart deploy/portal-next-deployment -n "$NAMESPACE"
+    kubectl rollout status deploy/portal-next-deployment -n "$NAMESPACE" --timeout=180s
+  fi
   info "A rollout invalidates the old port-forward binding — refreshing it (§8/§14)"
   install_launchd
   ok "update complete"

--- a/memex/Memex.Portal.Shared/Authentication/DevAuthController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/DevAuthController.cs
@@ -167,13 +167,18 @@ public class DevAuthController : ControllerBase
     /// </summary>
     private async Task<MeshNode> ProvisionDevUser(string personId)
     {
+        // 🚨 LOWERCASE the node id — the SAME mapping BootstrapController applies. DevLogin used to
+        // provision the node id verbatim ('Roland') while bootstrap lowercased ('roland'): two
+        // id-derivations for the same person, and the circuit's email-local-part heuristic
+        // (CircuitAccessHandler.UsernameFromEmail) is aligned with the lowercase convention.
+        var username = personId.Trim().ToLowerInvariant();
         var request = new UserOnboardingRequest(
-            Username: personId,
-            Email: $"{personId.ToLowerInvariant()}@dev.local",
+            Username: username,
+            Email: $"{username}@dev.local",
             FullName: personId,
             Role: Role.Admin.Id);
         var userNode = await _onboarding.CreateUser(request).FirstAsync();
-        await _onboarding.GrantSelfAdmin(personId).FirstAsync();
+        await _onboarding.GrantSelfAdmin(username).FirstAsync();
         return userNode;
     }
 

--- a/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
@@ -76,6 +76,11 @@ public partial class CollaborativeMarkdownView
     private Address? _kernelAddress;
     private Address KernelAddress => _kernelAddress ?? ResolveActivityAddress();
     private bool _codeSubmitted;
+    // True once THIS view actually created the per-view kernel Activity node (owner resolved +
+    // CreateActivityAndSubmit called). Gates dispose-time teardown so we never delete an activity
+    // that was never created (which would NotFound-storm the router). Distinct from _codeSubmitted,
+    // which is set even when the owner did not resolve and NO activity was created.
+    private bool _kernelActivityCreated;
     // Flipped (via CreateActivityAndSubmit's onReady) once the per-view Activity is created + routable.
     // Gates the LIVE kernel-area embed in RenderContentHtml so the GUI never subscribes to a
     // not-yet-created {owner}/_Activity/markdown-{id} (the subscribe-before-create NotFound storm).
@@ -384,6 +389,7 @@ public partial class CollaborativeMarkdownView
             MarkdownViewLogic.CreateActivityAndSubmit(
                 Hub, meshService, KernelAddress, ownerPath, _kernelId, _codeSubmissions,
                 onReady: OnKernelReady);
+            _kernelActivityCreated = true;
         }
     }
 
@@ -897,6 +903,39 @@ public partial class CollaborativeMarkdownView
         }
         dotNetRef?.Dispose();
         dotNetRef = null;
+        ReleaseKernelActivity();
         await base.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Deletes the per-view kernel <c>Activity</c> node on unmount so its hub tears down immediately
+    /// (SubscribeToOwnDeletion) instead of surviving to the 15-min idle timeout — the same
+    /// accumulation-of-live-hubs wedge the read-only <see cref="MarkdownView"/> release fixes. Guarded
+    /// on <see cref="_kernelActivityCreated"/> so a view that never created the activity never posts a
+    /// delete to a nonexistent address. Best-effort.
+    /// </summary>
+    private void ReleaseKernelActivity()
+    {
+        if (!_kernelActivityCreated || _kernelAddress is null)
+            return;
+        var activityPath = _kernelAddress.ToString();
+        var logger = Hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MarkdownExecution");
+        // See MarkdownView.ReleaseKernelActivity: in-circuit dispose deletes now; a full-page nav /
+        // tab close leaves the hub shutting down (ObjectDisposedException) → benign, idle timeout reaps.
+        try
+        {
+            Hub.ServiceProvider.GetService<IMeshService>()?.DeleteNode(activityPath)
+                .Subscribe(_ => { }, ex =>
+                {
+                    if (ex is ObjectDisposedException)
+                        logger?.LogDebug("Markdown kernel activity {Path} not deleted on dispose — circuit shutting down; idle timeout will reap it.", activityPath);
+                    else
+                        logger?.LogWarning(ex, "Markdown kernel activity {Path} delete-on-dispose failed (falls back to idle timeout)", activityPath);
+                });
+        }
+        catch (ObjectDisposedException)
+        {
+            // Circuit already tearing down — the idle timeout reaps the activity. Not an error.
+        }
     }
 }

--- a/src/MeshWeaver.Blazor/Components/MarkdownView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MarkdownView.razor.cs
@@ -49,6 +49,13 @@ public partial class MarkdownView
 
     private bool _codeSubmitted;
 
+    // True once THIS view actually created the per-view kernel Activity node (owner resolved +
+    // CreateActivityAndSubmit called). Gates the dispose-time teardown: deleting/cancelling an
+    // activity that was never created would post to a nonexistent address and NotFound-storm the
+    // router — the exact wedge class. Distinct from _codeSubmitted, which is set even when the
+    // owner did not resolve (SSR/prerender) and NO activity was created.
+    private bool _kernelActivityCreated;
+
     // Flipped (via CreateActivityAndSubmit's onReady) once the per-view Activity node is created and
     // routable. Gates the LIVE kernel-area embed in RenderHtml: until it's true the kernel result
     // areas render as a non-subscribing placeholder, so the GUI never subscribes to a not-yet-created
@@ -187,6 +194,7 @@ public partial class MarkdownView
             MarkdownViewLogic.CreateActivityAndSubmit(
                 Hub, meshService, KernelAddress, ownerPath, _kernelId, CodeSubmissions,
                 onReady: OnKernelReady);
+            _kernelActivityCreated = true;
         }
     }
 
@@ -205,13 +213,59 @@ public partial class MarkdownView
     }
 
     /// <summary>
-    /// Disposes resources held by this view, delegating to the base <c>DisposeAsync</c>
-    /// which tears down data bindings and reactive subscriptions.
+    /// Disposes resources held by this view: releases the per-view kernel Activity (so its hub tears
+    /// down NOW instead of lingering to the 15-min idle timeout), then delegates to the base
+    /// <c>DisposeAsync</c> which tears down data bindings and reactive subscriptions.
     /// </summary>
     /// <returns>A value task that completes once all resources are released.</returns>
     public override async ValueTask DisposeAsync()
     {
+        ReleaseKernelActivity();
         await base.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Deletes the per-view kernel <c>Activity</c> node on unmount. Deleting the node fires the owning
+    /// hub's <c>SubscribeToOwnDeletion</c> → the kernel hub (and its executor sub-hub, cancelling any
+    /// in-flight Roslyn compile) is disposed immediately, rather than surviving to the 15-min idle
+    /// timeout. Every doc-page visit created one of these; without release they accumulate as live
+    /// hubs that keep taking routed traffic — the CPU-starvation wedge that timed out <c>/healthz</c>.
+    /// <para>🚨 Guarded on <see cref="_kernelActivityCreated"/>: a view that never created the activity
+    /// (SSR/prerender, no resolvable owner) must NOT post a delete — routing a message to a nonexistent
+    /// <c>_Activity/markdown-*</c> address is the NotFound-storm we are avoiding. Delete-only, not
+    /// cancel-then-delete: the delete IS the teardown, so a separate cancel would only race to post to
+    /// an address the delete just removed. Best-effort — a failed delete falls back to the idle timeout.</para>
+    /// </summary>
+    private void ReleaseKernelActivity()
+    {
+        if (!_kernelActivityCreated || _kernelAddress is null)
+            return;
+        var activityPath = _kernelAddress.ToString();
+        var logger = Hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MarkdownExecution");
+        // In-circuit navigation (component disposes, hub alive) → the delete lands and tears the
+        // kernel hub down now. A FULL-page nav / tab close tears down the whole circuit, so the hub
+        // is already shutting down and the request can't register a response subject
+        // (ObjectDisposedException) — that is EXPECTED and benign: the kernel's own idle timeout
+        // reaps it. Distinguish that from a real delete failure so only the latter is a Warning; the
+        // try/catch covers a synchronous throw during shutdown (the DeleteNode observable may fault
+        // on subscribe rather than via OnError).
+        try
+        {
+            Hub.ServiceProvider.GetService<IMeshService>()?.DeleteNode(activityPath)
+                .Subscribe(_ => { }, ex => LogKernelReleaseFault(logger, ex, activityPath));
+        }
+        catch (ObjectDisposedException)
+        {
+            // Circuit already tearing down — the idle timeout reaps the activity. Not an error.
+        }
+    }
+
+    private static void LogKernelReleaseFault(ILogger? logger, Exception ex, string activityPath)
+    {
+        if (ex is ObjectDisposedException)
+            logger?.LogDebug("Markdown kernel activity {Path} not deleted on dispose — circuit shutting down; idle timeout will reap it.", activityPath);
+        else
+            logger?.LogWarning(ex, "Markdown kernel activity {Path} delete-on-dispose failed (falls back to idle timeout)", activityPath);
     }
 
     private void RenderHtml(RenderTreeBuilder builder)

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -277,12 +277,16 @@ export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = fals
     // Add placeholder styling
     updatePlaceholder(editorId, placeholder, showLineNumbers);
 
-    // Apply theme immediately to this editor instance to ensure correct colors
-    // This is needed because the editor may be created before the global theme sync runs
-    if (editorInstance) {
+    // Apply the CURRENT app theme immediately and UNCONDITIONALLY. monaco.editor.setTheme is
+    // GLOBAL (not per-instance), so it must run even when this editor isn't in BlazorMonaco's
+    // registry yet (getEditor returned null). Gating it on `editorInstance` (the content-change
+    // rewiring) meant a composer mounted AFTER the first editor — e.g. the chat composer inside
+    // the user-activity area — kept Monaco's default 'vs' (light) theme, so its glyphs rendered
+    // BLACK on the transparent-over-dark composer background (unreadable in dark mode). Re-syncing
+    // the global theme on every mount also heals a stale theme set before the app flipped to dark.
+    if (typeof monaco !== 'undefined' && monaco.editor) {
         const currentTheme = detectThemeFromDOM();
-        const monacoTheme = currentTheme === 'dark' ? 'vs-dark' : 'vs';
-        monaco.editor.setTheme(monacoTheme);
+        monaco.editor.setTheme(currentTheme === 'dark' ? 'vs-dark' : 'vs');
     }
     if (editorInstance) {
         // Handle content changes for placeholder AND push the value back to C#.

--- a/src/MeshWeaver.Hosting.Blazor/CircuitAccessHandler.cs
+++ b/src/MeshWeaver.Hosting.Blazor/CircuitAccessHandler.cs
@@ -271,7 +271,12 @@ public class CircuitAccessHandler : CircuitHandler
         if (string.IsNullOrEmpty(email))
             return email;
         var at = email.IndexOf('@');
-        return at > 0 ? email[..at] : email;
+        // 🚨 LOWERCASE — the same mapping onboarding applies (BootstrapController lowercases the
+        // username; post-v10 partition ids are lowercase). Preserving the email's casing here made
+        // the circuit ObjectId 'Roland' while the User node is 'roland' whenever the identity
+        // cache had not hydrated — the home page then rendered a TYPELESS hub ("Area not found:
+        // Activity"), and navigating it materialized a stub root that poisoned later resolutions.
+        return (at > 0 ? email[..at] : email).ToLowerInvariant();
     }
 
     /// <summary>

--- a/test/MeshWeaver.Portal.E2E.Test/CompileErrorPageE2ETest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/CompileErrorPageE2ETest.cs
@@ -25,7 +25,7 @@ public class CompileErrorPageE2ETest(PortalFixture fixture)
         var token = await fixture.MintTokenAsync(context);
 
         // Unique ids so reruns against a persisted portal don't collide.
-        const string partition = "Roland";
+        var partition = fixture.UserId;
         var suffix = Guid.NewGuid().ToString("N")[..8];
         var nodeTypeId = $"BrokenE2EType{suffix}";
         var instanceId = $"broken-e2e-instance-{suffix}";

--- a/test/MeshWeaver.Portal.E2E.Test/ComposerContextChipTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/ComposerContextChipTest.cs
@@ -21,26 +21,24 @@ public class ComposerContextChipTest(PortalFixture fixture)
         await using var context = await fixture.NewAuthenticatedContextAsync();
         var token = await fixture.MintTokenAsync(context);
 
-        // Seed: the per-user composer node (so the composer area resolves), a User node with a DISTINCT
-        // display name, and a THREAD satellite named "hi" whose owner (mainNode) is the "Roland" partition.
-        await SeedAsync(context, token, """
-            { "id": "ThreadComposer", "namespace": "Roland/_Thread", "name": "Chat Input",
-              "nodeType": "ThreadComposer", "mainNode": "Roland", "content": { "$type": "ThreadComposer" } }
+        // Seed: the per-user composer node (so the composer area resolves) and a THREAD satellite
+        // named "hi" whose owner (mainNode) is the user's partition. All ids use the RESOLVED user
+        // node id — a hardcoded 'Roland' seeded a SECOND capital-cased User root (the casing seam).
+        var uid = fixture.UserId;
+        await SeedAsync(context, token, $$"""
+            { "id": "ThreadComposer", "namespace": "{{uid}}/_Thread", "name": "Chat Input",
+              "nodeType": "ThreadComposer", "mainNode": "{{uid}}", "content": { "$type": "ThreadComposer" } }
             """);
-        await SeedAsync(context, token, """
-            { "id": "Roland", "name": "Roland Buergi", "nodeType": "User",
-              "mainNode": "Roland", "content": { "$type": "User" } }
-            """);
-        await SeedAsync(context, token, """
-            { "id": "hi", "namespace": "Roland/_Thread", "name": "hi", "nodeType": "Thread",
-              "mainNode": "Roland", "content": { "$type": "Thread" } }
+        await SeedAsync(context, token, $$"""
+            { "id": "hi", "namespace": "{{uid}}/_Thread", "name": "hi", "nodeType": "Thread",
+              "mainNode": "{{uid}}", "content": { "$type": "Thread" } }
             """);
 
         var page = await context.NewPageAsync();
         await page.SetViewportSizeAsync(1400, 1000);
 
         // Navigate to the satellite (the thread) — mesh URL shape is {base}/{meshpath}, no /node/ segment.
-        await page.GotoAsync($"{fixture.BaseUrl}/Roland/_Thread/hi",
+        await page.GotoAsync($"{fixture.BaseUrl}/{uid}/_Thread/hi",
             new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 90_000 });
 
         // The composer rendered — proves the view did NOT disappear on a render storm.
@@ -51,8 +49,8 @@ public class ComposerContextChipTest(PortalFixture fixture)
         // 🎯 The chip pins the OWNER main node, not the satellite. The chip's title attribute IS the
         // resolved context PATH (ReferenceChipCollection: title="@attachment.Path").
         var title = await chip.GetAttributeAsync("title");
-        title.Should().Be("Roland",
-            "the composer context resolves the satellite (Roland/_Thread/hi) to its OWNER (mainNode=Roland)");
+        title.Should().Be(uid,
+            $"the composer context resolves the satellite ({uid}/_Thread/hi) to its OWNER (mainNode={uid})");
 
         // 🎯 …and the chip is LABELED by the main node, never the satellite thread's name.
         var chipText = (await chip.Locator(".chip-text").InnerTextAsync()).Trim();

--- a/test/MeshWeaver.Portal.E2E.Test/DocExampleCatalog.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/DocExampleCatalog.cs
@@ -1,0 +1,110 @@
+using System.Text.RegularExpressions;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// Enumerates EVERY documentation page carrying executable <c>--render</c> examples, from the doc
+/// sources copied beside the tests (<c>DocData/**/*.md</c>, see the csproj) — so new doc pages are
+/// covered by the render sweep automatically, without anyone remembering to extend a hard-coded
+/// list. The kernel-level "does every block still execute" guarantee lives in CI
+/// (<c>DocExecutableBlocksTest</c>); this catalog feeds the BROWSER-level sweep that proves the
+/// rendered page mounts every example without error placeholders.
+/// </summary>
+public static class DocExampleCatalog
+{
+    /// <summary>
+    /// A fence line per CommonMark: up to 3 spaces of indentation, then a backtick/tilde run of
+    /// length ≥ 3, then the info string. A deeper-indented fence (AuthoringDocumentation's escaped
+    /// teaching samples sit at 4 spaces inside a <c>```text</c> fence) is CONTENT, not a fence.
+    /// </summary>
+    private static readonly Regex FenceLine = new(@"^ {0,3}(`{3,}|~{3,})\s*(.*)$", RegexOptions.Compiled);
+
+    private static readonly Regex RenderFlag = new(@"(^|\s)--render(\s|$)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Pages whose C#-fenced <c>--render</c> example EMBEDS a layout area that needs a LANGUAGE
+    /// WORKER (the python gate) — the fence-language heuristic can't see this: e.g.
+    /// <c>Doc/DataMesh/CallingPython</c>'s render fence is <c>csharp</c>, but it renders a
+    /// <c>PythonDemo</c> area that only resolves where the python worker is deployed. Without it the
+    /// area renders "Area not found". Kept small + explicit (a visible skip, not a silent pass).
+    /// </summary>
+    private static readonly IReadOnlySet<string> WorkerDependentPages =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Doc/DataMesh/CallingPython" };
+
+    /// <summary>One page's executable-example stats.</summary>
+    public sealed record PageExamples(int RenderCount, bool CSharpOnly);
+
+    /// <summary>A page whose examples can only EXECUTE where a language worker (python) is deployed —
+    /// either a non-C# fence, or a C# fence that embeds a worker-dependent area (see
+    /// <see cref="WorkerDependentPages"/>). The e2e stack ships no python gate, so these skip.</summary>
+    public static bool NeedsLanguageWorker(string docPath, PageExamples examples)
+        => !examples.CSharpOnly || WorkerDependentPages.Contains(docPath);
+
+    /// <summary>All doc pages (path → number of <c>--render</c> examples), examples or not.</summary>
+    public static IReadOnlyDictionary<string, int> AllPages()
+        => AllPageExamples().ToDictionary(p => p.Key, p => p.Value.RenderCount, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>All doc pages with example counts AND whether every example is C# — pages whose
+    /// examples need a LANGUAGE WORKER (python) can only execute where that worker is deployed.</summary>
+    public static IReadOnlyDictionary<string, PageExamples> AllPageExamples()
+    {
+        var root = Path.Combine(AppContext.BaseDirectory, "DocData");
+        var pages = new Dictionary<string, PageExamples>(StringComparer.OrdinalIgnoreCase);
+        if (!Directory.Exists(root))
+            return pages;
+        foreach (var file in Directory.EnumerateFiles(root, "*.md", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(root, file).Replace('\\', '/');
+            var rawPath = relative[..^".md".Length];
+            if (rawPath.EndsWith("/index", StringComparison.OrdinalIgnoreCase))
+                rawPath = rawPath[..^"/index".Length];
+            else if (rawPath.Equals("index", StringComparison.OrdinalIgnoreCase))
+                rawPath = "";
+            var docPath = rawPath.Length == 0 ? "Doc" : $"Doc/{rawPath}";
+            pages[docPath] = Analyze(File.ReadAllText(file));
+        }
+        return pages;
+    }
+
+    /// <summary>
+    /// Counts top-level fenced blocks whose info string carries <c>--render</c> — fence-aware, so
+    /// samples ESCAPED inside an enclosing fence (a <c>```text</c> or four-backtick teaching block)
+    /// never count. Mirrors how the markdown pipeline decides what becomes an executable cell.
+    /// </summary>
+    public static int CountRenderExamples(string markdown) => Analyze(markdown).RenderCount;
+
+    private static PageExamples Analyze(string markdown)
+    {
+        var count = 0;
+        var csharpOnly = true;
+        string? openMarker = null;
+        foreach (var line in markdown.Split('\n'))
+        {
+            var m = FenceLine.Match(line.TrimEnd());
+            if (!m.Success)
+                continue;
+            var marker = m.Groups[1].Value;
+            var info = m.Groups[2].Value;
+            if (openMarker is null)
+            {
+                openMarker = marker;
+                if (RenderFlag.IsMatch(info))
+                {
+                    count++;
+                    // The fence language routes the submission (```python → the Python worker).
+                    var language = info.TrimStart().Split(' ', '\t')[0];
+                    if (!string.IsNullOrEmpty(language)
+                        && !language.Equals("csharp", StringComparison.OrdinalIgnoreCase)
+                        && !language.Equals("cs", StringComparison.OrdinalIgnoreCase))
+                        csharpOnly = false;
+                }
+            }
+            // A closing fence: same character, at least the opening run's length, no info string.
+            else if (marker[0] == openMarker[0] && marker.Length >= openMarker.Length && info.Trim().Length == 0)
+            {
+                openMarker = null;
+            }
+        }
+        return new PageExamples(count, csharpOnly);
+    }
+}

--- a/test/MeshWeaver.Portal.E2E.Test/DocExamplesSweepTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/DocExamplesSweepTest.cs
@@ -1,0 +1,127 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// The AUTO-ENUMERATED companion to <see cref="DocExamplesRenderTest"/>: that suite pins deep,
+/// page-specific markers for a curated list; this sweep discovers EVERY doc page carrying
+/// <c>--render</c> examples from the doc sources themselves (<see cref="DocExampleCatalog"/>) and
+/// asserts the generic render contract on the pages the curated list does NOT cover — so a brand-new
+/// doc page with examples is browser-verified the moment it is written, with no list to remember.
+///
+/// <para>Generic contract per page: every example mounts a <c>.layout-area</c>, no example is stuck
+/// on the loading ring, and no error placeholder ("Area not found", "No renderer is registered",
+/// <c>.layout-area-error</c>, <c>.meshweaver-render-error</c>) renders. Content-specific assertions
+/// stay in the curated suite.</para>
+/// </summary>
+[Collection("portal-e2e")]
+public class DocExamplesSweepTest(PortalFixture fixture)
+{
+    /// <summary>Doc pages with examples that the curated suite does not already cover.</summary>
+    public static TheoryData<string, int> SweepPages()
+    {
+        var curated = CuratedPages().Select(p => p.DocPath).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var data = new TheoryData<string, int>();
+        foreach (var (docPath, count) in DocExampleCatalog.AllPages().OrderBy(p => p.Key, StringComparer.Ordinal))
+            if (count > 0 && !curated.Contains(docPath))
+                data.Add(docPath, count);
+        return data;
+    }
+
+    private static IEnumerable<(string DocPath, int ExampleCount)> CuratedPages() =>
+        DocExamplesRenderTest.ExamplePages
+            .Select(row => ((ITheoryDataRow)row).GetData())
+            .Select(data => ((string)data[0]!, (int)data[1]!));
+
+    /// <summary>
+    /// The catalog must rediscover every curated page with at least its pinned example count —
+    /// this pins the enumeration + fence parser against silently rotting to zero coverage.
+    /// </summary>
+    [Fact]
+    public void Catalog_DiscoversEveryCuratedPage()
+    {
+        var all = DocExampleCatalog.AllPages();
+        foreach (var (docPath, count) in CuratedPages())
+        {
+            all.ContainsKey(docPath).Should().BeTrue($"the sweep catalog must see the curated doc page {docPath}");
+            all[docPath].Should().BeGreaterThanOrEqualTo(count,
+                $"the fence parser must find at least the curated number of --render examples on {docPath}");
+        }
+    }
+
+    /// <summary>And the escaped teaching samples must NOT count (the AuthoringDocumentation trap).</summary>
+    [Fact]
+    public void Catalog_EscapedTeachingSamples_DoNotCount()
+    {
+        var all = DocExampleCatalog.AllPages();
+        all.ContainsKey("Doc/Architecture/AuthoringDocumentation").Should().BeTrue();
+        all["Doc/Architecture/AuthoringDocumentation"].Should().Be(0,
+            "--render inside an escaped ```text teaching fence is not an executable example");
+    }
+
+    [Theory(Timeout = 240_000)]
+    [MemberData(nameof(SweepPages))]
+    public async Task DocPage_Examples_MountAndRenderWithoutErrors(string docPath, int exampleCount)
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+        // Pages whose examples need a LANGUAGE WORKER can only execute where it is deployed — the
+        // e2e stack ships no python gate, so skip EXPLICITLY (a fail here would blame the page).
+        Assert.SkipWhen(
+            Environment.GetEnvironmentVariable("E2E_PYTHON") != "1"
+                && DocExampleCatalog.AllPageExamples().TryGetValue(docPath, out var ex)
+                && DocExampleCatalog.NeedsLanguageWorker(docPath, ex),
+            $"{docPath} needs a language worker (python) — the e2e stack has none (set E2E_PYTHON=1 when it does)");
+
+        // ONE shared authenticated context for the whole sweep (owned by the fixture): a fresh
+        // context + /dev/signin per page starved the portal under the sweep's kernel-compile load.
+        var context = await fixture.SharedAuthenticatedContextAsync();
+        // Pay the one-time Roslyn warm-up up front, not on whichever page runs first.
+        await fixture.EnsureKernelWarmAsync(context);
+        var page = await context.NewPageAsync();
+        try
+        {
+        await page.SetViewportSizeAsync(1400, 1000);
+
+        await page.GotoAsync($"{fixture.BaseUrl}/{docPath}",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 90_000 });
+
+        // 1. One .layout-area placeholder per --render block (at-least-N, attached).
+        var areas = page.Locator(".layout-area");
+        await areas.Nth(exampleCount - 1).WaitForAsync(
+            new LocatorWaitForOptions { State = WaitForSelectorState.Attached, Timeout = 90_000 });
+
+        // 2. Every example leaves the loading state: the area has real children and no progress
+        //    ring. Generous budget — the first kernel cell pays Roslyn warm-up / nuget restores.
+        await page.WaitForFunctionAsync($$"""
+            () => {
+              const areas = [...document.querySelectorAll('.layout-area')].slice(0, {{exampleCount}});
+              return areas.length >= {{exampleCount}} && areas.every(a =>
+                !a.querySelector('fluent-progress-ring') &&
+                (a.children.length > 0 || a.textContent.trim().length > 0));
+            }
+            """, null, new PageWaitForFunctionOptions { Timeout = 150_000 });
+
+        Directory.CreateDirectory("/tmp/doc-examples-sweep");
+        await page.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Path = $"/tmp/doc-examples-sweep/{docPath.Replace('/', '-')}.png",
+            FullPage = true
+        });
+
+        // 3. No error placeholders (the DocExamplesRenderTest contract, verbatim).
+        (await areas.GetByText("Area not found").CountAsync()).Should().Be(0,
+            $"no example on {docPath} may render the 'Area not found' placeholder");
+        (await areas.GetByText("No renderer is registered").CountAsync()).Should().Be(0,
+            $"no example on {docPath} may render the 'No renderer is registered' placeholder");
+        (await page.Locator(".layout-area-error").CountAsync()).Should().Be(0,
+            $"no example on {docPath} may render a 'Layout Area Error' div");
+        (await page.Locator(".meshweaver-render-error").CountAsync()).Should().Be(0,
+            $"no example on {docPath} may trip the per-area ErrorBoundary ('This area failed to render')");
+        }
+        finally
+        {
+            await page.CloseAsync();
+        }
+    }
+}

--- a/test/MeshWeaver.Portal.E2E.Test/HomeComposerVerifyTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/HomeComposerVerifyTest.cs
@@ -22,13 +22,13 @@ public class HomeComposerVerifyTest(PortalFixture fixture)
         var token = await fixture.MintTokenAsync(context);
         try
         {
-            await fixture.CreateNodeAsync(context, token, """
+            await fixture.CreateNodeAsync(context, token, $$"""
                 {
                   "id": "ThreadComposer",
-                  "namespace": "Roland/_Thread",
+                  "namespace": "{{fixture.UserId}}/_Thread",
                   "name": "Chat Input",
                   "nodeType": "ThreadComposer",
-                  "mainNode": "Roland",
+                  "mainNode": "{{fixture.UserId}}",
                   "content": { "$type": "ThreadComposer" }
                 }
                 """);
@@ -40,7 +40,7 @@ public class HomeComposerVerifyTest(PortalFixture fixture)
 
         var page = await context.NewPageAsync();
         await page.SetViewportSizeAsync(1280, 900);
-        await page.GotoAsync($"{fixture.BaseUrl}/User/Roland",
+        await page.GotoAsync($"{fixture.BaseUrl}/User/{fixture.UserId}",
             new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
 
         // The composer's message editor (the embedded ThreadChatControl's Monaco editor) is the last editor on the page.

--- a/test/MeshWeaver.Portal.E2E.Test/MeshWeaver.Portal.E2E.Test.csproj
+++ b/test/MeshWeaver.Portal.E2E.Test/MeshWeaver.Portal.E2E.Test.csproj
@@ -10,4 +10,11 @@
     <PackageReference Include="Microsoft.Playwright" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- The documentation source pages, copied beside the tests so the doc-example SWEEP
+         (DocExampleCatalog) can ENUMERATE every page carrying executable examples without
+         referencing (and thus building) the framework projects — this project stays Playwright-only. -->
+    <None Include="..\..\src\MeshWeaver.Documentation\Data\**\*.md" LinkBase="DocData" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/test/MeshWeaver.Portal.E2E.Test/PortalFixture.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/PortalFixture.cs
@@ -38,13 +38,17 @@ public sealed class PortalFixture : IAsyncLifetime
     public string UserPartition => User.ToLowerInvariant();
 
     /// <summary>
-    /// The DevLogin user's id EXACTLY as the User node / circuit identity carries it (the personId,
-    /// not lower-cased) — this is the user's <c>ObjectId</c> / home partition. The per-user registry
-    /// namespaces are <c>{UserId}/Skill</c>, <c>{UserId}/Agent</c>, … and an AccessAssignment granting
-    /// this user a role uses <c>accessObject = UserId</c>. (Distinct from <see cref="UserPartition"/>,
-    /// which is the lower-cased schema name.)
+    /// The DevLogin user's id EXACTLY as the User NODE carries it — resolved from the portal itself
+    /// (the token mint's <c>nodePath</c> first segment, the same contract portal-next boots from)
+    /// on the first authenticated context, falling back to the personId until then. 🚨 Never assume
+    /// the node id matches the personId's CASING: DevLogin provisions the user node lower-cased
+    /// ('roland' for person 'Roland'); seeding a namespace under the capital-cased id auto-creates a
+    /// TYPELESS STUB ROOT ('Roland') that shadows the real User node for every /{UserId} navigation —
+    /// the Blazor home then renders "Area not found: Activity" (the token-vs-circuit casing seam).
     /// </summary>
-    public string UserId => User;
+    public string UserId => _resolvedUserId ?? User;
+
+    private string? _resolvedUserId;
 
     /// <summary>True when a portal + browser are available, i.e. the tests should run.</summary>
     public bool Available => BaseUrl is not null && _browser is not null;
@@ -143,6 +147,33 @@ public sealed class PortalFixture : IAsyncLifetime
             throw new InvalidOperationException(
                 $"DevLogin for user '{person}' failed ({response?.Status}). " +
                 "A 4xx means E2E_USER is not a valid User node id; a persistent 5xx means the portal is unhealthy.");
+
+        // First default-user context: learn the REAL user node id from the token mint's nodePath
+        // ("{userId}/ApiToken/…") so seeds/URLs use the node's exact casing (see UserId).
+        if (person == User && _resolvedUserId is null)
+        {
+            try
+            {
+                var mint = await context.APIRequest.PostAsync($"{BaseUrl}/api/tokens", new APIRequestContextOptions
+                {
+                    DataObject = new { Label = "e2e-identity-probe", ExpiresInDays = 1 }
+                });
+                if ((int)mint.Status < 400)
+                {
+                    var json = await mint.JsonAsync();
+                    if (json!.Value.TryGetProperty("nodePath", out var nodePath))
+                    {
+                        var first = nodePath.GetString()?.Split('/').FirstOrDefault();
+                        if (!string.IsNullOrEmpty(first))
+                            _resolvedUserId = first;
+                    }
+                }
+            }
+            catch
+            {
+                // best effort — UserId falls back to the personId
+            }
+        }
         return context;
     }
 
@@ -291,8 +322,52 @@ public sealed class PortalFixture : IAsyncLifetime
         return false;
     }
 
+    private IBrowserContext? _sharedContext;
+
+    /// <summary>
+    /// ONE lazily-created authenticated context, shared across the read-only page SWEEPS
+    /// (DocExamplesSweepTest / PortalNextDocExamplesTest — 50+ theory cases each). A context (and
+    /// its /dev/signin) per case is what starved the resource-bounded e2e portal mid-suite: the
+    /// kernel-compile load stalls request handling and the NEXT case's signin times out. Tests are
+    /// serial (one collection), so sharing is race-free; pages are still per-test. Never dispose it
+    /// in a test — the fixture owns it.
+    /// </summary>
+    public async Task<IBrowserContext> SharedAuthenticatedContextAsync()
+        => _sharedContext ??= await NewAuthenticatedContextAsync();
+
+    private bool _kernelWarmed;
+
+    /// <summary>
+    /// One-time kernel warm-up for the doc-example sweeps: the FIRST Roslyn compile after a pod
+    /// roll takes 1-2 minutes and (on the resource-bounded e2e pod) starves concurrent request
+    /// handling — whichever sweep page happens to run first would pay that cost and fail its
+    /// per-page budget (a warm-up lottery, not a page defect). Loading one small executable page
+    /// up front and waiting for its kernel output isolates the boot cost so every sweep page
+    /// measures the actual render contract. The warm-up cost itself stays visible in this step's
+    /// duration on the first sweep test.
+    /// </summary>
+    public async Task EnsureKernelWarmAsync(IBrowserContext context)
+    {
+        if (_kernelWarmed) return;
+        var page = await context.NewPageAsync();
+        try
+        {
+            await page.GotoAsync($"{BaseUrl}/Doc/DataMesh/InteractiveMarkdown",
+                new PageGotoOptions { WaitUntil = WaitUntilState.Load, Timeout = 60_000 });
+            await page.GetByText("Hello World", new() { Exact = false }).First
+                .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 240_000 });
+            _kernelWarmed = true;
+        }
+        finally
+        {
+            await page.CloseAsync();
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
+        if (_sharedContext is not null)
+            await _sharedContext.DisposeAsync();
         if (_browser is not null)
             await _browser.DisposeAsync();
         _playwright?.Dispose();

--- a/test/MeshWeaver.Portal.E2E.Test/PortalNextDocExamplesTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/PortalNextDocExamplesTest.cs
@@ -16,18 +16,20 @@ namespace MeshWeaver.Portal.E2E;
 [Collection("portal-e2e")]
 public class PortalNextDocExamplesTest(PortalFixture fixture)
 {
-    public static TheoryData<string, int> ExamplePages()
+    // Just the page paths — the React sweep asserts the generic render contract (live engages, real
+    // content, no failure markers), not a per-example count, so it doesn't carry exampleCount.
+    public static TheoryData<string> ExamplePages()
     {
-        var data = new TheoryData<string, int>();
+        var data = new TheoryData<string>();
         foreach (var (docPath, count) in DocExampleCatalog.AllPages().OrderBy(p => p.Key, StringComparer.Ordinal))
             if (count > 0)
-                data.Add(docPath, count);
+                data.Add(docPath);
         return data;
     }
 
     [Theory(Timeout = 240_000)]
     [MemberData(nameof(ExamplePages))]
-    public async Task DocPage_RendersInReactShell_WithoutFailureMarkers(string docPath, int exampleCount)
+    public async Task DocPage_RendersInReactShell_WithoutFailureMarkers(string docPath)
     {
         Assert.SkipUnless(fixture.Available, fixture.SkipReason);
         // Pages whose examples need a LANGUAGE WORKER can only execute where it is deployed — the

--- a/test/MeshWeaver.Portal.E2E.Test/PortalNextDocExamplesTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/PortalNextDocExamplesTest.cs
@@ -1,0 +1,116 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// The portal-next (React, <c>/next</c>) twin of the doc-example render sweep: every doc page with
+/// <c>--render</c> examples (auto-enumerated by <see cref="DocExampleCatalog"/>) must render through
+/// the LIVE React shell without the React-side failure markers — the offline fallback, a live-area
+/// error, an "Unsupported control" fallback (a control type the Fluent pack doesn't register), a
+/// failed interactive kernel, or a raw unresolved <c>@@(</c> macro.
+///
+/// <para>Content-specific markers stay with <see cref="ReactDocViewsTest"/>; this sweep is the
+/// generic gate that keeps EVERY documented example at least mounting in the React GUI.</para>
+/// </summary>
+[Collection("portal-e2e")]
+public class PortalNextDocExamplesTest(PortalFixture fixture)
+{
+    public static TheoryData<string, int> ExamplePages()
+    {
+        var data = new TheoryData<string, int>();
+        foreach (var (docPath, count) in DocExampleCatalog.AllPages().OrderBy(p => p.Key, StringComparer.Ordinal))
+            if (count > 0)
+                data.Add(docPath, count);
+        return data;
+    }
+
+    [Theory(Timeout = 240_000)]
+    [MemberData(nameof(ExamplePages))]
+    public async Task DocPage_RendersInReactShell_WithoutFailureMarkers(string docPath, int exampleCount)
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+        // Pages whose examples need a LANGUAGE WORKER can only execute where it is deployed — the
+        // e2e stack ships no python gate, so skip EXPLICITLY (a fail here would blame the GUI).
+        Assert.SkipWhen(
+            Environment.GetEnvironmentVariable("E2E_PYTHON") != "1"
+                && DocExampleCatalog.AllPageExamples().TryGetValue(docPath, out var ex)
+                && DocExampleCatalog.NeedsLanguageWorker(docPath, ex),
+            $"{docPath} needs a language worker (python) — the e2e stack has none (set E2E_PYTHON=1 when it does)");
+        // ONE shared authenticated context for the whole sweep (owned by the fixture): a fresh
+        // context + /dev/signin per page starved the portal under the sweep's kernel-compile load.
+        var context = await fixture.SharedAuthenticatedContextAsync();
+        var probe = await context.APIRequest.GetAsync($"{fixture.BaseUrl}/next");
+        Assert.SkipUnless((int)probe.Status == 200,
+            $"/next not deployed on {fixture.BaseUrl} (HTTP {probe.Status}) — run 'memex-local e2e up'.");
+        // Pay the one-time Roslyn warm-up up front, not on whichever page runs first.
+        await fixture.EnsureKernelWarmAsync(context);
+
+        var page = await context.NewPageAsync();
+        try
+        {
+        await page.SetViewportSizeAsync(1400, 1000);
+        await page.GotoAsync($"{fixture.BaseUrl}/next/{docPath}", new PageGotoOptions { WaitUntil = WaitUntilState.Load });
+
+        // The LIVE stream must take over (data-mw-live flips after the first gRPC-web frame folds).
+        await page.Locator("[data-mw-live-area][data-mw-live='true']")
+            .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Attached, Timeout = 90_000 });
+
+        // The page body renders real content (not a skeleton): some non-trivial text.
+        await page.WaitForFunctionAsync("""
+            () => {
+              const area = document.querySelector('[data-mw-live-area]');
+              return area && area.textContent.trim().length > 80;
+            }
+            """, null, new PageWaitForFunctionOptions { Timeout = 120_000 });
+
+        // Examples execute through the per-view kernel: the "starting" notice must clear and the
+        // kernel must not report failure/unavailability (this portal HAS a kernel).
+        await page.WaitForFunctionAsync("""
+            () => !document.body.textContent.includes('Starting interactive kernel')
+            """, null, new PageWaitForFunctionOptions { Timeout = 150_000 });
+
+        Directory.CreateDirectory("/tmp/portal-next-doc-sweep");
+        await page.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Path = $"/tmp/portal-next-doc-sweep/{docPath.Replace('/', '-')}.png",
+            FullPage = true
+        });
+
+        // React-side failure markers — each one is a real defect, not cosmetics.
+        (await page.Locator("[data-mw-offline]").CountAsync())
+            .Should().Be(0, $"{docPath} must render live, not the offline fallback");
+        (await page.Locator("[data-mw-area-error]").CountAsync())
+            .Should().Be(0, $"{docPath} must not fail its live area");
+        (await page.GetByText("Unsupported control:", new() { Exact = false }).CountAsync())
+            .Should().Be(0, $"every control on {docPath} must have a React renderer (no red fallback)");
+        (await page.GetByText("Interactive kernel failed to start", new() { Exact = false }).CountAsync())
+            .Should().Be(0, $"the interactive kernel must boot for {docPath}");
+        (await page.GetByText("Interactive code execution is unavailable", new() { Exact = false }).CountAsync())
+            .Should().Be(0, $"the e2e portal has a kernel — {docPath} must not degrade to the unavailable notice");
+        // Raw @@ macros OUTSIDE code samples only — doc pages that TEACH the macro syntax
+        // (Doc/GUI/MeshSearch) legitimately render "@@(" inside <code>/<pre> spans.
+        (await page.EvaluateAsync<int>("""
+            () => {
+              let count = 0;
+              const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+              while (walker.nextNode()) {
+                const n = walker.currentNode;
+                if (!n.textContent.includes('@@(')) continue;
+                if (n.parentElement?.closest('code, pre, table')) continue;
+                count++;
+              }
+              return count;
+            }
+            """))
+            .Should().Be(0, $"every @@ area macro on {docPath} (outside code samples) must resolve to an embedded region");
+        }
+        finally
+        {
+            // Close the page so the react view UNMOUNTS — that releases the per-view kernel
+            // (MarkdownKernelSession.dispose → requestedStatus=Cancelled) instead of leaving
+            // 50+ live kernels + gRPC streams behind for the rest of the run.
+            await page.CloseAsync();
+        }
+    }
+}

--- a/test/MeshWeaver.Portal.E2E.Test/PortalNextNavigationTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/PortalNextNavigationTest.cs
@@ -1,0 +1,112 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// Pins the CLICK-NAVIGATION contract of the React shell — the regression suite for the
+/// "clicking a card does nothing / falls out of the React GUI" bug: every internal link the
+/// renderer emits (mesh result cards, markdown anchors from the server's Markdig HTML) must
+/// (1) actually navigate, (2) navigate CLIENT-SIDE through the Next router (no full page load —
+/// a full load on a root-absolute href escapes the /next base path into the Blazor portal), and
+/// (3) land on a live-rendered page. The fix is @meshweaver/react's NavigationProvider seam
+/// (area/navigation.tsx) wired to the Next router in portal-next's MeshNavigation.tsx.
+/// </summary>
+[Collection("portal-e2e")]
+public class PortalNextNavigationTest(PortalFixture fixture)
+{
+    private async Task<IBrowserContext> RequireNextAsync()
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+        var context = await fixture.NewAuthenticatedContextAsync();
+        var probe = await context.APIRequest.GetAsync($"{fixture.BaseUrl}/next");
+        Assert.SkipUnless((int)probe.Status == 200,
+            $"/next not deployed on {fixture.BaseUrl} (HTTP {probe.Status}) — run 'memex-local e2e up'.");
+        return context;
+    }
+
+    private static async Task<IPage> GotoLiveAsync(IBrowserContext context, string baseUrl, string path)
+    {
+        var page = await context.NewPageAsync();
+        await page.SetViewportSizeAsync(1600, 1000);
+        await page.GotoAsync($"{baseUrl}/next{path}", new PageGotoOptions { WaitUntil = WaitUntilState.Load });
+        // 150s: first touch of a per-node hub on a FRESH pod compiles/activates before rendering —
+        // the same cold-start budget the parity suite's composer test carries.
+        await page.Locator("[data-mw-live-area][data-mw-live='true']")
+            .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Attached, Timeout = 150_000 });
+        return page;
+    }
+
+    /// <summary>A survives-navigation marker: only a full page load wipes window state.</summary>
+    private static Task StampSpaMarkerAsync(IPage page) =>
+        page.EvaluateAsync("() => { window.__mwSpaMarker = 'alive'; }");
+
+    private static async Task AssertClientSideNavigationAsync(IPage page)
+    {
+        (await page.EvaluateAsync<string>("() => window.__mwSpaMarker ?? ''"))
+            .Should().Be("alive", "internal links must route through the Next router (SPA push), not a full page load");
+    }
+
+    // ── Markdown anchors: server-rendered "/Doc/…" hrefs route through the shell ─────────────────
+
+    [Fact(Timeout = 240_000)]
+    public async Task MarkdownLink_Click_NavigatesClientSide_InsideTheShell()
+    {
+        await using var context = await RequireNextAsync();
+        var page = await GotoLiveAsync(context, fixture.BaseUrl!, "/Doc/GUI");
+
+        // A rendered internal doc link (the Markdig HTML carries root-absolute "/Doc/…" hrefs).
+        var link = page.Locator("[data-mw-live-area] .mw-markdown a[href^='/Doc/']").First;
+        await link.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 90_000 });
+        var target = (await link.GetAttributeAsync("href"))!;
+
+        await StampSpaMarkerAsync(page);
+        await link.ClickAsync();
+
+        // The URL lands INSIDE the /next app (basePath applied by the router), on the link's target.
+        await page.WaitForURLAsync($"**/next{target}", new PageWaitForURLOptions { Timeout = 30_000 });
+        await AssertClientSideNavigationAsync(page);
+
+        // And the destination renders live in the same shell (150s: destination first-touch
+        // pays the cold-start budget, same as GotoLiveAsync).
+        await page.Locator("[data-mw-live-area][data-mw-live='true']")
+            .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Attached, Timeout = 150_000 });
+        (await page.Locator("[data-mw-header]").CountAsync())
+            .Should().BeGreaterThan(0, "the React shell chrome must survive the navigation");
+    }
+
+    // ── Result cards: mesh search/collection cards carry basePath hrefs and route client-side ────
+
+    [Fact(Timeout = 240_000)]
+    public async Task ResultCard_Click_NavigatesClientSide_ToTheNode()
+    {
+        await using var context = await RequireNextAsync();
+        var page = await GotoLiveAsync(context, fixture.BaseUrl!, "");
+
+        // The home regions (Open threads / Spaces tabs) render mesh result cards. Their hrefs must
+        // carry the /next base path — a root-absolute href here IS the escape-the-app bug.
+        var card = page.Locator("[data-mw-live-area] a[href^='/next/']").First;
+        try
+        {
+            await card.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 90_000 });
+        }
+        catch (TimeoutException)
+        {
+            var rootAbsolute = await page.Locator("[data-mw-live-area] a[href^='/']:not([href^='/next'])").CountAsync();
+            rootAbsolute.Should().Be(0,
+                "result cards must render /next-based hrefs — root-absolute hrefs escape the React app (the click bug)");
+            Assert.Skip("no result cards on the home regions (empty e2e data) — nothing to click");
+        }
+
+        var href = (await card.GetAttributeAsync("href"))!;
+        await StampSpaMarkerAsync(page);
+        await card.ClickAsync();
+
+        await page.WaitForURLAsync($"**{href}", new PageWaitForURLOptions { Timeout = 30_000 });
+        await AssertClientSideNavigationAsync(page);
+        // 150s: the destination page pays the same first-touch cold-start as GotoLiveAsync when the
+        // clicked node's hub has never been activated on this pod (e.g. a pinned Doc page).
+        await page.Locator("[data-mw-live-area][data-mw-live='true']")
+            .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Attached, Timeout = 150_000 });
+    }
+}

--- a/test/MeshWeaver.Portal.E2E.Test/SidePanelChatMultiMessageTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/SidePanelChatMultiMessageTest.cs
@@ -22,13 +22,13 @@ namespace MeshWeaver.Portal.E2E;
 [Collection("portal-e2e")]
 public class SidePanelChatMultiMessageTest(PortalFixture fixture)
 {
-    private const string ComposerSeedJson = """
+    private string ComposerSeedJson => $$"""
         {
           "id": "ThreadComposer",
-          "namespace": "Roland/_Thread",
+          "namespace": "{{fixture.UserId}}/_Thread",
           "name": "Chat Input",
           "nodeType": "ThreadComposer",
-          "mainNode": "Roland",
+          "mainNode": "{{fixture.UserId}}",
           "content": { "$type": "ThreadComposer" }
         }
         """;
@@ -67,15 +67,15 @@ public class SidePanelChatMultiMessageTest(PortalFixture fixture)
             Headers = new Dictionary<string, string> { ["authorization"] = $"Bearer {token}" },
             DataObject = new
             {
-                Path = "Roland/_Thread/ThreadComposer",
+                Path = $"{fixture.UserId}/_Thread/ThreadComposer",
                 Fields = "{\"content\":{\"$type\":\"ThreadComposer\",\"harness\":\"Harness/MeshWeaver\","
-                       + "\"modelName\":\"" + ModelPath + "\",\"contextPath\":\"Roland\"}}"
+                       + "\"modelName\":\"" + ModelPath + "\",\"contextPath\":\"" + fixture.UserId + "\"}}"
             }
         });
 
         var page = await context.NewPageAsync();
         await page.SetViewportSizeAsync(1400, 950);
-        await page.GotoAsync($"{fixture.BaseUrl}/User/Roland",
+        await page.GotoAsync($"{fixture.BaseUrl}/User/{fixture.UserId}",
             new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
 
         // 1) Open the side-panel chat via the layout's "Chat" toggle button.

--- a/test/MeshWeaver.Portal.E2E.Test/SidePanelChatSubmitWhileExecutingTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/SidePanelChatSubmitWhileExecutingTest.cs
@@ -24,14 +24,16 @@ namespace MeshWeaver.Portal.E2E;
 public class SidePanelChatSubmitWhileExecutingTest(PortalFixture fixture)
 {
     // Create-fallback for a fresh DB; the real harness/model/context is applied by the PATCH below
-    // (a PATCH, not create, so the post-creation seed handler can't reset it).
-    private const string ComposerSeedJson = """
+    // (a PATCH, not create, so the post-creation seed handler can't reset it). Uses the RESOLVED
+    // user node id — a hardcoded 'Roland' seeded a capital-cased namespace that materialized the
+    // typeless stub root (the casing seam) and now gets a proper 401 cross-partition rejection.
+    private string ComposerSeedJson => $$"""
         {
           "id": "ThreadComposer",
-          "namespace": "Roland/_Thread",
+          "namespace": "{{fixture.UserId}}/_Thread",
           "name": "Chat Input",
           "nodeType": "ThreadComposer",
-          "mainNode": "Roland",
+          "mainNode": "{{fixture.UserId}}",
           "content": { "$type": "ThreadComposer" }
         }
         """;
@@ -72,20 +74,19 @@ public class SidePanelChatSubmitWhileExecutingTest(PortalFixture fixture)
             Headers = new Dictionary<string, string> { ["authorization"] = $"Bearer {token}" },
             DataObject = new
             {
-                Path = "Roland/_Thread/ThreadComposer",
+                Path = $"{fixture.UserId}/_Thread/ThreadComposer",
                 Fields = "{\"content\":{\"$type\":\"ThreadComposer\",\"harness\":\"Harness/MeshWeaver\","
-                       + "\"modelName\":\"" + ModelPath + "\",\"contextPath\":\"Roland\"}}"
+                       + "\"modelName\":\"" + ModelPath + "\",\"contextPath\":\"" + fixture.UserId + "\"}}"
             }
         });
 
-        // Chat from a page in the WRITABLE 'Roland' partition — the /User/Roland home routes
+        // Chat from a page in the user's own WRITABLE partition — the /User/{id} home routes
         // thread-create to the system-managed 'User' partition (PartitionWriteGuard rejects it).
-        // CompileErrorPageE2ETest proves 'Roland' is writable for the DevLogin user.
         var chatPageId = "e2e-chat-" + Guid.NewGuid().ToString("N")[..8];
         await fixture.CreateNodeAsync(context, token, $$"""
             {
               "id": "{{chatPageId}}",
-              "namespace": "Roland",
+              "namespace": "{{fixture.UserId}}",
               "name": "E2E Chat Page",
               "nodeType": "Markdown",
               "content": { "$type": "MarkdownContent", "content": "# E2E chat page" }
@@ -94,7 +95,7 @@ public class SidePanelChatSubmitWhileExecutingTest(PortalFixture fixture)
 
         var page = await context.NewPageAsync();
         await page.SetViewportSizeAsync(1400, 950);
-        await page.GotoAsync($"{fixture.BaseUrl}/Roland/{chatPageId}",
+        await page.GotoAsync($"{fixture.BaseUrl}/{fixture.UserId}/{chatPageId}",
             new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
 
         // Open the side-panel chat (the layout's "Chat" toggle → ThreadChatView).

--- a/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/SidePanelChatTenMessagesTest.cs
@@ -21,13 +21,13 @@ public class SidePanelChatTenMessagesTest(PortalFixture fixture)
 {
     private const int MessageCount = 10;
 
-    private const string ComposerSeedJson = """
+    private string ComposerSeedJson => $$"""
         {
           "id": "ThreadComposer",
-          "namespace": "Roland/_Thread",
+          "namespace": "{{fixture.UserId}}/_Thread",
           "name": "Chat Input",
           "nodeType": "ThreadComposer",
-          "mainNode": "Roland",
+          "mainNode": "{{fixture.UserId}}",
           "content": { "$type": "ThreadComposer" }
         }
         """;
@@ -56,15 +56,15 @@ public class SidePanelChatTenMessagesTest(PortalFixture fixture)
             Headers = new Dictionary<string, string> { ["authorization"] = $"Bearer {token}" },
             DataObject = new
             {
-                Path = "Roland/_Thread/ThreadComposer",
+                Path = $"{fixture.UserId}/_Thread/ThreadComposer",
                 Fields = "{\"content\":{\"$type\":\"ThreadComposer\",\"harness\":\"Harness/MeshWeaver\","
-                       + "\"modelName\":\"" + ModelPath + "\",\"contextPath\":\"Roland\"}}"
+                       + "\"modelName\":\"" + ModelPath + "\",\"contextPath\":\"" + fixture.UserId + "\"}}"
             }
         });
 
         var page = await context.NewPageAsync();
         await page.SetViewportSizeAsync(1400, 950);
-        await page.GotoAsync($"{fixture.BaseUrl}/User/Roland",
+        await page.GotoAsync($"{fixture.BaseUrl}/User/{fixture.UserId}",
             new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
 
         // Open the side-panel chat.


### PR DESCRIPTION
Server + test-infra half of the React-GUI work (the React-client fixes ship in a follow-up PR — they compile-depend on unmerged React-interactive-markdown WIP).

## Identity casing — the "Area not found: Activity" home bug
The Blazor circuit derived `ObjectId` from the email local part **with casing preserved** (`Roland@… → Roland`) while onboarding lowercases the node id (`roland`). On an identity-cache miss the home rendered a **typeless hub** → "Area not found: Activity", and navigating it **materialized a stub root** that shadowed the real User node.
- `CircuitAccessHandler.UsernameFromEmail` now lowercases (matches onboarding).
- `DevAuthController.ProvisionDevUser` lowercases its node id (was a third divergent mapping).

## Blazor kernel-leak wedge
Per-view markdown kernels only died at the 15-min idle timeout. Under a doc sweep they accumulate as live hubs → CPU starvation → `/healthz` times out → the pod flaps out of the Service (the wedge).
- `MarkdownView` + `CollaborativeMarkdownView` now **delete the kernel Activity on dispose** (`SubscribeToOwnDeletion` tears the hub down immediately), guarded so a view that never created the activity never posts a delete to a nonexistent address (the NotFound-storm class). The circuit-teardown `ObjectDisposedException` is distinguished from a real failure and left to the idle timeout.
- **Verified:** the Blazor doc sweep ran through every page with the pod `ready=true`, `restarts=0` throughout — no wedge.

## Auto-enumerated doc-example E2E sweeps
- `DocExampleCatalog` parses every doc page's `--render` fences from the sources (no hardcoded list — new pages are covered automatically). `DocExamplesSweepTest` (Blazor) + `PortalNextDocExamplesTest` (React shell) assert every example mounts/executes without error markers. Language-worker (python) pages skip explicitly via `E2E_PYTHON`. `PortalNextNavigationTest` pins the click-navigation contract.
- `PortalFixture` resolves the real user node id from the token mint's `nodePath` (no casing assumption); one shared authenticated context + a one-time kernel warm-up so the sweep measures the page contract, not the cold-compile lottery.

## memex-local e2e deploy tuning
Readiness probe `timeoutSeconds: 5` (k8s default 1s flapped under compile load), pod 3cpu/6Gi, migration wait 900s (a progressing first-boot EmbeddingBackfill must not be killed by a short wait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)