### PR TITLE
refactor(space): drop redundant Space.Name — MeshNode.Name is the single source of truth

### DIFF
--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -287,7 +287,7 @@ public sealed class GitHubSyncService
                 NodeType = SpaceNodeType,
                 Name = newSpaceName,
                 State = MeshNodeState.Active,
-                Content = new Space { Name = newSpaceName },
+                Content = new Space(),
             };
             logger?.LogInformation("Importing {Repo}@{Ref} into new Space {Space}", repositoryUrl, commitish, newSpaceId);
             var createSpace = accessService is null || ctx is null

--- a/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
@@ -134,6 +134,10 @@ public static class SpaceLayoutAreas
         // Field pointers resolve against the node's Content JSON (the Space). Every control's edit
         // is a per-field read-modify-write straight to the node — see Doc/GUI/DataBinding "Node-bound DataContext".
         var contentCtx = LayoutAreaReference.GetMeshNodeDataContext(spacePath, bindContent: true);
+        // The name lives on MeshNode.Name (single source of truth), NOT on Space.Content — so the
+        // name field binds to the NODE (bindContent:false) and its "name" pointer resolves to
+        // MeshNode.Name. The body/logo/etc. fields stay on the content-bound context above.
+        var nodeCtx = LayoutAreaReference.GetMeshNodeDataContext(spacePath, bindContent: false);
 
         var container = Controls.Stack
             .WithWidth("100%")
@@ -156,7 +160,7 @@ public static class SpaceLayoutAreas
         {
             Immediate = true,
             Placeholder = "Space name",
-            DataContext = contentCtx
+            DataContext = nodeCtx
         }.WithStyle("flex: 1; font-size: 1.25rem; font-weight: 600;"));
 
         headerRow = headerRow.WithView(Controls.Html(
@@ -218,7 +222,7 @@ public static class SpaceLayoutAreas
             try { return JsonSerializer.Deserialize<Space>(raw, options); }
             catch (JsonException) { /* not Space JSON — fall through and treat it as the body */ }
         }
-        return new Space { Name = node.Name ?? node.Path, Body = raw };
+        return new Space { Body = raw };
     }
 
     private static UiControl BuildSpaceView(
@@ -228,7 +232,7 @@ public static class SpaceLayoutAreas
         bool canEdit)
     {
         var spacePath = node?.Path ?? host.Hub.Address.ToString();
-        var spaceName = space?.Name ?? node?.Name ?? spacePath;
+        var spaceName = node?.Name ?? spacePath;
 
         var shell = Controls.Stack
             .WithWidth("100%")
@@ -337,11 +341,12 @@ public static class SpaceLayoutAreas
     /// <summary>
     /// The space's H1 title as a click-to-edit heading. Read view is a plain heading; when
     /// <paramref name="canEdit"/> and the user clicks it, an inline <see cref="TextFieldControl"/>
-    /// bound to the Space content <c>name</c> field (node-bound DataContext) takes over, so the edit
-    /// writes straight back to the node stream — and to <see cref="MeshNode.Name"/> via the Space's
-    /// <c>[MeshNodeProperty(nameof(MeshNode.Name))]</c> mapping. Same mechanism the Space Edit area
-    /// (<see cref="BuildBodyEditor"/>) uses for the name field — the click-to-edit toggle is the only
-    /// thing living in <c>/data</c>. See Doc/GUI/DataBinding "Node-bound DataContext".
+    /// bound to <see cref="MeshNode.Name"/> via a node-bound DataContext (<c>bindContent:false</c>)
+    /// takes over, so the edit renames the node directly — <see cref="MeshNode.Name"/> is the single
+    /// source of truth for the space name (the <see cref="Space"/> content no longer carries a name).
+    /// Same mechanism the Space Edit area (<see cref="BuildBodyEditor"/>) uses for the name field —
+    /// the click-to-edit toggle is the only thing living in <c>/data</c>. See Doc/GUI/DataBinding
+    /// "Node-bound DataContext".
     /// </summary>
     private static UiControl BuildEditableTitle(
         LayoutAreaHost host, string spacePath, string spaceName, bool canEdit)
@@ -383,7 +388,10 @@ public static class SpaceLayoutAreas
             Immediate = true,
             AutoFocus = true,
             Placeholder = "Space name",
-            DataContext = LayoutAreaReference.GetMeshNodeDataContext(spacePath, bindContent: true)
+            // Bind to the NODE (bindContent:false): the space's name IS MeshNode.Name — the single
+            // source of truth — so the "name" pointer resolves to MeshNode.Name and the click-to-edit
+            // title renames the node directly.
+            DataContext = LayoutAreaReference.GetMeshNodeDataContext(spacePath, bindContent: false)
         }
         .WithStyle("font-size: 2rem; font-weight: 600; border: none; background: transparent; min-width: 300px; width: 100%;")
         .WithBlurAction(ctx =>

--- a/src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.Messaging;
@@ -21,11 +20,6 @@ namespace MeshWeaver.Graph;
 /// </summary>
 public record Space
 {
-    /// <summary>Display name of the space.</summary>
-    [Required]
-    [MeshNodeProperty(nameof(MeshNode.Name))]
-    public string Name { get; init; } = string.Empty;
-
     /// <summary>Short description of the space.</summary>
     public string? Description { get; init; }
 

--- a/test/MeshWeaver.GitSync.Test/GitHubSyncTestBase.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubSyncTestBase.cs
@@ -77,7 +77,7 @@ public abstract class GitHubSyncTestBase(ITestOutputHelper output) : MonolithMes
             NodeType = "Space",
             Name = name ?? id,
             State = MeshNodeState.Active,
-            Content = new Space { Name = name ?? id },
+            Content = new Space(),
         }).Timeout(60.Seconds()).ToTask();
 
     protected async Task<MeshNode> CreateMarkdown(string path, string name, string body)

