### PR TITLE
fix(create): remove CreateTransient — node Create menu broke on Postgres

### DIFF
--- a/src/MeshWeaver.AI/AgentView.cs
+++ b/src/MeshWeaver.AI/AgentView.cs
@@ -118,9 +118,13 @@ public static class AgentView
                 (h, c) => host.Workspace.GetMeshNodeStream()
                     .Select(node =>
                     {
-                        var agent = AsAgentConfiguration(node, host.Hub.JsonSerializerOptions);
-                        if (node == null || agent == null)
+                        if (node == null)
                             return RenderLoading("Loading agent...");
+                        // A freshly-created Agent has no AgentConfiguration content yet — the create
+                        // flow persists an Active node with null Content and edits it afterward. Show a
+                        // default (empty) config instead of an endless "Loading…".
+                        var agent = AsAgentConfiguration(node, host.Hub.JsonSerializerOptions)
+                                    ?? new AgentConfiguration { Id = node.Id };
                         return BuildDetailsLayout(host, node, agent);
                     }),
                 "Content"
@@ -260,9 +264,12 @@ public static class AgentView
                 (h, c) => host.Workspace.GetMeshNodeStream()
                     .Select(node =>
                     {
-                        var agent = AsAgentConfiguration(node, host.Hub.JsonSerializerOptions);
-                        if (node == null || agent == null)
+                        if (node == null)
                             return RenderLoading("Loading agent...");
+                        // A freshly-created Agent has no AgentConfiguration content yet — edit a
+                        // default (empty) config; the first Save persists it to the node stream.
+                        var agent = AsAgentConfiguration(node, host.Hub.JsonSerializerOptions)
+                                    ?? new AgentConfiguration { Id = node.Id };
                         return BuildEditLayout(host, node, agent);
                     }),
                 "Content"

--- a/src/MeshWeaver.AI/ModelProviderLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ModelProviderLayoutAreas.cs
@@ -52,8 +52,14 @@ public static class ModelProviderLayoutAreas
         => host.Workspace.GetMeshNodeStream()
             .Select(node =>
             {
-                if (node?.Content is not ModelProviderConfiguration cfg)
+                if (node is null)
                     return (UiControl?)Controls.Markdown("_No provider data._");
+
+                // A freshly-created provider has no config yet — the create flow persists an Active
+                // node with null Content and edits it here (Overview doubles as the Edit area). Show a
+                // default config so the endpoint + Enter Key controls render; writes persist it.
+                var cfg = node.ContentAs<ModelProviderConfiguration>(host.Hub.JsonSerializerOptions)
+                          ?? new ModelProviderConfiguration { Provider = node.Name ?? node.Id };
 
                 var path = node.Path;
                 var title = cfg.Label ?? cfg.Provider ?? path.Split('/').Last();

--- a/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
@@ -257,7 +257,7 @@ The legacy `workspace.UpdateMeshNode(update)` extension is `[Obsolete]` and poin
 ### Subscribe is mandatory on every cold-write surface
 
 - `meshService.CreateNode(node)` / `UpdateNode(node)` / `DeleteNode(path)` — cold; subscribe to commit.
-- `meshService.MoveNode(...)` / `meshService.CreateTransient(node)` — cold; subscribe.
+- `meshService.MoveNode(...)` / `meshService.CopyNode(...)` — cold; subscribe.
 - `remoteStream.Update(current => updated, ex => …)` — the `ex` callback fires on the stream's hub; the returned `void` IS the subscription.
 
 ---
@@ -486,7 +486,7 @@ If you find yourself using `.Take(N)` outside a `SelectMany` that immediately pr
 
 1. **No `Task<T>` / `async` / `await` in mesh-reachable code.** Public methods on services, handlers, layout areas, and click actions return `IObservable<T>` (or `void`). An `async Task` method that awaits a hub operation deadlocks the hub ActionBlock.
 
-2. **No `*Async` extension shims on `IMeshService`.** Use `meshService.CreateNode(node)` / `UpdateNode(node)` / `DeleteNode(path)` / `CreateTransient(node)` — these return `IObservable<MeshNode>`. Never use `.CreateNodeAsync(...)` / `.UpdateNodeAsync(...)` / `.DeleteNodeAsync(...)` / `.CreateTransientAsync(...)` — those extensions bridge to Task via `.ToTask()` and deadlock every time they are reached from a hub handler.
+2. **No `*Async` extension shims on `IMeshService`.** Use `meshService.CreateNode(node)` / `UpdateNode(node)` / `DeleteNode(path)` — these return `IObservable<MeshNode>`. Never use `.CreateNodeAsync(...)` / `.UpdateNodeAsync(...)` / `.DeleteNodeAsync(...)` — those extensions bridge to Task via `.ToTask()` and deadlock every time they are reached from a hub handler.
 
 3. **Use `hub.Observe(...)` instead of `RegisterCallback` / `AwaitResponse`.** The Task-returning overloads are `[Obsolete]`. Production code MUST use `hub.Observe(delivery)` (already-posted) or `hub.Observe(request, options?)` (also posts) — both return `IObservable<IMessageDelivery[<TResponse>]>`. `DeliveryFailure` flows via `OnError`; no Task-await deadlock surface, no silently-skipped callback.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DataAccessPatterns.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DataAccessPatterns.md
@@ -16,7 +16,6 @@ There are three access patterns, each covering a distinct class of operation:
 | Create node | Service | `meshService.CreateNode(node).Subscribe(...)` |
 | Update node | Service | `meshService.UpdateNode(node).Subscribe(...)` (routes through `GetMeshNodeStream(path).Update`) |
 | Create-or-update (upsert) | Request | `hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node)).Subscribe(...)` |
-| Create transient | Service | `meshService.CreateTransient(node).Subscribe(...)` |
 | Delete node | Service | `meshService.DeleteNode(path).Subscribe(...)` |
 | Write as system / hub | AccessService | `using (accessService.ImpersonateAsSystem()) { … }` / `ImpersonateAsHub(hub)` |
 | Move node | Message | `hub.Observe(new MoveNodeRequest(src, dst)).Subscribe(...)` |
@@ -131,9 +130,6 @@ meshService.CreateNode(node)
     .SelectMany(created => meshService.UpdateNode(created with { Name = "Renamed Team" }))
     .Subscribe(_ => { }, ex => logger.LogWarning(ex, "create+update failed"));
 
-// Transient node (UI edit-then-confirm flows)
-meshService.CreateTransient(node).Subscribe(...);
-
 // Delete — removes the node and all its descendants, bottom to top
 meshService.DeleteNode("org/Acme/OldTeam").Subscribe(...);
 
@@ -146,7 +142,6 @@ hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
 
 - `CreateNode` — runs `INodeValidator`, sets state to Active.
 - `UpdateNode` — validates; routes through the canonical `GetMeshNodeStream(path).Update` write path on the owning hub.
-- `CreateTransient` — persists in Transient state; caller confirms or discards.
 - `DeleteNode` — removes the node and all descendants (bottom to top).
 - `CreateOrUpdateNodeRequest` — upsert; checks existence on the handler side and dispatches create or merge-patch update (see [CQRS](/Doc/Architecture/CqrsAndContentAccess)).
 - Identity is auto-captured from `AccessService` and carried across `.Subscribe()` boundaries — see [AccessContextPropagation](/Doc/Architecture/AccessContextPropagation).

--- a/src/MeshWeaver.Documentation/Data/Architecture/SatelliteNodePatterns.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SatelliteNodePatterns.md
@@ -186,7 +186,7 @@ Doc/MyDoc/_Comment/abc123/reply1       (Reply node)
 | Mutation entry point | Hub message handlers | Click actions in layout areas |
 | Child list | Indexed `ThreadMessages` on the parent | Discovered via `Query` |
 | Text edits | `DataChangeRequest` via `_Exec` sub-hub | Direct `stream.Update` |
-| Node creation | `CreateNodeAsync` → confirm in handler | `CreateTransientAsync` → confirm via `stream.Update` |
+| Node creation | `CreateNodeAsync` → confirm in handler | `CreateNode` (Active) → edit via `stream.Update` |
 
 ---
 

--- a/src/MeshWeaver.Graph/CommentLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CommentLayoutAreas.cs
@@ -434,7 +434,10 @@ public static class CommentLayoutAreas
                             };
                             nodeFactory.CreateNode(replyNode).Subscribe(
                                 _ => host.UpdateData(replyPathStateId, ""),
-                                _ => host.UpdateData(replyPathStateId, ""));
+                                // Keep the draft form OPEN on failure (don't clear the state) so the user's
+                                // reply isn't silently lost, and log so the failure is diagnosable.
+                                ex => host.Hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>()
+                                    ?.LogWarning(ex, "Failed to create reply at {Path}", replyPath));
                         });
                     return Task.CompletedTask;
                 })));

--- a/src/MeshWeaver.Graph/CommentLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CommentLayoutAreas.cs
@@ -155,7 +155,7 @@ public static class CommentLayoutAreas
                         return Task.CompletedTask;
                     }));
         if (canAct)
-            rightGroup = rightGroup.WithView(BuildReplyButton(host, hubPath, comment, currentUser));
+            rightGroup = rightGroup.WithView(BuildReplyButton(host, hubPath));
         if (canAct && !isResolved && IsTopLevelComment(hubPath, comment))
             rightGroup = rightGroup.WithView(BuildResolveButton(host, hubPath, comment));
         if (canDelete || canComment)
@@ -215,7 +215,7 @@ public static class CommentLayoutAreas
                     .DistinctUntilChanged()
                     .Select(replyPath => string.IsNullOrEmpty(replyPath)
                         ? (UiControl?)null
-                        : BuildReplyCreateForm(h, replyPath, replyPathStateId));
+                        : BuildReplyCreateForm(h, replyPath, replyPathStateId, comment, currentUser));
             });
         }
 
@@ -365,13 +365,13 @@ public static class CommentLayoutAreas
 
     /// <summary>
     /// Builds the inline reply creation form with markdown editor, Cancel, and Create buttons.
-    /// Cancel deletes the transient node and hides the form.
-    /// Create sets the reply text, marks the node Active, and hides the form.
+    /// Cancel just closes the draft form (nothing was persisted).
+    /// Create writes the reply Active with its text in a single <c>CreateNode</c>.
     /// </summary>
