### PR TITLE
fix(persistence): seed node-persistence version across activations, separate from render clock (#325)

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -864,6 +864,29 @@ public static class DataExtensions
     }
 
     /// <summary>
+    /// The version the OWNER mints when it applies a cross-hub MeshNode patch. 🚨 #325: advance
+    /// FORWARD-ONLY from the node's OWN current version, not straight off the per-message hub clock
+    /// (<paramref name="hubVersion"/>). <see cref="IMessageHub.Version"/> resets to 0 on every
+    /// (re)activation, so stamping it verbatim rolls the node's Version BACKWARD after a recycle /
+    /// idle-release / replica restart — mirrors holding the higher pre-recycle version then DROP the
+    /// regressed frame under the sync monotonicity guard (the write-rollback + index-vs-resolution
+    /// split-brain of #325). Flooring at <c>currentVersion + 1</c> keeps it strictly increasing
+    /// across activations WITHOUT touching Hub.Version, so layout-area Fulls (which ride Hub.Version)
+    /// are unaffected — the 2026-06-18 "cannot find pinned doc" wedge cannot recur. Mirrors
+    /// <c>MeshNode.NextVersion</c>; inlined because this assembly cannot reference MeshNode
+    /// (same string-keyed approach used throughout this handler).
+    /// </summary>
+    private static long NextMeshNodeVersion(
+        System.Text.Json.Nodes.JsonObject currentNode, string versionKey, long hubVersion)
+    {
+        long currentVersion = 0;
+        if (currentNode[versionKey] is System.Text.Json.Nodes.JsonValue jv
+            && jv.TryGetValue<long>(out var parsed))
+            currentVersion = parsed;
+        return System.Math.Max(hubVersion, currentVersion + 1);
+    }
+
+    /// <summary>
     /// 🚨 Out-of-order / stale cross-hub patch guard for MeshNode MONOTONIC control fields.
     /// Applied to the parsed patch (against the LIVE node) BEFORE <see cref="MergePatchRecursive"/>.
     ///
@@ -1018,7 +1041,9 @@ public static class DataExtensions
                     if (typeof(T).FullName == "MeshWeaver.Mesh.MeshNode")
                     {
                         var versionKey = jsonOpts.PropertyNamingPolicy?.ConvertName("Version") ?? "Version";
-                        currentNode[versionKey] = version;
+                        // 🚨 #325: advance forward-only from the node's own version (max(hub, cur+1)),
+                        // never straight off the per-activation hub clock — see NextMeshNodeVersion.
+                        currentNode[versionKey] = NextMeshNodeVersion(currentNode, versionKey, version);
                     }
 
                     var mergedJson = currentNode.ToJsonString(jsonOpts);
@@ -1230,7 +1255,8 @@ public static class DataExtensions
                     ApplyMeshNodeMerge(currentNode, patchNode, isMeshNode: true,
                         request.Message, jsonOpts, mergeGuardLogger, hubPath);
                     // The OWNER mints the monotonic Version on apply (same rule as the deferred path).
-                    currentNode[versionKey] = version;
+                    // 🚨 #325: forward-only from the node's own version — see NextMeshNodeVersion.
+                    currentNode[versionKey] = NextMeshNodeVersion(currentNode, versionKey, version);
                     var merged = System.Text.Json.JsonSerializer
                         .Deserialize<T>(currentNode.ToJsonString(jsonOpts), jsonOpts);
                     if (merged is null)

--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeVersioning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeVersioning.md
@@ -91,19 +91,30 @@ message:       M1    M2    M3    M4    M5
 
 ## One Operation, One Version Stamp
 
