### PR TITLE
feat(course): Go-to-Exercise copy-to-home + collapsible course side-nav

### DIFF
--- a/src/MeshWeaver.Documentation/Data/GUI/CombiningLayoutAreas.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/CombiningLayoutAreas.md
@@ -141,6 +141,32 @@ A few rules keep such a page healthy:
 - **Keep each executable cell self-contained.** A `--render` block compiles on its own; declare the records and data it needs inside it.
 - **`@@` embeds the *default* area unless you name one.** `@@("/Doc/GUI/DataGrid")` renders that page's default view; add `/area/Overview` to pick a specific one.
 
+# Course affordances: "Go to Exercise" and a collapsible side-nav
+
+Any markdown page — a course page especially — gets two ready-made embeds that turn a wall of prose into a place a learner can *work*. Both resolve against the page's own path, so you enable each with a single line and nothing else.
+
+## "Go to Exercise" — copy-to-home button
+
+Drop this on an exercise page and the reader gets a button that gives them their **own writable copy** to work in:
+
+```markdown
+@@("area/GoToMyCopy")
+```
+
+On the first press it copies the page's parent *module* subtree into the reader's home space and opens the copy; on the second press it just goes to the copy — idempotent, never a duplicate. A signed-out visitor sees a gentle "sign in to take this" instead, and the author of the template (anyone with edit rights) is taken straight to the template rather than a copy. It reuses the same copy-to-home machinery as the read-only-node "copy to my home" flow, so the learner always lands on something they can edit.
+
+> Why a button and not a plain link? An embedded *auto-redirect* area only navigates when it is the top-level route — inline in a page it appears to "do nothing". A button's click drives navigation from anywhere, which is exactly what an inline embed needs.
+
+## A collapsible course side-nav
+
+To wrap a page in a reader shell — a collapsible left rail listing the containing space's pages, the page content on the right — link a learner to the page's **`/Learn`** area, or embed just the rail inline:
+
+```markdown
+@@("area/CourseNav")
+```
+
+`CourseNav` lists the current page's sibling pages (the containing space's direct children, ordered by their `Order` then name) with the current page highlighted, so a learner always sees where they are. `/Learn` puts that same nav in a collapsible splitter pane beside the page's Overview. Both work for any markdown space — there is no course-specific node type to declare; the nav is sourced from the space's own children. "Go to Exercise" lands the learner directly in the `/Learn` shell, so the two compose: press the button, get your copy, and read it with the side-nav already beside you.
+
 # See Also
 
 - [Layout Areas](../LayoutAreas) — what an area is and how to author one in C#

--- a/src/MeshWeaver.Graph/Education/EducationLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Education/EducationLayoutAreas.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Reactive.Linq;
+using MeshWeaver.Application.Styles;
 using MeshWeaver.Data;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
@@ -29,16 +30,24 @@ namespace MeshWeaver.Graph;
 ///   sees WHERE THEY ARE in the module. StartExercise lands the learner in this shell, and every nav link
 ///   points back into it, so the side-nav persists as they move between pages. Same shape as
 ///   <c>CodeLayoutAreas.Overview</c>.</item>
+///   <item><b><see cref="GoToMyCopy"/></b> — the same resolve-or-copy as <see cref="StartExercise"/>, but
+///   as an EMBEDDABLE button (<c>@@("area/GoToMyCopy")</c>) instead of an auto-redirect. A markdown course
+///   page drops it inline: the learner sees a "Go to Exercise" button; the first press copies the module
+///   into their home and opens it, the second press just goes to the copy. This is the shape a page embed
+///   needs — an embedded <c>StartExercise</c> renders a <see cref="RedirectControl"/> that only drives
+///   navigation as a top-level route, so inline it appears to "do nothing".</item>
 /// </list>
 ///
 /// <para>Registered on every node via <see cref="AddEducationLayoutAreas"/> (called from
 /// <c>MeshNodeLayoutAreas.AddDefaultLayoutAreas</c>), so any course page exposes <c>/StartExercise</c>,
