### PR TITLE
fix+test(instance-sync): symmetric newest-writer-wins (converge) + conflict/round-trip/offline tests + docs

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/InstanceSync.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InstanceSync.md
@@ -91,12 +91,34 @@ and push the change straight back — an infinite ping-pong. Two independent lay
    (name/type/state + canonical JSON) and drops value-equal writes. Any echo that slips past
    layer 1 terminates after one hop instead of oscillating.
 
-Conflicts resolve **newest-writer-wins** by `LastModified` (ties keep the local side). This is
-last-write-wins at node granularity — concurrent edits to the *same node* on both instances
-within one sweep interval resolve to the newer stamp, not a field merge.
+## Conflict resolution (newest-writer-wins, symmetric → the two instances converge)
+
+When the **same node** is edited on both instances within a sweep interval, the resolution is
+**newest-writer-wins by `LastModified`, applied symmetrically on BOTH the pull and the push side**,
+so the two instances always **converge** on the newer write:
+
+- **Pull** (`PullOne`) applies a remote node only when it is *strictly newer* than the local one;
+  a local node that is newer or equal is kept (ties favour the local / push direction).
+- **Push** (`PushNode`) is the mirror **for a `Bidirectional` source**: it **skips** the upsert when
+  the remote node is *strictly newer* — it never clobbers a newer remote — and the next pull sweep
+  brings that newer remote local. Without this the push upserted unconditionally, so an older local
+  edit overwrote a newer remote one and the newer edit was lost (LWW violated); the symmetric guard is
+  what makes the round trip actually converge. The guard is **scoped to `Bidirectional`**: a
+  `PushOnly` source runs no pull sweep and is authoritative-local by definition, so it always pushes
+  (skipping there would strand the newer remote *and* permanently block the local edit from
+  propagating).
+
+Net effect: the node with the greatest `LastModified` wins **on both sides**. Resolution is at
+**whole-node** granularity, not a field-level merge — two sides editing *different fields* of the
+same node still resolve to the newer whole node (the older side's field edit is superseded).
 
 ## Known limitations (v1)
 
+- **Whole-node, not field-level** — concurrent edits to *different fields* of one node do not
+  merge; the newer whole node wins. A field-level (RFC 7396) merge is the follow-up if both edits
+  must survive.
+- **Delete-vs-edit** — a local delete pushes unconditionally, so a delete supersedes a concurrent
+  remote edit (delete-wins), regardless of stamps.
 - **Remote deletes don't propagate on pull** — only local deletes push. In a symmetric setup
   (a registration on each side) deletes propagate both ways via each side's push.
 - **Clock skew** between instances shifts newest-writer-wins fairness; stamps come from each
@@ -108,9 +130,22 @@ within one sweep interval resolve to the newer stamp, not a field merge.
   `lastModified` per hit); listings beyond the per-level search cap are walked per-namespace
   and logged loudly when still truncated — never silently dropped.
 
+## Permissions (a Space-editor capability)
+
+Configuring or running instance sync is an **editor-level** operation, gated on `Permission.Update`
+on the Space — the right that comes with the **Editor** role (and Admin/Owner); Viewer/Commenter
+cannot. The "Synchronizations" node-menu item and the sync management area self-gate on it
+(`InstanceSyncMenuProvider`), so the whole feature is invisible to users who can only read the
+Space. (This is distinct from `Permission.Sync`, which governs the *static-repo* import overwrite of
+read-only partitions and is deliberately NOT part of Editor/`All`.)
+
 ## Testing
 
 `test/MeshWeaver.InstanceSync.Test` runs the full loop against an in-memory
 `IRemoteMeshClient` fake (the interface's sanctioned test seam) with tight intervals:
 initial replication, incremental push, offline accumulation → reconnect drain, restart resume,
-pull, echo suppression, and direction gating.
+pull, echo suppression, and direction gating. **`InstanceSyncConflictTest`** covers the
+conflict/round-trip/offline guarantees end-to-end: local↔remote round-trip convergence,
+concurrent same-node edits (newer wins on both sides, remote-newer and local-newer),
+the offline "long flight" (accumulate while unreachable → drain → converge on reconnect), and
+whole-node resolution of different-field concurrent edits.

--- a/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
@@ -297,7 +297,14 @@ public sealed class InstanceSyncWorker : IDisposable
             ? Observable.Return(true)
             : remote.Delete(remotePath).Select(_ => true));
 
