### PR TITLE
feat(graph): Deck node type — external slide order + auto hidable side-nav + Present

### DIFF
--- a/src/MeshWeaver.AI/Data/Skill/slide.md
+++ b/src/MeshWeaver.AI/Data/Skill/slide.md
@@ -1,0 +1,116 @@
+---
+nodeType: Skill
+name: /slide
+description: Author classroom slides and decks — a Slide is one pure-content page (one big picture, teaching prose in notes); a Deck orders slides EXTERNALLY in its manifest and auto-renders a hidable side-nav + Present.
+icon: Presentation
+category: Skills
+order: 16
+---
+
+A **Slide** is one page of a presentation. A **Deck** is the ordered set of slides — and the deck owns the order, declared EXTERNALLY in the deck node, not on each slide. Both ship from the platform (`AddGraph()`), so you author them as data: create nodes, set content, list the order. You never write a layout area for a deck — the Slide and Deck views already render the stage, the presenter bar, the hidable side-nav, and Present.
+
+Before authoring, skim [Slides & Decks](/Doc/GUI/SlidesAndDecks).
+
+# 1. The Slide node — pure content, classroom style
+
+A Slide's `Content` is a `SlideContent` record:
+
+- **`Content`** — the slide body as **markdown**. Raw HTML and SVG pass through the markdown pipeline unchanged, so a slide can be anything from a bullet list to a full-bleed illustration.
+- **`Notes`** — speaker notes (markdown), shown only in the Notes view. This is where the *teaching* lives.
+- **`Background`** — optional CSS background for the stage (e.g. `linear-gradient(135deg, #667eea 0%, #764ba2 100%)`). Null → the theme-aware default gradient.
+
+**Classroom style — the rule that makes a deck teach, not overwhelm:**
+
+- **Little text on the stage.** One idea per slide. A title and at most a few short lines.
+- **ONE big picture per slide.** Prefer a single inline **SVG** illustration that fills the stage — a diagram, a metaphor, a shape — over a wall of bullets. The stage is 16:9; let the picture own it.
+- **Put the prose in `Notes`.** The explanation, the worked example, the "why" — that is speaker-notes material, not stage material. The stage is the hook; the notes are the lesson.
+- **Responsive type.** Size text with `clamp()` so it scales with the stage: `font-size: clamp(18px, 3vw, 42px)`. Never hard-code a pixel size that only looks right at one width.
+
+A slide carries **no order of its own** — ordering is the deck's job (below). The slide is just content.
+
+```csharp
+new MeshNode("intro", "MyCourse/widgets")
+{
+    NodeType = "Slide",
+    Name = "What is a widget?",
+    Content = new SlideContent
+    {
+        Content = """
+            # What is a widget?
+
+            <svg viewBox="0 0 400 220" style="width:100%;height:auto">
+              <circle cx="200" cy="110" r="80" fill="#4f6bed"/>
+              <text x="200" y="118" text-anchor="middle" fill="white"
+                    style="font: 600 clamp(18px,3vw,42px) sans-serif">widget</text>
+            </svg>
+            """,
+        Notes = "A widget is the smallest unit of work. Draw the analogy to a Lego "
+              + "brick: self-contained, composable, and useless in isolation. Ask the "
+              + "class for three things in their world that behave like widgets."
+    }
+}
+```
+
+# 2. The Deck node — order is EXTERNAL
+
+A **Deck** (`NodeType = "Deck"`) is a node whose `Content` is a `DeckContent` record:
+
+- **`Title`** — optional display title for the welcome stage (falls back to the node name).
+- **`Description`** — optional markdown intro shown on the deck's welcome stage.
+- **`Slides`** — the **ordered list** of child references. **This IS the deck's order.** Each entry is a child id (relative — `"intro"`) or a full path. Reorder the deck by editing this one list; the slides never change.
+
+Why external order matters: the sequence lives in ONE place. Inserting a slide, dropping one, or re-sequencing the whole deck is a single edit to `Slides` — you never sweep an `Order` field across every slide, and two slides can't fight over the same position.
+
+The Deck's views are automatic:
+
+- **Overview** (default) → a splitter with a **hidable (collapsible) left side-nav** listing the slides in manifest order (each labeled by its slide's name), and a right welcome stage with the intro and a **▶ Present** button that opens the first slide chrome-free.
+- **Present** → redirects straight into the first slide's Present view, starting the walk.
+
+# 3. Present & click-to-advance
+
+Presenting is standard navigation, no bespoke messaging:
+
+- The **stage** is click-to-advance: clicking a slide navigates to the next slide (in the same mode — staying in Present when presenting). It uses a `RedirectControl` / href, the framework's normal navigation.
+- **Content** view = stage + a slim presenter bar (◀ Prev · "Slide n / N" · Deck · Present · Next ▶).
+- **Present** view = the chrome-free stage with only a corner counter — open it full-screen to present.
+- **Prev/Next/index/count** come from the deck's manifest when the slide's parent is a Deck; otherwise they fall back to sibling `MeshNode.Order`. Either way the slide stays pure content.
+
+# 4. Course usage — a Deck can sequence module pages too
+
+The manifest isn't limited to slides. A Deck can order **any** child pages — Markdown module pages of a course, for instance — giving the course a side-nav and a linear sequence from a single node, without touching each page. List the module page ids in the deck's `Slides`, in teaching order, and the deck's side-nav becomes the course TOC + walk-through. (Prev/Next click-to-advance is a Slide-view feature; module pages get the side-nav + ordered sequence.)
+
+# 5. Worked shape — a deck + its slides
+
+Create the deck, then the slides as its children, then list the order in the deck. Order is set ONCE, in the deck:
+
+```csharp
+// 1. The deck — the manifest is the order (external to the slides).
+new MeshNode("widgets", "MyCourse")
+{
+    NodeType = "Deck",
+    Name = "Intro to Widgets",
+    Content = new DeckContent
+    {
+        Title = "Intro to Widgets",
+        Description = "A five-minute tour. Press **Present** to begin.",
+        Slides = ["intro", "anatomy", "composing", "recap"]   // ← THIS is the order
+    }
+}
+
+// 2. The slides — pure content, no order of their own, created in any sequence.
+new MeshNode("anatomy", "MyCourse/widgets") { NodeType = "Slide", Name = "Anatomy", Content = new SlideContent { /* one big SVG + notes */ } };
+new MeshNode("intro",     "MyCourse/widgets") { NodeType = "Slide", Name = "What is a widget?", Content = new SlideContent { /* ... */ } };
+// … "composing", "recap" likewise.
+```
+
+Reorder later by editing only the deck:
+
+```csharp
+workspace.GetMeshNodeStream("MyCourse/widgets")
+    .Update(node => node with { Content = ((DeckContent)node.Content) with { Slides = ["intro", "composing", "anatomy", "recap"] } })
+    .Subscribe(_ => { }, ex => logger.LogWarning(ex, "reorder failed"));
+```
+
+# The litmus test
+
+If you're putting a `Order` number on each slide to sequence a deck, or pasting the lesson text onto the stage instead of into `Notes`, or hand-building a nav for the slides — **stop**. The order goes in the deck's `Slides` manifest (one place), the teaching goes in `Notes`, and the side-nav + Present are automatic. Full reference: [Slides & Decks](/Doc/GUI/SlidesAndDecks).

--- a/src/MeshWeaver.Documentation/Data/GUI/CombiningLayoutAreas.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/CombiningLayoutAreas.md
@@ -144,6 +144,7 @@ A few rules keep such a page healthy:
 # See Also
 
 - [Layout Areas](../LayoutAreas) — what an area is and how to author one in C#
+- [Slides & Decks](../SlidesAndDecks) — Slide/Deck node types you can embed inline or sequence as a deck
 - [Configurable Pages](../ConfigurablePages) — the reusable `@@("area/…")` home-page areas
 - [Adding Controls to a UI](../ContainerControl) — `Controls.Stack`, `WithView`, and the container types
 - [Data Binding](../DataBinding) — how a view stays live as its data changes

--- a/src/MeshWeaver.Documentation/Data/GUI/LayoutAreas.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/LayoutAreas.md
@@ -216,3 +216,4 @@ MeshWeaver.Layout.Controls.Stack
 - [Data Binding](../DataBinding) — How data flows between server and UI
 - [Adding Editable Forms](../Editor) — Auto-generated forms from records
 - [Observables](../Observables) — Reactive views that update when data changes
+- [Slides & Decks](../SlidesAndDecks) — the Slide and Deck node types, with slide order declared externally in the deck

--- a/src/MeshWeaver.Documentation/Data/GUI/SlidesAndDecks.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/SlidesAndDecks.md
@@ -1,0 +1,110 @@
+---
+Name: Slides & Decks
+Category: Documentation
+Description: The Slide and Deck node types — a Slide is one pure-content page, a Deck declares slide order EXTERNALLY in its manifest and auto-renders a hidable side-nav + Present.
+Icon: /static/NodeTypeIcons/presentation.svg
+---
+
+A presentation on the mesh is two node types working together. A **Slide** is one page — pure content, carrying no order of its own. A **Deck** is the ordered set of slides, and the deck owns the order: it lists its slides, in sequence, in a manifest on the deck node itself. Both ship from the platform (`AddGraph()`), so you never write a layout area for them — the Slide and Deck views already render the stage, the presenter bar, the collapsible side-nav, and Present.
+
+The point of this design: **the order lives in ONE place, external to the slides.** Reorder a deck, insert a page, or drop one by editing a single list — never by sweeping an `Order` field across every slide, and two slides can never fight over the same position.
+
+<svg viewBox="0 0 760 250" xmlns="http://www.w3.org/2000/svg" style="width:100%;max-width:760px;height:auto;display:block;margin:20px auto;" font-family="sans-serif" font-size="13">
+  <rect x="20" y="20" width="300" height="210" rx="10" fill="#1e2a3a" stroke="currentColor" stroke-opacity=".25" stroke-width="1.5"/>
+  <text x="170" y="44" text-anchor="middle" fill="currentColor" fill-opacity=".5" font-size="11" font-weight="600" letter-spacing="1">DECK NODE</text>
+  <rect x="40" y="56" width="260" height="60" rx="8" fill="#4f6bed"/>
+  <text x="170" y="78" text-anchor="middle" fill="#fff" font-weight="600" font-size="12">DeckContent.Slides</text>
+  <text x="170" y="98" text-anchor="middle" fill="#fff" font-size="11" fill-opacity=".9">[ "intro", "anatomy", "recap" ]  ← the order</text>
+  <text x="170" y="140" text-anchor="middle" fill="currentColor" fill-opacity=".6" font-size="11">one manifest = the whole sequence</text>
+  <text x="170" y="160" text-anchor="middle" fill="currentColor" fill-opacity=".6" font-size="11">edit here to reorder</text>
+  <rect x="360" y="20" width="380" height="210" rx="10" fill="#1a2530" stroke="currentColor" stroke-opacity=".25" stroke-width="1.5"/>
+  <text x="550" y="44" text-anchor="middle" fill="currentColor" fill-opacity=".5" font-size="11" font-weight="600" letter-spacing="1">CHILD SLIDES — PURE CONTENT</text>
+  <rect x="380" y="56" width="340" height="34" rx="6" fill="#26a69a"/>
+  <text x="550" y="77" text-anchor="middle" fill="#fff" font-size="12">intro — one big picture + notes</text>
+  <rect x="380" y="98" width="340" height="34" rx="6" fill="#26a69a"/>
+  <text x="550" y="119" text-anchor="middle" fill="#fff" font-size="12">anatomy — one big picture + notes</text>
+  <rect x="380" y="140" width="340" height="34" rx="6" fill="#26a69a"/>
+  <text x="550" y="161" text-anchor="middle" fill="#fff" font-size="12">recap — one big picture + notes</text>
+  <text x="550" y="200" text-anchor="middle" fill="currentColor" fill-opacity=".6" font-size="11">no Order field — the slide is just content</text>
+  <line x1="320" y1="86" x2="378" y2="73" stroke="currentColor" stroke-opacity=".45" stroke-width="1.5"/>
+  <line x1="320" y1="90" x2="378" y2="115" stroke="currentColor" stroke-opacity=".45" stroke-width="1.5"/>
+  <line x1="320" y1="94" x2="378" y2="157" stroke="currentColor" stroke-opacity=".45" stroke-width="1.5"/>
+</svg>
+
+# The Slide node
+
+A Slide's `Content` is a `SlideContent` record:
+
+- **`Content`** — the slide body as **markdown**. Raw HTML and SVG pass through the markdown pipeline unchanged, so a slide can be a bullet list or a full-bleed illustration.
+- **`Notes`** — speaker notes (markdown), shown only in the Notes view. This is where the *teaching* lives.
+- **`Background`** — optional CSS background for the stage (e.g. `linear-gradient(135deg, #667eea 0%, #764ba2 100%)`). Null → the theme-aware default gradient.
+
+**Classroom style.** A good slide is a hook, not a handout: little text on the stage, ideally **one big inline-SVG picture** that fills the 16:9 stage, and the actual explanation in `Notes`. Size type with `clamp()` (`font-size: clamp(18px, 3vw, 42px)`) so it scales with the stage instead of looking right at only one width.
+
+A Slide has **three views**:
+
+- **Content** (default) — the slide on a 16:9 stage with a slim presenter bar underneath (◀ Prev · "Slide n / N" · Deck · Present · Next ▶). Clicking the stage advances to the next slide.
+- **Present** — the chrome-free stage: click to advance, a small corner counter the only overlay. Open it full-screen to present.
+- **Notes** — the speaker notes plus a compact preview of the slide.
+
+# The Deck node — order is external
+
+A **Deck** (`NodeType = "Deck"`) is a node whose `Content` is a `DeckContent` record:
+
+- **`Title`** — optional display title for the welcome stage (falls back to the node name).
+- **`Description`** — optional markdown intro shown on the deck's welcome stage.
+- **`Slides`** — the **ordered list of child references**. **This IS the deck's order.** Each entry is a child id (relative — `"intro"`) or a full path.
+
+The Deck's views are automatic:
+
+- **Overview** (default) — a splitter with a **hidable (collapsible) left side-nav** listing the slides in manifest order (each labeled by its slide's name), and a right welcome stage carrying the intro and a **▶ Present** button that opens the first slide chrome-free.
+- **Present** — redirects straight into the first manifest slide's Present view, starting the walk.
+
+**How the order flows to the slides.** When a Slide's parent is a Deck with a non-empty `Slides` manifest, the Slide views resolve prev / next / index / count from that manifest — the deck's declared order wins over any `MeshNode.Order` on the slides. When the parent is **not** a Deck (a Markdown or Space parent, as in older decks), the slides fall back to ordering by `MeshNode.Order`. So existing decks keep working unchanged, and new decks get external order for free.
+
+# Present & click-to-advance
+
+Presenting is standard navigation — no bespoke messaging. The stage is a click-to-advance surface: a click renders a `RedirectControl` to the next slide (staying in Present mode when presenting), the same href/redirect mechanism every other area uses. Prev/Next buttons in the presenter bar navigate the same way.
+
+# Course usage — a Deck can sequence module pages too
+
+The manifest is not limited to slides. A Deck can order **any** child pages — the Markdown module pages of a course, for instance — giving the course a side-nav and a linear sequence from a single node, without touching each page. List the module-page ids in the deck's `Slides`, in teaching order, and the deck's side-nav becomes the course TOC + walk-through. (Slide-to-slide click-to-advance is a Slide-view feature; module pages get the side-nav and ordered sequence.)
+
+# Worked shape
+
+Create the deck, then the slides as its children, then list the order — once — in the deck:
+
+```csharp
+// The deck — the manifest is the order (external to the slides).
+new MeshNode("widgets", "MyCourse")
+{
+    NodeType = "Deck",
+    Name = "Intro to Widgets",
+    Content = new DeckContent
+    {
+        Title = "Intro to Widgets",
+        Description = "A five-minute tour. Press **Present** to begin.",
+        Slides = ["intro", "anatomy", "recap"]   // ← THIS is the order
+    }
+};
+
+// The slides — pure content, no order of their own, created in any sequence.
+new MeshNode("anatomy", "MyCourse/widgets") { NodeType = "Slide", Name = "Anatomy", Content = new SlideContent { /* one big SVG + notes */ } };
+new MeshNode("intro",   "MyCourse/widgets") { NodeType = "Slide", Name = "What is a widget?", Content = new SlideContent { /* ... */ } };
+new MeshNode("recap",   "MyCourse/widgets") { NodeType = "Slide", Name = "Recap", Content = new SlideContent { /* ... */ } };
+```
+
+Reorder later by editing only the deck — the slides never change:
+
+```csharp
+workspace.GetMeshNodeStream("MyCourse/widgets")
+    .Update(node => node with { Content = ((DeckContent)node.Content) with { Slides = ["intro", "recap", "anatomy"] } })
+    .Subscribe(_ => { }, ex => logger.LogWarning(ex, "reorder failed"));
+```
+
+# See Also
+
+- [Layout Areas](../LayoutAreas) — what an area is and how the Slide/Deck views are registered
+- [Combining Layout Areas in Markdown](../CombiningLayoutAreas) — embed a deck or slide area inline with prose
+- [Configurable Pages](../ConfigurablePages) — the reusable `@@("area/…")` home-page areas
+- [Data Binding](../DataBinding) — how a view stays live as its node changes

--- a/src/MeshWeaver.Graph/Configuration/DeckNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/DeckNodeType.cs
@@ -1,0 +1,88 @@
+using System.Collections.Immutable;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Provides configuration for Deck node types in the graph.
+/// A <b>Deck</b> is a presentation (or a course sequence) whose slide/page ORDER is
+/// declared EXTERNALLY, on the deck node itself, in <see cref="DeckContent.Slides"/> —
+/// an ordered list of child references. The individual <see cref="SlideNodeType">Slide</see>
+/// nodes stay pure content: they carry no order of their own, so re-sequencing a deck is
+/// a single edit to the deck's manifest, never a sweep across every slide.
+/// <para>
+/// The Deck's Overview renders a hidable side-nav built from that manifest plus a stage
+/// with a "Present" entry point (see <see cref="DeckLayoutAreas"/>). When a Slide's parent
+/// is a Deck, the Slide views resolve prev/next/index/count from the deck's manifest instead
+/// of the sibling <see cref="MeshNode.Order"/> fallback — see <see cref="SlideLayoutAreas"/>.
+/// </para>
+/// </summary>
+public static class DeckNodeType
+{
+    /// <summary>
+    /// The NodeType value used to identify deck nodes.
+    /// </summary>
+    public const string NodeType = "Deck";
+
+    /// <summary>
+    /// Inline deck/presentation-screen glyph (SVG data URI). Kept inline so the node
+    /// type needs no static-asset round-trip; it renders directly as an <c>&lt;img src&gt;</c>.
+    /// </summary>
+    private const string DeckIcon =
+        "data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='%234f6bed'%3E"
+        + "%3Cpath%20d='M3%204h18a1%201%200%200%201%201%201v10a1%201%200%200%201-1%201h-7v2h3v2H7v-2h3v-2H3a1%201%200%200%201-1-1V5a1%201%200%200%201%201-1zm2%203v6h14V7H5z'/%3E"
+        + "%3C/svg%3E";
+
+    /// <summary>
+    /// Registers the built-in "Deck" MeshNode on the mesh builder.
+    /// </summary>
+    public static TBuilder AddDeckType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        builder.ConfigureNodeTypeAccess(a => a.WithPublicRead(NodeType));
+        return builder;
+    }
+
+    /// <summary>
+    /// Creates a MeshNode definition for the Deck node type.
+    /// This provides HubConfiguration for nodes with nodeType="Deck": the deck views,
+    /// the <see cref="DeckContent"/> data source, and the create-a-Slide menu affordance.
+    /// </summary>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "Deck",
+        Icon = DeckIcon,
+        HubConfiguration = config => config
+            .AddDeckViews()
+            .AddMeshDataSource(s => s.WithContentType<DeckContent>())
+            // Creating a child from a Deck offers Slide — the deck's natural content.
+            .AddCreatableTypes(SlideNodeType.NodeType)
+    };
+}
+
+/// <summary>
+/// The content of a Deck MeshNode — a presentation / course sequence.
+/// Immutable; every mutation goes through
+/// <c>workspace.GetMeshNodeStream(path).Update(...)</c>.
+/// </summary>
+public record DeckContent
+{
+    /// <summary>Optional display title for the deck's welcome stage. Falls back to the node name.</summary>
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Optional markdown intro rendered on the deck's welcome stage (the Overview's
+    /// right pane). Falls back to a default welcome message when empty.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// The ordered list of child slide (or page) references — this IS the deck's order,
+    /// declared EXTERNALLY here rather than on each slide. Each entry is either the child's
+    /// id (relative to the deck, e.g. <c>"intro"</c>) or its full path; both resolve to a
+    /// child node under the deck. The side-nav, prev/next, and Present walk follow this order.
+    /// Default empty.
+    /// </summary>
+    public ImmutableList<string> Slides { get; init; } = ImmutableList<string>.Empty;
+}

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -35,6 +35,7 @@ public static class GraphConfigurationExtensions
                 .AddMarkdownType()
                 .AddHtmlType()
                 .AddSlideType()
