### PR TITLE
fix(content): eliminate SaveFileAsync file-lock race in content-collection writes

### DIFF
--- a/src/MeshWeaver.ContentCollections/FileSystemStreamProvider.cs
+++ b/src/MeshWeaver.ContentCollections/FileSystemStreamProvider.cs
@@ -65,7 +65,16 @@ public class FileSystemStreamProvider(string basePath) : IStreamProvider
             fullPath,
             FileMode.Create,
             FileAccess.Write,
-            FileShare.None,
+            // Single-writer / multi-reader / delete-tolerant sharing — MUST match the read path's
+            // tolerant share (GetStreamAsync/GetStreamWithMetadataAsync open FileShare.ReadWrite|Delete).
+            // FileShare.None takes an EXCLUSIVE advisory lock on Unix (.NET emulates FileShare via
+            // flock: None → LOCK_EX), which the OS refuses while a reader holds the file — and the
+            // FileSystemWatcher-driven UpdateArticle read legitimately overlaps a write. That
+            // exclusive-vs-shared clash is the "file is being used by another process" IOException
+            // this method threw under CI load. Content files are eventually-consistent and re-ingested
+            // on change, so a write must never demand exclusivity against the readers that already
+            // tolerate it. See NodeHubContentCollectionTest / ContentCollectionWriteReadRaceTest.
+            FileShare.Read | FileShare.Delete,
             4096,
             useAsync: true);
 
@@ -154,7 +163,11 @@ public class FileSystemStreamProvider(string basePath) : IStreamProvider
         {
             Directory.CreateDirectory(directory);
         }
-        await using var fileStream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, useAsync: true);
+        // Single-writer / multi-reader / delete-tolerant sharing — see WriteStreamAsync for the full
+        // rationale. FileShare.None takes an exclusive flock on Unix that clashes with the concurrent
+        // FileSystemWatcher-driven read (FileShare.ReadWrite|Delete) and threw the CI-only
+        // "used by another process" IOException at this exact line.
+        await using var fileStream = new FileStream(fullPath, FileMode.Create, FileAccess.Write, FileShare.Read | FileShare.Delete, 4096, useAsync: true);
         await content.CopyToAsync(fileStream, cancellationToken);
     }
 

--- a/test/MeshWeaver.ContentCollections.Test/ContentCollectionWriteReadRaceTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/ContentCollectionWriteReadRaceTest.cs
@@ -1,0 +1,80 @@
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Test;
+
+/// <summary>
+/// Pins the root cause of the CI-only <c>CollectionNamedArea_RendersBrowserForFolder_AndContentForFile</c>
+/// file-lock flake: a <see cref="FileSystemStreamProvider"/> WRITE must be able to open a content file
+/// while a concurrent READ of the same file is in flight.
+///
+/// <para>The read path (<see cref="FileSystemStreamProvider.GetStreamAsync"/> /
+/// <see cref="FileSystemStreamProvider.GetStreamWithMetadataAsync"/>) deliberately opens with the
+/// maximally-tolerant <c>FileShare.ReadWrite | FileShare.Delete</c> — content is eventually-consistent
+/// and re-ingested on change, so reads never block and are never blocked. The FileSystemWatcher-driven
+/// <c>ContentCollection.UpdateArticle</c> issues exactly such a read whenever a file changes, so a read
+/// legitimately overlaps a write.</para>
+///
+/// <para>The bug: the write opened with <c>FileShare.None</c>. On Unix, .NET emulates <c>FileShare</c>
+/// via <c>flock</c> — <c>FileShare.None</c> takes an EXCLUSIVE lock (<c>LOCK_EX</c>) which the OS refuses
+/// while a reader holds the file (<c>LOCK_SH</c>) — so the write threw
+/// <c>IOException: "... because it is being used by another process."</c> fast (not a timeout) under CI
+/// load. macOS uses <c>flock</c> too, so this reproduces here deterministically.</para>
+///
+/// <para>Without the fix (writer share <c>None</c>) the writes throw within a handful of iterations;
+/// with the correct single-writer/multi-reader/delete-tolerant share the writes never throw. No sleeps,
+/// no watcher-timing dependence — the concurrent reader is driven explicitly.</para>
+/// </summary>
+public class ContentCollectionWriteReadRaceTest
+{
+    [Fact]
+    public async Task Write_Succeeds_While_A_Concurrent_Read_Holds_The_File()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var dir = Path.Combine(AppContext.BaseDirectory, "Files", "WriteReadRace", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        var provider = new FileSystemStreamProvider(dir);
+        var bytes = "# Hello from the collection area"u8.ToArray();
+
+        // Seed the file so the reader has something to open from the very first iteration.
+        using (var seed = new MemoryStream(bytes))
+            await provider.SaveFileAsync("/sub", "hello.md", seed);
+
+        // A background reader that continuously opens the SAME file with the exact share the read
+        // path uses (FileShare.ReadWrite | FileShare.Delete) and holds the handle briefly — the
+        // in-flight-read condition the FileSystemWatcher creates in production.
+        using var readerCts = new CancellationTokenSource();
+        var reader = Task.Run(async () =>
+        {
+            while (!readerCts.IsCancellationRequested)
+            {
+                var (stream, _, _) = await provider.GetStreamWithMetadataAsync("/sub/hello.md", readerCts.Token);
+                if (stream is not null)
+                {
+                    using (stream)
+                    {
+                        var buffer = new byte[64];
+                        _ = await stream.ReadAsync(buffer, readerCts.Token);
+                    }
+                }
+            }
+        }, readerCts.Token);
+
+        try
+        {
+            // Hammer the write while the reader keeps a handle open. Every open must succeed —
+            // a write may not demand exclusivity against the readers that already tolerate it.
+            for (var i = 0; i < 300 && !ct.IsCancellationRequested; i++)
+            {
+                using var stream = new MemoryStream(bytes);
+                await provider.SaveFileAsync("/sub", "hello.md", stream);
+                await Task.Yield();
+            }
+        }
+        finally
+        {
+            readerCts.Cancel();
+            try { await reader; } catch (OperationCanceledException) { }
+        }
+    }
+}


