### PR TITLE
feat(eventlog): app-level event-log outbox (in-memory + Postgres + SQLite)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -38,6 +38,7 @@ using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Markdown.Export.Configuration;
 using MeshWeaver.Hosting.Activity;
 using MeshWeaver.Hosting.AzureBlob;
+using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Blazor;
 using MeshWeaver.Hosting.Persistence;
 using MeshWeaver.Hosting.PostgreSql;
@@ -172,6 +173,9 @@ public static class MemexConfiguration
         // the moment an invited user's account is created) — live via the change feed + reconciled
         // against current state on startup so a trigger during downtime still fires.
         services.AddHostedService<MeshWeaver.Graph.ScheduledActionRunner>();
+        // App-level event-log outbox: durably records every change-feed event (Postgres in prod via
+        // PostgreSqlEventLogStore, else in-memory) + replays not-yet-processed entries on startup.
+        services.AddMeshEventLog();
 
         // Microsoft Teams bot channel (bidirectional). Registered always but INERT unless Teams:Enabled
         // and Bot credentials are set (TeamsClient.IsConfigured gates the endpoint + sender). Activate by

--- a/memex/aspire/Memex.Database.Migration/Migrations/V40_CreateEventLogSchema.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V40_CreateEventLogSchema.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Database.Migration.Migrations;
+
+/// <summary>
+/// Creates the <c>events</c> schema backing the app-level event-log outbox
+/// (<c>PostgreSqlEventLogStore</c>): an append-only <c>events.event_log</c> of every mesh change and a
+/// per-consumer <c>events.action_cursor</c>. This is the durable, replayable event queue the
+/// scheduled-action / event-driven layer consumes.
+///
+/// <para><b>Idempotent</b>: all <c>CREATE … IF NOT EXISTS</c>. The <c>UNIQUE (path, kind, version)</c>
+/// makes <c>Append</c> idempotent (a replayed event is not re-logged), and <c>seq BIGSERIAL</c> is the
+/// monotonic cursor. No trigger on <c>mesh_nodes</c> — the log is written by the app-level writer
+/// subscribing to the change feed, so this migration touches no write path.</para>
+/// </summary>
+public sealed class V40_CreateEventLogSchema : IMigration
+{
+    public int Version => 40;
+    public string Description => "Create events schema (event_log + action_cursor) for the app-level event-log outbox";
+
+    public async Task RunAsync(MigrationContext ctx)
+    {
+        await using var cmd = ctx.DataSource.CreateCommand("""
+            CREATE SCHEMA IF NOT EXISTS events;
+
+            CREATE TABLE IF NOT EXISTS events.event_log (
+                seq         BIGSERIAL PRIMARY KEY,
+                occurred_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                namespace   TEXT NOT NULL DEFAULT '',
+                path        TEXT NOT NULL,
+                node_type   TEXT,
+                kind        TEXT NOT NULL,
+                version     BIGINT NOT NULL DEFAULT 0,
+                payload     JSONB,
+                CONSTRAINT uq_event_log_path_kind_version UNIQUE (path, kind, version)
+            );
+
+            CREATE TABLE IF NOT EXISTS events.action_cursor (
+                consumer_id TEXT PRIMARY KEY,
+                last_seq    BIGINT NOT NULL DEFAULT 0
+            );
+            """);
+        await cmd.ExecuteNonQueryAsync();
+
+        ctx.Logger.LogInformation("v40: created events schema (event_log + action_cursor)");
+    }
+}

--- a/memex/aspire/Memex.Database.Migration/Program.cs
+++ b/memex/aspire/Memex.Database.Migration/Program.cs
@@ -150,6 +150,7 @@ var migrations = new IMigration[]
     new V37_MoveAgentsToAgentNamespaceBySchema(),
     new V38_DropLegacyProviderSchema(),
     new V39_AddSyncBehaviorColumn(),
+    new V40_CreateEventLogSchema(),
 };
 
 var ctx = new MigrationContext(dataSource, connectionString, options, logger, initResult.IsFreshDb);

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlEventLogStore.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlEventLogStore.cs
@@ -12,23 +12,29 @@ namespace MeshWeaver.Hosting.PostgreSql;
 /// Durable Postgres <see cref="IEventLogStore"/> — the app-level outbox persisted in the
 /// <c>events</c> schema (created by the <c>V40</c> migration), so the event log survives restarts and
 /// is queryable/replayable across silos. Append is idempotent by <c>(path, kind, version)</c> via
