### PR TITLE
fix(chat): never block composer + persist default harness/model + logos + smooth title

### DIFF
--- a/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeChatClient.cs
+++ b/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeChatClient.cs
@@ -19,6 +19,10 @@ public class ClaudeCodeChatClient : IChatClient
     private readonly string? modelName;
     private readonly string? configDir;
     private readonly string? oauthToken;
+    // Which env var the resolved credential authenticates through: "oauth" (or null) → CLAUDE_CODE_OAUTH_TOKEN,
+    // "apiKey" → ANTHROPIC_API_KEY, "authToken" → ANTHROPIC_AUTH_TOKEN (+ baseUrl → ANTHROPIC_BASE_URL).
+    private readonly string? authMethod;
+    private readonly string? baseUrl;
     private readonly IMcpBackConnection? mcpBackConnection;
     private readonly string? userId;
     private readonly string? userName;
@@ -47,7 +51,9 @@ public class ClaudeCodeChatClient : IChatClient
         IMcpBackConnection? mcpBackConnection = null,
         string? userId = null,
         string? userName = null,
-        string? userEmail = null)
+        string? userEmail = null,
+        string? authMethod = null,
+        string? baseUrl = null)
     {
         this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         this.modelName = modelName;
@@ -58,6 +64,8 @@ public class ClaudeCodeChatClient : IChatClient
         // replica never share credentials or session state.
         this.configDir = configDir;
         this.oauthToken = oauthToken;
+        this.authMethod = authMethod;
+        this.baseUrl = baseUrl;
         // Automatic MCP back-connection (the mesh is the CLI's workspace) — resolved per spawn.
         this.mcpBackConnection = mcpBackConnection;
         this.userId = userId;
@@ -164,8 +172,28 @@ public class ClaudeCodeChatClient : IChatClient
             try { Directory.CreateDirectory(configDir); }
             catch (Exception ex) { logger?.LogWarning(ex, "Could not create CLAUDE_CONFIG_DIR {Dir}", configDir); }
         }
+        // Set EXACTLY the one env var the chosen auth method names — never two at once, so the CLI's
+        // documented precedence (ANTHROPIC_AUTH_TOKEN > ANTHROPIC_API_KEY > CLAUDE_CODE_OAUTH_TOKEN)
+        // can't pick a stale credential. `authMethod` null/"oauth" keeps the historical subscription-token
+        // behaviour; "apiKey"/"authToken" are the paths that used to be impossible because only the OAuth
+        // env var was ever set (the "passing the key never worked" report).
         if (!string.IsNullOrEmpty(effectiveToken))
-            env["CLAUDE_CODE_OAUTH_TOKEN"] = effectiveToken;
+        {
+            switch (authMethod?.ToLowerInvariant())
+            {
+                case "apikey":
+                    env["ANTHROPIC_API_KEY"] = effectiveToken;
+                    break;
+                case "authtoken":
+                    env["ANTHROPIC_AUTH_TOKEN"] = effectiveToken;
+                    if (!string.IsNullOrEmpty(baseUrl))
+                        env["ANTHROPIC_BASE_URL"] = baseUrl;
+                    break;
+                default: // "oauth" or null — Claude subscription token from `claude setup-token`.
+                    env["CLAUDE_CODE_OAUTH_TOKEN"] = effectiveToken;
+                    break;
+            }
+        }
 
         var claudeOptions = new ClaudeAgentOptions { Env = env };
 

--- a/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeHarness.cs
+++ b/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeHarness.cs
@@ -79,8 +79,13 @@ public sealed class ClaudeCodeHarness(IOptions<ClaudeCodeConfiguration> options)
         // API key — resolve it from the user's ClaudeCode provider node. Best-effort: the CLI also
         // reads its own .credentials.json from the per-user CLAUDE_CONFIG_DIR on the shared volume,
         // so an absent token simply means "rely on the config dir" (and Connect/login can populate it).
+        // Resolve the credential AND its auth method so the client can set the RIGHT env var —
+        // CLAUDE_CODE_OAUTH_TOKEN (subscription), ANTHROPIC_API_KEY (Console key), or
+        // ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL (gateway). Passing a key only as the OAuth-token
+        // env var is why API keys never authenticated.
         var resolver = hub.ServiceProvider.GetService<ChatClientCredentialResolver>();
-        var token = resolver?.ResolveConnectToken(Harnesses.ClaudeCode, userId);
+        var cred = resolver?.ResolveConnectCredential(Harnesses.ClaudeCode, userId);
+        var token = cred?.Token;
 
         var root = configuration.ConfigDirRoot?.TrimEnd('/');
         var configDir = !string.IsNullOrEmpty(root) && !string.IsNullOrEmpty(userId)
