### PR TITLE
feat(events): EventSubscription continuation-handler seam (stage 5 foundation)

### DIFF
--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -4,6 +4,7 @@ using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -261,8 +262,15 @@ public sealed class EventSubscriptionRunner(
                     .SelectMany(g => subscription.Pin
                         ? AsSystem(() => EventSubscriptionOps.Pin(hub, userId, subscription.TargetPath!)).Select(_ => g)
                         : Observable.Return(g)),
-            _ => Observable.Throw<MeshNode>(new InvalidOperationException(
-                $"Unsupported or incomplete event subscription {subscription.Id}")),
+            // Continuations whose effect lives above Graph (e.g. PostThreadMessage in MeshWeaver.AI) run
+            // through a registered IEventSubscriptionContinuationHandler resolved from DI, wrapped in
+            // AsSystem so the handler's writes run under the system identity.
+            _ => hub.ServiceProvider
+                    .GetServices<IEventSubscriptionContinuationHandler>()
+                    .FirstOrDefault(h => h.Handles == subscription.ContinuationType) is { } handler
+                ? AsSystem(() => handler.Run(subscription))
+                : Observable.Throw<MeshNode>(new InvalidOperationException(
+                    $"No continuation handler for {subscription.ContinuationType} (subscription {subscription.Id})")),
         };
 
     /// <summary>

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -262,6 +262,10 @@ public sealed class EventSubscriptionRunner(
                     .SelectMany(g => subscription.Pin
                         ? AsSystem(() => EventSubscriptionOps.Pin(hub, userId, subscription.TargetPath!)).Select(_ => g)
                         : Observable.Return(g)),
+            // A GrantSpaceAccess that failed the guard (missing TargetPath/Role/subject) is INCOMPLETE —
+            // surface that, don't fall through to the handler seam (which is only for non-native types).
+            EventContinuationType.GrantSpaceAccess => Observable.Throw<MeshNode>(new InvalidOperationException(
+                $"Incomplete GrantSpaceAccess event subscription {subscription.Id} (needs TargetPath, Role, and a subject)")),
             // Continuations whose effect lives above Graph (e.g. PostThreadMessage in MeshWeaver.AI) run
             // through a registered IEventSubscriptionContinuationHandler resolved from DI, wrapped in
             // AsSystem so the handler's writes run under the system identity.

--- a/src/MeshWeaver.Graph/IEventSubscriptionContinuationHandler.cs
+++ b/src/MeshWeaver.Graph/IEventSubscriptionContinuationHandler.cs
@@ -1,0 +1,24 @@
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// A pluggable continuation for an <see cref="EventSubscription"/> whose effect lives in a higher layer
+/// than <c>MeshWeaver.Graph</c> — e.g. the delegation backstop (<see cref="EventContinuationType.PostThreadMessage"/>)
+/// posts a sub-thread's result back into the parent thread, which needs <c>MeshWeaver.AI</c>'s thread
+/// submission surface that Graph cannot reference. Register an implementation in DI; the
+/// <c>EventSubscriptionRunner</c> resolves the one whose <see cref="Handles"/> matches a fired
+/// subscription's <see cref="EventSubscription.ContinuationType"/> and runs it (already under the system
+/// identity — do NOT re-impersonate). The natively-handled <see cref="EventContinuationType.GrantSpaceAccess"/>
+/// continuation does NOT go through this seam.
+/// </summary>
+public interface IEventSubscriptionContinuationHandler
+{
+    /// <summary>The continuation type this handler runs.</summary>
+    EventContinuationType Handles { get; }
+
+    /// <summary>Runs the continuation for a fired <paramref name="subscription"/> (cold — the caller
+    /// subscribes). Everything the effect needs is on the subscription (e.g. <see cref="EventSubscription.WatchPath"/>
+    /// = the source, <see cref="EventSubscription.TargetPath"/> = the destination).</summary>
+    IObservable<MeshNode> Run(EventSubscription subscription);
+}

--- a/src/MeshWeaver.Graph/IEventSubscriptionContinuationHandler.cs
+++ b/src/MeshWeaver.Graph/IEventSubscriptionContinuationHandler.cs
@@ -8,9 +8,13 @@ namespace MeshWeaver.Graph;
 /// posts a sub-thread's result back into the parent thread, which needs <c>MeshWeaver.AI</c>'s thread
 /// submission surface that Graph cannot reference. Register an implementation in DI; the
 /// <c>EventSubscriptionRunner</c> resolves the one whose <see cref="Handles"/> matches a fired
-/// subscription's <see cref="EventSubscription.ContinuationType"/> and runs it (already under the system
-/// identity — do NOT re-impersonate). The natively-handled <see cref="EventContinuationType.GrantSpaceAccess"/>
-/// continuation does NOT go through this seam.
+/// subscription's <see cref="EventSubscription.ContinuationType"/> and runs it. The runner wraps the
+/// returned observable in a system-impersonation scope, so <see cref="Run"/>'s construction and the
+/// initial subscribe are under the system identity. Because <c>AccessContext</c> is AsyncLocal, if your
+/// handler defers work onto a NEW async/reactive boundary it created itself, re-establish the identity
+/// there (the framework's write primitives already carry it through <c>.Subscribe</c>). The
+/// natively-handled <see cref="EventContinuationType.GrantSpaceAccess"/> continuation does NOT go through
+/// this seam.
 /// </summary>
 public interface IEventSubscriptionContinuationHandler
 {

--- a/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
+++ b/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
@@ -32,6 +32,19 @@ public class EventSubscriptionRunnerTest(ITestOutputHelper output) : MonolithMes
         public string Status { get; init; } = "";
     }
 
+    /// <summary>A test continuation handler for <see cref="EventContinuationType.PostThreadMessage"/> —
+    /// records the subscription it was dispatched, proving the runner's DI seam works.</summary>
+    public sealed class RecordingContinuationHandler : IEventSubscriptionContinuationHandler
+    {
+        public volatile string? RanForWatchPath;
+        public EventContinuationType Handles => EventContinuationType.PostThreadMessage;
+        public IObservable<MeshNode> Run(EventSubscription subscription)
+        {
+            RanForWatchPath = subscription.WatchPath;
+            return Observable.Return(new MeshNode("handled"));
+        }
+    }
+
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => ConfigureMeshBase(builder)
             .AddMeshNodes(new MeshNode(Space) { Name = "Invite Space", NodeType = "Space" })
@@ -39,7 +52,10 @@ public class EventSubscriptionRunnerTest(ITestOutputHelper output) : MonolithMes
             {
                 Name = "Watched",
                 HubConfiguration = c => c.AddMeshDataSource(s => s.WithContentType<WatchedContent>()),
-            });
+            })
+            .ConfigureServices(s => s
+                .AddSingleton<RecordingContinuationHandler>()
+                .AddSingleton<IEventSubscriptionContinuationHandler>(sp => sp.GetRequiredService<RecordingContinuationHandler>()));
 
     [Fact(Timeout = 60000)]
     public async Task PendingGrant_FiresWhenMatchingUserIsCreated()