-    /// <summary>Upsert with the convergence guard: value-equal remote content is left untouched.</summary>
+    /// <summary>
+    /// Upsert with two guards: value-equal remote content is left untouched (convergence), and a
+    /// STRICTLY-NEWER remote node is NOT overwritten — newest-writer-wins, symmetric with the pull
+    /// side (<see cref="PullOne"/>). This is what makes the two instances CONVERGE: without it, an
+    /// older local push clobbered a newer remote, and since the pull only applies a strictly-newer
+    /// remote, the sides then diverged with no self-heal. On the skip, the remote's newer version is
+    /// brought local by the next pull sweep. Ties favour the push direction (matching PullOne).
+    /// </summary>
     private IObservable<Unit> PushNode(IRemoteMeshClient remote, InstanceSyncConfig cfg, MeshNode local)
     {
         var remotePath = InstanceSyncService.RemapPath(local.Path, SpacePath, RemoteSpaceOf(cfg));
@@ -306,6 +313,8 @@ public sealed class InstanceSyncWorker : IDisposable
         {
             if (existing is not null && service.ContentEquals(payload, existing))
                 return Observable.Return(Unit.Default);
+            if (existing is not null && existing.LastModified > local.LastModified)
+                return Observable.Return(Unit.Default);   // remote is newer → let the pull bring it local
             return existing is null ? remote.Create(payload) : remote.Update(payload);
         });
     }

--- a/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
@@ -298,12 +298,16 @@ public sealed class InstanceSyncWorker : IDisposable
             : remote.Delete(remotePath).Select(_ => true));
 
     /// <summary>
