### PR TITLE
feat(react): GUI polish — pin control, inline-SVG cards, per-thread SVG icons

### DIFF
--- a/clients/react/src/controls/inputs.tsx
+++ b/clients/react/src/controls/inputs.tsx
@@ -22,6 +22,7 @@ import { useResolve } from "../area/context.js";
 import { useMeshLink } from "../area/navigation.js";
 import { str, useClick, useField, useOptions, useText } from "./common.js";
 import { resolveIconByName } from "./icon.js";
+import { controlStyle } from "../render/style.js";
 
 function field(control: UiControl, node: ReactNode): ReactNode {
   const label = useText(control.label);
@@ -184,11 +185,15 @@ function ButtonView({ control }: { control: UiControl }): ReactNode {
   // Blazor parity (ButtonView.razor): NavigateToHref navigates client-side FIRST, then the
   // ClickedEvent still posts so a server-side ClickAction runs too.
   const link = useMeshLink(useText(control.navigateToHref) || undefined);
+  // Honour the control's inline style (WithStyle) — e.g. the pinned-card unpin toggle sizes itself to
+  // a small circular icon button (min-width/width/height/border-radius). Without it the icon-only
+  // button renders at default width and reads as a bar. Blazor applies Style to the button the same way.
   return (
     <Button
       appearance={(useResolve(control.appearance) as any) ?? "secondary"}
       disabled={!!useResolve(control.disabled)}
       icon={iconOf(control.iconStart)}
+      style={controlStyle(control)}
       onClick={(e: React.MouseEvent) => {
         link.onClick?.(e);
         emitClick?.();

--- a/clients/react/src/controls/meshCardSvg.test.tsx
+++ b/clients/react/src/controls/meshCardSvg.test.tsx
@@ -1,0 +1,39 @@
+// Pins Issue 2: a MeshNodeCard whose imageUrl is an inline <svg> document renders it as an SVG
+// ELEMENT (not escaped source text, not the bare-initial placeholder). The server-side
+// GetImageUrlForNode now passes an inline-svg icon (top-level Icon / content avatar/logo/icon)
+// through verbatim, so the card receives a leading "<svg" string to detect.
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource, type AreaTree, type UiControl } from "../core.js";
+
+beforeAll(() => {
+  if (!window.matchMedia)
+    window.matchMedia = ((q: string) =>
+      ({ matches: false, media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent: () => false, onchange: null })) as unknown as typeof window.matchMedia;
+});
+
+function view(control: Record<string, unknown>) {
+  const source = new StaticAreaSource({ data: {}, areas: { main: control as unknown as UiControl } } satisfies AreaTree);
+  return render(<MeshAreaView source={source} rootArea="main" />);
+}
+
+const SVG = '<svg viewBox="0 0 10 10"><circle cx="5" cy="5" r="4" fill="green"/></svg>';
+
+describe("MeshNodeCard — inline SVG icon renders as an element", () => {
+  it("mounts the <svg> from imageUrl, not the bare initial", () => {
+    const { container } = view({
+      $type: "MeshNodeCard",
+      nodePath: "ns/X",
+      title: "Example",
+      imageUrl: SVG,
+      disableNavigation: true,
+    });
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.querySelector("circle")).not.toBeNull();
+    // The raw source string must NOT appear as visible text, and the initial placeholder must not show.
+    expect(container.textContent).not.toContain("<svg");
+    expect(container.querySelector(".mesh-node-card-placeholder")).toBeNull();
+  });
+});

--- a/clients/react/src/render/skins.tsx
+++ b/clients/react/src/render/skins.tsx
@@ -16,7 +16,7 @@ import type { Skin, UiControl } from "../area/types.js";
 import { useResolve } from "../area/context.js";
 import { resolveIconByName } from "../controls/icon.js";
 import { ControlRenderer, RenderArea, useChildAreas } from "./ControlRenderer.js";
-import { controlClass, cssAlign, cssSize } from "./style.js";
+import { controlClass, controlStyle, cssAlign, cssSize } from "./style.js";
 
 export interface SkinProps {
   skin: Skin;
@@ -39,8 +39,11 @@ export function DefaultStackSkin({ skin, control }: SkinProps): ReactNode {
     height: cssSize(skin.height),
     boxSizing: "border-box",
   };
+  // The control's own inline style (WithStyle) wins over the skin defaults — e.g. an overlay stack
+  // declared `position: absolute; top; right` (the pinned-card unpin toggle) must escape flow to sit
+  // ON the card, not render as a full-width bar below it. Blazor honours the Style the same way.
   return (
-    <div className={controlClass(control)} style={style}>
+    <div className={controlClass(control)} style={{ ...style, ...controlStyle(control) }}>
       <Children control={control} />
     </div>
   );

--- a/clients/react/src/render/styling.test.tsx
+++ b/clients/react/src/render/styling.test.tsx
@@ -49,6 +49,54 @@ describe("controlClass (WithClass) is applied, not dropped", () => {
   });
 });
 
+// Fix 1b: a control's inline WithStyle string must land on its root element for BOTH a container
+// (skin) and a Button leaf — otherwise an absolutely-positioned overlay stack (the pinned-card unpin
+// toggle) renders as a full-width bar in flow, and an icon-only circular button renders at default
+// width. The style must WIN over the skin/component defaults.
+describe("inline style (WithStyle) is honored on Stack and Button", () => {
+  it("an overlay Stack's position:absolute escapes flow and wins over skin defaults", () => {
+    const { container } = view({
+      areas: {
+        main: {
+          $type: "Stack",
+          class: "pin-overlay",
+          style: "position: absolute; top: 6px; right: 6px; z-index: 5;",
+          skins: [{ $type: "LayoutStack" }],
+          areas: [{ $type: "NamedArea", area: "b" }],
+        },
+        b: { $type: "Label", data: "x" },
+      },
+    });
+    const overlay = container.querySelector<HTMLElement>(".pin-overlay");
+    expect(overlay).not.toBeNull();
+    expect(overlay!.style.position).toBe("absolute");
+    expect(overlay!.style.top).toBe("6px");
+    expect(overlay!.style.right).toBe("6px");
+    expect(overlay!.style.zIndex).toBe("5");
+    // The skin's flex layout still applies underneath the overlay positioning.
+    expect(overlay!.style.display).toBe("flex");
+  });
+
+  it("a Button's inline size/border-radius lands on the rendered button", () => {
+    const { container } = view({
+      areas: {
+        main: { $type: "Stack", skins: [{ $type: "LayoutStack" }], areas: [{ $type: "NamedArea", area: "btn" }] },
+        btn: {
+          $type: "Button",
+          data: "",
+          style: "min-width: 28px; width: 28px; height: 28px; border-radius: 50%;",
+        },
+      },
+    });
+    const button = container.querySelector<HTMLElement>("button");
+    expect(button).not.toBeNull();
+    expect(button!.style.minWidth).toBe("28px");
+    expect(button!.style.width).toBe("28px");
+    expect(button!.style.height).toBe("28px");
+    expect(button!.style.borderRadius).toBe("50%");
+  });
+});
+
 // Fix 2: a pane sized "280px" must be a FIXED 280px column; a "*" pane fills the remainder. The old
 // code fed both through parseFloat → weights 280:1, ballooning the fixed menu to ~full width.
 describe("SplitterSkin sizes px vs star correctly", () => {

--- a/src/MeshWeaver.AI/ThreadIconGenerator.cs
+++ b/src/MeshWeaver.AI/ThreadIconGenerator.cs
@@ -1,0 +1,105 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// Pure, deterministic identicon generator: turns a stable seed (a thread's id and/or
+/// title) into a small, self-contained inline SVG avatar so every thread renders a
+/// distinct visual in the catalog. The SAME seed always yields the SAME SVG; different
+/// seeds are visually distinct.
+///
+/// <para>No external dependencies, no AI, no process-randomness: a SHA-256 of the seed
+/// drives a 5×5 vertically-mirrored cell grid over a rounded background, coloured from a
+/// hue derived off the same hash (<see cref="string.GetHashCode()"/> is deliberately
+/// avoided — it is randomised per process and would break determinism across runs).</para>
+///
+/// <para>The output is sanitiser-safe by construction: only <c>&lt;svg&gt;</c> and
+/// <c>&lt;rect&gt;</c> elements with static geometry + <c>fill</c> attributes — no
+/// <c>script</c>, <c>foreignObject</c>, or <c>on*</c> handlers — so it passes straight
+/// through the node card's inline-SVG rendering path (an <see cref="System.String"/> that
+/// starts with <c>&lt;svg</c>).</para>
+/// </summary>
+public static class ThreadIconGenerator
+{
+    // 5×5 identicon grid, 16px per cell → a clean 80×80 viewBox (no explicit width/height,
+    // so the icon scales to whatever the card sizes it to, like the line-art agent icons).
+    private const int Grid = 5;
+    private const int Cell = 16;
+    private const int Size = Grid * Cell;
+
+    /// <summary>
+    /// Produces a deterministic inline SVG identicon for <paramref name="seed"/> (typically a
+    /// thread's speaking id, optionally combined with its title). Returns a compact single-line
+    /// <c>&lt;svg …&gt;…&lt;/svg&gt;</c> string. Never throws; a null/empty seed still yields a
+    /// valid (constant) icon.
+    /// </summary>
+    /// <param name="seed">The stable seed to hash — same seed ⇒ same icon.</param>
+    /// <returns>Inline SVG markup, always starting with <c>&lt;svg</c> and ending with <c>&lt;/svg&gt;</c>.</returns>
+    public static string Generate(string? seed)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(seed ?? string.Empty));
+
+        // Hue from the first two bytes → 0..359; fixed saturation/lightness for a legible palette.
+        var hue = ((hash[0] << 8) | hash[1]) % 360;
+        var fg = HslToHex(hue, 0.60, 0.50);          // saturated foreground cells
+        var bg = HslToHex(hue, 0.45, 0.93);          // soft same-hue background
+
+        var sb = new StringBuilder(512);
+        sb.Append("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 ")
+          .Append(Size).Append(' ').Append(Size).Append("\">");
+
+        // Rounded background tile.
+        sb.Append("<rect width=\"").Append(Size).Append("\" height=\"").Append(Size)
+          .Append("\" rx=\"").Append(Cell).Append("\" fill=\"").Append(bg).Append("\"/>");
+
+        // Left half (columns 0..2) chosen by hash bits, mirrored onto the right half so the
+        // avatar is vertically symmetric (the classic GitHub-identicon shape). 3 cols × 5 rows
+        // = 15 bits, read from bytes past the two hue bytes (SHA-256 has 32 bytes — ample).
+        var bit = 16;
+        for (var col = 0; col < (Grid + 1) / 2; col++)
+        {
+            for (var row = 0; row < Grid; row++, bit++)
+            {
+                var on = ((hash[bit % hash.Length] >> (bit % 8)) & 1) == 1;
+                if (!on) continue;
+                AppendCell(sb, col, row, fg);
+                var mirror = Grid - 1 - col;
+                if (mirror != col)
+                    AppendCell(sb, mirror, row, fg);
+            }
+        }
+
+        sb.Append("</svg>");
+        return sb.ToString();
+    }
+
+    private static void AppendCell(StringBuilder sb, int col, int row, string fill) =>
+        sb.Append("<rect x=\"").Append(col * Cell).Append("\" y=\"").Append(row * Cell)
+          .Append("\" width=\"").Append(Cell).Append("\" height=\"").Append(Cell)
+          .Append("\" fill=\"").Append(fill).Append("\"/>");
+
+    // Deterministic HSL → "#rrggbb". h in [0,360); s,l in [0,1].
+    private static string HslToHex(double h, double s, double l)
+    {
+        var c = (1 - Math.Abs(2 * l - 1)) * s;
+        var hp = h / 60.0;
+        var x = c * (1 - Math.Abs(hp % 2 - 1));
+        double r = 0, g = 0, b = 0;
+        switch ((int)hp)
+        {
+            case 0: r = c; g = x; break;
+            case 1: r = x; g = c; break;
+            case 2: g = c; b = x; break;
+            case 3: g = x; b = c; break;
+            case 4: r = x; b = c; break;
+            default: r = c; b = x; break;
+        }
+        var m = l - c / 2;
+        return string.Create(CultureInfo.InvariantCulture,
+            $"#{To255(r + m):x2}{To255(g + m):x2}{To255(b + m):x2}");
+    }
+
+    private static int To255(double v) => Math.Clamp((int)Math.Round(v * 255), 0, 255);
+}

--- a/src/MeshWeaver.AI/ThreadIconGenerator.cs
+++ b/src/MeshWeaver.AI/ThreadIconGenerator.cs
@@ -56,7 +56,7 @@ public static class ThreadIconGenerator
 
         // Left half (columns 0..2) chosen by hash bits, mirrored onto the right half so the
         // avatar is vertically symmetric (the classic GitHub-identicon shape). 3 cols × 5 rows
-        // = 15 bits, read from bytes past the two hue bytes (SHA-256 has 32 bytes — ample).
+        // = 15 bits, one taken from each of hash bytes 16..30 (well past the 2 hue bytes; SHA-256 has 32).
         var bit = 16;
         for (var col = 0; col < (Grid + 1) / 2; col++)
         {

--- a/src/MeshWeaver.AI/ThreadNodeType.cs
+++ b/src/MeshWeaver.AI/ThreadNodeType.cs
@@ -23,10 +23,11 @@ public static class ThreadNodeType
     public const string NodeType = "Thread";
 
     /// <summary>
-    /// Default Icon for Thread instances. Must match <see cref="CreateMeshNode"/>.
-    /// Applied explicitly in <see cref="BuildThreadNode"/>/<see cref="BuildThreadWithMessages"/>
-    /// because thread creation goes via <c>CreateNodeRequest</c> on arbitrary parent hubs,
-    /// some of which don't have <c>INodeTypeService</c> registered to auto-copy the icon.
+    /// Default Icon for the Thread <em>type</em> node (<see cref="CreateMeshNode"/>).
+    /// Per-<em>instance</em> threads instead get a deterministic identicon from
+    /// <see cref="ThreadIconGenerator"/> in <see cref="BuildThreadNode"/>/<see cref="BuildThreadWithMessages"/>
+    /// so the catalog renders a distinct visual per thread; this glyph is the fallback for
+    /// the type itself and any consumer that reads the type default.
     /// </summary>
     public const string DefaultIcon = "/static/NodeTypeIcons/chat.svg";
 
@@ -143,7 +144,11 @@ public static class ThreadNodeType
         {
             Name = name,
             NodeType = NodeType,
-            Icon = DefaultIcon,
+            // Deterministic per-thread identicon (seeded by the stable speaking id) so the
+            // thread catalog renders a distinct visual per thread instead of one shared glyph.
+            // Same id ⇒ same icon (the fallback re-anchor below reuses the id and gets the same
+            // icon); the value is inline <svg>, which the node card renders directly.
+            Icon = ThreadIconGenerator.Generate(speakingId),
             MainNode = contextPath,
             Content = new Thread { CreatedBy = createdBy }
         };
@@ -201,7 +206,9 @@ public static class ThreadNodeType
         {
             Name = name,
             NodeType = NodeType,
-            Icon = DefaultIcon,
+            // Deterministic per-thread identicon (see BuildThreadNode) so the catalog shows a
+            // distinct visual per thread; inline <svg>, rendered directly by the node card.
+            Icon = ThreadIconGenerator.Generate(speakingId),
             MainNode = contextPath,
             Content = new Thread
             {

--- a/src/MeshWeaver.Graph/MeshNodeThumbnailControl.cs
+++ b/src/MeshWeaver.Graph/MeshNodeThumbnailControl.cs
@@ -36,17 +36,22 @@ public record MeshNodeThumbnailControl(
 
     /// <summary>
     /// Gets the image URL for a node. Public so other builders can reuse.
-    /// Priority: content.avatar > content.logo > node.Icon
+    /// Priority: content.avatar > content.logo > content.icon > node.Icon > NodeType default.
     /// Handles both typed objects and JsonElement/Dictionary content.
     /// User-entered paths starting with <c>content:</c> or <c>content/</c> are resolved
-    /// against the node's content collection.
+    /// against the node's content collection; an inline <c>&lt;svg&gt;…&lt;/svg&gt;</c> value is
+    /// returned verbatim (never treated as a path) so the client renders it inline.
     /// </summary>
     public static string? GetImageUrlForNode(MeshNode? node)
     {
         if (node == null)
             return null;
 
-        // First check content properties (avatar, logo)
+        // First check content properties (avatar, logo, icon). `icon`/`Icon` is included so a
+        // content-carried icon — commonly an inline <svg> — surfaces on the card instead of being
+        // dropped in favour of the generic NodeType default. ResolveContentPath returns inline SVG
+        // and URLs verbatim, resolves content:/content/ references, and returns null for legacy
+        // Fluent icon names (so those correctly fall through to node.Icon / the NodeType default).
         if (node.Content != null)
         {
             // Try JsonElement first (common when deserializing from JSON)
@@ -55,7 +60,9 @@ public record MeshNodeThumbnailControl(
                 var resolved = TryResolveJsonProperty(jsonElement, "avatar", node.Path)
                     ?? TryResolveJsonProperty(jsonElement, "Avatar", node.Path)
                     ?? TryResolveJsonProperty(jsonElement, "logo", node.Path)
-                    ?? TryResolveJsonProperty(jsonElement, "Logo", node.Path);
+                    ?? TryResolveJsonProperty(jsonElement, "Logo", node.Path)
+                    ?? TryResolveJsonProperty(jsonElement, "icon", node.Path)
+                    ?? TryResolveJsonProperty(jsonElement, "Icon", node.Path);
                 if (resolved != null)
                     return resolved;
             }
@@ -71,6 +78,12 @@ public record MeshNodeThumbnailControl(
                 if (dict.TryGetValue("logo", out var logo) || dict.TryGetValue("Logo", out logo))
                 {
                     var resolved = MeshNodeImageHelper.ResolveContentPath(logo?.ToString(), node.Path);
+                    if (!string.IsNullOrEmpty(resolved))
+                        return resolved;
+                }
+                if (dict.TryGetValue("icon", out var contentIcon) || dict.TryGetValue("Icon", out contentIcon))
+                {
+                    var resolved = MeshNodeImageHelper.ResolveContentPath(contentIcon?.ToString(), node.Path);
                     if (!string.IsNullOrEmpty(resolved))
                         return resolved;
                 }
@@ -95,6 +108,15 @@ public record MeshNodeThumbnailControl(
                     if (!string.IsNullOrEmpty(resolved))
                         return resolved;
                 }
+
+                var iconProperty = node.Content.GetType().GetProperty("Icon");
+                if (iconProperty != null)
+                {
+                    var resolved = MeshNodeImageHelper.ResolveContentPath(
+                        iconProperty.GetValue(node.Content) as string, node.Path);
+                    if (!string.IsNullOrEmpty(resolved))
+                        return resolved;
+                }
             }
         }
 
@@ -105,6 +127,9 @@ public record MeshNodeThumbnailControl(
         var thumbnail = GetThumbnail(node.Content);
         if (!string.IsNullOrEmpty(thumbnail))
         {
+            // Inline SVG thumbnail — return verbatim; it is markup, not a content-collection path.
+            if (MeshNodeImageHelper.IsInlineSvg(thumbnail))
+                return thumbnail;
             if (thumbnail.StartsWith("/") || thumbnail.StartsWith("http"))
                 return thumbnail;
             var ns = node.Namespace;

--- a/src/MeshWeaver.Graph/MeshNodeThumbnailControl.cs
+++ b/src/MeshWeaver.Graph/MeshNodeThumbnailControl.cs
@@ -36,7 +36,7 @@ public record MeshNodeThumbnailControl(
 
     /// <summary>
     /// Gets the image URL for a node. Public so other builders can reuse.
-    /// Priority: content.avatar > content.logo > content.icon > node.Icon > NodeType default.
+    /// Priority: content.avatar > content.logo > content.icon > MarkdownContent.Thumbnail > node.Icon > NodeType default.
     /// Handles both typed objects and JsonElement/Dictionary content.
     /// User-entered paths starting with <c>content:</c> or <c>content/</c> are resolved
     /// against the node's content collection; an inline <c>&lt;svg&gt;…&lt;/svg&gt;</c> value is

--- a/test/MeshWeaver.AI.Test/ThreadIconGeneratorTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadIconGeneratorTest.cs
@@ -1,0 +1,76 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the deterministic thread identicon generator: same seed ⇒ identical SVG, different
+/// seeds ⇒ distinct SVG, always valid + sanitiser-safe inline markup — and that the thread
+/// builders (<see cref="ThreadNodeType.BuildThreadNode"/> /
+/// <see cref="ThreadNodeType.BuildThreadWithMessages"/>) stamp that identicon on the node's
+/// <c>Icon</c> so the catalog renders a distinct visual per thread.
+/// </summary>
+public class ThreadIconGeneratorTest
+{
+    [Fact]
+    public void Generate_IsDeterministic_SameSeedSameSvg()
+    {
+        var a = ThreadIconGenerator.Generate("my-thread-a3f9");
+        var b = ThreadIconGenerator.Generate("my-thread-a3f9");
+        a.Should().Be(b, "the generator must be a pure function of its seed");
+    }
+
+    [Fact]
+    public void Generate_DifferentSeeds_ProduceDifferentSvg()
+    {
+        var a = ThreadIconGenerator.Generate("setting-up-ci-cd-a3f9");
+        var b = ThreadIconGenerator.Generate("enterprise-pricing-b7c2");
+        a.Should().NotBe(b, "distinct threads must look distinct");
+    }
+
+    [Fact]
+    public void Generate_ProducesValidInlineSvgMarkup()
+    {
+        var svg = ThreadIconGenerator.Generate("fix-login-bug-1234");
+
+        svg.Should().StartWith("<svg", "the node card renders values that start with <svg inline");
+        svg.Should().EndWith("</svg>");
+        svg.Should().Contain("viewBox=\"0 0 80 80\"");
+        svg.Should().Contain("<rect", "the identicon is composed of rect cells over a rounded background");
+        // Sanitiser-safe: no active content, no event handlers.
+        svg.Should().NotContain("<script");
+        svg.Should().NotContain("foreignObject");
+        svg.Should().NotContain(" on", "no on* event-handler attributes");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Generate_EmptyOrNullSeed_StillValid(string? seed)
+    {
+        var svg = ThreadIconGenerator.Generate(seed);
+        svg.Should().StartWith("<svg").And.EndWith("</svg>");
+        // Null and empty hash to the same bytes → identical, constant icon.
+        svg.Should().Be(ThreadIconGenerator.Generate(""));
+    }
+
+    [Fact]
+    public void BuildThreadNode_StampsDeterministicIdenticonOnIcon()
+    {
+        var node = ThreadNodeType.BuildThreadNode("User/rbuergi", "How do I set up CI/CD?", "rbuergi");
+
+        node.Icon.Should().StartWith("<svg", "per-instance threads get an inline SVG identicon, not the type glyph");
+        node.Icon.Should().Be(ThreadIconGenerator.Generate(node.Id),
+            "the icon is seeded by the thread's own (stable) speaking id");
+    }
+
+    [Fact]
+    public void BuildThreadWithMessages_StampsDeterministicIdenticonOnIcon()
+    {
+        var (node, _, _) = ThreadNodeType.BuildThreadWithMessages("User/rbuergi", "Fix the login bug", "rbuergi");
+
+        node.Icon.Should().StartWith("<svg");
+        node.Icon.Should().Be(ThreadIconGenerator.Generate(node.Id));
+    }
+}

--- a/test/MeshWeaver.Graph.Test/MeshNodeCardIconTest.cs
+++ b/test/MeshWeaver.Graph.Test/MeshNodeCardIconTest.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins that an inline <c>&lt;svg&gt;</c> icon flows through <see cref="MeshNodeThumbnailControl.GetImageUrlForNode"/>
+/// verbatim (never rewritten to a <c>/static/…</c> path) — from the node's top-level <c>Icon</c>, from a content
+/// <c>avatar</c>/<c>logo</c>, and from a content-level <c>icon</c> property. The card renderers (Blazor
+/// MeshNodeCardView and the React MeshNodeCardView) detect the leading <c>&lt;svg</c> and render it inline.
+/// </summary>
+public class MeshNodeCardIconTest
+{
+    private const string Svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"M0 0h24v24\"/></svg>";
+
+    [Fact]
+    public void TopLevelIcon_InlineSvg_ReturnedVerbatim()
+    {
+        var node = new MeshNode("X", "ns") { NodeType = "Markdown", Icon = Svg };
+        MeshNodeThumbnailControl.GetImageUrlForNode(node).Should().Be(Svg);
+    }
+
+    [Fact]
+    public void ContentAvatar_InlineSvg_ReturnedVerbatim()
+    {
+        var node = new MeshNode("X", "ns")
+        {
+            NodeType = "Markdown",
+            Content = new Dictionary<string, object> { ["avatar"] = Svg },
+        };
+        MeshNodeThumbnailControl.GetImageUrlForNode(node).Should().Be(Svg);
+    }
+
+    [Fact]
+    public void ContentIcon_Dictionary_InlineSvg_ReturnedVerbatim()
+    {
+        var node = new MeshNode("X", "ns")
+        {
+            NodeType = "Markdown",
+            Content = new Dictionary<string, object> { ["icon"] = Svg },
+        };
+        MeshNodeThumbnailControl.GetImageUrlForNode(node).Should().Be(Svg);
+    }
+
+    [Fact]
+    public void ContentIcon_JsonElement_InlineSvg_ReturnedVerbatim()
+    {
+        // A degraded JSON frame (cache / change-feed read) carrying the icon in its content —
+        // previously dropped in favour of the generic NodeType default; now surfaced verbatim.
+        var content = JsonSerializer.Deserialize<JsonElement>($"{{\"icon\": {JsonSerializer.Serialize(Svg)}}}");
+        var node = new MeshNode("X", "ns") { NodeType = "Markdown", Content = content };
+        MeshNodeThumbnailControl.GetImageUrlForNode(node).Should().Be(Svg);
+    }
+
+    [Fact]
+    public void ContentIcon_FluentName_FallsThroughToNodeTypeDefault()
+    {
+        // A legacy Fluent icon NAME in content is not renderable markup — it must fall through to the
+        // NodeType default rather than be surfaced as-is.
+        var node = new MeshNode("X", "ns")
+        {
+            NodeType = "Markdown",
+            Content = new Dictionary<string, object> { ["icon"] = "Document" },
+        };
+        MeshNodeThumbnailControl.GetImageUrlForNode(node).Should().Be("/static/NodeTypeIcons/document.svg");
+    }
+}


### PR DESCRIPTION
Follow-up to the `/next` GUI ship ([#268](https://github.com/Systemorph/MeshWeaver/pull/268)) — the remaining Blazor-vs-Next comparison polish items.

## Fixes
- **Pin/unpin control was a full-width "bar".** The React pack dropped `.WithStyle(...)` inline styles in `DefaultStackSkin` + `ButtonView`, so the pin toggle's absolute wrapper + circular-button sizing collapsed into a flow bar (easy to misclick → it wiped pins). Both now honor `controlStyle` → a small 28×28 circular icon button overlaid top-right, outside the card's nav `<a>`.
- **MeshNodeCard didn't render inline `<svg>` icons carried in content.** `GetImageUrlForNode` now considers content `icon`/`Icon` (priority `avatar > logo > icon > node.Icon > NodeType default`) and returns an inline `<svg>` verbatim (never `/static`-prefixed). Client already renders it via `isInlineSvg`/`sanitizeInlineSvg`.
- **Per-thread SVG identicons.** `ThreadNodeType.BuildThreadNode` now sets `Icon` to a deterministic, sanitizer-safe GitHub-style identicon (`ThreadIconGenerator`, SHA-256-seeded → stable per thread) instead of the static `chat.svg`, so the thread catalog shows a distinct icon per thread.

## Verification
- `@meshweaver/react` **144 tests** (typecheck clean).
- `MeshWeaver.AI` (7 `ThreadIconGeneratorTest`) + `MeshWeaver.Graph` (5 `MeshNodeCardIconTest`) tests pass.
- `Memex.Portal.Distributed` Release `-p:CIRun=true -warnaserror` → **0W/0E**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)