### PR TITLE
fix(layout): render numeric & boolean scalars (+[DisplayFormat]) in read-only Overview (#322)

### DIFF
--- a/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
+++ b/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
@@ -424,15 +424,18 @@ public static class LayoutClientExtensions
         if (value == null)
             return default;
 
-        // A string-typed control bound to a JSON array/object must DISPLAY it, not crash. The generic
-        // property form (EditorExtensions) has no control for an arbitrary IEnumerable<T> property, so it
-        // falls back to a string-bound LabelControl/TextFieldControl; deserializing "[...]"/"{...}" to
-        // string throws JsonException — which spammed the log 30x and left the field blank for the atioz
-        // Anthropic `models` array (["claude-opus-4-8",...]). Render a readable text form instead — a
-        // sensible, non-fatal display for a collection in a scalar slot. Genuine scalar-conversion
-        // failures (a malformed number/bool/date) still fall through to the catch below and are logged.
+        // A string-typed control bound to a non-string JSON scalar/collection must DISPLAY it, not crash.
+        // The generic read-only property form (EditorExtensions) has no control for an IEnumerable<T> and
+        // binds a NUMBER/BOOL scalar into a string-typed LabelControl; `Deserialize<string>("322.844")`
+        // (or `"[...]"`/`"{...}"`) throws JsonException — the catch below then returns null, so the field
+        // renders BLANK until you click to edit (issue #322; the atioz Anthropic `models` array crash).
+        // Render the readable text form instead: a scalar array becomes "a, b, c", and a Number/True/False
+        // token becomes its own text ("322.844"/"true"/"false"). This is the string-slot analogue of the
+        // numeric edit control deserializing the CLR type fine. Only a genuine string target is affected;
+        // any other T still deserializes as before and a real failure still falls through to the catch.
         if (conversion == null && typeof(T) == typeof(string)
-            && value.Value.ValueKind is JsonValueKind.Array or JsonValueKind.Object)
+            && value.Value.ValueKind is JsonValueKind.Array or JsonValueKind.Object
+                or JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False)
             return (T)(object)JsonElementToDisplayString(value.Value);
 
         try
@@ -469,10 +472,11 @@ public static class LayoutClientExtensions
     }
 
     /// <summary>
-    /// Renders a JSON array/object as readable text for a string-typed (read-only) control: a scalar
-    /// array becomes "a, b, c"; anything containing nested objects/arrays falls back to the raw JSON.
-    /// Lets a collection property that the generic form bound to a Label/TextField DISPLAY rather than
-    /// throw a string-conversion JsonException (the atioz `models` array crash).
+    /// Renders a non-string JSON value as readable text for a string-typed (read-only) control: a scalar
+    /// array becomes "a, b, c"; a Number/True/False/Object token becomes its raw JSON text ("322.844",
+    /// "true", "false"); anything containing nested objects/arrays falls back to the raw JSON. Lets a
+    /// numeric/boolean/collection property that the generic form bound to a Label/TextField DISPLAY
+    /// rather than throw a string-conversion JsonException (issue #322; the atioz `models` array crash).
     /// </summary>
     private static string JsonElementToDisplayString(JsonElement element)
     {

--- a/src/MeshWeaver.Layout/EditorExtensions.cs
+++ b/src/MeshWeaver.Layout/EditorExtensions.cs
@@ -971,6 +971,15 @@ public static class EditorExtensions
             var format = displayFormatAttr?.DataFormatString ?? "{0:d}";
             readOnlyControl = BuildFormattedDateLabel(host, propName, dataId, format);
         }
