### PR TITLE
fix(pg): top-level-index rebuild skips dropped partition schemas (42P01 merge-gate flake)

### DIFF
--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
@@ -138,6 +138,14 @@ public static class PostgreSqlSchemaInitializer
             BEGIN
                 FOR schema_rec IN SELECT schema_name FROM public.searchable_schemas ORDER BY schema_name
                 LOOP
+                    -- Skip a listed schema whose mesh_nodes table no longer exists. searchable_schemas
+                    -- can LAG a concurrent partition drop (DeletePartition does DROP SCHEMA … CASCADE):
+                    -- under load a just-dropped partition is still listed here, and referencing its
+                    -- gone table in the UNION fails the CREATE MATERIALIZED VIEW with
+                    -- `42P01 relation "<schema>.mesh_nodes" does not exist` — the flaky
+                    -- RebuildTopLevelIndex / SpaceDeletion class of failures. to_regclass returns NULL
+                    -- (no error) for an absent relation, so this is the race-safe existence guard.
+                    CONTINUE WHEN to_regclass(format('%I.mesh_nodes', schema_rec.schema_name)) IS NULL;
                     IF union_sql != '' THEN union_sql := union_sql || ' UNION ALL '; END IF;
                     -- Exactly the PARTITION ROOT: the namespace='' node whose id matches the
                     -- schema (partition) name CASE-INSENSITIVELY. The schema is the lowercased

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/TopLevelIndexTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/TopLevelIndexTests.cs
@@ -128,6 +128,51 @@ public class TopLevelIndexTests(PostgreSqlFixture fixture, ITestOutputHelper out
         }
     }
 
+    /// <summary>
+    /// Deterministic pin for the merge-gate flake: <c>searchable_schemas</c> LAGS a partition drop
+    /// (<c>DeletePartition</c> runs <c>DROP SCHEMA … CASCADE</c>), so under concurrent load the
+    /// rebuild's <c>UNION ALL</c> references <c>&lt;schema&gt;.mesh_nodes</c> for a schema that is gone
+    /// and <c>CREATE MATERIALIZED VIEW</c> fails with <c>42P01 relation … does not exist</c>. Reproduced
+    /// here without any race by listing a schema that has no backing schema/table — the exact stale
+    /// window. WITHOUT the <c>to_regclass</c> guard in <c>rebuild_top_level_index()</c> the rebuild call
+    /// below throws 42P01 (the flake); WITH it the vanished schema is skipped and the rebuild succeeds.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task RebuildTopLevelIndex_SkipsListedSchemaWithNoTable_NoRelationError()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var ghost = $"ghost{Guid.NewGuid():N}".ToLowerInvariant()[..14];
+
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionString);
+        await conn.OpenAsync(ct);
+
+        await using (var list = new NpgsqlCommand(
+            "INSERT INTO public.searchable_schemas (schema_name) VALUES (@s) ON CONFLICT DO NOTHING", conn))
+        {
+            list.Parameters.AddWithValue("s", ghost);
+            await list.ExecuteNonQueryAsync(ct);
+        }
+        try
+        {
+            // Throws 42P01 without the guard (references ghost.mesh_nodes, which does not exist).
+            await using (var rebuild = new NpgsqlCommand("SELECT public.rebuild_top_level_index()", conn))
+                await rebuild.ExecuteNonQueryAsync(ct);
+
+            await using var q = new NpgsqlCommand(
+                "SELECT COUNT(*) FROM public.top_level_index WHERE path = @s", conn);
+            q.Parameters.AddWithValue("s", ghost);
+            Convert.ToInt64(await q.ExecuteScalarAsync(ct)).Should().Be(0L,
+                "a listed-but-dropped schema is skipped, contributing no rows to the matview");
+        }
+        finally
+        {
+            await using var cleanup = new NpgsqlCommand(
+                "DELETE FROM public.searchable_schemas WHERE schema_name = @s", conn);
+            cleanup.Parameters.AddWithValue("s", ghost);
+            await cleanup.ExecuteNonQueryAsync(ct);
+        }
+    }
+
     [Fact(Timeout = 60000)]
     public async Task AutocompleteTopLevel_ReturnsScoredMatches_FromMatview_NoFanOut()
     {


### PR DESCRIPTION
Cures the recurring merge-gate flake in `MeshWeaver.Hosting.PostgreSql.Test` — `RebuildTopLevelIndex_IsIdempotent_AndQueryableWhenEmpty` / `SpaceDeletionPartitionDropTests` — pinned with the /debug skill's **bulk** technique (whole project in one process; passes in isolation, fails in bulk).

## Root cause
`rebuild_top_level_index()` builds a `UNION ALL` over `public.searchable_schemas`, referencing `<schema>.mesh_nodes`. `searchable_schemas` **lags a concurrent partition drop** (`DeletePartition` runs `DROP SCHEMA … CASCADE`), so under load a just-dropped partition is still listed → the `CREATE MATERIALIZED VIEW` references a gone table → **`42P01 relation "<schema>.mesh_nodes" does not exist`**.

## Fix (root cause, not a timeout)
Guard each UNION member with `to_regclass('<schema>.mesh_nodes') IS NOT NULL` (returns `NULL`, not an error, for an absent relation). The matview must only union tables that **exist** — a correctness invariant. A stale/racing schema-list entry can no longer inject a dead reference.

## Pinned + verified in bulk
- **Before:** ~2/3 of full-project runs failed with the 42P01.
- **After:** 4/4 full-project runs green (515 passed).

Release `-warnaserror` clean. One-line SQL guard.