### PR TITLE
feat(whisper): AKS helm chart for the centralized speech container

### DIFF
--- a/deploy/whisper/helm/.helmignore
+++ b/deploy/whisper/helm/.helmignore
@@ -1,0 +1,6 @@
+.DS_Store
+.git
+.gitignore
+*.tmp
+*.bak
+*.swp

--- a/deploy/whisper/helm/Chart.yaml
+++ b/deploy/whisper/helm/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: whisper-swiss-german
+description: >-
+  Centralized Swiss-German speech-to-text — a whisper.cpp server bound to the fine-tuned
+  Swiss-German model, exposed cluster-internally so the portal's POST /api/speech/transcribe
+  can forward audio to it (the model host never faces clients directly). See
+  deploy/whisper/ and Doc/Architecture/CentralizedSpeech.
+type: application
+version: 0.1.0
+# The whisper.cpp server tag baked into the image (deploy/whisper/Dockerfile pins v1.7.4).
+appVersion: "1.7.4"

--- a/deploy/whisper/helm/templates/NOTES.txt
+++ b/deploy/whisper/helm/templates/NOTES.txt
@@ -7,14 +7,19 @@ The server is cluster-internal (Service type {{ .Values.service.type }}) at:
 Point the portal at it so POST /api/speech/transcribe has somewhere to forward:
 
     Speech__Endpoint = http://{{ include "whisper.fullname" . }}:{{ .Values.service.port }}
-    Speech__Enabled  = true
-    Speech__Language  = {{ .Values.model.language }}
+    Speech__Enabled = true
+    Speech__Language = {{ .Values.model.language }}
 
 First pod start downloads the model (~547 MB) via an initContainer, then loads it — the
 startupProbe covers this, so give the pod a minute or two to become Ready.
 
-Smoke-test from inside the cluster:
+Check readiness from inside the cluster (a bare GET returns non-5xx once the model is loaded):
 
     kubectl run -it --rm curl --image=curlimages/curl --restart=Never -- \
-      -F file=@/dev/stdin -F language={{ .Values.model.language }} -F response_format=json \
+      -sf http://{{ include "whisper.fullname" . }}:{{ .Values.service.port }}/
+
+To transcribe, POST an audio file to /inference:
+
+    kubectl run -it --rm curl --image=curlimages/curl --restart=Never -- \
+      -F file=@your-audio.wav -F language={{ .Values.model.language }} -F response_format=json \
       http://{{ include "whisper.fullname" . }}:{{ .Values.service.port }}/inference

--- a/deploy/whisper/helm/templates/NOTES.txt
+++ b/deploy/whisper/helm/templates/NOTES.txt
@@ -1,0 +1,20 @@
+whisper-swiss-german is deploying.
+
+The server is cluster-internal (Service type {{ .Values.service.type }}) at:
+
+    http://{{ include "whisper.fullname" . }}:{{ .Values.service.port }}
+
+Point the portal at it so POST /api/speech/transcribe has somewhere to forward:
+
+    Speech__Endpoint = http://{{ include "whisper.fullname" . }}:{{ .Values.service.port }}
+    Speech__Enabled  = true
+    Speech__Language  = {{ .Values.model.language }}
+
+First pod start downloads the model (~547 MB) via an initContainer, then loads it — the
+startupProbe covers this, so give the pod a minute or two to become Ready.
+
+Smoke-test from inside the cluster:
+
+    kubectl run -it --rm curl --image=curlimages/curl --restart=Never -- \
+      -F file=@/dev/stdin -F language={{ .Values.model.language }} -F response_format=json \
+      http://{{ include "whisper.fullname" . }}:{{ .Values.service.port }}/inference

