### PR TITLE
feat(react-native): render HTML on native + wire @@ layout-area embeds

### DIFF
--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
-import { SafeAreaView, StatusBar } from "react-native";
-import { RegistryProvider, ScopeProvider, StaticAreaSource, type AreaSource } from "@meshweaver/react/core";
+import { SafeAreaView, StatusBar, LogBox } from "react-native";
+import {
+  RegistryProvider,
+  ScopeProvider,
+  StaticAreaSource,
+  EmbeddedAreaProvider,
+  createGrpcEmbeddedFactory,
+  type AreaSource,
+  type AreaSourceFactory,
+} from "@meshweaver/react/core";
 import { Mesh } from "@meshweaver/client-web";
 import { rnPack } from "./src/rnPack";
 import { sampleArea } from "./src/sample";
@@ -46,6 +54,11 @@ const CHAT: ChatOptions | null = {
 };
 // const CHAT: ChatOptions | null = null;
 
+// react-native-render-html (the native HTML renderer) still uses React's deprecated `defaultProps`,
+// which React 18.3 logs as a dev-only warning per node — suppress that one third-party message so it
+// doesn't bury real warnings (harmless; gone in a release build).
+LogBox.ignoreLogs([/Support for defaultProps will be removed/]);
+
 export default function App() {
   ensureWebStyles();
   return (
@@ -63,6 +76,8 @@ function AppInner() {
   const [source, setSource] = useState<AreaSource>(() => new StaticAreaSource(sampleArea));
   const [liveConnected, setLiveConnected] = useState(false);
   const [submitter, setSubmitter] = useState<ThreadSubmitter | undefined>(undefined);
+  // The factory `@@` layout-area embeds (LayoutAreaControl) open their nested area streams through.
+  const [embedFactory, setEmbedFactory] = useState<AreaSourceFactory | null>(null);
 
   const navigate = (t: NavTarget) => {
     setClientScreen(null);
@@ -88,8 +103,10 @@ function AppInner() {
         live = l;
         setSource(l.source);
         setLiveConnected(true);
-        // The SAME gRPC-web connection carries thread submissions (Mesh.startThread / Mesh.submitMessage).
+        // The SAME gRPC-web connection carries thread submissions (Mesh.startThread / Mesh.submitMessage)
+        // AND the nested streams that `@@("area/X")` layout-area embeds open.
         setSubmitter(Mesh.from(l.connection));
+        setEmbedFactory(() => createGrpcEmbeddedFactory(l.connection));
       })
       .catch((e) => { console.warn("[live] connect failed:", e?.message ?? String(e)); /* shell stays on the last-good source */ });
     return () => {
@@ -125,20 +142,22 @@ function AppInner() {
     <SafeAreaView style={{ flex: 1, backgroundColor: palette.appBg }}>
       <StatusBar />
       <RegistryProvider pack={rnPack}>
-        <NavContext.Provider value={navigate}>
-          <CurrentAddressContext.Provider value={nav.address}>
-            <ScopeProvider source={source} area={effNav.area}>
-              <Shell
-                source={source}
-                nav={effNav}
-                clientScreen={clientScreen}
-                onNavigate={navigate}
-                onClientScreen={setClientScreen}
-                onReconnect={reconnect}
-              />
-            </ScopeProvider>
-          </CurrentAddressContext.Provider>
-        </NavContext.Provider>
+        <EmbeddedAreaProvider factory={embedFactory}>
+          <NavContext.Provider value={navigate}>
+            <CurrentAddressContext.Provider value={nav.address}>
+              <ScopeProvider source={source} area={effNav.area}>
+                <Shell
+                  source={source}
+                  nav={effNav}
+                  clientScreen={clientScreen}
+                  onNavigate={navigate}
+                  onClientScreen={setClientScreen}
+                  onReconnect={reconnect}
+                />
+              </ScopeProvider>
+            </CurrentAddressContext.Provider>
+          </NavContext.Provider>
+        </EmbeddedAreaProvider>
       </RegistryProvider>
       {CHAT && (
         <ChatComposer

--- a/clients/react-native/package.json
+++ b/clients/react-native/package.json
@@ -27,6 +27,7 @@
     "react-dom": "18.3.1",
     "react-native": "0.76.5",
     "react-native-fetch-api": "^3.0.0",
+    "react-native-render-html": "^6.3.4",
     "react-native-web": "~0.19.13",
     "text-encoding": "^0.7.0",
     "web-streams-polyfill": "^4.3.0"

--- a/clients/react-native/src/nativeHtml.native.tsx
+++ b/clients/react-native/src/nativeHtml.native.tsx
@@ -1,0 +1,40 @@
+// React Native device HTML rendering — react-native-render-html turns server-prerendered HTML (doc
+// bodies, tables, links, styled spans) into native components. Bundled ONLY on a device: metro resolves
+// this .native file, while web/tsc/vitest use nativeHtml.tsx (no render-html dep). Same split as nativeFetch.
+import RenderHtml from "react-native-render-html";
+import { useWindowDimensions, Platform, StyleSheet } from "react-native";
+
+export function NativeHtml({ html }: { html: string }) {
+  const { width } = useWindowDimensions();
+  return (
+    <RenderHtml
+      source={{ html: html || "" }}
+      contentWidth={Math.max(240, (width || 360) - 88)}
+      baseStyle={BASE}
+      tagsStyles={TAGS}
+      systemFonts={SYSTEM_FONTS}
+      defaultTextProps={{ selectable: true }}
+      // RN's Image can't load SVGs or the doc's relative/about: URLs (that crashed the render). Drop
+      // images + inline SVG so the text/tables/links render; native icon rendering is a follow-up.
+      ignoredDomTags={IGNORED_TAGS}
+    />
+  );
+}
+
+const IGNORED_TAGS = ["img", "svg", "picture", "source"];
+const SYSTEM_FONTS = Platform.OS === "ios" ? ["System", "Menlo"] : ["sans-serif", "monospace"];
+const BASE = { color: "#242424", fontSize: 15, lineHeight: 22 } as any;
+const TAGS = {
+  h1: { fontSize: 24, fontWeight: "700", marginTop: 10, marginBottom: 8 },
+  h2: { fontSize: 20, fontWeight: "700", marginTop: 10, marginBottom: 6 },
+  h3: { fontSize: 17, fontWeight: "600", marginTop: 8, marginBottom: 4 },
+  p: { marginTop: 0, marginBottom: 8 },
+  a: { color: "#0f6cbd", textDecorationLine: "none" },
+  code: { fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace", fontSize: 13, backgroundColor: "#f2f2f2" },
+  pre: { backgroundColor: "#f5f5f5", padding: 10, borderRadius: 6 },
+  table: { borderWidth: StyleSheet.hairlineWidth, borderColor: "#ddd", marginBottom: 8 },
+  th: { fontWeight: "700", padding: 6, backgroundColor: "#f7f7f7" },
+  td: { padding: 6, borderTopWidth: StyleSheet.hairlineWidth, borderColor: "#eee" },
+  ul: { marginBottom: 8 },
+  li: { marginBottom: 4 },
+} as any;

--- a/clients/react-native/src/nativeHtml.tsx
+++ b/clients/react-native/src/nativeHtml.tsx
@@ -1,0 +1,33 @@
+// Web + test/fallback HTML rendering. On web (react-native-web) inject the HTML into a real DOM node;
+// elsewhere without a DOM or the native renderer (the vitest mock) strip tags to readable text. A device
+// build resolves nativeHtml.native.tsx instead (react-native-render-html) — the SAME platform-file split
+// as nativeFetch.*, so the render-html dep is bundled ONLY on a device; tsc/vitest/web never load it.
+import { createElement } from "react";
+import { Text, Platform, StyleSheet } from "react-native";
+
+export function NativeHtml({ html }: { html: string }) {
+  if (Platform.OS === "web")
+    return createElement("div", { className: "markdown-body", dangerouslySetInnerHTML: { __html: html || "" } });
+  return <Text style={styles.body}>{stripTags(html)}</Text>;
+}
+
+// Readable plaintext from HTML: turn block-closers into newlines, drop the rest of the tags, unescape the
+// common entities. Good enough for the no-DOM fallback (tests) — a device gets full rendering.
+function stripTags(h: string): string {
+  return (h || "")
+    .replace(/<\/(p|div|h[1-6]|li|tr|table)>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/[ \t]+/g, " ")
+    .replace(/ *\n */g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+const styles = StyleSheet.create({
+  body: { fontSize: 15, color: "#242424", lineHeight: 22 },
+});

--- a/clients/react-native/src/polyfills.d.ts
+++ b/clients/react-native/src/polyfills.d.ts
@@ -10,3 +10,8 @@ declare module "text-encoding" {
   export const TextEncoder: any;
   export const TextDecoder: any;
 }
+// Native-only HTML renderer (consumed exclusively by nativeHtml.native.tsx; the web build never bundles it).
+declare module "react-native-render-html" {
+  const RenderHtml: any;
+  export default RenderHtml;
+}

--- a/clients/react-native/src/rnPack.tsx
+++ b/clients/react-native/src/rnPack.tsx
@@ -210,33 +210,38 @@ const LayoutAreaEmbed: ControlComponent = ({ control }) => {
   const ref = (control.reference ?? {}) as any;
   const area = s(ref.area ?? ref.Area ?? "");
   const id = ref.id ?? ref.Id;
-  const key = `${address}|${area}|${id == null ? "" : s(id)}`;
+  const layout = ref.layout ?? ref.Layout;
+  // Progress options mirror the web LayoutAreaView: ShowProgress (default true) suppressed either by a
+  // false ShowProgress or SpinnerType "None".
+  const showProgress = useResolve(control.showProgress) !== false && s(control.spinnerType) !== "None";
+  const key = `${address}|${area}|${id == null ? "" : s(id)}|${s(layout)}`;
 
   const [handle, setHandle] = useState<EmbeddedAreaHandle | null>(null);
   useEffect(() => {
     if (!factory || !address) return;
-    const h = factory(address, { area: area || undefined, id });
+    const h = factory(address, { area: area || undefined, id, layout: layout ? String(layout) : undefined });
     setHandle(h);
     return () => { h?.dispose?.(); setHandle(null); };
-    // key captures address/area/id; factory identity change re-opens the nested subscription.
+    // key captures address/area/id/layout; factory identity change re-opens the nested subscription.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [factory, key]);
 
   if (!factory || !address)
     return <View style={styles.embed}><Text style={styles.label}>▦ {area || "layout area"} @ {address}</Text></View>;
-  if (!handle) return <ActivityIndicator />;
+  if (!handle) return showProgress ? <ActivityIndicator /> : null;
   const rootArea = handle.rootArea ?? area;
   return (
     <ScopeProvider source={handle.source} area={rootArea}>
-      <EmbeddedAreaBody rootArea={rootArea} />
+      <EmbeddedAreaBody rootArea={rootArea} showProgress={showProgress} />
     </ScopeProvider>
   );
 };
 
-// Inside the NESTED source's scope: spin until the embedded root area arrives, then render its tree.
-function EmbeddedAreaBody({ rootArea }: { rootArea: string }) {
+// Inside the NESTED source's scope: spin (unless progress is suppressed) until the embedded root area
+// arrives, then render its tree.
+function EmbeddedAreaBody({ rootArea, showProgress }: { rootArea: string; showProgress: boolean }) {
   const state = useAreaState();
-  if (state.areas?.[rootArea] == null) return <ActivityIndicator />;
+  if (state.areas?.[rootArea] == null) return showProgress ? <ActivityIndicator /> : null;
   return <RenderArea areaKey={rootArea} />;
 }
 

--- a/clients/react-native/src/rnPack.tsx
+++ b/clients/react-native/src/rnPack.tsx
@@ -2,18 +2,23 @@
 // renderer core (@meshweaver/react/core). This is the RN analog of MAUI's MauiViewPack and of the web
 // Fluent pack: SAME UiControl tree, native leaves. Drop it into <RegistryProvider pack={rnPack}>.
 
-import { createElement, useState } from "react";
+import { useEffect, useState } from "react";
 import { View, Text, TextInput, Pressable, Switch, ScrollView, ActivityIndicator, StyleSheet, Platform } from "react-native";
 import { marked } from "marked";
+import { NativeHtml } from "./nativeHtml";
 import {
   ControlRenderer,
   RenderArea,
+  ScopeProvider,
+  useAreaSourceFactory,
+  useAreaState,
   useBindingPointer,
   useChildAreas,
   useEmit,
   useResolve,
   useScope,
   type ControlComponent,
+  type EmbeddedAreaHandle,
   type LeafPack,
   type SkinComponent,
 } from "@meshweaver/react/core";
@@ -183,38 +188,57 @@ const DataGrid: ControlComponent = ({ control }) => {
   );
 };
 
-// Server-prerendered HTML (doc bodies, rich text). On web (react-native-web) inject it into a real DOM
-// node; on native there is no DOM, so strip tags to text — a full native HTML renderer is future work.
-const Html: ControlComponent = ({ control }) => {
-  const html = s(useResolve(control.data));
-  if (Platform.OS === "web")
-    return createElement("div", { className: "markdown-body", dangerouslySetInnerHTML: { __html: html } });
-  return <Text style={styles.body}>{html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim()}</Text>;
-};
+// Server-prerendered HTML (doc bodies, rich text) → NativeHtml renders it: real DOM on web, native
+// components (react-native-render-html) on a device, a stripped-text fallback in tests (see nativeHtml).
+const Html: ControlComponent = ({ control }) => <NativeHtml html={s(useResolve(control.data))} />;
 
-// Markdown / collaborative-markdown editors (read-only for now). CollaborativeMarkdownControl carries
-// its markdown in `value`; the plain Markdown control uses `data`. On web, convert markdown → HTML and
-// inject; on native (no DOM) fall back to the raw text.
+// Markdown / collaborative-markdown (read-only). CollaborativeMarkdownControl carries its markdown in
+// `value`; the plain Markdown control uses `data`. Convert markdown → HTML, then render via NativeHtml.
 const Markdown: ControlComponent = ({ control }) => {
   const md = s(useResolve(control.value ?? control.data ?? control.content ?? control.markdown));
-  if (Platform.OS === "web")
-    return createElement("div", {
-      className: "markdown-body",
-      dangerouslySetInnerHTML: { __html: marked.parse(md, { async: false }) as string },
-    });
-  return <Text style={styles.body}>{md}</Text>;
+  return <NativeHtml html={marked.parse(md, { async: false }) as string} />;
 };
 
-// An embedded layout area on ANOTHER address — a distinct subscription. Show a labelled placeholder;
-// wiring a nested live GrpcAreaSource per embed is future work.
+// A nested layout area on another address — the `@@("area/X")` embed (LayoutAreaControl). Opens a SECOND
+// area stream via the host's AreaSourceFactory (App wires createGrpcEmbeddedFactory on the live connection)
+// and renders that tree in its own scope — the native mirror of the web LayoutAreaView. Without a factory
+// (offline / tests) it falls back to a labelled marker.
 const LayoutAreaEmbed: ControlComponent = ({ control }) => {
-  const ref = control.reference as any;
+  const factory = useAreaSourceFactory();
+  const rawAddress = useResolve(control.address);
+  const address = typeof rawAddress === "string" ? rawAddress : s((rawAddress as any)?.address ?? (rawAddress as any)?.path);
+  const ref = (control.reference ?? {}) as any;
+  const area = s(ref.area ?? ref.Area ?? "");
+  const id = ref.id ?? ref.Id;
+  const key = `${address}|${area}|${id == null ? "" : s(id)}`;
+
+  const [handle, setHandle] = useState<EmbeddedAreaHandle | null>(null);
+  useEffect(() => {
+    if (!factory || !address) return;
+    const h = factory(address, { area: area || undefined, id });
+    setHandle(h);
+    return () => { h?.dispose?.(); setHandle(null); };
+    // key captures address/area/id; factory identity change re-opens the nested subscription.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [factory, key]);
+
+  if (!factory || !address)
+    return <View style={styles.embed}><Text style={styles.label}>▦ {area || "layout area"} @ {address}</Text></View>;
+  if (!handle) return <ActivityIndicator />;
+  const rootArea = handle.rootArea ?? area;
   return (
-    <View style={styles.embed}>
-      <Text style={styles.label}>▦ {s(ref?.area ?? ref?.Area) || "layout area"} @ {s(useResolve(control.address))}</Text>
-    </View>
+    <ScopeProvider source={handle.source} area={rootArea}>
+      <EmbeddedAreaBody rootArea={rootArea} />
+    </ScopeProvider>
   );
 };
+
+// Inside the NESTED source's scope: spin until the embedded root area arrives, then render its tree.
+function EmbeddedAreaBody({ rootArea }: { rootArea: string }) {
+  const state = useAreaState();
+  if (state.areas?.[rootArea] == null) return <ActivityIndicator />;
+  return <RenderArea areaKey={rootArea} />;
+}
 
 // ── input / editor controls (native twins of clients/react/src/controls/inputs.tsx) ────────────────
 const NumberField: ControlComponent = ({ control }) => {


### PR DESCRIPTION
Follow-up to #308. On the native app the doc HTML showed as **raw text** and `@@` embeds as a **placeholder** — both fixed and verified live on the iOS simulator (rendering `Doc/Architecture` from the local SQLite monolith).

## HTML renders on native
- `Html`/`Markdown` controls now render through **`NativeHtml`** — real DOM on web, native components via **`react-native-render-html`** on a device, a stripped-text fallback for tsc/vitest/web.
- Split into `nativeHtml.tsx` / `nativeHtml.native.tsx` (same platform-file pattern as `nativeFetch.*`) so the render-html dep is bundled **only on a device** — ambient-declared in `polyfills.d.ts`, and no test imports it, so CI's targeted install stays green.
- RN's `Image` can't load SVG or the doc's relative/`about:` URLs (that red-boxed the render) → drop `img`/`svg` tags. Icons are a follow-up (needs `react-native-svg` + a base-URL rewrite); text/tables/links/embeds all render.

## `@@` layout-area embeds work
- `App` wires `createGrpcEmbeddedFactory(connection)` via `EmbeddedAreaProvider`; the native `LayoutArea` control opens the nested area stream and renders it — the mirror of the web `LayoutAreaView`. Confirmed `area=Approvals` / `area=Comments` getting a live factory + handle.

Also silences react-native-render-html's deprecated-`defaultProps` dev LogBox warning.

## Tests (pre-flighted locally)
- `react-native`: `tsc --noEmit` clean + **55 vitest** green.
- `rn-web-e2e`: Playwright **5/5** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)