-/// <c>ON CONFLICT</c>. All I/O runs on the shared I/O pool (never a bare <c>FromAsync</c>).
+/// <c>ON CONFLICT</c>. All I/O runs on the Postgres I/O pools (never a bare <c>FromAsync</c>).
 /// </summary>
 public sealed class PostgreSqlEventLogStore : IEventLogStore
 {
+    private const string PoolAdapter = "eventlog";
     private readonly NpgsqlDataSource _dataSource;
-    private readonly IIoPool _ioPool;
+    // Writes on the cap-1 pg:{adapter} pool (serialises through a single connection, the adapter idiom);
+    // reads on the cap-16 pg-read:{adapter} pool. Both are bounded WELL under Npgsql's pool — unlike the
+    // FileSystem pool (cap 256), which could open enough concurrent commands to exhaust the connection pool.
+    private readonly IIoPool _writePool;
+    private readonly IIoPool _readPool;
     private static readonly JsonSerializerOptions JsonOptions = new();
 
-    /// <summary>Creates the store over the shared data source + I/O pool.</summary>
+    /// <summary>Creates the store over the shared data source + the Postgres read/write I/O pools.</summary>
     public PostgreSqlEventLogStore(NpgsqlDataSource dataSource, IoPoolRegistry? ioPoolRegistry = null)
     {
         _dataSource = dataSource;
-        _ioPool = ioPoolRegistry?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
+        _writePool = ioPoolRegistry?.Get(IoPoolNames.PostgresAdapterPrefix + PoolAdapter) ?? IoPool.Unbounded;
+        _readPool = ioPoolRegistry?.Get(IoPoolNames.PostgresReadAdapterPrefix + PoolAdapter) ?? IoPool.Unbounded;
     }
 
     /// <inheritdoc />
-    public IObservable<long> Append(MeshChangeEvent change) => _ioPool.Invoke(async ct =>
+    public IObservable<long> Append(MeshChangeEvent change) => _writePool.Invoke(async ct =>
     {
         // ON CONFLICT ... DO UPDATE (a no-op touch) so RETURNING always yields the seq — existing on
         // a duplicate, new otherwise — without a second round-trip.
@@ -52,7 +58,7 @@ public sealed class PostgreSqlEventLogStore : IEventLogStore
 
     /// <inheritdoc />
     public IObservable<IReadOnlyList<EventLogEntry>> ReadFrom(long afterSeq, int limit = 500) =>
-        _ioPool.Invoke(async ct =>
+        _readPool.Invoke(async ct =>
         {
             await using var cmd = _dataSource.CreateCommand("""
                 SELECT seq, payload FROM events.event_log
@@ -74,14 +80,14 @@ public sealed class PostgreSqlEventLogStore : IEventLogStore
         });
 
     /// <inheritdoc />
-    public IObservable<long> MaxSeq() => _ioPool.Invoke(async ct =>
+    public IObservable<long> MaxSeq() => _readPool.Invoke(async ct =>
     {
         await using var cmd = _dataSource.CreateCommand("SELECT COALESCE(MAX(seq), 0) FROM events.event_log;");
         return Convert.ToInt64(await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false));
     });
 
     /// <inheritdoc />
-    public IObservable<long> GetCursor(string consumerId) => _ioPool.Invoke(async ct =>
+    public IObservable<long> GetCursor(string consumerId) => _readPool.Invoke(async ct =>
     {
         await using var cmd = _dataSource.CreateCommand(
             "SELECT last_seq FROM events.action_cursor WHERE consumer_id = $1;");
@@ -91,7 +97,7 @@ public sealed class PostgreSqlEventLogStore : IEventLogStore
     });
 
     /// <inheritdoc />
-    public IObservable<Unit> SetCursor(string consumerId, long seq) => _ioPool.Invoke(async ct =>
+    public IObservable<Unit> SetCursor(string consumerId, long seq) => _writePool.Invoke(async ct =>
     {
         await using var cmd = _dataSource.CreateCommand("""
             INSERT INTO events.action_cursor (consumer_id, last_seq) VALUES ($1, $2)

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlEventLogStore.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlEventLogStore.cs
@@ -1,0 +1,105 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace MeshWeaver.Hosting.PostgreSql;
+
+/// <summary>
+/// Durable Postgres <see cref="IEventLogStore"/> — the app-level outbox persisted in the
+/// <c>events</c> schema (created by the <c>V40</c> migration), so the event log survives restarts and
+/// is queryable/replayable across silos. Append is idempotent by <c>(path, kind, version)</c> via
+/// <c>ON CONFLICT</c>. All I/O runs on the shared I/O pool (never a bare <c>FromAsync</c>).
+/// </summary>
+public sealed class PostgreSqlEventLogStore : IEventLogStore
+{
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly IIoPool _ioPool;
+    private static readonly JsonSerializerOptions JsonOptions = new();
+
+    /// <summary>Creates the store over the shared data source + I/O pool.</summary>
+    public PostgreSqlEventLogStore(NpgsqlDataSource dataSource, IoPoolRegistry? ioPoolRegistry = null)
+    {
+        _dataSource = dataSource;
+        _ioPool = ioPoolRegistry?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
+    }
+
+    /// <inheritdoc />
+    public IObservable<long> Append(MeshChangeEvent change) => _ioPool.Invoke(async ct =>
+    {
+        // ON CONFLICT ... DO UPDATE (a no-op touch) so RETURNING always yields the seq — existing on
+        // a duplicate, new otherwise — without a second round-trip.
+        await using var cmd = _dataSource.CreateCommand("""
+            INSERT INTO events.event_log (occurred_at, namespace, path, node_type, kind, version, payload)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (path, kind, version)
+            DO UPDATE SET occurred_at = events.event_log.occurred_at
+            RETURNING seq;
+            """);
+        cmd.Parameters.AddWithValue(change.Timestamp);
+        cmd.Parameters.AddWithValue(change.Namespace ?? "");
+        cmd.Parameters.AddWithValue(change.Path);
+        cmd.Parameters.AddWithValue((object?)change.NodeType ?? DBNull.Value);
+        cmd.Parameters.AddWithValue(change.Kind.ToString());
+        cmd.Parameters.AddWithValue(change.Version);
+        cmd.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Jsonb, Value = JsonSerializer.Serialize(change, JsonOptions) });
+        var seq = await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return Convert.ToInt64(seq);
+    });
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<EventLogEntry>> ReadFrom(long afterSeq, int limit = 500) =>
+        _ioPool.Invoke(async ct =>
+        {
+            await using var cmd = _dataSource.CreateCommand("""
+                SELECT seq, payload FROM events.event_log
+                WHERE seq > $1 ORDER BY seq LIMIT $2;
+                """);
+            cmd.Parameters.AddWithValue(afterSeq);
+            cmd.Parameters.AddWithValue(limit);
+            var list = new List<EventLogEntry>();
+            await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                var seq = reader.GetInt64(0);
+                var json = reader.GetString(1);
+                var evt = JsonSerializer.Deserialize<MeshChangeEvent>(json, JsonOptions);
+                if (evt is not null)
+                    list.Add(new EventLogEntry(seq, evt));
+            }
+            return (IReadOnlyList<EventLogEntry>)list;
+        });
+
+    /// <inheritdoc />
+    public IObservable<long> MaxSeq() => _ioPool.Invoke(async ct =>
+    {
+        await using var cmd = _dataSource.CreateCommand("SELECT COALESCE(MAX(seq), 0) FROM events.event_log;");
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false));
+    });
+
+    /// <inheritdoc />
+    public IObservable<long> GetCursor(string consumerId) => _ioPool.Invoke(async ct =>
+    {
+        await using var cmd = _dataSource.CreateCommand(
+            "SELECT last_seq FROM events.action_cursor WHERE consumer_id = $1;");
+        cmd.Parameters.AddWithValue(consumerId);
+        var v = await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return v is null or DBNull ? 0L : Convert.ToInt64(v);
+    });
+
+    /// <inheritdoc />
+    public IObservable<Unit> SetCursor(string consumerId, long seq) => _ioPool.Invoke(async ct =>
+    {
+        await using var cmd = _dataSource.CreateCommand("""
+            INSERT INTO events.action_cursor (consumer_id, last_seq) VALUES ($1, $2)
+            ON CONFLICT (consumer_id) DO UPDATE SET last_seq = GREATEST(events.action_cursor.last_seq, EXCLUDED.last_seq);
+            """);
+        cmd.Parameters.AddWithValue(consumerId);
+        cmd.Parameters.AddWithValue(seq);
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        return Unit.Default;
+    });
+}

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlExtensions.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlExtensions.cs
@@ -321,6 +321,13 @@ public static class PostgreSqlExtensions
         services.AddSingleton<IPartitionStorageProvider>(sp =>
             sp.GetRequiredService<PostgreSqlPartitionStorageProvider>());
 
+        // Durable event-log store (the events schema) — overrides the in-memory default from
+        // AddMeshEventLog(), so the app-level outbox survives restarts in prod.
+        services.Replace(ServiceDescriptor.Singleton<MeshWeaver.Hosting.IEventLogStore>(sp =>
+            new MeshWeaver.Hosting.PostgreSql.PostgreSqlEventLogStore(
+                sp.GetRequiredService<NpgsqlDataSource>(),
+                sp.GetService<MeshWeaver.Mesh.Threading.IoPoolRegistry>())));
+
         // Cross-schema query provider — UNION fan-out over searchable partitions.
         services.AddSingleton<ICrossSchemaQueryProvider>(sp =>
             new PostgreSqlCrossSchemaQueryProvider(

--- a/src/MeshWeaver.Hosting.Sqlite/SqliteEventLogStore.cs
+++ b/src/MeshWeaver.Hosting.Sqlite/SqliteEventLogStore.cs
@@ -1,0 +1,141 @@
+using System.Reactive;
+using System.Text.Json;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Data.Sqlite;
+
+namespace MeshWeaver.Hosting.Sqlite;
+
+/// <summary>
+/// SQLite <see cref="IEventLogStore"/> — the durable event-log outbox for the embedded / offline
+/// backend (MAUI and other single-file deployments). Mirrors <c>SqliteStorageAdapter</c>: one held
+/// <see cref="SqliteConnection"/>, all access serialised through a lock and run off the hub scheduler
+/// on the <see cref="IIoPool"/> (SQLite leaves are sync-blocking). Append is idempotent by
+/// <c>(path, kind, version)</c> via UPSERT. SQLite has no schemas, so the tables are
+/// <c>event_log</c> / <c>event_cursor</c> (created on construction).
+/// </summary>
+public sealed class SqliteEventLogStore : IEventLogStore, IDisposable
+{
+    private readonly object _lock = new();
+    private readonly SqliteConnection _connection;
+    private readonly IIoPool _ioPool;
+    private static readonly JsonSerializerOptions JsonOptions = new();
+
+    /// <summary>Opens the connection (kept open — an in-memory DB lives only while a connection is)
+    /// and creates the event-log tables.</summary>
+    public SqliteEventLogStore(string connectionString, IIoPool? ioPool = null)
+    {
+        _ioPool = ioPool ?? IoPool.Unbounded;
+        var csb = new SqliteConnectionStringBuilder(connectionString) { Pooling = false };
+        _connection = new SqliteConnection(csb.ConnectionString);
+        _connection.Open();
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS event_log (
+                seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+                occurred_at TEXT NOT NULL,
+                namespace   TEXT NOT NULL DEFAULT '',
+                path        TEXT NOT NULL,
+                node_type   TEXT,
+                kind        TEXT NOT NULL,
+                version     INTEGER NOT NULL DEFAULT 0,
+                payload     TEXT,
+                UNIQUE (path, kind, version)
+            );
+            CREATE TABLE IF NOT EXISTS event_cursor (
+                consumer_id TEXT PRIMARY KEY,
+                last_seq    INTEGER NOT NULL DEFAULT 0
+            );
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    /// <inheritdoc />
+    public IObservable<long> Append(MeshChangeEvent change) => _ioPool.InvokeBlocking(_ =>
+    {
+        lock (_lock)
+        {
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO event_log (occurred_at, namespace, path, node_type, kind, version, payload)
+                VALUES ($occurred, $ns, $path, $nt, $kind, $ver, $payload)
+                ON CONFLICT (path, kind, version) DO UPDATE SET occurred_at = occurred_at
+                RETURNING seq;
+                """;
+            cmd.Parameters.AddWithValue("$occurred", change.Timestamp.ToString("o"));
+            cmd.Parameters.AddWithValue("$ns", change.Namespace ?? "");
+            cmd.Parameters.AddWithValue("$path", change.Path);
+            cmd.Parameters.AddWithValue("$nt", (object?)change.NodeType ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("$kind", change.Kind.ToString());
+            cmd.Parameters.AddWithValue("$ver", change.Version);
+            cmd.Parameters.AddWithValue("$payload", JsonSerializer.Serialize(change, JsonOptions));
+            return Convert.ToInt64(cmd.ExecuteScalar());
+        }
+    });
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<EventLogEntry>> ReadFrom(long afterSeq, int limit = 500) =>
+        _ioPool.InvokeBlocking(_ =>
+        {
+            lock (_lock)
+            {
+                using var cmd = _connection.CreateCommand();
+                cmd.CommandText = "SELECT seq, payload FROM event_log WHERE seq > $after ORDER BY seq LIMIT $limit;";
+                cmd.Parameters.AddWithValue("$after", afterSeq);
+                cmd.Parameters.AddWithValue("$limit", limit);
+                var list = new List<EventLogEntry>();
+                using var reader = cmd.ExecuteReader();
+                while (reader.Read())
+                {
+                    var evt = JsonSerializer.Deserialize<MeshChangeEvent>(reader.GetString(1), JsonOptions);
+                    if (evt is not null)
+                        list.Add(new EventLogEntry(reader.GetInt64(0), evt));
+                }
+                return (IReadOnlyList<EventLogEntry>)list;
+            }
+        });
+
+    /// <inheritdoc />
+    public IObservable<long> MaxSeq() => _ioPool.InvokeBlocking(_ =>
+    {
+        lock (_lock)
+        {
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = "SELECT COALESCE(MAX(seq), 0) FROM event_log;";
+            return Convert.ToInt64(cmd.ExecuteScalar());
+        }
+    });
+
+    /// <inheritdoc />
+    public IObservable<long> GetCursor(string consumerId) => _ioPool.InvokeBlocking(_ =>
+    {
+        lock (_lock)
+        {
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = "SELECT last_seq FROM event_cursor WHERE consumer_id = $id;";
+            cmd.Parameters.AddWithValue("$id", consumerId);
+            var v = cmd.ExecuteScalar();
+            return v is null or DBNull ? 0L : Convert.ToInt64(v);
+        }
+    });
+
+    /// <inheritdoc />
+    public IObservable<Unit> SetCursor(string consumerId, long seq) => _ioPool.InvokeBlocking(_ =>
+    {
+        lock (_lock)
+        {
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO event_cursor (consumer_id, last_seq) VALUES ($id, $seq)
+                ON CONFLICT (consumer_id) DO UPDATE SET last_seq = MAX(event_cursor.last_seq, excluded.last_seq);
+                """;
+            cmd.Parameters.AddWithValue("$id", consumerId);
+            cmd.Parameters.AddWithValue("$seq", seq);
+            cmd.ExecuteNonQuery();
+            return Unit.Default;
+        }
+    });
+
+    /// <inheritdoc />
+    public void Dispose() => _connection.Dispose();
+}

--- a/src/MeshWeaver.Hosting.Sqlite/SqliteExtensions.cs
+++ b/src/MeshWeaver.Hosting.Sqlite/SqliteExtensions.cs
@@ -3,6 +3,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Hosting.Sqlite;
@@ -36,6 +37,11 @@ public static class SqliteExtensions
             sp.GetService<ILogger<SqliteStorageAdapter>>()));
         services.AddSingleton<IPartitionStorageProvider>(sp =>
             new SqlitePartitionStorageProvider(sp.GetRequiredService<SqliteStorageAdapter>()));
+        // Durable event-log store (SQLite) — overrides the in-memory default from AddMeshEventLog(),
+        // so the app-level outbox survives restarts on the embedded / offline (MAUI) backend. Uses
+        // the same DI-provided IIoPool as the storage adapter (SQLite is single-writer + serialised).
+        services.Replace(ServiceDescriptor.Singleton<MeshWeaver.Hosting.IEventLogStore>(sp =>
+            new SqliteEventLogStore(connectionString, sp.GetService<IIoPool>())));
         services.AddPartitionedCoreAndWrapperServices();
         // Vector-ranked search + autocomplete, fanned in alongside the pedestrian provider.
         services.AddSingleton<IMeshQueryProvider>(sp => new SqliteVectorMeshQuery(

--- a/src/MeshWeaver.Hosting/EventLog/EventLog.cs
+++ b/src/MeshWeaver.Hosting/EventLog/EventLog.cs
@@ -72,7 +72,8 @@ public sealed class InMemoryEventLogStore : IEventLogStore
     private readonly object _gate = new();
     private long _seq;
     private ImmutableList<EventLogEntry> _entries = ImmutableList<EventLogEntry>.Empty;
-    private readonly HashSet<(string, MeshChangeKind, long)> _seen = new();
+    // (Path, Kind, Version) → assigned seq: O(1) idempotency dedup (a linear scan of _entries would be O(n) per append).
+    private readonly Dictionary<(string, MeshChangeKind, long), long> _byKey = new();
     private readonly ConcurrentDictionary<string, long> _cursors = new();
 
     /// <inheritdoc />
@@ -81,13 +82,11 @@ public sealed class InMemoryEventLogStore : IEventLogStore
         lock (_gate)
         {
             var key = (change.Path, change.Kind, change.Version);
-            var existing = _entries.FirstOrDefault(e =>
-                e.Event.Path == change.Path && e.Event.Kind == change.Kind && e.Event.Version == change.Version);
-            if (existing is not null)
-                return Observable.Return(existing.Seq);
+            if (_byKey.TryGetValue(key, out var existingSeq))
+                return Observable.Return(existingSeq);
             var seq = ++_seq;
             _entries = _entries.Add(new EventLogEntry(seq, change));
-            _seen.Add(key);
+            _byKey[key] = seq;
             return Observable.Return(seq);
         }
     });
@@ -163,29 +162,39 @@ public sealed class EventLogReplayService(
     /// <summary>The consumer id whose cursor this replay advances (the scheduled-action runner).</summary>
     public const string RunnerConsumerId = "scheduled-actions";
 
+    /// <summary>Page size for the replay drain — must match <see cref="IEventLogStore.ReadFrom"/>'s cap.</summary>
+    private const int PageSize = 500;
+
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        // Replay durably-logged-but-unprocessed events into the feed, then checkpoint the cursor.
+        // Replay durably-logged-but-unprocessed events into the feed, checkpointing after each page and
+        // draining ALL pages (a single ReadFrom is capped at PageSize — a backlog larger than that would
+        // otherwise never fully replay). SetCursor faults propagate to the outer error sink, not swallowed.
         store.GetCursor(RunnerConsumerId)
-            .SelectMany(cursor => store.ReadFrom(cursor).Select(entries => (cursor, entries)))
-            .Subscribe(
-                x =>
-                {
-                    foreach (var entry in x.entries)
-                        changeFeed.Publish(entry.Event);
-                    if (x.entries.Count > 0)
-                    {
-                        var max = x.entries[^1].Seq;
-                        store.SetCursor(RunnerConsumerId, max).Subscribe(_ => { }, _ => { });
-                        logger?.LogInformation(
-                            "Replayed {Count} event-log entries (seq {From}→{To}) into the change feed",
-                            x.entries.Count, x.cursor, max);
-                    }
-                },
-                ex => logger?.LogWarning(ex, "Event-log replay failed"));
+            .SelectMany(ReplayFrom)
+            .Subscribe(_ => { }, ex => logger?.LogWarning(ex, "Event-log replay failed"));
         return Task.CompletedTask;
     }
+
+    /// <summary>Reads one page after <paramref name="cursor"/>, publishes it, advances the cursor, and — if
+    /// the page was full — recurses to drain the next page. A short page (or empty) ends the drain.</summary>
+    private IObservable<Unit> ReplayFrom(long cursor) =>
+        store.ReadFrom(cursor, PageSize).SelectMany(entries =>
+        {
+            if (entries.Count == 0)
+                return Observable.Return(Unit.Default);
+            foreach (var entry in entries)
+                changeFeed.Publish(entry.Event);
+            var max = entries[^1].Seq;
+            return store.SetCursor(RunnerConsumerId, max)
+                .Do(_ => logger?.LogInformation(
+                    "Replayed {Count} event-log entries (seq {From}→{To}) into the change feed",
+                    entries.Count, cursor, max))
+                .SelectMany(_ => entries.Count < PageSize
+                    ? Observable.Return(Unit.Default)   // short page → backlog drained
+                    : ReplayFrom(max));                 // full page → more may remain
+        });
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/MeshWeaver.Hosting/EventLog/EventLog.cs
+++ b/src/MeshWeaver.Hosting/EventLog/EventLog.cs
@@ -1,0 +1,192 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>Registration for the app-level event-log outbox.</summary>
+public static class EventLogExtensions
+{
+    /// <summary>
+    /// Registers the event-log writer + startup replay and the default in-memory
+    /// <see cref="IEventLogStore"/>. A backend (e.g. Postgres) can override the store with
+    /// <c>services.Replace(...)</c> for durability across restarts.
+    /// </summary>
+    public static IServiceCollection AddMeshEventLog(this IServiceCollection services)
+    {
+        services.TryAddSingleton<IEventLogStore, InMemoryEventLogStore>();
+        services.AddHostedService<EventLogWriter>();
+        services.AddHostedService<EventLogReplayService>();
+        return services;
+    }
+}
+
+/// <summary>
+/// A durable, append-only log of <see cref="MeshChangeEvent"/>s plus a per-consumer cursor — the
+/// app-level outbox for the scheduled-action / general event-driven layer. The
+/// <see cref="EventLogWriter"/> appends every change; the <see cref="EventLogReplayService"/> replays
+/// entries newer than a consumer's cursor into the change feed on startup, so an event a consumer has
+/// not yet processed (e.g. it lives in another silo, or restarted) still reaches it. Append is
+/// idempotent by <c>(Path, Kind, Version)</c>, so a replayed event is not re-logged (no feedback loop).
+///
+/// <para>Best-effort, NOT a transactional outbox: an event published while the writer itself is down
+/// is never logged. For the invite use case that gap is covered by <c>ScheduledActionRunner</c>'s
+/// startup reconciliation against current state — the durable log adds cross-process delivery + a
+/// queryable audit trail on top.</para>
+/// </summary>
+public interface IEventLogStore
+{
+    /// <summary>Appends an event, returning its sequence number. Idempotent by (Path, Kind, Version):
+    /// a duplicate returns the existing seq and does not add a row.</summary>
+    IObservable<long> Append(MeshChangeEvent change);
+
+    /// <summary>Reads events with <c>seq &gt; <paramref name="afterSeq"/></c> in seq order (up to <paramref name="limit"/>).</summary>
+    IObservable<IReadOnlyList<EventLogEntry>> ReadFrom(long afterSeq, int limit = 500);
+
+    /// <summary>The highest assigned sequence number (0 when empty).</summary>
+    IObservable<long> MaxSeq();
+
+    /// <summary>The last-processed seq for <paramref name="consumerId"/> (0 if none recorded).</summary>
+    IObservable<long> GetCursor(string consumerId);
+
+    /// <summary>Advances <paramref name="consumerId"/>'s cursor to <paramref name="seq"/>.</summary>
+    IObservable<Unit> SetCursor(string consumerId, long seq);
+}
+
+/// <summary>One logged event with its assigned sequence number.</summary>
+public sealed record EventLogEntry(long Seq, MeshChangeEvent Event);
+
+/// <summary>
+/// In-memory <see cref="IEventLogStore"/> — the default (monolith / tests) and the base the Orleans
+/// or PG store composes over. Instance state on a mesh-scoped singleton (never static), so it dies
+/// with the mesh.
+/// </summary>
+public sealed class InMemoryEventLogStore : IEventLogStore
+{
+    private readonly object _gate = new();
+    private long _seq;
+    private ImmutableList<EventLogEntry> _entries = ImmutableList<EventLogEntry>.Empty;
+    private readonly HashSet<(string, MeshChangeKind, long)> _seen = new();
+    private readonly ConcurrentDictionary<string, long> _cursors = new();
+
+    /// <inheritdoc />
+    public IObservable<long> Append(MeshChangeEvent change) => Observable.Defer(() =>
+    {
+        lock (_gate)
+        {
+            var key = (change.Path, change.Kind, change.Version);
+            var existing = _entries.FirstOrDefault(e =>
+                e.Event.Path == change.Path && e.Event.Kind == change.Kind && e.Event.Version == change.Version);
+            if (existing is not null)
+                return Observable.Return(existing.Seq);
+            var seq = ++_seq;
+            _entries = _entries.Add(new EventLogEntry(seq, change));
+            _seen.Add(key);
+            return Observable.Return(seq);
+        }
+    });
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<EventLogEntry>> ReadFrom(long afterSeq, int limit = 500) => Observable.Defer(() =>
+    {
+        lock (_gate)
+            return Observable.Return((IReadOnlyList<EventLogEntry>)_entries
+                .Where(e => e.Seq > afterSeq).OrderBy(e => e.Seq).Take(limit).ToList());
+    });
+
+    /// <inheritdoc />
+    public IObservable<long> MaxSeq() => Observable.Defer(() =>
+    {
+        lock (_gate) return Observable.Return(_seq);
+    });
+
+    /// <inheritdoc />
+    public IObservable<long> GetCursor(string consumerId) =>
+        Observable.Return(_cursors.GetValueOrDefault(consumerId, 0L));
+
+    /// <inheritdoc />
+    public IObservable<Unit> SetCursor(string consumerId, long seq)
+    {
+        _cursors.AddOrUpdate(consumerId, seq, (_, cur) => Math.Max(cur, seq));
+        return Observable.Return(Unit.Default);
+    }
+}
+
+/// <summary>
+/// Hosted service that durably records every change-feed event into the <see cref="IEventLogStore"/>.
+/// Subscribe-based (best-effort): the durable-outbox limitation is documented on <see cref="IEventLogStore"/>.
+/// </summary>
+public sealed class EventLogWriter(
+    IMeshChangeFeed changeFeed,
+    IEventLogStore store,
+    ILogger<EventLogWriter>? logger = null) : IHostedService, IDisposable
+{
+    private IDisposable? _subscription;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _subscription = changeFeed.Subscribe(change =>
+            store.Append(change).Subscribe(
+                _ => { },
+                ex => logger?.LogWarning(ex, "Event-log append failed for {Path}", change.Path)));
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _subscription?.Dispose();
+}
+
+/// <summary>
+/// Hosted service that, on startup, replays log entries a consumer has not yet processed (seq &gt; its
+/// cursor) into the change feed, then advances the cursor — so a consumer that missed events (another
+/// silo, a restart) sees them. Append idempotency means the replayed events are not re-logged.
+/// </summary>
+public sealed class EventLogReplayService(
+    IMeshChangeFeed changeFeed,
+    IEventLogStore store,
+    ILogger<EventLogReplayService>? logger = null) : IHostedService
+{
+    /// <summary>The consumer id whose cursor this replay advances (the scheduled-action runner).</summary>
+    public const string RunnerConsumerId = "scheduled-actions";
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Replay durably-logged-but-unprocessed events into the feed, then checkpoint the cursor.
+        store.GetCursor(RunnerConsumerId)
+            .SelectMany(cursor => store.ReadFrom(cursor).Select(entries => (cursor, entries)))
+            .Subscribe(
+                x =>
+                {
+                    foreach (var entry in x.entries)
+                        changeFeed.Publish(entry.Event);
+                    if (x.entries.Count > 0)
+                    {
+                        var max = x.entries[^1].Seq;
+                        store.SetCursor(RunnerConsumerId, max).Subscribe(_ => { }, _ => { });
+                        logger?.LogInformation(
+                            "Replayed {Count} event-log entries (seq {From}→{To}) into the change feed",
+                            x.entries.Count, x.cursor, max);
+                    }
+                },
+                ex => logger?.LogWarning(ex, "Event-log replay failed"));
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/test/MeshWeaver.Hosting.Sqlite.Test/SqliteEventLogStoreTest.cs
+++ b/test/MeshWeaver.Hosting.Sqlite.Test/SqliteEventLogStoreTest.cs
@@ -1,0 +1,64 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Hosting.Sqlite;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Sqlite.Test;
+
+/// <summary>
+/// Verifies the SQLite <see cref="IEventLogStore"/> (durable outbox for the embedded / MAUI backend)
+/// against a real in-memory SQLite DB — Append + idempotent dedup, ReadFrom by seq, MaxSeq, and the
+/// cursor. This also exercises the SQL-store contract shared with the Postgres implementation.
+/// </summary>
+public class SqliteEventLogStoreTest
+{
+    private static MeshChangeEvent Created(string id, long version = 1) =>
+        new(Namespace: "ns", Id: id, Path: id, Kind: MeshChangeKind.Created,
+            NodeType: "X", Version: version, Timestamp: DateTimeOffset.UtcNow);
+
+    private static SqliteEventLogStore NewStore() => new("Data Source=:memory:");
+
+    [Fact]
+    public async Task Append_is_idempotent_by_path_kind_version()
+    {
+        using var store = NewStore();
+        var seq1 = await store.Append(Created("A")).ToTask();
+        var seq2 = await store.Append(Created("B")).ToTask();
+        Assert.True(seq2 > seq1);
+
+        // Same (path, kind, version) → same seq, NO new row. (Assert row count, not MaxSeq: like
+        // Postgres BIGSERIAL, SQLite AUTOINCREMENT advances the counter even when ON CONFLICT turns
+        // the insert into an update, so seq can gap — harmless, seqs stay monotonic + unique.)
+        var seq1Again = await store.Append(Created("A")).ToTask();
+        Assert.Equal(seq1, seq1Again);
+        Assert.Equal(2, (await store.ReadFrom(0).ToTask()).Count);
+
+        // A new version of the same path IS a distinct event → a new row.
+        await store.Append(Created("A", version: 2)).ToTask();
+        Assert.Equal(3, (await store.ReadFrom(0).ToTask()).Count);
+    }
+
+    [Fact]
+    public async Task ReadFrom_and_cursor_roundtrip()
+    {
+        using var store = NewStore();
+        await store.Append(Created("A")).ToTask();
+        await store.Append(Created("B")).ToTask();
+        await store.Append(Created("C")).ToTask();
+
+        var all = await store.ReadFrom(0).ToTask();
+        Assert.Equal(new[] { "A", "B", "C" }, all.Select(e => e.Event.Path));
+
+        var afterFirst = await store.ReadFrom(all[0].Seq).ToTask();
+        Assert.Equal(new[] { "B", "C" }, afterFirst.Select(e => e.Event.Path));
+
+        // Cursor: default 0, then persisted (idempotent max).
+        Assert.Equal(0, await store.GetCursor("runner").ToTask());
+        await store.SetCursor("runner", 2).ToTask();
+        Assert.Equal(2, await store.GetCursor("runner").ToTask());
+        await store.SetCursor("runner", 1).ToTask();   // never regresses
+        Assert.Equal(2, await store.GetCursor("runner").ToTask());
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/EventLogTest.cs
+++ b/test/MeshWeaver.Hosting.Test/EventLogTest.cs
@@ -62,4 +62,25 @@ public class EventLogTest
         await new EventLogReplayService(feed, store).StartAsync(default);
         Assert.Empty(received);
     }
+
+    [Fact]
+    public async Task Replay_drains_all_pages_when_backlog_exceeds_one_page()
+    {
+        var feed = new InProcessMeshChangeFeed();
+        var store = new InMemoryEventLogStore();
+
+        // A backlog LARGER than the replay page size (500): a single ReadFrom page would leave the
+        // remainder unreplayed forever. The drain must paginate until the whole backlog is delivered.
+        const int count = 1201;
+        for (var i = 0; i < count; i++)
+            await store.Append(Created($"N{i}")).ToTask();
+
+        var received = new List<string>();
+        using var sub = feed.Subscribe(c => received.Add(c.Path));
+
+        await new EventLogReplayService(feed, store).StartAsync(default);
+
+        Assert.Equal(count, received.Count);   // every page drained, not just the first 500
+        Assert.Equal(count, await store.GetCursor(EventLogReplayService.RunnerConsumerId).FirstAsync().ToTask());
+    }
 }

--- a/test/MeshWeaver.Hosting.Test/EventLogTest.cs
+++ b/test/MeshWeaver.Hosting.Test/EventLogTest.cs
@@ -1,0 +1,65 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Hosting;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Unit tests for the app-level event-log outbox (in-memory store): the writer persists every
+/// change-feed event (idempotent by Path/Kind/Version), and the replay service redelivers
+/// not-yet-processed entries into the feed and advances the cursor.
+/// </summary>
+public class EventLogTest
+{
+    private static MeshChangeEvent Created(string id) =>
+        MeshChangeEvent.Created(new MeshNode(id) { NodeType = "X" });
+
+    [Fact]
+    public async Task Writer_persists_and_dedups()
+    {
+        var feed = new InProcessMeshChangeFeed();
+        var store = new InMemoryEventLogStore();
+        var writer = new EventLogWriter(feed, store);
+        await writer.StartAsync(default);
+
+        var a = Created("A");
+        feed.Publish(a);
+        feed.Publish(Created("B"));
+        Assert.Equal(2, (await store.ReadFrom(0).FirstAsync().ToTask()).Count);
+
+        // Re-publishing the SAME event (same Path/Kind/Version) does not add a row.
+        feed.Publish(a);
+        Assert.Equal(2, (await store.ReadFrom(0).FirstAsync().ToTask()).Count);
+        Assert.Equal(2, await store.MaxSeq().FirstAsync().ToTask());
+    }
+
+    [Fact]
+    public async Task Replay_redelivers_unprocessed_and_advances_cursor()
+    {
+        var feed = new InProcessMeshChangeFeed();
+        var store = new InMemoryEventLogStore();
+
+        // Two events already durably logged (as if written before this consumer existed).
+        await store.Append(Created("A")).ToTask();
+        await store.Append(Created("B")).ToTask();
+
+        // A fresh subscriber (stands in for the runner) attached AFTER those were logged.
+        var received = new List<string>();
+        using var sub = feed.Subscribe(c => received.Add(c.Path));
+
+        var replay = new EventLogReplayService(feed, store);
+        await replay.StartAsync(default);   // synchronous store ops → publishes on start
+
+        Assert.Contains("A", received);
+        Assert.Contains("B", received);
+        Assert.Equal(2, await store.GetCursor(EventLogReplayService.RunnerConsumerId).FirstAsync().ToTask());
+
+        // A second replay (e.g. another restart) with the cursor already at 2 redelivers nothing.
+        received.Clear();
+        await new EventLogReplayService(feed, store).StartAsync(default);
+        Assert.Empty(received);
+    }
+}


### PR DESCRIPTION
The durable, replayable event queue the scheduled-action / event-driven layer consumes — the **safer app-level outbox** (no per-write DB trigger; the runner's reconciliation covers the small best-effort gap).

### What's here
- **`IEventLogStore`** + writer + startup replay (`MeshWeaver.Hosting`): append-only log (idempotent by Path/Kind/Version) + a per-consumer cursor. `EventLogWriter` records every change-feed event; `EventLogReplayService` replays not-yet-processed entries into the feed on startup + advances the cursor.
- **Three backends**: `InMemoryEventLogStore` (default), **`PostgreSqlEventLogStore`** (`events` schema, V40 migration), **`SqliteEventLogStore`** (embedded / MAUI / offline). All bound their I/O through `IIoPool`; SQLite uses one held connection + a lock (its correct single-writer pattern), Postgres via `NpgsqlDataSource`.
- **V40 migration** creates the `events` schema (`event_log` + `action_cursor`). No trigger on `mesh_nodes` → touches no write path.
- **Wiring**: `AddMeshEventLog()` (portal) + the PG/SQLite backends `Replace` the in-memory store.

### Tests
- In-memory (`EventLogTest`) + SQLite (`SqliteEventLogStoreTest`) — writer persist+dedup, replay+cursor, ReadFrom — **green locally**. The Postgres store is exercised on CI.

Builds clean under `Release -warnaserror`.

### Follow-ups (per the plan)
The true **transactional-outbox** (per-write DB trigger, exact Update/Delete replay) and **Orleans time-based reminders** are deliberate next steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)