### PR TITLE
feat(react): implement the 5 remaining placeholder controls

### DIFF
--- a/clients/portal-next/src/client/live.ts
+++ b/clients/portal-next/src/client/live.ts
@@ -12,6 +12,7 @@
 
 import { GrpcAreaSource, type AreaSource } from "@meshweaver/react/core";
 import type {
+  ContentListing,
   MarkdownCellSubmission,
   MarkdownKernelSession,
   MeshNodeState,
@@ -74,9 +75,11 @@ export async function connectLive(baseUrl: string = window.location.origin): Pro
   const runDeleteNode = (path: string) => deleteNode(baseUrl, rawToken, path);
   const runStartKernel = (cells: MarkdownCellSubmission[]) =>
     startMarkdownKernel(connection, mesh, userId, cells, runDeleteNode);
+  const runListContent = (path: string) => listContent(baseUrl, rawToken, path);
+  const runUploadContent = (path: string, file: File) => uploadContent(baseUrl, rawToken, path, file);
   return {
     connection,
-    ops: adaptOps(mesh, runQuery, runAutocomplete, runRenderMarkdown, runStartKernel),
+    ops: adaptOps(mesh, runQuery, runAutocomplete, runRenderMarkdown, runStartKernel, runListContent, runUploadContent),
     userId,
     getNode: (path: string) => mesh.get(path).then((n) => n.raw as MeshNodeRow).catch(() => null),
     queryNodes: runQuery,
@@ -296,6 +299,8 @@ function adaptOps(
   runAutocomplete: (query: string, contextPath?: string) => Promise<AutocompleteRow[]>,
   runRenderMarkdown: (markdown: string, nodePath?: string) => Promise<RenderedMarkdown>,
   runStartKernel: (cells: MarkdownCellSubmission[]) => Promise<MarkdownKernelSession>,
+  runListContent: (path: string) => Promise<ContentListing>,
+  runUploadContent: (path: string, file: File) => Promise<void>,
 ): MeshOps {
   return {
     watch: (path: string) => watchNode(mesh, path),
@@ -311,7 +316,100 @@ function adaptOps(
     // Interactive markdown: the ONE Markdig parser renders server-side; the client hydrates.
     renderMarkdown: runRenderMarkdown,
     startMarkdownKernel: runStartKernel,
+    // Node read/create — NodeExport bundles a subtree of getNode reads; NodeImport re-creates them.
+    getNode: (path: string) => mesh.get(path).then((n) => n.raw as Record<string, unknown>).catch(() => null),
+    createNode: (node: Record<string, unknown>) => mesh.create(node).then(() => undefined),
+    // Document export: post ExportDocumentRequest, watch the Activity, return the rendered bytes.
+    exportDocument: (sourcePath: string, options) => exportDocument(mesh, sourcePath, options),
+    // File browser: list a content-collection directory + upload (REST — content isn't a mesh node).
+    listContent: runListContent,
+    uploadContent: runUploadContent,
   };
+}
+
+/** Content-collection listing (`POST /api/mesh/content/list`) — `path` = {node}/{collection}[/{dir}]. */
+async function listContent(baseUrl: string, token: string, path: string): Promise<ContentListing> {
+  const resp = await fetch(`${baseUrl}/api/mesh/content/list`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({ path }),
+  });
+  const text = await resp.text();
+  if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `content list failed (${resp.status})`);
+  const parsed = JSON.parse(text) as ContentListing;
+  return {
+    collection: String(parsed.collection ?? ""),
+    path: String(parsed.path ?? ""),
+    editable: !!parsed.editable,
+    items: Array.isArray(parsed.items) ? parsed.items : [],
+  };
+}
+
+/** Content upload (`POST /api/mesh/upload`, multipart) — `path` = {node}/{collection}/{filePath}. */
+async function uploadContent(baseUrl: string, token: string, path: string, file: File): Promise<void> {
+  const form = new FormData();
+  form.append("path", path);
+  form.append("file", file, file.name);
+  const resp = await fetch(`${baseUrl}/api/mesh/upload`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+    body: form,
+  });
+  const text = await resp.text();
+  if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `upload failed (${resp.status})`);
+}
+
+/**
+ * Run a document export the way the Blazor ExportDocumentView does: post ExportDocumentRequest to
+ * the SOURCE node hub, get back an ActivityPath, watch that Activity to a terminal Status, then
+ * decode the RenderedDocument (FileName, MimeType, Content:byte[]) from ActivityLog.ReturnValue.
+ * Content is base64 on the wire (byte[] JSON) → Uint8Array for the browser download.
+ */
+async function exportDocument(
+  mesh: Mesh,
+  sourcePath: string,
+  options: { format?: "pdf" | "docx"; title?: string; includeChildren?: boolean; coverPage?: boolean; tableOfContents?: boolean },
+): Promise<{ fileName: string; mimeType: string; bytes: Uint8Array }> {
+  if (!sourcePath) throw new Error("no source path to export");
+  const resp = await mesh.connection.observe(sourcePath, "ExportDocumentRequest", {
+    sourcePath,
+    options: {
+      format: options.format === "docx" ? "Docx" : "Pdf", // ExportFormat (string enum)
+      title: options.title ?? null,
+      includeChildren: options.includeChildren ?? false,
+      coverPage: options.coverPage ?? true,
+      tableOfContents: options.tableOfContents ?? true,
+    },
+  });
+  const m = resp.message;
+  const err = m["error"] ?? m["Error"];
+  if (err) throw new Error(String(err));
+  const activityPath = String(m["activityPath"] ?? m["ActivityPath"] ?? "");
+  if (!activityPath) throw new Error("export did not start (no activity path)");
+
+  for await (const node of mesh.watch(activityPath)) {
+    const content = (node.content ?? {}) as Record<string, unknown>;
+    const status = String(content["status"] ?? content["Status"] ?? "");
+    if (status === "Failed") throw new Error(String(content["error"] ?? content["Error"] ?? "export failed"));
+    if (status === "Succeeded" || status === "Completed") {
+      const rvRaw = content["returnValue"] ?? content["ReturnValue"];
+      const rv = (typeof rvRaw === "string" ? JSON.parse(rvRaw) : rvRaw) as Record<string, unknown> | null;
+      if (!rv) throw new Error("export produced no document");
+      return {
+        fileName: String(rv["fileName"] ?? rv["FileName"] ?? "document"),
+        mimeType: String(rv["mimeType"] ?? rv["MimeType"] ?? "application/octet-stream"),
+        bytes: base64ToBytes(String(rv["content"] ?? rv["Content"] ?? "")),
+      };
+    }
+  }
+  throw new Error("export activity ended before completion");
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
 }
 
 async function* watchNode(mesh: Mesh, path: string): AsyncIterable<MeshNodeState> {

--- a/clients/portal/src/live.ts
+++ b/clients/portal/src/live.ts
@@ -19,6 +19,7 @@
 
 import { GrpcAreaSource, type AreaSource } from "@meshweaver/react/core";
 import type {
+  ContentListing,
   MarkdownCellSubmission,
   MarkdownKernelSession,
   MeshNodeState,
@@ -74,13 +75,43 @@ export async function connectLive(baseUrl: string = window.location.origin): Pro
   const runRenderMarkdown = (markdown: string, nodePath2?: string) => renderMarkdown(baseUrl, rawToken, markdown, nodePath2);
   const runDeleteNode = (path: string) => deleteNode(baseUrl, rawToken, path);
   const runStartKernel = (cells: MarkdownCellSubmission[]) => startMarkdownKernel(connection, mesh, userId, cells, runDeleteNode);
+  const runListContent = (path: string) => listContent(baseUrl, rawToken, path);
+  const runUploadContent = (path: string, file: File) => uploadContent(baseUrl, rawToken, path, file);
 
   return {
     connection,
-    ops: adaptOps(mesh, runQuery, runAutocomplete, runRenderMarkdown, runStartKernel),
+    ops: adaptOps(mesh, runQuery, runAutocomplete, runRenderMarkdown, runStartKernel, runListContent, runUploadContent),
     userId,
     close: () => connection.close(),
   };
+}
+
+/** Content-collection listing (`POST /api/mesh/content/list`). */
+async function listContent(baseUrl: string, token: string, path: string): Promise<ContentListing> {
+  const resp = await fetch(`${baseUrl}/api/mesh/content/list`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({ path }),
+  });
+  const text = await resp.text();
+  if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `content list failed (${resp.status})`);
+  const parsed = JSON.parse(text) as ContentListing;
+  return {
+    collection: String(parsed.collection ?? ""),
+    path: String(parsed.path ?? ""),
+    editable: !!parsed.editable,
+    items: Array.isArray(parsed.items) ? parsed.items : [],
+  };
+}
+
+/** Content upload (`POST /api/mesh/upload`, multipart). */
+async function uploadContent(baseUrl: string, token: string, path: string, file: File): Promise<void> {
+  const form = new FormData();
+  form.append("path", path);
+  form.append("file", file, file.name);
+  const resp = await fetch(`${baseUrl}/api/mesh/upload`, { method: "POST", headers: { authorization: `Bearer ${token}` }, body: form });
+  const text = await resp.text();
+  if (!resp.ok || text.startsWith("Error:")) throw new Error(text || `upload failed (${resp.status})`);
 }
 
 /**
@@ -110,6 +141,8 @@ function adaptOps(
   runAutocomplete: (query: string, contextPath?: string) => Promise<AutocompleteRow[]>,
   runRenderMarkdown: (markdown: string, nodePath?: string) => Promise<RenderedMarkdown>,
   runStartKernel: (cells: MarkdownCellSubmission[]) => Promise<MarkdownKernelSession>,
+  runListContent: (path: string) => Promise<ContentListing>,
+  runUploadContent: (path: string, file: File) => Promise<void>,
 ): MeshOps {
   return {
     watch: (path: string) => watchNode(mesh, path),
@@ -123,7 +156,57 @@ function adaptOps(
     autocomplete: (query: string, contextPath?: string) => runAutocomplete(query, contextPath),
     renderMarkdown: runRenderMarkdown,
     startMarkdownKernel: runStartKernel,
+    // Node read/create (NodeExport/NodeImport) + document export — parity with portal-next.
+    getNode: (path: string) => mesh.get(path).then((n) => n.raw as MeshNodeRow).catch(() => null),
+    createNode: (node: Record<string, unknown>) => mesh.create(node).then(() => undefined),
+    exportDocument: (sourcePath: string, options) => exportDocument(mesh, sourcePath, options),
+    listContent: runListContent,
+    uploadContent: runUploadContent,
   };
+}
+
+/** Post ExportDocumentRequest, watch the Activity to terminal, decode the RenderedDocument bytes.
+ *  Mirrors portal-next/live.ts (the Blazor ExportDocumentView flow). */
+async function exportDocument(
+  mesh: Mesh,
+  sourcePath: string,
+  options: { format?: "pdf" | "docx"; title?: string; includeChildren?: boolean; coverPage?: boolean; tableOfContents?: boolean },
+): Promise<{ fileName: string; mimeType: string; bytes: Uint8Array }> {
+  if (!sourcePath) throw new Error("no source path to export");
+  const resp = await mesh.connection.observe(sourcePath, "ExportDocumentRequest", {
+    sourcePath,
+    options: {
+      format: options.format === "docx" ? "Docx" : "Pdf",
+      title: options.title ?? null,
+      includeChildren: options.includeChildren ?? false,
+      coverPage: options.coverPage ?? true,
+      tableOfContents: options.tableOfContents ?? true,
+    },
+  });
+  const m = resp.message;
+  const err = m["error"] ?? m["Error"];
+  if (err) throw new Error(String(err));
+  const activityPath = String(m["activityPath"] ?? m["ActivityPath"] ?? "");
+  if (!activityPath) throw new Error("export did not start (no activity path)");
+  for await (const node of mesh.watch(activityPath)) {
+    const content = (node.content ?? {}) as Record<string, unknown>;
+    const status = String(content["status"] ?? content["Status"] ?? "");
+    if (status === "Failed") throw new Error(String(content["error"] ?? content["Error"] ?? "export failed"));
+    if (status === "Succeeded" || status === "Completed") {
+      const rvRaw = content["returnValue"] ?? content["ReturnValue"];
+      const rv = (typeof rvRaw === "string" ? JSON.parse(rvRaw) : rvRaw) as Record<string, unknown> | null;
+      if (!rv) throw new Error("export produced no document");
+      const binary = atob(String(rv["content"] ?? rv["Content"] ?? ""));
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      return {
+        fileName: String(rv["fileName"] ?? rv["FileName"] ?? "document"),
+        mimeType: String(rv["mimeType"] ?? rv["MimeType"] ?? "application/octet-stream"),
+        bytes,
+      };
+    }
+  }
+  throw new Error("export activity ended before completion");
 }
 
 async function* watchNode(mesh: Mesh, path: string): AsyncIterable<MeshNodeState> {

--- a/clients/react/src/controls/documentControls.tsx
+++ b/clients/react/src/controls/documentControls.tsx
@@ -11,7 +11,6 @@ import { Button, Checkbox, Link, MessageBar, MessageBarBody, Radio, RadioGroup, 
 import { ArrowDownload20Regular } from "@fluentui/react-icons";
 import type { UiControl } from "../area/types.js";
 import { useResolve } from "../area/context.js";
-import { useMeshLink } from "../area/navigation.js";
 import { useMeshOps } from "../live/meshOps.js";
 import { str, useText } from "./common.js";
 
@@ -22,9 +21,6 @@ function DocumentSourceView({ control }: { control: UiControl }): ReactNode {
   const mime = useText(control.mime);
   const highlight = useText(control.highlight);
   const fileName = useText(control.fileName) || safeName(fileUrl);
-  // A /static/… URL is a resource, not an app route — the browser fetches it at the origin root
-  // (the ingress serves /static), so it works verbatim under the /next basePath or the SPA.
-  const download = useMeshLink(fileUrl || undefined);
   if (!fileUrl) return null;
   const isPdf = /pdf/i.test(mime) || /\.pdf(\?|$)/i.test(fileUrl);
 
@@ -58,7 +54,10 @@ function DocumentSourceView({ control }: { control: UiControl }): ReactNode {
           Highlighted passage: “{highlight}”
         </Text>
       ) : null}
-      <Link href={download.href} onClick={download.onClick} style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 12 }}>
+      {/* A /static/… URL is an ORIGIN resource, not an app route — keep it root-absolute so the
+          browser fetches it directly. Routing it through useMeshLink would rewrite it under the
+          host basePath (e.g. /next/static/… in portal-next) and 404. */}
+      <Link href={fileUrl} download style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 12 }}>
         <ArrowDownload20Regular fontSize={16} /> Download {fileName}
       </Link>
     </div>

