### PR TITLE
feat(ts): node kernel worker (run js/ts Code nodes) + hub programming model in Node

### DIFF
--- a/clients/typescript/.gitignore
+++ b/clients/typescript/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 dist/
 *.tsbuildinfo
+dist/
+node_modules/
+package-lock.json

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -35,6 +35,41 @@ for await (const node of mesh.watch("ACME/Backlog")) handle(node);   // live str
 mesh.close();
 ```
 
+## The node kernel — run `javascript` / `typescript` Code nodes
+
+A Code node whose `Language` is `javascript` or `typescript` has no in-process runtime on the mesh,
+so the .NET kernel routes its `SubmitCodeRequest` to a connected `node/*` worker
+(`CodeNodeType.ResolveKernelAddress` → `node/node-kernel`). This package ships that worker. It runs
+the snippet in a `vm` sandbox with REPL semantics (`console.log` captured; a trailing bare expression
+is the return value; `Inputs` exposes caller parameters; TypeScript is transpiled first) and patches
+the run's Activity node — so js/ts output surfaces identically to C# and python.
+
+```bash
+npm run build
+node dist/worker.js --url https://memex.meshweaver.cloud --token mw_... --address node/node-kernel
+# co-deployed gate (trusted loopback endpoint, no token; --reconnect outlives portal restarts):
+node dist/worker.js --url http://127.0.0.1:8082 --address node/node-kernel --reconnect
+node dist/worker.js --demo     # self-contained smoke test: execute a JS + a TS snippet
+```
+
+`npm test` executes real js/ts snippets through the kernel's `executeCode` core.
+
+## Define and run a hub in Node
+
+A hub is an **address** deliveries route to, **handlers** by message type (the C# `WithHandler<T>`),
+and **state** the handlers own. `Hub` (`src/examples/hub.ts`) is exactly that:
+
+```ts
+import { connect, Hub } from "@meshweaver/client";
+
+const conn = await connect("https://memex.meshweaver.cloud", { token: "mw_...", address: "node/counter" });
+let count = 0;
+new Hub(conn)
+  .register("Increment", (d) => { count += Number(d.message.by ?? 1); return ["Count", { value: count }]; })
+  .register("GetCount", () => ["Count", { value: count }]);
+// any participant: observe("node/counter", "Increment", { by: 5 }) → { value: 5 }
+```
+
 ## Status
 
 - **Transport / correlation / stream-demux** — complete and protocol-faithful (mirrors

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -11,17 +11,22 @@
       "import": "./dist/index.js"
     }
   },
+  "bin": {
+    "meshweaver-node-worker": "./dist/worker.js"
+  },
   "files": ["dist", "README.md"],
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsc && node --test test/*.test.mjs",
+    "demo": "tsc && node dist/worker.js --demo"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.12.0",
-    "@grpc/proto-loader": "^0.7.13"
+    "@grpc/proto-loader": "^0.7.13",
+    "typescript": "^5.6.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.6.0"
+    "@types/node": "^22.0.0"
   }
 }

--- a/clients/typescript/src/connection.ts
+++ b/clients/typescript/src/connection.ts
@@ -29,6 +29,7 @@ export class MeshConnection {
   private readonly call: DuplexCall;
   private readonly pending = new Map<string, (d: Delivery) => void>();
   private readonly subscriptions = new Map<string, (d: Delivery) => void>();
+  private inbound: ((d: Delivery) => void | Promise<void>) | null = null;
 
   private constructor(address: string, call: DuplexCall) {
     this.address = address;
@@ -82,7 +83,31 @@ export class MeshConnection {
     }
     // 2) live-stream change → demux by StreamId carried in the change message
     const streamId = (delivery.message["streamId"] ?? delivery.message["StreamId"]) as string | undefined;
-    if (streamId && this.subscriptions.has(streamId)) this.subscriptions.get(streamId)!(delivery);
+    if (streamId && this.subscriptions.has(streamId)) { this.subscriptions.get(streamId)!(delivery); return; }
+    // 3) an unsolicited inbound request targeted at us (e.g. SubmitCodeRequest) → the served handler
+    if (this.inbound) void this.inbound(delivery);
+  }
+
+  /**
+   * Register the handler for unsolicited inbound deliveries — requests targeted at THIS participant
+   * (a SubmitCodeRequest for a worker, a PandasCommand for the pandas node, …). Responses and
+   * live-stream frames are dispatched before this; the handler only sees genuine inbound requests.
+   */
+  serve(handler: (d: Delivery) => void | Promise<void>): void {
+    this.inbound = handler;
+  }
+
+  /**
+   * Reply to a request delivery. Correlated by RequestId = the request's id and routed back to its
+   * sender, so a caller's `observe(...)` resolves. `accessContext` may echo the request's identity.
+   */
+  respond(request: Delivery, messageType: string, message: Record<string, unknown>): void {
+    if (!request.sender) return;
+    const deliveryId = randomUUID().replace(/-/g, "");
+    this.call.write({ deliver: buildDeliver({
+      deliveryId, sender: this.address, target: request.sender, messageType, message,
+      requestId: request.id, accessContext: request.accessContext,
+    }) });
   }
 
   /** Post a request to `target` and await its response (correlated by RequestId). */
