### PR TITLE
fix(portal): node preview dialog no longer hijacks the header menu

### DIFF
--- a/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor
+++ b/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor
@@ -74,4 +74,15 @@
 @code
 {
     [Parameter] public bool Top { get; set; }
+
+    /// <summary>
+    /// Whether this area drives the global header menu (Node / Mesh / AI dropdowns). ONLY the
+    /// routed primary page sets this (ApplicationPage / AreaPage). Deliberately decoupled from
+    /// <see cref="Top"/>: a modal node PREVIEW (NodePreviewDialog) and embedded areas render
+    /// <see cref="Top"/>=true for full-area layout, but must NOT hijack the header menu — that
+    /// clobbered the current node's menu with the previewed/embedded node's (e.g. a Skill's,
+    /// leaving no Delete) and stuck there after the dialog closed, since the per-circuit menu
+    /// slot keeps its last value.
+    /// </summary>
+    [Parameter] public bool DrivesMenu { get; set; }
 }

--- a/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor.cs
@@ -184,13 +184,16 @@ public partial class LayoutAreaView
                 .Subscribe(
                     el => OnProgressStreamChanged(el.Value),
                     ex => OnReducedStreamError(ex, "progress")));
-            if (Top)
+            if (DrivesMenu)
             {
                 // Menus ride the SAME area stream, read via the renderer-agnostic hub.GetMenu API
                 // (MeshWeaver.Mesh.MenuStreamExtensions) — the framework counterpart of hub.GetQuery.
                 // No bespoke reduce + deserialize per context here; the native MAUI shell consumes the
                 // exact same observable. Each subscription registers on AreaStream so AreaStream.Dispose()
                 // tears it down (no separate menu-stream fields to track / null out).
+                // 🚨 Gated on DrivesMenu (NOT Top): only the routed primary page (ApplicationPage /
+                // AreaPage) owns the header menu. A modal preview (NodePreviewDialog) or an embedded
+                // area renders Top=true but must not clobber the current node's menu — see DrivesMenu.
                 SubscribeMenu("", null);
                 SubscribeMenu(NodeMenuContext, NodeMenuContext);
                 SubscribeMenu(MeshMenuContext, MeshMenuContext);

--- a/src/MeshWeaver.Blazor/Pages/ApplicationPage.razor
+++ b/src/MeshWeaver.Blazor/Pages/ApplicationPage.razor
@@ -70,7 +70,8 @@
     }
     else
     {
-        @* Interactive phase, resolved: LayoutAreaView with stream subscription *@
-        <LayoutAreaView ViewModel="@ViewModel" Top="true" />
+        @* Interactive phase, resolved: LayoutAreaView with stream subscription. DrivesMenu:
+           this routed page owns the header menu (a modal preview / embed must not). *@
+        <LayoutAreaView ViewModel="@ViewModel" Top="true" DrivesMenu="true" />
     }
 </CascadingValue>

--- a/src/MeshWeaver.Blazor/Pages/AreaPage.razor
+++ b/src/MeshWeaver.Blazor/Pages/AreaPage.razor
@@ -19,7 +19,7 @@
         }
         else
         {
-            <LayoutAreaView ViewModel="@ViewModel" Top="true" />
+            <LayoutAreaView ViewModel="@ViewModel" Top="true" DrivesMenu="true" />
         }
     </CascadingValue>
 </div>

--- a/test/MeshWeaver.Portal.E2E.Test/NodeMenuE2ETest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/NodeMenuE2ETest.cs
@@ -83,9 +83,11 @@ public class NodeMenuE2ETest(PortalFixture fixture)
                     await button.WaitForAsync(
                         new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 15_000 });
                     await button.ClickAsync();
-                    // The routed page drives $Menu:Node → Delete must be an item.
-                    await page.GetByText("Delete", new() { Exact = false }).First.WaitForAsync(
-                        new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 10_000 });
+                    // Scoped to a MENU ITEM (role=menuitem) — not page-body text — so this only passes
+                    // when Delete is genuinely IN the Node dropdown that the routed page drives.
+                    await page.GetByRole(AriaRole.Menuitem, new() { Name = "Delete", Exact = false }).First
+                        .WaitForAsync(
+                            new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 10_000 });
                     menuOk = true;
                 }
                 catch (TimeoutException) { /* grant not propagated yet — reload */ }