@@ -261,5 +277,54 @@ public class EventSubscriptionRunnerTest(ITestOutputHelper output) : MonolithMes
         await Mesh.GetWorkspace().GetMeshNodeStream($"{Space}/_Access/{InviteeId}_Access")
             .Where(n => n?.Content is AccessAssignment a && a.Roles.Any(r => r.Role == "Editor" && !r.Denied))
             .FirstAsync().Timeout(10.Seconds());
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task NodeStatusSubscription_DispatchesToRegisteredContinuationHandler()
+    {
+        // The delegation backstop's PostThreadMessage continuation lives above Graph (in MeshWeaver.AI),
+        // so the runner dispatches it to a registered IEventSubscriptionContinuationHandler. This pins
+        // that DI seam: a fired NodeStatus subscription with a non-native ContinuationType runs the handler.
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var handler = Mesh.ServiceProvider.GetRequiredService<RecordingContinuationHandler>();
+        const string watchId = "watched-handler";
+
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode(watchId)
+            {
+                NodeType = "Watched", Name = "Watched Handler",
+                Content = new WatchedContent { Status = "Running" },
+            }).Should().Emit();
+
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.NodeStatus,
+            WatchPath = watchId,
+            StatusField = "Status",
+            RestingValues = ["Idle"],
+            ContinuationType = EventContinuationType.PostThreadMessage,   // dispatched via the DI seam
+            TargetPath = "some/parent/thread",
+        };
+        await EventSubscriptionOps.CreateSubscription(meshService, subscription).Should().Emit();
+
+        using var runner = new EventSubscriptionRunner(Mesh, changeFeed, meshService, accessService,
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>());
+        await runner.StartAsync(default);
+
+        using (accessService.ImpersonateAsSystem())
+            await Mesh.GetWorkspace().GetMeshNodeStream(watchId)
+                .Update(n => n with { Content = new WatchedContent { Status = "Idle" } })
+                .Timeout(30.Seconds()).ToTask();
+
+        // The subscription fires and the registered handler ran for the watched path.
+        var final = await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Select(n => n?.Content as EventSubscription)
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.True(final!.Status == EventSubscriptionStatus.Fired,
+            $"subscription ended {final.Status}: {final.LastError}");
+        Assert.Equal(watchId, handler.RanForWatchPath);
     }
 }


### PR DESCRIPTION
## What

Adds **`IEventSubscriptionContinuationHandler`** — a DI-resolved seam so an `EventSubscription` continuation whose effect lives **above** `MeshWeaver.Graph` runs through a registered handler. The `EventSubscriptionRunner` dispatches any non-native `ContinuationType` (everything except the native `GrantSpaceAccess`) to the handler whose `Handles` matches, wrapped in `AsSystem` (system identity).

## Why

This is the **foundation for the durable delegation backstop** (stage 5 of the event-subscription unification). The delegation continuation (`PostThreadMessage` — post a sub-thread's result back into the parent thread) needs `MeshWeaver.AI`'s thread-submission surface, which `Graph` can't reference. The seam lets AI register that handler; the runner (in Graph) invokes it when a `NodeStatus`-resting subscription for a delegated sub-thread fires.

## Tests

`EventSubscriptionRunnerTest` (5/5): the existing NodeChange/Timer/NodeStatus/legacy coverage **plus** a new test proving a fired `PostThreadMessage` subscription dispatches to a DI-registered handler. Release `-warnaserror` clean.

## Next (the wedge-prone part — deliberately a separate, AI-test-validated pass)
The AI-side `PostThreadMessage` handler + wiring `ExecuteDelegationAsync` to create the durable backstop at delegation dispatch — **keeping the in-memory TCS fast path 100% intact** (the backstop only fires on reboot, guarded against double-delivery via the parent's unfinished-delegation check). That touches the delegation core with a subtle double-delivery/round-resume interaction, so it lands as a focused pass validated by the AI.Test shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)