+        else if (propType.IsIntegerType() || propType.IsRealType())
+        {
+            // A numeric scalar (int/decimal/double/… and their nullable variants) bound straight into a
+            // string LabelControl renders BLANK: the client's ConvertJson<string> can't deserialize a JSON
+            // number token to System.String (issue #322). Pre-stringify — honouring [DisplayFormat] so the
+            // read-only Overview matches the DataGrid (PropertyViewBuilder) — into a display /data slot and
+            // bind the label to that string, mirroring the DateTime/options branches.
+            readOnlyControl = BuildFormattedNumberLabel(host, propName, dataId, displayFormatAttr?.DataFormatString);
+        }
         else if (propType == typeof(bool) || propType == typeof(bool?))
         {
             readOnlyControl = new LabelControl(new JsonPointerReference(propName))
@@ -1161,6 +1170,72 @@ public static class EditorExtensions
                     return;
                 lastFormattedDate = formattedDate;
                 host.UpdateData(displayLabelId, formattedDate);
+            }));
+
+        return new LabelControl(new JsonPointerReference(LayoutAreaReference.GetDataPointer(displayLabelId)))
+            .WithStyle("padding: 8px; min-height: 32px;");
+    }
+
+    /// <summary>
+    /// Read-only display for a numeric scalar property: pre-stringifies the value into a display
+    /// <c>/data</c> slot and binds a <see cref="LabelControl"/> to it, mirroring
+    /// <see cref="BuildFormattedDateLabel"/>. Binding a JSON number straight into a string-typed label
+    /// renders BLANK (the client cannot deserialize a number token to <see cref="string"/> — issue #322),
+    /// so the value is formatted server-side here instead. When a <paramref name="format"/> from
+    /// <c>[DisplayFormat]</c> is supplied it is honoured (consistent with the DataGrid); a null/absent
+    /// numeric renders EMPTY, never <c>"0"</c>.
+    /// </summary>
+    private static UiControl BuildFormattedNumberLabel(
+        LayoutAreaHost host,
+        string propName,
+        string dataId,
+        string? format)
+    {
+        var displayLabelId = $"displayLabel_{dataId}_{propName}";
+
+        var dataStream = host.Stream.GetDataStream<JsonElement>(dataId);
+        // Use ReplaceDisposable to prevent duplicate subscriptions when the control is rebuilt.
+        string? lastFormatted = null;
+        host.ReplaceDisposable(displayLabelId,
+            dataStream.Select(data =>
+            {
+                if (data.ValueKind == JsonValueKind.Undefined)
+                    return "";
+
+                if (!data.TryGetProperty(propName, out var valueElement))
+                    return "";
+
+                // A nullable numeric that is null → EMPTY (not "0"); an unexpected shape → its raw text.
+                if (valueElement.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+                    return "";
+                if (valueElement.ValueKind != JsonValueKind.Number)
+                    return valueElement.ToString();
+
+                // No [DisplayFormat] → the JSON's own numeric text (no spurious ".0", no culture drift).
+                if (string.IsNullOrEmpty(format))
+                    return valueElement.GetRawText();
+
+                // [DisplayFormat] → format a real numeric value; decimal preserves precision for currency.
+                try
+                {
+                    if (valueElement.TryGetDecimal(out var dec))
+                        return string.Format(format, dec);
+                    if (valueElement.TryGetDouble(out var dbl))
+                        return string.Format(format, dbl);
+                }
+                catch (FormatException)
+                {
+                    // Malformed format string — fall through to the raw numeric text.
+                }
+                return valueElement.GetRawText();
+            })
+            .Subscribe(formatted =>
+            {
+                // Manual DistinctUntilChanged to avoid unnecessary emissions.
+                if (formatted == lastFormatted)
+                    return;
+                lastFormatted = formatted;
+                host.UpdateData(displayLabelId, formatted);
             }));
 
         return new LabelControl(new JsonPointerReference(LayoutAreaReference.GetDataPointer(displayLabelId)))

--- a/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
+++ b/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using MeshWeaver.Fixture;
 using MeshWeaver.Layout.Client;
 using MeshWeaver.Messaging;
@@ -354,7 +355,81 @@ public class LayoutClientExtensionsTest(ITestOutputHelper output) : HubTestBase(
 
         // Act & Assert
         Action act = () => hub.ConvertSingle<int?>(nullableDouble, null);
-        
+
         act.Should().Throw<OverflowException>("NaN values should throw when converting to nullable int");
+    }
+
+    // ---- Issue #322: a NUMBER/BOOL JSON token bound into a string-typed (read-only) LabelControl -------
+    // The read-only Overview binds a numeric/boolean scalar into a string Label. Before the fix,
+    // ConvertJson<string> ran Deserialize<string>("322.844") which throws JsonException on a number
+    // token → the catch returned null → the field rendered BLANK until click-to-edit. It must now
+    // render the value's text, the way a JSON array/object slot already does.
+
+    [Fact]
+    public void ConvertSingle_NumberJsonElement_ToString_RendersDecimalText()
+    {
+        var hub = GetHost();
+        var element = JsonSerializer.SerializeToElement(322.844m);
+
+        var result = hub.ConvertSingle<string>(element, null);
+
+        result.Should().Be("322.844", "a JSON number bound into a string Label must render as text, not blank");
+    }
+
+    [Fact]
+    public void ConvertSingle_IntegerJsonElement_ToString_RendersIntegerText()
+    {
+        var hub = GetHost();
+        var element = JsonSerializer.SerializeToElement(6);
+
+        var result = hub.ConvertSingle<string>(element, null);
+
+        result.Should().Be("6");
+    }
+
+    [Fact]
+    public void ConvertSingle_TrueJsonElement_ToString_RendersTrue()
+    {
+        var hub = GetHost();
+        var element = JsonSerializer.SerializeToElement(true);
+
+        var result = hub.ConvertSingle<string>(element, null);
+
+        result.Should().Be("true", "a JSON boolean bound into a string Label must render its value, not blank");
+    }
+
+    [Fact]
+    public void ConvertSingle_FalseJsonElement_ToString_RendersFalse()
+    {
+        var hub = GetHost();
+        var element = JsonSerializer.SerializeToElement(false);
+
+        var result = hub.ConvertSingle<string>(element, null);
+
+        result.Should().Be("false");
+    }
+
+    [Fact]
+    public void ConvertSingle_StringJsonElement_ToString_StillWorks()
+    {
+        // Regression: a genuine JSON string token must keep deserializing cleanly to string.
+        var hub = GetHost();
+        var element = JsonSerializer.SerializeToElement("hello");
+
+        var result = hub.ConvertSingle<string>(element, null);
+
+        result.Should().Be("hello");
+    }
+
+    [Fact]
+    public void ConvertSingle_NumberJsonElement_ToDouble_StillDeserializes()
+    {
+        // The numeric edit control binds the CLR type; that path must be untouched by the string fix.
+        var hub = GetHost();
+        var element = JsonSerializer.SerializeToElement(322.844m);
+
+        var result = hub.ConvertSingle<double>(element, null);
+
+        result.Should().Be(322.844);
     }
 }

--- a/test/MeshWeaver.Layout.Test/MapToToggleableControlTest.cs
+++ b/test/MeshWeaver.Layout.Test/MapToToggleableControlTest.cs
@@ -638,3 +638,223 @@ public class MarkdownToggleTest(ITestOutputHelper output) : HubTestBase(output)
         stack.Areas.Should().NotBeEmpty();
     }
 }