@@ -96,6 +101,6 @@ public sealed class ClaudeCodeHarness(IOptions<ClaudeCodeConfiguration> options)
         // `get`, never materialised to disk. No per-spawn skill writing here.
         return new ClaudeCodeChatClient(
             configuration, modelName: null, clientLogger, configDir, token,
-            mcp, userId, accessCtx?.Name, accessCtx?.Email);
+            mcp, userId, accessCtx?.Name, accessCtx?.Email, cred?.AuthMethod, cred?.BaseUrl);
     }
 }

--- a/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeHarness.cs
+++ b/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeHarness.cs
@@ -47,8 +47,8 @@ public sealed class ClaudeCodeHarness(IOptions<ClaudeCodeConfiguration> options)
     /// </summary>
     public IReadOnlyList<HarnessCommand> Commands { get; } =
     [
-        new("login", "Log in to your Claude subscription", HarnessCommandKind.Connect),
-        new("logout", "Log out of Claude Code", HarnessCommandKind.Disconnect),
+        new("login", "Connect: paste a key — /login <console-key> · /login token <setup-token> · /login gateway <url> <token>", HarnessCommandKind.Connect),
+        new("logout", "Forget the stored Claude Code credential", HarnessCommandKind.Disconnect),
     ];
 
     /// <summary>