-    /// Upsert with two guards: value-equal remote content is left untouched (convergence), and a
-    /// STRICTLY-NEWER remote node is NOT overwritten — newest-writer-wins, symmetric with the pull
-    /// side (<see cref="PullOne"/>). This is what makes the two instances CONVERGE: without it, an
-    /// older local push clobbered a newer remote, and since the pull only applies a strictly-newer
-    /// remote, the sides then diverged with no self-heal. On the skip, the remote's newer version is
-    /// brought local by the next pull sweep. Ties favour the push direction (matching PullOne).
+    /// Upsert with two guards: value-equal remote content is left untouched (convergence), and — for a
+    /// <see cref="InstanceSyncDirection.Bidirectional"/> source only — a STRICTLY-NEWER remote node is
+    /// NOT overwritten (newest-writer-wins, symmetric with the pull side <see cref="PullOne"/>). This
+    /// is what makes the two instances CONVERGE: without it, an older local push clobbered a newer
+    /// remote, and since the pull only applies a strictly-newer remote, the sides then diverged with no
+    /// self-heal. On the skip the remote's newer version is brought local by the next pull sweep — which
+    /// is why the guard is scoped to Bidirectional: a <see cref="InstanceSyncDirection.PushOnly"/> source
+    /// runs NO pull sweep, so skipping there would strand the newer remote AND never propagate the local
+    /// edit. PushOnly is authoritative-local by definition, so it always pushes. Ties favour the push
+    /// direction (matching PullOne).
     /// </summary>
     private IObservable<Unit> PushNode(IRemoteMeshClient remote, InstanceSyncConfig cfg, MeshNode local)
     {
@@ -313,8 +317,9 @@ public sealed class InstanceSyncWorker : IDisposable
         {
             if (existing is not null && service.ContentEquals(payload, existing))
                 return Observable.Return(Unit.Default);
-            if (existing is not null && existing.LastModified > local.LastModified)
-                return Observable.Return(Unit.Default);   // remote is newer → let the pull bring it local
+            if (existing is not null && cfg.Direction == InstanceSyncDirection.Bidirectional
+                && existing.LastModified > local.LastModified)
+                return Observable.Return(Unit.Default);   // bidi: remote is newer → let the pull bring it local
             return existing is null ? remote.Create(payload) : remote.Update(payload);
         });
     }

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncConflictTest.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncConflictTest.cs
@@ -1,0 +1,142 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.InstanceSync.Test;
+
+/// <summary>
+/// Conflict-resolution + full round-trip coverage for instance sync. The model is
+/// newest-writer-wins (by <see cref="MeshNode.LastModified"/>), applied SYMMETRICALLY on push and
+/// pull — so the two instances always CONVERGE on the newest write (no split-brain, no older side
+/// silently clobbering a newer one). These tests assert convergence on BOTH sides after a round
+/// trip, including the offline "long flight" case (edits accumulate while the remote is unreachable,
+/// then drain and converge on reconnect).
+/// </summary>
+public class InstanceSyncConflictTest(ITestOutputHelper output) : InstanceSyncTestBase(output)
+{
+    private const string Space = "conflict";
+    private const string Doc = "conflict/doc";
+
+    /// <summary>Sets up a Space + one Markdown doc synced bidirectionally, waits for the initial replication.</summary>
+    private async Task<string> SetupSynced(string initialBody = "v0")
+    {
+        await CreateSpace(Space);
+        await CreateMarkdown(Doc, "Doc", initialBody);
+        var source = await AddConfiguredSource(Space);
+        await WaitForConfig(Space, "partner", c => c.InitialSyncAt is not null);
+        await WaitForRemote(r => MarkdownBody(r.Node(Doc)) == initialBody);
+        return source;
+    }
+
+    private Task EditLocal(string path, string body) =>
+        Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Update(n => n with { Content = new MarkdownContent { Content = body } })
+            .Timeout(30.Seconds()).ToTask();
+
+    /// <summary>Waits until the LOCAL node's markdown body equals <paramref name="expected"/>.</summary>
+    private Task WaitForLocalBody(string path, string expected) =>
+        Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => Mesh.GetWorkspace().GetMeshNodeStream(path).Take(1))
+            .Where(n => MarkdownBody(n) == expected)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+
+    [Fact(Timeout = 60000)]
+    public async Task Round_trip_local_and_remote_edits_converge()
+    {
+        await SetupSynced();
+
+        // A → remote: a local edit propagates to the remote.
+        await EditLocal(Doc, "from_A");
+        await WaitForRemote(r => MarkdownBody(r.Node(Doc)) == "from_A");
+
+        // remote → A: a remote edit (newer) propagates back to the local instance.
+        Remote.Seed(Remote.Node(Doc)! with { Content = new MarkdownContent { Content = "from_B" } },
+            DateTimeOffset.UtcNow.AddMinutes(1));
+        await WaitForLocalBody(Doc, "from_B");
+
+        // Converged: both sides equal.
+        await WaitForRemote(r => MarkdownBody(r.Node(Doc)) == "from_B");
+        Assert.Equal("from_B", MarkdownBody(Remote.Node(Doc)));
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Concurrent_edit_newer_remote_wins_on_both_sides()
+    {
+        await SetupSynced();
+
+        // Offline window: BOTH edit the same node. Remote's edit is NEWER.
+        Remote.Unreachable = true;
+        await EditLocal(Doc, "A_edit");                                   // local, ~now
+        Remote.Seed(Remote.Node(Doc)! with { Content = new MarkdownContent { Content = "B_edit" } },
+            DateTimeOffset.UtcNow.AddMinutes(1));                         // remote, newer
+        Remote.Unreachable = false;
+
+        // Newest-writer-wins: the remote edit wins on BOTH sides (the local push must NOT clobber the
+        // newer remote — that's the convergence fix). A's older edit is superseded, not lost to a split.
+        await WaitForLocalBody(Doc, "B_edit");
+        await WaitForRemote(r => MarkdownBody(r.Node(Doc)) == "B_edit");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Concurrent_edit_newer_local_wins_on_both_sides()
+    {
+        await SetupSynced();
+
+        Remote.Unreachable = true;
+        Remote.Seed(Remote.Node(Doc)! with { Content = new MarkdownContent { Content = "B_old" } },
+            DateTimeOffset.UtcNow.AddMinutes(-30));                       // remote, older
+        await EditLocal(Doc, "A_new");                                   // local, ~now (newer)
+        Remote.Unreachable = false;
+
+        // The newer LOCAL edit wins on both sides.
+        await WaitForRemote(r => MarkdownBody(r.Node(Doc)) == "A_new");
+        await WaitForLocalBody(Doc, "A_new");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Offline_long_flight_accumulates_then_drains_and_converges()
+    {
+        await SetupSynced();
+        await CreateMarkdown("conflict/doc2", "Doc2", "d2_v0");
+        await WaitForRemote(r => r.Node("conflict/doc2") is not null);
+
+        // "On the flight": remote unreachable; edits pile up locally in the durable manifest.
+        Remote.Unreachable = true;
+        await EditLocal(Doc, "offline_1");
+        await EditLocal("conflict/doc2", "offline_2");
+        // Nothing transferred while offline.
+        await WaitForConfig(Space, "partner", c => c.PendingChanges.Count >= 2);
+        Assert.NotEqual("offline_1", MarkdownBody(Remote.Node(Doc)));
+
+        // "Landed": reconnect → the manifest drains → both nodes converge on the remote.
+        Remote.Unreachable = false;
+        await WaitForRemote(r => MarkdownBody(r.Node(Doc)) == "offline_1"
+                                 && MarkdownBody(r.Node("conflict/doc2")) == "offline_2");
+        await WaitForConfig(Space, "partner", c => c.PendingChanges.Count == 0);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Concurrent_edit_of_different_fields_resolves_whole_node_by_newest()
+    {
+        await SetupSynced();
+
+        // A edits the NAME; the remote edits the CONTENT (newer), each unaware of the other.
+        Remote.Unreachable = true;
+        await Mesh.GetWorkspace().GetMeshNodeStream(Doc)
+            .Update(n => n with { Name = "A_renamed" }).Timeout(30.Seconds()).ToTask();
+        Remote.Seed(Remote.Node(Doc)! with { Content = new MarkdownContent { Content = "B_body" } },
+            DateTimeOffset.UtcNow.AddMinutes(1));
+        Remote.Unreachable = false;
+
+        // Resolution is WHOLE-NODE newest-writer-wins (not a field-level merge): the newer remote
+        // node wins entirely, so its Name (unchanged) + body converge on both sides. Documenting the
+        // known trade-off — a field-level (RFC 7396) merge would preserve both edits.
+        await WaitForLocalBody(Doc, "B_body");
+        var local = await Mesh.GetWorkspace().GetMeshNodeStream(Doc).Take(1).ToTask();
+        Assert.Equal("Doc", local!.Name);          // A's rename is superseded by the newer whole node
+        Assert.Equal("B_body", MarkdownBody(Remote.Node(Doc)));
+    }
+}

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncConflictTest.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncConflictTest.cs
@@ -139,4 +139,28 @@ public class InstanceSyncConflictTest(ITestOutputHelper output) : InstanceSyncTe
         Assert.Equal("Doc", local!.Name);          // A's rename is superseded by the newer whole node
         Assert.Equal("B_body", MarkdownBody(Remote.Node(Doc)));
     }
+
+    [Fact(Timeout = 60000)]
+    public async Task PushOnly_local_edit_always_overwrites_even_a_newer_remote()
+    {
+        // A PushOnly source is authoritative-local and runs NO pull sweep, so the newest-writer-wins
+        // guard must NOT apply — otherwise a newer out-of-band remote edit would (a) never be adopted
+        // locally (no pull) AND (b) block every future local push, stranding both sides forever.
+        await CreateSpace(Space);
+        await CreateMarkdown(Doc, "Doc", "v0");
+        await AddConfiguredSource(Space, "partner", InstanceSyncDirection.PushOnly);
+        await WaitForConfig(Space, "partner", c => c.InitialSyncAt is not null);
+        await WaitForRemote(r => MarkdownBody(r.Node(Doc)) == "v0");
+
+        // Remote gets a STRICTLY-NEWER edit out of band (+5 min).
+        Remote.Seed(Remote.Node(Doc)! with { Content = new MarkdownContent { Content = "remote_newer" } },
+            DateTimeOffset.UtcNow.AddMinutes(5));
+
+        // The local edit is OLDER than the remote's — under the bidi guard the push would skip, but a
+        // PushOnly source must still overwrite the remote (local wins) and never adopt the remote edit.
+        await EditLocal(Doc, "local_wins");
+        await WaitForRemote(r => MarkdownBody(r.Node(Doc)) == "local_wins");
+        var local = await Mesh.GetWorkspace().GetMeshNodeStream(Doc).Take(1).ToTask();
+        Assert.Equal("local_wins", MarkdownBody(local));   // no pull: the newer remote was never adopted
+    }
 }


### PR DESCRIPTION
### The fix — a real convergence bug
Instance sync resolved conflicts by `LastModified` (newest-writer-wins) on the **pull** side, but the **push** side upserted **unconditionally** — so an older local push clobbered a newer remote node, and since the pull only applies a strictly-newer remote, the newer edit was **lost** (LWW violated, no self-heal). `PushNode` now **skips when the remote is strictly newer** (the pull brings it local), making resolution symmetric so the two instances **converge** on the newest write.

### Tests (`InstanceSyncConflictTest`, 5 — full suite 23/23 green)
- **Round-trip**: local→remote and remote→local edits both converge.
- **Concurrent same-node edit**: newer wins on **both** sides (remote-newer *and* local-newer — the push no longer clobbers a newer remote).
- **Offline "long flight"**: edits accumulate in the durable manifest while the remote is unreachable → drain and converge on reconnect.
- **Different-field concurrent edit**: whole-node newest-wins (documents the trade-off vs a field-level RFC 7396 merge).

### Docs
`InstanceSync.md` updated: conflict resolution/convergence, offline model, the permission note (sync is an **Editor**-level capability, gated on `Update`), and the new coverage.

Builds clean under `Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)