-    private static UiControl BuildReplyCreateForm(LayoutAreaHost host, string replyPath, string replyPathStateId)
+    private static UiControl BuildReplyCreateForm(LayoutAreaHost host, string replyPath, string replyPathStateId,
+        Comment comment, string currentUser)
     {
         var nodeFactory = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
-        var meshQuery = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
         var replyTextDataId = $"replyText_{replyPath.Replace("/", "_")}";
 
         host.UpdateData(replyTextDataId, new Dictionary<string, object?> { ["text"] = "" });
@@ -399,9 +399,8 @@ public static class CommentLayoutAreas
                 .WithAppearance(Appearance.Neutral)
                 .WithClickAction(_ =>
                 {
-                    nodeFactory.DeleteNode(replyPath).Subscribe(
-                        __ => host.UpdateData(replyPathStateId, ""),
-                        _  => host.UpdateData(replyPathStateId, ""));
+                    // Nothing was persisted — the draft lives only in the form's data stream.
+                    host.UpdateData(replyPathStateId, "");
                     return Task.CompletedTask;
                 }))
             .WithView(Controls.Button("Create")
@@ -409,28 +408,31 @@ public static class CommentLayoutAreas
                 .WithIconStart(FluentIcons.Add())
                 .WithClickAction(ctx =>
                 {
-                    // Read text, then look up the transient reply in the workspace stream
-                    // (not QueryAsync — AsynchronousCalls.md) and flip it to Active with the text.
+                    // Read the draft text, then write the reply with ONE CreateNode (Active, through the
+                    // access-control pipeline). No transient placeholder — the reply is authored at its
+                    // own replyPath, a child of the comment being replied to.
                     ctx.Host.Stream.GetDataStream<Dictionary<string, object?>>(replyTextDataId)
                         .Take(1)
                         .Subscribe(data =>
                         {
                             var text = data?.GetValueOrDefault("text")?.ToString() ?? "";
-
-                            var cache = host.Hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
-                            cache.Update(replyPath, n =>
+                            var replyId = replyPath.Split('/').Last();
+                            var replyNamespace = replyPath[..replyPath.LastIndexOf('/')];
+                            var replyNode = new MeshNode(replyId, replyNamespace)
                             {
-                                var replyComment = n.ContentAs<Comment>(host.Hub.JsonSerializerOptions);
-                                // Existing node whose content can't be recovered → leave it alone, NEVER clobber.
-                                if (n.Content is not null && replyComment is null)
-                                    return n;
-                                replyComment ??= new Comment();
-                                return n with
+                                Name = $"Reply to {comment.Author}",
+                                NodeType = CommentNodeType.NodeType,
+                                State = MeshNodeState.Active,
+                                Content = new Comment
                                 {
-                                    State = MeshNodeState.Active,
-                                    Content = replyComment with { Text = text }
-                                };
-                            }, host.Hub.JsonSerializerOptions).Subscribe(
+                                    Id = replyId,
+                                    PrimaryNodePath = comment.PrimaryNodePath,
+                                    Author = currentUser,
+                                    Status = CommentStatus.Active,
+                                    Text = text
+                                }
+                            };
+                            nodeFactory.CreateNode(replyNode).Subscribe(
                                 _ => host.UpdateData(replyPathStateId, ""),
                                 _ => host.UpdateData(replyPathStateId, ""));
                         });
@@ -441,9 +443,12 @@ public static class CommentLayoutAreas
     }
 
     /// <summary>
-    /// Builds the Reply icon button. Creates a transient reply node via IMeshService and shows inline Create area.
+    /// Builds the Reply icon button. Opens the inline reply form for a fresh reply path — NOTHING is
+    /// persisted until the user clicks Create (then one <c>CreateNode</c> writes the reply Active).
+    /// No transient placeholder is written, so an unsent draft never appears and there is no
+    /// PG-invisible node to resolve.
     /// </summary>
-    private static UiControl BuildReplyButton(LayoutAreaHost host, string hubPath, Comment comment, string currentUser)
+    private static UiControl BuildReplyButton(LayoutAreaHost host, string hubPath)
     {
         return Controls.Html("<span style=\"cursor: pointer; font-size: 0.8rem; color: var(--accent-fill-rest);\" title=\"Reply\">↩</span>")
             .WithClickAction(_ =>
@@ -451,30 +456,9 @@ public static class CommentLayoutAreas
                 var replyId = Guid.NewGuid().AsString();
                 var replyPath = $"{hubPath}/{replyId}";
                 var replyPathStateId = $"replyPath_{hubPath.Replace("/", "_")}";
-
-                var replyNode = new MeshNode(replyId, hubPath)
-                {
-                    Name = $"Reply to {comment.Author}",
-                    NodeType = CommentNodeType.NodeType,
-                    State = MeshNodeState.Transient,
-                    Content = new Comment
-                    {
-                        Id = replyId,
-                        PrimaryNodePath = comment.PrimaryNodePath,
-                        Author = currentUser,
-                        Status = CommentStatus.Active
-                    }
-                };
-
-                var nodeFactory = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
-                nodeFactory.CreateTransient(replyNode).Subscribe(
-                    _ =>
-                    {
-                        var expandedStateId = $"replies_expanded_{hubPath.Replace("/", "_")}";
-                        host.UpdateData(expandedStateId, true);
-                        host.UpdateData(replyPathStateId, replyPath);
-                    },
-                    _ => { });
+                var expandedStateId = $"replies_expanded_{hubPath.Replace("/", "_")}";
+                host.UpdateData(expandedStateId, true);
+                host.UpdateData(replyPathStateId, replyPath);
                 return Task.CompletedTask;
             });
     }

--- a/src/MeshWeaver.Graph/CommentsExtensions.cs
+++ b/src/MeshWeaver.Graph/CommentsExtensions.cs
@@ -403,7 +403,10 @@ public static class CommentsView
                             };
                             nodeFactory.CreateNode(commentNode).Subscribe(
                                 _ => host.UpdateData(stateId, ""),
-                                _ => host.UpdateData(stateId, ""));
+                                // Keep the draft form OPEN on failure (don't clear stateId) so the user's
+                                // text isn't silently lost, and log so the failure is diagnosable.
+                                ex => host.Hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>()
+                                    ?.LogWarning(ex, "Failed to create comment at {Path}", commentPath));
                         });
                     return Task.CompletedTask;
                 })));

--- a/src/MeshWeaver.Graph/CommentsExtensions.cs
+++ b/src/MeshWeaver.Graph/CommentsExtensions.cs
@@ -267,7 +267,7 @@ public static class CommentsView
 
         if (canComment && !string.IsNullOrEmpty(currentUser))
         {
-            headerRow = headerRow.WithView(BuildAddCommentButton(host, nodePath, currentUser));
+            headerRow = headerRow.WithView(BuildAddCommentButton(host, nodePath));
         }
 
         container = container.WithView(headerRow);
@@ -284,7 +284,7 @@ public static class CommentsView
                     if (string.IsNullOrEmpty(commentPath))
                         return (UiControl)Controls.Stack;
 
-                    return (UiControl)BuildCommentCreateForm(h, commentPath, newCommentPathStateId);
+                    return (UiControl)BuildCommentCreateForm(h, commentPath, newCommentPathStateId, nodePath, currentUser);
                 });
         });
 
@@ -337,10 +337,10 @@ public static class CommentsView
     /// Builds the inline comment creation form with markdown editor, Cancel, and Create buttons.
     /// Matches the Reply pattern from CommentLayoutAreas.
     /// </summary>
-    private static UiControl BuildCommentCreateForm(LayoutAreaHost host, string commentPath, string stateId)
+    private static UiControl BuildCommentCreateForm(LayoutAreaHost host, string commentPath, string stateId,
+        string nodePath, string currentUser)
     {
         var nodeFactory = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
-        var meshQuery = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
         var textDataId = $"commentText_{commentPath.Replace("/", "_")}";
 
         host.UpdateData(textDataId, new Dictionary<string, object?> { ["text"] = "" });
@@ -368,39 +368,40 @@ public static class CommentsView
                 .WithAppearance(Appearance.Neutral)
                 .WithClickAction(_ =>
                 {
-                    nodeFactory.DeleteNode(commentPath).Subscribe(
-                        __ => host.UpdateData(stateId, ""),
-                        _  => host.UpdateData(stateId, ""));
+                    // Nothing was persisted — the draft lives only in the form's data stream.
+                    // Just close the form; there is no placeholder node to delete.
+                    host.UpdateData(stateId, "");
                     return Task.CompletedTask;
                 }))
             .WithView(Controls.Button("Create")
                 .WithAppearance(Appearance.Accent)
                 .WithClickAction(ctx =>
                 {
-                    // Read text from the form data stream (canonical click-handler pattern),
-                    // then read the comment node via one-shot GetDataRequest — true
-                    // request/response, no SubscribeRequest+immediate-unsubscribe.
+                    // Read the draft text from the form data stream, then write the comment with ONE
+                    // CreateNode (Active, through the access-control pipeline). No transient placeholder
+                    // and no primary-node clobber — the comment is authored at its own commentPath.
                     ctx.Host.Stream.GetDataStream<Dictionary<string, object?>>(textDataId)
                         .Take(1)
                         .Subscribe(data =>
                         {
                             var text = data?.GetValueOrDefault("text")?.ToString() ?? "";
-
-                            var ownPath = host.Hub.Address.Path;
-                            var cache = host.Hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
-                            cache.Update(ownPath, n =>
+                            var commentId = commentPath.Split('/').Last();
+                            var commentNode = new MeshNode(commentId, $"{nodePath}/{CommentsExtensions.CommentPartition}")
                             {
-                                var c = n.ContentAs<Comment>(host.Hub.JsonSerializerOptions);
-                                // Existing node whose content can't be recovered → leave it alone, NEVER clobber.
-                                if (n.Content is not null && c is null)
-                                    return n;
-                                c ??= new Comment();
-                                return n with
+                                Name = "Comment",
+                                NodeType = CommentNodeType.NodeType,
+                                MainNode = nodePath,
+                                State = MeshNodeState.Active,
+                                Content = new Comment
                                 {
-                                    State = MeshNodeState.Active,
-                                    Content = c with { Text = text }
-                                };
-                            }, host.Hub.JsonSerializerOptions).Subscribe(
+                                    Id = commentId,
+                                    PrimaryNodePath = nodePath,
+                                    Author = currentUser,
+                                    Status = CommentStatus.Active,
+                                    Text = text
+                                }
+                            };
+                            nodeFactory.CreateNode(commentNode).Subscribe(
                                 _ => host.UpdateData(stateId, ""),
                                 _ => host.UpdateData(stateId, ""));
                         });
@@ -411,10 +412,12 @@ public static class CommentsView
     }
 
     /// <summary>
-    /// Builds the "Add Comment" emoji button. Creates a transient comment node (no MarkerId)
-    /// and shows the inline creation form.
+    /// Builds the "Add Comment" emoji button. Opens the inline creation form for a fresh comment
+    /// path — NOTHING is persisted until the user clicks Create (then a single <c>CreateNode</c>
+    /// writes the comment Active). No transient placeholder is written, so an unsent draft never
+    /// appears in the comment list and there is no PG-invisible node to resolve.
     /// </summary>
-    private static UiControl BuildAddCommentButton(LayoutAreaHost host, string nodePath, string currentUser)
+    private static UiControl BuildAddCommentButton(LayoutAreaHost host, string nodePath)
     {
         return Controls.Html("<span style=\"cursor: pointer; font-size: 0.85rem; color: var(--accent-fill-rest);\" title=\"Add Comment\">+ Comment</span>")
             .WithClickAction(_ =>
@@ -422,26 +425,7 @@ public static class CommentsView
                 var commentId = Guid.NewGuid().AsString();
                 var commentPath = $"{nodePath}/{CommentsExtensions.CommentPartition}/{commentId}";
                 var newCommentPathStateId = $"newComment_{nodePath.Replace("/", "_")}";
-
-                var commentNode = new MeshNode(commentId, $"{nodePath}/{CommentsExtensions.CommentPartition}")
-                {
-                    Name = "Comment",
-                    NodeType = CommentNodeType.NodeType,
-                    MainNode = nodePath,
-                    State = MeshNodeState.Transient,
-                    Content = new Comment
-                    {
-                        Id = commentId,
-                        PrimaryNodePath = nodePath,
-                        Author = currentUser,
-                        Status = CommentStatus.Active
-                    }
-                };
-
-                var nodeFactory = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
-                nodeFactory.CreateTransient(commentNode).Subscribe(
-                    _ => host.UpdateData(newCommentPathStateId, commentPath),
-                    _ => { /* surfaced elsewhere */ });
+                host.UpdateData(newCommentPathStateId, commentPath);
                 return Task.CompletedTask;
             });
     }

