### PR TITLE
feat(ai): per-round tool-call cap, immediate Stop acknowledgement, reasoning heartbeat (#321)

### DIFF
--- a/src/MeshWeaver.AI/AgentConfiguration.cs
+++ b/src/MeshWeaver.AI/AgentConfiguration.cs
@@ -93,6 +93,21 @@ public record AgentConfiguration
     /// Additional plugins are resolved by name from DI-registered IAgentPlugin services.
     /// </summary>
     public List<AgentPluginReference>? Plugins { get; init; }
+
+    /// <summary>
+    /// Optional per-round cap on the number of tool-call iterations the agent may run in a
+    /// single turn. Maps directly onto
+    /// <c>Microsoft.Extensions.AI.FunctionInvokingChatClient.MaximumIterationsPerRequest</c>
+    /// (wired in <see cref="ChatClientAgentFactory"/>). When <c>null</c> (the default) the
+    /// Microsoft.Extensions.AI default applies — high enough that a high-volume agent can
+    /// issue hundreds of tool calls in one round before it engages. Set a small value
+    /// (e.g. 20–30) for such agents to force natural break points: on reaching the cap the
+    /// framework strips tools on the final iteration (its
+    /// <c>PrepareOptionsForLastIteration</c> path) so the model returns a graceful final
+    /// answer rather than truncating, and the agent is additionally instructed to invite the
+    /// user to reply "continue" to run the next batch.
+    /// </summary>
+    public int? MaxToolCallsPerRound { get; init; }
 }
 
 /// <summary>

--- a/src/MeshWeaver.AI/ChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI/ChatClientAgentFactory.cs
@@ -212,8 +212,20 @@ public abstract class ChatClientAgentFactory : IChatClientFactory
         var accessService = Hub.ServiceProvider.GetService<AccessService>();
         var wrappedTools = tools.Select(tool => WrapToolWithAccessContext(tool, chat, accessService)).ToList();
 
+        // #321: when a per-round tool-call cap is configured, make the model AWARE of its
+        // budget so it wraps up gracefully with a "type continue" hand-off on reaching it.
+        // The HARD enforcement is FunctionInvokingChatClient.MaximumIterationsPerRequest (set
+        // below); this instruction only makes the limit self-documenting to the model so the
+        // graceful final answer reads as a summary rather than an abrupt stop.
+        var effectiveInstructions = instructions;
+        if (config.MaxToolCallsPerRound is { } capForPrompt && capForPrompt > 0)
+            effectiveInstructions +=
+                $"\n\n---\nTool-call budget: you may issue at most {capForPrompt} tool calls in this turn. " +
+                "If you reach this budget before finishing, stop, briefly summarise what you accomplished, " +
+                "and ask the user to reply \"continue\" to run the next batch.";
+
         var agent = new ChatClientAgent(
-            chatClient: chatClient, instructions: instructions,
+            chatClient: chatClient, instructions: effectiveInstructions,
             name: name, description: description,
             tools: wrappedTools, loggerFactory: null, services: null);
 
@@ -221,6 +233,17 @@ public abstract class ChatClientAgentFactory : IChatClientFactory
         if (functionInvoker != null)
         {
             functionInvoker.AllowConcurrentInvocation = true;
+            // #321: per-agent HARD cap on tool-call iterations. Without this,
+            // MaximumIterationsPerRequest falls back to the Microsoft.Extensions.AI default
+            // (high), so a high-volume agent can issue hundreds of tool calls in a single
+            // round before it engages. On reaching the cap the framework strips tools on the
+            // final iteration (PrepareOptionsForLastIteration) so the model returns a graceful
+            // final answer instead of truncating — it does NOT throw. It only logs "Reached
+            // maximum iteration count" internally and surfaces no distinct limit-reached signal
+            // to the streaming consumer, so the summary hand-off is driven by the instruction
+            // appended above rather than a framework callback.
+            if (config.MaxToolCallsPerRound is { } cap && cap > 0)
+                functionInvoker.MaximumIterationsPerRequest = cap;
             // Log the maximum iterations — if the model tries more tool calls than this, it stops
             Logger.LogInformation("[AgentFactory] FunctionInvoker for {Agent}: MaximumIterationsPerRequest={Max}",
                 name, functionInvoker.MaximumIterationsPerRequest);

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -31,6 +31,21 @@ internal static class ThreadExecution
     // for "live typing" while keeping patch volume bounded.
     private static readonly TimeSpan StreamingSampleInterval = TimeSpan.FromMilliseconds(100);
 
+    // #321: reasoning heartbeat. When the model produces no stream update for longer
+    // than this (between tool calls, or while a tool call is in flight), the streaming
+    // Sample(100ms) hot path stops emitting and the status line would otherwise freeze on
+    // the last tool-call stamp — "thinking" indistinguishable from "stuck". A gap longer
+    // than this threshold ticks a "Reasoning… (Ns)" heartbeat onto the thread's
+    // ExecutionStatus. Also the tick period, so writes stay bounded (one per interval).
+    private static readonly TimeSpan HeartbeatIdleThreshold = TimeSpan.FromSeconds(3);
+
+    // #321: acknowledgement stamped onto MeshThread.ExecutionStatus the instant a Stop
+    // (RequestedStatus = Cancelled) is observed while a round is executing, so the UI
+    // confirms the Stop was registered rather than freezing on the previous tool-call
+    // status while the in-flight tool call drains (up to its ~30s timeout).
+    internal const string CancellationRequestedStatus =
+        "Cancellation requested — stopping after current operation…";
+
     private sealed record StreamingSnapshot(
         string Text,
         ImmutableList<ToolCallEntry> ToolCalls,
@@ -1739,6 +1754,46 @@ internal static class ThreadExecution
                             StripSummaryBlock(s.Text), s.ToolCalls, s.NodeChanges,
                             request.AgentName, request.ModelName,
                             status: ThreadMessageStatus.Streaming));
