### PR TITLE
feat(chat): /navigate skill — pane-aware, resilient navigation + honest NavigateTo

### DIFF
--- a/src/MeshWeaver.AI/Data/Skill/navigate.md
+++ b/src/MeshWeaver.AI/Data/Skill/navigate.md
@@ -1,0 +1,30 @@
+---
+nodeType: Skill
+name: /navigate
+description: Take me there — open a node, doc, or page in the UI. Pane-aware (opens in the pane opposite the thread) and resilient (finds the best match even if the path is off).
+icon: Location
+category: Skills
+order: 3
+action:
+  kind: Navigate
+---
+
+Navigate the user to a place in the UI. Resolution is **resilient** and application is **pane-aware**.
+
+## Resolution — direct path first, else make sense of the row
+
+- **One argument that looks like a path** (`/navigate Doc/AI/ModelProviderSettings`, `/navigate @/rbuergi`, a pasted URL): resolve it as a **direct path** first. The URL is corrected automatically — a leading `@`, a stray `/node/` segment, a pasted `https://…host/…` prefix, doubled slashes, and percent-encoding are all cleaned up. If the exact node isn't there, fall back to the **best search match** rather than dead-ending.
+- **Free text** (`/navigate model settings`, `/navigate my notifications`): make sense of the context on the row — match it to a **skill** where one fits (so the user can *do* something, e.g. `/model` to change the model), otherwise **search** the mesh and open the best-matching node.
+
+Never report success for a place that doesn't exist. If nothing resolves, say so and offer the closest matches.
+
+## Application — always the opposite pane
+
+- **Thread is in the MAIN pane** → open the target in the **side panel** (so the conversation and its subject sit side by side).
+- **Thread is in the SIDE panel** → **change the URL and navigate the MAIN pane**.
+
+App routes with a query string (e.g. a `/search?…` results page) are pages, not renderable nodes — those always navigate the main view.
+
+## Prefer skills over raw routes
+
+When a user asks to *do* something ("change my model", "set up a provider", "manage access"), route them to the matching **skill** (`/model`, `/provider-keys`, `/access`) — a skill can navigate **and** carry out the task — rather than dropping them on a bare search URL.

--- a/src/MeshWeaver.AI/MeshPlugin.cs
+++ b/src/MeshWeaver.AI/MeshPlugin.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using MeshWeaver.AI.Navigation;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
@@ -164,21 +165,44 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
         });
     }
 
-    /// <summary>MCP/agent tool: shows a node's visual layout area inline in the chat UI.</summary>
-    /// <param name="path">The path to navigate to (resolved against context).</param>
-    /// <returns>A confirmation string naming the resolved path.</returns>
-    [Description("Displays a node's visual layout in the chat UI.")]
-    public string NavigateTo(
-        [Description("Path to navigate to (e.g., @graph/org1)")] string path)
+    /// <summary>
+    /// MCP/agent tool: takes the user to a place in the UI. Resolution is RESILIENT — a single path-shaped
+    /// argument is tried as a direct path first (with URL correction and a search fallback), free text is
+    /// interpreted (an intent→skill match, else the best-matching node) — and HONEST: it never reports
+    /// success for a place that does not exist. The resolved target renders in the chat's content view.
+    /// </summary>
+    /// <param name="path">A path (<c>@/Doc/AI/ModelProviderSettings</c>) or plain words describing where to go.</param>
+    /// <returns>A task with an honest confirmation of where it navigated, or that nothing matched.</returns>
+    [Description("Takes the user to a node, doc, or page in the UI. Resilient (resolves the best match even when the path is imperfect) and honest (NEVER claims to open a place that doesn't exist — if nothing matches it says so and lists the closest candidates). Pass a path (@/Doc/AI/ModelProviderSettings) or plain words describing where to go (\"model settings\").")]
+    public Task<string> NavigateTo(
+        [Description("A path (@/Doc/AI/ModelProviderSettings), or what the user is looking for in words.")] string path)
     {
         logger.LogInformation("NavigateTo called with path={Path}", path);
+        return WithContext(() =>
+            new NavigationResolver(hub).Resolve(path, chat.Context?.Context)
+                .Select(resolution => NavigateToResult(path, resolution)))
+            .FirstAsync().ToTask();
+    }
 
-        var resolvedPath = MeshOperations.ResolvePath(ResolveContextPath(path));
-        var address = new Address(resolvedPath);
-        var layoutControl = Controls.LayoutArea(address, string.Empty);
+    // Renders the resolved target inline and returns an honest result string. A page ROUTE can't render as
+    // a node view, so it's reported only. The pane-aware open is applied on the client (ThreadChatView).
+    private string NavigateToResult(string requested, NavigationResolution resolution)
+    {
+        if (resolution.Kind == NavigationTargetKind.Unresolved || string.IsNullOrEmpty(resolution.Target))
+        {
+            var alts = resolution.Alternatives.Count > 0
+                ? " Closest matches: " + string.Join(", ", resolution.Alternatives) + "."
+                : string.Empty;
+            return (resolution.Message ?? $"Couldn't find anywhere matching \"{requested}\".") + alts;
+        }
 
-        chat.DisplayLayoutArea(layoutControl);
-        return $"Navigating to: {resolvedPath}";
+        if (resolution.Kind != NavigationTargetKind.Route)
+            chat.DisplayLayoutArea(Controls.LayoutArea(new Address(resolution.Target.TrimStart('/')), string.Empty));
+
+        var note = resolution.WasCorrected && !string.IsNullOrEmpty(resolution.Message)
+            ? " " + resolution.Message
+            : string.Empty;
+        return $"Navigating to: {resolution.Target}.{note}";
     }
 
     /// <summary>MCP/agent tool (dev-only): runs xUnit tests via <c>dotnet test</c> on a repo-relative test project, optionally filtered.</summary>

