### PR TITLE
feat(speech): wire the portal /api/speech/transcribe endpoint

### DIFF
--- a/memex/Memex.Portal.Shared/Api/SpeechEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/SpeechEndpoints.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Speech;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Memex.Portal.Shared.Api;
+
+/// <summary>
+/// The client-facing speech-to-text endpoint from
+/// <see href="/Doc/Architecture/CentralizedSpeech">CentralizedSpeech</see>: <c>POST /api/speech/transcribe</c>.
+///
+/// <para>Every client — React Native, the Blazor composer, MAUI — posts audio HERE, behind the portal's
+/// Bearer auth, and the portal forwards it to the (typically cluster-internal) Whisper container via
+/// <see cref="ISpeechTranscriber"/>. The model host never faces clients directly — they only ever see this
+/// endpoint. The contract mirrors whisper.cpp's <c>/inference</c> (and the RN client's
+/// <c>SpeechTranscriptionClient</c>): multipart <c>{ file, language?, response_format? }</c> →
+/// <c>{"text": "…", "language": "…"}</c>.</para>
+/// </summary>
+public static class SpeechEndpoints
+{
+    /// <summary>
+    /// Maps <c>POST /api/speech/transcribe</c>. Same Bearer policy as the rest of the REST surface
+    /// (<c>/api/mesh/*</c>); antiforgery is disabled because a Bearer-auth multipart post carries no
+    /// antiforgery token (identical to <c>/api/mesh/upload</c>).
+    /// </summary>
+    public static IEndpointRouteBuilder MapSpeechApi(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost("/api/speech/transcribe", HandleTranscribe)
+            .RequireAuthorization(McpAuthenticationExtensions.PolicyName)
+            .DisableAntiforgery();
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleTranscribe(
+        HttpContext http, ISpeechTranscriber transcriber, CancellationToken ct)
+    {
+        // Off/unset => tell the caller plainly rather than 500. The mic UI also checks IsConfigured
+        // (via /api/mesh base-url / config) and stays hidden, so this is a belt-and-suspenders guard.
+        if (!transcriber.IsConfigured)
+            return Results.Json(
+                new { error = "Speech transcription is not configured (no Whisper endpoint, or disabled)." },
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+
+        if (!http.Request.HasFormContentType)
+            return Results.BadRequest(new { error = "Content-Type must be multipart/form-data." });
+
+        var form = await http.Request.ReadFormAsync(ct);
+        var file = form.Files.FirstOrDefault();
+        if (file is null || file.Length == 0)
+            return Results.BadRequest(new { error = "Form file 'file' is required." });
+
+        using var ms = new MemoryStream();
+        await using (var stream = file.OpenReadStream())
+            await stream.CopyToAsync(ms, ct);
+
+        // Only override the transcriber's defaults when the multipart part actually carries the value —
+        // SpeechTranscriptionOptions defaults (audio/wav, "de"/config language) must survive an omission.
+        var options = new SpeechTranscriptionOptions
+        {
+            Language = form["language"].FirstOrDefault() is { Length: > 0 } lang ? lang : null,
+        };
+        if (!string.IsNullOrWhiteSpace(file.ContentType))
+            options = options with { ContentType = file.ContentType };
+        if (!string.IsNullOrWhiteSpace(file.FileName))
+            options = options with { FileName = file.FileName };
+
+        // Reactive transcriber → Task only at this HTTP boundary (sanctioned SDK-surface adapter — the
+        // HTTP round-trip to Whisper runs on the HTTP IIoPool inside Transcribe). A transcriber fault is
+        // surfaced to the caller as 502, never swallowed; a client abort propagates as cancellation.
+        try
+        {
+            var transcript = await transcriber.Transcribe(ms.ToArray(), options).FirstAsync().ToTask(ct);
+            return Results.Json(new { text = transcript.Text, language = transcript.Language });
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return Results.Json(
+                new { error = $"Transcription failed: {ex.Message}" },
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+    }
+}

--- a/memex/Memex.Portal.Shared/Api/SpeechEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/SpeechEndpoints.cs
@@ -20,12 +20,19 @@ namespace Memex.Portal.Shared.Api;
 /// <para>Every client — React Native, the Blazor composer, MAUI — posts audio HERE, behind the portal's
 /// Bearer auth, and the portal forwards it to the (typically cluster-internal) Whisper container via
 /// <see cref="ISpeechTranscriber"/>. The model host never faces clients directly — they only ever see this
-/// endpoint. The contract mirrors whisper.cpp's <c>/inference</c> (and the RN client's
-/// <c>SpeechTranscriptionClient</c>): multipart <c>{ file, language?, response_format? }</c> →
-/// <c>{"text": "…", "language": "…"}</c>.</para>
+/// endpoint. Request: multipart <c>{ file, language? }</c> (the whisper.cpp <c>response_format</c>
+/// part the RN client sends is accepted for compatibility but ignored — the portal ALWAYS
+/// normalizes the container's reply to JSON). Response: <c>{"text": "…", "language": "…"}</c>.</para>
 /// </summary>
 public static class SpeechEndpoints
 {
+    /// <summary>
+    /// Cap on a single audio upload. Generous for speech (a minute of WAV ≈ a few MB) but bounds the
+    /// in-memory buffer well under the 200 MB multipart ceiling that <c>AddMeshApi</c> raises — so this
+    /// endpoint can't be turned into a large-allocation DoS.
+    /// </summary>
+    private const long MaxAudioBytes = 25L * 1024 * 1024;
+
     /// <summary>
     /// Maps <c>POST /api/speech/transcribe</c>. Same Bearer policy as the rest of the REST surface
     /// (<c>/api/mesh/*</c>); antiforgery is disabled because a Bearer-auth multipart post carries no
@@ -53,9 +60,14 @@ public static class SpeechEndpoints
             return Results.BadRequest(new { error = "Content-Type must be multipart/form-data." });
 
         var form = await http.Request.ReadFormAsync(ct);
-        var file = form.Files.FirstOrDefault();
+        var file = form.Files.GetFile("file");
         if (file is null || file.Length == 0)
-            return Results.BadRequest(new { error = "Form file 'file' is required." });
+            return Results.BadRequest(new { error = "Multipart file part 'file' is required." });
+        // Reject oversized uploads BEFORE buffering into memory (see MaxAudioBytes).
+        if (file.Length > MaxAudioBytes)
+            return Results.Json(
+                new { error = $"Audio too large: {file.Length} bytes (max {MaxAudioBytes})." },
+                statusCode: StatusCodes.Status413PayloadTooLarge);
 
         using var ms = new MemoryStream();
         await using (var stream = file.OpenReadStream())

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.SignalR\MeshWeaver.Hosting.SignalR.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Grpc\MeshWeaver.Hosting.Grpc.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Speech\MeshWeaver.Speech.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Courses\MeshWeaver.Courses.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.InstanceSync\MeshWeaver.InstanceSync.csproj" />

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -12,6 +12,7 @@ using MeshWeaver.AI.OpenAI;
 using MeshWeaver.AI.ClaudeCode;
 using MeshWeaver.AI.Copilot;
 using MeshWeaver.Blazor.AI;
+using MeshWeaver.Speech;
 using MeshWeaver.Blazor.GoogleMaps;
 using MeshWeaver.Blazor.Graph;
 using MeshWeaver.Blazor.Infrastructure;
@@ -432,6 +433,12 @@ public static class MemexConfiguration
         // REST surface for the mesh — same Bearer-token policy as MCP, lifts the
         // multipart upload size cap. See MeshApiEndpoints.
         services.AddMeshApi();
+
+        // Centralized speech-to-text: registers ISpeechTranscriber (the Whisper container client)
+        // and binds the `Speech` config section (Endpoint/Language/Enabled). The client-facing
+        // POST /api/speech/transcribe endpoint (MapSpeechApi) forwards audio to the container, so
+        // the model host stays behind portal auth. See Doc/Architecture/CentralizedSpeech.
+        services.AddSpeechTranscription(builder.Configuration);
     }
 
     extension<TBuilder>(TBuilder builder) where TBuilder : MeshBuilder
@@ -958,6 +965,10 @@ public static class MemexConfiguration
         // REST surface that mirrors MCP — POST /api/mesh/* (1:1 with MCP tools).
         // Same Bearer auth policy as /mcp; multipart upload at /api/mesh/upload.
         app.MapMeshApi();
+
+        // Centralized speech-to-text — POST /api/speech/transcribe (multipart audio → text),
+        // behind the same Bearer policy; forwards to the Whisper container via ISpeechTranscriber.
+        app.MapSpeechApi();
 
         app.MapMeshWeaver();
 


### PR DESCRIPTION
## What
Wires the client-facing speech endpoint from `Doc/Architecture/CentralizedSpeech`: **`POST /api/speech/transcribe`** on the portal. Clients (React Native, the Blazor composer, MAUI) post audio here — behind the portal's Bearer auth — and the portal forwards it to the (cluster-internal) Whisper container via `ISpeechTranscriber`, so the model host never faces clients directly.

## Why
The mesh client (`ISpeechTranscriber`/`WhisperContainerTranscriber`, tested) and the RN client (`SpeechTranscriptionClient`, tested) were already built to this exact contract, but the endpoint was never mapped and `AddSpeechTranscription()` was never called — so every client's transcribe call had nothing to hit. This is the "next" item called out in CentralizedSpeech.md.

## Changes
- `services.AddSpeechTranscription(builder.Configuration)` — registers `ISpeechTranscriber` + binds the `Speech` section (Endpoint/Language/Enabled), live via `IOptionsMonitor`.
- New `SpeechEndpoints.MapSpeechApi()` → `POST /api/speech/transcribe`: multipart `{ file, language?, response_format? }` → `{ text, language }`. Same Bearer policy as `/api/mesh/*`; antiforgery disabled (Bearer multipart, like `/api/mesh/upload`). Not-configured → **503**; transcriber fault → **502** with message (surfaced, never swallowed); client abort → cancellation. Reactive→Task bridge only at the HTTP boundary; the round-trip runs on the HTTP `IIoPool`.

## Verification
Builds clean under `-c Release -warnaserror`. The endpoint is thin glue over an already-tested contract (both `WhisperContainerTranscriber` server-side and the RN client are unit-tested against the same `/inference` shape; the transcriber→whisper path was verified live). No new endpoint test — the portal test project has no `WebApplicationFactory` harness and the sibling `/api/mesh` endpoints ship untested; end-to-end needs a configured `Speech:Endpoint` (the whisper container, or a local whisper.cpp server on :8080).

## Follow-ups (not in this PR)
Blazor composer mic button (needs this endpoint) · language picker UI · whisper AKS helm chart · broaden endpoint auth to also accept the browser cookie session for the Blazor mic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)