+
+                    // 💓 #321 reasoning heartbeat. Derived from the SAME `snapshots` stream:
+                    // every real emission (text chunk / tool call / result) restarts an idle
+                    // timer via Switch, so a heartbeat only fires during a genuine gap — the
+                    // stretches where the model reasons between (or during) tool calls and the
+                    // Sample(100ms) path is silent. Each tick stamps "Reasoning… (Ns)" onto the
+                    // thread's ExecutionStatus (otherwise null for the whole round, so this is
+                    // strictly additive — no existing writer competes). The write is guarded
+                    // inside the Update lambda to the still-Executing, not-cancel-requested state
+                    // so it never clobbers the cancellation ack or a terminal status, and the
+                    // subscription is disposed with the round via `using` on every exit path
+                    // (normal completion, requested cancel, timeout, error) — bounded and
+                    // self-cancelling, no hand-rolled Task/Timer/SemaphoreSlim.
+                    using var heartbeatSub = snapshots
+                        .Select(_ => 0L)
+                        .StartWith(0L)
+                        .Select(_ => Observable.Timer(HeartbeatIdleThreshold, HeartbeatIdleThreshold))
+                        .Switch()
+                        .Subscribe(ticks =>
+                        {
+                            if (ct.IsCancellationRequested)
+                                return;
+                            var elapsed = (int)((ticks + 1) * HeartbeatIdleThreshold.TotalSeconds);
+                            var heartbeatStatus = $"Reasoning… ({elapsed}s)";
+                            // Re-seed identity before the cross-thread cell/thread write — same
+                            // reason as PushToResponseMessage (the timer callback runs on a pool
+                            // thread where AsyncLocal Context was dropped).
+                            if (userAccessContext != null)
+                                parentHub.ServiceProvider.GetService<AccessService>()?.SetContext(userAccessContext);
+                            parentHub.GetWorkspace().GetMeshNodeStream(threadPath).Update(node =>
+                                node?.Content is MeshThread t
+                                    && t.Status == ThreadExecutionStatus.Executing
+                                    && t.RequestedStatus != ThreadExecutionStatus.Cancelled
+                                    ? node with { Content = t with { ExecutionStatus = heartbeatStatus } }
+                                    : node!)
+                                .Subscribe(
+                                    _ => { },
+                                    ex => logger.LogDebug(ex,
+                                        "[ThreadExec] Reasoning heartbeat stamp failed for {Path}", threadPath));
+                        });
                     var pendingCalls = ImmutableDictionary<string, FunctionCallContent>.Empty;
                     string? lastCallKey = null;
 
