### PR TITLE
feat(scheduled-actions): durable event-triggered actions + deferred space grants (core)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -168,6 +168,10 @@ public static class MemexConfiguration
         // (EmailSentAt==null), from ANY entry point (Invitations tab, MCP, REST). Self-skips
         // unless Email:Enabled. Decouples the invite email from the UI handler.
         services.AddHostedService<Email.InvitationEmailSender>();
+        // Scheduled-action runner: fires deferred, event-triggered actions (e.g. grant a Space role
+        // the moment an invited user's account is created) — live via the change feed + reconciled
+        // against current state on startup so a trigger during downtime still fires.
+        services.AddHostedService<MeshWeaver.Graph.ScheduledActionRunner>();
 
         // Microsoft Teams bot channel (bidirectional). Registered always but INERT unless Teams:Enabled
         // and Bot credentials are set (TeamsClient.IsConfigured gates the endpoint + sender). Activate by

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -47,6 +47,7 @@ public static class GraphConfigurationExtensions
                 .AddNotificationRuleType()
                 .AddNotificationChannelType()
                 .AddInvitationType()
+                .AddScheduledActionType()
                 .AddEmailType()
                 .AddEaCredentialType()
                 .AddTeamsConversationType()

--- a/src/MeshWeaver.Graph/Configuration/ScheduledActionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ScheduledActionNodeType.cs
@@ -10,10 +10,12 @@ namespace MeshWeaver.Graph.Configuration;
 /// search and create contexts.
 ///
 /// <para>Storage mirrors <see cref="InvitationNodeType"/>: the nodes live in the always-present
-/// <b>Admin</b> partition at <c>Admin/ScheduledAction/{id}</c>. Queries must be <b>path-scoped</b>
-/// (<c>path:Admin/ScheduledAction scope:children</c>) to route to the admin schema — a
-/// <c>namespace:Admin</c>-only query fans out cross-schema and deliberately EXCLUDES the admin
-/// schema. The runner enumerates them this way on startup to reconcile outstanding actions.</para>
+/// <b>Admin</b> partition at <c>Admin/ScheduledAction/{id}</c>. The PG query router routes purely by
+/// the path's first segment and does NOT yet consume the <c>QueryRoutingHints</c> below, so queries
+/// must be <b>path-scoped</b> (<c>path:Admin/ScheduledAction scope:children</c>) to reach the admin
+/// schema (a <c>namespace:Admin</c>-only query fans out cross-schema and deliberately EXCLUDES it).
+/// The runner enumerates them this way. The routing hint is kept so a path-less
+/// <c>nodeType:ScheduledAction</c> query works once the router honours it (same as InvitationNodeType).</para>
 /// </summary>
 public static class ScheduledActionNodeType
 {

--- a/src/MeshWeaver.Graph/Configuration/ScheduledActionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ScheduledActionNodeType.cs
@@ -1,0 +1,57 @@
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Registers the built-in "ScheduledAction" MeshNode. Scheduled actions are deferred,
+/// event-triggered effects (see <see cref="ScheduledAction"/>) — system-managed, excluded from
+/// search and create contexts.
+///
+/// <para>Storage mirrors <see cref="InvitationNodeType"/>: the nodes live in the always-present
+/// <b>Admin</b> partition at <c>Admin/ScheduledAction/{id}</c>. Queries must be <b>path-scoped</b>
+/// (<c>path:Admin/ScheduledAction scope:children</c>) to route to the admin schema — a
+/// <c>namespace:Admin</c>-only query fans out cross-schema and deliberately EXCLUDES the admin
+/// schema. The runner enumerates them this way on startup to reconcile outstanding actions.</para>
+/// </summary>
+public static class ScheduledActionNodeType
+{
+    /// <summary>The NodeType value identifying scheduled-action nodes.</summary>
+    public const string NodeType = "ScheduledAction";
+
+    /// <summary>Namespace under which scheduled-action nodes are created (Admin partition).</summary>
+    public const string Namespace = "Admin/ScheduledAction";
+
+    /// <summary>The partition (first path segment) scheduled actions live in.</summary>
+    public const string PartitionName = "Admin";
+
+    /// <summary>The path of a scheduled-action node: <c>Admin/ScheduledAction/{id}</c>.</summary>
+    public static string Path(string id) => $"{Namespace}/{id}";
+
+    /// <summary>
+    /// Registers the built-in "ScheduledAction" MeshNode plus the path-less
+    /// <c>nodeType:ScheduledAction → Admin</c> query-routing hint.
+    /// </summary>
+    public static TBuilder AddScheduledActionType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        builder.AddAutocompleteExcludedTypes(NodeType);
+        builder.AddQueryRoutingRule(query =>
+            query.ExtractNodeType() == NodeType && string.IsNullOrEmpty(query.Path)
+                ? new QueryRoutingHints { Partition = "Admin" }
+                : null);
+        return builder;
+    }
+
+    /// <summary>Creates a MeshNode definition for the ScheduledAction node type.</summary>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "Scheduled Action",
+        Icon = "/static/NodeTypeIcons/clock.svg",
+        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        HubConfiguration = config => config
+            .AddMeshDataSource(source => source
+                .WithContentType<ScheduledAction>())
+    };
+}