--- a/test/MeshWeaver.Graph.Test/SpaceResolveSpaceTest.cs
+++ b/test/MeshWeaver.Graph.Test/SpaceResolveSpaceTest.cs
@@ -25,14 +25,14 @@ public class SpaceResolveSpaceTest
     [Fact]
     public void TypedContent_ReturnedAsIs()
     {
-        var space = new Space { Name = "Acme", Body = "BODY" };
+        var space = new Space { Body = "BODY" };
         Assert.Same(space, SpaceLayoutAreas.ResolveSpace(Node(space), Options));
     }
 
     [Fact]
     public void JsonElementContent_Deserialized()
     {
-        var je = JsonSerializer.SerializeToElement(new Space { Name = "Acme", Body = "BODY" }, Options);
+        var je = JsonSerializer.SerializeToElement(new Space { Body = "BODY" }, Options);
         SpaceLayoutAreas.ResolveSpace(Node(je), Options)!.Body.Should().Be("BODY");
     }
 
@@ -48,10 +48,13 @@ public class SpaceResolveSpaceTest
     public void PlainString_TakenAsBody()
     {
         // "just a string" that is NOT JSON — keep it as the body so the page still shows it.
-        var space = SpaceLayoutAreas.ResolveSpace(Node("# Hello\n\nplain text body"), Options);
+        // The name is no longer carried on Space.Content; it lives on MeshNode.Name (the single
+        // source of truth), so assert the node name rather than a (now-removed) space.Name.
+        var node = Node("# Hello\n\nplain text body");
+        var space = SpaceLayoutAreas.ResolveSpace(node, Options);
         space.Should().NotBeNull();
         space!.Body.Should().Contain("plain text body");
-        space.Name.Should().Be("Acme");
+        node.Name.Should().Be("Acme");
     }
 
     [Fact]
@@ -89,7 +92,7 @@ public class SpaceResolveSpaceTest
     [Fact]
     public void BuildBodyContent_AuthoredBody_CarriesSpacePathAsNodePath()
     {
-        var space = new Space { Name = "Acme", Body = "# Hi\n\n@@(\"area/Search\")" };
+        var space = new Space { Body = "# Hi\n\n@@(\"area/Search\")" };
         var control = SpaceLayoutAreas.BuildBodyContent(space, Node(space), spacePath: "Acme");
 
         var md = Assert.IsType<MarkdownControl>(control);

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeckLayoutAreaTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeckLayoutAreaTest.cs
@@ -123,7 +123,7 @@ public class DeckLayoutAreaTest(ITestOutputHelper output) : MonolithMeshTestBase
         {
             Name = "Training Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Training Space" }
+            Content = new Space()
         }).Should().Emit();
 
         // Slides directly under the Space (a non-Deck parent), created out of order; Order,
@@ -280,7 +280,7 @@ public class DeckLayoutAreaTest(ITestOutputHelper output) : MonolithMeshTestBase
         {
             Name = "Training Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Training Space" }
+            Content = new Space()
         }).Should().Emit();
         return space;
     }