@@ -2729,6 +2784,24 @@ internal static class ThreadExecution
                 x =>
                 {
                     var thread = x.Thread!;
+
+                    // #321: acknowledge the Stop IMMEDIATELY. The round's own CTS self-cancel
+                    // (ExecuteMessageAsync) tears the round down only after the in-flight tool
+                    // call finishes or hits its timeout (~30s); during that window the status
+                    // line would otherwise stay frozen on the previous tool-call stamp with no
+                    // sign the Stop was received. Stamp the thread's ExecutionStatus now, guarded
+                    // to the still-executing + still-cancel-requested state so it never clobbers a
+                    // terminal write, and leaving RequestedStatus in place for the round's
+                    // terminal handler. The reasoning heartbeat is suppressed while
+                    // RequestedStatus == Cancelled, so this ack persists until the round settles.
+                    hub.GetWorkspace().GetMeshNodeStream().Update(
+                        curr => curr?.Content is MeshThread ackThread
+                                && ackThread.Status.IsExecuting()
+                                && ackThread.RequestedStatus == ThreadExecutionStatus.Cancelled
+                            ? curr with { Content = ackThread with { ExecutionStatus = CancellationRequestedStatus } }
+                            : curr!)
+                        .Subscribe(_ => { }, ex => logger?.LogDebug(ex,
+                            "[ThreadExec] Cancellation ack stamp failed for {ThreadPath}", threadPath));
 
                     // Propagate to every active delegation sub-thread via the
                     // canonical IMeshNodeStreamCache. The sub-thread is a

--- a/test/MeshWeaver.AI.Test/AgentToolWiringIntegrationTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentToolWiringIntegrationTest.cs
@@ -164,6 +164,54 @@ public class AgentToolWiringIntegrationTest : MonolithMeshTestBase
         }
     }
 
+    /// <summary>
+    /// #321: <see cref="AgentConfiguration.MaxToolCallsPerRound"/> must flow into the built
+    /// agent's <see cref="FunctionInvokingChatClient.MaximumIterationsPerRequest"/> — the real,
+    /// per-agent, framework-enforced cap on tool-call iterations. When unset, the value stays at
+    /// the Microsoft.Extensions.AI default (never silently forced to the configured value).
+    /// </summary>
+    [Fact]
+    public void MaxToolCallsPerRound_FlowsInto_MaximumIterationsPerRequest()
+    {
+        var capturingClient = Mesh.ServiceProvider.GetRequiredService<CapturingChatClient>();
+        var factory = Mesh.ServiceProvider.GetServices<IChatClientFactory>()
+            .OfType<CapturingChatClientFactory>().Single();
+        var chat = new AgentChatClient(Mesh.ServiceProvider);
+
+        var cappedConfig = new AgentConfiguration
+        {
+            Id = "CapAgent",
+            Description = "agent under test",
+            Instructions = "You are a test agent.",
+            MaxToolCallsPerRound = 7,
+        };
+        var uncappedConfig = cappedConfig with { Id = "UncappedAgent", MaxToolCallsPerRound = null };
+
+        var cappedAgent = factory.CreateAgent(
+            cappedConfig, chat,
+            new Dictionary<string, Microsoft.Agents.AI.ChatClientAgent>(),
+            [cappedConfig]);
+        var uncappedAgent = factory.CreateAgent(
+            uncappedConfig, chat,
+            new Dictionary<string, Microsoft.Agents.AI.ChatClientAgent>(),
+            [uncappedConfig]);
+
+        var cappedFicc = cappedAgent.ChatClient.GetService<FunctionInvokingChatClient>();
+        var uncappedFicc = uncappedAgent.ChatClient.GetService<FunctionInvokingChatClient>();
+
+        cappedFicc.Should().NotBeNull("the agent's chat-client pipeline includes FunctionInvokingChatClient");
+        uncappedFicc.Should().NotBeNull();
+
+        cappedFicc!.MaximumIterationsPerRequest.Should().Be(7,
+            "AgentConfiguration.MaxToolCallsPerRound must be wired onto the per-round FICC cap");
+        uncappedFicc!.MaximumIterationsPerRequest.Should().NotBe(7,
+            "when MaxToolCallsPerRound is unset the FICC keeps its framework default — the cap is " +
+            "never hardcoded to the configured value");
+
+        // Sanity: the capturing client is what the factory wrapped (no live model needed).
+        _ = capturingClient;
+    }
+
     #region Capturing Infrastructure
 
     /// <summary>

