### PR TITLE
feat(deploy): feature-flag language gates (python + node), default all included

### DIFF
--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -92,19 +92,21 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 10
             failureThreshold: 6
-{{- if (((.Values.grpc).pythonGate).enabled) }}
-        # ---- Python gate (TRUSTED co-deployed participant — see .Values.grpc.pythonGate) ----------
+{{- range $lang, $gate := (.Values.grpc).gates }}
+{{- if and $gate.enabled $gate.image }}
+        # ---- {{ $lang }} gate (TRUSTED co-deployed participant — see .Values.grpc.gates) ----------
         # Same pod ⇒ shares the network namespace ⇒ reaches the portal's 127.0.0.1-bound trusted gRPC
-        # endpoint. That reachability IS the authentication (no token). Executes `python` Code nodes
-        # exactly as the in-process Roslyn kernel executes C# ones. OFF unless the image is provided.
-        - name: "python-gate"
-          image: "{{ .Values.grpc.pythonGate.image }}"
+        # endpoint. That reachability IS the authentication (no token). Executes `{{ $lang }}` Code
+        # nodes exactly as the in-process Roslyn kernel executes C# ones. Rendered only when the
+        # language is enabled AND an image is supplied.
+        - name: "{{ $lang }}-gate"
+          image: "{{ $gate.image }}"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: "MESH_GRPC_URL"
-              value: "http://127.0.0.1:{{ .Values.grpc.trustedPort }}"
+              value: "http://127.0.0.1:{{ $.Values.grpc.trustedPort }}"
             - name: "MESH_GATE_ADDRESS"
-              value: "{{ .Values.grpc.pythonGate.address | default "py/python-kernel" }}"
+              value: "{{ $gate.address }}"
           resources:
             requests: { cpu: "25m", memory: "64Mi" }
             limits: { memory: "256Mi" }
@@ -113,6 +115,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
             capabilities: { drop: ["ALL"] }
+{{- end }}
 {{- end }}
       volumes:
         - name: "memex-data"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -38,20 +38,26 @@ grpc:
   enabled: true
   port: 8081
   trustedPort: 8082
-  # ---- Python gate sidecar (executes `python` Code nodes; OFF by default) ---
-  # A trusted, co-deployed participant that runs `meshweaver.worker` as a SIDECAR in the portal pod
-  # and connects to the trusted loopback endpoint above (127.0.0.1:{trustedPort}) — reachability
-  # across the shared pod network namespace IS the authentication, no token. It is the Python
-  # counterpart of the in-process Roslyn kernel: a Code node whose Language=="python" routes to it
-  # (address `py/python-kernel`), runs, and writes its result back onto the run's Activity node.
+  # ---- Language gates (execute foreign-language Code nodes as co-deployed sidecars) ---------------
+  # A gate is a TRUSTED participant sidecar in the portal pod that connects to the trusted loopback
+  # endpoint above (127.0.0.1:{trustedPort}) — reachability across the shared pod network namespace IS
+  # the authentication, no token. It is the foreign-language counterpart of the in-process Roslyn
+  # kernel: a Code node whose Language routes to the matching gate (CodeNodeType.ResolveKernelAddress),
+  # runs, and writes its result back onto the run's Activity node.
   #
-  # OFF by default: a deployment must (a) supply the image (built from deploy/python-gate/Dockerfile,
-  # pushed to a registry the cluster can pull) and (b) opt in — standing python execution is a
-  # deliberate capability, not a default. Enable in an overlay / --set.
-  pythonGate:
-    enabled: false
-    image: "meshweaver/python-gate:local"
-    address: "py/python-kernel"
+  # FEATURE FLAG per language: by default ALL languages are INCLUDED (enabled: true) — set a gate's
+  # enabled:false to opt a language out. A gate actually RUNS when it is enabled AND its image is
+  # supplied (built from deploy/{python,node}-gate/Dockerfile, pushed to a registry the cluster can
+  # pull); image left empty ⇒ no sidecar, so a bare install never crash-loops on a missing image.
+  gates:
+    python:
+      enabled: true
+      image: ""
+      address: "py/python-kernel"
+    node:
+      enabled: true
+      image: ""
+      address: "node/node-kernel"
 # ---- Portal Ingress (TLS via an ingress controller) -----------------------
 # Off by default (cloud envs wire ingress/TLS their own way). A self-host overlay
 # enables it with a hostname + a pre-created TLS secret. The proxy-*-timeout

