### PR TITLE
feat(ai): AI catalogs with scope tabs + create, thread-nav new-chat, avatar image generation

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -696,6 +696,10 @@ public static class MemexConfiguration
                         .WithHeartBeatHandler() // silently ack heartbeats on every per-node hub
                         .AddDefaultLayoutAreas()
                         .AddThreadsLayoutArea()
+                        // Scope-tabbed AI catalogs (Agents/Skills/Providers/Models) with per-tab
+                        // create buttons — the AI-menu targets below point here. Registered on every
+                        // per-node hub so they resolve when anchored on the type roots (/Agent/AiAgents …).
+                        .AddAiCatalogLayoutAreas()
                         .AddApiTokensSettingsTab()
                         // AI menu (top bar) — replaces the retired Models + AI Settings tabs. Each entry
                         // opens mesh search grouped by namespace, so every tier (global / space / user)
@@ -711,17 +715,19 @@ public static class MemexConfiguration
                             new NodeMenuItemDefinition("Threads", "AiThreads", Icon: "/static/NodeTypeIcons/chat.svg", Order: 10,
                                 Href: "/search?q=nodeType%3AThread&groupBy=Namespace",
                                 Tooltip: "Conversation threads across every namespace"),
+                            // Scope-tabbed catalogs (This space · User · Global) with per-tab "+" create,
+                            // anchored on the type roots so the catalog area resolves (AddAiCatalogLayoutAreas).
                             new NodeMenuItemDefinition("Models", "AiModels", Icon: "/static/NodeTypeIcons/sparkle.svg", Order: 20,
-                                Href: "/search?q=nodeType%3ALanguageModel&groupBy=Namespace",
-                                Tooltip: "Language models, grouped by provider"),
+                                Href: $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.ModelsArea}",
+                                Tooltip: "Language models — global, space, and user"),
                             new NodeMenuItemDefinition("Agents", "AiAgents", Icon: "/static/NodeTypeIcons/bot.svg", Order: 30,
-                                Href: "/search?q=nodeType%3AAgent&groupBy=Namespace",
+                                Href: $"/Agent/{AiCatalogLayoutAreas.AgentsArea}",
                                 Tooltip: "AI agents — global, space, and user"),
                             new NodeMenuItemDefinition("Skills", "AiSkills", Icon: "/static/NodeTypeIcons/rocket.svg", Order: 40,
-                                Href: "/search?q=nodeType%3ASkill&groupBy=Namespace",
-                                Tooltip: "Reusable skills"),
+                                Href: $"/{SkillNodeType.RootNamespace}/{AiCatalogLayoutAreas.SkillsArea}",
+                                Tooltip: "Reusable skills — global, space, and user"),
                             new NodeMenuItemDefinition("Providers", "AiProviders", Icon: "/static/NodeTypeIcons/key.svg", Order: 25,
-                                Href: "/search?q=nodeType%3AModelProvider&groupBy=Namespace",
+                                Href: $"/{ModelProviderNodeType.RootNamespace}/{AiCatalogLayoutAreas.ProvidersArea}",
                                 Tooltip: "AI providers — endpoints + keys"))
                         // Dedicated Admin menu (platform-wide GlobalSettings area), gated on root
                         // Permission.All: Invitations + Inbox.