-/// <c>/Learn</c>, and <c>/CourseNav</c>.</para>
+/// <c>/GoToMyCopy</c>, <c>/Learn</c>, and <c>/CourseNav</c>.</para>
 /// </summary>
 public static class EducationLayoutAreas
 {
-    /// <summary>Area name for the resolve-or-copy "Your Turn" landing.</summary>
+    /// <summary>Area name for the resolve-or-copy "Your Turn" landing (auto-redirect).</summary>
     public const string StartExerciseArea = "StartExercise";
+    /// <summary>Area name for the embeddable resolve-or-copy "Go to Exercise" button.</summary>
+    public const string GoToMyCopyArea = "GoToMyCopy";
     /// <summary>Area name for the course side-nav (table of contents).</summary>
     public const string CourseNavArea = "CourseNav";
     /// <summary>Area name for the reader shell (side-nav + page content).</summary>
@@ -48,38 +57,59 @@ public static class EducationLayoutAreas
     public static LayoutDefinition AddEducationLayoutAreas(this LayoutDefinition layout)
         => layout
             .WithView(StartExerciseArea, StartExercise)
+            .WithView(GoToMyCopyArea, GoToMyCopy)
             .WithView(CourseNavArea, CourseNav)
             .WithView(LearnArea, Learn);
 
     /// <summary>
     /// The "Your Turn" landing: ensure the viewing learner has a personal, writable copy of this
-    /// exercise's module, then open it in the <see cref="Learn"/> reader shell. Idempotent — a second
-    /// visit just navigates to the existing copy.
+    /// exercise's module (<see cref="EnsurePersonalCopy"/>), then open it in the <see cref="Learn"/>
+    /// reader shell via an auto-redirect. Idempotent — a second visit just navigates to the existing copy.
+    /// <para>Use <see cref="GoToMyCopy"/> instead to surface the same behaviour as a button that a
+    /// markdown page can embed inline (an embedded <see cref="RedirectControl"/> does not navigate).</para>
     /// </summary>
     [Browsable(false)]
     public static IObservable<UiControl?> StartExercise(LayoutAreaHost host, RenderingContext ctx)
+        => EnsurePersonalCopy(host.Hub, host.Hub.Address.ToString())
+            .Select(landing => (UiControl?)RedirectToLearn(landing));
+
+    /// <summary>
+    /// Resolve-or-copy: ensures the signed-in viewer has a personal, writable copy of this node's parent
+    /// MODULE subtree under their own partition, and emits the path to OPEN — the personal copy once one is
+    /// (or gets) made, or the source path itself when there is nothing to copy: no writable home, the node
+    /// already sits inside the viewer's own partition, the viewer AUTHORS the template (holds Update), or
+    /// the path is too shallow to have a module. Idempotent: an existing copy is reused, never duplicated.
+    /// <para>Cold + reactive end-to-end — the copy runs on <c>Subscribe</c>. Both <see cref="StartExercise"/>
+    /// and <see cref="GoToMyCopy"/>'s click action route through this one helper, so their behaviour cannot
+    /// drift.</para>
+    /// <para>Reuses <see cref="IMeshService.CopyNode"/> (ONE mesh copy request: Read on the source subtree
+    /// + Create under the learner's own partition — an RLS auto-grant the learner always holds). NOT
+    /// <see cref="NodeCopyHelper.CopyNodeTree"/>'s per-node <c>CreateNodeRequest</c>s routed through the
+    /// source node's own hub, which the access pipeline would evaluate as Create on the READ-ONLY source
+    /// and deny a learner.</para>
+    /// </summary>
+    /// <param name="hub">The hub whose address is the source node and whose ambient <see cref="AccessService"/> resolves the viewer.</param>
+    /// <param name="sourcePath">The full path of the node the viewer is looking at.</param>
+    public static IObservable<string> EnsurePersonalCopy(IMessageHub hub, string sourcePath)
     {
-        var hub = host.Hub;
-        var sourcePath = hub.Address.ToString();
         var viewer = ResolveViewerHome(hub.ServiceProvider.GetService<AccessService>());
 
-        // No writable home (anonymous / system / hub principal): nothing to copy INTO — just open the
-        // shared exercise in the reader shell (read-only for them).
-        // Already inside the viewer's own partition: they ARE in their copy — open it, no redirect loop.
+        // No writable home (anonymous / system / hub principal) → nothing to copy INTO.
+        // Already inside the viewer's own partition → they ARE in their copy; no redirect loop.
         if (string.IsNullOrEmpty(viewer)
             || sourcePath.StartsWith(viewer + "/", StringComparison.Ordinal))
-            return Observable.Return<UiControl?>(RedirectToLearn(sourcePath));
+            return Observable.Return(sourcePath);
 
         var segs = sourcePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
         // Need at least {course}/{page}: a bare partition root has no module subtree to copy.
         if (segs.Length < 2)
-            return Observable.Return<UiControl?>(RedirectToLearn(sourcePath));
+            return Observable.Return(sourcePath);
 
-        // Copy unit = the exercise's parent MODULE subtree; target = {viewer}/{course}, so the module's
-        // course-relative sub-path is preserved (course = the module's parent, "" for a 2-segment path).
-        var copyRoot = string.Join("/", segs[..^1]);       // the exercise's MODULE (its parent)
+        // Copy unit = the node's parent MODULE subtree; target = {viewer}/{module}, so the module's
+        // course-relative sub-path is preserved.
+        var copyRoot = string.Join("/", segs[..^1]);       // the node's MODULE (its parent)
         var targetRoot = $"{viewer}/{copyRoot}";           // the module's copy under the learner
-        var landingPath = $"{viewer}/{sourcePath}";        // the exercise page inside that copy
+        var landingPath = $"{viewer}/{sourcePath}";        // the node itself inside that copy
 
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Graph.Education");
@@ -88,10 +118,10 @@ public static class EducationLayoutAreas
         // which on a hub action block can be the system/owner identity rather than the viewer.
         return hub.GetEffectivePermissions(sourcePath, viewer).Take(1).SelectMany(perms =>
         {
-            // Author / maintainer of the template (has Update): show the template directly so authoring
-            // and preview keep working. Only read-only LEARNERS get redirected to a personal copy.
+            // Author / maintainer of the template (has Update): keep them on the template so authoring and
+            // preview keep working. Only read-only LEARNERS get a personal copy.
             if (perms.HasFlag(Permission.Update))
-                return Observable.Return<UiControl?>(RedirectToLearn(sourcePath));
+                return Observable.Return(sourcePath);
 
             // Existence check via query (returns empty for a missing node — no NotFound OnError, unlike a
             // point read). A prior-session copy is long indexed; skipping the copy when it exists makes the
@@ -101,23 +131,100 @@ public static class EducationLayoutAreas
                 .SelectMany(change =>
                 {
                     if (change.Items is { Count: > 0 })
-                        return Observable.Return<UiControl?>(RedirectToLearn(landingPath));
+                        return Observable.Return(landingPath);
 
-                    // ONE CopyNodeRequest routed through the mesh copy handler (Read on the source subtree +
-                    // Create on the TARGET under the learner's own partition). NOT per-node
-                    // CreateNodeRequests posted through the source node's OWN hub — the access pipeline would
-                    // check those as Create on the read-only source and deny the learner. The learner always
-                    // holds Create under their own {viewer}/… partition (RLS auto-grant).
                     return meshService.CopyNode(copyRoot, targetRoot, includeDescendants: true)
                         .Select(_ =>
                         {
                             logger?.LogInformation(
-                                "StartExercise: copied {Source} -> {Target} for {Viewer}", copyRoot, targetRoot, viewer);
-                            return (UiControl?)RedirectToLearn(landingPath);
+                                "EnsurePersonalCopy: copied {Source} -> {Target} for {Viewer}", copyRoot, targetRoot, viewer);
+                            return landingPath;
                         });
                 });
         });
     }
