### PR TITLE
fix(onboarding): recover just-onboarded users from a stale user-lookup cache

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
@@ -314,9 +314,20 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
                 _ => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(query)))
             .Take(1)
             .Select(change => (MeshNode?)change.Items.FirstOrDefault())
-            .Do(node => logger?.LogInformation(
-                "FindUserByEmail({Email}): cached miss re-read authoritatively → {Result}",
-                email, node?.Id ?? "(still none — genuinely not onboarded)"));
+            // Information ONLY on actual recovery (the stale-cache condition healed) — for a
+            // genuinely-not-onboarded user this path runs on every request, so the still-missing
+            // case is Debug to keep production (Loki) log volume down.
+            .Do(node =>
+            {
+                if (node is not null)
+                    logger?.LogInformation(
+                        "FindUserByEmail({Email}): recovered stale-empty cache via authoritative re-read → {User}",
+                        email, node.Id);
+                else
+                    logger?.LogDebug(
+                        "FindUserByEmail({Email}): authoritative re-read still finds no user (not onboarded)",
+                        email);
+            });
     }
 
     /// <summary>Back-compat overload used by callers that don't yet pass a logger.</summary>

--- a/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
@@ -22,6 +22,9 @@ namespace Memex.Portal.Shared.Authentication;
 /// <list type="bullet">
 /// <item><description>No user node (or Transient) → redirect /onboarding</description></item>
 /// <item><description>Active node → update AccessContext with username, pass through</description></item>
+/// <item><description>Active node but sitting ON /onboarding (bookmark, or a cold-start
+/// race that bounced them here before the User catalog hydrated) → redirect home;
+/// the profile form is not for an already-onboarded user</description></item>
 /// </list>
 /// </para>
 ///
@@ -60,9 +63,12 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
     /// </summary>
     private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(750);
 
