### PR TITLE
feat(indexing): per-chunk source page + on-page position — open the page and mark (#226)

### DIFF
--- a/src/MeshWeaver.AI/Plugins/ChunkNavigation.cs
+++ b/src/MeshWeaver.AI/Plugins/ChunkNavigation.cs
@@ -99,7 +99,7 @@ public static class ChunkNavigation
                                 : $"No chunk at index {chunkIndex}; valid range is 0..{total - 1}.",
                         }.ToJsonString();
 
-                    return new JsonObject
+                    var envelope = new JsonObject
                     {
                         ["found"] = true,
                         ["collectionPath"] = chunk.CollectionPath,
@@ -109,7 +109,13 @@ public static class ChunkNavigation
                         ["prevIndex"] = chunk.ChunkIndex > 0 ? chunk.ChunkIndex - 1 : null,
                         ["nextIndex"] = chunk.ChunkIndex < total - 1 ? chunk.ChunkIndex + 1 : null,
                         ["totalChunks"] = total,
-                    }.ToJsonString();
+                    };
+                    // Provenance for citing/marking the source page (present only when the source carried it).
+                    if (chunk.Page is int page)
+                        envelope["page"] = page;
+                    if (ChunkPositionJson.ToJsonObject(chunk.Position) is { } bbox)
+                        envelope["bbox"] = bbox;
+                    return envelope.ToJsonString();
                 }));
     }
 

--- a/src/MeshWeaver.Blazor/Components/DocumentSourceView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/DocumentSourceView.razor.cs
@@ -23,16 +23,21 @@ public partial class DocumentSourceView
     private object? MimeRaw { get; set; }
     private object? HighlightRaw { get; set; }
     private object? FileNameRaw { get; set; }
+    private object? PageRaw { get; set; }
+    private object? BoxRaw { get; set; }
 
     private string? FileUrl { get; set; }
     private string? Mime { get; set; }
     private string? Highlight { get; set; }
     private string? FileName { get; set; }
+    private int? Page { get; set; }
+    private string? Box { get; set; }
 
-    // Guards against re-invoking the (expensive) render when neither the file nor the passage changed
+    // Guards against re-invoking the (expensive) render when nothing that affects it changed
     // — the base re-runs BindData on every parameter set.
     private string? _renderedUrl;
     private string? _renderedHighlight;
+    private string? _renderedMark;
 
     /// <inheritdoc />
     protected override void BindData()
@@ -42,11 +47,15 @@ public partial class DocumentSourceView
         DataBind(ViewModel.Mime, x => x.MimeRaw);
         DataBind(ViewModel.Highlight, x => x.HighlightRaw);
         DataBind(ViewModel.FileName, x => x.FileNameRaw);
+        DataBind(ViewModel.Page, x => x.PageRaw);
+        DataBind(ViewModel.Box, x => x.BoxRaw);
 
         FileUrl = Coerce(FileUrlRaw);
         Mime = Coerce(MimeRaw);
         Highlight = Coerce(HighlightRaw);
         FileName = Coerce(FileNameRaw);
+        Box = Coerce(BoxRaw);
+        Page = int.TryParse(Coerce(PageRaw), out var page) ? page : null;
     }
 
     /// <summary>
@@ -69,14 +78,16 @@ public partial class DocumentSourceView
         if (jsModule is null || string.IsNullOrEmpty(FileUrl))
             return;
 
-        if (FileUrl == _renderedUrl && Highlight == _renderedHighlight)
+        var mark = $"{Page}|{Box}";
+        if (FileUrl == _renderedUrl && Highlight == _renderedHighlight && mark == _renderedMark)
             return;
         _renderedUrl = FileUrl;
         _renderedHighlight = Highlight;
+        _renderedMark = mark;
 
         try
         {
-            await jsModule.InvokeVoidAsync("render", containerRef, FileUrl, Mime, Highlight, FileName);
+            await jsModule.InvokeVoidAsync("render", containerRef, FileUrl, Mime, Highlight, FileName, Page, Box);
         }
         catch (JSDisconnectedException) { /* circuit gone — best-effort */ }
         catch (Exception ex)

--- a/src/MeshWeaver.Blazor/Components/DocumentSourceView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/DocumentSourceView.razor.js
@@ -15,15 +15,17 @@ const MAMMOTH_URL = new URL('mammoth/mammoth.browser.min.js', LIB_BASE).href;
 let pdfjsPromise = null;
 let mammothPromise = null;
 