@@ -307,7 +307,7 @@ public class DeckLayoutAreaTest(ITestOutputHelper output) : MonolithMeshTestBase
         {
             Name = "Training Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Training Space" }
+            Content = new Space()
         }).Should().Emit();
 
         var deck = $"{space}/widgets";

--- a/test/MeshWeaver.Hosting.Monolith.Test/SlideLayoutAreaTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SlideLayoutAreaTest.cs
@@ -164,7 +164,7 @@ public class SlideLayoutAreaTest(ITestOutputHelper output) : MonolithMeshTestBas
         {
             Name = "Training Deck",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Training Deck" }
+            Content = new Space()
         }).Should().Emit();
 
         var first = $"{deck}/intro";

--- a/test/MeshWeaver.Hosting.Monolith.Test/SpaceEditMarkdownTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SpaceEditMarkdownTest.cs
@@ -37,7 +37,7 @@ public class SpaceEditMarkdownTest(ITestOutputHelper output) : MonolithMeshTestB
         {
             Name = "Edit Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Edit Space", Body = "# Overview\n\nhello" }
+            Content = new Space { Body = "# Overview\n\nhello" }
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/SpaceEditableTitleTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SpaceEditableTitleTest.cs
@@ -39,7 +39,7 @@ public class SpaceEditableTitleTest(ITestOutputHelper output) : MonolithMeshTest
         {
             Name = spaceName,
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = spaceName }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/SpaceOverviewBodyTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SpaceOverviewBodyTest.cs
@@ -44,7 +44,7 @@ public class SpaceOverviewBodyTest(ITestOutputHelper output) : MonolithMeshTestB
         {
             Name = "Body Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Body Space", Body = $"# Overview\n\n{BodyMarker}" }
+            Content = new Space { Body = $"# Overview\n\n{BodyMarker}" }
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/AnonymousSpaceReadSecurityTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/AnonymousSpaceReadSecurityTests.cs
@@ -109,7 +109,7 @@ public class AnonymousSpaceReadSecurityTests(PostgreSqlFixture fixture, ITestOut
         {
             Name = space,
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = space }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Within(90.Seconds()).Emit();
 

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/EffectivePermissionPostgresTest.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/EffectivePermissionPostgresTest.cs
@@ -152,7 +152,7 @@ public class EffectivePermissionPostgresTest(PostgreSqlFixture fixture, ITestOut
         {
             Name = orgId,
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = orgId }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(orgNode).Should().Within(90.Seconds()).Emit();
 

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/FirstUserOnboardingTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/FirstUserOnboardingTests.cs
@@ -176,7 +176,7 @@ public class FirstUserOnboardingTests
                 Name = $"{org} Corp",
                 NodeType = SpaceNodeType.NodeType,
                 State = MeshNodeState.Active,
-                Content = new Space { Name = $"{org} Corp" }
+                Content = new Space()
             }, _options).Should().Within(30.Seconds()).Emit();
 
             // Register Organization as public_read in each org schema

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/GlobalAdminSpaceSearchTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/GlobalAdminSpaceSearchTests.cs
@@ -59,7 +59,7 @@ public class GlobalAdminSpaceSearchTests
                 Name = $"{org} Inc.",
                 NodeType = SpaceNodeType.NodeType,
                 State = MeshNodeState.Active,
-                Content = new Space { Name = $"{org} Inc." }
+                Content = new Space()
             }, _options, ct);
 
             // A child Markdown node under the org

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PartitionAccessSyncTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PartitionAccessSyncTests.cs
@@ -91,7 +91,7 @@ public class PartitionAccessSyncTests
             NodeType = SpaceNodeType.NodeType,
             State = MeshNodeState.Active,
             MainNode = space,
-            Content = new Space { Name = $"{space} Inc." }
+            Content = new Space()
         }, _options, ct);
 
         // Grant alice the Admin role at the Space scope via the standard
@@ -167,7 +167,7 @@ public class PartitionAccessSyncTests
             NodeType = SpaceNodeType.NodeType,
             State = MeshNodeState.Active,
             MainNode = space,
-            Content = new Space { Name = $"{space} Inc." }
+            Content = new Space()
         }, _options, ct);
 
         // Grant carol Admin the normal way — this also creates the access row + uep.

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceDeletionPartitionDropTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceDeletionPartitionDropTests.cs
@@ -68,7 +68,7 @@ public class SpaceDeletionPartitionDropTests(PostgreSqlFixture fixture, ITestOut
             NodeType = SpaceNodeType.NodeType,
             Name = "To Drop",
             State = MeshNodeState.Active,
-            Content = new Space { Name = "To Drop" },
+            Content = new Space(),
         }).Should().Within(60.Seconds()).Emit();
         created.Should().NotBeNull();
         await SchemaCount(spaceId).Should().Within(30.Seconds()).Be(1L);
