### PR TITLE
feat(ai): auto-discover Ollama/OpenAI-compatible models from the endpoint

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -93,6 +93,11 @@ data:
   OpenAICompatible__Endpoint: "{{ .Values.config.memex_portal.OpenAICompatible__Endpoint | default "" }}"
   OpenAICompatible__Models__0: "{{ .Values.config.memex_portal.OpenAICompatible__Models__0 | default "" }}"
   OpenAICompatible__Models__1: "{{ .Values.config.memex_portal.OpenAICompatible__Models__1 | default "" }}"
+  # Auto-discover the model list from the endpoint's /v1/models (Ollama etc.) instead of the
+  # static Models[] above — a pulled model then shows up in the picker without a config edit.
+  # When "true", leave Models[] empty (discovery owns this provider's child set). The embedding
+  # model (Embedding__Model) is excluded from the chat catalog. Empty/false = static behaviour.
+  OpenAICompatible__DiscoverModels: "{{ .Values.config.memex_portal.OpenAICompatible__DiscoverModels | default "" }}"
   # Tier → concrete model id (agents that declare ModelTier resolve through these).
   ModelTier__Heavy: "{{ .Values.config.memex_portal.ModelTier__Heavy }}"
   ModelTier__Standard: "{{ .Values.config.memex_portal.ModelTier__Standard }}"

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -264,6 +264,12 @@ public static class MemexConfiguration
         // ProviderModelLister fetches a provider's live model list (HTTP /models via
         // the I/O pool) so the add-provider flow lets users pick which models to bring.
         services.AddSingleton<Memex.Portal.Shared.Models.ProviderModelLister>();
+        // OpenAI-compatible (Ollama) auto-discovery — keeps the OpenAICompatible provider's
+        // LanguageModel catalog in sync with the models installed on its endpoint, so a locally
+        // pulled model shows up in the picker without editing OpenAICompatible:Models[]. Opt-in
+        // (OpenAICompatible:DiscoverModels=true) and inert otherwise; only when the provider is on.
+        if (features.Ai.Providers.OpenAICompatible)
+            services.AddHostedService<Memex.Portal.Shared.Models.OpenAICompatibleModelSync>();
 
         // GitHub sync — per-user OAuth credential (device flow) + bidirectional
         // Space ↔ GitHub sync (export = "sync back"; import = create / re-import a

--- a/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
+++ b/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
@@ -205,7 +205,10 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
                             })))
                     .ToArray();
 
-                return Observable.Merge(ops).LastOrDefaultAsync().Select(_ => Unit.Default);
+                // Concat (not Merge): apply the create/delete writes SEQUENTIALLY, so a large discovered
+                // list never fans out into a concurrent write storm against the mesh (Ollama lists are
+                // small, but a generic OpenAI-compatible endpoint could return hundreds).
+                return Observable.Concat(ops).LastOrDefaultAsync().Select(_ => Unit.Default);
             });
 
     /// <summary>The reconcile decision, split out as a pure function so it is deterministically testable.</summary>

--- a/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
+++ b/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
@@ -55,14 +55,20 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
     private readonly IMessageHub hub;
     private readonly IConfiguration configuration;
     private readonly ProviderModelLister lister;
-    private readonly AccessService accessService;
-    private readonly IMeshService meshService;
+    // 🚨 LAZY — resolved on FIRST USE, never in the constructor. Resolving IMeshService / touching the
+    // workspace eagerly builds the process-wide MeshNodeStreamCache hub; doing that during host startup
+    // (a hosted-service ctor runs at DI build time) can construct the cache BEFORE the Orleans stream
+    // provider is ready → an NRE that kills the cache hub and wedges the whole silo. A hosted service's
+    // ctor must be cheap and side-effect-free; all cache access is deferred to BeginDiscovery (below).
+    private readonly Lazy<AccessService> accessService;
+    private readonly Lazy<IMeshService> meshService;
     private readonly ILogger<OpenAICompatibleModelSync>? logger;
 
     // Live snapshot of the current OpenAICompatible model-child ids (kept fresh by the catalog query).
     // Instance field (never static), StringComparer.OrdinalIgnoreCase — model ids are case-insensitive.
     private volatile ImmutableHashSet<string> catalogIds =
         ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase);
+    private IDisposable? startupSub;
     private IDisposable? catalogSub;
     private IDisposable? timerSub;
 
@@ -76,9 +82,10 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
         this.configuration = configuration;
         this.lister = lister;
         this.logger = logger;