+    // NOTE: "/onboarding" is deliberately NOT here. It still must never redirect a
+    // not-yet-onboarded user back TO onboarding (that would loop), but an ALREADY-
+    // onboarded user who lands there must be redirected home — so the page is resolved
+    // (not blanket-excluded) and handled explicitly in BuildPipeline via onOnboardingPage.
     private static readonly HashSet<string> ExcludedPrefixes = new(StringComparer.OrdinalIgnoreCase)
     {
-        "/onboarding",
         "/welcome",
         "/login",
         "/auth/",
@@ -96,13 +102,22 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
         //     unauthenticated / virtual / excluded path); fall through to next.
         var outcome = await BuildPipeline(context).FirstAsync().ToTask();
 
+        if (outcome == OnboardingOutcome.RedirectHome)
+        {
+            // Already-onboarded user hit /onboarding — the profile form is not for them.
+            // Server-side 302 home, BEFORE the page renders: no circuit dependency, no
+            // "Loading…/Redirecting…" spinner, no chance of the form flashing up.
+            context.Response.Redirect("/");
+            return;
+        }
+
         if (outcome == OnboardingOutcome.Redirect)
         {
             // Carry the page the user was trying to reach into the onboarding URL so
             // the form can send them back there on completion — instead of dumping
             // everyone on "/". The target is always THIS request's own path+query on
             // this host, so it is inherently local (no open-redirect surface), and
-            // excluded paths (/onboarding, /login, assets, …) never reach here. A bare
+            // excluded paths (/login, assets, …) never reach here. A bare
             // "/" carries no returnUrl — onboarding falls back to "/" anyway.
             var target = $"{context.Request.Path}{context.Request.QueryString}";
             var location = string.IsNullOrEmpty(target) || target == "/"
@@ -115,7 +130,7 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
         await next(context);
     }
 
-    private enum OnboardingOutcome { PassThrough, Redirect }
+    private enum OnboardingOutcome { PassThrough, Redirect, RedirectHome }
 
     /// <summary>
     /// Builds the reactive onboarding pipeline. Returns an observable that
@@ -127,7 +142,13 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
     /// </summary>
     private IObservable<OnboardingOutcome> BuildPipeline(HttpContext context)
     {
-        if (context.User?.Identity?.IsAuthenticated != true || IsExcludedPath(context.Request.Path))
+        if (context.User?.Identity?.IsAuthenticated != true)
+            return Observable.Return(OnboardingOutcome.PassThrough);
+
+        // /onboarding is resolved (not blanket-excluded): a not-yet-onboarded user
+        // stays on the form, but an already-onboarded one is redirected home.
+        var onOnboardingPage = context.Request.Path.StartsWithSegments("/onboarding");
+        if (!onOnboardingPage && IsExcludedPath(context.Request.Path))
             return Observable.Return(OnboardingOutcome.PassThrough);
 
         var portalApp = context.RequestServices.GetService<PortalApplication>();
@@ -164,12 +185,27 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
         return FindUserByEmail(workspace, email, logger)
             .SelectMany(node =>
             {
+                // Not onboarded (no node, or only a Transient shell).
                 if (node == null || node.State == MeshNodeState.Transient)
                 {
+                    // On /onboarding: stay on the form — NEVER redirect back to
+                    // /onboarding (that would loop). Everywhere else: bounce there.
+                    if (onOnboardingPage)
+                        return Observable.Return(OnboardingOutcome.PassThrough);
+
                     logger.LogInformation(
                         "OnboardingMiddleware: Redirecting to onboarding for {Email} (node={NodeState})",
                         email, node?.State.ToString() ?? "(null — lookup returned no match)");
                     return Observable.Return(OnboardingOutcome.Redirect);
+                }
+
+                // Onboarded but sitting on /onboarding → the form isn't for them; go home.
+                if (onOnboardingPage)
+                {
+                    logger.LogInformation(
+                        "OnboardingMiddleware: {Email} is already onboarded — redirecting off /onboarding to home",
+                        email);
+                    return Observable.Return(OnboardingOutcome.RedirectHome);
                 }
 
                 var username = node.Id;
@@ -221,18 +257,29 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
     internal static IObservable<MeshNode?> FindUserByEmail(
         IWorkspace workspace, string email, ILogger? logger)
     {
-        // Cache id per-email — synced query result snapshot is shared across
-        // any concurrent request for the same email. The synced registry holds
-        // the entry for the workspace's lifetime; live mesh change events keep
-        // the snapshot fresh, so subsequent requests see up-to-date state.
-        return workspace.GetQuery(
-                $"auth:userByEmail:{email}",
-                $"nodeType:User content.email:{email} limit:1")
+        var query = $"nodeType:User content.email:{email} limit:1";
+
+        // Fast path: the shared, cross-request synced-query snapshot. For a user this process
+        // has ALREADY seen, this replays the cached hit with no DB round-trip.
+        return workspace.GetQuery($"auth:userByEmail:{email}", query)
             .Do(items => logger?.LogDebug(
                 "FindUserByEmail({Email}): synced query emit, items={Count}",
                 email, items.Count()))
             .Take(1)
             .Select(items => (MeshNode?)items.FirstOrDefault())
+            .SelectMany(cached => cached is not null
+                ? Observable.Return<MeshNode?>(cached)
+                // A cached HIT is authoritative; a cached MISS is NOT. This lookup is a pathless,
+                // auth-routed one-shot fan-out query, and workspace.GetQuery caches its result
+                // PERMANENTLY (Replay(1).AutoConnect(1)) with no live-delta source in the partitioned
+                // portal (the pg_notify listener is disabled). The middleware itself seeds an EMPTY
+                // snapshot while rendering the pre-onboarding / /onboarding requests — so a user
+                // onboarded afterwards would replay that empty snapshot and get bounced to
+                // /onboarding forever ("cannot advance", until a process restart clears the cache).
+                // On a miss, re-read the source of truth (auth.mesh_nodes) before concluding "no
+                // account". The DB row exists synchronously (the auth-mirror trigger fires inside the
+                // onboarding write), so the authoritative re-read finds the just-onboarded user.
+                : QueryUserByEmailAuthoritative(workspace, query, email, logger))
             .Timeout(LookupTimeout, Observable.Defer(() =>
             {
                 logger?.LogWarning(
@@ -240,6 +287,36 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
                     email, LookupTimeout);
                 return Observable.Return<MeshNode?>(null);
             }));
+    }
+
+    /// <summary>
+    /// Authoritative one-shot re-read of the User-by-email lookup that BYPASSES the permanent
+    /// synced-query cache. <see cref="IMeshService.Query{T}"/>'s first emission is a fresh
+    /// <c>Initial</c> fan-out snapshot straight off <c>auth.mesh_nodes</c>, so a user materialised
+    /// after the cache seeded empty is found. Invoked ONLY on a cached miss — the common
+    /// already-known-user path keeps its zero-DB cache hit. This is the read-after-write authoritative
+    /// path CQRS mandates for a gate that decides whether to bounce a user to onboarding.
+    ///
+    /// <para>Runs as System (<c>Observable.Using</c> holding an
+    /// <c>ImpersonateAsSystem</c> scope for the subscription) so the re-read has the SAME
+    /// RLS-bypassing visibility the synced layer uses internally — a not-yet-onboarded caller must
+    /// not be denied reading the infrastructure <c>auth</c> schema, or the recovery would never
+    /// fire.</para>
+    /// </summary>
+    private static IObservable<MeshNode?> QueryUserByEmailAuthoritative(
+        IWorkspace workspace, string query, string email, ILogger? logger)
+    {
+        var sp = workspace.Hub.ServiceProvider;
+        var meshService = sp.GetRequiredService<IMeshService>();
+        var accessService = sp.GetRequiredService<AccessService>();
+        return Observable.Using(
+                () => accessService.ImpersonateAsSystem(),
+                _ => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(query)))
+            .Take(1)
+            .Select(change => (MeshNode?)change.Items.FirstOrDefault())
+            .Do(node => logger?.LogInformation(
+                "FindUserByEmail({Email}): cached miss re-read authoritatively → {Result}",
+                email, node?.Id ?? "(still none — genuinely not onboarded)"));
     }
 
     /// <summary>Back-compat overload used by callers that don't yet pass a logger.</summary>

--- a/test/Memex.Portal.Shared.Test/OnboardingMiddlewareExclusionTest.cs
+++ b/test/Memex.Portal.Shared.Test/OnboardingMiddlewareExclusionTest.cs
@@ -14,7 +14,6 @@ public class OnboardingMiddlewareExclusionTest
         new(new ClaimsIdentity("TestAuth"));
 
     [Theory]
-    [InlineData("/onboarding")]
     [InlineData("/login")]
     [InlineData("/auth/callback")]
     [InlineData("/_framework/blazor.js")]
@@ -86,6 +85,26 @@ public class OnboardingMiddlewareExclusionTest
         var act = () => middleware.InvokeAsync(context);
         await act.Should().ThrowAsync<Exception>(
             because: "non-excluded paths should attempt onboarding check via PortalApplication");
+    }
+
+    [Fact]
+    public async Task OnboardingPage_IsResolved_NotBlanketExcluded()
+    {
+        // /onboarding is no longer blanket-excluded: it participates in the onboarded
+        // check so an ALREADY-onboarded user landing there gets redirected home. With no
+        // PortalApplication wired into RequestServices the resolution attempt surfaces
+        // (throws) — proving the path is no longer short-circuited to pass-through.
+        RequestDelegate next = _ => Task.CompletedTask;
+
+        var middleware = new OnboardingMiddleware(next, NullLogger<OnboardingMiddleware>.Instance);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/onboarding";
+        context.User = AuthenticatedUser;
+
+        var act = () => middleware.InvokeAsync(context);
+        await act.Should().ThrowAsync<Exception>(
+            because: "/onboarding now participates in the onboarded check to redirect onboarded users home");
     }
 
     [Theory]


### PR DESCRIPTION
## Problem
Users reported **"after onboarding I cannot advance"** — they complete the profile form but keep getting bounced back to `/onboarding` (until a pod restart).

## Root cause
`OnboardingMiddleware.FindUserByEmail` decides onboarded-vs-not via `workspace.GetQuery("auth:userByEmail:{email}", "nodeType:User content.email:…")`. That query is **pathless + auth-routed**, so on partitioned Postgres it's served by a **one-shot fan-out** (single empty `Initial`, no live cursor), and `workspace.GetQuery` caches the result **permanently** (`Replay(1).AutoConnect(1)`). The middleware runs on the pre-onboarding / `/onboarding` renders, so it **seeds that cache empty before the user exists**. After onboarding the DB is correct (the auth-mirror trigger writes the user synchronously) — but the cache replays the stale empty snapshot → `null` → redirect to `/onboarding` **forever**, per replica, until a process restart. (The partitioned `pg_notify` listener that could refresh it is disabled.)

## Fix
- A cached **hit** is authoritative; a cached **miss** is not. On a miss, `FindUserByEmail` now **re-reads the source of truth** via `IMeshService.Query` (as System — same RLS bypass the synced layer uses) before concluding "no account". The common already-known-user path keeps its zero-DB cache hit.
- `/onboarding` is no longer blanket-excluded from the middleware: an already-onboarded user who lands there now gets a **server-side 302 home** (`RedirectHome`) before the page renders, instead of relying on a client-side check that hits the same stale cache.

## Tests
`OnboardingMiddlewareExclusionTest` updated — `/onboarding` is now *resolved* (not excluded); added `OnboardingPage_IsResolved_NotBlanketExcluded`. Builds clean under `-c Release -warnaserror`; the 21 middleware tests pass.

**Note:** the authoritative-fallback branch has no automated integration test — the in-memory provider delivers live deltas (never goes stale) and the PG test fixture doesn't model prod's auth-mirror + partition registration, so the stale-cache condition can't be faithfully reproduced there. Root cause is established by code trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)