### PR TITLE
feat(events): EventSubscription Timer + NodeStatus triggers (stages 2–3)

### DIFF
--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -49,6 +49,8 @@ public sealed class EventSubscriptionRunner(
     // Live one-shot timers, keyed by subscription id — instance (never static), disposed on fire, on the
     // subscription leaving the pending set, and on runner stop. No leak.
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, IDisposable> timerSubs = new();
+    // Live NodeStatus watches, same lifecycle contract as timerSubs.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, IDisposable> statusSubs = new();
     private IDisposable? pendingSub;
     private IDisposable? feedSub;
     private IDisposable? legacySub;
@@ -78,14 +80,17 @@ public sealed class EventSubscriptionRunner(
                              { TriggerType: EventTriggerType.NodeChange, TriggerKind: MeshChangeKind.Created }))
                     Reconcile(s);
 
-                // Schedule one-shot timers for pending Timer subscriptions; cancel timers for any that
-                // left the pending set (fired / cancelled elsewhere).
+                // Schedule one-shot timers + NodeStatus watches for pending subscriptions; cancel any whose
+                // subscription left the pending set (fired / cancelled elsewhere).
                 foreach (var s in list.Where(s => s is { TriggerType: EventTriggerType.Timer, FireAt: not null }))
                     ScheduleTimer(s);
+                foreach (var s in list.Where(s => s is { TriggerType: EventTriggerType.NodeStatus, WatchPath.Length: > 0 }))
+                    WatchNodeStatus(s);
                 var pendingIds = list.Select(s => s.Id).ToHashSet();
-                foreach (var id in timerSubs.Keys.Where(id => !pendingIds.Contains(id)).ToList())
-                    if (timerSubs.TryRemove(id, out var d))
-                        d.Dispose();
+                foreach (var (subs, _) in new[] { (timerSubs, 0), (statusSubs, 0) })
+                    foreach (var id in subs.Keys.Where(id => !pendingIds.Contains(id)).ToList())
+                        if (subs.TryRemove(id, out var d))
+                            d.Dispose();
             }, ex => logger?.LogWarning(ex, "Event-subscriptions query failed"));
 
         // Live: fire on the actual change event.
@@ -193,6 +198,58 @@ public sealed class EventSubscriptionRunner(
         });
     }
 
+    /// <summary>
+    /// Watches the node at <see cref="EventSubscription.WatchPath"/> and fires when its
+    /// <see cref="EventSubscription.StatusField"/> enters <see cref="EventSubscription.RestingValues"/> —
+    /// after first seeing a non-resting (active) value when <see cref="EventSubscription.RequireActiveFirst"/>
+    /// (the delegation "saw-running → resting" semantics). Idempotent per id, self-disposing on fire, and
+    /// self-healing: uses <see cref="ActivityControlPlaneExtensions.SubscribeWithReEstablish"/>, which
+    /// re-establishes on a transient fault and terminally STOPS (no storm) when the watched node is gone.
+    /// On reboot the pending-set reconcile re-attaches the watch and a node that reached its resting state
+    /// during downtime fires immediately (restart-safe).
+    /// </summary>
+    private void WatchNodeStatus(EventSubscription subscription)
+    {
+        if (statusSubs.ContainsKey(subscription.Id))
+            return;
+        var slot = new System.Reactive.Disposables.SingleAssignmentDisposable();
+        if (!statusSubs.TryAdd(subscription.Id, slot))
+            return;   // lost the race
+        var sawActive = false;
+        var fired = false;
+        var statusField = subscription.StatusField is { Length: > 0 } f ? f : "Status";
+        // SingleAssignmentDisposable makes onNext firing synchronously-on-subscribe safe: slot.Dispose()
+        // marks it disposed, and the later `slot.Disposable = …` assignment then disposes the watch too.
+        slot.Disposable = ActivityControlPlaneExtensions.SubscribeWithReEstablish<MeshNode>(
+            () => AsSystem(() => hub.GetWorkspace().GetMeshNodeStream(subscription.WatchPath!)),
+            node =>
+            {
+                if (fired)
+                    return;
+                var status = node?.Content is null
+                    ? null
+                    : EventSubscriptionOps.ReadContentField(node, statusField, hub.JsonSerializerOptions);
+                if (status is null)
+                    return;
+                var resting = subscription.RestingValues.Any(v =>
+                    string.Equals(v, status, StringComparison.OrdinalIgnoreCase));
+                if (!resting)
+                {
+                    sawActive = true;
+                    return;
+                }
+                if (subscription.RequireActiveFirst && !sawActive)
+                    return;   // initial replayed-resting — the node never ran; wait for an active state first
+                fired = true;
+                statusSubs.TryRemove(subscription.Id, out _);
+                slot.Dispose();
+                Execute(subscription, subscription.SubjectId ?? "");
+            },
+            hub.Address,
+            logger,
+            $"EventSubscription.NodeStatus[{subscription.Id}]");
+    }
+
     private IObservable<MeshNode> BuildContinuation(EventSubscription subscription, string userId) =>
         subscription.ContinuationType switch
         {
@@ -289,8 +346,9 @@ public sealed class EventSubscriptionRunner(
         pendingSub?.Dispose();
         feedSub?.Dispose();
         legacySub?.Dispose();
-        foreach (var id in timerSubs.Keys.ToList())
-            if (timerSubs.TryRemove(id, out var d))
-                d.Dispose();
+        foreach (var subs in new[] { timerSubs, statusSubs })
+            foreach (var id in subs.Keys.ToList())
+                if (subs.TryRemove(id, out var d))
+                    d.Dispose();
     }
 }

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -30,9 +30,11 @@ namespace MeshWeaver.Graph;
 ///
 /// <para>This supersedes the former <c>ScheduledActionRunner</c>. On startup it migrates any legacy
 /// <c>Admin/ScheduledAction/{id}</c> nodes (from before the generalization) into