--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -1804,28 +1804,43 @@ public class AgentChatClient : IAgentChat
     /// </summary>
     private void ApplyStaleModelFallback()
     {
-        if (string.IsNullOrEmpty(currentModelName))
-            return;
         var resolver = hub.ServiceProvider.GetService<ChatClientCredentialResolver>();
         if (resolver is null)
             return;
-        if (resolver.Resolve(currentModelName) != CredentialResolution.Missing)
-            return; // the selected model resolves — nothing to heal.
+        // The selected model already resolves → nothing to heal. (A non-empty, resolvable selection.)
+        if (!string.IsNullOrEmpty(currentModelName)
+            && resolver.Resolve(currentModelName!) != CredentialResolution.Missing)
+            return;
+        // Either NO model is selected, or the selected one no longer resolves (deleted/refactored out of
+        // the catalog, or its provider is unconfigured). Seed the DEFAULT available model (lowest-Order
+        // resolvable) so the round runs on a working model instead of dead-ending on the first factory
+        // (OpenAI) with "(none selected)". When nothing resolves, `fallback` is empty → currentModelName
+        // stays as-is → the round surfaces the clear "No AI model available" message (FormatNoAgentError).
         var fallback = resolver.ResolveDefaultModelId();
         if (string.IsNullOrEmpty(fallback)
             || string.Equals(fallback, currentModelName, StringComparison.OrdinalIgnoreCase))
             return;
         var stale = currentModelName;
-        logger.LogWarning(
-            "[AgentChatClient] Selected model '{Stale}' does not resolve to a live model; "
-            + "falling back to default model '{Default}'.", stale, fallback);
         currentModelName = fallback;
-        // Surface the swap to the user (GetResponseAsync / GetStreamingResponseAsync emit it once).
-        // Without this the model silently changes under the user — they think their pinned model
-        // answered when it actually 404'd and the default stepped in.
-        staleModelNotice =
-            $"*The selected model `{stale}` is unavailable — it may have been removed from the catalog "
-            + $"or its provider is no longer configured. Using the default model `{fallback}` for this response.*";
+        // Only NOTIFY the user when we swapped AWAY from a model they had explicitly pinned. Seeding a
+        // default for an empty selection is silent — there was no user choice to override.
+        if (!string.IsNullOrEmpty(stale))
+        {
+            logger.LogWarning(
+                "[AgentChatClient] Selected model '{Stale}' does not resolve to a live model; "
+                + "falling back to default model '{Default}'.", stale, fallback);
+            // Surface the swap (GetResponseAsync / GetStreamingResponseAsync emit it once). Without this
+            // the model silently changes under the user — they think their pinned model answered when it
+            // actually 404'd and the default stepped in.
+            staleModelNotice =
+                $"*The selected model `{stale}` is unavailable — it may have been removed from the catalog "
+                + $"or its provider is no longer configured. Using the default model `{fallback}` for this response.*";
+        }
+        else
+        {
+            logger.LogDebug(
+                "[AgentChatClient] No model was selected; seeding default model '{Default}'.", fallback);
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -308,12 +308,22 @@ public static class AgentPickerProjection
                 .Select(a => a.Path)
                 .FirstOrDefault());
 
+        var credResolver = hub.ServiceProvider.GetService<ChatClientCredentialResolver>();
         var model = ObserveModels(workspace, hub, currentPath, nodeTypePath, selectedProviderPaths, userPath)
-            .Select(list => list
-                .Where(m => !string.IsNullOrEmpty(m.Path))
-                .OrderBy(m => m.Order)
-                .Select(m => m.Path)
-                .FirstOrDefault());
+            .Select(list =>
+            {
+                var ordered = list.Where(m => !string.IsNullOrEmpty(m.Path)).OrderBy(m => m.Order).ToList();
+                // Default to the lowest-Order model whose credentials actually RESOLVE — mirrors
+                // ChatClientCredentialResolver.ResolveDefaultModelId (the execution-time fallback), so the
+                // composer never DEFAULTS to a model with no provider/key configured (e.g. a "glm-5.2"
+                // catalog entry whose prices/provider were never entered). That divergence — composer picks
+                // lowest-Order, execution picks lowest-Order-that-resolves — is what surfaced as "selected
+                // model X unavailable, using default Y". Fall back to the first model so the composer is
+                // never left without a selection.
+                var resolvable = credResolver == null ? null
+                    : ordered.FirstOrDefault(m => credResolver.Resolve(m.Path!) != CredentialResolution.Missing);
+                return (resolvable ?? ordered.FirstOrDefault())?.Path;
+            });
 
         var harness = ObserveSnapshot(workspace, hub,
                 $"{HarnessesQueryId}|u={userPath ?? ""}|s={spacePath ?? ""}",

--- a/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
+++ b/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
@@ -323,6 +323,30 @@ public sealed class ChatClientCredentialResolver : IDisposable
     }
 
     /// <summary>
+    /// The full co-hosted-CLI credential: the decrypted token/key, the
+    /// <see cref="ModelProviderConfiguration.AuthMethod"/> that says WHICH env var to set, and the
+    /// optional gateway base URL. All fields null when the user hasn't connected.
+    /// </summary>
+    public sealed record HarnessCredential(string? Token, string? AuthMethod, string? BaseUrl);
+
+    /// <summary>
+    /// Method-aware companion to <see cref="ResolveConnectToken"/>: resolves the token AND its
+    /// <see cref="ModelProviderConfiguration.AuthMethod"/> (+ gateway <see cref="ModelProviderConfiguration.Endpoint"/>)
+    /// so the harness sets the RIGHT env var — the fix that lets a stored API key actually authenticate
+    /// (before, only <c>CLAUDE_CODE_OAUTH_TOKEN</c> was ever set). All-null when not connected.
+    /// </summary>
+    public HarnessCredential ResolveConnectCredential(string providerName, string? userPartition)
+    {
+        if (string.IsNullOrEmpty(providerName) || string.IsNullOrEmpty(userPartition))
+            return new HarnessCredential(null, null, null);
+        WatchPartition(userPartition!);
+        var providerPath = $"{ModelProviderNodeType.UserNamespacePath(userPartition!)}/{providerName}";
+        return TryGetProvider(ReadSnapshot(), providerPath, out var cfg) && cfg is not null
+            ? new HarnessCredential(Decrypt(cfg.ApiKey), cfg.AuthMethod, cfg.Endpoint)
+            : new HarnessCredential(null, null, null);
+    }
+
+    /// <summary>
     /// Decrypts a stored credential. Passthrough when no protector is registered
     /// or the value is legacy plaintext (see <see cref="IProviderKeyProtector"/>).
     /// </summary>

--- a/src/MeshWeaver.AI/ModelProviderConfiguration.cs
+++ b/src/MeshWeaver.AI/ModelProviderConfiguration.cs
@@ -56,6 +56,23 @@ public record ModelProviderConfiguration
     public string? ApiKey { get; init; }
 
     /// <summary>
+    /// How the stored <see cref="ApiKey"/> authenticates a co-hosted CLI harness (Claude Code /
+    /// Copilot), chosen at Connect time — mirrors Claude Code's own methods. Drives WHICH env var the
+    /// harness sets when it spawns the CLI (see the CLI's documented auth precedence):
+    /// <list type="bullet">
+    ///   <item><c>oauth</c> (or null) — a Claude subscription token from <c>claude setup-token</c> →
+    ///         <c>CLAUDE_CODE_OAUTH_TOKEN</c>. Null defaults here for backward compatibility with tokens
+    ///         stored before the method chooser existed.</item>
+    ///   <item><c>apiKey</c> — an Anthropic Console API key → <c>ANTHROPIC_API_KEY</c>.</item>
+    ///   <item><c>authToken</c> — a gateway/proxy bearer token → <c>ANTHROPIC_AUTH_TOKEN</c>, with
+    ///         <see cref="Endpoint"/> → <c>ANTHROPIC_BASE_URL</c>.</item>
+    /// </list>
+    /// Only the chosen method's env var is set (never two at once) so the CLI's precedence can't pick a
+    /// stale credential. Not a secret; safe to render (unlike <see cref="ApiKey"/>).
+    /// </summary>
+    public string? AuthMethod { get; init; }
+
+    /// <summary>
     /// Encrypted (<c>enc:</c>-tagged) raw MeshWeaver ApiToken (<c>mw_…</c>) auto-minted at Connect
     /// time for the co-hosted CLI's MCP back-connection. Re-read + decrypted at spawn and injected
     /// as a <c>Authorization: Bearer</c> header on the per-spawn HTTP MCP server, so the CLI calls

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -648,7 +648,7 @@ else
                 {
                     <button type="button" class="thread-chat-status-item is-clickable"
                             title="Harness — click to switch runtime" @onclick='() => OnStatusChipClick("harness", false)'>
-                        @ChipSvg("harness") @harnessId
+                        @HarnessIcon(boundHarness) @harnessId
                     </button>
                 }
                 @if (isClaudeCode || isCopilot)
@@ -845,8 +845,8 @@ else
                        the in-flight round. Disabled ONLY for genuinely un-sendable states: empty text or
                        no model. *@
                     <FluentButton Appearance="FluentAppearance.Accent" OnClick="SendMessage"
-                                  Disabled="@(string.IsNullOrWhiteSpace(MessageText) || (HasNoModels && ActiveHarness() is null))"
-                                  Title="@(HasNoModels && ActiveHarness() is null ? "No model available — configure one to chat" : "Send")">
+                                  Disabled="@(string.IsNullOrWhiteSpace(MessageText))"
+                                  Title="Send">
                         <FluentIcon Value="@(new Icons.Regular.Size20.Send())" Color="Color.Neutral" />
                     </FluentButton>
                 }

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -845,8 +845,8 @@ else
                        the in-flight round. Disabled ONLY for genuinely un-sendable states: empty text or
                        no model. *@
                     <FluentButton Appearance="FluentAppearance.Accent" OnClick="SendMessage"
