### PR TITLE
feat(gitsync): Octokit.Reactive via IoPool + full issues/PRs/webhooks integration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -212,6 +212,7 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.0-beta.3" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
+    <PackageVersion Include="Octokit.Reactive" Version="14.0.0" />
   </ItemGroup>
 
 </Project>

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -701,6 +701,8 @@ public static class MemexConfiguration
                         .AddTokenUsageSettingsTab()
                         // GitHub Sync tab — shows only on Space nodes (self-filtered).
                         .AddGitHubSyncSettingsTab()
+                        // GitHub Issues & PRs tab — browse/act on the repo's issues + pull requests.
+                        .AddGitHubIssuesTab()
                         // Instance Sync tab — replicate the Space to another MeshWeaver
                         // instance (self-filtered to Spaces, like the GitHub Sync tab).
                         .AddInstanceSyncSettingsTab()
@@ -932,6 +934,11 @@ public static class MemexConfiguration
         // requirement: needs HttpContext.User). Stores the per-user token at
         // {userId}/_Provider/GitHub. See Doc/Architecture/GitHubSync.
         app.MapGitHubConnect();
+
+        // GitHub webhooks — POST /webhooks/github. HMAC-verified (GitHub:Webhook:Secret), no
+        // browser session, so it does NOT need HttpContext.User. Refreshes synced issue nodes
+        // live. Register one webhook per repo (Issues + Issue comments) with the shared secret.
+        app.MapGitHubWebhook();
 
         // Use HTTPS redirection only for non-MCP paths (MCP needs HTTP for Claude Code)
         app.UseWhen(

--- a/memex/Memex.Portal.Shared/Social/GitHubWebhookEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/GitHubWebhookEndpoints.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.GitSync;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Social;
+
+/// <summary>
+/// The GitHub webhook receiver: <c>POST /webhooks/github</c>. GitHub calls this (unauthenticated
+/// by browser session — it is authenticated by the HMAC signature), so it verifies
+/// <c>X-Hub-Signature-256</c> against the shared secret <c>GitHub:Webhook:Secret</c> before doing
+/// any work, then hands the event to <see cref="GitHubWebhookProcessor"/> which refreshes the
+/// synced <c>{space}/_Issue/{number}</c> nodes of every Space that syncs the event's repository.
+///
+/// <para>Register ONE webhook per repo in GitHub → Settings → Webhooks, pointing at
+/// <c>https://{host}/webhooks/github</c>, content-type <c>application/json</c>, with the same
+/// secret, subscribed to the <c>Issues</c> + <c>Issue comments</c> events. The <c>async</c> here
+/// is the sanctioned HTTP-boundary bridge (mirrors <see cref="GitHubConnectEndpoints"/>); the
+/// processing itself is reactive.</para>
+/// </summary>
+public static class GitHubWebhookEndpoints
+{
+    private const string WebhookPath = "/webhooks/github";
+
+    public static IEndpointRouteBuilder MapGitHubWebhook(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost(WebhookPath, async (
+            HttpContext http,
+            GitHubWebhookProcessor processor,
+            IConfiguration config,
+            ILoggerFactory loggers) =>
+        {
+            var logger = loggers.CreateLogger("GitHubWebhook");
+
+            var secret = config["GitHub:Webhook:Secret"];
+            if (string.IsNullOrEmpty(secret))
+            {
+                logger.LogWarning("GitHub webhook received but no secret is configured (GitHub:Webhook:Secret).");
+                return Results.StatusCode(503);
+            }
+
+            // Read the raw body (needed byte-exact for the HMAC).
+            byte[] body;
+            using (var ms = new MemoryStream())
+            {
+                await http.Request.Body.CopyToAsync(ms, http.RequestAborted);
+                body = ms.ToArray();
+            }
+
+            var signature = http.Request.Headers["X-Hub-Signature-256"].ToString();
+            if (!GitHubWebhookProcessor.VerifySignature(secret, body, signature))
+            {
+                logger.LogWarning("GitHub webhook signature verification failed ({Bytes} bytes).", body.Length);
+                return Results.Unauthorized();
+            }
+
+            var eventType = http.Request.Headers["X-GitHub-Event"].ToString();
+            if (string.Equals(eventType, "ping", StringComparison.OrdinalIgnoreCase))
+                return Results.Ok(new { ok = true, pong = true });
+
+            using var doc = ParseOrNull(body);
+            if (doc is null)
+            {
+                logger.LogWarning("GitHub webhook body was not valid JSON.");
+                return Results.BadRequest();
+            }
+
+            // Process() reads the payload synchronously into materialized records before returning
+            // its observable, so the JsonDocument may be disposed once this handler returns. Bridge
+            // to Task ONCE here at the HTTP boundary; a processing failure is logged, never 500-thrown.
+            var updated = await processor.Process(eventType, doc.RootElement)
+                .Catch((Exception ex) =>
+                {
+                    logger.LogWarning(ex, "GitHub webhook processing failed for event {Event}.", eventType);
+                    return Observable.Return(0);
+                })
+                .FirstAsync()
+                .ToTask(http.RequestAborted);
+
+            return Results.Ok(new { ok = true, updated });
+        });
+
+        return endpoints;
+    }
+
+    private static JsonDocument? ParseOrNull(byte[] body)
+    {
+        try { return JsonDocument.Parse(body); }
+        catch (JsonException) { return null; }
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
@@ -1,7 +1,7 @@
 ---
 NodeType: Markdown
 Name: "Syncing a Space with GitHub"
-Abstract: "How to connect a Space to a GitHub repository and move content both ways: sync FROM GitHub (import a repo to create a Space, update to latest, re-import at a commit) and sync TO GitHub (commit/export the Space's nodes as a single commit). Plus the repo operations: create a branch, commit, checkout / update to latest, and open a pull request (AI-drafted, you edit, then submit) with live PR status sync and a link. Covers the per-user OAuth connection, the Space settings, and how operators enable it."
+Abstract: "How to connect a Space to a GitHub repository and move content both ways: sync FROM GitHub (import a repo to create a Space, update to latest, re-import at a commit) and sync TO GitHub (commit/export the Space's nodes as a single commit). Plus the repo operations: create a branch, commit, checkout / update to latest, and open a pull request (AI-drafted, you edit, then submit) with live PR status sync and a link. Plus browsing and acting on the repo's issues and pull requests: sync issues into the Space as nodes, create + comment on issues, list PRs live and merge them, and keep issues fresh via HMAC-verified GitHub webhooks. Covers the per-user OAuth connection, the Space settings, and how operators enable it."
 Icon: "<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><rect width='24' height='24' rx='4' fill='#24292f'/><path d='M12 4a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38l-.01-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.92-.89-1.17-.89-1.17-.73-.5.06-.49.06-.49.8.06 1.23.83 1.23.83.71 1.22 1.87.87 2.33.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.22 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.52.56.83 1.28.83 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48l-.01 2.2c0 .21.15.46.55.38A8 8 0 0 0 12 4Z' fill='white'/></svg>"
 Authors:
   - "Roland Buergi"
@@ -224,7 +224,54 @@ GitHub. Before a PR is opened it is simply a local **Draft**.
 
 ---
 
-## 6. Operator setup (enabling the feature)
+## 6. Issues & pull requests (browse and act)
+
+Beyond moving content, a Space can **track and act on the repository's issues and pull
+requests** — in the **Settings → GitHub Issues & PRs** tab. Structured lists are rendered
+with the framework's data grid (never hand-built HTML).
+
+### Issues — synced into the Space
+
+Issues are the one GitHub object that is **materialized** into the mesh. Click **Sync
+issues from GitHub** and every issue is mirrored to a node at `{space}/_Issue/{number}`
+(NodeType `GitHubIssue`) and listed in a **live** table (number, title, state, author,
+labels, comments, updated). The table binds to a synced query, so it refreshes itself as
+issues land — from a sync, from **Create issue** (opens a new issue on GitHub and
+materializes its node), or from a **webhook** (below). You can **create an issue** and
+**comment** on one straight from the mesh — both act on GitHub, then refresh the affected
+node. Programmatic: `IssueService.SyncIssues / SyncIssue / CreateIssue / CommentIssue /
+WatchIssueNodes`, and the activity `hub.SyncIssuesFromGitHub(...)`.
+
+### Pull requests — listed live, merge from the tab
+
+The tab lists **every** pull request in the repo (number, title, author, status, draft,
+head → base, updated), read **live** from GitHub (never persisted — a stored copy would
+drift). **Refresh pull requests** re-reads them. You can **merge** an open PR — enter its
+number and pick **Merge commit** or **Squash & merge** — which runs as a tracked activity.
+Programmatic: `PullRequestService.ListAll / GetDetail / Comment / Merge`, and the activity
+`hub.MergePullRequestOnGitHub(...)`. `GetDetail` additionally returns a **checks roll-up**
+(CI pass/fail/pending over the head commit) and a **reviews roll-up** (latest decision per
+reviewer).
+
+> The AI-drafted **open a pull request** flow (draft → edit → submit) lives in the
+> **GitHub Sync** tab (§5). This tab is for browsing and acting on issues + PRs that
+> already exist on GitHub.
+
+### Live updates via webhooks
+
+So the synced issue nodes stay fresh without polling, register a **GitHub webhook** per
+repo pointing at `https://{host}/webhooks/github` (content-type `application/json`),
+subscribed to the **Issues** and **Issue comments** events, with the shared secret from
+`GitHub:Webhook:Secret`. Each delivery is **HMAC-verified** (`X-Hub-Signature-256`) and
+then applied: the event payload carries the full issue, so the receiver updates the
+`{space}/_Issue/{number}` node of every Space that syncs that repo **without needing a
+token** — the update runs under the system identity, merging in the new comment on a
+comment event. Pull-request events are ignored (PR state is read live, so there is no node
+to refresh). See `GitHubWebhookProcessor`.
+
+---
+
+## 7. Operator setup (enabling the feature)
 
 Two pieces of server configuration enable GitHub Sync:
 
@@ -253,16 +300,28 @@ Two pieces of server configuration enable GitHub Sync:
    [AccessControl.md](/Doc/Architecture/AccessControl)). Without it, tokens are stored
    as plaintext (development only).
 
+3. **A webhook secret (optional — for live issue updates).** To keep synced issue nodes
+   fresh without polling, set a shared secret and register a webhook per repo (Issues +
+   Issue comments events) at `https://{host}/webhooks/github`:
+
+   ```jsonc
+   "GitHub": { "Webhook": { "Secret": "<random shared secret>" } }
+   ```
+
+   Keep it in the Key Vault and surface it as `GitHub__Webhook__Secret`. Deliveries are
+   HMAC-verified against it; absent the secret the endpoint returns 503 and issue nodes
+   refresh only on an explicit sync.
+
 All GitHub HTTP and serialization run through the controlled I/O pool — see
 [ControlledIoPooling.md](/Doc/Architecture/ControlledIoPooling).
 
 ---
 
-## 7. What is and isn't synced
+## 8. What is and isn't synced
 
 | Synced (export) | Not synced |
 |---|---|
-| Content nodes under the Space (markdown, typed, code), including nested folders | Satellites: `_Access`, `_Activity`, `_Thread`, `_Comment`, `_Notification`, `_PullRequest` |
+| Content nodes under the Space (markdown, typed, code), including nested folders | Satellites: `_Access`, `_Activity`, `_Thread`, `_Comment`, `_Notification`, `_PullRequest`, `_Issue` |
 | The Space root (as `index.json`) | The GitHub credential (`{you}/_Provider/GitHub`) and the sync config (`{space}/_GitSync`) |
 | | Nodes you marked to exclude from sync |
 

--- a/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
+++ b/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
@@ -141,4 +141,43 @@ public static class GitHubActivityExtensions
                 });
             }, onActivityCreated);
     }
+
+    /// <summary>Sync the configured repo's issues into <c>{space}/_Issue/{number}</c> nodes.
+    /// <paramref name="state"/> optionally filters to open/closed (null = all).</summary>
+    public static IObservable<string> SyncIssuesFromGitHub(
+        this IMessageHub hub, string spacePath, string userId, GitHubIssueState? state = null,
+        Action<string>? onActivityCreated = null)
+    {
+        var issues = hub.ServiceProvider.GetRequiredService<IssueService>();
+        return hub.RunActivity(spacePath, ActivityCategory.Import, $"Sync issues of {spacePath}",
+            ctx =>
+            {
+                ctx.Log("Listing issues on GitHub and mirroring them into the Space…");
+                return issues.SyncIssues(spacePath, userId, state).Select(count =>
+                {
+                    ctx.Log($"Synced {count} issue(s).");
+                    return Unit.Default;
+                });
+            }, onActivityCreated);
+    }
+
+    /// <summary>Merge an open pull request on the configured repo with the given strategy.</summary>
+    public static IObservable<string> MergePullRequestOnGitHub(
+        this IMessageHub hub, string spacePath, int number, GitHubMergeMethod method, string userId,
+        Action<string>? onActivityCreated = null)
+    {
+        var pr = hub.ServiceProvider.GetRequiredService<PullRequestService>();
+        return hub.RunActivity(spacePath, ActivityCategory.DataUpdate, $"Merge pull request #{number}",
+            ctx =>
+            {
+                ctx.Log($"Merging pull request #{number} ({method}) on GitHub…");
+                return pr.Merge(spacePath, number, method, null, null, userId).Select(r =>
+                {
+                    ctx.Log(r.Merged
+                        ? $"Pull request #{number} merged{(r.Sha is { Length: > 0 } s ? $" ({s[..Math.Min(8, s.Length)]})" : "")}."
+                        : $"Pull request #{number} was not merged: {r.Message}");
+                    return Unit.Default;
+                });
+            }, onActivityCreated);
+    }
 }