-/// <c>Admin/EventSubscription/{id}</c> so an in-flight invite is never dropped. Timer +
-/// NodeStatus triggers are added in later stages; only <see cref="EventTriggerType.NodeChange"/> is
-/// handled here.</para>
+/// <c>Admin/EventSubscription/{id}</c> so an in-flight invite is never dropped. Handles
+/// <see cref="EventTriggerType.NodeChange"/> (live change-feed + reconcile) and
+/// <see cref="EventTriggerType.Timer"/> (a one-shot <c>Observable.Timer</c> per pending subscription,
+/// with a past <c>FireAt</c> firing on the next startup — restart-safe at-least-once). The
+/// <see cref="EventTriggerType.NodeStatus"/> trigger is added in a later stage.</para>
 /// </summary>
 public sealed class EventSubscriptionRunner(
     IMessageHub hub,
@@ -44,6 +46,9 @@ public sealed class EventSubscriptionRunner(
     private readonly object gate = new();
     private IReadOnlyList<EventSubscription> pending = [];
     private readonly HashSet<string> migratedLegacyIds = [];
+    // Live one-shot timers, keyed by subscription id — instance (never static), disposed on fire, on the
+    // subscription leaving the pending set, and on runner stop. No leak.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, IDisposable> timerSubs = new();
     private IDisposable? pendingSub;
     private IDisposable? feedSub;
     private IDisposable? legacySub;
@@ -72,6 +77,15 @@ public sealed class EventSubscriptionRunner(
                 foreach (var s in list.Where(s => s is
                              { TriggerType: EventTriggerType.NodeChange, TriggerKind: MeshChangeKind.Created }))
                     Reconcile(s);
+
+                // Schedule one-shot timers for pending Timer subscriptions; cancel timers for any that
+                // left the pending set (fired / cancelled elsewhere).
+                foreach (var s in list.Where(s => s is { TriggerType: EventTriggerType.Timer, FireAt: not null }))
+                    ScheduleTimer(s);
+                var pendingIds = list.Select(s => s.Id).ToHashSet();
+                foreach (var id in timerSubs.Keys.Where(id => !pendingIds.Contains(id)).ToList())
+                    if (timerSubs.TryRemove(id, out var d))
+                        d.Dispose();
             }, ex => logger?.LogWarning(ex, "Event-subscriptions query failed"));
 
         // Live: fire on the actual change event.
@@ -133,11 +147,12 @@ public sealed class EventSubscriptionRunner(
         return string.Equals(actual, subscription.MatchValue, StringComparison.OrdinalIgnoreCase);
     }
 
+    // A NodeChange trigger's node id IS the subject (a User node's path IS the userId).
     private void Execute(EventSubscription subscription, MeshNode triggerNode)
-    {
-        // The triggering node's id is the user (a User node's path IS the userId).
-        var userId = triggerNode.Id;
+        => Execute(subscription, triggerNode.Id);
 
+    private void Execute(EventSubscription subscription, string userId)
+    {
         BuildContinuation(subscription, userId)
             .SelectMany(_ => AsSystem(() => EventSubscriptionOps.SetStatus(
                 hub, EventSubscriptionNodeType.Path(subscription.Id), EventSubscriptionStatus.Fired)))
@@ -152,6 +167,30 @@ public sealed class EventSubscriptionRunner(
                             hub, EventSubscriptionNodeType.Path(subscription.Id), EventSubscriptionStatus.Failed, ex.Message))
                         .Subscribe(_ => { }, _ => { });
                 });