+                .AddDeckType()
                 .AddCommentType()
                 .AddTrackedChangeType()
                 .AddAccessAssignmentType()

--- a/src/MeshWeaver.Graph/DeckLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/DeckLayoutAreas.cs
@@ -1,0 +1,252 @@
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// Layout views for Deck nodes — a presentation (or a course sequence) whose slide/page
+/// order is declared EXTERNALLY in <see cref="DeckContent.Slides"/> (on the deck node,
+/// not on each slide).
+/// <list type="bullet">
+///   <item><b>Overview</b> (default): a <see cref="SplitterControl"/> — a <b>hidable</b>
+///     (collapsible) left <see cref="NavMenuControl"/> listing the deck's slides in
+///     manifest order, and a right welcome stage with the deck intro and a "Present" entry
+///     point that opens the first slide chrome-free.</item>
+///   <item><b>Present</b>: redirects straight to the first manifest slide's Present view,
+///     starting the click-to-advance walk.</item>
+/// </list>
+/// The slides themselves stay pure content (see <see cref="SlideLayoutAreas"/>); the deck
+/// alone owns the order, so re-sequencing is one edit to the manifest.
+/// </summary>
+public static class DeckLayoutAreas
+{
+    /// <summary>Area name for the chrome-free Present redirect area.</summary>
+    public const string PresentArea = "Present";
+
+    private const string DefaultIntro =
+        "Use the side navigation to jump to any slide, or press **Present** to start the walk-through. "
+        + "Slides advance on click.";
+
+    private const string EmptyDeckHint =
+        "*This deck has no slides yet. Create Slide children and list their ids, in order, "
+        + "in the deck's `Slides` manifest.*";
+
+    /// <summary>
+    /// Registers the Deck node views (Overview, Present and the standard create/delete
+    /// areas) on the hub configuration.
+    /// </summary>
+    /// <param name="configuration">The message hub configuration to register on.</param>
+    /// <returns>The configuration with the Deck views registered.</returns>
+    public static MessageHubConfiguration AddDeckViews(this MessageHubConfiguration configuration)
+        => configuration
+            .AddDefaultLayoutAreas()
+            .Set(new PageLayoutOptions { MaxWidth = "1400px" })
+            .AddLayout(layout => layout
+                // Overriding the default Overview with the deck's splitter shell.
+                .WithView(MeshNodeLayoutAreas.OverviewArea, Overview)
+                .WithView(PresentArea, Present)
+                .WithView(MeshNodeLayoutAreas.CreateNodeArea, CreateLayoutArea.Create)
+                .WithView(MeshNodeLayoutAreas.DeleteArea, DeleteLayoutArea.Delete));
+
+    // ── Overview ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Renders the default Overview: a splitter with a collapsible left NavMenu built from
+    /// the deck's ordered <see cref="DeckContent.Slides"/> manifest (resolving each child
+    /// for its label), and a right welcome stage. The splitter renders once; only its panes
+    /// re-render reactively, so the user's collapse state survives content updates.
+    /// </summary>
+    /// <param name="host">The layout area host rendering the area.</param>
+    /// <param name="_">The rendering context for the area.</param>
+    /// <returns>The splitter shell for the Overview layout area.</returns>
+    [Browsable(false)]
+    public static UiControl Overview(LayoutAreaHost host, RenderingContext _)
+    {
+        var deckPath = host.Hub.Address.ToString();
+        var deckNodeStream = host.Workspace.GetMeshNodeStream();
+        var childrenStream = ObserveDeckChildren(host, deckPath);
+
+        return Controls.Splitter
+            .WithClass("shell-splitter")
+            .WithSkin(s => s.WithOrientation(Orientation.Horizontal).WithWidth("100%").WithHeight("100%"))
+            .WithView(
+                // Left pane: hidable NavMenu from the ordered manifest.
+                (h, c) => deckNodeStream.CombineLatest(childrenStream,
+                    (node, children) => BuildDeckNav(host, deckPath, node, children)),
+                skin => skin.WithSize("300px").WithMin("220px").WithMax("440px").WithCollapsible(true))
+            .WithView(
+                // Right pane: the welcome stage with the intro + Present entry point.
+                (h, c) => deckNodeStream.CombineLatest(childrenStream,
+                    (node, children) => BuildDeckStage(host, deckPath, node, children)),
+                skin => skin.WithSize("*"));
+    }
+
+    /// <summary>
+    /// Builds the left NavMenu: one entry per manifest slide, in order, resolving each
+    /// child node for its display label. The manifest is the source of truth for order.
+    /// </summary>
+    private static UiControl BuildDeckNav(
+        LayoutAreaHost host, string deckPath, MeshNode? deckNode,
+        IReadOnlyDictionary<string, MeshNode> children)
+    {
+        var deck = deckNode.ContentAs<DeckContent>(host.Hub.JsonSerializerOptions);
+        var refs = (deck?.Slides ?? ImmutableList<string>.Empty)
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .ToImmutableList();
+
+        var navMenu = Controls.NavMenu.WithSkin(s => s.WithWidth(300).WithCollapsible(false));
+        var group = new NavGroupControl(deckNode?.Name ?? deckNode?.Id ?? "Slides")
+            .WithSkin(s => s.WithExpanded(true));
+
+        if (refs.Count > 0)
+        {
+            var n = 0;
+            foreach (var slideRef in refs)
+            {
+                n++;
+                var path = ResolveChildPath(deckPath, slideRef);
+                children.TryGetValue(path, out var child);
+                var label = child?.Name ?? child?.Id ?? LastSegment(slideRef);
+                group = group.WithView(new NavLinkControl($"{n}. {label}", null, $"/{path}"));
+            }
+        }
+        else
+        {
+            group = group.WithView(Controls.Body("No slides in this deck yet.")
+                .WithStyle("padding: 4px 16px; display: block; color: var(--neutral-foreground-hint);"));
+        }
+
+        return navMenu.WithNavGroup(group);
+    }
+
+    /// <summary>
+    /// Builds the right welcome stage: the deck title, its markdown intro, and — when the
+    /// manifest has at least one slide — a "Present" button opening the first slide's
+    /// chrome-free Present view.
+    /// </summary>
+    private static UiControl BuildDeckStage(
+        LayoutAreaHost host, string deckPath, MeshNode? deckNode,
+        IReadOnlyDictionary<string, MeshNode> children)
+    {
+        var deck = deckNode.ContentAs<DeckContent>(host.Hub.JsonSerializerOptions);
+        var title = string.IsNullOrWhiteSpace(deck?.Title)
+            ? deckNode?.Name ?? deckNode?.Id ?? "Deck"
+            : deck!.Title!;
+
+        var firstRef = (deck?.Slides ?? ImmutableList<string>.Empty)
+            .FirstOrDefault(r => !string.IsNullOrWhiteSpace(r));
+
+        var container = Controls.Stack
+            .WithWidth("100%")
+            .WithStyle(MeshNodeLayoutAreas.GetContainerStyle(host));
+
+        container = container.WithView(Controls.H1(title).WithStyle("margin: 0 0 12px 0;"));
+
+        var intro = firstRef is null
+            ? EmptyDeckHint
+            : string.IsNullOrWhiteSpace(deck?.Description) ? DefaultIntro : deck!.Description!;
+        container = container.WithView(Controls.Markdown(intro)
+            .WithStyle("width: 100%; margin-bottom: 20px;"));
+
+        if (firstRef is not null)
+        {
+            var firstPath = ResolveChildPath(deckPath, firstRef);
+            container = container.WithView(Controls.Button("▶ Present")
+                .WithAppearance(Appearance.Accent)
+                .WithNavigateToHref(MeshNodeLayoutAreas.BuildUrl(firstPath, SlideLayoutAreas.PresentArea)));
+        }
+
+        return container;
+    }
+
+    // ── Present ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Renders the Present area: a redirect to the first manifest slide's Present view,
+    /// starting the click-to-advance walk. Reactive so it settles once the deck node loads.
+    /// </summary>
+    /// <param name="host">The layout area host rendering the area.</param>
+    /// <param name="_">The rendering context for the area.</param>
+    /// <returns>An observable stream of the view for the Present layout area.</returns>
+    [Browsable(false)]
+    public static IObservable<UiControl?> Present(LayoutAreaHost host, RenderingContext _)
+    {
+        var deckPath = host.Hub.Address.ToString();
+        return host.Workspace.GetMeshNodeStream()
+            .Select(node =>
+            {
+                var deck = node.ContentAs<DeckContent>(host.Hub.JsonSerializerOptions);
+                var firstRef = (deck?.Slides ?? ImmutableList<string>.Empty)
+                    .FirstOrDefault(r => !string.IsNullOrWhiteSpace(r));
+                if (firstRef is null)
+                    return (UiControl?)Controls.Markdown(EmptyDeckHint);
+                var firstPath = ResolveChildPath(deckPath, firstRef);
+                return new RedirectControl(
+                    MeshNodeLayoutAreas.BuildUrl(firstPath, SlideLayoutAreas.PresentArea));
+            });
+    }
+
+    // ── Deck resolution helpers (shared with SlideLayoutAreas) ────────────────
+
+    /// <summary>
+    /// Resolves a manifest reference to a full child path under the deck. A reference is
+    /// either the child's id (relative — <c>"intro"</c> → <c>"{deck}/intro"</c>) or already
+    /// a full path under the deck, in which case it is returned unchanged.
+    /// </summary>
+    internal static string ResolveChildPath(string deckPath, string slideRef)
+    {
+        var trimmed = slideRef.Trim().TrimStart('/');
+        if (trimmed.Length == 0)
+            return deckPath;
+        if (trimmed.StartsWith(deckPath + "/", StringComparison.Ordinal))
+            return trimmed;
+        return $"{deckPath}/{trimmed}";
+    }
+
+    private static string LastSegment(string reference)
+    {
+        var trimmed = reference.Trim().TrimEnd('/');
+        var idx = trimmed.LastIndexOf('/');
+        return idx >= 0 && idx < trimmed.Length - 1 ? trimmed[(idx + 1)..] : trimmed;
+    }
+
+    /// <summary>
+    /// Live observable of the deck's direct children (any node type), as a path → node map,
+    /// used to resolve manifest references to display labels. Starts empty so the shell
+    /// renders before the first query emission.
+    /// </summary>
+    private static IObservable<IReadOnlyDictionary<string, MeshNode>> ObserveDeckChildren(
+        LayoutAreaHost host, string deckPath)
+    {
+        var meshService = host.Hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null)
+            return Observable.Return<IReadOnlyDictionary<string, MeshNode>>(
+                ImmutableDictionary<string, MeshNode>.Empty);
+
+        return meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"namespace:{deckPath}"))
+            .Scan(ImmutableDictionary<string, MeshNode>.Empty, (map, change) =>
+            {
+                if (change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+                    return change.Items.ToImmutableDictionary(n => n.Path);
+                foreach (var item in change.Items)
+                    map = change.ChangeType switch
+                    {
+                        QueryChangeType.Added or QueryChangeType.Updated => map.SetItem(item.Path, item),
+                        QueryChangeType.Removed => map.Remove(item.Path),
+                        _ => map
+                    };
+                return map;
+            })
+            .Select(map => (IReadOnlyDictionary<string, MeshNode>)map)
+            .StartWith((IReadOnlyDictionary<string, MeshNode>)ImmutableDictionary<string, MeshNode>.Empty);
+    }
+}

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -366,6 +366,10 @@ public static class MeshNodeExtensions
         // Slide MeshNode Content — presentation pages (see SlideNodeType). Registered
         // under the short name so slide nodes round-trip typed across hub boundaries.
         typeRegistry.WithType(typeof(SlideContent), nameof(SlideContent));