-        // IMeshService is scoped per hub — resolve from the mesh hub's provider, not the web root.
-        accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
-        meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        // Cheap, side-effect-free ctor: NO service resolution, NO workspace/cache access. IMeshService is
+        // scoped per hub — resolve lazily from the mesh hub's provider on first use, never here.
+        accessService = new Lazy<AccessService>(() => hub.ServiceProvider.GetRequiredService<AccessService>());
+        meshService = new Lazy<IMeshService>(() => hub.ServiceProvider.GetRequiredService<IMeshService>());
     }
 
     /// <inheritdoc />
@@ -96,6 +103,34 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
         var period = TimeSpan.FromSeconds(
             Math.Max(15, configuration.GetValue("OpenAICompatible:DiscoverIntervalSeconds", 120)));
 
+        // 🚨 Defer EVERY mesh-cache touch (the catalog query AND the reconcile) until initialDelay past
+        // startup, off any hub thread. StartAsync runs during host startup, when the Orleans stream
+        // provider may not be ready; touching the workspace/cache then constructs the process cache hub
+        // too early and NREs. The one-shot timer here does nothing but schedule BeginDiscovery later, so
+        // this hosted service is inert during the fragile startup window. Wrapped so it can never wedge.
+        startupSub = Observable.Timer(initialDelay, TaskPoolScheduler.Default)
+            .Subscribe(_ =>
+            {
+                try
+                {
+                    BeginDiscovery(endpoint!, apiKey, embeddingModel, period);
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogError(ex, "[OpenAICompatibleModelSync] failed to start discovery — disabled for this run");
+                }
+            });
+
+        logger?.LogInformation(
+            "[OpenAICompatibleModelSync] Ollama/OpenAI-compatible model discovery enabled (endpoint {Endpoint}, first run in {Delay}s, every {Period}s)",
+            endpoint, initialDelay.TotalSeconds, period.TotalSeconds);
+        return Task.CompletedTask;
+    }
+
+    // Runs once, initialDelay past startup (Orleans is up by now), off any hub thread. Sets up the live
+    // catalog snapshot AND the periodic reconcile. This is the FIRST point the mesh cache is touched.
+    private void BeginDiscovery(string endpoint, string apiKey, string? embeddingModel, TimeSpan period)
+    {
         // (a) Live snapshot of the current OpenAICompatible LanguageModel child ids (system read — the
         //     Provider partition needs an identity). Constant query id: one registry entry, no leak.
         catalogSub = AsSystem(() => hub.GetWorkspace()
@@ -110,10 +145,10 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
                 ex => logger?.LogWarning(ex, "[OpenAICompatibleModelSync] catalog query failed"));
 
         // (b) Periodic reconcile: fetch the endpoint's live model list, diff against the catalog,
-        //     create/delete. Runs at initialDelay then every period, off any hub thread. A failed cycle
-        //     is logged and the loop continues (no watchdog resubscribe — the timer already re-fires).
-        timerSub = Observable.Timer(initialDelay, period, TaskPoolScheduler.Default)
-            .SelectMany(_ => Reconcile(endpoint!, apiKey, embeddingModel)
+        //     create/delete. Fires immediately (we're already past initialDelay) then every period. A
+        //     failed cycle is logged and the loop continues (no watchdog resubscribe — the timer re-fires).
+        timerSub = Observable.Timer(TimeSpan.Zero, period, TaskPoolScheduler.Default)
+            .SelectMany(_ => Reconcile(endpoint, apiKey, embeddingModel)
                 .Catch<Unit, Exception>(ex =>
                 {
                     logger?.LogWarning(ex,
@@ -123,11 +158,6 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
                 }))
             .Subscribe(_ => { },
                 ex => logger?.LogError(ex, "[OpenAICompatibleModelSync] discovery loop terminated"));
-
-        logger?.LogInformation(
-            "[OpenAICompatibleModelSync] Ollama/OpenAI-compatible model discovery enabled (endpoint {Endpoint}, first run in {Delay}s, every {Period}s)",
-            endpoint, initialDelay.TotalSeconds, period.TotalSeconds);
-        return Task.CompletedTask;
     }
 
     // Fetch → decide (pure ComputeDelta: drop embeddings, diff, empty-guard) → apply. Exposed internally
@@ -158,7 +188,7 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
                 catalogIds = catalogIds.Except(delta.ToRemove).Union(delta.ToAdd);
 
                 var ops = delta.ToAdd
-                    .Select(id => AsSystem(() => meshService.CreateOrUpdateNode(BuildModelNode(id)))
+                    .Select(id => AsSystem(() => meshService.Value.CreateOrUpdateNode(BuildModelNode(id)))
                         .Select(_ => Unit.Default)
                         .Catch<Unit, Exception>(ex =>
                         {
@@ -166,7 +196,7 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
                             return Observable.Return(Unit.Default);
                         }))
                     .Concat(delta.ToRemove
-                        .Select(id => AsSystem(() => meshService.DeleteNode($"{ProviderPath}/{id}"))
+                        .Select(id => AsSystem(() => meshService.Value.DeleteNode($"{ProviderPath}/{id}"))
                             .Select(_ => Unit.Default)
                             .Catch<Unit, Exception>(ex =>
                             {
@@ -254,7 +284,7 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
 
     // Construct AND subscribe under the system identity (no ambient AccessContext in a hosted service).
     private IObservable<T> AsSystem<T>(Func<IObservable<T>> factory) =>
-        Observable.Using(accessService.ImpersonateAsSystem, _ => Observable.Defer(factory));
+        Observable.Using(accessService.Value.ImpersonateAsSystem, _ => Observable.Defer(factory));
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken)
@@ -266,6 +296,7 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
+        startupSub?.Dispose();
         catalogSub?.Dispose();
         timerSub?.Dispose();
     }

--- a/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
+++ b/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
@@ -1,0 +1,272 @@
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using MeshWeaver.AI;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Models;
+
+/// <summary>
+/// Keeps the <c>OpenAICompatible</c> provider's <c>LanguageModel</c> catalog in sync with the models
+/// actually installed on the endpoint it points at — the local Ollama use case: pull a model
+/// (<c>ollama pull …</c>) and it shows up in the picker without hand-editing
+/// <c>OpenAICompatible:Models[]</c>.
+///
+/// <para>Opt-in, off by default: does nothing unless <c>OpenAICompatible:DiscoverModels=true</c> AND
+/// <c>OpenAICompatible:Endpoint</c> is set. When enabled, leave <c>OpenAICompatible:Models[]</c> empty —
+/// discovery OWNS this provider's child set (the static <see cref="BuiltInLanguageModelProvider"/> still
+/// seeds the parent <c>Provider/OpenAICompatible</c> node with the endpoint/key; only the model children
+/// come from here).</para>
+///
+/// <para>🚨 Reactive end-to-end, no ambient identity (a hosted service, not a request):
+/// <list type="bullet">
+///   <item>The model list is fetched via <see cref="ProviderModelLister"/> — its HTTP leaf runs inside
+///     the <c>IIoPool</c>, never on a hub thread.</item>
+///   <item>Every read AND write is wrapped in <see cref="AsSystem{T}"/>
+///     (<c>Using(ImpersonateAsSystem, Defer(factory))</c>) so it's constructed and subscribed under the
+///     system identity — mirrors <c>EventSubscriptionRunner</c>.</item>
+///   <item>Writes go through <see cref="IMeshService.CreateOrUpdateNode"/> (idempotent upsert — race-free
+///     re-runs) and <see cref="IMeshService.DeleteNode"/>. The child nodes match the platform shape
+///     <see cref="ModelProviderService"/> emits (<c>ProviderRef</c> → the parent provider node, no key on
+///     the child), so the chat-client factory resolves credentials the same way.</item>
+/// </list>
+/// </para>
+///
+/// <para>The reconcile diffs the endpoint's live list against a live catalog snapshot: additions are the
+/// point of the feature; removals reflect an <c>ollama rm</c>. Two guards keep it safe: an empty/failed
+/// fetch is skipped entirely (never wipes the catalog on a transient blip), and the embedding model
+/// (<c>Embedding:Model</c>, e.g. <c>bge-m3</c>) is excluded so it never pollutes the chat picker.</para>
+/// </summary>
+public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
+{
+    private const string ProviderName = "OpenAICompatible";
+    // "Provider/OpenAICompatible" — the parent ModelProvider node the built-in catalog seeds.
+    private static readonly string ProviderPath = $"{ModelProviderNodeType.RootNamespace}/{ProviderName}";
+
+    private readonly IMessageHub hub;
+    private readonly IConfiguration configuration;
+    private readonly ProviderModelLister lister;
+    private readonly AccessService accessService;
+    private readonly IMeshService meshService;
+    private readonly ILogger<OpenAICompatibleModelSync>? logger;
+
+    // Live snapshot of the current OpenAICompatible model-child ids (kept fresh by the catalog query).
+    // Instance field (never static), StringComparer.OrdinalIgnoreCase — model ids are case-insensitive.
+    private volatile ImmutableHashSet<string> catalogIds =
+        ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase);
+    private IDisposable? catalogSub;
+    private IDisposable? timerSub;
+
+    public OpenAICompatibleModelSync(
+        IMessageHub hub,
+        IConfiguration configuration,
+        ProviderModelLister lister,
+        ILogger<OpenAICompatibleModelSync>? logger = null)
+    {
+        this.hub = hub;
+        this.configuration = configuration;
+        this.lister = lister;
+        this.logger = logger;
+        // IMeshService is scoped per hub — resolve from the mesh hub's provider, not the web root.
+        accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var discover = configuration.GetValue("OpenAICompatible:DiscoverModels", false);
+        var endpoint = configuration["OpenAICompatible:Endpoint"];
+        if (!discover || string.IsNullOrWhiteSpace(endpoint))
+            return Task.CompletedTask; // inert unless explicitly enabled AND an endpoint is set
+
+        var apiKey = configuration["OpenAICompatible:ApiKey"] ?? string.Empty;
+        var embeddingModel = configuration["Embedding:Model"];
+        var initialDelay = TimeSpan.FromSeconds(
+            Math.Max(0, configuration.GetValue("OpenAICompatible:DiscoverInitialDelaySeconds", 20)));
+        var period = TimeSpan.FromSeconds(
+            Math.Max(15, configuration.GetValue("OpenAICompatible:DiscoverIntervalSeconds", 120)));
+
+        // (a) Live snapshot of the current OpenAICompatible LanguageModel child ids (system read — the
+        //     Provider partition needs an identity). Constant query id: one registry entry, no leak.
+        catalogSub = AsSystem(() => hub.GetWorkspace()
+                .GetQuery("openaicompatible-model-catalog",
+                    $"namespace:{ProviderPath} nodeType:{LanguageModelNodeType.NodeType} scope:descendants")
+                .Select(nodes => nodes
+                    .Select(n => n.Id)
+                    .Where(id => !string.IsNullOrEmpty(id))
+                    .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase)))
+            .Subscribe(
+                ids => catalogIds = ids,
+                ex => logger?.LogWarning(ex, "[OpenAICompatibleModelSync] catalog query failed"));
+
+        // (b) Periodic reconcile: fetch the endpoint's live model list, diff against the catalog,
+        //     create/delete. Runs at initialDelay then every period, off any hub thread. A failed cycle
+        //     is logged and the loop continues (no watchdog resubscribe — the timer already re-fires).
+        timerSub = Observable.Timer(initialDelay, period, TaskPoolScheduler.Default)
+            .SelectMany(_ => Reconcile(endpoint!, apiKey, embeddingModel)
+                .Catch<Unit, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "[OpenAICompatibleModelSync] discovery cycle failed (endpoint {Endpoint}) — will retry next cycle",
+                        endpoint);
+                    return Observable.Return(Unit.Default);
+                }))
+            .Subscribe(_ => { },
+                ex => logger?.LogError(ex, "[OpenAICompatibleModelSync] discovery loop terminated"));
+
+        logger?.LogInformation(
+            "[OpenAICompatibleModelSync] Ollama/OpenAI-compatible model discovery enabled (endpoint {Endpoint}, first run in {Delay}s, every {Period}s)",
+            endpoint, initialDelay.TotalSeconds, period.TotalSeconds);
+        return Task.CompletedTask;
+    }
+
+    // Fetch → decide (pure ComputeDelta: drop embeddings, diff, empty-guard) → apply. Exposed internally
+    // so a test can drive one reconcile deterministically.
+    internal IObservable<Unit> Reconcile(string endpoint, string apiKey, string? embeddingModel) =>
+        lister.ListModels(endpoint, apiKey, ProviderName, allowKeyless: true)
+            .SelectMany(all =>
+            {
+                var delta = ComputeDelta(all, catalogIds, embeddingModel);
+                if (delta.Skip)
+                {
+                    // An empty result (endpoint up but no models, or a malformed response) must NOT be read
+                    // as "delete everything". Skip the whole reconcile — adds resume once models return.
+                    logger?.LogWarning(
+                        "[OpenAICompatibleModelSync] endpoint {Endpoint} returned no chat models — skipping reconcile this cycle",
+                        endpoint);
+                    return Observable.Return(Unit.Default);
+                }
+                if (delta.ToAdd.Count == 0 && delta.ToRemove.Count == 0)
+                    return Observable.Return(Unit.Default);
+
+                logger?.LogInformation(
+                    "[OpenAICompatibleModelSync] reconcile: +{Add} -{Remove} at {Endpoint}",
+                    delta.ToAdd.Count, delta.ToRemove.Count, endpoint);
+
+                // Optimistically fold the delta in so a fast next tick doesn't re-apply before the live
+                // catalog query catches up; the query re-emits the ACTUAL state and self-corrects.
+                catalogIds = catalogIds.Except(delta.ToRemove).Union(delta.ToAdd);
+
+                var ops = delta.ToAdd
+                    .Select(id => AsSystem(() => meshService.CreateOrUpdateNode(BuildModelNode(id)))
+                        .Select(_ => Unit.Default)
+                        .Catch<Unit, Exception>(ex =>
+                        {
+                            logger?.LogWarning(ex, "[OpenAICompatibleModelSync] add model {Id} failed", id);
+                            return Observable.Return(Unit.Default);
+                        }))
+                    .Concat(delta.ToRemove
+                        .Select(id => AsSystem(() => meshService.DeleteNode($"{ProviderPath}/{id}"))
+                            .Select(_ => Unit.Default)
+                            .Catch<Unit, Exception>(ex =>
+                            {
+                                logger?.LogWarning(ex, "[OpenAICompatibleModelSync] remove model {Id} failed", id);
+                                return Observable.Return(Unit.Default);
+                            })))
+                    .ToArray();
+
+                return Observable.Merge(ops).LastOrDefaultAsync().Select(_ => Unit.Default);
+            });
+
+    /// <summary>The reconcile decision, split out as a pure function so it is deterministically testable.</summary>
+    internal readonly record struct CatalogDelta(
+        IReadOnlyList<string> ToAdd, IReadOnlyList<string> ToRemove, bool Skip);
+
+    /// <summary>
+    /// Pure diff: filter the endpoint's model list down to chat models (drop embeddings), then compute
+    /// what to add / remove versus the <paramref name="currentCatalog"/>. An all-empty desired set is
+    /// reported as <see cref="CatalogDelta.Skip"/> so the caller never wipes the catalog on a blip.
+    /// </summary>
+    internal static CatalogDelta ComputeDelta(
+        IReadOnlyList<string> endpointModels,
+        IReadOnlyCollection<string> currentCatalog,
+        string? embeddingModel)
+    {
+        var desired = endpointModels.Where(id => !string.IsNullOrWhiteSpace(id) && !IsEmbedding(id, embeddingModel))
+            .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        if (desired.Count == 0)
+            return new CatalogDelta(Array.Empty<string>(), Array.Empty<string>(), Skip: true);
+
+        var current = currentCatalog.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var desiredSet = desired.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var toAdd = desired.Where(id => !current.Contains(id)).ToList();
+        var toRemove = current.Where(id => !desiredSet.Contains(id)).ToList();
+        return new CatalogDelta(toAdd, toRemove, Skip: false);
+    }
+
+    // The platform-provider LanguageModel child shape (mirrors ModelProviderService.CreateProvider):
+    // no key on the child, endpoint/key resolved by following ProviderRef → the parent provider node.
+    internal static MeshNode BuildModelNode(string modelId)
+    {
+        var pricing = ModelPricing.Default(modelId); // null for local models → tokens shown without a cost
+        var def = new ModelDefinition
+        {
+            Id = modelId,
+            DisplayName = modelId,
+            Provider = ProviderName,
+            Endpoint = null,           // resolver follows ProviderRef
+            ApiKeySecretRef = null,    // never a key on a publicly-readable model child
+            ProviderRef = ProviderPath,
+            Order = 5,                 // OpenAICompatible catalog order
+            InputPricePerMillionTokens = pricing?.InputPerMillion,
+            OutputPricePerMillionTokens = pricing?.OutputPerMillion,
+            Currency = pricing?.Currency
+        };
+        return new MeshNode(modelId, ProviderPath)
+        {
+            NodeType = LanguageModelNodeType.NodeType,
+            Name = modelId,
+            Category = "Models",
+            Icon = "Sparkle",
+            State = MeshNodeState.Active,
+            MainNode = $"{ProviderPath}/{modelId}",
+            // create-if-absent: never pruned by the static importer, survives redeploys.
+            SyncBehavior = SyncBehavior.ExcludeThisAndChildren,
+            Content = def
+        };
+    }
+
+    // Exclude the deployment's embedding model from the chat catalog. The authoritative signal is the
+    // configured Embedding:Model (NOT a hardcoded model-name guess) — compared on the bare name (before
+    // the ':tag') so the config value "my-embedder" matches the endpoint's "my-embedder:latest".
+    internal static bool IsEmbedding(string modelId, string? embeddingModel)
+    {
+        if (string.IsNullOrWhiteSpace(embeddingModel))
+            return false;
+        return string.Equals(Bare(modelId), Bare(embeddingModel), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Bare(string id)
+    {
+        var idx = id.IndexOf(':');
+        return idx < 0 ? id : id[..idx];
+    }
+
+    // Construct AND subscribe under the system identity (no ambient AccessContext in a hosted service).
+    private IObservable<T> AsSystem<T>(Func<IObservable<T>> factory) =>
+        Observable.Using(accessService.ImpersonateAsSystem, _ => Observable.Defer(factory));
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        catalogSub?.Dispose();
+        timerSub?.Dispose();
+    }
+}

--- a/memex/Memex.Portal.Shared/Models/ProviderModelLister.cs
+++ b/memex/Memex.Portal.Shared/Models/ProviderModelLister.cs
@@ -52,9 +52,16 @@ public sealed class ProviderModelLister
     /// shape (Anthropic vs the OpenAI family). Sorted, de-duplicated. Throws (via
     /// OnError) on a non-success response so the UI can show the reason and fall back.
     /// </summary>
-    public IObservable<IReadOnlyList<string>> ListModels(string? endpoint, string apiKey, string? providerName = null)
+    /// <param name="allowKeyless">
+    /// When <c>true</c>, a blank <paramref name="apiKey"/> is permitted and the request is sent
+    /// without an <c>Authorization</c> header — for keyless local OpenAI-compatible endpoints
+    /// (Ollama, a bare vLLM/LM Studio) whose <c>/v1/models</c> needs no credential. The interactive
+    /// add-provider flow keeps the default (<c>false</c>): a user pasting a remote provider URL still
+    /// gets the "API key required" error rather than a silent 401.
+    /// </param>
+    public IObservable<IReadOnlyList<string>> ListModels(string? endpoint, string apiKey, string? providerName = null, bool allowKeyless = false)
     {
-        if (string.IsNullOrWhiteSpace(apiKey))
+        if (string.IsNullOrWhiteSpace(apiKey) && !allowKeyless)
             return Observable.Throw<IReadOnlyList<string>>(
                 new InvalidOperationException("An API key is required to fetch the model list."));
         return Http.Invoke(ct => ListAsync(endpoint, apiKey, providerName, ct));
@@ -81,8 +88,10 @@ public sealed class ProviderModelLister
             req.Headers.TryAddWithoutValidation("x-api-key", apiKey);
             req.Headers.TryAddWithoutValidation("anthropic-version", "2023-06-01");
         }
-        else
+        else if (!string.IsNullOrWhiteSpace(apiKey))
         {
+            // Keyless endpoints (Ollama) send no Authorization header; a remote OpenAI-family
+            // endpoint always has a non-blank key here (the ListModels guard enforces it).
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
         }
         req.Headers.Accept.ParseAdd("application/json");

--- a/test/Memex.Portal.Shared.Test/OpenAICompatibleModelSyncTest.cs
+++ b/test/Memex.Portal.Shared.Test/OpenAICompatibleModelSyncTest.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Memex.Portal.Shared.Models;
+using MeshWeaver.AI;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Unit tests for the pure decision logic behind Ollama / OpenAI-compatible model auto-discovery
+/// (<see cref="OpenAICompatibleModelSync"/>): the embedding filter, the add/remove diff + empty-guard
+/// (<see cref="OpenAICompatibleModelSync.ComputeDelta"/>), and the platform LanguageModel node shape
+/// (<see cref="OpenAICompatibleModelSync.BuildModelNode"/>). All deterministic — no mesh, no HTTP.
+/// The reactive fetch/write orchestration is covered by the framework primitives it composes
+/// (ProviderModelLister's IIoPool leaf, IMeshService.CreateOrUpdateNode/DeleteNode, the AsSystem pattern).
+/// </summary>
+public class OpenAICompatibleModelSyncTest
+{
+    // ── ComputeDelta ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeDelta_AddsMissingChatModels_AndExcludesTheEmbeddingModel()
+    {
+        // The configured embedding model (a second qwen here) is excluded from the chat catalog.
+        var endpoint = new[] { "qwen3.6:latest", "qwen3-coder:30b", "qwen3-embedding:latest" };
+
+        var delta = OpenAICompatibleModelSync.ComputeDelta(endpoint, Array.Empty<string>(), embeddingModel: "qwen3-embedding");
+
+        Assert.False(delta.Skip);
+        Assert.Equal(new[] { "qwen3.6:latest", "qwen3-coder:30b" }, delta.ToAdd);
+        Assert.Empty(delta.ToRemove);
+        Assert.DoesNotContain("qwen3-embedding:latest", delta.ToAdd); // the embedder never enters the chat catalog
+    }
+
+    [Fact]
+    public void ComputeDelta_RemovesCatalogEntriesNoLongerInstalled()
+    {
+        var endpoint = new[] { "qwen3.6:latest" };
+        var current = new[] { "qwen3.6:latest", "removed-model:latest" };
+
+        var delta = OpenAICompatibleModelSync.ComputeDelta(endpoint, current, embeddingModel: null);
+
+        Assert.False(delta.Skip);
+        Assert.Empty(delta.ToAdd);
+        Assert.Equal(new[] { "removed-model:latest" }, delta.ToRemove);
+    }
+
+    [Fact]
+    public void ComputeDelta_SteadyState_IsANoOp()
+    {
+        var models = new[] { "a:latest", "b:latest" };
+
+        var delta = OpenAICompatibleModelSync.ComputeDelta(models, models, embeddingModel: null);
+
+        Assert.False(delta.Skip);
+        Assert.Empty(delta.ToAdd);
+        Assert.Empty(delta.ToRemove);
+    }
+
+    [Fact]
+    public void ComputeDelta_CaseInsensitiveMatch_DoesNotChurnExistingModels()
+    {
+        var endpoint = new[] { "Keep:latest", "new:latest" };
+        var current = new[] { "keep:latest", "gone:latest" };
+
+        var delta = OpenAICompatibleModelSync.ComputeDelta(endpoint, current, embeddingModel: null);
+
+        Assert.Equal(new[] { "new:latest" }, delta.ToAdd);      // "Keep" matches "keep" → not re-added
+        Assert.Equal(new[] { "gone:latest" }, delta.ToRemove);  // "keep" is still present → not removed
+    }
+
+    [Fact]
+    public void ComputeDelta_EmptyDesired_Skips_WithoutWipingTheCatalog()
+    {
+        // Endpoint returns nothing usable (only the embedder, or a transient/malformed empty response).
+        var endpoint = new[] { "qwen3-embedding:latest" };
+        var current = new[] { "qwen3.6:latest", "qwen3-coder:30b" };
+
+        var delta = OpenAICompatibleModelSync.ComputeDelta(endpoint, current, embeddingModel: "qwen3-embedding");
+
+        Assert.True(delta.Skip);            // guarded: never delete the whole catalog on an empty result
+        Assert.Empty(delta.ToAdd);
+        Assert.Empty(delta.ToRemove);
+    }
+
+    [Fact]
+    public void ComputeDelta_TotallyEmptyEndpoint_Skips()
+    {
+        var delta = OpenAICompatibleModelSync.ComputeDelta(
+            Array.Empty<string>(), new[] { "a:latest" }, embeddingModel: null);
+
+        Assert.True(delta.Skip);
+        Assert.Empty(delta.ToRemove);
+    }
+
+    [Fact]
+    public void ComputeDelta_DeduplicatesDesired()
+    {
+        var endpoint = new[] { "a:latest", "A:latest", "b:latest" };
+
+        var delta = OpenAICompatibleModelSync.ComputeDelta(endpoint, Array.Empty<string>(), embeddingModel: null);
+
+        Assert.Equal(2, delta.ToAdd.Count); // "a:latest"/"A:latest" collapse to one
+        Assert.Contains("b:latest", delta.ToAdd);
+    }
+
+    // ── IsEmbedding ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("qwen3-embedding:latest", "qwen3-embedding", true)]  // matches configured embedder, tag on the endpoint side
+    [InlineData("qwen3-embedding", "qwen3-embedding:latest", true)]  // tag on the config side — still matches (tag-agnostic)
+    [InlineData("qwen3.6:latest", "qwen3-embedding", false)]         // a real chat model, not the configured embedder
+    [InlineData("qwen3-coder:30b", "qwen3-embedding", false)]        // chat model with a non-latest tag
+    [InlineData("qwen3.6:latest", null, false)]                     // no embedder configured → nothing excluded
+    [InlineData("qwen3.6:latest", "", false)]                      // blank embedder config → nothing excluded
+    public void IsEmbedding_ExcludesOnlyTheConfiguredEmbeddingModel(string modelId, string? embeddingModel, bool expected)
+        => Assert.Equal(expected, OpenAICompatibleModelSync.IsEmbedding(modelId, embeddingModel));
+
+    // ── BuildModelNode ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildModelNode_ProducesThePlatformProviderChildShape_WithTaggedId()
+    {
+        var node = OpenAICompatibleModelSync.BuildModelNode("qwen3.6:latest");
+
+        Assert.Equal("qwen3.6:latest", node.Id);                              // tag preserved as the wire id
+        Assert.Equal("Provider/OpenAICompatible", node.Namespace);
+        Assert.Equal("LanguageModel", node.NodeType);
+        Assert.Equal(SyncBehavior.ExcludeThisAndChildren, node.SyncBehavior); // create-if-absent, never pruned
+
+        var def = Assert.IsType<ModelDefinition>(node.Content);
+        Assert.Equal("qwen3.6:latest", def.Id);
+        Assert.Equal("OpenAICompatible", def.Provider);
+        Assert.Equal("Provider/OpenAICompatible", def.ProviderRef); // credentials resolved via the parent node
+        Assert.Null(def.Endpoint);                                   // resolver follows ProviderRef, not a copied endpoint
+        Assert.Null(def.ApiKeySecretRef);                            // never a key on a publicly-readable child
+    }
+}

--- a/test/MeshWeaver.AI.Test/ProviderModelListerTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderModelListerTest.cs
@@ -141,4 +141,22 @@ public class ProviderModelListerTest(ITestOutputHelper output) : AITestBase(outp
 
         handler.Last.Should().BeNull("a blank key must short-circuit before any HTTP call");
     }
+
+    /// <summary>
+    /// Keyless mode (Ollama): <c>allowKeyless: true</c> with a blank key fetches
+    /// <c>{base}/models</c> with NO <c>Authorization</c> header, instead of throwing.
+    /// This is the local-endpoint path the OpenAICompatible auto-discovery uses.
+    /// </summary>
+    [Fact]
+    public async Task AllowKeyless_BlankKey_FetchesWithoutAuthorizationHeader()
+    {
+        var (lister, handler) = Make("{\"data\":[{\"id\":\"qwen3.6:latest\"},{\"id\":\"bge-m3:latest\"}]}");
+
+        var ids = await lister.ListModels("http://ollama:11434/v1", apiKey: "", "OpenAICompatible", allowKeyless: true)
+            .Should().Within(10.Seconds()).Emit();
+
+        handler.Last!.RequestUri!.ToString().Should().Be("http://ollama:11434/v1/models");
+        handler.Last.Headers.Authorization.Should().BeNull("a keyless local endpoint sends no bearer");
+        ids.Should().Equal("bge-m3:latest", "qwen3.6:latest"); // sorted; the lister does not filter embedders
+    }
 }


### PR DESCRIPTION
## What

Opt-in auto-discovery of the model list from an OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, …), so installed models appear in the picker without hand-maintaining `OpenAICompatible:Models[]`.

