### PR TITLE
docs(skill): space skill — top-level types, @@ regions, contents catalog

### DIFF
--- a/src/MeshWeaver.AI/Data/Agent/Assistant.md
+++ b/src/MeshWeaver.AI/Data/Agent/Assistant.md
@@ -80,6 +80,13 @@ The complete rules — `@` path resolution, query syntax, MeshNode schemas, icon
 - Tool calls take the node's `path`, never its display name.
 - Before creating nodes, explore what exists (`Search('namespace:{contextPath}')`) and create in the current context's namespace — never under `Agent/` or other system namespaces unless explicitly asked.
 
+# Spaces and regions (`@@`)
+
+- **Top-level = any type; `Space` is the generic one.** A top-level node has an empty namespace (path = its id). Any partition-owning type can sit at top level, but a **Space** is the generic container — use it for a company/team/topic/project workspace. Creating one is a real **`create`** (never `update` a bare node into one) so the partition + your Admin grant get provisioned. Full recipe: load the **`/create-space`** skill.
+- **Embed a live area inline with `@@`.** In any markdown body, a reference at the **start of a line** either links (`@`) or **embeds** (`@@`). The contents catalog / children index of a node is its **`Search`** area — embed it with **`@@("area/Search")`** (relative to the current node), and put it at the **end of a Space body** under a `## Contents` heading. It is `Search`, NOT "Catalog" — `@@Catalog` does not render the index.
+- Other common regions: `@@("area/Overview")`, `@@("area/Threads")`, `@@("area/Files")`. Absolute form: `@@/{Path}/area/{Area}`; another node's default area: `@@Some/Node`.
+- **List a node's areas** with `Get('@{path}/layoutAreas/')` (plural). Note the standard node regions above are embeddable by name even though they don't appear in that listing (only custom/visible areas do).
+
 # Version history
 
 You have the Version tools directly (`GetVersions`, `GetVersion`, `RestoreVersion`, `RestoreFromPointInTime`) — no delegation needed:

--- a/src/MeshWeaver.AI/Data/Skill/create-space.md
+++ b/src/MeshWeaver.AI/Data/Skill/create-space.md
@@ -1,37 +1,95 @@
 ---
 nodeType: Skill
 name: /create-space
-description: Create a new Space so everything works — proper create, a nice summary, a logo, and an optional repo link
+description: Create a Space (the generic top-level container) end-to-end — proper create, a warm body, a logo, the live @@ regions that make a page useful, and the contents catalog at the bottom.
 icon: Sparkle
 category: Skills
 order: 5
 autoMount: true
 ---
 
-You are creating a new **Space** — a top-level tenant container with its own partition, home page, and content. Follow these steps so the Space works end-to-end, not just renders an empty shell.
+You are creating a new **Space** and wiring its home page so it works end-to-end — not an empty shell. A Space is a tenant container: its own Postgres partition, a home page, an Admin grant for you, and content underneath.
+
+# 0. Top level can be ANY type — Space is the generic one
+
+A **top-level** node has an empty `namespace`, so its path is just its id. A top-level node can be **any** node type that owns a partition — but **`Space` is the most generic**, so reach for it unless a more specific top-level type clearly fits (a company, team, topic, product, or project workspace all map naturally to a Space). Everything below (regions, catalog, body) applies to a Space; most of it applies to any node with a markdown body.
 
 # 1. Create it the right way — `create`, never `update`
 
 A Space MUST be created with a real **`create`** (CreateNodeRequest / MCP `create`). Creating triggers the server-side post-creation handler that **provisions the partition's Postgres schema, primes routing, and grants you Admin** at `{space}/_Access`. Converting a pre-existing bare node with `update` SKIPS that handler and leaves the Space half-provisioned (missing routing/grants → embedded areas don't load).
 
-- **Top-level only:** a Space's path is just its id (empty namespace). Use a short PascalCase id.
-- Shape: `nodeType: "Space"`, content `{ "$type": "Space", "name": "..." }`.
+- **Top-level only:** empty `namespace`, path = its id. Use a short PascalCase id.
+- Shape: `nodeType: "Space"`, content `{ "$type": "Space", "name": "...", "description": "...", "body": "...", "icon": "..." }`.
 
-# 2. Write a nice summary (the most important step)
+# 2. Write the body — the page (the most important step)
 
-Always author the Space's **`body`** (markdown) — a short, warm summary of **what the Space is about and what it's for**, plus how to get started. Do NOT leave it empty: an empty Space falls back to a generic welcome placeholder whose catalog embed shows nothing, which looks broken. Also set a one-line **`description`** (shown under the title).
+Two distinct fields:
 
