### PR TITLE
feat(client): surface hub InitializationError reason instead of generic "did not become addressable" (#323)

### DIFF
--- a/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
@@ -138,6 +138,41 @@ public partial class NamedAreaView
                         return;
                     }
 
+                    // The target hub's INITIALIZATION FAILED — a BuildupAction faulted or hung, so
+                    // the hub opened its Initialize gate in a FAILED state and now answers every
+                    // request with a typed DeliveryFailure carrying the real reason ("Hub '…'
+                    // initialization failed: <reason>"; see HubInitializationFailure.md). This is
+                    // TERMINAL-with-reason: a durably-failed hub will NOT recover on resubscribe, so
+                    // it is neither retried (the bounded reactive retry above already skips it — see
+                    // AreaErrorClassifier.ShouldRetryArea) nor collapsed into the generic "did not
+                    // become addressable" spinner. Render the actual reason so operators see WHAT
+                    // broke without reading server logs — and, because the reason stands on its own,
+                    // it stays informative even when the gate never opened and AreaToBeRendered is
+                    // empty (no area name ever resolved). Detected on the typed Failure — no NodeType
+                    // path lookup, no retry. Issue #323.
+                    if (AreaErrorClassifier.TryGetInitializationFailureReason(error) is { } initReason)
+                    {
+                        Logger.LogWarning(error,
+                            "Area {Area} target hub initialization failed — rendering the init-error reason instead of the generic 'did not become addressable' banner. Reason={Reason}",
+                            AreaToBeRendered, initReason);
+                        try
+                        {
+                            InvokeAsync(() =>
+                            {
+                                if (IsViewDisposed) return;
+                                try
+                                {
+                                    RootControl = new MarkdownControl(
+                                        $"**This view could not be initialised.**\n\n{initReason}");
+                                    RequestStateChange();
+                                }
+                                catch (ObjectDisposedException) { /* renderer gone */ }
+                            });
+                        }
+                        catch (ObjectDisposedException) { /* renderer gone */ }
+                        return;
+                    }
+
                     // Transient hub/network failures (request timeouts, undeliverable
                     // routing, dropped circuit) are usually self-healing — the upstream
                     // hub finishes initialising, the security pipeline emits its first

--- a/src/MeshWeaver.Layout/AreaErrorClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaErrorClassifier.cs
@@ -57,6 +57,42 @@ public static class AreaErrorClassifier
     }
 
     /// <summary>