--- a/test/MeshWeaver.AI.Test/CancellationAckTest.cs
+++ b/test/MeshWeaver.AI.Test/CancellationAckTest.cs
@@ -1,0 +1,168 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.ShortGuid;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshThread = MeshWeaver.AI.Thread;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// #321 (Stop not acknowledged immediately): pressing Stop writes
+/// <c>RequestedStatus = Cancelled</c> to the thread node, which the round's own CTS
+/// self-cancel tears down only after the in-flight tool call finishes/timeouts (~30s).
+/// The fix stamps <see cref="MeshThread.ExecutionStatus"/> =
+/// <see cref="ThreadExecution.CancellationRequestedStatus"/> the instant the cancel is
+/// observed while executing, so the UI confirms the Stop was registered instead of freezing
+/// on the previous tool-call status.
+///
+/// <para>Model-free: a fake <see cref="IChatClientFactory"/> yields one token and then hangs
+/// until its cancellation token fires — no live language model, but a real round that reaches
+/// <see cref="ThreadExecutionStatus.Executing"/> so the cancellation watcher's ack path runs.</para>
+/// </summary>
+public class CancellationAckTest : AITestBase
+{
+    public CancellationAckTest(ITestOutputHelper output) : base(output) { }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IChatClientFactory>(new HangingChatClientFactory());
+                return services;
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddAITypes();
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    [Fact]
+    public async Task Stop_ImmediatelyStampsCancellationAck_BeforeRoundTearsDown()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var threadId = Guid.NewGuid().AsString();
+        var threadPath = $"{MonolithMeshTestBase.TestPartition}/{ThreadNodeType.ThreadPartition}/{threadId}";
+        await NodeFactory.CreateNode(MeshNode.FromPath(threadPath) with
+        {
+            Name = $"Cancellation Ack Test Thread {threadId}",
+            NodeType = ThreadNodeType.NodeType,
+            MainNode = MonolithMeshTestBase.TestPartition,
+            Content = new MeshThread { CreatedBy = "rbuergi@systemorph.com" }
+        }).Should().Emit();
+
+        GetClient().SubmitMessage(
+            threadPath, "trigger the hanging stream",
+            modelName: "hanging-model", createdBy: "rbuergi@systemorph.com");
+
+        // Wait until the round is genuinely executing (hung mid-stream) so the cancellation
+        // watcher's `IsExecuting` filter — which gates the ack — matches.
+        await Mesh.GetWorkspace().GetMeshNodeStream(threadPath)
+            .Select(n => n?.Content as MeshThread)
+            .Where(t => t is not null)
+            .Should().Within(TimeSpan.FromSeconds(45))
+            .Match(t => t!.Status.IsExecuting() && t.ActiveMessageId is not null);
+
+        // Subscribe to the ack BEFORE pressing Stop (ToTask subscribes eagerly), so a transient
+        // ExecutionStatus == ack emission is never missed even though the terminal Cancelled write
+        // clears ExecutionStatus back to null shortly afterwards.
+        var ackObserved = Mesh.GetWorkspace().GetMeshNodeStream(threadPath)
+            .Select(n => (n?.Content as MeshThread)?.ExecutionStatus)
+            .Where(es => es == ThreadExecution.CancellationRequestedStatus)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(ct);
+
+        // Press Stop: the canonical thread-cancel is RequestedStatus = Cancelled on the node.
+        Mesh.GetWorkspace().GetMeshNodeStream(threadPath).Update(node =>
+                node?.Content is MeshThread t
+                    ? node with { Content = t with { RequestedStatus = ThreadExecutionStatus.Cancelled } }
+                    : node!)
+            .Subscribe(_ => { }, _ => { });
+
+        var ack = await ackObserved;
+        ack.Should().Be(ThreadExecution.CancellationRequestedStatus,
+            "the Stop must be acknowledged on ExecutionStatus immediately, before the round " +
+            "finishes draining the in-flight operation");
+
+        // And the round still settles into a terminal, non-executing state (no wedge).
+        await Mesh.GetWorkspace().GetMeshNodeStream(threadPath)
+            .Select(n => n?.Content as MeshThread)
+            .Where(t => t is not null)
+            .Should().Within(TimeSpan.FromSeconds(30))
+            .Match(t => !t!.Status.IsExecuting());
+    }
+
+    // ─── Chat client that yields one token, then hangs until cancelled ───
+    private sealed class HangingChatClient : IChatClient
+    {
+        public ChatClientMetadata Metadata => new("HangingProvider");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("non-streaming path must not be used");
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "partial ");
+            // Hang until the round's linked CTS fires — the same shape a hung HTTP read
+            // surfaces when its token is cancelled. This is the in-flight tool call that the
+            // Stop must be acknowledged over.
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(IChatClient) ? this : null;
+
+        public void Dispose() { }
+    }
+
+    private sealed class HangingChatClientFactory : IChatClientFactory
+    {
+        public string Name => "HangingFactory";
+        public IReadOnlyList<string> Models => ["hanging-model"];
+        public int Order => 0;
+
+        public Microsoft.Agents.AI.ChatClientAgent CreateAgent(
+            AgentConfiguration config,
+            IAgentChat chat,
+            IReadOnlyDictionary<string, Microsoft.Agents.AI.ChatClientAgent> existingAgents,
+            IReadOnlyList<AgentConfiguration> hierarchyAgents,
+            string? modelName = null)
+            => new(
+                chatClient: new HangingChatClient(),
+                instructions: config.Instructions ?? "You hang mid-stream.",
+                name: config.Id,
+                description: config.Description ?? config.Id,
+                tools: [],
+                loggerFactory: null,
+                services: null);
+
+        public Task<Microsoft.Agents.AI.ChatClientAgent> CreateAgentAsync(
+            AgentConfiguration config,
+            IAgentChat chat,
+            IReadOnlyDictionary<string, Microsoft.Agents.AI.ChatClientAgent> existingAgents,
+            IReadOnlyList<AgentConfiguration> hierarchyAgents,
+            string? modelName = null)
+            => Task.FromResult(CreateAgent(config, chat, existingAgents, hierarchyAgents, modelName));
+    }
+}