--- a/src/MeshWeaver.AI/Navigation/NavigationResolver.cs
+++ b/src/MeshWeaver.AI/Navigation/NavigationResolver.cs
@@ -1,0 +1,180 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.AI.Navigation;
+
+/// <summary>
+/// The reactive orchestration around the pure <see cref="NavigationTargetResolver"/>: it turns a raw
+/// navigation row into a concrete <see cref="NavigationResolution"/> by checking node existence and running
+/// the resilient search fallback / intent→skill match against the live mesh. Everything is
+/// <see cref="IObservable{T}"/> — compose and Subscribe, never await (AsynchronousCalls.md). Both the
+/// user-typed <c>/navigate</c> skill (client) and the agent's <c>NavigateTo</c> tool (server) call this,
+/// so "take me there" resolves the same way no matter who asks.
+/// </summary>
+public sealed class NavigationResolver
+{
+    private const int SearchTimeoutSeconds = 5;
+    // Bound on how long the authoritative single-node existence read waits before deciding "not there"
+    // and falling back to search — short so a wrong path corrects quickly, long enough for the live read.
+    private const int ExistsTimeoutSeconds = 2;
+
+    private readonly IMessageHub hub;
+    private readonly IMeshService mesh;
+    private readonly ILogger<NavigationResolver> logger;
+
+    /// <summary>Creates a resolver bound to the mesh services on <paramref name="hub"/>.</summary>
+    public NavigationResolver(IMessageHub hub)
+    {
+        this.hub = hub;
+        mesh = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        logger = hub.ServiceProvider.GetRequiredService<ILogger<NavigationResolver>>();
+    }
+
+    /// <summary>
+    /// Resolves a navigation row (the <c>/navigate</c> argument or the <c>NavigateTo</c> tool path) to a
+    /// concrete target. Single path-shaped argument → direct path first (with URL correction and a resilient
+    /// search fallback); free-text → an intent→skill match, else the best node search. Never throws and never
+    /// dead-ends: a failed search yields an <see cref="NavigationTargetKind.Unresolved"/> result with
+    /// alternatives, not an error.
+    /// </summary>
+    public IObservable<NavigationResolution> Resolve(string? row, string? contextPath = null)
+    {
+        switch (NavigationTargetResolver.Classify(row))
+        {
+            case NavigationInputKind.Empty:
+                return Observable.Return(NavigationResolution.Unresolved("Nothing to navigate to."));
+            case NavigationInputKind.DirectPath:
+                return ResolveDirect(row!.Trim(), contextPath);
+            default:
+                return ResolvePhrase(row!.Trim());
+        }
+    }
+
+    private IObservable<NavigationResolution> ResolveDirect(string row, string? contextPath)
+    {
+        var normalized = NavigationTargetResolver.NormalizePath(row);
+        var corrected = !string.Equals(normalized, row.TrimStart('@'), StringComparison.Ordinal);
+
+        // An app route (a page, e.g. /search?…) always "exists" and can't render in the side panel.
+        if (NavigationTargetResolver.IsRouteLike(normalized))
+            return Observable.Return(new NavigationResolution
+            {
+                Target = normalized,
+                Kind = NavigationTargetKind.Route,
+                WasCorrected = corrected,
+            });
+
+        var nodePath = normalized.TrimStart('/');
+
+        // A BARE single-segment token may be relative to the thread's context ("@MyChild" under context
+        // "ACME/Project"). Try it as an absolute path first, then under the context, before searching. A
+        // multi-segment path or an explicit "@/absolute" is treated as absolute — no context prefix.
+        var contextCandidate = !string.IsNullOrEmpty(contextPath)
+                               && !nodePath.Contains('/')
+                               && !row.TrimStart().StartsWith("@/", StringComparison.Ordinal)
+            ? $"{contextPath!.Trim('/')}/{nodePath}"
+            : null;
+
+        return ReadExact(nodePath).SelectMany(node =>
+        {
+            if (node is not null)
+                return Observable.Return(NodeResolution(node, corrected, null));
+            if (contextCandidate is not null)
+                return ReadExact(contextCandidate).SelectMany(ctxNode =>
+                    ctxNode is not null
+                        ? Observable.Return(NodeResolution(ctxNode, wasCorrected: true, null))
+                        : SearchFallback(nodePath, row));
+            return SearchFallback(nodePath, row);
+        });
+    }
+
+    // Resilient fallback — the node isn't there verbatim, so find the closest real one, or report honestly.
+    private IObservable<NavigationResolution> SearchFallback(string nodePath, string row)
+    {
+        var term = NavigationTargetResolver.LastSegment(nodePath);
+        return SearchNodes(term, 20).Select(candidates =>
+        {
+            var best = NavigationTargetResolver.PickBest(nodePath, candidates)
+                       ?? NavigationTargetResolver.PickBest(term, candidates);
+            return best is not null
+                ? NodeResolution(best, wasCorrected: true,
+                    $"Couldn't find “{nodePath}” — opened the closest match “{best.Path}”.", candidates)
+                : NavigationResolution.Unresolved($"Nothing in the mesh matches “{row}”.")
+                    with { Alternatives = TopPaths(candidates) };
+        });
+    }
+
+    // Authoritative single-node existence read (CqrsAndContentAccess.md: GetMeshNodeStream, not a lagged
+    // query) — exact-path filtered so a routing fallback can't return an ancestor. Times out to null (the
+    // node isn't there) → the caller runs the search fallback.
+    private IObservable<MeshNode?> ReadExact(string nodePath) =>
+        hub.GetWorkspace().GetMeshNodeStream(nodePath)
+            .Where(n => n is not null
+                        && string.Equals(n.Path, nodePath, StringComparison.OrdinalIgnoreCase))
+            .Take(1)
+            .Select(n => (MeshNode?)n)
+            .Timeout(TimeSpan.FromSeconds(ExistsTimeoutSeconds))
+            .Catch((Exception _) => Observable.Return((MeshNode?)null));
+
+    private IObservable<NavigationResolution> ResolvePhrase(string phrase)
+    {
+        // 1) Prefer a SKILL — a skill can do more than a route change ("change my model" → /model).
+        return SearchNodes("nodeType:Skill", 100)
+            .SelectMany(skills =>
+            {
+                var skill = NavigationTargetResolver.PickBestSkill(phrase, skills);
+                if (skill is not null)
+                    return Observable.Return(new NavigationResolution
+                    {
+                        Target = skill.Path,
+                        Kind = NavigationTargetKind.Skill,
+                        WasCorrected = true,
+                        Message = $"Runs {skill.Name ?? "/" + skill.Id}.",
+                    });
+
+                // 2) Otherwise, make sense of the phrase by searching the mesh for the best node.
+                return SearchNodes(phrase, 20).Select(candidates =>
+                {
+                    var best = NavigationTargetResolver.PickBest(phrase, candidates);
+                    return best is not null
+                        ? NodeResolution(best, wasCorrected: true,
+                            $"Opened the best match for “{phrase}”: “{best.Path}”.", candidates)
+                        : NavigationResolution.Unresolved($"Couldn't find anything for “{phrase}”.")
+                            with { Alternatives = TopPaths(candidates) };
+                });
+            });
+    }
+
+    private static NavigationResolution NodeResolution(
+        MeshNode node, bool wasCorrected, string? message, IReadOnlyList<MeshNode>? alternatives = null) =>
+        new()
+        {
+            Target = node.Path,
+            Kind = NavigationTargetKind.Node,
+            WasCorrected = wasCorrected,
+            Message = message,
+            Alternatives = alternatives is null ? [] : TopPaths(alternatives, exclude: node.Path),
+        };
+
+    private static IReadOnlyList<string> TopPaths(
+        IReadOnlyList<MeshNode> nodes, string? exclude = null, int take = 3) =>
+        nodes.Where(n => !string.IsNullOrEmpty(n.Path)
+                    && !string.Equals(n.Path, exclude, StringComparison.OrdinalIgnoreCase))
+            .Select(n => n.Path!).Distinct().Take(take).ToList();
+
+    private IObservable<IReadOnlyList<MeshNode>> SearchNodes(string query, int limit) =>
+        mesh.Query<MeshNode>(new MeshQueryRequest { Query = query, Limit = limit })
+            .Take(1)
+            .Select(change => (IReadOnlyList<MeshNode>)change.Items.ToList())
+            .Timeout(TimeSpan.FromSeconds(SearchTimeoutSeconds))
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex, "Navigation search failed for query {Query}", query);
+                return Observable.Return((IReadOnlyList<MeshNode>)[]);
+            });
+}