--- a/deploy/node-gate/Dockerfile
+++ b/deploy/node-gate/Dockerfile
@@ -1,0 +1,47 @@
+# The Node gate — a TRUSTED, co-deployed MeshWeaver participant that executes `javascript` /
+# `typescript` Code nodes.
+#
+# It runs as a SIDECAR inside the portal pod and connects to the portal's trusted loopback gRPC
+# endpoint (http://127.0.0.1:{Grpc:TrustedPort}). Reachability across the shared pod network
+# namespace IS the authentication — no API token, nothing to rotate. This is the Node counterpart of
+# the in-process Roslyn kernel: a Code node whose `Language` is `javascript`/`typescript` is routed to
+# this gate (address `node/node-kernel`, see CodeNodeType.ResolveKernelAddress), executed, and its
+# result written back onto the run's Activity node.
+#
+# Build from the REPO ROOT (the SDK package AND the one canonical proto both live there):
+#   docker build -f deploy/node-gate/Dockerfile -t meshweaver/node-gate:local .
+
+# ---- build stage: install deps + compile the TypeScript SDK to dist/ ------------------------------
+FROM node:22-slim AS build
+WORKDIR /app
+COPY clients/typescript/package.json ./
+RUN npm install --no-audit --no-fund
+COPY clients/typescript/tsconfig.json ./
+COPY clients/typescript/src ./src
+RUN npm run build && npm prune --omit=dev
+
+# ---- runtime stage: node + dist + prod deps + the one canonical proto -----------------------------
+FROM node:22-slim
+RUN useradd --create-home --uid 10001 gate
+WORKDIR /app
+COPY --from=build /app/package.json ./
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+# The canonical proto is loaded at runtime by @grpc/proto-loader (connection.ts reads MESHWEAVER_PROTO).
+COPY src/MeshWeaver.Hosting.Grpc/Protos/mesh.proto /app/mesh.proto
+# Numeric uid (not the name) so Kubernetes' runAsNonRoot check can verify non-root.
+USER 10001
+
+# The trusted endpoint + the well-known address the .NET side routes js/ts submissions to; both
+# overridable, defaults match deploy/helm values.grpc. NODE_ENV=production; no buffering so the
+# worker's connect line + errors reach the pod log immediately.
+ENV MESH_GRPC_URL=http://127.0.0.1:8082 \
+    MESH_GATE_ADDRESS=node/node-kernel \
+    MESHWEAVER_PROTO=/app/mesh.proto \
+    NODE_ENV=production
+
+# The node kernel serves SubmitCodeRequest against the trusted endpoint with NO token (trust is the
+# loopback). --reconnect: the gate outlives portal restarts and tolerates starting before the portal
+# has bound the endpoint. exec so node is the signalled process (clean SIGTERM; the worker's signal
+# handler stops the reconnect loop).
+CMD ["/bin/sh", "-c", "exec node dist/worker.js --url \"$MESH_GRPC_URL\" --address \"$MESH_GATE_ADDRESS\" --reconnect"]