--- a/src/MeshWeaver.GitSync/GitHubIssueModels.cs
+++ b/src/MeshWeaver.GitSync/GitHubIssueModels.cs
@@ -1,0 +1,97 @@
+using System.Collections.Immutable;
+using System.ComponentModel;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>The lifecycle state of a GitHub issue.</summary>
+public enum GitHubIssueState
+{
+    /// <summary>The issue is open on GitHub.</summary>
+    Open,
+
+    /// <summary>The issue is closed on GitHub.</summary>
+    Closed,
+}
+
+/// <summary>
+/// A GitHub issue mirrored into the Space as a satellite MeshNode at
+/// <c>{spacePath}/_Issue/{number}</c> (NodeType <c>GitHubIssue</c>). Unlike a pull request
+/// (whose live status is delegated), issues are content the user asked to <b>sync in</b> —
+/// so the node is a point-in-time snapshot refreshed by an explicit sync or a live webhook
+/// (see <c>GitHubWebhookProcessor</c>). It is display-only; edits to issues happen on
+/// GitHub (create / comment / close), never by mutating this node directly.
+/// </summary>
+public record GitHubIssue
+{
+    /// <summary>The GitHub issue number (the immutable handle, stable across syncs).</summary>
+    [Browsable(false)]
+    public int Number { get; init; }
+
+    /// <summary>The issue title.</summary>
+    [Description("Title")]
+    public string? Title { get; init; }
+
+    /// <summary>The issue body (markdown).</summary>
+    [Description("Body")]
+    public string? Body { get; init; }
+
+    /// <summary>Open / Closed on GitHub.</summary>
+    [Description("State")]
+    public GitHubIssueState State { get; init; }
+
+    /// <summary>The login of the user who opened the issue.</summary>
+    [Description("Author")]
+    public string? AuthorLogin { get; init; }
+
+    /// <summary>The issue's label names.</summary>
+    public ImmutableList<string> Labels { get; init; } = ImmutableList<string>.Empty;
+
+    /// <summary>The logins of the users assigned to the issue.</summary>
+    public ImmutableList<string> Assignees { get; init; } = ImmutableList<string>.Empty;
+
+    /// <summary>The number of comments on the issue.</summary>
+    public int CommentsCount { get; init; }
+
+    /// <summary>The <c>html_url</c> of the issue on GitHub.</summary>
+    [Browsable(false)]
+    public string? Url { get; init; }
+
+    /// <summary>When the issue was opened on GitHub.</summary>
+    public DateTimeOffset? CreatedAt { get; init; }
+
+    /// <summary>When the issue was last updated on GitHub.</summary>
+    public DateTimeOffset? UpdatedAt { get; init; }
+
+    /// <summary>When the issue was closed on GitHub (null while open).</summary>
+    public DateTimeOffset? ClosedAt { get; init; }
+
+    /// <summary>The issue's comments, populated on a detailed sync (empty on a list sync).</summary>
+    public ImmutableList<GitHubIssueComment> Comments { get; init; } = ImmutableList<GitHubIssueComment>.Empty;
+}
+
+/// <summary>A single comment on a GitHub issue (or pull request — a PR is an issue).</summary>
+public record GitHubIssueComment(
+    long Id,
+    string? AuthorLogin,
+    string? Body,
+    DateTimeOffset? CreatedAt,
+    string? Url);
+
+/// <summary>A request to open a new issue on GitHub.</summary>
+public record GitHubCreateIssueRequest
+{
+    /// <summary>The repository URL the issue is opened in.</summary>
+    public required string RepositoryUrl { get; init; }
+
+    /// <summary>The issue title.</summary>
+    public required string Title { get; init; }
+
+    /// <summary>The issue body (markdown); null for no description.</summary>
+    public string? Body { get; init; }
+
+    /// <summary>Optional label names to apply to the new issue.</summary>
+    public ImmutableList<string> Labels { get; init; } = ImmutableList<string>.Empty;
+
+    /// <summary>The committing user's OAuth access token (decrypted).</summary>
+    public required string AccessToken { get; init; }
+}

--- a/src/MeshWeaver.GitSync/GitHubIssuesTab.cs
+++ b/src/MeshWeaver.GitSync/GitHubIssuesTab.cs
@@ -114,7 +114,10 @@ public static class GitHubIssuesTab
         // Live issues grid — binds to the synced query, refreshes itself as issues land.
         host.RegisterForDisposal(issues.WatchIssueNodes(spacePath)
             .Select(nodes => MapIssues(host, nodes))
-            .Subscribe(rows => host.UpdateData(IssuesGridId, rows), _ => { }));
+            .Subscribe(
+                rows => host.UpdateData(IssuesGridId, rows),
+                // Surface a faulted synced query instead of a silently-frozen grid.
+                ex => host.UpdateData(ResultId, Err($"Issue list stopped updating: {ex.Message}"))));
         stack = stack.WithView(new DataGridControl(new JsonPointerReference(LayoutAreaReference.GetDataPointer(IssuesGridId)))
             .WithColumn(new PropertyColumnControl<int> { Property = nameof(GitHubIssueRow.Number).ToCamelCase() }.WithTitle("#"))
             .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubIssueRow.Title).ToCamelCase() }.WithTitle("Title"))

--- a/src/MeshWeaver.GitSync/GitHubIssuesTab.cs
+++ b/src/MeshWeaver.GitSync/GitHubIssuesTab.cs
@@ -1,0 +1,290 @@
+using System.Reactive.Linq;
+using MeshWeaver.Application.Styles;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Layout.DataGrid;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using MeshWeaver.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>A DataGrid row for a synced GitHub issue (plain, camel-cased for the grid binding).</summary>
+public record GitHubIssueRow(int Number, string Title, string State, string Author, string Labels, int Comments, string Updated);
+
+/// <summary>A DataGrid row for a live GitHub pull request summary.</summary>
+public record GitHubPrRow(int Number, string Title, string Author, string Status, string Draft, string Branches, string Updated);
+
+/// <summary>
+/// The "GitHub Issues &amp; PRs" settings tab — the browse/act surface for the issue + pull-request
+/// integration (the sync/commit/PR-draft flow lives in the "GitHub Sync" tab). Appears on the
+/// Settings page of any node within a Space (always acting on the containing Space), gated on
+/// Update, exactly like <see cref="GitHubSyncSettingsTab"/>.
+///
+/// <para>🚨 Structured data is rendered with <see cref="DataGridControl"/> bound to plain row
+/// records — NEVER hand-built HTML. Issues are mesh nodes, so their grid binds to a LIVE synced
+/// query (<see cref="IssueService.WatchIssueNodes"/>) and refreshes itself after a sync or webhook.
+/// Pull requests are read LIVE from GitHub (never persisted), pushed into the grid on load / refresh.</para>
+/// </summary>
+public static class GitHubIssuesTab
+{
+    /// <summary>The settings-menu item id for the GitHub Issues &amp; PRs tab.</summary>
+    public const string TabId = "GitHubIssues";
+
+    private const string ResultId = "ghIssuesResult";
+    private const string ActivityPathId = "ghIssuesActivityPath";
+    private const string NewIssueFormId = "ghNewIssueForm";
+    private const string MergeFormId = "ghMergeForm";
+    private const string IssuesGridId = "ghIssuesGrid";
+    private const string PrGridId = "ghPrGrid";
+
+    /// <summary>Registers the GitHub Issues &amp; PRs settings tab provider (shown on any node within a Space).</summary>
+    public static MessageHubConfiguration AddGitHubIssuesTab(this MessageHubConfiguration config)
+        => config.AddSettingsMenuItems(new SettingsMenuItemProvider(GetTab));
+
+    private static IObservable<IReadOnlyList<SettingsMenuItemDefinition>> GetTab(
+        LayoutAreaHost host, RenderingContext ctx)
+    {
+        IReadOnlyList<SettingsMenuItemDefinition> none = Array.Empty<SettingsMenuItemDefinition>();
+        var tab = new SettingsMenuItemDefinition(
+            Id: TabId,
+            Label: "GitHub Issues & PRs",
+            ContentBuilder: BuildContent,
+            Group: "Integration",
+            Icon: FluentIcons.Document(),
+            GroupIcon: FluentIcons.Document(),
+            Order: 260,
+            RequiredPermission: Permission.None);
+
+        var spaceRoot = SpaceRootPath(host.Hub.Address.ToString());
+        if (string.IsNullOrEmpty(spaceRoot))
+            return Observable.Return(none);
+
+        return host.Workspace.GetMeshNodeStream(spaceRoot)
+            .Select(node => string.Equals(node?.NodeType, GitHubSyncService.SpaceNodeType, StringComparison.Ordinal))
+            .CombineLatest(
+                host.Hub.GetEffectivePermissions(spaceRoot),
+                (isSpace, perms) => isSpace && perms.HasFlag(Permission.Update))
+            .DistinctUntilChanged()
+            .Select(show => show ? (IReadOnlyList<SettingsMenuItemDefinition>)new[] { tab } : none)
+            .Catch<IReadOnlyList<SettingsMenuItemDefinition>, Exception>(_ => Observable.Return(none))
+            .StartWith(none);
+    }
+
+    private static string SpaceRootPath(string? path) =>
+        string.IsNullOrEmpty(path) ? "" : path.Split('/', 2)[0];
+
+    internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack, MeshNode? node)
+    {
+        var sp = host.Hub.ServiceProvider;
+        var issues = sp.GetRequiredService<IssueService>();
+        var prs = sp.GetRequiredService<PullRequestService>();
+        var userId = sp.GetService<AccessService>()?.Context?.ObjectId ?? "";
+        var spacePath = SpaceRootPath(node?.Path ?? "");
+
+        if (string.IsNullOrEmpty(spacePath))
+            return stack.WithView(Controls.Html("<p><em>GitHub Issues are available inside a Space.</em></p>"));
+
+        stack = stack.WithView(Controls.H2("GitHub Issues & Pull Requests").WithStyle("margin:0 0 8px 0;"));
+        stack = stack.WithView(Controls.Html(
+            "<p style=\"font-size:0.85rem;color:var(--neutral-foreground-hint);margin-bottom:16px;\">" +
+            "Browse and act on the configured repository's issues and pull requests. Set the repository " +
+            "and connect GitHub in the <strong>GitHub Sync</strong> tab first.</p>"));
+
+        // ── Issues ─────────────────────────────────────────────────────────────
+        stack = stack.WithView(Section("Issues"));
+        stack = stack.WithView(Controls.Button("Sync issues from GitHub")
+            .WithAppearance(Appearance.Accent)
+            .WithClickAction(c =>
+            {
+                c.Host.UpdateData(ResultId, Pending("Syncing issues from GitHub…"));
+                c.Host.Hub.SyncIssuesFromGitHub(spacePath, userId,
+                        onActivityCreated: p => c.Host.UpdateData(ActivityPathId, p))
+                    .Subscribe(_ => { }, ex => c.Host.UpdateData(ResultId, Err(ex.Message)));
+                return Task.CompletedTask;
+            }));
+
+        stack = stack.WithView(BuildNewIssueForm(issues, spacePath, userId));
+
+        // Live issues grid — binds to the synced query, refreshes itself as issues land.
+        host.RegisterForDisposal(issues.WatchIssueNodes(spacePath)
+            .Select(nodes => MapIssues(host, nodes))
+            .Subscribe(rows => host.UpdateData(IssuesGridId, rows), _ => { }));
+        stack = stack.WithView(new DataGridControl(new JsonPointerReference(LayoutAreaReference.GetDataPointer(IssuesGridId)))
+            .WithColumn(new PropertyColumnControl<int> { Property = nameof(GitHubIssueRow.Number).ToCamelCase() }.WithTitle("#"))
+            .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubIssueRow.Title).ToCamelCase() }.WithTitle("Title"))
+            .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubIssueRow.State).ToCamelCase() }.WithTitle("State"))
+            .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubIssueRow.Author).ToCamelCase() }.WithTitle("Author"))
+            .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubIssueRow.Labels).ToCamelCase() }.WithTitle("Labels"))
+            .WithColumn(new PropertyColumnControl<int> { Property = nameof(GitHubIssueRow.Comments).ToCamelCase() }.WithTitle("Comments"))
+            .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubIssueRow.Updated).ToCamelCase() }.WithTitle("Updated"))
+            .WithItemSize(36)
+            .Resizable());
+
+        // ── Pull requests ────────────────────────────────────────────────────
+        stack = stack.WithView(Section("Pull requests"));
+        stack = stack.WithView(Controls.Button("Refresh pull requests")
+            .WithAppearance(Appearance.Outline)
+            .WithClickAction(c =>
+            {
+                PushPrs(prs, spacePath, userId, rows => c.Host.UpdateData(PrGridId, rows),
+                    err => c.Host.UpdateData(ResultId, Err(err)));
+                return Task.CompletedTask;
+            }));
+
+        stack = stack.WithView(BuildMergeForm(spacePath, userId));
+
+        // Initial PR load (live from GitHub, never persisted).
+        host.RegisterForDisposal(prs.ListAll(spacePath, null, userId)
+            .Select(MapPrs)
+            .Catch<IReadOnlyList<GitHubPrRow>, Exception>(_ =>
+                Observable.Return((IReadOnlyList<GitHubPrRow>)Array.Empty<GitHubPrRow>()))
+            .Subscribe(rows => host.UpdateData(PrGridId, rows), _ => { }));
+        stack = stack.WithView(new DataGridControl(new JsonPointerReference(LayoutAreaReference.GetDataPointer(PrGridId)))
+            .WithColumn(new PropertyColumnControl<int> { Property = nameof(GitHubPrRow.Number).ToCamelCase() }.WithTitle("#"))
+            .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubPrRow.Title).ToCamelCase() }.WithTitle("Title"))
+            .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubPrRow.Author).ToCamelCase() }.WithTitle("Author"))
+            .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubPrRow.Status).ToCamelCase() }.WithTitle("Status"))
+            .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubPrRow.Draft).ToCamelCase() }.WithTitle("Draft"))
+            .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubPrRow.Branches).ToCamelCase() }.WithTitle("Head → Base"))
+            .WithColumn(new PropertyColumnControl<string> { Property = nameof(GitHubPrRow.Updated).ToCamelCase() }.WithTitle("Updated"))
+            .WithItemSize(36)
+            .Resizable());
+
+        // ── Result area ─────────────────────────────────────────────────────
+        stack = stack.WithView((h, _) => h.Stream.GetDataStream<string>(ResultId)
+            .Select(html => string.IsNullOrEmpty(html)
+                ? (UiControl?)Controls.Stack.WithWidth("100%")
+                : (UiControl?)Controls.Stack.WithWidth("100%").WithView(Controls.Html(html)))
+            .StartWith((UiControl?)Controls.Stack.WithWidth("100%")));
+
+        return stack;
+    }
+
+    // ── Forms ──────────────────────────────────────────────────────────────────
+
+    private static UiControl BuildNewIssueForm(IssueService issues, string spacePath, string userId)
+    {
+        var row = Controls.Stack.WithOrientation(Orientation.Horizontal).WithStyle("gap:8px;align-items:flex-end;flex-wrap:wrap;");
+        row = row.WithView(new TextFieldControl(new JsonPointerReference("title"))
+        {
+            Label = "New issue title",
+            Placeholder = "e.g. Broken import on empty file",
+            DataContext = LayoutAreaReference.GetDataPointer(NewIssueFormId),
+        }.WithWidth("320px"));
+        row = row.WithView(new TextFieldControl(new JsonPointerReference("body"))
+        {
+            Label = "Body (optional)",
+            Placeholder = "Describe the issue…",
+            DataContext = LayoutAreaReference.GetDataPointer(NewIssueFormId),
+        }.WithWidth("320px"));
+        row = row.WithView(Controls.Button("Create issue")
+            .WithAppearance(Appearance.Outline)
+            .WithClickAction(c =>
+            {
+                c.Host.Stream.GetDataStream<Dictionary<string, object?>>(NewIssueFormId).Take(1).Subscribe(d =>
+                {
+                    var title = Str(d, "title");
+                    if (string.IsNullOrWhiteSpace(title))
+                    {
+                        c.Host.UpdateData(ResultId, Err("Enter a title for the new issue."));
+                        return;
+                    }
+                    issues.CreateIssue(spacePath, title, Str(d, "body"), null, userId).Subscribe(
+                        n => c.Host.UpdateData(ResultId, Ok($"Issue created — {n.Name}.")),
+                        ex => c.Host.UpdateData(ResultId, Err(ex.Message)));
+                });
+                return Task.CompletedTask;
+            }));
+        return row;
+    }
+
+    private static UiControl BuildMergeForm(string spacePath, string userId)
+    {
+        var row = Controls.Stack.WithOrientation(Orientation.Horizontal).WithStyle("gap:8px;align-items:flex-end;flex-wrap:wrap;");
+        row = row.WithView(new TextFieldControl(new JsonPointerReference("prNumber"))
+        {
+            Label = "Pull request # to merge",
+            Placeholder = "e.g. 42",
+            DataContext = LayoutAreaReference.GetDataPointer(MergeFormId),
+        }.WithWidth("200px"));
+        row = row.WithView(MergeButton("Merge commit", GitHubMergeMethod.Merge, spacePath, userId));
+        row = row.WithView(MergeButton("Squash & merge", GitHubMergeMethod.Squash, spacePath, userId));
+        return row;
+    }
+
+    private static UiControl MergeButton(string label, GitHubMergeMethod method, string spacePath, string userId) =>
+        Controls.Button(label)
+            .WithAppearance(Appearance.Outline)
+            .WithClickAction(c =>
+            {
+                c.Host.Stream.GetDataStream<Dictionary<string, object?>>(MergeFormId).Take(1).Subscribe(d =>
+                {
+                    if (!int.TryParse(Str(d, "prNumber"), out var number) || number <= 0)
+                    {
+                        c.Host.UpdateData(ResultId, Err("Enter the pull request number to merge."));
+                        return;
+                    }
+                    c.Host.UpdateData(ResultId, Pending($"Merging pull request #{number} ({method})…"));
+                    c.Host.Hub.MergePullRequestOnGitHub(spacePath, number, method, userId,
+                            onActivityCreated: p => c.Host.UpdateData(ActivityPathId, p))
+                        .Subscribe(_ => { }, ex => c.Host.UpdateData(ResultId, Err(ex.Message)));
+                });
+                return Task.CompletedTask;
+            });
+
+    // ── Mapping ──────────────────────────────────────────────────────────────
+
+    private static IReadOnlyList<GitHubIssueRow> MapIssues(LayoutAreaHost host, IReadOnlyList<MeshNode> nodes)
+    {
+        var opts = host.Hub.JsonSerializerOptions;
+        return nodes
+            .Select(n => n.ContentAs<GitHubIssue>(opts))
+            .Where(i => i is not null).Select(i => i!)
+            .OrderByDescending(i => i.Number)
+            .Select(i => new GitHubIssueRow(
+                i.Number, i.Title ?? "", i.State.ToString(), i.AuthorLogin ?? "",
+                string.Join(", ", i.Labels), i.CommentsCount,
+                i.UpdatedAt?.ToString("yyyy-MM-dd") ?? ""))
+            .ToList();
+    }
+
+    private static IReadOnlyList<GitHubPrRow> MapPrs(IReadOnlyList<GitHubPullRequestSummary> prs) =>
+        prs.OrderByDescending(p => p.Number)
+            .Select(p => new GitHubPrRow(
+                p.Number, p.Title, p.AuthorLogin ?? "", p.Status.ToString(),
+                p.Draft ? "draft" : "", $"{p.HeadBranch} → {p.BaseBranch}",
+                p.UpdatedAt?.ToString("yyyy-MM-dd") ?? ""))
+            .ToList();
+
+    private static void PushPrs(
+        PullRequestService prs, string spacePath, string userId,
+        Action<IReadOnlyList<GitHubPrRow>> onRows, Action<string> onError)
+    {
+        prs.ListAll(spacePath, null, userId).Select(MapPrs).Subscribe(onRows, ex => onError(ex.Message));
+    }
+
+    // ── Small view helpers ─────────────────────────────────────────────────────
+
+    private static UiControl Section(string title) =>
+        Controls.H3(title).WithStyle("margin:16px 0 8px 0;border-top:1px solid var(--neutral-stroke-divider-rest);padding-top:12px;");
+
+    private static string Str(Dictionary<string, object?>? d, string key) =>
+        d is not null && d.TryGetValue(key, out var v) && v is not null ? v.ToString() ?? "" : "";
+
+    private static string Ok(string m) =>
+        $"<p style=\"color:#22c55e;font-size:0.85rem;margin:8px 0;\">✓ {Esc(m)}</p>";
+
+    private static string Err(string m) =>
+        $"<p style=\"color:#ef4444;font-size:0.85rem;margin:8px 0;\">✗ {Esc(m)}</p>";
+
+    private static string Pending(string m) =>
+        $"<p style=\"color:var(--neutral-foreground-hint);font-size:0.85rem;margin:8px 0;\">… {Esc(m)}</p>";
+
+    private static string Esc(string s) => System.Web.HttpUtility.HtmlEncode(s);
+}