+    }
+
+    /// <summary>
+    /// Schedules a one-shot timer for a pending <see cref="EventTriggerType.Timer"/> subscription
+    /// (idempotent per id — the slot is reserved before subscribing, so two pending-set emissions can't
+    /// double-schedule). A <see cref="EventSubscription.FireAt"/> already in the past fires immediately,
+    /// which — since the subscription node is durable and its <c>Pending → Fired</c> gates re-entry —
+    /// gives restart-safe at-least-once firing (a timer due during downtime fires on the next boot).
+    /// </summary>
+    private void ScheduleTimer(EventSubscription subscription)
+    {
+        if (timerSubs.ContainsKey(subscription.Id))
+            return;
+        var slot = new System.Reactive.Disposables.SingleAssignmentDisposable();
+        if (!timerSubs.TryAdd(subscription.Id, slot))
+            return;   // lost the race — another emission just scheduled this id
+        var delay = subscription.FireAt!.Value - DateTimeOffset.UtcNow;
+        if (delay < TimeSpan.Zero)
+            delay = TimeSpan.Zero;
+        slot.Disposable = Observable.Timer(delay).Subscribe(_tick =>
+        {
+            timerSubs.TryRemove(subscription.Id, out _);
+            Execute(subscription, subscription.SubjectId ?? "");
+        });
     }
 
     private IObservable<MeshNode> BuildContinuation(EventSubscription subscription, string userId) =>
@@ -250,5 +289,8 @@ public sealed class EventSubscriptionRunner(
         pendingSub?.Dispose();
         feedSub?.Dispose();
         legacySub?.Dispose();
+        foreach (var id in timerSubs.Keys.ToList())
+            if (timerSubs.TryRemove(id, out var d))
+                d.Dispose();
     }
 }

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -30,11 +30,12 @@ namespace MeshWeaver.Graph;
 ///
 /// <para>This supersedes the former <c>ScheduledActionRunner</c>. On startup it migrates any legacy
 /// <c>Admin/ScheduledAction/{id}</c> nodes (from before the generalization) into
-/// <c>Admin/EventSubscription/{id}</c> so an in-flight invite is never dropped. Handles
-/// <see cref="EventTriggerType.NodeChange"/> (live change-feed + reconcile) and
+/// <c>Admin/EventSubscription/{id}</c> so an in-flight invite is never dropped. Handles all three
+/// trigger kinds: <see cref="EventTriggerType.NodeChange"/> (live change-feed + reconcile),
 /// <see cref="EventTriggerType.Timer"/> (a one-shot <c>Observable.Timer</c> per pending subscription,
