### PR TITLE
fix(voice): host the Swiss-German model on a GitHub release (dead download URL)

### DIFF
--- a/deploy/whisper/README.md
+++ b/deploy/whisper/README.md
@@ -14,7 +14,7 @@ MAUI all reach one endpoint. The mesh side is `MeshWeaver.Speech` (`WhisperConta
 cd deploy/whisper
 # 1. Fetch the Swiss-German model (~547 MB) into ./models/ (same file the on-device client downloads):
 mkdir -p models
-curl -fSL https://memex.meshweaver.cloud/MeshWeaver/static/Speech/ggml-swiss-german-turbo-q5_0.bin \
+curl -fSL https://github.com/Systemorph/MeshWeaver/releases/download/voice-model-swiss-german/ggml-swiss-german-turbo-q5_0.bin \
      -o models/model.bin
 # 2. Build + start the container:
 docker compose up --build -d

--- a/deploy/whisper/docker-compose.yml
+++ b/deploy/whisper/docker-compose.yml
@@ -4,7 +4,7 @@
 #
 # The model is NOT baked into the image (it's ~547 MB and swappable) — drop it in ./models/model.bin first:
 #   mkdir -p models && curl -fSL \
-#     https://memex.meshweaver.cloud/MeshWeaver/static/Speech/ggml-swiss-german-turbo-q5_0.bin \
+#     https://github.com/Systemorph/MeshWeaver/releases/download/voice-model-swiss-german/ggml-swiss-german-turbo-q5_0.bin \
 #     -o models/model.bin
 # (Same file the on-device MAUI client downloads — see Doc/Architecture/OnDeviceVoice.)
 

--- a/memex/Memex.Client/Voice/VoiceModelCatalog.cs
+++ b/memex/Memex.Client/Voice/VoiceModelCatalog.cs
@@ -50,19 +50,19 @@ public sealed class VoiceModelCatalog
         _provisionAppleImage = provisionAppleImage;
         (_fileName, _url) = model switch
         {
-            // The converted Flurin17 Swiss-German fine-tune (no public GGML), quantized to q5_0 (~547 MB
-            // vs 1.5 GB f16 — faster + iPhone-RAM-friendly, negligible quality loss). Hosted as a GitHub
-            // release asset (the earlier memex.meshweaver.cloud/static/Speech URL was never published —
-            // it returned the portal's SPA index.html, so every first-use download got 88 KB of HTML).
-            // The CoreML "apple image" (…-encoder.mlmodelc.zip) lives in the SAME release so the derived
-            // URL resolves. Downloaded on first use like the others.
+            // The converted Flurin17 Swiss-German fine-tune (no public GGML), quantized to q5_0:
+            // ~547 MB vs 1.5 GB f16 — faster + iPhone-RAM-friendly, negligible quality loss. Hosted as
+            // a GitHub release asset. The earlier memex.meshweaver.cloud/static/Speech URL was never
+            // published — it returned the portal's SPA index.html, so every first-use download got
+            // 88 KB of HTML. The CoreML "apple image" (…-encoder.mlmodelc.zip) lives in the SAME release
+            // so the derived URL resolves. Downloaded on first use like the others.
             WhisperModelSize.SwissGerman => ("ggml-swiss-german-turbo-q5_0.bin",
                 "https://github.com/Systemorph/MeshWeaver/releases/download/voice-model-swiss-german/ggml-swiss-german-turbo-q5_0.bin"),
             WhisperModelSize.LargeV3Turbo => ("ggml-large-v3-turbo.bin", GgmlBaseUrl + "ggml-large-v3-turbo.bin"),
             _ => ("ggml-base.bin", GgmlBaseUrl + "ggml-base.bin"),
         };
         // The CoreML "apple image" (encoder) is hosted next to the ggml model as a .zip when one exists
-        // (our static collection for Swiss German; ggerganov's HF repo for base/large). Same directory,
+        // (our GitHub release for Swiss German; ggerganov's HF repo for base/large). Same directory,
         // filename derived by whisper.cpp's own rule so the runtime auto-loads it.
         _appleImageUrl = _url is null ? null : DeriveAppleImageZipUrl(_url);
     }

--- a/memex/Memex.Client/Voice/VoiceModelCatalog.cs
+++ b/memex/Memex.Client/Voice/VoiceModelCatalog.cs
@@ -51,11 +51,13 @@ public sealed class VoiceModelCatalog
         (_fileName, _url) = model switch
         {
             // The converted Flurin17 Swiss-German fine-tune (no public GGML), quantized to q5_0 (~547 MB
-            // vs 1.5 GB f16 — faster + iPhone-RAM-friendly, negligible quality loss). Served from the
-            // MeshWeaver space's "static" FileSystem content collection (the AKS file-share mount),
-            // downloaded on first use like the others.
+            // vs 1.5 GB f16 — faster + iPhone-RAM-friendly, negligible quality loss). Hosted as a GitHub
+            // release asset (the earlier memex.meshweaver.cloud/static/Speech URL was never published —
+            // it returned the portal's SPA index.html, so every first-use download got 88 KB of HTML).
+            // The CoreML "apple image" (…-encoder.mlmodelc.zip) lives in the SAME release so the derived
+            // URL resolves. Downloaded on first use like the others.
             WhisperModelSize.SwissGerman => ("ggml-swiss-german-turbo-q5_0.bin",
-                "https://memex.meshweaver.cloud/MeshWeaver/static/Speech/ggml-swiss-german-turbo-q5_0.bin"),
+                "https://github.com/Systemorph/MeshWeaver/releases/download/voice-model-swiss-german/ggml-swiss-german-turbo-q5_0.bin"),
             WhisperModelSize.LargeV3Turbo => ("ggml-large-v3-turbo.bin", GgmlBaseUrl + "ggml-large-v3-turbo.bin"),
             _ => ("ggml-base.bin", GgmlBaseUrl + "ggml-base.bin"),
         };


### PR DESCRIPTION
## Problem
`VoiceModelCatalog` + `deploy/whisper` (README/compose) pointed the Swiss-German GGML download at `https://memex.meshweaver.cloud/MeshWeaver/static/Speech/ggml-swiss-german-turbo-q5_0.bin` — but that file was never published there. The URL returns the portal's SPA `index.html`, so every first-use download (MAUI on-device, and the whisper container's model fetch) silently got ~88 KB of **HTML** instead of the 547 MB model → garbage transcription.

## Fix
Host both assets on a **GitHub release** (tag `voice-model-swiss-german`, non-semver so it won't trigger the release workflow):
- `ggml-swiss-german-turbo-q5_0.bin` (547 MB)
- `ggml-swiss-german-turbo-encoder.mlmodelc.zip` (the CoreML "apple image", 929 MB) — same release so `VoiceModelCatalog`'s **derived** encoder URL resolves.

Point `VoiceModelCatalog.cs`, the whisper README, and docker-compose at the release. **Verified:** the release URL now serves `application/octet-stream` with the GGML magic (`lmgg`), not HTML.

Note: `Memex.Client` (MAUI) isn't in the CI solution, so the `.cs` change (a URL string literal) isn't CI-compiled; the other two files are docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)