--- a/src/MeshWeaver.GitSync/GitHubPullRequestModels.cs
+++ b/src/MeshWeaver.GitSync/GitHubPullRequestModels.cs
@@ -1,0 +1,106 @@
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// A compact pull-request row for the "all pull requests" list. Read LIVE from GitHub —
+/// never persisted (a stored copy would drift). One row per open/closed PR in the repo.
+/// </summary>
+public record GitHubPullRequestSummary(
+    int Number,
+    string Title,
+    string? AuthorLogin,
+    PullRequestStatus Status,
+    bool Draft,
+    string? HeadBranch,
+    string? BaseBranch,
+    string Url,
+    DateTimeOffset? CreatedAt,
+    DateTimeOffset? UpdatedAt);
+
+/// <summary>The rolled-up state of a pull request's CI checks.</summary>
+public enum GitHubCheckState
+{
+    /// <summary>No checks are configured / reported for the head commit.</summary>
+    None,
+
+    /// <summary>At least one check is still queued or in progress (and none have failed).</summary>
+    Pending,
+
+    /// <summary>Every reported check concluded successfully (or neutral / skipped).</summary>
+    Passed,
+
+    /// <summary>At least one check failed (failure / timed-out / cancelled / action-required).</summary>
+    Failed,
+}
+
+/// <summary>A roll-up of the head commit's CI check runs.</summary>
+public record GitHubCheckSummary(int Total, int Passed, int Failed, int Pending, GitHubCheckState Overall)
+{
+    /// <summary>An empty summary (no checks reported).</summary>
+    public static GitHubCheckSummary Empty { get; } = new(0, 0, 0, 0, GitHubCheckState.None);
+}
+
+/// <summary>A roll-up of a pull request's reviews (latest decision per reviewer).</summary>
+public record GitHubReviewSummary(int Approved, int ChangesRequested, int Commented)
+{
+    /// <summary>An empty summary (no reviews).</summary>
+    public static GitHubReviewSummary Empty { get; } = new(0, 0, 0);
+}
+
+/// <summary>
+/// The LIVE, delegated detail of a single pull request — number, branches, mergeability, a
+/// checks roll-up and a reviews roll-up. Read on demand from GitHub, never stored.
+/// </summary>
+public record GitHubPullRequestDetail(
+    int Number,
+    string Title,
+    string? Body,
+    string? AuthorLogin,
+    PullRequestStatus Status,
+    bool Draft,
+    string? HeadBranch,
+    string? BaseBranch,
+    string? HeadSha,
+    string Url,
+    bool? Mergeable,
+    string? MergeableState,
+    int CommentsCount,
+    GitHubCheckSummary Checks,
+    GitHubReviewSummary Reviews);
+
+/// <summary>The GitHub merge strategy for closing a pull request.</summary>
+public enum GitHubMergeMethod
+{
+    /// <summary>Create a merge commit (default).</summary>
+    Merge,
+
+    /// <summary>Squash the PR commits into one, then merge.</summary>
+    Squash,
+
+    /// <summary>Rebase the PR commits onto the base, then merge.</summary>
+    Rebase,
+}
+
+/// <summary>A request to merge an open pull request on GitHub.</summary>
+public record GitHubMergePullRequestRequest
+{
+    /// <summary>The repository URL the pull request belongs to.</summary>
+    public required string RepositoryUrl { get; init; }
+
+    /// <summary>The pull request number to merge.</summary>
+    public required int Number { get; init; }
+
+    /// <summary>The merge strategy. Defaults to a merge commit.</summary>
+    public GitHubMergeMethod Method { get; init; } = GitHubMergeMethod.Merge;
+
+    /// <summary>Optional merge-commit title; null lets GitHub pick the default.</summary>
+    public string? CommitTitle { get; init; }
+
+    /// <summary>Optional merge-commit message body; null lets GitHub pick the default.</summary>
+    public string? CommitMessage { get; init; }
+
+    /// <summary>The committing user's OAuth access token (decrypted).</summary>
+    public required string AccessToken { get; init; }
+}
+
+/// <summary>The outcome of a merge attempt.</summary>
+public record GitHubMergeResult(bool Merged, string? Sha, string? Message);

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -33,6 +33,8 @@ public static class GitHubSyncConfiguration
         services.AddSingleton<GitHubCredentialService>();
         services.AddSingleton<GitHubSyncService>();
         services.AddSingleton<PullRequestService>();
+        services.AddSingleton<IssueService>();
+        services.AddSingleton<GitHubWebhookProcessor>();
         // Surfaces the per-space GitHub sync sources on the partition administration page
         // (PartitionSyncAdminLayoutArea resolves all IPartitionSyncSourceProvider from DI).
         services.AddSingleton<IPartitionSyncSourceProvider>(sp => new GitHubPartitionSyncSourceProvider(
@@ -99,6 +101,16 @@ public static class GitHubSyncConfiguration
                 ExcludeFromContext = new HashSet<string> { "search", "create" },
                 HubConfiguration = config => config
                     .AddMeshDataSource(source => source.WithContentType<GitHubPullRequest>()),
+            },
+            // GitHubIssue satellite ({space}/_Issue/{number}). A synced mirror of a repo issue —
+            // a satellite type, so the export filter skips it (issues are never written to the repo).
+            new MeshNode(IssueService.NodeType)
+            {
+                Name = "GitHub Issue",
+                IsSatelliteType = true,
+                ExcludeFromContext = new HashSet<string> { "search", "create" },
+                HubConfiguration = config => config
+                    .AddMeshDataSource(source => source.WithContentType<GitHubIssue>()),
             });
 
         // Also register the content types on the mesh hub + every per-node hub so reads via
