### PR TITLE
fix(portal): Safari code-copy + actionable @@Catalog error

### DIFF
--- a/src/MeshWeaver.Blazor/Components/CodeBlock.razor
+++ b/src/MeshWeaver.Blazor/Components/CodeBlock.razor
@@ -4,8 +4,9 @@
 <div @ref="CodeBlockElement" class="code-content">
     @((MarkupString)(Html ?? ""))
     @* Copy is wired natively in JS (setupCopyButton) — a Blazor @@onclick round-trips over SignalR
-       and loses the user gesture, so Safari rejects navigator.clipboard.writeText. *@
-    <i class="copy-to-clipboard"></i>
+       and loses the user gesture, so Safari rejects navigator.clipboard.writeText. role/tabindex/
+       aria make the <i> a keyboard- and screen-reader-accessible button. *@
+    <i class="copy-to-clipboard" role="button" tabindex="0" title="Copy code" aria-label="Copy code"></i>
 </div>
 
 @code {

--- a/src/MeshWeaver.Blazor/Components/CodeBlock.razor
+++ b/src/MeshWeaver.Blazor/Components/CodeBlock.razor
@@ -1,9 +1,11 @@
-﻿@using Microsoft.JSInterop
+@using Microsoft.JSInterop
 @inject IJSRuntime JsRuntime
 
 <div @ref="CodeBlockElement" class="code-content">
     @((MarkupString)(Html ?? ""))
-    <i class="copy-to-clipboard" @onclick="CopyToClipboard"></i>
+    @* Copy is wired natively in JS (setupCopyButton) — a Blazor @@onclick round-trips over SignalR
+       and loses the user gesture, so Safari rejects navigator.clipboard.writeText. *@
+    <i class="copy-to-clipboard"></i>
 </div>
 
 @code {
@@ -26,27 +28,14 @@
                 // Add a small delay to ensure DOM is fully rendered
                 await Task.Delay(10);
                 await jsModule.InvokeVoidAsync("highlightBlock", CodeBlockElement);
+                // Attach the native copy handler so the clipboard write runs inside the click
+                // gesture (Safari-safe). Idempotent — guarded by a data-attribute in JS.
+                await jsModule.InvokeVoidAsync("setupCopyButton", CodeBlockElement);
             }
         }
         catch (Exception ex)
         {
             Console.WriteLine($"Error highlighting code: {ex.Message}");
-        }
-    }
-
-    private async Task CopyToClipboard()
-    {
-        try
-        {
-            if (jsModule is not null)
-            {
-                var codeText = await jsModule.InvokeAsync<string>("getCodeText", CodeBlockElement);
-                await JsRuntime.InvokeVoidAsync("navigator.clipboard.writeText", codeText);
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error copying to clipboard: {ex.Message}");
         }
     }
 }

--- a/src/MeshWeaver.Blazor/Components/CodeBlock.razor.js
+++ b/src/MeshWeaver.Blazor/Components/CodeBlock.razor.js
@@ -70,15 +70,24 @@ export function setupCopyButton(element) {
     }
     button.dataset.copyWired = "1";
 
-    button.addEventListener("click", () => {
+    const doCopy = () => {
         const text = getCodeText(element);
-        // Called synchronously in the click handler so Safari's gesture check passes.
+        // Called synchronously in the gesture handler so Safari's gesture check passes.
         if (navigator.clipboard && window.isSecureContext) {
             navigator.clipboard.writeText(text).then(
                 () => flashCopied(button),
                 () => { if (copyViaExecCommand(text)) flashCopied(button); });
         } else if (copyViaExecCommand(text)) {
             flashCopied(button);
+        }
+    };
+
+    button.addEventListener("click", doCopy);
+    // Keyboard activation for the role="button" icon (Enter / Space).
+    button.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            doCopy();
         }
     });
 }