+        // Deck MeshNode Content — the EXTERNAL, ordered slide manifest (see DeckNodeType).
+        // Registered under the short name so a Deck round-trips typed across hub boundaries;
+        // SlideLayoutAreas reads a slide's parent Deck node to resolve the play order.
+        typeRegistry.WithType(typeof(DeckContent), nameof(DeckContent));
         // Backend-computed editable-field metadata sent to the GUI inside the node-content editor control.
         typeRegistry.WithType(typeof(MeshNodeEditorField), nameof(MeshNodeEditorField));
         // Security content types (AccessAssignment / PartitionAccessPolicy / RoleAssignment / Role).

--- a/src/MeshWeaver.Graph/SlideLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/SlideLayoutAreas.cs
@@ -21,10 +21,13 @@ namespace MeshWeaver.Graph;
 ///     counter is the only overlay. Open this full-screen to present.</item>
 ///   <item><b>Notes</b>: speaker notes plus a compact preview of the slide.</item>
 /// </list>
-/// A deck is any parent whose children are Slide nodes; prev/next resolve the sibling
-/// Slide nodes of the same parent ordered by <see cref="MeshNode.Order"/> (lower first,
-/// null last, ties broken by path). Navigation uses the standard href/redirect
-/// mechanism (<c>WithNavigateToHref</c> for buttons, <see cref="RedirectControl"/>
+/// When a slide's parent is a <see cref="DeckNodeType">Deck</see> with a non-empty
+/// <see cref="DeckContent.Slides"/> manifest, prev/next/index/count follow that EXTERNAL,
+/// deck-owned order. Otherwise a deck is any parent whose children are Slide nodes and
+/// prev/next resolve the sibling Slide nodes of the same parent ordered by
+/// <see cref="MeshNode.Order"/> (lower first, null last, ties broken by path) — so existing
+/// decks with Markdown/Space parents keep working unchanged. Navigation uses the standard
+/// href/redirect mechanism (<c>WithNavigateToHref</c> for buttons, <see cref="RedirectControl"/>
 /// from the stage click action) — no bespoke messages.
 /// </summary>
 public static class SlideLayoutAreas
