### PR TITLE
feat(invite): invite a person by email to a Space (service + node-menu UI)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -103,6 +103,9 @@ public static class MemexConfiguration
         services.AddScoped<Memex.Portal.Shared.Authentication.UserOnboardingService>();
         // Invitation service — reads/writes Invitation nodes for invitation-only onboarding.
         services.AddScoped<Memex.Portal.Shared.Authentication.InvitationService>();
+        // Space invite — grant an existing user now, or schedule the grant (+ create an invitation)
+        // for when an unknown email's account is created. Backed by the ScheduledActionRunner.
+        services.AddSingleton<MeshWeaver.Graph.SpaceInviteService>();
 
         // Configure Radzen
         services.AddRadzenServices();

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Data;
 using MeshWeaver.Domain;
+using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
@@ -9,6 +10,7 @@ using MeshWeaver.Mesh.Services.LanguageServer;
 using MeshWeaver.Messaging;
 using MeshWeaver.NuGet;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace MeshWeaver.Graph.Configuration;
 
@@ -128,13 +130,22 @@ public static class GraphConfigurationExtensions
             builder.ConfigureDefaultNodeHub(config => config
                 .WithGraphTypes()
                 .AddDefaultLayoutAreas()
+                // "Invite people" node-menu item on a Space + the invite form area it opens. The
+                // provider self-gates (Space + Update), so it's inert on non-Space nodes.
+                .AddLayout(layout => layout
+                    .WithView(SpaceInviteLayoutArea.AreaName, SpaceInviteLayoutArea.Render))
                 // Owner-injection at the sync chokepoint: lets SynchronizationStream.Update resolve the
                 // node OWNER (CreatedBy) from the node already in its Current when no live/creation
                 // context survives — the cold-start FIRST-write race (the owning hub establishes its
                 // standing identity asynchronously). Per-node hub so Host.ServiceProvider has it.
-                .WithServices(services => services
-                    .AddSingleton<MeshWeaver.Data.Serialization.IStreamOwnerResolver,
-                        MeshNodeStreamOwnerResolver>()));
+                .WithServices(services =>
+                {
+                    services.AddSingleton<MeshWeaver.Data.Serialization.IStreamOwnerResolver,
+                        MeshNodeStreamOwnerResolver>();
+                    services.TryAddEnumerable(
+                        ServiceDescriptor.Scoped<Mesh.INodeMenuProvider, SpaceInviteMenuProvider>());
+                    return services;
+                }));
 
             // Seed the built-in NodeCopy + Mirror script templates as Code MeshNodes
             // at Templates/Import/{NodeCopy,Mirror}. ImportLayoutArea fires