-                                  Disabled="@(string.IsNullOrWhiteSpace(MessageText) || HasNoModels)"
-                                  Title="@(HasNoModels ? "No model available — configure one to chat" : "Send")">
+                                  Disabled="@(string.IsNullOrWhiteSpace(MessageText) || (HasNoModels && ActiveHarness() is null))"
+                                  Title="@(HasNoModels && ActiveHarness() is null ? "No model available — configure one to chat" : "Send")">
                         <FluentIcon Value="@(new Icons.Regular.Size20.Send())" Color="Color.Neutral" />
                     </FluentButton>
                 }

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -988,8 +988,25 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                     var harness = ActiveHarness();
                     var commandName = parsed.Command.Name;
                     var isRuntimeSwitch = string.Equals(commandName, "harness", StringComparison.OrdinalIgnoreCase);
-                    var isHarnessOwnedCommand = harness?.Commands.Any(
-                        c => string.Equals(c.Name, commandName, StringComparison.OrdinalIgnoreCase)) == true;
+                    var harnessCmd = harness?.Commands.FirstOrDefault(
+                        c => string.Equals(c.Name, commandName, StringComparison.OrdinalIgnoreCase));
+                    // 🔑 A harness AUTH command (/login, /logout — Connect/Disconnect) CANNOT be performed
+                    // by the headless `claude --print` CLI (no interactive OAuth), so it must NEVER be
+                    // forwarded — forwarding it was exactly why login did nothing. The PORTAL owns the
+                    // credential: HandleHarnessAuthCommand stores a pasted key / token (choose the method)
+                    // as the harness's ModelProvider node, which the ClaudeCode client reads back.
+                    var isHarnessAuthCommand = harnessCmd is
+                        { Kind: MeshWeaver.AI.HarnessCommandKind.Connect or MeshWeaver.AI.HarnessCommandKind.Disconnect };
+                    if (harness is not null && !isRuntimeSwitch && isHarnessAuthCommand)
+                    {
+                        HandleHarnessAuthCommand(harness, harnessCmd!, userMessageText);
+                        MessageText = null;
+                        if (monacoEditor != null)
+                            _ = ClearMonacoAsync();
+                        StateHasChanged();
+                        return;
+                    }
+                    var isHarnessOwnedCommand = harnessCmd is not null;
                     var isHarnessNodePick = string.Equals(commandName, "agent", StringComparison.OrdinalIgnoreCase)
                         || string.Equals(commandName, "model", StringComparison.OrdinalIgnoreCase);
                     // Forward only under a CLI harness, and never /harness (always MeshWeaver-owned).
@@ -1224,6 +1241,128 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         // /agent /model /harness + any Space/NodeType/user-defined one) — there is no C# registry.
         ResolveSkillNodeAndRun(parsedCommand);
         await InvokeAsync(StateHasChanged);
