### PR TITLE
fix(ai-test): repair the 2 hidden AI.Test failures (stale assertions, not flakes)

### DIFF
--- a/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
+++ b/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
@@ -278,8 +278,9 @@ public class ChatClientCredentialResolverTest : AITestBase
             "the canonical wire id of a path selection is the node's ModelDefinition.Id");
         resolver.ResolveModelId(modelId).Should().Be(modelId,
             "bare ids pass through unchanged");
-        resolver.ResolveModelId($"{root}/nope/never-{suffix}").Should().Be($"{root}/nope/never-{suffix}",
-            "an unknown path passes through unchanged (caller falls back)");
+        resolver.ResolveModelId($"{root}/nope/never-{suffix}").Should().Be($"never-{suffix}",
+            "an UNRESOLVED path yields its LAST SEGMENT as the wire id — sending the whole path as the " +
+            "model name 400s (ResolveModelId's documented fallback); only a bare id passes through unchanged");
     }
 
     [Fact]

--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "create-markdown", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys", "slide");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "create-markdown", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys", "pull-request", "slide");
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);


### PR DESCRIPTION
Fixes the **"2 hidden AI.Test failures"** that have been open on `main` since 2026-07-03. These are **real, deterministic bugs — not flakes**: both fail in isolation.

## Why they were hidden
Under `dotnet test` (the VSTest adapter, xunit.runner.visualstudio) benign teardown `ObjectDisposedException` noise gets escalated to **"Catastrophic failure"**, which makes the run report **"0 Failed"** and silently drop ~20 tests. Running the test project as its native xUnit executable (`MeshWeaver.AI.Test.dll -diagnostics`) tells the truth: the ODE lines are `Errors: 0` diagnostics, and these two show up as plain `[FAIL]` with full stacks.

## The two stale assertions
1. **`SkillHarnessImportSourceTest.SkillStaticRepoSource_Emits_BuiltInSkills_UnderSkillPartition`** — the expected built-in-skill list was missing **`pull-request`**. `BuiltInSkillProvider` serves one node per `Data/Skill/*.md`, and `pull-request.md` is a committed skill added after the test was written. → add it to the expected list.
2. **`ChatClientCredentialResolverTest.Resolve_ByFullNodePath_…`** — asserted an unknown path "passes through unchanged", but `ResolveModelId` **deliberately** returns the **last path segment** for an unresolved path (documented at `ChatClientCredentialResolver.cs:389` — *sending the whole path as the wire model name 400s*). The assertion was stale; align it with the intended, documented behaviour (only a bare id passes through unchanged).

Test-only change (2 assertions).

## Verification
Both pass in isolation and in the full project, via the native runner **and** `dotnet test`: **Failed: 0, Passed: 775/780** (up from 755 — the ~20 tests VSTest was dropping are recovered).

> Note: the separate VSTest-adapter escalation of benign teardown ODEs to "Catastrophic failure" (native runner reports `Errors: 0` for it) is **unaffected by this PR and remains open** — it's a deeper disposal-race/adapter interaction. This PR fixes the real, deterministic test failures that were masked underneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)