### PR TITLE
fix(ai): resolve full node context (namespace/id/path) into the agent prompt

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -517,21 +517,13 @@ public class AgentChatClient : IAgentChat
             messageText.AppendLine("# Current Application Context");
             messageText.AppendLine();
             messageText.AppendLine(
-                "The node, layout area, and query parameters the user is viewing right now (JSON, serialized with the mesh's standard options). This is a REFERENCE — load node CONTENT on demand with the Get tool; it is NOT inlined here.");
+                "You DO know where the user is. The JSON below resolves the current node's IDENTITY — `path`, `namespace`, `id`, `nodeType`, `name` — plus the owner `address`, the layout `area`/`areaId`, the remaining `path`, and the query `parameters`. Use it directly to resolve `@` relative references and to act on the current node; do NOT say you don't know the context. It is IDENTITY only — load node CONTENT on demand with the Get tool (never inlined here).");
             messageText.AppendLine("```json");
-            // 🎯 JSON-serialize the navigation context with the mesh's normal options: the OWNER
-            // (main-node) address, the layout area + id, the optional query parameters as KVP, and
-            // the current node's IDENTITY (path/type/name) — never its content (reference + tool-load).
-            messageText.AppendLine(JsonSerializer.Serialize(new
-            {
-                address = Context.Address?.ToString() ?? Context.Context,
-                area = Context.LayoutArea?.Area,
-                areaId = Context.LayoutArea?.Id,
-                parameters = Context.Parameters,
-                node = Context.Node is null
-                    ? null
-                    : new { path = Context.Node.Path, nodeType = Context.Node.NodeType, name = Context.Node.Name }
-            }, hub.JsonSerializerOptions));
+            // 🎯 One shape, defined on AgentContext.ToPromptContext() so the prompt and its unit
+            // test never drift: the OWNER (main-node) address, the layout area + id, the remaining
+            // path, the optional query parameters as KVP, and the current node's IDENTITY resolved
+            // to path + namespace + id + nodeType + name — never its content (reference + tool-load).
+            messageText.AppendLine(JsonSerializer.Serialize(Context.ToPromptContext(), hub.JsonSerializerOptions));
             messageText.AppendLine("```");
             messageText.AppendLine();
 

--- a/src/MeshWeaver.AI/AgentContext.cs
+++ b/src/MeshWeaver.AI/AgentContext.cs
@@ -55,6 +55,33 @@ public record AgentContext
     public IReadOnlyList<AgentConfiguration>? AvailableAgents { get; init; }
 
     /// <summary>
+    /// Projects this context into the compact IDENTITY object shipped to the agent's system
+    /// prompt ("# Current Application Context"). It resolves the current node fully — its
+    /// <c>path</c>, <c>namespace</c>, <c>id</c>, <c>nodeType</c>, <c>name</c> — alongside the
+    /// owner <c>address</c>, the layout <c>area</c>/<c>areaId</c>, the remaining <c>path</c>, and
+    /// the optional query <c>parameters</c>. Reference only — never node content (loaded on demand
+    /// via the Get tool). Kept as ONE method so the prompt and its unit test assert the SAME shape.
+    /// </summary>
+    public object ToPromptContext() => new
+    {
+        address = Address?.ToString() ?? Context,
+        area = LayoutArea?.Area,
+        areaId = LayoutArea?.Id,
+        path = Path,
+        parameters = Parameters,
+        node = Node is null
+            ? null
+            : new
+            {
+                path = Node.Path,
+                @namespace = Node.Namespace,
+                id = Node.Id,
+                nodeType = Node.NodeType,
+                name = Node.Name,
+            },
+    };
+
+    /// <summary>
     /// Standard prefixes that indicate the reference type when used as first segment.
     /// These get stripped and the remaining path is parsed as addressType/addressId/...
     /// </summary>

--- a/src/MeshWeaver.AI/Data/Agent/ToolsReference.md
+++ b/src/MeshWeaver.AI/Data/Agent/ToolsReference.md
@@ -51,7 +51,26 @@ The leading `/` after `@` is load-bearing: `@/X` ≠ `@X`.
 
 ### Context comes from the user message
 
-Every user message carries a **"Current Application Context"** header with the canonical path of the node the user is currently viewing. **That is the path to use when resolving `@...` relative references.** Examples:
+Every user message carries a **"Current Application Context"** header. **You DO know where the user is — do not claim otherwise.** The header is a JSON object with the current node's IDENTITY fully resolved, shipped on every round:
+
+```json
+{
+  "address": "PartnerRe/AIConsulting",   // owner (main-node) address of what the user is viewing
+  "area": "Overview",                     // layout area, if any
+  "areaId": "…",                          // layout area id, if any
+  "path": "Tasks/123",                    // remaining path after the node, if any
+  "parameters": { "from": "5" },          // optional ?k=v query params on the URL
+  "node": {                               // the current node — IDENTITY only (content via Get)
+    "path": "PartnerRe/AIConsulting/FinalReport",
+    "namespace": "PartnerRe/AIConsulting",
+    "id": "FinalReport",
+    "nodeType": "Markdown",
+    "name": "Final Report – …"
+  }
+}
+```
+
+`node.path` (== `namespace`/`id`) **is the canonical path to use when resolving `@...` relative references** and to act on the current node. It is IDENTITY only — load the node's CONTENT on demand with the `Get` tool. Examples:
 
 - Context = `PartnerRe/AIConsulting`, agent calls `Get('@FinalReport')` → resolves to `@/PartnerRe/AIConsulting/FinalReport`.
 - Context = `PartnerRe/AIConsulting`, agent calls `Get('@/OrgA/Docs/other')` → resolves to `@/OrgA/Docs/other` (absolute — context ignored).

