### PR TITLE
fix(portal): harden node menu against partition-root wipe + MeshWeaver default + composer focus

### DIFF
--- a/memex/Memex.Portal.Shared/Pages/Onboarding.razor
+++ b/memex/Memex.Portal.Shared/Pages/Onboarding.razor
@@ -1,5 +1,10 @@
 @page "/onboarding"
 @attribute [Microsoft.AspNetCore.Authorization.Authorize]
+@* No portal header/top menu on onboarding: the user has no partition/identity resolved yet,
+   so the node/mesh/AI menus have nothing to act on (and rendering them here is what surfaced
+   the "menu on the onboarding screen" issue). EmptyLayout is the same bare shell Welcome uses. *@
+@layout EmptyLayout
+@using MeshWeaver.Blazor.Layouts
 @using MeshWeaver.Blazor.Infrastructure
 @using MeshWeaver.Data
 @using MeshWeaver.Graph
@@ -239,8 +244,12 @@ else
                 existingUserFound = true;
                 checkCompleted = true;
                 StateHasChanged();
-                // Client-side only, no forceLoad — preserves the resolved circuit.
-                Navigation.NavigateTo(SafeReturnUrl());
+                // Profile already exists AND this identity resolved to it (State: Active) ⇒ the user
+                // is onboarded and has access — they must never sit on the onboarding screen. Send them
+                // HOME, not to SafeReturnUrl(): a returnUrl of "/onboarding" (the page bounced them here)
+                // would loop straight back. Client-side only, no forceLoad — preserves the resolved circuit.
+                var target = SafeReturnUrl();
+                Navigation.NavigateTo(target == "/onboarding" ? "/" : target);
             });
         }
         else

--- a/src/MeshWeaver.AI/BuiltInHarnessProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInHarnessProvider.cs
@@ -45,7 +45,7 @@ public sealed class BuiltInHarnessProvider(IEnumerable<IHarness> harnesses) : IS
                 Name = def.DisplayName ?? def.Id,
                 Icon = def.Icon,
                 // Carry the harness Order onto the node so the default-composer selection (and the picker)
-                // can honor it: MeshWeaver=0 leads, ClaudeCode=1, Copilot=2. Without this every harness
+                // can honor it: MeshWeaver=-1 leads (default), ClaudeCode=1, Copilot=2. Without this every harness
                 // node has Order=null, so ObserveDefaultComposer's OrderBy(n => n.Order ?? 0) is a no-op and
                 // the default falls to an ARBITRARY harness (a CLI one). A composer stuck on a CLI harness
                 // shows the harness's slash-commands in the / menu instead of the nodeType:Skill catalog —

--- a/src/MeshWeaver.AI/MeshWeaverHarness.cs
+++ b/src/MeshWeaver.AI/MeshWeaverHarness.cs
@@ -21,7 +21,10 @@ public sealed class MeshWeaverHarness : IHarness
         DisplayName = "MeshWeaver",
         Description = "MeshWeaver agents with a selectable model.",
         Icon = "/static/NodeTypeIcons/meshweaver-logo.svg",
-        Order = 0,
+        // -1 = the "make this the default" convention (AgentPickerProjection.ObserveDefaultComposer
+        // picks the LOWEST-Order harness). MeshWeaver must lead the picker AND be the catalog default,
+        // ahead of ClaudeCode (1) and Copilot (2).
+        Order = -1,
         IsDefault = true,
         SupportsAgentSelection = true
     };

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -2194,11 +2194,18 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         try
         {
             if (monacoEditor != null)
+            {
                 await monacoEditor.ClearAsync();
+                // Keep the composer focused after clearing so the user can immediately type the next
+                // message — including WHILE the current round streams (the composer never blocks on the
+                // running round). Clearing the editor on submit otherwise blurred it, so focus was lost
+                // the moment a round started. Best-effort: focusing an already-focused editor is a no-op.
+                await monacoEditor.FocusAsync();
+            }
         }
         catch (Exception ex) when (!_isDisposed)
         {
-            Logger.LogDebug(ex, "[ThreadChat:{InstanceId}] Failed to clear Monaco editor", _instanceId);
+            Logger.LogDebug(ex, "[ThreadChat:{InstanceId}] Failed to clear/focus Monaco editor", _instanceId);
         }
     }
 