+    }
+
+    /// <summary>
+    /// Handle a harness AUTH slash-command (login/logout) LOCALLY — the portal owns the credential; the
+    /// headless CLI cannot authenticate itself, so forwarding <c>/login</c> to it did nothing. Terminal-native,
+    /// like Claude Code: paste the credential right in the composer and pick the method.
+    /// <list type="bullet">
+    /// <item><c>/login &lt;key&gt;</c> — infers the method from the token shape (Anthropic Console key
+    ///   <c>sk-ant-api…</c> → ANTHROPIC_API_KEY; subscription token <c>sk-ant-oat…</c> → CLAUDE_CODE_OAUTH_TOKEN).</item>
+    /// <item><c>/login key &lt;k&gt;</c> — force the API-key method; <c>/login token &lt;t&gt;</c> — force the
+    ///   subscription OAuth token (from <c>claude setup-token</c>).</item>
+    /// <item><c>/login gateway &lt;base-url&gt; &lt;token&gt;</c> — a gateway/proxy (ANTHROPIC_AUTH_TOKEN + ANTHROPIC_BASE_URL).</item>
+    /// <item><c>/logout</c> — forget the stored credential.</item>
+    /// </list>
+    /// The credential is encrypted at rest (<see cref="MeshWeaver.AI.IProviderKeyProtector"/>) and stored as
+    /// the harness's <c>ModelProvider</c> node at <c>{user}/_Memex/{harnessId}</c> — the SAME path
+    /// <c>ChatClientCredentialResolver.ResolveConnectCredential</c> reads, so writer and reader agree.
+    /// </summary>
+    private void HandleHarnessAuthCommand(MeshWeaver.AI.IHarness harness, MeshWeaver.AI.HarnessCommand cmd, string? rawText)
+    {
+        if (cmd.Kind == MeshWeaver.AI.HarnessCommandKind.Disconnect)
+        {
+            ClearHarnessCredential(harness);
+            return;
+        }
+        // Connect: everything after the leading "/login" word is the pasted argument(s).
+        var rest = (rawText ?? string.Empty).Trim();
+        var sp = rest.IndexOf(' ');
+        var args = sp < 0 ? string.Empty : rest[(sp + 1)..].Trim();
+        if (string.IsNullOrEmpty(args))
+        {
+            ShowSkillStatus(
+                $"To connect {harness.Definition.DisplayName}, paste a credential here — "
+                + "`/login <key>` (Anthropic Console key), `/login token <oauth-token>` "
+                + "(from `claude setup-token`), or `/login gateway <base-url> <token>`.", false);
+            return;
+        }
+        var parts = args.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        string method, credential;
+        string? baseUrl = null;
+        var head = parts[0].ToLowerInvariant();
+        if (head == "key" && parts.Length >= 2) { method = "apiKey"; credential = parts[1]; }
+        else if (head == "token" && parts.Length >= 2) { method = "oauth"; credential = parts[1]; }
+        else if (head == "gateway" && parts.Length >= 3) { method = "authToken"; baseUrl = parts[1]; credential = parts[2]; }
+        else
+        {
+            credential = parts[0];
+            // Infer: Anthropic subscription OAuth tokens are "sk-ant-oat…"; Console keys "sk-ant-api…".
+            method = credential.StartsWith("sk-ant-oat", StringComparison.OrdinalIgnoreCase) ? "oauth" : "apiKey";
+        }
+        StoreHarnessCredential(harness, method, credential, baseUrl);
+    }
+
+    /// <summary>Encrypt + persist the pasted credential as the harness's ModelProvider node (create-or-update).</summary>
+    private void StoreHarnessCredential(MeshWeaver.AI.IHarness harness, string method, string credential, string? baseUrl)
+    {
+        var accessService = Hub.ServiceProvider.GetService<AccessService>();
+        var owner = accessService?.Context?.ObjectId ?? accessService?.CircuitContext?.ObjectId;
+        if (string.IsNullOrEmpty(owner))
+        {
+            ShowSkillStatus("Can't store the credential — you don't appear to be signed in.", true);
+            return;
+        }
+        var providerPath = $"{MeshWeaver.AI.ModelProviderNodeType.UserNamespacePath(owner)}/{harness.Id}";
+        var protector = Hub.ServiceProvider.GetService<MeshWeaver.AI.IProviderKeyProtector>();
+        var stored = protector is null ? credential : protector.Protect(credential);
+        var node = MeshWeaver.Mesh.MeshNode.FromPath(providerPath) with
+        {
+            NodeType = MeshWeaver.AI.ModelProviderNodeType.NodeType,
+            Name = harness.Definition.DisplayName,
+            Icon = "/static/NodeTypeIcons/key.svg",
+            Content = new MeshWeaver.AI.ModelProviderConfiguration
+            {
+                Provider = harness.Id,
+                ApiKey = stored,
+                AuthMethod = method,
+                Endpoint = baseUrl,
+                CreatedAt = DateTimeOffset.UtcNow
+            }
+        };
+        var label = method switch
+        {
+            "apiKey" => "API key",
+            "oauth" => "subscription token",
+            "authToken" => "gateway token",
+            _ => "credential"
+        };
+        MeshQuery.CreateOrUpdateNode(node).Subscribe(
+            _ => InvokeAsync(() =>
+            {
+                ShowSkillStatus($"{harness.Definition.DisplayName} connected with your {label} — new chats will use it.", false);
+                StateHasChanged();
+            }),
+            ex => InvokeAsync(() =>
+            {
+                ShowSkillStatus($"Couldn't store the credential: {ex.Message}", true);
+                StateHasChanged();
+            }));
+    }
+
+    /// <summary>Delete the harness's stored credential node (the <c>/logout</c> path).</summary>
+    private void ClearHarnessCredential(MeshWeaver.AI.IHarness harness)
+    {
+        var accessService = Hub.ServiceProvider.GetService<AccessService>();
+        var owner = accessService?.Context?.ObjectId ?? accessService?.CircuitContext?.ObjectId;
+        if (string.IsNullOrEmpty(owner))
+        {
+            ShowSkillStatus("Nothing to disconnect — you don't appear to be signed in.", true);
+            return;
+        }
+        var providerPath = $"{MeshWeaver.AI.ModelProviderNodeType.UserNamespacePath(owner)}/{harness.Id}";
+        MeshQuery.DeleteNode(providerPath).Subscribe(
+            _ => InvokeAsync(() =>
+            {
+                ShowSkillStatus($"{harness.Definition.DisplayName} disconnected — its stored credential was removed.", false);
+                StateHasChanged();
+            }),
+            ex => InvokeAsync(() =>
+            {
+                ShowSkillStatus($"Couldn't disconnect: {ex.Message}", true);
+                StateHasChanged();
+            }));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -701,12 +701,36 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     {
         if (string.IsNullOrEmpty(_templatePath))
             return;
+        // Apply to the ACTIVE composer (the thread's embedded composer inside a thread, the per-user
+        // composer node out of one).
+        ApplyComposerSelection(_templatePath!, harness, agentPath, modelName, ensure: false, "Saving your selection");
+
+        // ALSO persist the selection as the user's DEFAULT composer, so a NEW chat (or a re-init after the
+        // catalog changes) restores the last-used harness/model/agent instead of snapping back to the
+        // catalog default — this is the "harness jumped back to Claude Code" report. Out of a thread the
+        // default IS _templatePath (the second write is idempotent); inside a thread it is a different node
+        // that may not be materialised yet, so ensure it first (never Update an absent node → NotFound storm).
+        var defaultPath = string.IsNullOrEmpty(_userHome)
+            ? null : MeshWeaver.AI.ThreadComposerNodeType.PathFor(_userHome);
+        if (!string.IsNullOrEmpty(defaultPath) && !string.Equals(defaultPath, _templatePath, StringComparison.Ordinal))
+            ApplyComposerSelection(defaultPath!, harness, agentPath, modelName, ensure: true, "Saving your default");
+    }
+
+    /// <summary>
+    /// Merges the (harness/agent/model) selection onto a composer node's <c>ThreadComposer</c> content —
+    /// coalescing only the provided fields (a null arg leaves that field untouched), bad-data tolerant (an
+    /// unreadable node is left alone, never clobbered). When <paramref name="ensure"/> is set the node is
+    /// CreateNode'd first (benign <c>NodeAlreadyExists</c>) so a not-yet-materialised per-user default
+    /// composer does not NotFound-storm the partition hub on Update.
+    /// </summary>
+    private void ApplyComposerSelection(string path, string? harness, string? agentPath, string? modelName, bool ensure, string errorContext)
+    {
         // Reached from the slash-command picker AFTER Rx hops (skill query → picker query → InvokeAsync),
         // where the circuit AccessService's Context AND CircuitContext have been nulled by the Blazor
         // inbound-activity finally. UpdateMeshNodeAsCircuitUser re-establishes the DURABLE circuit user on
         // the hub AccessService for Update's synchronous capture, so the composer write is attributed to
         // the real user instead of null (→ "Saving your selection: Access denied").
-        UpdateMeshNodeAsCircuitUser(_templatePath, node =>
+        void Write() => UpdateMeshNodeAsCircuitUser(path, node =>
         {
             var existing = MeshWeaver.AI.ThreadComposerNodeType.ComposerOf(node, Hub.JsonSerializerOptions, Logger);
             if (node?.Content is not null && existing is null)
@@ -719,7 +743,21 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             };
             return MeshWeaver.AI.ThreadComposerNodeType.WithComposer(
                 node!, updated, Hub.JsonSerializerOptions, Logger);
-        }, ex => SurfaceError(ex, "Saving your selection"));
+        }, ex => SurfaceError(ex, errorContext));
+
+        if (!ensure)
+        {
+            Write();
+            return;
+        }
+        // Create the node (benign if it already exists), THEN merge the selection — CreateNode registers a
+        // routable node, unlike Update which only patches an existing one.
+        MeshQuery.CreateNode(MeshWeaver.Mesh.MeshNode.FromPath(path) with
+        {
+            NodeType = MeshWeaver.AI.ThreadComposerNodeType.NodeType,
+            Name = "Chat Input",
+            Content = new MeshWeaver.AI.ThreadComposer()
+        }).Subscribe(_ => InvokeAsync(Write), _ => InvokeAsync(Write));
     }
 
     /// <summary>
