### PR TITLE
feat(auth): Sign in with GitHub — same identity/access as Entra by verified email

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -933,6 +933,11 @@ public static class MemexConfiguration
         // {userId}/_Provider/GitHub. See Doc/Architecture/GitHubSync.
         app.MapGitHubConnect();
 
+        // "Sign in with GitHub" — an authentication provider (distinct from the connect endpoints
+        // above). Reuses the same GitHub:OAuth creds; issues the Entra-shaped cookie so a GitHub
+        // login resolves to the same mesh user as an Entra login with that verified email.
+        app.MapGitHubLogin();
+
         // Use HTTPS redirection only for non-MCP paths (MCP needs HTTP for Claude Code)
         app.UseWhen(
             context => !context.Request.Path.StartsWithSegments("/mcp"),

--- a/memex/Memex.Portal.Shared/Pages/Login.razor
+++ b/memex/Memex.Portal.Shared/Pages/Login.razor
@@ -44,6 +44,18 @@
             <p class="signin-label">No external sign-in providers are configured.</p>
         }
 
+        @if (ShowGitHubLogin)
+        {
+            <div class="provider-row" style="margin-top: 0.75rem;">
+                <button type="button" class="provider-btn provider-github"
+                        @onclick="NavigateToGitHubLogin"
+                        aria-label="Sign in with GitHub" title="Sign in with GitHub">
+                    <span class="provider-logo">@((MarkupString)GitHubLogo)</span>
+                    <span class="provider-name">GitHub</span>
+                </button>
+            </div>
+        }
+
         @if (ShowDevLogin)
         {
             <div class="divider"><span>Developer Mode</span></div>
@@ -81,6 +93,13 @@
     private IReadOnlyList<ExternalProviderConfig> Providers { get; set; } = [];
     private bool ShowDevLogin { get; set; }
     private bool ShowLinkedInPublishing { get; set; }
+    private bool ShowGitHubLogin { get; set; }
+
+    private void NavigateToGitHubLogin()
+    {
+        var url = ReturnUrl != null ? $"/login/github?returnUrl={Uri.EscapeDataString(ReturnUrl)}" : "/login/github";
+        Navigation.NavigateTo(url, forceLoad: true);
+    }
 
     private void NavigateToDevLogin()
     {
@@ -117,6 +136,10 @@
         // The "Connect LinkedIn for publishing" connect needs Social:LinkedIn:ClientId; hide the button
         // entirely when it's absent (the connect endpoint 500s without it).
         ShowLinkedInPublishing = !string.IsNullOrEmpty(Configuration["Social:LinkedIn:ClientId"]);
+
+        // "Sign in with GitHub" appears only when the GitHub OAuth App is configured
+        // (GitHub:OAuth:ClientId) — otherwise /login/github redirects back with an error.
+        ShowGitHubLogin = !string.IsNullOrEmpty(Configuration["GitHub:OAuth:ClientId"]);
     }
 
     private string GetProviderLoginUrl(string providerName)
@@ -145,4 +168,6 @@
     private const string AppleLogo = """<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35c-1.09-.46-2.09-.48-3.24 0c-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8c1.18-.24 2.31-.93 3.57-.84c1.51.12 2.65.72 3.4 1.8c-3.12 1.87-2.38 5.98.48 7.13c-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25c.29 2.58-2.34 4.5-3.74 4.25z"/></svg>""";
 
     private const string DefaultLogo = """<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="currentColor" d="M12 17a2 2 0 0 1-2-2c0-1.11.89-2 2-2a2 2 0 0 1 2 2a2 2 0 0 1-2 2m6 3V10H6v10h12m0-12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V10c0-1.11.89-2 2-2h1V6a5 5 0 0 1 5-5a5 5 0 0 1 5 5v2h-2V6a3 3 0 0 0-3-3a3 3 0 0 0-3 3v2h8z"/></svg>""";
+
+    private const string GitHubLogo = """<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="#181717" d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39c.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61c-.55-1.39-1.34-1.76-1.34-1.76c-1.09-.75.08-.73.08-.73c1.21.09 1.84 1.24 1.84 1.24c1.07 1.84 2.81 1.31 3.5 1c.11-.78.42-1.31.76-1.61c-2.67-.3-5.47-1.33-5.47-5.93c0-1.31.47-2.38 1.24-3.22c-.13-.3-.54-1.52.11-3.18c0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 3-.4c1.02 0 2.05.14 3 .4c2.28-1.55 3.29-1.23 3.29-1.23c.66 1.66.25 2.88.12 3.18c.77.84 1.24 1.91 1.24 3.22c0 4.61-2.81 5.63-5.49 5.93c.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.82.58A12.01 12.01 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z"/></svg>""";
 }