--- a/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
+using MeshWeaver.Graph.Security;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Mesh;
@@ -123,9 +124,19 @@ public static class NodeMenuItemsExtensions
             //   30-38  content / history / sync    📁 🕘 🔌 (🔄)
             //   50     lifecycle                   ♻️
 
+            // A USER partition root (the user's home) is NOT a normal editable node: Edit / Move /
+            // Copy / Delete on the root would rewrite, relocate, duplicate or WIPE the entire
+            // partition (the node-menu-delete-wiped-my-partition incident). Suppress those four on
+            // a protected root — the viewer-scoped Pin stays. Delete is additionally hard-blocked
+            // server-side by PartitionRootDeletionGuard; this keeps it off the menu in the first place.
+            var isProtectedRoot = PartitionRootDeletionGuard.IsUserPartitionRoot(menuNode);
+
             // ── Group 1: edit / organize ──
-            var edit = MeshNodeLayoutAreas.GetEditMenuItem(menuPath, perms);
-            if (edit != null) items.Add(edit with { Order = 10, Icon = "✏️" });
+            if (!isProtectedRoot)
+            {
+                var edit = MeshNodeLayoutAreas.GetEditMenuItem(menuPath, perms);
+                if (edit != null) items.Add(edit with { Order = 10, Icon = "✏️" });
+            }
 
             var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
             var viewerId = accessService?.Context?.ObjectId
@@ -133,14 +144,17 @@ public static class NodeMenuItemsExtensions
             var pin = PinLayoutArea.GetMenuItem(menuPath, viewerId);
             if (pin != null) items.Add(pin with { Order = 12, Icon = "🔖" });
 
-            var move = MoveLayoutArea.GetMenuItem(menuPath, perms);
-            if (move != null) items.Add(move with { Order = 14, Icon = "➡️" });
+            if (!isProtectedRoot)
+            {
+                var move = MoveLayoutArea.GetMenuItem(menuPath, perms);
+                if (move != null) items.Add(move with { Order = 14, Icon = "➡️" });
 
-            var copy = CopyLayoutArea.GetMenuItem(menuPath, perms);
-            if (copy != null) items.Add(copy with { Order = 16, Icon = "📋" });
+                var copy = CopyLayoutArea.GetMenuItem(menuPath, perms);
+                if (copy != null) items.Add(copy with { Order = 16, Icon = "📋" });
 
-            var delete = DeleteLayoutArea.GetMenuItem(menuPath, perms);
-            if (delete != null) items.Add(delete with { Order = 18, Icon = "🗑️" });
+                var delete = DeleteLayoutArea.GetMenuItem(menuPath, perms);
+                if (delete != null) items.Add(delete with { Order = 18, Icon = "🗑️" });
+            }
             var hasGroup1 = items.Count > 0;
 
             // ── Group 2: content / history / sync ── (InstanceSync adds "Synchronizations" at 36)
@@ -194,15 +208,23 @@ public static class NodeMenuItemsExtensions
         });
 
     /// <summary>
-    /// Shared node lookup: resolves the effective menu node (satellite → main), its name,
-    /// and the user's permissions. Reads the OWN MeshNode via the canonical
-    /// <c>MeshNodeReference</c> reducer (per <c>Doc/Architecture/AsynchronousCalls.md</c> —
-    /// never <c>GetStream&lt;MeshNode&gt;().FirstOrDefault</c>); if the own node is a
-    /// satellite, fetches the main node via <see cref="MeshNodeStreamExtensions.GetMeshNodeStream(IWorkspace,string)"/>
-    /// (which routes to the owning hub's reducer remotely). The result is a <b>live</b> stream:
-    /// it re-emits on node content changes and — via the <c>CombineLatest</c> with
+    /// Shared node lookup: resolves the node being viewed, its name, and the user's permissions.
+    /// Reads the OWN MeshNode via the canonical <c>MeshNodeReference</c> reducer (per
+    /// <c>Doc/Architecture/AsynchronousCalls.md</c> — never <c>GetStream&lt;MeshNode&gt;().FirstOrDefault</c>).
+    /// The result is a <b>live</b> stream: it re-emits on node content changes and — via the
+    /// <c>CombineLatest</c> with
     /// <see cref="MeshWeaver.Mesh.HubPermissionExtensions.GetEffectivePermissions(MeshWeaver.Messaging.IMessageHub, string)"/> — on
     /// permission changes (the access-race fix).