@@ -92,16 +101,15 @@ function copyViaExecCommand(text) {
     ta.style.left = "0";
     ta.style.opacity = "0";
     document.body.appendChild(ta);
-    ta.focus();
-    ta.select();
-    let ok = false;
     try {
-        ok = document.execCommand("copy");
+        ta.focus();
+        ta.select();
+        return document.execCommand("copy");
     } catch {
-        ok = false;
+        return false;
+    } finally {
+        document.body.removeChild(ta);   // always clean up, even if select/execCommand throws
     }
-    document.body.removeChild(ta);
-    return ok;
 }
 
 function flashCopied(button) {

--- a/src/MeshWeaver.Blazor/Components/CodeBlock.razor.js
+++ b/src/MeshWeaver.Blazor/Components/CodeBlock.razor.js
@@ -47,3 +47,64 @@ export function getCodeText(element) {
     const codeElement = element.querySelector("pre code") || element.querySelector("code");
     return codeElement ? codeElement.textContent : element.textContent || "";
 }
+
+/**
+ * Wires the copy-to-clipboard icon inside the code block to a NATIVE click handler.
+ *
+ * Safari only permits navigator.clipboard.writeText from inside the synchronous call stack of a
+ * user gesture (a "transient activation"). The previous Blazor Server `@onclick` handler
+ * round-tripped over SignalR and then invoked writeText from the server -> JS, i.e. outside the
+ * gesture — Chrome tolerates that, Safari rejects it with NotAllowedError, so the button silently
+ * did nothing. Attaching a native DOM click listener here keeps the whole read-then-write in the
+ * gesture. A synchronous execCommand("copy") fallback covers older Safari / non-secure contexts.
+ *
+ * @param {HTMLElement} element - The code-block container holding the `.copy-to-clipboard` icon.
+ */
+export function setupCopyButton(element) {
+    if (!element) {
+        return;
+    }
+    const button = element.querySelector(".copy-to-clipboard");
+    if (!button || button.dataset.copyWired === "1") {
+        return;   // idempotent — OnAfterRenderAsync can re-run
+    }
+    button.dataset.copyWired = "1";
+
+    button.addEventListener("click", () => {
+        const text = getCodeText(element);
+        // Called synchronously in the click handler so Safari's gesture check passes.
+        if (navigator.clipboard && window.isSecureContext) {
+            navigator.clipboard.writeText(text).then(
+                () => flashCopied(button),
+                () => { if (copyViaExecCommand(text)) flashCopied(button); });
+        } else if (copyViaExecCommand(text)) {
+            flashCopied(button);
+        }
+    });
+}
+
+function copyViaExecCommand(text) {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.top = "0";
+    ta.style.left = "0";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    let ok = false;
+    try {
+        ok = document.execCommand("copy");
+    } catch {
+        ok = false;
+    }
+    document.body.removeChild(ta);
+    return ok;
+}
+
+function flashCopied(button) {
+    button.classList.add("copied");
+    setTimeout(() => button.classList.remove("copied"), 1200);
+}

--- a/src/MeshWeaver.Layout/Domain/DomainLayoutAreas.cs
+++ b/src/MeshWeaver.Layout/Domain/DomainLayoutAreas.cs
@@ -72,7 +72,8 @@ public static class DomainLayoutAreas
 
     /// <summary>
     /// Renders a catalog view listing all entities of the type named in the area reference Id.
-    /// Throws when no type is specified or the type is not registered in the data context.
+    /// Returns an actionable caution when no type is specified; throws when the named type is not
+    /// registered in the data context.
     /// </summary>
     /// <param name="area">The layout area host providing workspace and type-registry access.</param>
     /// <param name="ctx">The rendering context for this area.</param>
@@ -81,7 +82,14 @@ public static class DomainLayoutAreas
     public static UiControl Catalog(LayoutAreaHost area, RenderingContext ctx)
     {
         if (area.Reference.Id is not string collection)
-            throw new InvalidOperationException("No type specified for catalog.");
+            // "Catalog" lists all entities of a registered data TYPE, so it needs one. Written bare
+            // (@@Catalog) it has no Id — that used to throw a dead-end "No type specified" error.
+            // Guide the author to the right syntax instead: a type catalog needs the type, and a
+            // Space's own contents are the separate node-children "Search" area.
+            return Error(
+                "**Catalog needs a type.** Use `@@Catalog/TypeName` to list every entity of a "
+                + "registered type (e.g. `@@Catalog/User`). To embed this node's own contents, use "
+                + "`@@(\"area/Search\")` instead.");
         var typeDefinition = area.Hub.ServiceProvider.GetRequiredService<ITypeRegistry>().GetTypeDefinition(collection);
         if (typeDefinition == null)
             throw new DataSourceConfigurationException(


### PR DESCRIPTION
Two markdown-viewer fixes reported from a Space.

### 1. Code-block "copy" button did nothing in Safari
On Blazor Server the `@onclick` copy handler round-tripped over SignalR and then called `navigator.clipboard.writeText` from the server→JS interop — i.e. **outside the click gesture**. Safari only permits clipboard writes inside a user gesture's synchronous call stack (Chrome is lenient), so it rejected the write with `NotAllowedError` and the button silently did nothing.

**Fix:** wire the copy icon to a **native DOM click listener** (`CodeBlock.razor.js` `setupCopyButton`) so the read-then-write stays in the gesture, with a synchronous `execCommand("copy")` fallback for older Safari / non-secure contexts. Removes the Blazor `CopyToClipboard` interop hop.

### 2. `@@Catalog` in a Space showed a dead-end error
`@@Catalog` (no type) hit the type-catalog area, which lists entities of a **registered data type** and requires one — throwing `No type specified for catalog.` A Space's own contents are the separate `Search` area.

**Fix:** replace the thrown exception with an actionable caution: use `@@Catalog/TypeName` (e.g. `@@Catalog/User`) for a type catalog, or `@@("area/Search")` to embed the node's own contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)