--- a/src/MeshWeaver.Graph/ScheduledActionOps.cs
+++ b/src/MeshWeaver.Graph/ScheduledActionOps.cs
@@ -1,0 +1,105 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// Reactive helpers shared by the invite entry point and the
+/// background <see cref="ScheduledActionRunner"/>: create the durable action node, grant a role,
+/// pin a Space to a user's dashboard, and flip an action's lifecycle state. All cold observables —
+/// callers Subscribe to drive the write; all run under the caller's <c>AccessContext</c> (the
+/// runner wraps them in <c>ImpersonateAsSystem</c>).
+/// </summary>
+public static class ScheduledActionOps
+{
+    /// <summary>Creates the durable <see cref="ScheduledAction"/> node at <c>Admin/ScheduledAction/{id}</c>.</summary>
+    public static IObservable<MeshNode> CreateAction(IMeshService meshService, ScheduledAction action)
+        => meshService.CreateNode(new MeshNode(action.Id, ScheduledActionNodeType.Namespace)
+        {
+            NodeType = ScheduledActionNodeType.NodeType,
+            Name = $"{action.ActionKind} → {action.TargetPath}",
+            Content = action,
+        });
+
+    /// <summary>Grants <paramref name="userId"/> the <paramref name="role"/> on <paramref name="spacePath"/>
+    /// by creating the <c>{space}/_Access/{user}_Access</c> assignment (create-or-update = idempotent).
+    /// Builds the node the same way <c>AccessControlLayoutArea.CreateAssignment</c> does.</summary>
+    public static IObservable<MeshNode> Grant(IMeshService meshService, string userId, string spacePath, string role)
+    {
+        var idSafe = userId.Replace('/', '_').Replace('@', '_');
+        var node = new MeshNode($"{idSafe}_Access", $"{spacePath}/_Access")
+        {
+            NodeType = Configuration.AccessAssignmentNodeType.NodeType,
+            Name = $"{userId} Access",
+            MainNode = spacePath,
+            Content = new AccessAssignment
+            {
+                AccessObject = userId,
+                DisplayName = userId,
+                Roles = [new RoleAssignment { Role = role, Denied = false }],
+            },
+        };
+        return meshService.CreateOrUpdateNode(node);
+    }
+
+    /// <summary>Adds <paramref name="path"/> to <paramref name="userId"/>'s pinned dashboard list (idempotent).</summary>
+    public static IObservable<MeshNode> Pin(IMessageHub hub, string userId, string path)
+        => hub.GetWorkspace().GetMeshNodeStream(userId).Update(node =>
+        {
+            if (node.Content is not User user)
+                return node;
+            if (user.PinnedPaths.Contains(path))
+                return node;   // already pinned — no-op
+            return node with { Content = user with { PinnedPaths = [.. user.PinnedPaths, path] } };
+        });
+
+    /// <summary>Flips an action to its terminal state (Fired on success, Failed with the error otherwise).</summary>
+    public static IObservable<MeshNode> SetStatus(
+        IMessageHub hub, string actionId, ScheduledActionStatus status, string? error = null)
+        => hub.GetWorkspace().GetMeshNodeStream(ScheduledActionNodeType.Path(actionId)).Update(node =>
+        {
+            if (node.Content is not ScheduledAction a)
+                return node;
+            return node with
+            {
+                Content = a with
+                {
+                    Status = status,
+                    FiredAt = status == ScheduledActionStatus.Fired ? DateTimeOffset.UtcNow : a.FiredAt,
+                    LastError = error,
+                },
+            };
+        });
+
+    /// <summary>
+    /// Reads a content field (e.g. <c>email</c>) off a node's content as a string, case-insensitively —
+    /// serializes the (possibly typed) Content to JSON and looks the property up. Used to evaluate a
+    /// <see cref="ScheduledAction.MatchField"/> against the triggering node.
+    /// </summary>
+    public static string? ReadContentField(MeshNode node, string field, JsonSerializerOptions options)
+    {
+        try
+        {
+            var json = node.Content is JsonElement je
+                ? JsonNode.Parse(je.GetRawText())
+                : JsonSerializer.SerializeToNode(node.Content, options);
+            if (json is not JsonObject obj)
+                return null;
+            foreach (var (key, value) in obj)
+                if (string.Equals(key, field, StringComparison.OrdinalIgnoreCase))
+                    return value?.GetValue<string>();
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/MeshWeaver.Graph/ScheduledActionRunner.cs
+++ b/src/MeshWeaver.Graph/ScheduledActionRunner.cs
@@ -19,12 +19,20 @@ namespace MeshWeaver.Graph;
 ///     runner was down — e.g. the invitee signed up during a deploy — still fires. The durable state
 ///     is the action node itself (Pending → Fired), so nothing is lost.</item>
 /// </list>
-/// Effects run under <c>ImpersonateAsSystem</c> and are idempotent (create-or-update grant, pin is a
-/// set-add, the terminal <c>Fired</c> write gates re-entry), so the two paths can't double-grant.
+/// Effects are idempotent (create-or-update grant, pin is a set-add, the terminal <c>Fired</c> write
+/// gates re-entry), so the two paths can't double-grant.
 ///
-/// <para>NOTE: this reconciles against current state, which is exact for <see cref="MeshChangeKind.Created"/>
-/// triggers (the entity persists). A durable event-log + cursor (a separate PG queue) is the follow-up
-/// that would also give exact replay for Update/Delete triggers and a general event stream.</para>
+/// <para>🚨 The runner has NO ambient <c>AccessContext</c> (it's a background hosted service, not a
+/// request). Every read AND write goes through <see cref="AsSystem{T}"/> — <c>Using(ImpersonateAsSystem,
+/// Defer(factory))</c> — so the operation is both CONSTRUCTED and subscribed under the system identity.
+/// Both matter: the write primitives capture the caller identity when constructed (so a grant built
+/// outside the scope would capture nothing and fail closed), and reads capture it at subscribe. Deferring
+/// construction into the <c>Using</c> factory covers the <c>SelectMany</c> inners too, which would
+/// otherwise be constructed on a downstream emission thread with no system context.</para>
+///
+/// <para>Reconciliation is exact for <see cref="MeshChangeKind.Created"/> triggers (the entity persists).
+/// A durable event-log + cursor (a separate PG queue) is the follow-up that would also give exact replay
+/// for Update/Delete triggers and a general event stream.</para>
 /// </summary>
 public sealed class ScheduledActionRunner(
     IMessageHub hub,
@@ -41,10 +49,10 @@ public sealed class ScheduledActionRunner(
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        // Live snapshot of outstanding actions; re-emits on add / fire / cancel.
-        pendingSub = hub.GetWorkspace()
-            .GetQuery("scheduled-actions",
-                $"path:{ScheduledActionNodeType.Namespace} scope:children nodeType:{ScheduledActionNodeType.NodeType}")
+        // Live snapshot of outstanding actions; re-emits on add / fire / cancel. Reading the Admin
+        // partition needs an identity → system. (Constant query id: one registry entry, no leak.)
+        pendingSub = AsSystem(() => hub.GetWorkspace().GetQuery("scheduled-actions",
+                $"path:{ScheduledActionNodeType.Namespace} scope:children nodeType:{ScheduledActionNodeType.NodeType}"))
             .Subscribe(nodes =>
             {
                 var list = (nodes ?? [])
@@ -75,8 +83,8 @@ public sealed class ScheduledActionRunner(
         if (candidates.Count == 0)
             return;
 
-        // Read the triggering node once; evaluate each candidate's field match against it.
-        hub.GetMeshNode(e.Path, TimeSpan.FromSeconds(10)).Subscribe(node =>
+        // Read the triggering node once (system identity); evaluate each candidate's field match.
+        AsSystem(() => hub.GetMeshNode(e.Path, TimeSpan.FromSeconds(10))).Subscribe(node =>
         {
             if (node is null)
                 return;
@@ -91,12 +99,20 @@ public sealed class ScheduledActionRunner(
         var query = $"nodeType:{action.TriggerNodeType}";
         if (action is { MatchField.Length: > 0, MatchValue.Length: > 0 })
             query += $" content.{action.MatchField}:{action.MatchValue}";
-        hub.GetWorkspace().GetQuery($"sa-recon:{action.Id}", query).Take(1).Subscribe(nodes =>
-        {
-            var node = (nodes ?? []).FirstOrDefault(n => Matches(action, n));
-            if (node is not null)
-                Execute(action, node);
-        }, ex => logger?.LogWarning(ex, "Reconcile query for action {Id} failed", action.Id));
+
+        // One-shot lookup via Query<T> (NOT the workspace GetQuery, which caches by id for the
+        // workspace lifetime — a per-action id would leak a registry entry each time). Take the
+        // initial snapshot and stop.
+        AsSystem(() => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(query))
+                .Where(c => c.ChangeType == QueryChangeType.Initial)
+                .Select(c => c.Items)
+                .Take(1))
+            .Subscribe(items =>
+            {
+                var node = items.FirstOrDefault(n => Matches(action, n));
+                if (node is not null)
+                    Execute(action, node);
+            }, ex => logger?.LogWarning(ex, "Reconcile query for action {Id} failed", action.Id));
     }
 
     private bool Matches(ScheduledAction action, MeshNode node)
@@ -113,19 +129,9 @@ public sealed class ScheduledActionRunner(
     {
         // The triggering node's id is the user (a User node's path IS the userId).
         var userId = triggerNode.Id;
-        IObservable<MeshNode> effect = action.ActionKind switch
-        {
-            ScheduledActionKind.GrantSpaceAccess
-                when action is { TargetPath.Length: > 0, Role.Length: > 0 } =>
-                GrantAndMaybePin(userId, action.TargetPath!, action.Role!, action.Pin),
-            _ => Observable.Throw<MeshNode>(
-                new InvalidOperationException($"Unsupported or incomplete scheduled action {action.Id}")),
-        };
 
-        // System identity for the grant/pin AND the terminal status write (all in the Admin/user
-        // partitions). Fire only flips to Fired after the effect lands.
-        Observable.Using(accessService.ImpersonateAsSystem,
-                _ => effect.SelectMany(_ => ScheduledActionOps.SetStatus(hub, action.Id, ScheduledActionStatus.Fired)))
+        BuildEffect(action, userId)
+            .SelectMany(_ => AsSystem(() => ScheduledActionOps.SetStatus(hub, action.Id, ScheduledActionStatus.Fired)))
             .Subscribe(
                 _ => logger?.LogInformation(
                     "Scheduled action {Id} fired: {Kind} {Role} for {User} on {Target}",
@@ -133,19 +139,27 @@ public sealed class ScheduledActionRunner(
                 ex =>
                 {
                     logger?.LogWarning(ex, "Scheduled action {Id} failed", action.Id);
-                    Observable.Using(accessService.ImpersonateAsSystem,
-                            _ => ScheduledActionOps.SetStatus(hub, action.Id, ScheduledActionStatus.Failed, ex.Message))
+                    AsSystem(() => ScheduledActionOps.SetStatus(hub, action.Id, ScheduledActionStatus.Failed, ex.Message))
                         .Subscribe(_ => { }, _ => { });
                 });
     }
 
-    private IObservable<MeshNode> GrantAndMaybePin(string userId, string space, string role, bool pin)
+    private IObservable<MeshNode> BuildEffect(ScheduledAction action, string userId) => action.ActionKind switch
     {
-        var grant = ScheduledActionOps.Grant(meshService, userId, space, role);
-        return pin
-            ? grant.SelectMany(g => ScheduledActionOps.Pin(hub, userId, space).Select(_ => g))
-            : grant;
-    }
+        ScheduledActionKind.GrantSpaceAccess when action is { TargetPath.Length: > 0, Role.Length: > 0 } =>
+            AsSystem(() => ScheduledActionOps.Grant(meshService, userId, action.TargetPath!, action.Role!))
+                .SelectMany(g => action.Pin
+                    ? AsSystem(() => ScheduledActionOps.Pin(hub, userId, action.TargetPath!)).Select(_ => g)
+                    : Observable.Return(g)),
+        _ => Observable.Throw<MeshNode>(new InvalidOperationException(
+            $"Unsupported or incomplete scheduled action {action.Id}")),
+    };
+
+    /// <summary>Runs a freshly-constructed <paramref name="factory"/> operation under the system
+    /// identity — the runner has no ambient AccessContext, and both reads and writes capture identity
+    /// at construction/subscribe. <c>Defer</c> moves construction inside the impersonation scope.</summary>
+    private IObservable<T> AsSystem<T>(Func<IObservable<T>> factory)
+        => Observable.Using(accessService.ImpersonateAsSystem, _ => Observable.Defer(factory));
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken)

--- a/src/MeshWeaver.Graph/ScheduledActionRunner.cs
+++ b/src/MeshWeaver.Graph/ScheduledActionRunner.cs
@@ -1,0 +1,163 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// Executes deferred <see cref="ScheduledAction"/>s. Two paths keep it resilient across restarts:
+/// <list type="bullet">
+///   <item><b>Live</b> — subscribes to the mesh change feed; when a node of a pending action's
+///     <see cref="ScheduledAction.TriggerNodeType"/> is changed and its field matches, the action fires.</item>
+///   <item><b>Reconcile</b> — a live query over the outstanding actions re-evaluates each on startup
+///     (and whenever the set changes) against CURRENT state, so a trigger that happened while the
+///     runner was down — e.g. the invitee signed up during a deploy — still fires. The durable state
+///     is the action node itself (Pending → Fired), so nothing is lost.</item>
+/// </list>
+/// Effects run under <c>ImpersonateAsSystem</c> and are idempotent (create-or-update grant, pin is a
+/// set-add, the terminal <c>Fired</c> write gates re-entry), so the two paths can't double-grant.
+///
+/// <para>NOTE: this reconciles against current state, which is exact for <see cref="MeshChangeKind.Created"/>
+/// triggers (the entity persists). A durable event-log + cursor (a separate PG queue) is the follow-up
+/// that would also give exact replay for Update/Delete triggers and a general event stream.</para>
+/// </summary>
+public sealed class ScheduledActionRunner(
+    IMessageHub hub,
+    IMeshChangeFeed changeFeed,
+    IMeshService meshService,
+    AccessService accessService,
+    ILogger<ScheduledActionRunner>? logger = null) : IHostedService, IDisposable
+{
+    private readonly object gate = new();
+    private IReadOnlyList<ScheduledAction> pending = [];
+    private IDisposable? pendingSub;
+    private IDisposable? feedSub;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Live snapshot of outstanding actions; re-emits on add / fire / cancel.
+        pendingSub = hub.GetWorkspace()
+            .GetQuery("scheduled-actions",
+                $"path:{ScheduledActionNodeType.Namespace} scope:children nodeType:{ScheduledActionNodeType.NodeType}")
+            .Subscribe(nodes =>
+            {
+                var list = (nodes ?? [])
+                    .Select(n => n.Content as ScheduledAction)
+                    .Where(a => a is { Status: ScheduledActionStatus.Pending })
+                    .Select(a => a!)
+                    .ToList();
+                lock (gate) pending = list;
+
+                // Reconcile Created-trigger actions against current state (catch missed triggers).
+                foreach (var action in list.Where(a => a.TriggerKind == MeshChangeKind.Created))
+                    Reconcile(action);
+            }, ex => logger?.LogWarning(ex, "Scheduled-actions query failed"));
+
+        // Live: fire on the actual change event.
+        feedSub = changeFeed.Subscribe(OnChange);
+        return Task.CompletedTask;
+    }
+
+    private void OnChange(MeshChangeEvent e)
+    {
+        List<ScheduledAction> candidates;
+        lock (gate)
+            candidates = pending
+                .Where(a => a.TriggerKind == e.Kind
+                            && string.Equals(a.TriggerNodeType, e.NodeType, StringComparison.Ordinal))
+                .ToList();
+        if (candidates.Count == 0)
+            return;
+
+        // Read the triggering node once; evaluate each candidate's field match against it.
+        hub.GetMeshNode(e.Path, TimeSpan.FromSeconds(10)).Subscribe(node =>
+        {
+            if (node is null)
+                return;
+            foreach (var action in candidates)
+                if (Matches(action, node))
+                    Execute(action, node);
+        }, ex => logger?.LogWarning(ex, "Reading triggering node {Path} failed", e.Path));
+    }
+
+    private void Reconcile(ScheduledAction action)
+    {
+        var query = $"nodeType:{action.TriggerNodeType}";
+        if (action is { MatchField.Length: > 0, MatchValue.Length: > 0 })
+            query += $" content.{action.MatchField}:{action.MatchValue}";
+        hub.GetWorkspace().GetQuery($"sa-recon:{action.Id}", query).Take(1).Subscribe(nodes =>
+        {
+            var node = (nodes ?? []).FirstOrDefault(n => Matches(action, n));
+            if (node is not null)
+                Execute(action, node);
+        }, ex => logger?.LogWarning(ex, "Reconcile query for action {Id} failed", action.Id));
+    }
+
+    private bool Matches(ScheduledAction action, MeshNode node)
+    {
+        if (!string.Equals(action.TriggerNodeType, node.NodeType, StringComparison.Ordinal))
+            return false;
+        if (action.MatchField is not { Length: > 0 } field)
+            return true;
+        var actual = ScheduledActionOps.ReadContentField(node, field, hub.JsonSerializerOptions);
+        return string.Equals(actual, action.MatchValue, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void Execute(ScheduledAction action, MeshNode triggerNode)
+    {
+        // The triggering node's id is the user (a User node's path IS the userId).
+        var userId = triggerNode.Id;
+        IObservable<MeshNode> effect = action.ActionKind switch
+        {
+            ScheduledActionKind.GrantSpaceAccess
+                when action is { TargetPath.Length: > 0, Role.Length: > 0 } =>
+                GrantAndMaybePin(userId, action.TargetPath!, action.Role!, action.Pin),
+            _ => Observable.Throw<MeshNode>(
+                new InvalidOperationException($"Unsupported or incomplete scheduled action {action.Id}")),
+        };
+
+        // System identity for the grant/pin AND the terminal status write (all in the Admin/user
+        // partitions). Fire only flips to Fired after the effect lands.
+        Observable.Using(accessService.ImpersonateAsSystem,
+                _ => effect.SelectMany(_ => ScheduledActionOps.SetStatus(hub, action.Id, ScheduledActionStatus.Fired)))
+            .Subscribe(
+                _ => logger?.LogInformation(
+                    "Scheduled action {Id} fired: {Kind} {Role} for {User} on {Target}",
+                    action.Id, action.ActionKind, action.Role, userId, action.TargetPath),
+                ex =>
+                {
+                    logger?.LogWarning(ex, "Scheduled action {Id} failed", action.Id);
+                    Observable.Using(accessService.ImpersonateAsSystem,
+                            _ => ScheduledActionOps.SetStatus(hub, action.Id, ScheduledActionStatus.Failed, ex.Message))
+                        .Subscribe(_ => { }, _ => { });
+                });
+    }
+
+    private IObservable<MeshNode> GrantAndMaybePin(string userId, string space, string role, bool pin)
+    {
+        var grant = ScheduledActionOps.Grant(meshService, userId, space, role);
+        return pin
+            ? grant.SelectMany(g => ScheduledActionOps.Pin(hub, userId, space).Select(_ => g))
+            : grant;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        pendingSub?.Dispose();
+        feedSub?.Dispose();
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/ScheduledAction.cs
+++ b/src/MeshWeaver.Mesh.Contract/ScheduledAction.cs
@@ -1,0 +1,98 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using MeshWeaver.Mesh.Services;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>Lifecycle state of a <see cref="ScheduledAction"/>.</summary>
+public enum ScheduledActionStatus
+{
+    /// <summary>Waiting for its trigger to fire.</summary>
+    Pending,
+    /// <summary>The trigger matched and the action ran successfully.</summary>
+    Fired,
+    /// <summary>The action was attempted but failed (see <see cref="ScheduledAction.LastError"/>).</summary>
+    Failed,
+    /// <summary>Withdrawn before firing.</summary>
+    Cancelled
+}
+
+/// <summary>The kind of effect a <see cref="ScheduledAction"/> performs when it fires.</summary>
+public enum ScheduledActionKind
+{
+    /// <summary>Grant the triggering user a role on <see cref="ScheduledAction.TargetPath"/>
+    /// (and pin it to their dashboard when <see cref="ScheduledAction.Pin"/>). The flagship
+    /// case: an email invite to a Space that lands access the moment the invitee's account exists.</summary>
+    GrantSpaceAccess
+}
+
+/// <summary>
+/// A deferred, event-triggered action — the durable record of "when THIS happens, do THAT",
+/// surviving restarts. Stored as a MeshNode in the always-present <b>Admin</b> partition
+/// (<c>Admin/_ScheduledAction/{id}</c>), so the <c>ScheduledActionRunner</c> can enumerate every
+/// outstanding action on startup and reconcile it against current state (a matching event that
+/// arrived while the runner was down still fires).
+///
+/// <para>The trigger observes the mesh change feed: an action fires when a node of
+/// <see cref="TriggerNodeType"/> is <see cref="TriggerKind"/>-changed and its content field
+/// <see cref="MatchField"/> equals <see cref="MatchValue"/>. The invite feature uses
+/// <c>{TriggerNodeType: "User", TriggerKind: Created, MatchField: "email", MatchValue: the invitee}</c>.</para>
+/// </summary>
+public record ScheduledAction
+{
+    /// <summary>Unique identifier for the action.</summary>
+    [Browsable(false)]
+    [Key]
+    public string Id { get; init; } = Guid.NewGuid().ToString();
+
+    // ── Trigger (event observation) ──
+
+    /// <summary>The <see cref="MeshNode.NodeType"/> whose change fires this action (e.g. <c>User</c>).</summary>
+    public string TriggerNodeType { get; init; } = "";
+
+    /// <summary>Which change kind fires it (default <see cref="MeshChangeKind.Created"/>).</summary>
+    public MeshChangeKind TriggerKind { get; init; } = MeshChangeKind.Created;
+
+    /// <summary>The content field on the triggering node to match (e.g. <c>email</c>). When null,
+    /// any node of <see cref="TriggerNodeType"/> matches.</summary>
+    public string? MatchField { get; init; }
+
+    /// <summary>The value <see cref="MatchField"/> must equal (case-insensitive) for a match.</summary>
+    public string? MatchValue { get; init; }
+
+    // ── Effect ──
+
+    /// <summary>What the action does when it fires.</summary>
+    public ScheduledActionKind ActionKind { get; init; } = ScheduledActionKind.GrantSpaceAccess;
+
+    /// <summary>The node the effect targets — for <see cref="ScheduledActionKind.GrantSpaceAccess"/>, the Space path.</summary>
+    public string? TargetPath { get; init; }
+
+    /// <summary>The role to grant (e.g. <c>Editor</c>) for <see cref="ScheduledActionKind.GrantSpaceAccess"/>.</summary>
+    public string? Role { get; init; }
+
+    /// <summary>Also pin <see cref="TargetPath"/> to the granted user's dashboard.</summary>
+    public bool Pin { get; init; }
+
+    // ── Lifecycle (runner-managed) ──
+
+    /// <summary>Current state.</summary>
+    [Browsable(false)]
+    public ScheduledActionStatus Status { get; init; } = ScheduledActionStatus.Pending;
+
+    /// <summary>Who created the action (ObjectId of the inviting user).</summary>
+    [Browsable(false)]
+    public string? CreatedBy { get; init; }
+
+    /// <summary>When the action was created.</summary>
+    [Browsable(false)]
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>When the action fired (set on success).</summary>
+    [Browsable(false)]
+    public DateTimeOffset? FiredAt { get; init; }
+
+    /// <summary>The last failure, if any — cleared on success.</summary>
+    [Browsable(false)]
+    public string? LastError { get; init; }
+}

--- a/src/MeshWeaver.Mesh.Contract/ScheduledAction.cs
+++ b/src/MeshWeaver.Mesh.Contract/ScheduledAction.cs
@@ -29,7 +29,7 @@ public enum ScheduledActionKind
 /// <summary>
 /// A deferred, event-triggered action — the durable record of "when THIS happens, do THAT",
 /// surviving restarts. Stored as a MeshNode in the always-present <b>Admin</b> partition
-/// (<c>Admin/_ScheduledAction/{id}</c>), so the <c>ScheduledActionRunner</c> can enumerate every
+/// (<c>Admin/ScheduledAction/{id}</c>), so the <c>ScheduledActionRunner</c> can enumerate every
 /// outstanding action on startup and reconcile it against current state (a matching event that
 /// arrived while the runner was down still fires).
 ///

--- a/test/MeshWeaver.Graph.Test/MeshWeaver.Graph.Test.csproj
+++ b/test/MeshWeaver.Graph.Test/MeshWeaver.Graph.Test.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.NuGet\MeshWeaver.NuGet.csproj" />

--- a/test/MeshWeaver.Graph.Test/ScheduledActionRunnerTest.cs
+++ b/test/MeshWeaver.Graph.Test/ScheduledActionRunnerTest.cs
@@ -1,0 +1,87 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// End-to-end test of <see cref="ScheduledActionRunner"/>: a pending "grant Editor on a Space when
+/// a User with email X is created" action fires the moment that User is created — creating the
+/// AccessAssignment and pinning the Space — and flips itself to <see cref="ScheduledActionStatus.Fired"/>.
+/// This is the mechanism behind the deferred email invite (grant lands when the invitee onboards).
+/// </summary>
+public class ScheduledActionRunnerTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Space = "InviteSpace";
+    private const string InviteeEmail = "newcomer@acme.com";
+    private const string InviteeId = "newcomer";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(new MeshNode(Space) { Name = "Invite Space", NodeType = "Space" });
+
+    [Fact(Timeout = 60000)]
+    public async Task PendingGrant_FiresWhenMatchingUserIsCreated()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        // Start the runner BEFORE the triggering write so the live change-feed path is armed.
+        using var runner = new ScheduledActionRunner(Mesh, changeFeed, meshService, accessService);
+        await runner.StartAsync(default);
+
+        // A pending action: when a User with email == InviteeEmail is created, grant Editor on the
+        // Space and pin it. (What the invite feature writes for an invited, not-yet-onboarded person.)
+        var action = new ScheduledAction
+        {
+            TriggerNodeType = "User",
+            TriggerKind = MeshChangeKind.Created,
+            MatchField = "email",
+            MatchValue = InviteeEmail,
+            ActionKind = ScheduledActionKind.GrantSpaceAccess,
+            TargetPath = Space,
+            Role = "Editor",
+            Pin = true,
+        };
+        await ScheduledActionOps.CreateAction(meshService, action).Should().Emit();
+
+        // The invitee onboards — their User node is created (as onboarding does: a new user
+        // partition is provisioned under the system identity). This publishes a Created event the
+        // runner observes.
+        using (accessService.ImpersonateAsSystem())
+        {
+            await meshService.CreateNode(new MeshNode(InviteeId)
+            {
+                NodeType = "User",
+                Name = "Newcomer",
+                Content = new User { Email = InviteeEmail, FullName = "Newcomer" },
+            }).Should().Emit();
+        }
+
+        // The grant landed: the AccessAssignment appears at {space}/_Access/{user}_Access with Editor.
+        var assignmentPath = $"{Space}/_Access/{InviteeId}_Access";
+        var granted = await Mesh.GetWorkspace().GetMeshNodeStream(assignmentPath)
+            .Where(n => n?.Content is AccessAssignment a
+                        && a.Roles.Any(r => r.Role == "Editor" && !r.Denied))
+            .FirstAsync().Timeout(30.Seconds());
+        Assert.NotNull(granted);
+
+        // The Space was pinned to the invitee's dashboard.
+        await Mesh.GetWorkspace().GetMeshNodeStream(InviteeId)
+            .Where(n => n?.Content is User u && u.PinnedPaths.Contains(Space))
+            .FirstAsync().Timeout(30.Seconds());
+
+        // The action flipped to Fired (so it won't re-run).
+        await Mesh.GetWorkspace().GetMeshNodeStream(ScheduledActionNodeType.Path(action.Id))
+            .Where(n => n?.Content is ScheduledAction sa && sa.Status == ScheduledActionStatus.Fired)
+            .FirstAsync().Timeout(30.Seconds());
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ScheduledActionRunnerTest.cs
+++ b/test/MeshWeaver.Graph.Test/ScheduledActionRunnerTest.cs
@@ -33,9 +33,11 @@ public class ScheduledActionRunnerTest(ITestOutputHelper output) : MonolithMeshT
         var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
         var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
         var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var runnerLogger = Mesh.ServiceProvider
+            .GetService<Microsoft.Extensions.Logging.ILogger<ScheduledActionRunner>>();
 
         // Start the runner BEFORE the triggering write so the live change-feed path is armed.
-        using var runner = new ScheduledActionRunner(Mesh, changeFeed, meshService, accessService);
+        using var runner = new ScheduledActionRunner(Mesh, changeFeed, meshService, accessService, runnerLogger);
         await runner.StartAsync(default);
 
         // A pending action: when a User with email == InviteeEmail is created, grant Editor on the
@@ -66,22 +68,27 @@ public class ScheduledActionRunnerTest(ITestOutputHelper output) : MonolithMeshT
             }).Should().Emit();
         }
 
+        // Wait for the action to reach a TERMINAL state first (race-free — the action node already
+        // exists, so the stream waits for the update rather than erroring on a missing node). A Failed
+        // status surfaces the runner's real error in the assertion message.
+        var final = await Mesh.GetWorkspace().GetMeshNodeStream(ScheduledActionNodeType.Path(action.Id))
+            .Select(n => n?.Content as ScheduledAction)
+            .Where(sa => sa is not null and not { Status: ScheduledActionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.True(final!.Status == ScheduledActionStatus.Fired,
+            $"action ended {final.Status}: {final.LastError}");
+
         // The grant landed: the AccessAssignment appears at {space}/_Access/{user}_Access with Editor.
         var assignmentPath = $"{Space}/_Access/{InviteeId}_Access";
         var granted = await Mesh.GetWorkspace().GetMeshNodeStream(assignmentPath)
             .Where(n => n?.Content is AccessAssignment a
                         && a.Roles.Any(r => r.Role == "Editor" && !r.Denied))
-            .FirstAsync().Timeout(30.Seconds());
+            .FirstAsync().Timeout(10.Seconds());
         Assert.NotNull(granted);
 
         // The Space was pinned to the invitee's dashboard.
         await Mesh.GetWorkspace().GetMeshNodeStream(InviteeId)
             .Where(n => n?.Content is User u && u.PinnedPaths.Contains(Space))
-            .FirstAsync().Timeout(30.Seconds());
-
-        // The action flipped to Fired (so it won't re-run).
-        await Mesh.GetWorkspace().GetMeshNodeStream(ScheduledActionNodeType.Path(action.Id))
-            .Where(n => n?.Content is ScheduledAction sa && sa.Status == ScheduledActionStatus.Fired)
-            .FirstAsync().Timeout(30.Seconds());
+            .FirstAsync().Timeout(10.Seconds());
     }
 }


### PR DESCRIPTION
The **scheduled action** primitive the email-invite feature builds on: a deferred, event-triggered effect that survives restarts. The flagship case — *grant a Space role the moment an invited user's account is created* — works end-to-end and is tested.

### What's here
- **`ScheduledAction`** (Mesh.Contract) — the durable record: Trigger `{NodeType, Kind, MatchField, MatchValue}` + Effect `{GrantSpaceAccess, TargetPath, Role, Pin}` + Status. Stored at `Admin/ScheduledAction/{id}` (Admin partition, path-scoped, excluded from search/create — mirrors `InvitationNodeType`).
- **`ScheduledActionOps`** (Graph) — reactive Grant (builds the `AccessAssignment` the same way `AccessControlLayoutArea` does) / Pin (`User.PinnedPaths` set-add) / CreateAction / SetStatus / ReadContentField.
- **`ScheduledActionRunner`** (Graph, `IHostedService`) — fires two ways: **live** off the mesh change feed, and **reconciled** against current state on startup / whenever the pending set changes, so a trigger that happened during downtime (the invitee onboarded mid-deploy) still fires. Effects run under `ImpersonateAsSystem` and are idempotent (create-or-update grant, set-add pin, terminal `Fired` write gates re-entry) — the two paths can't double-grant.
- Registered the node type + hosted service.
- **Test**: a pending "grant Editor + pin on `User(email)` Created" fires when the matching User is created — asserts the `AccessAssignment`, the pin, and `Fired`. Green.

### Scope / follow-ups
This uses **node-based durability + startup reconciliation**, which is exact for **Created** triggers (the entity persists). Deferred to follow-ups (per the plan):
- **PR-2** — the **invite entry point**: `SpaceInviteService` (existing user → grant now; absent → `ScheduledAction` + `InvitationService.CreateInvitation` + space-invite email) + invite UI on a Space.
- **PR-3** — the durable **PG `events` event-log + cursor** (exact Update/Delete replay + a general decoupled queue) and Orleans ADO.NET reminders for time-based triggers.

Builds clean under `Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)