### PR TITLE
fix(messaging): cap deferred backlog behind a stuck init gate — permanent memory-leak/wedge fix

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -69,6 +69,25 @@ public class MessageService : IMessageService
     private static readonly TimeSpan DeferralTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
+    /// Hard cap on the deferred backlog held behind closed init gates. A hub that is legitimately
+    /// initialising drains its gate in well under a second, so it never accrues a deep deferred
+    /// backlog. A backlog past this cap means the gate is STUCK — a client sync/cache hub whose
+    /// <c>[Initialize]</c> never opens (the Safari sync-race wedge). Past the cap, every further
+    /// message would otherwise be queued AND armed with its own <see cref="DeferralTimeout"/> timer,
+    /// so a writer flooding a never-initialising hub accumulates deferred deliveries + timers without
+    /// bound until the action block starves and <c>/healthz</c> times out — the confirmed OOM wedge.
+    /// Past the cap we DROP overflow deferrals instead (see the deferral path). This is a stuck-gate
+    /// SAFETY NET, not a tuning knob: raising it does not fix a stuck gate, it just delays the wedge.
+    /// </summary>
+    private const int MaxDeferredMessages = 512;
+
+    /// <summary>
+    /// One-shot latch so a gate-stuck overflow logs ONE Error per stuck episode (not per dropped
+    /// message). Reset to 0 when a gate opens and the deferred queue drains (<see cref="OpenGate"/>).
+    /// </summary>
+    private int _deferralOverflowLogged;
+
+    /// <summary>
     /// Tracks every delivery currently in <see cref="deferredQueue"/>. Removed
     /// when <see cref="ProcessDeferredMessage"/> drains it. The deferral-timeout
     /// timer fires <see cref="ReportFailure"/> for any entry still here when its
@@ -238,6 +257,9 @@ public class MessageService : IMessageService
                         lock (turnGate)
                             while (deferredQueue.Count > 0)
                                 mainQueue.Enqueue(deferredQueue.Dequeue());
+                        // Gate opened + drained — the hub is no longer stuck, so re-arm the one-shot
+                        // gate-stuck logger for any future episode.
+                        Interlocked.Exchange(ref _deferralOverflowLogged, 0);
                         KickDrain();
 
                         logger.LogDebug("Message hub {address} fully initialized (all gates opened)", Address);