--- a/memex/Memex.Portal.Shared/Social/GitHubLoginEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/GitHubLoginEndpoints.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using MeshWeaver.GitSync;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Social;
+
+/// <summary>
+/// "Sign in with GitHub" — a first-class AUTHENTICATION provider (distinct from
+/// <see cref="GitHubConnectEndpoints"/>, which only CONNECTS a GitHub identity for repo sync
+/// without signing anyone in). It runs the same GitHub OAuth authorization-code flow
+/// (<see cref="GitHubOAuthService"/>, reusing the already-configured <c>GitHub:OAuth</c> creds),
+/// then issues the portal cookie with the <b>IDENTICAL claim shape</b> Entra login produces via
+/// <c>ExternalAuthController</c> — so a GitHub login resolves, through
+/// <c>UserContextMiddleware</c>, to the SAME mesh <c>User.Id</c> as an Entra login with the same
+/// verified email. That is how the user's decision "GitHub users get the same access as Entra
+/// users" is realized: no special-case access logic, just the same identity by email.
+///
+///   GET /login/github?returnUrl=…            — start (CSRF state cookie, redirect to GitHub authorize)
+///   GET /login/github/callback?code=&amp;state=  — exchange code → token, fetch verified email, sign in
+///
+/// <para><b>GitHub App note.</b> The configured credential is a GitHub App (client id <c>Ov23…</c>),
+/// which supports this user-authorization flow on the same endpoints. Resolving the user's email
+/// needs the App's "Email addresses: Read" account permission; without it the login FAILS
+/// gracefully (never a fabricated identity). The App must whitelist the callback URL
+/// <c>{portal}/login/github/callback</c>.</para>
+/// </summary>
+public static class GitHubLoginEndpoints
+{
+    public const string StateCookieName = "gh_login_state";
+    private const string CallbackPath = "/login/github/callback";
+
+    /// <summary>
+    /// The single gate deciding WHO may sign in with GitHub. Today it admits everyone (the user's
+    /// explicit choice: "any GitHub account = same access as Entra users"). To restrict later —
+    /// e.g. to Systemorph org members or an allowlist — this is the ONE line to change (add the org
+    /// check here and thread the token through; nothing else needs to move).
+    /// </summary>
+    internal static bool IsGitHubUserAllowed(string? login, string email) => true;
+
+    public static IEndpointRouteBuilder MapGitHubLogin(this IEndpointRouteBuilder endpoints)
+    {
+        // START — NOT RequireAuthorization: this IS the sign-in.
+        endpoints.MapGet("/login/github", (
+            HttpContext http,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string? returnUrl,
+            GitHubOAuthService oauth) =>
+        {
+            if (!oauth.IsConfigured)
+                return Results.Redirect("/login?error=" + Uri.EscapeDataString("GitHub sign-in is not configured on this server."));
+
+            var state = GenerateState();
+            var ru = SafeLocal(returnUrl);
+            http.Response.Cookies.Append(StateCookieName,
+                WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes($"{state}|{ru}")),
+                new CookieOptions
+                {
+                    HttpOnly = true,
+                    Secure = true,
+                    SameSite = SameSiteMode.Lax,
+                    MaxAge = TimeSpan.FromMinutes(10),
+                });
+
+            return Results.Redirect(oauth.BuildAuthorizeUrl(BuildRedirectUri(http), state));
+        });
+
+        // CALLBACK — exchange code, fetch the verified email, sign the user in with the Entra claim shape.
+        endpoints.MapGet(CallbackPath, async (
+            HttpContext http,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string? code,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string? state,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string? error,
+            GitHubOAuthService oauth,
+            ILoggerFactory loggers) =>
+        {
+            var logger = loggers.CreateLogger("GitHubLogin");
+
+            string cookieState = "", returnUrl = "/";
+            if (http.Request.Cookies.TryGetValue(StateCookieName, out var cookie) && !string.IsNullOrEmpty(cookie))
+            {
+                http.Response.Cookies.Delete(StateCookieName);
+                try
+                {
+                    var parts = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(cookie)).Split('|', 2);
+                    cookieState = parts[0];
+                    returnUrl = parts.Length > 1 ? parts[1] : "/";
+                }
+                catch { /* malformed cookie — fails the state check below */ }
+            }
+
+            IResult Fail(string reason)
+            {
+                logger.LogWarning("GitHub sign-in failed: {Reason}", reason);
+                return Results.Redirect("/login?error=" + Uri.EscapeDataString(reason));
+            }
+
+            if (!string.IsNullOrEmpty(error)) return Fail(error!);
+            if (string.IsNullOrEmpty(cookieState)) return Fail("missing or bad sign-in state cookie (CSRF)");
+            if (!string.Equals(cookieState, state, StringComparison.Ordinal)) return Fail("sign-in state mismatch (CSRF)");
+            if (string.IsNullOrEmpty(code)) return Fail("no authorization code returned by GitHub");
+
+            var redirectUri = BuildRedirectUri(http);
+            // Reactive end-to-end; bridge to Task ONCE at the HTTP boundary (the sanctioned edge
+            // pattern, as in GitHubConnectEndpoints / OAuthConnectController). Exchange the code,
+            // then fetch login + primary verified email together.
+            return await oauth.ExchangeCode(code!, redirectUri)
+                .SelectMany(token => oauth.GetLogin(token.AccessToken)
+                    .Catch<string?, Exception>(_ => Observable.Return<string?>(null))
+                    .SelectMany(login => oauth.GetPrimaryEmail(token.AccessToken)
+                        .Catch<string?, Exception>(_ => Observable.Return<string?>(null))
+                        .Select(mail => (login, email: mail))))
+                .SelectMany(async t =>
+                {
+                    var (login, email) = t;
+                    if (string.IsNullOrEmpty(email))
+                        return Fail("GitHub sign-in needs a verified email — ensure the GitHub App has "
+                                    + "'Email addresses: Read' account permission and your GitHub email is verified.");
+                    if (!IsGitHubUserAllowed(login, email))
+                        return Fail("This GitHub account is not permitted to sign in.");
+
+                    // The SAME cookie identity ExternalAuthController builds for Entra: objectId = email,
+                    // preferred_username = email, name + email claims. UserContextMiddleware maps the email
+                    // to the mesh User.Id downstream → same user, same access as an Entra login.
+                    var name = login ?? email;
+                    var claims = new List<Claim>
+                    {
+                        new(ClaimTypes.NameIdentifier, email),
+                        new(ClaimTypes.Name, name),
+                        new("name", name),
+                        new("preferred_username", email),
+                        new(ClaimTypes.Email, email),
+                        new("email", email),
+                    };
+                    var principal = new ClaimsPrincipal(
+                        new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme));
+                    await http.SignInAsync(
+                        CookieAuthenticationDefaults.AuthenticationScheme,
+                        principal,
+                        new AuthenticationProperties
+                        {
+                            IsPersistent = true,
+                            ExpiresUtc = DateTimeOffset.UtcNow.AddDays(14),
+                        });
+                    logger.LogInformation("GitHub sign-in for {Email} (login {Login})", email, login);
+                    return (IResult)Results.Redirect(SafeLocal(returnUrl));
+                })
+                .Catch((Exception ex) =>
+                {
+                    logger.LogWarning(ex, "GitHub sign-in failed during token exchange / profile fetch");
+                    return Observable.Return(Fail(ex.Message));
+                })
+                .FirstAsync()
+                .ToTask(http.RequestAborted);
+        });
+
+        return endpoints;
+    }
+
+    /// <summary>Only ever redirect to a local path — never an attacker-supplied absolute URL (open-redirect guard).</summary>
+    internal static string SafeLocal(string? returnUrl) =>
+        string.IsNullOrWhiteSpace(returnUrl) || !returnUrl.StartsWith("/", StringComparison.Ordinal) || returnUrl.StartsWith("//", StringComparison.Ordinal)
+            ? "/"
+            : returnUrl;
+
+    private static string GenerateState()
+    {
+        Span<byte> buf = stackalloc byte[24];
+        RandomNumberGenerator.Fill(buf);
+        return WebEncoders.Base64UrlEncode(buf);
+    }
+
+    private static string BuildRedirectUri(HttpContext http) =>
+        $"{http.Request.Scheme}://{http.Request.Host}{CallbackPath}";
+}

