### PR TITLE
feat(access): grant access by email to not-yet-provisioned users from the Access Control UI (#213)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/GrantingAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GrantingAccess.md
@@ -67,7 +67,7 @@ The **Subject (User or Group)** picker is bound to the canonical queries in `Acc
 
 The picker loads the subject set once (capped at 500 nodes) and filters **in-memory, diacritic- and case-insensitively** (`SearchText.Fold`): typing "Burgi" finds "Bürgi". On installations with more subjects than the cap, typed text additionally runs the normal server-side search and the union is shown, so users beyond the cap remain findable (that path matches by substring, without diacritic folding).
 
-**Limitation — not-yet-provisioned users.** A `User` node is created at first login/onboarding, so a person who has never logged in cannot be picked. Either invite them first (platform admin → Invitations), or grant by principal via MCP (Recipe 3 below with the exact login userId) — the assignment lies dormant until they exist.
+**Not-yet-provisioned users — grant by email.** A `User` node is created at first login/onboarding, so a person who has never signed in has no node to *pick*. The **Add** row therefore also takes an **email**: leave the subject picker empty and type the address instead. If an account already exists it is granted the selected role immediately; otherwise the person is invited and a durable deferred grant — an `EventSubscription` (see [EventSubscriptions](/Doc/Architecture/EventSubscriptions)) — lands the **same role at this exact `{scope}/_Access`** the moment they sign up. The scheduled grant is byte-identical to the immediate one, so the invitee ends up with exactly the assignment an already-provisioned subject would. (You can still grant by principal via MCP — Recipe 3 below with the exact login userId — for a fully headless setup.)
 
 ---
 

--- a/src/MeshWeaver.Graph/AccessControlLayoutArea.cs
+++ b/src/MeshWeaver.Graph/AccessControlLayoutArea.cs
@@ -139,8 +139,10 @@ public static class AccessControlLayoutArea
             .WithStyle("width: 100%;");
 
     /// <summary>
-    /// The inline add row: a user picker (root-namespace users) + a role select (default Editor) + an
-    /// Add button that creates the AccessAssignment node. The created assignment appears in the current
+    /// The inline add row: a user/group picker (already-provisioned subjects) OR an email field (invite
+    /// someone who hasn't signed up yet) + a role select (default Editor) + an Add button. A picked subject
+    /// creates the AccessAssignment node directly; an email grants the role now when an account exists, or
+    /// invites + schedules a deferred grant otherwise. Either way the assignment appears in the current
     /// section automatically (reactive MeshSearch).
     /// </summary>
     private static UiControl BuildAddRow(LayoutAreaHost host, string nodePath)
@@ -149,6 +151,7 @@ public static class AccessControlLayoutArea
         host.UpdateData(formId, new Dictionary<string, object?>
         {
             ["accessObject"] = "",
+            ["email"] = "",
             ["role"] = Role.Editor.Id
         });
         var dataContext = LayoutAreaReference.GetDataPointer(formId);
@@ -160,6 +163,10 @@ public static class AccessControlLayoutArea
             Label = "Add user or group",
             DataContext = dataContext
         }.WithStyle("flex: 1; min-width: 220px;");
+
+        var emailField = (new TextFieldControl(new JsonPointerReference("email"))
+            { Label = "…or invite by email", DataContext = dataContext })
+            .WithStyle("flex: 1; min-width: 220px;");
 
         var roleSelect = (new SelectControl(new JsonPointerReference("role"), Array.Empty<object>())
                 .WithOptions(new[] { Role.Admin.Id, Role.Editor.Id, Role.Viewer.Id, Role.Commenter.Id }))
@@ -174,24 +181,77 @@ public static class AccessControlLayoutArea
                     .Subscribe(form =>
                     {
                         var subject = form.GetValueOrDefault("accessObject")?.ToString()?.Trim();
+                        var email = form.GetValueOrDefault("email")?.ToString()?.Trim();
                         var role = form.GetValueOrDefault("role")?.ToString()?.Trim();
-                        if (string.IsNullOrEmpty(subject))
+                        if (string.IsNullOrEmpty(role)) role = Role.Editor.Id;
+
+                        // A picked, already-provisioned subject wins; otherwise fall back to the email
+                        // path (grant now if the account exists, else invite + deferred grant on sign-up).
+                        if (!string.IsNullOrEmpty(subject))
                         {
-                            ShowValidationError(ctx, "Please select a **user**.");
+                            CreateAssignment(ctx, nodePath, subject, role);
                             return;
                         }
-                        if (string.IsNullOrEmpty(role)) role = Role.Editor.Id;
-                        CreateAssignment(ctx, nodePath, subject, role);
+                        if (!string.IsNullOrEmpty(email))
+                        {
+                            if (!email.Contains('@'))
+                            {
+                                ShowValidationError(ctx, "Please enter a valid **email address**.");
+                                return;
+                            }
+                            GrantByEmail(ctx, nodePath, email, role);
+                            return;
+                        }
+                        ShowValidationError(ctx,
+                            "Select a **user or group**, or enter an **email address** to invite someone "
+                            + "who hasn't signed up yet.");
                     });
             }));
 
         return Controls.Stack
-            .WithOrientation(Orientation.Horizontal)
-            .WithStyle("align-items: flex-end; gap: 12px; margin-top: 8px;")
-            .WithView(userPicker)
-            .WithView(roleSelect)
-            .WithView(addButton);
+            .WithView(Controls.Stack
+                .WithOrientation(Orientation.Horizontal)
+                .WithStyle("align-items: flex-end; gap: 12px; margin-top: 8px; flex-wrap: wrap;")
+                .WithView(userPicker)
+                .WithView(emailField)
+                .WithView(roleSelect)
+                .WithView(addButton))
+            .WithView(Controls.Markdown(
+                    "Pick an existing user or group — or enter an email to grant access to someone who "
+                    + "hasn't signed up yet: they're invited, and the grant lands automatically the moment "
+                    + "they sign in.")
+                .WithStyle("font-size: 12px; opacity: .75; margin-top: 4px;"));
     }
+
+    /// <summary>
+    /// Grants <paramref name="role"/> at <c>{nodePath}/_Access</c> to <paramref name="email"/> — immediately
+    /// when an account already exists, otherwise via an Invitation + a durable deferred EventSubscription
+    /// that lands the SAME role at the SAME node path the moment that person signs up. Reuses
+    /// <see cref="SpaceInviteService"/>'s grant-or-schedule primitive with pinning OFF (a granular grant,
+    /// not a Space invite). The immediate grant runs under the caller's (admin's) identity; the Admin-partition
+    /// invitation + subscription writes run as system inside the service.
+    /// </summary>
+    private static void GrantByEmail(UiActionContext ctx, string nodePath, string email, string role)
+    {
+        var sp = ctx.Host.Hub.ServiceProvider;
+        var accessService = sp.GetRequiredService<AccessService>();
+        var svc = new SpaceInviteService(ctx.Host.Hub, sp.GetRequiredService<IMeshService>(), accessService);
+        var invitedBy = accessService.Context?.ObjectId;
+
+        svc.GrantOrScheduleAccess(nodePath, email, role, pin: false, invitedBy,
+                note: $"Invited to {(string.IsNullOrEmpty(nodePath) ? "the root scope" : nodePath)}")
+            .Subscribe(
+                outcome => ShowInfoDialog(ctx,
+                    outcome == SpaceInviteOutcome.Granted
+                        ? $"**{email}** already has an account — granted **{role}** here."
+                        : $"Invited **{email}** as **{role}**. Access is granted automatically when they sign up.",
+                    "Access"),
+                ex => ShowInfoDialog(ctx, $"Failed to grant access: {ex.Message}", "Error"));
+    }
+
+    private static void ShowInfoDialog(UiActionContext ctx, string markdown, string title) =>
+        ctx.Host.UpdateArea(DialogControl.DialogArea,
+            Controls.Dialog(Controls.Markdown(markdown), title).WithSize("S").WithClosable(true));
 
     /// <summary>
     /// Creates an AccessAssignment node for <paramref name="subject"/> with a single

--- a/src/MeshWeaver.Graph/SpaceInviteService.cs
+++ b/src/MeshWeaver.Graph/SpaceInviteService.cs
@@ -39,9 +39,26 @@ public sealed class SpaceInviteService(
     AccessService accessService,
     ILogger<SpaceInviteService>? logger = null)
 {
-    /// <summary>Invites <paramref name="email"/> to <paramref name="spacePath"/> with <paramref name="role"/>.</summary>
+    /// <summary>Invites <paramref name="email"/> to <paramref name="spacePath"/> with <paramref name="role"/>
+    /// (the Space flavour — also pins the Space to the dashboard when <paramref name="pin"/>).</summary>
     public IObservable<SpaceInviteOutcome> Invite(
         string spacePath, string email, string role, bool pin, string? invitedBy)
+        => GrantOrScheduleAccess(spacePath, email, role, pin, invitedBy, note: $"Invited to space {spacePath}");
+
+    /// <summary>
+    /// The general grant-or-schedule primitive behind BOTH the Space invite and the granular Access
+    /// Control "grant by email" path. Grants <paramref name="role"/> at <c>{nodePath}/_Access</c> to an
+    /// existing account NOW; or — when no account exists yet — creates an <c>Invitation</c> plus a durable
+    /// deferred <see cref="EventSubscription"/> (<see cref="EventContinuationType.GrantSpaceAccess"/> with
+    /// <see cref="EventSubscription.TargetPath"/> = <paramref name="nodePath"/>,
+    /// <see cref="EventSubscription.Role"/> = <paramref name="role"/>) that lands the SAME role at the SAME
+    /// node path the moment a <c>User</c> with that email is created. The scheduled grant is byte-identical
+    /// to the immediate one, so an invitee ends up with exactly the assignment an already-provisioned
+    /// subject would. Space invites pass <paramref name="pin"/> = true (also pin the Space); the Access
+    /// Control UI passes <paramref name="pin"/> = false (a bare granular grant — pinning is Space-only).
+    /// </summary>
+    public IObservable<SpaceInviteOutcome> GrantOrScheduleAccess(
+        string nodePath, string email, string role, bool pin, string? invitedBy, string? note = null)
     {
         var normalizedEmail = email.Trim();
 
@@ -54,8 +71,8 @@ public sealed class SpaceInviteService(
             {
                 var existing = users.FirstOrDefault(u => EmailMatches(u, normalizedEmail));
                 return existing is not null
-                    ? GrantNow(existing.Id, spacePath, role, pin)
-                    : ScheduleAndInvite(spacePath, normalizedEmail, role, pin, invitedBy);
+                    ? GrantNow(existing.Id, nodePath, role, pin)
+                    : ScheduleAndInvite(nodePath, normalizedEmail, role, pin, invitedBy, note);
             });
     }
 
@@ -74,7 +91,7 @@ public sealed class SpaceInviteService(
     }
 
     private IObservable<SpaceInviteOutcome> ScheduleAndInvite(
-        string spacePath, string email, string role, bool pin, string? invitedBy)
+        string spacePath, string email, string role, bool pin, string? invitedBy, string? note = null)
     {
         var subscription = new EventSubscription
         {
@@ -96,7 +113,7 @@ public sealed class SpaceInviteService(
         {
             NodeType = InvitationNodeType.NodeType,
             Name = $"Invitation {email}",
-            Content = new Invitation { Email = email, InvitedBy = invitedBy, Note = $"Invited to space {spacePath}" },
+            Content = new Invitation { Email = email, InvitedBy = invitedBy, Note = note ?? $"Invited to space {spacePath}" },
         };
 
         // Both writes land in the Admin partition → system identity, constructed inside the scope.

--- a/test/MeshWeaver.Graph.Test/AccessControlGrantByEmailTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessControlGrantByEmailTest.cs
@@ -1,0 +1,167 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The Access Control UI "grant by email" path (issue #213 remaining gap): granting access to a person
+/// who has no <c>User</c> node yet. Exercises the primitive the add-row calls —
+/// <see cref="SpaceInviteService.GrantOrScheduleAccess"/> with pinning OFF — at a GRANULAR node path with a
+/// NON-default role, proving the deferred grant carries the SELECTED (role, nodePath) rather than a
+/// hardcoded Space/Editor grant, and that an already-provisioned user is granted immediately.
+///
+/// <para>The unknown-email case creates an <c>Invitation</c> + a durable <see cref="EventSubscription"/>
+/// (<see cref="EventContinuationType.GrantSpaceAccess"/>) that fires on the invitee's <c>User</c> creation
+/// via <see cref="EventSubscriptionRunner"/> — landing exactly the assignment an immediate grant would, at
+/// <c>{nodePath}/_Access</c>, with NO dashboard pin (pinning is Space-invite-only).</para>
+/// </summary>
+public class AccessControlGrantByEmailTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Space = "AclSpace";
+    // A granular node INSIDE the space — the target of the Access Control grant (not the space root).
+    private const string TargetNode = "Section";
+    private const string TargetPath = $"{Space}/{TargetNode}";
+    private const string InviteeEmail = "newcomer@acme.com";
+    private const string InviteeId = "newcomer";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(new MeshNode(Space) { Name = "Acl Space", NodeType = "Space" });
+
+    private SpaceInviteService NewService()
+        => new(Mesh,
+            Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
+            Mesh.ServiceProvider.GetRequiredService<AccessService>(),
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<SpaceInviteService>>());
+
+    private IObservable<MeshNode> CreateTargetNode(IMeshService meshService)
+        // A plain node under the space to scope the grant to (its type is irrelevant to the grant).
+        => meshService.CreateNode(new MeshNode(TargetNode, Space)
+        {
+            NodeType = "Group",
+            Name = "Section",
+            Content = new AccessObject { Description = "A section inside the space" },
+        });
+
+    [Fact(Timeout = 60000)]
+    public async Task GrantByEmail_UnknownUser_SchedulesGrantAtNodePath_ThenLandsOnSignUp()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        using (accessService.ImpersonateAsSystem())
+            await CreateTargetNode(meshService).Should().Emit();
+
+        // Arm the runner BEFORE the triggering write so the live change-feed path fires the grant.
+        using var runner = new EventSubscriptionRunner(Mesh, changeFeed, meshService, accessService,
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>());
+        await runner.StartAsync(default);
+
+        // The Access Control UI grants "Viewer" (a non-default role) at the granular node path, with NO pin.
+        var outcome = await NewService()
+            .GrantOrScheduleAccess(TargetPath, InviteeEmail, "Viewer", pin: false, invitedBy: "admin")
+            .FirstAsync().Timeout(30.Seconds());
+        Assert.Equal(SpaceInviteOutcome.Invited, outcome);
+
+        // A deferred subscription was scheduled carrying the SELECTED role + node path (not Space/Editor),
+        // with Pin off — the byte-identical shape of an immediate grant.
+        await Mesh.GetWorkspace().GetQuery("acl-inv-subs",
+                $"path:{EventSubscriptionNodeType.Namespace} scope:children nodeType:{EventSubscriptionNodeType.NodeType}")
+            .Where(nodes => (nodes ?? []).Any(n => n.Content is EventSubscription s
+                && s.TriggerType == EventTriggerType.NodeChange
+                && s.ContinuationType == EventContinuationType.GrantSpaceAccess
+                && s.MatchValue == InviteeEmail
+                && s.TargetPath == TargetPath
+                && s.Role == "Viewer"
+                && !s.Pin))
+            .FirstAsync().Timeout(30.Seconds());
+
+        // An Invitation node was created for the email.
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{InvitationNodeType.Namespace}/{SpaceInviteService.Slug(InviteeEmail)}")
+            .Where(n => n?.Content is Invitation inv && inv.Email == InviteeEmail)
+            .FirstAsync().Timeout(30.Seconds());
+
+        // The invitee signs up — their User node is created (as onboarding does).
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode(InviteeId)
+            {
+                NodeType = "User",
+                Name = "Newcomer",
+                Content = new User { Email = InviteeEmail, FullName = "Newcomer" },
+            }).Should().Emit();
+
+        // Wait for the subscription to reach its terminal state first (race-free — the grant completes
+        // BEFORE the Fired write, so once Fired is observed the AccessAssignment already exists; a stream
+        // on a still-missing node errors). The id is deterministic: grant_{email}_{nodePath}.
+        var subId = $"grant_{SpaceInviteService.Slug(InviteeEmail)}_{SpaceInviteService.Slug(TargetPath)}";
+        var final = await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subId))
+            .Select(n => n?.Content as EventSubscription)
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.True(final!.Status == EventSubscriptionStatus.Fired,
+            $"subscription ended {final.Status}: {final.LastError}");
+
+        // The grant lands: AccessAssignment at {nodePath}/_Access/{user}_Access with the SELECTED role.
+        var granted = await Mesh.GetWorkspace().GetMeshNodeStream($"{TargetPath}/_Access/{InviteeId}_Access")
+            .Where(n => n?.Content is AccessAssignment a
+                        && a.AccessObject == InviteeId
+                        && a.Roles.Any(r => r.Role == "Viewer" && !r.Denied))
+            .FirstAsync().Timeout(20.Seconds());
+        Assert.NotNull(granted);
+
+        // No pin (Access Control grants are pin-free): the invitee's dashboard was NOT touched.
+        var user = await Mesh.GetWorkspace().GetMeshNodeStream(InviteeId)
+            .Where(n => n?.Content is User).FirstAsync().Timeout(10.Seconds());
+        Assert.DoesNotContain(TargetPath, ((User)user!.Content!).PinnedPaths);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task GrantByEmail_ExistingUser_GrantsSelectedRoleImmediately_NoPin()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        using (accessService.ImpersonateAsSystem())
+        {
+            await CreateTargetNode(meshService).Should().Emit();
+            await meshService.CreateNode(new MeshNode(InviteeId)
+            {
+                NodeType = "User",
+                Name = "Newcomer",
+                Content = new User { Email = InviteeEmail, FullName = "Newcomer" },
+            }).Should().Emit();
+        }
+
+        // Wait until the account is queryable by email (the primitive looks it up that way).
+        await meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:User content.email:{InviteeEmail}"))
+            .Where(c => c.ChangeType == QueryChangeType.Initial && c.Items.Any(n => n.Id == InviteeId))
+            .FirstAsync().Timeout(30.Seconds());
+
+        // Grant "Commenter" (a non-default role) at the granular node path, with NO pin.
+        var outcome = await NewService()
+            .GrantOrScheduleAccess(TargetPath, InviteeEmail, "Commenter", pin: false, invitedBy: "admin")
+            .FirstAsync().Timeout(30.Seconds());
+        Assert.Equal(SpaceInviteOutcome.Granted, outcome);
+
+        // The assignment landed immediately at {nodePath}/_Access with the selected role.
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{TargetPath}/_Access/{InviteeId}_Access")
+            .Where(n => n?.Content is AccessAssignment a
+                        && a.AccessObject == InviteeId
+                        && a.Roles.Any(r => r.Role == "Commenter" && !r.Denied))
+            .FirstAsync().Timeout(20.Seconds());
+
+        // No pin: the user's dashboard was not touched.
+        var user = await Mesh.GetWorkspace().GetMeshNodeStream(InviteeId)
+            .Where(n => n?.Content is User).FirstAsync().Timeout(10.Seconds());
+        Assert.DoesNotContain(TargetPath, ((User)user!.Content!).PinnedPaths);
+    }
+}


### PR DESCRIPTION
## What

Closes the remaining open part of #213. The subject-picker base bug (queries returning zero rows) was already fixed on main (PR #217, `AccessSubjectQueries` + `FilterInMemory`). The remaining open gap was: **no way to grant access to a person who has never signed in** (there is no `User` node to pick).

The Access Control **Add** row now also takes an **email**. Leave the subject picker empty and enter an address:

- **Account already exists** → the selected role is granted immediately at `{nodePath}/_Access` (runs under the admin's identity).
- **No account yet** → an `Invitation` is created plus a durable deferred `EventSubscription` that lands the **same role at the same `{nodePath}/_Access`** the moment that person signs up (Admin-partition writes run as system, exactly as `SpaceInviteService` does).

## How the deferred grant carries the selected role + node path

It **reuses the existing** `EventContinuationType.GrantSpaceAccess` continuation — **no new continuation type or fields**. That continuation was already general: it calls `EventSubscriptionOps.Grant(meshService, userId, TargetPath, Role)`, which creates the `AccessAssignment` at an **arbitrary** `{TargetPath}/_Access` with an **arbitrary** role. The "space" in the name refers only to the flagship use case and the optional dashboard **pin**. The Access Control path sets:

- `TargetPath = nodePath` (the selected node)
- `Role = role` (the selected role)
- `Pin = false` (pinning is Space-invite-only)

so the scheduled grant is **byte-identical** to the immediate one an already-provisioned subject would receive.

`SpaceInviteService`'s grant-or-schedule logic is generalized into a public `GrantOrScheduleAccess(nodePath, email, role, pin, invitedBy, note)`; `Invite(...)` now delegates to it with `pin: true` (keeping Space-only pinning in the Space flow). The Access Control UI calls it with `pin: false`.

## Files

- `src/MeshWeaver.Graph/AccessControlLayoutArea.cs` — email field + role in the Add row; `GrantByEmail` helper routing to the primitive.
- `src/MeshWeaver.Graph/SpaceInviteService.cs` — extracted general `GrantOrScheduleAccess` primitive; `Invite` delegates.
- `src/MeshWeaver.Documentation/Data/Architecture/GrantingAccess.md` — updated the "not-yet-provisioned users" limitation note.
- `test/MeshWeaver.Graph.Test/AccessControlGrantByEmailTest.cs` — two tests (no mocking, `MonolithMeshTestBase`): deferred grant to an unknown email at a granular node path with a non-default role fires on sign-up and lands the correct `AccessAssignment` (with no pin); existing-user email grants the selected role immediately.

## Verification

- `dotnet build ... -c Release -warnaserror -p:CIRun=true` — clean for `MeshWeaver.Graph` and `MeshWeaver.Graph.Test`.
- New tests pass (2/2); invite/subscription regression suite (`SpaceInviteServiceTest`, `SpaceInviteMenuTest`, `GroupInviteExtensionsTest`, `EventSubscriptionRunnerTest`) pass (11/11); `DocumentationLinkIntegrityTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)