@@ -290,10 +293,12 @@ public static class SlideLayoutAreas
     // ── Deck resolution ──────────────────────────────────────────────────────
 
     /// <summary>
-    /// Live observable of the deck's slides: the sibling Slide nodes sharing this
-    /// node's parent, ordered by <see cref="MeshNode.Order"/> (null last), ties
-    /// broken by path. Starts with an empty list so the stage renders before the
-    /// first query emission.
+    /// Live observable of the deck's slides in play order. When this slide's PARENT is a
+    /// <see cref="DeckNodeType">Deck</see> with a non-empty <see cref="DeckContent.Slides"/>
+    /// manifest, the order comes from that EXTERNAL manifest — the deck owns the sequence,
+    /// not the slides. Otherwise a deck is any parent whose children are Slide nodes and they
+    /// play by <see cref="MeshNode.Order"/> (null last), ties broken by path. Starts with an
+    /// empty list so the stage renders before the first query emission.
     /// </summary>
     private static IObservable<IReadOnlyList<MeshNode>> ObserveDeckSlides(LayoutAreaHost host)
     {
@@ -302,7 +307,8 @@ public static class SlideLayoutAreas
         if (meshService is null || parentPath is null)
             return Observable.Return<IReadOnlyList<MeshNode>>([]);
 
-        return meshService
+        // Candidate set: the sibling Slide nodes sharing this node's parent.
+        var siblingSlides = meshService
             .Query<MeshNode>(MeshQueryRequest.FromQuery(
                 $"namespace:{parentPath} nodeType:{SlideNodeType.NodeType}"))
             .Scan(ImmutableDictionary<string, MeshNode>.Empty, (map, change) =>
@@ -317,12 +323,63 @@ public static class SlideLayoutAreas
                         _ => map
                     };
                 return map;
-            })
-            .Select(map => (IReadOnlyList<MeshNode>)map.Values
-                .OrderBy(n => n.Order ?? int.MaxValue)
-                .ThenBy(n => n.Path, StringComparer.Ordinal)
-                .ToImmutableList())
+            });
+
+        // The parent's own node — if it is a Deck with a manifest, that manifest IS the order.
+        // StartWith(null) lets the combined stream render on the Order fallback until the parent
+        // node arrives (and stays on the fallback for any non-Deck parent, e.g. a Markdown deck).
+        var parentManifest = host.Workspace.GetMeshNodeStream(parentPath)
+            .Select(parent => DeckManifestPaths(parent, parentPath, host))
+            .StartWith((IReadOnlyList<string>?)null);
+
+        return siblingSlides
+            .CombineLatest(parentManifest, OrderSlides)
             .StartWith((IReadOnlyList<MeshNode>)ImmutableList<MeshNode>.Empty);