@@ -973,18 +1011,12 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 }
             }
 
-            // No usable MESH model → don't submit under the MeshWeaver harness (the agent has nothing to
-            // run). A CLI harness (Claude Code / Copilot) runs its OWN subscription model, so an empty
-            // mesh catalog must NOT block it — that was the "can type but Enter/Send does nothing under
-            // Claude Code" report. Slash commands short-circuit above, so /model, /harness, /login still
-            // work with an empty catalog.
-            if (HasNoModels && ActiveHarness() is null)
-            {
-                lastCommandStatus = "No language model is available — add one in Settings → Language Models to chat.";
-                lastCommandStatusIsError = true;
-                StateHasChanged();
-                return;
-            }
+            // 🚫 The composer NEVER blocks. We do not gate submission on model/harness availability here —
+            // that is the "chat is chronically disabled / Enter does nothing" report. A CLI harness (Claude
+            // Code / Copilot) runs its OWN subscription model; and even under the MeshWeaver harness with an
+            // empty catalog the message is accepted and the "no AI model available" condition is surfaced in
+            // the thread OUTPUT (the wedges-to-zero graceful sink), not by dead-ending the input box. Slash
+            // commands still short-circuit above, so /model, /harness, /login work regardless.
 
             // Attempt to begin submission — rejects empty text and concurrent submissions
             if (!submissionHandler.TryBeginSubmit(userMessageText))