--- a/test/MeshWeaver.AI.Test/AgentContextPromptTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentContextPromptTest.cs
@@ -1,0 +1,70 @@
+#pragma warning disable CS1591
+
+using System.Collections.Generic;
+using System.Text.Json;
+using MeshWeaver.AI;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Unit tests for <see cref="AgentContext.ToPromptContext"/> — the SINGLE shape shipped to the
+/// agent's system prompt ("# Current Application Context"). Guards that the shipped context is
+/// RESOLVED into the identity parts an agent needs to know where it is — <c>namespace</c>,
+/// <c>id</c>, the node <c>path</c> (nodePath), the remaining <c>path</c>, and the optional query
+/// <c>parameters</c> — so agents can never legitimately claim "I don't know the context".
+/// The prompt (AgentChatClient) and this test call the exact same method, so they can't drift.
+/// </summary>
+public class AgentContextPromptTest
+{
+    [Fact]
+    public void ToPromptContext_resolves_namespace_id_nodePath_path_and_parameters()
+    {
+        var context = new AgentContext
+        {
+            Address = new Address("PartnerRe", "AIConsulting"),
+            Context = "PartnerRe/AIConsulting",
+            Path = "Tasks/123",
+            Parameters = new Dictionary<string, string> { ["from"] = "5", ["to"] = "8" },
+            Node = new MeshNode("FinalReport", "PartnerRe/AIConsulting")
+            {
+                Name = "Final Report",
+                NodeType = "Markdown",
+            },
+        };
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(context.ToPromptContext()));
+        var root = doc.RootElement;
+
+        // Top level: the remaining path after the node + the optional query parameters.
+        Assert.Equal("Tasks/123", root.GetProperty("path").GetString());
+        Assert.Equal("5", root.GetProperty("parameters").GetProperty("from").GetString());
+        Assert.Equal("8", root.GetProperty("parameters").GetProperty("to").GetString());
+
+        // Node IDENTITY fully resolved: nodePath (path) + namespace + id + nodeType + name.
+        var node = root.GetProperty("node");
+        Assert.Equal("PartnerRe/AIConsulting/FinalReport", node.GetProperty("path").GetString());
+        Assert.Equal("PartnerRe/AIConsulting", node.GetProperty("namespace").GetString());
+        Assert.Equal("FinalReport", node.GetProperty("id").GetString());
+        Assert.Equal("Markdown", node.GetProperty("nodeType").GetString());
+        Assert.Equal("Final Report", node.GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public void ToPromptContext_without_node_still_ships_address_and_null_node()
+    {
+        var context = new AgentContext
+        {
+            Address = new Address("PartnerRe", "AIConsulting"),
+            Context = "PartnerRe/AIConsulting",
+        };
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(context.ToPromptContext()));
+        var root = doc.RootElement;
+
+        Assert.False(string.IsNullOrEmpty(root.GetProperty("address").GetString()));
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("node").ValueKind);
+    }
+}


### PR DESCRIPTION
## Problem

Agents kept claiming they didn't know the current context — even though the context **is** shipped end-to-end (MCP `start_thread(contextPath)` → thread message → round → `AgentChatClient` "# Current Application Context"). Two reasons:
1. The node object shipped only `path` / `nodeType` / `name` — **not** `namespace`, `id`, or the remaining `path`, so the context wasn't fully *resolved*.
2. The wording ("This is a REFERENCE — … NOT inlined here") read like the agent *didn't* have the info.

## Fix

- **`AgentContext.ToPromptContext()`** — one method that resolves the context into `{ address, area, areaId, path, parameters, node{ path, namespace, id, nodeType, name } }`. `AgentChatClient` serializes via it (single source of truth — the prompt and its test can't drift).
- **Wording** in the system prompt: "**You DO know where the user is** … use it directly … do NOT say you don't know the context. It is IDENTITY only — load CONTENT on demand via Get."
- **`ToolsReference.md`** now shows the exact JSON shape shipped every round and states the agent knows its location.
- **`AgentContextPromptTest`** — pure unit test asserting `namespace` / `id` / `nodePath` / `path` / `parameters` all surface (+ null-node case).

## Verification

- `MeshWeaver.AI.Test` builds clean under CI flags (`-c Release -warnaserror -p:CIRun=true`): 0/0.
- `AgentContextPromptTest`: 2/2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)