+    }
+
+    /// <summary>
+    /// If <paramref name="parent"/> is a Deck with a non-empty manifest, returns its entries
+    /// resolved to full child paths (the deck's declared order); otherwise <c>null</c> (→ the
+    /// <see cref="MeshNode.Order"/> fallback).
+    /// </summary>
+    private static IReadOnlyList<string>? DeckManifestPaths(
+        MeshNode? parent, string parentPath, LayoutAreaHost host)
+    {
+        if (parent is null || !string.Equals(parent.NodeType, DeckNodeType.NodeType, StringComparison.Ordinal))
+            return null;
+        var refs = parent.ContentAs<DeckContent>(host.Hub.JsonSerializerOptions)?.Slides;
+        if (refs is null || refs.Count == 0)
+            return null;
+        return refs
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .Select(r => DeckLayoutAreas.ResolveChildPath(parentPath, r))
+            .ToImmutableList();
+    }
+
+    /// <summary>
+    /// Orders the candidate slide set: by the deck-manifest position when a manifest is present
+    /// (slides absent from the manifest fall to the end, then by Order/path); otherwise by
+    /// <see cref="MeshNode.Order"/> (null last), ties broken by path.
+    /// </summary>
+    private static IReadOnlyList<MeshNode> OrderSlides(
+        IReadOnlyDictionary<string, MeshNode> slides, IReadOnlyList<string>? manifestPaths)
+    {
+        if (manifestPaths is { Count: > 0 })
+        {
+            var position = new Dictionary<string, int>(StringComparer.Ordinal);
+            for (var i = 0; i < manifestPaths.Count; i++)
+                position.TryAdd(manifestPaths[i], i);
+            return slides.Values
+                .OrderBy(n => position.TryGetValue(n.Path, out var i) ? i : int.MaxValue)
+                .ThenBy(n => n.Order ?? int.MaxValue)
+                .ThenBy(n => n.Path, StringComparer.Ordinal)
+                .ToImmutableList();
+        }
+
+        return slides.Values
+            .OrderBy(n => n.Order ?? int.MaxValue)
+            .ThenBy(n => n.Path, StringComparer.Ordinal)
+            .ToImmutableList();
     }
 
     /// <summary>