--- a/clients/react/src/controls/documentControls.tsx
+++ b/clients/react/src/controls/documentControls.tsx
@@ -1,0 +1,166 @@
+// Document controls — the React implementations of DocumentSourceControl and ExportDocumentControl
+// (previously long-tail placeholders). Both mirror the Blazor views:
+//   - DocumentSource: renders a document already served at a /static/… URL — an <iframe> for
+//     browser-native types (PDF), a download card otherwise, plus the highlighted passage.
+//   - ExportDocument: a small options form that runs the server export (ExportDocumentRequest →
+//     Activity → RenderedDocument bytes) through MeshOps.exportDocument and triggers a download.
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Button, Checkbox, Link, MessageBar, MessageBarBody, Radio, RadioGroup, Spinner, Text } from "@fluentui/react-components";
+import { ArrowDownload20Regular } from "@fluentui/react-icons";
+import type { UiControl } from "../area/types.js";
+import { useResolve } from "../area/context.js";
+import { useMeshLink } from "../area/navigation.js";
+import { useMeshOps } from "../live/meshOps.js";
+import { str, useText } from "./common.js";
+
+// ---- DocumentSource ------------------------------------------------------------------------------
+
+function DocumentSourceView({ control }: { control: UiControl }): ReactNode {
+  const fileUrl = useText(control.fileUrl);
+  const mime = useText(control.mime);
+  const highlight = useText(control.highlight);
+  const fileName = useText(control.fileName) || safeName(fileUrl);
+  // A /static/… URL is a resource, not an app route — the browser fetches it at the origin root
+  // (the ingress serves /static), so it works verbatim under the /next basePath or the SPA.
+  const download = useMeshLink(fileUrl || undefined);
+  if (!fileUrl) return null;
+  const isPdf = /pdf/i.test(mime) || /\.pdf(\?|$)/i.test(fileUrl);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8, width: "100%", minWidth: 0 }}>
+      {isPdf ? (
+        <iframe
+          src={fileUrl}
+          title={fileName}
+          style={{ width: "100%", height: "70vh", border: "1px solid var(--colorNeutralStroke2)", borderRadius: 4 }}
+        />
+      ) : (
+        <div
+          style={{
+            border: "1px solid var(--colorNeutralStroke2)",
+            borderRadius: 6,
+            padding: 16,
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+          }}
+        >
+          <Text weight="semibold">{fileName}</Text>
+          <Text size={200} style={{ color: "var(--colorNeutralForeground3)" }}>
+            In-browser preview isn't available for this file type — download it to view.
+          </Text>
+        </div>
+      )}
+      {highlight ? (
+        <Text size={200} italic style={{ color: "var(--colorNeutralForeground3)" }}>
+          Highlighted passage: “{highlight}”
+        </Text>
+      ) : null}
+      <Link href={download.href} onClick={download.onClick} style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 12 }}>
+        <ArrowDownload20Regular fontSize={16} /> Download {fileName}
+      </Link>
+    </div>
+  );
+}
+
+function safeName(url: string): string {
+  const last = url.split("/").pop() || "document";
+  try {
+    return decodeURIComponent(last.split("?")[0]) || "document";
+  } catch {
+    return last.split("?")[0] || "document";
+  }
+}
+
+// ---- ExportDocument ------------------------------------------------------------------------------
+
+type ExportState = { status: "idle" } | { status: "exporting" } | { status: "error"; message: string };
+
+function ExportDocumentView({ control }: { control: UiControl }): ReactNode {
+  const ops = useMeshOps();
+  const sourcePath = useText(control.sourcePath);
+  const nodeName = useText(control.nodeName);
+  const hasDescendants = !!useResolve(control.hasDescendants);
+  const defaultFormat = (str(useResolve(control.defaultFormat)) || "pdf").toLowerCase() === "docx" ? "docx" : "pdf";
+
+  const [format, setFormat] = useState<"pdf" | "docx">(defaultFormat as "pdf" | "docx");
+  const [includeChildren, setIncludeChildren] = useState(false);
+  const [state, setState] = useState<ExportState>({ status: "idle" });
+
+  if (!ops?.exportDocument)
+    return (
+      <MessageBar intent="info">
+        <MessageBarBody>Document export isn't available in this frontend.</MessageBarBody>
+      </MessageBar>
+    );
+
+  const run = () => {
+    if (!sourcePath || state.status === "exporting") return;
+    setState({ status: "exporting" });
+    ops
+      .exportDocument!(sourcePath, { format, title: nodeName || undefined, includeChildren })
+      .then((doc) => {
+        triggerDownload(doc.bytes, doc.fileName, doc.mimeType);
+        setState({ status: "idle" });
+      })
+      .catch((e) => setState({ status: "error", message: e instanceof Error ? e.message : String(e) }));
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12, maxWidth: 420 }}>
+      <div>
+        <Text weight="semibold" size={300}>
+          Format
+        </Text>
+        <RadioGroup layout="horizontal" value={format} onChange={(_, d) => setFormat(d.value === "docx" ? "docx" : "pdf")}>
+          <Radio value="pdf" label="PDF" />
+          <Radio value="docx" label="Word (.docx)" />
+        </RadioGroup>
+      </div>
+      {hasDescendants ? (
+        <Checkbox
+          checked={includeChildren}
+          label="Include child pages"
+          onChange={(_, d) => setIncludeChildren(!!d.checked)}
+        />
+      ) : null}
+      <Button
+        appearance="primary"
+        icon={state.status === "exporting" ? <Spinner size="tiny" /> : <ArrowDownload20Regular />}
+        disabled={state.status === "exporting" || !sourcePath}
+        onClick={run}
+      >
+        {state.status === "exporting" ? "Exporting…" : `Export ${format.toUpperCase()}`}
+      </Button>
+      {state.status === "error" ? (
+        <MessageBar intent="error">
+          <MessageBarBody>Export failed: {state.message}</MessageBarBody>
+        </MessageBar>
+      ) : null}
+    </div>
+  );
+}
+
+/** Trigger a browser download of raw bytes without leaking the object URL. */
+export function triggerDownload(bytes: Uint8Array, fileName: string, mimeType: string): void {
+  // Copy into a plain ArrayBuffer-backed view — TS's Blob rejects Uint8Array<ArrayBufferLike>
+  // (it could be SharedArrayBuffer-backed); the copy is also what guarantees a detached buffer.
+  const part = bytes.slice().buffer;
+  const blob = new Blob([part], { type: mimeType || "application/octet-stream" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Revoke after the click has been dispatched.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+export const documentControls = {
+  DocumentSource: DocumentSourceView,
+  ExportDocument: ExportDocumentView,
+};

--- a/clients/react/src/controls/fileBrowser.tsx
+++ b/clients/react/src/controls/fileBrowser.tsx
@@ -166,7 +166,18 @@ const rowStyle: React.CSSProperties = {
 
 function Row({ onClick, icon, name, meta, muted }: { onClick: () => void; icon: ReactNode; name: string; meta?: string; muted?: boolean }): ReactNode {
   return (
-    <div role="button" tabIndex={0} onClick={onClick} onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && onClick()} style={{ ...rowStyle, cursor: "pointer" }}>
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault(); // Space would otherwise scroll the page on a role="button" element
+          onClick();
+        }
+      }}
+      style={{ ...rowStyle, cursor: "pointer" }}
+    >
       {icon}
       <Text weight={muted ? "regular" : "semibold"} style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", color: muted ? "var(--colorNeutralForeground3)" : undefined }}>
         {name}

--- a/clients/react/src/controls/fileBrowser.tsx
+++ b/clients/react/src/controls/fileBrowser.tsx
@@ -1,0 +1,218 @@
+// FileBrowser — the React implementation of FileBrowserControl (formerly a placeholder). Browses a
+// content collection over the REST content surface: list (POST /api/mesh/content/list) + download
+// (the /content/{node}/{collection}{path} static URL) + upload (POST /api/mesh/upload). The owning
+// node path comes from control.nodePath (stamped server-side) or, as a fallback, the first segment
+// of control.urlBasePath (/{node}/{area}/{collection}); the collection lives on that node's hub.
+
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button, Link, MessageBar, MessageBarBody, Spinner, Text } from "@fluentui/react-components";
+import { ArrowUpload20Regular, Folder20Regular, Document20Regular, ArrowUp20Regular } from "@fluentui/react-icons";
+import type { UiControl } from "../area/types.js";
+import { useResolve } from "../area/context.js";
+import { useMeshOps, type ContentItem, type ContentListing } from "../live/meshOps.js";
+import { str, useText } from "./common.js";
+
+function FileBrowserView({ control }: { control: UiControl }): ReactNode {
+  const ops = useMeshOps();
+  const collection = useText(control.collection);
+  const nodePath = useText(control.nodePath) || nodeFromUrlBase(str(useResolve(control.urlBasePath)));
+  const readOnly = !!useResolve(control.readOnly);
+  const initialDir = normalizeDir(str(useResolve(control.path)));
+
+  const [dir, setDir] = useState(initialDir);
+  const [listing, setListing] = useState<ContentListing | null>(null);
+  const [state, setState] = useState<{ status: "idle" | "loading" | "uploading" } | { status: "error"; message: string }>({ status: "loading" });
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const listPath = useMemo(() => joinPath(nodePath, collection, dir), [nodePath, collection, dir]);
+
+  const refresh = useMemo(
+    () => () => {
+      if (!ops?.listContent || !nodePath || !collection) return;
+      setState({ status: "loading" });
+      ops
+        .listContent(listPath)
+        .then((l) => {
+          setListing(l);
+          setState({ status: "idle" });
+        })
+        .catch((e) => setState({ status: "error", message: e instanceof Error ? e.message : String(e) }));
+    },
+    [ops, listPath, nodePath, collection],
+  );
+
+  useEffect(refresh, [refresh]);
+
+  if (!ops?.listContent)
+    return (
+      <MessageBar intent="info">
+        <MessageBarBody>The file browser isn't available in this frontend.</MessageBarBody>
+      </MessageBar>
+    );
+  if (!nodePath || !collection)
+    return (
+      <MessageBar intent="warning">
+        <MessageBarBody>This file browser is missing its node/collection context.</MessageBarBody>
+      </MessageBar>
+    );
+
+  const canWrite = !readOnly && listing?.editable !== false && !!ops.uploadContent;
+
+  const onUpload = (file: File) => {
+    if (!ops.uploadContent) return;
+    setState({ status: "uploading" });
+    ops
+      .uploadContent(`${joinPath(nodePath, collection, dir)}/${file.name}`.replace(/\/{2,}/g, "/"), file)
+      .then(() => refresh())
+      .catch((e) => setState({ status: "error", message: e instanceof Error ? e.message : String(e) }));
+  };
+
+  const parent = parentDir(dir);
+  const items = listing?.items ?? [];
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8, width: "100%", minWidth: 0 }}>
+      {/* Breadcrumb + upload */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Text weight="semibold" style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>
+          {collection}
+          {dir}
+        </Text>
+        {canWrite ? (
+          <>
+            <input
+              ref={fileRef}
+              type="file"
+              style={{ display: "none" }}
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) onUpload(f);
+                e.target.value = "";
+              }}
+            />
+            <Button
+              size="small"
+              icon={state.status === "uploading" ? <Spinner size="tiny" /> : <ArrowUpload20Regular />}
+              disabled={state.status === "uploading"}
+              onClick={() => fileRef.current?.click()}
+            >
+              {state.status === "uploading" ? "Uploading…" : "Upload"}
+            </Button>
+          </>
+        ) : null}
+      </div>
+
+      {state.status === "error" ? (
+        <MessageBar intent="error">
+          <MessageBarBody>{state.message}</MessageBarBody>
+        </MessageBar>
+      ) : null}
+
+      <div style={{ border: "1px solid var(--colorNeutralStroke2)", borderRadius: 6, overflow: "hidden" }}>
+        {parent !== null ? (
+          <Row onClick={() => setDir(parent!)} icon={<ArrowUp20Regular />} name=".." muted />
+        ) : null}
+        {state.status === "loading" ? (
+          <div style={{ padding: 16, display: "flex", justifyContent: "center" }}>
+            <Spinner size="tiny" label="Loading…" />
+          </div>
+        ) : items.length === 0 ? (
+          <div style={{ padding: 16 }}>
+            <Text size={200} italic style={{ color: "var(--colorNeutralForeground3)" }}>
+              This folder is empty.
+            </Text>
+          </div>
+        ) : (
+          items.map((it) => (
+            <FileRow
+              key={it.path}
+              item={it}
+              onOpenFolder={() => setDir(normalizeDir(it.path))}
+              downloadUrl={fileUrl(nodePath, collection, it.path)}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FileRow({ item, onOpenFolder, downloadUrl }: { item: ContentItem; onOpenFolder: () => void; downloadUrl: string }): ReactNode {
+  if (item.kind === "folder")
+    return <Row onClick={onOpenFolder} icon={<Folder20Regular />} name={item.name} meta={item.itemCount != null ? `${item.itemCount} item${item.itemCount === 1 ? "" : "s"}` : undefined} />;
+  return (
+    <div style={rowStyle}>
+      <Document20Regular />
+      <Link href={downloadUrl} download style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {item.name}
+      </Link>
+      {item.lastModified ? (
+        <Text size={100} style={{ color: "var(--colorNeutralForeground3)" }}>
+          {new Date(item.lastModified).toLocaleDateString()}
+        </Text>
+      ) : null}
+    </div>
+  );
+}
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "6px 10px",
+  borderBottom: "1px solid var(--colorNeutralStroke3)",
+};
+
+function Row({ onClick, icon, name, meta, muted }: { onClick: () => void; icon: ReactNode; name: string; meta?: string; muted?: boolean }): ReactNode {
+  return (
+    <div role="button" tabIndex={0} onClick={onClick} onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && onClick()} style={{ ...rowStyle, cursor: "pointer" }}>
+      {icon}
+      <Text weight={muted ? "regular" : "semibold"} style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", color: muted ? "var(--colorNeutralForeground3)" : undefined }}>
+        {name}
+      </Text>
+      {meta ? (
+        <Text size={100} style={{ color: "var(--colorNeutralForeground3)" }}>
+          {meta}
+        </Text>
+      ) : null}
+    </div>
+  );
+}
+
+// ---- path helpers --------------------------------------------------------------------------------
+
+/** Owning node from a "/{node}/{area}/{collection}" UrlBasePath fallback. */
+function nodeFromUrlBase(urlBase: string): string {
+  return urlBase.split("/").filter(Boolean)[0] ?? "";
+}
+
+/** A collection-relative directory, always leading-slash, no trailing slash ("/" is the root). */
+function normalizeDir(p: string): string {
+  const trimmed = (p || "/").replace(/\/+$/, "");
+  return trimmed.startsWith("/") ? trimmed || "/" : `/${trimmed}`;
+}
+
+/** The parent directory, or null at the collection root. */
+function parentDir(dir: string): string | null {
+  if (dir === "/" || dir === "") return null;
+  const idx = dir.lastIndexOf("/");
+  return idx <= 0 ? "/" : dir.slice(0, idx);
+}
+
+/** The content-list path: {node}/{collection}[/{dir}] (dir slashes normalized out). */
+function joinPath(node: string, collection: string, dir: string): string {
+  const d = dir.replace(/^\/+|\/+$/g, "");
+  return d ? `${node}/${collection}/${d}` : `${node}/${collection}`;
+}
+
+/** The static content URL for a file (each segment encoded). */
+function fileUrl(node: string, collection: string, itemPath: string): string {
+  const rel = itemPath.replace(/^\/+/, "");
+  const enc = (s: string) => s.split("/").map(encodeURIComponent).join("/");
+  return `/content/${enc(node)}/${encodeURIComponent(collection)}/${enc(rel)}`;
+}
+
+export const fileBrowserControls = {
+  FileBrowser: FileBrowserView,
+};

--- a/clients/react/src/controls/mesh.tsx
+++ b/clients/react/src/controls/mesh.tsx
@@ -8,6 +8,9 @@ import { str, useField, useText } from "./common.js";
 import { AddressAreaEmbed, sanitizeInlineSvg } from "./display.js";
 import { ThreadChatView } from "./threadChat.js";
 import { MeshNodeCollectionView, MeshSearchView } from "./meshLive.js";
+import { documentControls } from "./documentControls.js";
+import { nodeTransferControls } from "./nodeTransfer.js";
+import { fileBrowserControls } from "./fileBrowser.js";
 
 function MeshNodePickerView({ control }: { control: UiControl }): ReactNode {
   const f = useField(control);
@@ -170,25 +173,12 @@ function placeholder(label: string) {
 }
 
 /**
- * The remaining registered-but-placeholder $types — every entry needs a live mesh service
- * (file storage, thread execution, import/export pipelines) beyond the AreaSource contract.
- * parity.test.ts ratchets this list: it may only SHRINK as controls get real implementations.
+ * The remaining registered-but-placeholder $types. parity.test.ts ratchets this list: it may only
+ * SHRINK as controls get real implementations — it is now EMPTY (every mesh control is real).
  */
-export const placeholderControlTypes = [
-  "FileBrowser",
-  "ExportDocument",
-  "NodeExport",
-  "NodeImport",
-  "DocumentSource",
-] as const;
+export const placeholderControlTypes = [] as const;
 
-const placeholderLabels: Record<(typeof placeholderControlTypes)[number], string> = {
-  FileBrowser: "File browser",
-  ExportDocument: "Export document",
-  NodeExport: "Node export",
-  NodeImport: "Node import",
-  DocumentSource: "Document source",
-};
+const placeholderLabels: Record<(typeof placeholderControlTypes)[number], string> = {};
 
 export const meshControls = {
   MeshSearch: MeshSearchView,
@@ -200,5 +190,9 @@ export const meshControls = {
   ThreadMessageBubble: ThreadMessageBubbleView,
   ThreadChat: ThreadChatView,
   LayoutAreaDefinition: LayoutAreaDefinitionView,
+  // Document, node-transfer, and file-browser controls (formerly placeholders) — real implementations.
+  ...documentControls,
+  ...nodeTransferControls,
+  ...fileBrowserControls,
   ...Object.fromEntries(placeholderControlTypes.map((t) => [t, placeholder(placeholderLabels[t])])),
 };

--- a/clients/react/src/controls/nodeTransfer.tsx
+++ b/clients/react/src/controls/nodeTransfer.tsx
@@ -154,7 +154,9 @@ function NodeImportView({ control }: { control: UiControl }): ReactNode {
         <MessageBar intent={state.failed > 0 ? "warning" : "success"}>
           <MessageBarBody>
             Imported {state.created} node{state.created === 1 ? "" : "s"}
-            {state.failed > 0 ? `; ${state.failed} skipped (already present — enable Force to overwrite)` : ""}.
+            {state.failed > 0
+              ? `; ${state.failed} failed${force ? "" : " (existing nodes need Force to overwrite)"}`
+              : ""}.
           </MessageBarBody>
         </MessageBar>
       ) : null}

--- a/clients/react/src/controls/nodeTransfer.tsx
+++ b/clients/react/src/controls/nodeTransfer.tsx
@@ -1,0 +1,207 @@
+// Node transfer controls — the React implementations of NodeExportControl / NodeImportControl
+// (previously long-tail placeholders). The Blazor views are stubbed (their low-level
+// IMeshExport/ImportService were removed in the 2026-05-12 persistence cull), so there is no ZIP
+// format to interop with; these implement a real, self-consistent JSON-BUNDLE round-trip over the
+// EXISTING verbs — no revived service, no new server surface:
+//   - Export: query the subtree (search scope:descendants) + read each node's raw JSON (getNode),
+//     bundle to a { meshExport, root, nodes[] } document, and download it.
+//   - Import: read a bundle, RE-TARGET each node's path/namespace from its export root onto the
+//     chosen target, and re-create it (createNode → the node's owner partition).
+
+import type { ReactNode } from "react";
+import { useRef, useState } from "react";
+import { Button, Field, Input, MessageBar, MessageBarBody, Spinner, Switch, Text } from "@fluentui/react-components";
+import { ArrowDownload20Regular, ArrowUpload20Regular } from "@fluentui/react-icons";
+import type { UiControl } from "../area/types.js";
+import { useResolve } from "../area/context.js";
+import { useMeshOps } from "../live/meshOps.js";
+import { str, useText } from "./common.js";
+import { triggerDownload } from "./documentControls.js";
+
+/** The bundle wire shape — self-describing so an import can re-target from the recorded root. */
+interface MeshBundle {
+  meshExport: number;
+  root: string;
+  exportedAt?: string;
+  nodes: Record<string, unknown>[];
+}
+
+const BUNDLE_VERSION = 1;
+
+// ---- NodeExport ----------------------------------------------------------------------------------
+
+function NodeExportView({ control }: { control: UiControl }): ReactNode {
+  const ops = useMeshOps();
+  const sourcePath = useText(control.sourcePath);
+  const nodeName = useText(control.nodeName) || safeSlug(sourcePath);
+  const [state, setState] = useState<{ status: "idle" | "exporting" } | { status: "error"; message: string }>({ status: "idle" });
+
+  if (!ops?.search || !ops.getNode)
+    return unavailable("Node export isn't available in this frontend.");
+
+  const run = () => {
+    if (!sourcePath || state.status === "exporting") return;
+    setState({ status: "exporting" });
+    (async () => {
+      // The root plus every descendant. search(basePath) scopes to the subtree.
+      const rows = await ops.search!("scope:descendants", sourcePath, 5000);
+      const paths = new Set<string>([sourcePath]);
+      for (const r of rows) {
+        const p = str(r.path);
+        if (p) paths.add(p);
+      }
+      const nodes: Record<string, unknown>[] = [];
+      for (const p of paths) {
+        const node = await ops.getNode!(p);
+        if (node) nodes.push(node);
+      }
+      const bundle: MeshBundle = { meshExport: BUNDLE_VERSION, root: sourcePath, nodes };
+      const bytes = new TextEncoder().encode(JSON.stringify(bundle, null, 2));
+      triggerDownload(bytes, `${nodeName}.mesh.json`, "application/json");
+      setState({ status: "idle" });
+    })().catch((e) => setState({ status: "error", message: e instanceof Error ? e.message : String(e) }));
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10, maxWidth: 420 }}>
+      <Text size={200} style={{ color: "var(--colorNeutralForeground3)" }}>
+        Downloads <b>{sourcePath || "this node"}</b> and its descendants as a portable JSON bundle.
+      </Text>
+      <Button
+        appearance="primary"
+        icon={state.status === "exporting" ? <Spinner size="tiny" /> : <ArrowDownload20Regular />}
+        disabled={state.status === "exporting" || !sourcePath}
+        onClick={run}
+      >
+        {state.status === "exporting" ? "Exporting…" : "Export node"}
+      </Button>
+      {state.status === "error" ? errorBar(state.message) : null}
+    </div>
+  );
+}
+
+// ---- NodeImport ----------------------------------------------------------------------------------
+
+type ImportState =
+  | { status: "idle" }
+  | { status: "importing" }
+  | { status: "done"; created: number; failed: number }
+  | { status: "error"; message: string };
+
+function NodeImportView({ control }: { control: UiControl }): ReactNode {
+  const ops = useMeshOps();
+  const targetPath = useText(control.targetPath);
+  const forceDefault = !!useResolve(control.force);
+  const [force, setForce] = useState(forceDefault);
+  const [state, setState] = useState<ImportState>({ status: "idle" });
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  if (!ops?.createNode)
+    return unavailable("Node import isn't available in this frontend.");
+
+  const onFile = (file: File) => {
+    setState({ status: "importing" });
+    (async () => {
+      const text = await file.text();
+      const bundle = JSON.parse(text) as MeshBundle;
+      if (!bundle || typeof bundle !== "object" || !Array.isArray(bundle.nodes))
+        throw new Error("Not a MeshWeaver node bundle (.mesh.json).");
+      const root = str(bundle.root);
+      let created = 0;
+      let failed = 0;
+      for (const raw of bundle.nodes) {
+        const node = retarget(raw, root, targetPath);
+        if (force) delete (node as Record<string, unknown>).createdBy; // let the server re-stamp
+        try {
+          await ops.createNode!(node);
+          created++;
+        } catch {
+          failed++; // e.g. already exists without force — counted, not fatal
+        }
+      }
+      setState({ status: "done", created, failed });
+    })().catch((e) => setState({ status: "error", message: e instanceof Error ? e.message : String(e) }));
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10, maxWidth: 460 }}>
+      <Field label={`Import into: ${targetPath || "(target unset)"}`}>
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".json,application/json"
+          style={{ display: "none" }}
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) onFile(f);
+            e.target.value = ""; // allow re-selecting the same file
+          }}
+        />
+        <Input readOnly value="" placeholder="Choose a .mesh.json bundle…" contentAfter={
+          <Button
+            appearance="primary"
+            size="small"
+            icon={state.status === "importing" ? <Spinner size="tiny" /> : <ArrowUpload20Regular />}
+            disabled={state.status === "importing" || !targetPath}
+            onClick={() => fileRef.current?.click()}
+          >
+            {state.status === "importing" ? "Importing…" : "Choose file"}
+          </Button>
+        } />
+      </Field>
+      <Switch checked={force} label="Force (overwrite existing)" onChange={(_, d) => setForce(!!d.checked)} />
+      {state.status === "done" ? (
+        <MessageBar intent={state.failed > 0 ? "warning" : "success"}>
+          <MessageBarBody>
+            Imported {state.created} node{state.created === 1 ? "" : "s"}
+            {state.failed > 0 ? `; ${state.failed} skipped (already present — enable Force to overwrite)` : ""}.
+          </MessageBarBody>
+        </MessageBar>
+      ) : null}
+      {state.status === "error" ? errorBar(state.message) : null}
+    </div>
+  );
+}
+
+// ---- helpers -------------------------------------------------------------------------------------
+
+/** Re-point a node's path + namespace from its export root onto the import target. */
+function retarget(raw: Record<string, unknown>, root: string, target: string): Record<string, unknown> {
+  const node = { ...raw };
+  const rebase = (value: unknown): unknown => {
+    const s = str(value as never);
+    if (!s || !root) return value;
+    if (s === root) return target;
+    if (s.startsWith(root + "/")) return target + s.slice(root.length);
+    return value;
+  };
+  if ("path" in node) node.path = rebase(node.path);
+  if ("namespace" in node) node.namespace = rebase(node.namespace);
+  if ("mainNode" in node) node.mainNode = rebase(node.mainNode);
+  return node;
+}
+
+function safeSlug(path: string): string {
+  return (path.split("/").pop() || "node").replace(/[^a-zA-Z0-9._-]+/g, "-") || "node";
+}
+
+function unavailable(message: string): ReactNode {
+  return (
+    <MessageBar intent="info">
+      <MessageBarBody>{message}</MessageBarBody>
+    </MessageBar>
+  );
+}
+
+function errorBar(message: string): ReactNode {
+  return (
+    <MessageBar intent="error">
+      <MessageBarBody>{message}</MessageBarBody>
+    </MessageBar>
+  );
+}
+
+export const nodeTransferControls = {
+  NodeExport: NodeExportView,
+  NodeImport: NodeImportView,
+};