--- a/src/MeshWeaver.Graph/CreateLayoutArea.cs
+++ b/src/MeshWeaver.Graph/CreateLayoutArea.cs
@@ -23,7 +23,9 @@ namespace MeshWeaver.Graph;
 /// <summary>
 /// Layout area for creating new mesh nodes.
 /// Shows a unified "Create New" form with type autocomplete, namespace, name, and id fields.
-/// For transient nodes, shows the content type editor with Create/Cancel buttons.
+/// On submit it persists ONE <see cref="MeshNodeState.Active"/> node via a single
+/// <c>CreateNode</c> (through the access-control pipeline) and navigates to the new node's Edit
+/// area — no transient placeholder is ever written to storage.
 /// </summary>
 public static class CreateLayoutArea
 {
@@ -44,11 +46,10 @@ public static class CreateLayoutArea
             Href: MeshNodeLayoutAreas.BuildUrl(hubPath, MeshNodeLayoutAreas.CreateNodeArea, createQs));
     }
     /// <summary>
-    /// Main entry point for the Create layout area.
-    /// - If current node is Transient: renders the Create editor inline (same UI as Edit).
-    ///   The user confirms via Save, which flips state to Active. No auto-redirect to Edit
-    ///   (that would race with workspace replication and report "node does not exist").
-    /// - Otherwise: shows the unified Create New form with type picker.
+    /// Main entry point for the Create layout area. Shows the unified "Create New" form with the
+    /// type picker (or a NodeType-specific <see cref="NodeTypeDefinition.BuildCreate"/> override,
+    /// e.g. Thread's chat composer). Submitting the form creates the node and navigates to its
+    /// Edit area; nothing is persisted until that single <c>CreateNode</c>.
     /// </summary>
     public static IObservable<UiControl?> Create(LayoutAreaHost host, RenderingContext _)
     {
@@ -94,9 +95,13 @@ public static class CreateLayoutArea
     }
 
     /// <summary>
-    /// The default Create UI: confirm-edit for a transient content node, else the generic
-    /// "Create New" form. Used when no NodeType-specific
+    /// The default Create UI: the generic "Create New" form. Used when no NodeType-specific
     /// <see cref="NodeTypeDefinition.BuildCreate"/> applies (or one yielded <c>null</c>).