--- a/src/MeshWeaver.AI/Navigation/NavigationTargetResolver.cs
+++ b/src/MeshWeaver.AI/Navigation/NavigationTargetResolver.cs
@@ -1,0 +1,338 @@
+using System.Text.RegularExpressions;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.AI.Navigation;
+
+/// <summary>
+/// How a <c>/navigate</c> argument row (or the <c>NavigateTo</c> tool's <c>path</c>) is interpreted.
+/// The rule the user asked for: <b>try a direct path mapping first when the row is a single argument;
+/// otherwise make sense of the free-text context the user typed on the row</b>.
+/// </summary>
+public enum NavigationInputKind
+{
+    /// <summary>Nothing to resolve — navigate to the current context / home.</summary>
+    Empty,
+
+    /// <summary>A single path-shaped token (<c>Doc/AI/ModelProviderSettings</c>, <c>@/rbuergi</c>, a
+    /// quoted spaced path, a pasted URL, a <c>/search?…</c> route). Resolve by DIRECT PATH first.</summary>
+    DirectPath,
+
+    /// <summary>Free-text prose (<c>change my model</c>, <c>my notifications</c>). Resolve by CONTEXT —
+    /// match an intent → skill, else semantic search for the best node.</summary>
+    Phrase,
+}
+
+/// <summary>What a resolution landed on, so the caller can apply the right pane-aware action.</summary>
+public enum NavigationTargetKind
+{
+    /// <summary>Could not resolve to anything usable.</summary>
+    Unresolved,
+
+    /// <summary>A mesh node path — renders in either pane (pane-aware navigation applies).</summary>
+    Node,
+
+    /// <summary>An app route (a Blazor <c>@page</c> such as <c>/search?…</c>, <c>/GlobalSettings</c>) —
+    /// a page, not a renderable node, so it always navigates the main view by URL.</summary>
+    Route,
+
+    /// <summary>A behaviour skill (e.g. <c>/model</c>) — the caller RUNS the skill rather than navigating,
+    /// because a skill "does more" than a route change.</summary>
+    Skill,
+}
+
+/// <summary>
+/// The outcome of resolving a navigation row: the concrete target, its kind, whether we had to correct /
+/// interpret the literal input (so the caller can say "opened the closest match …"), and any alternatives.
+/// </summary>
+public record NavigationResolution
+{
+    /// <summary>The resolved path / route / skill path; <c>null</c> when <see cref="Kind"/> is Unresolved.</summary>
+    public string? Target { get; init; }
+
+    /// <summary>What <see cref="Target"/> is, so the caller applies the correct action.</summary>
+    public NavigationTargetKind Kind { get; init; }
+
+    /// <summary>True when the result is not the literal input — a URL correction, a search fallback, or an
+    /// interpreted phrase. The caller surfaces this ("Couldn't find X — opened the closest match Y").</summary>
+    public bool WasCorrected { get; init; }
+
+    /// <summary>A short human-facing note about the resolution (shown under the chat input).</summary>
+    public string? Message { get; init; }
+
+    /// <summary>Other candidates worth offering, best-first.</summary>
+    public IReadOnlyList<string> Alternatives { get; init; } = [];
+
+    /// <summary>The canonical "nothing resolved" result.</summary>
+    public static NavigationResolution Unresolved(string? message = null) =>
+        new() { Kind = NavigationTargetKind.Unresolved, Target = null, Message = message };
+}
+
+/// <summary>
+/// The PURE, deterministic core of navigation resolution — no mesh access, no async, fully unit-testable.
+/// It classifies the row (<see cref="Classify"/>), corrects a path/URL into a clean mesh path or route
+/// (<see cref="NormalizePath"/>), tells a route from a node (<see cref="IsRouteLike"/>), and ranks search
+/// candidates for the resilient fallback (<see cref="Score"/> / <see cref="PickBest"/>). The reactive
+/// orchestration that does existence checks and search lives in <c>NavigationResolver</c> and composes
+/// these primitives.
+/// </summary>
+public static class NavigationTargetResolver
+{
+    private static readonly Regex MultiSlash = new("/{2,}", RegexOptions.Compiled);
+    private static readonly Regex NodeSegment = new("(?i)/node/", RegexOptions.Compiled);
+
+    // The real top-level Blazor @page routes (pages, not mesh nodes). A leading-slash token whose first
+    // segment is one of these is an app route, navigated by URL — never rendered in the side panel.
+    // A pattern switch, not a static collection (the no-static-state rule forbids even a constant set).
+    private static bool IsPageRoute(string segment) => segment.ToLowerInvariant() switch
+    {
+        "search" or "chat" or "create" or "welcome" or "login"
+            or "onboarding" or "privacy" or "dev" or "globalsettings" => true,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Classifies a raw navigation row. Empty → <see cref="NavigationInputKind.Empty"/>; a single
+    /// path-shaped token (no unquoted whitespace, or a fully-quoted spaced path) →
+    /// <see cref="NavigationInputKind.DirectPath"/>; free-text prose → <see cref="NavigationInputKind.Phrase"/>.
+    /// </summary>
+    public static NavigationInputKind Classify(string? row)
+    {
+        var s = row?.Trim();
+        if (string.IsNullOrEmpty(s))
+            return NavigationInputKind.Empty;
+
+        // A fully-quoted string is one argument even with interior spaces (a spaced file/node path).
+        if (s.Length >= 2 &&
+            ((s[0] == '"' && s[^1] == '"') || (s[0] == '\'' && s[^1] == '\'')))
+            return s.Length > 2 ? NavigationInputKind.DirectPath : NavigationInputKind.Empty;
+
+        // Ignore a single leading @ (unified-content-reference prefix) for the token test.
+        var core = s.StartsWith('@') ? s[1..] : s;
+        if (core.Length == 0)
+            return NavigationInputKind.Empty;
+
+        // One token (no whitespace) → a path; multiple words → free-text context.
+        return core.AsSpan().IndexOfAny(" \t\r\n") < 0
+            ? NavigationInputKind.DirectPath
+            : NavigationInputKind.Phrase;
+    }
+
+    /// <summary>
+    /// Corrects a path/URL token into a clean, navigable path. Strips a leading <c>@</c> and surrounding
+    /// quotes; strips a scheme+host (<c>https://host/…</c> → <c>/…</c>); percent-decodes the path part;
+    /// removes a stray <c>/node/</c> segment; collapses duplicate slashes; trims a trailing slash. A route
+    /// query string (after <c>?</c>) is preserved verbatim. Returns the cleaned token (a leading slash is
+    /// preserved — it distinguishes an app route from a mesh path; see <see cref="IsRouteLike"/>).
+    /// </summary>
+    public static string NormalizePath(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return string.Empty;
+
+        var s = token.Trim();
+
+        // Strip one layer of matching surrounding quotes.
+        if (s.Length >= 2 &&
+            ((s[0] == '"' && s[^1] == '"') || (s[0] == '\'' && s[^1] == '\'')))
+            s = s[1..^1].Trim();
+
+        // Any remaining quote characters are illegal in a path — drop them.
+        if (s.IndexOfAny(['"', '\'']) >= 0)
+            s = s.Replace("\"", string.Empty).Replace("'", string.Empty);
+
+        s = s.TrimStart('@');
+
+        // Strip scheme + host: keep everything from the first '/' after "://".
+        var schemeIdx = s.IndexOf("://", StringComparison.Ordinal);
+        if (schemeIdx >= 0)
+        {
+            var afterScheme = schemeIdx + 3;
+            var firstSlash = s.IndexOf('/', afterScheme);
+            s = firstSlash >= 0 ? s[firstSlash..] : "/";
+        }
+
+        // Split off a query string so decoding/slash-collapsing never touches it.
+        string query = string.Empty;
+        var q = s.IndexOf('?');
+        if (q >= 0)
+        {
+            query = s[q..];
+            s = s[..q];
+        }
+
+        // Percent-decode the path part only (mesh paths never url-encode separators; a pasted URL might).
+        if (s.IndexOf('%') >= 0)
+        {
+            try { s = Uri.UnescapeDataString(s); }
+            catch (UriFormatException) { /* leave as-is */ }
+        }
+
+        s = NodeSegment.Replace(s, "/");     // remove a mistaken /node/ segment
+        var hadLeadingSlash = s.StartsWith('/');
+        s = MultiSlash.Replace(s, "/");      // collapse // → /
+        if (s.Length > 1)
+            s = s.TrimEnd('/');
+        if (hadLeadingSlash && !s.StartsWith('/'))
+            s = "/" + s;
+
+        return s + query;
+    }
+
+    /// <summary>
+    /// True when a normalized token is an APP ROUTE (a Blazor page) rather than a mesh node: it carries a
+    /// query string, or it is a leading-slash path whose first segment is a known top-level page route.
+    /// A mesh node path (<c>Doc/AI/X</c>, or a pasted <c>/rbuergi/Foo</c>) is NOT route-like.
+    /// </summary>
+    public static bool IsRouteLike(string? normalizedPath)
+    {
+        if (string.IsNullOrEmpty(normalizedPath))
+            return false;
+        if (normalizedPath.Contains('?'))
+            return true;
+        if (!normalizedPath.StartsWith('/'))
+            return false;
+        var firstSegment = normalizedPath[1..].Split('/', 2)[0];
+        return IsPageRoute(firstSegment);
+    }
+
+    /// <summary>The last <c>/</c>-delimited segment of a path (used for name/last-segment matching).</summary>
+    public static string LastSegment(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return string.Empty;
+        var trimmed = path.TrimEnd('/');
+        var idx = trimmed.LastIndexOf('/');
+        return idx >= 0 ? trimmed[(idx + 1)..] : trimmed;
+    }
+
+    /// <summary>
+    /// A deterministic relevance score of a candidate node against a query token (path or phrase). Higher
+    /// is better; <c>0</c> means "no meaningful match" (the caller discards it). Favours exact path, then
+    /// exact last-segment/name, then containment, with a shorter-path (more specific) tie-breaker folded in.
+    /// Pure — the resilient search fallback re-ranks raw search hits through this.
+    /// </summary>
+    public static int Score(string? query, MeshNode candidate)
+    {
+        if (candidate is null || string.IsNullOrWhiteSpace(query))
+            return 0;
+
+        var qy = query.Trim().TrimStart('@').Trim('/').ToLowerInvariant();
+        if (qy.Length == 0)
+            return 0;
+        var qLast = LastSegment(qy);
+
+        var path = (candidate.Path ?? string.Empty).Trim('/').ToLowerInvariant();
+        var name = (candidate.Name ?? candidate.Id ?? string.Empty).ToLowerInvariant();
+        var pLast = LastSegment(path);
+
+        var score = 0;
+        if (path == qy) score += 1000;
+        else if (pLast == qLast && qLast.Length > 0) score += 500;
+        if (name == qy || name == qLast) score += 400;
+        if (score == 0)
+        {
+            // Substring / token overlap — the free-text phrase case.
+            if (name.Contains(qy)) score += 160;
+            if (path.Contains(qy)) score += 120;
+            var overlap = qy.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .Count(tok => tok.Length > 2 && (name.Contains(tok) || path.Contains(tok)));
+            score += overlap * 40;
+        }
+        if (score == 0)
+            return 0;
+
+        // Tie-breakers baked into the score: prefer shorter (more specific) paths, then explicit Order.
+        score += Math.Max(0, 40 - path.Length / 4);
+        score += Math.Max(0, 20 - (candidate.Order ?? 0));
+        return score;
+    }
+
+    /// <summary>
+    /// Picks the best candidate for a query from a raw search result set, or <c>null</c> when none scores
+    /// above zero. Deterministic: highest <see cref="Score"/>, ties broken by shorter path then ordinal
+    /// name — so the same inputs always yield the same target.
+    /// </summary>
+    public static MeshNode? PickBest(string? query, IEnumerable<MeshNode> candidates)
+    {
+        MeshNode? best = null;
+        var bestScore = 0;
+        foreach (var c in candidates ?? [])
+        {
+            var s = Score(query, c);
+            if (s <= 0)
+                continue;
+            if (s > bestScore ||
+                (s == bestScore && best is not null && ComparePreferred(c, best) < 0))
+            {
+                best = c;
+                bestScore = s;
+            }
+        }
+        return best;
+    }
+
+    /// <summary>
+    /// Scores a SKILL against a free-text phrase for the "navigate to a skill" intent. The strong signal is
+    /// the skill's name word appearing as a token in the phrase (<c>"change my model"</c> → <c>/model</c>);
+    /// description-token overlap is a weak reinforcement. Returns <c>0</c> when the phrase does not mention
+    /// the skill's name word at all — so a phrase only routes to a skill when it clearly asks for one, and
+    /// otherwise falls through to node search. Pure.
+    /// </summary>
+    public static int ScoreSkill(string? phrase, string? skillName, string? description)
+    {
+        if (string.IsNullOrWhiteSpace(phrase) || string.IsNullOrWhiteSpace(skillName))
+            return 0;
+
+        var nameWord = skillName.Trim().TrimStart('/').ToLowerInvariant();
+        if (nameWord.Length == 0)
+            return 0;
+
+        var tokens = phrase.ToLowerInvariant()
+            .Split([' ', '\t', '\r', '\n', ',', '.', '?', '!'], StringSplitOptions.RemoveEmptyEntries);
+
+        // The name word must appear in the phrase — the required strong signal.
+        if (!tokens.Contains(nameWord))
+            return 0;
+
+        var score = 200;
+        var desc = (description ?? string.Empty).ToLowerInvariant();
+        foreach (var tok in tokens)
+            if (tok.Length > 2 && tok != nameWord && desc.Contains(tok))
+                score += 15;
+        return score;
+    }
+
+    /// <summary>
+    /// Picks the best skill for a phrase (highest <see cref="ScoreSkill"/> over name + description), or
+    /// <c>null</c> when the phrase doesn't clearly name a skill. Deterministic ties: highest score, then
+    /// shorter path, then ordinal name.
+    /// </summary>
+    public static MeshNode? PickBestSkill(string? phrase, IEnumerable<MeshNode> skills)
+    {
+        MeshNode? best = null;
+        var bestScore = 0;
+        foreach (var s in skills ?? [])
+        {
+            var score = ScoreSkill(phrase, s.Name ?? s.Id, s.Description);
+            if (score <= 0)
+                continue;
+            if (score > bestScore ||
+                (score == bestScore && best is not null && ComparePreferred(s, best) < 0))
+            {
+                best = s;
+                bestScore = score;
+            }
+        }
+        return best;
+    }
+
+    // Prefer the shorter path, then ordinal-least name — a stable, total order for ties.
+    private static int ComparePreferred(MeshNode a, MeshNode b)
+    {
+        var la = (a.Path ?? string.Empty).Length;
+        var lb = (b.Path ?? string.Empty).Length;
+        if (la != lb)
+            return la - lb;
+        return string.CompareOrdinal(a.Name ?? a.Id, b.Name ?? b.Id);
+    }
+}

--- a/src/MeshWeaver.AI/SkillNodeType.cs
+++ b/src/MeshWeaver.AI/SkillNodeType.cs
@@ -208,6 +208,16 @@ public enum SkillActionKind
     /// <summary>Load a node/document into the content window.</summary>
     OpenContent,
 
+    /// <summary>
+    /// Navigate the UI to a target path — pane-aware and resilient. The target is the typed argument
+    /// (<c>/navigate Doc/AI/ModelProviderSettings</c>) or, when the row is empty, the skill's own
+    /// <see cref="SkillAction.ContentPath"/> / path. Resolution is resilient (single arg → direct path
+    /// first, else make sense of the free-text context, always falling back to the best search hit), and
+    /// application is pane-aware: a thread in the MAIN pane opens the target in the SIDE panel; a thread in
+    /// the SIDE panel changes the URL and navigates the MAIN pane.
+    /// </summary>
+    Navigate,
+
     /// <summary>Log in / connect this provider's CLI subscription.</summary>
     Connect,
 

--- a/src/MeshWeaver.AI/SkillView.cs
+++ b/src/MeshWeaver.AI/SkillView.cs
@@ -133,6 +133,9 @@ public static class SkillView
         SkillActionKind.OpenContent => string.IsNullOrWhiteSpace(action.ContentPath)
             ? "Opens content"
             : $"Opens `{action.ContentPath}`",
+        SkillActionKind.Navigate => string.IsNullOrWhiteSpace(action.ContentPath)
+            ? "Navigates the UI to a path (pane-aware, resilient)"
+            : $"Navigates to `{action.ContentPath}` (pane-aware, resilient)",
         SkillActionKind.Connect => string.IsNullOrWhiteSpace(action.Provider)
             ? "Connects a provider"
             : $"Connects {Escape(action.Provider!)}",

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1288,6 +1288,21 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 }
                 ShowSkillStatus(skill.Name ?? skill.Id, false);
                 break;