--- a/clients/react/src/core.ts
+++ b/clients/react/src/core.ts
@@ -29,6 +29,10 @@ export {
   type MarkdownCellSubmission,
   type MarkdownKernelSession,
   type RenderedMarkdown,
+  type DocumentDownload,
+  type DocumentExportOptions,
+  type ContentListing,
+  type ContentItem,
 } from "./live/meshOps.js";
 export {
   EmbeddedAreaProvider,

--- a/clients/react/src/live/meshOps.tsx
+++ b/clients/react/src/live/meshOps.tsx
@@ -85,6 +85,57 @@ export interface MeshOps {
    * markdown itself. Hosts without it fall back to the plain client-side renderer.
    */
   renderMarkdown?(markdown: string, nodePath?: string): Promise<RenderedMarkdown>;
+  /** Optional single-node read — the raw hub-serialized MeshNode JSON at `path` (NodeExport bundles
+   *  a subtree of these). Null when absent/unreadable. */
+  getNode?(path: string): Promise<Record<string, unknown> | null>;
+  /** Optional node create — the NodeImport fan-out re-creates each bundled node via this (routes to
+   *  the node's owner partition, throws on a refused create). */
+  createNode?(node: Record<string, unknown>): Promise<void>;
+  /**
+   * Optional document export — the client twin of the Blazor ExportDocumentView: posts
+   * ExportDocumentRequest to the source node hub, watches the returned Activity to a terminal
+   * status, and resolves the rendered PDF/DOCX bytes for a browser download. Absent → the control
+   * renders a "not available here" notice.
+   */
+  exportDocument?(sourcePath: string, options: DocumentExportOptions): Promise<DocumentDownload>;
+  /** Optional content-collection listing — the read half of the file browser. `path` is
+   *  `{node}/{collection}[/{dir}]`. Absent → the browser renders a "not available" notice. */
+  listContent?(path: string): Promise<ContentListing>;
+  /** Optional content upload (multipart) — `path` is `{node}/{collection}/{filePath}`. */
+  uploadContent?(path: string, file: File): Promise<void>;
+}
+
+/** A content-collection directory listing (the /api/mesh/content/list shape). */
+export interface ContentListing {
+  collection: string;
+  path: string;
+  editable: boolean;
+  items: ContentItem[];
+}
+
+/** One entry in a content-collection directory. */
+export interface ContentItem {
+  kind: "folder" | "file" | "unknown";
+  name: string;
+  path: string;
+  itemCount?: number;
+  lastModified?: string;
+}
+
+/** A rendered export ready for a browser download (the RenderedDocument wire shape, decoded). */
+export interface DocumentDownload {
+  fileName: string;
+  mimeType: string;
+  bytes: Uint8Array;
+}
+
+/** The subset of DocumentExportOptions the React export form drives. */
+export interface DocumentExportOptions {
+  format?: "pdf" | "docx";
+  title?: string;
+  includeChildren?: boolean;
+  coverPage?: boolean;
+  tableOfContents?: boolean;
 }
 
 export type { MarkdownCellSubmission, MarkdownKernelSession, RenderedMarkdown } from "../controls/interactiveMarkdown.js";

--- a/clients/react/src/render/parity.test.ts
+++ b/clients/react/src/render/parity.test.ts
@@ -52,8 +52,21 @@ describe("React ↔ Blazor control parity", () => {
   // placeholderControlTypes AND from this pinned list. Adding a NEW placeholder fails here — every
   // new control must ship a real implementation.
   it("the placeholder long-tail only ever shrinks", () => {
-    const pinned = ["DocumentSource", "ExportDocument", "FileBrowser", "NodeExport", "NodeImport"];
+    // Every mesh control now has a real implementation (documentControls.tsx, nodeTransfer.tsx,
+    // fileBrowser.tsx). The placeholder long-tail is EMPTY — no control renders as a bare badge.
+    const pinned: string[] = [];
     expect([...placeholderControlTypes].sort()).toEqual(pinned.sort());
+  });
+
+  it("the un-placeholdered controls are all real, distinct components", () => {
+    const real = ["DocumentSource", "ExportDocument", "NodeExport", "NodeImport", "FileBrowser"].map(
+      (key) => {
+        expect(typeof controlRegistry[key]).toBe("function");
+        return controlRegistry[key];
+      },
+    );
+    // No two of them collapsed to the same component.
+    expect(new Set(real).size).toBe(real.length);
   });
 
   // RATCHET: formerly-thin controls that now have REAL implementations — regressing one to an

--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -107,6 +107,12 @@ public static class MeshApiEndpoints
         group.MapPost("/resolve", (HttpContext http, IMessageHub rootHub, PathBody body, CancellationToken ct) =>
             RunString(http, rootHub, ct, ops => ops.Resolve(body.Path)));
 
+        // Content-collection directory listing — the read half of the React FileBrowser. Path is
+        // "{node}/{collection}[/{dir}]"; download uses the existing /content|/static URLs, add uses
+        // /upload. Returns { collection, path, editable, items:[…] } (or "Error: …").
+        group.MapPost("/content/list", (HttpContext http, IMessageHub rootHub, PathBody body, CancellationToken ct) =>
+            RunString(http, rootHub, ct, ops => ops.ContentList(body.Path)));
+
         // Mirror Push/Pull — these talk to the mesh hub directly (same as MCP plugin's PostMirror).
         group.MapPost("/mirror", HandleMirror);
 

--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -1807,7 +1807,13 @@ public class MeshOperations
 
             var remainderParts = resolution.Remainder.Split('/', StringSplitOptions.RemoveEmptyEntries);
             var collectionName = remainderParts[0];
-            var dir = string.Join("/", remainderParts.Skip(1));
+            var dirParts = remainderParts.Skip(1).ToArray();
+            // The FileSystem provider resolves the listing dir with an unguarded Path.Combine(basePath, dir),
+            // so a '..' (or a backslash-embedded) segment would traverse OUTSIDE the collection scope. Reject
+            // traversal at the boundary — the listing contract is strictly "within this collection".
+            if (dirParts.Any(p => p is "." or ".." || p.Contains('\\') || p.Contains("..")))
+                return Observable.Return("Error: the directory path must not contain '.', '..', or backslash segments.");
+            var dir = string.Join("/", dirParts);
             var targetAddress = (Address)resolution.Prefix;
             var qualifiedCollectionName = $"{resolution.Prefix}/{collectionName}";
 

--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -1781,6 +1781,103 @@ public class MeshOperations
     }
 
     /// <summary>
+    /// Lists a content collection directory — the read half of the file browser. Path shape is
+    /// <c>{node}/{collection}[/{dir}]</c> (e.g. <c>Systemorph/content</c> or
+    /// <c>Systemorph/content/images</c>). Mirrors <see cref="Upload"/>'s resolve → collection-config →
+    /// IoPool flow, then enumerates <c>GetCollectionItems</c>. Returns JSON
+    /// <c>{ collection, path, editable, items: [{ kind, name, path, itemCount?, lastModified? }] }</c>
+    /// or a descriptive <c>Error: …</c> string.
+    /// </summary>
+    public IObservable<string> ContentList(string path)
+    {
+        logger.LogInformation("ContentList path={Path}", path);
+        if (string.IsNullOrWhiteSpace(path))
+            return Observable.Return("Error: path is required.");
+        var resolvedPath = ResolvePath(path).TrimStart('/');
+        if (string.IsNullOrWhiteSpace(resolvedPath))
+            return Observable.Return("Error: path is required.");
+
+        var pathResolver = hub.ServiceProvider.GetRequiredService<IPathResolver>();
+        return pathResolver.ResolvePath(resolvedPath).SelectMany(resolution =>
+        {
+            if (resolution == null)
+                return Observable.Return($"Error: no matching node for path '{resolvedPath}'");
+            if (string.IsNullOrEmpty(resolution.Remainder))
+                return Observable.Return("Error: path must include '{collection}[/{dir}]' after the node path (e.g. 'Systemorph/content').");
+
+            var remainderParts = resolution.Remainder.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            var collectionName = remainderParts[0];
+            var dir = string.Join("/", remainderParts.Skip(1));
+            var targetAddress = (Address)resolution.Prefix;
+            var qualifiedCollectionName = $"{resolution.Prefix}/{collectionName}";
+
+            // Same collection-config lookup the static GET endpoint + Upload use — .Timeout is
+            // mandatory (a node hub without AddContentCollections never answers this).
+            return hub.Observe(
+                new GetDataRequest(new ContentCollectionReference([collectionName])),
+                o => o.WithTarget(targetAddress))
+                .Take(1)
+                .Timeout(TimeSpan.FromSeconds(30))
+                .Select(collectionResponse =>
+                {
+                    IReadOnlyCollection<ContentCollectionConfig>? configs = collectionResponse?.Message switch
+                    {
+                        GetDataResponse { Data: JsonElement je } =>
+                            JsonSerializer.Deserialize<ContentCollectionConfig[]>(je, hub.JsonSerializerOptions),
+                        GetDataResponse { Data: IReadOnlyCollection<ContentCollectionConfig> direct } => direct,
+                        _ => null
+                    };
+                    var sourceConfig = configs?.FirstOrDefault(c => c.Name == collectionName);
+                    if (sourceConfig == null) return (ContentCollectionConfig?)null;
+                    return sourceConfig with { Name = qualifiedCollectionName, Address = targetAddress };
+                })
+                .SelectMany(collectionConfig =>
+                {
+                    if (collectionConfig == null)
+                        return Observable.Return($"Error: collection '{collectionName}' not found on '{resolution.Prefix}'.");
+
+                    var contentService = hub.ServiceProvider.GetService<IContentService>();
+                    if (contentService == null)
+                        return Observable.Return("Error: content service not configured on the hub.");
+
+                    contentService.AddConfiguration(collectionConfig);
+                    var ioPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
+                    return ioPool.Run(async ct =>
+                    {
+                        var collection = await contentService.GetCollectionAsync(qualifiedCollectionName, ct).ConfigureAwait(false);
+                        if (collection == null)
+                            return $"Error: failed to initialize collection '{qualifiedCollectionName}'.";
+
+                        var items = new List<object>();
+                        await foreach (var item in collection.GetCollectionItems(dir, ct).ConfigureAwait(false))
+                            items.Add(item switch
+                            {
+                                FolderItem f => (object)new { kind = "folder", name = f.Name, path = f.Path, itemCount = f.ItemCount },
+                                FileItem fi => new { kind = "file", name = fi.Name, path = fi.Path, lastModified = fi.LastModified },
+                                _ => new { kind = "unknown", name = item.Name, path = item.Path },
+                            });
+
+                        return JsonSerializer.Serialize(new
+                        {
+                            collection = qualifiedCollectionName,
+                            path = dir,
+                            editable = collectionConfig.IsEditable,
+                            items,
+                        }, hub.JsonSerializerOptions);
+                    });
+                });
+        })
+        .Catch((Exception ex) =>
+        {
+            logger.LogWarning(ex, "ContentList failed for {Path}", path);
+            var message = ex is TimeoutException
+                ? "the node did not respond to the content-collection lookup in time — confirm the path resolves to a content-enabled node."
+                : ex.Message;
+            return Observable.Return($"Error: {message}");
+        });
+    }
+
+    /// <summary>
     /// Deletes one or more nodes (and their descendants) given a JSON array of path strings.
     /// </summary>
     /// <param name="paths">A JSON array of node paths to delete.</param>

--- a/src/MeshWeaver.ContentCollections/CollectionLayoutArea.cs
+++ b/src/MeshWeaver.ContentCollections/CollectionLayoutArea.cs
@@ -32,6 +32,7 @@ public static class CollectionLayoutArea
 
         var fileBrowser = new FileBrowserControl(collection)
             .WithPath(path)
+            .WithNodePath(host.Hub.Address.ToString())
             .WithUrlBasePath(
                 $"/{host.Hub.Address}/{ContentCollectionsExtensions.CollectionAreaName}/{ContentCollectionsExtensions.EncodeCollectionName(collection)}")
             .WithCollectionConfiguration(collectionConfig);

--- a/src/MeshWeaver.ContentCollections/FileBrowserLayoutAreas.cs
+++ b/src/MeshWeaver.ContentCollections/FileBrowserLayoutAreas.cs
@@ -28,6 +28,7 @@ public static class FileBrowserLayoutAreas
 
         var fileBrowser = new FileBrowserControl(collection)
             .WithPath(path)
+            .WithNodePath(host.Hub.Address.ToString())
             .WithUrlBasePath(
                 $"/{host.Hub.Address}/{ContentCollectionsExtensions.FileBrowserAreaName}/{ContentCollectionsExtensions.EncodeCollectionName(collection)}");
 

--- a/src/MeshWeaver.Layout/FileBrowserControl.cs
+++ b/src/MeshWeaver.Layout/FileBrowserControl.cs
@@ -98,5 +98,17 @@
         /// <param name="readOnly">When <c>true</c>, only read operations are available in the browser UI.</param>
         public FileBrowserControl WithReadOnly(bool readOnly = true)
             => this with { ReadOnly = readOnly };
+
+        /// <summary>
+        /// The OWNING node path (the collection lives on this node's hub). The remote React browser
+        /// needs it to build the content-listing path <c>{NodePath}/{Collection}{Path}</c> — the
+        /// scope doesn't otherwise expose the owning address. Blazor ignores it (it resolves the
+        /// collection in-process). Set via <see cref="WithNodePath"/>.
+        /// </summary>
+        public string? NodePath { get; init; }
+
+        /// <summary>Returns a copy stamped with the owning node path (for the remote file browser).</summary>
+        public FileBrowserControl WithNodePath(string nodePath)
+            => this with { NodePath = nodePath };
     }
 }


