### PR TITLE
chore(logging): surface node-create audit breadcrumb at Information

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -18,6 +18,14 @@
       // Loki. Low volume (NOT per-message); connection-DOWN is Warning so it shows even if this is
       // lowered. The "what's going on in Blazor" channel.
       "MeshWeaver.Blazor.Circuit": "Information",
+      // Node-creation audit breadcrumb — exactly one line per node created/confirmed
+      // ("Node created at {Path} by {CreatedBy}", HandleCreateNodeRequest). Deliberately
+      // surfaced at Information (the rest of MeshWeaver stays Warning) so Loki holds a
+      // who-created-what trail. Volume tracks WRITE activity, NOT time: an idle portal
+      // emits zero; a boot static-repo import and chat rounds emit a bounded burst. This
+      // is the "one object = one log line" channel — orders of magnitude below the
+      // per-message MESSAGE_FLOW trace that only appears when MeshWeaver is forced to Trace.
+      "MeshWeaver.Mesh.CreateNode": "Information",
       "Microsoft": "Warning",
       "Microsoft.AspNetCore": "Warning",
       "Orleans": "Warning",


### PR DESCRIPTION
## What
Surface the **node-creation audit breadcrumb** at `Information` in the production `appsettings.json`.

The line already exists in `HandleCreateNodeRequest`:
```
"Node created at {Path} by {CreatedBy}"   // and "Confirmed transient node at {Path}"
```
on category `MeshWeaver.Mesh.CreateNode` — but `MeshWeaver` is capped at `Warning`, so it never reaches Loki. This raises **just that one category** to `Information`, mirroring the existing `MeshWeaver.Blazor.Circuit` audit channel.

## Why
Gives Loki a **who-created-what** trail — "one object = one log line." Volume tracks **write activity, not time**: an idle portal emits zero; a boot static-repo import and chat rounds emit a bounded burst. Orders of magnitude below the per-message `MESSAGE_FLOW` trace (which only appears when `MeshWeaver` is forced to `Trace`).

## Context
Fell out of diagnosing a memex.localhost "wedge" that was actually a stray `MeshWeaver=Trace` env override left on the deployment (37K log lines/min). Root cause cleared separately; this makes the intended per-create audit line visible without re-opening the firehose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)