### PR TITLE
fix(memex-local): working install route + two silent deploy-script bugs (#285)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,15 +37,16 @@ The template contains the complete Memex portal solution (Blazor Server monolith
 
 ### Local Kubernetes stack (macOS)
 
-A prod-like stack on Colima k3s, installable via Homebrew:
+A prod-like stack on Colima k3s. The default (local-build) path needs a checkout,
+so the CLI runs straight from it:
 
 ```bash
-brew tap systemorph/memex https://github.com/Systemorph/MeshWeaver.git
-brew install --HEAD systemorph/memex/memex-local
-memex-local up
+./deploy/homebrew/bin/memex-local up
+# …or symlink it onto your PATH: ln -s "$PWD/deploy/homebrew/bin/memex-local" ~/.local/bin/memex-local
 ```
 
-Opens at `https://memex.localhost:8443`. See [`deploy/homebrew`](deploy/homebrew) for details.
+Opens at `https://memex.localhost:8443`. A Homebrew install (via a local tap) is
+also supported — see [`deploy/homebrew`](deploy/homebrew) for details.
 
 ### Deploy to production
 

--- a/deploy/homebrew/Formula/memex-local.rb
+++ b/deploy/homebrew/Formula/memex-local.rb
@@ -4,14 +4,25 @@
 # memex-local — stand up the prod-like memex stack on Colima k3s (Mac), 1:1 with
 # Doc/Architecture/LocalColimaMac. The formula declares the brew toolchain and
 # installs the orchestration CLI; it vendors a snapshot of the deploy/helm chart
-# so a standalone install works, while a live MEMEX_REPO/MEMEX_CHART_DIR always
-# wins (the deploy/helm chart stays the single source of truth).
+# so a standalone install works (refreshed by `brew reinstall`). Run-from-checkout
+# mode uses the live deploy/helm (or MEMEX_REPO/MEMEX_CHART_DIR) directly — that
+# checkout stays the single source of truth. NOTE: a brew install's wrapper sets
+# MEMEX_CHART_DIR to the vendored snapshot, so on a brew install an *exported*
+# MEMEX_CHART_DIR/MEMEX_REPO does NOT override it — use run-from-checkout for that.
 #
-# Tap + install:
-#   brew tap systemorph/memex https://github.com/Systemorph/MeshWeaver.git
+# Install (brew) — requires a local tap: current Homebrew only discovers formulae
+# at a tap's root/Formula, and this formula lives at the nested
+# deploy/homebrew/Formula/, so `brew install ./…/memex-local.rb` and a two-arg tap
+# of the monorepo are both rejected. Until a real tap repo
+# (Systemorph/homebrew-memex) is published, create a local tap from the checkout:
+#   brew tap-new systemorph/memex
+#   cp deploy/homebrew/Formula/memex-local.rb "$(brew --repo systemorph/memex)/Formula/"
 #   brew install --HEAD systemorph/memex/memex-local
-#   # (or, if the tap repo is cloned locally:)
-#   brew install --HEAD ./deploy/homebrew/Formula/memex-local.rb
+#
+# Or skip brew entirely — the CLI runs straight from the checkout (its designed
+# run-from-checkout mode resolves the chart + share assets from the repo):
+#   ln -s "$PWD/deploy/homebrew/bin/memex-local" ~/.local/bin/memex-local   # (~/.local/bin on PATH)
+#   # …or just call ./deploy/homebrew/bin/memex-local directly.
 #
 # Then:
 #   memex-local up        # full stack
@@ -29,9 +40,12 @@ class MemexLocal < Formula
   head "https://github.com/Systemorph/MeshWeaver.git", branch: "main"
 
   # Runtime toolchain — exactly the tools LocalColimaMac.md §1 installs.
-  # The .NET SDK cask is needed only for the local-build image path (Option B,
-  # §3); the ACR-pull path (Option A) does not require it.
-  depends_on cask: "dotnet-sdk"
+  # NOTE: the .NET SDK is intentionally NOT a formula dependency. `depends_on cask:`
+  # is rejected by current Homebrew ("Unsupported special dependency: :cask"), it's
+  # needed only for the local-build image path (Option B, §3) — the ACR-pull path
+  # (Option A) needs no SDK — and LocalColimaMac.md §1 treats the standalone .NET
+  # installer as equally valid. The requirement is surfaced in `caveats` and enforced
+  # at runtime by `preflight()` / `doctor` (which check for `dotnet` on the build path).
   depends_on "colima"          # k3s VM
   depends_on "helm"            # chart install/upgrade
   depends_on "kubernetes-cli"  # kubectl
@@ -66,8 +80,11 @@ class MemexLocal < Formula
 
       Notes:
         * The default image path builds a native arm64 portal image locally
-          (Option B, §3) and needs the MeshWeaver source — set MEMEX_REPO to your
-          checkout, or use `memex-local up --from-acr` to pull from ACR (Option A).
+          (Option B, §3) and needs the MeshWeaver source AND the .NET SDK (10.0):
+          install it from https://dotnet.microsoft.com/download or
+          `brew install --cask dotnet-sdk`, then set MEMEX_REPO to your checkout.
+          Or use `memex-local up --from-acr` to pull from ACR (Option A) — that
+          path needs no SDK (run `az acr login -n meshweaver` first).
         * Fill in your Microsoft Entra app values in ~/.memex-local/values.local.yaml
           (generated on first run), or uncomment Authentication__EnableDevLogin
           for a no-Azure login.

--- a/deploy/homebrew/README.md
+++ b/deploy/homebrew/README.md
@@ -13,20 +13,40 @@ truth.
 
 ## Install
 
-```bash
-# Tap this repo and install the HEAD formula:
-brew tap systemorph/memex https://github.com/Systemorph/MeshWeaver.git
-brew install --HEAD systemorph/memex/memex-local
+The default (Option B) image path builds the portal locally, so **you need a
+checkout anyway** — and the CLI is designed to run straight from it. That's the
+supported route today:
 
-# …or install straight from a local checkout of this repo:
-brew install --HEAD ./deploy/homebrew/Formula/memex-local.rb
+```bash
+# Run straight from the checkout (resolves the chart + share assets from the repo):
+./deploy/homebrew/bin/memex-local up
+
+# …or put it on PATH via a symlink (a `git pull` then updates CLI + chart together):
+ln -s "$PWD/deploy/homebrew/bin/memex-local" ~/.local/bin/memex-local   # (~/.local/bin on PATH)
+memex-local up
 ```
 
-The formula declares the **exact toolchain `LocalColimaMac.md` §1 installs**:
-`colima`, `kubernetes-cli` (kubectl), `helm`, `mkcert`, `ollama`, `socket_vmnet`,
-plus the **`dotnet-sdk` cask** (needed only for the local-build image path,
-Option B). It vendors a snapshot of `deploy/helm` into the bottle so a standalone
-install works; a live `MEMEX_REPO`/`MEMEX_CHART_DIR` always overrides it.
+**Brew route (needs a local tap for now).** Current Homebrew discovers formulae
+only at a tap's root or top-level `Formula/`; this formula lives at the nested
+`deploy/homebrew/Formula/`, so `brew install ./…/memex-local.rb` and a two-arg tap
+of the monorepo are both rejected, and `systemorph/memex` isn't a published tap
+yet. Until `Systemorph/homebrew-memex` exists, build a local tap from the checkout:
+
+```bash
+brew tap-new systemorph/memex
+cp deploy/homebrew/Formula/memex-local.rb "$(brew --repo systemorph/memex)/Formula/"
+brew install --HEAD systemorph/memex/memex-local
+```
+
+The formula declares the **exact brew toolchain `LocalColimaMac.md` §1 installs**:
+`colima`, `kubernetes-cli` (kubectl), `helm`, `mkcert`, `ollama`, `socket_vmnet`.
+The **.NET SDK** (10.0) is *not* a formula dependency (`depends_on cask:` is rejected
+by current Homebrew, and only the local-build path needs it) — install it separately
+for Option B (`brew install --cask dotnet-sdk` or the standalone installer); the
+`--from-acr` path (Option A) needs no SDK. The formula vendors a snapshot of
+`deploy/helm` into the install so a brew install works standalone; that vendored
+snapshot is refreshed by `brew reinstall`. In **run-from-checkout** mode the live
+`deploy/helm` (or `MEMEX_REPO`/`MEMEX_CHART_DIR`) is used directly.
 
 ## Use
 

--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -404,8 +404,15 @@ helm_deploy() {
   # /data/dataprotection-keys (persisted DP keys, 678690598) → without this it crashloops with
   # "Access to the path '/data/dataprotection-keys' is denied". Make the node dir writable so a fresh
   # node (or a first deploy) doesn't hit the crash. Idempotent; single-node k3s so all pods share it.
-  colima ssh -- 'sudo mkdir -p /var/lib/memex-portal-data && sudo chmod 0777 /var/lib/memex-portal-data' 2>/dev/null \
-    || warn "could not make /var/lib/memex-portal-data writable on the node — portal may crashloop on DataProtection keys"
+  #
+  # NB: `colima ssh -- '<compound>'` hands the single-quoted string to the remote as ONE argv token,
+  # so bash tries to exec a command literally named "sudo mkdir … && sudo chmod …" → exit 127. Wrap in
+  # `sh -c` so the remote shell parses the &&. Keep stderr (no 2>/dev/null) so a real failure is visible
+  # in the warning instead of a silent miss that later surfaces as a crash-looping DataProtection pod.
+  local perms_err
+  if ! perms_err="$(colima ssh -- sh -c 'sudo mkdir -p /var/lib/memex-portal-data && sudo chmod 0777 /var/lib/memex-portal-data' 2>&1)"; then
+    warn "could not make /var/lib/memex-portal-data writable on the node — portal may crashloop on DataProtection keys${perms_err:+: $perms_err}"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -1150,6 +1157,12 @@ cmd_version() { printf 'memex-local 0.1.0 (chart: memex %s)\n' "$(resolve_chart 
 # the host-built local loop (the in-pod ACR poll can't reach a local-built image — see ReleaseStrategy).
 readonly AUTOROLL_LABEL="com.memex.local.autoroll"
 readonly AUTOROLL_PLIST="$HOME/Library/LaunchAgents/${AUTOROLL_LABEL}.plist"
+# launchd execs THIS stable copy (not the checkout path): a run-from-checkout under a
+# TCC-protected folder (e.g. ~/Documents) is "Operation not permitted" for launchd, and a
+# brew Cellar path moves on `reinstall`. $LOCAL_HOME is outside TCC and stable — same reason
+# the §7 port-forward agent runs a copy in $LOCAL_HOME. The _tick needs only docker+kubectl
+# (no chart/share assets), so a plain copy of the script suffices.
+readonly AUTOROLL_TICK_SCRIPT="$LOCAL_HOME/autoroll-tick"
 readonly AUTOROLL_STATE="$LOCAL_HOME/autoroll.digest"
 readonly AUTOROLL_LOG="$LOCAL_HOME/autoroll.log"
 readonly AUTOROLL_IMAGE="memex-portal-ai-local:latest"   # the moving tag the build writes (then tags $PORTAL_IMAGE)
@@ -1205,7 +1218,11 @@ cmd_autoroll() {
       # Seed BOTH digests with the CURRENT images so the watcher rolls on the NEXT rebuild, not on install.
       docker image inspect "$AUTOROLL_IMAGE" --format '{{.Id}}' 2>/dev/null > "$AUTOROLL_STATE" || true
       docker image inspect "$AUTOROLL_MIG_IMAGE" --format '{{.Id}}' 2>/dev/null > "$AUTOROLL_MIG_STATE" || true
-      local self; self="${SELF_DIR}/$(basename "$0")"
+      # Install a stable copy of THIS script into $LOCAL_HOME and point launchd at it (see
+      # AUTOROLL_TICK_SCRIPT above) — so autoroll works regardless of where the CLI lives (a checkout
+      # under a TCC-protected folder, or a brew Cellar path that moves on reinstall).
+      install -m 0755 "${SELF_DIR}/$(basename "$0")" "$AUTOROLL_TICK_SCRIPT"
+      local self="$AUTOROLL_TICK_SCRIPT"
       cat > "$AUTOROLL_PLIST" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -1230,11 +1247,23 @@ PLIST
       ;;
     down)
       launchctl unload "$AUTOROLL_PLIST" >/dev/null 2>&1 || true
-      rm -f "$AUTOROLL_PLIST"
+      rm -f "$AUTOROLL_PLIST" "$AUTOROLL_TICK_SCRIPT"
       ok "Auto-roll OFF (portal stays on its current image)."
       ;;
     status)
-      if launchctl list 2>/dev/null | grep -q "$AUTOROLL_LABEL"; then ok "Auto-roll: RUNNING"; else info "Auto-roll: stopped"; fi
+      if launchctl list 2>/dev/null | grep -q "$AUTOROLL_LABEL"; then
+        # Surface the agent's LAST EXIT STATUS — "RUNNING" alone hides a tick that fails every pass
+        # (e.g. launchd can't exec the program). launchctl prints `"LastExitStatus" = N;`.
+        local last_exit
+        last_exit="$(launchctl list "$AUTOROLL_LABEL" 2>/dev/null | sed -n 's/.*"LastExitStatus" = \([0-9-]*\).*/\1/p')"
+        if [ -n "$last_exit" ] && [ "$last_exit" != "0" ]; then
+          warn "Auto-roll: LOADED but last tick exited $last_exit (failing every pass — check $AUTOROLL_LOG)"
+        else
+          ok "Auto-roll: RUNNING"
+        fi
+      else
+        info "Auto-roll: stopped"
+      fi
       info "portal:    $AUTOROLL_IMAGE   last: $(cat "$AUTOROLL_STATE" 2>/dev/null || echo none)"
       info "migration: $AUTOROLL_MIG_IMAGE   last: $(cat "$AUTOROLL_MIG_STATE" 2>/dev/null || echo none)"
       info "deployment image: $(kubectl -n "$NAMESPACE" get "deploy/$PORTAL_DEPLOYMENT" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo '?')"

--- a/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
@@ -40,7 +40,7 @@ brew install socket_vmnet
 
 You also need the **.NET SDK** (10.0) to build the portal image — install from [dotnet.microsoft.com](https://dotnet.microsoft.com/download) or `brew install --cask dotnet-sdk`.
 
-> **Prefer one command?** `deploy/homebrew/` ships a Homebrew formula + a `memex-local` CLI that automates **every step on this page**, idempotently — `brew install` the tap, then `memex-local up` (and `down` / `status` / `logs` / `update`). See `deploy/homebrew/README.md`. The rest of this page is the manual reference the CLI follows 1:1.
+> **Prefer one command?** `deploy/homebrew/` ships a `memex-local` CLI that automates **every step on this page**, idempotently. Since Option B needs a checkout anyway, run it straight from there — `./deploy/homebrew/bin/memex-local up` (or symlink it onto your PATH) — then `up` / `down` / `status` / `logs` / `update`. A brew install works too (via a local tap, until a tap repo is published). See `deploy/homebrew/README.md`. The rest of this page is the manual reference the CLI follows 1:1.
 
 The work splits across three areas, which the rest of this page walks through in order:
 


### PR DESCRIPTION
Fixes #285 — the documented Homebrew install path failed on a current Homebrew (verified on a real Apple-Silicon Mac), plus two silent deploy-script bugs found in the same run.

## Formula
- Removed `depends_on cask: "dotnet-sdk"` — current Homebrew rejects `:cask` special deps ("Unsupported special dependency: :cask"). The SDK requirement is now surfaced via `caveats` and enforced at runtime by `preflight`/`doctor`. Only the local-build path (Option B) needs it; `--from-acr` (Option A) doesn't.

## Docs (formula header, `deploy/homebrew/README.md`, root `Readme.md`, `LocalColimaMac.md` §1)
- Document the **run-from-checkout** route (direct call or a PATH symlink) that works today — the default Option B build needs a checkout anyway. Document the **local-tap** route for brew (nested `deploy/homebrew/Formula/` isn't discoverable by a plain tap; no public tap published yet) and mark the public tap as pending.
- Correct the overstated "live `MEMEX_CHART_DIR` always wins" claim to match the wrapper: a brew install uses its vendored chart snapshot (refreshed by `brew reinstall`); run-from-checkout uses the live `deploy/helm`.

## Script bug 1 — silent `exit 127` (DATA-VOLUME PERMS)
`colima ssh -- '<compound>'` hands the single-quoted `sudo mkdir … && sudo chmod …` to the remote as **one argv token** → bash tries to exec a command with that literal name → exit 127. This is the silent miss that later crash-loops the portal on `/data/dataprotection-keys`. Wrapped in `sh -c` so the remote shell parses the `&&`, and kept stderr so a real failure shows in the warning.

## Script bug 2 — autoroll launchd TCC-blocked
`autoroll up` embedded the CLI's resolved path (checkout or brew Cellar) in the launchd plist. From a TCC-protected folder (e.g. `~/Documents`) launchd gets "Operation not permitted" and fails **every tick**, while `autoroll status` still reported RUNNING; the Cellar path also moves on `brew reinstall`. Now launchd execs a **stable copy in `$LOCAL_HOME`** (same pattern as the §7 port-forward agent — the `_tick` needs only docker+kubectl), and `autoroll status` surfaces the agent's last exit code so a failing tick is visible.

## Validation
`ruby -c` ✓ · `bash -n` ✓ · `shellcheck -S error` clean · no new internal doc links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)