### PR TITLE
fix(course): filter internal/satellite (_-prefixed) nodes from the course side-nav rail

### DIFF
--- a/src/MeshWeaver.Graph/Education/EducationLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Education/EducationLayoutAreas.cs
@@ -282,9 +282,11 @@ public static class EducationLayoutAreas
     /// <summary>
     /// The pages a course side-nav lists for <paramref name="moduleRoot"/>: the module's DIRECT children
     /// (deeper support nodes such as <c>Source/…</c> are excluded to keep the TOC a clean page list), ordered
-    /// by <see cref="MeshNode.Order"/> then <see cref="MeshNode.Name"/> (case-insensitive). Pure — the
-    /// nav-rendering and the ordering contract are the same function, so a test can pin the order without
-    /// reaching through the render/serialization layer.
+    /// by <see cref="MeshNode.Order"/> then <see cref="MeshNode.Name"/> (case-insensitive). Internal /
+    /// satellite nodes — any whose final path segment starts with <c>_</c> (<c>_GitSync</c>, <c>_Access</c>,
+    /// <c>_Thread</c>, <c>_Activity</c>, …) — are filtered out: they are plumbing, never learner-facing pages.
+    /// Pure — the nav-rendering and the ordering contract are the same function, so a test can pin the order
+    /// without reaching through the render/serialization layer.
     /// </summary>
     /// <param name="moduleRoot">The containing space (the current page's parent module) whose children are listed.</param>
     /// <param name="mainNodes">The module + its main descendants (the <c>scope:subtree is:main</c> query result).</param>
@@ -293,12 +295,20 @@ public static class EducationLayoutAreas
     {
         var prefix = moduleRoot + "/";
         return mainNodes
-            .Where(n => !string.IsNullOrEmpty(n.Path)
-                        && n.Path.StartsWith(prefix, StringComparison.Ordinal)
-                        && !n.Path.AsSpan(prefix.Length).Contains('/'))
+            .Where(n => !string.IsNullOrEmpty(n.Path) && IsDirectChildPage(n.Path.AsSpan(), prefix))
             .OrderBy(n => n.Order)
             .ThenBy(n => n.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    // A direct-child PAGE of the module: sits immediately under moduleRoot (no deeper), and its own segment
+    // is not an internal/satellite node (leading '_' — _GitSync, _Access, _Thread, …).
+    private static bool IsDirectChildPage(ReadOnlySpan<char> path, string prefix)
+    {
+        if (!path.StartsWith(prefix, StringComparison.Ordinal))
+            return false;
+        var segment = path[prefix.Length..];
+        return segment.Length > 0 && !segment.Contains('/') && segment[0] != '_';
     }
 
     private static UiControl BuildCourseNav(

--- a/test/MeshWeaver.AI.Test/EducationStartExerciseTest.cs
+++ b/test/MeshWeaver.AI.Test/EducationStartExerciseTest.cs
@@ -226,6 +226,29 @@ public class EducationStartExerciseTest(ITestOutputHelper output) : MonolithMesh
         pages.Select(p => p.Name).Should().Equal("Your Turn", "Solutions");
     }
 
+    [Fact]
+    public void SelectCoursePages_FiltersInternalSatelliteNodes()
+    {
+        // The nav rail is learner-facing: internal / satellite nodes (any whose final path segment starts
+        // with '_' — _GitSync, _Access, _Thread, _Activity, …) are plumbing and must NOT appear as pages.
+        const string moduleRoot = "TestCourse/Module1";
+        var nodes = new[]
+        {
+            new MeshNode("Module1", "TestCourse") { Name = "Module 1" }, // the module root itself
+            new MeshNode("Intro", moduleRoot) { Name = "Intro", Order = 1 },
+            new MeshNode("_GitSync", moduleRoot) { Name = "GitHub Sync", Order = 2 }, // internal — filtered
+            new MeshNode("TDD", moduleRoot) { Name = "TDD", Order = 3 },
+            new MeshNode("_Access", moduleRoot) { Name = "Access", Order = 4 },        // satellite — filtered
+        };
+
+        var pages = EducationLayoutAreas.SelectCoursePages(moduleRoot, nodes);
+
+        // Only the real pages survive, order (Order then Name) preserved; every '_'-prefixed node is gone.
+        pages.Select(p => p.Path).Should().Equal(
+            "TestCourse/Module1/Intro",
+            "TestCourse/Module1/TDD");
+    }
+
     [Fact(Timeout = 120_000)]
     public async Task Learn_ReaderShell_IsSplitter_WithCollapsibleNavPane()
     {


### PR DESCRIPTION
## Problem

`EducationLayoutAreas.SelectCoursePages(moduleRoot, mainNodes)` returned the module root's direct children and rendered them as the `CourseNav` learner-facing rail — but it included **internal / satellite nodes**. For example `_GitSync` showed up as a nav item ("GitHub Sync — Systemorph/AgenticEngineering"). Any node whose final path segment starts with `_` (`_GitSync`, `_Access`, `_Thread`, `_Activity`, `_Memex`, `_Notification`, …) is plumbing and must never appear in the course side-nav.

## Fix

In `SelectCoursePages`, additionally exclude any node whose final path segment starts with `_`. The existing filter (direct children of `moduleRoot`, no deeper) and ordering (`Order` then `Name`, case-insensitive) are unchanged — it stays a pure function. Extracted the predicate into a small `IsDirectChildPage` helper that also guards the empty-remainder edge case.

## Test

Extended `EducationStartExerciseTest` with a pure-function case: given children `[Intro, _GitSync, TDD, _Access]`, the result is `[Intro, TDD]` (internal `_`-nodes filtered, order preserved).

Built `-c Release -p:CIRun=true -warnaserror` clean (0 warnings); both `SelectCoursePages` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)