+    ///
+    /// <para>🚨 The menu targets the node <b>being viewed</b> (<paramref name="host"/>'s own hub
+    /// path), NEVER a satellite's owner. The old code retargeted a satellite's menu to
+    /// <c>own.MainNode</c>, so opening the node menu on a thread anchored under a user's home
+    /// (<c>MainNode = {user}</c>) and hitting Delete posted
+    /// <c>DeleteNodeRequest({user}, Recursive)</c> — deleting the entire partition root, not the
+    /// thread (the catastrophic node-menu delete). Every per-node op (Edit/Move/Copy/Delete) now
+    /// operates on <c>hubPath</c>: "delete this thread" deletes the thread. A hard guard
+    /// (<see cref="MeshWeaver.Graph.Security.PartitionRootDeletionGuard"/>) additionally blocks
+    /// deleting a user partition root even if some other caller targets it.</para>
     /// </summary>
     private static IObservable<(string menuPath, string nodeName, MeshNode? menuNode, Permission perms)>
         GetMenuContext(LayoutAreaHost host)
@@ -218,23 +240,26 @@ public static class NodeMenuItemsExtensions
             .Catch<MeshNode, Exception>(_ => Observable.Return<MeshNode>(null!));
 
         var menuContext = ownNodeStream
-            .SelectMany(own =>
-            {
-                var isSatellite = own != null && own.MainNode != own.Path;
-                var menuPath = isSatellite ? own!.MainNode : hubPath;
-                if (!isSatellite || string.Equals(menuPath, hubPath, StringComparison.Ordinal))
-                {
-                    return Observable.Return((menuPath: menuPath, nodeName: own?.Name ?? "", menuNode: own));
-                }
-                // Satellite: resolve main node via the standard remote-stream path.
-                return host.Workspace.GetMeshNodeStream(menuPath)
-                    .Select(main => (menuPath: menuPath, nodeName: main?.Name ?? own?.Name ?? "", menuNode: (MeshNode?)main))
-                    .Catch<(string menuPath, string nodeName, MeshNode? menuNode), Exception>(_ =>
-                        Observable.Return((menuPath: menuPath, nodeName: own?.Name ?? "", menuNode: (MeshNode?)null)));
-            });
+            .Select(own => (menuPath: hubPath, nodeName: own?.Name ?? "", menuNode: (MeshNode?)own));
+
+        // 🔒 The node/mesh menu is an AUTHORING surface — it must fail CLOSED when logged out.
+        // A logged-out (anonymous / virtual) visitor gets NO menu items, even on a public-read
+        // node: they may still READ the content (a separate path), but every menu item is gated on
+        // the viewer's effective Permission, and anonymous would otherwise pick up the public-read
+        // grant (Read) and surface read-based items (Files, Versions). Force Permission.None for an
+        // unauthenticated viewer so the whole menu drops — each item's null-guard already reacts to
+        // it. Same anonymous/virtual test as PermissionEvaluator.ResolveUserId.
+        var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
+        var viewerContext = accessService?.Context ?? accessService?.CircuitContext;
+        var isAuthenticated = !string.IsNullOrEmpty(viewerContext?.ObjectId)
+                              && viewerContext?.IsVirtual != true;
+
+        var permsStream = isAuthenticated
+            ? host.Hub.GetEffectivePermissions(hubPath)
+            : Observable.Return(Permission.None);
 
         return menuContext
-            .CombineLatest(host.Hub.GetEffectivePermissions(hubPath),
+            .CombineLatest(permsStream,
                 (ctx, perms) => (ctx.menuPath, ctx.nodeName, ctx.menuNode, perms));
     }
 

