### PR TITLE
test(e2e): login-dialog above-header regression + IO-pool the Claude client's file edges

### DIFF
--- a/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeChatClient.cs
+++ b/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeChatClient.cs
@@ -145,7 +145,8 @@ public class ClaudeCodeChatClient : IChatClient
         // Blocking .credentials.json read routed through the IO pool (off the subscribing thread, bounded).
         var effectiveToken = !string.IsNullOrEmpty(oauthToken)
             ? oauthToken
-            : await ioPool.InvokeBlocking(_ => ReadCredentialsToken(configDir)).FirstAsync().ToTask(cancellationToken);
+            : await ioPool.InvokeBlocking(ct => { ct.ThrowIfCancellationRequested(); return ReadCredentialsToken(configDir); })
+                .FirstAsync().ToTask(cancellationToken);
         if (!string.IsNullOrEmpty(configDir) && string.IsNullOrEmpty(effectiveToken))
         {
             throw new AuthRequiredException(
@@ -182,7 +183,7 @@ public class ClaudeCodeChatClient : IChatClient
             // Blocking mkdir routed through the IO pool (off the subscribing thread, bounded); best-effort.
             try
             {
-                await ioPool.InvokeBlocking(_ => { Directory.CreateDirectory(configDir!); return 0; })
+                await ioPool.InvokeBlocking(ct => { ct.ThrowIfCancellationRequested(); Directory.CreateDirectory(configDir!); return 0; })
                     .FirstAsync().ToTask(cancellationToken);
             }
             catch (Exception ex) { logger?.LogWarning(ex, "Could not create CLAUDE_CONFIG_DIR {Dir}", configDir); }

--- a/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeChatClient.cs
+++ b/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeChatClient.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using ClaudeAgentSdk;
 using MeshWeaver.AI.Connect;
+using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 
@@ -16,6 +17,10 @@ namespace MeshWeaver.AI.ClaudeCode;
 public class ClaudeCodeChatClient : IChatClient
 {
     private readonly ClaudeCodeConfiguration configuration;
+    // The bounded I/O pool — the client's sync/blocking file edges (mkdir, credentials read) run OFF the
+    // subscribing thread through this, never as bare sync calls (ControlledIoPooling.md). Falls back to
+    // IoPool.Unbounded when the harness didn't supply one (e.g. a unit test constructing the client directly).
+    private readonly IIoPool ioPool;
     private readonly string? modelName;
     private readonly string? configDir;
     private readonly string? oauthToken;
@@ -53,9 +58,11 @@ public class ClaudeCodeChatClient : IChatClient
         string? userName = null,
         string? userEmail = null,
         string? authMethod = null,
-        string? baseUrl = null)
+        string? baseUrl = null,
+        IIoPool? ioPool = null)
     {
         this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        this.ioPool = ioPool ?? IoPool.Unbounded;
         this.modelName = modelName;
         this.logger = logger;
         // Per-user isolation for co-hosted multi-user (Phase 5b): each spawn
@@ -135,7 +142,10 @@ public class ClaudeCodeChatClient : IChatClient
         // reload / pod restart, fall back to the token persisted in .credentials.json on the shared
         // config-dir volume — so we still set CLAUDE_CODE_OAUTH_TOKEN and authenticate instead of
         // surfacing a spurious "Not logged in". (Sync file read; this is the off-hub SDK leaf.)
-        var effectiveToken = !string.IsNullOrEmpty(oauthToken) ? oauthToken : ReadCredentialsToken(configDir);
+        // Blocking .credentials.json read routed through the IO pool (off the subscribing thread, bounded).
+        var effectiveToken = !string.IsNullOrEmpty(oauthToken)
+            ? oauthToken
+            : await ioPool.InvokeBlocking(_ => ReadCredentialsToken(configDir)).FirstAsync().ToTask(cancellationToken);
         if (!string.IsNullOrEmpty(configDir) && string.IsNullOrEmpty(effectiveToken))
         {
             throw new AuthRequiredException(
@@ -169,7 +179,12 @@ public class ClaudeCodeChatClient : IChatClient
         if (!string.IsNullOrEmpty(configDir))
         {
             env["CLAUDE_CONFIG_DIR"] = configDir;
-            try { Directory.CreateDirectory(configDir); }
+            // Blocking mkdir routed through the IO pool (off the subscribing thread, bounded); best-effort.
+            try
+            {
+                await ioPool.InvokeBlocking(_ => { Directory.CreateDirectory(configDir!); return 0; })
+                    .FirstAsync().ToTask(cancellationToken);
+            }
             catch (Exception ex) { logger?.LogWarning(ex, "Could not create CLAUDE_CONFIG_DIR {Dir}", configDir); }
         }
         // Set EXACTLY the one env var the chosen auth method names — never two at once, so the CLI's

--- a/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeHarness.cs
+++ b/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeHarness.cs
@@ -1,4 +1,5 @@
 using MeshWeaver.AI.Connect;
+using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -93,6 +94,10 @@ public sealed class ClaudeCodeHarness(IOptions<ClaudeCodeConfiguration> options)
             : null;
         var mcp = hub.ServiceProvider.GetService<IMcpBackConnection>();
         var clientLogger = hub.ServiceProvider.GetService<ILogger<ClaudeCodeChatClient>>();
+        // The mesh-scoped Process IoPool the client routes its blocking file edges through (mkdir,
+        // credentials read) — off the subscribing thread, bounded. Null when unregistered → the client
+        // falls back to IoPool.Unbounded.
+        var ioPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Process);
 
         // Note: the shared workspace dir (configuration.SkillsDirectory) holds the AGENTS.md the reactive
         // AgentSkillSyncService maintains — base "mesh-via-MCP" instructions plus the platform skill
@@ -101,6 +106,6 @@ public sealed class ClaudeCodeHarness(IOptions<ClaudeCodeConfiguration> options)
         // `get`, never materialised to disk. No per-spawn skill writing here.
         return new ClaudeCodeChatClient(
             configuration, modelName: null, clientLogger, configDir, token,
-            mcp, userId, accessCtx?.Name, accessCtx?.Email, cred?.AuthMethod, cred?.BaseUrl);
+            mcp, userId, accessCtx?.Name, accessCtx?.Email, cred?.AuthMethod, cred?.BaseUrl, ioPool);
     }
 }

