### PR TITLE
fix(ai): resolve models by full path + send tools only to models that support them

### DIFF
--- a/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
+++ b/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
@@ -153,7 +153,10 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
         //     create/delete. Fires immediately (we're already past initialDelay) then every period. A
         //     failed cycle is logged and the loop continues (no watchdog resubscribe — the timer re-fires).
         timerSub = Observable.Timer(TimeSpan.Zero, period, TaskPoolScheduler.Default)
-            .SelectMany(_ => Reconcile(endpoint, apiKey, embeddingModel)
+            // Concat (not SelectMany): reconcile cycles run STRICTLY ONE AT A TIME — a tick that fires
+            // while the previous cycle is still running queues behind it instead of overlapping. This
+            // keeps the single-shot backfill flag and the catalog diff free of any concurrent access.
+            .Select(_ => Observable.Defer(() => Reconcile(endpoint, apiKey, embeddingModel))
                 .Catch<Unit, Exception>(ex =>
                 {
                     logger?.LogWarning(ex,
@@ -161,6 +164,7 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
                         endpoint);
                     return Observable.Return(Unit.Default);
                 }))
+            .Concat()
             .Subscribe(_ => { },
                 ex => logger?.LogError(ex, "[OpenAICompatibleModelSync] discovery loop terminated"));
     }

--- a/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
+++ b/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
@@ -64,6 +64,11 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
     private readonly Lazy<IMeshService> meshService;
     private readonly ILogger<OpenAICompatibleModelSync>? logger;
 
+    // One-shot: the FIRST reconcile after start re-stamps EVERY discovered model (probe + upsert), so
+    // nodes created before ModelDefinition.SupportsTools existed get their capability backfilled. After
+    // that the normal presence-diff runs (no per-cycle rewrites).
+    private bool backfilledToolSupport;
+
     // Live snapshot of the current OpenAICompatible model-child ids (kept fresh by the catalog query).
     // Instance field (never static), StringComparer.OrdinalIgnoreCase — model ids are case-insensitive.
     private volatile ImmutableHashSet<string> catalogIds =
@@ -176,26 +181,43 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
                         endpoint);
                     return Observable.Return(Unit.Default);
                 }
-                if (delta.ToAdd.Count == 0 && delta.ToRemove.Count == 0)
+                var toAdd = delta.ToAdd;
+                var toRemove = delta.ToRemove;
+                if (!backfilledToolSupport)
+                {
+                    // First reconcile after start: re-stamp EVERY desired chat model (== the diff against
+                    // an empty catalog) so nodes created before ModelDefinition.SupportsTools existed get
+                    // it backfilled via the idempotent CreateOrUpdate. After this, the presence-diff runs
+                    // (toAdd = genuinely new only), so there are no per-cycle rewrites.
+                    backfilledToolSupport = true;
+                    toAdd = ComputeDelta(all, Array.Empty<string>(), embeddingModel).ToAdd;
+                }
+                if (toAdd.Count == 0 && toRemove.Count == 0)
                     return Observable.Return(Unit.Default);
 
                 logger?.LogInformation(
                     "[OpenAICompatibleModelSync] reconcile: +{Add} -{Remove} at {Endpoint}",
-                    delta.ToAdd.Count, delta.ToRemove.Count, endpoint);
+                    toAdd.Count, toRemove.Count, endpoint);
 
                 // Optimistically fold the delta in so a fast next tick doesn't re-apply before the live
                 // catalog query catches up; the query re-emits the ACTUAL state and self-corrects.
-                catalogIds = catalogIds.Except(delta.ToRemove).Union(delta.ToAdd);
+                catalogIds = catalogIds.Except(toRemove).Union(toAdd);
 