+
+    /// <summary>
+    /// The embeddable "Go to Exercise" button — the resolve-or-copy of <see cref="EnsurePersonalCopy"/>
+    /// surfaced as a control a markdown course page drops inline with <c>@@("area/GoToMyCopy")</c>. Reactive
+    /// render:
+    /// <list type="bullet">
+    ///   <item>no writable home → a gentle "sign in to take this" message;</item>
+    ///   <item>the copy already exists (or the viewer owns/authors the template) → a "Go to Exercise →"
+    ///   button;</item>
+    ///   <item>otherwise → a "Go to Exercise" button.</item>
+    /// </list>
+    /// The label is cosmetic; the CLICK always routes through <see cref="EnsurePersonalCopy"/> (idempotent),
+    /// so it copies-then-navigates on the first press and just navigates on the second — and works even if
+    /// the render-time existence snapshot was stale.
+    /// </summary>
+    [Browsable(false)]
+    public static IObservable<UiControl?> GoToMyCopy(LayoutAreaHost host, RenderingContext ctx)
+    {
+        var hub = host.Hub;
+        var sourcePath = hub.Address.ToString();
+        var viewer = ResolveViewerHome(hub.ServiceProvider.GetService<AccessService>());
+
+        if (string.IsNullOrEmpty(viewer))
+            return Observable.Return<UiControl?>(SignInHint());
+
+        var segs = sourcePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        // Already the viewer's own copy (or too shallow to have a module subtree) → the copy IS the source:
+        // a plain "Go to Exercise →" that opens it in the reader shell.
+        if (segs.Length < 2 || sourcePath.StartsWith(viewer + "/", StringComparison.Ordinal))
+            return Observable.Return<UiControl?>(GoButton(sourcePath, alreadyMine: true));
+
+        var landingPath = $"{viewer}/{sourcePath}";
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+
+        return hub.GetEffectivePermissions(sourcePath, viewer).Take(1).SelectMany(perms =>
+        {
+            // Author / maintainer (holds Update on the template): open the template itself, no personal copy.
+            if (perms.HasFlag(Permission.Update))
+                return Observable.Return<UiControl?>(GoButton(sourcePath, alreadyMine: true));
+
+            // Existence drives the arrow on the LABEL only; the click always ensures-then-navigates.
+            return meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{landingPath}"))
+                .Take(1)
+                .Select(change => (UiControl?)GoButton(sourcePath, alreadyMine: change.Items is { Count: > 0 }));
+        });
+    }
+
+    /// <summary>
+    /// The "Go to Exercise" button. Its click action runs <see cref="EnsurePersonalCopy"/> and, on success,
+    /// navigates into the resolved copy's <see cref="Learn"/> reader shell (so the learner lands WITH the
+    /// collapsible course side-nav). Errors surface through a dialog rather than a silent no-op.
+    /// </summary>
+    private static UiControl GoButton(string sourcePath, bool alreadyMine) =>
+        Controls.Button(alreadyMine ? "Go to Exercise →" : "Go to Exercise")
+            .WithAppearance(Appearance.Accent)
+            .WithIconStart(FluentIcons.Play())
+            .WithClickAction(ctx =>
+            {
+                var hub = ctx.Host.Hub;
+                var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+                    ?.CreateLogger("MeshWeaver.Graph.Education");
+                EnsurePersonalCopy(hub, sourcePath).Subscribe(
+                    landing => ctx.NavigateTo(new LayoutAreaReference(LearnArea).ToHref(landing)),
+                    ex =>
+                    {
+                        logger?.LogWarning(ex, "GoToMyCopy failed for {Source}", sourcePath);
+                        ctx.Host.UpdateArea(DialogControl.DialogArea, Controls.Dialog(
+                                Controls.Markdown($"**Couldn't open your copy:**\n\n{ex.Message}"),
+                                "Go to Exercise")
+                            .WithSize("M").WithClosable(true));
+                    });
+                return Task.CompletedTask;
+            });
+
+    /// <summary>
+    /// The sign-in hint shown by <see cref="GoToMyCopy"/> when there is no writable home to copy into.
+    /// </summary>
+    private static UiControl SignInHint() =>
+        Controls.Stack.WithStyle("padding: 12px;")
+            .WithView(Controls.Markdown(
+                "**Sign in to take this exercise.** We'll copy it into your own space so you can work on " +
+                "your own version — that needs a signed-in account."));
 
     /// <summary>
     /// Reader shell: a horizontal <c>Splitter</c> with the course side-nav (<see cref="CourseNav"/>) on