--- a/test/MeshWeaver.Portal.E2E.Test/LoginDialogAboveHeaderTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/LoginDialogAboveHeaderTest.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Xunit;
@@ -70,26 +70,31 @@ public class LoginDialogAboveHeaderTest(PortalFixture fixture)
 
         // Assert BY RENDERING: at a point inside the sticky header's band AND the dialog's horizontal span,
         // the topmost painted element is the dialog (not the header). Also assert it is position:fixed.
-        var verdict = await page.EvaluateAsync<Dictionary<string, object>>(@"() => {
+        // EvaluateAsync deserializes to JsonElement — read with GetBoolean()/GetString() so the assertions
+        // actually execute (a Dictionary<string,object> would leave them as JsonElement and never compare).
+        // The JS ALWAYS returns the full shape so property access is safe even when the dialog is missing.
+        var verdict = await page.EvaluateAsync<JsonElement>(@"() => {
             const w = document.querySelector('.thread-chat-widget');
             const hdr = document.querySelector('.layout > header, header');
-            if (!w || !hdr) return { found: false };
+            if (!w || !hdr) return { found: false, position: '', overlapsHeader: false, popupAboveHeader: false };
             const cs = getComputedStyle(w), wr = w.getBoundingClientRect(), hr = hdr.getBoundingClientRect();
-            let overHeader = null;
-            if (wr.top < hr.bottom) {
+            const overlaps = wr.top < hr.bottom;
+            let overHeader = false;
+            if (overlaps) {
                 const px = Math.round((Math.max(wr.left, hr.left) + Math.min(wr.right, hr.right)) / 2);
                 const py = Math.round(hr.top + hr.height / 2);
                 const el = document.elementFromPoint(px, py);
                 overHeader = !!(el && el.closest('.thread-chat-widget'));
             }
-            return { found: true, position: cs.position, overlapsHeader: wr.top < hr.bottom, popupAboveHeader: overHeader };
+            return { found: true, position: cs.position, overlapsHeader: overlaps, popupAboveHeader: overHeader };
         }");
 
-        verdict.Should().ContainKey("found");
-        verdict["found"].Should().Be(true, "the /login dialog (.thread-chat-widget) must open");
-        verdict["position"].Should().Be("fixed", "the popup must be position:fixed to escape the chat overflow clip + stacking trap");
+        verdict.GetProperty("found").GetBoolean().Should().BeTrue("the /login dialog (.thread-chat-widget) must open");
+        verdict.GetProperty("position").GetString().Should().Be("fixed",
+            "the popup must be position:fixed to escape the chat overflow clip + stacking trap");
         // When the popup overlaps the header band, the topmost element there MUST be the dialog, not the header.
-        if (verdict.TryGetValue("overlapsHeader", out var ov) && ov is true)
-            verdict["popupAboveHeader"].Should().Be(true, "the login dialog must render ABOVE the sticky header, not behind it");
+        if (verdict.GetProperty("overlapsHeader").GetBoolean())
+            verdict.GetProperty("popupAboveHeader").GetBoolean().Should().BeTrue(
+                "the login dialog must render ABOVE the sticky header, not behind it");
     }
 }