-                var ops = delta.ToAdd
-                    .Select(id => AsSystem(() => meshService.Value.CreateOrUpdateNode(BuildModelNode(id)))
-                        .Select(_ => Unit.Default)
+                var ops = toAdd
+                    // Probe each NEW model's tool-calling capability (Ollama /api/show) BEFORE creating
+                    // its node, so the agent round never sends tools to a model that can't handle them
+                    // (a roleplay model would 400). Indeterminate/non-Ollama → null (assume supported).
+                    .Select(id => lister.SupportsTools(endpoint, id)
+                        .Catch<bool?, Exception>(_ => Observable.Return<bool?>(null))
+                        .SelectMany(supportsTools =>
+                            AsSystem(() => meshService.Value.CreateOrUpdateNode(BuildModelNode(id, supportsTools)))
+                                .Select(_ => Unit.Default))
                         .Catch<Unit, Exception>(ex =>
                         {
                             logger?.LogWarning(ex, "[OpenAICompatibleModelSync] add model {Id} failed", id);
                             return Observable.Return(Unit.Default);
                         }))
-                    .Concat(delta.ToRemove
+                    .Concat(toRemove
                         .Select(id => AsSystem(() => meshService.Value.DeleteNode($"{ProviderPath}/{id}"))
                             .Select(_ => Unit.Default)
                             .Catch<Unit, Exception>(ex =>
@@ -239,7 +261,8 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
 
     // The platform-provider LanguageModel child shape (mirrors ModelProviderService.CreateProvider):
     // no key on the child, endpoint/key resolved by following ProviderRef → the parent provider node.
-    internal static MeshNode BuildModelNode(string modelId)
+    // supportsTools: the endpoint's declared tool-calling capability (null = unknown → assume supported).
+    internal static MeshNode BuildModelNode(string modelId, bool? supportsTools = null)
     {
         var pricing = ModelPricing.Default(modelId); // null for local models → tokens shown without a cost
         var def = new ModelDefinition
@@ -251,6 +274,7 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
             ApiKeySecretRef = null,    // never a key on a publicly-readable model child
             ProviderRef = ProviderPath,
             Order = 5,                 // OpenAICompatible catalog order
+            SupportsTools = supportsTools, // gates whether the agent round sends tool definitions
             InputPricePerMillionTokens = pricing?.InputPerMillion,
             OutputPricePerMillionTokens = pricing?.OutputPerMillion,
             Currency = pricing?.Currency

--- a/memex/Memex.Portal.Shared/Models/ProviderModelLister.cs
+++ b/memex/Memex.Portal.Shared/Models/ProviderModelLister.cs
@@ -122,4 +122,58 @@ public sealed class ProviderModelLister
 
     private static string Truncate(string s) =>
         string.IsNullOrEmpty(s) ? "" : (s.Length <= 200 ? s : s[..200] + "…");
+
+    /// <summary>
+    /// Whether <paramref name="modelId"/> supports tool/function calling, per the endpoint's declared
+    /// capabilities. Ollama-specific: the OpenAI-wire base has no capabilities endpoint, so this hits
+    /// <c>{base}/api/show</c> (dropping a trailing <c>/v1</c>) and checks whether <c>capabilities</c>
+    /// contains <c>"tools"</c>. Returns:
+    /// <list type="bullet">
+    ///   <item><c>true</c> — capabilities include <c>tools</c>.</item>
+    ///   <item><c>false</c> — capabilities were returned and do NOT include <c>tools</c> (a definitively
+    ///     tool-less model, e.g. a roleplay model reporting <c>[completion]</c>).</item>
+    ///   <item><c>null</c> — indeterminate (not Ollama / no <c>/api/show</c> / probe failed): the caller
+    ///     assumes tools ARE supported (historical behaviour).</item>
+    /// </list>
+    /// Runs on the <see cref="IoPoolNames.Http"/> pool; never throws (probe failures surface as null).
+    /// </summary>
+    public IObservable<bool?> SupportsTools(string? endpoint, string modelId) =>
+        Http.Invoke(ct => SupportsToolsAsync(endpoint, modelId, ct));
+
+    private async Task<bool?> SupportsToolsAsync(string? endpoint, string modelId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint) || string.IsNullOrWhiteSpace(modelId))
+            return null;
+        var baseUrl = endpoint.Trim().TrimEnd('/');
+        if (baseUrl.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
+            baseUrl = baseUrl[..^3].TrimEnd('/');
+        var url = baseUrl + "/api/show";
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = new StringContent(
+                    $"{{\"model\":{JsonSerializer.Serialize(modelId)}}}",
+                    System.Text.Encoding.UTF8, "application/json")
+            };
+            using var resp = await http.SendAsync(req, ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+                return null; // not an Ollama endpoint, or the model is unknown → indeterminate
+            var json = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("capabilities", out var caps)
+                || caps.ValueKind != JsonValueKind.Array)
+                return null; // no capabilities array → indeterminate
+            foreach (var c in caps.EnumerateArray())
+                if (c.ValueKind == JsonValueKind.String
+                    && string.Equals(c.GetString(), "tools", StringComparison.OrdinalIgnoreCase))
+                    return true;
+            return false; // capabilities present but no "tools" → definitively unsupported
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "Capability probe (/api/show) failed for {Model} at {Url}", modelId, url);
+            return null;
+        }
+    }
 }

--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -901,21 +901,38 @@ public class AgentChatClient : IAgentChat
         // ChatClientAgent constructor places them).
         var functionInvoker = agent.ChatClient.GetService<FunctionInvokingChatClient>();
         var chatOptions = new ChatOptions();
-        var tools = functionInvoker?.AdditionalTools is { Count: > 0 } additionalTools
-            ? additionalTools.ToList()
-            : new List<AITool>();
-        // Mid-round inbox: inject check_inbox so the agent can drain follow-up messages
-        // queued DURING the in-flight round and fold them inline into the current response.
-        // This is the reactive two-stage channel the prior disable-note prescribed — NOT the
-        // old TCS-on-hub-scheduler gate that deadlocked. Stage 1: the submission watcher
-        // OFFERS newly-pending messages into the per-thread ThreadInboxChannel (in-memory,
-        // no node write). Stage 2: check_inbox DRAINS that channel SYNCHRONOUSLY — no
-        // stream.Update, no Subscribe onto the hub action-block scheduler — so the
-        // TaskCompletionSource bridge can no longer resume a continuation on the hub thread
-        // (the old deadlock/"thread disappears" cause is gone). The thread node is written
-        // only at round boundaries (start commit + terminal fold). See ThreadInboxChannel.
-        tools.Add(InboxTool.CreateCheckInboxTool(hub, logger));
-        chatOptions.Tools = tools;
+        // 🚨 Only attach tools if the selected model SUPPORTS tool/function calling. A model KNOWN not
+        // to (an Ollama roleplay model like TieFighter — capabilities=[completion]) returns HTTP 400
+        // "does not support tools" the moment ANY tool definition is sent. For such a model we send a
+        // plain, tool-free chat request so it works as a chat/creative model instead of erroring the
+        // whole round. Unknown → assume supported (historical behaviour). See
+        // ChatClientCredentialResolver.ModelSupportsTools + ModelDefinition.SupportsTools.
+        var modelSupportsTools = hub.ServiceProvider.GetService<ChatClientCredentialResolver>()
+            ?.ModelSupportsTools(currentModelName) ?? true;
+        var tools = new List<AITool>();
+        if (modelSupportsTools)
+        {
+            if (functionInvoker?.AdditionalTools is { Count: > 0 } additionalTools)
+                tools.AddRange(additionalTools);
+            // Mid-round inbox: inject check_inbox so the agent can drain follow-up messages
+            // queued DURING the in-flight round and fold them inline into the current response.
+            // This is the reactive two-stage channel the prior disable-note prescribed — NOT the
+            // old TCS-on-hub-scheduler gate that deadlocked. Stage 1: the submission watcher
+            // OFFERS newly-pending messages into the per-thread ThreadInboxChannel (in-memory,
+            // no node write). Stage 2: check_inbox DRAINS that channel SYNCHRONOUSLY — no
+            // stream.Update, no Subscribe onto the hub action-block scheduler — so the
+            // TaskCompletionSource bridge can no longer resume a continuation on the hub thread
+            // (the old deadlock/"thread disappears" cause is gone). The thread node is written
+            // only at round boundaries (start commit + terminal fold). See ThreadInboxChannel.
+            tools.Add(InboxTool.CreateCheckInboxTool(hub, logger));
+            chatOptions.Tools = tools;
+        }
+        else
+        {
+            logger.LogInformation(
+                "[AgentChat] Model '{Model}' does not support tools — sending a tool-free chat request (agent + inbox tools omitted).",
+                currentModelName ?? "(none)");
+        }
         // Tools marked [HiddenTool] are internal plumbing: their calls must not reach the chat
         // UI as tool-call chrome nor the Information logs. The filter stays generic; with the
         // inbox disabled there are currently no hidden tools, so it is a no-op. Collect their

--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -894,11 +894,11 @@ public class AgentChatClient : IAgentChat
             turnMessages.Count, agent.Name, untruncatedCount);
         currentAttachments = null;
 