@@ -655,6 +677,28 @@ public class MessageService : IMessageService
                         // If we still need to defer, post to deferred buffer and return
                         if (shouldDefer)
                         {
+                            // 🛡️ Stuck-gate safety net. A legitimately-initialising hub drains its gate in
+                            // well under a second, so it never accrues a deep deferred backlog; a backlog
+                            // past MaxDeferredMessages means the gate is STUCK (a client sync/cache hub whose
+                            // [Initialize] never opens). Deferring further messages there would queue them AND
+                            // arm a 30s timer each, accumulating unbounded memory until the action block starves
+                            // and /healthz times out — the confirmed OOM wedge. DROP the overflow (Ignored — NOT
+                            // a DeliveryFailure, so a fire-and-forget writer's retry isn't fed; a client re-syncs
+                            // a fresh Full on reconnect) so memory stays bounded. Log ONE Error per stuck episode.
+                            int deferredDepth;
+                            lock (turnGate) deferredDepth = deferredQueue.Count;
+                            if (deferredDepth >= MaxDeferredMessages)
+                            {
+                                if (Interlocked.Exchange(ref _deferralOverflowLogged, 1) == 0)
+                                    logger.LogError(
+                                        "GATE-STUCK in hub {Address}: {Depth} messages deferred behind gates [{Gates}] past "
+                                        + "the {Cap} cap — the gate is not opening (a dependency's [Initialize] never fired, "
+                                        + "e.g. a client sync/cache hub). Dropping overflow deferrals to bound memory and keep "
+                                        + "the action block draining. Find and fix why the gate never opens.",
+                                        Address, deferredDepth, string.Join(",", gates.Keys), MaxDeferredMessages);
+                                MessageTrace.Write($"hub={Address} msg={name} id={delivery.Id} DROPPED_GATE_STUCK depth={deferredDepth}");
+                                return Observable.Return(delivery.Ignored());
+                            }
                             logger.LogDebug("Deferring on-target message {MessageType} (ID: {MessageId}) in {Address}",
                                 delivery.Message.GetType().Name, delivery.Id, Address);
                             MessageTrace.Write($"hub={Address} msg={name} id={delivery.Id} DEFERRED gates=[{string.Join(",", gates.Keys)}]");

--- a/test/MeshWeaver.Messaging.Hub.Test/DeferredBacklogBoundedTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DeferredBacklogBoundedTest.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Deterministic repro for the sync-storm memory-leak / wedge: a hub whose init gate never opens (a
+/// client sync/cache hub whose <c>[Initialize]</c> never fires) used to defer EVERY inbound message +
+/// arm a 30s timer each, so a writer flooding it accumulated the deferred buffer without bound until
+/// the action block starved and <c>/healthz</c> timed out (memory 4.3Gi on memex.localhost, cleared
+/// only by a restart). The stuck-gate safety net (<c>MessageService.MaxDeferredMessages</c>) caps the
+/// deferred backlog and drops the overflow, so memory stays bounded no matter how hard the stuck hub
+/// is flooded. This test floods a never-opening-gate hub well past the cap and asserts the deferred
+/// backlog does NOT grow past it.
+/// </summary>
+public class DeferredBacklogBoundedTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>A plain non-system, non-[CanBeIgnored] message → defers behind a closed gate.</summary>
+    private record Filler(int N);
+
+    /// <summary>Mirror of the internal <c>MessageService.MaxDeferredMessages</c> — kept in sync deliberately.</summary>
+    private const int Cap = 512;
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => configuration
+            .WithTypes(typeof(Filler))
+            // A user gate that never opens: every non-bypass message defers behind it forever —
+            // exactly a client sync/cache hub whose [Initialize] never fires.
+            .WithInitializationGate("test-never-opens", _ => false);
+
+    [Fact(Timeout = 30000)]
+    public async Task DeferredBacklog_StaysBounded_WhenGateNeverOpens()
+    {
+        var host = GetHost();
+
+        // Flood well past the cap. WITHOUT the safety net every one of these queues in the deferred
+        // buffer (+ a 30s timer each) — the unbounded accumulation that OOM-wedged the portal.
+        const int posts = Cap + 300;
+        for (var i = 0; i < posts; i++)
+            host.Post(new Filler(i), o => o.WithTarget(host.Address));
+
+        // Poll the PUBLIC disposal diagnostics (reports "deferred=<N>" per hub) until the deferred
+        // backlog is stable across two reads — the single-threaded action block defers messages one at
+        // a time, so the count climbs to the cap and then holds as overflow is dropped.
+        int Deferred()
+        {
+            var diag = host.GetDisposalDiagnostics();
+            var max = 0;
+            foreach (Match m in Regex.Matches(diag, @"deferred=(\d+)"))
+                max = Math.Max(max, int.Parse(m.Groups[1].Value));
+            return max;
+        }
+
+        int prev = -1, cur = Deferred();
+        for (var i = 0; i < 120 && cur != prev; i++)
+        {
+            await Task.Delay(100);
+            prev = cur;
+            cur = Deferred();
+        }
+
+        Assert.True(cur > 0, $"messages should have deferred behind the never-opening gate (sanity; saw {cur})");
+        Assert.True(cur <= Cap,
+            $"deferred backlog must stay bounded at the cap {Cap}; saw {cur} — unbounded accumulation is the wedge");
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/DeferredBacklogBoundedTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DeferredBacklogBoundedTest.cs
@@ -45,6 +45,9 @@ public class DeferredBacklogBoundedTest(ITestOutputHelper output) : HubTestBase(
         // Poll the PUBLIC disposal diagnostics (reports "deferred=<N>" per hub) until the deferred
         // backlog is stable across two reads — the single-threaded action block defers messages one at
         // a time, so the count climbs to the cap and then holds as overflow is dropped.
+        // The HOST hub is the ONLY hub this test floods, so it holds the deepest deferred backlog;
+        // other hubs (mesh router / hosted hubs) never approach it. The max deferred= across the
+        // diagnostics therefore IS the host's backlog in this test.
         int Deferred()
         {
             var diag = host.GetDisposalDiagnostics();
@@ -54,16 +57,22 @@ public class DeferredBacklogBoundedTest(ITestOutputHelper output) : HubTestBase(
             return max;
         }
 
-        int prev = -1, cur = Deferred();
-        for (var i = 0; i < 120 && cur != prev; i++)
+        // Wait until the backlog has CLIMBED and SETTLED at a NON-ZERO value (two consecutive equal,
+        // non-zero reads). Never exit on the initial 0 before the action block starts deferring — that
+        // would flake under CI load. If it never climbs, the loop runs out and `settled` stays 0, so the
+        // first assert fails CLEARLY rather than silently passing.
+        var settled = 0;
+        for (var i = 0; i < 150; i++)
         {
             await Task.Delay(100);
-            prev = cur;
-            cur = Deferred();
+            var d = Deferred();
+            if (d > 0 && d == settled) break;   // stable + non-zero → the backlog has settled
+            settled = d;
         }
 
-        Assert.True(cur > 0, $"messages should have deferred behind the never-opening gate (sanity; saw {cur})");
-        Assert.True(cur <= Cap,
-            $"deferred backlog must stay bounded at the cap {Cap}; saw {cur} — unbounded accumulation is the wedge");
+        Assert.True(settled > 0,
+            $"backlog should climb and settle behind the never-opening gate (last saw {settled})");
+        Assert.True(settled <= Cap,
+            $"deferred backlog must stay bounded at the cap {Cap}; settled at {settled} — unbounded accumulation is the wedge");
     }
 }


### PR DESCRIPTION
## The wedge (root cause, confirmed on memex.localhost)
A hub whose init gate never opens — a client sync/cache hub whose `[Initialize]` never fires (the Safari sync-race) — deferred **every** inbound message AND armed a 30s `DeferralTimeout` timer for each. A writer flooding it (a runaway thread emitting `DataChangedEvent`s) accumulated the deferred buffer + timers **without bound** → the single action block starved → `/healthz` timed out → **OOM wedge** (memory 4.3Gi, cleared only by restart).

## Fix
`MessageService.MaxDeferredMessages` (512) caps the deferred backlog. A legitimately-initialising hub drains its gate in <1s and never accrues a deep backlog, so a backlog past the cap means the gate is **stuck**. Past the cap the overflow is **dropped** (`Ignored` — not a `DeliveryFailure`, so a fire-and-forget writer's retry isn't fed; a client re-syncs a fresh Full on reconnect). Memory stays bounded, the action block keeps draining. One `Error` per stuck episode (re-armed when the gate opens). Stuck-gate safety net, **not** a tuning knob.

## Test
`DeferredBacklogBoundedTest` — floods a never-opening-gate hub past the cap, asserts the deferred backlog does **not** grow past it (deterministic repro). Green: repro 1/1, gate/init regression 11/11, `-c Release -warnaserror`.

Fixes the wedge from task #11. Note: this bounds the wedge/leak at the messaging layer; the *upstream* cause (a runaway thread + a client sync hub that never initialises) is still worth a separate look, but this makes it non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)