@@ -98,7 +98,7 @@ public class SpaceDeletionPartitionDropTests(PostgreSqlFixture fixture, ITestOut
             NodeType = SpaceNodeType.NodeType,
             Name = "Recreated",
             State = MeshNodeState.Active,
-            Content = new Space { Name = "Recreated" },
+            Content = new Space(),
         }).Should().Within(60.Seconds()).Emit();
         await SchemaCount(spaceId).Should().Within(30.Seconds()).Be(1L);
         var reseeded = await meshService.CreateNode(new MeshNode("page", spaceId)

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceMainTableChildCreateTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceMainTableChildCreateTests.cs
@@ -73,7 +73,7 @@ public class SpaceMainTableChildCreateTests(PostgreSqlFixture fixture, ITestOutp
             NodeType = SpaceNodeType.NodeType,
             Name = spaceId,
             State = MeshNodeState.Active,
-            Content = new Space { Name = spaceId },
+            Content = new Space(),
         }).Should().Within(45.Seconds()).Emit();
         space.Path.Should().Be(spaceId);
 

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceMarkdownTypedContentColdLoadTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceMarkdownTypedContentColdLoadTests.cs
@@ -73,7 +73,7 @@ public class SpaceMarkdownTypedContentColdLoadTests(PostgreSqlFixture fixture, I
             NodeType = SpaceNodeType.NodeType,
             Name = spaceId,
             State = MeshNodeState.Active,
-            Content = new Space { Name = spaceId },
+            Content = new Space(),
         }).Should().Within(45.Seconds()).Emit();
         space.Path.Should().Be(spaceId);
 
@@ -167,7 +167,7 @@ public class SpaceMarkdownTypedContentColdLoadTests(PostgreSqlFixture fixture, I
             NodeType = SpaceNodeType.NodeType,
             Name = spaceId,
             State = MeshNodeState.Active,
-            Content = new Space { Name = spaceId },
+            Content = new Space(),
         }).Should().Within(45.Seconds()).Emit();
 
         // The exact shape the atioz agent submitted (MCP create deserializes the

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceNamespaceVisibilityTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceNamespaceVisibilityTests.cs
@@ -46,7 +46,7 @@ public class SpaceNamespaceVisibilityTests
         {
             Name = "PartnerRe AG",
             NodeType = "Space",
-            Content = new Space { Name = "PartnerRe AG" }
+            Content = new Space()
         }, _options).Should().Within(30.Seconds()).Emit();
 
         // Seed a child node under the Space

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceOnboardingIntegrationTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SpaceOnboardingIntegrationTests.cs
@@ -180,7 +180,7 @@ public class SpaceOnboardingIntegrationTests(PostgreSqlFixture fixture, ITestOut
             NodeType = SpaceNodeType.NodeType,
             Name = spaceId,
             State = MeshNodeState.Active,
-            Content = new Space { Name = spaceId },
+            Content = new Space(),
         }).Should().Within(45.Seconds()).Emit();
         created.Should().NotBeNull();
         string.IsNullOrEmpty(created.Namespace).Should().BeTrue(
@@ -271,7 +271,7 @@ public class SpaceOnboardingIntegrationTests(PostgreSqlFixture fixture, ITestOut
             NodeType = SpaceNodeType.NodeType,
             Name = spaceId,
             State = MeshNodeState.Active,
-            Content = new Space { Name = spaceId },
+            Content = new Space(),
         }).Should().Within(45.Seconds()).Emit();
         created.Should().NotBeNull("creating a Space over a pre-existing bare schema must heal it, not fail");
         created.Path.Should().Be(spaceId);
@@ -405,7 +405,7 @@ public class SpaceOnboardingIntegrationTests(PostgreSqlFixture fixture, ITestOut
                 NodeType = SpaceNodeType.NodeType,
                 Name = spaceId,
                 State = MeshNodeState.Active,
-                Content = new Space { Name = spaceId },
+                Content = new Space(),
             })
             .Take(1)
             .Materialize()
@@ -456,7 +456,7 @@ public class SpaceOnboardingIntegrationTests(PostgreSqlFixture fixture, ITestOut
             NodeType = "Space",
             Name = orgId,
             State = MeshNodeState.Active,
-            Content = new Space { Name = orgId },
+            Content = new Space(),
         }).Should().Within(30.Seconds()).Emit();
         orgRoot.Should().NotBeNull();
 
