### PR TITLE
feat(instance-sync): OAuth "connect to remote instance"

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -934,6 +934,11 @@ public static class MemexConfiguration
         // {userId}/_Provider/GitHub. See Doc/Architecture/GitHubSync.
         app.MapGitHubConnect();
 
+        // Instance Sync — OAuth+PKCE "connect to a remote MeshWeaver instance" endpoints
+        // (/connect/instance[/callback]). Redirects to the remote's own login and stores the
+        // returned mw_ token as the sync party's RemoteToken. See InstanceConnectEndpoints.
+        app.MapInstanceConnect();
+
         // GitHub webhooks — POST /webhooks/github. HMAC-verified (GitHub:Webhook:Secret), no
         // browser session, so it does NOT need HttpContext.User. Refreshes synced issue nodes
         // live. Register one webhook per repo (Issues + Issue comments) with the shared secret.

--- a/memex/Memex.Portal.Shared/Social/InstanceConnectEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/InstanceConnectEndpoints.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Threading.Tasks;
+using MeshWeaver.InstanceSync;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Social;
+
+/// <summary>
+/// OAuth 2.0 + PKCE "connect to a remote MeshWeaver instance" flow for instance sync. Lets a user
+/// authorize this portal against ANOTHER MeshWeaver instance's own login — the remote exposes its
+/// own OAuth server (see <c>OAuthConnectController</c>) — so the returned <c>mw_</c> token is stored
+/// as the sync party's <see cref="InstanceSyncConfig.RemoteToken"/> instead of pasting a token by hand:
+///
+///   GET /connect/instance?spaceId=&amp;sourceId=&amp;returnPath=  — start (read RemoteUrl, PKCE cookie, redirect to the remote's /authorize)
+///   GET /connect/instance/callback?code=&amp;state=             — exchange code at the remote /token, store RemoteToken, redirect back
+///
+/// Mirrors <see cref="GitHubConnectEndpoints"/>: a CSRF state cookie, a reactive body bridged to Task
+/// once at the HTTP boundary, and error redirects that carry the real reason back to the Sync view.
+/// The remote URL is read server-side from the party config — never trusted from a query parameter —
+/// and the cookie carries the PKCE verifier + resolved token endpoint so the callback re-reads nothing.
+/// </summary>
+public static class InstanceConnectEndpoints
+{
+    /// <summary>The CSRF/PKCE state cookie name.</summary>
+    public const string StateCookieName = "inst_connect_state";
+    private const string CallbackPath = "/connect/instance/callback";
+
+    /// <summary>Maps the two connect endpoints. Registered from <c>MemexConfiguration</c> next to <c>MapGitHubConnect</c>.</summary>
+    public static IEndpointRouteBuilder MapInstanceConnect(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/connect/instance", (
+            HttpContext http,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string? spaceId,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string? sourceId,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string? returnPath,
+            InstanceSyncService sync,
+            InstanceOAuthService oauth,
+            ILoggerFactory loggers) =>
+        {
+            var logger = loggers.CreateLogger("InstanceConnect");
+            if (!http.User.Identity?.IsAuthenticated ?? true)
+                return Task.FromResult(Results.Challenge(new AuthenticationProperties
+                { RedirectUri = http.Request.Path + http.Request.QueryString }));
+
+            var rp = string.IsNullOrWhiteSpace(returnPath) ? "/" : returnPath!;
+            if (string.IsNullOrWhiteSpace(spaceId) || string.IsNullOrWhiteSpace(sourceId))
+                return Task.FromResult((IResult)Results.Redirect(SafeReturn(rp, "instance-error", "missing spaceId/sourceId")));
+
+            var redirectUri = BuildRedirectUri(http);
+
+            // Reactive: read the party's RemoteUrl (authoritative, via the node stream), discover the
+            // remote's endpoints, set the PKCE/CSRF cookie, redirect to the remote's /authorize. Bridge
+            // to Task ONCE at the HTTP boundary — the sanctioned edge pattern (see GitHub callback).
+            return sync.ReadConfigAuthoritative(spaceId!, sourceId!)
+                .Timeout(TimeSpan.FromSeconds(10))
+                .SelectMany(cfg =>
+                {
+                    var remoteUrl = cfg?.RemoteUrl?.Trim();
+                    if (string.IsNullOrWhiteSpace(remoteUrl))
+                        return Observable.Return((IResult)Results.Redirect(
+                            SafeReturn(rp, "instance-error", "set the remote instance URL first, then Connect")));
+
+                    return oauth.Discover(remoteUrl!).Select(ep =>
+                    {
+                        var verifier = InstanceOAuthService.NewVerifier();
+                        var challenge = InstanceOAuthService.Challenge(verifier);
+                        var state = InstanceOAuthService.NewState();
+
+                        // Cookie payload = the callback's full working set (each field base64url'd, so
+                        // '|'/'.' in a returnPath can't corrupt the split): state, party, remote URL,
+                        // resolved token endpoint, PKCE verifier, returnPath.
+                        var payload = string.Join(".", new[]
+                        {
+                            state, spaceId!, sourceId!, remoteUrl!, ep.Token, verifier, rp
+                        }.Select(Enc));
+
+                        http.Response.Cookies.Append(StateCookieName, payload, new CookieOptions
+                        {
+                            HttpOnly = true,
+                            Secure = true,
+                            SameSite = SameSiteMode.Lax,
+                            MaxAge = TimeSpan.FromMinutes(10),
+                        });
+
+                        return (IResult)Results.Redirect(
+                            InstanceOAuthService.BuildAuthorizeUrl(ep.Authorize, redirectUri, challenge, state));
+                    });
+                })
+                .Catch((Exception ex) =>
+                {
+                    logger.LogWarning(ex, "Instance connect start failed for {Space}/{Source}", spaceId, sourceId);
+                    return Observable.Return((IResult)Results.Redirect(SafeReturn(rp, "instance-error", ex.Message)));
+                })
+                .FirstAsync()
+                .ToTask(http.RequestAborted);
+        }).RequireAuthorization();
+
+        endpoints.MapGet(CallbackPath, (
+            HttpContext http,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string? code,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string? state,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string? error,
+            InstanceSyncService sync,
+            InstanceOAuthService oauth,
+            ILoggerFactory loggers) =>
+        {
+            var logger = loggers.CreateLogger("InstanceConnect");
+
+            // Recover the working set (and CSRF state) from the cookie FIRST, so every failure below
+            // redirects the user BACK to the Sync view WITH a visible reason — never a silent bounce.
+            string cookieState = "", spaceId = "", sourceId = "", remoteUrl = "", tokenEndpoint = "",
+                   verifier = "", returnPath = "/";
+            if (http.Request.Cookies.TryGetValue(StateCookieName, out var cookie) && !string.IsNullOrEmpty(cookie))
+            {
+                http.Response.Cookies.Delete(StateCookieName);
+                try
+                {
+                    var p = cookie.Split('.');
+                    cookieState = Dec(p[0]); spaceId = Dec(p[1]); sourceId = Dec(p[2]);
+                    remoteUrl = Dec(p[3]); tokenEndpoint = Dec(p[4]); verifier = Dec(p[5]);
+                    returnPath = p.Length > 6 ? Dec(p[6]) : "/";
+                }
+                catch { /* malformed cookie — the state check below fails it cleanly */ }
+            }
+
+            IResult Fail(string reason)
+            {
+                logger.LogWarning("Instance connect failed: {Reason} (user {User})", reason, http.User.Identity?.Name);
+                return Results.Redirect(SafeReturn(returnPath, "instance-error", reason));
+            }
+
+            if (!string.IsNullOrEmpty(error))
+                return Task.FromResult(Fail(error!));
+            if (string.IsNullOrEmpty(cookieState))
+                return Task.FromResult(Fail("missing or bad connect-state cookie (CSRF)"));
+            if (!string.Equals(cookieState, state, StringComparison.Ordinal))
+                return Task.FromResult(Fail("connect-state mismatch (CSRF)"));
+            if (string.IsNullOrEmpty(code))
+                return Task.FromResult(Fail("no authorization code returned by the remote instance"));
+
+            var redirectUri = BuildRedirectUri(http);
+            var configPath = InstanceSyncService.ConfigPath(spaceId, sourceId);
+
+            // Reactive: exchange the code at the remote /token, then store the returned mw_ token as
+            // the party's RemoteToken (the worker reads it as the Bearer token). Bridge to Task once.
+            return oauth.ExchangeCode(tokenEndpoint, code!, redirectUri, verifier)
+                .SelectMany(token => sync.UpdateConfig(configPath, c => c with
+                {
+                    RemoteUrl = remoteUrl,
+                    RemoteToken = token,
+                    Active = true,
+                }))
+                .Select(_ =>
+                {
+                    logger.LogInformation("Stored remote-instance token for {ConfigPath}", configPath);
+                    return (IResult)Results.Redirect(SafeReturn(returnPath, "instance-ok", null));
+                })
+                .Catch((Exception ex) =>
+                {
+                    logger.LogWarning(ex, "Instance connect callback failed for {ConfigPath}", configPath);
+                    return Observable.Return((IResult)Results.Redirect(SafeReturn(returnPath, "instance-error", ex.Message)));
+                })
+                .FirstAsync()
+                .ToTask(http.RequestAborted);
+        }).RequireAuthorization();
+
+        return endpoints;
+    }
+
+    private static string SafeReturn(string returnPath, string status, string? reason)
+    {
+        var rp = string.IsNullOrWhiteSpace(returnPath) || !returnPath.StartsWith("/", StringComparison.Ordinal) ? "/" : returnPath;
+        var sep = rp.Contains('?') ? "&" : "?";
+        var url = $"{rp}{sep}connect={status}";
+        if (!string.IsNullOrEmpty(reason))
+            url += $"&reason={Uri.EscapeDataString(reason!)}";
+        return url;
+    }
+
+    private static string BuildRedirectUri(HttpContext http) =>
+        $"{http.Request.Scheme}://{http.Request.Host}{CallbackPath}";
+
+    private static string Enc(string s) => WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(s ?? ""));
+    private static string Dec(string s) => Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(s));
+}