+
+/// <summary>
+/// Issue #322: numeric and boolean scalar content fields rendered BLANK in the read-only Overview
+/// (visible only after click-to-edit). The read-only numeric branch now pre-stringifies the value —
+/// honouring <c>[DisplayFormat]</c> — into a display <c>/data</c> slot, and the client's
+/// <c>ConvertJson&lt;string&gt;</c> renders number/bool tokens as text. These tests pin both:
+/// numeric values (formatted and raw), nullable-null → empty, boolean read-only, and that clicking
+/// a numeric still swaps to a <see cref="NumberFieldControl"/> and round-trips.
+/// </summary>
+[Collection("ReadonlyNumericRenderingTests")]
+public class ReadonlyNumericRenderingTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    public record NumericEntity
+    {
+        [Key]
+        public string Id { get; init; } = string.Empty;
+
+        [Display(Name = "Amount")]
+        [DisplayFormat(DataFormatString = "{0:N1}")]
+        public decimal Amount { get; init; }
+
+        [Display(Name = "Page")]
+        public int? Page { get; init; }
+
+        [Display(Name = "Empty Page")]
+        public int? EmptyPage { get; init; }
+
+        [Display(Name = "Ratio")]
+        public double Ratio { get; init; }
+
+        [Display(Name = "Flag")]
+        public bool Flag { get; init; }
+    }
+
+    // Value chosen so the {0:N1} rendering ("322.8") differs from the stored value (322.844) —
+    // proving [DisplayFormat] is applied, not just the raw number.
+    private static NumericEntity TestData => new()
+    {
+        Id = "num-1",
+        Amount = 322.844m,
+        Page = 6,
+        EmptyPage = null,
+        Ratio = 2.5,
+        Flag = true
+    };
+
+    private const string DataId = "numeric_test";
+    private const string NumericView = nameof(NumericView);
+
+    private UiControl NumericViewDefinition(LayoutAreaHost host, RenderingContext ctx)
+    {
+        host.UpdateData(DataId, TestData);
+
+        var grid = Controls.LayoutGrid.WithSkin(s => s.WithSpacing(2));
+        foreach (var prop in typeof(NumericEntity).GetProperties())
+        {
+            var control = host.Hub.ServiceProvider.MapToToggleableControl(prop, DataId, canEdit: true, host);
+            grid = grid.WithView(control, s => s.WithXs(12).WithMd(6));
+        }
+        return grid;
+    }
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+    {
+        return base.ConfigureHost(configuration)
+            .AddLayout(layout => layout.WithView(NumericView, NumericViewDefinition));
+    }
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    private static string DisplayPointer(string propName)
+        => LayoutAreaReference.GetDataPointer($"displayLabel_{DataId}_{propName}");
+
+    /// <summary>
+    /// Renders the numeric view on a fresh client and forces every property cell's reactive
+    /// read-only view to materialise — a named area (and thus <see cref="BuildFormattedNumberLabel"/>'s
+    /// display-slot subscription) only runs once its control stream is subscribed, exactly as the real
+    /// Overview subscribes each cell. Returns the client stream to read the resulting display slots.
+    /// </summary>
+    private async Task<ISynchronizationStream<JsonElement>> RenderNumericView()
+    {
+        var client = GetClient();
+        var stream = client.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), new LayoutAreaReference(NumericView));
+
+        var control = await stream.GetControlStream(NumericView)
+            .Should().Within(10.Seconds()).Match(x => x is LayoutGridControl);
+        var grid = control.Should().BeOfType<LayoutGridControl>().Subject;
+
+        foreach (var area in grid.Areas)
+        {
+            var cellId = area.Area.ToString()!;
+            var cell = await stream.GetControlStream(cellId).Should().Within(5.Seconds()).Match(x => x is not null);
+            if (cell is StackControl cellStack && cellStack.Areas.Count > 1)
+            {
+                var reactiveId = cellStack.Areas.Skip(1).First().Area.ToString()!;
+                await stream.GetControlStream(reactiveId).Should().Within(5.Seconds()).Match(x => x is not null);
+            }
+        }
+
+        return stream;
+    }
+
+    [Fact]
+    public async Task ReadonlyDecimal_WithDisplayFormat_RendersFormattedValue()
+    {
+        var stream = await RenderNumericView();
+
+        // [DisplayFormat("{0:N1}")] applied → "322.8" (culture-computed here so the assertion is
+        // culture-independent), NOT the raw "322.844" and NOT blank.
+        var expected = string.Format("{0:N1}", 322.844m);
+        expected.Should().NotBe("322.844");
+        await stream
+            .GetDataStream<string>(new JsonPointerReference(DisplayPointer("amount")))
+            .Should().Within(5.Seconds()).Match(x => x == expected);
+    }
+
+    [Fact]
+    public async Task ReadonlyNullableInt_WithValue_RendersValue()
+    {
+        var stream = await RenderNumericView();
+
+        // No [DisplayFormat] → the number's own text; must be the value, not blank.
+        await stream
+            .GetDataStream<string>(new JsonPointerReference(DisplayPointer("page")))
+            .Should().Within(5.Seconds()).Match(x => x == "6");
+    }
+
+    [Fact]
+    public async Task ReadonlyNullableInt_Null_RendersEmpty()
+    {
+        var stream = await RenderNumericView();
+
+        // A nullable numeric that is null renders EMPTY, never "0".
+        await stream
+            .GetDataStream<string>(new JsonPointerReference(DisplayPointer("emptyPage")))
+            .Should().Within(5.Seconds()).Match(x => x == "");
+    }
+
+    [Fact]
+    public async Task ReadonlyDouble_RendersValue()
+    {
+        var stream = await RenderNumericView();
+
+        await stream
+            .GetDataStream<string>(new JsonPointerReference(DisplayPointer("ratio")))
+            .Should().Within(5.Seconds()).Match(x => x == "2.5");
+    }
+
+    [Fact]
+    public async Task ReadonlyBool_RendersItsValue()
+    {
+        var client = GetClient();
+        var stream = client.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), new LayoutAreaReference(NumericView));
+
+        var control = await stream.GetControlStream(NumericView)
+            .Should().Within(10.Seconds()).Match(x => x is LayoutGridControl);
+
+        var grid = control.Should().BeOfType<LayoutGridControl>().Subject;
+
+        // The bool ("Flag") is the last property; its toggleable cell is a Stack whose reactive
+        // read-only view is a LabelControl bound to the "flag" pointer (not a blank/missing control).
+        var flagAreaId = grid.Areas.Last().Area.ToString()!;
+        var flagStack = await stream.GetControlStream(flagAreaId)
+            .Should().Within(5.Seconds()).Match(x => x is StackControl);
+        var reactiveAreaId = flagStack.Should().BeOfType<StackControl>().Subject
+            .Areas.Skip(1).First().Area.ToString()!;
+
+        var readonlyView = await stream.GetControlStream(reactiveAreaId)
+            .Should().Within(5.Seconds()).Match(x => x is not null);
+        // The read-only bool cell wraps a clickable Stack around the LabelControl; unwrap to the label.
+        readonlyView.Should().BeOfType<StackControl>();
+
+        // The value the bool label binds to is present (true) — the ConvertJson<string> rendering of
+        // that true token to "true" is pinned by LayoutClientExtensionsTest.
+        await stream
+            .GetDataStream<bool>(new JsonPointerReference(LayoutAreaReference.GetDataPointer(DataId, "flag")))
+            .Should().Within(5.Seconds()).Match(x => x);
+    }
+
+    [Fact]
+    public async Task ClickNumeric_SwitchesToNumberField_AndRoundTrips()
+    {
+        var client = GetClient();
+        var stream = client.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), new LayoutAreaReference(NumericView));
+
+        var control = await stream.GetControlStream(NumericView)
+            .Should().Within(10.Seconds()).Match(x => x is LayoutGridControl);
+        var grid = control.Should().BeOfType<LayoutGridControl>().Subject;
+
+        // "Amount" is the second property (after the [Key] Id) → its toggleable cell.
+        var amountAreaId = grid.Areas.Skip(1).First().Area.ToString()!;
+        var amountStack = await stream.GetControlStream(amountAreaId)
+            .Should().Within(5.Seconds()).Match(x => x is StackControl);
+        var reactiveAreaId = amountStack.Should().BeOfType<StackControl>().Subject
+            .Areas.Skip(1).First().Area.ToString()!;
+
+        // Read-only first.
+        await stream.GetControlStream(reactiveAreaId).Should().Within(5.Seconds()).Match(x => x is StackControl);
+
+        var editStream = stream.GetControlStream(reactiveAreaId).Where(x => x is NumberFieldControl);
+
+        // Click → edit control must be a NumberFieldControl (the numeric edit path is untouched).
+        client.Post(new ClickedEvent(reactiveAreaId, stream.StreamId), o => o.WithTarget(CreateHostAddress()));
+        var editControl = await editStream.Should().Within(5.Seconds()).Emit();
+        editControl.Should().BeOfType<NumberFieldControl>();
+
+        // Round-trip: an edit persists to the bound /data slot.
+        stream.UpdatePointer(400.5m, LayoutAreaReference.GetDataPointer(DataId), new JsonPointerReference("amount"));
+        var updated = await stream
+            .GetDataStream<NumericEntity>(new JsonPointerReference(LayoutAreaReference.GetDataPointer(DataId)))
+            .Should().Within(5.Seconds()).Match(x => x != null && x.Amount == 400.5m);
+        updated!.Amount.Should().Be(400.5m);
+    }
+}


