### PR TITLE
fix(social): LinkedIn OAuth callback stamps LinkedIn/LinkedInProfile type

### DIFF
--- a/memex/Memex.Portal.Shared/Social/LinkedInConnectEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/LinkedInConnectEndpoints.cs
@@ -33,10 +33,10 @@ namespace Memex.Portal.Shared.Social;
 ///   GET /connect/linkedin?profile={path}        — start the flow (sets CSRF cookie, redirects to LinkedIn)
 ///   GET /connect/linkedin/callback?code=…       — finish the flow, persist credential + LinkedInProfile node
 ///
-/// Everything else (pulling past posts, comments, likes, computing analytics,
-/// appending telemetry samples) lives as Code on the <c>Systemorph/LinkedInProfile</c>
-/// NodeType — see the <c>LinkedInPullActions</c> Code piece. That keeps the
-/// deployed binary stable while the actual ingest logic can be edited without a deploy.
+/// Everything else (analytics dashboard, CSV telemetry import) lives as Code on the
+/// <c>LinkedIn/LinkedInProfile</c> NodeType — see the <c>LinkedInProfileLayoutAreas</c>
+/// Code piece. That keeps the deployed binary stable while the dashboard/ingest logic
+/// can be edited without a deploy.
 /// </summary>
 public static class LinkedInConnectEndpoints
 {
@@ -200,7 +200,7 @@ public static class LinkedInConnectEndpoints
             var profileNode = new MeshNode("LinkedIn", profilePath)
             {
                 Name = displayName ?? "LinkedIn",
-                NodeType = "Systemorph/LinkedInProfile",
+                NodeType = "LinkedIn/LinkedInProfile",
                 State = MeshNodeState.Active,
                 Content = new Dictionary<string, object?>
                 {


### PR DESCRIPTION
## What

The `/connect/linkedin` OAuth callback upserts a profile node and hardcoded its `NodeType` as the legacy `Systemorph/LinkedInProfile`. That type has been **relocated to a top-level `LinkedIn` partition** (`LinkedIn/LinkedInProfile`) with a rebuilt, reactive + controls-only Overview (migrated off the now-removed `IMeshService.QueryAsync`, no hand-built HTML). This one-line change stamps the new type so the callback upserts against the **compiling** NodeType instead of overwriting the connected profile with the broken legacy one.

## Why

Part of reorganizing LinkedIn into a clean top-level `LinkedIn` partition (partition + `LinkedIn/LinkedInProfile` NodeType + `LinkedIn/rbuergi/LinkedIn` profile + Overview login button) — all done via the mesh. This is the only binary change required: without it, clicking "Sign in with LinkedIn" would re-stamp the profile with `Systemorph/LinkedInProfile`, which no longer compiles.

Config (`Social:LinkedIn:ClientId/Secret`) is already present on memex-cloud from KeyVault; no config change needed.

## Verification

- `Memex.Portal.Shared` builds clean under CI flags (`-c Release -warnaserror -p:CIRun=true`): 0 warnings, 0 errors, against current `main`.
- The `LinkedIn/LinkedInProfile` NodeType compiles `Ok` on meshweaver.cloud and its Overview renders (name header, login button, status, stats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)