### PR TITLE
feat(chat): composer defaults inherit from the user's master composer

### DIFF
--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -285,6 +285,9 @@ public static class AgentPickerProjection
     /// <summary>Named-query id for the harnesses synced subscription.</summary>
     public const string HarnessesQueryId = "Harnesses";
 
+    /// <summary>Named-query id for the user's MASTER composer ({user}/_Thread/ThreadComposer) read.</summary>
+    public const string MasterComposerQueryId = "MasterComposer";
+
     /// <summary>
     /// The DEFAULT composer selection — resolved purely by ORDER, never hardcoded. For each registry
     /// (agent / model / harness) the default is the node with the LOWEST <c>Order</c> (the <c>Order = -1</c>
@@ -335,9 +338,38 @@ public static class AgentPickerProjection
                 .Select(n => n.Path)
                 .FirstOrDefault());
 
-        return agent.CombineLatest(model, harness,
-            (a, m, h) => new ThreadComposer { AgentName = a, ModelName = m, Harness = h });
+        // 🎯 The user's MASTER composer ({user}/_Thread/ThreadComposer) is the single source of truth for
+        // chat defaults. Any composer WITHOUT its own selection — a new thread, or a namespace that has no
+        // standard composer of its own — INHERITS the master's harness/model/agent/effort. The catalog
+        // (lowest-Order, resolved above) is ONLY the fallback for a brand-new master the user has never
+        // touched. Read via a query (empty-on-absent — no NotFound storm), never a direct GetMeshNodeStream
+        // on the maybe-absent exact path; the seed handler normally makes it present.
+        var jsonOptions = hub.JsonSerializerOptions;
+        var masterLogger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.AI.AgentPickerProjection");
+        var master = string.IsNullOrEmpty(userPath)
+            ? System.Reactive.Linq.Observable.Return<ThreadComposer?>(null)
+            : ObserveSnapshot(workspace, hub,
+                    $"{MasterComposerQueryId}|u={userPath}",
+                    $"namespace:{userPath}/{ThreadNodeType.ThreadPartition} nodeType:{ThreadComposerNodeType.NodeType}")
+                .Select(snapshot => snapshot
+                    .Where(n => string.Equals(n.NodeType, ThreadComposerNodeType.NodeType, StringComparison.OrdinalIgnoreCase))
+                    .Select(n => ThreadComposerNodeType.ComposerOf(n, jsonOptions, masterLogger))
+                    .FirstOrDefault(c => c is not null));
+
+        return agent.CombineLatest(model, harness, master,
+            (a, m, h, mstr) => new ThreadComposer
+            {
+                Harness   = FirstNonEmpty(mstr?.Harness, h),
+                ModelName = FirstNonEmpty(mstr?.ModelName, m),
+                AgentName = FirstNonEmpty(mstr?.AgentName, a),
+                Effort    = mstr?.Effort
+            });
     }
+
+    /// <summary>First non-empty of the two — master value wins, catalog fallback.</summary>
+    private static string? FirstNonEmpty(string? primary, string? fallback)
+        => string.IsNullOrEmpty(primary) ? fallback : primary;
 
     /// <summary>
     /// The model picker queries: the system <c>Provider</c> catalog plus per-context / per-NodeType /

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -18,30 +18,44 @@ function syncMonacoTheme(effectiveTheme) {
     }
 }
 
