### PR TITLE
test(persistence): deterministic repro for node split-brain/version-regression (#325)

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeVersionRegressionOnRecycleTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeVersionRegressionOnRecycleTest.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Deterministic repro for issue #325 — a MeshNode's <see cref="MeshNode.Version"/>
+/// regresses (rolls BACKWARD) after the owning per-node hub is recycled / reactivated
+/// (idle-release, <c>Recycle</c>/<see cref="DisposeRequest"/>, or a replica restart).
+///
+/// <para><b>Root cause (verified here).</b> Every owner-side write stamps the node's
+/// Version from the owning hub's per-activation monotonic message counter
+/// (<c>_workspace.Hub.Version</c> — <c>MeshNodeStreamExtensions.cs:592</c>). The SAME
+/// clock stamps every sync-stream frame the owner originates — the init/base Full, value
+/// updates, and layout renders — via <c>SynchronizationStream.OwnerVersion()</c>
+/// (<c>Owner.Equals(Host.Address) ? Hub.Version : …</c>). <see cref="IMessageHub.Version"/>
+/// is "incremented once per message processed" and starts at 0 on EVERY activation; it is
+/// NEVER seeded from the persisted node's Version (the <c>SetInitialVersion(node.Version)</c>
+/// seed was removed from <c>MeshNodeTypeSource</c> because it re-stamped the clock BACKWARD
+/// on catalog pushes and dropped live layout Fulls). So after a deactivate → reactivate
+/// cycle the fresh hub's LOW counter sits BELOW the version the node already carries, and
+/// the node's next write stamps a Version below the old one → the counter rolls back
+/// (the "v113 read back as v3" symptom).</para>
+///
+/// <para><b>Downstream (why the writes "vanish" / a write "hangs").</b> A mirror that
+/// cached the higher pre-recycle version applies the sync monotonicity guard
+/// (<c>SynchronizationStream</c> drops an incoming frame whose <c>Version &lt; Current.Version</c>).
+/// It therefore DROPS the regressed post-recycle Full — staying stuck on the stale snapshot
+/// and never confirming the write (the "index/resolution split-brain", "no initial state",
+/// and "first UpdateNode hung indefinitely" symptoms). This test pins the trigger (the clock
+/// reset below the live node version) directly, without depending on that downstream hang.</para>
+///
+/// <para><b>Status: pins the cause; does NOT fix it.</b> The fix is to seed the owner hub's
+/// Version clock forward-only on activation (a guarded <c>SetInitialVersion</c> that never
+/// regresses the clock and never reintroduces the catalog-push Full-drop) — a change to a
+/// pervasive, load-bearing clock, out of scope for this repro. The final assertion therefore
+/// documents the CURRENT (defective) behaviour so the test is green until the fix lands; when
+/// the root cause is fixed, FLIP it to <c>clockAfter &gt;= nodeVersionBefore</c> and this test
+/// becomes the fix's proof.</para>
+/// </summary>
+public class NodeVersionRegressionOnRecycleTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    protected override bool ShareMeshAcrossTests => true;
+
+    [Fact(Timeout = 60000)]
+    public async Task OwnerVersionClock_ResetsBelowLiveNodeVersion_OnRecycle_Pins325()
+    {
+        var path = $"{TestPartition}/version-regress-target";
+
+        // Arrange — create the node. Markdown activates without a Roslyn compile.
+        await NodeFactory.CreateNode(
+                new MeshNode("version-regress-target", TestPartition)
+                { Name = "v0", NodeType = "Markdown" })
+            .Should().Within(30.Seconds()).Emit();
+
+        // Resolve the owning per-node hub address (the hub that stamps this node's writes).
+        var resolution = await PathResolver.ResolvePath(path).Should().Within(30.Seconds()).Emit();
+        resolution.Should().NotBeNull($"path '{path}' should resolve to an owning hub");
+        var address = new Address(resolution!.Prefix.ToString()!);
+
+        // Drive the owning hub's Version clock UP with a burst of distinct writes. Each
+        // write is a message on the owner → Hub.Version climbs and is stamped onto
+        // node.Version. Distinct names guarantee every write applies (the no-op guard
+        // drops value-equal updates).
+        for (var i = 1; i <= 30; i++)
+        {
+            var name = $"v{i}";
+            await NodeFactory.UpdateNode(
+                    new MeshNode("version-regress-target", TestPartition)
+                    { Name = name, NodeType = "Markdown" })
+                .Should().Within(30.Seconds()).Match(n => n.Name == name);
+        }
+
+        // The authoritative version the node now carries, and the owner clock behind it.
+        var before = await ReadNode(path).Should().Within(30.Seconds())
+            .Match(n => n is { Name: "v30" });
+        var nodeVersionBefore = before!.Version;
+        var ownerBefore = Mesh.GetHostedHub(address, HostedHubCreation.Never);
+        ownerBefore.Should().NotBeNull("the owner hub must be live after the write burst");
+        var clockBefore = ownerBefore!.Version;
+        Output.WriteLine(
+            $"[#325] nodeVersionBefore={nodeVersionBefore}, ownerClockBefore={clockBefore}");
+        nodeVersionBefore.Should().BeGreaterThan(0,
+            "the write burst must have advanced the node Version off the owner clock");
+
+        // Act — recycle the owner hub (DisposeRequest). Its next activation resets
+        // Hub.Version to 0.
+        Mesh.Post(new DisposeRequest(), o => o.WithTarget(address));
+
+        // Reactively wait for the reset: keep pinging to force reactivation, then read the
+        // (re)activated owner's Version. The pre-dispose hub still reports its high clock
+        // (filtered out); the reset is proven the moment the reactivated owner reports a
+        // clock strictly BELOW clockBefore. No fixed delay — we wait on the actual condition.
+        var clockAfter = await Observable.Interval(TimeSpan.FromMilliseconds(200)).StartWith(0L)
+            .SelectMany(_ => Mesh.Observe(new PingRequest(), o => o.WithTarget(address))
+                .Select(_ => Mesh.GetHostedHub(address, HostedHubCreation.Never)?.Version ?? -1L)
+                .Catch((Exception _) => Observable.Return(-1L)))
+            .Should().Within(30.Seconds()).Match(v => v >= 0 && v < clockBefore);
+        Output.WriteLine($"[#325] ownerClockAfter(reactivated)={clockAfter}");
+
+        // Assert — PIN #325. The reactivated owner's Version clock (the SAME clock that
+        // stamps the node's next write, and every sync Full) sits BELOW the version the
+        // node already carries. So the node's very next write rolls the version backward,
+        // and any mirror that cached the higher version drops the regressed frame. The
+        // CORRECT post-fix invariant is clockAfter >= nodeVersionBefore (seed the clock
+        // forward-only on activation).
+        clockAfter.Should().BeLessThan(nodeVersionBefore,
+            $"#325 repro: the reactivated owner clock ({clockAfter}) is below the live node "
+            + $"Version ({nodeVersionBefore}) — the next write rolls the Version backward. "
+            + "This documents the defect; the correct post-fix invariant is "
+            + "clockAfter >= nodeVersionBefore.");
+    }
+}