--- a/src/MeshWeaver.AI/AIExtensions.cs
+++ b/src/MeshWeaver.AI/AIExtensions.cs
@@ -183,6 +183,9 @@ public static class AIExtensions
         public IServiceCollection AddAgentChatServices()
         {
             services.AddTransient<IIconGenerator, IconGenerator>();
+            // Named, factory-pooled HttpClient for the image generator (avoids per-instance
+            // `new HttpClient()` socket exhaustion; also guarantees IHttpClientFactory is present).
+            services.AddHttpClient(nameof(ImageGenerator));
             services.AddTransient<IImageGenerator, ImageGenerator>();
             services.AddTransient<IDescriptionGenerator, DescriptionGenerator>();
 

--- a/src/MeshWeaver.AI/AIExtensions.cs
+++ b/src/MeshWeaver.AI/AIExtensions.cs
@@ -183,6 +183,7 @@ public static class AIExtensions
         public IServiceCollection AddAgentChatServices()
         {
             services.AddTransient<IIconGenerator, IconGenerator>();
+            services.AddTransient<IImageGenerator, ImageGenerator>();
             services.AddTransient<IDescriptionGenerator, DescriptionGenerator>();
 
             // Slash-skills are declarative nodeType:Skill mesh nodes (BuiltInSkillProvider, imported to

--- a/src/MeshWeaver.AI/AiCatalogLayoutAreas.cs
+++ b/src/MeshWeaver.AI/AiCatalogLayoutAreas.cs
@@ -1,0 +1,129 @@
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Layout.Domain;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// The top-bar AI menu's catalog areas — Agents / Skills / Providers / Models — each a
+/// <b>scope-tabbed</b> catalog (This space · User · Global) with a "+" create button per tab.
+///
+/// <para>Replaces the old flat <c>/search?q=nodeType:X&amp;groupBy=Namespace</c> targets: those
+/// grouped by namespace but offered no way to <b>create</b> a new entry, which is the gap this
+/// closes. Each tab is a scoped <see cref="MeshSearchControl"/> (via
+/// <see cref="CatalogExtensions.WithMeshSearch"/>) whose <c>CreateNodeType</c> renders the "+"
+/// button — the same primitive the Threads catalog and the user home page already use.</para>
+///
+/// <para><b>Scope.</b> The catalog is anchored on the node it is opened from
+/// (<c>host.Hub.Address</c>). The <c>This space</c> tab shows ONLY when that anchor is a real
+/// partition that is neither the global type root nor the viewer's own home — so the global
+/// top-bar entry (anchored on the type root, e.g. <c>/Agent/AiAgents</c>) shows just
+/// <c>User</c> + <c>Global</c>, matching the ask "if started from the user, there will be no
+/// space".</para>
+/// </summary>
+public static class AiCatalogLayoutAreas
+{
+    /// <summary>Area name for the scope-tabbed Agents catalog. Menu href: <c>/Agent/AiAgents</c>.</summary>
+    public const string AgentsArea = "AiAgents";
+    /// <summary>Area name for the scope-tabbed Skills catalog. Menu href: <c>/Skill/AiSkills</c>.</summary>
+    public const string SkillsArea = "AiSkills";
+    /// <summary>Area name for the scope-tabbed Providers catalog. Menu href: <c>/Provider/AiProviders</c>.</summary>
+    public const string ProvidersArea = "AiProviders";
+    /// <summary>Area name for the scope-tabbed Models catalog. Menu href: <c>/Provider/AiModels</c>.</summary>
+    public const string ModelsArea = "AiModels";
+
+    /// <summary>Registers the four AI catalog areas on a layout definition.</summary>
+    public static LayoutDefinition AddAiCatalogLayoutAreas(this LayoutDefinition layout)
+        => layout
+            .WithView(AgentsArea, AgentsCatalog)
+            .WithView(SkillsArea, SkillsCatalog)
+            .WithView(ProvidersArea, ProvidersCatalog)
+            .WithView(ModelsArea, ModelsCatalog);
+
+    /// <summary>Registers the four AI catalog areas on a hub configuration.</summary>
+    public static MessageHubConfiguration AddAiCatalogLayoutAreas(this MessageHubConfiguration configuration)
+        => configuration.AddLayout(layout => layout.AddAiCatalogLayoutAreas());
+
+    private static UiControl AgentsCatalog(LayoutAreaHost host, RenderingContext _)
+        => BuildScopeCatalog(host, "agents", AgentNodeType.NodeType, globalNamespace: "Agent");
+
+    private static UiControl SkillsCatalog(LayoutAreaHost host, RenderingContext _)
+        => BuildScopeCatalog(host, "skills", SkillNodeType.NodeType, globalNamespace: SkillNodeType.RootNamespace);
+
+    private static UiControl ProvidersCatalog(LayoutAreaHost host, RenderingContext _)
+        => BuildScopeCatalog(host, "providers", ModelProviderNodeType.NodeType, globalNamespace: ModelProviderNodeType.RootNamespace);
+
+    private static UiControl ModelsCatalog(LayoutAreaHost host, RenderingContext _)
+        // Models live UNDER the "Provider" partition (LanguageModelNodeType remark), so the global
+        // scope roots at ModelProviderNodeType.RootNamespace ("Provider"), not "Model".
+        => BuildScopeCatalog(host, "models", LanguageModelNodeType.NodeType, globalNamespace: ModelProviderNodeType.RootNamespace);
+
+    /// <summary>
+    /// Builds a <see cref="Controls.Tabs"/> catalog with the This-space / User / Global scope tabs
+    /// for <paramref name="nodeType"/>. Each tab is a namespace-scoped mesh search whose
+    /// <c>CreateNodeType</c> shows the "+" button; new nodes are created in that tab's namespace.
+    /// </summary>
+    private static UiControl BuildScopeCatalog(
+        LayoutAreaHost host, string plural, string nodeType, string globalNamespace)
+    {
+        var contextNs = host.Hub.Address.ToString();
+        var viewerHome = ResolveViewerHome(host);
+
+        var tabs = Controls.Tabs.WithSkin(s => s.WithWidth("100%"));
+
+        // "This space" — only when anchored on a real partition that is neither the global type
+        // root nor the viewer's own home (that IS the "User" tab). Absent from the global top-bar
+        // entry and from a user's own area.
+        var isSpace = !string.IsNullOrEmpty(contextNs)
+            && !string.Equals(contextNs, globalNamespace, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(contextNs, viewerHome, StringComparison.OrdinalIgnoreCase);
+        if (isSpace)
+            tabs = tabs.WithMeshSearch("This space",
+                @namespace: contextNs, scope: "descendants", nodeType: nodeType,
+                createNodeType: nodeType, createNamespace: contextNs,
+                placeholder: $"Search {plural} in this space…", configure: ScopeSearch);
+
+        // "User" — the viewer's own partition.
+        if (!string.IsNullOrEmpty(viewerHome))
+            tabs = tabs.WithMeshSearch("User",
+                @namespace: viewerHome, scope: "descendants", nodeType: nodeType,
+                createNodeType: nodeType, createNamespace: viewerHome,
+                placeholder: $"Search your {plural}…", configure: ScopeSearch);
+
+        // "Global" — the platform-wide type root.
+        tabs = tabs.WithMeshSearch("Global",
+            @namespace: globalNamespace, scope: "descendants", nodeType: nodeType,
+            createNodeType: nodeType, createNamespace: globalNamespace,
+            placeholder: $"Search global {plural}…", configure: ScopeSearch);
+
+        return tabs;
+    }
+
+    // Common per-tab search skin — a reactive flat card grid with an inviting empty state.
+    private static MeshSearchControl ScopeSearch(MeshSearchControl s) => s
+        .WithRenderMode(MeshSearchRenderMode.Flat)
+        .WithShowEmptyMessage(true)
+        .WithReactiveMode(true)
+        .WithMaxColumns(4);
+
+    /// <summary>
+    /// Resolves the current viewer's home partition (their <c>ObjectId</c>), skipping the
+    /// system identity and hub principals — mirrors <c>ThreadComposerView.ResolveUser</c>.
+    /// Returns <c>null</c> while the identity is still resolving (no "User" tab is shown then).
+    /// </summary>
+    private static string? ResolveViewerHome(LayoutAreaHost host)
+    {
+        var access = host.Hub.ServiceProvider.GetService<AccessService>();
+        if (access is null)
+            return null;
+        foreach (var candidate in new[] { access.Context?.ObjectId, access.CircuitContext?.ObjectId })
+            if (!string.IsNullOrEmpty(candidate)
+                && candidate != WellKnownUsers.System
+                && !AccessService.LooksLikeHubPrincipal(candidate))
+                return candidate;
+        return null;
+    }
+}

--- a/src/MeshWeaver.AI/ImageGenerator.cs
+++ b/src/MeshWeaver.AI/ImageGenerator.cs
@@ -1,0 +1,216 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reactive.Linq;
+using System.Text;
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// Default <see cref="IImageGenerator"/> — the raster counterpart to <see cref="IconGenerator"/>.
+/// Selects an image-capable <see cref="ModelDefinition"/> (<see cref="ModelCapability.Image"/>),
+/// resolves its endpoint + (decrypted) key via <see cref="ChatClientCredentialResolver"/>, and
+/// dispatches by the model's <see cref="ModelDefinition.Provider"/> to a backend:
+/// <list type="bullet">
+///   <item><c>AzureOpenAI</c> → Azure OpenAI Images (<c>/openai/deployments/{id}/images/generations</c>).</item>
+///   <item><c>OpenAI</c> (or any OpenAI-compatible gateway) → <c>/v1/images/generations</c>.</item>
+///   <item><c>Automatic1111</c> / <c>ComfyUI</c> / <c>StableDiffusion</c> / <c>Local</c> → A1111 <c>/sdapi/v1/txt2img</c>.</item>
+///   <item><c>Ollama</c> → surfaced as unsupported (Ollama has no text-to-image endpoint).</item>
+/// </list>
+/// Every HTTP round runs through the shared <see cref="IoPoolNames.Http"/> I/O pool — never on the
+/// hub scheduler, never <c>Observable.FromAsync</c> — and the public surface stays
+/// <see cref="IObservable{T}"/> end to end.
+/// </summary>
+public sealed class ImageGenerator : IImageGenerator
+{
+    private readonly IMeshService meshService;
+    private readonly ChatClientCredentialResolver resolver;
+    private readonly IIoPool httpPool;
+    private readonly HttpClient httpClient;
+    private readonly JsonSerializerOptions jsonOptions;
+    private readonly ILogger<ImageGenerator>? logger;
+
+    /// <summary>Creates the generator, resolving its collaborators from <paramref name="services"/>.</summary>
+    public ImageGenerator(IServiceProvider services)
+    {
+        meshService = services.GetRequiredService<IMeshService>();
+        resolver = services.GetRequiredService<ChatClientCredentialResolver>();
+        httpPool = services.GetRequiredService<IoPoolRegistry>().Get(IoPoolNames.Http);
+        httpClient = services.GetService<IHttpClientFactory>()?.CreateClient(nameof(ImageGenerator)) ?? new HttpClient();
+        jsonOptions = services.GetRequiredService<IMessageHub>().JsonSerializerOptions;
+        logger = services.GetService<ILogger<ImageGenerator>>();
+    }
+
+    /// <inheritdoc />
+    public IObservable<GeneratedImage> GenerateImageAsync(
+        string prompt, string? size = null, string? modelId = null, CancellationToken ct = default)
+        => ResolveImageModel(modelId)
+            .SelectMany(def =>
+            {
+                // Endpoint + key from the ModelProvider node (ApiKey already decrypted), falling back
+                // to any endpoint stamped directly on the model.
+                var creds = resolver.Resolve(def.Id);
+                var endpoint = FirstNonEmpty(creds.Endpoint, def.Endpoint);
+                // Bound + off-hub: the whole HTTP round runs on the shared Http I/O pool.
+                return httpPool.Invoke(token => GenerateCore(def, endpoint, creds.ApiKey, prompt, size, token));
+            });
+
+    /// <summary>
+    /// Picks the image model: the one whose id matches <paramref name="modelId"/>, or — when none is
+    /// given — the first <see cref="ModelCapability.Image"/> model by <see cref="ModelDefinition.Order"/>.
+    /// Listing models is a legitimate query use (not a single-node content read).
+    /// </summary>
+    private IObservable<ModelDefinition> ResolveImageModel(string? modelId)
+        => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{LanguageModelNodeType.NodeType}"))
+            .Take(1)
+            .Select(change =>
+            {
+                var defs = change.Items
+                    .Select(n => n.ContentAs<ModelDefinition>(jsonOptions, logger))
+                    .Where(d => d is not null)
+                    .Select(d => d!)
+                    .ToList();
+                var chosen = !string.IsNullOrWhiteSpace(modelId)
+                    ? defs.FirstOrDefault(d => string.Equals(d.Id, modelId, StringComparison.OrdinalIgnoreCase))
+                    : defs.Where(d => d.Capability == ModelCapability.Image)
+                          .OrderBy(d => d.Order).ThenBy(d => d.Id, StringComparer.OrdinalIgnoreCase)
+                          .FirstOrDefault();
+                return chosen ?? throw new InvalidOperationException(
+                    "No image-generation model is configured. Create a Model with Capability = Image under a Provider " +
+                    "(Azure OpenAI Images, OpenAI, or a local Stable-Diffusion endpoint such as Automatic1111 / ComfyUI).");
+            });
+
+    private async Task<GeneratedImage> GenerateCore(
+        ModelDefinition def, string? endpoint, string? apiKey, string prompt, string? size, CancellationToken ct)
+    {
+        var provider = (def.Provider ?? string.Empty).Trim();
+        if (provider.Equals("Ollama", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException(
+                "Ollama does not support image generation. Use Azure OpenAI Images, OpenAI, or a local " +
+                "Stable-Diffusion endpoint (Automatic1111 / ComfyUI).");
+        if (IsLocalStableDiffusion(provider))
+            return await GenerateStableDiffusion(endpoint, apiKey, prompt, size, ct).ConfigureAwait(false);
+        // OpenAI + Azure OpenAI + any OpenAI-compatible gateway share the /images/generations shape.
+        return await GenerateOpenAiImages(
+            azure: provider.Equals("AzureOpenAI", StringComparison.OrdinalIgnoreCase),
+            def, endpoint, apiKey, prompt, size, ct).ConfigureAwait(false);
+    }
+
+    private async Task<GeneratedImage> GenerateOpenAiImages(
+        bool azure, ModelDefinition def, string? endpoint, string? apiKey, string prompt, string? size, CancellationToken ct)
+    {
+        var body = new Dictionary<string, object?> { ["prompt"] = prompt, ["n"] = 1 };
+        if (!string.IsNullOrWhiteSpace(size)) body["size"] = size;
+
+        string url;
+        HttpRequestMessage request;
+        if (azure)
+        {
+            if (string.IsNullOrWhiteSpace(endpoint))
+                throw new InvalidOperationException("The Azure OpenAI image model needs an Endpoint on its Provider node.");
+            url = $"{endpoint.TrimEnd('/')}/openai/deployments/{Uri.EscapeDataString(def.Id)}/images/generations?api-version=2024-10-21";
+            request = new HttpRequestMessage(HttpMethod.Post, url);
+            if (!string.IsNullOrWhiteSpace(apiKey))
+                request.Headers.TryAddWithoutValidation("api-key", apiKey);
+        }
+        else
+        {
+            var baseUrl = string.IsNullOrWhiteSpace(endpoint) ? "https://api.openai.com" : endpoint.TrimEnd('/');
+            url = $"{baseUrl}/v1/images/generations";
+            body["model"] = def.Id;
+            request = new HttpRequestMessage(HttpMethod.Post, url);
+            if (!string.IsNullOrWhiteSpace(apiKey))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        }
+        request.Content = JsonBody(body);
+
+        using (request)
+        using (var resp = await httpClient.SendAsync(request, ct).ConfigureAwait(false))
+        {
+            var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+                throw new InvalidOperationException($"Image API returned {(int)resp.StatusCode}: {Truncate(text)}");
+
+            using var doc = JsonDocument.Parse(text);
+            if (!doc.RootElement.TryGetProperty("data", out var data)
+                || data.ValueKind != JsonValueKind.Array || data.GetArrayLength() == 0)
+                throw new InvalidOperationException("Image API response contained no data.");
+            var first = data[0];
+            if (first.TryGetProperty("b64_json", out var b64) && b64.ValueKind == JsonValueKind.String)
+                return new GeneratedImage(Convert.FromBase64String(b64.GetString()!), "image/png");
+            if (first.TryGetProperty("url", out var urlEl) && urlEl.ValueKind == JsonValueKind.String)
+            {
+                var bytes = await httpClient.GetByteArrayAsync(urlEl.GetString()!, ct).ConfigureAwait(false);
+                return new GeneratedImage(bytes, "image/png");
+            }
+            throw new InvalidOperationException("Image API response contained no image bytes.");
+        }
+    }
+
+    private async Task<GeneratedImage> GenerateStableDiffusion(
+        string? endpoint, string? apiKey, string prompt, string? size, CancellationToken ct)
+    {
+        var baseUrl = (string.IsNullOrWhiteSpace(endpoint) ? "http://127.0.0.1:7860" : endpoint).TrimEnd('/');
+        var (width, height) = ParseSize(size, 512);
+        var body = new Dictionary<string, object?>
+        {
+            ["prompt"] = prompt,
+            ["steps"] = 20,
+            ["width"] = width,
+            ["height"] = height,
+        };
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/sdapi/v1/txt2img") { Content = JsonBody(body) };
+        if (!string.IsNullOrWhiteSpace(apiKey))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        using var resp = await httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Stable-Diffusion endpoint returned {(int)resp.StatusCode}: {Truncate(text)}");
+
+        using var doc = JsonDocument.Parse(text);
+        if (!doc.RootElement.TryGetProperty("images", out var images)
+            || images.ValueKind != JsonValueKind.Array || images.GetArrayLength() == 0)
+            throw new InvalidOperationException("Stable-Diffusion response contained no images.");
+        var b64 = images[0].GetString() ?? throw new InvalidOperationException("Stable-Diffusion image was empty.");
+        // Strip an optional data: URI prefix ("data:image/png;base64,....").
+        if (b64.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+        {
+            var comma = b64.IndexOf(',');
+            if (comma >= 0) b64 = b64[(comma + 1)..];
+        }
+        return new GeneratedImage(Convert.FromBase64String(b64), "image/png");
+    }
+
+    private static HttpContent JsonBody(object body)
+        => new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+
+    private static bool IsLocalStableDiffusion(string provider)
+        => provider.Equals("Automatic1111", StringComparison.OrdinalIgnoreCase)
+        || provider.Equals("A1111", StringComparison.OrdinalIgnoreCase)
+        || provider.Equals("StableDiffusion", StringComparison.OrdinalIgnoreCase)
+        || provider.Equals("ComfyUI", StringComparison.OrdinalIgnoreCase)
+        || provider.Equals("Local", StringComparison.OrdinalIgnoreCase);
+
+    private static string? FirstNonEmpty(params string?[] values)
+        => values.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+
+    private static (int width, int height) ParseSize(string? size, int fallback)
+    {
+        if (!string.IsNullOrWhiteSpace(size))
+        {
+            var parts = size.Split('x', 'X');
+            if (parts.Length == 2 && int.TryParse(parts[0], out var w) && int.TryParse(parts[1], out var h))
+                return (w, h);
+        }
+        return (fallback, fallback);
+    }
+
+    private static string Truncate(string s) => s.Length <= 500 ? s : s[..500];
+}

--- a/src/MeshWeaver.AI/ImageGenerator.cs
+++ b/src/MeshWeaver.AI/ImageGenerator.cs
@@ -42,7 +42,9 @@ public sealed class ImageGenerator : IImageGenerator
         meshService = services.GetRequiredService<IMeshService>();
         resolver = services.GetRequiredService<ChatClientCredentialResolver>();
         httpPool = services.GetRequiredService<IoPoolRegistry>().Get(IoPoolNames.Http);
-        httpClient = services.GetService<IHttpClientFactory>()?.CreateClient(nameof(ImageGenerator)) ?? new HttpClient();
+        // Named, factory-pooled client — never a raw `new HttpClient()` per transient instance
+        // (handler/socket exhaustion). AddAgentChatServices registers the named client + the factory.
+        httpClient = services.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(ImageGenerator));
         jsonOptions = services.GetRequiredService<IMessageHub>().JsonSerializerOptions;
         logger = services.GetService<ILogger<ImageGenerator>>();
     }
@@ -57,8 +59,13 @@ public sealed class ImageGenerator : IImageGenerator
                 // to any endpoint stamped directly on the model.
                 var creds = resolver.Resolve(def.Id);
                 var endpoint = FirstNonEmpty(creds.Endpoint, def.Endpoint);
-                // Bound + off-hub: the whole HTTP round runs on the shared Http I/O pool.
-                return httpPool.Invoke(token => GenerateCore(def, endpoint, creds.ApiKey, prompt, size, token));
+                // Bound + off-hub: the whole HTTP round runs on the shared Http I/O pool. Link the
+                // caller's token with the pool's so an explicit cancellation is honoured too.
+                return httpPool.Invoke(async token =>
+                {
+                    using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, token);
+                    return await GenerateCore(def, endpoint, creds.ApiKey, prompt, size, linked.Token).ConfigureAwait(false);
+                });
             });
 
     /// <summary>
@@ -146,8 +153,11 @@ public sealed class ImageGenerator : IImageGenerator
                 return new GeneratedImage(Convert.FromBase64String(b64.GetString()!), "image/png");
             if (first.TryGetProperty("url", out var urlEl) && urlEl.ValueKind == JsonValueKind.String)
             {
-                var bytes = await httpClient.GetByteArrayAsync(urlEl.GetString()!, ct).ConfigureAwait(false);
-                return new GeneratedImage(bytes, "image/png");
+                using var imgResp = await httpClient.GetAsync(urlEl.GetString()!, ct).ConfigureAwait(false);
+                imgResp.EnsureSuccessStatusCode();
+                var mediaType = imgResp.Content.Headers.ContentType?.MediaType ?? "image/png";
+                var bytes = await imgResp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
+                return new GeneratedImage(bytes, mediaType);
             }
             throw new InvalidOperationException("Image API response contained no image bytes.");
         }

