### PR TITLE
feat(mcp): Space instance-sync MCP tool

### DIFF
--- a/src/MeshWeaver.Blazor.AI/McpMeshPlugin.cs
+++ b/src/MeshWeaver.Blazor.AI/McpMeshPlugin.cs
@@ -6,6 +6,8 @@ using System.Text.Json;
 using MeshWeaver.AI;
 using MeshWeaver.AI.Plugins;
 using MeshWeaver.Data.Completion;
+using MeshWeaver.InstanceSync;
+using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Services.LanguageServer;
 using MeshWeaver.Messaging;
@@ -367,6 +369,42 @@ Recommended: 'icon' as an inline SVG starting with <svg, using currentColor. 'co
         [Description("Current path of the node (e.g., @OrgA/Child)")] string sourcePath,
         [Description("New path for the node (e.g., @OrgB/Child)")] string targetPath)
         => ops.Move(sourcePath, targetPath).FirstAsync().ToTask();
+
+    /// <summary>
+    /// Sets up bi-directional instance sync of a Space with a remote MeshWeaver instance by writing
+    /// the <c>{space}/_Sync/{id}</c> registration — through the caller's session hub, so it is
+    /// permission-checked (writing under <c>_Sync</c> requires Editor/Update on the Space).
+    /// </summary>
+    [McpServerTool(Title = "Sync a Space with a remote instance", Destructive = false, Idempotent = true, OpenWorld = true)]
+    [Description(@"Configures instance sync for a Space: replicate it to another MeshWeaver instance and keep changes flowing both ways. Replication starts automatically; conflicts resolve newest-writer-wins and converge on both sides. The registration is written under {space}/_Sync, so it runs under YOUR identity and requires Editor (Update) on the Space.")]
+    public Task<string> Sync(
+        [Description("The Space path to sync (e.g. 'ACME').")] string space,
+        [Description("The remote MeshWeaver instance URL (e.g. https://memex.meshweaver.cloud).")] string remoteUrl,
+        [Description("An API token (mw_…) issued by the remote instance.")] string remoteToken,
+        [Description("Sync direction: 'Bidirectional' (default), 'PushOnly', or 'PullOnly'.")] string direction = "Bidirectional",
+        [Description("A name for this sync party (default 'partner').")] string name = "partner",
+        [Description("The Space id on the remote (blank = same id as this Space).")] string? remoteSpace = null)
+    {
+        var dir = Enum.TryParse<InstanceSyncDirection>(direction, ignoreCase: true, out var d)
+            ? d : InstanceSyncDirection.Bidirectional;
+        var id = new string((name ?? "partner").Trim().ToLowerInvariant()
+            .Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray()).Trim('-');
+        if (id.Length == 0) id = "partner";
+        var node = new MeshNode(id, $"{space}/{InstanceSyncService.ConfigId}")
+        {
+            NodeType = InstanceSyncService.ConfigNodeType,
+            Name = name,
+            Content = new InstanceSyncConfig
+            {
+                RemoteUrl = remoteUrl,
+                RemoteToken = remoteToken,
+                RemoteSpace = string.IsNullOrWhiteSpace(remoteSpace) ? null : remoteSpace,
+                Direction = dir,
+                Active = true,
+            },
+        };
+        return ops.Create(JsonSerializer.Serialize(node, rootHub.JsonSerializerOptions)).FirstAsync().ToTask();
+    }
 
     /// <summary>
     /// Copies a node and all its descendants to a target namespace, preserving

--- a/src/MeshWeaver.Blazor.AI/McpMeshPlugin.cs
+++ b/src/MeshWeaver.Blazor.AI/McpMeshPlugin.cs
@@ -375,20 +375,29 @@ Recommended: 'icon' as an inline SVG starting with <svg, using currentColor. 'co
     /// the <c>{space}/_Sync/{id}</c> registration — through the caller's session hub, so it is
     /// permission-checked (writing under <c>_Sync</c> requires Editor/Update on the Space).
     /// </summary>