--- a/deploy/whisper/helm/templates/_helpers.tpl
+++ b/deploy/whisper/helm/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{/* Chart name, overridable via .Values.nameOverride. */}}
+{{- define "whisper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Fully qualified app name: <release>-<chart>, or the release name if it already contains the chart name. */}}
+{{- define "whisper.fullname" -}}
+{{- if contains .Chart.Name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "whisper.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Common selector labels — must be stable across upgrades. */}}
+{{- define "whisper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "whisper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/* Common labels. */}}
+{{- define "whisper.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "whisper.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}

--- a/deploy/whisper/helm/templates/deployment.yaml
+++ b/deploy/whisper/helm/templates/deployment.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "whisper.fullname" . }}
+  labels:
+    {{- include "whisper.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "whisper.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "whisper.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # Fetch the (large, un-baked) model once per pod into a shared emptyDir. Reuses the whisper
+      # image — it ships curl — so no extra image dependency. whisper-server then loads /models/model.bin.
+      initContainers:
+        - name: fetch-model
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              if [ ! -s /models/model.bin ]; then
+                echo "Downloading whisper model from $MODEL_URL ..."
+                curl -fSL --retry 3 --retry-delay 5 "$MODEL_URL" -o /models/model.bin
+              fi
+              echo "Model ready: $(wc -c < /models/model.bin) bytes"
+          env:
+            - name: MODEL_URL
+              value: {{ .Values.model.url | quote }}
+          volumeMounts:
+            - name: models
+              mountPath: /models
+      containers:
+        - name: whisper
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # The image CMD already runs whisper-server with these envs on :8080 (see Dockerfile).
+          env:
+            - name: WHISPER_MODEL
+              value: /models/model.bin
+            - name: WHISPER_LANGUAGE
+              value: {{ .Values.model.language | quote }}
+            - name: WHISPER_THREADS
+              value: {{ .Values.model.threads | quote }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          # A bare GET returns a non-5xx once the server is up AND the model is loaded — so the
+          # startupProbe gates the model download + load before readiness/liveness begin.
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            {{- with .Values.startupProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            {{- with .Values.readinessProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            {{- with .Values.livenessProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: models
+              mountPath: /models
+      volumes:
+        - name: models
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/whisper/helm/templates/deployment.yaml
+++ b/deploy/whisper/helm/templates/deployment.yaml
@@ -34,7 +34,11 @@ spec:
               set -e
               if [ ! -s /models/model.bin ]; then
                 echo "Downloading whisper model from $MODEL_URL ..."
-                curl -fSL --retry 3 --retry-delay 5 "$MODEL_URL" -o /models/model.bin
+                # Download to a temp file and move into place only on success — an interrupted curl
+                # must NOT leave a partial /models/model.bin (the -s guard would then skip re-download
+                # and the server would loop trying to load a corrupt model).
+                curl -fSL --retry 3 --retry-delay 5 "$MODEL_URL" -o /models/model.bin.tmp
+                mv /models/model.bin.tmp /models/model.bin
               fi
               echo "Model ready: $(wc -c < /models/model.bin) bytes"
           env:

--- a/deploy/whisper/helm/templates/service.yaml
+++ b/deploy/whisper/helm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "whisper.fullname" . }}
+  labels:
+    {{- include "whisper.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "whisper.selectorLabels" . | nindent 4 }}

--- a/deploy/whisper/helm/values.yaml
+++ b/deploy/whisper/helm/values.yaml
@@ -1,0 +1,58 @@
+# Values for the centralized Swiss-German whisper.cpp server (deploy/whisper/Dockerfile).
+# The container is cluster-internal: the portal reaches it at http://<release>-whisper-swiss-german:8080
+# and forwards audio via ISpeechTranscriber. Point the portal at it with:
+#   Speech__Endpoint = http://<release>-whisper-swiss-german:8080
+#   Speech__Enabled  = true
+
+replicaCount: 1
+
+image:
+  # Build deploy/whisper/Dockerfile and push to your registry (e.g. ACR):
+  #   az acr build -r meshweaver -t whisper-swiss-german:1.7.4 deploy/whisper
+  repository: meshweaver.azurecr.io/whisper-swiss-german
+  tag: "1.7.4"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# The whisper model is NOT baked into the image (it's ~547 MB and swappable). An initContainer
+# fetches it once per pod into a shared emptyDir; whisper-server then loads it from /models/model.bin.
+model:
+  # Default: the GitHub-release asset that VoiceModelCatalog + deploy/whisper also use.
+  url: "https://github.com/Systemorph/MeshWeaver/releases/download/voice-model-swiss-german/ggml-swiss-german-turbo-q5_0.bin"
+  # Whisper language hint. "de" transcribes Swiss German OUT as Standard German (best for strong
+  # dialect); "auto" detects (en/de/…) at some accuracy cost on heavy dialect.
+  language: "de"
+  threads: 4
+
+service:
+  type: ClusterIP
+  port: 8080
+
+# whisper.cpp (CPU large-v3-turbo q5) wants a few cores + RAM for the model + compute buffers.
+resources:
+  requests:
+    cpu: "1"
+    memory: 2Gi
+  limits:
+    cpu: "4"
+    memory: 6Gi
+
+# Model load + first request take time; probes are generous so the pod isn't killed while warming.
+startupProbe:
+  # Gates readiness/liveness until the server answers — covers the model download + load.
+  failureThreshold: 60
+  periodSeconds: 10
+readinessProbe:
+  periodSeconds: 15
+  timeoutSeconds: 5
+livenessProbe:
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 5
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+podAnnotations: {}


### PR DESCRIPTION
## What
A helm chart (`deploy/whisper/helm`) to deploy the whisper.cpp Swiss-German speech server to AKS, cluster-internal.

## Why
The portal's `POST /api/speech/transcribe` (#332) forwards to a Whisper container via `ISpeechTranscriber`, but only docker-compose existed — nothing deployed the container to AKS, so the endpoint returns **503** in prod. This is the missing prod piece.

## Chart
- **deployment**: an initContainer fetches the ~547 MB model (not baked into the image) from the GitHub release (#343) into a shared `emptyDir`; the whisper container loads `/models/model.bin`. Init reuses the whisper image (ships `curl`) — no extra dependency. Startup/readiness/liveness probes `GET /` (non-5xx once the model is loaded), generous `startupProbe` to cover download+load.
- **service**: ClusterIP :8080 → `http://<release>-whisper-swiss-german:8080`.
- **values**: image repo/tag, model url (defaults to the release asset) + language + threads, resources, probe tunables. `NOTES.txt` shows how to point the portal (`Speech__Endpoint`/`Enabled`).

## Verification
`helm lint` (0 failures) + `helm template` (renders correctly). YAML-only — doesn't affect the .NET CI. Deploying it + setting the portal's `Speech` config is the remaining ops step (build/push the image to ACR first: `az acr build -r meshweaver -t whisper-swiss-german:1.7.4 deploy/whisper`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)