-        // ChatOptions MUST include the agent's tools. Without them, the inner
-        // client (AzureClaudeChatClient) never sends tool definitions to Claude,
-        // and FunctionInvokingChatClient has nothing to match against.
-        // Get tools from FunctionInvokingChatClient.AdditionalTools (where the
-        // ChatClientAgent constructor places them).
+        // ChatOptions carries the agent's tools — WHEN the selected model supports them (see the gate
+        // below). For a tool-capable model, without them the inner client (AzureClaudeChatClient) never
+        // sends tool definitions and FunctionInvokingChatClient has nothing to match against; the tools
+        // come from FunctionInvokingChatClient.AdditionalTools (where the ChatClientAgent ctor places
+        // them). For a model KNOWN not to support tools, we send NONE (a plain chat request).
         var functionInvoker = agent.ChatClient.GetService<FunctionInvokingChatClient>();
         var chatOptions = new ChatOptions();
         // 🚨 Only attach tools if the selected model SUPPORTS tool/function calling. A model KNOWN not

--- a/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
+++ b/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
@@ -383,7 +383,29 @@ public sealed class ChatClientCredentialResolver : IDisposable
     {
         if (string.IsNullOrEmpty(modelNameOrPath) || !modelNameOrPath.Contains('/'))
             return modelNameOrPath;
-        return FindDefinitionByNodePath(ReadSnapshot(), modelNameOrPath)?.Id ?? modelNameOrPath;
+        var def = FindDefinitionByNodePath(ReadSnapshot(), modelNameOrPath);
+        if (def != null)
+            return def.Id;
+        // Unresolved path (node not yet in the warm snapshot): the wire id is the LAST SEGMENT — never
+        // the whole path (sending "Provider/OpenAICompatible/qwen3.6:latest" as the model name 400s).
+        return modelNameOrPath[(modelNameOrPath.LastIndexOf('/') + 1)..];
+    }
+
+    /// <summary>
+    /// Whether the selected model may be sent tool/function definitions. Returns FALSE only when the
+    /// resolved catalog entry is KNOWN not to support tools (<see cref="ModelDefinition.SupportsTools"/>
+    /// == <c>false</c>) — an Ollama roleplay model (TieFighter) that returns HTTP 400 "does not support
+    /// tools". Unknown / not-found / not-set → TRUE (assume supported — the historical behaviour).
+    /// Accepts a bare id or a full node PATH; for a bare id that matches several catalog entries, a
+    /// declared "no tools" on ANY of them wins (safer to omit tools than to 400 the whole round).
+    /// </summary>
+    public bool ModelSupportsTools(string? modelNameOrPath)
+    {
+        if (string.IsNullOrEmpty(modelNameOrPath)) return true;
+        var snapshot = ReadSnapshot();
+        if (modelNameOrPath.Contains('/'))
+            return FindDefinitionByNodePath(snapshot, modelNameOrPath)?.SupportsTools != false;
+        return !FindModelDefinitions(snapshot, modelNameOrPath).Any(d => d.SupportsTools == false);
     }
 
     /// <summary>