--- a/test/MeshWeaver.Portal.E2E.Test/LoginDialogAboveHeaderTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/LoginDialogAboveHeaderTest.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// Regression guard for the recurring "chat popup renders BEHIND the sticky top bar" bug. The <c>/login</c>
+/// dialog — and the <c>/agent</c> · <c>/model</c> pickers, same <c>.thread-chat-widget</c> — must paint
+/// ABOVE the header. The popup is <c>position:fixed</c> (z-index 10000) so it escapes BOTH the chat's
+/// overflow clip AND the header's stacking context (z-index 1100); a z-index-only fix never worked because
+/// <c>.body-content { z-index: 1 }</c> trapped it in a lower stacking context and <c>overflow</c> clipped
+/// the header band. This asserts BY RENDERING: <c>elementFromPoint</c> over the header returns the dialog.
+/// Drives the real DevLogin portal: <c>memex-local e2e test LoginDialogAboveHeaderTest</c>.
+/// </summary>
+[Collection("portal-e2e")]
+public class LoginDialogAboveHeaderTest(PortalFixture fixture)
+{
+    [Fact(Timeout = 180_000)]
+    public async Task LoginDialog_RendersAboveTheStickyHeader()
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+
+        await using var context = await fixture.NewAuthenticatedContextAsync();
+        var token = await fixture.MintTokenAsync(context);
+
+        // The composer must be on the ClaudeCode harness so /login opens the harness LOGIN dialog rather
+        // than resolving as a MeshWeaver skill.
+        var composerPath = $"{fixture.UserId}/_Thread/ThreadComposer";
+        try
+        {
+            await fixture.CreateNodeAsync(context, token, $$"""
+                { "id": "ThreadComposer", "namespace": "{{fixture.UserId}}/_Thread", "name": "Chat Input",
+                  "nodeType": "ThreadComposer", "mainNode": "{{fixture.UserId}}",
+                  "content": { "$type": "ThreadComposer", "harness": "ClaudeCode" } }
+                """);
+        }
+        catch (InvalidOperationException) { /* already seeded — fine */ }
+        await fixture.PatchNodeAsync(context, token, composerPath, "{\"content\":{\"harness\":\"ClaudeCode\"}}");
+
+        var page = await context.NewPageAsync();
+        await page.SetViewportSizeAsync(1400, 800);
+        await page.GotoAsync($"{fixture.BaseUrl}/{fixture.UserId}",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 90_000 });
+        page.Url.Should().NotContain("/login");
+
+        // Open the composer (side panel) + focus its Monaco editor.
+        var toggle = page.Locator(".side-panel-toggle button, .side-panel-toggle fluent-button").First;
+        await toggle.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+        await toggle.ClickAsync();
+        var editor = page.Locator(".thread-chat-footer .monaco-editor").Last;
+        await editor.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+        await page.WaitForTimeoutAsync(800);
+
+        // Type /login and submit — Escape first dismisses Monaco's command-autocomplete so Enter submits
+        // the message (which routes to the harness Connect command → OpenLoginDialog) instead of accepting
+        // a completion.
+        await editor.ClickAsync();
+        await page.Keyboard.TypeAsync("/login");
+        await page.WaitForTimeoutAsync(400);
+        await page.Keyboard.PressAsync("Escape");
+        await page.WaitForTimeoutAsync(200);
+        await page.Keyboard.PressAsync("Enter");
+
+        var widget = page.Locator(".thread-chat-widget");
+        await widget.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 20_000 });
+        await page.ScreenshotAsync(new PageScreenshotOptions { Path = "/tmp/login-dialog-above-header.png" });
+
+        // Assert BY RENDERING: at a point inside the sticky header's band AND the dialog's horizontal span,
+        // the topmost painted element is the dialog (not the header). Also assert it is position:fixed.
+        var verdict = await page.EvaluateAsync<Dictionary<string, object>>(@"() => {
+            const w = document.querySelector('.thread-chat-widget');
+            const hdr = document.querySelector('.layout > header, header');
+            if (!w || !hdr) return { found: false };
+            const cs = getComputedStyle(w), wr = w.getBoundingClientRect(), hr = hdr.getBoundingClientRect();
+            let overHeader = null;
+            if (wr.top < hr.bottom) {
+                const px = Math.round((Math.max(wr.left, hr.left) + Math.min(wr.right, hr.right)) / 2);
+                const py = Math.round(hr.top + hr.height / 2);
+                const el = document.elementFromPoint(px, py);
+                overHeader = !!(el && el.closest('.thread-chat-widget'));
+            }
+            return { found: true, position: cs.position, overlapsHeader: wr.top < hr.bottom, popupAboveHeader: overHeader };
+        }");
+
+        verdict.Should().ContainKey("found");
+        verdict["found"].Should().Be(true, "the /login dialog (.thread-chat-widget) must open");
+        verdict["position"].Should().Be("fixed", "the popup must be position:fixed to escape the chat overflow clip + stacking trap");
+        // When the popup overlaps the header band, the topmost element there MUST be the dialog, not the header.
+        if (verdict.TryGetValue("overlapsHeader", out var ov) && ov is true)
+            verdict["popupAboveHeader"].Should().Be(true, "the login dialog must render ABOVE the sticky header, not behind it");
+    }
+}