@@ -1233,6 +1265,22 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         };
         return new MarkupString(
             $"<svg class=\"chip-svg\" viewBox=\"0 0 16 16\" width=\"12\" height=\"12\" fill=\"currentColor\" aria-hidden=\"true\"><path d=\"{path}\"/></svg>");
+    }
+
+    /// <summary>
+    /// The harness's OWN brand icon for the status chip — the inline SVG carried on
+    /// <see cref="MeshWeaver.AI.Harness.Icon"/> (e.g. Claude Code's terracotta burst). Falls back to the
+    /// generic hexagon glyph when the harness is unknown or ships no inline SVG. This is why the harness
+    /// logo now renders instead of the placeholder hexagon.
+    /// </summary>
+    private MarkupString HarnessIcon(string? harnessId)
+    {
+        var harness = MeshWeaver.AI.HarnessNodeType.ResolveHarness(Hub.ServiceProvider, harnessId);
+        var icon = harness?.Definition.Icon;
+        // Only raw inline SVG (starts with '<') is safe to emit as markup; a URL/path is not an icon here.
+        return !string.IsNullOrEmpty(icon) && icon.TrimStart().StartsWith('<')
+            ? new MarkupString($"<span class=\"chip-svg\" aria-hidden=\"true\">{icon}</span>")
+            : ChipSvg("harness");
     }
 
     /// <summary>
@@ -2100,12 +2148,36 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     // ─── Hero-header: inline title / description editing + Mark Done ───
 
     /// <summary>Enter title edit mode, seeding the editor with the current name and focusing it.</summary>
+    // Rendered true on the first pass and set true before every StateHasChanged that MUST paint (entering
+    // or leaving an inline title/description edit, focus). See ShouldRender.
+    private bool _forceRender = true;
+
+    /// <summary>
+    /// Render isolation for the inline title/description editors. While an edit is in flight this large
+    /// component would otherwise re-diff the WHOLE thread on every <c>Immediate</c> keystroke AND on every
+    /// background thread-stream emission — visibly "bumping" the caret and making typing feel janky. We
+    /// therefore SUPPRESS re-renders while editing, painting only when a real state transition needs it
+    /// (flagged via <see cref="_forceRender"/>). The edited text is still captured server-side by the
+    /// two-way binding regardless of ShouldRender, so Enter/blur commit the latest value. (GUI/DataBinding.md
+    /// render-isolation — the sanctioned alternative to extracting a node-bound child component here.)
+    /// </summary>
+    protected override bool ShouldRender()
+    {
+        if (_forceRender)
+        {
+            _forceRender = false;
+            return true;
+        }
+        return !(isEditingTitle || isEditingDescription);
+    }
+
     private void BeginTitleEdit()
     {
         if (IsReadOnlyThread || isEditingTitle) return;
         editTitleText = ThreadViewModel?.Name ?? "";
         isEditingTitle = true;
         _focusTitleOnRender = true;
+        _forceRender = true;
         StateHasChanged();
     }
 