--- a/src/MeshWeaver.AI/ModelDefinition.cs
+++ b/src/MeshWeaver.AI/ModelDefinition.cs
@@ -107,6 +107,16 @@ public record ModelDefinition
     public string? Currency { get; init; }
 
     /// <summary>
+    /// Whether the model supports tool / function calling. <c>null</c> = unknown (assume it does —
+    /// the historical behaviour). <c>false</c> = the model is KNOWN not to support tools, so the agent
+    /// round must NOT send any tool definitions (an Ollama roleplay model like TieFighter returns
+    /// HTTP 400 "does not support tools" otherwise). Set at discovery time from the endpoint's declared
+    /// capabilities (Ollama <c>/api/show</c> → <c>capabilities</c> contains <c>"tools"</c>).
+    /// </summary>
+    [System.ComponentModel.Description("Supports tool/function calling")]
+    public bool? SupportsTools { get; init; }
+
+    /// <summary>
     /// Projects this definition into the lighter <see cref="ModelInfo"/>
     /// shape consumed by the chat picker.
     /// </summary>

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -857,17 +857,18 @@ internal static class ThreadExecution
     {
         // Selections arrive as picked node PATHS ("Harness/MeshWeaver",
         // "Provider/Anthropic/claude-…", "Agent/Assistant", "AgenticPension/Agent/Datenextraktion").
-        // Models and harnesses match bare REGISTERED ids (the last path segment), so they
-        // normalize at this boundary. The AGENT does NOT: a space-scoped agent
-        // ("AgenticPension/Agent/Datenextraktion") collides with a built-in of the same
-        // last segment when collapsed to the bare id, so it must resolve by FULL PATH.
-        // AgentChatClient.SetSelectedAgent / SelectAgent match the full path (with a
-        // bare-id fallback). The cell stamp's display name is normalized to the short
-        // name where it's written (PushToResponseMessage), so the persisted AgentName
-        // stays the friendly last segment, not the full path.
+        // The HARNESS matches a bare REGISTERED id (last path segment), so it normalizes here.
+        // The MODEL and the AGENT do NOT: two catalog entries can share a bare id (a keyless global
+        // Provider/OpenAICompatible/qwen3.6:latest vs a user's keyed copy, or the same id under two
+        // providers), so collapsing to the bare id resolves the WRONG node — the model must resolve by
+        // FULL PATH. AgentChatClient.Initialize already does this (ChatClientCredentialResolver.
+        // ResolveModelId → node-path lookup → the exact node's wire id + credentials + capabilities);
+        // stripping the path here defeated it. Keep the model path; the resolver collapses it to the
+        // wire id at the exact node. (The cell-stamp display name is normalized to the short name at
+        // write time in PushToResponseMessage, so the persisted friendly name is unaffected.)
         request = request with
         {
-            ModelName = SelectionId.IdOf(request.ModelName),
+            ModelName = request.ModelName,
             Harness = SelectionId.IdOf(request.Harness)
         };
         var parentHub = hub.Configuration.ParentHub!;

--- a/test/Memex.Portal.Shared.Test/OpenAICompatibleModelSyncTest.cs
+++ b/test/Memex.Portal.Shared.Test/OpenAICompatibleModelSyncTest.cs
@@ -136,5 +136,17 @@ public class OpenAICompatibleModelSyncTest
         Assert.Equal("Provider/OpenAICompatible", def.ProviderRef); // credentials resolved via the parent node
         Assert.Null(def.Endpoint);                                   // resolver follows ProviderRef, not a copied endpoint
         Assert.Null(def.ApiKeySecretRef);                            // never a key on a publicly-readable child
+        Assert.Null(def.SupportsTools);                              // default: unknown (assume supported)
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    [InlineData(null)]
+    public void BuildModelNode_CarriesTheProbedToolSupport(bool? supportsTools)
+    {
+        var node = OpenAICompatibleModelSync.BuildModelNode("tiefighter:q6_k", supportsTools);
+        var def = Assert.IsType<ModelDefinition>(node.Content);
+        Assert.Equal(supportsTools, def.SupportsTools);
     }
 }