@@ -172,22 +279,36 @@ public static class EducationLayoutAreas
             .Select(change => BuildCourseNav(moduleRoot, currentPath, change.Items));
     }
 
-    private static UiControl BuildCourseNav(
-        string moduleRoot, string currentPath, IReadOnlyCollection<MeshNode> mainNodes)
+    /// <summary>
+    /// The pages a course side-nav lists for <paramref name="moduleRoot"/>: the module's DIRECT children
+    /// (deeper support nodes such as <c>Source/…</c> are excluded to keep the TOC a clean page list), ordered
+    /// by <see cref="MeshNode.Order"/> then <see cref="MeshNode.Name"/> (case-insensitive). Pure — the
+    /// nav-rendering and the ordering contract are the same function, so a test can pin the order without
+    /// reaching through the render/serialization layer.
+    /// </summary>
+    /// <param name="moduleRoot">The containing space (the current page's parent module) whose children are listed.</param>
+    /// <param name="mainNodes">The module + its main descendants (the <c>scope:subtree is:main</c> query result).</param>
+    public static IReadOnlyList<MeshNode> SelectCoursePages(
+        string moduleRoot, IReadOnlyCollection<MeshNode> mainNodes)
     {
-        var root = mainNodes.FirstOrDefault(n => string.Equals(n.Path, moduleRoot, StringComparison.Ordinal));
-        var groupTitle = root?.Name ?? moduleRoot.Split('/').Last();
-
-        // Direct children of the module = the pages. Deeper support nodes (e.g. Source/…) are left out of
-        // the TOC to keep it a clean page list; ordered by Order then Name.
         var prefix = moduleRoot + "/";
-        var pages = mainNodes
+        return mainNodes
             .Where(n => !string.IsNullOrEmpty(n.Path)
                         && n.Path.StartsWith(prefix, StringComparison.Ordinal)
                         && !n.Path.AsSpan(prefix.Length).Contains('/'))
             .OrderBy(n => n.Order)
             .ThenBy(n => n.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    private static UiControl BuildCourseNav(
+        string moduleRoot, string currentPath, IReadOnlyCollection<MeshNode> mainNodes)
+    {
+        var root = mainNodes.FirstOrDefault(n => string.Equals(n.Path, moduleRoot, StringComparison.Ordinal));
+        var groupTitle = root?.Name ?? moduleRoot.Split('/').Last();
+
+        // Direct children of the module = the pages (ordered by Order then Name).
+        var pages = SelectCoursePages(moduleRoot, mainNodes);
 
         var group = new NavGroupControl(groupTitle).WithSkin(s => s.WithExpanded(true));
 

--- a/test/MeshWeaver.AI.Test/EducationStartExerciseTest.cs
+++ b/test/MeshWeaver.AI.Test/EducationStartExerciseTest.cs
@@ -3,10 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
@@ -18,16 +21,27 @@ using Xunit;
 namespace MeshWeaver.AI.Test;
 
 /// <summary>
-/// The edu module's <see cref="EducationLayoutAreas.StartExercise"/> "Your Turn" resolve-or-copy flow.
+/// The edu module's resolve-or-copy + reader-shell layout areas
+/// (<see cref="EducationLayoutAreas.StartExercise"/> / <see cref="EducationLayoutAreas.EnsurePersonalCopy"/>,
+/// <see cref="EducationLayoutAreas.GoToMyCopy"/>, <see cref="EducationLayoutAreas.CourseNav"/> /
+/// <see cref="EducationLayoutAreas.Learn"/>).
 ///
 /// <para>Real RLS (<see cref="MonolithMeshTestBase.ConfigureMeshBase"/> — NO <c>PublicAdminAccess</c>) so a
 /// learner is a genuine read-only user: a public <b>Viewer</b> grant on the course lets them SEE it, but
-/// they lack Update, so StartExercise gives them a personal, writable copy under their own partition
-/// instead of the shared template. Drives the production area through
-/// <see cref="MeshOperations.RenderArea"/> (which waits for the area to materialize — so the async copy
-/// completes) under the learner's identity, and asserts: (1) redirect into the learner's OWN copy's
-/// <c>Learn</c> reader shell, (2) the module subtree was copied under the learner, (3) a second visit is
-/// idempotent (no re-copy).</para>
+/// they lack Update, so the resolve-or-copy gives them a personal, writable copy under their own partition
+/// instead of the shared template.</para>
+///
+/// <list type="bullet">
+///   <item>StartExercise (auto-redirect) via <see cref="MeshOperations.RenderArea"/> under the learner:
+///   redirect into the learner's OWN copy's <c>Learn</c> shell, the module subtree copied under the
+///   learner, and a second visit idempotent (no re-copy).</item>
+///   <item>The embeddable <see cref="EducationLayoutAreas.GoToMyCopy"/> button renders a "Go to Exercise"
+///   button for a read-only learner (the click's resolve-or-copy logic, <see cref="EducationLayoutAreas.EnsurePersonalCopy"/>,
+///   creates the copy once and is idempotent thereafter).</item>
+///   <item><see cref="EducationLayoutAreas.CourseNav"/> lists the containing space's child pages ordered by
+///   <c>Order</c>, and the <see cref="EducationLayoutAreas.Learn"/> reader shell's nav pane is
+///   collapsible.</item>
+/// </list>
 /// </summary>
 public class EducationStartExerciseTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -49,16 +63,23 @@ public class EducationStartExerciseTest(ITestOutputHelper output) : MonolithMesh
                         Roles = [new RoleAssignment { Role = "Viewer" }]
                     }
                 },
-                // A minimal course: landing → module → two pages (Exercises + Solutions).
+                // A minimal course: landing → module → two pages. Ex1 ("Your Turn") is given a LOWER Order
+                // than Solutions even though its name sorts AFTER — so the CourseNav ordering test can prove
+                // the nav follows Order, not the alphabet.
                 new MeshNode("TestCourse")
                 { Name = "Test Course", NodeType = "Markdown", Content = new MarkdownContent { Content = "# Test Course" } },
                 new MeshNode("Module1", "TestCourse")
                 { Name = "Module 1", NodeType = "Markdown", Content = new MarkdownContent { Content = "# Module 1" } },
                 new MeshNode("Ex1", "TestCourse/Module1")
-                { Name = "Your Turn", NodeType = "Markdown", Content = new MarkdownContent { Content = "# Exercises" } },
+                { Name = "Your Turn", NodeType = "Markdown", Order = 1, Content = new MarkdownContent { Content = "# Exercises" } },
                 new MeshNode("Solutions", "TestCourse/Module1")
-                { Name = "Solutions", NodeType = "Markdown", Content = new MarkdownContent { Content = "# Solutions" } }
+                { Name = "Solutions", NodeType = "Markdown", Order = 2, Content = new MarkdownContent { Content = "# Solutions" } }
             );