--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys", "slide");
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -29,7 +29,7 @@ public class SkillNodeTypeTest
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
         skills.Should().OnlyContain(n => n.Namespace == SkillNodeType.RootNamespace);
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys", "slide");
 
         var def = (SkillDefinition)skills.Single(n => n.Id == "model").Content!;
         def.Action!.Kind.Should().Be(SkillActionKind.Pick);

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeckLayoutAreaTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeckLayoutAreaTest.cs
@@ -1,0 +1,231 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Structural tests for the Deck node type (ships from the platform via
+/// <c>AddGraph()</c> → <see cref="DeckNodeType.AddDeckType{TBuilder}"/>).
+/// A Deck declares its slide ORDER EXTERNALLY, in <see cref="DeckContent.Slides"/> on the
+/// deck node itself — NOT on each slide. When a Slide's parent is a Deck with a non-empty
+/// manifest, the Slide views resolve prev/next/index/count from that manifest, overriding
+/// the sibling <see cref="MeshNode.Order"/> fallback. Slides under a non-Deck parent keep
+/// ordering by <see cref="MeshNode.Order"/>.
+/// </summary>
+public class DeckLayoutAreaTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// DeckContent must round-trip through the mesh hub's polymorphic serializer under its
+    /// SHORT name discriminator — without the WithGraphTypes registration the manifest
+    /// degrades to an untyped JsonElement across hub boundaries and the slide views can't
+    /// read the parent deck's order.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public void DeckContent_RoundTrips_WithShortTypeDiscriminator()
+    {
+        var options = Mesh.JsonSerializerOptions;
+        var content = new DeckContent
+        {
+            Title = "Intro to Widgets",
+            Description = "A short deck.",
+            Slides = ["c", "a", "b"]
+        };
+
+        var json = JsonSerializer.SerializeToElement<object>(content, options);
+        json.GetProperty("$type").GetString().Should().Be(nameof(DeckContent),
+            "DeckContent must serialize under its short type name");
+
+        var back = JsonSerializer.Deserialize<object>(json.GetRawText(), options);
+        back.Should().BeOfType<DeckContent>();
+        var recovered = (DeckContent)back!;
+        // Record equality compares the ImmutableList field by reference, so assert the
+        // fields individually — the external, ordered manifest is what must survive.
+        recovered.Title.Should().Be(content.Title);
+        recovered.Description.Should().Be(content.Description);
+        recovered.Slides.Should().Equal(new[] { "c", "a", "b" },
+            "the external order must survive the round-trip");
+    }
+
+    /// <summary>
+    /// A Deck parent whose manifest is <c>[c, a, b]</c> orders its slides c → a → b even
+    /// though their <see cref="MeshNode.Order"/> (a=1, b=2, c=3) says otherwise. Rendering
+    /// the manifest-MIDDLE slide (<c>a</c>) must resolve prev = <c>c</c>, next = <c>b</c>,
+    /// and counter "Slide 2 / 3" — proving order is externalized to the deck, not the slides.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task ManifestOrder_OverridesSlideOrder()
+    {
+        var (space, _, a, b, c) = await SeedDeck(slides: ["c", "a", "b"]);
+
+        var workspace = GetClient(client => client.AddData()).GetWorkspace();
+        var reference = new LayoutAreaReference(SlideLayoutAreas.ContentArea);
+        // Render slide "a" — manifest-middle (position 2 of c,a,b), yet Order-1.
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address(a), reference);
+
+        var root = await stream.GetControlStream(reference.Area!)
+            .Should().Within(30.Seconds()).Match(control => control is StackControl);
+        var stack = (StackControl)root!;
+
+        var barPath = AreaPath(stack, SlideLayoutAreas.PresenterBarArea);
+        var bar = (StackControl)(await stream.GetControlStream(barPath)
+            .Should().Within(30.Seconds()).Match(control =>
+                control is StackControl b2 && b2.Areas.Count >= 5))!;
+
+        var prev = (ButtonControl)(await stream
+            .GetControlStream(AreaPath(bar, SlideLayoutAreas.PrevButtonArea))
+            .Should().Within(10.Seconds()).Match(control => control is ButtonControl))!;
+        prev.NavigateToHref!.ToString().Should().Be(
+            MeshNodeLayoutAreas.BuildUrl(c, SlideLayoutAreas.ContentArea),
+            "the manifest puts 'c' before 'a', regardless of MeshNode.Order");
+
+        var next = (ButtonControl)(await stream
+            .GetControlStream(AreaPath(bar, SlideLayoutAreas.NextButtonArea))
+            .Should().Within(10.Seconds()).Match(control => control is ButtonControl))!;
+        next.NavigateToHref!.ToString().Should().Be(
+            MeshNodeLayoutAreas.BuildUrl(b, SlideLayoutAreas.ContentArea),
+            "the manifest puts 'b' after 'a', regardless of MeshNode.Order");
+
+        await stream.GetControlStream(AreaPath(bar, SlideLayoutAreas.CounterArea))
+            .Should().Within(10.Seconds()).Match(control =>
+                control is LabelControl label && "Slide 2 / 3".Equals(label.Data?.ToString()),
+            "the counter must reflect the manifest position (2 of 3), not the Order position");
+
+        await CleanupDeck(space);
+    }
+
+    /// <summary>
+    /// Fallback: slides under a NON-Deck parent (a Space) keep ordering by
+    /// <see cref="MeshNode.Order"/>. Rendering the Order-2 slide must resolve the Order-1 and
+    /// Order-3 siblings as prev/next — proving the Deck-manifest override does NOT disturb the
+    /// existing sibling-Order behavior.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task NonDeckParent_FallsBackToSlideOrder()
+    {
+        var space = $"Space{Guid.NewGuid():N}"[..16];
+        await NodeFactory.CreateNode(MeshNode.FromPath(space) with
+        {
+            Name = "Training Space",
+            NodeType = SpaceNodeType.NodeType,
+            Content = new Space { Name = "Training Space" }
+        }).Should().Emit();
+
+        // Slides directly under the Space (a non-Deck parent), created out of order; Order,
+        // not path or creation order, must rule. Path-alphabetical is end < intro < mid.
+        var intro = $"{space}/intro";
+        var mid = $"{space}/mid";
+        var end = $"{space}/end";
+        await CreateSlide(end, "End", 3, "# Thanks!");
+        await CreateSlide(intro, "Welcome", 1, "# Welcome");
+        await CreateSlide(mid, "Main", 2, "# Main");
+
+        var workspace = GetClient(client => client.AddData()).GetWorkspace();
+        var reference = new LayoutAreaReference(SlideLayoutAreas.ContentArea);
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address(mid), reference);
+
+        var root = await stream.GetControlStream(reference.Area!)
+            .Should().Within(30.Seconds()).Match(control => control is StackControl);
+        var stack = (StackControl)root!;
+
+        var barPath = AreaPath(stack, SlideLayoutAreas.PresenterBarArea);
+        var bar = (StackControl)(await stream.GetControlStream(barPath)
+            .Should().Within(30.Seconds()).Match(control =>
+                control is StackControl b && b.Areas.Count >= 5))!;
+
+        var prev = (ButtonControl)(await stream
+            .GetControlStream(AreaPath(bar, SlideLayoutAreas.PrevButtonArea))
+            .Should().Within(10.Seconds()).Match(control => control is ButtonControl))!;
+        prev.NavigateToHref!.ToString().Should().Be(
+            MeshNodeLayoutAreas.BuildUrl(intro, SlideLayoutAreas.ContentArea),
+            "with a non-Deck parent, prev is the Order-1 sibling");
+
+        var next = (ButtonControl)(await stream
+            .GetControlStream(AreaPath(bar, SlideLayoutAreas.NextButtonArea))
+            .Should().Within(10.Seconds()).Match(control => control is ButtonControl))!;
+        next.NavigateToHref!.ToString().Should().Be(
+            MeshNodeLayoutAreas.BuildUrl(end, SlideLayoutAreas.ContentArea),
+            "with a non-Deck parent, next is the Order-3 sibling");
+
+        await NodeFactory.DeleteNode(space).Should().Emit();
+    }
+
+    /// <summary>
+    /// Seeds a Deck with three Slide children. The Deck's <see cref="DeckContent.Slides"/>
+    /// manifest declares the order (<paramref name="slides"/>), while each Slide's
+    /// <see cref="MeshNode.Order"/> (a=1, b=2, c=3) deliberately CONTRADICTS it and the slides
+    /// are created out of order. Everything lives inside a top-level Space partition.
+    /// </summary>
+    private async Task<(string Space, string Deck, string A, string B, string C)> SeedDeck(
+        ImmutableList<string> slides)
+    {
+        var space = $"Space{Guid.NewGuid():N}"[..16];
+        await NodeFactory.CreateNode(MeshNode.FromPath(space) with
+        {
+            Name = "Training Space",
+            NodeType = SpaceNodeType.NodeType,
+            Content = new Space { Name = "Training Space" }
+        }).Should().Emit();
+
+        var deck = $"{space}/widgets";
+        await NodeFactory.CreateNode(MeshNode.FromPath(deck) with
+        {
+            Name = "Widgets Deck",
+            NodeType = DeckNodeType.NodeType,
+            Content = new DeckContent { Title = "Widgets", Slides = slides }
+        }).Should().Emit();
+
+        var a = $"{deck}/a";
+        var b = $"{deck}/b";
+        var c = $"{deck}/c";
+        // Created out of order, Orders contradict the manifest — the manifest must rule.
+        await CreateSlide(c, "Gamma", 3, "# Gamma");
+        await CreateSlide(a, "Alpha", 1, "# Alpha");
+        await CreateSlide(b, "Beta", 2, "# Beta");
+
+        return (space, deck, a, b, c);
+    }
+
+    private async Task CreateSlide(string path, string name, int order, string body)
+        => await NodeFactory.CreateNode(MeshNode.FromPath(path) with
+        {
+            Name = name,
+            NodeType = SlideNodeType.NodeType,
+            Order = order,
+            Content = new SlideContent { Content = body, Notes = $"Notes for {name}" }
+        }).Should().Emit();
+
+    // Deleting the Space removes its whole partition (and every node inside it).
+    private async Task CleanupDeck(string space)
+        => await NodeFactory.DeleteNode(space).Should().Emit();
+
+    /// <summary>
+    /// Resolves the FULL area path of a named child area (area paths render as
+    /// <c>{parent}/{name}</c>; matching by suffix keeps the tests independent of the
+    /// parent's own path).
+    /// </summary>
+    private static string AreaPath(StackControl parent, string name)
+    {
+        var path = parent.Areas
+            .Select(area => area.Area?.ToString())
+            .FirstOrDefault(p => p != null && p.EndsWith($"/{name}", StringComparison.Ordinal));
+        path.Should().NotBeNull($"expected a child area named '{name}'");
+        return path!;
+    }
+}