-When a `MeshNode` is mutated through the framework write path — `MeshNodeStreamHandle.Update`, for both the own-node and remote-node branches — the framework stamps the result:
+When a `MeshNode` is mutated through the framework write path — `MeshNodeStreamHandle.Update`, for both the own-node and remote-node branches — the framework stamps the result via `MeshNode.NextVersion`:
 
 ```csharp
-updated = updated with { Version = _workspace.Hub.Version };
+updated = updated with { Version = MeshNode.NextVersion(_workspace.Hub.Version, current.Version) };
+// NextVersion(hubVersion, currentVersion) => max(hubVersion, currentVersion + 1)
 ```
 
-The lambda you pass to `Update` does **not** set `Version` itself. The framework owns the clock. One operation (one message handler running one `Update`) produces exactly one new `Version` value, equal to the hub clock at that point.
+The lambda you pass to `Update` does **not** set `Version` itself. The framework owns the clock. One operation (one message handler running one `Update`) produces exactly one new `Version` value: the hub clock at that point **or** one above the node's own version, whichever is higher.
 
 This has three practical consequences:
 
-- **A node mutated during message N has `Version == N`.** Two different nodes changed by the same message share that version — they were touched by the same operation.
+- **A node mutated during message N normally has `Version == N`.** While the hub clock leads, `NextVersion` returns it, so two different nodes changed by the same message share that version — they were touched by the same operation.
 - **`Version` is monotonic per node but not contiguous.** A node updated under message 3 and again under message 47 jumps `3 → 47`. Never assert `newVersion == oldVersion + 1`; always assert `newVersion > oldVersion`.
 - **Subscribers rely on monotonicity, not contiguity.** The `UpdateOwn` baseline check and `DistinctUntilChanged(n => n.Version)` both work correctly under non-contiguous version sequences.
+
+## Monotonic Across Activations — the `NextVersion` Floor (#325)
+
+The hub clock (`MessageHub.Version`) resets to **0 on every activation** and is the *same* clock that stamps the owning hub's **layout-area render Fulls**. If a node's `Version` were stamped straight off that clock, a deactivate → reactivate cycle (idle-release, `Recycle`/`DisposeRequest`, or a replica restart) would stamp the node's next write with the fresh *low* clock — rolling its `Version` **backward** below the value it already carried. A caller that re-reads the node (`get`/`UpdateNode`) then sees an OLDER version than the writes it just confirmed — the write-rollback / "v113 read back as v3" of [issue #325](https://github.com/Systemorph/MeshWeaver/issues/325).
+
+`MeshNode.NextVersion` fixes this **without touching the hub clock**: it floors the stamp at `current.Version + 1`. The node loads its persisted `Version` verbatim on activation (`MeshNodeTypeSource.BuildInstanceCollection` leaves it alone — a load is a read), so the floor keeps every post-reactivation write **strictly above** the last persisted version. The node's `Version` is therefore a persistence clock that is monotonic *across* activations, while `Hub.Version` stays the per-activation render clock. The floor is applied at every place the owner mints a node `Version`: the own-write path (`MeshNodeStreamExtensions.UpdateOwn`), the persistence re-stamp (`MeshNodeTypeSource.UpdateImpl`), and the cross-hub merge apply (`DataExtensions.NextMeshNodeVersion`).
+
+> **Why not re-seed `Hub.Version` from the node?** That was tried (`SetInitialVersion(node.Version)`) and reverted: `Hub.Version` also stamps layout Fulls, which advance per *render* and run far ahead of a doc/static node's low `Version`. Re-seeding the shared clock *backward* to the node version on a catalog push made the monotonicity guard drop every later layout Full — the atioz 2026-06-18 "cannot find pinned doc" wedge. The node-version floor keeps the two clocks separate: layout Fulls keep using `Hub.Version` untouched.
+
+> **Frame version stays `Hub.Version`.** The sync-stream *frame* version (what the receive-side monotonicity guard compares) is deliberately left on `Hub.Version` — it is reliably monotonic **within** an activation (the owner `++`s it per message), whereas the node's content `Version` is *not* present on every emitted frame (a partial cross-hub patch carries no `Version` field, so its reduced value reads `0`). Tying the frame version to the content `Version` therefore makes it flap `7 → 0/incoming → 11` and the guard drops legitimate mid-stream frames — it broke the activity/export relay. The remaining cross-**silo** mirror-drop after a recycle (the "index vs node-resolution split-brain" symptom, observable only on a multi-replica portal) is a separate mirror-side concern, tracked on #325.
 
 ## Every Change Is Stamped — Including Updates — and Only by the Owner
 