--- a/src/MeshWeaver.AI/ModelDefinition.cs
+++ b/src/MeshWeaver.AI/ModelDefinition.cs
@@ -107,6 +107,16 @@ public record ModelDefinition
     public string? Currency { get; init; }
 
     /// <summary>
+    /// What the model DOES — chat completion (default), text embedding, or raster
+    /// image generation. Lets one catalog hold chat models AND image models: the
+    /// image generator (<c>IImageGenerator</c>) selects the first model whose
+    /// <see cref="Capability"/> is <see cref="ModelCapability.Image"/>. Existing chat
+    /// catalog rollouts leave this at the default (<see cref="ModelCapability.Chat"/>).
+    /// </summary>
+    [System.ComponentModel.Description("Capability: Chat, Embedding, or Image")]
+    public ModelCapability Capability { get; init; } = ModelCapability.Chat;
+
+    /// <summary>
     /// Projects this definition into the lighter <see cref="ModelInfo"/>
     /// shape consumed by the chat picker.
     /// </summary>
@@ -116,4 +126,18 @@ public record ModelDefinition
         Provider = Provider,
         Order = Order != 0 ? Order : factoryOrder
     };
+}
+
+/// <summary>
+/// What a <see cref="ModelDefinition"/> is used for. A single model catalog can hold
+/// chat, embedding, and image models side by side; the consumer filters by capability.
+/// </summary>
+public enum ModelCapability
+{
+    /// <summary>Chat completion (the default) — consumed by <c>IChatClientFactory</c>.</summary>
+    Chat = 0,
+    /// <summary>Text embedding — consumed by the embedding pipeline.</summary>
+    Embedding = 1,
+    /// <summary>Text-to-image (raster) generation — consumed by <c>IImageGenerator</c>.</summary>
+    Image = 2,
 }

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -67,6 +67,10 @@ else
                     <FluentIcon Value="@(new Icons.Regular.Size16.Navigation())" Color="Color.Neutral" />
                 </button>
                 <span class="thread-nav-title">Threads</span>