### PR DESCRIPTION
## What

A new **Deck** node type whose slide/page **order is declared EXTERNALLY** — in a manifest on the deck node itself (`DeckContent.Slides`), not on each slide. Slides stay pure content, so re-sequencing a deck is a single edit to the deck's manifest, never a sweep across every slide, and two slides can never fight over the same position.

## How the order is externalized

- `DeckContent` is `{ string? Title, string? Description, ImmutableList<string> Slides }`. **`Slides` is the ordered list of child references (relative ids or full paths) — this IS the deck's order.**
- **`DeckLayoutAreas.Overview`** builds a hidable (collapsible) left `NavMenu` by walking that manifest in order (resolving each ref to its child node for the label), beside a right welcome stage with the intro and a **▶ Present** button.
- **`SlideLayoutAreas`** now resolves prev/next/index/count from the parent Deck's manifest when the slide's parent is a `Deck` with a non-empty `Slides` list; otherwise it **falls back to the existing sibling `MeshNode.Order`** behavior — so existing decks with Markdown/Space parents keep working unchanged.
- A **Present** area on the Deck redirects into the first manifest slide's chrome-free Present walk.

Everything is `IObservable<T>` end-to-end (compose + the framework subscribes) — no async/await/Task in view code. Order comes from a reactive read of the parent node stream combined with the sibling-slide query. Views are framework Controls only (`Splitter`/`NavMenu`/`NavGroup`/`NavLink`/`Stack`/`Markdown`/`Button`) — no hand-rolled HTML.

