### PR TITLE
fix(chat+ui): side-panel editor fills height; thread falls back to home on read-only node

### DIFF
--- a/src/MeshWeaver.AI/HubThreadExtensions.cs
+++ b/src/MeshWeaver.AI/HubThreadExtensions.cs
@@ -187,8 +187,13 @@ public static class HubThreadExtensions
 
         // Create under the requested namespace. If that partition denies thread creation (the user
         // lacks Thread permission there — e.g. a read-only Doc/* partition), FALL BACK to the user's
-        // OWN partition ({createdBy}/_Thread/{id}), keeping MainNode = the original namespace so the
+        // OWN partition ({home}/_Thread/{id}), keeping MainNode = the original namespace so the
         // thread stays linked to the node the user was viewing and the agent keeps its context.
+        // The home partition is the caller-supplied createdBy, or — when the caller didn't pass one
+        // (e.g. a click on a Doc page where the ambient AccessContext is null at post time, so the
+        // GUI's inline createdBy resolves null) — the robustly-captured submitter identity. Without
+        // this, the fallback silently no-ops on a null createdBy and the raw "Access denied" surfaces.
+        var fallbackHome = string.IsNullOrEmpty(createdBy) ? submitterObjectId : createdBy;
         AttemptCreate(namespacePath, threadNode, canFallBack: true);
 
         void AttemptCreate(string targetNamespace, MeshNode node, bool canFallBack)
@@ -215,7 +220,7 @@ public static class HubThreadExtensions
                         var err = (response.Message as CreateNodeResponse)?.Error ?? "unknown";
                         if (canFallBack && TryBuildUserPartitionFallback(targetNamespace, err, out var fb))
                         {
-                            AttemptCreate(createdBy!, fb!, canFallBack: false);
+                            AttemptCreate(fallbackHome!, fb!, canFallBack: false);
                             return;
                         }
                         onError?.Invoke($"Thread creation failed: {err}");