@@ -96,10 +121,11 @@ export class MeshConnection {
     });
   }
 
-  /** Fire-and-forget a message to `target`. */
-  post(target: string, messageType: string, message: Record<string, unknown>): void {
+  /** Fire-and-forget a message to `target`, optionally under the caller's `accessContext`. */
+  post(target: string, messageType: string, message: Record<string, unknown>,
+       accessContext?: Record<string, unknown>): void {
     const deliveryId = randomUUID().replace(/-/g, "");
-    this.call.write({ deliver: buildDeliver({ deliveryId, sender: this.address, target, messageType, message }) });
+    this.call.write({ deliver: buildDeliver({ deliveryId, sender: this.address, target, messageType, message, accessContext }) });
   }
 
   /** Open a live stream: post a subscribe request, then yield each change addressed back to us. */
@@ -121,6 +147,14 @@ export class MeshConnection {
     } finally {
       this.subscriptions.delete(streamId);
     }
+  }
+
+  /** Resolves when the underlying stream ends or errors — lets a gate detect a dropped portal and reconnect. */
+  waitClosed(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.call.on("end", () => resolve());
+      this.call.on("error", () => resolve());
+    });
   }
 
   close(): void {

--- a/clients/typescript/src/envelope.ts
+++ b/clients/typescript/src/envelope.ts
@@ -15,6 +15,7 @@ export interface Delivery {
   requestId?: string;
   messageType?: string;
   message: Record<string, unknown>;
+  accessContext?: Record<string, unknown>;
   raw: Record<string, unknown>;
 }
 
@@ -24,15 +25,21 @@ export function buildDeliver(opts: {
   target: string;
   messageType: string;
   message: Record<string, unknown>;
+  requestId?: string;
+  accessContext?: Record<string, unknown>;
 }): string {
-  return JSON.stringify({
+  const envelope: Record<string, unknown> = {
     [TYPE_KEY]: DELIVERY_TYPE,
     id: opts.deliveryId,
     sender: opts.sender,
     target: opts.target,
     message: { [TYPE_KEY]: opts.messageType, ...opts.message },
-    properties: {},
-  });
+    // A response carries the request's id under RequestId so the requester correlates it.
+    properties: opts.requestId ? { [REQUEST_ID]: opts.requestId } : {},
+  };
+  // Echo the caller's identity so a trusted worker writes AS the requesting user (see worker.ts).
+  if (opts.accessContext) envelope.accessContext = opts.accessContext;
+  return JSON.stringify(envelope);
 }
 
 export function parseDelivery(payload: string): Delivery {
@@ -46,6 +53,7 @@ export function parseDelivery(payload: string): Delivery {
     requestId: get(props, REQUEST_ID) as string | undefined,
     messageType: typeof message === "object" ? (message[TYPE_KEY] as string | undefined) : undefined,
     message: typeof message === "object" ? message : {},
+    accessContext: get(root, "accessContext") as Record<string, unknown> | undefined,
     raw: root,
   };
 }

--- a/clients/typescript/src/examples/hub.ts
+++ b/clients/typescript/src/examples/hub.ts
@@ -1,0 +1,70 @@
+// Define and run a HUB in Node. A hub on the mesh is three things (C#, python, and here alike): an
+// ADDRESS deliveries route to, HANDLERS keyed by message type (the C# `WithHandler<T>`), and STATE
+// the handlers own. `Hub` is exactly that in Node; the runnable example below is a stateful counter
+// hub other participants / agents drive over the mesh.
+//
+//   npm run build
+//   MESH_TOKEN=mw_... node dist/examples/hub.js          # → memex.meshweaver.cloud as node/counter
+//
+// Then from any participant: observe("node/counter", "Increment", { by: 5 }) → { value: 5 }.
+import { connect, MeshConnection } from "../connection.js";
+import type { Delivery } from "../envelope.js";
+
+/** A handler returns `[responseType, payload]` to reply (correlated to the sender), or `null` to stay silent. */
+export type Handler = (delivery: Delivery) =>
+  | [string, Record<string, unknown>] | null
+  | Promise<[string, Record<string, unknown>] | null>;
+
+/** The hub programming model in Node: an address, handlers by message type, owned state. */
+export class Hub {
+  private readonly handlers = new Map<string, Handler>();
+
+  constructor(private readonly conn: MeshConnection) {
+    conn.serve((d) => this.dispatch(d));
+  }
+
+  /** Register the handler for `messageType` — this hub's `WithHandler<T>`. Chainable. */
+  register(messageType: string, handler: Handler): this {
+    this.handlers.set(messageType, handler);
+    return this;
+  }
+
+  get address(): string {
+    return this.conn.address;
+  }
+
+  private async dispatch(delivery: Delivery): Promise<void> {
+    const handler = delivery.messageType ? this.handlers.get(delivery.messageType) : undefined;
+    if (!handler) return; // not one of ours — ignore quietly
+    try {
+      const reply = await handler(delivery);
+      if (reply) this.conn.respond(delivery, reply[0], reply[1]);
+    } catch (e) {
+      // A raising handler answers with an error instead of wedging — errors always propagate.
+      this.conn.respond(delivery, "ErrorResponse", { error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+}
+
+/** A runnable example: a stateful counter hub. `count` is the state the handlers own. */
+async function main(): Promise<void> {
+  const url = process.env.MESH_URL ?? "https://memex.meshweaver.cloud";
+  const address = process.env.MESH_ADDRESS ?? "node/counter";
+  const conn = await connect(url, { token: process.env.MESH_TOKEN, address });
+
+  let count = 0;
+  new Hub(conn)
+    .register("Increment", (d) => { count += Number(d.message.by ?? 1); return ["Count", { value: count }]; })
+    .register("GetCount", () => ["Count", { value: count }]);
+
+  console.log(`counter hub running as ${conn.address} → ${url}. Drive it with Increment / GetCount.`);
+  await new Promise<void>((resolve) => {
+    process.once("SIGINT", resolve);
+    process.once("SIGTERM", resolve);
+  });
+  conn.close();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -14,3 +14,7 @@ export { Mesh, type MeshOptions } from "./mesh.js";
 export { MeshConnection, connect, type ConnectOptions } from "./connection.js";
 export { type Delivery } from "./envelope.js";
 export { type MeshNode } from "./types.js";
+// The node kernel: execute javascript/typescript Code nodes routed from the mesh (node/node-kernel).
+export { executeCode, CodeWorker, serve as serveNodeKernel, DEFAULT_WORKER_ADDRESS, type ExecResult, type ServeOptions } from "./worker.js";
+// The hub programming model in Node (address + handlers by message type + state).
+export { Hub, type Handler } from "./examples/hub.js";

--- a/clients/typescript/src/worker.ts
+++ b/clients/typescript/src/worker.ts
@@ -1,0 +1,177 @@
+// The node kernel — the Node/Bun counterpart of clients/python's `meshweaver.worker`. A Code node
+// whose Language is `javascript` or `typescript` has no in-process runtime on the mesh, so the .NET
+// kernel routes its SubmitCodeRequest to a connected `node/*` worker (CodeNodeType.ResolveKernelAddress
+// → node/node-kernel). This module executes the snippet and writes the result to the SAME Activity
+// node subscribers already watch — so js/ts output surfaces identically to C# and python.
+//
+//   npx @meshweaver/node-worker --url https://memex.meshweaver.cloud --token mw_... --address node/node-kernel
+//   # co-deployed gate (trusted loopback, no token):
+//   node dist/worker.js --url http://127.0.0.1:8082 --address node/node-kernel --reconnect
+import * as vm from "node:vm";
+import { MeshConnection, connect } from "./connection.js";
+import type { Delivery } from "./envelope.js";
+
+/** The stable address the .NET kernel routes javascript/typescript submissions to. */
+export const DEFAULT_WORKER_ADDRESS = "node/node-kernel";
+
+export interface ExecResult {
+  stdout: string;
+  returnValue: unknown; // best-effort JSON-able (the trailing expression's value)
+  error: string | null; // the formatted throw, or null on success
+}
+
+function jsonable(value: unknown): unknown {
+  if (value === undefined) return null;
+  // Normalize to a plain JSON value — it crosses the wire as JSON, and this also detaches a vm-realm
+  // object from the sandbox's prototypes. Non-serializable values (functions, cycles) stringify.
+  try { return JSON.parse(JSON.stringify(value)); }
+  catch { return String(value); }
+}
+
+function fmt(a: unknown): string {
+  if (typeof a === "string") return a;
+  try { return JSON.stringify(a); } catch { return String(a); }
+}
+
+/** Strip TypeScript types → runnable JavaScript with the bundled compiler (lazy — plain-JS runs pay nothing). */
+async function transpileTs(code: string): Promise<string> {
+  const ts = (await import("typescript")).default;
+  return ts.transpileModule(code, {
+    compilerOptions: { target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.None },
+  }).outputText;
+}
+
+/**
+ * Execute a js/ts snippet in a fresh sandbox — the testable core (no mesh). REPL semantics matching
+ * the python worker: `console.log(...)` is captured as output, a trailing bare expression is the
+ * return value (vm's completion value), `Inputs` exposes caller parameters. Any throw is caught and
+ * formatted — a worker never wedges on a bad snippet.
+ */
+export async function executeCode(
+  code: string, language = "javascript", inputs: Record<string, unknown> = {},
+): Promise<ExecResult> {
+  const out: string[] = [];
+  const log = (...a: unknown[]) => { out.push(a.map(fmt).join(" ")); };
+  const sandbox: Record<string, unknown> = {
+    Inputs: inputs,
+    console: { log, info: log, warn: log, error: log, debug: log },
+  };
+  let returnValue: unknown = null;
+  let error: string | null = null;
+  try {
+    const js = language.toLowerCase() === "typescript" ? await transpileTs(code) : code;
+    returnValue = vm.runInNewContext(js, vm.createContext(sandbox), { timeout: 30_000, displayErrors: true });
+  } catch (e) {
+    error = e instanceof Error ? (e.stack ?? e.message) : String(e);
+  }
+  return { stdout: out.join("\n"), returnValue: jsonable(returnValue), error };
+}
+
+/** Serves SubmitCodeRequest deliveries: execute the js/ts and patch the run's Activity node. */
+export class CodeWorker {
+  constructor(private readonly conn: MeshConnection) {
+    conn.serve((d) => this.handle(d));
+  }
+
+  private async handle(delivery: Delivery): Promise<void> {
+    if (delivery.messageType !== "SubmitCodeRequest") return; // not ours — ignore quietly
+    const msg = delivery.message;
+    const code = (msg.code ?? msg.Code ?? "") as string;
+    const language = (msg.language ?? msg.Language ?? "javascript") as string;
+    const activityPath = (msg.activityLogPath ?? msg.ActivityLogPath) as string | undefined;
+    const inputs = (msg.inputs ?? msg.Inputs ?? {}) as Record<string, unknown>;
+
+    const result = await executeCode(code, language, inputs);
+    const status = result.error === null ? "Succeeded" : "Failed";
+    const messages = [result.stdout, result.error].filter((m): m is string => !!m).map((m) => ({ message: m }));
+
+    // Patch the Activity node (RFC 7396 merge under `patch`), under the requester's identity so a
+    // trusted worker writes AS the user whose Code node this run is — like the in-process C# kernel.
+    if (activityPath) {
+      this.conn.post(activityPath, "PatchDataRequest", {
+        reference: { $type: "MeshNodeReference" },
+        patch: { content: { status, messages, returnValue: result.returnValue } },
+      }, delivery.accessContext);
+    }
+    // Reply for request/response callers (the .NET dispatch awaiting a result).
+    this.conn.respond(delivery, "SubmitCodeResponse", {
+      status, returnValue: result.returnValue, output: result.stdout, error: result.error,
+    });
+  }
+}
+
+export interface ServeOptions {
+  token?: string;
+  address?: string;
+  /** Gate mode: on a failed/dropped connection, wait and reconnect instead of exiting (outlives portal restarts). */
+  reconnect?: boolean;
+  retrySeconds?: number;
+}
+
+/** Connect + serve as the node kernel until SIGINT/SIGTERM, with an optional reconnect loop. */
+export async function serve(url: string, opts: ServeOptions = {}): Promise<void> {
+  const address = opts.address ?? DEFAULT_WORKER_ADDRESS;
+  const retryMs = (opts.retrySeconds ?? 3) * 1000;
+  let stopping = false;
+  const stop = new Promise<"stop">((resolve) => {
+    const done = () => { stopping = true; resolve("stop"); };
+    process.once("SIGINT", done);
+    process.once("SIGTERM", done);
+  });
+
+  while (!stopping) {
+    let conn: MeshConnection | null = null;
+    try {
+      conn = await connect(url, { token: opts.token, address });
+      new CodeWorker(conn);
+      console.log(`node kernel connected as ${address} → ${url}`);
+      const reason = await Promise.race([stop, conn.waitClosed().then(() => "closed" as const)]);
+      conn.close();
+      if (reason === "stop" || !opts.reconnect) return;
+      console.error(`node kernel connection closed; reconnecting in ${retryMs / 1000}s`);
+    } catch (e) {
+      conn?.close();
+      if (!opts.reconnect) throw e;
+      console.error(`node kernel connect failed (${String(e)}); reconnecting in ${retryMs / 1000}s`);
+    }
+    if (!stopping) await Promise.race([stop, new Promise((r) => setTimeout(r, retryMs))]);
+  }
+}
+
+/** Self-contained smoke test: execute a JS and a TS snippet, verify the computed value + captured output. */
+export async function runDemo(): Promise<boolean> {
+  const js = await executeCode("console.log('hello from node'); 6 * 7", "javascript");
+  const ts = await executeCode("const answer: number = 6 * 7; console.log(`ts computed ${answer}`); answer", "typescript");
+  console.log(JSON.stringify({ js, ts }, null, 2));
+  const ok = js.returnValue === 42 && ts.returnValue === 42
+    && js.stdout.includes("hello from node") && ts.stdout.includes("ts computed 42");
+  console.log(ok ? "demo self-check OK" : "demo self-check FAILED");
+  return ok;
+}
+
+interface Args { url?: string; token?: string; address?: string; reconnect: boolean; demo: boolean; }
+function parseArgs(argv: string[]): Args {
+  const a: Args = { reconnect: false, demo: false };
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case "--url": a.url = argv[++i]; break;
+      case "--token": a.token = argv[++i]; break;
+      case "--address": a.address = argv[++i]; break;
+      case "--reconnect": a.reconnect = true; break;
+      case "--demo": a.demo = true; break;
+    }
+  }
+  return a;
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  if (args.demo) { process.exit((await runDemo()) ? 0 : 1); }
+  if (!args.url) { console.error("usage: node-worker --url <portal> [--token mw_..] [--address node/node-kernel] [--reconnect] | --demo"); process.exit(2); }
+  await serve(args.url, { token: args.token, address: args.address, reconnect: args.reconnect });
+}
+
+// Run when invoked directly (node dist/worker.js …), not when imported.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}

--- a/clients/typescript/test/worker.test.mjs
+++ b/clients/typescript/test/worker.test.mjs
@@ -1,0 +1,36 @@
+// Executes javascript & typescript Code-node snippets through the node kernel's execution core
+// (the same `executeCode` the CodeWorker runs on every SubmitCodeRequest). Runs against the built
+// output — `npm test` builds first. Node's built-in test runner, no extra deps.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { executeCode } from "../dist/worker.js";
+
+test("javascript node: captures console output and the trailing-expression value", async () => {
+  const r = await executeCode("console.log('hello node'); 6 * 7", "javascript");
+  assert.equal(r.error, null);
+  assert.equal(r.returnValue, 42);              // trailing bare expression = return value (REPL)
+  assert.match(r.stdout, /hello node/);         // console.log captured
+});
+
+test("typescript node: types are stripped, then executed", async () => {
+  const r = await executeCode("const answer: number = 6 * 7; console.log(`ts=${answer}`); answer", "typescript");
+  assert.equal(r.error, null);
+  assert.equal(r.returnValue, 42);
+  assert.match(r.stdout, /ts=42/);
+});
+
+test("Inputs global carries caller parameters (as the C# kernel binds Inputs)", async () => {
+  const r = await executeCode("Inputs.a + Inputs.b", "javascript", { a: 20, b: 22 });
+  assert.equal(r.returnValue, 42);
+});
+
+test("a throwing snippet is captured as an error — the worker never wedges", async () => {
+  const r = await executeCode("throw new Error('boom')", "javascript");
+  assert.equal(r.returnValue, null);
+  assert.match(r.error ?? "", /boom/);
+});
+
+test("an object return value round-trips JSON-able", async () => {
+  const r = await executeCode("({ mean: 42, ok: true })", "javascript");
+  assert.deepEqual(r.returnValue, { mean: 42, ok: true });
+});


### PR DESCRIPTION
Phase 1 of the multi-language platform (companion to #313, which routes js/ts Code nodes to `node/node-kernel`). Gives that address a worker, and delivers the **Node hub examples** you asked for.

## Node kernel worker (`worker.ts`)
The Node/Bun counterpart of `clients/python`'s `meshweaver.worker`. `executeCode(code, language, inputs)` runs a snippet in a `vm` sandbox with **REPL semantics** — `console.log` captured as output, a trailing bare expression is the return value, `Inputs` exposes caller params, **TypeScript is transpiled first** (bundled compiler), any throw is captured (never wedges). `CodeWorker` serves `SubmitCodeRequest` → execute → **patch the run's Activity node** (RFC 7396, under the requester's `accessContext`) + reply `SubmitCodeResponse` — so js/ts output surfaces identically to C# and python. `serve()` has a `--reconnect` gate loop; CLI + `--demo`.

```bash
node dist/worker.js --url https://memex.meshweaver.cloud --token mw_… --address node/node-kernel
node dist/worker.js --url http://127.0.0.1:8082 --address node/node-kernel --reconnect   # trusted gate, no token
node dist/worker.js --demo   # executes a JS + a TS snippet, self-checks the result
```

## Inbound seam on `MeshConnection`
Adds `serve(handler)` (unsolicited inbound requests), `respond(request, …)` (RequestId-correlated), `post(…accessContext)`, `waitClosed()`; the envelope carries `requestId` + `accessContext`. Previously the connection only handled responses + stream frames.

## The hub programming model in Node (`examples/hub.ts`)
`Hub` = an **address** + **handlers by message type** (the C# `WithHandler<T>`) + **owned state**. Runnable stateful counter hub included.

```ts
new Hub(conn)
  .register("Increment", (d) => { count += Number(d.message.by ?? 1); return ["Count", { value: count }]; })
  .register("GetCount", () => ["Count", { value: count }]);
```

## Tests
`test/worker.test.mjs` — 5 tests executing **real js + ts** through `executeCode` (Node's built-in runner, no extra deps): console capture + trailing-value, TS transpile+run, `Inputs`, error capture, object round-trip. All green; `npm run demo` self-check passes (js→42, ts→42).

No .NET changes — CI is the standard .NET build (unaffected). `typescript` becomes a runtime dep (the worker transpiles ts at execution time).

## Next (per plan)
Feature-flagged runtimes (opt-in python/node gates, default all) → then a **node gate image + sidecar** and making the doc examples live on memex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)