--- a/memex/Memex.Portal.Shared/Social/InstanceConnectEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/InstanceConnectEndpoints.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using MeshWeaver.InstanceSync;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -33,6 +34,10 @@ public static class InstanceConnectEndpoints
     /// <summary>The CSRF/PKCE state cookie name.</summary>
     public const string StateCookieName = "inst_connect_state";
     private const string CallbackPath = "/connect/instance/callback";
+    // The cookie carries the PKCE verifier AND the server-side token-exchange target, so it must be
+    // integrity-protected: a logged-in user could otherwise forge it and steer the token POST to an
+    // arbitrary URL. DataProtection encrypts + signs it; Unprotect fails closed on any tampering.
+    private const string ProtectorPurpose = "MeshWeaver.InstanceConnect.v1";
 
     /// <summary>Maps the two connect endpoints. Registered from <c>MemexConfiguration</c> next to <c>MapGitHubConnect</c>.</summary>
     public static IEndpointRouteBuilder MapInstanceConnect(this IEndpointRouteBuilder endpoints)
@@ -44,6 +49,7 @@ public static class InstanceConnectEndpoints
             [Microsoft.AspNetCore.Mvc.FromQuery] string? returnPath,
             InstanceSyncService sync,
             InstanceOAuthService oauth,
+            IDataProtectionProvider dp,
             ILoggerFactory loggers) =>
         {
             var logger = loggers.CreateLogger("InstanceConnect");
@@ -55,6 +61,7 @@ public static class InstanceConnectEndpoints
             if (string.IsNullOrWhiteSpace(spaceId) || string.IsNullOrWhiteSpace(sourceId))
                 return Task.FromResult((IResult)Results.Redirect(SafeReturn(rp, "instance-error", "missing spaceId/sourceId")));
 
+            var protector = dp.CreateProtector(ProtectorPurpose);
             var redirectUri = BuildRedirectUri(http);
 
             // Reactive: read the party's RemoteUrl (authoritative, via the node stream), discover the
@@ -68,6 +75,12 @@ public static class InstanceConnectEndpoints
                     if (string.IsNullOrWhiteSpace(remoteUrl))
                         return Observable.Return((IResult)Results.Redirect(
                             SafeReturn(rp, "instance-error", "set the remote instance URL first, then Connect")));
+                    // Only follow an absolute http(s) URL — "foo" would otherwise become "foo/authorize"
+                    // and a non-http scheme could steer the discovery/token request somewhere unintended.
+                    if (!Uri.TryCreate(remoteUrl, UriKind.Absolute, out var uri)
+                        || (uri.Scheme != Uri.UriSchemeHttps && uri.Scheme != Uri.UriSchemeHttp))
+                        return Observable.Return((IResult)Results.Redirect(
+                            SafeReturn(rp, "instance-error", "the remote URL must be an absolute http(s) URL")));
 
                     return oauth.Discover(remoteUrl!).Select(ep =>
                     {
@@ -77,11 +90,12 @@ public static class InstanceConnectEndpoints
 
                         // Cookie payload = the callback's full working set (each field base64url'd, so
                         // '|'/'.' in a returnPath can't corrupt the split): state, party, remote URL,
-                        // resolved token endpoint, PKCE verifier, returnPath.
-                        var payload = string.Join(".", new[]
+                        // resolved token endpoint, PKCE verifier, returnPath. DataProtected so it can't
+                        // be forged to steer the token exchange at a different endpoint.
+                        var payload = protector.Protect(string.Join(".", new[]
                         {
                             state, spaceId!, sourceId!, remoteUrl!, ep.Token, verifier, rp
-                        }.Select(Enc));
+                        }.Select(Enc)));
 
                         http.Response.Cookies.Append(StateCookieName, payload, new CookieOptions
                         {
@@ -111,6 +125,7 @@ public static class InstanceConnectEndpoints
             [Microsoft.AspNetCore.Mvc.FromQuery] string? error,
             InstanceSyncService sync,
             InstanceOAuthService oauth,
+            IDataProtectionProvider dp,
             ILoggerFactory loggers) =>
         {
             var logger = loggers.CreateLogger("InstanceConnect");
@@ -124,12 +139,13 @@ public static class InstanceConnectEndpoints
                 http.Response.Cookies.Delete(StateCookieName);
                 try
                 {
-                    var p = cookie.Split('.');
+                    // Unprotect first — a forged/tampered cookie throws here and fails the flow closed.
+                    var p = dp.CreateProtector(ProtectorPurpose).Unprotect(cookie).Split('.');
                     cookieState = Dec(p[0]); spaceId = Dec(p[1]); sourceId = Dec(p[2]);
                     remoteUrl = Dec(p[3]); tokenEndpoint = Dec(p[4]); verifier = Dec(p[5]);
                     returnPath = p.Length > 6 ? Dec(p[6]) : "/";
                 }
-                catch { /* malformed cookie — the state check below fails it cleanly */ }
+                catch { /* malformed / tampered cookie — the state check below fails it cleanly */ }
             }
 
             IResult Fail(string reason)

--- a/src/MeshWeaver.InstanceSync/InstanceOAuthService.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceOAuthService.cs
@@ -1,0 +1,123 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.InstanceSync;
+
+/// <summary>
+/// Server-side OAuth 2.0 + PKCE client for connecting instance sync to a REMOTE MeshWeaver
+/// instance. Every MeshWeaver instance exposes its own OAuth authorization server (RFC 8414
+/// <c>.well-known</c> + <c>/authorize</c> + <c>/token</c>, a public client secured by PKCE with no
+/// pre-registration — see <c>OAuthConnectController</c>), so the user's browser is redirected to
+/// the remote's own login (Microsoft / Google / …) and the returned <c>mw_</c> token is stored as
+/// the party's <see cref="InstanceSyncConfig.RemoteToken"/> — the user never pastes a token.
+///
+/// <para>Mirrors the MAUI <c>MeshOAuthClient</c>, but reactive + <see cref="IIoPool"/>-bounded for
+/// the portal: <c>InstanceConnectEndpoints</c> drives it from the <c>/connect/instance</c> flow.
+/// 🚨 Reactive end-to-end — the HTTP leaves run on the Http I/O pool, never a bare
+/// <c>Observable.FromAsync</c>.</para>
+/// </summary>
+public sealed class InstanceOAuthService
+{
+    /// <summary>The fixed public client id this portal presents to a remote's <c>/authorize</c> +
+    /// <c>/token</c>. The remote accepts any client_id (PKCE-secured, no pre-registration required
+    /// — see <c>OAuthConnectController.Authorize</c>), so no dynamic <c>/register</c> is needed.</summary>
+    public const string ClientId = "meshweaver-instance-sync";
+
+    private readonly IIoPool _httpPool;
+    private readonly HttpClient _http;
+    private readonly ILogger<InstanceOAuthService>? _logger;
+
+    /// <summary>Creates the service, resolving the mesh-scoped Http I/O pool the HTTP leaves route through.</summary>
+    public InstanceOAuthService(IMessageHub hub, ILogger<InstanceOAuthService>? logger = null)
+    {
+        _httpPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
+        _http = new HttpClient();
+        _logger = logger;
+    }
+
+    /// <summary>The remote's authorize + token endpoints.</summary>
+    public readonly record struct Endpoints(string Authorize, string Token);
+
+    /// <summary>
+    /// Discovers the remote's authorize + token endpoints from its RFC 8414 / OIDC metadata,
+    /// falling back to the conventional <c>{base}/authorize</c> + <c>{base}/token</c> (every
+    /// MeshWeaver instance serves those). One pooled GET; the fallback needs no HTTP.
+    /// </summary>
+    public IObservable<Endpoints> Discover(string remoteUrl)
+    {
+        var baseUrl = remoteUrl.TrimEnd('/');
+        return _httpPool.Invoke(async ct =>
+        {
+            foreach (var well in new[] { "/.well-known/oauth-authorization-server", "/.well-known/openid-configuration" })
+            {
+                try
+                {
+                    var json = await _http.GetStringAsync(baseUrl + well, ct).ConfigureAwait(false);
+                    using var doc = JsonDocument.Parse(json);
+                    var a = doc.RootElement.TryGetProperty("authorization_endpoint", out var ae) ? ae.GetString() : null;
+                    var t = doc.RootElement.TryGetProperty("token_endpoint", out var te) ? te.GetString() : null;
+                    if (!string.IsNullOrEmpty(a) && !string.IsNullOrEmpty(t))
+                        return new Endpoints(a!, t!);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogDebug(ex, "OAuth metadata {Well} not served by {Remote}; trying next / fallback", well, baseUrl);
+                }
+            }
+            return new Endpoints(baseUrl + "/authorize", baseUrl + "/token");
+        });
+    }
+
+    /// <summary>Builds the remote <c>/authorize</c> redirect (PKCE S256, our callback as redirect_uri).</summary>
+    public static string BuildAuthorizeUrl(string authorizeEndpoint, string redirectUri, string codeChallenge, string state) =>
+        $"{authorizeEndpoint}?response_type=code" +
+        $"&client_id={Uri.EscapeDataString(ClientId)}" +
+        $"&redirect_uri={Uri.EscapeDataString(redirectUri)}" +
+        $"&state={Uri.EscapeDataString(state)}" +
+        $"&code_challenge={codeChallenge}&code_challenge_method=S256";
+
+    /// <summary>
+    /// Exchanges the authorization code at the remote's <c>/token</c> (PKCE public client, no
+    /// secret) for the remote's <c>mw_</c> access token. Pooled POST; throws with the remote's body
+    /// on failure so the callback surfaces the real reason instead of a silent bounce.
+    /// </summary>
+    public IObservable<string> ExchangeCode(string tokenEndpoint, string code, string redirectUri, string codeVerifier) =>
+        _httpPool.Invoke(async ct =>
+        {
+            using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = "authorization_code",
+                ["code"] = code,
+                ["redirect_uri"] = redirectUri,
+                ["client_id"] = ClientId,
+                ["code_verifier"] = codeVerifier,
+            });
+            using var resp = await _http.PostAsync(tokenEndpoint, form, ct).ConfigureAwait(false);
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+                throw new InvalidOperationException($"Remote token exchange failed ({(int)resp.StatusCode}): {body}");
+            using var doc = JsonDocument.Parse(body);
+            return doc.RootElement.TryGetProperty("access_token", out var at) && at.GetString() is { Length: > 0 } tok
+                ? tok
+                : throw new InvalidOperationException("Remote token response contained no access_token.");
+        });
+
+    // ── PKCE + CSRF helpers ──
+
+    /// <summary>A high-entropy PKCE code verifier (64 random bytes, base64url).</summary>
+    public static string NewVerifier() => Base64Url(RandomNumberGenerator.GetBytes(64));
+
+    /// <summary>The S256 challenge for a verifier.</summary>
+    public static string Challenge(string verifier) => Base64Url(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
+
+    /// <summary>A random CSRF state token (24 random bytes, base64url).</summary>
+    public static string NewState() => Base64Url(RandomNumberGenerator.GetBytes(24));
+
+    private static string Base64Url(byte[] data) =>
+        Convert.ToBase64String(data).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+}

--- a/src/MeshWeaver.InstanceSync/InstanceSyncConfiguration.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncConfiguration.cs
@@ -30,6 +30,9 @@ public static class InstanceSyncConfiguration
         // host (or test) that registered its own factory wins.
         services.TryAddSingleton<IRemoteMeshClientFactory, McpRemoteMeshClientFactory>();
         services.AddSingleton<InstanceSyncService>();
+        // Server-side OAuth+PKCE client for the "Connect to remote instance" flow (drives the
+        // /connect/instance endpoints; stores the returned mw_ token as the party's RemoteToken).
+        services.AddSingleton<InstanceOAuthService>();
         services.AddSingleton<InstanceSyncCoordinator>();
         services.AddHostedService(sp => sp.GetRequiredService<InstanceSyncCoordinator>());
         // Surfaces the per-space remote-instance sync sources on the partition administration

--- a/src/MeshWeaver.InstanceSync/InstanceSyncLayoutArea.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncLayoutArea.cs
@@ -87,6 +87,20 @@ public static class InstanceSyncLayoutArea
         // config node's stream (per-field auto-persisting; no replica, no save subscription).
         card = card.WithView(MeshNodeContentEditorControl.ForType(source.Path, typeof(InstanceSyncConfig)));
 
+        // OAuth alternative to pasting a token: full-page redirect to the remote instance's OWN
+        // login (/connect/instance → the remote's /authorize), then the callback stores the
+        // returned mw_ token as RemoteToken. Needs the Remote URL above to be set first (the
+        // endpoint reads it server-side and redirects back with a reason if it's blank).
+        var returnPath = MeshNodeLayoutAreas.BuildUrl(spacePath, AreaName);
+        var connectHref = "/connect/instance"
+            + $"?spaceId={Uri.EscapeDataString(spacePath)}"
+            + $"&sourceId={Uri.EscapeDataString(source.Id)}"
+            + $"&returnPath={Uri.EscapeDataString(returnPath)}";
+        card = card.WithView(Controls.Button("Connect with the remote's login (OAuth)")
+            .WithAppearance(Appearance.Outline)
+            .WithIconStart(FluentIcons.PlugConnected())
+            .WithNavigateToHref(connectHref));
+
         var sourcePath = source.Path;
         var configPath = InstanceSyncService.ConfigPath(spacePath, source.Id);
         var actions = Controls.Stack

--- a/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
@@ -159,6 +159,7 @@ public sealed class InstanceSyncService(
             return node with { Content = update(current) };
         });
 
+
     /// <summary>
     /// Appends a local change to the durable manifest, coalescing by path: only the LATEST
     /// pending state of a node matters because the drain pushes CURRENT content. Ordering of


### PR DESCRIPTION
Instance sync can now authenticate to a remote MeshWeaver instance via **OAuth** instead of pasting an API token. In the **Synchronizations** area, "Connect with the remote's login (OAuth)" redirects the browser to the **remote instance's own login** (Microsoft / Google / …); the returned `mw_` token is stored as the party's `RemoteToken` (which the sync worker already consumes as its Bearer credential).

### How it works
Every MeshWeaver instance already exposes an RFC 8414 OAuth authorization server (`OAuthConnectController`), so any instance can BE the remote. Its `/authorize` accepts any `client_id` secured by PKCE with **no pre-registration**, so no dynamic `/register` is needed — a fixed public client id + PKCE suffices.

1. `GET /connect/instance?spaceId=&sourceId=&returnPath=` — reads the party's `RemoteUrl` server-side (`ReadConfigAuthoritative`, not a query param), discovers the remote's endpoints (`.well-known` + fallback), sets a CSRF/PKCE state cookie carrying the verifier + resolved token endpoint, and redirects to the remote's `/authorize`.
2. User logs into the **remote** the normal way → remote redirects to `GET /connect/instance/callback?code=&state=`.
3. The callback exchanges the code at the remote's `/token` (PKCE, public client) and writes `RemoteToken` onto `{space}/_Sync/{sourceId}`.

### Pieces
- **`InstanceOAuthService`** (`src/MeshWeaver.InstanceSync`) — reactive, `IIoPool`-bounded OAuth+PKCE client (Discover / BuildAuthorizeUrl / ExchangeCode + PKCE helpers). Mirrors the MAUI `MeshOAuthClient`.
- **`InstanceConnectEndpoints`** (`Memex.Portal.Shared`) — the two endpoints, mirroring `GitHubConnectEndpoints` (CSRF cookie, reactive body bridged to Task once, error redirects with the real reason).
- **Connect button** in the Synchronizations party card; `InstanceOAuthService` registered + `app.MapInstanceConnect()`.

Builds clean under `Release -warnaserror`. Follow-up (not in this PR): an auth-mode marker to hide the manual token field when OAuth is used; an E2E loopback test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)