### PR DESCRIPTION
Fixes #321

Three related agent-runtime failures during high-volume, multi-tool-call rounds. Each is grounded in the actual code paths named in the issue; changes are deliberately conservative.

## 1. Per-agent tool-call cap
- `AgentConfiguration.MaxToolCallsPerRound` (`int?`, after `Plugins`, with XML docs).
- `ChatClientAgentFactory` now SETS `FunctionInvokingChatClient.MaximumIterationsPerRequest` from it (previously the value was only read/logged, so it fell back to the Microsoft.Extensions.AI default). This is a **real, framework-enforced per-agent cap**, not an ignored counter.
- **Limit-reached behaviour:** I verified against `Microsoft.Extensions.AI` 10.5.2 that `FunctionInvokingChatClient` does **not** throw on the cap — it logs `"Reached maximum iteration count …"` internally and, via `PrepareOptionsForLastIteration`, strips tools on the final iteration so the model returns a graceful final answer (no truncation). It surfaces **no distinct limit-reached signal** to the streaming consumer, so a ThreadExecution-side auto-detected "limit reached" push would require guessing internal iteration semantics (risking false messages on natural completions). Per the issue's "keep it SAFE and documented rather than guessing" guidance, the "type continue" hand-off is instead driven by a short instruction appended to the agent's system prompt when the cap is set, backed by the hard FICC cap. **Flagged for review** (see below).

## 2. Immediate Stop acknowledgement
`InstallCancellationWatcher` now stamps `Thread.ExecutionStatus = "Cancellation requested — stopping after current operation…"` the instant `RequestedStatus == Cancelled` is observed while executing — before the round's CTS self-cancel drains the in-flight tool call (~30s). Guarded to the still-executing / still-cancel-requested state so it never clobbers a terminal write.

## 3. Reasoning heartbeat between tool calls
A reactive `"Reasoning… (Ns)"` heartbeat derived from the **existing** `snapshots` stream in the streaming loop: every real emission restarts an idle timer via `.Switch()`, and a gap > 3s ticks `ExecutionStatus`. Guarded to the still-Executing / not-cancel-requested state and disposed with the round via `using` on every exit path — bounded, self-cancelling, **no hand-rolled `Task`/`Timer`/`SemaphoreSlim`**. Strictly additive: `ExecutionStatus` was otherwise `null` for the whole round.

## Tests (no mocking)
- `AgentToolWiringIntegrationTest.MaxToolCallsPerRound_FlowsInto_MaximumIterationsPerRequest` — a configured cap flows into the built agent's `MaximumIterationsPerRequest`; unset keeps the framework default (never hardcoded).
- `CancellationAckTest.Stop_ImmediatelyStampsCancellationAck_BeforeRoundTearsDown` — model-free: a fake hanging chat client yields one token then hangs; pressing Stop is proven to stamp the ack immediately, and the round still settles terminally.

## Verification
- `dotnet build … -c Release -warnaserror -p:CIRun=true` clean for both `MeshWeaver.AI` and `MeshWeaver.AI.Test` (0 warnings; ~55s build — no compile-time regression).
- New tests pass; regression-ran `StreamingTimeoutTest`, `AgentToolWiringIntegrationTest`, `ThreadSubmissionIntegrationTest`, `DelegationTest`, `DelegationIntegrationTest` — all green.

## Flagged for review
The auto-detected, ThreadExecution-side pushed "Reached the configured limit of N tool calls" message was intentionally **not** implemented, because `FunctionInvokingChatClient` exposes no clean limit-reached vs natural-completion distinction to the streaming consumer (verified). The chosen instruction-based hand-off + hard cap is safe and documented; if a deterministic pushed summary is desired, it would need a framework-level signal or an agreed iteration-count heuristic. `AgentConfiguration.MaxToolCallsPerRound` on the JSON-backed agent record deserializes automatically; wiring it into `.md`-frontmatter agent parsing (if desired) is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)