@@ -93,11 +95,16 @@ public class NodeMenuE2ETest(PortalFixture fixture)
             }
 
             menuOk.Should().BeTrue(
-                "the Space's Node menu must be driven by the routed page and contain Delete "
+                "the Space's Node menu must be driven by the routed page and contain a Delete menu item "
                 + "(an empty menu means the routed page stopped driving $Menu:Node)");
 
-            // The menu is headed by the Space's OWN name — not a stale previewed node's.
-            await page.GetByText("Menu E2E", new() { Exact = false }).First.WaitForAsync(
+            // The dropdown that holds Delete is headed by the Space's OWN name — scoped to THAT
+            // <fluent-menu> (not the page's <h1>), so a stale previewed-node header would fail here.
+            var nodeMenu = page.Locator("fluent-menu").Filter(new()
+            {
+                Has = page.GetByRole(AriaRole.Menuitem, new() { Name = "Delete", Exact = false }),
+            });
+            await nodeMenu.GetByText("Menu E2E", new() { Exact = false }).First.WaitForAsync(
                 new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 10_000 });
 
             await page.ScreenshotAsync(new PageScreenshotOptions { Path = "/tmp/node-menu.png" });

--- a/test/MeshWeaver.Portal.E2E.Test/NodeMenuE2ETest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/NodeMenuE2ETest.cs
@@ -1,0 +1,110 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// The space "⋯" Node menu (Cube icon, <c>#node-menu-anchor</c>) must be driven by the routed
+/// page and show the standard per-node operations — headed by the node's own name. This guards
+/// the fix that decoupled "drives the header menu" from <c>Top</c>: only the routed primary page
+/// (ApplicationPage / AreaPage) drives the menu now, so a wiring slip (e.g. forgetting
+/// <c>DrivesMenu</c> on the page) would leave the Node menu EMPTY — which this test catches.
+/// The dropdown is populated per-circuit from <c>$Menu:Node</c>; with a healthy grant the viewer
+/// has Delete, so "Delete" must be present and the header must be the Space's name (not a stale
+/// previewed node's).
+/// </summary>
+[Collection("portal-e2e")]
+public class NodeMenuE2ETest(PortalFixture fixture)
+{
+    private const string Space = "menue2e";
+
+    [Fact(Timeout = 180_000)]
+    public async Task SpaceNodeMenu_ShowsDelete_HeadedByTheSpaceName()
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+
+        await using var context = await fixture.NewAuthenticatedContextAsync();
+        var token = await fixture.MintTokenAsync(context);
+
+        try
+        {
+            try
+            {
+                await fixture.CreateNodeAsync(context, token, $$"""
+                    {
+                      "id": "{{Space}}",
+                      "name": "Menu E2E",
+                      "nodeType": "Space",
+                      "content": { "$type": "Space", "name": "Menu E2E" }
+                    }
+                    """);
+            }
+            catch (InvalidOperationException) { /* persisted from a prior run */ }
+
+            // A token-created Space grants the token identity (lowercase partition key); the browser
+            // circuit authenticates as the DevLogin ObjectId. Grant the circuit identity so it has
+            // Delete on the Space (the whole point of the assertion) — same shape as the sync E2E.
+            try
+            {
+                await fixture.CreateNodeAsync(context, token, $$"""
+                    {
+                      "id": "{{fixture.UserId}}_CircuitAccess",
+                      "namespace": "{{Space}}/_Access",
+                      "name": "{{fixture.UserId}} Access",
+                      "nodeType": "AccessAssignment",
+                      "mainNode": "{{Space}}",
+                      "content": {
+                        "$type": "AccessAssignment",
+                        "accessObject": "{{fixture.UserId}}",
+                        "displayName": "{{fixture.UserId}}",
+                        "roles": [ { "$type": "RoleAssignment", "role": "Admin" } ]
+                      }
+                    }
+                    """);
+            }
+            catch (InvalidOperationException) { }
+
+            (await fixture.WaitUntilReadableAsync(context, token, Space, TimeSpan.FromSeconds(60)))
+                .Should().BeTrue("the seeded space must be readable before driving the UI");
+
+            var page = await context.NewPageAsync();
+            await page.SetViewportSizeAsync(1400, 1000);
+
+            // The creator-admin grant on a fresh space propagates eventually; retry the load so a
+            // circuit that subscribed before the grant landed re-subscribes (same rule as the sync E2E).
+            var menuOk = false;
+            for (var attempt = 0; attempt < 8 && !menuOk; attempt++)
+            {
+                await page.GotoAsync($"{fixture.BaseUrl}/{Space}",
+                    new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 90_000 });
+                var button = page.Locator("#node-menu-anchor, [aria-label='Node menu']").First;
+                try
+                {
+                    await button.WaitForAsync(
+                        new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 15_000 });
+                    await button.ClickAsync();
+                    // The routed page drives $Menu:Node → Delete must be an item.
+                    await page.GetByText("Delete", new() { Exact = false }).First.WaitForAsync(
+                        new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 10_000 });
+                    menuOk = true;
+                }
+                catch (TimeoutException) { /* grant not propagated yet — reload */ }
+                catch (PlaywrightException) { }
+            }
+
+            menuOk.Should().BeTrue(
+                "the Space's Node menu must be driven by the routed page and contain Delete "
+                + "(an empty menu means the routed page stopped driving $Menu:Node)");
+
+            // The menu is headed by the Space's OWN name — not a stale previewed node's.
+            await page.GetByText("Menu E2E", new() { Exact = false }).First.WaitForAsync(
+                new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 10_000 });
+
+            await page.ScreenshotAsync(new PageScreenshotOptions { Path = "/tmp/node-menu.png" });
+        }
+        finally
+        {
+            await fixture.DeleteNodeAsync(context, token, Space);
+        }
+    }
+}