+    /// <para>The form runs on the PARENT node's hub and never writes a placeholder/transient
+    /// node. On submit it builds one <see cref="MeshNodeState.Active"/> node and persists it with
+    /// a single <c>CreateNode</c> (flowing through the CreateNodeRequest access-control pipeline),
+    /// then navigates to the new node's Edit area — the owning hub knows the node's content type
+    /// and materialises the type-specific content editor there.</para>
     /// </summary>
     private static IObservable<UiControl?> BuildDefaultCreate(LayoutAreaHost host, string currentPath)
     {
@@ -104,388 +109,7 @@ public static class CreateLayoutArea
             ?? Observable.Return<MeshNode[]>(Array.Empty<MeshNode>());
 
         return nodeStream.Take(1).Select(nodes =>
-        {
-            var currentNode = nodes.FirstOrDefault(n => n.Path == currentPath);
-
-            if (currentNode?.State == MeshNodeState.Transient)
-            {
-                // Content-editor types (Markdown, etc.) don't need a separate "Create" confirmation —
-                // the Edit view is itself the authoring surface, so flip transient→Active and jump there.
-                if (IsDirectEditContentType(host, currentNode))
-                {
-                    ConfirmTransient(host, currentNode);
-                    var editHref = MeshNodeLayoutAreas.BuildUrl(currentNode.Path, MeshNodeLayoutAreas.EditArea);
-                    return (UiControl?)new RedirectControl(editHref);
-                }
-                return (UiControl?)BuildCreateEditor(host, currentNode);
-            }
-
-            return (UiControl?)BuildCreateNewForm(host, nodes, currentPath);
-        });
-    }
-
-    /// <summary>
-    /// True when the transient node's content is edited directly (Markdown, etc.)
-    /// — no intermediate Create form needed; go straight to Edit.
-    /// </summary>
-    private static bool IsDirectEditContentType(LayoutAreaHost host, MeshNode node)
-    {
-        if (node.NodeType == "Markdown")
-            return true;
-
-        // Inspect the hub's MeshDataSource ContentType (same resolution BuildCreateEditor uses).
-        var contentType = host.Workspace.DataContext.DataSources
-            .OfType<MeshDataSource>()
-            .FirstOrDefault(ds => ds.ContentType != null)?.ContentType;
-        return contentType != null
-            && contentType.Name.Contains("Markdown", StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// Flips a transient node to Active state. Fire-and-forget Subscribe — no await in the click path.
-    /// </summary>
-    private static void ConfirmTransient(LayoutAreaHost host, MeshNode transient)
-    {
-        var logger = host.Hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>();
-        var meshService = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
-        var active = transient with { State = MeshNodeState.Active };
-        meshService.CreateNode(active).Subscribe(
-            _ => { /* fire-and-forget success */ },
-            ex => logger?.LogWarning(ex, "Failed to confirm transient node {Path}", transient.Path));
-    }
-
-    /// <summary>
-    /// Builds the Create editor for a transient node (own node).
-    /// 1. Resolves ContentType from MeshDataSource
-    /// 2. Creates content instance using MeshDataSource.CreateContentInstance
-    /// 3. Shows edit form for content type with editable Id field
-    /// 4. Create button: If Id unchanged, confirm at same path. If Id changed, create new node + delete transient.
-    /// 5. Cancel button: removes transient node and navigates back
-    /// </summary>
-    private static UiControl BuildCreateEditor(
-        LayoutAreaHost host,
-        MeshNode node)
-    {
-        var nodePath = node.Path;
-        var parentPath = node.GetParentPath();
-        var transientId = node.Id; // The GUID-based transient Id
-        var desiredId = node.DesiredId ?? transientId; // User's intended Id (from dialog)
-
-        // Get MeshDataSource from workspace to resolve ContentType
-        var workspace = host.Workspace;
-        var meshDataSource = workspace.DataContext.DataSources
-            .OfType<MeshDataSource>()
-            .FirstOrDefault(ds => ds.ContentType != null);
-        var contentType = meshDataSource?.ContentType;
-
-        // Create content instance using MeshDataSource
-        object? contentInstance = node.Content;
-        if (contentInstance == null && meshDataSource != null)
-        {
-            contentInstance = meshDataSource.CreateContentInstance(node);
-        }
-
-        var cancelUrl = !string.IsNullOrEmpty(parentPath)
-            ? $"/{parentPath}"
-            : $"/{nodePath}";
-        var nodeFactory = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
-        var logger = host.Hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>();
-
-        // Set up metadata data binding for Name field
-        var metadataDataId = $"create_metadata_{nodePath.Replace("/", "_")}";
-        var metadataFormData = new Dictionary<string, object?>
-        {
-            ["name"] = node.Name ?? "",
-            ["id"] = desiredId
-        };
-        host.UpdateData(metadataDataId, metadataFormData);
-
-        var stack = Controls.Stack.WithWidth("100%").WithStyle("padding: 24px; height: 100%; display: flex; flex-direction: column;");
-
-        // Header: "Create {Name}" - data-bound to name field
-        stack = stack.WithView((h, _) =>
-            h.Stream.GetDataStream<Dictionary<string, object?>>(metadataDataId)
-                .Select(metadata =>
-                {
-                    var name = metadata?.GetValueOrDefault("name")?.ToString() ?? node.Name ?? node.Id;
-                    return Controls.H2($"Create {name}").WithStyle("margin: 0 0 24px 0;");
-                }));
-
-        // Name field only (Id is hidden - computed from Name)
-        stack = stack.WithView(Controls.Stack
-            .WithWidth("100%")
-            .WithStyle("margin-bottom: 24px;")
-            .WithView(Controls.Body("Name").WithStyle("font-weight: 600; margin-bottom: 4px;"))
-            .WithView(new TextFieldControl(new JsonPointerReference("name"))
-            {
-                Placeholder = "Display name",
-                Immediate = true,
-                DataContext = LayoutAreaReference.GetDataPointer(metadataDataId)
-            }.WithStyle("width: 100%;")));
-
-        // Content type editor - use Overview with isToggleable=false for pure edit mode
-        if (contentType != null && contentInstance != null)
-        {
-            var dataId = $"create_{nodePath.Replace("/", "_")}";
-            host.UpdateData(dataId, contentInstance);
-
-            var editor = Layout.Domain.EditLayoutArea.Overview(host, contentType, dataId, canEdit: true, isToggleable: false);
-            stack = stack.WithView(Controls.Stack.WithStyle("flex: 1; min-height: 0;").WithView(editor));
-
-            // Buttons: Cancel on left, Create on right
-            stack = stack.WithView(Controls.Stack
-                .WithOrientation(Orientation.Horizontal)
-                .WithHorizontalGap(12)
-                .WithStyle("margin-top: 24px; justify-content: flex-start;")
-                .WithView(Controls.Button("Cancel")
-                    .WithAppearance(Appearance.Neutral)
-                    .WithClickAction(ctx =>
-                    {
-                        nodeFactory.DeleteNode(nodePath).Subscribe(
-                            _ => ctx.NavigateTo(cancelUrl),
-                            _ => ctx.NavigateTo(cancelUrl));
-                        return Task.CompletedTask;
-                    }))
-                .WithView(Controls.Button("Create")
-                    .WithAppearance(Appearance.Accent)
-                    .WithIconStart(FluentIcons.Add())
-                    .WithClickAction(ctx =>
-                    {
-                        // Get metadata and content from data streams
-                        ctx.Host.Stream.GetDataStream<Dictionary<string, object?>>(metadataDataId)
-                            .Take(1)
-                            .Subscribe(
-                                metadata =>
-                                {
-                                    var currentName = metadata.GetValueOrDefault("name")?.ToString()?.Trim() ?? node.Name;
-
-                                    ctx.Host.Stream.GetDataStream<JsonElement>(dataId)
-                                        .Take(1)
-                                        .Subscribe(
-                                            jsonContent =>
-                                            {
-                                                try
-                                                {
-                                                    var currentContent = jsonContent.Deserialize(contentType!, ctx.Host.Hub.JsonSerializerOptions);
-                                                    HandleConfirmCreate(ctx, host, logger, node, nodePath,
-                                                        currentName, currentContent, contentType);
-                                                }
-                                                catch (Exception ex)
-                                                {
-                                                    logger?.LogError(ex, "Error preparing CreateNodeRequest for {NodePath}", nodePath);
-                                                    ShowErrorDialog(ctx, "Creation Failed", ex.Message);
-                                                }
-                                            },
-                                            ex =>
-                                            {
-                                                logger?.LogError(ex, "Error getting content from data stream for {NodePath}", nodePath);
-                                                ShowErrorDialog(ctx, "Creation Failed", ex.Message);
-                                            });
-                                },
-                                ex =>
-                                {
-                                    logger?.LogError(ex, "Error getting metadata from data stream for {NodePath}", nodePath);
-                                    ShowErrorDialog(ctx, "Creation Failed", ex.Message);
-                                });
-                    })));
-        }
-        else if (node.NodeType == "Markdown")
-        {
-            // Markdown editor with auto-save (no Done button — Create/Cancel handles state)
-            var rawContent = MarkdownOverviewLayoutArea.GetMarkdownContent(node);
-            var editor = new MarkdownEditorControl()
-                .WithDocumentId(nodePath)
-                .WithValue(rawContent ?? "")
-                .WithHeight("100%")
-                .WithPlaceholder("Start writing your markdown content...")
-                .WithAutoSave(host.Hub.Address.ToString(), nodePath);
-            stack = stack.WithView(Controls.Stack.WithStyle("flex: 1; min-height: 0;").WithView(editor));
-
-            // Buttons: Cancel on left, Create on right
-            stack = stack.WithView(Controls.Stack
-                .WithOrientation(Orientation.Horizontal)
-                .WithHorizontalGap(12)
-                .WithStyle("margin-top: 12px; flex-shrink: 0; justify-content: flex-start;")
-                .WithView(Controls.Button("Cancel")
-                    .WithAppearance(Appearance.Neutral)
-                    .WithClickAction(ctx =>
-                    {
-                        nodeFactory.DeleteNode(nodePath).Subscribe(
-                            _ => ctx.NavigateTo(cancelUrl),
-                            _ => ctx.NavigateTo(cancelUrl));
-                        return Task.CompletedTask;
-                    }))
-                .WithView(Controls.Button("Create")
-                    .WithAppearance(Appearance.Accent)
-                    .WithIconStart(FluentIcons.Add())
-                    .WithClickAction(ctx =>
-                    {
-                        ctx.Host.Stream.GetDataStream<Dictionary<string, object?>>(metadataDataId)
-                            .Take(1)
-                            .Subscribe(
-                                metadata =>
-                                {
-                                    try
-                                    {
-                                        var currentName = metadata.GetValueOrDefault("name")?.ToString()?.Trim() ?? node.Name;
-                                        HandleConfirmCreate(ctx, host, logger, node, nodePath,
-                                            currentName, null, null);
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        logger?.LogError(ex, "Error preparing CreateNodeRequest for {NodePath}", nodePath);
-                                        ShowErrorDialog(ctx, "Creation Failed", ex.Message);
-                                    }
-                                },
-                                ex =>
-                                {
-                                    logger?.LogError(ex, "Error getting metadata from data stream for {NodePath}", nodePath);
-                                    ShowErrorDialog(ctx, "Creation Failed", ex.Message);
-                                });
-                    })));
-        }
-        else
-        {
-            // No content type editor — the metadata Name field above is sufficient.
-            // Buttons: Cancel on left, Create on right
-            stack = stack.WithView(Controls.Stack
-                .WithOrientation(Orientation.Horizontal)
-                .WithHorizontalGap(12)
-                .WithStyle("margin-top: 24px; justify-content: flex-start;")
-                .WithView(Controls.Button("Cancel")
-                    .WithAppearance(Appearance.Neutral)
-                    .WithClickAction(ctx =>
-                    {
-                        nodeFactory.DeleteNode(nodePath).Subscribe(
-                            _ => ctx.NavigateTo(cancelUrl),
-                            _ => ctx.NavigateTo(cancelUrl));
-                        return Task.CompletedTask;
-                    }))
-                .WithView(Controls.Button("Create")
-                    .WithAppearance(Appearance.Accent)
-                    .WithIconStart(FluentIcons.Add())
-                    .WithClickAction(ctx =>
-                    {
-                        ctx.Host.Stream.GetDataStream<Dictionary<string, object?>>(metadataDataId)
-                            .Take(1)
-                            .Subscribe(
-                                metadata =>
-                                {
-                                    try
-                                    {
-                                        var currentName = metadata.GetValueOrDefault("name")?.ToString()?.Trim() ?? node.Name;
-                                        HandleConfirmCreate(ctx, host, logger, node, nodePath,
-                                            currentName, null, null);
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        logger?.LogError(ex, "Error preparing CreateNodeRequest for {NodePath}", nodePath);
-                                        ShowErrorDialog(ctx, "Creation Failed", ex.Message);
-                                    }
-                                },
-                                ex =>
-                                {
-                                    logger?.LogError(ex, "Error getting metadata from data stream for {NodePath}", nodePath);
-                                    ShowErrorDialog(ctx, "Creation Failed", ex.Message);
-                                });
-                    })));
-        }
-
-        return stack;
-    }
-
-    /// <summary>
-    /// Handles Create when Id is unchanged - confirms transient node at same path.
-    /// </summary>
-    private static void HandleConfirmCreate(
-        UiActionContext ctx,
-        LayoutAreaHost host,
-        ILogger? logger,
-        MeshNode node,
-        string nodePath,
-        string? currentName,
-        object? currentContent,
-        Type? contentType)
-    {
-        // Update node with content and state=Active
-        var updatedNode = node with
-        {
-            Name = currentName ?? node.Name,
-            Content = currentContent ?? node.Content,
-            State = MeshNodeState.Active
-        };
-
-        logger?.LogInformation("Confirming transient node at {NodePath} with content type {ContentType}",
-            nodePath, contentType?.Name ?? "none");
-
-        var nodeFactory = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
-        nodeFactory.CreateNode(updatedNode)
-            .Subscribe(
-                _ =>
-                {
-                    logger?.LogInformation("Successfully confirmed node at {NodePath}", nodePath);
-                    ctx.NavigateTo($"/{nodePath}");
-                },
-                ex =>
-                {
-                    var error = ex.Message ?? "Unknown error";
-                    logger?.LogWarning("CreateNodeRequest failed for {NodePath}: {Error}", nodePath, error);
-                    ShowErrorDialog(ctx, "Creation Failed", error);
-                });
-    }
-
-    /// <summary>
-    /// Handles Create when Id is changed - creates new node at new path and deletes transient.
-    /// </summary>
-    private static void HandleIdChangeCreate(
-        UiActionContext ctx,
-        LayoutAreaHost host,
-        IMeshService nodeFactory,
-        ILogger? logger,
-        MeshNode transientNode,
-        string? currentName,
-        string newId,
-        object? currentContent,
-        Type? contentType)
-    {
-        // Build new path with the changed Id
-        var newPath = $"{transientNode.Namespace}/{newId}";
-        var transientPath = transientNode.Path;
-
-        // Create the new node at the new path
-        var newNode = MeshNode.FromPath(newPath) with
-        {
-            Name = currentName ?? transientNode.Name,
-            NodeType = transientNode.NodeType,
-            Icon = transientNode.Icon,
-            Category = transientNode.Category,
-            Content = currentContent ?? transientNode.Content,
-            State = MeshNodeState.Active
-        };
-
-        logger?.LogInformation("Creating new node at {NewPath} (Id changed from transient {TransientPath})",
-            newPath, transientPath);
-
-        nodeFactory.CreateNode(newNode)
-            .Subscribe(
-                _ =>
-                {
-                    logger?.LogInformation("Successfully created node at {NewPath}", newPath);
-
-                    // Delete the transient node via its own Observable — no await, no InvokeAsync.
-                    nodeFactory.DeleteNode(transientPath).Subscribe(
-                        __ => logger?.LogInformation("Deleted transient node at {TransientPath}", transientPath),
-                        ex => logger?.LogWarning(ex, "Failed to delete transient node at {TransientPath}", transientPath));
-
-                    // Navigate to the new node
-                    ctx.NavigateTo($"/{newPath}");
-                },
-                ex =>
-                {
-                    var error = ex.Message ?? "Unknown error";
-                    logger?.LogWarning("CreateNodeRequest failed for {NewPath}: {Error}", newPath, error);
-                    ShowErrorDialog(ctx, "Creation Failed", error);
-                });
+            (UiControl?)BuildCreateNewForm(host, nodes, currentPath));
     }
 
     private static void ShowErrorDialog(UiActionContext ctx, string title, string message)
@@ -791,8 +415,9 @@ public static class CreateLayoutArea
             .WithAppearance(Appearance.Accent)
             .WithClickAction(actx =>
             {
-                // Reactive click — read form, CreateTransient (which completes after persist),
-                // then navigate. No await on the click path (AsynchronousCalls.md).
+                // Reactive click — read form, CreateNode (completes after the create response),
+                // then navigate to the new node's Edit area. No await on the click path
+                // (AsynchronousCalls.md).
                 actx.Host.Stream.GetDataStream<Dictionary<string, object?>>(formId)
                     .Take(1)
                     .Subscribe(formValues =>
@@ -847,22 +472,24 @@ public static class CreateLayoutArea
                             NodeType = selectedType,
                             Icon = string.IsNullOrEmpty(icon) ? typeRegistration?.Icon : icon,
                             Category = typeRegistration?.Category,
-                            DesiredId = id,
-                            State = MeshNodeState.Transient
+                            State = MeshNodeState.Active
                         };
 
-                        logger?.LogInformation("Creating transient node at {NodePath} with type {NodeType}", nodePath, selectedType);
+                        logger?.LogInformation("Creating node at {NodePath} with type {NodeType}", nodePath, selectedType);
 
-                        // CreateTransient surfaces "Node already exists" via OnError when a non-transient
-                        // node sits at this path — caught below and shown as a friendly error. No pre-flight
-                        // existence query (those go through the lagged read index — AsynchronousCalls.md).
-                        nodeFactory.CreateTransient(newNode)
+                        // ONE authoritative create through the CreateNodeRequest pipeline (identity +
+                        // access-control validators). No transient placeholder is written — the owning hub
+                        // materialises the node's default content on create, and we land on its Edit area so
+                        // the type-specific content editor renders on the hub that knows the content type.
+                        // "Node already exists" / "Access denied" surface via OnError — no pre-flight
+                        // existence query (those read the lagged index — AsynchronousCalls.md).
+                        nodeFactory.CreateNode(newNode)
                         .Subscribe(
                             _ =>
                             {
-                                logger?.LogInformation("Successfully created transient node at {NodePath}", nodePath);
-                                var createUrl = MeshNodeLayoutAreas.BuildUrl(nodePath, MeshNodeLayoutAreas.CreateNodeArea);
-                                actx.NavigateTo(createUrl);
+                                logger?.LogInformation("Successfully created node at {NodePath}", nodePath);
+                                var editUrl = MeshNodeLayoutAreas.BuildUrl(nodePath, MeshNodeLayoutAreas.EditArea);
+                                actx.NavigateTo(editUrl);
                             },
                             ex =>
                             {
@@ -944,14 +571,5 @@ public static class CreateLayoutArea
         pascalCase = Regex.Replace(pascalCase, @"[^a-zA-Z0-9]", "");
 
         return pascalCase ?? "";
-    }
-
-    /// <summary>
-    /// Gets the last segment of a path.
-    /// </summary>
-    private static string GetLastPathSegment(string path)
-    {
-        var lastSlash = path.LastIndexOf('/');
-        return lastSlash >= 0 ? path[(lastSlash + 1)..] : path;
     }
 }

--- a/src/MeshWeaver.Graph/GroupsLayoutArea.cs
+++ b/src/MeshWeaver.Graph/GroupsLayoutArea.cs
@@ -5,6 +5,7 @@ using MeshWeaver.Domain;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Layout.Domain;
+using Microsoft.Extensions.Logging;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
@@ -295,7 +296,8 @@ public static class GroupsLayoutArea
                                             // land on Edit to pick the group. No transient placeholder.
                                             nodeFactory.CreateNode(newNode).Subscribe(
                                                 _ => saveCtx.NavigateTo($"/{path}/{MeshNodeLayoutAreas.EditArea}"),
-                                                _ => { });
+                                                ex => saveCtx.Hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>()
+                                                    ?.LogWarning(ex, "Failed to create group membership at {Path}", path));
                                         });
                                 });
                         });