+
+    // The layout-client config so GetClient().GetWorkspace() + GetControlStream can render an area to a
+    // typed UiControl (the pattern VersionViewsTest uses).
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
 
     [Fact(Timeout = 120_000)]
     public async Task StartExercise_Learner_CopiesModuleToOwnNamespace_AndRedirectsToLearn()
@@ -116,6 +137,125 @@ public class EducationStartExerciseTest(ITestOutputHelper output) : MonolithMesh
             access.SetCircuitContext(null);
             access.SetContext(null);
         }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task GoToMyCopy_RendersButton_ForReadOnlyViewer()
+    {
+        // The embeddable "Go to Exercise" affordance (@@("area/GoToMyCopy")) renders a clickable BUTTON —
+        // NOT an auto-redirect. A read-only viewer (the auto-login user holds only the public Viewer grant
+        // here) is offered the copy-to-home button; the copy itself runs on click, so rendering the area
+        // has no side effect.
+        var control = await RenderControl(EducationLayoutAreas.GoToMyCopyArea);
+
+        var button = control.Should().BeOfType<ButtonControl>(
+            "GoToMyCopy renders a button a markdown page can embed — an embedded RedirectControl would " +
+            "never drive top-level navigation").Subject;
+        button.Data?.ToString().Should().Contain("Go to Exercise");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task GoToExercise_EnsurePersonalCopy_CopiesOnce_AndIsIdempotent()
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var learner = new AccessContext { ObjectId = LearnerId, Name = "Learner" };
+        access.SetContext(learner);
+        access.SetCircuitContext(learner);
+        try
+        {
+            var landingExpected = $"{LearnerId}/TestCourse/Module1/Ex1";
+
+            // The click logic behind the GoToMyCopy button: resolve-or-copy the module into the learner's
+            // home and return the copy's landing path. Cold + reactive — the copy runs on Subscribe.
+            Task<string> Ensure()
+            {
+                using (access.SwitchAccessContext(learner))
+                    return EducationLayoutAreas.EnsurePersonalCopy(Mesh, "TestCourse/Module1/Ex1")
+                        .FirstAsync().Timeout(TimeSpan.FromSeconds(60)).ToTask();
+            }
+
+            // 1. First press: copies the module subtree under the learner and resolves to the copy.
+            var landing1 = await Ensure();
+            landing1.Should().Be(landingExpected, "the learner is routed into THEIR OWN copy, not the template");
+
+            var copied = await PollUntilPaths(
+                $"path:{LearnerId}/TestCourse/Module1 scope:subtree is:main",
+                paths => paths.Contains($"{LearnerId}/TestCourse/Module1/Ex1")
+                         && paths.Contains($"{LearnerId}/TestCourse/Module1/Solutions"));
+            copied.Should().Contain($"{LearnerId}/TestCourse/Module1/Ex1");
+            copied.Should().Contain($"{LearnerId}/TestCourse/Module1/Solutions");
+            var copiedCount = copied.Count;
+
+            // 2. Second press: idempotent — resolves to the SAME copy without duplicating anything.
+            var landing2 = await Ensure();
+            landing2.Should().Be(landingExpected);
+
+            var afterSecond = await PollUntilPaths(
+                $"path:{LearnerId}/TestCourse/Module1 scope:subtree is:main", _ => true);
+            afterSecond.Count.Should().Be(copiedCount,
+                "resolve-or-copy is idempotent — the second press navigates to the existing copy, not a re-copy");
+        }
+        finally
+        {
+            access.SetCircuitContext(null);
+            access.SetContext(null);
+        }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task CourseNav_ListsSpaceChildPages_OrderedByOrderThenName()
+    {
+        // The nav is sourced from the containing space's DIRECT children and ordered by Order then Name —
+        // the same pure function the side-nav renders with, fed the REAL query result so the ordering is
+        // pinned without reaching through the render/serialization layer (a keyed EntityStore does not
+        // preserve nav-link sequence for a string scan).
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var change = await meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery("path:TestCourse/Module1 scope:subtree is:main"))
+            .Where(c => c.ChangeType == QueryChangeType.Initial).Take(1)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+
+        var pages = EducationLayoutAreas.SelectCoursePages("TestCourse/Module1", change.Items);
+
+        // Only the module's direct-child PAGES (the module root itself is excluded), in Order sequence:
+        // Ex1 ("Your Turn", Order 1) BEFORE Solutions (Order 2) — the REVERSE of alphabetical, proving the
+        // nav follows Order, not the name.
+        pages.Select(p => p.Path).Should().Equal(
+            "TestCourse/Module1/Ex1",
+            "TestCourse/Module1/Solutions");
+        pages.Select(p => p.Name).Should().Equal("Your Turn", "Solutions");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task Learn_ReaderShell_IsSplitter_WithCollapsibleNavPane()
+    {
+        // The Learn reader shell is a Splitter whose nav (left) pane is collapsible — the one-line way to
+        // enable the "collapsible course side-nav" (link a page to /Learn).
+        var control = await RenderControl(EducationLayoutAreas.LearnArea);
+
+        var splitter = control.Should().BeOfType<SplitterControl>(
+            "the Learn reader shell is a Splitter — nav pane + page content").Subject;
+        var navPane = splitter.Areas.First();
+        var paneSkin = navPane.Skins.OfType<SplitterPaneSkin>().FirstOrDefault();
+        paneSkin.Should().NotBeNull("the nav pane carries a SplitterPaneSkin");
+        paneSkin!.Collapsible.Should().Be(true, "the course side-nav pane is collapsible");
+    }
+
+    // Renders one area on the TestCourse/Module1/Ex1 node through the layout client (GetControlStream), so
+    // the assertion inspects the real deserialized UiControl the browser would receive.
+    private async Task<UiControl?> RenderControl(string area)
+    {
+        var client = GetClient();
+        var nodeAddress = new Address("TestCourse/Module1/Ex1");
+        await client.Observe(new PingRequest(), o => o.WithTarget(nodeAddress))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+
+        var reference = new LayoutAreaReference(area);
+        var stream = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(nodeAddress, reference);
+        return await stream.GetControlStream(reference.Area!)
+            .Where(c => c is not null)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
     }
 
     // Re-queries until the predicate holds (or times out) — the sanctioned wait-on-condition pattern for


### PR DESCRIPTION
Two reusable course affordances in the edu module (`EducationLayoutAreas`), reusing existing framework mechanisms. Both areas are registered on every node, so any markdown course page can use them.

## Part A — embeddable "Go to Exercise" copy-to-home button
The user reported the "Go to Exercise" affordance "does not do anything". Root cause: the shipped `StartExercise` renders a `RedirectControl`, which only drives navigation as a **top-level route** — embedded in a page via `@@("area/StartExercise")` it appears to do nothing.

New `GoToMyCopy` area renders a **button** instead (works when embedded):
- no writable home → a gentle "sign in to take this" message;
- otherwise → a **"Go to Exercise"** button whose click resolve-or-copies the exercise's module into the viewer's home and opens it in the `/Learn` shell;
- idempotent: the second press just navigates to the existing copy (`→` label).

**Reuse:** the resolve-or-copy logic is extracted into the shared reactive `EnsurePersonalCopy` helper that BOTH `StartExercise` and the button route through, so they can't drift. It reuses `IMeshService.CopyNode` (Read source + Create under the learner's own partition) — the same mechanism the tested `StartExercise` flow uses, **not** `NodeCopyHelper`'s per-node creates, which the access pipeline denies a read-only learner. Same copy-to-home shape as `CodeLayoutAreas` "copy to my home".

