### PR TITLE
fix(mesh): tombstone before fan-out — fully close space-deletion resurrection (follow-up to #347)

### DIFF
--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -857,9 +857,9 @@ public static class MeshDataSourceExtensions
             {
                 case DataChangeKind.Deleted:
                     cache.IsDeleted = true;
-                    // Publish the delete to the mesh-scoped tombstone so a DIFFERENT hub instance
-                    // that later activates for this path drops its resurrecting activation-save.
-                    recentlyDeleted?.MarkDeleted(ownPath);
+                    // The mesh-scoped tombstone is populated synchronously by the delete handler
+                    // (HandleDeleteNodeRequest, before the fan-out that activates this hub) — no
+                    // MarkDeleted needed here; this only tracks the own-node cache flag.
                     return;
 
                 case DataChangeKind.Created:

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -898,6 +898,10 @@ public static class MeshExtensions
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var workspace = hub.ServiceProvider.GetRequiredService<IWorkspace>();
         var meshHub = ResolveMeshHub(hub);
+        // "Delete wins" tombstone — populated SYNCHRONOUSLY here so it is in place before this
+        // delete's response returns, i.e. before any later hub activation can resurrect the row.
+        // (Null on meshes without Graph — the resurrect race is Graph's per-node-hub save path.)
+        var recentlyDeleted = hub.ServiceProvider.GetService<RecentlyDeletedRegistry>();
 
         var deleteRequest = request.Message;
         // 🚨 Capture the caller's identity FROM THE DELIVERY at handler entry.
@@ -1080,6 +1084,19 @@ public static class MeshExtensions
                                         logger.LogDebug(
                                             "[DeleteNode] committing path={Path} count={Count}",
                                             path, collected.ToDelete.Count);
+
+                                        // 🚨 "Delete wins" — tombstone every path BEFORE the fan-out.
+                                        // FanOutDeleteSubtree ACTIVATES each leaf's per-node hub to
+                                        // process its own delete, and that activation's save (the
+                                        // workspace sees the just-loaded node as an "add") is exactly
+                                        // what resurrects the row. Marking here — before any leaf hub
+                                        // is activated — guarantees the resurrecting save's guard
+                                        // already sees the tombstone. Marking only on success (after
+                                        // the delete) lost a check-before-mark race: the activation
+                                        // save checked ~14 ms before the mark and slipped through.
+                                        foreach (var dp in collected.ToDelete)
+                                            recentlyDeleted?.MarkDeleted(dp);
+                                        recentlyDeleted?.MarkDeleted(path);
 
                                         return FanOutDeleteSubtree(
                                                 meshHub, storage, path, collected.ToDelete,

--- a/src/MeshWeaver.Mesh.Contract/Services/RecentlyDeletedRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/RecentlyDeletedRegistry.cs
@@ -1,29 +1,30 @@
 using System.Collections.Concurrent;
 using System.Threading;
 
-namespace MeshWeaver.Graph;
+namespace MeshWeaver.Mesh.Services;
 
 /// <summary>
-/// Mesh-scoped durable tombstone for just-deleted node paths — the "delete wins" guard
-/// against the resurrect-after-delete write race.
+/// Mesh-scoped durable tombstone for just-deleted node paths — the "delete wins" guard against the
+/// resurrect-after-delete write race.
 ///
-/// <para>When a node is deleted, a per-node hub that (re)activates AFTER the delete gets a
-/// STALE own-node snapshot from the routing catalog stream's <c>Replay(1)</c> buffer. Its
-/// <see cref="MeshNodeTypeSource"/> workspace then sees that snapshot as an "add" and queues a
-/// debounced save that RE-PERSISTS (resurrects) the deleted row — confirmed as the intermittent
-/// <c>SpaceDeletionPartitionDropTests</c> bulk flake (a <c>SAVE-WRITE</c> lands on the deleted
-/// path ~200 ms after the delete, and every subsequent read then correctly sees a live row).</para>
+/// <para>When a node is deleted, a per-node hub that (re)activates AFTER the delete gets a STALE
+/// own-node snapshot from the routing catalog stream's <c>Replay(1)</c> buffer. Its per-node
+/// TypeSource workspace then sees that snapshot as an "add" and queues a debounced save that
+/// RE-PERSISTS (resurrects) the deleted row — the intermittent <c>SpaceDeletionPartitionDropTests</c>
+/// flake (a save lands on the deleted path ~200 ms after the delete, so every later read correctly
+/// sees a live row).</para>
 ///
-/// <para>The per-hub <c>MeshNodeTypeSource._recentlyDeleted</c> guard only covers the SAME hub
-/// instance; it can't stop a resurrection driven by a DIFFERENT hub instance that activated after
-/// the delete (which starts with an empty per-hub set). This registry is a single MESH-scoped
-/// instance (registered in <c>AddGraph</c> alongside <c>PartitionRegistry</c>), so the delete
-/// notification caught by the owning hub is visible to any later-activating hub for the same path,
-/// which drops its resurrecting save.</para>
+/// <para>Population is <b>synchronous, at the delete source</b>: <c>HandleDeleteNodeRequest</c> marks
+/// every path it deletes here BEFORE it returns its response — so the tombstone is in place before the
+/// deleting call completes, and therefore before any later hub can activate and resurrect the row.
+/// This is what makes the guard deterministic: an earlier attempt that populated only from the async
+/// per-hub <c>storage.Changes</c> subscriber still raced at cold start (no per-node hub was active yet
+/// to observe the delete). Per-node hubs (via the Graph MeshDataSource guards) then READ this registry
+/// and drop a resurrecting save; a legitimate re-create <see cref="Clear"/>s the tombstone.</para>
 ///
-/// <para>Instance-only state (a <see cref="ConcurrentDictionary{TKey,TValue}"/> — the lifetime is
-/// the mesh singleton's, never <c>static</c>; see NoStaticState.md). TTL-bounded so the map can't
-/// grow unbounded, and cleared on a legitimate re-create so a same-id recreate persists normally.</para>
+/// <para>Instance-only state (a <see cref="ConcurrentDictionary{TKey,TValue}"/> — the lifetime is the
+/// mesh singleton's, never <c>static</c>; see NoStaticState.md). TTL-bounded so the map can't grow
+/// unbounded, and cleared on a legitimate re-create so a same-id recreate persists normally.</para>
 /// </summary>
 public sealed class RecentlyDeletedRegistry
 {
@@ -41,9 +42,9 @@ public sealed class RecentlyDeletedRegistry
     // for tombstones that are never re-checked (IsRecentlyDeleted only prunes the key it looks up).
     private long _lastPruneTicks;
 
-    /// <summary>Records <paramref name="path"/> as just-deleted. Called from the owning hub's
-    /// <c>storage.Changes</c> Deleted handler. Opportunistically prunes expired tombstones (time-gated)
-    /// so a delete that is never re-read afterwards doesn't leak an entry forever.</summary>
+    /// <summary>Records <paramref name="path"/> as just-deleted. Called synchronously from the delete
+    /// handler for every deleted path. Opportunistically prunes expired tombstones (time-gated) so a
+    /// delete that is never re-read afterwards doesn't leak an entry forever.</summary>
     public void MarkDeleted(string? path)
     {
         if (string.IsNullOrEmpty(path))
@@ -64,7 +65,7 @@ public sealed class RecentlyDeletedRegistry
     }
 
     /// <summary>Clears the tombstone for <paramref name="path"/> — a legitimate (re)create so a
-    /// same-id node persists normally. Called from the Created/Updated change handler.</summary>
+    /// same-id node persists normally. Called from the Created change handler.</summary>
     public void Clear(string? path)
     {
         if (!string.IsNullOrEmpty(path))

--- a/test/MeshWeaver.Graph.Test/RecentlyDeletedRegistryTest.cs
+++ b/test/MeshWeaver.Graph.Test/RecentlyDeletedRegistryTest.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Mesh.Services;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;


### PR DESCRIPTION
## Follow-up to #347
#347's mesh-scoped `RecentlyDeletedRegistry` cut the resurrect-after-delete flake ~3× but a **~3% residual** remained — it reddened `main` once (on #347's merge commit; main recovered on the next commit).

## Root cause of the residual (pinned)
Instrumenting the registry's **instance identity** showed the registry *is* shared, but the guard's `CHECK` ran **~14 ms before** the delete's `MARK`:
```
CHECK ... path=Admin/Partition/… hit=False   ← guard checks first
MARK  ... path=Admin/Partition/…             ← delete marks 14ms later
```
`FanOutDeleteSubtree` **activates each leaf's per-node hub to process its own delete**, and *that activation's* save (the workspace sees the just-loaded node as an "add") resurrects the row — racing the mark, which #347 set only via the async `storage.Changes` subscriber / on delete-success (both too late).

## Fix — mark before the fan-out (deterministic)
Populate the tombstone **synchronously in `HandleDeleteNodeRequest`, before `FanOutDeleteSubtree` activates any leaf hub**. `RecentlyDeletedRegistry` moves to `MeshWeaver.Mesh.Contract` (where the delete handler lives) so the mark happens at the delete source. The Graph per-node-hub guards (`MeshNodeTypeSource.UpdateImpl` add-flush + `HandleSaveMeshNode` sampler) still read it and drop the resurrecting save; a re-create clears it.

## Verification
- **120/120** and **96/96** under 8× parallel load (was ~3/96 with *every* prior population strategy).
- Full `MeshWeaver.Hosting.PostgreSql.Test` regression: **516 passed, 0 failed**.
- Release `-warnaserror` (CI flags): clean.
- Instance-identity diagnostics confirmed `MARK` now precedes `CHECK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)