--- a/src/MeshWeaver.Graph/GroupsLayoutArea.cs
+++ b/src/MeshWeaver.Graph/GroupsLayoutArea.cs
@@ -290,8 +290,11 @@ public static class GroupsLayoutArea
                                                     Groups = [new MembershipEntry { Group = "" }]
                                                 }
                                             };
-                                            nodeFactory.CreateTransient(newNode).Subscribe(
-                                                _ => saveCtx.NavigateTo($"/{path}/{MeshNodeLayoutAreas.CreateNodeArea}"),
+                                            // One authoritative create (Active, through the access-control
+                                            // pipeline) — the membership content is already built above, so
+                                            // land on Edit to pick the group. No transient placeholder.
+                                            nodeFactory.CreateNode(newNode).Subscribe(
+                                                _ => saveCtx.NavigateTo($"/{path}/{MeshNodeLayoutAreas.EditArea}"),
                                                 _ => { });
                                         });
                                 });

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -1684,14 +1684,14 @@ public static class MeshNodeLayoutAreas
             // A freshly-created node carries no Content yet — the create flow persists an Active
             // node with null Content (never a transient placeholder) and lands here on its own hub.
             // That hub knows the node's content type via its MeshDataSource, so materialise a default
-            // instance to edit; the form binds to the node stream and the first field write persists
-            // it. Seed the /data projection too so default values render immediately.
+            // instance to resolve the form SHAPE (contentType). The form binds to the node stream
+            // below, so the first field write persists it — we deliberately do NOT seed the /data
+            // projection here: this method re-runs on every render (the permissions CombineLatest),
+            // and an unconditional seed could reset in-progress edits before the first write lands.
             var dataSource = host.Workspace.DataContext.DataSources
                 .OfType<MeshDataSource>()
                 .FirstOrDefault(ds => ds.ContentType != null);
             instance = dataSource?.CreateContentInstance(node);
-            if (instance != null)
-                host.UpdateData(Layout.Domain.EditLayoutArea.GetDataId(node.Path), instance);
         }
         if (instance == null)
             return Controls.Stack.WithWidth("100%").WithStyle(GetContainerStyle(host))

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -1680,6 +1680,20 @@ public static class MeshNodeLayoutAreas
 
         var instance = node.Content;
         if (instance == null)
+        {
+            // A freshly-created node carries no Content yet — the create flow persists an Active
+            // node with null Content (never a transient placeholder) and lands here on its own hub.
+            // That hub knows the node's content type via its MeshDataSource, so materialise a default
+            // instance to edit; the form binds to the node stream and the first field write persists
+            // it. Seed the /data projection too so default values render immediately.
+            var dataSource = host.Workspace.DataContext.DataSources
+                .OfType<MeshDataSource>()
+                .FirstOrDefault(ds => ds.ContentType != null);
+            instance = dataSource?.CreateContentInstance(node);
+            if (instance != null)
+                host.UpdateData(Layout.Domain.EditLayoutArea.GetDataId(node.Path), instance);
+        }
+        if (instance == null)
             return Controls.Stack.WithWidth("100%").WithStyle(GetContainerStyle(host))
                 .WithView(BuildHeader(host, node, false))
                 .WithView(Controls.Markdown("*No content type configured for this node.*")

--- a/src/MeshWeaver.Hosting/HubNodePersistence.cs
+++ b/src/MeshWeaver.Hosting/HubNodePersistence.cs
@@ -85,21 +85,4 @@ internal sealed class HubNodePersistence(
                 });
             });
     }
-
-    /// <summary>
-    /// Persists a node in <see cref="MeshNodeState.Transient"/> via the
-    /// storage adapter directly — the CreateNodeRequest pipeline would force
-    /// the node to <c>Active</c>. This is the only CRUD path that bypasses
-    /// hub messaging, mirroring <see cref="MeshService.CreateTransient"/>.
-    /// </summary>
-    public IObservable<MeshNode> CreateTransient(MeshNode node)
-    {
-        var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
-        if (persistence is null)
-            return CreateNode(node);
-        var transient = node with { State = MeshNodeState.Transient };
-        return persistence.Write(transient, hub.JsonSerializerOptions)
-            .Where(n => n is not null)
-            .Select(n => n!);
-    }
 }

--- a/src/MeshWeaver.Hosting/MeshService.cs
+++ b/src/MeshWeaver.Hosting/MeshService.cs
@@ -201,25 +201,6 @@ internal sealed class MeshService(
         }).CarryAccessContext(hub.ServiceProvider);
     }
 