+                <button class="thread-nav-new" @onclick="StartNewComposer"
+                        title="New chat — start a fresh, empty composer (keeps your harness/agent/model)">
+                    <FluentIcon Value="@(new Icons.Regular.Size16.Add())" Color="Color.Neutral" />
+                </button>
             </div>
 
             @if (!string.IsNullOrEmpty(navCtx))

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -2915,6 +2915,44 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     }
 
     /// <summary>
+    /// "New chat" from the in-thread navigation menu: clears the in-progress draft (message text +
+    /// attachments) on the per-user default <c>ThreadComposer</c> node — KEEPING harness/agent/model —
+    /// then navigates to the standalone composer page (<c>/chat</c>). Mirrors the side panel's New-Chat
+    /// button (<see cref="ThreadSidePanelContent.OnNewChat"/>); no thread is created here (a thread is
+    /// only created on submit). Ensures the node exists first (benign create) so clearing a
+    /// not-yet-materialised default composer does not NotFound-storm the partition hub on Update.
+    /// </summary>
+    private void StartNewComposer()
+    {
+        var defaultPath = string.IsNullOrEmpty(_userHome)
+            ? null : MeshWeaver.AI.ThreadComposerNodeType.PathFor(_userHome);
+        if (!string.IsNullOrEmpty(defaultPath))
+        {
+            void Clear() => UpdateMeshNodeAsCircuitUser(defaultPath!, node =>
+            {
+                if (node is null) return node!;
+                var ci = node.ContentAs<MeshWeaver.AI.ThreadComposer>(Hub.JsonSerializerOptions, Logger);
+                if (ci is null) return node;
+                if (string.IsNullOrEmpty(ci.MessageContent)
+                    && (ci.Attachments is null || ci.Attachments.Count == 0)
+                    && ci.OpenThreadPath is null)
+                    return node;
+                return node with { Content = ci with { MessageContent = null, Attachments = null, OpenThreadPath = null } };
+            }, ex => SurfaceError(ex, "Starting a new chat"));
+
+            // Create the node (benign if it already exists), THEN clear — CreateNode registers a routable
+            // node, unlike Update which only patches an existing one (see ApplyComposerSelection).
+            MeshQuery.CreateNode(MeshWeaver.Mesh.MeshNode.FromPath(defaultPath!) with
+            {
+                NodeType = MeshWeaver.AI.ThreadComposerNodeType.NodeType,
+                Name = "Chat Input",
+                Content = new MeshWeaver.AI.ThreadComposer()
+            }).Subscribe(_ => InvokeAsync(Clear), _ => InvokeAsync(Clear));
+        }
+        NavigationManager.NavigateTo("/chat");
+    }
+
+    /// <summary>
     /// Option-Tab handler: cycles to the NEXT of my other open threads and opens it. Wraps around;
     /// no-op when there are none. Bound on the thread container's keydown (Alt+Tab / Option-Tab).
     /// </summary>

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
@@ -1634,6 +1634,7 @@ button.thread-chat-status-item {
 }
 
 .thread-nav-cycle,
