### PR TITLE
feat(graph): click-to-edit title on the Space top-level default page

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
@@ -4,6 +4,7 @@ using MeshWeaver.Application.Styles;
 using MeshWeaver.Data;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
+using MeshWeaver.Layout.Domain;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 
@@ -42,14 +43,20 @@ public static class SpaceLayoutAreas
         // every Space showed the node icon + the welcome placeholder instead of its own
         // logo/body. Read the Space off the node's Content via ContentAs (handles the
         // typed-instance, JsonElement, and null cases).
-        return nodeStream.Select(node =>
-        {
-            if (node == null)
-                return Controls.Markdown("*Loading...*") as UiControl;
+        // Compose with the effective-permission stream so the space's title is click-to-edit
+        // ONLY for a user who can Update the node (mirrors MeshNodeLayoutAreas.Overview) — pure
+        // observable composition, no await.
+        return nodeStream.CombineLatest(
+            host.Hub.GetEffectivePermissions(hubPath),
+            (node, permissions) =>
+            {
+                if (node == null)
+                    return Controls.Markdown("*Loading...*") as UiControl;
 
-            var space = ResolveSpace(node, options);
-            return BuildSpaceView(host, space, node);
-        });
+                var canEdit = permissions.HasFlag(Permission.Update);
+                var space = ResolveSpace(node, options);
+                return BuildSpaceView(host, space, node, canEdit);
+            });
     }
 
     /// <summary>
