### PR TITLE
feat(react-native): local-first portal on iPhone — SQLite monolith over gRPC-web, editors, speech

### DIFF
--- a/clients/grpc-web/src/connection.ts
+++ b/clients/grpc-web/src/connection.ts
@@ -19,11 +19,16 @@ export interface ConnectOptions {
   /** Sink for background send/stream faults that have no awaiting caller (default `console.error`). */
   onError?: (error: unknown) => void;
   /**
-   * Inject the Connect transport instead of the default gRPC-web one. Use to supply a custom `fetch`
-   * (e.g. a streaming-fetch polyfill on React Native) or an in-memory transport for tests. When set,
-   * `token` is ignored — add your own auth interceptor to the transport.
+   * Inject the Connect transport instead of the default gRPC-web one. Use to supply an in-memory
+   * transport for tests. When set, `token` AND `fetch` are ignored — add your own auth interceptor.
    */
   transport?: Transport;
+  /**
+   * Custom `fetch` for the default gRPC-web transport — the seam for React Native, whose Hermes `fetch`
+   * can't stream a server response body (pass a streaming-fetch polyfill). Ignored when `transport` is
+   * set. Web/Node leave it undefined and get the platform fetch.
+   */
+  fetch?: typeof globalThis.fetch;
 }
 
 /** Bearer-token interceptor — the token rides in gRPC-web call metadata, exactly like the Node SDK. */
@@ -57,7 +62,7 @@ export class MeshWebConnection {
     const address = opts.address ?? `node/${newId()}`;
     const transport =
       opts.transport ??
-      createGrpcWebTransport({ baseUrl: url, interceptors: opts.token ? [bearer(opts.token)] : [] });
+      createGrpcWebTransport({ baseUrl: url, fetch: opts.fetch, interceptors: opts.token ? [bearer(opts.token)] : [] });
     const conn = new MeshWebConnection(address, createClient(Mesh, transport), opts.onError ?? console.error);
     return conn.open();
   }

--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -36,8 +36,15 @@ interface ChatOptions {
   namespacePath: string;
   speech?: { url?: string; token?: string; path?: string; language?: string } | null;
 }
-const CHAT: ChatOptions | null = null;
-// const CHAT: ChatOptions = { namespacePath: "rbuergi", speech: { language: "de" } };
+// Speech enabled for the local-simulator demo: a standalone build has no served origin, so point
+// speech at the local Whisper container explicitly (deploy/whisper → http://localhost:8080/inference;
+// localhost reaches the host Mac from the simulator). Drop `speech.url`/`speech.path` in a mesh-served
+// deployment and the endpoint follows the current instance (see the useMemo below).
+const CHAT: ChatOptions | null = {
+  namespacePath: "rbuergi",
+  speech: { url: "http://localhost:8080", path: "/inference", language: "de" },
+};
+// const CHAT: ChatOptions | null = null;
 
 export default function App() {
   ensureWebStyles();
@@ -84,7 +91,7 @@ function AppInner() {
         // The SAME gRPC-web connection carries thread submissions (Mesh.startThread / Mesh.submitMessage).
         setSubmitter(Mesh.from(l.connection));
       })