### PR DESCRIPTION
## The flake

CI-only, load-dependent, **not** a timeout — fails fast (~21 ms):

```
System.IO.IOException : The process cannot access the file
'.../bin/Release/net10.0/Files/NodeContent/TestOrg/sub/hello.md'
because it is being used by another process.
   at MeshWeaver.ContentCollections.FileSystemStreamProvider.SaveFileAsync(...) FileSystemStreamProvider.cs:157
   at MeshWeaver.ContentCollections.ContentCollection.SaveFileAsync(...) ContentCollection.cs:142
```

Observed on `NodeHubContentCollectionTest.CollectionNamedArea_RendersBrowserForFolder_AndContentForFile`. This is a **new manifestation** of the `CollectionNamedArea` watcher-race flake family — the *timeout* manifestation was fixed in #238; this is a **file-lock / sharing violation on write**.

## Root cause (exact, proven)

`FileSystemStreamProvider` **writes** (`WriteStreamAsync`, `SaveFileAsync`) opened the file with `FileShare.None`, while the **read** path (`GetStreamAsync` / `GetStreamWithMetadataAsync`) opens with the deliberately-tolerant `FileShare.ReadWrite | FileShare.Delete`.

On Unix, .NET emulates `FileShare` via `flock`:
- `FileShare.None` → **exclusive** `LOCK_EX`
- a held reader → `LOCK_SH`

`LOCK_EX` is refused while a reader holds `LOCK_SH`, so the **write** throws `IOException: "... used by another process"`. The concurrent reader is the `FileSystemWatcher`-driven `ContentCollection.UpdateArticle`, which reads the file on every change and legitimately overlaps a write. macOS uses `flock` too, so it reproduces locally under load.

There is **no undisposed handle** — the readers dispose correctly. The defect is that the write *demanded exclusivity* against readers the read path is explicitly built to tolerate (content is eventually-consistent and re-ingested on change). `FileShare.None` on the write is simply inconsistent with that contract.

Confirmed empirically (probe table):

| reader share | writer share | result |
|---|---|---|
| `ReadWrite\|Delete` (read path) | `None` (old write) | **FAILED** |
| `ReadWrite\|Delete` | `Read` | OK |
| `ReadWrite\|Delete` | `ReadWrite` | OK |

## Fix (correct sharing semantics, not a mask)

Both write sites now use **single-writer / multi-reader / delete-tolerant** sharing — `FileShare.Read | FileShare.Delete` — matching the read path's intent: a write permits concurrent readers (and deletes, which reads already permit) but does not lock them out. This is not a blanket widening to hide an undisposed handle; it makes the write's sharing contract consistent with the read contract.

## Verification

- Reproduced deterministically: a tight write/read loop over the real provider fails from iteration ~5 (once watcher reads are in flight) **without** the fix; `failures=0` **with** it.
- New pin `ContentCollectionWriteReadRaceTest` drives an explicitly-open reader (`FileShare.ReadWrite|Delete`) concurrently with 300 writes — throws the exact IOException without the fix, passes with it. No sleeps, no watcher-timing dependence.
- `dotnet build -c Release -warnaserror -p:CIRun=true` clean (src + test).
- Full `MeshWeaver.ContentCollections.Test` suite green (17 tests), including the previously-flaking `CollectionNamedArea` test and the #238 ingest pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)