--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -217,11 +217,15 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
         // content change. The owner re-stamps Version on every update (below), so without
         // this guard each re-fire of the workspace pipeline would look like a fresh change
         // (a new version per dispatch) and spin an infinite re-stamp loop.
+        // Pair each updated node with the version it PREVIOUSLY carried (_lastSaved) so the
+        // re-stamp below can advance forward-only from the node's own version (#325) — a fresh
+        // Hub.Version alone regresses it after a recycle.
         var updates = instances.Instances
             .Where(x => _lastSaved.Instances.TryGetValue(x.Key, out var existing)
                         && existing is MeshNode ex && x.Value is MeshNode nv
                         && !ex.Equals(nv with { Version = ex.Version }))
-            .Select(x => (MeshNode)x.Value)
+            .Select(x => (Node: (MeshNode)x.Value,
+                          PreviousVersion: ((MeshNode)_lastSaved.Instances[x.Key]).Version))
             .ToArray();
 
         var deletes = _lastSaved.Instances
@@ -280,8 +284,18 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
         // then saves the bumped version.
         if (updates.Length > 0)
         {
+            // 🚨 #325: advance forward-only from each node's OWN previous version, never straight
+            // off hubVersion. hubVersion resets to 0 on reactivation, so a plain `Version =
+            // hubVersion` re-stamp regresses the node's version after a recycle — the authoritative
+            // `get`/read then returns a version BELOW the writes it just confirmed (the write-
+            // rollback / "v113 read back as v3" of #325). MeshNode.NextVersion keeps it strictly
+            // increasing across activations WITHOUT touching Hub.Version (so layout Fulls, which
+            // ride Hub.Version, are unaffected — the 2026-06-18 wedge cannot recur).
             var stampedUpdates = updates
-                .Select(n => n with { Version = hubVersion })
+                .Select(u => u.Node with
+                {
+                    Version = MeshNode.NextVersion(hubVersion, u.PreviousVersion)
+                })
                 .ToArray();
             instances = instances with
             {

--- a/src/MeshWeaver.Mesh.Contract/MeshNode.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNode.cs
@@ -208,11 +208,34 @@ public record MeshNode([property: Key] string Id, [property: Editable(false)] st
     public string? LastModifiedBy { get; init; }
 
     /// <summary>
-    /// The hub version when this node was last saved.
-    /// Used to restore hub version on restart.
+    /// The node's persistence clock — a version that increases <b>monotonically across
+    /// activations</b> and identifies the last operation that mutated this node.
+    /// <para>🚨 This is deliberately NOT the same clock as <see cref="IMessageHub.Version"/>.
+    /// The hub clock resets to 0 on every (re)activation and also stamps the owning hub's
+    /// LAYOUT-render Fulls; stamping <see cref="Version"/> straight from the fresh hub clock
+    /// made it REGRESS after a deactivate → reactivate cycle (idle-release / recycle / replica
+    /// restart) — the write-rollback / "v113 read back as v3" version regression of issue #325.
+    /// The node's Version is advanced forward-only from its OWN persisted value via
+    /// <see cref="NextVersion(long, long)"/>, so it survives a recycle without regressing while
+    /// the hub clock (and thus layout Fulls) is never touched. See
+    /// <c>Doc/Architecture/MeshNodeVersioning.md</c>.</para>
     /// </summary>
     [Editable(false)]
     public long Version { get; init; }
+
+    /// <summary>
+    /// Computes the next persistence <see cref="Version"/> for a write to a node that currently
+    /// carries <paramref name="currentVersion"/>, given the owning hub's per-message clock
+    /// <paramref name="hubVersion"/>. The result is <c>max(hubVersion, currentVersion + 1)</c>:
+    /// it tracks the hub clock while that clock leads (preserving the "1 op = 1 version stamp"
+    /// model within an activation), but never falls to or below the version the node already
+    /// carries. After a recycle the hub clock has reset toward 0 while the node loaded its
+    /// persisted <paramref name="currentVersion"/> verbatim, so the <c>+ 1</c> floor keeps the
+    /// node's Version strictly increasing across activations — the fix for issue #325 that does
+    /// NOT re-seed the shared hub clock (which would drop layout Fulls, the 2026-06-18 wedge).
+    /// </summary>
+    public static long NextVersion(long hubVersion, long currentVersion)
+        => Math.Max(hubVersion, currentVersion + 1);
 
     /// <summary>
     /// The lifecycle state of this node.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -589,7 +589,14 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     // by the OWNING hub here (this is an own write on the owner).
                     // DateTime/LastModified is NOT a cross-machine clock, so it must
                     // never drive reconciliation; the owner's monotonic Version does.
-                    updated = updated with { Version = _workspace.Hub.Version };
+                    // 🚨 #325: advance forward-only from the node's OWN version, not straight
+                    // off Hub.Version (which resets to 0 on every reactivation and would stamp a
+                    // LOWER version after a recycle → rollback + split-brain). See
+                    // MeshNode.NextVersion / Doc/Architecture/MeshNodeVersioning.md.
+                    updated = updated with
+                    {
+                        Version = MeshNode.NextVersion(_workspace.Hub.Version, current.Version)
+                    };
                     var newStore = store.Update(nameof(MeshNode), c => c.Update(updated.Id, updated));
                     return dsStream.ApplyChanges(new EntityStoreAndUpdates(newStore,
                         [new EntityUpdate(nameof(MeshNode), updated.Id, updated) { OldValue = current }],

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeVersionRegressionOnRecycleTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeVersionRegressionOnRecycleTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
@@ -11,39 +12,38 @@ using Xunit;
 namespace MeshWeaver.Hosting.Monolith.Test;
 
 /// <summary>
-/// Deterministic repro for issue #325 — a MeshNode's <see cref="MeshNode.Version"/>
-/// regresses (rolls BACKWARD) after the owning per-node hub is recycled / reactivated
-/// (idle-release, <c>Recycle</c>/<see cref="DisposeRequest"/>, or a replica restart).
+/// Deterministic proof for the fix of issue #325 — a MeshNode's <see cref="MeshNode.Version"/>
+/// must NOT regress (roll BACKWARD) when the owning per-node hub's <see cref="IMessageHub.Version"/>
+/// clock is low relative to the version the node already carries. That "low hub clock + high node
+/// version" state is exactly what a recycle / idle-release / replica restart produces: the hub
+/// clock is "incremented once per message processed" and starts at <b>0 on every activation</b>,
+/// while the node reloads its persisted (high) Version verbatim.
 ///
-/// <para><b>Root cause (verified here).</b> Every owner-side write stamps the node's
-/// Version from the owning hub's per-activation monotonic message counter
-/// (<c>_workspace.Hub.Version</c> — <c>MeshNodeStreamExtensions.cs:592</c>). The SAME
-/// clock stamps every sync-stream frame the owner originates — the init/base Full, value
-/// updates, and layout renders — via <c>SynchronizationStream.OwnerVersion()</c>
-/// (<c>Owner.Equals(Host.Address) ? Hub.Version : …</c>). <see cref="IMessageHub.Version"/>
-/// is "incremented once per message processed" and starts at 0 on EVERY activation; it is
-/// NEVER seeded from the persisted node's Version (the <c>SetInitialVersion(node.Version)</c>
-/// seed was removed from <c>MeshNodeTypeSource</c> because it re-stamped the clock BACKWARD
-/// on catalog pushes and dropped live layout Fulls). So after a deactivate → reactivate
-/// cycle the fresh hub's LOW counter sits BELOW the version the node already carries, and
-/// the node's next write stamps a Version below the old one → the counter rolls back
-/// (the "v113 read back as v3" symptom).</para>
+/// <para><b>The #325 trigger, reproduced deterministically.</b> Rather than race a recycle against
+/// the debounced persistence sampler (a bursty write followed by an immediate deactivate can drop
+/// unflushed writes AND races the data-source reload — a SEPARATE effect), this test DURABLY seeds
+/// the node at a high Version (1000) via <c>CreateNode</c> (which preserves a caller-supplied
+/// Version &gt; 0). The owner then activates with a fresh, LOW hub clock — the identical
+/// post-recycle state — with no reload race to confound the measurement.</para>
 ///
-/// <para><b>Downstream (why the writes "vanish" / a write "hangs").</b> A mirror that
-/// cached the higher pre-recycle version applies the sync monotonicity guard
-/// (<c>SynchronizationStream</c> drops an incoming frame whose <c>Version &lt; Current.Version</c>).
-/// It therefore DROPS the regressed post-recycle Full — staying stuck on the stale snapshot
-/// and never confirming the write (the "index/resolution split-brain", "no initial state",
-/// and "first UpdateNode hung indefinitely" symptoms). This test pins the trigger (the clock
-/// reset below the live node version) directly, without depending on that downstream hang.</para>
+/// <para><b>The fix (what this proves).</b> The node's persistence version is decoupled from the
+/// per-activation hub clock: every place the owner mints a node Version advances it forward-only
+/// from the node's OWN version via <see cref="MeshNode.NextVersion(long, long)"/>
+/// (<c>max(Hub.Version, current.Version + 1)</c>) — the own-write path (UpdateOwn), the persistence
+/// re-stamp (MeshNodeTypeSource.UpdateImpl), and the cross-hub merge apply
+/// (DataExtensions.NextMeshNodeVersion). So a write made while the hub clock sits far below the node
+/// version still lands a Version strictly ABOVE it — the authoritative <c>get</c> never regresses.
+/// Crucially the fix does NOT touch <c>Hub.Version</c> (re-seeding that shared clock backward is
+/// what dropped live layout Fulls, the atioz 2026-06-18 "cannot find pinned doc" wedge), and it
+/// does NOT retie the sync-stream FRAME version to the content Version (that version is absent on a
+/// partial cross-hub patch frame, so the frame would flap and drop legitimate mid-stream updates —
+/// it broke the activity/export relay). The residual cross-SILO mirror-drop after a recycle (the
+/// "index vs node-resolution split-brain", observable only on a multi-replica portal) is a separate
+/// mirror-side concern tracked on #325.</para>
 ///
-/// <para><b>Status: pins the cause; does NOT fix it.</b> The fix is to seed the owner hub's
-/// Version clock forward-only on activation (a guarded <c>SetInitialVersion</c> that never
-/// regresses the clock and never reintroduces the catalog-push Full-drop) — a change to a
-/// pervasive, load-bearing clock, out of scope for this repro. The final assertion therefore
-/// documents the CURRENT (defective) behaviour so the test is green until the fix lands; when
-/// the root cause is fixed, FLIP it to <c>clockAfter &gt;= nodeVersionBefore</c> and this test
-/// becomes the fix's proof.</para>
+/// <para>Before the fix the low hub clock stamped a Version BELOW the live node version (the repro
+/// measured 64 → 2, "v113 read back as v3"). This test was GREEN while it asserted that defect; it
+/// now asserts <c>afterVersion &gt; nodeVersionBefore</c> — the fix's proof.</para>
 /// </summary>
 public class NodeVersionRegressionOnRecycleTest(ITestOutputHelper output)
     : MonolithMeshTestBase(output)
@@ -52,71 +52,62 @@ public class NodeVersionRegressionOnRecycleTest(ITestOutputHelper output)
     protected override bool ShareMeshAcrossTests => true;
 
     [Fact(Timeout = 60000)]
-    public async Task OwnerVersionClock_ResetsBelowLiveNodeVersion_OnRecycle_Pins325()
+    public async Task NodeVersion_DoesNotRegress_WhenHubClockIsBelowNodeVersion_Proves325Fix()
     {
         var path = $"{TestPartition}/version-regress-target";
+        const long seededVersion = 1000L;
 
-        // Arrange — create the node. Markdown activates without a Roslyn compile.
+        // Arrange — DURABLY persist the node at a HIGH version (1000). CreateNode preserves a
+        // caller-supplied Version > 0 (HandleCreateNodeRequest, pinned by MeshNodeVersionSyncTest),
+        // so 1000 is persisted verbatim and the owner loads it verbatim on activation. This is the
+        // faithful post-recycle state: high persisted node version, fresh low hub clock.
         await NodeFactory.CreateNode(
                 new MeshNode("version-regress-target", TestPartition)
-                { Name = "v0", NodeType = "Markdown" })
+                { Name = "seed", NodeType = "Markdown", Version = seededVersion })
             .Should().Within(30.Seconds()).Emit();
 
-        // Resolve the owning per-node hub address (the hub that stamps this node's writes).
+        // Confirm the owner loaded the seeded high version (authoritative owner round-trip).
+        var before = await ReadNode(path).Should().Within(30.Seconds())
+            .Match(n => n is { Version: seededVersion });
+        var nodeVersionBefore = before!.Version;
+
+        // The #325 TRIGGER is present: the owning hub's per-activation clock sits FAR BELOW the
+        // node version. The old code stamped the node's next write straight off this low clock →
+        // the version rolled backward. (Resolve the owner and read its live Hub.Version to prove
+        // the gap; the fix must survive it WITHOUT re-seeding this shared clock.)
         var resolution = await PathResolver.ResolvePath(path).Should().Within(30.Seconds()).Emit();
         resolution.Should().NotBeNull($"path '{path}' should resolve to an owning hub");
         var address = new Address(resolution!.Prefix.ToString()!);
-
-        // Drive the owning hub's Version clock UP with a burst of distinct writes. Each
-        // write is a message on the owner → Hub.Version climbs and is stamped onto
-        // node.Version. Distinct names guarantee every write applies (the no-op guard
-        // drops value-equal updates).
-        for (var i = 1; i <= 30; i++)
-        {
-            var name = $"v{i}";
-            await NodeFactory.UpdateNode(
-                    new MeshNode("version-regress-target", TestPartition)
-                    { Name = name, NodeType = "Markdown" })
-                .Should().Within(30.Seconds()).Match(n => n.Name == name);
-        }
-
-        // The authoritative version the node now carries, and the owner clock behind it.
-        var before = await ReadNode(path).Should().Within(30.Seconds())
-            .Match(n => n is { Name: "v30" });
-        var nodeVersionBefore = before!.Version;
-        var ownerBefore = Mesh.GetHostedHub(address, HostedHubCreation.Never);
-        ownerBefore.Should().NotBeNull("the owner hub must be live after the write burst");
-        var clockBefore = ownerBefore!.Version;
+        var owner = Mesh.GetHostedHub(address, HostedHubCreation.Never);
+        owner.Should().NotBeNull("the owner hub must be live after the seeded read");
+        var hubClock = owner!.Version;
         Output.WriteLine(
-            $"[#325] nodeVersionBefore={nodeVersionBefore}, ownerClockBefore={clockBefore}");
-        nodeVersionBefore.Should().BeGreaterThan(0,
-            "the write burst must have advanced the node Version off the owner clock");
+            $"[#325] nodeVersionBefore(seeded)={nodeVersionBefore}, ownerHubClock={hubClock}");
+        hubClock.Should().BeLessThan(nodeVersionBefore,
+            $"the owner hub clock ({hubClock}) sits BELOW the live node Version ({nodeVersionBefore}) "
+            + "— the exact #325 trigger the fix must survive WITHOUT re-seeding Hub.Version.");
 
-        // Act — recycle the owner hub (DisposeRequest). Its next activation resets
-        // Hub.Version to 0.
-        Mesh.Post(new DisposeRequest(), o => o.WithTarget(address));
+        // Act — write through the canonical mesh-node stream (the same surface the GUI/agents use).
+        var client = GetClient(c => c.AddData());
+        var stream = client.GetWorkspace().GetMeshNodeStream(path);
+        stream.Update(n => n with { Name = "after" })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"[#325] write error: {ex.Message}"));
 
-        // Reactively wait for the reset: keep pinging to force reactivation, then read the
-        // (re)activated owner's Version. The pre-dispose hub still reports its high clock
-        // (filtered out); the reset is proven the moment the reactivated owner reports a
-        // clock strictly BELOW clockBefore. No fixed delay — we wait on the actual condition.
-        var clockAfter = await Observable.Interval(TimeSpan.FromMilliseconds(200)).StartWith(0L)
-            .SelectMany(_ => Mesh.Observe(new PingRequest(), o => o.WithTarget(address))
-                .Select(_ => Mesh.GetHostedHub(address, HostedHubCreation.Never)?.Version ?? -1L)
-                .Catch((Exception _) => Observable.Return(-1L)))
-            .Should().Within(30.Seconds()).Match(v => v >= 0 && v < clockBefore);
-        Output.WriteLine($"[#325] ownerClockAfter(reactivated)={clockAfter}");
+        // Assert — THE FIX. Read the authoritative post-write node from the owner. Its Version must
+        // have advanced FORWARD, above the pre-write version — never rolled back to the low hub
+        // clock (MeshNode.NextVersion floors it at current.Version + 1). Before the fix it stamped
+        // ~hubClock, so the authoritative get read a version BELOW the confirmed writes ("v113 read
+        // back as v3").
+        var after = await Observable.Interval(TimeSpan.FromMilliseconds(200)).StartWith(0L)
+            .SelectMany(_ => ReadNode(path).Catch((Exception _) => Observable.Return<MeshNode?>(null)))
+            .Should().Within(30.Seconds()).Match(n => n is { Name: "after" });
+        Output.WriteLine(
+            $"[#325] nodeVersionBefore={nodeVersionBefore}, nodeVersionAfterWrite={after!.Version}");
 
-        // Assert — PIN #325. The reactivated owner's Version clock (the SAME clock that
-        // stamps the node's next write, and every sync Full) sits BELOW the version the
-        // node already carries. So the node's very next write rolls the version backward,
-        // and any mirror that cached the higher version drops the regressed frame. The
-        // CORRECT post-fix invariant is clockAfter >= nodeVersionBefore (seed the clock
-        // forward-only on activation).
-        clockAfter.Should().BeLessThan(nodeVersionBefore,
-            $"#325 repro: the reactivated owner clock ({clockAfter}) is below the live node "
-            + $"Version ({nodeVersionBefore}) — the next write rolls the Version backward. "
-            + "This documents the defect; the correct post-fix invariant is "
-            + "clockAfter >= nodeVersionBefore.");
+        after.Version.Should().BeGreaterThan(nodeVersionBefore,
+            $"#325 FIX: the write's node Version ({after.Version}) must stay ABOVE the pre-write "
+            + $"Version ({nodeVersionBefore}) even though the owner hub clock is only {hubClock} — "
+            + "the node's persistence version is monotonic (MeshNode.NextVersion), decoupled from "
+            + "the per-activation Hub.Version clock that resets on every reactivation.");
     }
 }


