### PR TITLE
docs: multi-language Code nodes (python + javascript/typescript) + Node hub page

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ForeignLanguageIntegration.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ForeignLanguageIntegration.md
@@ -80,7 +80,10 @@ where the exact request `$type` awaits a live capture.
   await mesh.patch("ACME/Stories/42", {"content": {"done": True}})  # python → mesh
   ```
 - **Node / Bun — `clients/typescript` (`@meshweaver/client`)**: `@grpc/grpc-js` transport (proto loaded at
-  runtime via `@grpc/proto-loader` — no codegen step), `AsyncIterable` streams, same surface.
+  runtime via `@grpc/proto-loader` — no codegen step), `AsyncIterable` streams, same surface. It also
+  ships the **node kernel** (`worker.ts`) that executes `javascript`/`typescript` Code nodes routed to
+  `node/node-kernel`, and the **`Hub`** helper for defining a hub in Node (see
+  [Python Code Nodes](../PythonCodeNodes) for the execution model).
 - **Browser / React Native — `clients/grpc-web` (`@meshweaver/client-web`)**: the same `observe`/`post`/`watch`
   surface over the **gRPC-web split** (Connect-ES), for platforms that can't do the bidi `Open` (no HTTP/2
   duplex / no Node `http2`). It's a `MeshConnectionLike`, so it feeds the renderer's `GrpcAreaSource` directly.

--- a/src/MeshWeaver.Documentation/Data/Architecture/PythonCodeNodes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PythonCodeNodes.md
@@ -15,12 +15,13 @@ connected Python worker and the output attaches directly below the code:
 That is the whole feature. What you just ran is a **Code node** whose `Language` is `python`:
 `print(...)` was captured as output, the trailing bare expression became the return value (REPL
 semantics), and `Inputs` carried the caller's parameters. A `csharp` node (the default) runs
-**in-process** on the mesh's Roslyn kernel; a `python` node is **routed over the mesh to a connected
-worker** instead — the same gRPC bridge that lets any Python process join the mesh as a participant
-(see [Foreign Language Integration](../ForeignLanguageIntegration)). The worker runs
-the script and writes the result back onto the same **Activity node** every subscriber already
-watches, so a Python run surfaces output **identically** to a C# one. With no worker connected the run
-reports that in the same output pane — nothing hangs.
+**in-process** on the mesh's Roslyn kernel; a **foreign-language** node is **routed over the mesh to a
+connected worker** instead — `python` → `py/python-kernel`, `javascript`/`typescript` →
+`node/node-kernel` (`CodeNodeType.ResolveKernelAddress`) — the same gRPC bridge that lets any process
+join the mesh as a participant (see [Foreign Language Integration](../ForeignLanguageIntegration)). The
+worker runs the script and writes the result back onto the same **Activity node** every subscriber
+already watches, so a python **or** js/ts run surfaces output **identically** to a C# one. With no
+worker connected the run reports that in the same output pane — nothing hangs.
 
 ## Inside the node
 
@@ -65,11 +66,14 @@ wedges on a bad snippet.
    every subscriber (the Code node's Output pane, the activity feed, tests) sees it
 ```
 
-The only .NET-side change relative to C# is **where the submission is sent**: C# stays in-process;
-`python` is addressed to the worker. The concurrency-critical Roslyn `KernelExecutor` is untouched —
+The only .NET-side change relative to C# is **where the submission is sent** —
+`CodeNodeType.ResolveKernelAddress(language, activityPath)` picks the target: `python` →
+`py/python-kernel`, `javascript`/`typescript` → `node/node-kernel` (the Node worker, `clients/typescript`),
+everything else in-process. Each worker executes and patches the same ActivityLog, so js/ts output
+surfaces exactly like python and C#. The concurrency-critical Roslyn `KernelExecutor` is untouched —
 it only ever runs C#.
 
-## Run a Python worker
+## Run a language worker
 
 The worker lives in the Python SDK (`clients/python`). It connects as a **stable** participant
 address so the kernel can target it:
@@ -86,6 +90,11 @@ python -m meshweaver.worker \
 
 It registers under `py/python-kernel`, then waits for `SubmitCodeRequest` deliveries. Each one runs
 in a fresh namespace.
+
+> **javascript / typescript** — the **Node worker** is the exact equivalent, from `clients/typescript`:
+> `npm run build && node dist/worker.js --url … --address node/node-kernel`. It runs the snippet in a
+> `vm` sandbox with the same REPL semantics (`console.log` captured, trailing expression = return value,
+> `Inputs` global; TypeScript is transpiled first). Same wire contract, same Activity write-back.
 
 > **Identity / access.** The worker writes the Activity node under the identity of its `--token`. That
 > identity needs write access to where activities are stored (the runner's home partition). Use a token
@@ -109,18 +118,22 @@ the in-process Roslyn kernel: the C# kernel runs in the portal process; the pyth
 portal *pod*, and a run executes under the requesting user's identity (the gate echoes the delivery's
 `AccessContext`), not a standing service credential — nothing to rotate.
 
-Enable it in the Helm chart (OFF by default; the deployment must supply the image):
+Gates are **feature-flagged** per language under `grpc.gates` — every language is **included by
+default**; a gate runs once its image is supplied (empty image ⇒ no sidecar). Set `enabled: false` to
+opt a language out:
 
 ```yaml
 grpc:
-  pythonGate:
-    enabled: true
-    image: <registry>/meshweaver/python-gate:<tag>   # deploy/python-gate/Dockerfile
+  gates:
+    python:
+      image: <registry>/meshweaver/python-gate:<tag>   # deploy/python-gate/Dockerfile
+    node:
+      image: <registry>/meshweaver/node-gate:<tag>     # deploy/node-gate/Dockerfile — runs js/ts
 ```
 
