### PR TITLE
fix(layout): graceful placeholder for a vanished embedded area

### DIFF
--- a/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
@@ -184,10 +184,43 @@ public partial class NamedAreaView
                         return;
                     }
 
-                    // Access denied / validation failures / not-found are user-action
-                    // outcomes (the user lacks the right; the input was invalid; the
-                    // node was deleted) — not engineering errors. Log them as Warning
-                    // so production log dashboards don't page on every "user clicked
+                    // The target node/hub is GONE (routing NotFound). Its raw diagnostic
+                    // ("No node found at '…/_Activity/markdown-…'. Closest ancestor is '…'
+                    // (remainder='…')") is a framework-internal string that must NEVER reach an end
+                    // user. It surfaced verbatim when an embedded per-view interactive-kernel Activity
+                    // idle-disposed (KernelContainer.DisposeOnTimeout, 15 min) under a still-open area:
+                    // there is no push-signal for owner death — only this control stream's own re-read
+                    // discovers the miss, which is exactly why this handler is the right place to catch
+                    // it. Render a graceful, honest placeholder instead of the raw error, still logging
+                    // the failure for authors. NOT retried above (a gone node won't self-heal — that is
+                    // the transient "not yet online" case, a different message).
+                    if (AreaErrorClassifier.IsNodeGoneNotFound(error))
+                    {
+                        Logger.LogWarning(error,
+                            "Area {Area} target is gone (routing NotFound) — rendering unavailable placeholder instead of the raw diagnostic",
+                            AreaToBeRendered);
+                        try
+                        {
+                            InvokeAsync(() =>
+                            {
+                                if (IsViewDisposed) return;
+                                try
+                                {
+                                    RootControl = new MarkdownControl(
+                                        "**This view is no longer available.** It may have been removed, or its "
+                                        + "interactive session ended. Reload the page to retry.");
+                                    RequestStateChange();
+                                }
+                                catch (ObjectDisposedException) { /* renderer gone */ }
+                            });
+                        }
+                        catch (ObjectDisposedException) { /* renderer gone */ }
+                        return;
+                    }
+
+                    // Access denied / validation failures are user-action outcomes (the user
+                    // lacks the right; the input was invalid) — not engineering errors. Log them
+                    // as Warning so production log dashboards don't page on every "user clicked
                     // a thing they couldn't do". Real errors (NullReferenceException,
                     // IO failures, runtime crashes) still land at Error level.
                     if (AreaErrorClassifier.IsExpectedUserActionFailure(error))

--- a/src/MeshWeaver.Layout/AreaErrorClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaErrorClassifier.cs
@@ -83,6 +83,33 @@ public static class AreaErrorClassifier
     }
 
     /// <summary>