--- a/deploy/node-gate/README.md
+++ b/deploy/node-gate/README.md
@@ -1,0 +1,43 @@
+# Node gate
+
+A **trusted, co-deployed** MeshWeaver participant that executes `javascript` / `typescript` Code
+nodes. It runs as a **sidecar in the portal pod** and connects to the portal's trusted loopback gRPC
+endpoint (`http://127.0.0.1:{Grpc:TrustedPort}`, default `8082`). Reachability across the shared pod
+network namespace **is** the authentication — no API token, nothing to rotate. It is the Node
+counterpart of the in-process Roslyn kernel: a Code node whose `Language` is `javascript`/`typescript`
+is routed to the gate (address `node/node-kernel`, see `CodeNodeType.ResolveKernelAddress`), executed,
+and its result written back onto the run's Activity node — surfacing exactly like a C# run. Runs
+execute under the *requesting user's* identity (the gate echoes the delivery's `AccessContext`).
+
+The kernel runs the snippet in a `vm` sandbox with REPL semantics (`console.log` captured; a trailing
+bare expression is the return value; `Inputs` exposes caller parameters; TypeScript is transpiled
+first). Full SDK + worker: `clients/typescript`. Trust model: `GrpcOptions.TrustedPort`.
+
+## Build
+
+The image compiles the TypeScript SDK (`clients/typescript`) and packs the **one canonical** proto
+(`src/MeshWeaver.Hosting.Grpc/Protos/mesh.proto`), so build from the **repo root**:
+
+```bash
+docker build -f deploy/node-gate/Dockerfile -t <registry>/meshweaver/node-gate:<tag> .
+docker push <registry>/meshweaver/node-gate:<tag>
+```
+
+## Enable
+
+Language gates are **feature-flagged** under `grpc.gates`: every language is **included by default**
+(`enabled: true`), but a gate only RUNS once its image is supplied. Point the `node` gate at the
+pushed image:
+
+```yaml
+grpc:
+  enabled: true          # the trusted endpoint the gate connects to
+  gates:
+    node:
+      enabled: true       # default; set false to opt javascript/typescript out
+      image: <registry>/meshweaver/node-gate:<tag>
+      address: node/node-kernel
+```
+
+`MESH_GRPC_URL` and `MESH_GATE_ADDRESS` (the container's env) override the endpoint and address; the
+defaults match `deploy/helm` `values.grpc`. The Python gate is the sibling — see `deploy/python-gate`.

--- a/deploy/python-gate/README.md
+++ b/deploy/python-gate/README.md
@@ -24,17 +24,21 @@ docker push <registry>/meshweaver/python-gate:<tag>
 
 ## Enable
 
-OFF by default (standing arbitrary-python execution is a deliberate capability, and the image must be
-provided). Turn it on in a Helm overlay / `--set`, pointing at the pushed image:
+Language gates are **feature-flagged** under `grpc.gates`: every language is **included by default**
+(`enabled: true`), but a gate only RUNS once its image is supplied (empty image ⇒ no sidecar, so a
+bare install never crash-loops). Point the `python` gate at the pushed image in a Helm overlay /
+`--set`:
 
 ```yaml
 grpc:
   enabled: true          # the trusted endpoint the gate connects to
-  pythonGate:
-    enabled: true
-    image: <registry>/meshweaver/python-gate:<tag>
-    address: py/python-kernel
+  gates:
+    python:
+      enabled: true       # default; set false to opt python out
+      image: <registry>/meshweaver/python-gate:<tag>
+      address: py/python-kernel
 ```
 
 `MESH_GRPC_URL` and `MESH_GATE_ADDRESS` (the container's env) override the endpoint and address; the
-defaults match `deploy/helm` `values.grpc`.
+defaults match `deploy/helm` `values.grpc`. The Node gate (`javascript`/`typescript`) is the sibling —
+see `deploy/node-gate`.


### PR DESCRIPTION
Phase 2 of the multi-language platform: opt-in **feature flags** for the language runtimes, **default = all included**.

## What
Generalize the single python gate into a `grpc.gates` map keyed by language. Each gate is a feature flag: **every language is included by default** (`enabled: true`); a deployment sets `enabled: false` to opt a language out. A gate actually **runs** when it is enabled AND its image is supplied — image left empty ⇒ no sidecar, so a bare `helm install` never crash-loops on a missing image.

```yaml
grpc:
  gates:
    python: { enabled: true, image: "", address: py/python-kernel }
    node:   { enabled: true, image: "", address: node/node-kernel }
```

Verified with `helm template`:
- default (images empty) → **0** gate sidecars
- both images set → **python + node** sidecars
- `node.enabled=false` → **python only**

## Also
- **`deploy/node-gate/Dockerfile` + README** — the Node gate: compiles the TypeScript SDK and runs `node dist/worker.js --reconnect` against the trusted loopback, executing `javascript`/`typescript` Code nodes at `node/node-kernel` (mirrors `deploy/python-gate`; pairs with the worker in #316).
- `deployment.yaml`: the single guarded sidecar → a `range` over `grpc.gates`.
- python-gate README updated to the `gates.python` shape.

No .NET changes — CI is the standard build.

## Next
Doc sweep for the multi-language reality (in progress), then the memex deployment (build/push both gate images, point the overlay at them, roll) to make the doc examples live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)