-Write the summary in the owner's voice: its purpose, what kind of content lives here, and 2–4 bullet points on how to use it. A focused summary beats a wall of text.
+- **`description`** — a one-line tagline shown under the title in the header. Short.
+- **`body`** — the page itself: markdown authored in the owner's voice (purpose, what lives here, 2–4 bullets on how to use it, then the **contents catalog** — see §4). Do NOT leave `body` empty: an empty Space falls back to a generic welcome placeholder that looks broken.
 
-# 3. Give it a logo and an icon
+The body is plain markdown — headings, links, tables, and **`@@` region embeds** all work.
 
-- **`icon`** — an inline SVG (or named icon) for the node, shown in lists and menus.
+# 3. Regions: embed live areas inline with `@@`
+
+A page's markdown can embed **regions** — live layout areas rendered inline. Put the reference at the **start of a line**. `@` makes a *link*; `@@` *embeds* the area in place.
+
+**Common node regions** (available on every node; embed by name):
+
+| Region | Embed (relative) | Shows |
+|---|---|---|
+| **Search** (the contents catalog) | `@@("area/Search")` | The node's children / namespace index — the "what's inside" catalog |
+| Overview | `@@("area/Overview")` | The node's default content view |
+| Threads | `@@("area/Threads")` | Discussion threads on the node |
+| Files | `@@("area/Files")` | The node's content-collection file browser |
+| Comments | `@@("area/Comments")` | Comments on the node |
+| Versions | `@@("area/Versions")` | Version history |
+
+**Reference forms:**
+
+- `@@("area/Search")` — **relative** to the current page (resolves to THIS node's Search area). Use this inside a Space body.
+- `@@/{Space}/area/Search` — **absolute** (any node, from anywhere).
+- `@@Some/Node` — embeds another node's **default** (Overview) area.
+- `@@Some/Node/Threads` — embeds a **specific** area of another node.
+
+> 🚨 The contents catalog region is named **Search**, not "Catalog". `@@Catalog` does **not** render the children index — embed the catalog with **`@@("area/Search")`**.
+
+# 4. Put the contents catalog at the END of the body
+
+The standard idiom (what the default Space template ships) is to end the `body` with a Contents section:
+
+```markdown
+## Contents
+
+@@("area/Search")
+```
+
+Tune it via query params: `@@("area/Search?groupBy=type")` (or `category` / `flat`), `@@("area/Search?subtree=true")` to include the whole subtree. See the *Mesh Search & Catalogs* doc.
+
+# 5. How to list a node's layout areas (regions)
+
+To see the areas registered on a node, use the **plural `layoutAreas`** reference:
+
+```
+Get('@{path}/layoutAreas/')
+```
+
+It returns each area's name + description. Two caveats the test below pins:
+
+- It is **`layoutAreas`** (plural — LISTS the areas). The singular **`area/{Name}`** fetches ONE area's rendered payload — that's not how you list.
+- The listing returns only **catalog-visible** areas (custom / author-defined ones). The **standard node regions in the table above are `[Browsable(false)]`** — fully embeddable via `@@("area/Search")` etc., but they do **not** show up in the `layoutAreas` listing. So don't conclude a region is missing just because it isn't listed — the standard ones you embed by name.
+
+Retrieval mechanism + the visible-vs-embeddable rule are pinned by `LayoutAreaRetrievalTest` (test/MeshWeaver.Graph.Test).
+
+# 6. Give it a logo and an icon
+
+- **`icon`** — an inline SVG (or named icon like `Building`) shown in lists and menus.
 - **`logo`** — an image URL or data URI for the large header image (e.g. a served `/static/...svg`). Without a logo the header falls back to the node icon or the name's initials.
 
-# 4. (Optional) Link a GitHub repository
+# 7. (Optional) Link a GitHub repository
 
-To work on code from inside the Space, create a `{space}/_GitSync` node (`nodeType: GitHubSyncConfig`) with `repositoryUrl` + `branch` (default `main`). The **Code workspace** settings tab can then check the repo out, edit files in the browser, and commit + push as the user.
+To work on code from inside the Space, create a `{space}/_GitSync` node (`nodeType: GitHubSyncConfig`) with `repositoryUrl` + `branch` (default `main`). The **Code workspace** settings tab can then check out the repo, edit files in the browser, and commit + push as the user.
 
-# 5. Verify
+# 8. Verify
 
-Open the Space's home page: the logo, name, and your summary should render (not the welcome placeholder), and `{space}/_Access` should hold your Admin grant. Then add the first pages or start a thread.
+Open the Space's home page: the logo, name, and your `body` should render (not the welcome placeholder), the `@@("area/Search")` catalog should list the children, and `{space}/_Access` should hold your Admin grant. Then add the first pages or start a thread.

--- a/test/MeshWeaver.Graph.Test/LayoutAreaRetrievalTest.cs
+++ b/test/MeshWeaver.Graph.Test/LayoutAreaRetrievalTest.cs
@@ -50,7 +50,7 @@ public class LayoutAreaRetrievalTest(ITestOutputHelper output) : HubTestBase(out
     private static IObservable<UiControl?> Dashboard(LayoutAreaHost host, RenderingContext ctx)
         => Observable.Return<UiControl?>(Controls.Markdown("# Space Dashboard"));
 
-    [Fact]
+    [HubFact]
     public async Task GetLayoutAreasRequest_ListsVisibleAreasOnly()
     {
         GetHost();
@@ -77,7 +77,7 @@ public class LayoutAreaRetrievalTest(ITestOutputHelper output) : HubTestBase(out
         names.Should().NotContain("Threads");
     }
 
-    [Fact]
+    [HubFact]
     public async Task LayoutAreasUnifiedReference_MatchesTheTypedRequest()
     {
         GetHost();

--- a/test/MeshWeaver.Graph.Test/LayoutAreaRetrievalTest.cs
+++ b/test/MeshWeaver.Graph.Test/LayoutAreaRetrievalTest.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Documents — and pins — HOW an agent retrieves the list of layout areas ("regions") on a node,
+/// and the one non-obvious rule about WHAT that list contains. Regions are the live areas you can
+/// embed inline in markdown with the <c>@@</c> operator (e.g. <c>@@("area/Search")</c> for a
+/// Space's contents catalog).
+///
+/// <para><b>How to retrieve.</b> Two equivalent surfaces, both exercised here:</para>
+/// <list type="number">
+///   <item><see cref="GetLayoutAreasRequest"/> → <see cref="LayoutAreasResponse.Areas"/> (typed message).</item>
+///   <item><c>GetDataRequest(new UnifiedReference("layoutAreas:"))</c> — the wire behind the MCP /
+///     agent call <c>Get('@Node/Path/layoutAreas/')</c>.</item>
+/// </list>
+/// <para>🔑 The reference is PLURAL <c>layoutAreas</c> (LISTS the areas). The SINGULAR
+/// <c>area/{Name}</c> reference fetches ONE area's rendered payload. Listing is NOT <c>area/</c>.</para>
+///
+/// <para><b>What the list contains (the gotcha).</b> The listing returns only the areas with a
+/// <em>visible</em> <see cref="LayoutAreaDefinition"/> — i.e. author-facing / catalog areas. The
+/// STANDARD node regions (Overview, Search, Threads, Files, Chat, Edit, …) are all
+/// <c>[Browsable(false)]</c>, so they are <b>embeddable via <c>@@("area/Search")</c> but do NOT
+/// appear in the <c>layoutAreas</c> listing.</b> This test proves both halves: a custom visible
+/// area shows up; the Browsable(false) standard areas do not.</para>
+/// </summary>
+public class LayoutAreaRetrievalTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string CustomVisibleArea = "SpaceDashboard";
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddLayout(layout => layout
+                // The full standard node area set (Overview, Search, Threads, …) — every one
+                // [Browsable(false)], so none are advertised in the layoutAreas listing.
+                .AddDefaultLayoutAreas()
+                // A custom, catalog-visible area (no [Browsable(false)]) WITH a description —
+                // this is what an author registers to make an area discoverable + embeddable.
+                .WithView(CustomVisibleArea, Dashboard,
+                    a => a.WithDescription("A custom, catalog-visible layout area.")));
+
+    private static IObservable<UiControl?> Dashboard(LayoutAreaHost host, RenderingContext ctx)
+        => Observable.Return<UiControl?>(Controls.Markdown("# Space Dashboard"));
+
+    [Fact]
+    public async Task GetLayoutAreasRequest_ListsVisibleAreasOnly()
+    {
+        GetHost();
+        var client = GetClient();
+
+        var response = await client
+            .Observe(new GetLayoutAreasRequest(), o => o.WithTarget(CreateHostAddress()))
+            .Should().Emit();
+
+        var areas = response.Message.Areas.ToList();
+        var names = areas.Select(a => a.Area).ToList();
+
+        Output.WriteLine($"{areas.Count} VISIBLE layout area(s) returned by layoutAreas:");
+        foreach (var a in areas.OrderBy(a => a.Area))
+            Output.WriteLine($"  - {a.Area}: {a.Description ?? a.Title}");
+
+        // A custom area with its own (non-Browsable-false) definition IS listed.
+        names.Should().Contain(CustomVisibleArea);
+
+        // The standard node regions are [Browsable(false)] — embeddable via @@("area/Search"),
+        // but deliberately NOT advertised in the listing. This is the rule the skill documents.
+        names.Should().NotContain("Overview");
+        names.Should().NotContain("Search");
+        names.Should().NotContain("Threads");
+    }
+
+    [Fact]
+    public async Task LayoutAreasUnifiedReference_MatchesTheTypedRequest()
+    {
+        GetHost();
+        var client = GetClient();
+
+        // This GetDataRequest is exactly what the agent's Get('@Node/Path/layoutAreas/') resolves to.
+        var viaReference = await client
+            .Observe(new GetDataRequest(new UnifiedReference("layoutAreas:")), o => o.WithTarget(CreateHostAddress()))
+            .Should().Emit();
+        viaReference.Message.Error.Should().BeNull();
+
+        var referenceAreas = (viaReference.Message.Data as IEnumerable<LayoutAreaDefinition>)?
+            .Select(a => a.Area).OrderBy(a => a).ToList();
+        referenceAreas.Should().NotBeNull("the layoutAreas: reference returns a list of LayoutAreaDefinition");
+        referenceAreas!.Should().Contain(CustomVisibleArea);
+
+        var viaRequest = await client
+            .Observe(new GetLayoutAreasRequest(), o => o.WithTarget(CreateHostAddress()))
+            .Should().Emit();
+        var requestAreas = viaRequest.Message.Areas.Select(a => a.Area).OrderBy(a => a).ToList();
+
+        // Both surfaces resolve to the same underlying LayoutDefinition.AreaDefinitions — same list
+        // (both projected + sorted, so an order-sensitive sequence compare is exact).
+        referenceAreas.Should().Equal(requestAreas);
+    }
+}


### PR DESCRIPTION
## What & why

Agents were fumbling Space creation and inline region embeds (see the [YouTube thread](https://memex.meshweaver.cloud/YouTube/_Thread/pls-put-index-on-this-page-as-well-db8a): `@@Catalog` rendered nothing, `EditContent` was tried on a structured `Space`, the catalog region was misnamed). This makes the mechanics explicit in the skill, the Assistant prompt, and a test.

### `/create-space` skill (`src/MeshWeaver.AI/Data/Skill/create-space.md`)
- **Top level = any type; `Space` is the generic one.**
- **Regions via `@@`** — `@` links, `@@` embeds (at line start); table of common node regions (Search, Overview, Threads, Files, Comments, Versions) + all four reference forms.
- **Contents catalog** — end the Space `body` with `@@("area/Search")` (exactly what `SpaceNodeType.WelcomeMarkdown` ships), **not** `@@Catalog`.
- **Listing areas** — `Get('@{path}/layoutAreas/')` (plural), with the visible-vs-embeddable caveat.

### Assistant prompt (`src/MeshWeaver.AI/Data/Agent/Assistant.md`)
New "Spaces and regions (`@@`)" section stating the same facts concisely.

### Test (`test/MeshWeaver.Graph.Test/LayoutAreaRetrievalTest.cs`, 2 tests)
Pins **how to retrieve** the area list (both `GetLayoutAreasRequest` and the `layoutAreas:` unified reference behind `Get('@node/layoutAreas/')`) and the **gotcha**: standard node regions are `[Browsable(false)]` — embeddable via `@@` but not advertised in the `layoutAreas` listing; a custom visible area is.

## Corrections to prior assumptions
- Listing is **`layoutAreas`** (plural), not `area/` (singular = one area's payload).
- The children/contents catalog region is **`Search`**, not `Catalog`.

## Verification
- `LayoutAreaRetrievalTest` — both tests pass.
- `dotnet build test/MeshWeaver.Graph.Test -c Release -p:CIRun=true -warnaserror` → **0 warnings, 0 errors**.
- `SkillNodeTypeTest`'s exact skill-id set is preserved (enhanced the existing `create-space`, no new id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)