+    /// True when the failure is a routing <b>NotFound</b> — the target node/hub no longer exists
+    /// (or never did). This is the "the thing you were viewing is gone" case, distinct from the
+    /// other <see cref="IsExpectedUserActionFailure"/> outcomes (access denied / validation), which
+    /// carry an actionable message worth showing verbatim.
+    ///
+    /// <para>Why it needs its own predicate: the routing layer's raw diagnostic —
+    /// <c>"No node found at 'rbuergi/_Activity/markdown-…'. Closest ancestor is 'rbuergi'
+    /// (remainder='…')"</c> — is a FRAMEWORK-INTERNAL string that must never reach an end user. It
+    /// surfaced verbatim when an ephemeral per-view interactive-kernel Activity idle-disposed under a
+    /// still-open embedded area (there is no push-signal for owner death — only the area's own re-read
+    /// discovers the miss). The GUI renders a graceful "view is no longer available" placeholder for
+    /// this case instead, while still logging the raw failure for authors. NOT retried (a gone node
+    /// won't come back on its own — that is <see cref="IsTransientHubFailure"/>'s "not yet online"
+    /// case, which is a DIFFERENT message: "target hub was not found").</para>
+    /// </summary>
+    public static bool IsNodeGoneNotFound(Exception? ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            if (e is DeliveryFailureException
+                && (e.Message ?? string.Empty).StartsWith("No node found", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// The single predicate the area subscription hands to
     /// <see cref="AreaStreamRetry.RetryAreaWithBackoff{T}"/>: retry ONLY a transient hub
     /// miss — never a teardown <see cref="ObjectDisposedException"/> (benign) and never a

--- a/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
+++ b/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
@@ -70,6 +70,35 @@ public class AreaErrorClassifierTest
     public void IsExpectedUserActionFailure_FalseForEngineeringError()
         => AreaErrorClassifier.IsExpectedUserActionFailure(new NullReferenceException()).Should().BeFalse();
 
+    // ── IsNodeGoneNotFound: routing NotFound → render a graceful placeholder, never the raw text ──
+
+    [Theory]
+    [InlineData("No node found at Foo/Bar")]
+    [InlineData("No node found at 'rbuergi/_Activity/markdown-wXXCCP7IukWc4chwFrhLbw'. Closest ancestor is 'rbuergi' (remainder='_Activity/markdown-wXXCCP7IukWc4chwFrhLbw').")]
+    public void IsNodeGoneNotFound_TrueForRoutingNotFound(string message)
+        => AreaErrorClassifier.IsNodeGoneNotFound(Failure(message, ErrorType.NotFound)).Should().BeTrue(
+            "the raw routing NotFound diagnostic must be caught and replaced with a graceful placeholder, "
+            + "not surfaced verbatim to the user (the ephemeral-kernel teardown symptom)");
+
+    [Theory]
+    [InlineData("Access denied: user lacks Read")]
+    [InlineData("Validation failed for X")]
+    public void IsNodeGoneNotFound_FalseForOtherUserActionFailures(string message)
+        => AreaErrorClassifier.IsNodeGoneNotFound(Failure(message, ErrorType.Unauthorized)).Should().BeFalse(
+            "access-denied / validation carry an actionable message worth showing verbatim — only a "
+            + "gone node gets the generic 'no longer available' placeholder");
+
+    [Fact]
+    public void IsNodeGoneNotFound_FalseForTransientHubNotYetOnline()
+        // "target hub was not found" is the transient not-yet-online case (retried), NOT a gone node.
+        => AreaErrorClassifier.IsNodeGoneNotFound(
+                Failure("The target hub was not found for address Foo/Bar", ErrorType.NotFound)).Should().BeFalse();
+
+    [Fact]
+    public void IsNodeGoneNotFound_FalseForNonDeliveryFailure()
+        => AreaErrorClassifier.IsNodeGoneNotFound(new InvalidOperationException("No node found at X")).Should().BeFalse(
+            "only a routing DeliveryFailure counts — a coincidental message on some other exception must not");
+
     // ── ShouldRetryArea: the single predicate the subscription hands the retry operator ──
 
     [Fact]


### PR DESCRIPTION
## The bug (reported)

Navigating to an interactive-markdown page surfaced a raw framework routing diagnostic to the end user:

> **Error loading area:** No node found at `rbuergi/_Activity/markdown-wXXCCP7IukWc4chwFrhLbw`. Closest ancestor is `rbuergi` (remainder=`_Activity/markdown-…`).

## Root cause

Each viewer gets a private, ephemeral interactive-kernel `Activity` at `{viewer}/_Activity/markdown-{id}` (code cells run *as the viewer*). It **self-disposes after 15 min idle** (`KernelContainer.DisposeOnTimeout`). The kernel result-area subscriptions outlive it, and a later re-resolution routes to the vanished address. There is **no push-signal for owner death** — only the area's own re-read discovers the miss — so `NamedAreaView.onError` is where it surfaces.

## Fix

`AreaErrorClassifier.IsNodeGoneNotFound` classifies the routing NotFound, and `NamedAreaView` renders a graceful **"This view is no longer available — reload to retry"** placeholder instead of the raw internal diagnostic (still logged at Warning for authors). Distinct from access-denied/validation (keep their actionable message) and from the transient "not yet online" case (retried). Verified by a repro that falsified an earlier view-side liveness-watch approach (no push-signal), pointing the fix here.

## Test

`AreaErrorClassifierTest` — 6 new cases pinning the gone-vs-transient-vs-access-denied boundary (24 total green). Stream-layer contract (`SubscribeRequestNotFoundSurfaceTest`) unaffected — it asserts the exception, not the rendered text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)