@@ -179,7 +186,8 @@ public static class SpaceLayoutAreas
     private static UiControl BuildSpaceView(
         LayoutAreaHost host,
         Space? space,
-        MeshNode? node)
+        MeshNode? node,
+        bool canEdit)
     {
         var spacePath = node?.Path ?? host.Hub.Address.ToString();
         var spaceName = space?.Name ?? node?.Name ?? spacePath;
@@ -188,7 +196,7 @@ public static class SpaceLayoutAreas
             .WithWidth("100%")
             .WithStyle($"height: 100%; overflow-y: auto; {ThinScrollbar}");
 
-        shell = shell.WithView(BuildHeader(space, node, spaceName));
+        shell = shell.WithView(BuildHeader(host, space, node, spaceName, spacePath, canEdit));
         shell = shell.WithView(BuildBodyContent(space, node, spacePath));
 
         if (IsSystemorph(spacePath))
@@ -203,8 +211,12 @@ public static class SpaceLayoutAreas
 
     /// <summary>
     /// Logo + name + description + stats row. GitHub-style header, fixed at the top.
+    /// The name renders as a click-to-edit title (see <see cref="BuildEditableTitle"/>) when
+    /// <paramref name="canEdit"/> — an editor renames the space in place; everyone else sees a
+    /// plain heading.
     /// </summary>
-    private static UiControl BuildHeader(Space? space, MeshNode? node, string spaceName)
+    private static UiControl BuildHeader(
+        LayoutAreaHost host, Space? space, MeshNode? node, string spaceName, string spacePath, bool canEdit)
     {
         var description = space?.Description;
         var logo = space?.Logo ?? GetNodeLogo(node);
@@ -244,8 +256,7 @@ public static class SpaceLayoutAreas
 
         var infoColumn = Controls.Stack.WithStyle("gap: 8px; flex: 1;");
 
-        infoColumn = infoColumn.WithView(Controls.Html(
-            $"<h1 style=\"margin: 0; font-size: 2rem; font-weight: 600;\">{System.Web.HttpUtility.HtmlEncode(spaceName)}</h1>"));
+        infoColumn = infoColumn.WithView(BuildEditableTitle(host, spacePath, spaceName, canEdit));
 
         if (!string.IsNullOrEmpty(description))
         {
@@ -301,6 +312,64 @@ public static class SpaceLayoutAreas
 
         return container;
     }
+
+    /// <summary>
+    /// The space's H1 title as a click-to-edit heading. Read view is a plain heading; when
+    /// <paramref name="canEdit"/> and the user clicks it, an inline <see cref="TextFieldControl"/>
+    /// bound to the Space content <c>name</c> field (node-bound DataContext) takes over, so the edit
+    /// writes straight back to the node stream — and to <see cref="MeshNode.Name"/> via the Space's
+    /// <c>[MeshNodeProperty(nameof(MeshNode.Name))]</c> mapping. Same mechanism the Space Edit area
+    /// (<see cref="BuildBodyEditor"/>) uses for the name field — the click-to-edit toggle is the only
+    /// thing living in <c>/data</c>. See Doc/GUI/DataBinding "Node-bound DataContext".
+    /// </summary>
+    private static UiControl BuildEditableTitle(
+        LayoutAreaHost host, string spacePath, string spaceName, bool canEdit)
+    {
+        var editStateId = $"editState_{EditLayoutArea.GetDataId(spacePath)}_spaceTitle";
+        var editStateStream = host.Stream.GetDataStream<bool>(editStateId);
+
+        return Controls.Stack
+            .WithView((_, _) =>
+                editStateStream
+                    .StartWith(false)
+                    .DistinctUntilChanged()
+                    .Select(isEditing =>
+                        isEditing && canEdit
+                            ? BuildTitleEditView(spacePath, editStateId)
+                            : BuildTitleReadView(spaceName, editStateId, canEdit)));
+    }
+
+    private static UiControl BuildTitleReadView(string spaceName, string editStateId, bool canEdit)
+    {
+        var titleStack = Controls.Stack
+            .WithStyle($"cursor: {(canEdit ? "pointer" : "default")};")
+            .WithView(Controls.Html(
+                $"<h1 style=\"margin: 0; font-size: 2rem; font-weight: 600;\">{System.Web.HttpUtility.HtmlEncode(spaceName)}</h1>"));
+
+        if (canEdit)
+            titleStack = titleStack.WithClickAction(ctx =>
+            {
+                ctx.Host.UpdateData(editStateId, true);
+                return Task.CompletedTask;
+            });
+
+        return titleStack;
+    }
+
+    private static UiControl BuildTitleEditView(string spacePath, string editStateId)
+        => new TextFieldControl(new JsonPointerReference("name"))
+        {
+            Immediate = true,
+            AutoFocus = true,
+            Placeholder = "Space name",
+            DataContext = LayoutAreaReference.GetMeshNodeDataContext(spacePath, bindContent: true)
+        }
+        .WithStyle("font-size: 2rem; font-weight: 600; border: none; background: transparent; min-width: 300px; width: 100%;")
+        .WithBlurAction(ctx =>
+        {
+            ctx.Host.UpdateData(editStateId, false);
+            return Task.CompletedTask;
+        });
 
     /// <summary>
     /// Body content — priority: node.PreRenderedHtml → space.Body → default welcome markdown.

--- a/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
@@ -50,6 +50,12 @@ public static class SpaceLayoutAreas
             host.Hub.GetEffectivePermissions(hubPath),
             (node, permissions) =>
             {
+                // Gate on Read first (mirrors MeshNodeLayoutAreas.Overview): a user without Read
+                // must get Access Denied, not sit forever on "Loading..." should the node stream
+                // never emit for them.
+                if (!permissions.HasFlag(Permission.Read))
+                    return (UiControl?)MeshNodeLayoutAreas.BuildAccessDenied(hubPath);
+
                 if (node == null)
                     return Controls.Markdown("*Loading...*") as UiControl;
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/SpaceEditableTitleTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SpaceEditableTitleTest.cs
@@ -1,0 +1,87 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The Space Overview is the default page for every top-level partition root (a Space is the
+/// partition-owning node type). Its name renders as a <b>click-to-edit</b> title: for a user who can
+/// <see cref="MeshWeaver.Mesh.Security.Permission.Update"/> the node the heading is wrapped in a
+/// clickable container that toggles an inline name editor; everyone else sees a plain heading. This
+/// pins the editor affordance that replaced the old static <c>&lt;h1&gt;</c>.
+/// </summary>
+public class SpaceEditableTitleTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddSpaceType();
+
+    [Fact(Timeout = 60000)]
+    public async Task SpaceOverview_RendersClickToEditTitle_ForEditor()
+    {
+        // The test base logs rbuergi in as Admin, so canEdit == true on the freshly-created space.
+        var spaceId = $"TitleSpace{Guid.NewGuid():N}"[..18];
+        const string spaceName = "Title Space";
+        var spaceNode = MeshNode.FromPath(spaceId) with
+        {
+            Name = spaceName,
+            NodeType = SpaceNodeType.NodeType,
+            Content = new Space { Name = spaceName }
+        };
+        await NodeFactory.CreateNode(spaceNode).Should().Emit();
+
+        var workspace = GetClient(c => c.AddData()).GetWorkspace();
+        var reference = new LayoutAreaReference("Overview");
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address(spaceId), reference);
+
+        var root = await stream.GetControlStream(reference.Area!)
+            .Should().Within(30.Seconds()).Match(c => c is StackControl);
+        var shell = (StackControl)root!;
+        shell.Areas.Should().NotBeEmpty("Overview composes at least a header");
+
+        // Walk ONLY the header subtree (the first Overview child) so we never touch the body's
+        // @@("area/Search") catalog embed. Collect every resolvable descendant control.
+        var headerArea = shell.Areas[0].Area?.ToString();
+        headerArea.Should().NotBeNull();
+
+        var controls = new List<UiControl>();
+        async Task Collect(string area, int depth)
+        {
+            if (depth > 6)
+                return;
+            var control = await stream.GetControlStream(area)
+                .Should().Within(15.Seconds()).Match(c => c != null);
+            controls.Add(control!);
+            if (control is StackControl sc)
+                foreach (var name in sc.Areas.Select(a => a.Area?.ToString()).Where(n => !string.IsNullOrEmpty(n)))
+                    await Collect(name!, depth + 1);
+        }
+        await Collect(headerArea!, 0);
+
+        controls.Should().Contain(
+            c => c is HtmlControl h && (h.Data?.ToString() ?? "").Contains(spaceName)
+                 && (h.Data?.ToString() ?? "").Contains("<h1"),
+            "the space name renders as an <h1> title");
+
+        controls.Should().Contain(
+            c => c is StackControl s && s.IsClickable,
+            "an editor's title is wrapped in a clickable click-to-edit container "
+            + "(the affordance that replaced the old static <h1>)");
+
+        await NodeFactory.DeleteNode(spaceId).Should().Emit();
+    }
+}


### PR DESCRIPTION
## What

Every top-level partition root (`namespace == ""`, id == the partition/schema name) is a `Space` node, so `SpaceLayoutAreas.Overview` is the **default page for any partition living on the schemas**. It already ships, via `SpaceNodeType.WelcomeMarkdown`:

- the "this page can be configured" placeholder text + link to the config guide (`/Doc/GUI/ConfigurablePages`), and
- the contents catalog — `@@("area/Search")`.

This PR adds the one missing piece: an **inline, click-to-edit title**.

## How

- `SpaceLayoutAreas.Overview` composes the node stream with `host.Hub.GetEffectivePermissions(...)` to derive `canEdit = Permission.Update` (same shape as `MeshNodeLayoutAreas.Overview`) — pure observable, no async.
- The header name renders through new `BuildEditableTitle` / `BuildTitleReadView` / `BuildTitleEditView` helpers. Read view is a plain heading; when the user can edit **and** clicks it, a `TextFieldControl` bound to the Space content `name` field (node-bound `DataContext`) takes over and writes straight back to the node stream — and to `MeshNode.Name` via Space's `[MeshNodeProperty(nameof(MeshNode.Name))]` mapping. This is exactly the mechanism the Space **Edit** area already uses for the name field; only the click-to-edit toggle lives in `/data`. No `/data` replica, no hand-rolled binding, no `async`.

## Test

`SpaceEditableTitleTest` renders a Space Overview as an editor, walks the header subtree, and asserts the name renders as an `<h1>` **and** is wrapped in a clickable click-to-edit container (the affordance that replaced the old static `<h1>`). Green locally alongside the existing `SpaceOverviewBodyTest`; both build clean under Release + `-warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)