+    /// Returns the init-failure reason of a target hub whose <c>Initialize</c> gate FAILED to open
+    /// (a BuildupAction faulted or hung → the hub entered its FAILED state and now answers every
+    /// request with a typed <see cref="DeliveryFailure"/> carrying
+    /// <c>"Hub '&lt;addr&gt;' initialization failed: &lt;reason&gt;"</c>), or <c>null</c>.
+    ///
+    /// <para>This is a TERMINAL-with-reason case — distinct from both
+    /// <see cref="IsTransientHubFailure"/> (a not-yet-online hub that self-heals on retry) and
+    /// <see cref="TryGetCompilationInProgressNodeType"/> (a transient mid-compile NACK swapped to
+    /// the Progress view). A durably-failed hub will NOT recover on resubscribe, so it must NOT be
+    /// retried; and its failure carries the ACTUAL reason, so the GUI renders that reason instead of
+    /// the generic "did not become addressable after N retries" spinner (which, when the gate never
+    /// opened, doesn't even carry an area name). The reason string is authoritative — the same one
+    /// <c>MessageHub.EnterInitializationFailedState</c> stamped from <c>InitializationError</c>. See
+    /// <c>Doc/Architecture/HubInitializationFailure.md</c> and issue #323.</para>
+    /// </summary>
+    public static string? TryGetInitializationFailureReason(Exception? ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            if (e is DeliveryFailureException dfe)
+            {
+                // Both init-failure banners the hub emits — the first request's
+                // "initialization failed — <reason>" (HandleInitialize's .Catch) and every later
+                // request's "initialization failed: <reason>" (EnterInitializationFailedState's
+                // refusal rule) — carry this distinctive substring. Match on the typed failure's
+                // message, not a bare Exception.Message, so a coincidental string on some other
+                // exception can't be mistaken for a hub init failure.
+                var msg = dfe.Failure.Message ?? string.Empty;
+                if (msg.Contains("initialization failed", StringComparison.OrdinalIgnoreCase))
+                    return msg;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
     /// True for outcomes caused by the user's action (access denied, validation rejection,
     /// node not found) rather than an engineering fault — used to pick a Warning (not Error)
     /// log level so dashboards don't page on "user clicked a thing they couldn't do".
@@ -112,12 +148,14 @@ public static class AreaErrorClassifier
     /// <summary>
     /// The single predicate the area subscription hands to
     /// <see cref="AreaStreamRetry.RetryAreaWithBackoff{T}"/>: retry ONLY a transient hub
-    /// miss — never a teardown <see cref="ObjectDisposedException"/> (benign) and never a
+    /// miss — never a teardown <see cref="ObjectDisposedException"/> (benign), never a
     /// <see cref="ErrorType.CompilationInProgress"/> NACK (handled immediately by swapping
-    /// to the Progress view, not by spinning).
+    /// to the Progress view, not by spinning), and never a hub init failure (durably FAILED —
+    /// a resubscribe hits the same failed hub, so the reason is rendered once, not retried).
     /// </summary>
     public static bool ShouldRetryArea(Exception? ex)
         => ex is not ObjectDisposedException
            && TryGetCompilationInProgressNodeType(ex) is null
+           && TryGetInitializationFailureReason(ex) is null
            && IsTransientHubFailure(ex);
 }

--- a/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
+++ b/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
@@ -99,6 +99,46 @@ public class AreaErrorClassifierTest
         => AreaErrorClassifier.IsNodeGoneNotFound(new InvalidOperationException("No node found at X")).Should().BeFalse(
             "only a routing DeliveryFailure counts — a coincidental message on some other exception must not");
 
+    // ── TryGetInitializationFailureReason: a FAILED hub → render the reason, terminal, no retry (#323) ──
+
+    [Theory]
+    // The first request that triggered init (HandleInitialize's .Catch — em-dash form):
+    [InlineData("Hub 'AgenticPension/x' initialization failed — a BuildupAction faulted (InvalidOperationException: seed missing)")]
+    // Every later request (EnterInitializationFailedState's refusal rule — colon form):
+    [InlineData("Hub 'AgenticPension/x' initialization failed: seed missing")]
+    public void TryGetInitializationFailureReason_ReturnsReasonForBothBanners(string message)
+        => AreaErrorClassifier.TryGetInitializationFailureReason(Failure(message, ErrorType.Failed))
+            .Should().Be(message,
+                "a hub that failed initialization carries the real reason in its DeliveryFailure — the "
+                + "client must surface it, not the generic 'did not become addressable' banner");
+
+    [Fact]
+    public void TryGetInitializationFailureReason_NullForCompilationInProgress()
+        // A CompilationInProgress NACK is a DISTINCT, transient case (swap to Progress) — not an init failure.
+        => AreaErrorClassifier.TryGetInitializationFailureReason(
+                Failure("compiling", ErrorType.CompilationInProgress, "Foo/Bar")).Should().BeNull();
+
+    [Fact]
+    public void TryGetInitializationFailureReason_NullForOtherDeliveryFailure()
+        => AreaErrorClassifier.TryGetInitializationFailureReason(
+                Failure("The target hub was not found for address Foo/Bar", ErrorType.NotFound)).Should().BeNull();
+
+    [Fact]
+    public void TryGetInitializationFailureReason_NullForNonDeliveryFailure()
+        => AreaErrorClassifier.TryGetInitializationFailureReason(
+                new InvalidOperationException("Hub 'x' initialization failed: boom")).Should().BeNull(
+            "only a typed DeliveryFailure counts — a coincidental message on some other exception must not");
+
+    [Fact]
+    public void InitializationFailure_ClassifiesAsTerminalWithReason_NotTransient()
+    {
+        // The init-failure banner must NOT be mistaken for a transient (retried) miss — otherwise the
+        // client would spin against a durably-failed hub instead of showing the reason once.
+        var initFailure = Failure("Hub 'x' initialization failed: seed missing", ErrorType.Failed);
+        AreaErrorClassifier.TryGetInitializationFailureReason(initFailure).Should().NotBeNull();
+        AreaErrorClassifier.IsTransientHubFailure(initFailure).Should().BeFalse();
+    }
+
     // ── ShouldRetryArea: the single predicate the subscription hands the retry operator ──
 
     [Fact]
@@ -113,6 +153,12 @@ public class AreaErrorClassifierTest
     [Fact]
     public void ShouldRetryArea_FalseForDisposal_BenignTeardown()
         => AreaErrorClassifier.ShouldRetryArea(new ObjectDisposedException("circuit")).Should().BeFalse();
+
+    [Fact]
+    public void ShouldRetryArea_FalseForInitializationFailure_TerminalNotRetried()
+        // A durably-failed hub won't recover on resubscribe — render the reason once, never spin (#323).
+        => AreaErrorClassifier.ShouldRetryArea(
+                Failure("Hub 'x' initialization failed: seed missing", ErrorType.Failed)).Should().BeFalse();
 
     [Fact]
     public void ShouldRetryArea_FalseForPermanentError()


### PR DESCRIPTION
## Problem

When a hub's `Initialize` gate fails or never opens (a BuildupAction faulted or hung → the hub enters its FAILED state, per `Doc/Architecture/HubInitializationFailure.md`), the hub answers every request with a typed `DeliveryFailure` carrying the real reason: `Hub '<addr>' initialization failed: <reason>`.

The client previously collapsed that into the generic **"Area unavailable — did not become addressable after N retries"** banner, hiding the actual cause. Operators had to read server logs — and when the gate never opened, `AreaToBeRendered` was empty so the banner didn't even carry the area path.

## Fix

1. **`AreaErrorClassifier.TryGetInitializationFailureReason`** — new TYPED classification that recognises an `InitializationError`-bearing `DeliveryFailure` (both banner forms: the em-dash `HandleInitialize` `.Catch` message and the colon `EnterInitializationFailedState` refusal message) and returns its reason string. Kept **distinct** from the transient hub miss (retried) and the `CompilationInProgress` NACK (swap-to-Progress) — each remains its own case.
2. **`ShouldRetryArea`** now excludes init failures explicitly: a durably-FAILED hub won't recover on resubscribe, so this is **TERMINAL-with-reason**, never spun.
3. **`NamedAreaView`** renders the init reason (placed before the transient branch) so the user sees WHAT broke. The reason stands on its own, staying informative even when the area path is empty.

## Tests (no mocking)

`AreaErrorClassifierTest` (dependency-free, real `DeliveryFailureException`):
- both init-failure banner forms classify as terminal-with-reason and expose the reason;
- `CompilationInProgress` still classifies as the transient case;
- init failure is NOT transient and `ShouldRetryArea` is false for it.

All 31 `AreaErrorClassifierTest` cases pass; `MeshWeaver.Blazor` + `MeshWeaver.Layout` + `MeshWeaver.Layout.Test` build clean under `-c Release -warnaserror -p:CIRun=true`.

Fixes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)