--- a/test/MeshWeaver.AI.Test/ProviderModelListerTest.cs
+++ b/test/MeshWeaver.AI.Test/ProviderModelListerTest.cs
@@ -159,4 +159,27 @@ public class ProviderModelListerTest(ITestOutputHelper output) : AITestBase(outp
         handler.Last.Headers.Authorization.Should().BeNull("a keyless local endpoint sends no bearer");
         ids.Should().Equal("bge-m3:latest", "qwen3.6:latest"); // sorted; the lister does not filter embedders
     }
+
+    /// <summary>
+    /// Tool-support probe: POSTs to <c>{base}/api/show</c> (the <c>/v1</c> segment dropped) and reads
+    /// Ollama's <c>capabilities</c>. "tools" present → true; capabilities without "tools" → false;
+    /// a failed/non-Ollama probe → null (indeterminate → caller assumes supported).
+    /// </summary>
+    [Fact]
+    public async Task SupportsTools_ReadsOllamaCapabilities_AtApiShow()
+    {
+        var (withTools, h1) = Make("{\"capabilities\":[\"completion\",\"tools\"]}");
+        (await withTools.SupportsTools("http://ollama:11434/v1", "qwen3.6:latest")
+            .Should().Within(10.Seconds()).Emit()).Should().Be(true);
+        h1.Last!.Method.Should().Be(HttpMethod.Post);
+        h1.Last.RequestUri!.ToString().Should().Be("http://ollama:11434/api/show"); // /v1 stripped, /api/show
+
+        var (noTools, _) = Make("{\"capabilities\":[\"completion\"]}");
+        (await noTools.SupportsTools("http://ollama:11434/v1", "tiefighter:q6_k")
+            .Should().Within(10.Seconds()).Emit()).Should().Be(false);
+
+        var (failed, _) = Make("{\"error\":\"not found\"}", System.Net.HttpStatusCode.NotFound);
+        (await failed.SupportsTools("https://openrouter.ai/api/v1", "x")
+            .Should().Within(10.Seconds()).Emit()).Should().BeNull("a non-Ollama / failed probe is indeterminate");
+    }
 }


