### PR TITLE
feat(chat): bring back the interactive Claude Code login dialog (method chooser + browser URL)

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -699,6 +699,104 @@ else
            module-defined one) pops THIS one menu. The command supplied the query + title; the
            host queried the mesh (OpenPicker) and listed the nodes; clicking one writes its PATH
            to the command's composer field. No per-command widget. *@
+        @* Interactive login (Connect) dialog — /login opens it. (1) choose a method, (2) account →
+           redirect to the browser auth URL, (3) paste a code/token only if the flow needs it; a still-valid
+           token completes silently. API key / gateway store a pasted credential. *@
+        @if (LoginDialogOpen)
+        {
+            <div class="thread-chat-widget">
+                <div class="thread-chat-widget-header">
+                    <span>Log in to @(_loginHarness!.Definition.DisplayName)</span>
+                    <button class="thread-msg-action-btn" @onclick="CancelConnect" title="Close">&#10005;</button>
+                </div>
+                <FluentStack Orientation="Microsoft.FluentUI.AspNetCore.Components.Orientation.Vertical" VerticalGap="10"
+                             Style="padding:12px 14px; flex:1 1 auto; min-height:0; overflow-y:auto;">
+                    @if (_loginMethod is null)
+                    {
+                        <div style="color:var(--neutral-foreground-hint);">How do you want to sign in?</div>
+                        @if (_connectProvider is not null)
+                        {
+                            <FluentButton Appearance="FluentAppearance.Accent" Style="width:100%;"
+                                          OnClick="@(() => ChooseLoginMethod("account"))">
+                                Log in with your @(_loginHarness!.Definition.DisplayName) account (browser)
+                            </FluentButton>
+                        }
+                        <FluentButton Appearance="FluentAppearance.Neutral" Style="width:100%;"
+                                      OnClick="@(() => ChooseLoginMethod("apiKey"))">Use an API key</FluentButton>
+                        <FluentButton Appearance="FluentAppearance.Neutral" Style="width:100%;"
+                                      OnClick="@(() => ChooseLoginMethod("gateway"))">Use a gateway / proxy</FluentButton>
+                    }
+                    else if (_loginMethod == "account")
+                    {
+                        @switch (_connectStatus)
+                        {
+                            case MeshWeaver.AI.Connect.ConnectStatus.Connected:
+                                <div style="color:var(--success-foreground, #16a34a);">&#10003; Connected — you can chat now.</div>
+                                break;
+
+                            case MeshWeaver.AI.Connect.ConnectStatus.Error err:
+                                <div style="color:var(--error-foreground, #dc2626);">@err.Reason</div>
+                                <FluentButton Appearance="FluentAppearance.Accent"
+                                              OnClick="@(() => StartHarnessConnect(_loginHarness!))">Try again</FluentButton>
+                                <FluentButton Appearance="FluentAppearance.Neutral"
+                                              OnClick="@(() => ChooseLoginMethod("apiKey"))">Use an API key instead</FluentButton>
+                                break;
+
+                            case MeshWeaver.AI.Connect.ConnectStatus.Connecting c when !string.IsNullOrEmpty(c.Challenge.VerificationUrl):
+                                <div><strong>1</strong>&nbsp; Open the authorization page and approve:</div>
+                                <FluentAnchor Href="@c.Challenge.VerificationUrl" Target="_blank"
+                                              Appearance="FluentAppearance.Accent">Open authorization page&nbsp;↗</FluentAnchor>
+                                @if (c.Challenge.RequiresPastedCode)
+                                {
+                                    <div style="margin-top:4px;"><strong>2</strong>&nbsp; Paste the code shown, then submit:</div>
+                                    <FluentTextField @bind-Value="_connectCode" Immediate="true" Placeholder="Paste code"
+                                                     @onkeydown="OnConnectInputKeyDown" Style="width:100%;" />
+                                    <FluentButton Appearance="FluentAppearance.Accent" Style="width:100%;"
+                                                  Disabled="@(_connectBusy || string.IsNullOrWhiteSpace(_connectCode))"
+                                                  OnClick="SubmitConnectCode">@(_connectBusy ? "Verifying…" : "Submit code")</FluentButton>
+                                }
+                                else if (!string.IsNullOrEmpty(c.Challenge.UserCode))
+                                {
+                                    <div>Enter this code in the browser: <strong>@c.Challenge.UserCode</strong></div>
+                                    <div style="color:var(--neutral-foreground-hint);">Waiting for authorization…</div>
+                                }
+                                break;
+
+                            default:
+                                <div style="color:var(--neutral-foreground-hint);">Starting login…</div>
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        @if (_connectStatus is MeshWeaver.AI.Connect.ConnectStatus.Error keyErr)
+                        {
+                            <div style="color:var(--error-foreground, #dc2626);">@keyErr.Reason</div>
+                        }
+                        @if (_loginMethod == "gateway")
+                        {
+                            <div>Gateway base URL:</div>
+                            <FluentTextField @bind-Value="_connectBaseUrl" Immediate="true" Placeholder="https://…" Style="width:100%;" />
+                            <div style="margin-top:4px;">Gateway token:</div>
+                        }
+                        else
+                        {
+                            <div>Paste your Anthropic Console API key (starts with
+                                <span style="font-family:var(--monospace-font-family,ui-monospace,monospace);">sk-ant-api</span>):</div>
+                        }
+                        <FluentTextField @bind-Value="_connectCode" Immediate="true"
+                                         Placeholder="@(_loginMethod == "gateway" ? "token" : "sk-ant-api…")"
+                                         TextFieldType="Microsoft.FluentUI.AspNetCore.Components.TextFieldType.Password"
+                                         @onkeydown="OnConnectInputKeyDown" Style="width:100%;" />
+                        <FluentButton Appearance="FluentAppearance.Accent" Style="width:100%;"
+                                      Disabled="@(_connectBusy || string.IsNullOrWhiteSpace(_connectCode))"
+                                      OnClick="SubmitLoginCredential">Save</FluentButton>
+                        <FluentButton Appearance="FluentAppearance.Neutral" Style="width:100%;"
+                                      OnClick="@(() => { _loginMethod = null; _connectStatus = null; _connectCode = string.Empty; _connectBaseUrl = string.Empty; })">← Back</FluentButton>
+                    }
+                </FluentStack>
+            </div>
+        }
         @if (pendingPicker is { } picker)
         {
             <div class="thread-chat-widget"

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -704,7 +704,10 @@ else
            token completes silently. API key / gateway store a pasted credential. *@
         @if (LoginDialogOpen)
         {
-            <div class="thread-chat-widget">
+            @* stopPropagation on the ROOT div (a native element) so Enter/Esc/arrows in the dialog don't
+               bubble to the thread shell's global shortcuts — the modifier can't sit on the FluentTextField
+               components (it conflicts with their @onkeydown parameter), so it lives here. *@
+            <div class="thread-chat-widget" @onkeydown:stopPropagation="true">
                 <div class="thread-chat-widget-header">
                     <span>Log in to @(_loginHarness!.Definition.DisplayName)</span>
                     <button class="thread-msg-action-btn" @onclick="CancelConnect" title="Close">&#10005;</button>
@@ -750,7 +753,7 @@ else
                                 {
                                     <div style="margin-top:4px;"><strong>2</strong>&nbsp; Paste the code shown, then submit:</div>
                                     <FluentTextField @bind-Value="_connectCode" Immediate="true" Placeholder="Paste code"
-                                                     @onkeydown="OnConnectInputKeyDown" @onkeydown:stopPropagation="true" Style="width:100%;" />
+                                                     @onkeydown="OnConnectInputKeyDown" Style="width:100%;" />
                                     <FluentButton Appearance="FluentAppearance.Accent" Style="width:100%;"
                                                   Disabled="@(_connectBusy || string.IsNullOrWhiteSpace(_connectCode))"
                                                   OnClick="SubmitConnectCode">@(_connectBusy ? "Verifying…" : "Submit code")</FluentButton>
@@ -776,8 +779,7 @@ else
                         @if (_loginMethod == "gateway")
                         {
                             <div>Gateway base URL:</div>
-                            <FluentTextField @bind-Value="_connectBaseUrl" Immediate="true" Placeholder="https://…"
-                                             @onkeydown:stopPropagation="true" Style="width:100%;" />
+                            <FluentTextField @bind-Value="_connectBaseUrl" Immediate="true" Placeholder="https://…" Style="width:100%;" />
                             <div style="margin-top:4px;">Gateway token:</div>
                         }
                         else
@@ -788,7 +790,7 @@ else
                         <FluentTextField @bind-Value="_connectCode" Immediate="true"
                                          Placeholder="@(_loginMethod == "gateway" ? "token" : "sk-ant-api…")"
                                          TextFieldType="Microsoft.FluentUI.AspNetCore.Components.TextFieldType.Password"
-                                         @onkeydown="OnConnectInputKeyDown" @onkeydown:stopPropagation="true" Style="width:100%;" />
+                                         @onkeydown="OnConnectInputKeyDown" Style="width:100%;" />
                         <FluentButton Appearance="FluentAppearance.Accent" Style="width:100%;"
                                       Disabled="@(_connectBusy || string.IsNullOrWhiteSpace(_connectCode))"
                                       OnClick="SubmitLoginCredential">Save</FluentButton>

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -750,7 +750,7 @@ else
                                 {
                                     <div style="margin-top:4px;"><strong>2</strong>&nbsp; Paste the code shown, then submit:</div>
                                     <FluentTextField @bind-Value="_connectCode" Immediate="true" Placeholder="Paste code"
-                                                     @onkeydown="OnConnectInputKeyDown" Style="width:100%;" />
+                                                     @onkeydown="OnConnectInputKeyDown" @onkeydown:stopPropagation="true" Style="width:100%;" />
                                     <FluentButton Appearance="FluentAppearance.Accent" Style="width:100%;"
                                                   Disabled="@(_connectBusy || string.IsNullOrWhiteSpace(_connectCode))"
                                                   OnClick="SubmitConnectCode">@(_connectBusy ? "Verifying…" : "Submit code")</FluentButton>
@@ -776,7 +776,8 @@ else
                         @if (_loginMethod == "gateway")
                         {
                             <div>Gateway base URL:</div>
-                            <FluentTextField @bind-Value="_connectBaseUrl" Immediate="true" Placeholder="https://…" Style="width:100%;" />
+                            <FluentTextField @bind-Value="_connectBaseUrl" Immediate="true" Placeholder="https://…"
+                                             @onkeydown:stopPropagation="true" Style="width:100%;" />
                             <div style="margin-top:4px;">Gateway token:</div>
                         }
                         else
@@ -787,7 +788,7 @@ else
                         <FluentTextField @bind-Value="_connectCode" Immediate="true"
                                          Placeholder="@(_loginMethod == "gateway" ? "token" : "sk-ant-api…")"
                                          TextFieldType="Microsoft.FluentUI.AspNetCore.Components.TextFieldType.Password"
-                                         @onkeydown="OnConnectInputKeyDown" Style="width:100%;" />
+                                         @onkeydown="OnConnectInputKeyDown" @onkeydown:stopPropagation="true" Style="width:100%;" />
                         <FluentButton Appearance="FluentAppearance.Accent" Style="width:100%;"
                                       Disabled="@(_connectBusy || string.IsNullOrWhiteSpace(_connectCode))"
                                       OnClick="SubmitLoginCredential">Save</FluentButton>

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1871,6 +1871,24 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             }
         }
 
+        // Anchor the FIXED chat popup (login dialog / agent-model picker) just above the composer. The
+        // widget is position:fixed (so it escapes the chat's overflow clip and paints over the sticky
+        // header); JS sets its left/width/bottom to hover over .thread-chat-input-content and keeps it
+        // there on resize. Runs on every render while a popup is open (cheap; no-op when none).
+        if ((LoginDialogOpen || pendingPicker is not null) && !_isDisposed)
+        {
+            try
+            {
+                _scrollModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.js");
+                await _scrollModule.InvokeVoidAsync("anchorChatPopup");
+            }
+            catch (Exception ex) when (!_isDisposed)
+            {
+                Logger.LogDebug(ex, "[ThreadChat:{InstanceId}] anchorChatPopup failed", _instanceId);
+            }
+        }
+
         if (_focusPickerOnRender && pendingPicker is not null)
         {
             _focusPickerOnRender = false;

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1263,7 +1263,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     {
         if (cmd.Kind == MeshWeaver.AI.HarnessCommandKind.Disconnect)
         {
-            ClearHarnessCredential(harness);
+            DisconnectHarness(harness);
             return;
         }
         // Connect: everything after the leading "/login" word is the pasted argument(s).
@@ -1272,10 +1272,10 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         var args = sp < 0 ? string.Empty : rest[(sp + 1)..].Trim();
         if (string.IsNullOrEmpty(args))
         {
-            ShowSkillStatus(
-                $"To connect {harness.Definition.DisplayName}, paste a credential here — "
-                + "`/login <key>` (Anthropic Console key), `/login token <oauth-token>` "
-                + "(from `claude setup-token`), or `/login gateway <base-url> <token>`.", false);
+            // No args → open the interactive login DIALOG: (1) choose a method, (2) for the account
+            // method redirect to the browser auth URL, (3) collect a pasted code/token only if the flow
+            // needs one — and it completes silently when the current token is still valid.
+            OpenLoginDialog(harness);
             return;
         }
         var parts = args.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
@@ -1292,6 +1292,223 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             method = credential.StartsWith("sk-ant-oat", StringComparison.OrdinalIgnoreCase) ? "oauth" : "apiKey";
         }
         StoreHarnessCredential(harness, method, credential, baseUrl);
+    }
+
+    // ─────────────────────── Interactive login (Connect) dialog ───────────────────────
+    // /login (no args) opens this. Step 1 picks a method (Claude account / API key / gateway); step 2
+    // runs it: the ACCOUNT method drives ConnectSessionManager.StartConnect (redirect to the browser auth
+    // URL, paste the code back ONLY if the flow asks for one, complete silently when the token is still
+    // valid); API key / gateway store a pasted credential via StoreHarnessCredential.
+    private MeshWeaver.AI.IHarness? _loginHarness;
+    private string? _loginMethod;                 // null = method chooser; "account" | "apiKey" | "gateway"
+    private MeshWeaver.AI.Connect.ConnectProvider? _connectProvider;
+    private MeshWeaver.AI.Connect.ConnectStatus? _connectStatus;
+    private string _connectCode = "";             // pasted code (account) / key (apiKey) / token (gateway)
+    private string _connectBaseUrl = "";          // gateway base URL
+    private bool _connectBusy;
+    private IDisposable? _connectSub;
+
+    /// <summary>True while the login dialog is up — the composer hides its picker/selectors underneath.</summary>
+    private bool LoginDialogOpen => _loginHarness is not null;
+
+    /// <summary>Open the login dialog on the method-chooser step (mutually exclusive with the node picker).</summary>
+    private void OpenLoginDialog(MeshWeaver.AI.IHarness harness)
+    {
+        pendingPicker = null;
+        pickerNodes = [];
+        lastCommandStatus = null;
+        _connectSub?.Dispose();
+        _connectSub = null;
+        _loginHarness = harness;
+        _loginMethod = null;
+        _connectProvider = harness.AuthProvider;
+        _connectStatus = null;
+        _connectCode = "";
+        _connectBaseUrl = "";
+        _connectBusy = false;
+        StateHasChanged();
+    }
+
+    /// <summary>A login method was chosen — for the account method kick off the browser (URL) flow now.</summary>
+    private void ChooseLoginMethod(string method)
+    {
+        _loginMethod = method;
+        _connectStatus = null;
+        _connectCode = "";
+        _connectBaseUrl = "";
+        _connectBusy = false;
+        if (method == "account" && _loginHarness is { } h)
+            StartHarnessConnect(h);
+        else
+            StateHasChanged();
+    }
+
+    /// <summary>
+    /// Runs the harness's per-user ACCOUNT login (<c>ConnectSessionManager.StartConnect</c>) and renders
+    /// the challenge inline. Each <c>ConnectStatus</c> drives the dialog: Connecting → show the auth URL
+    /// (+ a paste field when <c>RequiresPastedCode</c>); Connected → "✓" then auto-close; Error → retry. A
+    /// login that finds a still-valid token completes straight to Connected with no URL/paste step.
+    /// </summary>
+    private void StartHarnessConnect(MeshWeaver.AI.IHarness harness)
+    {
+        var provider = harness.AuthProvider;
+        if (provider is null)
+        {
+            _connectStatus = new MeshWeaver.AI.Connect.ConnectStatus.Error($"{harness.Definition.DisplayName} has no account login.");
+            StateHasChanged();
+            return;
+        }
+        var sessionManager = Hub.ServiceProvider.GetService<MeshWeaver.AI.Connect.ConnectSessionManager>();
+        if (sessionManager is null || !sessionManager.Supports(provider.Value))
+        {
+            _connectStatus = new MeshWeaver.AI.Connect.ConnectStatus.Error(
+                "Account login is not available in this deployment — use an API key instead.");
+            StateHasChanged();
+            return;
+        }
+        if (string.IsNullOrEmpty(_userHome))
+        {
+            _connectStatus = new MeshWeaver.AI.Connect.ConnectStatus.Error("No user identity for login.");
+            StateHasChanged();
+            return;
+        }
+        _connectProvider = provider;
+        _connectStatus = null;   // "Starting login…" until the first emission
+        _connectCode = "";
+        _connectBusy = false;
+        _connectSub?.Dispose();
+        var configDir = ResolveProbeConfigDir(harness.Id);
+        _connectSub = sessionManager.StartConnect(_userHome!, provider.Value, configDir)
+            .Subscribe(
+                status => InvokeAsync(() =>
+                {
+                    if (_isDisposed) return;
+                    _connectStatus = status;
+                    _connectBusy = false;
+                    StateHasChanged();
+                    if (status is MeshWeaver.AI.Connect.ConnectStatus.Connected)
+                        ScheduleConnectAutoClose();
+                }),
+                ex => InvokeAsync(() =>
+                {
+                    if (_isDisposed) return;
+                    _connectStatus = new MeshWeaver.AI.Connect.ConnectStatus.Error(ex.Message);
+                    _connectBusy = false;
+                    StateHasChanged();
+                }));
+        StateHasChanged();
+    }
+
+    /// <summary>Submit the pasted code for the account paste-code flow and drive it to completion.</summary>
+    private void SubmitConnectCode()
+    {
+        if (_connectProvider is not { } provider || string.IsNullOrWhiteSpace(_connectCode) || string.IsNullOrEmpty(_userHome))
+            return;
+        var sessionManager = Hub.ServiceProvider.GetService<MeshWeaver.AI.Connect.ConnectSessionManager>();
+        if (sessionManager is null)
+            return;
+        var code = _connectCode.Trim();
+        _connectBusy = true;
+        _connectSub?.Dispose();
+        _connectSub = sessionManager.SubmitCode(_userHome!, provider, code)
+            .Subscribe(
+                status => InvokeAsync(() =>
+                {
+                    if (_isDisposed) return;
+                    _connectStatus = status;
+                    _connectBusy = false;
+                    StateHasChanged();
+                    if (status is MeshWeaver.AI.Connect.ConnectStatus.Connected)
+                        ScheduleConnectAutoClose();
+                }),
+                ex => InvokeAsync(() =>
+                {
+                    if (_isDisposed) return;
+                    _connectStatus = new MeshWeaver.AI.Connect.ConnectStatus.Error(ex.Message);
+                    _connectBusy = false;
+                    StateHasChanged();
+                }));
+        StateHasChanged();
+    }
+
+    /// <summary>Store the pasted API key / gateway token as the harness credential, then close the dialog.</summary>
+    private void SubmitLoginCredential()
+    {
+        if (_loginHarness is not { } harness || string.IsNullOrWhiteSpace(_connectCode))
+            return;
+        var isGateway = _loginMethod == "gateway";
+        var baseUrl = isGateway ? _connectBaseUrl.Trim() : null;
+        if (isGateway && string.IsNullOrWhiteSpace(baseUrl))
+        {
+            _connectStatus = new MeshWeaver.AI.Connect.ConnectStatus.Error("Enter the gateway base URL.");
+            StateHasChanged();
+            return;
+        }
+        StoreHarnessCredential(harness, isGateway ? "authToken" : "apiKey", _connectCode.Trim(), baseUrl);
+        CloseLoginDialog();
+    }
+
+    /// <summary>Enter submits the active field (account code, or the API key / gateway token).</summary>
+    private void OnConnectInputKeyDown(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs e)
+    {
+        if (e.Key != "Enter") return;
+        if (_loginMethod == "account") SubmitConnectCode();
+        else SubmitLoginCredential();
+    }
+
+    /// <summary>Reactively auto-dismiss the dialog ~1.2s after a successful login (no Task.Delay).</summary>
+    private void ScheduleConnectAutoClose()
+    {
+        _connectSub?.Dispose();
+        _connectSub = System.Reactive.Linq.Observable.Timer(TimeSpan.FromSeconds(1.2))
+            .Subscribe(_ => InvokeAsync(() => { if (!_isDisposed) CloseLoginDialog(); }));
+    }
+
+    /// <summary>Dismiss the login dialog and tear down any live account-login session.</summary>
+    private void CancelConnect()
+    {
+        if (_connectProvider is { } p && !string.IsNullOrEmpty(_userHome))
+            Hub.ServiceProvider.GetService<MeshWeaver.AI.Connect.ConnectSessionManager>()?.Cancel(_userHome!, p);
+        CloseLoginDialog();
+    }
+
+    /// <summary>Clear all login-dialog UI state (does NOT cancel — used after success or by CancelConnect).</summary>
+    private void CloseLoginDialog()
+    {
+        _connectSub?.Dispose();
+        _connectSub = null;
+        _loginHarness = null;
+        _loginMethod = null;
+        _connectProvider = null;
+        _connectStatus = null;
+        _connectCode = "";
+        _connectBaseUrl = "";
+        _connectBusy = false;
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Log out of a CLI harness: forget the stored per-user credential (the ModelProvider node the
+    /// harness reads) AND clear the CLI's own cached credentials in the per-user config dir.
+    /// </summary>
+    private void DisconnectHarness(MeshWeaver.AI.IHarness harness)
+    {
+        if (harness.AuthProvider is { } provider && !string.IsNullOrEmpty(_userHome))
+            Hub.ServiceProvider.GetService<MeshWeaver.AI.Connect.ConnectSessionManager>()?.Cancel(_userHome!, provider);
+        var configDir = ResolveProbeConfigDir(harness.Id);
+        if (!string.IsNullOrEmpty(configDir))
+        {
+            try
+            {
+                var creds = System.IO.Path.Combine(configDir, ".credentials.json");
+                if (System.IO.File.Exists(creds)) System.IO.File.Delete(creds);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "[ThreadChat:{InstanceId}] logout: clear credentials failed", _instanceId);
+            }
+        }
+        ClearHarnessCredential(harness);
     }
 
     /// <summary>Encrypt + persist the pasted credential as the harness's ModelProvider node (create-or-update).</summary>
@@ -3519,6 +3736,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             _navContextSubscription?.Dispose();
             composerSubscription?.Dispose();
             composerDefaultsSubscription?.Dispose();
+            _connectSub?.Dispose();
             foreach (var sub in harnessRuntimeSubs) sub.Dispose();
             harnessRuntimeSubs.Clear();
             agentSubscription?.Dispose();

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1451,7 +1451,9 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     /// <summary>Enter submits the active field (account code, or the API key / gateway token).</summary>
     private void OnConnectInputKeyDown(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs e)
     {
-        if (e.Key != "Enter") return;
+        // Don't re-fire while a submit/verify is already in flight — the button is disabled but the Enter
+        // key path is not, so a repeated Enter would dispose+restart _connectSub and spam the connect flow.
+        if (e.Key != "Enter" || _connectBusy) return;
         if (_loginMethod == "account") SubmitConnectCode();
         else SubmitLoginCredential();
     }

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
@@ -593,10 +593,16 @@ button.thread-chat-status-item {
     /* Floating popup ABOVE the input (a command palette popping up), anchored to
        .thread-chat-input-content — does not push the Monaco DOM. Floating-popup tier (10000) so it
        opens ABOVE the menu bar (z-index 1100 in PortalLayoutBase) instead of being covered by it. */
-    position: absolute;
-    bottom: calc(100% + 6px);
+    /* position: FIXED (not absolute) so the popup escapes the chat's overflow clip — .body-content and
+       .layout(overflow:hidden) otherwise clip anything painting in the sticky header's band above the
+       scroll area, so an absolute popup could never sit over the header no matter its z-index. Fixed +
+       z-index 10000 puts it in the root/top stacking layer, above every sticky heading (≤1100). No
+       ancestor has transform/filter (verified), so fixed is NOT trapped. JS (anchorChatPopup) sets
+       left/width/bottom each frame to hover just above the composer; the fallback keeps it on-screen. */
+    position: fixed;
     left: 0;
     right: 0;
+    bottom: 96px;
     z-index: 10000;
     border: 1px solid var(--neutral-stroke-rest);
     border-radius: 8px;

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.js
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.js
@@ -50,3 +50,30 @@ export function attach(container) {
         }
     };
 }
+
+// Anchor the FIXED chat popup (login dialog / agent·model picker) just above the composer.
+// The widget is position:fixed to escape the chat's overflow clip and paint OVER the sticky header;
+// here we set its left/width/bottom to hover over .thread-chat-input-content. Registered once, a resize
+// listener keeps it aligned. Idempotent + cheap; a no-op when no popup is present.
+let _popupResizeBound = false;
+export function anchorChatPopup() {
+    const reposition = () => {
+        const w = document.querySelector('.thread-chat-widget');
+        const anchor = document.querySelector('.thread-chat-input-content')
+            || document.querySelector('.thread-chat-input-area');
+        if (!w || !anchor) return;
+        const r = anchor.getBoundingClientRect();
+        if (r.width === 0) return;
+        w.style.left = Math.round(r.left) + 'px';
+        w.style.width = Math.round(r.width) + 'px';
+        w.style.right = 'auto';
+        // Sit its bottom edge 6px above the composer's top edge.
+        w.style.bottom = Math.round(window.innerHeight - r.top + 6) + 'px';
+    };
+    reposition();
+    if (!_popupResizeBound) {
+        _popupResizeBound = true;
+        window.addEventListener('resize', reposition, { passive: true });
+        window.addEventListener('scroll', reposition, { passive: true, capture: true });
+    }
+}

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
@@ -90,8 +90,14 @@
         min-height: 0; /* Allow flex shrinking */
         height: 100%;
         width: 100%;
+        /* position: relative WITHOUT a z-index — it must NOT create a stacking context. A `z-index: 1`
+           here trapped EVERY chat popup (the /agent · /model pickers AND the login dialog) inside a
+           z-index:1 context, so no inner z-index — not even 10000 — could rise above the sticky header
+           (z-index 1100). That is the recurring "popup renders BEHIND the top bar" bug. With no z-index
+           the popups' own z-index participates in the root stacking context and correctly paints above
+           every sticky heading. body-content is a flex column whose inner areas scroll, so it does not
+           itself overflow/clip the popups. */
         position: relative;
-        z-index: 1;
     }
 
     /* Thin auto-hiding scrollbar inside splitter panes */


### PR DESCRIPTION
## Why

Per request: bring back the interactive login **dialog** for Claude Code (the Connect widget #249 removed), improved so the user can **(1)** choose the login method, **(2)** be redirected to the browser auth URL, **(3)** paste a code/token only if needed, and **(4)** have it complete silently when the current token is still valid.

## What

`/login` (no args) opens an inline dialog:
- **Step 1 — method chooser**: "Log in with your Claude account (browser)" · "Use an API key" · "Use a gateway / proxy".
- **Account** → `ConnectSessionManager.StartConnect` drives `claude setup-token`, scrapes the auth URL → dialog shows "Open authorization page ↗". Collects a pasted code only when `RequiresPastedCode`; otherwise completes to "✓ Connected" + auto-close (the still-valid-token case).
- **API key / gateway** → paste the credential, stored encrypted as the harness's `ModelProvider` node (the path `ChatClientCredentialResolver.ResolveConnectCredential` reads).

Reuses the shared, still-wired `ConnectSessionManager` + strategies + the registered `IConnectTokenSink` (`Memex.Portal.Shared`). `/login <key>` remains an inline shortcut; `/logout` fully disconnects (deletes the stored node + clears the CLI's cached credentials). `_connectSub` torn down in `DisposeAsync`.

## Testing

- `dotnet build src/MeshWeaver.Blazor.Portal -c Release -warnaserror -p:CIRun=true` → green.
- Deploying to memex.localhost for interactive verification of the browser flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)