### PR TITLE
docs(skills): document the @/ link + @@ embed convention for mesh authoring

### DIFF
--- a/src/MeshWeaver.AI/Data/Agent/Assistant.md
+++ b/src/MeshWeaver.AI/Data/Agent/Assistant.md
@@ -76,7 +76,7 @@ The user can type follow-ups while you work. Those messages queue until you call
 
 The complete rules — `@` path resolution, query syntax, MeshNode schemas, icon requirements — are in the Tools Reference below. The three you use in every reply:
 
-- Mesh links in markdown output: **absolute** `[text](@/Full/Path)` — never bare names, never `@/` inside raw HTML `href` (write `<a href="/Full/Path">` there).
+- Mesh links in markdown output: **absolute** `[text](@/Full/Path)` — a bare path is just text, so always wrap it; never `@/` inside a raw HTML `href` (write `<a href="/Full/Path">` there) or in an HTTP URL. Embed a live area inline with double-`@@`: `@@("path/area/Name")` — single `@`/`@/` links, double `@@` embeds.
 - Tool calls take the node's `path`, never its display name.
 - Before creating nodes, explore what exists (`Search('namespace:{contextPath}')`) and create in the current context's namespace — never under `Agent/` or other system namespaces unless explicitly asked.
 

--- a/src/MeshWeaver.AI/Data/Skill/create-space.md
+++ b/src/MeshWeaver.AI/Data/Skill/create-space.md
@@ -58,6 +58,15 @@ A page's markdown can embed **regions** — live layout areas rendered inline. P
 
 > 🚨 The contents catalog region is named **Search**, not "Catalog". `@@Catalog` does **not** render the children index — embed the catalog with **`@@("area/Search")`**.
 
+## Links vs embeds: `[text](@/Path)` links, `@@` embeds
+
+Body text also **links** to other nodes. To link, use a normal markdown link with the `@/` prefix — the renderer strips the `@` and resolves it to the node's URL:
+
+- **Link** (navigate) → single `@`/`@/`: a markdown link `[Reinsurance](@/Systemorph/Reinsurance)`.
+- **Embed** (render inline) → double `@@`: `@@("area/Search")` renders the live area in place.
+- A **bare path is just text**, not a link — always wrap it: `[text](@/Path)`.
+- 🚨 `@/` and `@@` are **local mesh-authoring syntax — markdown body only.** NEVER put `@/` in a raw HTML `href` (an `href` needs a plain `/Path`, e.g. `<a href="/Systemorph/Reinsurance">`) or in an external HTTP URL. Full reference: [Unified Path](/Doc/DataMesh/UnifiedPath).
+
 # 4. Put the contents catalog at the END of the body
 
 The standard idiom (what the default Space template ships) is to end the `body` with a Contents section:

--- a/src/MeshWeaver.AI/Data/Skill/layout-area.md
+++ b/src/MeshWeaver.AI/Data/Skill/layout-area.md
@@ -57,6 +57,15 @@ In a layout area (hub-reachable): **no `async`/`await`/`Task<T>`/`Observable.Fro
 
 The same controls language renders in a native client too — same `GetMeshNodeStream` / `Update`, marshalling UI updates with `MainThread.BeginInvokeOnMainThread`: [Data Binding in a MAUI Client](/Doc/GUI/DataBindingMaui).
 
+# 6. Mesh links in markdown content
+
+Wherever you author markdown — a `Controls.Markdown`, a node body, a doc page — reference other mesh nodes with the `@` notation, never a bare path:
+
+- **Link** (navigate) → single `@`/`@/`: a markdown link `[text](@/Full/Path)`. The renderer strips the `@` and resolves it to the node's URL.
+- **Embed** (render inline) → double `@@`: `@@("path/area/Name")` renders a live layout area in place.
+- A **bare path is just text**, not a link — always wrap it in `[text](@/Path)`.
+- 🚨 `@/` and `@@` are **local mesh-authoring syntax — markdown body only.** NEVER put `@/` inside a raw HTML `href` (an `href` needs a plain `/Path`) or an HTTP URL. Full reference: [Unified Path](/Doc/DataMesh/UnifiedPath).
+
 # The litmus test
 
 If you're reaching for a string of HTML, a `/data` replica + a save subscription, a `*Request` type to change a node, or `.Take(1)` on a live stream — **stop**. You've dropped under the controls language. Find the control, the node stream, or the `RequestedXxx` field. Full reference: GUI/DataBinding, GUI/LayoutAreas, the "Never hand-roll UI" rule in AGENTS.md.

--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys", "slide");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "create-markdown", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys", "slide");
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -29,7 +29,7 @@ public class SkillNodeTypeTest
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
         skills.Should().OnlyContain(n => n.Namespace == SkillNodeType.RootNamespace);
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "code", "create-group", "create-markdown", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys", "slide");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "create-markdown", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys", "slide");
 
         var def = (SkillDefinition)skills.Single(n => n.Id == "model").Content!;
         def.Action!.Kind.Should().Be(SkillActionKind.Pick);


### PR DESCRIPTION
## What

Documents the mesh link-syntax convention (verified against `Doc/DataMesh/UnifiedPath` and the AGENTS.md "@/ is Local-Only" section) in the two authoring skills and the default agent:

- **`Skill/create-space`** — new "Links vs embeds" subsection under §3.
- **`Skill/layout-area`** — new "§6. Mesh links in markdown content".
- **`Agent/Assistant`** — tightened the existing links bullet into the full rule.

The convention, stated consistently in all three:

- **Link** to a node → a markdown link with the `@/` prefix: `[text](@/Path)`. The renderer strips the `@` and resolves it to the node's URL.
- **Embed** a live layout area inline → `@@("path/area/Name")`. Single `@`/`@/` links; double `@@` embeds.
- `@/` and `@@` are **local-only mesh-authoring syntax** — markdown **body** only, **never** inside a raw HTML `href` (an `href` needs a plain `/Path`) or an HTTP URL.
- A path with no `@` is just text, not a link.

## Incidental: restore CI green

Two skill-catalog assertions (`SkillNodeTypeTest`, `SkillHarnessImportSourceTest`) were **already red on `main`**: the shipped catalog now includes `clear` / `create-group` / `create-markdown`, but the hardcoded expected lists hadn't been updated (unrelated to this docs change). Updated both enumerations to the actual 14-skill catalog so this PR is green and mergeable.

## Verification (local)

- `DocumentationLinkIntegrityTest` — **green** (validates every Doc/Agent/Skill link; the new `[Unified Path](/Doc/DataMesh/UnifiedPath)` cross-links resolve; example `@/…` paths are backticked so they're not treated as links).
- `MeshWeaver.AI.Test --filter Skill` — **25/25 green** under `-c Release -p:CIRun=true -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)