+            case MeshWeaver.AI.SkillActionKind.Navigate:
+                // "Take me there" — resolve the row resiliently, then navigate PANE-AWARE. Target is the
+                // typed argument (or, when empty, the skill's own ContentPath / path).
+                var navRow = string.IsNullOrWhiteSpace(parsed.RawArguments)
+                    ? (string.IsNullOrEmpty(action.ContentPath) ? skill.Path : action.ContentPath)
+                    : parsed.RawArguments.Trim();
+                if (string.IsNullOrWhiteSpace(navRow))
+                {
+                    ShowSkillStatus("Where to? Try `/navigate <path or what you're looking for>`.", true);
+                    break;
+                }
+                lastCommandStatus = null;
+                lastCommandStatusIsError = false;
+                RunNavigate(navRow!);
+                break;
             default:
                 // Instruction skill + typed task → re-enter the normal submission path with the
                 // composed message (it never starts with '/', so it cannot re-parse as a command).
@@ -1300,6 +1315,84 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 else
                     ShowSkillStatus(skill.Description ?? $"/{skill.Id}", false);
                 break;
+        }
+    }
+
+    /// <summary>
+    /// Resolves a navigation row (resilient: direct path first, else free-text context; always the best
+    /// available match) and applies the result PANE-AWARE. Reactive — resolve then Subscribe, never await.
+    /// </summary>
+    private void RunNavigate(string row)
+    {
+        var resolver = new MeshWeaver.AI.Navigation.NavigationResolver(Hub);
+        RunUnderCircuitUser(resolver.Resolve(row, initialContext))
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(8))
+            .Subscribe(
+                resolution => InvokeAsync(() =>
+                {
+                    if (_isDisposed) return;
+                    ApplyNavigation(resolution);
+                }),
+                ex => InvokeAsync(() =>
+                {
+                    if (_isDisposed) return;
+                    ShowSkillStatus($"Couldn't navigate to “{row}”: {ex.Message}", true);
+                }));
+    }
+
+    /// <summary>
+    /// Applies a resolved navigation. A matched SKILL is RUN (a skill does more than a route change); an app
+    /// ROUTE navigates the main view by URL; a NODE navigates pane-aware; Unresolved surfaces the message.
+    /// </summary>
+    private void ApplyNavigation(MeshWeaver.AI.Navigation.NavigationResolution resolution)
+    {
+        switch (resolution.Kind)
+        {
+            case MeshWeaver.AI.Navigation.NavigationTargetKind.Skill:
+                var skillId = LastSegment(resolution.Target);
+                // Guard against re-entering /navigate; in that degenerate case just open its page.
+                if (string.Equals(skillId, "navigate", StringComparison.OrdinalIgnoreCase))
+                {
+                    ApplyPaneAwareNavigation(resolution.Target!);
+                    break;
+                }
+                ResolveSkillNodeAndRun(new MeshWeaver.AI.Parsing.ParsedCommand
+                {
+                    Name = skillId ?? string.Empty,
+                    Arguments = [],
+                    RawArguments = string.Empty,
+                });
+                break;
+            case MeshWeaver.AI.Navigation.NavigationTargetKind.Route:
+                // A page route (e.g. /search?…) — a page, not a renderable node, so always the main view.
+                NavigationService.NavigateTo(resolution.Target!);
+                ShowSkillStatus(resolution.Message ?? $"Opened {resolution.Target}", false);
+                break;
+            case MeshWeaver.AI.Navigation.NavigationTargetKind.Node:
+                ApplyPaneAwareNavigation(resolution.Target!);
+                ShowSkillStatus(resolution.Message ?? $"Opened {LastSegment(resolution.Target)}", false);
+                break;
+            default:
+                ShowSkillStatus(resolution.Message ?? "Couldn't find anywhere to go.", true);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// The pane-aware rule (identical to <see cref="OnContextChipClicked"/>): a thread in the SIDE panel
+    /// changes the URL and navigates the MAIN pane; a thread in the MAIN pane opens the target in the SIDE
+    /// panel — so the conversation and the place it sent you sit side by side.
+    /// </summary>
+    private void ApplyPaneAwareNavigation(string path)
+    {
+        var clean = path.TrimStart('/');
+        if (IsInSidePanel)
+            NavigationService.NavigateTo($"/{clean}");
+        else
+        {
+            SidePanelState.SetTitle(LastSegment(clean));
+            SidePanelState.OpenWithContent(clean);
         }
     }
 

--- a/src/MeshWeaver.Documentation/Data/AI/ChatCommands.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ChatCommands.md
@@ -6,6 +6,7 @@ slash-*commands* are skills. A skill's "doing" can be:
 
 - **open a combobox and select** a node (an agent / model / harness) → write the pick to the composer;
 - **load a document/manual into the content window**;
+- **navigate the UI to a node/doc/page** — pane-aware and resilient (`/navigate`, see below);
 - **connect / log in** a CLI harness;
 - **inject instructions** — a `SKILL.md` body mounted to the Claude Code / Copilot CLIs and advertised to
   the MeshWeaver agent to load on demand.
@@ -36,11 +37,11 @@ public record SkillDefinition
 
 public record SkillAction
 {
-    public required SkillActionKind Kind { get; init; }   // Pick | OpenContent | Connect | Disconnect
+    public required SkillActionKind Kind { get; init; }   // Pick | OpenContent | Navigate | Connect | Disconnect
     public string? Query { get; init; }        // Pick: the combobox query (+ `sort:order`)
     public string? Field { get; init; }        // Pick: camelCase ThreadComposer field (harness|agentName|modelName)
     public string? Title { get; init; }        // Pick: combobox title
-    public string? ContentPath { get; init; }  // OpenContent: node/path to load into the content window
+    public string? ContentPath { get; init; }  // OpenContent / Navigate: node/path (Navigate: optional fixed target)
     public string? Provider { get; init; }     // Connect/Disconnect: ClaudeCode | Copilot
 }
 ```
@@ -126,6 +127,23 @@ This guidance lives in the shared agent base prompt (`AgentChatClient`); the age
 
 - **`OpenContent`** — load a node/manual into the content window (side panel) via the navigation bridge
   (`SidePanelState.SetContentPath`). Set `action.contentPath`, or pair a `Pick` with the content window.
+- **`Navigate`** — **take me there.** Navigate the UI to a node, doc, or page. Ships as the built-in
+  **`/navigate`** skill (`src/MeshWeaver.AI/Data/Skill/navigate.md`). Two properties make it robust:
+  - **Pane-aware** — the target opens in the pane *opposite* the thread, so the conversation and where it
+    sent you sit side by side (the same rule as the context chip, `OnContextChipClicked`):
+    a thread in the **main pane** opens the target in the **side panel**; a thread in the **side panel**
+    **changes the URL and navigates the main pane**.
+  - **Resilient** (`NavigationResolver` + the pure, unit-tested `NavigationTargetResolver`) — a **single
+    path-shaped argument** is resolved as a **direct path first** (with URL correction: a leading `@`, a
+    stray `/node/` segment, a pasted `https://host/…` prefix, doubled slashes and percent-encoding are all
+    cleaned up), and if the exact node isn't there it **falls back to the best search match** rather than
+    dead-ending; **free text** (`/navigate model settings`) is made sense of by matching an
+    **intent → skill** first (so "change my model" runs **`/model`** — a skill *does* more than a route
+    change), otherwise the best-matching node. It **never claims to open a place that doesn't exist**.
+
+  The agent's server-side `NavigateTo` tool routes through the same resolver, so "take me there" resolves
+  honestly no matter who asks. Tested by `NavigationTargetResolverTest` (the pure algorithm) and
+  `MeshPluginTest` (resilient + honest resolution against the live mesh).
 - **`Connect` / `Disconnect`** — harness auth. Under a non-MeshWeaver harness, `/login` and `/logout` are
   owned by the harness (`IHarness.Commands`) and route to its connect flow; they take priority in dispatch.
 - **`Instructions`** (no `Action`) — a pure-instruction skill (its how-to is the markdown body). Skills are
@@ -159,8 +177,9 @@ When the user runs `/name`, the chat view (`ThreadChatView.HandleSlashCommandAsy
 1. **harness-owned command?** (`/login`, `/logout` under a non-MeshWeaver harness) → route to the harness.
 2. **otherwise** → resolve a `nodeType:Skill` **mesh node** by slash word (with namespace inheritance,
    `ResolveSkillNodeAndRun`) and run its `Action` — `Pick` pops the combobox, `OpenContent` loads the
-   content window. A pure-instruction skill with trailing text submits the task as a round with a
-   `load_skill` directive (see above); without trailing text it shows the skill's help.
+   content window, `Navigate` resolves the target and opens it pane-aware. A pure-instruction skill with
+   trailing text submits the task as a round with a `load_skill` directive (see above); without trailing
+   text it shows the skill's help.
 
 The view contains **no per-skill code** — only the generic picker + content-window callbacks. All pick
 skills write to the same `ThreadComposer`.

--- a/test/MeshWeaver.AI.Test/MeshPluginTest.cs
+++ b/test/MeshWeaver.AI.Test/MeshPluginTest.cs
@@ -478,7 +478,7 @@ public class MeshPluginTest : MonolithMeshTestBase
     #region NavigateTo
 
     [Fact]
-    public void NavigateTo_ValidPath_ReturnsNavigatingMessage()
+    public async Task NavigateTo_ValidPath_ResolvesAndReturnsNavigatingMessage()
     {
         var displayedControls = new List<LayoutAreaControl>();
         var mockChat = new MockAgentChat
@@ -487,23 +487,51 @@ public class MeshPluginTest : MonolithMeshTestBase
         };
         var plugin = new MeshPlugin(Mesh, mockChat);
 
-        var result = plugin.NavigateTo("@Agent/Orchestrator");
+        // NavigateTo now RESOLVES against the live mesh (honest — no false success), so target must exist.
+        var uniqueId = $"NavTarget_{Guid.NewGuid():N}";
+        var path = $"ACME/{uniqueId}";
+        await plugin.Create(JsonSerializer.Serialize(new
+        {
+            id = uniqueId, @namespace = "ACME", name = "Nav Target", nodeType = "Markdown"
+        }));
+
+        var result = await plugin.NavigateTo($"@{path}");
 
         result.Should().Contain("Navigating to:");
-        result.Should().Contain("Agent/Orchestrator");
+        result.Should().Contain(path);
         displayedControls.Should().HaveCount(1, "DisplayLayoutArea should have been called once");
     }
 
     [Fact]
-    public void NavigateTo_StripsAtPrefix()
+    public async Task NavigateTo_StripsAtPrefix()
     {
         var mockChat = new MockAgentChat();
         var plugin = new MeshPlugin(Mesh, mockChat);
 
-        var result = plugin.NavigateTo("@ACME/ProductLaunch");
+        var uniqueId = $"NavAt_{Guid.NewGuid():N}";
+        var path = $"ACME/{uniqueId}";
+        await plugin.Create(JsonSerializer.Serialize(new
+        {
+            id = uniqueId, @namespace = "ACME", name = "Nav At", nodeType = "Markdown"
+        }));
 
-        result.Should().Contain("ACME/ProductLaunch");
+        var result = await plugin.NavigateTo($"@{path}");
+
+        result.Should().Contain(path);
         result.Should().NotContain("@ACME");
+    }
+
+    [Fact]
+    public async Task NavigateTo_NonExistentPath_IsHonest_DoesNotClaimSuccess()
+    {
+        var mockChat = new MockAgentChat();
+        var plugin = new MeshPlugin(Mesh, mockChat);
+
+        // A path that cannot resolve to anything — the old tool falsely said "Navigating to: …".
+        var result = await plugin.NavigateTo("@ACME/there-is-no-such-node-xyz-9999");
+
+        result.Should().NotContain("Navigating to: ACME/there-is-no-such-node-xyz-9999",
+            "the tool must never claim to open a node that doesn't exist");
     }
 
     #endregion

--- a/test/MeshWeaver.AI.Test/NavigationTargetResolverTest.cs
+++ b/test/MeshWeaver.AI.Test/NavigationTargetResolverTest.cs
@@ -1,0 +1,221 @@
+#pragma warning disable CS1591
+
+using MeshWeaver.AI.Navigation;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// The PURE navigation-resolution algorithm (<see cref="NavigationTargetResolver"/>): the classifier that
+/// decides "single path argument" vs "free-text context", the URL/path corrector, route-vs-node detection,
+/// and the deterministic candidate ranking that backs the resilient search fallback. No mesh, no async —
+/// exactly the algorithm the user asked to have pinned by unit tests.
+/// </summary>
+public class NavigationTargetResolverTest
+{
+    // ─────────────────────────── Classify: one argument → DirectPath, prose → Phrase ───────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\"\"")]
+    public void Classify_Empty(string? row) =>
+        NavigationTargetResolver.Classify(row).Should().Be(NavigationInputKind.Empty);
+
+    [Theory]
+    [InlineData("Doc/AI/ModelProviderSettings")]              // a single node path
+    [InlineData("@/rbuergi")]                                  // @-absolute
+    [InlineData("@Doc/AI/ModelProviderSettings")]              // @-relative
+    [InlineData("/GlobalSettings")]                            // an app route
+    [InlineData("/search?q=nodeType:LanguageModel&groupBy=Namespace")] // a query route (no spaces)
+    [InlineData("https://memex.meshweaver.cloud/rbuergi/_Thread/x")]   // a pasted URL
+    [InlineData("\"My Report.md\"")]                           // a quoted spaced path = ONE argument
+    [InlineData("'Doc/My Notes'")]
+    public void Classify_SingleArgument_IsDirectPath(string row) =>
+        NavigationTargetResolver.Classify(row).Should().Be(NavigationInputKind.DirectPath);
+
+    [Theory]
+    [InlineData("change my model")]
+    [InlineData("take me to my notifications")]
+    [InlineData("where do I set up a provider")]
+    [InlineData("model settings")]
+    public void Classify_FreeText_IsPhrase(string row) =>
+        NavigationTargetResolver.Classify(row).Should().Be(NavigationInputKind.Phrase);
+
+    // ─────────────────────────── NormalizePath: correct the URL ───────────────────────────
+
+    [Theory]
+    [InlineData("Doc/AI/ModelProviderSettings", "Doc/AI/ModelProviderSettings")] // already clean
+    [InlineData("@Doc/AI/ModelProviderSettings", "Doc/AI/ModelProviderSettings")] // strip @
+    [InlineData("  @/rbuergi/Foo  ", "/rbuergi/Foo")]                             // trim + keep leading /
+    [InlineData("\"My Report.md\"", "My Report.md")]                              // strip quotes
+    [InlineData("Doc//AI///X", "Doc/AI/X")]                                       // collapse //
+    [InlineData("Doc/AI/X/", "Doc/AI/X")]                                         // trim trailing /
+    [InlineData("Doc/node/AI/X", "Doc/AI/X")]                                     // drop stray /node/
+    [InlineData("/node/Foo", "/Foo")]
+    public void NormalizePath_CleansPaths(string input, string expected) =>
+        NavigationTargetResolver.NormalizePath(input).Should().Be(expected);
+
+    [Theory]
+    // scheme + host stripped, path kept
+    [InlineData("https://memex.meshweaver.cloud/Doc/AI/X", "/Doc/AI/X")]
+    [InlineData("http://memex-portal-service:8080/Doc/AI/ModelProviderSettings", "/Doc/AI/ModelProviderSettings")]
+    public void NormalizePath_StripsSchemeAndHost(string input, string expected) =>
+        NavigationTargetResolver.NormalizePath(input).Should().Be(expected);
+
+    [Fact]
+    public void NormalizePath_PercentDecodesPath_ButPreservesQueryStringVerbatim()
+    {
+        // The path part is decoded; the query string after '?' is kept exactly (its ':' / '&' matter).
+        NavigationTargetResolver.NormalizePath("/My%20Space/Report")
+            .Should().Be("/My Space/Report");
+        NavigationTargetResolver.NormalizePath("/search?q=nodeType%3AThread&groupBy=Namespace")
+            .Should().Be("/search?q=nodeType%3AThread&groupBy=Namespace");
+    }
+
+    // ─────────────────────────── IsRouteLike: page routes vs mesh nodes ───────────────────────────
+
+    [Theory]
+    [InlineData("/search?q=nodeType:LanguageModel", true)]   // query string ⇒ page
+    [InlineData("/GlobalSettings", true)]                    // known page route
+    [InlineData("/search", true)]
+    [InlineData("/Doc/AI/X", false)]                         // leading slash but a mesh node
+    [InlineData("Doc/AI/ModelProviderSettings", false)]      // plain node path
+    [InlineData("/rbuergi/_Thread/x", false)]                // pasted-URL node path
+    public void IsRouteLike_DistinguishesPagesFromNodes(string path, bool expected) =>
+        NavigationTargetResolver.IsRouteLike(path).Should().Be(expected);
+
+    // ─────────────────────────── LastSegment ───────────────────────────
+
+    [Theory]
+    [InlineData("Doc/AI/ModelProviderSettings", "ModelProviderSettings")]
+    [InlineData("rbuergi", "rbuergi")]
+    [InlineData("Doc/AI/X/", "X")]
+    [InlineData("", "")]
+    public void LastSegment_TakesTrailingToken(string path, string expected) =>
+        NavigationTargetResolver.LastSegment(path).Should().Be(expected);
+
+    // ─────────────────────────── Score / PickBest: the resilient fallback ranking ───────────────────────────
+
+    private static MeshNode Node(string path, string? name = null, int? order = null)
+    {
+        var node = MeshNode.FromPath(path);
+        return node with { Name = name, Order = order, NodeType = "Markdown" };
+    }
+
+    [Fact]
+    public void Score_ExactPath_BeatsLastSegment_BeatsContains()
+    {
+        var exact = Node("Doc/AI/ModelProviderSettings");
+        var lastSeg = Node("Doc/Other/ModelProviderSettings");
+        var contains = Node("Doc/AI/ModelProviderSettingsLegacyExtra");
+
+        var q = "Doc/AI/ModelProviderSettings";
+        NavigationTargetResolver.Score(q, exact)
+            .Should().BeGreaterThan(NavigationTargetResolver.Score(q, lastSeg));
+        NavigationTargetResolver.Score(q, lastSeg)
+            .Should().BeGreaterThan(NavigationTargetResolver.Score(q, contains));
+    }
+
+    [Fact]
+    public void Score_ZeroWhenNoMeaningfulMatch()
+    {
+        NavigationTargetResolver.Score("totally-unrelated-xyz", Node("Doc/AI/ModelProviderSettings"))
+            .Should().Be(0);
+        NavigationTargetResolver.Score("", Node("Doc/AI/X")).Should().Be(0);
+    }
+
+    [Fact]
+    public void PickBest_ChoosesExactPath_OverPartialHits()
+    {
+        var candidates = new[]
+        {
+            Node("Doc/AI/ModelProviderSetup", "Setting Up Model Providers"),
+            Node("Doc/AI/ModelProviderSettings", "AI Model Provider Settings"),
+            Node("Doc/AI/ProviderConfiguration", "AI Provider Configuration"),
+        };
+
+        NavigationTargetResolver.PickBest("Doc/AI/ModelProviderSettings", candidates)!
+            .Path.Should().Be("Doc/AI/ModelProviderSettings");
+    }
+
+    [Fact]
+    public void PickBest_PhraseMatchesByNameTokens()
+    {
+        var candidates = new[]
+        {
+            Node("Doc/AI/ExecutiveAssistant", "The Executive Assistant Agent"),
+            Node("Doc/AI/ModelProviderSettings", "AI Model Provider Settings"),
+            Node("Doc/Architecture/NoStaticState", "No Static State"),
+        };
+
+        // "model provider settings" free text → the model-provider-settings page.
+        NavigationTargetResolver.PickBest("model provider settings", candidates)!
+            .Path.Should().Be("Doc/AI/ModelProviderSettings");
+    }
+
+    [Fact]
+    public void PickBest_ReturnsNull_WhenNothingScores()
+    {
+        var candidates = new[] { Node("Doc/AI/X", "X"), Node("Doc/AI/Y", "Y") };
+        NavigationTargetResolver.PickBest("zzz-nonexistent-topic", candidates).Should().BeNull();
+    }
+
+    // ─────────────────────────── ScoreSkill / PickBestSkill: "navigate to a skill" ───────────────────────────
+
+    [Fact]
+    public void ScoreSkill_RequiresTheSkillNameWord_InThePhrase()
+    {
+        // "change my model" names /model → scores; description overlap ("model") reinforces.
+        NavigationTargetResolver.ScoreSkill("change my model", "/model", "Switch the AI model")
+            .Should().BeGreaterThan(0);
+        // A phrase that never says "model" does not route to /model.
+        NavigationTargetResolver.ScoreSkill("open my notifications", "/model", "Switch the AI model")
+            .Should().Be(0);
+    }
+
+    [Fact]
+    public void PickBestSkill_ChangeMyModel_PicksModelSkill()
+    {
+        var skills = new[]
+        {
+            SkillNode("model", "/model", "Switch the AI model for subsequent messages"),
+            SkillNode("access", "/access", "Hand out access rights to mesh nodes"),
+            SkillNode("navigate", "/navigate", "Take me there — open a node or page in the UI"),
+        };
+
+        NavigationTargetResolver.PickBestSkill("change my model", skills)!
+            .Id.Should().Be("model");
+    }
+
+    [Fact]
+    public void PickBestSkill_UnrelatedPhrase_ReturnsNull_SoItFallsThroughToNodeSearch()
+    {
+        var skills = new[]
+        {
+            SkillNode("model", "/model", "Switch the AI model"),
+            SkillNode("access", "/access", "Hand out access rights"),
+        };
+        NavigationTargetResolver.PickBestSkill("take me to the quarterly report", skills)
+            .Should().BeNull();
+    }
+
+    private static MeshNode SkillNode(string id, string name, string description) =>
+        new(id, "Skill") { Name = name, Description = description, NodeType = "Skill" };
+
+    [Fact]
+    public void PickBest_IsDeterministic_ShorterPathWinsTies()
+    {
+        // Two equal last-segment matches; the shorter (more specific) path is the stable winner.
+        var shorter = Node("ACME/Report");
+        var longer = Node("ACME/Deeply/Nested/Report");
+        var candidates = new[] { longer, shorter };
+
+        NavigationTargetResolver.PickBest("Report", candidates)!.Path.Should().Be("ACME/Report");
+        // Same set, reversed input order → same winner (determinism).
+        NavigationTargetResolver.PickBest("Report", new[] { shorter, longer })!
+            .Path.Should().Be("ACME/Report");
+    }
+}

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -29,13 +29,17 @@ public class SkillNodeTypeTest
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
         skills.Should().OnlyContain(n => n.Namespace == SkillNodeType.RootNamespace);
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-space", "harness", "layout-area", "maui", "model", "provider-keys");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys");
 
         var def = (SkillDefinition)skills.Single(n => n.Id == "model").Content!;
         def.Action!.Kind.Should().Be(SkillActionKind.Pick);
         def.Action.Query.Should().Be("namespace:Provider nodeType:LanguageModel scope:descendants sort:order");
         def.Action.Field.Should().Be("modelName");
         def.Action.Title.Should().Be("Choose a model");
+
+        // /navigate is a Navigate-action skill — the pane-aware, resilient "take me there".
+        var nav = (SkillDefinition)skills.Single(n => n.Id == "navigate").Content!;
+        nav.Action!.Kind.Should().Be(SkillActionKind.Navigate);
     }
 
     [Fact]


### PR DESCRIPTION
## What & why

"Take me there" now works. When the assistant points you at a place, you can navigate there — and the resolution is **honest** (never claims to open a node that doesn't exist — the exact `@AiSettings` false-success bug from the reported thread) and **resilient** (finds the best match even when the path is imperfect).

### The `/navigate` skill (pane-aware)
A new `Navigate` skill-action kind + built-in **`/navigate`** skill. Pane-aware exactly like the context chip (`OnContextChipClicked`):
- thread in the **main pane** → target opens in the **side panel**;
- thread in the **side panel** → **changes the URL and navigates the main pane**.

So the conversation and where it sent you sit side by side.

### Resilient resolution (shared by the skill and the agent tool)
- **`NavigationTargetResolver`** — a pure, fully unit-tested algorithm:
  - `Classify`: a single path-shaped argument → **direct path first**; free text → **make sense of the context**.
  - `NormalizePath`: URL correction — strips a leading `@`, quotes, a pasted `https://host/…` prefix, a stray `/node/` segment, doubled slashes, and percent-encoding; preserves query strings.
  - `Score`/`PickBest` (search-fallback ranking) and `ScoreSkill`/`PickBestSkill` (intent→skill).
- **`NavigationResolver`** — reactive orchestration: authoritative `GetMeshNodeStream` existence check (no index lag) → search fallback when a path is off; free text → an **intent→skill** match first (so "change my model" runs **`/model`** — a skill *does* more than a route change), else the best node. Never dead-ends.
- **`MeshPlugin.NavigateTo`** (the agent's server-side tool) now routes through the resolver and **never reports success for a place that doesn't exist** — it returns the closest matches instead.

## Tests
- `NavigationTargetResolverTest` — 55 pure-algorithm cases (classify / normalize / route-vs-node / ranking / skill-intent).
- `MeshPluginTest` — resilient + honest resolution against the live mesh, incl. a non-existent-path honesty test.
- `SkillNodeTypeTest` — catalog + the `/navigate` Navigate action.
- Docs: `ChatCommands.md` documents `/navigate`; `DocumentationLinkIntegrityTest` green.

Built clean under `-warnaserror` (Release) for `MeshWeaver.AI` and `MeshWeaver.Blazor.Portal`, verified in a worktree merged with current `main`.

## Scoped follow-up (not in this PR)
Make the **agent's** tool drive a true opposite-pane open via a server→client navigation directive. Today the agent path resolves honestly and renders the resolved target inline (the existing live-only `DisplayLayoutArea` channel); full agent-initiated pane-aware navigation needs new plumbing through the chat streaming/rendering path and is intentionally deferred to keep this PR's CI green and low-risk. The `/navigate` skill already delivers pane-aware navigation when invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