@@ -106,11 +118,13 @@ public static class GitHubSyncConfiguration
         builder.ConfigureHub(c => c
             .WithType<GitHubCredential>(nameof(GitHubCredential))
             .WithType<GitHubSyncConfig>(nameof(GitHubSyncConfig))
-            .WithType<GitHubPullRequest>(nameof(GitHubPullRequest)));
+            .WithType<GitHubPullRequest>(nameof(GitHubPullRequest))
+            .WithType<GitHubIssue>(nameof(GitHubIssue)));
         builder.ConfigureDefaultNodeHub(c => c
             .WithType<GitHubCredential>(nameof(GitHubCredential))
             .WithType<GitHubSyncConfig>(nameof(GitHubSyncConfig))
-            .WithType<GitHubPullRequest>(nameof(GitHubPullRequest)));
+            .WithType<GitHubPullRequest>(nameof(GitHubPullRequest))
+            .WithType<GitHubIssue>(nameof(GitHubIssue)));
         return builder;
     }
 }

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -155,7 +155,7 @@ public sealed class GitHubWebhookProcessor
                     () => accessService.ImpersonateAsSystem(),
                     _ => hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)).FirstAsync())
                 .SelectMany(d => d.Message.Success
-                    ? Observable.Return(node)
+                    ? Observable.Return(d.Message.Node ?? node)
                     : Observable.Throw<MeshNode>(new InvalidOperationException(
                         $"Webhook upsert of issue #{issue.Number} into {space} failed: {d.Message.Error}")));
         });

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -1,0 +1,240 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Reactive.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// Applies verified GitHub <c>issues</c> / <c>issue_comment</c> webhook events to the mesh so
+/// synced <see cref="GitHubIssue"/> nodes stay live without polling. The event payload already
+/// carries the full issue object, so this needs <b>no OAuth token</b>: it maps the payload
+/// directly onto the <c>{spacePath}/_Issue/{number}</c> node of every Space configured to sync
+/// that repository, merging in the new comment on a comment event and preserving comments already
+/// synced. The write runs under the system identity (an infrastructure mirror update, the same
+/// identity model as the instance-sync pull and <c>StaticRepoImporter</c>).
+///
+/// <para>Pull-request events are intentionally ignored: PR state is read LIVE (delegated) and
+/// never materialized, so there is no node to refresh. Reactive end-to-end — no
+/// <c>async</c>/<c>await</c>. Signature verification (<see cref="VerifySignature"/>) is a pure
+/// static so the HTTP endpoint can reject a forged request before any work is scheduled.</para>
+/// </summary>
+public sealed class GitHubWebhookProcessor
+{
+    private readonly IMessageHub hub;
+    private readonly IMeshService meshService;
+    private readonly ILogger? logger;
+
+    /// <summary>Initializes a new instance of the <see cref="GitHubWebhookProcessor"/> class.</summary>
+    public GitHubWebhookProcessor(
+        IMessageHub hub, IMeshService meshService, ILogger<GitHubWebhookProcessor>? logger = null)
+    {
+        this.hub = hub;
+        this.meshService = meshService;
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// Verifies GitHub's <c>X-Hub-Signature-256</c> header (<c>sha256=&lt;hex&gt;</c>) is the
+    /// HMAC-SHA256 of the raw request body under the shared <paramref name="secret"/>, in constant
+    /// time. Returns false on any missing/misshaped input rather than throwing.
+    /// </summary>
+    public static bool VerifySignature(string? secret, byte[] body, string? signatureHeader)
+    {
+        if (string.IsNullOrEmpty(secret) || body is null || string.IsNullOrEmpty(signatureHeader))
+            return false;
+        const string prefix = "sha256=";
+        if (!signatureHeader.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+        var provided = signatureHeader[prefix.Length..].ToLowerInvariant();
+        var expected = Convert.ToHexString(
+            HMACSHA256.HashData(Encoding.UTF8.GetBytes(secret), body)).ToLowerInvariant();
+        var a = Encoding.ASCII.GetBytes(expected);
+        var b = Encoding.ASCII.GetBytes(provided);
+        return a.Length == b.Length && CryptographicOperations.FixedTimeEquals(a, b);
+    }
+
+    /// <summary>
+    /// Processes one verified webhook (event name + parsed payload) and emits the number of issue
+    /// nodes updated across all Spaces that sync the event's repository. Non-issue events, a
+    /// payload without an issue, or an unmatched repo all emit <c>0</c>.
+    /// </summary>
+    public IObservable<int> Process(string eventType, JsonElement payload)
+    {
+        var isIssues = string.Equals(eventType, "issues", StringComparison.OrdinalIgnoreCase);
+        var isComment = string.Equals(eventType, "issue_comment", StringComparison.OrdinalIgnoreCase);
+        if (!isIssues && !isComment)
+            return Observable.Return(0);
+        if (!payload.TryGetProperty("issue", out var issueEl) || issueEl.ValueKind != JsonValueKind.Object)
+            return Observable.Return(0);
+        if (!TryGetRepoUrl(payload, out var repoUrl))
+            return Observable.Return(0);
+
+        var issue = MapIssue(issueEl);
+        // A comment event carries only the NEW comment (not the full list) and no token to fetch
+        // the rest — so merge it into whatever comments were already synced onto the node.
+        GitHubIssueComment? newComment = isComment
+            && payload.TryGetProperty("comment", out var cEl) && cEl.ValueKind == JsonValueKind.Object
+                ? MapComment(cEl)
+                : null;
+
+        return MatchingSpaces(repoUrl).SelectMany(spaces =>
+        {
+            if (spaces.Count == 0)
+            {
+                logger?.LogInformation("GitHub webhook for {Repo} matched no synced Space.", repoUrl);
+                return Observable.Return(0);
+            }
+            logger?.LogInformation("GitHub webhook ({Event}) → refreshing issue #{Number} in {Count} Space(s).",
+                eventType, issue.Number, spaces.Count);
+            return spaces
+                .Select(space => UpsertFromWebhook(space, issue, newComment))
+                .Merge(4)
+                .ToList()
+                .Select(list => list.Count);
+        });
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>The distinct Space paths whose GitHub sync config targets <paramref name="repoUrl"/>.</summary>
+    private IObservable<IReadOnlyList<string>> MatchingSpaces(string repoUrl)
+    {
+        var target = ParseSafe(repoUrl);
+        return meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{GitHubSyncService.ConfigNodeType}"))
+            .Take(1)
+            .Select(c => (IReadOnlyList<string>)c.Items
+                .Where(n => RepoMatches(n, target))
+                .Select(n => n.Path.Split('/', 2)[0])
+                .Where(s => s.Length > 0)
+                .Distinct(StringComparer.Ordinal)
+                .ToList());
+    }
+
+    private bool RepoMatches(MeshNode node, (string Owner, string Repo) target)
+    {
+        var cfg = node.ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions, logger);
+        if (cfg?.RepositoryUrl is not { Length: > 0 } url) return false;
+        var (owner, repo) = ParseSafe(url);
+        return owner.Length > 0
+            && string.Equals(owner, target.Owner, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(repo, target.Repo, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Upserts the issue node for one Space, preserving already-synced comments and
+    /// merging the webhook's new comment when present. Written under the system identity.</summary>
+    private IObservable<MeshNode> UpsertFromWebhook(string space, GitHubIssue issue, GitHubIssueComment? newComment)
+    {
+        var path = IssueService.IssuePath(space, issue.Number);
+        return ReadExisting(path).SelectMany(existing =>
+        {
+            var comments = existing?.Comments ?? ImmutableList<GitHubIssueComment>.Empty;
+            if (newComment is not null)
+                comments = comments.RemoveAll(c => c.Id == newComment.Id).Add(newComment);
+            var merged = issue with { Comments = comments };
+            var node = new MeshNode(issue.Number.ToString(), IssueService.IssueNamespace(space))
+            {
+                NodeType = IssueService.NodeType,
+                Name = issue.Title is { Length: > 0 } t ? $"#{issue.Number} {t}" : $"Issue #{issue.Number}",
+                State = MeshNodeState.Active,
+                MainNode = space,
+                Content = merged,
+            };
+            var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+            return Observable.Using(
+                    () => accessService.ImpersonateAsSystem(),
+                    _ => hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)).FirstAsync())
+                .SelectMany(d => d.Message.Success
+                    ? Observable.Return(node)
+                    : Observable.Throw<MeshNode>(new InvalidOperationException(
+                        $"Webhook upsert of issue #{issue.Number} into {space} failed: {d.Message.Error}")));
+        });
+    }
+
+    /// <summary>Tolerant read of the existing issue node's content (null on absent — never a point read).</summary>
+    private IObservable<GitHubIssue?> ReadExisting(string path)
+        => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{path}"))
+            .Take(1)
+            .Select(c => c.Items.FirstOrDefault(n => string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase)))
+            .Select(n => n.ContentAs<GitHubIssue>(hub.JsonSerializerOptions, logger));
+
+    private static (string Owner, string Repo) ParseSafe(string url)
+    {
+        try { return OctokitGitHubRepoClient.ParseRepoUrl(url); }
+        catch { return ("", ""); }
+    }
+
+    private static bool TryGetRepoUrl(JsonElement payload, out string url)
+    {
+        url = "";
+        if (!payload.TryGetProperty("repository", out var r) || r.ValueKind != JsonValueKind.Object)
+            return false;
+        var full = GetString(r, "full_name");
+        if (!string.IsNullOrEmpty(full)) { url = $"https://github.com/{full}"; return true; }
+        var html = GetString(r, "html_url");
+        if (!string.IsNullOrEmpty(html)) { url = html!; return true; }
+        return false;
+    }
+
+    private static GitHubIssue MapIssue(JsonElement e) => new()
+    {
+        Number = GetInt(e, "number"),
+        Title = GetString(e, "title"),
+        Body = GetString(e, "body"),
+        State = string.Equals(GetString(e, "state"), "closed", StringComparison.OrdinalIgnoreCase)
+            ? GitHubIssueState.Closed : GitHubIssueState.Open,
+        AuthorLogin = e.TryGetProperty("user", out var u) ? GetString(u, "login") : null,
+        Labels = GetArray(e, "labels", el => GetString(el, "name")),
+        Assignees = GetArray(e, "assignees", el => GetString(el, "login")),
+        CommentsCount = GetInt(e, "comments"),
+        Url = GetString(e, "html_url"),
+        CreatedAt = GetDate(e, "created_at"),
+        UpdatedAt = GetDate(e, "updated_at"),
+        ClosedAt = GetDate(e, "closed_at"),
+    };
+
+    private static GitHubIssueComment MapComment(JsonElement c) =>
+        new(GetLong(c, "id"),
+            c.TryGetProperty("user", out var u) ? GetString(u, "login") : null,
+            GetString(c, "body"),
+            GetDate(c, "created_at"),
+            GetString(c, "html_url"));
+
+    private static string? GetString(JsonElement e, string name)
+        => e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private static int GetInt(JsonElement e, string name)
+        => e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number ? v.GetInt32() : 0;
+
+    private static long GetLong(JsonElement e, string name)
+        => e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number ? v.GetInt64() : 0;
+
+    private static DateTimeOffset? GetDate(JsonElement e, string name)
+        => e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+           && DateTimeOffset.TryParse(v.GetString(), CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind, out var d)
+            ? d : null;
+
+    private static ImmutableList<string> GetArray(JsonElement e, string name, Func<JsonElement, string?> select)
+    {
+        if (!e.TryGetProperty(name, out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return ImmutableList<string>.Empty;
+        var builder = ImmutableList.CreateBuilder<string>();
+        foreach (var el in arr.EnumerateArray())
+        {
+            var s = select(el);
+            if (!string.IsNullOrEmpty(s)) builder.Add(s!);
+        }
+        return builder.ToImmutable();
+    }
+}

--- a/src/MeshWeaver.GitSync/IGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/IGitHubRepoClient.cs
@@ -54,6 +54,52 @@ public interface IGitHubRepoClient
     /// </summary>
     IObservable<GitHubPullRequestInfo> GetPullRequestStatus(
         string repositoryUrl, int number, string accessToken);
+
+    // ── Issues ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Lists the repository's issues (pull requests excluded — GitHub returns PRs from the
+    /// issues endpoint), optionally filtered to <paramref name="state"/> (null = all states).
+    /// One <see cref="GitHubIssue"/> per issue, WITHOUT comments (a list read).
+    /// </summary>
+    IObservable<IReadOnlyList<GitHubIssue>> ListIssues(
+        string repositoryUrl, GitHubIssueState? state, string accessToken);
+
+    /// <summary>
+    /// Reads a single issue plus its comments — the detailed read used to hydrate the
+    /// <c>{spacePath}/_Issue/{number}</c> node's full content.
+    /// </summary>
+    IObservable<GitHubIssue> GetIssue(string repositoryUrl, int number, string accessToken);
+
+    /// <summary>Opens a new issue on GitHub and emits the created issue (with its assigned number).</summary>
+    IObservable<GitHubIssue> CreateIssue(GitHubCreateIssueRequest request);
+
+    /// <summary>Posts a comment on issue <paramref name="number"/> and emits the created comment.</summary>
+    IObservable<GitHubIssueComment> CommentIssue(
+        string repositoryUrl, int number, string body, string accessToken);
+
+    // ── Pull requests (richer) ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Lists the repository's pull requests, optionally filtered to <paramref name="state"/>
+    /// (null = all states). One compact <see cref="GitHubPullRequestSummary"/> per PR.
+    /// </summary>
+    IObservable<IReadOnlyList<GitHubPullRequestSummary>> ListPullRequests(
+        string repositoryUrl, PullRequestStatus? state, string accessToken);
+
+    /// <summary>
+    /// Reads a pull request's live detail — mergeability, a CI-checks roll-up (over the head
+    /// commit) and a reviews roll-up (latest decision per reviewer). Delegated, never stored.
+    /// </summary>
+    IObservable<GitHubPullRequestDetail> GetPullRequestDetail(
+        string repositoryUrl, int number, string accessToken);
+
+    /// <summary>Posts a comment on pull request <paramref name="number"/> (a PR is an issue) and emits it.</summary>
+    IObservable<GitHubIssueComment> CommentPullRequest(
+        string repositoryUrl, int number, string body, string accessToken);
+
+    /// <summary>Merges an open pull request with the requested strategy; emits the merge outcome.</summary>
+    IObservable<GitHubMergeResult> MergePullRequest(GitHubMergePullRequestRequest request);
 }
 
 /// <summary>A point-in-time snapshot of a repo subtree — the resolved commit SHA + its files.</summary>

--- a/src/MeshWeaver.GitSync/IssueService.cs
+++ b/src/MeshWeaver.GitSync/IssueService.cs
@@ -1,0 +1,215 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// GitHub <b>issue</b> integration for a Space: list/sync repo issues into satellite MeshNodes,
+/// read a single issue with its comments, open new issues, and comment — all authenticated as
+/// the calling user through their stored OAuth credential.
+///
+/// <para>Issues are the one GitHub object the user asked to <b>materialize</b> (read/sync into
+/// the mesh): each is mirrored to <c>{spacePath}/_Issue/{number}</c> (NodeType
+/// <c>GitHubIssue</c>) via the canonical create-or-update verb, and refreshed by an explicit
+/// sync or a live webhook. Mutations (create / comment) run ON GitHub and then re-sync the
+/// affected node — the node is never edited directly. Reactive end-to-end (no
+/// <c>async</c>/<c>await</c>): every GitHub leaf is bridged through <c>IIoPool</c> inside
+/// <see cref="OctokitGitHubRepoClient"/>; this service only composes those observables.</para>
+/// </summary>
+public sealed class IssueService
+{
+    /// <summary>The <see cref="MeshNode.NodeType"/> of a synced GitHub-issue node.</summary>
+    public const string NodeType = "GitHubIssue";
+    /// <summary>The satellite namespace segment under a Space that holds issue nodes.</summary>
+    public const string SatelliteSegment = "_Issue";
+
+    private readonly IMessageHub hub;
+    private readonly IMeshService meshService;
+    private readonly IGitHubRepoClient repoClient;
+    private readonly GitHubCredentialService credentials;
+    private readonly GitHubSyncService sync;
+    private readonly ILogger? logger;
+
+    /// <summary>Initializes a new instance of the <see cref="IssueService"/> class.</summary>
+    public IssueService(
+        IMessageHub hub,
+        IMeshService meshService,
+        IGitHubRepoClient repoClient,
+        GitHubCredentialService credentials,
+        GitHubSyncService sync,
+        ILogger<IssueService>? logger = null)
+    {
+        this.hub = hub;
+        this.meshService = meshService;
+        this.repoClient = repoClient;
+        this.credentials = credentials;
+        this.sync = sync;
+        this.logger = logger;
+    }
+
+    /// <summary>The satellite namespace under a Space that holds issue nodes: <c>{spacePath}/_Issue</c>.</summary>
+    public static string IssueNamespace(string spacePath) => $"{spacePath}/{SatelliteSegment}";
+
+    /// <summary>The node path for the issue with the given number: <c>{spacePath}/_Issue/{number}</c>.</summary>
+    public static string IssuePath(string spacePath, int number) => $"{IssueNamespace(spacePath)}/{number}";
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Sync (read GitHub → mesh nodes)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Lists the configured repo's issues (optionally filtered by <paramref name="state"/>) and
+    /// upserts one <c>{spacePath}/_Issue/{number}</c> node per issue. Emits the number synced.
+    /// </summary>
+    public IObservable<int> SyncIssues(string spacePath, string userId, GitHubIssueState? state = null)
+    {
+        return WithRepoAndToken(spacePath, userId, (repoUrl, _, token) =>
+            repoClient.ListIssues(repoUrl, state, token).SelectMany(issues =>
+            {
+                if (issues.Count == 0)
+                {
+                    logger?.LogInformation("No issues to sync for {Space}.", spacePath);
+                    return Observable.Return(0);
+                }
+                logger?.LogInformation("Syncing {Count} issue(s) into {Space}.", issues.Count, spacePath);
+                return issues
+                    .Select(issue => UpsertIssueNode(spacePath, issue))
+                    .Merge(4)
+                    .ToList()
+                    .Select(list => list.Count);
+            }));
+    }
+
+    /// <summary>
+    /// Reads a single issue (with its comments) from GitHub and upserts its node — the
+    /// detailed refresh used after a comment or from a webhook. Emits the refreshed node.
+    /// </summary>
+    public IObservable<MeshNode> SyncIssue(string spacePath, int number, string userId)
+    {
+        return WithRepoAndToken(spacePath, userId, (repoUrl, _, token) =>
+            repoClient.GetIssue(repoUrl, number, token)
+                .SelectMany(issue => UpsertIssueNode(spacePath, issue)));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Mutations (act on GitHub → re-sync node)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Opens a new issue on GitHub, then materializes its node. Emits the created node.
+    /// </summary>
+    public IObservable<MeshNode> CreateIssue(
+        string spacePath, string title, string? body, IReadOnlyList<string>? labels, string userId)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            return Observable.Throw<MeshNode>(new InvalidOperationException("Enter a title for the issue."));
+        return WithRepoAndToken(spacePath, userId, (repoUrl, _, token) =>
+            repoClient.CreateIssue(new GitHubCreateIssueRequest
+            {
+                RepositoryUrl = repoUrl,
+                Title = title.Trim(),
+                Body = body,
+                Labels = labels?.ToImmutableList() ?? ImmutableList<string>.Empty,
+                AccessToken = token,
+            }).SelectMany(issue => UpsertIssueNode(spacePath, issue)));
+    }
+
+    /// <summary>
+    /// Posts a comment on an issue, then re-syncs that issue's node (so its comment count +
+    /// comment list reflect the new comment). Emits the refreshed node.
+    /// </summary>
+    public IObservable<MeshNode> CommentIssue(string spacePath, int number, string body, string userId)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return Observable.Throw<MeshNode>(new InvalidOperationException("Enter a comment."));
+        return WithRepoAndToken(spacePath, userId, (repoUrl, _, token) =>
+            repoClient.CommentIssue(repoUrl, number, body, token)
+                // Re-read the full issue (with comments) and upsert — the node stays authoritative.
+                .SelectMany(_ => repoClient.GetIssue(repoUrl, number, token))
+                .SelectMany(issue => UpsertIssueNode(spacePath, issue)));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Reads (mesh)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>The Space's synced issue nodes (ordering is left to the caller — query lists children).</summary>
+    public IObservable<IReadOnlyList<MeshNode>> ListIssueNodes(string spacePath) =>
+        meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"path:{IssueNamespace(spacePath)} scope:children nodeType:{NodeType}"))
+            .Take(1)
+            .Select(c => (IReadOnlyList<MeshNode>)c.Items.ToList());
+
+    /// <summary>
+    /// LIVE stream of the Space's synced issue nodes — re-emits whenever an issue is synced,
+    /// created, or updated (via the shared synced query). The GUI grid binds to this so it
+    /// refreshes on its own after a sync or a webhook.
+    /// </summary>
+    public IObservable<IReadOnlyList<MeshNode>> WatchIssueNodes(string spacePath) =>
+        hub.GetWorkspace()
+            .GetQuery($"gh-issues:{spacePath}",
+                $"path:{IssueNamespace(spacePath)} scope:children nodeType:{NodeType}")
+            .Select(nodes => (IReadOnlyList<MeshNode>)(nodes?.ToList() ?? new List<MeshNode>()));
+
+    /// <summary>Live content of one issue node (or null when absent) — the authoritative single-node stream.</summary>
+    public IObservable<GitHubIssue?> WatchIssue(string issuePath) =>
+        hub.GetWorkspace().GetMeshNodeStream(issuePath).Select(node => Extract<GitHubIssue>(node));
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Helpers
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Create-or-update the <c>{spacePath}/_Issue/{number}</c> node with the issue snapshot.
+    /// The number is a stable, immutable handle, so it IS the node id — re-syncing an existing
+    /// issue updates the same node in place.
+    /// </summary>
+    private IObservable<MeshNode> UpsertIssueNode(string spacePath, GitHubIssue issue)
+    {
+        var node = new MeshNode(issue.Number.ToString(), IssueNamespace(spacePath))
+        {
+            NodeType = NodeType,
+            Name = issue.Title is { Length: > 0 } t ? $"#{issue.Number} {t}" : $"Issue #{issue.Number}",
+            State = MeshNodeState.Active,
+            MainNode = spacePath,
+            Content = issue,
+        };
+        return hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
+            .FirstAsync()
+            .Select(d => d.Message)
+            .SelectMany(resp => resp.Success
+                ? Observable.Return(node)
+                : Observable.Throw<MeshNode>(new InvalidOperationException(
+                    $"Failed to sync issue #{issue.Number}: {resp.Error}")));
+    }
+
+    /// <summary>Resolves (repo URL, config, token) for the Space + user, then runs the operation.</summary>
+    private IObservable<T> WithRepoAndToken<T>(
+        string spacePath, string userId, Func<string, GitHubSyncConfig, string, IObservable<T>> op)
+    {
+        return sync.ReadConfig(spacePath).Take(1).SelectMany(config =>
+        {
+            if (config?.RepositoryUrl is not { Length: > 0 } repoUrl)
+                return Observable.Throw<T>(new InvalidOperationException(
+                    "No repository URL is set for this Space. Set one in the GitHub Sync settings, then try again."));
+            return credentials.Get(userId).Take(1).SelectMany(cred =>
+            {
+                if (cred?.AccessToken is not { Length: > 0 } token)
+                    return Observable.Throw<T>(new InvalidOperationException(
+                        "Connect your GitHub account first (GitHub Sync settings → Connect)."));
+                return op(repoUrl, config, token);
+            });
+        });
+    }
+
+    // ContentAs (tolerant): typed → as-is, degraded JsonElement → recovered, otherwise null + LOGGED.
+    private T? Extract<T>(MeshNode? node) where T : class
+        => node.ContentAs<T>(hub.JsonSerializerOptions, logger);
+}

--- a/src/MeshWeaver.GitSync/IssueService.cs
+++ b/src/MeshWeaver.GitSync/IssueService.cs
@@ -181,11 +181,14 @@ public sealed class IssueService
             MainNode = spacePath,
             Content = issue,
         };