--- a/src/MeshWeaver.Graph/Security/PartitionRootDeletionGuard.cs
+++ b/src/MeshWeaver.Graph/Security/PartitionRootDeletionGuard.cs
@@ -1,0 +1,90 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Security;
+
+/// <summary>
+/// Structural guard that makes a USER partition root undeletable by an interactive caller.
+///
+/// <para>A user's partition root is their home node — <c>{userId}</c> at the root namespace
+/// (<c>''</c>) with NodeType <c>User</c> (the exact shape <c>UserOnboardingService.CreateUser</c>
+/// writes). A recursive delete of that node wipes the user's ENTIRE partition — threads, API
+/// tokens, model settings, the self-admin grant — and drops the user into the onboarding
+/// redirect on their next sign-in. That is precisely the catastrophic incident this guard exists
+/// to make impossible: a node-menu Delete invoked on a thread anchored directly under the home
+/// (the thread's <c>MainNode = {userId}</c>) resolved to the partition root and deleted the whole
+/// partition. The menu-target fix (<c>NodeMenuItemsExtensions.GetMenuContext</c>) stops the menu
+/// from ever aiming at the owner; this guard is the defence-in-depth that rejects the delete even
+/// if some other caller aims at a user root directly.</para>
+///
+/// <para>Runs on <see cref="NodeOperation.Delete"/> only, alongside the other delete validators
+/// (they AND-compose — the first failure wins), and — as an <see cref="IOwnerEnforcedNodeValidator"/>
+/// — authoritatively on the owning per-node hub where the delete ROOT is validated
+/// (<c>MeshExtensions.RunDeletionValidatorsWithWarningsObs</c>). A rejection on the root aborts the
+/// whole cascade before any fan-out fires.</para>
+///
+/// <para><b>System is exempt.</b> Legitimate infrastructure / deliberate admin off-boarding runs
+/// under <c>ImpersonateAsSystem</c> and may still remove a user partition; only the interactive
+/// path — the user's own circuit or an admin's circuit — is blocked, which is exactly where the
+/// accidental menu delete originates. <c>Space</c> roots stay deletable (they own a partition too
+/// but carry an explicit <c>PartitionDropPostDeletionHandler</c> teardown); this guard is scoped
+/// to <c>User</c> roots only.</para>
+/// </summary>
+public sealed class PartitionRootDeletionGuard : INodeValidator, IOwnerEnforcedNodeValidator
+{
+    private readonly ILogger<PartitionRootDeletionGuard>? _logger;
+
+    /// <summary>Initializes the guard.</summary>
+    /// <param name="logger">Optional logger; blocked deletes are recorded at Warning.</param>
+    public PartitionRootDeletionGuard(ILogger<PartitionRootDeletionGuard>? logger = null)
+        => _logger = logger;
+
+    /// <summary>Delete only — this guard never affects create/read/update/move.</summary>
+    public IReadOnlyCollection<NodeOperation> SupportedOperations => [NodeOperation.Delete];
+
+    /// <summary>
+    /// Rejects the delete when the target node is a user partition root and the caller is not the
+    /// System identity; otherwise accepts.
+    /// </summary>
+    /// <param name="context">The delete validation context (the ROOT node of the operation).</param>
+    /// <returns>An observable emitting exactly one <see cref="NodeValidationResult"/>.</returns>
+    public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
+    {
+        if (!IsUserPartitionRoot(context.Node))
+            return Observable.Return(NodeValidationResult.Valid());
+
+        // System (middleware / onboarding / deliberate admin off-boarding) may still remove a
+        // user partition; only interactive callers are blocked. Same System-exempt pattern as
+        // PartitionWriteGuardValidator.
+        var userId = context.AccessContext?.ObjectId;
+        if (string.Equals(userId, WellKnownUsers.System, StringComparison.OrdinalIgnoreCase))
+            return Observable.Return(NodeValidationResult.Valid());
+
+        _logger?.LogWarning(
+            "PartitionRootDeletionGuard: blocked Delete of user partition root '{Path}' by {User}",
+            context.Node.Path, userId ?? "(anonymous)");
+        return Observable.Return(NodeValidationResult.Invalid(
+            $"'{context.Node.Path}' is a user partition root (home) and cannot be deleted — that would " +
+            "remove the entire partition (threads, tokens, settings, access grants) and lock the user out. " +
+            "Delete the specific child node (e.g. the thread) instead.",
+            NodeRejectionReason.Unauthorized));
+    }
+
+    /// <summary>
+    /// A USER partition root: a bare single-segment path (no <c>/</c>, not a <c>_</c>-satellite) at
+    /// the root namespace (<c>''</c>) whose NodeType is <c>User</c> — the
+    /// <c>UserOnboardingService.CreateUser</c> partition-root shape. Shared with the node-menu
+    /// suppression so "what is protected" has one definition.
+    /// </summary>
+    /// <param name="node">The node to classify; may be null.</param>
+    public static bool IsUserPartitionRoot(MeshNode? node)
+        => node is not null
+           && string.Equals(node.NodeType, "User", StringComparison.OrdinalIgnoreCase)
+           && string.IsNullOrEmpty(node.Namespace)
+           && !string.IsNullOrWhiteSpace(node.Path)
+           && !node.Path.Contains('/')
+           && !node.Path.StartsWith('_');
+}