-    [McpServerTool(Title = "Sync a Space with a remote instance", Destructive = false, Idempotent = true, OpenWorld = true)]
+    // NOT Idempotent: ops.Create errors if the {space}/_Sync/{id} registration already exists, so a
+    // retry fails rather than being a safe no-op (reconfigure via the GUI or delete-then-recreate).
+    [McpServerTool(Title = "Sync a Space with a remote instance", Destructive = false, Idempotent = false, OpenWorld = true)]
     [Description(@"Configures instance sync for a Space: replicate it to another MeshWeaver instance and keep changes flowing both ways. Replication starts automatically; conflicts resolve newest-writer-wins and converge on both sides. The registration is written under {space}/_Sync, so it runs under YOUR identity and requires Editor (Update) on the Space.")]
     public Task<string> Sync(
-        [Description("The Space path to sync (e.g. 'ACME').")] string space,
+        [Description("The top-level Space id to sync (e.g. 'ACME') — a single segment, NOT a nested path.")] string space,
         [Description("The remote MeshWeaver instance URL (e.g. https://memex.meshweaver.cloud).")] string remoteUrl,
         [Description("An API token (mw_…) issued by the remote instance.")] string remoteToken,
         [Description("Sync direction: 'Bidirectional' (default), 'PushOnly', or 'PullOnly'.")] string direction = "Bidirectional",
         [Description("A name for this sync party (default 'partner').")] string name = "partner",
         [Description("The Space id on the remote (blank = same id as this Space).")] string? remoteSpace = null)
     {
+        // Instance sync only recognises a registration at {space}/_Sync/{id} where {space} is a single
+        // top-level segment (the coordinator ignores any other shape) — reject a nested path up front
+        // instead of silently writing a registration that never activates.
+        space = space?.Trim().Trim('/') ?? "";
+        if (space.Length == 0 || space.Contains('/'))
+            return Task.FromResult($"Error: 'space' must be a single top-level Space id (no '/'); got '{space}'.");
         var dir = Enum.TryParse<InstanceSyncDirection>(direction, ignoreCase: true, out var d)
             ? d : InstanceSyncDirection.Bidirectional;
-        var id = new string((name ?? "partner").Trim().ToLowerInvariant()
-            .Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray()).Trim('-');
+        // Use the SAME (case-preserving) sanitizer the GUI uses, so a given name maps to ONE id — a
+        // lower-cased copy here would create a duplicate registration differing only by casing.
+        var id = InstanceSyncService.SanitizeSourceId(name ?? "partner");
         if (id.Length == 0) id = "partner";
         var node = new MeshNode(id, $"{space}/{InstanceSyncService.ConfigId}")
         {

--- a/src/MeshWeaver.Blazor.AI/MeshWeaver.Blazor.AI.csproj
+++ b/src/MeshWeaver.Blazor.AI/MeshWeaver.Blazor.AI.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\MeshWeaver.ContentCollections\MeshWeaver.ContentCollections.csproj" />
     <ProjectReference Include="..\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
+    <ProjectReference Include="..\MeshWeaver.InstanceSync\MeshWeaver.InstanceSync.csproj" />
     <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
     <ProjectReference Include="..\MeshWeaver.Messaging.Hub\MeshWeaver.Messaging.Hub.csproj" />
   </ItemGroup>

--- a/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncService.cs
@@ -137,8 +137,10 @@ public sealed class InstanceSyncService(
     public IObservable<bool> RemoveSyncSource(string spacePath, string sourceId) =>
         meshService.DeleteNode(ConfigPath(spacePath, sourceId));
 
-    /// <summary>Sanitizes a display name into a node id: letters/digits/dash/underscore only.</summary>
-    private static string SanitizeSourceId(string name) =>
+    /// <summary>Sanitizes a display name into a node id: letters/digits only, others → dash, trimmed.
+    /// Case-preserving — every writer (GUI, MCP) must go through this so the same name yields the same
+    /// id (a lower-cased copy would create a duplicate registration differing only by casing).</summary>
+    public static string SanitizeSourceId(string name) =>
         new string(name.Trim()
             .Select(c => char.IsLetterOrDigit(c) ? c : '-')
             .ToArray()).Trim('-');


### PR DESCRIPTION
## What

Adds a **`Sync`** tool to the `meshweaver` MCP server (`McpMeshPlugin`) that configures **instance sync** for a Space from an agent/assistant: it registers a `{space}/_Sync/{id}` `InstanceSyncConfig` node (remote URL, remote token, direction, remote-space id), which starts bi-directional replication with a remote MeshWeaver instance — the same registration the GUI's **Synchronizations** node-menu item writes.

## Why it's safe

The write goes through the caller's **session hub** (`ops.Create(...)`), so it runs under the **caller's identity** and is **permission-checked**: writing under `{space}/_Sync` requires **Editor (Update)** on the Space. Viewers/commenters can't configure sync. No new mutation surface — just the existing `Create` path with a typed `InstanceSyncConfig` payload.

## Notes

- `InstanceSyncConfig` / `InstanceSyncDirection` from `MeshWeaver.InstanceSync` (added a project reference to `MeshWeaver.Blazor.AI`).
- Direction parses case-insensitively; defaults to `Bidirectional`.
- Conflict resolution (newest-writer-wins, symmetric → converge) is covered by the sync service tests (#272).

🤖 Generated with [Claude Code](https://claude.com/claude-code)