@@ -521,7 +521,7 @@ public class SpaceOnboardingIntegrationTests(PostgreSqlFixture fixture, ITestOut
             NodeType = SpaceNodeType.NodeType,
             Name = spaceId,
             State = MeshNodeState.Active,
-            Content = new Space { Name = spaceId },
+            Content = new Space(),
         }).Should().Within(45.Seconds()).Emit();
         created.Should().NotBeNull("any authenticated user must be able to create a top-level Space");
         created.Path.Should().Be(spaceId);
@@ -555,7 +555,7 @@ public class SpaceOnboardingIntegrationTests(PostgreSqlFixture fixture, ITestOut
             NodeType = SpaceNodeType.NodeType,
             Name = spaceId,
             State = MeshNodeState.Active,
-            Content = new Space { Name = spaceId },
+            Content = new Space(),
         }).Should().Within(45.Seconds()).Emit();
 
         var firstAdminPath = $"{spaceId}/_Access/{TestUsers.Admin.ObjectId}_Access";

--- a/test/MeshWeaver.InstanceSync.Test/InstanceSyncTestBase.cs
+++ b/test/MeshWeaver.InstanceSync.Test/InstanceSyncTestBase.cs
@@ -49,7 +49,7 @@ public abstract class InstanceSyncTestBase(ITestOutputHelper output) : MonolithM
             NodeType = "Space",
             Name = name ?? id,
             State = MeshNodeState.Active,
-            Content = new Space { Name = name ?? id },
+            Content = new Space(),
         }).Timeout(60.Seconds()).ToTask();
 
     protected async Task<MeshNode> CreateMarkdown(string path, string name, string body)

--- a/test/MeshWeaver.NodeOperations.Test/CreateSpaceTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/CreateSpaceTest.cs
@@ -37,7 +37,7 @@ public class CreateSpaceTest(ITestOutputHelper output) : MonolithMeshTestBase(ou
         {
             Name = "Test Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Test Space" }
+            Content = new Space()
         };
         var created = await NodeFactory.CreateNode(spaceNode).Should().Emit();
 

--- a/test/MeshWeaver.NodeOperations.Test/EffectivePermissionTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/EffectivePermissionTest.cs
@@ -40,7 +40,7 @@ public class EffectivePermissionTest(ITestOutputHelper output) : MonolithMeshTes
         {
             Name = "Systemorph",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Systemorph" }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Within(45.Seconds()).Emit();
 

--- a/test/MeshWeaver.NodeOperations.Test/GlobalAdminSpaceCrudTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/GlobalAdminSpaceCrudTest.cs
@@ -40,7 +40,7 @@ public class GlobalAdminSpaceCrudTest(ITestOutputHelper output) : MonolithMeshTe
         {
             Name = "Test Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Test Space" }
+            Content = new Space()
         };
 
         var created = await NodeFactory.CreateNode(spaceNode).Should().Emit();
@@ -61,7 +61,7 @@ public class GlobalAdminSpaceCrudTest(ITestOutputHelper output) : MonolithMeshTe
         {
             Name = "Test Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Test Space" }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 
