### PR TITLE
feat(chat): omit empty /model categories + add /clear new-thread skill

### DIFF
--- a/src/MeshWeaver.AI/Data/Skill/clear.md
+++ b/src/MeshWeaver.AI/Data/Skill/clear.md
@@ -1,0 +1,13 @@
+---
+nodeType: Skill
+name: /clear
+description: Start a new, empty conversation
+icon: Add
+category: Skills
+order: 1
+action:
+  kind: NewThread
+---
+
+`/clear` starts a fresh conversation — it clears the current thread and opens a new, empty chat.
+Your harness, agent, and model selection are kept, so you can keep going with a clean slate.

--- a/src/MeshWeaver.AI/SkillNodeType.cs
+++ b/src/MeshWeaver.AI/SkillNodeType.cs
@@ -224,8 +224,9 @@ public enum SkillActionKind
     /// <summary>Log out / forget this provider's CLI subscription.</summary>
     Disconnect,
 
-    /// <summary>Start a fresh, empty conversation — clears the current thread and opens the new-chat
-    /// composer (side panel) or navigates to the standalone chat page (main pane). Powers <c>/clear</c>.</summary>
+    /// <summary>Start a fresh, empty conversation — instantiates the new-chat composer (the same path as
+    /// the "+" new-chat button: it clears the current thread and shows the empty composer in place, with
+    /// no navigation). Powers <c>/clear</c>.</summary>
     NewThread,
 }
 

--- a/src/MeshWeaver.AI/SkillNodeType.cs
+++ b/src/MeshWeaver.AI/SkillNodeType.cs
@@ -223,6 +223,10 @@ public enum SkillActionKind
 
     /// <summary>Log out / forget this provider's CLI subscription.</summary>
     Disconnect,
+
+    /// <summary>Start a fresh, empty conversation — clears the current thread and opens the new-chat
+    /// composer (side panel) or navigates to the standalone chat page (main pane). Powers <c>/clear</c>.</summary>
+    NewThread,
 }
 
 /// <summary>

--- a/src/MeshWeaver.AI/SkillView.cs
+++ b/src/MeshWeaver.AI/SkillView.cs
@@ -142,6 +142,7 @@ public static class SkillView
         SkillActionKind.Disconnect => string.IsNullOrWhiteSpace(action.Provider)
             ? "Disconnects a provider"
             : $"Disconnects {Escape(action.Provider!)}",
+        SkillActionKind.NewThread => "Starts a new, empty conversation",
         _ => action.Kind.ToString(),
     };
 

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1728,6 +1728,14 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 lastCommandStatusIsError = false;
                 RunNavigate(navRow!);
                 break;
+            case MeshWeaver.AI.SkillActionKind.NewThread:
+                // "/clear" — just instantiate a fresh new-chat composer (the same path as the "+" button:
+                // OnSidePanelAction("New") clears the open thread and shows the empty new-chat composer).
+                // No navigation — the composer replaces the current thread in place.
+                lastCommandStatus = null;
+                lastCommandStatusIsError = false;
+                SidePanelState.RequestAction("New");
+                break;
             default:
                 // Instruction skill + typed task → re-enter the normal submission path with the
                 // composed message (it never starts with '/', so it cannot re-parse as a command).
@@ -2049,9 +2057,10 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
 
                 // Group selectable nodes under their non-selectable title (model providers → their
                 // nested models). No titles present (the /agent, /harness pickers) → the flat
-                // Order/Name list above stays as-is.
+                // Order/Name list above stays as-is. Drop any group title left with no models under it
+                // (a provider present in the catalog but with nothing to pick is just an empty header).
                 if (nodes.Any(IsPickerHeaderNode))
-                    nodes = ArrangePickerGroups(nodes);
+                    nodes = RemoveEmptyPickerGroups(ArrangePickerGroups(nodes));
 
                 pendingPicker = picker;
                 pickerNodes = nodes;
@@ -2132,6 +2141,22 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             .ThenBy(n => n.Order ?? 0)
             .ThenBy(n => n.Name ?? n.Id, StringComparer.OrdinalIgnoreCase)
             .ToList();
+
+    /// <summary>
+    /// Drops group-title nodes (a model provider) that have NO selectable item under them — a provider
+    /// present in the catalog but with no models to pick is just an empty header. A model's group key is
+    /// its parent path (== its provider's path), so a title survives only if some model shares its path.
+    /// </summary>
+    private static List<MeshNode> RemoveEmptyPickerGroups(List<MeshNode> nodes)
+    {
+        var groupsWithItems = nodes
+            .Where(n => !IsPickerHeaderNode(n))
+            .Select(n => ParentPath(n.Path))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return nodes
+            .Where(n => !IsPickerHeaderNode(n) || groupsWithItems.Contains(n.Path))
+            .ToList();
+    }
 
     /// <summary>First selectable (non-title) index, or -1 when the list is titles-only / empty.</summary>
     private int FirstSelectablePickerIndex()


### PR DESCRIPTION
Two small chat-composer improvements (requested).

## 1. Omit empty categories from the `/model` picker
A provider present in the catalog but with **no selectable models** was still rendered as a group header (an empty category). `RemoveEmptyPickerGroups` (in `ThreadChatView.razor.cs`'s `RunPicker`) drops any `ModelProvider` title node whose path no `LanguageModel` shares — so only providers with pickable models show a header.

## 2. `/clear` — start a new conversation
New `SkillActionKind.NewThread` + a `clear.md` skill. `/clear` **instantiates the new-chat composer** (the same path as the side panel's "+" button → `OnSidePanelAction("New")`), clearing the open thread and keeping your harness/agent/model selection. No navigation — the composer replaces the current thread in place.

Files: `SkillNodeType.cs` (enum), `SkillView.cs` (describe), `Data/Skill/clear.md` (skill node, auto-embedded via `Data\**\*.md`), `ThreadChatView.razor.cs` (`RunSkill` case + picker filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)