@@ -2134,12 +2206,14 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             UpdateMeshNodeAsCircuitUser(threadPath, node => node with { Name = newName },
                 ex => SurfaceError(ex, "Saving the title"));
         }
+        _forceRender = true;
         StateHasChanged();
     }
 
     private void CancelTitleEdit()
     {
         isEditingTitle = false;
+        _forceRender = true;
         StateHasChanged();
     }
 
@@ -2150,6 +2224,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         editDescriptionText = ThreadViewModel?.Description ?? "";
         isEditingDescription = true;
         _focusDescOnRender = true;
+        _forceRender = true;
         StateHasChanged();
     }
 
@@ -2175,12 +2250,14 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             UpdateMeshNodeAsCircuitUser(threadPath, node => node with { Description = normalized },
                 ex => SurfaceError(ex, "Saving the description"));
         }
+        _forceRender = true;
         StateHasChanged();
     }
 
     private void CancelDescriptionEdit()
     {
         isEditingDescription = false;
+        _forceRender = true;
         StateHasChanged();
     }
 

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -973,10 +973,12 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 }
             }
 
-            // No usable model in the catalog → don't submit (the agent has nothing to run). Send is already
-            // disabled in the UI with a hint; this also guards the Enter/OnSubmit path. Slash commands have
-            // short-circuited above, so /model, /harness, /login etc. still work with an empty catalog.
-            if (HasNoModels)
+            // No usable MESH model → don't submit under the MeshWeaver harness (the agent has nothing to
+            // run). A CLI harness (Claude Code / Copilot) runs its OWN subscription model, so an empty
+            // mesh catalog must NOT block it — that was the "can type but Enter/Send does nothing under
+            // Claude Code" report. Slash commands short-circuit above, so /model, /harness, /login still
+            // work with an empty catalog.
+            if (HasNoModels && ActiveHarness() is null)
             {
                 lastCommandStatus = "No language model is available — add one in Settings → Language Models to chat.";
                 lastCommandStatusIsError = true;

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
@@ -447,6 +447,22 @@ button.thread-chat-status-item {
     opacity: 0.72;
 }
 
+/* Harness BRAND icon (Claude Code / Copilot) — an inline <svg> wrapped in a <span class="chip-svg">.
+   It carries its own colours (a terracotta burst, etc.), so it must NOT be dimmed like the monochrome
+   glyph chips, and its viewBox (20×20, no width/height) must be sized down to the chip glyph size. */
+.thread-chat-status-item span.chip-svg {
+    display: inline-flex;
+    align-items: center;
+    width: 14px;
+    height: 14px;
+    opacity: 1;
+}
+
+.thread-chat-status-item span.chip-svg svg {
+    width: 100%;
+    height: 100%;
+}
+
 .thread-chat-status-sep {
     color: var(--neutral-stroke-rest);
 }

--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-space", "harness", "layout-area", "maui", "model", "provider-keys");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys");
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);


### PR DESCRIPTION
## Why

A cluster of chat-composer QA reports, all rooted in the composer either **blocking** or **forgetting** the user's selection:

- **"Chat is always blocked / Enter does nothing."** Both the Send button and the submit path hard-gated on `HasNoModels && ActiveHarness() is null`. With no configured mesh model under the MeshWeaver harness the input box was dead. → Per wedges-to-zero, the composer **never blocks**; an un-runnable round surfaces the "No AI model available" hint in the thread **output**, not by disabling the UI.
- **"No AI model available … factory 'OpenAI' for model '(none selected)'."** `ApplyStaleModelFallback` only healed a *stale* pinned model, never an *empty* selection, so "no model picked" dead-ended on the first factory (OpenAI). → It now also seeds the default resolvable model when nothing is selected (silent — no user choice to override). When nothing resolves at all, the clear provider-config message shows.
- **"Harness jumped back to Claude Code."** Changing harness/model *inside a thread* only wrote the thread's composer, never the per-user default. → `WriteComposerSelection` now also persists the selection to the per-user default composer (ensuring the node first), so a new chat restores the last-used harness/model/agent.
- **"Harness logos still not coming."** The status chip rendered a generic hexagon. → It now renders each harness's own inline brand SVG (`HarnessIcon`).
- **"Title editing is bumpy."** `Immediate` keystrokes + background thread-stream emissions re-diffed the whole huge component, bumping the caret. → Render isolation via `ShouldRender` while an inline title/description edit is in flight.

Builds on the prior commit (auth-method backbone: `AuthMethod` field + env-var-by-credential-type in the Claude Code client + `ResolveConnectCredential`).

## Testing

- `dotnet build src/MeshWeaver.Blazor.Portal -c Release -warnaserror -p:CIRun=true` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)