### PR DESCRIPTION
## What this is

A **deterministic repro test** that pins the root cause behind #325 (node write rollback + version regression + index/resolution split-brain on a deployed multi-replica portal). **Repro only — no production change.**

`test/MeshWeaver.Hosting.Monolith.Test/NodeVersionRegressionOnRecycleTest.cs` — runs in ~1s, green today.

## Verified root cause

Every owner-side node write stamps `MeshNode.Version` from the owning per-node hub's **per-activation** message counter `_workspace.Hub.Version` (`MeshNodeStreamExtensions.cs:592`). The **same clock** stamps every sync-stream frame the owner originates — the init/base Full, value updates, and layout renders — via `SynchronizationStream.OwnerVersion()` (`Owner.Equals(Host.Address) ? Hub.Version : …`, `SynchronizationStream.cs:507`).

`IMessageHub.Version` is *"incremented once per message processed"* (`MessageHub.cs:143`) and **starts at 0 on every activation**. It is **never seeded** from the persisted node's Version — `SetInitialVersion(node.Version)` was removed from `MeshNodeTypeSource` (`MeshNodeTypeSource.cs:508`) because re-stamping the clock backward on catalog pushes dropped live layout Fulls. `SetInitialVersion` still exists and is still asserted by `MeshNodeVersionSyncTest.MessageHub_HasSetInitialVersionMethod`, but nothing calls it on activation.