### PR DESCRIPTION
## Symptom
On a Space, the "⋯" **Node** menu (cube icon) showed **"skill" as its title** and was **missing Delete** (and other node ops).

## Root cause
The header Node/Mesh/AI menus are a single **per-circuit `MenuItemsProvider` slot per context**, written by whichever `LayoutAreaView` has `Top=true` (`LayoutAreaView.SubscribeMenu`, gated on `Top`). But `Top` *also* means "render as a full-page area" (page title, 100vh) — and **`NodePreviewDialog`** (a transient modal preview of a referenced node, opened from a chat chip; its own comment promises "returns to the thread untouched") sets `Top=true` purely for that rendering.

So previewing a node — commonly a **Skill** in the AI/chat surface — overwrote the current Space's Node menu with the previewed node's menu (no Delete, since the viewer may lack it there), and it **stuck after dismiss** because the `BehaviorSubject` slot keeps its last value and the primary area doesn't re-emit. Embedded areas (`LayoutArea` forwarding `Top=true`) clobbered it the same way. Permissions were confirmed healthy, ruling out a gating cause.

## Fix
Decouple "drives the header menu" from `Top`: new `LayoutAreaView.DrivesMenu` parameter gates `SubscribeMenu`, set **only** on the routed primary pages (`ApplicationPage`, `AreaPage`). `NodePreviewDialog` keeps `Top=true` for its layout but no longer drives the menu; embedded `LayoutArea`s never should and now don't.

## Verification
- `test/MeshWeaver.Portal.E2E.Test/NodeMenuE2ETest` (DevLogin e2e Blazor portal): a Space's Node menu is driven by the routed page — contains **Delete**, headed by the **Space's own name** (catches a wiring slip that would leave the menu empty).
- Live-verified on the e2e portal: previewing a node then dismissing leaves the Space's Node menu intact.
- CI-parity `Release -warnaserror` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)