### PR TITLE
fix(space): markdown-backed Space edits actual content (empty editor fix)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
@@ -104,16 +104,20 @@ public static class SpaceLayoutAreas
     }
 
     /// <summary>
-    /// True when the Space's node content is a <see cref="MarkdownContent"/> (or its degraded
-    /// JsonElement form) rather than a structured <see cref="Space"/>. The Doc and Skill partition
-    /// roots ship this way, so their editable markdown lives in <c>content</c> — they must be edited
-    /// with the standard markdown editor, not the <c>Space.body</c> field editor (which reads blank).
+    /// True when the Space's node content is a <see cref="MarkdownContent"/> — or its degraded
+    /// JsonElement form, including the legacy <c>MarkdownDocument</c> discriminator — rather than a
+    /// structured <see cref="Space"/>. The Doc and Skill partition roots ship this way, so their
+    /// editable markdown lives in <c>content</c>: they must be edited with the standard markdown
+    /// editor, not the <c>Space.body</c> field editor (which reads blank).
     /// </summary>
     private static bool IsMarkdownBacked(MeshNode? node) =>
         node?.Content is MarkdownContent
         || (node?.Content is JsonElement je
             && je.ValueKind == JsonValueKind.Object
             && je.TryGetProperty("$type", out var t)
+            // Guard the ValueKind before GetString(): a non-string $type (malformed content / a
+            // future serializer change) would otherwise throw out of the render lambda.
+            && t.ValueKind == JsonValueKind.String
             && t.GetString() is "MarkdownContent" or "MarkdownDocument");
 
     /// <summary>

--- a/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
@@ -5,6 +5,7 @@ using MeshWeaver.Data;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Layout.Domain;
+using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 
@@ -77,16 +78,43 @@ public static class SpaceLayoutAreas
     /// <c>MarkdownContent</c>, which would destroy the structured Space; the node-bound field pointer
     /// is the content-object-preserving variant of the same mechanism. See Doc/GUI/DataBinding.
     /// </summary>
-    public static IObservable<UiControl?> Edit(LayoutAreaHost host, RenderingContext _)
+    public static IObservable<UiControl?> Edit(LayoutAreaHost host, RenderingContext ctx)
     {
         var hubPath = host.Hub.Address.ToString();
         // Compose with the permission stream — pure observable, no await (mirrors MeshNodeLayoutAreas.EditNode).
         return host.Workspace.GetMeshNodeStream().CombineLatest(
             host.Hub.GetEffectivePermissions(hubPath),
-            (node, permissions) => !permissions.HasFlag(Permission.Update)
-                ? (UiControl?)MeshNodeLayoutAreas.BuildAccessDenied(hubPath)
-                : (UiControl?)BuildBodyEditor(node, hubPath));
+            (node, permissions) =>
+            {
+                if (!permissions.HasFlag(Permission.Update))
+                    return (UiControl?)MeshNodeLayoutAreas.BuildAccessDenied(hubPath);
+
+                // 🚨 A markdown-backed Space (the Doc + Skill partition roots ship their landing page
+                // as a MarkdownContent, NOT a structured Space — their seeding layer can't reference
+                // the Space type) keeps its editable markdown in `content`, not `Space.body`. Binding
+                // the editor to the `body` field pointer (BuildBodyEditor) therefore reads NOTHING →
+                // the blank editor. Edit those with the SAME standard markdown editor a Markdown node
+                // uses: it loads MarkdownContent.content and re-prerenders on save (safe — the content
+                // already IS a MarkdownContent, so WithAutoSave replaces nothing structured).
+                if (IsMarkdownBacked(node))
+                    return (UiControl?)MarkdownEditLayoutArea.Edit(host, ctx);
+
+                return (UiControl?)BuildBodyEditor(node, hubPath);
+            });
     }
+
+    /// <summary>
+    /// True when the Space's node content is a <see cref="MarkdownContent"/> (or its degraded
+    /// JsonElement form) rather than a structured <see cref="Space"/>. The Doc and Skill partition
+    /// roots ship this way, so their editable markdown lives in <c>content</c> — they must be edited
+    /// with the standard markdown editor, not the <c>Space.body</c> field editor (which reads blank).
+    /// </summary>
+    private static bool IsMarkdownBacked(MeshNode? node) =>
+        node?.Content is MarkdownContent
+        || (node?.Content is JsonElement je
+            && je.ValueKind == JsonValueKind.Object
+            && je.TryGetProperty("$type", out var t)
+            && t.GetString() is "MarkdownContent" or "MarkdownDocument");
 
     /// <summary>
     /// Builds the body editor: a back link, an editable name, and the markdown editor — all bound to