So after a **deactivate → reactivate** cycle (idle-release / `Recycle`/`DisposeRequest` / replica restart) the fresh hub's low counter sits **below** the version the node already carries. The node's next write stamps a lower version → the counter **rolls back** (the "v113 read back as v3" symptom). Any mirror that cached the higher version then **drops** the regressed frame via the sync monotonicity guard (`SynchronizationStream.cs:1163`, drops incoming `Version < Current.Version`) — which is the **index/resolution split-brain**, **"no initial state"**, and **"first `UpdateNode` hung indefinitely"** symptoms (my first repro attempt reproduced that hang directly: a post-recycle write never completed for 60s because the mirror guard dropped its echo).

## What the test proves

Drives the owner clock up with a 30-write burst, then recycles the owner and observes the reactivated owner's clock:

```
[#325] nodeVersionBefore=63, ownerClockBefore=64
[#325] ownerClockAfter(reactivated)=2
```

The owner Version clock reset **64 → 2**, strictly below the live node version (63) — so the node's very next write rolls the Version backward. Deterministic: it waits on the reset condition (reactive ping + read loop), never a fixed delay.

## Corrections to the earlier (stage-1) hypotheses

- **"10-minute debounced write queue with no flush-on-deactivation"** — **wrong.** The 10-min figure is the `_updateQueues` MemoryCache sliding expiration for the write-**queue handle** (`MeshNodeStreamCache.cs:314-325`). Persistence is a **200 ms `Observable.Sample`** (`MeshDataSource.cs:614,723`); the data source is explicitly *"pure — no debounce buffer, no FlushOnDispose"* (`MeshDataSource.cs:203`). (A last unflushed write on a same-window dispose is a real but separate, smaller window; it is **not** the version-regression mechanism.)
- **Read-vs-Query state-filter mismatch** — **not the split-brain cause.** Read-by-path (`PostgreSqlStorageAdapter.Read`/`FindBestPrefixMatch`/`ResolvePath`) applies **no** state filter; `Query`/`Search` (`PostgreSqlSqlGenerator.cs:195`) filters `state = 2`. Since the node is Active (visible to `Query`), a *looser* Read would also find it — the `get`/`patch` "not found" is a **resolution/activation** failure (owner returns NotFound during a restart window, then the `MeshNodeStreamCache` storm-breaker negative cache, `MeshNodeStreamCache.cs:257-268,787`, pins it fast-fail for up to 5 min while `Query` still hits Postgres), **not** a SQL state filter.

## Why repro-only (no fix here)

`Hub.Version` is a **pervasive, load-bearing clock** — node content versions, sync Fulls/changes (`DataExtensions.cs:555,663`), cross-hub reconciliation, and layout-render ordering all key on it. The correct fix is to **seed the owner clock forward-only on activation** (a guarded `SetInitialVersion(max(Hub.Version, persistedNode.Version))` that never regresses the clock and never reintroduces the catalog-push Full-drop). That is exactly the kind of version-clock change the codebase has regressed on twice (the atioz 2026-06-18 layout-Full wedge). It is out of scope for a repro and must not be shipped speculatively.

When the clock is seeded forward-only, flip the final assertion to `clockAfter >= nodeVersionBefore` and this test becomes the fix's proof.

## Multi-replica note

The single-process test reproduces the trigger (clock reset below live version) and, in the first attempt, the mirror-guard hang. The full **cross-replica** split-brain (one silo's mirror stuck at the high version while another silo's owner + Postgres carry the regressed version) needs a multi-silo harness to observe end-to-end, but its mechanism is the same monotonicity guard dropping the regressed frame.

Refs #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