-// Detect theme from DOM when themeHandler is not available
+// The OS preference, the ultimate arbiter when the app theme is "System".
+function osPrefersDark() {
+    return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+}
+
+// Resolve the CURRENTLY-RENDERED effective theme ('dark' | 'light'), correct even when the app theme
+// mode is "System" (follow the OS). Order of authority:
+//   1. document.documentElement[data-theme] — what themeHandler.applyTheme() ACTUALLY wrote (already
+//      resolved System→OS). This reflects what's on screen right now; it's the most reliable signal and
+//      is re-written whenever the app mode OR the OS preference changes.
+//   2. themeHandler.getEffectiveTheme() — recomputes from the current mode (also resolves System→OS).
+//   3. body[data-theme] / dark classes — legacy FluentDesignTheme signals.
+//   4. the OS preference directly.
+// A literal 'system' value anywhere is resolved via the OS — never treated as a theme name (that was
+// the "black font": 'system' !== 'dark' → the light 'vs' theme with black glyphs on the dark composer).
 function detectThemeFromDOM() {
-    // FluentDesignTheme sets data-theme on document.body
-    const bodyTheme = document.body?.getAttribute('data-theme');
-    if (bodyTheme) {
-        return bodyTheme;
+    const resolve = (v) => {
+        if (v === 'dark' || v === 'light') return v;
+        if (v === 'system' || v === 'auto') return osPrefersDark() ? 'dark' : 'light';
+        return null;
+    };
+    const htmlTheme = resolve(document.documentElement.getAttribute('data-theme'));
+    if (htmlTheme) return htmlTheme;
+    if (typeof window.themeHandler !== 'undefined'
+        && typeof window.themeHandler.getEffectiveTheme === 'function') {
+        const handlerTheme = resolve(window.themeHandler.getEffectiveTheme());
+        if (handlerTheme) return handlerTheme;
     }
-    // Also check documentElement as fallback
-    const htmlTheme = document.documentElement.getAttribute('data-theme');
-    if (htmlTheme) {
-        return htmlTheme;
-    }
-    // Check for dark/fluent-dark class on body or html
-    if (document.body?.classList.contains('dark') ||
+    const bodyTheme = resolve(document.body?.getAttribute('data-theme'));
+    if (bodyTheme) return bodyTheme;
+    if (document.documentElement.classList.contains('dark-theme') ||
+        document.body?.classList.contains('dark') ||
         document.body?.classList.contains('fluent-dark') ||
         document.documentElement.classList.contains('dark') ||
         document.documentElement.classList.contains('fluent-dark')) {
         return 'dark';
     }
-    // Fallback to system preference
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        return 'dark';
-    }
-    return 'light';
+    return osPrefersDark() ? 'dark' : 'light';
 }
 
 // Register theme change callback (called from initEditor when Monaco is ready)
@@ -285,16 +299,11 @@ export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = fals
     // BLACK on the transparent-over-dark composer background (unreadable in dark mode). Re-syncing
     // the global theme on every mount also heals a stale theme set before the app flipped to dark.
     if (typeof monaco !== 'undefined' && monaco.editor) {
-        // Prefer the AUTHORITATIVE app theme (window.themeHandler) — the SAME source the theme-change
-        // callback uses (ensureThemeCallbackRegistered) — and only fall back to DOM sniffing when it's
-        // absent. Using detectThemeFromDOM here unconditionally was the "black font on the user page"
-        // bug: FluentDesignTheme doesn't always mirror the effective theme onto body[data-theme], so DOM
-        // sniffing returned 'light' while the app was dark, and this mount-time setTheme (GLOBAL) then
-        // RESET every editor to 'vs' (black glyphs) right after the callback had correctly set 'vs-dark'.
-        const currentTheme = (typeof window.themeHandler !== 'undefined' && window.themeHandler.getEffectiveTheme)
-            ? window.themeHandler.getEffectiveTheme()
-            : detectThemeFromDOM();
-        monaco.editor.setTheme(currentTheme === 'dark' ? 'vs-dark' : 'vs');
+        // detectThemeFromDOM now resolves the EFFECTIVE theme even under the "System" mode (documentElement
+        // [data-theme] that applyTheme wrote → themeHandler.getEffectiveTheme → OS preference), so a composer
+        // mounted after the first editor (e.g. inside the user-activity area) no longer resets Monaco to the
+        // light 'vs' theme and render black glyphs on the dark composer background.
+        monaco.editor.setTheme(detectThemeFromDOM() === 'dark' ? 'vs-dark' : 'vs');
     }
     if (editorInstance) {
         // Handle content changes for placeholder AND push the value back to C#.

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -285,7 +285,15 @@ export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = fals
     // BLACK on the transparent-over-dark composer background (unreadable in dark mode). Re-syncing
     // the global theme on every mount also heals a stale theme set before the app flipped to dark.
     if (typeof monaco !== 'undefined' && monaco.editor) {
-        const currentTheme = detectThemeFromDOM();
+        // Prefer the AUTHORITATIVE app theme (window.themeHandler) — the SAME source the theme-change
+        // callback uses (ensureThemeCallbackRegistered) — and only fall back to DOM sniffing when it's
+        // absent. Using detectThemeFromDOM here unconditionally was the "black font on the user page"
+        // bug: FluentDesignTheme doesn't always mirror the effective theme onto body[data-theme], so DOM
+        // sniffing returned 'light' while the app was dark, and this mount-time setTheme (GLOBAL) then
+        // RESET every editor to 'vs' (black glyphs) right after the callback had correctly set 'vs-dark'.
+        const currentTheme = (typeof window.themeHandler !== 'undefined' && window.themeHandler.getEffectiveTheme)
+            ? window.themeHandler.getEffectiveTheme()
+            : detectThemeFromDOM();
         monaco.editor.setTheme(currentTheme === 'dark' ? 'vs-dark' : 'vs');
     }
     if (editorInstance) {


### PR DESCRIPTION
## Why

A cleaner, single-source-of-truth model for chat-composer defaults, per request: **the user's master composer (`{user}/_Thread/ThreadComposer`) is the master setting**, and any composer without its own selection — a new thread, or a namespace with no standard composer of its own — **inherits** its harness/model/agent/effort. The catalog (lowest-Order) is only the fallback for a brand-new master.

Before, `ObserveDefaultComposer` seeded new composers straight from the catalog, so a selection could "snap back" to the catalog default rather than the user's own choice.

## What

- `ObserveDefaultComposer` now reads the master composer via a query (`namespace:{user}/_Thread nodeType:ThreadComposer` — empty-on-absent, no NotFound storm) and coalesces **master-first, catalog-fallback** per field.
- The existing `FillDefaultsAndProject` seed carries those values onto the new composer → "copy from the user's composer when the namespace has none" for free.
- Pairs with the #253 dual-write (a change keeps the master current), so the master always reflects the latest choice and everything inherits it.

## Testing

- `dotnet build src/MeshWeaver.AI -c Release -warnaserror -p:CIRun=true` → green.
- Deploying to memex.localhost for interactive verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)