### PR DESCRIPTION
## What

The two remaining follow-ups from the chat/login work:

**#8 — E2E regression test** (`LoginDialogAboveHeaderTest`): drives the real `/login` dialog in a browser (DevLogin portal) and asserts **by rendering** that `.thread-chat-widget` is `position: fixed` and paints **above** the sticky header — `elementFromPoint` over the header returns the dialog, not the header. Pins the recurring "popup behind the top bar" fix (PR #260) so it can't regress; also the first slice of Playwright Claude Code harness E2E coverage.

**#15 — IO-pool the Claude client's blocking file edges**: `ClaudeCodeChatClient`'s two sync file ops on the `IChatClient` streaming leaf — the `.credentials.json` read and the `CLAUDE_CONFIG_DIR` mkdir — now route through `IIoPool.InvokeBlocking` (off the subscribing thread, bounded, cancellable, diagnosable) per ControlledIoPooling.md, instead of bare sync calls. The harness supplies the mesh-scoped Process pool (`IoPoolRegistry.Get(IoPoolNames.Process)`); the client falls back to `IoPool.Unbounded` for direct unit construction.

## Testing

- `dotnet build src/MeshWeaver.AI.ClaudeCode` + `test/MeshWeaver.Portal.E2E.Test` -c Release -warnaserror → green.
- The E2E test runs via `memex-local e2e test LoginDialogAboveHeaderTest` against a live portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)