-/** Render `fileUrl` into `container` and highlight `highlight`. Entry point called from .NET. */
-export async function render(container, fileUrl, mime, highlight, fileName) {
+/** Render `fileUrl` into `container` and highlight `highlight`. Entry point called from .NET.
+ *  `page` (1-based) + `bbox` ({x,y,w,h} normalized, or its JSON) mark the exact region on a PDF page. */
+export async function render(container, fileUrl, mime, highlight, fileName, page, bbox) {
     if (!container) return;
     container.innerHTML = '<div class="mw-docsource-loading">Loading document…</div>';
 
     const kind = classify(mime, fileUrl);
+    const box = parseBox(bbox);
     try {
         if (kind === 'pdf') {
-            await renderPdf(container, fileUrl, highlight);
+            await renderPdf(container, fileUrl, highlight, page, box);
         } else if (kind === 'docx') {
             await renderDocx(container, fileUrl, highlight);
         } else {
@@ -34,6 +36,18 @@ export async function render(container, fileUrl, mime, highlight, fileName) {
         console.warn('DocumentSourceView render failed', err);
         fallback(container, fileUrl, highlight, fileName,
             'The document could not be displayed inline.');
+    }
+}
+
+/** Normalize the bbox argument (a {x,y,w,h} object or its JSON string) to an object, or null. */
+function parseBox(bbox) {
+    if (!bbox) return null;
+    if (typeof bbox === 'object') return bbox;
+    try {
+        const b = JSON.parse(bbox);
+        return (b && typeof b === 'object') ? b : null;
+    } catch {
+        return null;
     }
 }
 
@@ -62,7 +76,7 @@ function loadPdfjs() {
     return pdfjsPromise;
 }
 
-async function renderPdf(container, url, highlight) {
+async function renderPdf(container, url, highlight, targetPage, box) {
     const pdfjsLib = await loadPdfjs();
     const doc = await pdfjsLib.getDocument({ url }).promise;
 
@@ -71,12 +85,18 @@ async function renderPdf(container, url, highlight) {
     pages.className = 'mw-docsource-pages';
     container.appendChild(pages);
 
+    // If a stored bbox is given, remember the target page's element + viewport so we can overlay the
+    // highlight rectangle once it's rendered (precise, unlike the string-match fallback).
+    let markPageEl = null;
+    let markViewport = null;
+
     for (let n = 1; n <= doc.numPages; n++) {
         const page = await doc.getPage(n);
         const viewport = page.getViewport({ scale: 1.35 });
 
         const pageEl = document.createElement('div');
         pageEl.className = 'mw-pdf-page';
+        pageEl.style.position = 'relative';
         pageEl.style.width = viewport.width + 'px';
         pageEl.style.height = viewport.height + 'px';
 
@@ -107,10 +127,39 @@ async function renderPdf(container, url, highlight) {
         }
 
         pages.appendChild(pageEl);
+        if (box && targetPage === n) {
+            markPageEl = pageEl;
+            markViewport = viewport;
+        }
     }
 
-    const first = highlightInElement(container, highlight);
-    scrollToMark(first);
+    // Prefer the precise stored-bbox rectangle; fall back to the verbatim text match when there's none.
+    let boxMark = null;
+    if (markPageEl && box)
+        boxMark = drawBoxOverlay(markPageEl, markViewport, box);
+    const textMark = highlightInElement(container, highlight);
+    scrollToMark(boxMark || textMark);
+}
+
+/**
+ * Overlays a highlight rectangle at the normalized `box` ({x,y,w,h}, top-left origin) on a rendered page.
+ * The page element is positioned relative, so the absolute rectangle lands over the exact glyphs.
+ */
+function drawBoxOverlay(pageEl, viewport, box) {
+    const el = document.createElement('div');
+    el.className = 'mw-pdf-boxmark';
+    el.style.position = 'absolute';
+    el.style.left = (box.x * viewport.width) + 'px';
+    el.style.top = (box.y * viewport.height) + 'px';
+    el.style.width = Math.max(4, box.w * viewport.width) + 'px';
+    el.style.height = Math.max(4, box.h * viewport.height) + 'px';
+    el.style.background = 'rgba(255, 209, 0, 0.30)';
+    el.style.outline = '2px solid #ffb300';
+    el.style.borderRadius = '2px';
+    el.style.pointerEvents = 'none';
+    el.style.zIndex = '3';
+    pageEl.appendChild(el);
+    return el;
 }
 
 // ── DOCX (mammoth) ───────────────────────────────────────────────────────────

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexSettingsTab.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexSettingsTab.cs
@@ -105,11 +105,14 @@ public static class ContentIndexSettingsTab
 
         stack = stack.WithView(Controls.Html(StatusHtml(true,
             "Active — new uploads to this space index automatically. Use <em>Re-index all content</em> to " +
-            "(re)index files already in the collection; unchanged files are skipped.")));
+            "(re)index files already in the collection; unchanged files are skipped. Use <em>Rebuild</em> to " +
+            "force re-extraction of every file — e.g. to backfill page/position provenance onto files that " +
+            "were indexed before it existed.")));
 
         // ── Re-index (operations-as-script Activity) ──────────────────────────
         stack = stack.WithView(Section("Re-index"));
-        stack = stack.WithView(Controls.Button("Re-index all content")
+        var reindexRow = Controls.Stack.WithWidth("100%").WithStyle("flex-direction:row; gap:8px; flex-wrap:wrap;");
+        reindexRow = reindexRow.WithView(Controls.Button("Re-index all content")
             .WithAppearance(Appearance.Accent)
             .WithClickAction(c =>
             {
@@ -118,6 +121,18 @@ public static class ContentIndexSettingsTab
                     .Subscribe(_ => { }, ex => c.Host.UpdateData(ResultId, Err(ex.Message)));
                 return Task.CompletedTask;
             }));
+        // Rebuild: forces re-extraction past the hash gate — backfills page/position onto already-indexed
+        // (content-unchanged) files, which a plain re-index would skip.
+        reindexRow = reindexRow.WithView(Controls.Button("Rebuild (re-extract page/position)")
+            .WithAppearance(Appearance.Outline)
+            .WithClickAction(c =>
+            {
+                observer.ReindexAll(new[] { collectionPath },
+                        onActivityCreated: path => c.Host.UpdateData(ActivityPathId, path), force: true)
+                    .Subscribe(_ => { }, ex => c.Host.UpdateData(ResultId, Err(ex.Message)));
+                return Task.CompletedTask;
+            }));
+        stack = stack.WithView(reindexRow);
 
         // Live activity progress panel: binds to the running re-index activity (Messages + Status stream
         // live; Cancel flips RequestedStatus = Cancelled). Empty until a run starts.

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingObserver.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingObserver.cs
@@ -158,8 +158,13 @@ public sealed class ContentIndexingObserver : IContentUploadObserver
     /// <param name="collectionPaths">The qualified collection paths to re-index (e.g. <c>Systemorph/content</c>).</param>
     /// <param name="onActivityCreated">Fires once with the activity path the moment it is created, so a
     /// GUI (the Content Indexing settings tab) can bind its live progress panel immediately.</param>
+    /// <param name="force">
+    /// When true every file is re-extracted, re-chunked, re-embedded and replaced even if unchanged
+    /// (bypasses the hash gate) — this is how a rebuild <b>backfills</b> new per-chunk provenance
+    /// (page/position) onto files indexed before it existed. When false (default) unchanged files skip.
+    /// </param>
     public IObservable<string> ReindexAll(
-        IReadOnlyCollection<string> collectionPaths, Action<string>? onActivityCreated = null)
+        IReadOnlyCollection<string> collectionPaths, Action<string>? onActivityCreated = null, bool force = false)
     {
         ArgumentNullException.ThrowIfNull(collectionPaths);
 
@@ -183,14 +188,14 @@ public sealed class ContentIndexingObserver : IContentUploadObserver
         return ContentIndexingActivity.Run(
             hub,
             partition,
-            $"Re-index {collectionPaths.Count} collection(s)",
+            $"Re-index {collectionPaths.Count} collection(s){(force ? " (rebuild)" : "")}",
             // One collection at a time (Concat) keeps the progress log ordered. Each collection emits
             // its count of FAILED files (per-file errors are isolated below, so every file is still
             // attempted). The counts roll up: a non-zero total fails the WHOLE activity so its terminal
             // Status reflects reality (and the activity-failure → admin notification fires), while the
             // per-file errors stay in the log. A clean run completes with a single Unit.
             ctx => collectionPaths
-                .Select(c => ReindexCollection(c, ctx))
+                .Select(c => ReindexCollection(c, ctx, force))
                 .ToObservable()
                 .Concat()
                 .Aggregate(0, (total, failed) => total + failed)
@@ -209,7 +214,8 @@ public sealed class ContentIndexingObserver : IContentUploadObserver
     /// owning activity ends Failed when any file failed. Cancellation is NOT a per-file failure: it
     /// propagates so the activity terminates Cancelled.
     /// </summary>
-    private IObservable<int> ReindexCollection(string collectionPath, ContentIndexingActivityContext ctx) =>
+    private IObservable<int> ReindexCollection(
+        string collectionPath, ContentIndexingActivityContext ctx, bool force) =>
         Observable.Defer(() =>
         {
             ctx.Log($"Scanning collection '{collectionPath}'.");
@@ -226,7 +232,7 @@ public sealed class ContentIndexingObserver : IContentUploadObserver
                             if (bytes is null)
                                 return Observable.Return(0);
                             var fileName = System.IO.Path.GetFileName(filePath);
-                            return indexingService.IndexFile(collectionPath, filePath, fileName, bytes)
+                            return indexingService.IndexFile(collectionPath, filePath, fileName, bytes, force)
                                 .Take(1)
                                 .Select(result =>
                                 {

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/DocumentLayoutAreas.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/DocumentLayoutAreas.cs
@@ -210,7 +210,8 @@ public static class DocumentLayoutAreas
 
         var fileName = string.IsNullOrEmpty(document.Name) ? document.FilePath : document.Name;
         var position = total > 0 ? $"{index + 1} / {total}" : (index + 1).ToString();
-        panel = panel.WithView(Controls.H3($"{fileName} · block {position}"));
+        var pageSuffix = chunk?.Page is int page ? $" · page {page}" : "";
+        panel = panel.WithView(Controls.H3($"{fileName} · block {position}{pageSuffix}"));
 
         if (chunk is null)
         {
@@ -254,16 +255,17 @@ public static class DocumentLayoutAreas
         var terms = host.GetQueryStringParamValue("q") ?? "";
         var index = ParseIndex(host.GetQueryStringParamValue("index"));
         return host.Workspace.GetMeshNodeStream()
-            .Select(node => (UiControl?)BuildSource(host, node, index, terms));
+            .Select(node => BuildSource(host, node, index, terms))
+            .Switch();
     }
 
-    private static UiControl BuildSource(LayoutAreaHost host, MeshNode? node, int index, string terms)
+    private static IObservable<UiControl?> BuildSource(LayoutAreaHost host, MeshNode? node, int index, string terms)
     {
         var container = Controls.Stack.WithWidth("100%").WithStyle(ContainerStyle);
 
         var document = node?.ContentAs<Document>(host.Hub.JsonSerializerOptions);
         if (document is null)
-            return container.WithView(Controls.Markdown("_No document data._"));
+            return Observable.Return((UiControl?)container.WithView(Controls.Markdown("_No document data._")));
 
         var nodePath = node?.Path ?? host.Hub.Address.ToString();
         var fileName = string.IsNullOrEmpty(document.Name) ? document.FilePath : document.Name;
@@ -272,9 +274,21 @@ public static class DocumentLayoutAreas
         container = container.WithView(Controls.H2(fileName));
         container = container.WithView(Controls.Button("← Back to blocks").WithAppearance(Appearance.Outline)
             .WithClickAction(c => { c.NavigateTo(BuildAreaHref(nodePath, BlocksArea, index, terms)); return Task.CompletedTask; }));
-        container = container.WithView(new DocumentSourceControl(fileUrl, document.Mime, terms, fileName)
-            .WithStyle("display:block; width:100%; min-height:600px;"));
-        return container;
+
+        // Load the deep-linked chunk's stored provenance (page + on-page box) so the viewer marks the exact
+        // region — precise and independent of whether the chunk text can be re-found by string match. When
+        // the store/chunk/position is absent the viewer falls back to the verbatim text highlight (terms).
+        var store = host.Hub.ServiceProvider.GetService<IChunkedContentVectorStore>();
+        var provenance = store is null
+            ? Observable.Return<ContentChunk?>(null)
+            : store.GetChunk(document.CollectionPath, document.FilePath, index)
+                .Take(1)
+                .Catch<ContentChunk?, Exception>(_ => Observable.Return<ContentChunk?>(null));
+
+        return provenance.Select(chunk => (UiControl?)container.WithView(
+            new DocumentSourceControl(fileUrl, document.Mime, terms, fileName)
+                .WithMark(chunk?.Page, ChunkPositionJson.Serialize(chunk?.Position))
+                .WithStyle("display:block; width:100%; min-height:600px;")));
     }
 
     /// <summary>

--- a/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgreSqlChunkedContentVectorStore.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgreSqlChunkedContentVectorStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Text.Json;
+using System.Threading;
 using MeshWeaver.Mesh.Threading;
 using Npgsql;
 using NpgsqlTypes;
@@ -85,6 +86,51 @@ public sealed class PostgreSqlChunkedContentVectorStore : IChunkedContentVectorS
 
     /// <summary>The mesh database the indexer writes/queries (content-index tables in partition schemas).</summary>
     internal NpgsqlDataSource DataSource => _dataSource;
+
+    /// <summary>
+    /// The column list every chunk read projects, in the order <see cref="ReadChunkAsync"/> expects. One
+    /// constant so the three read paths (Search / SearchSubtree / GetChunk) can never drift in column order.
+    /// </summary>
+    private const string ChunkColumns =
+        "collection_path, file_path, chunk_index, content_hash, chunk_text, metadata, embedding, page, bbox";
+
+    /// <summary>
+    /// Maps the current reader row (projected via <see cref="ChunkColumns"/>) to a <see cref="ContentChunk"/>,
+    /// including its page + normalized bbox provenance. Shared by all three read paths.
+    /// </summary>
+    private static async Task<ContentChunk> ReadChunkAsync(NpgsqlDataReader reader, CancellationToken ct)
+    {
+        ImmutableDictionary<string, string>? metadata = null;
+        if (!await reader.IsDBNullAsync(5, ct).ConfigureAwait(false))
+        {
+            var json = reader.GetString(5);
+            var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+            if (dict is { Count: > 0 })
+                metadata = dict.ToImmutableDictionary(StringComparer.Ordinal);
+        }
+
+        float[]? embedding = null;
+        if (!await reader.IsDBNullAsync(6, ct).ConfigureAwait(false))
+            embedding = reader.GetFieldValue<Vector>(6).ToArray();
+
+        int? page = await reader.IsDBNullAsync(7, ct).ConfigureAwait(false)
+            ? null
+            : reader.GetInt32(7);
+        var position = await reader.IsDBNullAsync(8, ct).ConfigureAwait(false)
+            ? null
+            : ChunkPositionJson.Deserialize(reader.GetString(8));
+
+        return new ContentChunk(
+            CollectionPath: reader.GetString(0),
+            FilePath: reader.GetString(1),
+            ChunkIndex: reader.GetInt32(2),
+            Text: await reader.IsDBNullAsync(4, ct).ConfigureAwait(false) ? string.Empty : reader.GetString(4),
+            ContentHash: await reader.IsDBNullAsync(3, ct).ConfigureAwait(false) ? string.Empty : reader.GetString(3),
+            Embedding: embedding,
+            Metadata: metadata,
+            Page: page,
+            Position: position);
+    }
 
     /// <summary>
     /// The partition schema for a collection path: the first path segment, lower-cased — exactly how the
@@ -206,8 +252,8 @@ public sealed class PostgreSqlChunkedContentVectorStore : IChunkedContentVectorS
                 ins.CommandText = $"""
                     INSERT INTO "{schema}".content_chunks
                         (collection_path, file_path, chunk_index, source_address, content_hash,
-                         chunk_text, metadata, embedding, last_modified)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+                         chunk_text, metadata, embedding, page, bbox, last_modified)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
                     """;
                 ins.Parameters.AddWithValue(chunk.CollectionPath);
                 ins.Parameters.AddWithValue(chunk.FilePath);
@@ -227,6 +273,13 @@ public sealed class PostgreSqlChunkedContentVectorStore : IChunkedContentVectorS
                     ins.Parameters.AddWithValue(new Vector(chunk.Embedding));
                 else
                     ins.Parameters.AddWithValue(DBNull.Value);
+                // page + bbox provenance: the source page the chunk begins on and its normalized box there.
+                ins.Parameters.AddWithValue((object?)chunk.Page ?? DBNull.Value);
+                ins.Parameters.Add(new NpgsqlParameter
+                {
+                    Value = (object?)ChunkPositionJson.Serialize(chunk.Position) ?? DBNull.Value,
+                    NpgsqlDbType = NpgsqlDbType.Jsonb,
+                });
                 await ins.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
             }
 
@@ -242,7 +295,7 @@ public sealed class PostgreSqlChunkedContentVectorStore : IChunkedContentVectorS
         return EnsureProvisioned(schema).SelectMany(_ => _pool.Invoke<IReadOnlyList<ContentChunk>>(async ct =>
         {
             await using var cmd = _dataSource.CreateCommand($"""
-                SELECT collection_path, file_path, chunk_index, content_hash, chunk_text, metadata, embedding
+                SELECT {ChunkColumns}
                 FROM "{schema}".content_chunks
                 WHERE collection_path = $1 AND embedding IS NOT NULL
                 ORDER BY embedding <=> $2
@@ -255,29 +308,7 @@ public sealed class PostgreSqlChunkedContentVectorStore : IChunkedContentVectorS
             var results = new List<ContentChunk>();
             await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
             while (await reader.ReadAsync(ct).ConfigureAwait(false))
-            {
-                ImmutableDictionary<string, string>? metadata = null;
-                if (!await reader.IsDBNullAsync(5, ct).ConfigureAwait(false))
-                {
-                    var json = reader.GetString(5);
-                    var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-                    if (dict is { Count: > 0 })
-                        metadata = dict.ToImmutableDictionary(StringComparer.Ordinal);
-                }
-
-                float[]? embedding = null;
-                if (!await reader.IsDBNullAsync(6, ct).ConfigureAwait(false))
-                    embedding = reader.GetFieldValue<Vector>(6).ToArray();
-
-                results.Add(new ContentChunk(
-                    CollectionPath: reader.GetString(0),
-                    FilePath: reader.GetString(1),
-                    ChunkIndex: reader.GetInt32(2),
-                    Text: await reader.IsDBNullAsync(4, ct).ConfigureAwait(false) ? string.Empty : reader.GetString(4),
-                    ContentHash: await reader.IsDBNullAsync(3, ct).ConfigureAwait(false) ? string.Empty : reader.GetString(3),
-                    Embedding: embedding,
-                    Metadata: metadata));
-            }
+                results.Add(await ReadChunkAsync(reader, ct).ConfigureAwait(false));
 
             return results;
         }));
@@ -294,7 +325,7 @@ public sealed class PostgreSqlChunkedContentVectorStore : IChunkedContentVectorS
         return EnsureProvisioned(schema).SelectMany(_ => _pool.Invoke<IReadOnlyList<ContentChunk>>(async ct =>
         {
             await using var cmd = _dataSource.CreateCommand($"""
-                SELECT collection_path, file_path, chunk_index, content_hash, chunk_text, metadata, embedding
+                SELECT {ChunkColumns}
                 FROM "{schema}".content_chunks
                 WHERE (collection_path = $1 OR collection_path LIKE $2 ESCAPE '\') AND embedding IS NOT NULL
                 ORDER BY embedding <=> $3
@@ -308,29 +339,7 @@ public sealed class PostgreSqlChunkedContentVectorStore : IChunkedContentVectorS
             var results = new List<ContentChunk>();
             await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
             while (await reader.ReadAsync(ct).ConfigureAwait(false))
-            {
-                ImmutableDictionary<string, string>? metadata = null;
-                if (!await reader.IsDBNullAsync(5, ct).ConfigureAwait(false))
-                {
-                    var json = reader.GetString(5);
-                    var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-                    if (dict is { Count: > 0 })
-                        metadata = dict.ToImmutableDictionary(StringComparer.Ordinal);
-                }
-
-                float[]? embedding = null;
-                if (!await reader.IsDBNullAsync(6, ct).ConfigureAwait(false))
-                    embedding = reader.GetFieldValue<Vector>(6).ToArray();
-
-                results.Add(new ContentChunk(
-                    CollectionPath: reader.GetString(0),
-                    FilePath: reader.GetString(1),
-                    ChunkIndex: reader.GetInt32(2),
-                    Text: await reader.IsDBNullAsync(4, ct).ConfigureAwait(false) ? string.Empty : reader.GetString(4),
-                    ContentHash: await reader.IsDBNullAsync(3, ct).ConfigureAwait(false) ? string.Empty : reader.GetString(3),
-                    Embedding: embedding,
-                    Metadata: metadata));
-            }
+                results.Add(await ReadChunkAsync(reader, ct).ConfigureAwait(false));
 
             return results;
         }));
@@ -360,7 +369,7 @@ public sealed class PostgreSqlChunkedContentVectorStore : IChunkedContentVectorS
         return EnsureProvisioned(schema).SelectMany(_ => _pool.Invoke<ContentChunk?>(async ct =>
         {
             await using var cmd = _dataSource.CreateCommand($"""
-                SELECT collection_path, file_path, chunk_index, content_hash, chunk_text, metadata, embedding
+                SELECT {ChunkColumns}
                 FROM "{schema}".content_chunks
                 WHERE collection_path = $1 AND file_path = $2 AND chunk_index = $3
                 """);
@@ -372,27 +381,7 @@ public sealed class PostgreSqlChunkedContentVectorStore : IChunkedContentVectorS
             if (!await reader.ReadAsync(ct).ConfigureAwait(false))
                 return null;
 
-            ImmutableDictionary<string, string>? metadata = null;
-            if (!await reader.IsDBNullAsync(5, ct).ConfigureAwait(false))
-            {
-                var json = reader.GetString(5);
-                var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-                if (dict is { Count: > 0 })
-                    metadata = dict.ToImmutableDictionary(StringComparer.Ordinal);
-            }
-
-            float[]? embedding = null;
-            if (!await reader.IsDBNullAsync(6, ct).ConfigureAwait(false))
-                embedding = reader.GetFieldValue<Vector>(6).ToArray();
-
-            return new ContentChunk(
-                CollectionPath: reader.GetString(0),
-                FilePath: reader.GetString(1),
-                ChunkIndex: reader.GetInt32(2),
-                Text: await reader.IsDBNullAsync(4, ct).ConfigureAwait(false) ? string.Empty : reader.GetString(4),
-                ContentHash: await reader.IsDBNullAsync(3, ct).ConfigureAwait(false) ? string.Empty : reader.GetString(3),
-                Embedding: embedding,
-                Metadata: metadata);
+            return await ReadChunkAsync(reader, ct).ConfigureAwait(false);
         }));
     }
 

--- a/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgreSqlContentChunkSchema.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.PostgreSql/PostgreSqlContentChunkSchema.cs
@@ -55,6 +55,15 @@ public static class PostgreSqlContentChunkSchema
             UNIQUE (collection_path, file_path, chunk_index)
         );
 
+        -- Per-chunk source provenance (added after the table's first release; ADD COLUMN IF NOT EXISTS is
+        -- idempotent and runs on every boot, so existing partitions gain the columns on next provision —
+        -- no separate DbVersion migration, the content-index schema is self-provisioning per partition).
+        --   page — one-based source page the chunk begins on (NULL for non-paged formats).
+        --   bbox — normalized top-left-origin box {x,y,w,h} (fractions of the page) so a viewer can open
+        --          the page and mark the region; NULL when the position is unknown.
+        ALTER TABLE "{{schema}}".content_chunks ADD COLUMN IF NOT EXISTS page INT;
+        ALTER TABLE "{{schema}}".content_chunks ADD COLUMN IF NOT EXISTS bbox JSONB;
+
         CREATE INDEX IF NOT EXISTS idx_content_chunks_collection_file
             ON "{{schema}}".content_chunks (collection_path, file_path);
 

--- a/src/MeshWeaver.ContentCollections.Indexing/ChunkPosition.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/ChunkPosition.cs
@@ -1,0 +1,32 @@
+namespace MeshWeaver.ContentCollections.Indexing;
+
+/// <summary>
+/// The location of a chunk on its source page, as a <b>normalized</b> bounding box: every coordinate is a
+/// fraction of the page in <c>[0, 1]</c> with a <b>top-left origin</b> (the UI/screen convention — x grows
+/// right, y grows down). Normalization is deliberate: a viewer can overlay a highlight rectangle at any
+/// render scale (a thumbnail, a full page, a zoomed page) without knowing the source page's point size.
+///
+/// <para>Produced by <see cref="ITextExtractor"/> from the source document's own text-layout coordinates
+/// (for PDFs, PdfPig word bounding boxes) and carried on a <see cref="ContentChunk"/> so a consumer can
+/// literally open the source page and mark the region a chunk (or an extracted value) came from. Null when
+/// the source format carries no layout (txt/markdown/docx) or the position could not be resolved.</para>
+/// </summary>
+/// <param name="X">Left edge as a fraction of page width, <c>[0, 1]</c>.</param>
+/// <param name="Y">Top edge as a fraction of page height, <c>[0, 1]</c> (top-left origin).</param>
+/// <param name="Width">Box width as a fraction of page width, <c>[0, 1]</c>.</param>
+/// <param name="Height">Box height as a fraction of page height, <c>[0, 1]</c>.</param>
+public sealed record ChunkPosition(double X, double Y, double Width, double Height)
+{
+    /// <summary>
+    /// The smallest box that contains both this and <paramref name="other"/> — used to grow a chunk's box
+    /// to cover every word (span) that falls inside its text window on the same page.
+    /// </summary>
+    public ChunkPosition Union(ChunkPosition other)
+    {
+        var left = Math.Min(X, other.X);
+        var top = Math.Min(Y, other.Y);
+        var right = Math.Max(X + Width, other.X + other.Width);
+        var bottom = Math.Max(Y + Height, other.Y + other.Height);
+        return new ChunkPosition(left, top, right - left, bottom - top);
+    }
+}

--- a/src/MeshWeaver.ContentCollections.Indexing/ChunkPositionJson.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/ChunkPositionJson.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Nodes;
+
+namespace MeshWeaver.ContentCollections.Indexing;
+
+/// <summary>
+/// The one canonical JSON shape for a <see cref="ChunkPosition"/> — <c>{ "x", "y", "w", "h" }</c>, each a
+/// fraction of the page in <c>[0, 1]</c> with a top-left origin. Shared by every surface (the pgvector
+/// <c>bbox</c> column, the <c>search_chunks</c>/<c>get_chunk</c> tool envelopes, and the document viewer),
+/// so the box a chunk is stored with is exactly the box the UI marks — no per-surface reformatting drift.
+/// </summary>
+public static class ChunkPositionJson
+{
+    /// <summary>Serializes a position to the canonical JSON string, or null when there is no position.</summary>
+    public static string? Serialize(ChunkPosition? position) =>
+        ToJsonObject(position)?.ToJsonString();
+
+    /// <summary>Builds the canonical <c>{x,y,w,h}</c> node, or null when there is no position.</summary>
+    public static JsonObject? ToJsonObject(ChunkPosition? position) =>
+        position is null
+            ? null
+            : new JsonObject
+            {
+                ["x"] = position.X,
+                ["y"] = position.Y,
+                ["w"] = position.Width,
+                ["h"] = position.Height,
+            };
+
+    /// <summary>
+    /// Parses the canonical JSON back into a <see cref="ChunkPosition"/>, or null for null/empty input.
+    /// Missing keys default to 0 (a degenerate but harmless box) — the JSONB is validated by Postgres on
+    /// write and always written by <see cref="Serialize"/>, so this never has to defend against invalid JSON.
+    /// </summary>
+    public static ChunkPosition? Deserialize(string? json)
+    {
+        if (string.IsNullOrEmpty(json))
+            return null;
+        if (JsonNode.Parse(json) is not JsonObject obj)
+            return null;
+        return new ChunkPosition(
+            obj["x"]?.GetValue<double>() ?? 0,
+            obj["y"]?.GetValue<double>() ?? 0,
+            obj["w"]?.GetValue<double>() ?? 0,
+            obj["h"]?.GetValue<double>() ?? 0);
+    }
+}

--- a/src/MeshWeaver.ContentCollections.Indexing/ContentChunk.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/ContentChunk.cs
@@ -19,7 +19,15 @@ namespace MeshWeaver.ContentCollections.Indexing;
 /// <param name="Embedding">
 /// The embedding vector for <see cref="Text"/>, or null if the chunk has not been embedded yet.
 /// </param>
-/// <param name="Metadata">Optional free-form metadata (e.g. source content-type, page number).</param>
+/// <param name="Metadata">Optional free-form metadata (e.g. source content-type).</param>
+/// <param name="Page">
+/// One-based source page the chunk begins on, or null when the source format carries no layout
+/// (txt/markdown/docx) or the page could not be resolved. Provenance for citing/marking the source.
+/// </param>
+/// <param name="Position">
+/// The chunk's normalized bounding box on <see cref="Page"/> (fractions of the page, top-left origin), or
+/// null when unknown. Lets a viewer open the source page and mark the exact region the chunk came from.
+/// </param>
 public sealed record ContentChunk(
     string CollectionPath,
     string FilePath,
@@ -27,4 +35,6 @@ public sealed record ContentChunk(
     string Text,
     string ContentHash,
     float[]? Embedding,
-    ImmutableDictionary<string, string>? Metadata = null);
+    ImmutableDictionary<string, string>? Metadata = null,
+    int? Page = null,
+    ChunkPosition? Position = null);

--- a/src/MeshWeaver.ContentCollections.Indexing/ContentChunkSearch.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/ContentChunkSearch.cs
@@ -144,7 +144,8 @@ public static class ContentChunkSearch
     {
         var results = new JsonArray();
         foreach (var hit in result.Hits)
-            results.Add(new JsonObject
+        {
+            var hitObj = new JsonObject
             {
                 ["documentPath"] = hit.DocumentPath,
                 ["collectionPath"] = hit.CollectionPath,
@@ -152,7 +153,15 @@ public static class ContentChunkSearch
                 ["chunkIndex"] = hit.ChunkIndex,
                 ["rank"] = hit.Rank,
                 ["snippet"] = hit.Snippet,
-            });
+            };
+            // Provenance (only when the source carried it): the page the chunk begins on and its normalized
+            // box there, so a consumer can cite the page and open+mark the exact region.
+            if (hit.Page is int page)
+                hitObj["page"] = page;
+            if (ChunkPositionJson.ToJsonObject(hit.Position) is { } bbox)
+                hitObj["bbox"] = bbox;
+            results.Add(hitObj);
+        }
 
         var obj = new JsonObject
         {
@@ -192,7 +201,8 @@ public static class ContentChunkSearch
         chunks.Take(limit)
             .Select((hit, rank) => new ChunkHit(
                 DocumentPaths.For(hit.CollectionPath, hit.FilePath),
-                hit.CollectionPath, hit.FilePath, hit.ChunkIndex, rank, Snippet(hit.Text)))
+                hit.CollectionPath, hit.FilePath, hit.ChunkIndex, rank, Snippet(hit.Text),
+                hit.Page, hit.Position))
             .ToArray();
 
     /// <summary>Maps a parsed <see cref="QueryScope"/> to the content-search scope, defaulting to subtree.</summary>
@@ -265,8 +275,11 @@ public static class ContentChunkSearch
 /// <param name="ChunkIndex">The 0-based chunk index within the file (feed back into <c>get_chunk</c>).</param>
 /// <param name="Rank">0-based best-first relevance position.</param>
 /// <param name="Snippet">A one-line, ~160-char preview of the chunk text.</param>
+/// <param name="Page">One-based source page the chunk begins on, or null when the source carries no layout.</param>
+/// <param name="Position">The chunk's normalized on-page box, or null when unknown — for open+mark.</param>
 public record ChunkHit(
-    string DocumentPath, string CollectionPath, string FilePath, int ChunkIndex, int Rank, string Snippet);
+    string DocumentPath, string CollectionPath, string FilePath, int ChunkIndex, int Rank, string Snippet,
+    int? Page = null, ChunkPosition? Position = null);
 
 /// <summary>
 /// The outcome of a content search: the resolved namespace + scope, the ranked hits, and a human-readable

--- a/src/MeshWeaver.ContentCollections.Indexing/ContentIndexingService.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/ContentIndexingService.cs
@@ -90,10 +90,19 @@ public sealed class ContentIndexingService
     /// every chunk (bounded merge), and replaces the file's chunks in the store. Cold: subscribe to
     /// run. Emits exactly one <see cref="IndexResult"/>.
     /// </summary>
+    /// <param name="force">
+    /// When true the hash gate is bypassed: the file is always re-extracted, re-chunked, re-embedded and
+    /// its chunks replaced, even if its content is unchanged. This is how a reindex <b>backfills</b> new
+    /// per-chunk provenance (page/position) onto files that were indexed before it existed — the content
+    /// is identical, so the plain hash gate would skip them forever.
+    /// </param>
     public IObservable<IndexResult> IndexFile(
-        string collectionPath, string filePath, string fileName, byte[] bytes)
+        string collectionPath, string filePath, string fileName, byte[] bytes, bool force = false)
     {
         var hash = ComputeSha256(bytes);
+
+        if (force)
+            return IndexChanged(collectionPath, filePath, fileName, bytes, hash);
 
         return _store.GetFileHash(collectionPath, filePath)
             .Take(1)
@@ -153,12 +162,12 @@ public sealed class ContentIndexingService
 
     private IObservable<IndexResult> IndexChanged(
         string collectionPath, string filePath, string fileName, byte[] bytes, string hash) =>
-        _extractor.ExtractText(fileName, bytes)
+        _extractor.ExtractDocument(fileName, bytes)
             .Take(1)
-            .SelectMany(text =>
+            .SelectMany(document =>
             {
-                var chunkTexts = TextChunker.Chunk(text, _options.ChunkSize, _options.ChunkOverlap);
-                if (chunkTexts.Count == 0)
+                var chunks = TextChunker.ChunkPositioned(document, _options.ChunkSize, _options.ChunkOverlap);
+                if (chunks.Count == 0)
                 {
                     _logger.LogInformation(
                         "No text extracted from '{FilePath}' in '{Collection}'; recording NoText.",
@@ -169,12 +178,12 @@ public sealed class ContentIndexingService
                         .Select(_ => IndexResult.NoText);
                 }
 
-                // Chunk branch: embed every chunk, replace the file's stored chunk set, and report
-                // how many were stored. This is exactly the original behavior.
-                var chunkBranch = EmbedChunks(collectionPath, filePath, hash, chunkTexts)
-                    .SelectMany(chunks =>
-                        _store.ReplaceFileChunks(collectionPath, filePath, chunks)
-                            .Select(_ => chunks.Count));
+                // Chunk branch: embed every chunk (carrying its page/position provenance), replace the
+                // file's stored chunk set, and report how many were stored.
+                var chunkBranch = EmbedChunks(collectionPath, filePath, hash, chunks)
+                    .SelectMany(embedded =>
+                        _store.ReplaceFileChunks(collectionPath, filePath, embedded)
+                            .Select(_ => embedded.Count));
 
                 // Document branch: ONE summarize per document (never per chunk), then write the
                 // per-file Document via the sink. Only runs when BOTH summarizer + sink are wired;
@@ -182,7 +191,7 @@ public sealed class ContentIndexingService
                 // — giving exactly today's behavior when either is absent. The summarize call is
                 // its own IIoPool leaf inside the ISummarizer impl; the orchestration holds no slot.
                 return chunkBranch.SelectMany(storedCount =>
-                    WriteDocumentBranch(collectionPath, filePath, fileName, text, bytes, hash, storedCount)
+                    WriteDocumentBranch(collectionPath, filePath, fileName, document.Text, bytes, hash, storedCount)
                         .Select(_ => IndexResult.Indexed(storedCount)));
             });
 
@@ -216,23 +225,26 @@ public sealed class ContentIndexingService
     }
 
     /// <summary>
-    /// Embeds every chunk text via the embedder, bounded-merged (NOT a held-slot serial loop), and
-    /// reassembles them back into <see cref="ContentChunk"/>s in their original order.
+    /// Embeds every chunk's text via the embedder, bounded-merged (NOT a held-slot serial loop), and
+    /// reassembles them back into <see cref="ContentChunk"/>s in their original order — each carrying its
+    /// page/position provenance from the <see cref="PositionedChunk"/>.
     /// </summary>
     private IObservable<IReadOnlyList<ContentChunk>> EmbedChunks(
-        string collectionPath, string filePath, string hash, IReadOnlyList<string> chunkTexts) =>
-        chunkTexts
-            // Pair each text with its index up front so order survives the unordered merge.
-            .Select((chunkText, index) =>
-                _embedder.Embed(chunkText)
+        string collectionPath, string filePath, string hash, IReadOnlyList<PositionedChunk> chunks) =>
+        chunks
+            // Pair each chunk with its index up front so order survives the unordered merge.
+            .Select((chunk, index) =>
+                _embedder.Embed(chunk.Text)
                     .Take(1)
                     .Select(embedding => new ContentChunk(
                         CollectionPath: collectionPath,
                         FilePath: filePath,
                         ChunkIndex: index,
-                        Text: chunkText,
+                        Text: chunk.Text,
                         ContentHash: hash,
-                        Embedding: embedding)))
+                        Embedding: embedding,
+                        Page: chunk.Page,
+                        Position: chunk.Position)))
             .ToObservable()
             // Each Embed leaf acquires its OWN pool slot; this merge just bounds how many we
             // subscribe to at once. The orchestration holds no slot while they run.

--- a/src/MeshWeaver.ContentCollections.Indexing/ExtractedDocument.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/ExtractedDocument.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.ContentCollections.Indexing;
+
+/// <summary>
+/// A run of extracted text that maps a character range in <see cref="ExtractedDocument.Text"/> to the
+/// source <see cref="Page"/> it came from and its <see cref="Box"/> on that page. For a PDF, one span per
+/// extracted word — so any character window (a chunk) resolves to the page(s) and box(es) it overlaps.
+/// </summary>
+/// <param name="Start">Zero-based start offset of the run within <see cref="ExtractedDocument.Text"/>.</param>
+/// <param name="Length">Length of the run in characters.</param>
+/// <param name="Page">One-based source page number the run was extracted from.</param>
+/// <param name="Box">The run's normalized bounding box on <see cref="Page"/>.</param>
+public sealed record PositionedSpan(int Start, int Length, int Page, ChunkPosition Box)
+{
+    /// <summary>The exclusive end offset (<see cref="Start"/> + <see cref="Length"/>).</summary>
+    public int End => Start + Length;
+}
+
+/// <summary>
+/// The result of extracting a content file: the plain <see cref="Text"/> that gets chunked and embedded,
+/// plus optional positional <see cref="Spans"/> that pin ranges of that text back to their source page and
+/// on-page box. <see cref="Spans"/> is empty for formats with no layout (txt/markdown/docx) — those chunks
+/// carry no page/position. For PDFs it is dense (one span per word), so <see cref="TextChunker.ChunkPositioned"/>
+/// can attribute each chunk to a page + region.
+/// </summary>
+/// <param name="Text">The extracted document text (unchanged in role — this is what is chunked/embedded).</param>
+/// <param name="Spans">
+/// Positional spans over <see cref="Text"/>, ordered by <see cref="PositionedSpan.Start"/>. Empty when the
+/// source format carries no layout.
+/// </param>
+public sealed record ExtractedDocument(string Text, ImmutableArray<PositionedSpan> Spans)
+{
+    /// <summary>An empty extraction (no text, no spans) — the result for unknown/binary/empty files.</summary>
+    public static readonly ExtractedDocument Empty = new(string.Empty, ImmutableArray<PositionedSpan>.Empty);
+
+    /// <summary>Wraps plain text with no positional information (the txt/markdown/docx case).</summary>
+    public static ExtractedDocument PlainText(string text) =>
+        string.IsNullOrEmpty(text) ? Empty : new(text, ImmutableArray<PositionedSpan>.Empty);
+}
+
+/// <summary>
+/// One chunk produced by <see cref="TextChunker.ChunkPositioned"/>: the chunk <see cref="Text"/> plus the
+/// source <see cref="Page"/> it begins on and its <see cref="Position"/> (box) on that page. <see cref="Page"/>
+/// and <see cref="Position"/> are null when the source carries no layout (txt/markdown/docx).
+/// </summary>
+/// <param name="Text">The chunk text (a character window of the extracted document text).</param>
+/// <param name="Page">One-based page the chunk begins on, or null when unknown.</param>
+/// <param name="Position">The chunk's normalized box on <see cref="Page"/>, or null when unknown.</param>
+public sealed record PositionedChunk(string Text, int? Page, ChunkPosition? Position);

--- a/src/MeshWeaver.ContentCollections.Indexing/ITextExtractor.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/ITextExtractor.cs
@@ -1,3 +1,5 @@
+using System.Reactive.Linq;
+
 namespace MeshWeaver.ContentCollections.Indexing;
 
 /// <summary>
@@ -13,4 +15,14 @@ public interface ITextExtractor
     /// formats) then completes.
     /// </summary>
     IObservable<string> ExtractText(string fileName, byte[] bytes);
+
+    /// <summary>
+    /// Extracts the document text <b>together with positional spans</b> (page + on-page box per run),
+    /// so chunks can carry page/position provenance. For formats with a text layout (PDF) the result's
+    /// <see cref="ExtractedDocument.Spans"/> is dense; for plain formats it is empty and this degrades to
+    /// <see cref="ExtractText"/>. Default implementation wraps <see cref="ExtractText"/> as plain text, so
+    /// an extractor with no layout information (or a test double) need not override it.
+    /// </summary>
+    IObservable<ExtractedDocument> ExtractDocument(string fileName, byte[] bytes) =>
+        ExtractText(fileName, bytes).Select(ExtractedDocument.PlainText);
 }

--- a/src/MeshWeaver.ContentCollections.Indexing/TextChunker.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/TextChunker.cs
@@ -8,6 +8,12 @@ namespace MeshWeaver.ContentCollections.Indexing;
 /// </summary>
 public static class TextChunker
 {
+    /// <summary>A half-open character window <c>[Start, Start+Length)</c> of the source text.</summary>
+    private readonly record struct TextWindow(int Start, int Length)
+    {
+        public int End => Start + Length;
+    }
+
     /// <summary>
     /// Splits <paramref name="text"/> into fixed-size character windows that overlap by
     /// <paramref name="overlap"/> characters. Deterministic for given inputs.
@@ -30,31 +36,106 @@ public static class TextChunker
         if (string.IsNullOrEmpty(text))
             return ImmutableArray<string>.Empty;
 
-        // Clamp overlap into [0, size-1] so the stride (size - overlap) is always >= 1 — a stride
-        // of 0 would loop forever. This is a guard, not a band-aid: callers pass sane values, but a
-        // pure function must terminate for every input.
+        var builder = ImmutableArray.CreateBuilder<string>();
+        foreach (var window in Windows(text!.Length, size, overlap))
+            builder.Add(text.Substring(window.Start, window.Length));
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Chunks the extracted document into the same character windows as <see cref="Chunk"/>, but attributes
+    /// each chunk to its source <b>page</b> and <b>on-page box</b> using the document's positional spans.
+    /// A chunk is attributed to the page where it <i>begins</i> (the first overlapping span's page), and its
+    /// <see cref="PositionedChunk.Position"/> is the union of every span on that page inside the window — so
+    /// the box covers exactly the chunk's content on its starting page, even across a line break. When the
+    /// document has no spans (txt/markdown/docx) every chunk carries a null page/position.
+    /// </summary>
+    /// <param name="document">The extracted text + positional spans (from <see cref="ITextExtractor.ExtractDocument"/>).</param>
+    /// <param name="size">Window size in characters. Must be positive.</param>
+    /// <param name="overlap">Characters shared between consecutive windows; clamped into <c>[0, size)</c>.</param>
+    /// <returns>The ordered positioned chunks (empty when the document text is empty).</returns>
+    public static IReadOnlyList<PositionedChunk> ChunkPositioned(ExtractedDocument document, int size, int overlap)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (size < 1)
+            throw new ArgumentOutOfRangeException(nameof(size), size, "Chunk size must be positive.");
+
+        var text = document.Text;
+        if (string.IsNullOrEmpty(text))
+            return ImmutableArray<PositionedChunk>.Empty;
+
+        var spans = document.Spans;
+        var builder = ImmutableArray.CreateBuilder<PositionedChunk>();
+
+        // Spans are ordered by Start and windows advance monotonically, so a single cursor over the spans
+        // suffices — advance it past every span that ends at/before the current window's start (those can
+        // never overlap this or any later window).
+        var cursor = 0;
+        foreach (var window in Windows(text.Length, size, overlap))
+        {
+            while (cursor < spans.Length && spans[cursor].End <= window.Start)
+                cursor++;
+
+            int? page = null;
+            ChunkPosition? position = null;
+            for (var i = cursor; i < spans.Length && spans[i].Start < window.End; i++)
+            {
+                var span = spans[i];
+                if (span.End <= window.Start)
+                    continue; // fully before the window (defensive; cursor should have skipped it)
+                if (page is null)
+                {
+                    page = span.Page;
+                    position = span.Box;
+                }
+                else if (span.Page == page)
+                {
+                    position = position!.Union(span.Box);
+                }
+                // Spans on a page after the chunk's start page are left out of the box — the chunk is
+                // attributed to where it begins.
+            }
+
+            builder.Add(new PositionedChunk(text.Substring(window.Start, window.Length), page, position));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// The ordered character windows for a text of <paramref name="textLength"/>: fixed <paramref name="size"/>
+    /// windows advancing by <c>size - overlap</c>, the last one truncated to the text end. Shared by both
+    /// <see cref="Chunk"/> and <see cref="ChunkPositioned"/> so the two never drift.
+    /// </summary>
+    private static IEnumerable<TextWindow> Windows(int textLength, int size, int overlap)
+    {
+        if (textLength <= 0)
+            yield break;
+
+        // Clamp overlap into [0, size-1] so the stride (size - overlap) is always >= 1 — a stride of 0
+        // would loop forever. Guard, not band-aid: a pure function must terminate for every input.
         if (overlap < 0)
             overlap = 0;
         if (overlap >= size)
             overlap = size - 1;
 
         // Shorter than one window → exactly one chunk (the whole text).
-        if (text.Length <= size)
-            return ImmutableArray.Create(text);
-
-        var stride = size - overlap;
-        var builder = ImmutableArray.CreateBuilder<string>();
-        for (var start = 0; start < text.Length; start += stride)
+        if (textLength <= size)
         {
-            var length = Math.Min(size, text.Length - start);
-            builder.Add(text.Substring(start, length));
-
-            // The final window reaches the end of the text — stop so we never emit a trailing
-            // duplicate sub-window covering only the overlap tail.
-            if (start + length >= text.Length)
-                break;
+            yield return new TextWindow(0, textLength);
+            yield break;
         }
 
-        return builder.ToImmutable();
+        var stride = size - overlap;
+        for (var start = 0; start < textLength; start += stride)
+        {
+            var length = Math.Min(size, textLength - start);
+            yield return new TextWindow(start, length);
+
+            // The final window reaches the end of the text — stop so we never emit a trailing duplicate
+            // sub-window covering only the overlap tail.
+            if (start + length >= textLength)
+                yield break;
+        }
     }
 }

--- a/src/MeshWeaver.ContentCollections.Indexing/TextExtractor.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/TextExtractor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Text;
 using DocSharp.Docx;
 using MeshWeaver.Mesh.Threading;
@@ -11,6 +12,10 @@ namespace MeshWeaver.ContentCollections.Indexing;
 /// Default <see cref="ITextExtractor"/>. Dispatches by file extension and runs the actual
 /// decode/parse as a CPU leaf through <see cref="IIoPool.InvokeBlocking{T}"/> — never on the
 /// calling hub scheduler, bounded by the pool. Unknown / binary formats extract to empty (logged).
+///
+/// <para>For PDFs, extraction is <b>positional</b>: the text is built word-by-word from PdfPig's laid-out
+/// words, and each word becomes a <see cref="PositionedSpan"/> (page + normalized on-page box), so a chunk
+/// can be pinned back to the page + region it came from. Other formats extract to plain text (no spans).</para>
 /// </summary>
 public sealed class TextExtractor : ITextExtractor
 {
@@ -40,17 +45,24 @@ public sealed class TextExtractor : ITextExtractor
         var extension = Path.GetExtension(fileName).ToLowerInvariant();
         // The whole parse is a synchronous, CPU-bound leaf — PdfPig, DocSharp and StreamReader all
         // block. InvokeBlocking runs it on the limited-concurrency scheduler, off the hub thread.
+        return _ioPool.InvokeBlocking(_ => Extract(extension, fileName, bytes).Text);
+    }
+
+    /// <inheritdoc/>
+    public IObservable<ExtractedDocument> ExtractDocument(string fileName, byte[] bytes)
+    {
+        var extension = Path.GetExtension(fileName).ToLowerInvariant();
         return _ioPool.InvokeBlocking(_ => Extract(extension, fileName, bytes));
     }
 
-    private string Extract(string extension, string fileName, byte[] bytes)
+    private ExtractedDocument Extract(string extension, string fileName, byte[] bytes)
     {
         switch (extension)
         {
             case ".pdf":
                 return ExtractPdf(bytes);
             case ".docx":
-                return ExtractDocx(bytes);
+                return ExtractedDocument.PlainText(ExtractDocx(bytes));
             case ".md":
             case ".markdown":
             case ".txt":
@@ -59,28 +71,79 @@ public sealed class TextExtractor : ITextExtractor
             case ".html":
             case ".htm":
             case ".xml":
-                return DecodeUtf8(bytes);
+                return ExtractedDocument.PlainText(DecodeUtf8(bytes));
             default:
                 _logger.LogInformation(
                     "No text extractor for extension '{Extension}' (file '{FileName}'); extracting to empty.",
                     extension, fileName);
-                return string.Empty;
+                return ExtractedDocument.Empty;
         }
     }
 
-    private static string ExtractPdf(byte[] bytes)
+    /// <summary>
+    /// Extracts a PDF word-by-word (PdfPig's laid-out words, in reading order): builds the text as words
+    /// joined by spaces within a page and newlines between pages, and records one <see cref="PositionedSpan"/>
+    /// per word (its page + normalized top-left-origin box). So any character window of the resulting text
+    /// resolves to the page(s) + region(s) it covers.
+    /// </summary>
+    private static ExtractedDocument ExtractPdf(byte[] bytes)
     {
         using var document = PdfDocument.Open(bytes);
         var sb = new StringBuilder();
+        var spans = ImmutableArray.CreateBuilder<PositionedSpan>();
+
         foreach (var page in document.GetPages())
         {
+            var pageWidth = page.Width;
+            var pageHeight = page.Height;
             if (sb.Length > 0)
                 sb.Append('\n');
-            sb.Append(page.Text);
+
+            var first = true;
+            foreach (var word in page.GetWords())
+            {
+                var text = word.Text;
+                if (string.IsNullOrEmpty(text))
+                    continue;
+                if (!first)
+                    sb.Append(' ');
+                first = false;
+
+                var start = sb.Length;
+                sb.Append(text);
+
+                // Skip positioning on degenerate page sizes rather than dividing by zero — the word's
+                // text is still indexed, just without a resolvable box.
+                if (pageWidth > 0 && pageHeight > 0)
+                    spans.Add(new PositionedSpan(
+                        start, text.Length, page.Number, NormalizeBox(word.BoundingBox, pageWidth, pageHeight)));
+            }
         }
 
-        return sb.ToString();
+        return new ExtractedDocument(sb.ToString(), spans.ToImmutable());
     }
+
+    /// <summary>
+    /// Normalizes a PdfPig word bounding box (PDF space: points, origin bottom-left, y up) to a
+    /// <see cref="ChunkPosition"/> (fractions of the page, origin top-left, y down) so a viewer can overlay
+    /// the highlight at any render scale. Uses min/max so a rotated/flipped rectangle still yields a
+    /// positive box, and clamps to <c>[0, 1]</c>.
+    /// </summary>
+    private static ChunkPosition NormalizeBox(UglyToad.PdfPig.Core.PdfRectangle box, double pageWidth, double pageHeight)
+    {
+        var leftPt = Math.Min(box.Left, box.Right);
+        var rightPt = Math.Max(box.Left, box.Right);
+        var topPt = Math.Max(box.Top, box.Bottom);      // higher PDF y = visual top
+        var bottomPt = Math.Min(box.Top, box.Bottom);
+
+        var x = Clamp01(leftPt / pageWidth);
+        var width = Clamp01((rightPt - leftPt) / pageWidth);
+        var y = Clamp01(1.0 - topPt / pageHeight);       // flip to top-left origin
+        var height = Clamp01((topPt - bottomPt) / pageHeight);
+        return new ChunkPosition(x, y, width, height);
+    }
+
+    private static double Clamp01(double value) => value < 0 ? 0 : value > 1 ? 1 : value;
 
     private static string ExtractDocx(byte[] bytes)
     {

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContentChunkNavigation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContentChunkNavigation.md
@@ -21,7 +21,9 @@ When a content file is indexed, its extracted text is sliced into overlapping **
 
 The overlap means a sentence straddling a window boundary still lands wholly inside at least one chunk, so a semantic hit is never split across two windows. Every chunk of one file carries the same whole-file `content_hash` (the hash gate's "did this file change?" key); per-chunk identity is `chunk_index`.
 
-Chunks live in a per-partition Postgres `content_chunks` table — one schema per partition, exactly like `mesh_nodes` and the satellite tables (see [Postgres Schema Architecture](../PostgresSchemaArchitecture)). The columns are `collection_path, file_path, chunk_index, content_hash, chunk_text, metadata, embedding, last_modified`. The in-memory store (`InMemoryChunkedContentVectorStore`) backs the unit-tested core with the identical contract.
+Chunks live in a per-partition Postgres `content_chunks` table — one schema per partition, exactly like `mesh_nodes` and the satellite tables (see [Postgres Schema Architecture](../PostgresSchemaArchitecture)). The columns are `collection_path, file_path, chunk_index, content_hash, chunk_text, metadata, embedding, page, bbox, last_modified`. The in-memory store (`InMemoryChunkedContentVectorStore`) backs the unit-tested core with the identical contract.
+
+The `page` + `bbox` columns are **source provenance** — see [Source provenance](#source-provenance-page--position) below. They are added by an idempotent `ADD COLUMN IF NOT EXISTS` in the (self-provisioning, per-partition) schema script, so an existing partition gains them on its next provision — there is no separate `DbVersion` migration.
 
 ## Retrieval vs. extraction
 
@@ -37,8 +39,8 @@ The chunk tools are deliberately **not** a substitute for a full-document read. 
 | Tool | Granularity | Returns | Use when |
 |---|---|---|---|
 | `search` | **Document node** | the file's `Document` node (chunk index dropped) | "which file is about X?" — navigation, linking |
-| `search_chunks` | **chunk** | `{documentPath, collectionPath, filePath, chunkIndex, rank, snippet}` per hit | "find the passages about X" — gather context |
-| `get_chunk` | **one chunk** | `{text, prevIndex, nextIndex, totalChunks, …}` | read a known chunk + step to neighbours |
+| `search_chunks` | **chunk** | `{documentPath, collectionPath, filePath, chunkIndex, rank, snippet, page?, bbox?}` per hit | "find the passages about X" — gather context |
+| `get_chunk` | **one chunk** | `{text, prevIndex, nextIndex, totalChunks, page?, bbox?, …}` | read a known chunk + step to neighbours |
 
 ### `search` — Document-level
 
@@ -76,11 +78,13 @@ When a query carries a `namespace:` token the targeted form wins and the `scope`
   "text": "…the full 1000-char window…",
   "prevIndex": 3,
   "nextIndex": 5,
-  "totalChunks": 12
+  "totalChunks": 12,
+  "page": 4,
+  "bbox": { "x": 0.12, "y": 0.34, "w": 0.61, "h": 0.08 }
 }
 ```
 
-`prevIndex` is `null` at index 0; `nextIndex` is `null` at the last chunk; `totalChunks` lets the caller bound the range. An out-of-range index (or a file that was never indexed) returns `{found:false, totalChunks, message}` carrying the valid range, never an error. This is how an agent reads a `search_chunks` hit in full and then walks forward or backward through the document a window at a time.
+`prevIndex` is `null` at index 0; `nextIndex` is `null` at the last chunk; `totalChunks` lets the caller bound the range. An out-of-range index (or a file that was never indexed) returns `{found:false, totalChunks, message}` carrying the valid range, never an error. This is how an agent reads a `search_chunks` hit in full and then walks forward or backward through the document a window at a time. `page` + `bbox` are present only when the source carried a layout (PDFs) — see [Source provenance](#source-provenance-page--position).
 
 ## Where the tools live
 
@@ -99,6 +103,19 @@ The Content Indexing settings tab is the in-portal surface for the index. Beside
 - A **tool-call inspector**: each search shows the exact `search_chunks(query: "namespace:… scope:subtree …", limit: N)` it maps to, and an opened chunk shows its `get_chunk(collectionPath, filePath, chunkIndex)`. Because the box drives the *same* `ContentChunkSearch` engine the agent tools use, the displayed call is the real one — a way to see how the agent retrieves content, and to debug what a given query actually matches.
 
 The store reads (`GetChunk`, `GetChunkCount`) are on `IChunkedContentVectorStore`. Like every read in the indexing core they are reactive and cold (`IObservable<T>`), and the Postgres implementation runs the DB round-trip through the cap-1 `pg:vector` I/O pool (see [Controlled I/O Pooling](../ControlledIoPooling)) — never a bare `Observable.FromAsync`. When content indexing is not wired into a host, the store/embedder are absent and the tools degrade to a clear "not available" envelope instead of throwing.
+
+## Source provenance (page + position)
+
+Every chunk carries **where it came from** in the source document, so a consumer can cite the page and *open the source page and mark the exact region* — not just quote text.
+
+- **`page`** — the one-based source page the chunk begins on.
+- **`bbox`** — the chunk's normalized bounding box on that page: `{x, y, w, h}`, each a fraction of the page in `[0,1]` with a **top-left origin**. Normalized so a viewer can overlay the highlight at any render scale without knowing the page's point size.
+
+**Extraction is positional.** For PDFs the extractor (`TextExtractor`) builds the text word-by-word from PdfPig's laid-out words and records one span (page + box, in PDF points → normalized top-left) per word. The chunker (`TextChunker.ChunkPositioned`) then attributes each character window to the page it *begins* on and unions the boxes of the words inside the window on that page — so a chunk that straddles a line break still gets one tight box, and a chunk that crosses a page boundary is pinned to its starting page. Formats with no layout (txt/markdown/docx) carry a null `page`/`bbox` and degrade gracefully.
+
+**Marking in the viewer.** The `Document` node's **Source** area renders the original PDF (PDF.js) and, given the deep-linked chunk's `page` + `bbox`, scrolls to that page and overlays a highlight rectangle at the exact region — precise and robust, independent of whether the chunk text can be re-found by string match. When the position is absent it falls back to the verbatim text-match highlight. The block reader also shows `· page N` in each block's header.
+
+**Backfilling existing collections.** The plain re-index is hash-gated — an unchanged file is skipped, so it would never gain provenance. The Content Indexing tab's **Rebuild** button (and `ContentIndexingObserver.ReindexAll(..., force: true)`) bypasses the hash gate to re-extract, re-chunk and re-store every file, populating `page`/`bbox` on files indexed before the feature existed.
 
 ## Reading a document end to end
 

--- a/src/MeshWeaver.Layout/DocumentSourceControl.cs
+++ b/src/MeshWeaver.Layout/DocumentSourceControl.cs
@@ -6,19 +6,29 @@ namespace MeshWeaver.Layout;
 /// route serving the raw file) and, by <see cref="Mime"/>, drives PDF.js (PDF) or mammoth (DOCX) to
 /// render the document, then finds <see cref="Highlight"/> in the rendered text and marks it.
 ///
-/// <para>No stored offsets: the highlight is a verbatim text match (the chunk text / query terms),
-/// located in the rendered document at view time. Unsupported types and load failures degrade to a
-/// download link plus the highlighted passage text — never a blank pane.</para>
+/// <para>The highlight can be located two ways. When a chunk's stored provenance is available,
+/// <see cref="Page"/> + <see cref="Box"/> mark the exact region on the exact page (a highlight rectangle
+/// overlaid on the rendered PDF page, scrolled into view) — precise and robust. When they are absent the
+/// viewer falls back to a verbatim <see cref="Highlight"/> text match located in the rendered document at
+/// view time. Unsupported types and load failures degrade to a download link plus the highlighted passage
+/// text — never a blank pane.</para>
 /// </summary>
 /// <param name="FileUrl">The URL that serves the raw original file (e.g. <c>/static/{collection}/{file}</c>).</param>
 /// <param name="Mime">The file's content type (drives PDF vs DOCX rendering). Null = infer / fall back.</param>
 /// <param name="Highlight">The passage to find and mark in the rendered document (query terms or chunk text).</param>
 /// <param name="FileName">Display name for the file, used as the download-link text in the fallback.</param>
+/// <param name="Page">One-based page to scroll to and mark on (PDF only), or null for no page target.</param>
+/// <param name="Box">
+/// The normalized bounding box to mark on <see cref="Page"/>, as the canonical JSON <c>{x,y,w,h}</c>
+/// (fractions of the page, top-left origin), or null when no stored position is available.
+/// </param>
 public record DocumentSourceControl(
     object FileUrl,
     object? Mime = null,
     object? Highlight = null,
-    object? FileName = null)
+    object? FileName = null,
+    object? Page = null,
+    object? Box = null)
     : UiControl<DocumentSourceControl>(ModuleSetup.ModuleName, ModuleSetup.ApiVersion)
 {
     /// <summary>Returns a copy whose highlight passage is <paramref name="passage"/>.</summary>
@@ -28,4 +38,9 @@ public record DocumentSourceControl(
     /// <summary>Returns a copy whose display file name is <paramref name="name"/>.</summary>
     /// <param name="name">The file name shown as the download-link text in the fallback.</param>
     public DocumentSourceControl WithFileName(string name) => this with { FileName = name };
+
+    /// <summary>Returns a copy that marks page <paramref name="page"/> at the normalized <paramref name="box"/>.</summary>
+    /// <param name="page">One-based page to scroll to and mark on.</param>
+    /// <param name="box">Canonical <c>{x,y,w,h}</c> JSON of the normalized on-page box, or null.</param>
+    public DocumentSourceControl WithMark(int? page, string? box) => this with { Page = page, Box = box };
 }

--- a/test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test/PostgreSqlChunkedContentVectorStoreTests.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test/PostgreSqlChunkedContentVectorStoreTests.cs
@@ -129,6 +129,38 @@ public class PostgreSqlChunkedContentVectorStoreTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ReplaceAndSearch_RoundTripsPageAndPosition()
+    {
+        const string collection = "Prov";
+        const string file = "Prov/report.pdf";
+        var box = new ChunkPosition(0.10, 0.20, 0.30, 0.05);
+
+        var chunk = new ContentChunk(
+            CollectionPath: collection,
+            FilePath: file,
+            ChunkIndex: 0,
+            Text: "page-marked chunk",
+            ContentHash: "h1",
+            Embedding: OneHot(0),
+            Metadata: null,
+            Page: 7,
+            Position: box);
+
+        await _store.ReplaceFileChunks(collection, file, [chunk]).Should().Within(60.Seconds()).Emit();
+
+        // Search round-trips the page + normalized box…
+        var nearest = await _store.Search(collection, OneHot(0), topK: 1).Should().Within(30.Seconds()).Emit();
+        nearest.Should().HaveCount(1);
+        nearest[0].Page.Should().Be(7);
+        nearest[0].Position.Should().Be(box);
+
+        // …and so does GetChunk by index (the get_chunk / block-reader read path).
+        var byIndex = await _store.GetChunk(collection, file, 0).Should().Within(30.Seconds()).Emit();
+        byIndex!.Page.Should().Be(7);
+        byIndex.Position.Should().Be(box);
+    }
+
+    [Fact]
     public async Task ReplaceWithEmptySet_ClearsHash_AndRemovesChunks()
     {
         const string collection = "Empty";

--- a/test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test/PostgreSqlContentChunkSchemaTests.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.PostgreSql.Test/PostgreSqlContentChunkSchemaTests.cs
@@ -37,6 +37,11 @@ public class PostgreSqlContentChunkSchemaTests
         ddl.Should().Contain("metadata        JSONB");
         ddl.Should().Contain("source_address  TEXT");
 
+        // Per-chunk provenance columns — added idempotently so existing partitions gain them on next
+        // provision (no separate DbVersion migration; the content-index schema is self-provisioning).
+        ddl.Should().Contain("ADD COLUMN IF NOT EXISTS page INT");
+        ddl.Should().Contain("ADD COLUMN IF NOT EXISTS bbox JSONB");
+
         // The HNSW cosine index — the nearest-neighbour search path.
         ddl.Should().Contain("USING hnsw (embedding vector_cosine_ops)");
 

--- a/test/MeshWeaver.ContentCollections.Indexing.Test/ContentChunkSearchTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Test/ContentChunkSearchTest.cs
@@ -188,4 +188,27 @@ public class ContentChunkSearchTest
         json.Should().Contain("\"results\":");
         json.Should().Contain("\"chunkIndex\":");
     }
+
+    [Fact]
+    public async Task ToJson_IncludesPageAndBbox_WhenChunkCarriesProvenance()
+    {
+        var pos = new ChunkPosition(0.1, 0.2, 0.3, 0.05);
+        _store.ReplaceFileChunks("PROV/content", "p.pdf", new[]
+        {
+            new ContentChunk("PROV/content", "p.pdf", 0, "provenance carrying chunk",
+                ContentHash: "h", Embedding: _embedder.Embed("provenance carrying chunk").Wait(),
+                Metadata: null, Page: 3, Position: pos),
+        }).Wait();
+
+        var result = await Search("namespace:PROV/content provenance");
+
+        var hit = result.Hits.Should().ContainSingle().Subject;
+        hit.Page.Should().Be(3);
+        hit.Position.Should().Be(pos);
+
+        var json = ContentChunkSearch.ToJson(result);
+        json.Should().Contain("\"page\":3");
+        json.Should().Contain("\"bbox\":");
+        json.Should().Contain("\"x\":0.1");
+    }
 }

--- a/test/MeshWeaver.ContentCollections.Indexing.Test/ContentIndexingServiceTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Test/ContentIndexingServiceTest.cs
@@ -43,8 +43,8 @@ public class ContentIndexingServiceTest : IDisposable
         return path;
     }
 
-    private async Task<IndexResult> Index(string filePath, string fileName) =>
-        await _service.IndexFile(Collection, filePath, fileName, File.ReadAllBytes(filePath))
+    private async Task<IndexResult> Index(string filePath, string fileName, bool force = false) =>
+        await _service.IndexFile(Collection, filePath, fileName, File.ReadAllBytes(filePath), force)
             .FirstAsync().ToTask();
 
     private async Task<IReadOnlyList<ContentChunk>> Search(string text, int topK) =>
@@ -129,6 +129,45 @@ public class ContentIndexingServiceTest : IDisposable
         var hits = await Search("revenue regions", topK: 10);
         hits.Should().NotBeEmpty();
         hits.Should().Contain(c => c.Text.Contains("Revenue"));
+    }
+
+    [Fact]
+    public async Task PdfFile_ChunksCarryPageAndPosition()
+    {
+        var bytes = PdfTestFixtures.OnePagePdf(
+            "Quarterly report",
+            "Revenue grew across all regions this quarter.");
+        var filePath = Path.Combine(_tempDir, "prov.pdf");
+        File.WriteAllBytes(filePath, bytes);
+
+        (await Index(filePath, "prov.pdf")).Status.Should().Be(IndexStatus.Indexed);
+
+        var hits = await Search("revenue regions", topK: 50);
+        hits.Should().NotBeEmpty();
+        // Every chunk of a paged PDF carries its source page + on-page box (provenance for open+mark).
+        hits.Should().OnlyContain(c => c.Page == 1);
+        hits.Should().OnlyContain(c => c.Position != null);
+    }
+
+    [Fact]
+    public async Task ForceReindex_BypassesHashGate_AndReExtractsProvenance()
+    {
+        var bytes = PdfTestFixtures.OnePagePdf(
+            "Balance sheet 2024",
+            "Total assets grew year over year.");
+        var filePath = Path.Combine(_tempDir, "backfill.pdf");
+        File.WriteAllBytes(filePath, bytes);
+
+        (await Index(filePath, "backfill.pdf")).Status.Should().Be(IndexStatus.Indexed);
+        // Unchanged bytes → a normal re-index is skipped by the hash gate.
+        (await Index(filePath, "backfill.pdf")).Status.Should().Be(IndexStatus.Skipped);
+        // force → re-extracted + re-stored even though the content is identical — the backfill path.
+        var forced = await Index(filePath, "backfill.pdf", force: true);
+        forced.Status.Should().Be(IndexStatus.Indexed);
+        forced.ChunkCount.Should().BeGreaterThan(0);
+
+        (await Search("total assets", topK: 50))
+            .Should().OnlyContain(c => c.Page == 1 && c.Position != null);
     }
 
     [Fact]

--- a/test/MeshWeaver.ContentCollections.Indexing.Test/PdfTestFixtures.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Test/PdfTestFixtures.cs
@@ -26,4 +26,18 @@ internal static class PdfTestFixtures
 
         return builder.Build();
     }
+
+    /// <summary>Builds a multi-page PDF; each element of <paramref name="pages"/> is one page's single line.</summary>
+    public static byte[] MultiPagePdf(params string[] pages)
+    {
+        var builder = new PdfDocumentBuilder();
+        var font = builder.AddStandard14Font(Standard14Font.Helvetica);
+        foreach (var line in pages)
+        {
+            var page = builder.AddPage(595, 842);
+            page.AddText(line, 12, new PdfPoint(50, 800), font);
+        }
+
+        return builder.Build();
+    }
 }

--- a/test/MeshWeaver.ContentCollections.Indexing.Test/TextChunkerTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Test/TextChunkerTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using MeshWeaver.ContentCollections.Indexing;
 using Xunit;
 
@@ -5,6 +6,62 @@ namespace MeshWeaver.ContentCollections.Indexing.Test;
 
 public class TextChunkerTest
 {
+    // ── ChunkPositioned: page/position attribution ───────────────────────────
+
+    [Fact]
+    public void ChunkPositioned_PlainDocument_HasNullPageAndPosition()
+    {
+        var doc = ExtractedDocument.PlainText(new string('x', 250));
+        var chunks = TextChunker.ChunkPositioned(doc, 100, 10);
+
+        chunks.Should().HaveCountGreaterThan(1);
+        chunks.Should().OnlyContain(c => c.Page == null && c.Position == null);
+        // The text windows match the plain Chunk() windows exactly.
+        chunks.Select(c => c.Text).Should().Equal(TextChunker.Chunk(doc.Text, 100, 10));
+    }
+
+    [Fact]
+    public void ChunkPositioned_AttributesToStartPage_AndUnionsBoxesOnThatPage()
+    {
+        // "AAAA BBBB CCCC" — AAAA/BBBB on page 1, CCCC on page 2.
+        var text = "AAAA BBBB CCCC";
+        var spans = ImmutableArray.Create(
+            new PositionedSpan(0, 4, 1, new ChunkPosition(0.10, 0.10, 0.20, 0.05)),
+            new PositionedSpan(5, 4, 1, new ChunkPosition(0.10, 0.20, 0.20, 0.05)),
+            new PositionedSpan(10, 4, 2, new ChunkPosition(0.10, 0.10, 0.20, 0.05)));
+        var doc = new ExtractedDocument(text, spans);
+
+        // One window over the whole text: attributed to page 1 (where it begins); box unions the two
+        // page-1 words (AAAA + BBBB) and EXCLUDES the page-2 word.
+        var single = TextChunker.ChunkPositioned(doc, 100, 0);
+        single.Should().ContainSingle();
+        single[0].Page.Should().Be(1);
+        single[0].Position!.X.Should().BeApproximately(0.10, 1e-9);
+        single[0].Position!.Y.Should().BeApproximately(0.10, 1e-9);
+        single[0].Position!.Width.Should().BeApproximately(0.20, 1e-9);
+        single[0].Position!.Height.Should().BeApproximately(0.15, 1e-9); // 0.10..0.25
+    }
+
+    [Fact]
+    public void ChunkPositioned_ChunkStartingOnLaterPage_TakesThatPage()
+    {
+        var text = "AAAA BBBB CCCC"; // len 14
+        var spans = ImmutableArray.Create(
+            new PositionedSpan(0, 4, 1, new ChunkPosition(0.10, 0.10, 0.20, 0.05)),
+            new PositionedSpan(5, 4, 1, new ChunkPosition(0.10, 0.20, 0.20, 0.05)),
+            new PositionedSpan(10, 4, 2, new ChunkPosition(0.30, 0.40, 0.20, 0.05)));
+        var doc = new ExtractedDocument(text, spans);
+
+        // size 9, overlap 0 → windows [0,9) and [9,14). The first is page 1 (AAAA+BBBB), the second is
+        // page 2 (CCCC only) — proving per-chunk attribution across a page boundary.
+        var chunks = TextChunker.ChunkPositioned(doc, 9, 0);
+        chunks.Should().HaveCount(2);
+        chunks[0].Page.Should().Be(1);
+        chunks[1].Page.Should().Be(2);
+        chunks[1].Position!.X.Should().BeApproximately(0.30, 1e-9);
+        chunks[1].Position!.Y.Should().BeApproximately(0.40, 1e-9);
+    }
+
     [Fact]
     public void EmptyText_ProducesNoChunks()
     {

--- a/test/MeshWeaver.ContentCollections.Indexing.Test/TextExtractorTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Test/TextExtractorTest.cs
@@ -14,6 +14,9 @@ public class TextExtractorTest
     private async Task<string> Extract(string fileName, byte[] bytes) =>
         await _extractor.ExtractText(fileName, bytes).FirstAsync().ToTask();
 
+    private async Task<ExtractedDocument> ExtractDoc(string fileName, byte[] bytes) =>
+        await _extractor.ExtractDocument(fileName, bytes).FirstAsync().ToTask();
+
     [Fact]
     public async Task Txt_DecodesUtf8()
     {
@@ -60,5 +63,49 @@ public class TextExtractorTest
         var bytes = new byte[] { 0x00, 0x01, 0x02, 0xFF, 0xFE };
         var text = await Extract("blob.bin", bytes);
         text.Should().BeEmpty();
+    }
+
+    // ── ExtractDocument: positional spans ────────────────────────────────────
+
+    [Fact]
+    public async Task ExtractDocument_Pdf_CarriesPageOneSpansInsideTheUnitBox()
+    {
+        var bytes = PdfTestFixtures.OnePagePdf("Revenue grew across regions this quarter");
+        var doc = await ExtractDoc("report.pdf", bytes);
+
+        doc.Text.Should().Contain("Revenue");
+        doc.Spans.Should().NotBeEmpty();
+        // Every span is on page 1 and every normalized coordinate is within the unit page box.
+        doc.Spans.Should().OnlyContain(s => s.Page == 1);
+        doc.Spans.Should().OnlyContain(s =>
+            s.Box.X >= 0 && s.Box.X <= 1 && s.Box.Y >= 0 && s.Box.Y <= 1 &&
+            s.Box.Width > 0 && s.Box.Width <= 1 && s.Box.Height > 0 && s.Box.Height <= 1);
+
+        // The line sits at x=50/595 (left margin) and y=800/842 (near the top) — so the first word's box
+        // is on the left and near the top (small Y with the top-left origin).
+        var first = doc.Spans[0];
+        first.Box.X.Should().BeLessThan(0.2);
+        first.Box.Y.Should().BeLessThan(0.15);
+        // The span text is a slice of the document text at the span's offset.
+        doc.Text.Substring(first.Start, first.Length).Should().Be("Revenue");
+    }
+
+    [Fact]
+    public async Task ExtractDocument_Pdf_MultiPage_SpansCarryDistinctPages()
+    {
+        var bytes = PdfTestFixtures.MultiPagePdf("First page alpha", "Second page bravo");
+        var doc = await ExtractDoc("two.pdf", bytes);
+
+        doc.Spans.Select(s => s.Page).Distinct().OrderBy(p => p).Should().Equal(1, 2);
+        // A page-2 word maps to page 2.
+        doc.Spans.Should().Contain(s => s.Page == 2 && doc.Text.Substring(s.Start, s.Length) == "bravo");
+    }
+
+    [Fact]
+    public async Task ExtractDocument_Txt_HasTextButNoSpans()
+    {
+        var doc = await ExtractDoc("notes.txt", Encoding.UTF8.GetBytes("plain text has no layout"));
+        doc.Text.Should().Contain("plain text");
+        doc.Spans.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
Closes #226 (and its follow-up: *"put position in page that we can mark … extract directly from the docs that we can literally open the page and mark"*).

Every indexed chunk now carries **where it came from** — the source **page** and a normalized **on-page bounding box** — so a consumer can cite the page and **open the source PDF page and mark the exact region**, not just quote text.

## Extraction is positional (no marker transformer needed)
`TextExtractor` builds PDF text **word-by-word** from PdfPig's laid-out words and records one span (page + box, PDF points → normalized top-left `[0,1]`) per word. The coordinates come straight from the PDF — no dependency on the `PdfContentTransformer`/`<!-- Seite N -->` marker approach the issue anticipated (which wasn't on `main`). Non-PDF formats (txt/md/docx) carry a null page/position and index exactly as before.

## Chunking attributes each window to a page + box
`TextChunker.ChunkPositioned` attributes each character window to the page it **begins** on and unions the boxes of the words inside the window on that page — a tight box across a line break, and a chunk crossing a page boundary is pinned to its starting page. It shares the window generator with the existing string `Chunk()` so the two never drift.

## Model + storage
- `ContentChunk` gains `int? Page` + `ChunkPosition? Position`.
- pgvector `content_chunks` gains `page INT` + `bbox JSONB` via idempotent `ADD COLUMN IF NOT EXISTS` in the **self-provisioning per-partition** schema — **no separate `DbVersion` migration**; existing partitions gain the columns on next provision. INSERT + all three read paths carry them (the triplicated reader mapping is consolidated into one `ReadChunkAsync`).
- `ChunkPositionJson` is the single canonical `{x,y,w,h}` shape shared by the store, the tool envelopes, and the viewer — no per-surface drift.

## Surfaces
- **`search_chunks` / `get_chunk`** envelopes include `page` + `bbox` (present only when the source carried a layout).
- **Document `Source` viewer**: given the deep-linked chunk's `page` + `bbox`, PDF.js scrolls to the page and overlays a **precise highlight rectangle** — robust, independent of re-finding the text by string match; falls back to the verbatim text-match highlight when the position is absent. The block reader header shows `· page N`.
- **Backfill**: the `Content Indexing` tab's new **Rebuild** button (and `ReindexAll(force: true)`) bypasses the hash gate to re-extract/re-store every file, populating `page`/`bbox` on files indexed before this existed (a plain re-index skips unchanged files).

## Tests
Page/position attribution across a chunk boundary; PDF positional extraction (page + unit-box) incl. multi-page; PDF end-to-end carries provenance; force re-index bypasses the hash gate; `search_chunks` JSON carries page/bbox; pgvector schema columns + store round-trip (Testcontainers, runs in CI).

**Verification:** all touched `src` projects build Release `-warnaserror` clean; **51 indexing unit tests green**; documentation link-integrity green. (The pgvector store round-trip runs under Docker in CI.)

Unblocks #196 (page-verified provenance for the AgenticPension Bilanz entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)