### PR TITLE
fix(social): register ApiCredential NodeType so LinkedIn connect persists

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -541,6 +541,11 @@ public static class MemexConfiguration
                 // Register the instance-sync content type ({space}/_Sync/{sourceId} config
                 // nodes) on the mesh + per-node hubs so they (de)serialize.
                 .AddInstanceSyncTypes()
+                // Register the ApiCredential satellite NodeType (+ PlatformCredential content type)
+                // so the LinkedIn/X connect callbacks can create {profile}/_ApiCredentials/{platform}
+                // credential nodes. Without this the create throws "NodeType 'ApiCredential' is not
+                // registered" — the OAuth callback's persist step fails and sign-in reports failure.
+                .AddApiCredentialType()
                 // Seed root-scope Admin AccessAssignments for users listed under
                 // `Auth:GlobalAdmins` so configured admins bypass per-partition
                 // RLS for cross-partition operations (list Spaces, create

--- a/memex/Memex.Portal.Shared/Social/LinkedInConnectEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/LinkedInConnectEndpoints.cs
@@ -240,6 +240,9 @@ public static class LinkedInConnectEndpoints
 
             upsertCredential
                 .SelectMany(_ => upsertProfile)
+                // Never let a stuck reactive write freeze the browser on the callback — a hang
+                // surfaces as an error redirect, not an indefinite spinner (see /async).
+                .Timeout(TimeSpan.FromSeconds(20))
                 .Subscribe(
                     _ =>
                     {


### PR DESCRIPTION
## What

The `/connect/linkedin` OAuth callback creates a credential node at `{profile}/_ApiCredentials/linkedin` with `NodeType = "ApiCredential"`. But `ApiCredentialNodeType.AddApiCredentialType()` (which registers the type via `AddMeshNodes(CreateMeshNode())` + `WithMeshType<PlatformCredential>()`) was **never called** in the mesh builder. So the create threw `NodeType 'ApiCredential' is not registered`, the callback's persist step failed → `?connect=linkedin-error`, and the browser froze first (the `.Catch(→UpdateNode)` fallback tried to update a non-existent node, and the routing retried before surfacing).

This was latent — never hit until someone actually completed the connect flow.

## Fix

1. Wire `.AddApiCredentialType()` into the portal mesh builder (next to `.AddGitHubSyncTypes()` / `.AddInstanceSyncTypes()`).
2. Add a defensive `.Timeout(20s)` on the callback's persistence chain so a stuck reactive write surfaces as an error redirect instead of an indefinite browser freeze (per the `/async` rule — never let a hung write park the request).

## Verification

- `Memex.Portal.Shared` builds clean under CI flags (`-c Release -warnaserror -p:CIRun=true`): 0/0, against current `main`.
- Reproduced the root cause on meshweaver.cloud: creating a `Group` at `LinkedIn/rbuergi/_ApiCredentials/probe` succeeds (path/partition fine), but `nodeType: ApiCredential` fails with the exact "not registered" error.

Follow-up to #296 (which relocated the profile NodeType). Together they make the LinkedIn Overview "Sign in with LinkedIn" flow persist a credential end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)