--- a/test/MeshWeaver.Hosting.Monolith.Test/SpaceEditMarkdownTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SpaceEditMarkdownTest.cs
@@ -70,6 +70,51 @@ public class SpaceEditMarkdownTest(ITestOutputHelper output) : MonolithMeshTestB
     }
 
     /// <summary>
+    /// The Doc + Skill partition roots are <c>nodeType: Space</c> but ship their landing page as a
+    /// <see cref="MeshWeaver.Markdown.MarkdownContent"/> (their seeding layer can't reference the
+    /// Space type). Such a Space keeps its markdown in <c>content</c>, NOT <c>Space.body</c> — so the
+    /// body-field editor read blank (the reported "editor is empty" bug). The Edit area must instead
+    /// route to the standard markdown editor, which LOADS the content and re-prerenders on save.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task SpaceEdit_MarkdownBackedSpace_LoadsContentIntoStandardEditor()
+    {
+        const string body = "# Welcome\n\nthis markdown must load into the editor";
+        var spaceId = $"MdSpace{Guid.NewGuid():N}"[..16];
+        var spaceNode = MeshNode.FromPath(spaceId) with
+        {
+            Name = "Markdown Space",
+            NodeType = SpaceNodeType.NodeType,
+            // MarkdownContent — the Doc/Skill shape, NOT a structured Space object.
+            Content = new MeshWeaver.Markdown.MarkdownContent { Content = body }
+        };
+        await NodeFactory.CreateNode(spaceNode).Should().Emit();
+
+        var workspace = GetClient(c => c.AddData()).GetWorkspace();
+        var reference = new LayoutAreaReference(MeshNodeLayoutAreas.EditArea);
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address(spaceId), reference);
+
+        var controls = new List<UiControl>();
+        await CollectControls(stream, reference.Area!, controls);
+
+        var editor = controls.OfType<MarkdownEditorControl>().FirstOrDefault();
+        Assert.True(editor is not null,
+            "a markdown-backed Space Edit area must render a MarkdownEditorControl");
+
+        // The bug: the editor opened EMPTY. It must load the MarkdownContent.content verbatim.
+        editor!.Value.Should().Be(body,
+            "the markdown-backed Space editor must load its content (the empty-editor bug)");
+
+        // Standard markdown editor path: WithValue + WithAutoSave (re-prerenders on save). This is the
+        // opposite of the structured-Space case, whose editor is node-bound with AutoSaveAddress null.
+        editor.AutoSaveAddress.Should().NotBeNull(
+            "a markdown-backed Space edits via the standard WithAutoSave markdown editor");
+
+        await NodeFactory.DeleteNode(spaceId).Should().Emit();
+    }
+
+    /// <summary>
     /// Resolves the control at <paramref name="areaName"/> and, when it is a container, recurses into
     /// its child areas — accumulating every resolved control so the test can assert on the whole tree.
     /// </summary>


### PR DESCRIPTION
## Problem

Reported: *"when clicking edit on a space, the editor is empty."*

The `Doc` and `Skill` partition roots are `nodeType: Space`, but their landing page ships as a **`MarkdownContent`**, not a structured `Space` object — their seeding layer (`MeshWeaver.Documentation`) can't reference the `Space` type in `MeshWeaver.Graph`. Live-confirmed: `@Doc`'s content is `{"$type":"MarkdownContent","content":"# MeshWeaver Documentation…"}`.

`SpaceLayoutAreas.Edit` hard-bound its Monaco editor to the `body` JSON pointer (`Value = new JsonPointerReference("body")`), which only exists on a `Space` object. For a markdown-backed Space the pointer resolves to nothing → **blank editor**.

## Fix

Detect a markdown-backed Space (`IsMarkdownBacked`) and route it to the standard `MarkdownEditLayoutArea.Edit` — the same editor every Markdown node uses. It loads `MarkdownContent.content` and re-prerenders on save (safe: the content already **is** a `MarkdownContent`, so `WithAutoSave` replaces nothing structured). Structured `Space` objects keep the `body`-field editor unchanged.

## Companion icon symptom

The reported *"icon not shown on Space Overview"* is **already fixed on `main`** (`BuildLogoMarkup` renders inline-SVG/emoji/URL icons correctly instead of forcing everything into `<img src>`). It's "still not shown" only because that fix hasn't reached the deployed portal yet — this PR merging + deploy delivers both.

## Verification
- `dotnet build src/MeshWeaver.Graph -c Release -warnaserror -p:CIRun=true` → 0 warnings, 0 errors.
- Editor logic: `Doc`/`Skill` (MarkdownContent) → standard markdown editor loads their welcome markdown; `Systemorph` (Organization) and fresh `Space` objects → body-field editor unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)