+        // The write runs as the calling user: AccessContext is an AsyncLocal that ExecutionContext
+        // carries across the IoPool's ConfigureAwait(false) hops, so it is still set here even after
+        // the repoClient round-trip. Return the server-reconciled node (version/normalization) on success.
         return hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
             .FirstAsync()
             .Select(d => d.Message)
             .SelectMany(resp => resp.Success
-                ? Observable.Return(node)
+                ? Observable.Return(resp.Node ?? node)
                 : Observable.Throw<MeshNode>(new InvalidOperationException(
                     $"Failed to sync issue #{issue.Number}: {resp.Error}")));
     }

--- a/src/MeshWeaver.GitSync/MeshWeaver.GitSync.csproj
+++ b/src/MeshWeaver.GitSync/MeshWeaver.GitSync.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <PackageReference Include="Octokit" />
+    <PackageReference Include="Octokit.Reactive" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Reactive" />
   </ItemGroup>

--- a/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
@@ -317,7 +317,12 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
                     ? Observable.Return(GitHubCheckSummary.Empty)
                     : Http.InvokeObservable(ct => client.Check.Run.GetAllForReference(owner, repo, headSha))
                         .Select(SummarizeChecks)
-                        .Catch<GitHubCheckSummary, ApiException>(_ => Observable.Return(GitHubCheckSummary.Empty));
+                        // Only "no checks configured / no checks:read scope" (404 / 403) degrade to empty;
+                        // a real error (auth, 5xx) must surface, not be silently hidden as "no checks".
+                        .Catch<GitHubCheckSummary, ApiException>(ex =>
+                            ex is NotFoundException || ex.StatusCode == System.Net.HttpStatusCode.Forbidden
+                                ? Observable.Return(GitHubCheckSummary.Empty)
+                                : Observable.Throw<GitHubCheckSummary>(ex));
                 // Both leaves emit exactly once → Zip pairs them into a single detail emission.
                 return reviews.Zip(checks, (rev, chk) => ToDetail(pr, headSha, chk, rev));
             });

--- a/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
@@ -1,17 +1,23 @@
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using System.Text;
 using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.Logging;
 using Octokit;
+using Octokit.Reactive;
 
 namespace MeshWeaver.GitSync;
 
 /// <summary>
-/// Production <see cref="IGitHubRepoClient"/> over the Octokit Git Data API. Every
-/// Octokit <c>…Async</c> leaf is bridged through the <see cref="IoPoolNames.Http"/>
-/// pool (<c>pool.Invoke(ct =&gt; client.X(…))</c>) and composed reactively — no
+/// Production <see cref="IGitHubRepoClient"/> over the Octokit.Reactive Git Data API. Every
+/// GitHub leaf is a native <see cref="IObservable{T}"/> from
+/// <see cref="IObservableGitHubClient"/> bridged through the <see cref="IoPoolNames.Http"/>
+/// pool (<c>Http.InvokeObservable(ct =&gt; client.X(…))</c>) and composed reactively — no
 /// <c>async</c>/<c>await</c>/<c>Task</c> escapes a method signature, per
-/// <c>Doc/Architecture/ControlledIoPooling.md</c>.
+/// <c>Doc/Architecture/ControlledIoPooling.md</c>. The reactive client's observables are
+/// themselves <c>FromAsync</c>-shaped, so routing every one through
+/// <see cref="IIoPool.InvokeObservable{T}"/> keeps them concurrency-bounded and off the hub
+/// scheduler (they would otherwise deadlock a hub/grain turn).
 ///
 /// <para>Export uses a single commit: blob per file → one tree → commit → update
 /// ref. Mirror is achieved by reconstructing the tree from scratch (no base_tree):
@@ -27,8 +33,8 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
 
     private IIoPool Http => ioPools.Get(IoPoolNames.Http);
 
-    private static GitHubClient Client(string token) =>
-        new(Product) { Credentials = new Credentials(token) };
+    private static IObservableGitHubClient Client(string token) =>
+        new ObservableGitHubClient(new GitHubClient(Product) { Credentials = new Credentials(token) });
 
     /// <summary>Parses <c>https://github.com/owner/repo(.git)</c> into (owner, repo).</summary>
     public static (string Owner, string Repo) ParseRepoUrl(string url)
@@ -106,7 +112,7 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
                             foreach (var (path, sha) in exportEntries)
                                 newTree.Tree.Add(new NewTreeItem { Path = path, Mode = BlobMode, Type = TreeType.Blob, Sha = sha });
 