## Files

**Added**
- `src/MeshWeaver.Graph/Configuration/DeckNodeType.cs` — `DeckContent` + `DeckNodeType` (`AddDeckType`, PublicRead, `CreatableTypes` Deck→[Slide], inline SVG icon)
- `src/MeshWeaver.Graph/DeckLayoutAreas.cs` — `AddDeckViews` (Overview splitter with hidable side-nav + Present)
- `src/MeshWeaver.AI/Data/Skill/slide.md` — `/slide` authoring skill (Slide + Deck, classroom style, external order, course usage)
- `src/MeshWeaver.Documentation/Data/GUI/SlidesAndDecks.md` — the doc page
- `test/MeshWeaver.Hosting.Monolith.Test/DeckLayoutAreaTest.cs` — the tests

**Changed**
- `src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs` — `.AddDeckType()` in the `AddGraph()` chain
- `src/MeshWeaver.Graph/MeshNodeExtensions.cs` — register `DeckContent` in `WithGraphTypes` (typed round-trip across hubs)
- `src/MeshWeaver.Graph/SlideLayoutAreas.cs` — manifest-aware ordering with the `MeshNode.Order` fallback
- `src/MeshWeaver.Documentation/Data/GUI/{LayoutAreas,CombiningLayoutAreas}.md` — cross-links to the new page
- `test/MeshWeaver.AI.Test/{SkillNodeTypeTest,SkillHarnessImportSourceTest}.cs` — skill-catalog lists include `/slide`

## Tests

- `DeckLayoutAreaTest`: (a) a Deck with `Slides=[c,a,b]` orders slides c→a→b even though their `MeshNode.Order` says otherwise → prev/next/index/count on the manifest-middle slide follow the manifest; (b) slides under a **non-Deck** (Space) parent still order by `MeshNode.Order`; (c) `DeckContent` round-trips under its short `$type`.
- All 6 Slide + Deck layout tests green; `DocumentationLinkIntegrity` green; the two skill-catalog tests green.
- `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Graph` and the touched test projects (0 warnings). Branch merged with current `origin/main` before building.

## Follow-up

Migrating the AgenticEngineering course decks to `Deck` nodes is a **content step** and out of scope here (no memex-mesh changes in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)