When `OpenAICompatible:DiscoverModels=true`, `OpenAICompatibleModelSync` (a reactive `IHostedService`) queries the endpoint's `/v1/models` on startup and every 2 minutes, diffs against the current catalog, and reconciles the `Provider/OpenAICompatible/{model}` `LanguageModel` nodes (create new, remove gone). Pull a model → it shows up; `ollama rm` it → it's removed.

## How it fits the architecture

- **Reactive, no async on hub threads** — the HTTP leaf runs inside the `IIoPool` (via the existing `ProviderModelLister`); every read/write is wrapped in `Using(ImpersonateAsSystem, Defer(...))`, mirroring `EventSubscriptionRunner`.
- **Idempotent, race-free writes** via `IMeshService.CreateOrUpdateNode` / `DeleteNode`.
- **Node shape** mirrors `ModelProviderService.CreateProvider` (no key on the child; `ProviderRef` → the parent provider node the built-in catalog seeds).
- **Guards** — an empty/failed fetch is skipped entirely (never wipes the catalog on a blip); the configured `Embedding:Model` is excluded from the chat set (no hardcoded model-name guessing).
- **Opt-in** behind `OpenAICompatible:DiscoverModels` (helm knob) + the existing `Features:Ai:Providers:OpenAICompatible` flag. Default off = current static behaviour unchanged. When on, leave `Models[]` empty — discovery owns the child set.

## Tests

- `OpenAICompatibleModelSyncTest` (pure): `ComputeDelta` (add / remove / no-op / empty-guard / case-insensitive / dedup), `IsEmbedding` (config-only exclusion), `BuildModelNode` (node shape).
- `ProviderModelListerTest`: keyless path sends no `Authorization` header.

## Verified live

Deployed to a local Ollama-backed portal: discovery logged `reconcile: +5 -1` and the 5 chat models landed at `Provider/OpenAICompatible/*` (embedder `bge-m3` correctly excluded), confirmed directly in Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)