+.thread-nav-new,
 .thread-nav-reveal {
     appearance: none;
     -webkit-appearance: none;
@@ -1648,7 +1649,12 @@ button.thread-chat-status-item {
     color: var(--neutral-foreground-rest);
 }
 .thread-nav-cycle:hover,
+.thread-nav-new:hover,
 .thread-nav-reveal:hover { background: var(--neutral-fill-stealth-hover); }
+
+/* "New chat" sits at the end of the toolbar (after the title, which is hidden in top-bar mode). */
+.thread-nav-new { margin-left: auto; }
+.nav-topbar .thread-nav-new { margin-left: 0; }
 
 /* Hidden state: a small inline reveal toggle above the conversation. */
 .thread-nav-reveal {

--- a/src/MeshWeaver.Graph/CreateLayoutArea.cs
+++ b/src/MeshWeaver.Graph/CreateLayoutArea.cs
@@ -506,7 +506,8 @@ public static class CreateLayoutArea
         const string boxStyle = "width:48px;height:48px;display:flex;align-items:center;justify-content:center;border:1px solid var(--neutral-stroke-rest);border-radius:6px;color:var(--neutral-foreground-rest);";
         if (icon.TrimStart().StartsWith("<svg", StringComparison.OrdinalIgnoreCase))
             return Controls.Html($"<div style=\"{boxStyle}\">{icon}</div>");
-        if (icon.StartsWith("http", StringComparison.OrdinalIgnoreCase) || icon.StartsWith("/"))
+        if (icon.StartsWith("http", StringComparison.OrdinalIgnoreCase) || icon.StartsWith("/")
+            || icon.StartsWith("data:image", StringComparison.OrdinalIgnoreCase))
             return Controls.Html($"<div style=\"{boxStyle}\"><img src=\"{System.Web.HttpUtility.HtmlAttributeEncode(icon)}\" style=\"max-width:32px;max-height:32px;\" /></div>");
         return Controls.Html($"<div style=\"{boxStyle}\"><span style=\"font-size:12px;\">{System.Web.HttpUtility.HtmlEncode(icon)}</span></div>");
     }
@@ -525,28 +526,115 @@ public static class CreateLayoutArea
                 "Icon generator service is not registered. Call AddAgentChatServices().");
             return Task.CompletedTask;
         }