### PR DESCRIPTION
Fixes #322

## Problem

Numeric and boolean content fields render **blank** in the default node Overview (read-only). The value is present on the node; it only appears after clicking to edit. Because the defect is in shared code reached by `AddDefaultLayoutAreas()`, it affects every numeric/boolean scalar on any node type.

## Root cause (two layers, both fixed at the root)

1. **`ConvertJson<string>` throws on a number/bool token.** The read-only view of a `double`/`int`/`decimal`/`bool` falls into a `LabelControl` bound to a `string?`. `ConvertSingle<string>` → `ConvertJson<string>` ran `JsonSerializer.Deserialize<string>("322.844")`, which cannot deserialize a JSON **Number**/**True**/**False** token to `System.String` → throws `JsonException` → the catch returns `null` → blank. A special case already rendered JSON **arrays/objects** in a string slot as text, but not the scalar kinds.
2. **`[DisplayFormat]` ignored for numerics.** Only the `DateTime` read-only branch consumed `displayFormatAttr`; the numeric branch did not — so even a raw-number fix would show `322.844`, not the declared `322.8`. `DataGrid` already honours `[DisplayFormat]`.

## Fix

1. In `ConvertJson<T>` where `T == string`, render `Number`/`True`/`False` JSON scalars as their text (same spirit as the existing array/object branch) instead of `Deserialize<string>` → catch → null. This fixes bool read-only and covers enum-as-number.
2. `BuildReadonlyControl` now routes numeric scalars — `int`/`decimal`/`double`/… and their nullable variants, via the nullable-aware `IsIntegerType()`/`IsRealType()` — through a new `BuildFormattedNumberLabel` that pre-stringifies the value **honouring `[DisplayFormat]`** (consistent with the DataGrid) into a display `/data` slot and binds the `LabelControl` to it, mirroring `BuildFormattedDateLabel`. A nullable numeric that is `null` renders **empty**, never `"0"`.

Editing (click → `NumberFieldControl` → blur) is untouched and still round-trips.

## Tests (no mocking)

- `LayoutClientExtensionsTest`: `ConvertSingle<string>` renders decimal/int/`true`/`false` tokens as text; JSON string + numeric-CLR paths still work (regression).
- `ReadonlyNumericRenderingTest`: `[DisplayFormat("{0:N1}")]` → `322.8`; nullable int with value → `6`; nullable int `null` → empty; `double` → `2.5`; boolean read-only renders its value; clicking a numeric still swaps to `NumberFieldControl` and round-trips.

Full Layout.Test suite green (293 passed); `MeshWeaver.Layout`/`MeshWeaver.Graph`/`MeshWeaver.Blazor` build clean under `-c Release -warnaserror -p:CIRun=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)