-      .catch(() => { /* connection failed — the shell stays on the last-good source */ });
+      .catch((e) => { console.warn("[live] connect failed:", e?.message ?? String(e)); /* shell stays on the last-good source */ });
     return () => {
       cancelled = true;
       live?.connection.close();

--- a/clients/react-native/app.json
+++ b/clients/react-native/app.json
@@ -6,8 +6,19 @@
     "orientation": "portrait",
     "userInterfaceStyle": "light",
     "newArchEnabled": true,
-    "ios": { "supportsTablet": true },
-    "android": {},
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "cloud.meshweaver.mobile",
+      "infoPlist": {
+        "NSAppTransportSecurity": {
+          "NSAllowsLocalNetworking": true
+        }
+      }
+    },
+    "android": { "package": "cloud.meshweaver.mobile" },
+    "extra": {
+      "portalUrl": "http://localhost:5250"
+    },
     "plugins": [
       "expo-asset",
       "expo-font",

--- a/clients/react-native/eas.json
+++ b/clients/react-native/eas.json
@@ -1,0 +1,26 @@
+{
+  "cli": {
+    "version": ">= 12.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": { "simulator": true }
+    },
+    "simulator": {
+      "distribution": "internal",
+      "ios": { "simulator": true }
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/clients/react-native/package.json
+++ b/clients/react-native/package.json
@@ -6,8 +6,8 @@
   "main": "expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
-    "ios": "expo start --ios",
-    "android": "expo start --android",
+    "ios": "expo run:ios",
+    "android": "expo run:android",
     "web": "expo start --web",
     "web:export": "expo export --platform web",
     "typecheck": "tsc --noEmit",
@@ -26,7 +26,10 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.76.5",
-    "react-native-web": "~0.19.13"
+    "react-native-fetch-api": "^3.0.0",
+    "react-native-web": "~0.19.13",
+    "text-encoding": "^0.7.0",
+    "web-streams-polyfill": "^4.3.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.48.0",

--- a/clients/react-native/src/Shell.tsx
+++ b/clients/react-native/src/Shell.tsx
@@ -343,7 +343,7 @@ const makeStyles = (p: Palette) => StyleSheet.create({
   brand: { flexDirection: "row", alignItems: "center", gap: 8, width: 210 },
   brandMobile: { flexDirection: "row", alignItems: "center" },
   hamburger: { width: 34, height: 34, borderRadius: 8, alignItems: "center", justifyContent: "center" },
-  hamburgerText: { fontSize: 20, color: "#242424" },
+  hamburgerText: { fontSize: 20, color: p.text },
   scrim: { position: "absolute", top: 0, left: 0, right: 0, bottom: 0, backgroundColor: "rgba(0,0,0,0.35)", zIndex: 1 },
   drawer: { position: "absolute", top: 0, left: 0, bottom: 0, zIndex: 2, elevation: 8, shadowColor: "#000", shadowOpacity: 0.2, shadowRadius: 12, shadowOffset: { width: 2, height: 0 } },
   logo: { width: 26, height: 26, borderRadius: 6, backgroundColor: p.accent, alignItems: "center", justifyContent: "center" },

--- a/clients/react-native/src/Shell.tsx
+++ b/clients/react-native/src/Shell.tsx
@@ -14,7 +14,7 @@
 // layout store as $Menu:{context} (Node / Mesh / AI; see NodeMenuItemsExtensions), plus the in-app
 // client contexts (You: profile / voice / connect) — the same split the MAUI PortalShellPage renders.
 import { useEffect, useState, useSyncExternalStore, type ReactNode } from "react";
-import { View, Text, TextInput, Pressable, ScrollView, StyleSheet } from "react-native";
+import { View, Text, TextInput, Pressable, ScrollView, StyleSheet, useWindowDimensions } from "react-native";
 import { RenderArea, type AreaSource, type AreaTree } from "@meshweaver/react/core";
 import { type NavTarget } from "./nav";
 import { CLIENT_MENUS, ClientScreen, type ClientDestination } from "./screens";
@@ -68,35 +68,68 @@ export function Shell({
 }): ReactNode {
   const tree = useTree(source);
   const styles = useSheet();
+  // Responsive: the fixed left menu (236) + right TOC (250) don't fit a phone — the content column would
+  // be squeezed to zero width. On a narrow viewport the menu becomes a slide-over (hamburger in the top
+  // bar), the TOC is hidden, and the content takes the FULL width. Wide viewports keep the 3-column shell.
+  const { width } = useWindowDimensions();
+  const isMobile = width < 760;
+  const [menuOpen, setMenuOpen] = useState(false);
+  const navigate = (t: NavTarget) => { setMenuOpen(false); onNavigate(t); };
+  const clientNav = (d: ClientDestination | null) => { setMenuOpen(false); onClientScreen(d); };
+
+  const menu = (
+    <LeftMenu tree={tree} nav={nav} clientScreen={clientScreen} onNavigate={navigate} onClientScreen={clientNav} />
+  );
+  const main = clientScreen ? (
+    <View style={styles.content}>
+      <ClientScreen destination={clientScreen} onConnected={onReconnect} />
+    </View>
+  ) : (
+    <ContentPane source={source} nav={nav} onNavigate={onNavigate} />
+  );
+
   return (
     <View style={styles.root}>
-      <TopBar onNavigate={onNavigate} />
+      <TopBar onNavigate={onNavigate} isMobile={isMobile} onToggleMenu={() => setMenuOpen((o) => !o)} />
       <Breadcrumb nav={nav} clientScreen={clientScreen} onNavigate={onNavigate} />
       <View style={styles.body}>
-        <LeftMenu tree={tree} nav={nav} clientScreen={clientScreen} onNavigate={onNavigate} onClientScreen={onClientScreen} />
-        {clientScreen ? (
-          <View style={styles.content}>
-            <ClientScreen destination={clientScreen} onConnected={onReconnect} />
-          </View>
+        {isMobile ? (
+          <>
+            {main}
+            {menuOpen ? (
+              <>
+                <Pressable style={styles.scrim} onPress={() => setMenuOpen(false)} />
+                <View style={styles.drawer}>{menu}</View>
+              </>
+            ) : null}
+          </>
         ) : (
-          <ContentPane source={source} nav={nav} onNavigate={onNavigate} />
+          <>
+            {menu}
+            {main}
+            <RightSidebar contentKey={clientScreen ?? `${nav.address}/${nav.area}`} />
+          </>
         )}
-        <RightSidebar contentKey={clientScreen ?? `${nav.address}/${nav.area}`} />
       </View>
     </View>
   );
 }
 
 // ── top bar ───────────────────────────────────────────────────────────────────
-function TopBar({ onNavigate }: { onNavigate: (t: NavTarget) => void }): ReactNode {
+function TopBar({ onNavigate, isMobile, onToggleMenu }: { onNavigate: (t: NavTarget) => void; isMobile: boolean; onToggleMenu: () => void }): ReactNode {
   const [q, setQ] = useState("");
   const styles = useSheet();
   const { mode, toggle, palette } = useTheme();
   return (
     <View style={styles.topbar}>
-      <Pressable style={styles.brand} onPress={() => onNavigate(HOME)}>
+      {isMobile ? (
+        <Pressable style={styles.hamburger} onPress={onToggleMenu} accessibilityLabel="Menu">
+          <Text style={styles.hamburgerText}>☰</Text>
+        </Pressable>
+      ) : null}
+      <Pressable style={isMobile ? styles.brandMobile : styles.brand} onPress={() => onNavigate(HOME)}>
         <View style={styles.logo}><Text style={styles.logoMark}>◆</Text></View>
-        <Text style={styles.brandText}>MeshWeaver</Text>
+        {isMobile ? null : <Text style={styles.brandText}>MeshWeaver</Text>}
       </Pressable>
       <View style={styles.searchWrap}>
         <Text style={styles.searchIcon}>⌕</Text>
@@ -308,6 +341,11 @@ const makeStyles = (p: Palette) => StyleSheet.create({
   root: { flex: 1, backgroundColor: p.appBg },
   topbar: { height: 52, flexDirection: "row", alignItems: "center", paddingHorizontal: 14, gap: 12, backgroundColor: p.topbarBg, borderBottomWidth: 1, borderBottomColor: p.border },
   brand: { flexDirection: "row", alignItems: "center", gap: 8, width: 210 },
+  brandMobile: { flexDirection: "row", alignItems: "center" },
+  hamburger: { width: 34, height: 34, borderRadius: 8, alignItems: "center", justifyContent: "center" },
+  hamburgerText: { fontSize: 20, color: "#242424" },
+  scrim: { position: "absolute", top: 0, left: 0, right: 0, bottom: 0, backgroundColor: "rgba(0,0,0,0.35)", zIndex: 1 },
+  drawer: { position: "absolute", top: 0, left: 0, bottom: 0, zIndex: 2, elevation: 8, shadowColor: "#000", shadowOpacity: 0.2, shadowRadius: 12, shadowOffset: { width: 2, height: 0 } },
   logo: { width: 26, height: 26, borderRadius: 6, backgroundColor: p.accent, alignItems: "center", justifyContent: "center" },
   logoMark: { color: p.onAccent, fontSize: 14, fontWeight: "700" },
   brandText: { fontSize: 15, fontWeight: "700", color: p.text },

--- a/clients/react-native/src/connection.ts
+++ b/clients/react-native/src/connection.ts
@@ -14,15 +14,34 @@ export interface MeshInstance {
   local: boolean;
 }
 
+import Constants from "expo-constants";
+
 const INSTANCES_KEY = "mw.instances";
 const CURRENT_KEY = "mw.currentInstance";
+
+// The mesh a NATIVE build dials by default (it has no serving origin like the web build). Configured in
+// app.json → expo.extra.portalUrl; defaults to the LOCAL monolith mesh — Memex.LocalMesh, the in-process
+// SQLite-backed mesh sidecar (the MAUI-parity local-first host), reachable from the iOS simulator at
+// http://localhost:5250 anonymously (no token). Point it at a remote portal via Connect-to-mesh + a token.
+const DEFAULT_PORTAL_URL = String((Constants.expoConfig?.extra as any)?.portalUrl ?? "http://localhost:5250");
+
+/** The default portal URL a native build dials (app.json → expo.extra.portalUrl); prefill for the connect form. */
+export function defaultPortalUrl(): string {
+  return DEFAULT_PORTAL_URL;
+}
 
 const sameOrigin = (): string =>
   typeof window !== "undefined" && window.location ? window.location.origin : "";
 
-/** The always-present "Local" instance — the mesh that served this build, dialled anonymously. */
+/**
+ * The always-present default instance. Web (served by the mesh) → same-origin, anonymous. Native has no
+ * serving origin, so it dials the configured default portal (the user supplies a token in-app).
+ */
 export function localInstance(): MeshInstance {
-  return { name: "Local", url: sameOrigin(), token: "", local: true };
+  const origin = sameOrigin();
+  return origin
+    ? { name: "Local", url: origin, token: "", local: true }
+    : { name: "Local mesh", url: DEFAULT_PORTAL_URL, token: "", local: true };
 }
 
 function read<T>(key: string): T | null {

--- a/clients/react-native/src/editors.test.tsx
+++ b/clients/react-native/src/editors.test.tsx
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import TestRenderer, { type ReactTestRendererJSON } from "react-test-renderer";
+import { RegistryProvider, ScopeProvider, RenderArea, StaticAreaSource, type AreaTree } from "@meshweaver/react/core";
+import { rnPack } from "./rnPack";
+
+// Headless proof that EVERY editor the RN leaf pack adds actually renders to native components AND
+// resolves its /data binding — the runtime counterpart to `tsc`. Mirrors rnPack.test.tsx's harness.
+
+const ref = (area: string) => ({ $type: "NamedArea", area });
+const ptr = (pointer: string) => ({ $type: "JsonPointerReference", pointer });
+
+const tree: AreaTree = {
+  data: {
+    age: 42,
+    color: "green",
+    size: "M",
+    volume: 30,
+    when: "2026-07-06T14:30:00Z",
+    city: "Zurich",
+    query: "",
+    code: "const x = 1;\nconsole.log(x);",
+    md: "# Notes\n\nbody",
+  },
+  areas: {
+    main: {
+      $type: "Stack",
+      skins: [{ $type: "LayoutStack", verticalGap: 8 }],
+      areas: [
+        ref("num"), ref("sel"), ref("radio"), ref("slider"), ref("date"), ref("dt"),
+        ref("combo"), ref("search"), ref("code"), ref("mdedit"), ref("diff"),
+        ref("sample"), ref("err"), ref("menu"), ref("form"),
+      ],
+    },
+    num: { $type: "NumberField", label: "Age", data: ptr("/data/age") },
+    sel: { $type: "Select", label: "Color", data: ptr("/data/color"), options: [{ value: "red", text: "Red" }, { value: "green", text: "Green" }] },
+    radio: { $type: "RadioGroup", label: "Size", data: ptr("/data/size"), options: [{ value: "S", text: "Small" }, { value: "M", text: "Medium" }] },
+    slider: { $type: "Slider", label: "Volume", data: ptr("/data/volume"), min: 0, max: 100, step: 5 },
+    date: { $type: "Date", label: "When", data: ptr("/data/when") },
+    dt: { $type: "DateTime", label: "When exactly", data: ptr("/data/when") },
+    combo: { $type: "Combobox", label: "City", data: ptr("/data/city"), options: [{ value: "Zurich", text: "Zurich" }, { value: "Bern", text: "Bern" }] },
+    search: { $type: "SearchBox", data: ptr("/data/query"), placeholder: "Find" },
+    code: { $type: "CodeEditor", label: "Code", data: ptr("/data/code") },
+    mdedit: { $type: "MarkdownEditor", label: "Notes", data: ptr("/data/md") },
+    diff: { $type: "DiffEditor", original: "old line", data: "new line" },
+    sample: { $type: "CodeSample", data: "readonly();" },
+    err: { $type: "Exception", message: "Boom happened" },
+    menu: { $type: "MenuItem", title: "Open", isClickable: true },
+    form: { $type: "EditForm", areas: [ref("num")] },
+  },
+};
+
+type Json = ReactTestRendererJSON;
+
+function render(): Json {
+  let root!: TestRenderer.ReactTestRenderer;
+  TestRenderer.act(() => {
+    root = TestRenderer.create(
+      <RegistryProvider pack={rnPack}>
+        <ScopeProvider source={new StaticAreaSource(tree)} area="main">
+          <RenderArea areaKey="main" />
+        </ScopeProvider>
+      </RegistryProvider>,
+    );
+  });
+  return root.toJSON() as Json;
+}
+
+function* walk(node: Json | Json[] | null): Generator<Json> {
+  if (node == null) return;
+  if (Array.isArray(node)) { for (const n of node) yield* walk(n); return; }
+  yield node;
+  if (node.children) for (const c of node.children) yield* walk(c as Json);
+}
+
+function textOf(node: Json): string {
+  let out = "";
+  for (const c of node.children ?? []) {
+    if (typeof c === "string") out += c;
+    else if (c && typeof c === "object") out += textOf(c as Json);
+  }
+  return out;
+}
+
+describe("RN leaf pack renders every editor + resolves its binding", () => {
+  const nodes = [...walk(render())];
+  const byType = (t: string) => nodes.filter((n) => n.type === t);
+  const inputValues = byType("TextInput").map((n) => String(n.props.value ?? ""));
+  const allText = byType("Text").map(textOf);
+  const hasText = (needle: string) => allText.some((t) => t.includes(needle));
+
+  it("never hits the Unsupported fallback", () => {
+    expect(hasText("Unsupported")).toBe(false);
+  });
+
+  it("NumberField binds the numeric value into a TextInput", () => {
+    expect(inputValues).toContain("42");
+  });
+
+  it("Select renders options and ticks the bound one", () => {
+    expect(hasText("Red")).toBe(true);
+    expect(hasText("Green")).toBe(true);
+    expect(hasText("✓")).toBe(true); // "green" is selected
+  });
+
+  it("RadioGroup renders its option labels", () => {
+    expect(hasText("Small")).toBe(true);
+    expect(hasText("Medium")).toBe(true);
+  });
+
+  it("Slider shows the bound value", () => {
+    expect(hasText("30")).toBe(true);
+  });
+
+  it("Date / DateTime slice the ISO value to the right width", () => {
+    expect(inputValues).toContain("2026-07-06"); // Date → 10 chars
+    expect(inputValues).toContain("2026-07-06T14:30"); // DateTime → 16 chars
+  });
+
+  it("Combobox binds the freeform value", () => {
+    expect(inputValues).toContain("Zurich");
+  });
+
+  it("CodeEditor + MarkdownEditor bind their text into editable TextInputs", () => {
+    expect(inputValues.some((v) => v.includes("console.log(x)"))).toBe(true);
+    expect(inputValues.some((v) => v.includes("# Notes"))).toBe(true);
+  });
+
+  it("DiffEditor shows original and modified", () => {
+    expect(hasText("old line")).toBe(true);
+    expect(hasText("new line")).toBe(true);
+  });
+
+  it("CodeSample + Exception + MenuItem render their content", () => {
+    expect(hasText("readonly();")).toBe(true);
+    expect(hasText("Boom happened")).toBe(true);
+    expect(hasText("Open")).toBe(true);
+  });
+});

--- a/clients/react-native/src/grpcWebTextCodec.test.ts
+++ b/clients/react-native/src/grpcWebTextCodec.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { bytesToBase64, base64GroupsToBytes, base64DecodeStream } from "./grpcWebTextCodec";
+
+// The gRPC-web-text codec is the whole reason the native transport works: base64 survives Hermes' lossy
+// UTF-8 text-streaming where raw binary corrupts. These run in Node (global ReadableStream) and pin the
+// two things that actually broke on-device — bytes > 0x7F, and the trailer flag (0x80) across chunk splits.
+
+function everyByte(n: number): Uint8Array {
+  const a = new Uint8Array(n);
+  for (let i = 0; i < n; i++) a[i] = i & 255;
+  return a;
+}
+function asciiChunks(s: string, size: number): Uint8Array[] {
+  const bytes = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i);
+  const chunks: Uint8Array[] = [];
+  for (let i = 0; i < bytes.length; i += size) chunks.push(bytes.subarray(i, i + size));
+  return chunks;
+}
+function streamFromChunks(chunks: Uint8Array[]): any {
+  let i = 0;
+  return new (globalThis as any).ReadableStream({
+    pull(c: any) { if (i < chunks.length) c.enqueue(chunks[i++]); else c.close(); },
+  });
+}
+async function readAll(stream: any): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const parts: Uint8Array[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    parts.push(value);
+  }
+  const len = parts.reduce((a, p) => a + p.length, 0);
+  const out = new Uint8Array(len);
+  let o = 0;
+  for (const p of parts) { out.set(p, o); o += p.length; }
+  return out;
+}
+const eq = (a: Uint8Array, b: Uint8Array) => a.length === b.length && a.every((v, i) => v === b[i]);
+
+describe("gRPC-web-text codec", () => {
+  it("round-trips every byte value (incl. > 0x7F) and every padding length", () => {
+    for (const n of [0, 1, 2, 3, 4, 5, 255, 256, 257, 1000]) {
+      const src = everyByte(n);
+      const back = base64GroupsToBytes(bytesToBase64(src));
+      expect(eq(back, src)).toBe(true);
+    }
+  });
+
+  it("matches a reference base64 vector", () => {
+    // "Man" → "TWFu"; a high byte 0xFF → "/w=="
+    expect(bytesToBase64(new Uint8Array([0x4d, 0x61, 0x6e]))).toBe("TWFu");
+    expect(bytesToBase64(new Uint8Array([0xff]))).toBe("/w==");
+    expect([...base64GroupsToBytes("/w==")]).toEqual([0xff]);
+  });
+
+  it("streaming-decodes across ANY chunk boundary, preserving high bytes", async () => {
+    const src = everyByte(777); // includes the full 0x00..0xFF range repeatedly
+    const b64 = bytesToBase64(src);
+    for (const size of [1, 2, 3, 4, 5, 7, 64, 999]) {
+      const decoded = await readAll(base64DecodeStream(streamFromChunks(asciiChunks(b64, size))));
+      expect(eq(decoded, src)).toBe(true);
+    }
+  });
+
+  it("preserves a gRPC-web data frame + trailer frame (the 0x80 flag) byte-for-byte", async () => {
+    // A gRPC-web data frame: [0x00][len:4 BE][payload], then the trailer frame: [0x80][len:4 BE][text].
+    const payload = everyByte(200); // binary protobuf-ish body, lots of bytes > 0x7F
+    const trailerText = new TextEncoder().encode("grpc-status:0\r\n");
+    const frame = (flag: number, body: Uint8Array) => {
+      const f = new Uint8Array(5 + body.length);
+      f[0] = flag;
+      f[1] = (body.length >>> 24) & 255;
+      f[2] = (body.length >>> 16) & 255;
+      f[3] = (body.length >>> 8) & 255;
+      f[4] = body.length & 255;
+      f.set(body, 5);
+      return f;
+    };
+    const data = frame(0x00, payload);
+    const trailer = frame(0x80, trailerText);
+    const whole = new Uint8Array(data.length + trailer.length);
+    whole.set(data, 0);
+    whole.set(trailer, data.length);
+
+    const b64 = bytesToBase64(whole);
+    // Feed byte-by-byte — the most hostile split.
+    const decoded = await readAll(base64DecodeStream(streamFromChunks(asciiChunks(b64, 1))));
+
+    expect(eq(decoded, whole)).toBe(true);
+    expect(decoded[0]).toBe(0x00); // data frame flag
+    expect(decoded[data.length]).toBe(0x80); // trailer frame flag survived — the exact byte that corrupted
+  });
+});

--- a/clients/react-native/src/grpcWebTextCodec.ts
+++ b/clients/react-native/src/grpcWebTextCodec.ts
@@ -1,0 +1,107 @@
+// gRPC-web-TEXT (base64) codec — the platform-agnostic core of the React Native transport
+// (nativeFetch.native.ts). Kept import-free (no react-native-fetch-api) so it unit-tests under Node/vitest,
+// where the base64 round-trip and the chunk-boundary streaming decode — the parts that actually break on
+// binary data > 0x7F — are verified deterministically. Uses the GLOBAL ReadableStream (Node has it; RN gets
+// the web-streams polyfill installed before use).
+
+const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const REV = (() => {
+  const r = new Int16Array(128).fill(-1);
+  for (let i = 0; i < B64.length; i++) r[B64.charCodeAt(i)] = i;
+  return r;
+})();
+
+export function toUint8(body: any): Uint8Array {
+  if (body == null) return new Uint8Array(0);
+  if (body instanceof Uint8Array) return body;
+  if (body instanceof ArrayBuffer) return new Uint8Array(body);
+  if (ArrayBuffer.isView(body)) return new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+  return new Uint8Array(0);
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let out = "";
+  let i = 0;
+  for (; i + 2 < bytes.length; i += 3) {
+    const n = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+    out += B64[(n >> 18) & 63] + B64[(n >> 12) & 63] + B64[(n >> 6) & 63] + B64[n & 63];
+  }
+  const rem = bytes.length - i;
+  if (rem === 1) {
+    const n = bytes[i] << 16;
+    out += B64[(n >> 18) & 63] + B64[(n >> 12) & 63] + "==";
+  } else if (rem === 2) {
+    const n = (bytes[i] << 16) | (bytes[i + 1] << 8);
+    out += B64[(n >> 18) & 63] + B64[(n >> 12) & 63] + B64[(n >> 6) & 63] + "=";
+  }
+  return out;
+}
+
+// Decode a base64 string whose length is a multiple of 4 (may carry '=' padding at group ends). Over-
+// allocates then trims, so mid-stream padded groups (per-block base64) decode correctly too. Non-base64
+// bytes (stray whitespace) are skipped rather than throwing.
+export function base64GroupsToBytes(s: string): Uint8Array {
+  const out = new Uint8Array((Math.ceil(s.length / 4)) * 3);
+  let o = 0;
+  for (let i = 0; i + 3 < s.length; i += 4) {
+    const c2 = s.charCodeAt(i + 2);
+    const c3 = s.charCodeAt(i + 3);
+    const a = REV[s.charCodeAt(i)];
+    const b = REV[s.charCodeAt(i + 1)];
+    const c = c2 === 61 ? 0 : REV[c2]; // 61 = '='
+    const d = c3 === 61 ? 0 : REV[c3];
+    if (a < 0 || b < 0 || c < 0 || d < 0) continue;
+    const n = (a << 18) | (b << 12) | (c << 6) | d;
+    out[o++] = (n >> 16) & 255;
+    if (c2 !== 61) out[o++] = (n >> 8) & 255;
+    if (c3 !== 61) out[o++] = n & 255;
+  }
+  return out.subarray(0, o);
+}
+
+/**
+ * Wrap a ReadableStream of ASCII base64 bytes (the grpc-web-text response) as a ReadableStream of the
+ * decoded binary bytes connect-web's envelope reader expects. Buffers partial 4-char groups across chunk
+ * boundaries — the split-point robustness is what the unit test hammers.
+ */
+export function base64DecodeStream(src: any): any {
+  const Stream = (globalThis as any).ReadableStream;
+  const reader = src.getReader();
+  let buf = "";
+  return new Stream({
+    // Loop until this pull ENQUEUES or CLOSES — a pull that reads a chunk not completing a 4-char group
+    // must not resolve empty (that strands the pending reader: the stream won't re-pull until the next
+    // read() that never comes → deadlock). Keep reading source chunks until a group is ready or done.
+    async pull(controller: any) {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          const rest = buf;
+          buf = "";
+          if (rest.length) {
+            const padded = rest + "=".repeat((4 - (rest.length % 4)) % 4);
+            const bytes = base64GroupsToBytes(padded);
+            if (bytes.length) controller.enqueue(bytes);
+          }
+          controller.close();
+          return;
+        }
+        let s = "";
+        for (let i = 0; i < value.length; i++) s += String.fromCharCode(value[i]);
+        buf += s;
+        const cut = buf.length - (buf.length % 4);
+        if (cut > 0) {
+          const bytes = base64GroupsToBytes(buf.slice(0, cut));
+          buf = buf.slice(cut);
+          if (bytes.length) {
+            controller.enqueue(bytes);
+            return;
+          }
+        }
+      }
+    },
+    cancel(reason: any) {
+      try { reader.cancel(reason); } catch { /* already released */ }
+    },
+  });
+}

--- a/clients/react-native/src/grpcWebTextCodec.ts
+++ b/clients/react-native/src/grpcWebTextCodec.ts
@@ -40,16 +40,20 @@ export function bytesToBase64(bytes: Uint8Array): string {
 // Decode a base64 string whose length is a multiple of 4 (may carry '=' padding at group ends). Over-
 // allocates then trims, so mid-stream padded groups (per-block base64) decode correctly too. Non-base64
 // bytes (stray whitespace) are skipped rather than throwing.
+// REV is only 128 wide; a char code ≥ 128 (or NaN past the end) indexes out of bounds → `undefined`,
+// which is NOT caught by a `< 0` check. Fold every out-of-range/non-base64 char to -1 so it's skipped.
+const rev = (cc: number): number => (cc >= 0 && cc < 128 ? REV[cc] : -1);
+
 export function base64GroupsToBytes(s: string): Uint8Array {
   const out = new Uint8Array((Math.ceil(s.length / 4)) * 3);
   let o = 0;
   for (let i = 0; i + 3 < s.length; i += 4) {
     const c2 = s.charCodeAt(i + 2);
     const c3 = s.charCodeAt(i + 3);
-    const a = REV[s.charCodeAt(i)];
-    const b = REV[s.charCodeAt(i + 1)];
-    const c = c2 === 61 ? 0 : REV[c2]; // 61 = '='
-    const d = c3 === 61 ? 0 : REV[c3];
+    const a = rev(s.charCodeAt(i));
+    const b = rev(s.charCodeAt(i + 1));
+    const c = c2 === 61 ? 0 : rev(c2); // 61 = '='
+    const d = c3 === 61 ? 0 : rev(c3);
     if (a < 0 || b < 0 || c < 0 || d < 0) continue;
     const n = (a << 18) | (b << 12) | (c << 6) | d;
     out[o++] = (n >> 16) & 255;

--- a/clients/react-native/src/live.ts
+++ b/clients/react-native/src/live.ts
@@ -9,6 +9,7 @@
 
 import { GrpcAreaSource, type AreaSource } from "@meshweaver/react/core";
 import { connect, type MeshWebConnection } from "@meshweaver/client-web";
+import { nativeStreamingFetch } from "./nativeFetch";
 
 export interface LiveOptions {
   /** Portal base URL, e.g. https://atioz.meshweaver.cloud */
@@ -30,7 +31,9 @@ export interface LiveSource {
 
 /** Connect over gRPC-web and return a started AreaSource the renderer consumes, plus the connection to close. */
 export async function createLiveSource(opts: LiveOptions): Promise<LiveSource> {
-  const connection = await connect(opts.url, { token: opts.token });
+  // On a device the Hermes fetch can't stream the Connect server-stream; nativeStreamingFetch() supplies
+  // the polyfilled streaming fetch (undefined on web → the browser fetch is used unchanged).
+  const connection = await connect(opts.url, { token: opts.token, fetch: nativeStreamingFetch() });
   const source = new GrpcAreaSource(connection, opts.address, { area: opts.area, id: opts.id });
   void source.start(); // folds the live area stream into the tree as merge-patches arrive
   return { source, connection };

--- a/clients/react-native/src/meshControls.test.tsx
+++ b/clients/react-native/src/meshControls.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import TestRenderer, { type ReactTestRendererJSON } from "react-test-renderer";
+import { RegistryProvider, ScopeProvider, RenderArea, StaticAreaSource, type AreaTree } from "@meshweaver/react/core";
+import { rnPack } from "./rnPack";
+
+// Headless proof that the mesh display controls render (and the picker binds) — so a streamed portal
+// area lands on real native components, never the Unsupported fallback.
+
+const ref = (area: string) => ({ $type: "NamedArea", area });
+const ptr = (pointer: string) => ({ $type: "JsonPointerReference", pointer });
+
+const tree: AreaTree = {
+  data: { picker: "acme/Sales" },
+  areas: {
+    main: {
+      $type: "Stack",
+      skins: [{ $type: "LayoutStack" }],
+      areas: [ref("picker"), ref("user"), ref("bubbleU"), ref("bubbleA"), ref("card"), ref("ladef"), ref("chat"), ref("search")],
+    },
+    picker: { $type: "MeshNodePicker", label: "Node", data: ptr("/data/picker") },
+    user: { $type: "UserProfile", name: "Ada Lovelace" },
+    bubbleU: { $type: "ThreadMessageBubble", role: "user", message: "hi there" },
+    bubbleA: { $type: "ThreadMessageBubble", role: "assistant", message: "hello back" },
+    card: { $type: "MeshNodeCard", nodePath: "acme/Sales", title: "Sales", description: "Q3 numbers", imageUrl: "📊" },
+    ladef: { $type: "LayoutAreaDefinition", definition: { title: "Overview", description: "the overview area" } },
+    chat: { $type: "ThreadChat" },
+    search: { $type: "MeshSearch" },
+  },
+};
+
+type Json = ReactTestRendererJSON;
+
+function render(): Json {
+  let root!: TestRenderer.ReactTestRenderer;
+  TestRenderer.act(() => {
+    root = TestRenderer.create(
+      <RegistryProvider pack={rnPack}>
+        <ScopeProvider source={new StaticAreaSource(tree)} area="main">
+          <RenderArea areaKey="main" />
+        </ScopeProvider>
+      </RegistryProvider>,
+    );
+  });
+  return root.toJSON() as Json;
+}
+
+function* walk(node: Json | Json[] | null): Generator<Json> {
+  if (node == null) return;
+  if (Array.isArray(node)) { for (const n of node) yield* walk(n); return; }
+  yield node;
+  if (node.children) for (const c of node.children) yield* walk(c as Json);
+}
+function textOf(node: Json): string {
+  let out = "";
+  for (const c of node.children ?? []) {
+    if (typeof c === "string") out += c;
+    else if (c && typeof c === "object") out += textOf(c as Json);
+  }
+  return out;
+}
+
+describe("RN leaf pack renders the mesh display controls", () => {
+  const nodes = [...walk(render())];
+  const byType = (t: string) => nodes.filter((n) => n.type === t);
+  const inputValues = byType("TextInput").map((n) => String(n.props.value ?? ""));
+  const allText = byType("Text").map(textOf);
+  const hasText = (needle: string) => allText.some((t) => t.includes(needle));
+
+  it("never hits the Unsupported fallback", () => {
+    expect(hasText("Unsupported")).toBe(false);
+  });
+
+  it("MeshNodePicker binds the node path", () => {
+    expect(inputValues).toContain("acme/Sales");
+  });
+
+  it("UserProfile shows the avatar initial + name", () => {
+    expect(hasText("Ada Lovelace")).toBe(true);
+    expect(hasText("A")).toBe(true); // avatar initial
+  });
+
+  it("ThreadMessageBubble renders both roles' text", () => {
+    expect(hasText("hi there")).toBe(true);
+    expect(hasText("hello back")).toBe(true);
+  });
+
+  it("MeshNodeCard shows emoji, title, description", () => {
+    expect(hasText("📊")).toBe(true);
+    expect(hasText("Sales")).toBe(true);
+    expect(hasText("Q3 numbers")).toBe(true);
+  });
+
+  it("LayoutAreaDefinition shows title + description", () => {
+    expect(hasText("Overview")).toBe(true);
+    expect(hasText("the overview area")).toBe(true);
+  });
+
+  it("live-ops controls degrade to a labeled placeholder (not Unsupported)", () => {
+    expect(hasText("Thread chat")).toBe(true);
+    expect(hasText("Search results")).toBe(true);
+  });
+});

--- a/clients/react-native/src/nativeFetch.native.ts
+++ b/clients/react-native/src/nativeFetch.native.ts
@@ -1,0 +1,91 @@
+// React Native (Hermes) transport for gRPC-web. Two Hermes limitations to defeat:
+//
+//  1. Hermes' built-in `fetch` can't expose a readable response body — but the mesh's `Connect` call is
+//     a gRPC-web SERVER STREAM, so the transport must read the body incrementally. react-native-fetch-api
+//     surfaces the body as a stream (via XHR `textStreaming`).
+//  2. That streaming path is TEXT: RN decodes the response bytes as UTF-8 and react-native-fetch-api
+//     re-encodes them (Fetch.js), which is LOSSY for any byte > 0x7F — so binary gRPC-web frames (and the
+//     trailer) corrupt ("missing trailer"). The tiny ASCII ack survives, larger protobuf frames don't.
+//
+// Fix: speak gRPC-web-TEXT (base64) instead of binary. Base64 is ASCII, so it round-trips the lossy text
+// path intact. The server (Grpc.AspNetCore.Web `UseGrpcWeb()`) already accepts `application/grpc-web-text`.
+// connect-web only speaks BINARY gRPC-web, so we transcode transparently in the fetch seam: base64-encode
+// the request body + flip the content-type to grpc-web-text on the way out, and base64-DECODE the response
+// stream + present it back as `application/grpc-web+proto` on the way in. connect-web keeps doing binary
+// gRPC-web against a fully binary-looking Response; the wire underneath is ASCII. Injected via
+// connect(url, { fetch }) in live.ts. Web uses nativeFetch.ts (no transcode — browsers stream binary fine).
+// The base64 + stream logic lives in grpcWebTextCodec.ts (unit-tested under Node).
+import { fetch as rnFetch } from "react-native-fetch-api";
+import { ReadableStream } from "web-streams-polyfill";
+import { TextEncoder, TextDecoder } from "text-encoding";
+import { base64DecodeStream, bytesToBase64, toUint8 } from "./grpcWebTextCodec";
+
+let installed = false;
+function installGlobals(): void {
+  if (installed) return;
+  const g = globalThis as any;
+  if (typeof g.ReadableStream === "undefined") g.ReadableStream = ReadableStream;
+  if (typeof g.TextEncoder === "undefined") g.TextEncoder = TextEncoder;
+  if (typeof g.TextDecoder === "undefined") g.TextDecoder = TextDecoder;
+  installed = true;
+}
+
+// react-native-fetch-api's Headers ingests ONLY its own Headers class / an array / a plain object — NOT
+// the global Headers instance connect-web hands us (its fields aren't own-enumerable), so those headers
+// silently vanish. Flatten to [name, value] pairs so Content-Type et al. survive.
+function toHeaderPairs(h: any): [string, string][] {
+  if (!h) return [];
+  if (Array.isArray(h)) return h as [string, string][];
+  if (typeof h.forEach === "function") {
+    const out: [string, string][] = [];
+    h.forEach((value: string, name: string) => out.push([name, value]));
+    return out;
+  }
+  return Object.keys(h).map((name) => [name, String(h[name])]);
+}
+
+const GRPC_WEB_BINARY = /^application\/grpc-web(\+proto)?$/i;
+
+export function nativeStreamingFetch(): typeof globalThis.fetch {
+  installGlobals();
+  return (async (input: any, init?: any) => {
+    const pairs = toHeaderPairs(init?.headers);
+    const ctIdx = pairs.findIndex(([k]) => k.toLowerCase() === "content-type");
+    const isGrpcWeb = ctIdx >= 0 && GRPC_WEB_BINARY.test(pairs[ctIdx][1]);
+
+    // Non-gRPC-web (e.g. the speech multipart POST) — plain streaming fetch, headers preserved.
+    if (!isGrpcWeb) {
+      return rnFetch(input, { ...(init ?? {}), headers: pairs, reactNative: { textStreaming: true } });
+    }
+
+    // Request: base64 the binary envelope + advertise grpc-web-text. The server (Grpc.AspNetCore.Web)
+    // only RESPONDS in text (base64) when the request ACCEPTS it — without this Accept header it replies
+    // binary grpc-web, which then corrupts over Hermes' UTF-8 text streaming. connect-web never sets it.
+    const outPairs = pairs
+      .filter(([k]) => k.toLowerCase() !== "accept")
+      .map(([k, v]): [string, string] =>
+        k.toLowerCase() === "content-type" ? [k, v.replace(/grpc-web/i, "grpc-web-text")] : [k, v],
+      );
+    outPairs.push(["Accept", "application/grpc-web-text+proto"]);
+    const body = init?.body != null ? bytesToBase64(toUint8(init.body)) : undefined;
+
+    const resp: any = await rnFetch(input, {
+      ...(init ?? {}),
+      headers: outPairs,
+      body,
+      reactNative: { textStreaming: true },
+    });
+
+    // Response: base64-decode the stream + present a binary grpc-web+proto face to connect-web.
+    const headers = new Headers();
+    resp.headers?.forEach?.((value: string, name: string) => headers.set(name, value));
+    headers.set("content-type", "application/grpc-web+proto");
+
+    return {
+      status: resp.status,
+      ok: resp.status >= 200 && resp.status < 300,
+      headers,
+      body: resp.body ? base64DecodeStream(resp.body) : null,
+    };
+  }) as unknown as typeof globalThis.fetch;
+}

--- a/clients/react-native/src/nativeFetch.ts
+++ b/clients/react-native/src/nativeFetch.ts
@@ -1,0 +1,6 @@
+// Default (web / react-native-web): the browser fetch already exposes a readable response body, so the
+// gRPC-web Connect server-stream works with no override. Metro/Expo picks nativeFetch.native.ts on a
+// device instead (streaming-fetch polyfill); tsc resolves this file, so keep the signatures identical.
+export function nativeStreamingFetch(): typeof globalThis.fetch | undefined {
+  return undefined;
+}

--- a/clients/react-native/src/polyfills.d.ts
+++ b/clients/react-native/src/polyfills.d.ts
@@ -1,0 +1,12 @@
+// Ambient module declarations for the React-Native-only streaming-fetch polyfills (no shipped types).
+// These are consumed exclusively by nativeFetch.native.ts; the web build never bundles them.
+declare module "react-native-fetch-api" {
+  export const fetch: (input: any, init?: any) => Promise<any>;
+}
+declare module "web-streams-polyfill" {
+  export const ReadableStream: any;
+}
+declare module "text-encoding" {
+  export const TextEncoder: any;
+  export const TextDecoder: any;
+}

--- a/clients/react-native/src/rnPack.tsx
+++ b/clients/react-native/src/rnPack.tsx
@@ -2,7 +2,7 @@
 // renderer core (@meshweaver/react/core). This is the RN analog of MAUI's MauiViewPack and of the web
 // Fluent pack: SAME UiControl tree, native leaves. Drop it into <RegistryProvider pack={rnPack}>.
 
-import { createElement } from "react";
+import { createElement, useState } from "react";
 import { View, Text, TextInput, Pressable, Switch, ScrollView, ActivityIndicator, StyleSheet, Platform } from "react-native";
 import { marked } from "marked";
 import {
@@ -19,6 +19,55 @@ import {
 } from "@meshweaver/react/core";
 
 const s = (v: unknown): string => (v == null ? "" : String(v));
+
+// ── shared binding helpers (the native twins of clients/react/src/controls/common.ts, which is NOT
+//    exported from @meshweaver/react/core — the binding primitives it builds on ARE). Every editor reads
+//    its value with useResolve and writes back through the /data pointer via emit({kind:"update"}). ──
+interface Field {
+  value: unknown;
+  setValue: (v: unknown) => void;
+  onBlur: () => void;
+  disabled: boolean;
+  label: string;
+  placeholder: string;
+}
+function useField(control: any): Field {
+  const bound = control.data ?? control.isChecked;
+  const value = useResolve(bound);
+  const pointer = useBindingPointer(bound);
+  const disabled = !!useResolve(control.disabled);
+  const label = s(useResolve(control.label));
+  const placeholder = s(useResolve(control.placeholder));
+  const emit = useEmit();
+  const { area } = useScope();
+  return {
+    value,
+    disabled,
+    label,
+    placeholder,
+    setValue: (v) => { if (pointer) emit({ kind: "update", area, pointer, value: v }); },
+    onBlur: () => emit({ kind: "blur", area }),
+  };
+}
+function useOptions(control: any): { value: unknown; text: string }[] {
+  const opts = useResolve(control.options);
+  if (!Array.isArray(opts)) return [];
+  return opts.map((o: any) => {
+    if (o != null && typeof o === "object") {
+      const value = "item" in o ? o.item : "value" in o ? o.value : o.text;
+      return { value, text: s(o.text ?? value) };
+    }
+    return { value: o, text: s(o) };
+  });
+}
+function Labeled({ label, children }: { label?: string; children: React.ReactNode }) {
+  return (
+    <View style={{ gap: 4 }}>
+      {label ? <Text style={styles.label}>{label}</Text> : null}
+      {children}
+    </View>
+  );
+}
 
 function Children({ control }: { control: any }) {
   return (
@@ -167,6 +216,320 @@ const LayoutAreaEmbed: ControlComponent = ({ control }) => {
   );
 };
 
+// ── input / editor controls (native twins of clients/react/src/controls/inputs.tsx) ────────────────
+const NumberField: ControlComponent = ({ control }) => {
+  const f = useField(control);
+  return (
+    <Labeled label={f.label}>
+      <TextInput
+        style={styles.input}
+        value={f.value == null || f.value === "" ? "" : String(f.value)}
+        keyboardType="numeric"
+        editable={!f.disabled}
+        placeholder={f.placeholder}
+        onChangeText={(t) => f.setValue(t === "" ? null : Number(t))}
+        onBlur={f.onBlur}
+      />
+    </Labeled>
+  );
+};
+
+const SearchBox: ControlComponent = ({ control }) => {
+  const f = useField(control);
+  return (
+    <View style={styles.searchRow}>
+      <Text style={styles.searchIcon}>🔍</Text>
+      <TextInput
+        style={styles.searchInput}
+        value={s(f.value)}
+        placeholder={f.placeholder || "Search"}
+        autoCapitalize="none"
+        onChangeText={f.setValue}
+        onBlur={f.onBlur}
+      />
+    </View>
+  );
+};
+
+// Select / Listbox — a tap-to-choose option list (no native <Picker> dependency). Selected row is ticked.
+const OptionList: ControlComponent = ({ control }) => {
+  const f = useField(control);
+  const options = useOptions(control);
+  return (
+    <Labeled label={f.label}>
+      <View style={styles.optionList}>
+        {options.map((o, i) => {
+          const selected = s(o.value) === s(f.value);
+          return (
+            <Pressable
+              key={i}
+              style={[styles.optionRow, selected && styles.optionRowSelected]}
+              onPress={() => !f.disabled && f.setValue(o.value)}
+            >
+              <Text style={styles.optionCheck}>{selected ? "✓" : ""}</Text>
+              <Text style={styles.body}>{o.text}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </Labeled>
+  );
+};
+
+const RadioGroup: ControlComponent = ({ control }) => {
+  const f = useField(control);
+  const options = useOptions(control);
+  return (
+    <Labeled label={f.label}>
+      <View style={{ gap: 6 }}>
+        {options.map((o, i) => {
+          const selected = s(o.value) === s(f.value);
+          return (
+            <Pressable key={i} style={styles.radioRow} onPress={() => !f.disabled && f.setValue(o.value)}>
+              <View style={[styles.radioOuter, selected && styles.radioOuterOn]}>
+                {selected ? <View style={styles.radioInner} /> : null}
+              </View>
+              <Text style={styles.body}>{o.text}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </Labeled>
+  );
+};
+
+// Combobox — freeform TextInput that also filters + picks from the options (Fluent Combobox twin).
+const Combobox: ControlComponent = ({ control }) => {
+  const f = useField(control);
+  const options = useOptions(control);
+  const [open, setOpen] = useState(false);
+  const text = s(f.value);
+  const filtered = options.filter((o) => o.text.toLowerCase().includes(text.toLowerCase()));
+  return (
+    <Labeled label={f.label}>
+      <TextInput
+        style={styles.input}
+        value={text}
+        editable={!f.disabled}
+        placeholder={f.placeholder}
+        autoCapitalize="none"
+        onChangeText={(t) => { f.setValue(t); setOpen(true); }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => { setOpen(false); f.onBlur(); }}
+      />
+      {open && filtered.length > 0 ? (
+        <View style={styles.optionList}>
+          {filtered.map((o, i) => (
+            <Pressable key={i} style={styles.optionRow} onPress={() => { f.setValue(o.value); setOpen(false); }}>
+              <Text style={styles.body}>{o.text}</Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+    </Labeled>
+  );
+};
+
+const Slider: ControlComponent = ({ control }) => {
+  const f = useField(control);
+  const min = Number(useResolve(control.min) ?? 0);
+  const max = Number(useResolve(control.max) ?? 100);
+  const step = Number(useResolve(control.step) ?? 1);
+  const val = Number(f.value ?? min);
+  const clamp = (n: number) => Math.max(min, Math.min(max, n));
+  const pct = max > min ? Math.round(((clamp(val) - min) / (max - min)) * 100) : 0;
+  return (
+    <Labeled label={f.label}>
+      <View style={styles.sliderRow}>
+        <Pressable style={styles.stepBtn} onPress={() => !f.disabled && f.setValue(clamp(val - step))}>
+          <Text style={styles.stepTxt}>−</Text>
+        </Pressable>
+        <View style={styles.sliderTrack}><View style={[styles.sliderFill, { width: `${pct}%` }]} /></View>
+        <Pressable style={styles.stepBtn} onPress={() => !f.disabled && f.setValue(clamp(val + step))}>
+          <Text style={styles.stepTxt}>＋</Text>
+        </Pressable>
+        <Text style={styles.sliderVal}>{Number.isFinite(val) ? val : min}</Text>
+      </View>
+    </Labeled>
+  );
+};
+
+// Date / DateTime — the web renders an <input type=date> bound to the ISO string sliced to 10/16 chars.
+// Native mirrors that with a text field (a native wheel picker is future polish); binding is identical.
+const DateInput: ControlComponent = ({ control }) => {
+  const f = useField(control);
+  return (
+    <Labeled label={f.label}>
+      <TextInput style={styles.input} value={f.value ? String(f.value).slice(0, 10) : ""} editable={!f.disabled}
+        placeholder="YYYY-MM-DD" autoCapitalize="none" onChangeText={f.setValue} onBlur={f.onBlur} />
+    </Labeled>
+  );
+};
+const DateTimeInput: ControlComponent = ({ control }) => {
+  const f = useField(control);
+  return (
+    <Labeled label={f.label}>
+      <TextInput style={styles.input} value={f.value ? String(f.value).slice(0, 16) : ""} editable={!f.disabled}
+        placeholder="YYYY-MM-DDTHH:MM" autoCapitalize="none" onChangeText={f.setValue} onBlur={f.onBlur} />
+    </Labeled>
+  );
+};
+
+const MenuItem: ControlComponent = ({ control }) => {
+  const emit = useEmit();
+  const { area } = useScope();
+  return (
+    <Pressable style={styles.menuItem} onPress={() => control.isClickable && emit({ kind: "click", area })}>
+      <Text style={styles.body}>{s(useResolve(control.title))}</Text>
+    </Pressable>
+  );
+};
+
+// ── code / markdown editors (native twins of controls/editors.tsx). Monaco is DOM-only; the web pack
+//    itself falls back to a plain <textarea> when Monaco isn't loaded — native uses the same shape: a
+//    monospace multiline TextInput, fully bound. ──────────────────────────────────────────────────
+const CodeEditor: ControlComponent = ({ control }) => {
+  const f = useField(control);
+  return (
+    <Labeled label={f.label}>
+      <TextInput
+        style={styles.codeInput}
+        value={s(f.value)}
+        editable={!f.disabled}
+        multiline
+        autoCapitalize="none"
+        autoCorrect={false}
+        spellCheck={false}
+        onChangeText={f.setValue}
+        onBlur={f.onBlur}
+      />
+    </Labeled>
+  );
+};
+
+const DiffEditor: ControlComponent = ({ control }) => {
+  const original = s(useResolve(control.original ?? control.originalValue));
+  const modified = s(useResolve(control.data ?? control.modified ?? control.modifiedValue));
+  return (
+    <View style={{ gap: 6 }}>
+      <Text style={styles.label}>− original</Text>
+      <ScrollView horizontal style={styles.codeBlock}><Text style={[styles.code, styles.diffOld]}>{original}</Text></ScrollView>
+      <Text style={styles.label}>＋ modified</Text>
+      <ScrollView horizontal style={styles.codeBlock}><Text style={[styles.code, styles.diffNew]}>{modified}</Text></ScrollView>
+    </View>
+  );
+};
+
+// Auto-generated form container (EditForm) — renders its child field areas in a column.
+const EditForm: ControlComponent = ({ control }) => (
+  <View style={{ gap: 10 }}>
+    <Children control={control} />
+  </View>
+);
+
+// ── read-only display twins (controls/display.tsx) ─────────────────────────────────────────────────
+const CodeSample: ControlComponent = ({ control }) => (
+  <ScrollView horizontal style={styles.codeBlock}>
+    <Text style={styles.code}>{s(useResolve(control.data ?? control.code ?? control.value))}</Text>
+  </ScrollView>
+);
+
+const Exception: ControlComponent = ({ control }) => (
+  <View style={styles.exception}>
+    <Text style={styles.exceptionText}>⚠ {s(useResolve(control.message ?? control.data ?? control.title))}</Text>
+  </View>
+);
+
+const Spacer: ControlComponent = () => <View style={{ flex: 1 }} />;
+
+// Icon — emoji / short glyphs render directly; a Fluent icon NAME (no DOM SVG on native) shows a chip.
+const Icon: ControlComponent = ({ control }) => {
+  const v = useResolve(control.icon ?? control.data);
+  const name = typeof v === "string" ? v : s((v as any)?.id ?? (v as any)?.Id ?? (v as any)?.provider);
+  return <Text style={styles.body}>{name && [...name].length <= 2 ? name : "▨"}</Text>;
+};
+
+// ── mesh display controls (native twins of controls/mesh.tsx) ──────────────────────────────────────
+const MeshNodePicker: ControlComponent = ({ control }) => {
+  const f = useField(control);
+  return (
+    <Labeled label={f.label}>
+      <TextInput style={styles.input} value={s(f.value)} editable={!f.disabled}
+        placeholder="Pick a node (path)…" autoCapitalize="none" onChangeText={f.setValue} onBlur={f.onBlur} />
+    </Labeled>
+  );
+};
+
+const UserProfile: ControlComponent = ({ control }) => {
+  const name = s(useResolve(control.name)) || s(useResolve(control.data));
+  const initial = (name.trim()[0] ?? "?").toUpperCase();
+  return (
+    <View style={styles.userRow}>
+      <View style={styles.avatar}><Text style={styles.avatarText}>{initial}</Text></View>
+      <Text style={styles.body}>{name}</Text>
+    </View>
+  );
+};
+
+const ThreadMessageBubble: ControlComponent = ({ control }) => {
+  const role = s(useResolve(control.role)) || "user";
+  const mine = /user/i.test(role);
+  const text = s(useResolve(control.message)) || s(useResolve(control.data));
+  return (
+    <View style={{ flexDirection: "row", justifyContent: mine ? "flex-end" : "flex-start" }}>
+      <View style={[styles.bubble, mine ? styles.bubbleMine : styles.bubbleTheirs]}>
+        <Text style={styles.body}>{text}</Text>
+      </View>
+    </View>
+  );
+};
+
+// A mesh node as a card: emoji/initial + title + description; taps fire a server click when clickable.
+const MeshNodeCard: ControlComponent = ({ control }) => {
+  const emit = useEmit();
+  const { area } = useScope();
+  const nodePath = s(useResolve(control.nodePath));
+  const title = s(useResolve(control.title)) || nodePath;
+  const description = s(useResolve(control.description));
+  const imageUrl = s(useResolve(control.imageUrl));
+  const isEmoji = !!imageUrl && !imageUrl.includes("/") && !imageUrl.startsWith("data:") && !imageUrl.trimStart().toLowerCase().startsWith("<svg");
+  const initial = (title.trim()[0] ?? "?").toUpperCase();
+  const clickable = !!control.isClickable || (!control.disableNavigation && !!nodePath);
+  const inner = (
+    <View style={styles.nodeCard}>
+      <View style={styles.nodeCardIcon}><Text style={styles.nodeCardIconText}>{isEmoji ? imageUrl : initial}</Text></View>
+      <View style={{ flex: 1 }}>
+        <Text style={styles.nodeCardTitle} numberOfLines={1}>{title}</Text>
+        {description ? <Text style={styles.label} numberOfLines={2}>{description}</Text> : null}
+      </View>
+    </View>
+  );
+  return clickable ? (
+    <Pressable onPress={() => control.isClickable && emit({ kind: "click", area })}>{inner}</Pressable>
+  ) : inner;
+};
+
+const LayoutAreaDefinitionCard: ControlComponent = ({ control }) => {
+  const def = (control.definition ?? {}) as any;
+  const title = s(def.title ?? def.area);
+  const description = s(def.description);
+  return (
+    <View style={styles.nodeCard}>
+      <View style={{ flex: 1 }}>
+        <Text style={styles.nodeCardTitle}>{title}</Text>
+        {description ? <Text style={styles.label}>{description}</Text> : null}
+      </View>
+    </View>
+  );
+};
+
+// Live-ops controls (chat/search/collection) need a connected mesh (useMeshOps) — labeled placeholders
+// until the live-portal wiring lands, so a streamed area never falls through to "Unsupported".
+const livePlaceholder = (label: string): ControlComponent =>
+  function LivePlaceholder() {
+    return <View style={styles.embed}><Text style={styles.label}>▦ {label}</Text></View>;
+  };
+
 const fallback: ControlComponent = ({ control }) => <Text style={{ color: "#d83b01" }}>Unsupported: {control.$type}</Text>;
 
 export const rnPack: LeafPack = {
@@ -189,6 +552,38 @@ export const rnPack: LeafPack = {
     NavLink,
     DataGrid,
     Catalog: DataGrid,
+    // inputs / editors
+    NumberField,
+    SearchBox,
+    Select: OptionList,
+    Listbox: OptionList,
+    RadioGroup,
+    Combobox,
+    Slider,
+    Date: DateInput,
+    DateTime: DateTimeInput,
+    MenuItem,
+    MarkdownEditor: CodeEditor,
+    CodeEditor,
+    Editor: CodeEditor,
+    DiffEditor,
+    EditForm,
+    // read-only display
+    CodeSample,
+    Highlight: CodeSample,
+    Exception,
+    Spacer,
+    Icon,
+    // mesh display controls
+    MeshNodePicker,
+    UserProfile,
+    ThreadMessageBubble,
+    MeshNodeCard,
+    LayoutAreaDefinition: LayoutAreaDefinitionCard,
+    ThreadChat: livePlaceholder("Thread chat"),
+    MeshSearch: livePlaceholder("Search results"),
+    MeshNodeCollection: livePlaceholder("Node collection"),
+    Appearance: livePlaceholder("Appearance"),
   },
   fallback,
 };
@@ -208,4 +603,58 @@ const styles = StyleSheet.create({
   cell: { minWidth: 110, padding: 8, fontSize: 13 },
   headerCell: { fontWeight: "700" },
   embed: { padding: 12, borderRadius: 8, borderWidth: 1, borderStyle: "dashed", borderColor: "#c7c7c7", backgroundColor: "#fafafa" },
+  // search
+  searchRow: { flexDirection: "row", alignItems: "center", gap: 6, borderWidth: 1, borderColor: "#ccc", borderRadius: 6, paddingHorizontal: 8, backgroundColor: "white" },
+  searchIcon: { fontSize: 14 },
+  searchInput: { flex: 1, paddingVertical: 8, fontSize: 14 },
+  // option lists (Select / Listbox / Combobox)
+  optionList: { borderWidth: 1, borderColor: "#e1e1e1", borderRadius: 6, overflow: "hidden", backgroundColor: "white" },
+  optionRow: { flexDirection: "row", alignItems: "center", gap: 8, paddingVertical: 10, paddingHorizontal: 10, borderBottomWidth: StyleSheet.hairlineWidth, borderColor: "#eee" },
+  optionRowSelected: { backgroundColor: "#eef4fb" },
+  optionCheck: { width: 16, color: "#0f6cbd", fontWeight: "700" },
+  // radio
+  radioRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+  radioOuter: { width: 20, height: 20, borderRadius: 10, borderWidth: 2, borderColor: "#8a8886", alignItems: "center", justifyContent: "center" },
+  radioOuterOn: { borderColor: "#0f6cbd" },
+  radioInner: { width: 10, height: 10, borderRadius: 5, backgroundColor: "#0f6cbd" },
+  // slider
+  sliderRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+  sliderTrack: { flex: 1, height: 6, borderRadius: 3, backgroundColor: "#e1e1e1", overflow: "hidden" },
+  sliderFill: { height: 6, backgroundColor: "#0f6cbd" },
+  sliderVal: { minWidth: 32, textAlign: "right", fontSize: 13, color: "#242424" },
+  stepBtn: { width: 28, height: 28, borderRadius: 14, backgroundColor: "#edebe9", alignItems: "center", justifyContent: "center" },
+  stepTxt: { fontSize: 16, color: "#242424" },
+  // menu item
+  menuItem: { paddingVertical: 10, paddingHorizontal: 8 },
+  // code
+  code: { fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace", fontSize: 12.5, color: "#242424" },
+  codeInput: {
+    fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
+    fontSize: 12.5,
+    minHeight: 120,
+    borderWidth: 1,
+    borderColor: "#ccc",
+    borderRadius: 6,
+    padding: 10,
+    backgroundColor: "#1e1e1e00",
+    color: "#242424",
+    textAlignVertical: "top",
+  },
+  codeBlock: { backgroundColor: "#f5f5f5", borderRadius: 6, padding: 10 },
+  diffOld: { color: "#b00020" },
+  diffNew: { color: "#0a7d2c" },
+  // exception
+  exception: { backgroundColor: "#fdeaea", borderColor: "#f3b3b3", borderWidth: 1, borderRadius: 6, padding: 10 },
+  exceptionText: { color: "#a4262c", fontSize: 13 },
+  // mesh controls
+  userRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+  avatar: { width: 28, height: 28, borderRadius: 14, backgroundColor: "#0f6cbd", alignItems: "center", justifyContent: "center" },
+  avatarText: { color: "white", fontSize: 12, fontWeight: "700" },
+  bubble: { maxWidth: "78%", paddingVertical: 8, paddingHorizontal: 12, borderRadius: 12 },
+  bubbleMine: { backgroundColor: "#cfe4fa" },
+  bubbleTheirs: { backgroundColor: "#f0f0f0" },
+  nodeCard: { flexDirection: "row", alignItems: "center", gap: 12, padding: 12, borderRadius: 8, borderWidth: 1, borderColor: "#e1e1e1", backgroundColor: "white" },
+  nodeCardIcon: { width: 48, height: 48, borderRadius: 6, backgroundColor: "#cfe4fa", alignItems: "center", justifyContent: "center" },
+  nodeCardIconText: { fontSize: 22, fontWeight: "600", color: "#0f6cbd" },
+  nodeCardTitle: { fontSize: 15, fontWeight: "600", color: "#242424" },
 });

--- a/clients/react-native/src/rnPack.tsx
+++ b/clients/react-native/src/rnPack.tsx
@@ -227,7 +227,13 @@ const NumberField: ControlComponent = ({ control }) => {
         keyboardType="numeric"
         editable={!f.disabled}
         placeholder={f.placeholder}
-        onChangeText={(t) => f.setValue(t === "" ? null : Number(t))}
+        // Empty → null; otherwise only commit a FINITE parse. Intermediate input ("-", "1.", "1e")
+        // parses to NaN — never push that into the bound mesh data.
+        onChangeText={(t) => {
+          if (t === "") { f.setValue(null); return; }
+          const n = Number(t);
+          if (Number.isFinite(n)) f.setValue(n);
+        }}
         onBlur={f.onBlur}
       />
     </Labeled>

--- a/clients/react-native/src/screens.tsx
+++ b/clients/react-native/src/screens.tsx
@@ -3,7 +3,7 @@
 // mesh): Voice (speech), Connect (remote instances), Profile, Settings.
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { View, Text, TextInput, Pressable, ScrollView, StyleSheet } from "react-native";
-import { loadInstances, saveInstance, removeInstance, setCurrentInstance, currentInstance, type MeshInstance } from "./connection";
+import { loadInstances, saveInstance, removeInstance, setCurrentInstance, currentInstance, defaultPortalUrl, type MeshInstance } from "./connection";
 import { useStyles, useTheme, type Palette } from "./theme";
 
 const useSheet = () => useStyles(makeStyles);
@@ -123,7 +123,7 @@ function ConnectScreen({ onConnected }: { onConnected: () => void }): ReactNode 
   const [instances, setInstances] = useState<MeshInstance[]>(loadInstances());
   const [current, setCurrent] = useState(currentInstance().name);
   const [name, setName] = useState("");
-  const [url, setUrl] = useState("");
+  const [url, setUrl] = useState(defaultPortalUrl()); // prefill the cloud portal — just paste a token
   const [token, setToken] = useState("");
 
   const refresh = () => {

--- a/clients/react-native/src/screens.tsx
+++ b/clients/react-native/src/screens.tsx
@@ -123,7 +123,7 @@ function ConnectScreen({ onConnected }: { onConnected: () => void }): ReactNode 
   const [instances, setInstances] = useState<MeshInstance[]>(loadInstances());
   const [current, setCurrent] = useState(currentInstance().name);
   const [name, setName] = useState("");
-  const [url, setUrl] = useState(defaultPortalUrl()); // prefill the cloud portal — just paste a token
+  const [url, setUrl] = useState(defaultPortalUrl()); // prefill the default portal (the local monolith) — edit + paste a token for a remote one
   const [token, setToken] = useState("");
 
   const refresh = () => {


### PR DESCRIPTION
Makes the Expo app deployable as a **native iPhone app** and attaches it to the local **monolith mesh** (`Memex.LocalMesh`, SQLite) the way the MAUI client does — verified rendering live `Doc/Architecture` on the iOS simulator.

## What's in it
- **iOS deploy** — `ios.bundleIdentifier` (`cloud.meshweaver.mobile`) + ATS local-networking + `eas.json`. `expo prebuild` / `run:ios` builds + launches on the simulator (0 errors).
- **Live portal over native gRPC-web** — Hermes can't stream binary gRPC-web (its `textStreaming` path is UTF‑8‑lossy → *"missing trailer"* / *"Cannot allocate ArrayBuffer"*), so the app speaks **grpc-web-text (base64, ASCII-safe)** and transcodes transparently in the fetch seam: connect-web keeps doing binary against a binary-looking `Response`; the request adds `Accept: application/grpc-web-text+proto` (the server only replies text with it). `connect()` gains an optional `fetch` (`clients/grpc-web`). The base64 codec is unit-tested (the `0x80` trailer flag survives byte-by-byte splits). Auto-connect targets the local monolith (`app.json` → `extra.portalUrl`, default `http://localhost:5250`).
- **Leaf-pack parity** — ~20 editor + mesh display controls (NumberField / Select / Listbox / RadioGroup / Combobox / Slider / Date / DateTime / code+markdown editors / EditForm / UserProfile / MeshNodeCard / MeshNodePicker / ThreadMessageBubble / …), all on core RN primitives (no native-module deps), each render+binding unit-tested.
- **Responsive Shell** — mobile drawer (hamburger) + full-width content; the fixed 3-column shell had squeezed the content column to zero width on a phone.
- **Speech composer** — expo-av → centralized Whisper `/inference` (verified against the contract).

## Tests (pre-flighted locally)
- `react-native`: `tsc --noEmit` clean + **55 vitest** green (editors, mesh controls, grpc-web-text codec, speech, sample render).
- `grpc-web`: typecheck green (new optional `fetch`).
- `rn-web-e2e`: Playwright **5/5** green.

New deps (RN only): `react-native-fetch-api`, `web-streams-polyfill`, `text-encoding` (pure-JS polyfills, native-only via `nativeFetch.native.ts`; ambient-declared so CI's targeted install still typechecks).

## Follow-up (cosmetic)
Native `Html`/`Markdown` leaves show raw HTML-in-markdown as text (no DOM) — polishing needs `react-native-render-html` or a WebView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)