+
+        // Patch specific keys onto the LATEST form snapshot (re-read each time) so a field the
+        // user edits while the (multi-second) icon round runs is not clobbered by a stale copy.
+        void PatchForm(Action<Dictionary<string, object?>> mutate) =>
+            actx.Host.Stream.GetDataStream<Dictionary<string, object?>>(formId).Take(1).Subscribe(form =>
+            {
+                var next = form is null ? new Dictionary<string, object?>() : new Dictionary<string, object?>(form);
+                mutate(next);
+                actx.Host.UpdateData(formId, next);
+            });
+
+        // Single reactive chain (no nested Subscribe): read the form → generate → write back.
         actx.Host.Stream.GetDataStream<Dictionary<string, object?>>(formId)
             .Take(1)
-            .Subscribe(form =>
+            .SelectMany(form =>
             {
                 var currentName = form?.GetValueOrDefault("name")?.ToString() ?? "";
-                var currentDesc = form?.GetValueOrDefault("description")?.ToString();
-                if (string.IsNullOrWhiteSpace(currentName) && string.IsNullOrWhiteSpace(currentDesc))
+                // Prefer the dedicated icon description; fall back to the node description.
+                var iconDesc = form?.GetValueOrDefault("iconDescription")?.ToString();
+                if (string.IsNullOrWhiteSpace(iconDesc))
+                    iconDesc = form?.GetValueOrDefault("description")?.ToString();
+                if (string.IsNullOrWhiteSpace(currentName) && string.IsNullOrWhiteSpace(iconDesc))
                 {
                     ShowErrorDialog(actx, "Regenerate Icon",
                         "Enter a Name or Description first — the agent uses those to craft the icon.");
-                    return;
+                    return Observable.Empty<string>();
                 }
-                generator.GenerateSvgAsync(currentName, currentDesc).Subscribe(
-                    svg =>
-                    {
-                        var updated = form is null
-                            ? new Dictionary<string, object?> { ["icon"] = svg }
-                            : new Dictionary<string, object?>(form) { ["icon"] = svg };
-                        actx.Host.UpdateData(formId, updated);
-                    },
-                    ex => ShowErrorDialog(actx, "Icon Generation Failed", ex.Message));
+                // Spinner up immediately so the button gives feedback during the agent turn.
+                PatchForm(f => f["iconGenerating"] = true);
+                // Bound the round: a missing / non-responding utility-tier model must surface as a
+                // VISIBLE error, never an indefinite silent hang (ErrorPropagationAndWedges) — the
+                // "pressing the button does nothing" report.
+                return generator.GenerateSvgAsync(currentName, iconDesc)
+                    .Timeout(TimeSpan.FromSeconds(90));
+            })
+            .Subscribe(
+                svg => PatchForm(f => { f["icon"] = svg; f["iconGenerating"] = false; }),
+                ex =>
+                {
+                    PatchForm(f => f["iconGenerating"] = false);
+                    ShowErrorDialog(actx, "Icon Generation Failed",
+                        ex is TimeoutException
+                            ? "The icon agent didn't respond in time. Make sure a utility-tier model is configured for icon generation."
+                            : ex.Message);
+                });
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Handles the Create form's "Generate image" click: builds a prompt from Name + Icon description,
+    /// invokes <see cref="IImageGenerator"/> (a configured image model — Azure OpenAI Images, OpenAI, or a
+    /// local Stable-Diffusion endpoint), and writes the resulting PNG back into the form's "icon" slot as a
+    /// <c>data:</c> URI. Inline storage is deliberate here: the node does not exist yet, so a data URI is
+    /// self-contained and renders directly (a content-collection URL is a follow-up for large images).
+    /// </summary>
+    private static Task RegenerateFormImage(UiActionContext actx, string formId)
+    {
+        var generator = actx.Host.Hub.ServiceProvider.GetService<IImageGenerator>();
+        if (generator == null)
+        {
+            ShowErrorDialog(actx, "Generate Image",
+                "Image generator service is not registered. Call AddAgentChatServices().");
+            return Task.CompletedTask;
+        }
+
+        void PatchForm(Action<Dictionary<string, object?>> mutate) =>
+            actx.Host.Stream.GetDataStream<Dictionary<string, object?>>(formId).Take(1).Subscribe(form =>
+            {
+                var next = form is null ? new Dictionary<string, object?>() : new Dictionary<string, object?>(form);
+                mutate(next);
+                actx.Host.UpdateData(formId, next);
             });
+
+        actx.Host.Stream.GetDataStream<Dictionary<string, object?>>(formId)
+            .Take(1)
+            .SelectMany(form =>
+            {
+                var name = form?.GetValueOrDefault("name")?.ToString() ?? "";
+                // Prefer the dedicated icon description; fall back to the node description.
+                var iconDesc = form?.GetValueOrDefault("iconDescription")?.ToString();
+                if (string.IsNullOrWhiteSpace(iconDesc))
+                    iconDesc = form?.GetValueOrDefault("description")?.ToString();
+                var prompt = string.Join(". ", new[] { name, iconDesc }.Where(s => !string.IsNullOrWhiteSpace(s)));
+                if (string.IsNullOrWhiteSpace(prompt))
+                {
+                    ShowErrorDialog(actx, "Generate Image",
+                        "Enter a Name or an Icon description first — the image model uses those as the prompt.");
+                    return Observable.Empty<GeneratedImage>();
+                }
+                PatchForm(f => f["iconGenerating"] = true);
+                // Bound the round: a missing / non-responding image endpoint must surface as a VISIBLE
+                // error, never an indefinite silent hang (ErrorPropagationAndWedges).
+                return generator.GenerateImageAsync(prompt)
+                    .Timeout(TimeSpan.FromSeconds(120));
+            })
+            .Subscribe(
+                image =>
+                {
+                    var dataUrl = $"data:{image.ContentType};base64,{Convert.ToBase64String(image.Data)}";
+                    PatchForm(f => { f["icon"] = dataUrl; f["iconGenerating"] = false; });
+                },
+                ex =>
+                {
+                    PatchForm(f => f["iconGenerating"] = false);
+                    ShowErrorDialog(actx, "Image Generation Failed",
+                        ex is TimeoutException
+                            ? "The image model didn't respond in time. Check the image model / endpoint configuration."
+                            : ex.Message);
+                });
         return Task.CompletedTask;
     }
 
@@ -650,6 +738,7 @@ public static class CreateLayoutArea
             ["name"] = "",
             ["id"] = "",
             ["description"] = "",
+            ["iconDescription"] = "",
             ["icon"] = defaultTypeIcon ?? ""
         });
         var dataContext = LayoutAreaReference.GetDataPointer(formId);