### PR DESCRIPTION
## Summary

Fixes the **node write-rollback / version regression** of #325: on a deployed portal, committed writes rolled back and the `MeshNode.Version` counter regressed (the "v113 read back as v3" symptom) after the owning per-node hub was recycled / idle-released / restarted.

**Root cause.** Every write stamped `MeshNode.Version` straight from the owning hub's per-activation counter `Hub.Version`, which starts at **0 on every activation** (`MessageHub.cs`). After a deactivate → reactivate cycle the fresh low clock stamped a `Version` **below** the value the node already carried, so an authoritative `get` / `UpdateNode` read an OLDER version than the writes it had just confirmed. Deterministic repro landed earlier in #341.

## The fix — separate the node-persistence clock from the render clock

`MeshNode.NextVersion(hubVersion, currentVersion) = max(hubVersion, currentVersion + 1)` floors every stamp **one above the node's OWN version**, which loads from persistence verbatim across a recycle — so the version is monotonic **across** activations **without ever touching `Hub.Version`**. Applied at every place the owner mints a node `Version`:

- own-write path — `MeshNodeStreamExtensions.UpdateOwn`
- persistence re-stamp — `MeshNodeTypeSource.UpdateImpl` (updates branch)
- cross-hub merge apply — `DataExtensions.NextMeshNodeVersion` (both the in-turn and deferred `PatchDataRequest` paths — this is the dominant path GUI/agents/tests use)