-/// with a past <c>FireAt</c> firing on the next startup — restart-safe at-least-once). The
-/// <see cref="EventTriggerType.NodeStatus"/> trigger is added in a later stage.</para>
+/// with a past <c>FireAt</c> firing on the next startup — restart-safe at-least-once), and
+/// <see cref="EventTriggerType.NodeStatus"/> (a self-healing node-stream watch that fires when the
+/// watched node's status reaches a resting value).</para>
 /// </summary>
 public sealed class EventSubscriptionRunner(
     IMessageHub hub,
@@ -193,7 +194,8 @@ public sealed class EventSubscriptionRunner(
             delay = TimeSpan.Zero;
         slot.Disposable = Observable.Timer(delay).Subscribe(_tick =>
         {
-            timerSubs.TryRemove(subscription.Id, out _);
+            if (timerSubs.TryRemove(subscription.Id, out var d))
+                d.Dispose();
             Execute(subscription, subscription.SubjectId ?? "");
         });
     }
@@ -253,7 +255,8 @@ public sealed class EventSubscriptionRunner(
     private IObservable<MeshNode> BuildContinuation(EventSubscription subscription, string userId) =>
         subscription.ContinuationType switch
         {
-            EventContinuationType.GrantSpaceAccess when subscription is { TargetPath.Length: > 0, Role.Length: > 0 } =>
+            EventContinuationType.GrantSpaceAccess
+                when subscription is { TargetPath.Length: > 0, Role.Length: > 0 } && !string.IsNullOrEmpty(userId) =>
                 AsSystem(() => EventSubscriptionOps.Grant(meshService, userId, subscription.TargetPath!, subscription.Role!))
                     .SelectMany(g => subscription.Pin
                         ? AsSystem(() => EventSubscriptionOps.Pin(hub, userId, subscription.TargetPath!)).Select(_ => g)

--- a/src/MeshWeaver.Mesh.Contract/EventSubscription.cs
+++ b/src/MeshWeaver.Mesh.Contract/EventSubscription.cs
@@ -23,8 +23,7 @@ public enum EventTriggerType
     /// <summary>Fire when a node of <see cref="EventSubscription.TriggerNodeType"/> is
     /// <see cref="EventSubscription.TriggerKind"/>-changed and its field matches (the invite→grant case).</summary>
     NodeChange = 0,
-    /// <summary>Fire at (or after) a time, once, or on an interval (a <c>FireAt</c>/<c>Interval</c> —
-    /// stage 2).</summary>
+    /// <summary>Fire once at (or after) a time (<see cref="EventSubscription.FireAt"/>).</summary>
     Timer = 1,
     /// <summary>Fire when a watched node reaches a resting status — its status field enters the
     /// subscription's resting values (the delegation "sub-thread finished" case, stage 3).</summary>
@@ -87,6 +86,11 @@ public record EventSubscription
     /// <summary>[NodeChange] The value <see cref="MatchField"/> must equal (case-insensitive) to match.</summary>
     public string? MatchValue { get; init; }
 
+    // Timer trigger
+    /// <summary>[Timer] Fire once at (or after) this instant. A time already in the past fires on the
+    /// next startup reconcile (at-least-once, restart-safe). (Repeating/interval timers are a follow-up.)</summary>
+    public DateTimeOffset? FireAt { get; init; }
+
     // ── Effect ───────────────────────────────────────────────────────────────
 
     /// <summary>What this does when it fires.</summary>
@@ -95,6 +99,12 @@ public record EventSubscription
     /// <summary>The node the continuation targets — for <see cref="EventContinuationType.GrantSpaceAccess"/>
     /// the Space path.</summary>
     public string? TargetPath { get; init; }
+
+    /// <summary>The subject the continuation acts on when the trigger carries no node (e.g. a
+    /// <see cref="EventTriggerType.Timer"/>) — for <see cref="EventContinuationType.GrantSpaceAccess"/> the
+    /// user to grant. For a <see cref="EventTriggerType.NodeChange"/> trigger the subject is the triggering
+    /// node's id and this is ignored.</summary>
+    public string? SubjectId { get; init; }
 
     /// <summary>[GrantSpaceAccess] The role to grant (e.g. <c>Editor</c>).</summary>
     public string? Role { get; init; }

--- a/src/MeshWeaver.Mesh.Contract/EventSubscription.cs
+++ b/src/MeshWeaver.Mesh.Contract/EventSubscription.cs
@@ -91,6 +91,26 @@ public record EventSubscription
     /// next startup reconcile (at-least-once, restart-safe). (Repeating/interval timers are a follow-up.)</summary>
     public DateTimeOffset? FireAt { get; init; }
 
+    // NodeStatus trigger
+    /// <summary>[NodeStatus] The node to watch — fire when its <see cref="StatusField"/> reaches a resting
+    /// value. The delegation case watches the sub-thread; a status leaves "running" → the parent continues.</summary>
+    public string? WatchPath { get; init; }
+
+    /// <summary>[NodeStatus] The content field holding the status (default <c>Status</c>). Read as a string
+    /// (an enum serialises as its name), compared case-insensitively against <see cref="RestingValues"/>.</summary>
+    public string? StatusField { get; init; }
+
+    /// <summary>[NodeStatus] The status values that count as "resting" — fire when the watched node's
+    /// <see cref="StatusField"/> enters this set (e.g. <c>Idle</c>/<c>Cancelled</c>/<c>Done</c>). Any value
+    /// NOT in this set is "active/busy".</summary>
+    public System.Collections.Immutable.ImmutableList<string> RestingValues { get; init; }
+        = System.Collections.Immutable.ImmutableList<string>.Empty;
+
+    /// <summary>[NodeStatus] Only fire AFTER the watched node was first seen in a non-resting (active) state
+    /// — so an initial replayed-resting emission (the node was never running) does not fire. The delegation
+    /// "sawRunning then terminal" semantics.</summary>
+    public bool RequireActiveFirst { get; init; }
+
     // ── Effect ───────────────────────────────────────────────────────────────
 
     /// <summary>What this does when it fires.</summary>

--- a/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
+++ b/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
@@ -159,4 +159,42 @@ public class EventSubscriptionRunnerTest(ITestOutputHelper output) : MonolithMes
         Assert.True(final!.Status == EventSubscriptionStatus.Fired,
             $"migrated subscription ended {final.Status}: {final.LastError}");
     }
+
+    [Fact(Timeout = 60000)]
+    public async Task TimerSubscription_FiresAtItsTime_GrantingTheSubject()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        // A one-shot timer whose FireAt is already in the past → fires the moment the runner schedules it
+        // (the restart-safe "a timer due during downtime fires on the next boot" path). No trigger node,
+        // so the subject is carried on the subscription (SubjectId).
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.Timer,
+            FireAt = DateTimeOffset.UtcNow.AddSeconds(-1),
+            ContinuationType = EventContinuationType.GrantSpaceAccess,
+            SubjectId = InviteeId,
+            TargetPath = Space,
+            Role = "Editor",
+        };
+        await EventSubscriptionOps.CreateSubscription(meshService, subscription).Should().Emit();
+
+        using var runner = new EventSubscriptionRunner(Mesh, changeFeed, meshService, accessService,
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>());
+        await runner.StartAsync(default);
+
+        // Fires: the subscription flips to Fired and the Editor grant lands for the subject.
+        var final = await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Select(n => n?.Content as EventSubscription)
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.True(final!.Status == EventSubscriptionStatus.Fired,
+            $"timer subscription ended {final.Status}: {final.LastError}");
+
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{Space}/_Access/{InviteeId}_Access")
+            .Where(n => n?.Content is AccessAssignment a && a.Roles.Any(r => r.Role == "Editor" && !r.Denied))
+            .FirstAsync().Timeout(10.Seconds());
+    }
 }