-    public IObservable<MeshNode> CreateTransient(MeshNode node)
-    {
-        var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
-        if (persistence == null)
-            return CreateNode(node);
-
-        // Persistence ALLOWED here — `CreateTransient` is the canonical entry that
-        // sets a transient MeshNode into the mesh. The request handler path for
-        // `CreateNodeRequest` would force the node to `Active`; we deliberately want
-        // a node in `Transient` state to register it without a permanent commit, so we
-        // write straight through `IStorageAdapter`. This is the *only* IMeshService
-        // method allowed to bypass the hub-message pipeline — every other CRUD method
-        // routes through `Post + RegisterCallback` and never touches persistence.
-        var transientNode = node with { State = MeshNodeState.Transient };
-        return persistence.Write(transientNode, hub.JsonSerializerOptions)
-            .Where(n => n is not null)
-            .Select(n => n!);
-    }
-
     public IObservable<MeshNode> CopyNode(string sourcePath, string targetPath,
         bool includeDescendants = true, bool includeSatellites = false)
         => Observable.Defer(() =>

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshService.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshService.cs
@@ -14,7 +14,7 @@ public interface IMeshService
     // Returns cold IObservable that captures AccessContext at call time.
     // Emits a single item then completes, or errors on failure.
     // For await-based callers, use the extension methods in MeshServiceExtensions
-    // (CreateNodeAsync, UpdateNodeAsync, DeleteNodeAsync, CreateTransientAsync).
+    // (CreateNodeAsync, UpdateNodeAsync, DeleteNodeAsync).
 
     /// <summary>
     /// Creates a new node with validation.
@@ -47,13 +47,6 @@ public interface IMeshService
     /// Routes through DeleteNodeRequest for proper security enforcement.
     /// </summary>
     IObservable<bool> DeleteNode(string path);
-
-    /// <summary>
-    /// Creates a transient node for UI creation flows.
-    /// The node is persisted in Transient state but NOT confirmed.
-    /// Call DeleteNode to cancel or CreateNode to confirm.
-    /// </summary>
-    IObservable<MeshNode> CreateTransient(MeshNode node);
 
     /// <summary>
     /// Copies a node (and optionally its subtree and satellites) to a new path.

--- a/src/MeshWeaver.Mesh.Contract/Services/MeshServiceExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/MeshServiceExtensions.cs
@@ -30,13 +30,6 @@ public static class MeshServiceExtensions
         => ToTask<bool>(service.DeleteNode(path), ct);
 
     /// <summary>
-    /// Creates a transient node asynchronously via the mesh service.
-    /// </summary>
-    public static Task<MeshNode> CreateTransientAsync(
-        this IMeshService service, MeshNode node, CancellationToken ct = default)
-        => ToTask(service.CreateTransient(node), ct);
-
-    /// <summary>
     /// Converts an observable to a task that completes with the first emitted value.
     /// </summary>
     public static Task<T> ToTask<T>(IObservable<T> observable, CancellationToken ct = default)

--- a/test/MeshWeaver.Acme.Test/TodoCreateFlowTest.cs
+++ b/test/MeshWeaver.Acme.Test/TodoCreateFlowTest.cs
@@ -178,13 +178,13 @@ public class TodoCreateFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
         {
             Name = "Test Task",
             NodeType = "ACME/Project/Todo",
-            State = MeshNodeState.Transient
+            State = MeshNodeState.Active
         };
 
         try
         {
             // Create the transient node via NodeFactory
-            await NodeFactory.CreateTransient(transientNode).Should().Emit();
+            await NodeFactory.CreateNode(transientNode).Should().Emit();
             Output.WriteLine("Transient node created.");
 
             // Initialize the node's hub. 30 s Ping budget — activating a brand-new
@@ -253,12 +253,12 @@ public class TodoCreateFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
         {
             Name = "Editor Test Task",
             NodeType = "ACME/Project/Todo",
-            State = MeshNodeState.Transient
+            State = MeshNodeState.Active
         };
 
         try
         {
-            await NodeFactory.CreateTransient(transientNode).Should().Emit();
+            await NodeFactory.CreateNode(transientNode).Should().Emit();
             Output.WriteLine("Transient node created successfully");
 
             var nodeAddress = new Address(nodePath);
@@ -337,15 +337,15 @@ public class TodoCreateFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
         {
             Name = "Create Test Task",
             NodeType = "ACME/Project/Todo",
-            State = MeshNodeState.Transient
+            State = MeshNodeState.Active
         };
 
         try
         {
             // Step 1: Create transient node (simulates BuildCreateChildForm)
-            var createdNode = await NodeFactory.CreateTransient(transientNode).Should().Emit();
+            var createdNode = await NodeFactory.CreateNode(transientNode).Should().Emit();
             createdNode.Should().NotBeNull("Transient node should be created");
-            createdNode.State.Should().Be(MeshNodeState.Transient);
+            createdNode.State.Should().Be(MeshNodeState.Active);
             Output.WriteLine($"Transient node created: {createdNode.Path}");
 
             // Step 2: Initialize the node's hub (required for sending CreateNodeRequest).
@@ -421,23 +421,23 @@ public class TodoCreateFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
         {
             Name = "E2E Test Task",
             NodeType = "ACME/Project/Todo",
-            State = MeshNodeState.Transient
+            State = MeshNodeState.Active
         };
 
         try
         {
             // Step 1: Create transient node
-            var createdNode = await NodeFactory.CreateTransient(transientNode).Should().Emit();
+            var createdNode = await NodeFactory.CreateNode(transientNode).Should().Emit();
             createdNode.Should().NotBeNull("Transient node should be created");
-            createdNode.State.Should().Be(MeshNodeState.Transient, "Node should be in Transient state");
+            createdNode.State.Should().Be(MeshNodeState.Active, "Node should be in Active state");
             createdNode.Name.Should().Be("E2E Test Task");
             Output.WriteLine($"Created transient node: {createdNode.Path}");
 
             // Step 2: Retrieve the node via stream
             var retrievedNode = await ReadNode(nodePath)
-                .Should().Within(60.Seconds()).Match(n => n is not null && n.State == MeshNodeState.Transient);
+                .Should().Within(60.Seconds()).Match(n => n is not null && n.State == MeshNodeState.Active);
             retrievedNode.Should().NotBeNull("Transient node should be retrievable");
-            retrievedNode!.State.Should().Be(MeshNodeState.Transient);
+            retrievedNode!.State.Should().Be(MeshNodeState.Active);
             retrievedNode.Name.Should().Be("E2E Test Task");
             retrievedNode.NodeType.Should().Be("ACME/Project/Todo");
             Output.WriteLine($"Retrieved transient node successfully");
@@ -509,38 +509,39 @@ public class TodoCreateFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
     #region Verification Tests
 
     /// <summary>
-    /// Test that simulates the actual UI create flow:
-    /// 1. Create transient node WITHOUT content (like CreateChild does)
-    /// 2. Initialize hub (which creates content instance via MeshDataSource.CreateContentInstance)
-    /// 3. Confirm node with content from workspace
-    /// 4. Verify content fields are preserved
+    /// Simulates the actual UI create → edit flow:
+    /// 1. Create the node WITHOUT content (one Active CreateNode, as the Create form does now)
+    /// 2. Initialize the node's hub
+    /// 3. Fill the content via UpdateNode (what the Edit area does after creation)
+    /// 4. Verify the content fields are preserved
     ///
-    /// This reproduces the bug where content fields (category, priority, etc.) are empty after create.
+    /// Guards that a node created empty and edited afterward keeps its fields (category, priority, …).
     /// </summary>
     [Fact(Timeout = 60000)]
-    public async Task CreateFlow_TransientNodeWithoutContent_PreservesContentFieldsAfterConfirm()
+    public async Task CreateFlow_NodeWithoutContent_PreservesContentFieldsAfterEdit()
     {
         var client = GetClient();
 
         var uniqueId = Guid.NewGuid().ToString("N")[..8];
         var nodePath = $"ACME/ProductLaunch/Todo/UIFlowTest{uniqueId}";
 
-        Output.WriteLine($"Creating transient node at: {nodePath}");
+        Output.WriteLine($"Creating node at: {nodePath}");
 
-        // Step 1: Create transient node WITHOUT content (simulates CreateChild flow)
-        // In real UI, this is done by BuildCreateChildForm which only sets Name/Description/NodeType
-        var transientNode = MeshNode.FromPath(nodePath) with
+        // Step 1: Create the node WITHOUT content (this is how the Create form works now — one
+        // CreateNode of an Active node; the type-specific content is filled afterward on the Edit
+        // area). In real UI, the form only sets Name/Description/NodeType before CreateNode.
+        var node = MeshNode.FromPath(nodePath) with
         {
             Name = "UI Flow Test Task",
             NodeType = "ACME/Project/Todo",
-            State = MeshNodeState.Transient
-            // NOTE: No Content set - this is how CreateChild creates the node
+            State = MeshNodeState.Active
+            // NOTE: No Content set — the Edit area fills it after creation.
         };
 
         try
         {
-            await NodeFactory.CreateTransient(transientNode).Should().Emit();
-            Output.WriteLine("Transient node created (without content).");
+            await NodeFactory.CreateNode(node).Should().Emit();
+            Output.WriteLine("Node created (without content).");
 
             // Step 2: Initialize the node's hub (this triggers MeshDataSource initialization)
             var nodeAddress = new Address(nodePath);
@@ -574,23 +575,25 @@ public class TodoCreateFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
                 status = "Planning"
             };
 
-            // Step 5: Confirm the node (simulates Create button click)
-            var activeNode = transientNode with
+            // Step 5: Fill the content via an Update — exactly what the Edit area does after the
+            // node is created (the new create→edit flow). No second CreateNode: the node already
+            // exists Active, so a duplicate create would fault with "Node already exists".
+            var editedNode = node with
             {
-                State = MeshNodeState.Active,
                 Content = editedContent
             };
 
-            client.Post(
-                new CreateNodeRequest(activeNode),
-                o => o.WithTarget(nodeAddress));
+            await NodeFactory.UpdateNode(editedNode).Should().Emit();
 
-            // Step 6: Wait for node to become Active on the live stream (same
-            // rationale as step 3 — the canonical wait-for-state primitive).
+            // Step 6: Wait for the edited content to land on the live stream (same wait-for-state
+            // primitive as step 3 — the node is already Active, so gate on the content instead).
             var confirmedNode = await client.GetWorkspace().GetMeshNodeStream(nodePath)
-                .Should().Within(60.Seconds()).Match(node => node is not null && node.State == MeshNodeState.Active);
+                .Should().Within(60.Seconds()).Match(n =>
+                    n is not null
+                    && n.Content is not null
+                    && JsonSerializer.Serialize(n.Content).Contains("Testing"));
 
-            Output.WriteLine($"Node confirmed. Content type: {confirmedNode.Content?.GetType().Name ?? "null"}");
+            Output.WriteLine($"Node edited. Content type: {confirmedNode.Content?.GetType().Name ?? "null"}");
             if (confirmedNode.Content != null)
             {
                 var contentJson = JsonSerializer.Serialize(confirmedNode.Content);
@@ -656,14 +659,14 @@ public class TodoCreateFlowTest(ITestOutputHelper output) : MonolithMeshTestBase
         {
             Name = "Data Request Test Task",
             NodeType = "ACME/Project/Todo",
-            State = MeshNodeState.Transient,
+            State = MeshNodeState.Active,
             Content = todoContent
         };
 
         try
         {
             // Step 1: Create transient node
-            await NodeFactory.CreateTransient(transientNode).Should().Emit();
+            await NodeFactory.CreateNode(transientNode).Should().Emit();
             Output.WriteLine("Transient node created.");
 
             // Step 2: Initialize the node's hub. 30 s Ping budget — activating a

--- a/test/MeshWeaver.Hosting.Monolith.Test/CreatableTypesIntegrationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CreatableTypesIntegrationTest.cs
@@ -734,43 +734,43 @@ public class CreatableTypesIntegrationTest : MonolithMeshTestBase
     }
 
     /// <summary>
-    /// Test that creating a TRANSIENT node and then requesting Edit view works.
+    /// Test that creating a node and then requesting Edit view works.
     /// This is the exact flow from the simplified Create form:
     /// 1. User fills in Name + Description
-    /// 2. CreateTransientNodeAsync is called (NOT CreateNodeAsync which confirms immediately)
+    /// 2. CreateNode is called, persisting a single Active node
     /// 3. Redirect to /{nodePath}/Edit
-    /// 4. Edit view should load and show "Draft" badge
+    /// 4. Edit view should load
     /// </summary>
     [Fact(Timeout = 20000)]
-    public async Task CreateTransientNode_ThenRequestEditView_Succeeds()
+    public async Task CreateNode_ThenRequestEditView_Succeeds()
     {
         // Arrange - Create a unique node path
         var uniqueId = Guid.NewGuid().ToString("N")[..8];
-        var nodePath = $"test-transient-{uniqueId}";
+        var nodePath = $"test-node-{uniqueId}";
         var nodeAddress = new Address(nodePath);
 
-        Output.WriteLine($"Test: Creating TRANSIENT node at {nodePath}");
+        Output.WriteLine($"Test: Creating node at {nodePath}");
 
-        // Step 1: Create TRANSIENT node via IMeshCatalog (like the new Create form does)
+        // Step 1: Create node via IMeshCatalog (like the new Create form does)
         var node = MeshNode.FromPath(nodePath) with
         {
-            Name = "Test Transient Node",
+            Name = "Test Node",
             NodeType = "Markdown",
-            State = MeshNodeState.Transient, // Explicitly transient
-            Content = MarkdownContent.Parse($"# Test Transient\n\nThis is transient.", nodePath)
+            State = MeshNodeState.Active,
+            Content = MarkdownContent.Parse($"# Test Node\n\nThis is a node.", nodePath)
         };
 
-        Output.WriteLine($"Step 1: Calling NodeFactory.CreateTransientAsync for {nodePath}");
+        Output.WriteLine($"Step 1: Calling NodeFactory.CreateNode for {nodePath}");
 
-        var createdNode = await NodeFactory.CreateTransient(node).Should().Within(20.Seconds()).Emit();
-        Output.WriteLine($"CreateTransientAsync completed: Path={createdNode.Path}, State={createdNode.State}");
-        createdNode.State.Should().Be(MeshNodeState.Transient, "Node should be in Transient state");
+        var createdNode = await NodeFactory.CreateNode(node).Should().Within(20.Seconds()).Emit();
+        Output.WriteLine($"CreateNode completed: Path={createdNode.Path}, State={createdNode.State}");
+        createdNode.State.Should().Be(MeshNodeState.Active, "Node should be in Active state");
 
-        // Step 2: Verify node exists with Transient state via stream
-        Output.WriteLine($"Step 2: Verifying transient node exists");
+        // Step 2: Verify node exists with Active state via stream
+        Output.WriteLine($"Step 2: Verifying node exists");
         var persistedNode = await ReadNode(nodePath).Should().Within(ReadNodeTimeout).Emit();
-        persistedNode.Should().NotBeNull($"Transient node {nodePath} should exist");
-        persistedNode!.State.Should().Be(MeshNodeState.Transient, "Persisted node should be Transient");
+        persistedNode.Should().NotBeNull($"Node {nodePath} should exist");
+        persistedNode!.State.Should().Be(MeshNodeState.Active, "Persisted node should be Active");
         Output.WriteLine($"Node found: State={persistedNode.State}, Name={persistedNode.Name}");
 
         // Diagnostic: Check what's in the static-node provider chain
@@ -804,7 +804,7 @@ public class CreatableTypesIntegrationTest : MonolithMeshTestBase
         // Step 3: Verify via stream (CQRS-correct)
         Output.WriteLine($"Step 3: Getting node via per-node stream");
         var catalogNode = await ReadNode(nodePath).Should().Within(ReadNodeTimeout).Emit();
-        catalogNode.Should().NotBeNull($"Stream should return the transient node");
+        catalogNode.Should().NotBeNull($"Stream should return the node");
 
         // Step 4: Request Edit view (simulates redirect)
         Output.WriteLine($"Step 4: Requesting Edit layout (simulates redirect to /{nodePath}/Edit)");
@@ -828,9 +828,9 @@ public class CreatableTypesIntegrationTest : MonolithMeshTestBase
             Output.WriteLine($"Edit layout content: {rawText[..Math.Min(500, rawText.Length)]}...");
         }
 
-        editLayout.Value.ValueKind.Should().NotBe(JsonValueKind.Undefined, "Edit layout should not be undefined for transient node");
+        editLayout.Value.ValueKind.Should().NotBe(JsonValueKind.Undefined, "Edit layout should not be undefined for the node");
 
-        Output.WriteLine("SUCCESS: CreateTransientNode -> Edit flow completed");
+        Output.WriteLine("SUCCESS: CreateNode -> Edit flow completed");
 
         // Cleanup
         Output.WriteLine($"Cleanup: Deleting test node {nodePath}");

--- a/test/MeshWeaver.Portal.E2E.Test/CreateMenuE2ETest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/CreateMenuE2ETest.cs
@@ -1,0 +1,140 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// The node <b>Create</b> flow must create the node and land on its Edit area — it must NOT show
+/// "Area not found — No renderer is registered for area …".
+/// <para>Regression guard for the transient-create bug: the old flow wrote a <c>Transient</c>
+/// MeshNode and then navigated to <c>/{path}/Create</c>. On Postgres, path-resolution only returns
+/// <c>state = 2</c> (Active) rows, so the just-written transient node was invisible — the router
+/// treated the node id as an <i>area name</i> on the parent hub and rendered
+/// "No renderer is registered for area {id} on hub {parent}". This is a REAL portal (PG-backed)
+/// running the working tree, so it reproduces exactly what the browser hit.</para>
+/// <para>The fix writes ONE <c>Active</c> node via <c>CreateNode</c> and navigates to
+/// <c>/{path}/Edit</c>, whose owning hub knows the content type and renders the editor.</para>
+/// </summary>
+[Collection("portal-e2e")]
+public class CreateMenuE2ETest(PortalFixture fixture)
+{
+    [Theory(Timeout = 180_000)]
+    [InlineData("Markdown", "TomNote", "TomNote")]
+    [InlineData("Agent", "Tom", "Tom")]
+    public async Task Create_LandsOnEditArea_NotAreaNotFound(string nodeType, string nodeName, string expectedId)
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+
+        var space = $"createe2e{nodeType.ToLowerInvariant()}";
+
+        await using var context = await fixture.NewAuthenticatedContextAsync();
+        var token = await fixture.MintTokenAsync(context);
+
+        try
+        {
+            // Seed a Space to create under (idempotent across reruns).
+            try
+            {
+                await fixture.CreateNodeAsync(context, token, $$"""
+                    {
+                      "id": "{{space}}",
+                      "name": "Create E2E",
+                      "nodeType": "Space",
+                      "content": { "$type": "Space", "name": "Create E2E" }
+                    }
+                    """);
+            }
+            catch (InvalidOperationException) { /* persisted from a prior run */ }
+
+            // The browser circuit authenticates as the DevLogin ObjectId; grant it Admin on the
+            // Space so it has Create there (same shape as the Node-menu / sync E2E).
+            try
+            {
+                await fixture.CreateNodeAsync(context, token, $$"""
+                    {
+                      "id": "{{fixture.UserId}}_CircuitAccess",
+                      "namespace": "{{space}}/_Access",
+                      "name": "{{fixture.UserId}} Access",
+                      "nodeType": "AccessAssignment",
+                      "mainNode": "{{space}}",
+                      "content": {
+                        "$type": "AccessAssignment",
+                        "accessObject": "{{fixture.UserId}}",
+                        "displayName": "{{fixture.UserId}}",
+                        "roles": [ { "$type": "RoleAssignment", "role": "Admin" } ]
+                      }
+                    }
+                    """);
+            }
+            catch (InvalidOperationException) { }
+
+            (await fixture.WaitUntilReadableAsync(context, token, space, TimeSpan.FromSeconds(60)))
+                .Should().BeTrue("the seeded space must be readable before driving the UI");
+
+            var page = await context.NewPageAsync();
+            await page.SetViewportSizeAsync(1400, 1000);
+
+            // Drive the Create form directly with the type preset (the "+"/Create menu item lands
+            // here with ?type=). The creator-admin grant on a fresh space propagates eventually, so
+            // retry the whole create round until the form is reachable and the create succeeds.
+            var landedOnEdit = false;
+            string? lastUrl = null;
+            for (var attempt = 0; attempt < 8 && !landedOnEdit; attempt++)
+            {
+                await page.GotoAsync($"{fixture.BaseUrl}/{space}/Create?type={nodeType}",
+                    new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 90_000 });
+
+                var nameField = page.GetByPlaceholder("Enter a name...").First;
+                try
+                {
+                    await nameField.WaitForAsync(
+                        new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 15_000 });
+                }
+                catch (TimeoutException) { continue; /* grant not propagated — reload */ }
+
+                // The Name field is a <fluent-text-field> web component (its inner <input> lives in
+                // the shadow DOM), so Fill on the host fails — click to focus, then type.
+                await nameField.ClickAsync();
+                await page.Keyboard.TypeAsync(nodeName);
+
+                await page.GetByRole(AriaRole.Button, new() { Name = "Create", Exact = true }).First
+                    .ClickAsync();
+
+                try
+                {
+                    // The fix navigates to /{space}/{id}/Edit. Wait for that URL specifically.
+                    await page.WaitForURLAsync($"**/{space}/{expectedId}/Edit", new() { Timeout = 20_000 });
+                    landedOnEdit = true;
+                }
+                catch (TimeoutException)
+                {
+                    lastUrl = page.Url;
+                    // Not on Edit — could be a propagation retry, or the bug (stuck on /Create with
+                    // an "Area not found"). Loop unless the page shows the regression signature.
+                }
+
+                // Hard failure the moment the regression text appears — never silently retry past it.
+                var bodyText = await page.InnerTextAsync("body");
+                bodyText.Should().NotContain("No renderer is registered for area",
+                    $"creating a {nodeType} must not render the area-not-found page (transient-create regression). URL={page.Url}");
+                bodyText.Should().NotContain("Area not found",
+                    $"creating a {nodeType} must land on the node's Edit area, not 'Area not found'. URL={page.Url}");
+            }
+
+            landedOnEdit.Should().BeTrue(
+                $"creating a {nodeType} named '{nodeName}' must land on /{space}/{expectedId}/Edit; last URL was {lastUrl}");
+
+            // The created node must actually exist (Active) — the Edit URL alone could be reached
+            // with a broken node, so confirm via the read API the browser's grant can see.
+            (await fixture.WaitUntilReadableAsync(context, token, $"{space}/{expectedId}", TimeSpan.FromSeconds(30)))
+                .Should().BeTrue($"the created node {space}/{expectedId} must be persisted and readable");
+
+            await page.ScreenshotAsync(new PageScreenshotOptions { Path = $"/tmp/create-{nodeType}.png" });
+        }
+        finally
+        {
+            await fixture.DeleteNodeAsync(context, token, $"{space}/{expectedId}");
+            await fixture.DeleteNodeAsync(context, token, space);
+        }
+    }
+}

--- a/test/MeshWeaver.Security.Test/NodeCreationAccessTest.cs
+++ b/test/MeshWeaver.Security.Test/NodeCreationAccessTest.cs
@@ -21,8 +21,8 @@ namespace MeshWeaver.Security.Test;
 /// <summary>
 /// Tests for node creation access control, specifically testing:
 /// 1. CreateNode without permission returns Unauthorized
-/// 2. CreateNode with permission creates transient node
-/// 3. Id change during creation creates new node and deletes transient
+/// 2. CreateNode with permission creates an Active node
+/// 3. Creating a node at its desired final path
 /// </summary>
 public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -117,8 +117,8 @@ public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTest
     }
 
     /// <summary>
-    /// Tests the Id change flow: when user changes Id during creation,
-    /// a new node is created at the new path and the transient node is deleted.
+    /// Tests that an Editor-role user can create a node directly at its
+    /// desired final path.
     /// </summary>
     [Fact(Timeout = 20000)]
     public async Task CreateNode_IdChanged_CreatesNewNodeAndDeletesTransient()
@@ -128,29 +128,14 @@ public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTest
 
         const string userId = "editor-user";
         const string parentNamespace = "Editor/Projects";
-        var transientId = Guid.NewGuid().AsString();
         var desiredId = "MyNewProject";
-        var transientPath = $"{parentNamespace}/{transientId}";
         var finalPath = $"{parentNamespace}/{desiredId}";
 
         // Grant Editor role — runtime AccessAssignment node.
         await meshService.CreateNode(AssignmentNodeFactory.UserRole(userId, "Editor", parentNamespace))
             .Should().Emit();
 
-        // Step 1: Create transient node with GUID-based Id
-        var transientNode = MeshNode.FromPath(transientPath) with
-        {
-            Name = "My New Project",
-            NodeType = "Markdown",
-            State = MeshNodeState.Transient,
-            DesiredId = desiredId // User wants this as final Id
-        };
-
-        var createdTransient = await NodeFactory.CreateTransient(transientNode).Should().Emit();
-        createdTransient.Should().NotBeNull("Transient node should be created");
-        Output.WriteLine($"Transient node created at: {createdTransient.Path}");
-
-        // Step 2: "Confirm" by creating new node at final path with Active state
+        // Create the node directly at the final path with Active state.
         var finalNode = MeshNode.FromPath(finalPath) with
         {
             Name = "My New Project",
@@ -158,20 +143,13 @@ public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTest
             State = MeshNodeState.Active
         };
 
-        // Create the final node
         var createdFinal = await NodeFactory.CreateNode(finalNode).Should().Emit();
         createdFinal.Should().NotBeNull("Final node should be created");
         createdFinal.State.Should().Be(MeshNodeState.Active, "Final node should be Active");
         createdFinal.Path.Should().Be(finalPath, "Final node should be at desired path");
         Output.WriteLine($"Final node created at: {createdFinal.Path}");
 
-        // Step 3: Delete the transient node
-        await NodeFactory.DeleteNode(transientPath).Should().Emit();
-
-        // Verify: Transient should be gone, final should exist (stream reads)
-        var transientAfterDelete = await ReadNode(transientPath).Should().Emit();
-        transientAfterDelete.Should().BeNull("Transient node should be deleted");
-
+        // Verify: final node should exist (stream read)
         var finalAfterCreate = await ReadNode(finalPath).Should().Emit();
         finalAfterCreate.Should().NotBeNull("Final node should exist");
         finalAfterCreate!.State.Should().Be(MeshNodeState.Active);
@@ -181,19 +159,19 @@ public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTest
     }
 
     /// <summary>
-    /// Tests that DesiredId property is properly persisted with the transient node.
+    /// Tests that DesiredId property is properly persisted with the created node.
     /// </summary>
     [Fact(Timeout = 20000)]
-    public async Task CreateTransientNode_PreservesDesiredId()
+    public async Task CreateNode_PreservesDesiredId()
     {
         // Arrange
         var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
 
         const string userId = "test-user";
         const string parentPath = "Test/DesiredId";
-        var transientId = Guid.NewGuid().AsString();
+        var nodeId = Guid.NewGuid().AsString();
         var desiredId = "UserPreferredId";
-        var nodePath = $"{parentPath}/{transientId}";
+        var nodePath = $"{parentPath}/{nodeId}";
 
         // Grant Admin role — runtime AccessAssignment node.
         await meshService.CreateNode(AssignmentNodeFactory.UserRole(userId, "Admin", parentPath))
@@ -203,12 +181,12 @@ public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTest
         {
             Name = "Test DesiredId Persistence",
             NodeType = "Markdown",
-            State = MeshNodeState.Transient,
+            State = MeshNodeState.Active,
             DesiredId = desiredId
         };
 
         // Act
-        var createdNode = await NodeFactory.CreateTransient(node).Should().Emit();
+        var createdNode = await NodeFactory.CreateNode(node).Should().Emit();
 
         // Assert
         createdNode.Should().NotBeNull();
@@ -224,8 +202,7 @@ public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTest
     }
 
     /// <summary>
-    /// Tests that confirming a transient node (Transient -> Active) works correctly
-    /// via CreateNodeRequest when node already exists.
+    /// Tests that an Admin-role user can create an Active node via CreateNode.
     /// </summary>
     [Fact(Timeout = 20000)]
     public async Task ConfirmTransientNode_UpdatesStateToActive()
@@ -242,19 +219,7 @@ public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTest
         await meshService.CreateNode(AssignmentNodeFactory.UserRole(userId, "Admin", parentPath))
             .Should().Emit();
 
-        // Step 1: Create transient node via NodeFactory
-        var transientNode = MeshNode.FromPath(nodePath) with
-        {
-            Name = "Confirm Test Node",
-            NodeType = "Markdown",
-            State = MeshNodeState.Transient
-        };
-
-        var createdTransient = await NodeFactory.CreateTransient(transientNode).Should().Emit();
-        createdTransient.State.Should().Be(MeshNodeState.Transient);
-
-        // Step 2: Confirm by creating with Active state via CreateNode
-        // Re-create the node at the same path - the handler will confirm it
+        // Create the node directly with Active state via NodeFactory.
         var activeNode = MeshNode.FromPath(nodePath) with
         {
             Name = "Confirm Test Node",
@@ -265,9 +230,9 @@ public class NodeCreationAccessTest(ITestOutputHelper output) : MonolithMeshTest
         var confirmedNode = await NodeFactory.CreateNode(activeNode).Should().Emit();
 
         // Assert
-        confirmedNode.Should().NotBeNull("Confirmed node should be returned");
-        confirmedNode.State.Should().Be(MeshNodeState.Active, "Node should be Active after confirmation");
-        confirmedNode.Path.Should().Be(nodePath, "Path should remain the same");
+        confirmedNode.Should().NotBeNull("Created node should be returned");
+        confirmedNode.State.Should().Be(MeshNodeState.Active, "Node should be Active");
+        confirmedNode.Path.Should().Be(nodePath, "Path should match");
 
         // Verify persistence (stream read)
         var fetchedNode = await ReadNode(nodePath).Should().Emit();


### PR DESCRIPTION
## The bug

The node **Create** menu showed **"Area not found — No renderer is registered for area \`{id}\`"** on every Postgres-backed portal (reported on an Agent at \`/TestSpace/Tom/Create\`, but it hit **every** node type).

## Root cause

The old create flow wrote a **\`Transient\`** placeholder node — \`meshService.CreateTransient\`, which also **bypassed the \`CreateNodeRequest\` access-control pipeline** (it wrote straight to \`IStorageAdapter\`) — then navigated to \`/{path}/Create\`. \`PostgreSqlSqlGenerator\` hardcodes \`n.state = 2\` (Active only), so path-resolution could not see the transient node → it treated the node id as an *area name* on the parent hub. InMemory tests have no state filter, so CI never caught it.

The standard areas were **never** missing — every node hub already inherits them via \`ConfigureDefaultNodeHub → AddDefaultLayoutAreas\`.

## The fix (remove \`CreateTransient\` entirely)

- **\`CreateLayoutArea\`** builds ONE \`Active\` node and persists it with a single **\`CreateNode\`** (through access control), then navigates to \`/{path}/Edit\`.
- **Editors materialise default content** when a fresh node has none — generic \`EditNode\` (via \`MeshDataSource.CreateContentInstance\`), \`AgentView\` (Details + Edit), \`ModelProvider\` — so a new Agent/Model shows an editable form instead of "Loading…".
- **Comment / reply / group** create flows carry the draft in-memory and \`CreateNode\` on submit (also fixes a latent bug where comment-create wrote to the *primary* node's path).
- **\`CreateTransient\` removed** from \`IMeshService\`, \`MeshService\`, \`HubNodePersistence\`, \`MeshServiceExtensions\`. \`MeshNodeState.Transient\` enum value kept (persisted contract). Docs updated.

## Verification

- Full-solution Release \`-warnaserror\` build (merged with main): green.
- Tests: \`CreatableTypesIntegrationTest\`, \`NodeCreationAccessTest\`, \`TodoCreateFlowTest\`, \`CreateLayoutAreaIntegrationTest\`, comment/reply — all pass.
- **Playwright E2E** (new \`CreateMenuE2ETest\`) against a real PG-backed DevLogin portal: Agent **and** Markdown create → land on \`/Edit\`, no "Area not found". 2/2 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)