--- a/src/MeshWeaver.Hosting/Security/SecurityServiceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Security/SecurityServiceExtensions.cs
@@ -54,6 +54,10 @@ public static class SecurityServiceExtensions
                 // no longer lazily CREATE SCHEMAs on arbitrary writes (the atioz ghost-
                 // schema fix). See Doc/Architecture/PartitionStorageRouting.md.
                 services.AddScoped<INodeValidator, OwnsPartitionProvisioningValidator>();
+                // Makes a USER partition root undeletable by an interactive caller — the
+                // defence-in-depth behind the node-menu-delete-wiped-my-partition incident.
+                // System stays exempt (deliberate off-boarding); Spaces stay deletable.
+                services.AddScoped<INodeValidator, PartitionRootDeletionGuard>();
                 return services;
             })
             // Mesh hub: needed wherever code calls hub.CheckPermission on the

--- a/test/MeshWeaver.Security.Test/MenuAccessControlTest.cs
+++ b/test/MeshWeaver.Security.Test/MenuAccessControlTest.cs
@@ -41,11 +41,18 @@ public class MenuAccessControlTest(ITestOutputHelper output) : MonolithMeshTestB
     private const string NodePath = "TestOrg/TestProject";
     private const string TestUserId = "TestUser";
 
+    private const string UserRootPath = "userhome";
+
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => ConfigureMeshBase(builder)
             .AddMeshNodes(
                 new MeshNode("TestOrg") { Name = "Test Organization" },
-                new MeshNode("TestProject", "TestOrg") { Name = "Test Project" }
+                new MeshNode("TestProject", "TestOrg") { Name = "Test Project" },
+                // A USER partition root (the shape UserOnboardingService.CreateUser writes): bare
+                // single-segment path, namespace '', NodeType "User". The node menu must SUPPRESS
+                // Edit/Move/Copy/Delete on it (deleting the home wipes the whole partition — the
+                // node-menu-delete incident). PartitionRootDeletionGuard.IsUserPartitionRoot gates it.
+                new MeshNode(UserRootPath) { NodeType = "User", Name = "User Home" }
             )
             .ConfigureDefaultNodeHub(c => c.AddDefaultLayoutAreas());
 
@@ -327,4 +334,36 @@ public class MenuAccessControlTest(ITestOutputHelper output) : MonolithMeshTestB
             ["Administrator", "Editor", "Viewer", "Commenter"],
             "static roles should not leak into generic children queries");
     }