@@ -754,9 +843,21 @@ public static class CreateLayoutArea
             DataContext = dataContext
         }.WithRows(3).WithStyle("width: 100%; margin-bottom: 16px;"));
 
+        // 8b. Icon description — an OPTIONAL, dedicated seed for the avatar/icon generator,
+        //     separate from the node Description so the user can steer the icon's imagery
+        //     ("a friendly robot holding a compass") without changing what the node is about.
+        //     Falls back to the Description above when left empty.
+        stack = stack.WithView(new TextAreaControl(new JsonPointerReference("iconDescription"))
+        {
+            Label = "Icon description (optional)",
+            Placeholder = "Describe the icon/avatar to generate — e.g. \"a friendly robot holding a compass\". Falls back to the description above.",
+            Immediate = true,
+            DataContext = dataContext
+        }.WithRows(2).WithStyle("width: 100%; margin-bottom: 16px;"));
+
         // 9. Icon: "Icon" label, live preview, Regenerate button.
         // Preview is data-bound so it reflects live updates (default from the chosen type,
-        // or a regenerated SVG from the Node Initializer agent).
+        // a regenerated SVG from the Node Initializer agent, or a spinner while generating).
         stack = stack.WithView(Controls.Body("Icon")
             .WithStyle("font-weight: 600; display: block; margin-bottom: 6px;"));
         stack = stack.WithView(Controls.Stack
@@ -766,6 +867,12 @@ public static class CreateLayoutArea
             .WithView((h, _) => h.Stream.GetDataStream<Dictionary<string, object?>>(formId)
                 .Select(form =>
                 {
+                    // "iconGenerating" flips true while the agent round runs so the preview shows
+                    // activity — the round is a full agent turn (seconds), so without this the
+                    // Regenerate button looks dead. Value survives a JSON round-trip as either a
+                    // CLR bool ("True") or a JsonElement ("true"), so compare case-insensitively.
+                    if (string.Equals(form?.GetValueOrDefault("iconGenerating")?.ToString(), "true", StringComparison.OrdinalIgnoreCase))
+                        return Controls.Progress("Generating…", 0);
                     var icon = form?.GetValueOrDefault("icon")?.ToString() ?? "";
                     return string.IsNullOrEmpty(icon)
                         ? Controls.Html("<div style=\"width:48px;height:48px;border:1px dashed var(--neutral-stroke-rest);border-radius:6px;\"></div>")
@@ -774,7 +881,13 @@ public static class CreateLayoutArea
             .WithView(Controls.Button("Regenerate")
                 .WithAppearance(Appearance.Neutral)
                 .WithIconStart(FluentIcons.Sparkle())
-                .WithClickAction(actx => RegenerateFormIcon(actx, formId))));
+                .WithClickAction(actx => RegenerateFormIcon(actx, formId)))
+            // "Generate image" — a real raster avatar via a configured image model (IImageGenerator),
+            // as opposed to "Regenerate" which draws a vector SVG through the NodeInitializer agent.
+            .WithView(Controls.Button("Generate image")
+                .WithAppearance(Appearance.Neutral)
+                .WithIconStart(FluentIcons.Image())
+                .WithClickAction(actx => RegenerateFormImage(actx, formId))));
 
         // 10. Button row: Cancel on left, Create on right
         var cancelUrl = MeshNodeLayoutAreas.BuildUrl(parentPath, MeshNodeLayoutAreas.OverviewArea);

--- a/src/MeshWeaver.Mesh.Contract/Services/IImageGenerator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IImageGenerator.cs
@@ -1,0 +1,30 @@
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// A generated raster image — the bytes plus their MIME type (typically <c>image/png</c>).
+/// </summary>
+/// <param name="Data">The encoded image bytes.</param>
+/// <param name="ContentType">The MIME type, e.g. <c>image/png</c>.</param>
+public sealed record GeneratedImage(byte[] Data, string ContentType);
+
+/// <summary>
+/// Generates a <b>raster</b> image (PNG) from a text prompt using a configured
+/// image-generation model — the companion to <see cref="IIconGenerator"/> (which produces
+/// vector SVG via an LLM). Implementations route the HTTP round through the I/O pool and
+/// select the backend (Azure OpenAI Images, OpenAI, or a local Stable-Diffusion endpoint)
+/// from the chosen model's provider.
+/// </summary>
+public interface IImageGenerator
+{
+    /// <summary>
+    /// Produces a raster image for <paramref name="prompt"/>. Emits exactly once on success;
+    /// OnError on failure (no image model configured, provider unsupported, network error,
+    /// cancellation).
+    /// </summary>
+    /// <param name="prompt">The text description of the image to generate.</param>
+    /// <param name="size">Optional <c>WxH</c> hint (e.g. <c>1024x1024</c>); backend default when null.</param>
+    /// <param name="modelId">Optional explicit image-model id; the first image-capable model when null.</param>
+    /// <param name="ct">Cancels the underlying HTTP round.</param>
+    IObservable<GeneratedImage> GenerateImageAsync(
+        string prompt, string? size = null, string? modelId = null, CancellationToken ct = default);
+}


### PR DESCRIPTION
## Summary
Four UI/AI features, wired on the framework's existing pieces:

1. **Thread-nav "New chat" button** — clears the per-user composer draft (keeps harness/agent/model) and opens a fresh `/chat` composer. `ThreadChatView`.
2. **AI catalog scope tabs + create** — Agents/Skills/Providers/Models now render tabbed scope catalogs (**This space · User · Global**) with a per-tab **"+" create**, replacing the flat `/search?groupBy=Namespace` targets that offered no way to create. New `AiCatalogLayoutAreas` (mirrors `ThreadsView`); AI menu repointed to the type-root catalog areas.
3. **Create-Agent icon fix + avatar box** — the icon "Regenerate" ran a full LLM round with no feedback and no bound (the "button does nothing" report); now a spinner + single `SelectMany` chain + 90s timeout → visible error. Plus a dedicated **"Icon description"** box (falls back to Description).
4. **Image-generation models (first increment)** — `ModelCapability` enum + field on `ModelDefinition`; `IImageGenerator`/`GeneratedImage`; an `ImageGenerator` that dispatches by provider to **Azure OpenAI Images / OpenAI / a local Stable-Diffusion endpoint (Automatic1111/ComfyUI)**, all `IIoPool`-routed (**Ollama** surfaced as unsupported — it has no text-to-image endpoint). A **"Generate image"** button on the create form yields a `data:`-URL avatar. Configure by creating a `ModelProvider` + a `LanguageModel` with `Capability = Image` (now creatable via #2).

## Notes
- Compile-verified (Release `-warnaserror`, 0 warnings), **not yet run live**.
- Follow-ups: filter `Capability=Image` out of the chat model picker; content-collection URL storage for large rasters instead of an inline data URI; an image-model picker in the avatar UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)