### PR DESCRIPTION
## What

Replaces the last **registered-but-placeholder** React controls with real implementations, so the Fluent React pack renders every Blazor control 1:1. The `parity.test.ts` placeholder ratchet is now **empty** — no mesh control renders as a bare badge anymore.

### Client controls (`clients/react/src/controls`)
- **`documentControls.tsx`** — `DocumentSource` (iframe/download of the `/static` URL with the highlight query) and `ExportDocument` (format + include-children form → `ops.exportDocument` → browser download).
- **`nodeTransfer.tsx`** — `NodeExport` (`search scope:descendants` + `getNode` → a MeshBundle JSON download) and `NodeImport` (bundle file → retarget paths → `createNode` fan-out).
- **`fileBrowser.tsx`** — `FileBrowser` (browse via `ops.listContent`, download via the `/content` URL, upload via `ops.uploadContent`; honours `ReadOnly` + the collection's `editable` flag).

### Ops surface (`meshOps.tsx`)
`getNode`, `createNode`, `exportDocument`, `listContent`, `uploadContent` added to `MeshOps`; `DocumentDownload` / `DocumentExportOptions` / `ContentListing` / `ContentItem` types re-exported from `core.ts`. **Both hosts** (portal-next, Vite SPA) implement them over the REST verbs.

### Server
- `MeshOperations.ContentList` — mirrors `Upload`'s resolve → collection-config → `IoPool(FileSystem)` → `GetCollectionItems` flow — exposed as `POST /api/mesh/content/list`.
- `FileBrowserControl.NodePath` (+ `WithNodePath`), stamped in the canonical FileBrowser / Collection layout areas so the remote browser can build the `{node}/{collection}[/{dir}]` listing path (Blazor ignores it — it resolves the collection in-process).

## Verification
- **React**: `typecheck` ✓ · `test` 116/116 ✓ · `build` ✓
- **portal-next** + **Vite SPA**: `tsc --noEmit` ✓
- **.NET**: `Memex.Portal.Distributed` `-c Release -p:CIRun=true -warnaserror` → **0 warnings, 0 errors** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)