--- a/src/MeshWeaver.GitSync/GitHubOAuthService.cs
+++ b/src/MeshWeaver.GitSync/GitHubOAuthService.cs
@@ -70,7 +70,46 @@ public sealed class GitHubOAuthService
     public IObservable<string?> GetLogin(string accessToken) =>
         Http.Invoke(ct => GetLoginAsync(accessToken, ct));
 
+    /// <summary>
+    /// Resolves the user's PRIMARY VERIFIED email — the identity key for "Sign in with GitHub"
+    /// (so a GitHub login maps to the SAME mesh user as an Entra login with that email). Returns
+    /// <c>null</c> when no primary verified email is obtainable — e.g. the GitHub App lacks the
+    /// "Email addresses: Read" account permission (the <c>/user/emails</c> call 403s) or the user
+    /// has no verified email. Callers MUST fail the login gracefully on null, never fabricate an
+    /// identity from the login handle. (The <c>scope=user:email</c> param is ignored by GitHub
+    /// Apps — access is governed by the App's account permissions, not the OAuth scope.)
+    /// </summary>
+    public IObservable<string?> GetPrimaryEmail(string accessToken) =>
+        Http.Invoke(ct => GetPrimaryEmailAsync(accessToken, ct));
+
     // ── HTTP leaves (run inside the I/O pool) ────────────────────────────────