--- a/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
+++ b/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -25,9 +26,20 @@ public class EventSubscriptionRunnerTest(ITestOutputHelper output) : MonolithMes
     private const string InviteeEmail = "newcomer@acme.com";
     private const string InviteeId = "newcomer";
 
+    /// <summary>A tiny node content with a flippable status field — the watched node for the NodeStatus test.</summary>
+    public record WatchedContent
+    {
+        public string Status { get; init; } = "";
+    }
+
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => ConfigureMeshBase(builder)
-            .AddMeshNodes(new MeshNode(Space) { Name = "Invite Space", NodeType = "Space" });
+            .AddMeshNodes(new MeshNode(Space) { Name = "Invite Space", NodeType = "Space" })
+            .AddMeshNodes(new MeshNode("Watched")
+            {
+                Name = "Watched",
+                HubConfiguration = c => c.AddMeshDataSource(s => s.WithContentType<WatchedContent>()),
+            });
 
     [Fact(Timeout = 60000)]
     public async Task PendingGrant_FiresWhenMatchingUserIsCreated()
@@ -192,6 +204,59 @@ public class EventSubscriptionRunnerTest(ITestOutputHelper output) : MonolithMes
             .FirstAsync().Timeout(40.Seconds());
         Assert.True(final!.Status == EventSubscriptionStatus.Fired,
             $"timer subscription ended {final.Status}: {final.LastError}");
