### PR TITLE
fix(kernel): add MeshWeaver.Layout.Composition to default script imports

### DIFF
--- a/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
@@ -451,6 +451,10 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
                 "Microsoft.Extensions.Logging",
                 "MeshWeaver.Application.Styles",
                 "MeshWeaver.Layout",
+                // LayoutAreaHost + RenderingContext live here — used by the WithView((host, ctx) => …)
+                // lambda in nearly every `--render` layout cell. Companion to MeshWeaver.Layout above,
+                // so authors don't have to add the extra using for the standard layout-area pattern.
+                "MeshWeaver.Layout.Composition",
                 "MeshWeaver.Layout.DataGrid",
                 "MeshWeaver.Messaging",
                 "MeshWeaver.Mesh"


### PR DESCRIPTION
`LayoutAreaHost` + `RenderingContext` live in `MeshWeaver.Layout.Composition` and are used by the `WithView((host, ctx) => …)` lambda in nearly every `--render` layout cell — but only `MeshWeaver.Layout` was in the kernel's default imports, so every such cell had to add the extra `using` or fail with CS0246. Adds it as the companion to `MeshWeaver.Layout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)