+
+    [Fact(Timeout = 30000)]
+    public async Task Menu_UserPartitionRoot_HidesEditMoveCopyDelete()
+    {
+        // Admin ON the user partition root. WITHOUT the suppression this would show Edit/Move/Copy/Delete
+        // (Admin has every permission); the partition-root guard hides those four — deleting/moving/
+        // copying/editing a user's HOME node wipes or relocates the entire partition (the node-menu-delete
+        // incident). Read-only + lifecycle items still render, proving perms enriched (not a timing miss).
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        await meshService.CreateNode(AssignmentNodeFactory.UserRole(TestUserId, "Admin", UserRootPath)).Should().Emit();
+
+        var client = GetClientWithUser();
+        var nodeAddress = new Address(UserRootPath);
+        await client.Observe(new PingRequest(), o => o.WithTarget(nodeAddress)).Should().Within(15.Seconds()).Emit();
+
+        // Wait until Admin perms enrich — "Recycle" (requires Update) is the marker: WITHOUT suppression
+        // "Edit" would appear at the SAME enrichment, so Recycle-present + Edit-absent proves suppression,
+        // not a race.
+        var items = await FetchAllMenuItems(client, nodeAddress, its => its.Any(i => i.Label == "Recycle"));
+
+        Output.WriteLine($"Menu items for Admin on user partition root: {string.Join(", ", items.Select(i => i.Label))}");
+
+        items.Select(i => i.Label).Should().NotContain(
+            ["Edit", "Move", "Copy", "Delete"],
+            "a user partition root must never offer edit/move/copy/delete — those wipe/relocate the whole partition");
+    }
+
+    // NOTE: a logged-out/anonymous menu render test is intentionally omitted here — this test harness
+    // auto-logs-in the default admin (TestUsers.DevLogin), so GetClient() cannot produce a truly
+    // unauthenticated viewer without harness surgery. The logged-out gating (GetMenuContext forces
+    // Permission.None when AccessService has no ObjectId) is a small, self-contained change on the same
+    // path these tests exercise; it is verified end-to-end in a real (unauthenticated) browser session.
 }