### PR DESCRIPTION
Two model-plumbing fixes (reported: "models don't identify with full path" + a new Ollama model returning `HTTP 400 … does not support tools`).

## 1. Full-path model identity
`ThreadExecution` stripped the model selection to a **bare id** (`SelectionId.IdOf`) before the round, so two catalog entries sharing an id (a keyless global `Provider/OpenAICompatible/qwen3.6:latest` vs a user's keyed copy, or the same id under two providers) resolved the **wrong node**. Now the model keeps its **full path** — `AgentChatClient.Initialize` already resolves it via `ChatClientCredentialResolver.ResolveModelId` (node-path lookup) to the **exact** node's wire id. `ResolveModelId` is hardened to fall back to the **last path segment** when a path isn't in the warm snapshot, so a raw path is never sent to the endpoint as a model name. (Harness still normalizes to bare id.)

## 2. Tools only if the model supports them
Ollama roleplay models (TieFighter → `capabilities: [completion]`) return `HTTP 400 "does not support tools"` the moment any tool is sent.
- `ModelDefinition.SupportsTools` (`null` = unknown → assume supported).
- OpenAICompatible discovery probes Ollama **`/api/show`** (`ProviderModelLister.SupportsTools`, `/v1` dropped) and stamps each model, with a **first-reconcile backfill** so models created before this field existed get re-stamped.
- `AgentChatClient` gates the whole tool list — **agent tools *and* the inbox tool** — on `ChatClientCredentialResolver.ModelSupportsTools`. A known-tool-less model gets a plain, tool-free chat request instead of erroring the round.

## Tests
`ProviderModelListerTest.SupportsTools_ReadsOllamaCapabilities_AtApiShow` (tools / no-tools / probe-fail → true/false/null); `OpenAICompatibleModelSyncTest.BuildModelNode_CarriesTheProbedToolSupport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)