### PR TITLE
fix(course): exclude GitHubSyncConfig from the course-nav query

### DIFF
--- a/src/MeshWeaver.Graph/Education/EducationLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Education/EducationLayoutAreas.cs
@@ -274,8 +274,13 @@ public static class EducationLayoutAreas
 
         // Module + its main descendants in one live query; BuildCourseNav renders the module as the group
         // header and its direct children as links (reactive — the nav follows adds/renames).
+        // GitHubSyncConfig (`{space}/_GitSync`) is a non-satellite internal config node — it's a real main
+        // node (MainNode == Path), so `is:main` correctly keeps it; exclude it by type here so it never
+        // appears as a learner-facing page in the rail. (See SatelliteEntityPatterns.md — the reader
+        // filters internal main-nodes; we do NOT forge a satellite MainNode on the node itself.)
         return meshService
-            .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{moduleRoot} scope:subtree is:main"))
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"path:{moduleRoot} scope:subtree is:main -nodeType:GitHubSyncConfig"))
             .Select(change => BuildCourseNav(moduleRoot, currentPath, change.Items));
     }
 


### PR DESCRIPTION
The course side-nav queried `path:{module} scope:subtree is:main` and leaned on an in-memory `_`-prefix filter to hide internal nodes — which wasn't reliably dropping `_GitSync` on the live render.

`_GitSync` (`GitHubSyncConfig`) is a **non-satellite main node** (`MainNode == Path`), so `is:main` correctly keeps it. The right fix is at the **reader**: exclude it **in the query** (`-nodeType:GitHubSyncConfig`) so the query provider drops it — independent of any post-query in-memory filter (and robust to assembly staleness). Per the `MainNode` invariant (#351 / SatelliteEntityPatterns.md), we filter internal main-nodes on the reader, never forge a satellite `MainNode` on the node.

Build: `MeshWeaver.Graph -c Release -warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)