+
+    private async Task<string?> GetPrimaryEmailAsync(string accessToken, CancellationToken ct)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, options.UserApiUrl.TrimEnd('/') + "/emails");
+        req.Headers.Accept.ParseAdd("application/vnd.github+json");
+        req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+        using var resp = await http.SendAsync(req, ct).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode) return null;
+        var json = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(json);
+        if (doc.RootElement.ValueKind != JsonValueKind.Array) return null;
+
+        // GitHub returns the addresses in no guaranteed order — pick the primary+verified one;
+        // fall back to any verified address so a user whose primary isn't flagged still resolves.
+        string? verifiedFallback = null;
+        foreach (var e in doc.RootElement.EnumerateArray())
+        {
+            var email = GetStr(e, "email");
+            if (string.IsNullOrEmpty(email)) continue;
+            var verified = e.TryGetProperty("verified", out var v) && v.ValueKind == JsonValueKind.True;
+            var primary = e.TryGetProperty("primary", out var p) && p.ValueKind == JsonValueKind.True;
+            if (!verified) continue;
+            if (primary) return email;
+            verifiedFallback ??= email;
+        }
+        return verifiedFallback;
+    }
 
     private async Task<GitHubToken> ExchangeCodeAsync(string code, string redirectUri, CancellationToken ct)
     {

--- a/test/Memex.Portal.Shared.Test/GitHubLoginEndpointsTest.cs
+++ b/test/Memex.Portal.Shared.Test/GitHubLoginEndpointsTest.cs
@@ -1,0 +1,37 @@
+using Memex.Portal.Shared.Social;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Security-critical logic of the "Sign in with GitHub" provider: the open-redirect guard on the
+/// post-login return path (an attacker must not be able to bounce a freshly-authenticated user to an
+/// external site), and the sign-in allow-predicate (which today admits everyone per the deployment
+/// decision, and is the single place to tighten to an org allowlist later). The full authorize →
+/// callback → cookie flow + the GitHub email fetch are integration-level (HTTP + cookies) and are
+/// exercised by the e2e portal stack.
+/// </summary>
+public class GitHubLoginEndpointsTest
+{
+    [Theory]
+    [InlineData(null, "/")]                                   // no return → home
+    [InlineData("", "/")]                                     // empty → home
+    [InlineData("   ", "/")]                                  // whitespace → home
+    [InlineData("/AgenticEngineering/Training", "/AgenticEngineering/Training")] // local path preserved
+    [InlineData("/space/x?tab=1", "/space/x?tab=1")]          // local path + query preserved
+    [InlineData("https://evil.example.com", "/")]            // absolute URL rejected
+    [InlineData("http://evil.example.com/x", "/")]           // absolute URL rejected
+    [InlineData("//evil.example.com", "/")]                  // protocol-relative rejected
+    [InlineData("evil.example.com", "/")]                    // bare host (no leading slash) rejected
+    public void SafeLocal_RejectsExternalRedirects_KeepsLocalPaths(string? input, string expected) =>
+        Assert.Equal(expected, GitHubLoginEndpoints.SafeLocal(input));
+
+    [Fact]
+    public void IsGitHubUserAllowed_AdmitsEveryone_Today()
+    {
+        // The deployment decision: any GitHub account may sign in (same access as an Entra user).
+        // If this ever tightens to an allowlist, this test documents the change point.
+        Assert.True(GitHubLoginEndpoints.IsGitHubUserAllowed("octocat", "octocat@example.com"));
+        Assert.True(GitHubLoginEndpoints.IsGitHubUserAllowed(null, "someone@example.com"));
+    }
+}


### PR DESCRIPTION
Adds 'Sign in with GitHub' to the portal login page (requested by the deployment owner). GitHub login runs the OAuth flow via the already-configured `GitHub:OAuth` creds and issues the **same cookie claim shape as Entra** (identity = primary verified email), so `UserContextMiddleware` resolves it to the same mesh user → same access, no special-casing.

- `GetPrimaryEmail` (primary+verified; null → graceful failure, never a fabricated identity).
- `IsGitHubUserAllowed` = the one-line gate to tighten to an org allowlist later (admits everyone today, per the owner's choice).
- Open-redirect guard on the return path; button shown only when configured.
- Tests 10/10 (redirect guard + allow-predicate); full flow is e2e. Release `-warnaserror` 0/0.

**GitHub App settings required** (client id `Ov23…`): 'Email addresses: Read' account permission, callback URL `https://memex.meshweaver.cloud/login/github/callback`.

**Security:** any GitHub account = full Entra-equivalent access — the owner's explicit informed choice; `IsGitHubUserAllowed` is where to restrict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)