### Why NOT re-seed `Hub.Version` (the delicate part)
`Hub.Version` also stamps the hub's **layout-area render Fulls**, which run far ahead of a doc/static node's low version. Re-seeding the shared clock backward dropped live layout Fulls — the atioz **2026-06-18 "cannot find pinned doc" wedge** (`e25f466e1`). The node-version floor keeps the two clocks separate: `Hub.Version` and layout Fulls are untouched, so that wedge cannot recur.

### Why the sync-stream FRAME version stays on `Hub.Version`
`Hub.Version` is reliably monotonic **within** an activation, whereas the content `Version` is **absent on a partial cross-hub patch frame** (the reduced value reads `0`). An earlier attempt to tie the frame version to the content `Version` made it flap (`7 → incoming → 11`), so the receive-side monotonicity guard dropped legitimate mid-stream frames — it hung the activity/export relay (`ExportDocumentScriptRelayTest`). That approach is **not** in this PR.

### Residual (flagged for a human decision)
The **cross-silo mirror-drop** after a recycle (the "index vs node-resolution split-brain" symptom, observable only on a **multi-replica** portal) is left as a separate **mirror-side** concern on #325 — it needs a mirror-reset-on-recycle design and a multi-silo repro, and the frame-version approach that would have addressed it is unsafe (see above). This PR fixes the authoritative version regression (the reproducible core); it does not claim the multi-silo split-brain.

## Proof / testing
- `NodeVersionRegressionOnRecycleTest` **flipped** from asserting the defect to asserting the fix (post-recycle write's `Version` stays above the pre-recycle version). Deterministic (durable high-version seed instead of racing the debounced sampler).
- Green locally: full **Hosting.Monolith** suite (310 passed, 0 failed), `StreamVersionMonotonicity`, `VersionHistory`, `MeshNodeVersionSync`, `ChangeFeedVersionGate`, `ResubscribeOnOwnerDispose`, `DataChangeStreamUpdate` + `InlineEditing` (layout-Full guard — the 2026-06-18 wedge symptom), `DocumentationLinkIntegrity`.
- `dotnet build -c Release -warnaserror -p:CIRun=true` clean for `MeshWeaver.Mesh.Contract`, `MeshWeaver.Data`, `MeshWeaver.Graph`.

**Do not merge without a green CI run.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)