-Today `python` targets the single well-known `py/python-kernel` address. A worker **pool** (lease a
-worker per run, or per partition) and other languages (`node`/`bun` → a `node/*` gate) are the natural
-next step — the routing branch and the sidecar list are the two places that grow.
+Each language is its own gate (`py/python-kernel`, `node/node-kernel`); the same shape adds the next
+(`bun`, a language pool that leases a worker per run/partition). The routing branch
+(`ResolveKernelAddress`) and the `grpc.gates` map are the two places that grow.
 
 ## Related
 

--- a/src/MeshWeaver.Documentation/Data/DataMesh/NodeStandaloneHub.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/NodeStandaloneHub.md
@@ -1,0 +1,63 @@
+---
+Name: A standalone hub in Node
+Category: Documentation
+Description: Program a MeshWeaver hub in Node/TypeScript — its own address, message handlers, owned state — connect it to the mesh, and (as the node kernel) execute javascript/typescript Code nodes.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><circle cx="4" cy="6" r="2"/><circle cx="20" cy="6" r="2"/><circle cx="4" cy="18" r="2"/><circle cx="20" cy="18" r="2"/><path d="M6 7l4 3M18 7l-4 3M6 17l4-3M18 17l-4-3"/></svg>
+---
+
+# A standalone hub in Node
+
+A hub on the mesh is three things: an **address** deliveries route to, **message handlers** keyed by
+message type (the C# `WithHandler<T>`), and **state** the handlers own. None of that is .NET-specific.
+This page programs a hub in Node/TypeScript, connects it to the mesh over gRPC, and serves it — the
+Node counterpart of [A standalone hub in Python](../PythonStandaloneHub).
+
+The working code is `clients/typescript/src/examples/hub.ts`; the SDK is `@meshweaver/client`
+(`clients/typescript`).
+
+## Define the hub
+
+`Hub` is the model — an address, handlers by message type, owned state. A raising handler answers with
+an `ErrorResponse` instead of wedging; the reply is correlated back to the sender automatically.
+
+```typescript
+import { connect, Hub } from "@meshweaver/client";
+
+const conn = await connect("https://memex.meshweaver.cloud", { token: "mw_…", address: "node/counter" });
+
+let count = 0;                                              // the state the handlers own
+new Hub(conn)
+  .register("Increment", (d) => { count += Number(d.message.by ?? 1); return ["Count", { value: count }]; })
+  .register("GetCount", () => ["Count", { value: count }]);
+```
+
+Any participant now drives it over the mesh: `observe("node/counter", "Increment", { by: 5 })` returns
+`{ value: 5 }`. The hub reads the mesh (`mesh.get` / `mesh.search` / `mesh.watch`) and writes back
+(`mesh.patch` / `mesh.create`) exactly like a C# hub — see
+[Foreign Language Integration](../../Architecture/ForeignLanguageIntegration).
+
+## Run it as the node kernel
+
+The same SDK ships the **node kernel** — a specialised hub at `node/node-kernel` that executes
+`javascript`/`typescript` Code nodes routed to it (`CodeNodeType.ResolveKernelAddress`). It runs the
+snippet in a `vm` sandbox with REPL semantics (`console.log` captured, a trailing expression is the
+return value, `Inputs` exposes caller parameters; TypeScript is transpiled first) and patches the run's
+Activity node — so js/ts output surfaces identically to python and C#.
+
+```bash
+cd clients/typescript
+npm install && npm run build
+node dist/worker.js --url https://memex.meshweaver.cloud --token mw_… --address node/node-kernel
+node dist/worker.js --demo     # self-contained smoke test: execute a JS + a TS snippet
+```
+
+In a deployment it ships as a **trusted sidecar** in the portal pod (the Node gate,
+`deploy/node-gate`), connecting to the trusted loopback endpoint with **no token** — reachability is
+the authentication. It is feature-flagged alongside the python gate under `grpc.gates` (every language
+included by default). Full model: [Python Code Nodes](../../Architecture/PythonCodeNodes).
+
+## Related
+
+- [A standalone hub in Python](../PythonStandaloneHub) — the same hub model in Python.
+- [Python Code Nodes](../../Architecture/PythonCodeNodes) — how a Code node routes to a language worker and back.
+- [Foreign Language Integration](../../Architecture/ForeignLanguageIntegration) — the gRPC bridge and every client SDK.


### PR DESCRIPTION
The docs sweep for the multi-language platform (#313 routing, #316 node worker, #318 gates).

- **`Architecture/PythonCodeNodes`** — routing is now language-general (`CodeNodeType.ResolveKernelAddress`: python→`py/python-kernel`, js/ts→`node/node-kernel`, else in-process); "Run a **language** worker" adds the Node worker; the sidecar section uses the feature-flagged `grpc.gates` map (every language included by default; a gate runs when its image is set) showing both python + node gates.
- **`Architecture/ForeignLanguageIntegration`** — the Node SDK bullet notes the node kernel (`worker.ts`) + the `Hub` helper.
- **`DataMesh/NodeStandaloneHub`** (new) — define + run a hub in Node (the `Hub` model) and run it as the node kernel; the Node counterpart of the Python standalone-hub page.

Link + embed integrity tests green (relative cross-area links use `../../`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)