@@ -224,7 +229,7 @@ public static class HubThreadExtensions
                     {
                         if (canFallBack && TryBuildUserPartitionFallback(targetNamespace, ex.Message, out var fb))
                         {
-                            AttemptCreate(createdBy!, fb!, canFallBack: false);
+                            AttemptCreate(fallbackHome!, fb!, canFallBack: false);
                             return;
                         }
                         onError?.Invoke($"Thread creation failed: {ex.Message}");
@@ -237,19 +242,19 @@ public static class HubThreadExtensions
         bool TryBuildUserPartitionFallback(string targetNamespace, string? error, out MeshNode? fallbackNode)
         {
             fallbackNode = null;
-            if (string.IsNullOrEmpty(createdBy)
+            if (string.IsNullOrEmpty(fallbackHome)
                 || string.IsNullOrEmpty(error)
                 || !error.Contains("Access denied", StringComparison.OrdinalIgnoreCase))
                 return false;
 
             // Already in the user's own partition → falling back can't help; surface the error.
             var targetPartition = targetNamespace.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
-            if (string.Equals(targetPartition, createdBy, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(targetPartition, fallbackHome, StringComparison.OrdinalIgnoreCase))
                 return false;
 
-            // Re-anchor the SAME thread (id + seeded content) under {createdBy}/_Thread/{id}, but keep
+            // Re-anchor the SAME thread (id + seeded content) under {fallbackHome}/_Thread/{id}, but keep
             // MainNode pointing at the original namespace so thread→source navigation + agent context hold.
-            fallbackNode = ThreadNodeType.BuildThreadNode(createdBy!, userText, createdBy, threadNode.Id) with
+            fallbackNode = ThreadNodeType.BuildThreadNode(fallbackHome!, userText, fallbackHome, threadNode.Id) with
             {
                 MainNode = string.IsNullOrEmpty(mainNode) ? namespacePath : mainNode,
                 Content = seededThread

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
@@ -266,9 +266,12 @@
                             <CascadingValue Name="IsInSidePanel" Value="@true" IsFixed="true">
                                 @if (sidePanelViewModel != null)
                                 {
-                                    @* Resolved content — render via LayoutAreaView (same as main page) *@
+                                    @* Resolved content — render via LayoutAreaView (same as main page).
+                                       Fill=true (NOT Top — that would hijack the page title/menu) so a
+                                       full-height editor fills the panel instead of collapsing to ~4 lines. *@
                                     <LayoutAreaView @key="@SidePanelState.ContentPath"
                                                     ViewModel="@sidePanelViewModel"
+                                                    Fill="true"
                                                     Area="@($"sidepanel-{SidePanelState.ContentPath}")" />
                                 }
                                 else

--- a/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor
+++ b/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor
@@ -1,7 +1,7 @@
 @using MeshWeaver.Layout
 @inherits BlazorView<LayoutAreaControl, LayoutAreaView>
 
-<div class="layout-area-container @(IsContentLoaded ? "content-loaded" : "content-loading") @(Top ? "top-area" : "")" style="@Style">
+<div class="layout-area-container @(IsContentLoaded ? "content-loaded" : "content-loading") @((Top || Fill) ? "fill-area" : "")" style="@Style">
     @* Surface NodeType compile progress when the stream hasn't emitted yet so the
        user sees "Compiling <path> (Ns)…" instead of an indefinite spinner. *@
     @if (!IsContentLoaded)
@@ -74,6 +74,16 @@
 @code
 {
     [Parameter] public bool Top { get; set; }
+
+    /// <summary>
+    /// Make this area FILL its parent's height (the same stretch a top-level page gets),
+    /// WITHOUT the other <see cref="Top"/> semantics (page &lt;title&gt;, meta head, header menu).
+    /// The side panel hosts a resolved node area but must NOT hijack the page title/menu, so it
+    /// passes <c>Fill=true</c> instead of <c>Top=true</c>. Without it a full-height editor
+    /// (Markdown/Code at height:100%) collapses to its Monaco min-height (~4 lines) because
+    /// height:100% resolves against an auto-height parent. See LayoutAreaView.razor.css.
+    /// </summary>
+    [Parameter] public bool Fill { get; set; }
 
     /// <summary>
     /// Whether this area drives the global header menu (Node / Mesh / AI dropdowns). ONLY the

--- a/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/LayoutAreaView.razor.css
@@ -12,16 +12,20 @@
     flex-direction: column;
 }
 
-/* Default: a top-level (page) area fills the full available height.
+/* A fill area stretches its content to the full available height.
    The container already fills (.body-content is a definite-height flex column
    and .layout-area-container is flex:1), but the single control rendered inside
    would otherwise take only its natural height — so page backgrounds "stop in the
    middle", and fixed-height leaves (code view, pdf, editors) don't reach the
-   bottom. Stretching the top-level content gives it the full height to fill or
-   scroll within. Only applies to top-level pages (Top=true) and only once the
-   content has loaded, so embedded areas and the loading spinner are untouched.
-   Authors who set an explicit height still win: flex-basis:auto reads it, and
-   flex-grow merely lets it reach the bottom.
+   bottom. Stretching the content gives it the full height to fill or scroll within.
+   The `fill-area` class is set for top-level pages (Top=true) AND for areas that
+   explicitly opt in (Fill=true — e.g. a node area hosted in the side panel, which
+   must NOT be Top since that would hijack the page title/menu). Without this, a
+   full-height editor (Markdown/Code at height:100%) hosted in the side panel
+   collapses to its Monaco min-height (~4 lines). Only applies once the content has
+   loaded, so embedded areas and the loading spinner are untouched. Authors who set
+   an explicit height still win: flex-basis:auto reads it, and flex-grow merely lets
+   it reach the bottom.
 
    🚨 ::deep is REQUIRED: the single child here is the rendered control's root element,
    which belongs to a CHILD component (e.g. MarkdownView's <article class="markdown-body">,
@@ -30,7 +34,7 @@
    matches the child-component element — the rule silently no-ops and the page background
    "stops in the middle" (the start-screen full-height regression). ::deep stops scoping for
    `> *` so it matches the real child regardless of which component rendered it. */
-.layout-area-container.top-area.content-loaded ::deep > * {
+.layout-area-container.fill-area.content-loaded ::deep > * {
     flex: 1 1 auto;
     min-height: 0;
 }

--- a/test/MeshWeaver.Threading.Test/ThreadCreationTest.cs
+++ b/test/MeshWeaver.Threading.Test/ThreadCreationTest.cs
@@ -579,6 +579,89 @@ public class ThreadPermissionTest(ITestOutputHelper output) : MonolithMeshTestBa
     }
 
     [Fact]
+    public async Task StartThread_WithoutThreadPermission_FallsBackToUserPartition()
+    {
+        // Create context node "SecureProject" as admin
+        TestUsers.DevLogin(Mesh, new AccessContext { ObjectId = AdminUserId, Name = "Admin" });
+        await Mesh.GetEffectivePermissions("SecureProject", AdminUserId)
+            .Should().Within(10.Seconds()).Match(p => p.HasFlag(Permission.Create));
+        await NodeFactory.CreateNode(
+            new MeshNode("SecureProject") { Name = "Secure Project", NodeType = "Space" }).Should().Emit();
+
+        // The viewer has a provisioned home partition (as every onboarded user does).
+        await NodeFactory.CreateNode(
+            new MeshNode(ViewerUserId) { Name = "Viewer Home", NodeType = "Space" }).Should().Emit();
+
+        // Switch to viewer (Read+Execute only, NO Thread permission on SecureProject).
+        TestUsers.DevLogin(Mesh, new AccessContext { ObjectId = ViewerUserId, Name = "Viewer" });
+
+        var client = GetClient();
+        var createdTcs = new TaskCompletionSource<MeshNode>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var errorTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Act — the viewer starts a thread while "viewing" a node they can't write to.
+        // StartThread should transparently re-anchor the thread under the viewer's OWN
+        // partition ({ViewerUserId}/_Thread/...) instead of surfacing an Access-denied error.
+        client.StartThread(
+            namespacePath: "SecureProject",
+            userText: "Viewer starting a thread on a read-only node",
+            createdBy: ViewerUserId,
+            authorName: "Viewer",
+            onCreated: node => createdTcs.TrySetResult(node),
+            onError: err => errorTcs.TrySetResult(err));
+
+        var completed = await Task.WhenAny(createdTcs.Task, errorTcs.Task)
+            .WaitAsync(15.Seconds(), TestContext.Current.CancellationToken);
+        if (completed == errorTcs.Task)
+            Assert.Fail($"StartThread should have fallen back to the user's partition, but errored: {await errorTcs.Task}");
+
+        var node = await createdTcs.Task;
+        Output.WriteLine($"Fallback thread path: {node.Path}, MainNode: {node.MainNode}");
+        // Thread lands under the viewer's OWN partition, NOT SecureProject.
+        node.Path.Should().StartWith($"{ViewerUserId}/{ThreadNodeType.ThreadPartition}/");
+        // ...and keeps MainNode pointing at the node the user was viewing.
+        node.MainNode.Should().Be("SecureProject");
+    }
+
+    [Fact]
+    public async Task StartThread_WithoutThreadPermission_NullCreatedBy_StillFallsBackToUserPartition()
+    {
+        // Create context node "SecureProject" as admin
+        TestUsers.DevLogin(Mesh, new AccessContext { ObjectId = AdminUserId, Name = "Admin" });
+        await Mesh.GetEffectivePermissions("SecureProject", AdminUserId)
+            .Should().Within(10.Seconds()).Match(p => p.HasFlag(Permission.Create));
+        await NodeFactory.CreateNode(
+            new MeshNode("SecureProject") { Name = "Secure Project", NodeType = "Space" }).Should().Emit();
+        await NodeFactory.CreateNode(
+            new MeshNode(ViewerUserId) { Name = "Viewer Home", NodeType = "Space" }).Should().Emit();
+
+        TestUsers.DevLogin(Mesh, new AccessContext { ObjectId = ViewerUserId, Name = "Viewer" });
+
+        var client = GetClient();
+        var createdTcs = new TaskCompletionSource<MeshNode>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var errorTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Act — the GUI often does NOT pass createdBy (the ambient AccessContext is null at click
+        // time). StartThread must still fall back to the user's home by resolving the identity from
+        // the captured submitter — not silently no-op and surface the raw "Access denied".
+        client.StartThread(
+            namespacePath: "SecureProject",
+            userText: "Viewer starting a thread with no explicit createdBy",
+            createdBy: null,
+            onCreated: node => createdTcs.TrySetResult(node),
+            onError: err => errorTcs.TrySetResult(err));
+
+        var completed = await Task.WhenAny(createdTcs.Task, errorTcs.Task)
+            .WaitAsync(15.Seconds(), TestContext.Current.CancellationToken);
+        if (completed == errorTcs.Task)
+            Assert.Fail($"StartThread should have fallen back to the user's partition, but errored: {await errorTcs.Task}");
+
+        var node = await createdTcs.Task;
+        node.Path.Should().StartWith($"{ViewerUserId}/{ThreadNodeType.ThreadPartition}/");
+        node.MainNode.Should().Be("SecureProject");
+    }
+
+    [Fact]
     public async Task CreateThread_WithoutUpdatePermission_IsDenied()
     {
         // Create context node as admin first


### PR DESCRIPTION
## Two side-panel fixes

### 1. Monaco editor collapsed to ~4 lines in the side panel
The "stretch content to fill height" CSS rule in `LayoutAreaView` was gated on the `.top-area` class (`Top=true`). The **main page** renders areas with `Top=true` so editors fill; the **side panel** deliberately does **not** set `Top` (it would hijack the page `<title>` and the header menu). So a `height:100%` editor (Markdown/Code) resolved `100%` against an auto-height parent and collapsed to Monaco's `min-height` (~4 lines).

**Fix:** add a `Fill` parameter to `LayoutAreaView` that applies the same fill stretch **without** the `Top` side-effects; the side panel passes `Fill="true"`. The internal trigger class was renamed `top-area` → `fill-area` (set on `Top || Fill`), so top-level page behavior is unchanged.

### 2. "Access denied … lacks Thread permission" when opening a thread on a read-only node
`StartThread` already had a fallback that re-anchors a thread under the user's home partition on access denial (keeping the viewed node as `MainNode`/context). But it gated on the caller-supplied `createdBy`, which the GUI passes as **null** on a Doc page (the ambient `AccessContext` is null at click time) → the fallback silently no-op'd and the raw "Access denied" surfaced.

**Fix:** resolve the home from `createdBy ?? submitterObjectId` — the submitter identity `StartThread` already captures robustly — so it never no-ops for a real user. Opening a thread on e.g. `Doc/DataMesh/PythonPandasNode` now silently creates it in the user's home.

## Tests
- `StartThread_WithoutThreadPermission_FallsBackToUserPartition` (explicit `createdBy`)
- `StartThread_WithoutThreadPermission_NullCreatedBy_StillFallsBackToUserPartition` (the real GUI case)
- existing `CreateThread_WithoutUpdatePermission_IsDenied` still green

Release `-warnaserror` build clean; 3 thread tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