-                            return Http.Invoke(ct => client.Git.Tree.Create(owner, repo, newTree))
+                            return Http.InvokeObservable(ct => client.Git.Tree.Create(owner, repo, newTree))
                                 .SelectMany(tree =>
                                 {
                                     var commit = head.CommitSha is { Length: > 0 } parent
@@ -115,7 +121,7 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
                                     var who = new Committer(request.AuthorName, request.AuthorEmail, DateTimeOffset.UtcNow);
                                     commit.Author = who;
                                     commit.Committer = who;
-                                    return Http.Invoke(ct => client.Git.Commit.Create(owner, repo, commit));
+                                    return Http.InvokeObservable(ct => client.Git.Commit.Create(owner, repo, commit));
                                 })
                                 .SelectMany(commit => UpdateRef(client, owner, repo, branch, commit.Sha, head.RefExists)
                                     .Select(_ => new GitHubPushResult(
@@ -153,7 +159,7 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
                     return Observable.Return(new RepoSnapshot(head.CommitSha!, Array.Empty<RepoFile>()));
 
                 return blobs
-                    .Select(e => Http.Invoke(ct => client.Git.Blob.Get(owner, repo, e.Sha))
+                    .Select(e => Http.InvokeObservable(ct => client.Git.Blob.Get(owner, repo, e.Sha))
                         .Select(blob => new RepoFile(
                             prefix.Length == 0 ? e.Path : e.Path[prefix.Length..],
                             DecodeBlob(blob))))
@@ -180,7 +186,7 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
             {
                 logger?.LogInformation("Creating branch {Branch} from {BaseRef} ({Sha}) in {Owner}/{Repo}.",
                     newBranch, baseRef, sha[..Math.Min(8, sha.Length)], owner, repo);
-                return Http.Invoke(ct => client.Git.Reference.Create(
+                return Http.InvokeObservable(ct => client.Git.Reference.Create(
                         owner, repo, new NewReference($"refs/heads/{newBranch}", sha)))
                     .Select(reference => new GitHubBranchResult(newBranch, reference.Object.Sha));
             });
@@ -200,7 +206,7 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
 
         var newPr = new NewPullRequest(request.Title, head, baseBranch) { Body = request.Body ?? "" };
         logger?.LogInformation("Opening PR {Head} → {Base} in {Owner}/{Repo}.", head, baseBranch, owner, repo);
-        return Http.Invoke(ct => client.PullRequest.Create(owner, repo, newPr))
+        return Http.InvokeObservable(ct => client.PullRequest.Create(owner, repo, newPr))
             .Select(ToInfo);
     }
 
@@ -214,8 +220,135 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
     {
         var (owner, repo) = ParseRepoUrl(repositoryUrl);
         var client = Client(accessToken);
-        return Http.Invoke(ct => client.PullRequest.Get(owner, repo, number))
+        return Http.InvokeObservable(ct => client.PullRequest.Get(owner, repo, number))
             .Select(ToInfo);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Issues
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<GitHubIssue>> ListIssues(
+        string repositoryUrl, GitHubIssueState? state, string accessToken)
+    {
+        var (owner, repo) = ParseRepoUrl(repositoryUrl);
+        var client = Client(accessToken);
+        var request = new RepositoryIssueRequest { State = MapStateFilter(state) };
+        // GetAllForRepository streams one Issue per page-item AND includes pull requests (a PR is an
+        // issue on GitHub); drop those, map, and .ToList() so the pool-bridged leaf emits one list.
+        return Http.InvokeObservable(ct => client.Issue.GetAllForRepository(owner, repo, request)
+                .Where(i => i.PullRequest is null)
+                .Select(ToIssue)
+                .ToList())
+            .Select(list => (IReadOnlyList<GitHubIssue>)list);
+    }
+
+    /// <inheritdoc />
+    public IObservable<GitHubIssue> GetIssue(string repositoryUrl, int number, string accessToken)
+    {
+        var (owner, repo) = ParseRepoUrl(repositoryUrl);
+        var client = Client(accessToken);
+        return Http.InvokeObservable(ct => client.Issue.Get(owner, repo, number))
+            .SelectMany(issue => Http.InvokeObservable(ct =>
+                    client.Issue.Comment.GetAllForIssue(owner, repo, number).ToList())
+                .Select(comments => ToIssue(issue) with
+                {
+                    Comments = comments.Select(ToComment).ToImmutableList(),
+                }));
+    }
+
+    /// <inheritdoc />
+    public IObservable<GitHubIssue> CreateIssue(GitHubCreateIssueRequest request)
+    {
+        var (owner, repo) = ParseRepoUrl(request.RepositoryUrl);
+        var client = Client(request.AccessToken);
+        var newIssue = new NewIssue(request.Title) { Body = request.Body ?? "" };
+        foreach (var label in request.Labels)
+            newIssue.Labels.Add(label);
+        logger?.LogInformation("Creating issue '{Title}' in {Owner}/{Repo}.", request.Title, owner, repo);
+        return Http.InvokeObservable(ct => client.Issue.Create(owner, repo, newIssue))
+            .Select(ToIssue);
+    }
+
+    /// <inheritdoc />
+    public IObservable<GitHubIssueComment> CommentIssue(
+        string repositoryUrl, int number, string body, string accessToken)
+    {
+        var (owner, repo) = ParseRepoUrl(repositoryUrl);
+        var client = Client(accessToken);
+        return Http.InvokeObservable(ct => client.Issue.Comment.Create(owner, repo, number, body))
+            .Select(ToComment);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Pull requests (richer: list / detail / comment / merge)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<GitHubPullRequestSummary>> ListPullRequests(
+        string repositoryUrl, PullRequestStatus? state, string accessToken)
+    {
+        var (owner, repo) = ParseRepoUrl(repositoryUrl);
+        var client = Client(accessToken);
+        var request = new PullRequestRequest { State = MapPrStateFilter(state) };
+        return Http.InvokeObservable(ct => client.PullRequest.GetAllForRepository(owner, repo, request)
+                .Select(ToSummary)
+                .ToList())
+            .Select(list => (IReadOnlyList<GitHubPullRequestSummary>)list);
+    }
+
+    /// <inheritdoc />
+    public IObservable<GitHubPullRequestDetail> GetPullRequestDetail(
+        string repositoryUrl, int number, string accessToken)
+    {
+        var (owner, repo) = ParseRepoUrl(repositoryUrl);
+        var client = Client(accessToken);
+        return Http.InvokeObservable(ct => client.PullRequest.Get(owner, repo, number))
+            .SelectMany(pr =>
+            {
+                var headSha = pr.Head?.Sha;
+                var reviews = Http.InvokeObservable(ct =>
+                        client.PullRequest.Review.GetAll(owner, repo, number).ToList())
+                    .Select(SummarizeReviews);
+                // Checks live over the head commit; a repo with no checks / a token lacking the
+                // checks scope returns empty rather than failing the whole detail read.
+                var checks = string.IsNullOrEmpty(headSha)
+                    ? Observable.Return(GitHubCheckSummary.Empty)
+                    : Http.InvokeObservable(ct => client.Check.Run.GetAllForReference(owner, repo, headSha))
+                        .Select(SummarizeChecks)
+                        .Catch<GitHubCheckSummary, ApiException>(_ => Observable.Return(GitHubCheckSummary.Empty));
+                // Both leaves emit exactly once → Zip pairs them into a single detail emission.
+                return reviews.Zip(checks, (rev, chk) => ToDetail(pr, headSha, chk, rev));
+            });
+    }
+
+    /// <inheritdoc />
+    public IObservable<GitHubIssueComment> CommentPullRequest(
+        string repositoryUrl, int number, string body, string accessToken)
+        // A pull request IS an issue on GitHub — PR conversation comments go through the issues API.
+        => CommentIssue(repositoryUrl, number, body, accessToken);
+
+    /// <inheritdoc />
+    public IObservable<GitHubMergeResult> MergePullRequest(GitHubMergePullRequestRequest request)
+    {
+        var (owner, repo) = ParseRepoUrl(request.RepositoryUrl);
+        var client = Client(request.AccessToken);
+        var merge = new MergePullRequest
+        {
+            CommitTitle = request.CommitTitle,
+            CommitMessage = request.CommitMessage,
+            MergeMethod = request.Method switch
+            {
+                GitHubMergeMethod.Squash => PullRequestMergeMethod.Squash,
+                GitHubMergeMethod.Rebase => PullRequestMergeMethod.Rebase,
+                _ => PullRequestMergeMethod.Merge,
+            },
+        };
+        logger?.LogInformation("Merging PR #{Number} in {Owner}/{Repo} ({Method}).",
+            request.Number, owner, repo, request.Method);
+        return Http.InvokeObservable(ct => client.PullRequest.Merge(owner, repo, request.Number, merge))
+            .Select(m => new GitHubMergeResult(m.Merged, m.Sha, m.Message));
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────
@@ -230,18 +363,104 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
         : pr.State.Value == ItemState.Closed ? PullRequestStatus.Closed
         : PullRequestStatus.Open;
 
+    /// <summary>Our issue-state filter → Octokit's <see cref="ItemStateFilter"/> (null = all).</summary>
+    private static ItemStateFilter MapStateFilter(GitHubIssueState? state) => state switch
+    {
+        GitHubIssueState.Open => ItemStateFilter.Open,
+        GitHubIssueState.Closed => ItemStateFilter.Closed,
+        _ => ItemStateFilter.All,
+    };
+
+    /// <summary>Our PR-status filter → Octokit's <see cref="ItemStateFilter"/> (Merged folds into Closed).</summary>
+    private static ItemStateFilter MapPrStateFilter(PullRequestStatus? state) => state switch
+    {
+        PullRequestStatus.Open => ItemStateFilter.Open,
+        PullRequestStatus.Closed or PullRequestStatus.Merged => ItemStateFilter.Closed,
+        _ => ItemStateFilter.All,
+    };
+
+    /// <summary>Maps an Octokit <see cref="Issue"/> to our snapshot record (comments filled separately).</summary>
+    private static GitHubIssue ToIssue(Issue issue) => new()
+    {
+        Number = issue.Number,
+        Title = issue.Title,
+        Body = issue.Body,
+        State = issue.State.Value == ItemState.Closed ? GitHubIssueState.Closed : GitHubIssueState.Open,
+        AuthorLogin = issue.User?.Login,
+        Labels = issue.Labels.Select(l => l.Name).ToImmutableList(),
+        Assignees = issue.Assignees.Select(a => a.Login).ToImmutableList(),
+        CommentsCount = issue.Comments,
+        Url = issue.HtmlUrl,
+        CreatedAt = issue.CreatedAt,
+        UpdatedAt = issue.UpdatedAt,
+        ClosedAt = issue.ClosedAt,
+    };
+
+    /// <summary>Maps an Octokit <see cref="IssueComment"/> to our comment record.</summary>
+    private static GitHubIssueComment ToComment(IssueComment c) =>
+        new(c.Id, c.User?.Login, c.Body, c.CreatedAt, c.HtmlUrl);
+
+    /// <summary>Maps an Octokit <see cref="PullRequest"/> to our list-row summary.</summary>
+    private static GitHubPullRequestSummary ToSummary(PullRequest pr) =>
+        new(pr.Number, pr.Title, pr.User?.Login, MapStatus(pr), pr.Draft,
+            pr.Head?.Ref, pr.Base?.Ref, pr.HtmlUrl, pr.CreatedAt, pr.UpdatedAt);
+
+    /// <summary>Combines the PR + its check/review roll-ups into the live detail record.</summary>
+    private static GitHubPullRequestDetail ToDetail(
+        PullRequest pr, string? headSha, GitHubCheckSummary checks, GitHubReviewSummary reviews) =>
+        new(pr.Number, pr.Title, pr.Body, pr.User?.Login, MapStatus(pr), pr.Draft,
+            pr.Head?.Ref, pr.Base?.Ref, headSha, pr.HtmlUrl,
+            pr.Mergeable, pr.MergeableState?.StringValue, pr.Comments, checks, reviews);
+
+    /// <summary>Rolls PR reviews up to the latest decision per reviewer (dismissed / pending don't count).</summary>
+    private static GitHubReviewSummary SummarizeReviews(IList<PullRequestReview> reviews)
+    {
+        int approved = 0, changes = 0, commented = 0;
+        var latestPerReviewer = reviews
+            .Where(r => r.User?.Login is { Length: > 0 })
+            .GroupBy(r => r.User!.Login, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.OrderBy(r => r.SubmittedAt).Last());
+        foreach (var r in latestPerReviewer)
+        {
+            var s = r.State.Value;
+            if (s == PullRequestReviewState.Approved) approved++;
+            else if (s == PullRequestReviewState.ChangesRequested) changes++;
+            else if (s == PullRequestReviewState.Commented) commented++;
+        }
+        return new GitHubReviewSummary(approved, changes, commented);
+    }
+
+    /// <summary>Rolls the head commit's check runs up to totals + an overall state.</summary>
+    private static GitHubCheckSummary SummarizeChecks(CheckRunsResponse resp)
+    {
+        int passed = 0, failed = 0, pending = 0;
+        foreach (var run in resp.CheckRuns)
+        {
+            if (run.Status.Value != CheckStatus.Completed) { pending++; continue; }
+            var c = run.Conclusion?.Value;
+            if (c is CheckConclusion.Success or CheckConclusion.Neutral or CheckConclusion.Skipped) passed++;
+            else failed++;
+        }
+        var total = passed + failed + pending;
+        var overall = failed > 0 ? GitHubCheckState.Failed
+            : pending > 0 ? GitHubCheckState.Pending
+            : total > 0 ? GitHubCheckState.Passed
+            : GitHubCheckState.None;
+        return new GitHubCheckSummary(total, passed, failed, pending, overall);
+    }
+
     /// <summary>Resolves a commitish (branch name OR SHA) to its commit SHA — cheap, no tree read.</summary>
-    private IObservable<string> ResolveRefSha(GitHubClient client, string owner, string repo, string commitish)
+    private IObservable<string> ResolveRefSha(IObservableGitHubClient client, string owner, string repo, string commitish)
         => IsSha(commitish)
-            ? Http.Invoke(ct => client.Git.Commit.Get(owner, repo, commitish)).Select(c => c.Sha)
-            : Http.Invoke(ct => client.Git.Reference.Get(owner, repo, $"heads/{commitish}"))
+            ? Http.InvokeObservable(ct => client.Git.Commit.Get(owner, repo, commitish)).Select(c => c.Sha)
+            : Http.InvokeObservable(ct => client.Git.Reference.Get(owner, repo, $"heads/{commitish}"))
                 .Select(reference => reference.Object.Sha);
 
     private sealed record HeadInfo(string? CommitSha, bool RefExists, IReadOnlyList<(string Path, string Sha)> ExistingBlobs);
 
     /// <summary>Ensures the repo exists; creates it private (under the user or the org) when missing.</summary>
-    private IObservable<bool> EnsureRepo(GitHubClient client, string owner, string repo, bool createIfMissing)
-        => Http.Invoke(ct => client.Repository.Get(owner, repo))
+    private IObservable<bool> EnsureRepo(IObservableGitHubClient client, string owner, string repo, bool createIfMissing)
+        => Http.InvokeObservable(ct => client.Repository.Get(owner, repo))
             .Select(_ => false)
             .Catch<bool, NotFoundException>(_ =>
             {
@@ -250,17 +469,17 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
                         $"Repository {owner}/{repo} does not exist and auto-create is disabled."));
                 var newRepo = new NewRepository(repo) { Private = true, AutoInit = false };
                 logger?.LogInformation("Creating private GitHub repo {Owner}/{Repo}.", owner, repo);
-                return Http.Invoke(ct => client.User.Current())
+                return Http.InvokeObservable(ct => client.User.Current())
                     .SelectMany(me => string.Equals(me.Login, owner, StringComparison.OrdinalIgnoreCase)
-                        ? Http.Invoke(ct => client.Repository.Create(newRepo))
-                        : Http.Invoke(ct => client.Repository.Create(owner, newRepo)))
+                        ? Http.InvokeObservable(ct => client.Repository.Create(newRepo))
+                        : Http.InvokeObservable(ct => client.Repository.Create(owner, newRepo)))
                     .Select(_ => true);
             });
 
     /// <summary>Reads the branch head commit + its recursive blob list. Tolerates an empty repo (no ref yet).</summary>
-    private IObservable<HeadInfo> ReadHead(GitHubClient client, string owner, string repo, string branch)
-        => Http.Invoke(ct => client.Git.Reference.Get(owner, repo, $"heads/{branch}"))
-            .SelectMany(reference => Http.Invoke(ct => client.Git.Commit.Get(owner, repo, reference.Object.Sha))
+    private IObservable<HeadInfo> ReadHead(IObservableGitHubClient client, string owner, string repo, string branch)
+        => Http.InvokeObservable(ct => client.Git.Reference.Get(owner, repo, $"heads/{branch}"))
+            .SelectMany(reference => Http.InvokeObservable(ct => client.Git.Commit.Get(owner, repo, reference.Object.Sha))
                 .SelectMany(commit => TreeOf(client, owner, repo, commit)))
             // No commit to build on → no head, no existing blobs (the export then makes a first,
             // PARENT-LESS commit that creates the branch ref). GitHub signals "no commit" TWO ways:
@@ -290,11 +509,11 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
     /// lacks this branch is left untouched — the normal parent-less-commit + create-ref path handles it.
     /// </summary>
     private IObservable<HeadInfo> EnsureInitialCommit(
-        GitHubClient client, string owner, string repo, string branch, string prefix, HeadInfo head)
+        IObservableGitHubClient client, string owner, string repo, string branch, string prefix, HeadInfo head)
         => head.RefExists
             ? Observable.Return(head)
             : IsRepoEmpty(client, owner, repo).SelectMany(empty => empty
-                ? Http.Invoke(ct => client.Repository.Content.CreateFile(owner, repo, prefix + ".gitkeep",
+                ? Http.InvokeObservable(ct => client.Repository.Content.CreateFile(owner, repo, prefix + ".gitkeep",
                         new CreateFileRequest("Initialize repository (MeshWeaver sync)",
                             "Created by MeshWeaver to initialize this repository.\n", branch)))
                     .SelectMany(_ => ReadHead(client, owner, repo, branch))
@@ -302,8 +521,10 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
 
     /// <summary>True when the repo has no commits at all (a freshly-created repo): GitHub lists zero
     /// branches for an empty repo, and some endpoints 409 "Git Repository is empty.".</summary>
-    private IObservable<bool> IsRepoEmpty(GitHubClient client, string owner, string repo)
-        => Http.Invoke(ct => client.Repository.Branch.GetAll(owner, repo))
+    private IObservable<bool> IsRepoEmpty(IObservableGitHubClient client, string owner, string repo)
+        // The reactive GetAll streams one Branch per page-item; .ToList() reduces the stream to a
+        // single IList so the pool-bridged leaf emits exactly one value (empty ⇔ no branches).
+        => Http.InvokeObservable(ct => client.Repository.Branch.GetAll(owner, repo).ToList())
             .Select(branches => branches.Count == 0)
             .Catch<bool, ApiException>(ex => IsMissingOrEmptyRepo(ex)
                 ? Observable.Return(true)
@@ -314,16 +535,16 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
     /// blob list. Unlike <see cref="ReadHead"/> this does NOT swallow NotFound — a
     /// re-import at a non-existent commit/branch must surface a clear error.
     /// </summary>
-    private IObservable<HeadInfo> ResolveCommitish(GitHubClient client, string owner, string repo, string commitish)
+    private IObservable<HeadInfo> ResolveCommitish(IObservableGitHubClient client, string owner, string repo, string commitish)
         => IsSha(commitish)
-            ? Http.Invoke(ct => client.Git.Commit.Get(owner, repo, commitish))
+            ? Http.InvokeObservable(ct => client.Git.Commit.Get(owner, repo, commitish))
                 .SelectMany(commit => TreeOf(client, owner, repo, commit))
-            : Http.Invoke(ct => client.Git.Reference.Get(owner, repo, $"heads/{commitish}"))
-                .SelectMany(reference => Http.Invoke(ct => client.Git.Commit.Get(owner, repo, reference.Object.Sha))
+            : Http.InvokeObservable(ct => client.Git.Reference.Get(owner, repo, $"heads/{commitish}"))
+                .SelectMany(reference => Http.InvokeObservable(ct => client.Git.Commit.Get(owner, repo, reference.Object.Sha))
                     .SelectMany(commit => TreeOf(client, owner, repo, commit)));
 
-    private IObservable<HeadInfo> TreeOf(GitHubClient client, string owner, string repo, Commit commit)
-        => Http.Invoke(ct => client.Git.Tree.GetRecursive(owner, repo, commit.Tree.Sha))
+    private IObservable<HeadInfo> TreeOf(IObservableGitHubClient client, string owner, string repo, Commit commit)
+        => Http.InvokeObservable(ct => client.Git.Tree.GetRecursive(owner, repo, commit.Tree.Sha))
             .Select(tree => new HeadInfo(
                 commit.Sha, true,
                 tree.Tree
@@ -336,12 +557,12 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
         s.Length is >= 7 and <= 40 && s.All(Uri.IsHexDigit);
 
     private IObservable<IReadOnlyList<(string Path, string Sha)>> CreateBlobs(
-        GitHubClient client, string owner, string repo, IReadOnlyList<RepoFile> files, string prefix)
+        IObservableGitHubClient client, string owner, string repo, IReadOnlyList<RepoFile> files, string prefix)
     {
         if (files.Count == 0)
             return Observable.Return((IReadOnlyList<(string, string)>)Array.Empty<(string, string)>());
         return files
-            .Select(f => Http.Invoke(ct => client.Git.Blob.Create(owner, repo,
+            .Select(f => Http.InvokeObservable(ct => client.Git.Blob.Create(owner, repo,
                     new NewBlob { Content = f.Content, Encoding = EncodingType.Utf8 }))
                 .Select(blob => (Path: prefix + f.Path, blob.Sha)))
             .Merge(8)
@@ -350,10 +571,10 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
     }
 
     private IObservable<Octokit.Reference> UpdateRef(
-        GitHubClient client, string owner, string repo, string branch, string commitSha, bool refExists)
+        IObservableGitHubClient client, string owner, string repo, string branch, string commitSha, bool refExists)
         => refExists
-            ? Http.Invoke(ct => client.Git.Reference.Update(owner, repo, $"heads/{branch}", new ReferenceUpdate(commitSha)))
-            : Http.Invoke(ct => client.Git.Reference.Create(owner, repo, new NewReference($"refs/heads/{branch}", commitSha)));
+            ? Http.InvokeObservable(ct => client.Git.Reference.Update(owner, repo, $"heads/{branch}", new ReferenceUpdate(commitSha)))
+            : Http.InvokeObservable(ct => client.Git.Reference.Create(owner, repo, new NewReference($"refs/heads/{branch}", commitSha)));
 
     private static string DecodeBlob(Blob blob) =>
         string.Equals(blob.Encoding.StringValue, "base64", StringComparison.OrdinalIgnoreCase)

--- a/src/MeshWeaver.GitSync/PullRequestService.cs
+++ b/src/MeshWeaver.GitSync/PullRequestService.cs
@@ -236,6 +236,61 @@ public sealed class PullRequestService
     }
 
     // ══════════════════════════════════════════════════════════════════════════
+    //  Richer PR reads (delegated, live — list / detail / comment / merge)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Lists ALL of the configured repo's pull requests (optionally filtered to
+    /// <paramref name="state"/>) LIVE from GitHub — one compact summary row per PR. Never
+    /// persisted; the GUI binds this straight into a table.
+    /// </summary>
+    public IObservable<IReadOnlyList<GitHubPullRequestSummary>> ListAll(
+        string spacePath, PullRequestStatus? state, string userId)
+    {
+        return WithRepoAndToken(spacePath, userId, (repoUrl, _, token) =>
+            repoClient.ListPullRequests(repoUrl, state, token));
+    }
+
+    /// <summary>
+    /// Reads one PR's live detail (mergeability + a checks roll-up + a reviews roll-up),
+    /// delegated to GitHub and never stored.
+    /// </summary>
+    public IObservable<GitHubPullRequestDetail> GetDetail(string spacePath, int number, string userId)
+    {
+        return WithRepoAndToken(spacePath, userId, (repoUrl, _, token) =>
+            repoClient.GetPullRequestDetail(repoUrl, number, token));
+    }
+
+    /// <summary>Posts a conversation comment on a pull request and emits the created comment.</summary>
+    public IObservable<GitHubIssueComment> Comment(string spacePath, int number, string body, string userId)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return Observable.Throw<GitHubIssueComment>(new InvalidOperationException("Enter a comment."));
+        return WithRepoAndToken(spacePath, userId, (repoUrl, _, token) =>
+            repoClient.CommentPullRequest(repoUrl, number, body, token));
+    }
+
+    /// <summary>
+    /// Merges an open pull request with the requested strategy. Emits the merge outcome; a
+    /// non-mergeable PR surfaces GitHub's error (never a silent no-op).
+    /// </summary>
+    public IObservable<GitHubMergeResult> Merge(
+        string spacePath, int number, GitHubMergeMethod method,
+        string? commitTitle, string? commitMessage, string userId)
+    {
+        return WithRepoAndToken(spacePath, userId, (repoUrl, _, token) =>
+            repoClient.MergePullRequest(new GitHubMergePullRequestRequest
+            {
+                RepositoryUrl = repoUrl,
+                Number = number,
+                Method = method,
+                CommitTitle = commitTitle,
+                CommitMessage = commitMessage,
+                AccessToken = token,
+            }));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
     //  Reads / writes
     // ══════════════════════════════════════════════════════════════════════════
 

--- a/src/MeshWeaver.Mesh.Contract/Threading/IIoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IIoPool.cs
@@ -1,4 +1,5 @@
 using System.Reactive;
+using System.Reactive.Threading.Tasks;
 
 namespace MeshWeaver.Mesh.Threading;
 
@@ -59,6 +60,24 @@ public interface IIoPool
     /// duration of the enumeration and emitting each item as <c>OnNext</c>.
     /// </summary>
     IObservable<T> InvokeStream<T>(Func<CancellationToken, IAsyncEnumerable<T>> source);
+
+    /// <summary>
+    /// Bridges an <see cref="IObservable{T}"/> I/O leaf — e.g. an Octokit.Reactive
+    /// <c>ObservableGitHubClient</c> call — into the pool: the leaf is subscribed on a
+    /// ThreadPool thread behind the concurrency gate and its <b>last</b> value is emitted
+    /// once it completes. It composes on <see cref="Invoke{T}"/>, so the async gate,
+    /// <c>ConfigureAwait(false)</c> and off-hub scheduling all come from there — a reactive
+    /// SDK leaf (itself <c>FromAsync</c>-shaped and otherwise unbounded on the subscribing
+    /// hub scheduler) can never deadlock a hub/grain turn or exceed the pool's cap.
+    ///
+    /// <para>The leaf must emit at least one value (a single-item call, or a multi-item
+    /// paginated <c>GetAll…</c> reduced with <c>.ToList()</c>/<c>.Any()</c> at the call
+    /// site so the single emitted value is the whole result). This is the sanctioned
+    /// reactive-SDK counterpart to <see cref="InvokeStream{T}"/>; the <c>.ToTask()</c>
+    /// bridge lives here, in the pool — never at the call site.</para>
+    /// </summary>
+    IObservable<T> InvokeObservable<T>(Func<CancellationToken, IObservable<T>> source)
+        => Invoke(ct => source(ct).ToTask(ct));
 
     /// <summary>Operations currently in flight through this pool. Diagnostics / tests only.</summary>
     int CurrentInFlight { get; }

--- a/test/MeshWeaver.GitSync.Test/FakeGitHubRepoClient.cs
+++ b/test/MeshWeaver.GitSync.Test/FakeGitHubRepoClient.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using MeshWeaver.GitSync;
 
@@ -22,8 +23,12 @@ public sealed class FakeGitHubRepoClient : IGitHubRepoClient
     private readonly Dictionary<string, Dictionary<string, string>> _branches = new(StringComparer.Ordinal);
     // repoKey → list of PRs (number-keyed)
     private readonly Dictionary<string, Dictionary<int, FakePullRequest>> _prs = new(StringComparer.Ordinal);
+    // repoKey → issues (number-keyed)
+    private readonly Dictionary<string, Dictionary<int, GitHubIssue>> _issues = new(StringComparer.Ordinal);
     private int _counter;
     private int _prNumber;
+    private int _issueNumber;
+    private long _commentId;
 
     private sealed record FakePullRequest(
         int Number, string Url, string Title, string? Body,
@@ -165,6 +170,159 @@ public sealed class FakeGitHubRepoClient : IGitHubRepoClient
                 $"Fake repo '{repositoryUrl}' has no PR #{number}."));
         }
     });
+
+    // ── Issues ───────────────────────────────────────────────────────────────
+
+    /// <summary>Seeds an issue into the fake repo (for sync tests). Returns the assigned number.</summary>
+    public int SeedIssue(string repositoryUrl, string title, string? body = null, GitHubIssueState state = GitHubIssueState.Open)
+    {
+        lock (_lock)
+        {
+            var key = Key(repositoryUrl);
+            var number = ++_issueNumber;
+            var (owner, repo) = OctokitGitHubRepoClient.ParseRepoUrl(repositoryUrl);
+            Issues(key)[number] = new GitHubIssue
+            {
+                Number = number, Title = title, Body = body, State = state, AuthorLogin = "tester",
+                CommentsCount = 0, Url = $"https://github.com/{owner}/{repo}/issues/{number}",
+                CreatedAt = DateTimeOffset.UtcNow, UpdatedAt = DateTimeOffset.UtcNow,
+            };
+            return number;
+        }
+    }
+
+    public IObservable<IReadOnlyList<GitHubIssue>> ListIssues(
+        string repositoryUrl, GitHubIssueState? state, string accessToken) => Observable.Defer(() =>
+    {
+        lock (_lock)
+        {
+            var all = _issues.TryGetValue(Key(repositoryUrl), out var m)
+                ? m.Values : Enumerable.Empty<GitHubIssue>();
+            var list = all
+                .Where(i => state is null || i.State == state)
+                // A list read carries no comments (matches the real client).
+                .Select(i => i with { Comments = ImmutableList<GitHubIssueComment>.Empty })
+                .OrderByDescending(i => i.Number)
+                .ToList();
+            return Observable.Return((IReadOnlyList<GitHubIssue>)list);
+        }
+    });
+
+    public IObservable<GitHubIssue> GetIssue(string repositoryUrl, int number, string accessToken) => Observable.Defer(() =>
+    {
+        lock (_lock)
+        {
+            if (_issues.TryGetValue(Key(repositoryUrl), out var m) && m.TryGetValue(number, out var issue))
+                return Observable.Return(issue);
+            return Observable.Throw<GitHubIssue>(new InvalidOperationException(
+                $"Fake repo '{repositoryUrl}' has no issue #{number}."));
+        }
+    });
+
+    public IObservable<GitHubIssue> CreateIssue(GitHubCreateIssueRequest request) => Observable.Defer(() =>
+    {
+        lock (_lock)
+        {
+            var key = Key(request.RepositoryUrl);
+            var number = ++_issueNumber;
+            var (owner, repo) = OctokitGitHubRepoClient.ParseRepoUrl(request.RepositoryUrl);
+            var issue = new GitHubIssue
+            {
+                Number = number, Title = request.Title, Body = request.Body, State = GitHubIssueState.Open,
+                AuthorLogin = "tester", Labels = request.Labels, CommentsCount = 0,
+                Url = $"https://github.com/{owner}/{repo}/issues/{number}",
+                CreatedAt = DateTimeOffset.UtcNow, UpdatedAt = DateTimeOffset.UtcNow,
+            };
+            Issues(key)[number] = issue;
+            return Observable.Return(issue);
+        }
+    });
+
+    public IObservable<GitHubIssueComment> CommentIssue(
+        string repositoryUrl, int number, string body, string accessToken) => Observable.Defer(() =>
+    {
+        lock (_lock)
+        {
+            var key = Key(repositoryUrl);
+            if (!_issues.TryGetValue(key, out var m) || !m.TryGetValue(number, out var issue))
+                return Observable.Throw<GitHubIssueComment>(new InvalidOperationException(
+                    $"Fake repo '{repositoryUrl}' has no issue #{number}."));
+            var comment = new GitHubIssueComment(++_commentId, "tester", body, DateTimeOffset.UtcNow, null);
+            m[number] = issue with
+            {
+                CommentsCount = issue.CommentsCount + 1,
+                Comments = issue.Comments.Add(comment),
+            };
+            return Observable.Return(comment);
+        }
+    });
+
+    // ── Pull requests (richer) ────────────────────────────────────────────────
+
+    public IObservable<IReadOnlyList<GitHubPullRequestSummary>> ListPullRequests(
+        string repositoryUrl, PullRequestStatus? state, string accessToken) => Observable.Defer(() =>
+    {
+        lock (_lock)
+        {
+            var all = _prs.TryGetValue(Key(repositoryUrl), out var m)
+                ? m.Values : Enumerable.Empty<FakePullRequest>();
+            var list = all
+                .Where(pr => state is null || MatchesFilter(pr.Status, state.Value))
+                .Select(pr => new GitHubPullRequestSummary(
+                    pr.Number, pr.Title, "tester", pr.Status, false, pr.Head, pr.Base, pr.Url,
+                    DateTimeOffset.UtcNow, DateTimeOffset.UtcNow))
+                .OrderByDescending(s => s.Number)
+                .ToList();
+            return Observable.Return((IReadOnlyList<GitHubPullRequestSummary>)list);
+        }
+    });
+
+    public IObservable<GitHubPullRequestDetail> GetPullRequestDetail(
+        string repositoryUrl, int number, string accessToken) => Observable.Defer(() =>
+    {
+        lock (_lock)
+        {
+            if (_prs.TryGetValue(Key(repositoryUrl), out var m) && m.TryGetValue(number, out var pr))
+                return Observable.Return(new GitHubPullRequestDetail(
+                    pr.Number, pr.Title, pr.Body, "tester", pr.Status, false, pr.Head, pr.Base,
+                    "headsha", pr.Url, Mergeable: true, MergeableState: "clean", CommentsCount: 0,
+                    GitHubCheckSummary.Empty, GitHubReviewSummary.Empty));
+            return Observable.Throw<GitHubPullRequestDetail>(new InvalidOperationException(
+                $"Fake repo '{repositoryUrl}' has no PR #{number}."));
+        }
+    });
+
+    public IObservable<GitHubIssueComment> CommentPullRequest(
+        string repositoryUrl, int number, string body, string accessToken) => Observable.Defer(() =>
+    {
+        lock (_lock)
+            return Observable.Return(new GitHubIssueComment(++_commentId, "tester", body, DateTimeOffset.UtcNow, null));
+    });
+
+    public IObservable<GitHubMergeResult> MergePullRequest(GitHubMergePullRequestRequest request) => Observable.Defer(() =>
+    {
+        lock (_lock)
+        {
+            var key = Key(request.RepositoryUrl);
+            if (_prs.TryGetValue(key, out var m) && m.TryGetValue(request.Number, out var pr))
+            {
+                m[request.Number] = pr with { Status = PullRequestStatus.Merged };
+                return Observable.Return(new GitHubMergeResult(true, "mergedsha", "Pull request successfully merged"));
+            }
+            return Observable.Throw<GitHubMergeResult>(new InvalidOperationException(
+                $"Fake repo '{request.RepositoryUrl}' has no PR #{request.Number}."));
+        }
+    });
+
+    private static bool MatchesFilter(PullRequestStatus status, PullRequestStatus filter) =>
+        filter == PullRequestStatus.Open ? status == PullRequestStatus.Open
+        : status is PullRequestStatus.Closed or PullRequestStatus.Merged;
+
+    private Dictionary<int, GitHubIssue> Issues(string key)
+    {
+        if (!_issues.TryGetValue(key, out var i)) _issues[key] = i = new();
+        return i;
+    }
 
     private Dictionary<string, string> Branches(string key)
     {

--- a/test/MeshWeaver.GitSync.Test/GitHubSyncTestBase.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubSyncTestBase.cs
@@ -30,7 +30,7 @@ public abstract class GitHubSyncTestBase(ITestOutputHelper output) : MonolithMes
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder)
             .AddGitHubSyncTypes()
-            .ConfigureDefaultNodeHub(c => c.AddGitHubSyncSettingsTab())
+            .ConfigureDefaultNodeHub(c => c.AddGitHubSyncSettingsTab().AddGitHubIssuesTab())
             .ConfigureServices(s =>
             {
                 s.AddGitHubSyncServices();
@@ -47,6 +47,8 @@ public abstract class GitHubSyncTestBase(ITestOutputHelper output) : MonolithMes
 
     protected GitHubSyncService Sync => Mesh.ServiceProvider.GetRequiredService<GitHubSyncService>();
     protected PullRequestService PullRequests => Mesh.ServiceProvider.GetRequiredService<PullRequestService>();
+    protected IssueService Issues => Mesh.ServiceProvider.GetRequiredService<IssueService>();
+    protected GitHubWebhookProcessor Webhooks => Mesh.ServiceProvider.GetRequiredService<GitHubWebhookProcessor>();
     protected GitHubCredentialService Credentials => Mesh.ServiceProvider.GetRequiredService<GitHubCredentialService>();
     protected IProviderKeyProtector Protector => Mesh.ServiceProvider.GetRequiredService<IProviderKeyProtector>();
     // The DevLogin user the test base logs in (TestUsers.Admin). Read directly rather than
@@ -95,6 +97,15 @@ public abstract class GitHubSyncTestBase(ITestOutputHelper output) : MonolithMes
         (await Observable.Interval(100.Milliseconds()).StartWith(0L)
             .SelectMany(_ => ReadNode(path))
             .Where(n => n is not null)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask())!;
+
+    /// <summary>Waits for the issue node at <paramref name="path"/> to satisfy <paramref name="predicate"/>.</summary>
+    protected async Task<GitHubIssue> WaitForIssue(string path, Func<GitHubIssue, bool> predicate) =>
+        (await Issues.WatchIssue(path)
+            .Where(i => i is not null && predicate(i))
+            .Select(i => i!)
             .FirstAsync()
             .Timeout(30.Seconds())
             .ToTask())!;

--- a/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
@@ -1,0 +1,126 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using MeshWeaver.GitSync;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// The GitHub webhook receiver: HMAC signature verification (pure) and payload-driven,
+/// token-free upsert of <c>{space}/_Issue/{number}</c> nodes for every Space that syncs the
+/// event's repository.
+/// </summary>
+public class GitHubWebhookProcessorTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    [Fact]
+    public void VerifySignature_MatchesGitHubHmac_AndRejectsForgeries()
+    {
+        const string secret = "s3cr3t";
+        var body = Encoding.UTF8.GetBytes("{\"hello\":\"world\"}");
+        var sig = "sha256=" + Convert.ToHexString(
+            HMACSHA256.HashData(Encoding.UTF8.GetBytes(secret), body)).ToLowerInvariant();
+
+        Assert.True(GitHubWebhookProcessor.VerifySignature(secret, body, sig));
+        Assert.True(GitHubWebhookProcessor.VerifySignature(secret, body, sig.ToUpperInvariant())); // hex case-insensitive
+        Assert.False(GitHubWebhookProcessor.VerifySignature(secret, body, "sha256=deadbeef"));
+        Assert.False(GitHubWebhookProcessor.VerifySignature("wrong-secret", body, sig));
+        Assert.False(GitHubWebhookProcessor.VerifySignature(secret, body, null));
+        Assert.False(GitHubWebhookProcessor.VerifySignature("", body, sig));
+        Assert.False(GitHubWebhookProcessor.VerifySignature(secret, body, "md5=whatever"));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Process_IssuesEvent_UpsertsIssueNodeInMatchingSpace()
+    {
+        await Connect();
+        var space = "GhWo" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Webhook Open Space");
+        var repo = "https://github.com/test/webhook-open";
+        await Sync.SaveConfig(space, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+
+        var payload = JsonDocument.Parse($$"""
+        {
+          "action": "opened",
+          "repository": { "full_name": "test/webhook-open" },
+          "issue": {
+            "number": 42, "title": "Webhook issue", "body": "from hook", "state": "open",
+            "user": { "login": "octocat" },
+            "labels": [ { "name": "bug" } ], "assignees": [],
+            "comments": 0, "html_url": "https://github.com/test/webhook-open/issues/42",
+            "created_at": "2026-07-04T10:00:00Z", "updated_at": "2026-07-04T10:00:00Z"
+          }
+        }
+        """).RootElement;
+
+        var updated = await Webhooks.Process("issues", payload).Timeout(60.Seconds()).ToTask();
+        Assert.Equal(1, updated);
+
+        var issue = await WaitForIssue(IssueService.IssuePath(space, 42), i => i.Number == 42);
+        Assert.Equal("Webhook issue", issue.Title);
+        Assert.Equal(GitHubIssueState.Open, issue.State);
+        Assert.Equal("octocat", issue.AuthorLogin);
+        Assert.Contains("bug", issue.Labels);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Process_IssueCommentEvent_MergesCommentOntoExistingNode()
+    {
+        await Connect();
+        var space = "GhWc" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Webhook Comment Space");
+        var repo = "https://github.com/test/webhook-comment";
+        await Sync.SaveConfig(space, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+
+        // Sync issue #7 first (node starts with zero comments).
+        var number = Fake.SeedIssue(repo, "Existing issue");
+        await Issues.SyncIssue(space, number, UserId).Timeout(60.Seconds()).ToTask();
+        await WaitForIssue(IssueService.IssuePath(space, number), i => i.CommentsCount == 0);
+
+        var payload = JsonDocument.Parse($$"""
+        {
+          "action": "created",
+          "repository": { "full_name": "test/webhook-comment" },
+          "issue": {
+            "number": {{number}}, "title": "Existing issue", "state": "open",
+            "user": { "login": "octocat" }, "labels": [], "assignees": [],
+            "comments": 1, "html_url": "https://github.com/test/webhook-comment/issues/{{number}}"
+          },
+          "comment": {
+            "id": 555, "body": "a webhook comment", "user": { "login": "reviewer" },
+            "created_at": "2026-07-04T11:00:00Z",
+            "html_url": "https://github.com/test/webhook-comment/issues/7#issuecomment-555"
+          }
+        }
+        """).RootElement;
+
+        var updated = await Webhooks.Process("issue_comment", payload).Timeout(60.Seconds()).ToTask();
+        Assert.Equal(1, updated);
+
+        var issue = await WaitForIssue(IssueService.IssuePath(space, number), i => i.CommentsCount == 1);
+        Assert.Contains(issue.Comments, c => c.Id == 555 && c.Body == "a webhook comment");
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Process_UnmatchedRepo_UpsertsNothing()
+    {
+        await Connect();
+        var space = "GhWu" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Webhook Unmatched Space");
+        await Sync.SaveConfig(space, "https://github.com/test/some-repo", "main", null, true, true)
+            .Timeout(30.Seconds()).ToTask();
+
+        var payload = JsonDocument.Parse("""
+        {
+          "action": "opened",
+          "repository": { "full_name": "someone/other-repo" },
+          "issue": { "number": 1, "title": "nope", "state": "open", "comments": 0 }
+        }
+        """).RootElement;
+
+        var updated = await Webhooks.Process("issues", payload).Timeout(60.Seconds()).ToTask();
+        Assert.Equal(0, updated);
+    }
+}

--- a/test/MeshWeaver.GitSync.Test/IssueOperationsTest.cs
+++ b/test/MeshWeaver.GitSync.Test/IssueOperationsTest.cs
@@ -1,0 +1,94 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.GitSync;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// GitHub <b>issue</b> integration over the in-memory fake: syncing repo issues into
+/// <c>{space}/_Issue/{number}</c> nodes, opening a new issue (which materializes its node),
+/// and commenting (which posts on GitHub then refreshes the node's comment count + list).
+/// </summary>
+public class IssueOperationsTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    [Fact(Timeout = 120000)]
+    public async Task SyncIssues_MaterializesRepoIssuesAsNodes()
+    {
+        await Connect();
+        var space = "GhIs" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Issue Space");
+        var repo = "https://github.com/test/issue-space";
+        await Sync.SaveConfig(space, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+
+        var n1 = Fake.SeedIssue(repo, "First issue", "body one");
+        var n2 = Fake.SeedIssue(repo, "Second issue", "body two", GitHubIssueState.Closed);
+
+        var count = await Issues.SyncIssues(space, UserId).Timeout(60.Seconds()).ToTask();
+        Assert.Equal(2, count);
+
+        var issue1 = await WaitForIssue(IssueService.IssuePath(space, n1), i => i.Title == "First issue");
+        Assert.Equal(GitHubIssueState.Open, issue1.State);
+        Assert.Equal(n1, issue1.Number);
+
+        var issue2 = await WaitForIssue(IssueService.IssuePath(space, n2), i => i.State == GitHubIssueState.Closed);
+        Assert.Equal("Second issue", issue2.Title);
+
+        // The Space lists both synced issue nodes.
+        var nodes = await Issues.ListIssueNodes(space).Timeout(30.Seconds()).ToTask();
+        Assert.Equal(2, nodes.Count);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task SyncIssues_OpenFilter_ExcludesClosed()
+    {
+        await Connect();
+        var space = "GhIf" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Issue Filter Space");
+        var repo = "https://github.com/test/issue-filter";
+        await Sync.SaveConfig(space, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+
+        Fake.SeedIssue(repo, "Open one");
+        Fake.SeedIssue(repo, "Closed one", state: GitHubIssueState.Closed);
+
+        var count = await Issues.SyncIssues(space, UserId, GitHubIssueState.Open).Timeout(60.Seconds()).ToTask();
+        Assert.Equal(1, count);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task CreateIssue_OpensOnGitHub_AndMaterializesNode()
+    {
+        await Connect();
+        var space = "GhIc" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Issue Create Space");
+        var repo = "https://github.com/test/issue-create";
+        await Sync.SaveConfig(space, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+
+        var node = await Issues.CreateIssue(space, "New bug", "It broke", new[] { "bug" }, UserId)
+            .Timeout(60.Seconds()).ToTask();
+
+        var issue = await WaitForIssue(node.Path, i => i.Title == "New bug");
+        Assert.Equal(GitHubIssueState.Open, issue.State);
+        Assert.Contains("bug", issue.Labels);
+        Assert.False(string.IsNullOrEmpty(issue.Url));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task CommentIssue_PostsOnGitHub_ThenRefreshesNode()
+    {
+        await Connect();
+        var space = "GhIm" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Issue Comment Space");
+        var repo = "https://github.com/test/issue-comment";
+        await Sync.SaveConfig(space, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+
+        var number = Fake.SeedIssue(repo, "Needs discussion");
+        await Issues.SyncIssue(space, number, UserId).Timeout(60.Seconds()).ToTask();
+        await WaitForIssue(IssueService.IssuePath(space, number), i => i.CommentsCount == 0);
+
+        await Issues.CommentIssue(space, number, "Here is my thought", UserId).Timeout(60.Seconds()).ToTask();
+
+        var updated = await WaitForIssue(IssueService.IssuePath(space, number), i => i.CommentsCount == 1);
+        Assert.Contains(updated.Comments, c => c.Body == "Here is my thought");
+    }
+}

--- a/test/MeshWeaver.GitSync.Test/PullRequestRicherTest.cs
+++ b/test/MeshWeaver.GitSync.Test/PullRequestRicherTest.cs
@@ -1,0 +1,57 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.GitSync;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// The richer pull-request surface (all delegated LIVE to GitHub, never persisted): listing every
+/// PR, reading one PR's detail (mergeability + check/review roll-ups), commenting, and merging.
+/// </summary>
+public class PullRequestRicherTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    [Fact(Timeout = 120000)]
+    public async Task ListAll_Detail_Comment_Merge_FlowThroughToGitHub()
+    {
+        await Connect();
+        var space = "GhPl" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "PR List Space");
+        var repo = "https://github.com/test/pr-list-space";
+        await Sync.SaveConfig(space, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+
+        // Seed an open PR on the fake repo (as if opened directly on GitHub).
+        var opened = await Fake.OpenPullRequest(new GitHubOpenPullRequestRequest
+        {
+            RepositoryUrl = repo,
+            Title = "Add feature",
+            Body = "adds the feature",
+            HeadBranch = "feature/x",
+            BaseBranch = "main",
+            AccessToken = "t",
+        }).Timeout(30.Seconds()).ToTask();
+
+        // List (all) surfaces it.
+        var all = await PullRequests.ListAll(space, null, UserId).Timeout(60.Seconds()).ToTask();
+        Assert.Contains(all, s => s.Number == opened.Number && s.Title == "Add feature" && s.Status == PullRequestStatus.Open);
+
+        // Detail is delegated live.
+        var detail = await PullRequests.GetDetail(space, opened.Number, UserId).Timeout(60.Seconds()).ToTask();
+        Assert.Equal(opened.Number, detail.Number);
+        Assert.True(detail.Mergeable);
+        Assert.Equal(GitHubCheckState.None, detail.Checks.Overall);
+
+        // Comment posts on GitHub.
+        var comment = await PullRequests.Comment(space, opened.Number, "LGTM", UserId).Timeout(60.Seconds()).ToTask();
+        Assert.Equal("LGTM", comment.Body);
+
+        // Merge (squash) closes it as Merged.
+        var merge = await PullRequests.Merge(space, opened.Number, GitHubMergeMethod.Squash, null, null, UserId)
+            .Timeout(60.Seconds()).ToTask();
+        Assert.True(merge.Merged);
+
+        // A closed-filter list now reports it Merged (live from GitHub, never a stored field).
+        var closed = await PullRequests.ListAll(space, PullRequestStatus.Closed, UserId).Timeout(60.Seconds()).ToTask();
+        Assert.Contains(closed, s => s.Number == opened.Number && s.Status == PullRequestStatus.Merged);
+    }
+}


### PR DESCRIPTION
## Summary
Two things the user asked for: replace Octokit with its **reactive** counterpart, and add **full GitHub issue + pull-request integration** (issues, PRs, live webhooks).

### Octokit → Octokit.Reactive, IoPool-bridged
- New `IIoPool.InvokeObservable<T>` default-interface bridge (`Invoke(ct => source(ct).ToTask(ct))`) — the sanctioned way to route Octokit.Reactive's `FromAsync`-shaped observables through the pool, so the client is natively reactive **and** stays concurrency-bounded / off-hub (no bare `FromAsync` escapes the pool).
- `OctokitGitHubRepoClient` rewritten on `IObservableGitHubClient`; the whole Octokit surface stays confined to that one file.

### Issues (materialized as `{space}/_Issue/{number}` nodes)
- `IssueService`: sync / create / comment, plus a live `WatchIssueNodes`. New `GitHubIssue` node type.

### Richer pull requests (read live, never persisted)
- `IGitHubRepoClient` + `PullRequestService`: `ListAll`, `GetDetail` (mergeability + **CI-checks** and **reviews** roll-ups), `Comment`, `Merge`.

### Live webhooks
- `GitHubWebhookProcessor` — HMAC-verified, **token-free** (maps the payload directly), upserts issue nodes under the system identity across every Space syncing that repo.
- `POST /webhooks/github` endpoint (`GitHub:Webhook:Secret`). Issues + issue-comment events only (PRs are live).

### GUI + wiring
- "GitHub Issues & PRs" settings tab — live **DataGrid** of issues + PR list + create/comment/merge forms (framework controls only, no hand-built HTML).
- Activity extensions `hub.SyncIssuesFromGitHub`, `hub.MergePullRequestOnGitHub`.
- `Doc/Architecture/GitHubSync.md` updated.

## Testing
- 9 new tests (issue sync/create/comment, richer-PR list/detail/comment/merge, webhook signature + payload upsert). **68 GitSync tests green.**
- `dotnet build -c Release -p:CIRun=true -warnaserror` clean across the whole solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)