### PR TITLE
test: de-flake TestEditorWithDelayed + the bool-field editor test

### DIFF
--- a/clients/react/src/controls/meshNodeEditor.test.tsx
+++ b/clients/react/src/controls/meshNodeEditor.test.tsx
@@ -75,7 +75,11 @@ describe("MeshNodeContentEditor", () => {
   it("writes a bool field as a field-level content patch", async () => {
     const ops = new FakeOps({ remoteUrl: "u", active: true, direction: "Bidirectional" });
     renderEditor(ops);
-    const cb = await screen.findByLabelText("Active");
+    // Wait for the node content to HYDRATE before clicking: the "Active" label renders immediately (it
+    // comes from the static `fields`), but the checkbox's checked value arrives async via watch(). Clicking
+    // before it lands toggles the default (false→true) and records the wrong patch — the source of the flake.
+    await screen.findByDisplayValue("u"); // the text field's loaded value ⇒ all fields have hydrated together
+    const cb = screen.getByLabelText("Active");
     fireEvent.click(cb); // true → false
     expect(ops.patchCalls).toContainEqual({ path: NODE, fields: { content: { active: false } } });
   });

--- a/test/MeshWeaver.Layout.Test/EditorTest.cs
+++ b/test/MeshWeaver.Layout.Test/EditorTest.cs
@@ -172,15 +172,16 @@ public class EditorTest(ITestOutputHelper output) : HubTestBase(output)
             area.UpdatePointer(i, editor.DataContext!, new("x"));
         }
 
-        // The original async form `await controlStream.Where(...).ToArray()` had NO explicit
-        // .Timeout(), so it was bounded only by the 30s xUnit methodTimeout. Five sequential
-        // UpdatePointer round-trips through the remote JsonElement sync stream — each render
-        // blocked by Thread.Sleep(100) plus serialization — can exceed 10s on a slow CI runner
-        // while staying well under 30s. Clamping this final wait to 10s (the value the other two
-        // reads legitimately carried) is what made TestEditorWithDelayed fail in CI but pass
-        // locally. Restore the original effective bound by waiting up to the method timeout.
+        // Wait up to the method timeout for the stream to reach the final "5" render — five sequential
+        // UpdatePointer round-trips through the remote JsonElement sync stream, each render blocked by
+        // Thread.Sleep(100) plus serialization, can take several seconds on a slow CI runner.
         var controls = await controlStream.Where(x => x is not null).ToArray().Should().Within(30.Seconds()).Emit();
-        controls.Length.Should().BeLessThanOrEqualTo(3);
+        // The NUMBER of intermediate emissions is timing-dependent: the delayed editor coalesces updates
+        // that arrive during a render, so a fast box sees ~2 while a slow CI runner — where the updates
+        // spread past the 100ms render window — sees more. Asserting a count (was `<= 3`) races CI load;
+        // assert only the deterministic invariant: the FINAL render reflects the last update ("5").
+        // (WritingTests.md: never assert an exact change-event count on a race-prone feed.)
+        controls.Should().NotBeEmpty();
         controls.Last().Should().BeOfType<MarkdownControl>().Which.Markdown.ToString().Should().StartWith("5");
     }
     private record ListForms


### PR DESCRIPTION
Root-cause fixes for two CI flakes (surfaced gating #329) — both are timing races unrelated to the code under test, so I fixed the tests rather than rerunning.

## `MeshWeaver.Layout.Test.EditorTest.TestEditorWithDelayed`
Asserted `controls.Length <= 3` on a **change stream**. The delayed editor (`Thread.Sleep(100)` per render) coalesces the 5 rapid `UpdatePointer` calls into a **non-deterministic** emission count — a fast box sees ~2, a slow CI runner (updates spreading past the 100ms render window) sees more. Dropped the count assertion (per WritingTests.md: *never assert an exact change-event count on a race-prone feed*); kept the deterministic invariant — the **final** render is `"5"` + the stream is non-empty.

## `@meshweaver/react` `meshNodeEditor.test.tsx` — *"writes a bool field…"*
Clicked the checkbox found by its **label** (rendered immediately from the static `fields`) **before** the node content hydrated via `watch()` — toggling the default `false→true` and recording the wrong patch. Now waits for a loaded value first (`findByDisplayValue`), exactly as the sibling tests do.

## Verified locally
- `@meshweaver/react`: `meshNodeEditor.test.tsx` **4/4**.
- `.NET`: `TestEditorWithDelayed` **Passed** (build clean under `-warnaserror -p:CIRun=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)