## Part B — collapsible course side-nav
`CourseNav` / `Learn` already ship (collapsible `Splitter` left pane + `NavMenu`, sourced from the containing space's child pages). This PR extracts the pure `SelectCoursePages` helper (direct children, ordered by `Order` then `Name`) so the ordering contract is testable, and **documents the one-line enable**.

**One-line way to enable the side-nav** (in `Doc/GUI/CombiningLayoutAreas`):
- link a learner to the page's **`/Learn`** area (the collapsible reader shell: nav rail + page Overview), or
- embed just the rail inline: **`@@("area/CourseNav")`**.

Works for any markdown space — no course-specific node type needed.

## Tests
`MonolithMeshTestBase`, real RLS, no mocks/sleeps (`test/MeshWeaver.AI.Test/EducationStartExerciseTest.cs`):
- `GoToMyCopy_RendersButton_ForReadOnlyViewer` — the embed renders a `ButtonControl`.
- `GoToExercise_EnsurePersonalCopy_CopiesOnce_AndIsIdempotent` — copy-to-home creates the copy once, second invoke is idempotent (no duplicate).
- `CourseNav_ListsSpaceChildPages_OrderedByOrderThenName` — pure ordering over the real query result (a keyed `EntityStore` won't preserve nav order for a string scan).
- `Learn_ReaderShell_IsSplitter_WithCollapsibleNavPane` — typed `GetControlStream` proves the nav pane is collapsible.

All 5 Education tests green; `DocumentationLinkIntegrityTest` green; touched projects build clean under `-c Release -p:CIRun=true -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)