--- a/test/MeshWeaver.Security.Test/PartitionRootDeletionGuardTest.cs
+++ b/test/MeshWeaver.Security.Test/PartitionRootDeletionGuardTest.cs
@@ -1,0 +1,97 @@
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// Unit coverage for <see cref="PartitionRootDeletionGuard"/> — the structural guard that makes a
+/// USER partition root undeletable by an interactive caller (the defence-in-depth behind the
+/// node-menu-delete-wiped-my-partition incident). Pure validator logic, no mesh needed.
+/// </summary>
+public class PartitionRootDeletionGuardTest
+{
+    private static readonly PartitionRootDeletionGuard Guard = new();
+
+    private static Task<NodeValidationResult> Validate(MeshNode node, string? userId) =>
+        Guard.Validate(new NodeValidationContext
+        {
+            Operation = NodeOperation.Delete,
+            Node = node,
+            AccessContext = userId is null ? null : new AccessContext { ObjectId = userId, Name = userId },
+        }).FirstAsync().ToTask();
+
+    /// <summary>The exact shape UserOnboardingService.CreateUser writes: id={user}, namespace='', User.</summary>
+    private static MeshNode UserRoot(string id) => new(id) { NodeType = "User", State = MeshNodeState.Active };
+
+    [Fact]
+    public void Guard_HandlesOnlyDelete()
+        => Assert.Equal(NodeOperation.Delete, Assert.Single(Guard.SupportedOperations));
+
+    [Fact]
+    public async Task InteractiveUser_CannotDelete_UserPartitionRoot()
+    {
+        var result = await Validate(UserRoot("rbuergi"), "rbuergi");
+
+        Assert.False(result.IsValid);
+        Assert.Equal(NodeRejectionReason.Unauthorized, result.Reason);
+        Assert.Contains("partition root", result.ErrorMessage!);
+    }
+
+    [Fact]
+    public async Task Admin_OtherUser_StillCannotDelete_AUserPartitionRoot()
+    {
+        // Even a different (would-be admin) interactive caller is blocked — only System is exempt.
+        var result = await Validate(UserRoot("rbuergi"), "someadmin");
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public async Task System_MayDelete_UserPartitionRoot()
+    {
+        // Deliberate infrastructure / off-boarding runs as System and is exempt.
+        var result = await Validate(UserRoot("rbuergi"), WellKnownUsers.System);
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public async Task SpaceRoot_IsNotProtected()
+    {
+        // A Space owns a partition too but is deletable (it carries an explicit teardown handler).
+        var result = await Validate(new MeshNode("acme") { NodeType = "Space", State = MeshNodeState.Active }, "rbuergi");
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public async Task ChildAndSatelliteNodes_AreNotProtected()
+    {
+        // A namespaced node under the user's partition is NOT the root — deleting a thread/child must
+        // remain possible (that is the whole point of the fix).
+        Assert.True((await Validate(new MeshNode("mythread", "rbuergi/_Thread") { NodeType = "User" }, "rbuergi")).IsValid);
+        Assert.True((await Validate(new MeshNode("note", "rbuergi") { NodeType = "Markdown" }, "rbuergi")).IsValid);
+    }
+
+    [Theory]
+    [InlineData("rbuergi", "", "User", true)]        // canonical root
+    [InlineData("rbuergi", "", "user", true)]        // NodeType case-insensitive
+    [InlineData("acme", "", "Space", false)]         // Space root
+    [InlineData("rbuergi", "somens", "User", false)] // namespaced → not a root
+    [InlineData("thread", "rbuergi/_Thread", "User", false)] // satellite
+    [InlineData("_Access", "", "User", false)]       // '_'-prefixed reserved segment
+    public void IsUserPartitionRoot_ClassifiesShapes(string id, string ns, string nodeType, bool expected)
+    {
+        var node = new MeshNode(id, ns) { NodeType = nodeType, State = MeshNodeState.Active };
+        Assert.Equal(expected, PartitionRootDeletionGuard.IsUserPartitionRoot(node));
+    }
+
+    [Fact]
+    public void IsUserPartitionRoot_Null_IsFalse()
+        => Assert.False(PartitionRootDeletionGuard.IsUserPartitionRoot(null));
+}


### PR DESCRIPTION
## Why

A user's entire partition got wiped by clicking **Delete** in the node menu on a **thread** anchored under their home. Root cause: the node menu retargeted every op (including Delete) from the viewed node to the satellite's **owner** (`MainNode`), so Delete posted `DeleteNodeRequest({user}, Recursive)` against the partition root. This PR fixes that at the source and adds defense-in-depth, plus a couple of chat quality-of-life fixes from the same session.

## Node menu / partition-root hardening

- **Menu targets the viewed node, never the owner** (`NodeMenuItemsExtensions.GetMenuContext`). "Delete this thread" now deletes the thread.
- **`PartitionRootDeletionGuard`** — a new `INodeValidator` (`IOwnerEnforcedNodeValidator`, Delete-only): a **User partition root is undeletable** by an interactive caller (System-exempt for deliberate off-boarding). Rejecting the delete root aborts the whole cascade. Registered in `AddRowLevelSecurity` alongside `PartitionWriteGuardValidator`.
- **Suppress Edit/Move/Copy/Delete** on a user partition root in the menu (Pin / read / lifecycle remain).
- **Menu fails closed when logged out** — an unauthenticated viewer gets `Permission.None`, so the authoring menu renders nothing even on a public-read node.
- **Onboarding** — bare `EmptyLayout` (no portal top menu) + redirect **home** when the profile already exists (never loops back to `/onboarding`).

## Chat

- **`MeshWeaverHarness.Order = -1`** so MeshWeaver leads the picker and is the catalog default.
- **Keep the composer focused** after clear-on-submit so it stays focused while a round streams.

## Tests

- `PartitionRootDeletionGuardTest` — **13** cases (guard logic + `IsUserPartitionRoot` shapes: root vs Space vs satellite vs namespaced vs System-exempt).
- `MenuAccessControlTest.Menu_UserPartitionRoot_HidesEditMoveCopyDelete`.
- Green locally under `-c Release -warnaserror`: guard 13/13, `MenuAccessControlTest` 9/9, `Blazor.Portal` 0/0.

## Notes / not in scope

- The **logged-out render test** was omitted deliberately — this harness auto-logs-in the default admin, so `GetClient()` can't produce a truly anonymous viewer; the gating is verified in a real unauthenticated browser session.
- The **composer-focus** change compiles clean but needs a real-browser check (Blazor/Monaco focus isn't unit-testable).
- A separate Safari-only `DataChangedEvent` sync-storm (undeliverable events deferred 30s → `DeliveryFailure`) is a core message-routing change tracked separately — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