@@ -82,14 +82,14 @@ public class GlobalAdminSpaceCrudTest(ITestOutputHelper output) : MonolithMeshTe
         {
             Name = "Original Name",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Original Name" }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 
         var updated = spaceNode with
         {
             Name = "Updated Name",
-            Content = new Space { Name = "Updated Name", Description = "Updated description" }
+            Content = new Space { Description = "Updated description" }
         };
         await NodeFactory.UpdateNode(updated).Should().Emit();
 
@@ -110,7 +110,7 @@ public class GlobalAdminSpaceCrudTest(ITestOutputHelper output) : MonolithMeshTe
         {
             Name = "To Delete",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "To Delete" }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 
@@ -131,7 +131,7 @@ public class GlobalAdminSpaceCrudTest(ITestOutputHelper output) : MonolithMeshTe
         {
             Name = "Partition Cleanup",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Partition Cleanup" }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 
@@ -167,7 +167,7 @@ public class GlobalAdminSpaceCrudTest(ITestOutputHelper output) : MonolithMeshTe
         {
             Name = "Permission Test Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Permission Test Space" }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 
@@ -198,7 +198,7 @@ public class GlobalAdminSpaceCrudTest(ITestOutputHelper output) : MonolithMeshTe
         {
             Name = "Test Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Test Space" }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 

--- a/test/MeshWeaver.NodeOperations.Test/SpaceMenuAndAccessTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/SpaceMenuAndAccessTest.cs
@@ -44,7 +44,7 @@ public class SpaceMenuAndAccessTest(ITestOutputHelper output) : MonolithMeshTest
         {
             Name = "Test Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Test Space" }
+            Content = new Space()
         };
         var created = await NodeFactory.CreateNode(spaceNode).Should().Emit();
         created.Should().NotBeNull();
@@ -76,7 +76,7 @@ public class SpaceMenuAndAccessTest(ITestOutputHelper output) : MonolithMeshTest
         {
             Name = "Test Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Test Space" }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 
@@ -108,7 +108,7 @@ public class SpaceMenuAndAccessTest(ITestOutputHelper output) : MonolithMeshTest
         {
             Name = "Test Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Test Space" }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 
@@ -134,7 +134,7 @@ public class SpaceMenuAndAccessTest(ITestOutputHelper output) : MonolithMeshTest
         {
             Name = "Test Space",
             NodeType = SpaceNodeType.NodeType,
-            Content = new Space { Name = "Test Space" }
+            Content = new Space()
         };
         await NodeFactory.CreateNode(spaceNode).Should().Emit();
 

--- a/test/MeshWeaver.NodeOperations.Test/SpaceNodeCreationTest.cs
+++ b/test/MeshWeaver.NodeOperations.Test/SpaceNodeCreationTest.cs
@@ -58,7 +58,6 @@ public class SpaceNodeCreationTest(ITestOutputHelper output) : MonolithMeshTestB
 
         var spaceContent = new Space
         {
-            Name = "Acme Corp",
             Description = "A test space",
             Website = "https://acme.example.com",
             Location = "Switzerland",

--- a/test/MeshWeaver.Security.Test/UserPublicReadTest.cs
+++ b/test/MeshWeaver.Security.Test/UserPublicReadTest.cs
@@ -40,7 +40,7 @@ public class UserPublicReadTest(ITestOutputHelper output) : MonolithMeshTestBase
                     Name = "Acme Corp",
                     NodeType = "Space",
                     State = MeshNodeState.Active,
-                    Content = new Space { Name = "Acme Corp" }
+                    Content = new Space()
                 },
                 // Second user for nodeType query tests
                 new MeshNode("Bob", "User")
@@ -144,7 +144,7 @@ public class UserPublicReadTest(ITestOutputHelper output) : MonolithMeshTestBase
         {
             Name = "Globex Corp",
             NodeType = "Space",
-            Content = new Space { Name = "Globex Corp" }
+            Content = new Space()
         };
         var created = await NodeFactory.CreateNode(orgNode).Should().Emit();
         created.Should().NotBeNull();


### PR DESCRIPTION
## What
The `Space` content record duplicated the node's display name via `[MeshNodeProperty(nameof(MeshNode.Name))]`. That projection only runs **node→content** at materialization, with no reliable write-back — so editing the Space page wrote `content.Name` while the **catalog reads `MeshNode.Name`**, leaving them desynced (e.g. a space renamed on its page still showed the old title in the catalog).

This removes `content.Name` entirely so **`MeshNode.Name` is the single source of truth** (matching `AccessObject`/`User`/`Group`, which keep Id/Name/Icon only on the node).

## Changes
- **`SpaceNodeType.cs`** — dropped the `Name` property from the `Space` record.
- **`SpaceLayoutAreas.cs`** — both editable name fields (the header click-to-edit title + the Edit-page name) now bind to the **node** via `GetMeshNodeDataContext(spacePath, bindContent:false)`, so `"name"` resolves to `MeshNode.Name` and edits persist to the node directly (this fixes the desync at the source). `ResolveSpace`/`BuildSpaceView` read `node.Name`.
- **`GitHubSyncService.cs`** — `Content = new Space()` (the node already sets `Name`).
- **~24 test files** — moved `Name` off `new Space { … }` onto the enclosing `MeshNode` initializer; `SpaceResolveSpaceTest` now asserts `node.Name`.

`Space.Icon` is intentionally left as-is (separate follow-up if wanted).

## Verification
- `-c Release -p:CIRun=true -warnaserror`: **0 warnings / 0 errors**.
- `SpaceResolveSpace` 8/8 · `SpaceEditableTitle|SpaceEditMarkdown|SpaceOverviewBody` 4/4 · NodeOperations Space suite 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)