--- a/src/MeshWeaver.Graph/ScheduledActionOps.cs
+++ b/src/MeshWeaver.Graph/ScheduledActionOps.cs
@@ -19,9 +19,11 @@ namespace MeshWeaver.Graph;
 /// </summary>
 public static class ScheduledActionOps
 {
-    /// <summary>Creates the durable <see cref="ScheduledAction"/> node at <c>Admin/ScheduledAction/{id}</c>.</summary>
+    /// <summary>Writes the durable <see cref="ScheduledAction"/> node at <c>Admin/ScheduledAction/{id}</c>.
+    /// Upsert by id — a deterministic id (e.g. per invitee+space) makes a re-invite idempotent instead
+    /// of piling up duplicate actions.</summary>
     public static IObservable<MeshNode> CreateAction(IMeshService meshService, ScheduledAction action)
-        => meshService.CreateNode(new MeshNode(action.Id, ScheduledActionNodeType.Namespace)
+        => meshService.CreateOrUpdateNode(new MeshNode(action.Id, ScheduledActionNodeType.Namespace)
         {
             NodeType = ScheduledActionNodeType.NodeType,
             Name = $"{action.ActionKind} → {action.TargetPath}",

--- a/src/MeshWeaver.Graph/SpaceInviteLayoutArea.cs
+++ b/src/MeshWeaver.Graph/SpaceInviteLayoutArea.cs
@@ -1,0 +1,102 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// The "Invite" node-menu area — invite a person to this Space by email. A framework-standard form
+/// (email + role + pin, bound to a transient data section like <c>AccessControlLayoutArea</c>'s
+/// add-row) and an Invite button that calls <see cref="SpaceInviteService"/>: an existing user is
+/// granted immediately; an unknown email is scheduled + invited so access lands on sign-up.
+/// </summary>
+public static class SpaceInviteLayoutArea
+{
+    /// <summary>Area name (the "Invite people" node-menu item navigates here).</summary>
+    public const string AreaName = "Invite";
+
+    /// <summary>The containing Space of a node path (first segment — spaces are top-level).</summary>
+    private static string SpaceOf(string path) => path.Split('/', 2)[0];
+
+    /// <summary>Renders the invite form for the containing Space.</summary>
+    public static IObservable<UiControl?> Render(LayoutAreaHost host, RenderingContext _)
+    {
+        var spacePath = SpaceOf(host.Hub.Address.ToString());
+        if (string.IsNullOrEmpty(spacePath))
+            return Observable.Return<UiControl?>(Controls.Markdown("*Invites are available inside a Space.*"));
+
+        var formId = $"space_invite_{Guid.NewGuid():N}";
+        host.UpdateData(formId, new Dictionary<string, object?>
+        {
+            ["email"] = "",
+            ["role"] = Role.Editor.Id,
+            ["pin"] = true,
+        });
+        var dataContext = LayoutAreaReference.GetDataPointer(formId);
+
+        var emailField = (new TextFieldControl(new JsonPointerReference("email"))
+            { Label = "Email address", DataContext = dataContext })
+            .WithStyle("flex: 1; min-width: 240px;");
+        var roleSelect = (new SelectControl(new JsonPointerReference("role"), Array.Empty<object>())
+                .WithOptions(new[] { Role.Admin.Id, Role.Editor.Id, Role.Viewer.Id, Role.Commenter.Id }))
+            with { Label = "Role", DataContext = dataContext };
+        var pinCheck = new CheckBoxControl(new JsonPointerReference("pin"))
+            { Label = "Pin the Space to their dashboard", DataContext = dataContext };
+
+        var inviteButton = Controls.Button("Invite")
+            .WithAppearance(Appearance.Accent)
+            .WithClickAction((Action<UiActionContext>)(ctx =>
+                ctx.Host.Stream.GetDataStream<Dictionary<string, object?>>(formId)
+                    .Take(1)
+                    .Subscribe(form => Submit(ctx, spacePath, form))));
+
+        var stack = Controls.Stack
+            .WithView(Controls.H2("Invite people").WithStyle("margin: 0 0 8px 0;"))
+            .WithView(Controls.Markdown(
+                "Invite someone to this Space by email. If they already have an account they get "
+                + "access immediately; otherwise they're invited, and access is granted automatically "
+                + "the moment they sign up."))
+            .WithView(Controls.Stack
+                .WithOrientation(Orientation.Horizontal)
+                .WithStyle("align-items: flex-end; gap: 12px; flex-wrap: wrap;")
+                .WithView(emailField)
+                .WithView(roleSelect)
+                .WithView(inviteButton))
+            .WithView(pinCheck);
+
+        return Observable.Return<UiControl?>(stack);
+    }
+
+    private static void Submit(UiActionContext ctx, string spacePath, IReadOnlyDictionary<string, object?> form)
+    {
+        var email = form.GetValueOrDefault("email")?.ToString()?.Trim();
+        var role = form.GetValueOrDefault("role")?.ToString()?.Trim();
+        var pin = form.GetValueOrDefault("pin") is true or "true" or "True";
+        if (string.IsNullOrEmpty(email) || !email.Contains('@'))
+        {
+            ShowDialog(ctx, "Please enter a valid **email address**.");
+            return;
+        }
+        if (string.IsNullOrEmpty(role)) role = Role.Editor.Id;
+
+        var sp = ctx.Host.Hub.ServiceProvider;
+        var svc = new SpaceInviteService(
+            ctx.Host.Hub, sp.GetRequiredService<IMeshService>(), sp.GetRequiredService<AccessService>());
+        var invitedBy = sp.GetService<AccessService>()?.Context?.ObjectId;
+
+        svc.Invite(spacePath, email, role, pin, invitedBy).Subscribe(
+            outcome => ShowDialog(ctx, outcome == SpaceInviteOutcome.Granted
+                ? $"**{email}** already has an account — granted **{role}** on this Space."
+                : $"Invited **{email}** as **{role}**. They'll get access automatically when they sign up."),
+            ex => ShowDialog(ctx, $"Invite failed: {ex.Message}"));
+    }
+
+    private static void ShowDialog(UiActionContext ctx, string markdown) =>
+        ctx.Host.UpdateArea(DialogControl.DialogArea,
+            Controls.Dialog(Controls.Markdown(markdown), "Invite").WithSize("S").WithClosable(true));
+}

--- a/src/MeshWeaver.Graph/SpaceInviteMenuProvider.cs
+++ b/src/MeshWeaver.Graph/SpaceInviteMenuProvider.cs
@@ -1,0 +1,52 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// DI-registered <see cref="INodeMenuProvider"/> that adds "Invite people" to the NODE menu on a
+/// Space — opening <see cref="SpaceInviteLayoutArea"/>. Shown on a Space (its root or a descendant)
+/// for a viewer who may Update it; the access-race fix re-emits when the permission enriches.
+/// </summary>
+public sealed class SpaceInviteMenuProvider : INodeMenuProvider
+{
+    /// <summary>The NodeType value identifying a Space.</summary>
+    private const string SpaceNodeType = "Space";
+
+    /// <inheritdoc />
+    public string Context => NodeMenuItemsExtensions.NodeMenuContext;
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyCollection<NodeMenuItemDefinition>> GetItems(
+        LayoutAreaHost host, RenderingContext ctx)
+    {
+        var hubPath = host.Hub.Address.ToString();
+        var spaceRoot = hubPath.Split('/', 2)[0];
+        IReadOnlyCollection<NodeMenuItemDefinition> none = [];
+        if (string.IsNullOrEmpty(spaceRoot))
+            return Observable.Return(none);
+
+        var item = new NodeMenuItemDefinition(
+            Label: "Invite people",
+            Area: SpaceInviteLayoutArea.AreaName,
+            Icon: "✉️",
+            Order: 8,   // a Space-management action, at the top of the node menu
+            Href: MeshNodeLayoutAreas.BuildUrl(hubPath, SpaceInviteLayoutArea.AreaName),
+            Tooltip: "Invite someone to this Space by email");
+
+        return host.Workspace.GetMeshNodeStream(spaceRoot)
+            .Select(node => string.Equals(node?.NodeType, SpaceNodeType, StringComparison.Ordinal))
+            .CombineLatest(
+                host.Hub.GetEffectivePermissions(spaceRoot),
+                (isSpace, perms) => isSpace && perms.HasFlag(Permission.Update))
+            .DistinctUntilChanged()
+            .Select(show => show ? (IReadOnlyCollection<NodeMenuItemDefinition>)[item] : none)
+            .Catch<IReadOnlyCollection<NodeMenuItemDefinition>, Exception>(_ => Observable.Return(none))
+            .StartWith(none);
+    }
+}

--- a/src/MeshWeaver.Graph/SpaceInviteService.cs
+++ b/src/MeshWeaver.Graph/SpaceInviteService.cs
@@ -78,6 +78,9 @@ public sealed class SpaceInviteService(
     {
         var action = new ScheduledAction
         {
+            // Deterministic id per invitee+space → a re-invite upserts the SAME action (idempotent)
+            // instead of piling up duplicate pending grants.
+            Id = $"grant_{Slug(email)}_{Slug(spacePath)}",
             TriggerNodeType = "User",
             TriggerKind = MeshChangeKind.Created,
             MatchField = "email",
@@ -95,9 +98,9 @@ public sealed class SpaceInviteService(
             Content = new Invitation { Email = email, InvitedBy = invitedBy, Note = $"Invited to space {spacePath}" },
         };
 
-        // Both writes land in the Admin partition → system identity, constructed inside the scope
-        // (create-or-update = idempotent, so a re-invite is harmless). The existing
-        // InvitationEmailSender emails the Pending invitation.
+        // Both writes land in the Admin partition → system identity, constructed inside the scope.
+        // Both are upserts keyed by a deterministic id/slug, so a re-invite overwrites rather than
+        // duplicating. The existing InvitationEmailSender emails the Pending invitation.
         return Observable.Using(accessService.ImpersonateAsSystem, _ => Observable.Defer(() =>
                 ScheduledActionOps.CreateAction(meshService, action)
                     .SelectMany(_ => meshService.CreateOrUpdateNode(invitation))))
@@ -114,9 +117,9 @@ public sealed class SpaceInviteService(
         return string.Equals(actual, email, StringComparison.OrdinalIgnoreCase);
     }
 
-    /// <summary>The Invitation node id from an email — MUST match <c>InvitationService.Slugify</c>
-    /// (lower-case, non-alphanumerics → <c>_</c>, no trim) so a re-invite lands on the SAME node
-    /// rather than creating a duplicate invitation.</summary>
+    /// <summary>A node-id slug from a string — lower-case, trimmed, non-alphanumerics → <c>_</c>.
+    /// For an email this matches the effective <c>InvitationService</c> path (which trims the email
+    /// before <c>Slugify</c>), so a re-invite lands on the SAME invitation node.</summary>
     internal static string Slug(string email) =>
         new(email.Trim().ToLowerInvariant().Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray());
 }

--- a/src/MeshWeaver.Graph/SpaceInviteService.cs
+++ b/src/MeshWeaver.Graph/SpaceInviteService.cs
@@ -1,0 +1,122 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>The result of an <see cref="SpaceInviteService.Invite"/> call.</summary>
+public enum SpaceInviteOutcome
+{
+    /// <summary>The email already had an account — access was granted immediately.</summary>
+    Granted,
+    /// <summary>The email is not on the system yet — an invitation was created and a scheduled
+    /// action will grant access (and pin) the moment their account is created.</summary>
+    Invited,
+}
+
+/// <summary>
+/// Invites a person (by email) to a Space. Two cases, composed from existing pieces — nothing new
+/// invented:
+/// <list type="bullet">
+///   <item><b>Already on the system</b> → grant the role now (an AccessAssignment) and
+///     optionally pin the Space to their dashboard.</item>
+///   <item><b>Not yet on the system</b> → create an <c>Invitation</c> (the existing
+///     <c>InvitationEmailSender</c> emails any Pending invitation; in invitation-only mode it also
+///     unlocks onboarding) AND a <see cref="ScheduledAction"/> that grants + pins the moment a
+///     <c>User</c> with that email is created. So the access lands automatically on sign-up — surviving
+///     restarts via <see cref="ScheduledActionRunner"/>.</item>
+/// </list>
+/// The immediate grant runs under the CALLER's identity (the inviting admin, who has rights on the
+/// Space). The Admin-partition writes (invitation + scheduled action) run as system.
+/// </summary>
+public sealed class SpaceInviteService(
+    IMessageHub hub,
+    IMeshService meshService,
+    AccessService accessService,
+    ILogger<SpaceInviteService>? logger = null)
+{
+    /// <summary>Invites <paramref name="email"/> to <paramref name="spacePath"/> with <paramref name="role"/>.</summary>
+    public IObservable<SpaceInviteOutcome> Invite(
+        string spacePath, string email, string role, bool pin, string? invitedBy)
+    {
+        var normalizedEmail = email.Trim();
+
+        // Look up an existing account by email (one-shot initial snapshot).
+        return meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:User content.email:{normalizedEmail}"))
+            .Where(c => c.ChangeType == QueryChangeType.Initial)
+            .Select(c => c.Items)
+            .Take(1)
+            .SelectMany(users =>
+            {
+                var existing = users.FirstOrDefault(u => EmailMatches(u, normalizedEmail));
+                return existing is not null
+                    ? GrantNow(existing.Id, spacePath, role, pin)
+                    : ScheduleAndInvite(spacePath, normalizedEmail, role, pin, invitedBy);
+            });
+    }
+
+    private IObservable<SpaceInviteOutcome> GrantNow(string userId, string spacePath, string role, bool pin)
+    {
+        // Runs under the caller's identity (the inviting admin has rights on the Space).
+        var grant = ScheduledActionOps.Grant(meshService, userId, spacePath, role);
+        var effect = pin
+            ? grant.SelectMany(g => ScheduledActionOps.Pin(hub, userId, spacePath).Select(_ => g))
+            : grant;
+        return effect.Select(_ =>
+        {
+            logger?.LogInformation("Granted {Role} on {Space} to existing user {User}", role, spacePath, userId);
+            return SpaceInviteOutcome.Granted;
+        });
+    }
+
+    private IObservable<SpaceInviteOutcome> ScheduleAndInvite(
+        string spacePath, string email, string role, bool pin, string? invitedBy)
+    {
+        var action = new ScheduledAction
+        {
+            TriggerNodeType = "User",
+            TriggerKind = MeshChangeKind.Created,
+            MatchField = "email",
+            MatchValue = email,
+            ActionKind = ScheduledActionKind.GrantSpaceAccess,
+            TargetPath = spacePath,
+            Role = role,
+            Pin = pin,
+            CreatedBy = invitedBy,
+        };
+        var invitation = new MeshNode(Slug(email), InvitationNodeType.Namespace)
+        {
+            NodeType = InvitationNodeType.NodeType,
+            Name = $"Invitation {email}",
+            Content = new Invitation { Email = email, InvitedBy = invitedBy, Note = $"Invited to space {spacePath}" },
+        };
+
+        // Both writes land in the Admin partition → system identity, constructed inside the scope
+        // (create-or-update = idempotent, so a re-invite is harmless). The existing
+        // InvitationEmailSender emails the Pending invitation.
+        return Observable.Using(accessService.ImpersonateAsSystem, _ => Observable.Defer(() =>
+                ScheduledActionOps.CreateAction(meshService, action)
+                    .SelectMany(_ => meshService.CreateOrUpdateNode(invitation))))
+            .Select(_ =>
+            {
+                logger?.LogInformation("Invited {Email} to {Space} ({Role}); grant scheduled on sign-up", email, spacePath, role);
+                return SpaceInviteOutcome.Invited;
+            });
+    }
+
+    private bool EmailMatches(MeshNode userNode, string email)
+    {
+        var actual = ScheduledActionOps.ReadContentField(userNode, "email", hub.JsonSerializerOptions);
+        return string.Equals(actual, email, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The Invitation node id from an email — MUST match <c>InvitationService.Slugify</c>
+    /// (lower-case, non-alphanumerics → <c>_</c>, no trim) so a re-invite lands on the SAME node
+    /// rather than creating a duplicate invitation.</summary>
+    internal static string Slug(string email) =>
+        new(email.Trim().ToLowerInvariant().Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray());
+}

--- a/test/MeshWeaver.Graph.Test/SpaceInviteMenuTest.cs
+++ b/test/MeshWeaver.Graph.Test/SpaceInviteMenuTest.cs
@@ -1,0 +1,62 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Verifies the "Invite people" NODE-menu item (<see cref="SpaceInviteMenuProvider"/>) appears on a
+/// Space and is absent on a non-Space node — the provider self-gates on <c>NodeType == "Space"</c>
+/// (plus Update), so it never leaks onto ordinary nodes.
+/// </summary>
+public class SpaceInviteMenuTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Space = "InviteMenuSpace";
+    private const string Plain = "InviteMenuPlain";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder).AddMeshNodes(
+            new MeshNode(Space) { Name = "Space", NodeType = "Space" },
+            new MeshNode(Plain) { Name = "Plain" });   // no NodeType → not a Space
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .AddLayoutClient()
+            .WithTypes(typeof(MenuControl), typeof(NodeMenuItemDefinition));
+
+    private IObservable<IReadOnlyList<NodeMenuItemDefinition>> NodeMenu(Address nodeAddress)
+        => GetClient().GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(
+                nodeAddress, new LayoutAreaReference(MeshNodeLayoutAreas.OverviewArea))
+            .GetControlStream(MenuControl.GetMenuArea(NodeMenuItemsExtensions.NodeMenuContext))
+            .Where(x => x is MenuControl)
+            .Select(x => (IReadOnlyList<NodeMenuItemDefinition>)((MenuControl)x!).Items);
+
+    [Fact(Timeout = 60000)]
+    public async Task InviteItem_ShownOnSpace()
+    {
+        // Admin (auto-logged-in) has Update on the Space → the item appears.
+        var items = await NodeMenu(new Address(Space))
+            .Where(i => i.Any(m => m.Label == "Invite people"))
+            .FirstAsync().Timeout(30.Seconds());
+        Assert.Contains(items, m => m.Label == "Invite people"
+            && m.Area == SpaceInviteLayoutArea.AreaName);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task InviteItem_HiddenOnNonSpace()
+    {
+        // Wait until the node menu has rendered (Edit is a standard item), then assert Invite is absent.
+        var items = await NodeMenu(new Address(Plain))
+            .Where(i => i.Any(m => m.Label == "Edit"))
+            .FirstAsync().Timeout(30.Seconds());
+        Assert.DoesNotContain(items, m => m.Label == "Invite people");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/SpaceInviteServiceTest.cs
+++ b/test/MeshWeaver.Graph.Test/SpaceInviteServiceTest.cs
@@ -1,0 +1,88 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Tests <see cref="SpaceInviteService"/> — the two invite cases: an existing account is granted
+/// immediately; an unknown email is scheduled (a <see cref="ScheduledAction"/>) and invited (an
+/// <c>Invitation</c> node), so the grant lands automatically when they sign up.
+/// </summary>
+public class SpaceInviteServiceTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Space = "TeamSpace";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(new MeshNode(Space) { Name = "Team Space", NodeType = "Space" });
+
+    private SpaceInviteService NewService()
+        => new(Mesh,
+            Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
+            Mesh.ServiceProvider.GetRequiredService<AccessService>(),
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<SpaceInviteService>>());
+
+    [Fact(Timeout = 60000)]
+    public async Task InviteExistingUser_GrantsImmediately()
+    {
+        const string email = "bob@acme.com";
+        const string userId = "bob";
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode(userId)
+            {
+                NodeType = "User",
+                Name = "Bob",
+                Content = new User { Email = email, FullName = "Bob" },
+            }).Should().Emit();
+
+        // Wait until the account is queryable by email (the service looks it up that way).
+        await meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:User content.email:{email}"))
+            .Where(c => c.ChangeType == QueryChangeType.Initial && c.Items.Any(n => n.Id == userId))
+            .FirstAsync().Timeout(30.Seconds());
+
+        var outcome = await NewService().Invite(Space, email, "Editor", pin: true, invitedBy: "admin")
+            .FirstAsync().Timeout(30.Seconds());
+        Assert.Equal(SpaceInviteOutcome.Granted, outcome);
+
+        // The AccessAssignment landed with Editor, and the Space was pinned.
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{Space}/_Access/{userId}_Access")
+            .Where(n => n?.Content is AccessAssignment a && a.Roles.Any(r => r.Role == "Editor" && !r.Denied))
+            .FirstAsync().Timeout(20.Seconds());
+        await Mesh.GetWorkspace().GetMeshNodeStream(userId)
+            .Where(n => n?.Content is User u && u.PinnedPaths.Contains(Space))
+            .FirstAsync().Timeout(20.Seconds());
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task InviteAbsentEmail_SchedulesGrantAndCreatesInvitation()
+    {
+        const string email = "carol@acme.com";
+
+        var outcome = await NewService().Invite(Space, email, "Viewer", pin: false, invitedBy: "admin")
+            .FirstAsync().Timeout(30.Seconds());
+        Assert.Equal(SpaceInviteOutcome.Invited, outcome);
+
+        // A scheduled action was created to grant Viewer on the Space when this email's User appears.
+        await Mesh.GetWorkspace().GetQuery("inv-actions",
+                $"path:{ScheduledActionNodeType.Namespace} scope:children nodeType:{ScheduledActionNodeType.NodeType}")
+            .Where(nodes => (nodes ?? []).Any(n => n.Content is ScheduledAction a
+                && a.MatchValue == email && a.TargetPath == Space && a.Role == "Viewer"))
+            .FirstAsync().Timeout(30.Seconds());
+
+        // An Invitation node was created for the email (the InvitationEmailSender emails it).
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{InvitationNodeType.Namespace}/{SpaceInviteService.Slug(email)}")
+            .Where(n => n?.Content is Invitation inv && inv.Email == email)
+            .FirstAsync().Timeout(30.Seconds());
+    }
+}


### PR DESCRIPTION
Invite someone to a Space by email — built on the scheduled-action core (#261), composing existing pieces.

### Behaviour
- **Already on the system** → grant the role now (an `AccessAssignment`) and optionally pin the Space to their dashboard.
- **Not yet on the system** → create an **`Invitation`** (the existing `InvitationEmailSender` emails it) **and** a **`ScheduledAction`** that grants + pins the moment a `User` with that email is created — so access lands automatically on sign-up, surviving restarts via `ScheduledActionRunner`. Deterministic action/invitation ids → a re-invite upserts rather than duplicating.

### UI (node-menu item)
- **`SpaceInviteMenuProvider`** adds **"Invite people"** (✉️) to a Space's ⋯ menu, self-gated on `NodeType == "Space"` + Update (never leaks onto ordinary nodes).
- **`SpaceInviteLayoutArea`** — a framework-standard form (email + role + pin) + an Invite button that calls `SpaceInviteService` and reports the outcome in a dialog.

### Tests (4, all green)
- Existing user → immediate grant + pin.
- Unknown email → a `ScheduledAction` (grant on User-created) + an `Invitation` node.
- "Invite people" shows on a Space; absent on a non-Space node.

Builds clean under `Release -warnaserror`. The durable PG `events` event-log + cursor + Orleans time-triggers are the final follow-up layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)