+
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{Space}/_Access/{InviteeId}_Access")
+            .Where(n => n?.Content is AccessAssignment a && a.Roles.Any(r => r.Role == "Editor" && !r.Denied))
+            .FirstAsync().Timeout(10.Seconds());
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task NodeStatusSubscription_FiresWhenWatchedNodeReachesResting()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        const string watchId = "watched1";
+
+        // A watched node currently "Running" (active).
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode(watchId)
+            {
+                NodeType = "Watched",
+                Name = "Watched 1",
+                Content = new WatchedContent { Status = "Running" },
+            }).Should().Emit();
+
+        // Fire when the watched node's Status reaches "Idle" (resting), granting the subject.
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.NodeStatus,
+            WatchPath = watchId,
+            StatusField = "Status",
+            RestingValues = ["Idle"],
+            ContinuationType = EventContinuationType.GrantSpaceAccess,
+            SubjectId = InviteeId,
+            TargetPath = Space,
+            Role = "Editor",
+        };
+        await EventSubscriptionOps.CreateSubscription(meshService, subscription).Should().Emit();
+
+        using var runner = new EventSubscriptionRunner(Mesh, changeFeed, meshService, accessService,
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>());
+        await runner.StartAsync(default);
+
+        // Flip the watched node to a resting status → the subscription fires.
+        using (accessService.ImpersonateAsSystem())
+            await Mesh.GetWorkspace().GetMeshNodeStream(watchId)
+                .Update(n => n with { Content = new WatchedContent { Status = "Idle" } })
+                .Timeout(30.Seconds()).ToTask();
+
+        var final = await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Select(n => n?.Content as EventSubscription)
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.True(final!.Status == EventSubscriptionStatus.Fired,
+            $"node-status subscription ended {final.Status}: {final.LastError}");
 
         await Mesh.GetWorkspace().GetMeshNodeStream($"{Space}/_Access/{InviteeId}_Access")
             .Where(n => n?.Content is AccessAssignment a && a.Roles.Any(r => r.Role == "Editor" && !r.Denied))


### PR DESCRIPTION
## What (stages 2–3 of the durable event-subscription facility)

Builds on the `EventSubscription` primitive (stage 1, #280) with two more trigger kinds, so the one durable runner now reacts to **CRUD events** (stage 1), **timers**, and **node-status resting**.

### Stage 2 — Timer trigger
Fire a continuation at/after `FireAt`. The runner schedules one `Observable.Timer` per pending Timer subscription (idempotent per id via a reserved slot; disposed on fire / leaving the pending set / runner stop). A `FireAt` already in the past fires immediately on the next boot — since the node is durable and `Pending→Fired` gates re-entry, that's **restart-safe at-least-once WITHOUT Orleans reminders** (verified: reminders aren't wired and the monolith has no Orleans, so node-reconcile is the host-uniform substrate). A timer carries no trigger node, so the continuation subject is on the subscription (`SubjectId`).

### Stage 3 — NodeStatus-resting trigger
Fire when a watched node's status field reaches a resting value — the "sub-thread finished" detection delegation will use (stage 5). Reuses the existing self-healing `SubscribeWithReEstablish` (re-establishes on transient fault, terminally **stops with no storm** when the watched node is gone), tracks `RequireActiveFirst` (an initial replayed-resting of a node that never ran doesn't fire), and fires when `StatusField` ∈ `RestingValues`. On reboot the reconcile re-attaches and a node that went resting during downtime fires immediately.

## Tests
`EventSubscriptionRunnerTest` now covers **4/4**: NodeChange grant, legacy migration, **Timer fires at its time**, **NodeStatus fires on Running→Idle**. Graph.Test builds Release `-warnaserror` clean.

## Next
Stage 4 (round disposition) + stage 5 (delegation durable backstop) + docs land in a follow-up PR (isolating the AI-core change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)