### PR TITLE
fix(react-native): correct native layout — toolbar wrap, title clipping, header dead space

### DIFF
--- a/clients/react-native/src/nativeHtml.native.tsx
+++ b/clients/react-native/src/nativeHtml.native.tsx
@@ -2,22 +2,31 @@
 // bodies, tables, links, styled spans) into native components. Bundled ONLY on a device: metro resolves
 // this .native file, while web/tsc/vitest use nativeHtml.tsx (no render-html dep). Same split as nativeFetch.
 import RenderHtml from "react-native-render-html";
-import { useWindowDimensions, Platform, StyleSheet } from "react-native";
+import { View, useWindowDimensions, Platform, StyleSheet } from "react-native";
 
 export function NativeHtml({ html }: { html: string }) {
   const { width } = useWindowDimensions();
+  // Strip the inline style off HEADINGS and DIVS (keep <span> colors):
+  //  • headings — `<h1 style="font-size:2rem; line-height:1.15; letter-spacing:-0.02em">` makes render-html
+  //    lay out a too-tight bold run that clips the first glyph (the "D" in "Doc").
+  //  • divs — the doc header is a web "card" (`<div style="background:linear-gradient; padding:40px;
+  //    margin:30px; min-height…">`) whose gradient/icon don't render natively but whose padding/height
+  //    still reserve a big empty band after the title. Dropping div styles collapses that dead space.
+  const cleaned = (html || "").replace(/(<(?:h[1-6]|div)\b[^>]*?)\sstyle="[^"]*"/gi, "$1");
   return (
-    <RenderHtml
-      source={{ html: html || "" }}
-      contentWidth={Math.max(240, (width || 360) - 88)}
-      baseStyle={BASE}
-      tagsStyles={TAGS}
-      systemFonts={SYSTEM_FONTS}
-      defaultTextProps={{ selectable: true }}
-      // RN's Image can't load SVGs or the doc's relative/about: URLs (that crashed the render). Drop
-      // images + inline SVG so the text/tables/links render; native icon rendering is a follow-up.
-      ignoredDomTags={IGNORED_TAGS}
-    />
+    <View style={{ paddingLeft: 2 }}>
+      <RenderHtml
+        source={{ html: cleaned }}
+        contentWidth={Math.max(240, (width || 360) - 96)}
+        baseStyle={BASE}
+        tagsStyles={TAGS}
+        systemFonts={SYSTEM_FONTS}
+        defaultTextProps={{ selectable: true }}
+        // RN's Image can't load SVGs or the doc's relative/about: URLs (that crashed the render), and the
+        // NodeType icons 404 on the headless mesh sidecar — drop images/SVG so text/tables/links render.
+        ignoredDomTags={IGNORED_TAGS}
+      />
+    </View>
   );
 }
 

--- a/clients/react-native/src/nativeHtml.native.tsx
+++ b/clients/react-native/src/nativeHtml.native.tsx
@@ -1,18 +1,20 @@
 // React Native device HTML rendering — react-native-render-html turns server-prerendered HTML (doc
 // bodies, tables, links, styled spans) into native components. Bundled ONLY on a device: metro resolves
 // this .native file, while web/tsc/vitest use nativeHtml.tsx (no render-html dep). Same split as nativeFetch.
+import { useMemo } from "react";
 import RenderHtml from "react-native-render-html";
 import { View, useWindowDimensions, Platform, StyleSheet } from "react-native";
 
 export function NativeHtml({ html }: { html: string }) {
   const { width } = useWindowDimensions();
-  // Strip the inline style off HEADINGS and DIVS (keep <span> colors):
+  // Strip the inline style off HEADINGS and DIVS (keep <span> colors). Memoized on `html` — NativeHtml
+  // re-renders on width changes/parent renders, and this shouldn't re-run the regex each time.
   //  • headings — `<h1 style="font-size:2rem; line-height:1.15; letter-spacing:-0.02em">` makes render-html
   //    lay out a too-tight bold run that clips the first glyph (the "D" in "Doc").
   //  • divs — the doc header is a web "card" (`<div style="background:linear-gradient; padding:40px;
   //    margin:30px; min-height…">`) whose gradient/icon don't render natively but whose padding/height
   //    still reserve a big empty band after the title. Dropping div styles collapses that dead space.
-  const cleaned = (html || "").replace(/(<(?:h[1-6]|div)\b[^>]*?)\sstyle="[^"]*"/gi, "$1");
+  const cleaned = useMemo(() => (html || "").replace(/(<(?:h[1-6]|div)\b[^>]*?)\sstyle="[^"]*"/gi, "$1"), [html]);
   return (
     <View style={{ paddingLeft: 2 }}>
       <RenderHtml

--- a/clients/react-native/src/rnPack.tsx
+++ b/clients/react-native/src/rnPack.tsx
@@ -85,11 +85,24 @@ function Children({ control }: { control: any }) {
 }
 
 // ── skins (layout) ──────────────────────────────────────────────────────────
-const stack: SkinComponent = ({ skin, control }) => (
-  <View style={{ flexDirection: s(skin.orientation).toLowerCase() === "horizontal" ? "row" : "column", gap: (skin.verticalGap ?? skin.horizontalGap ?? 8) as number }}>
-    <Children control={control} />
-  </View>
-);
+const stack: SkinComponent = ({ skin, control }) => {
+  const horizontal = s(skin.orientation).toLowerCase() === "horizontal";
+  return (
+    <View
+      style={{
+        flexDirection: horizontal ? "row" : "column",
+        // Row: WRAP (a toolbar of node actions overflows a phone otherwise) and size children to their
+        // content height (default `stretch` blew buttons up to fill the row). Column: keep `stretch` so
+        // children fill the width (cards, text, the doc body).
+        flexWrap: horizontal ? "wrap" : "nowrap",
+        alignItems: horizontal ? "flex-start" : "stretch",
+        gap: (skin.verticalGap ?? skin.horizontalGap ?? 8) as number,
+      }}
+    >
+      <Children control={control} />
+    </View>
+  );
+};
 
 const card: SkinComponent = ({ control }) => (
   <View style={styles.card}>


### PR DESCRIPTION
Follow-up to #329 — corrects the native layout issues from the on-device screenshots.

- **Toolbar overflow / giant buttons** → the `stack` skin now **wraps** row stacks and top-aligns their children. Default `alignItems: stretch` had blown the node-action toolbar (Edit/Copy/Move/Delete) up to fill the row height, and without wrap it ran off the right edge. Column stacks keep `stretch` (fill width).
- **Clipped title** ("Đoc") → strip the inline style off headings. The doc's `<h1 style="font-size:2rem; line-height:1.15; letter-spacing:-0.02em">` made react-native-render-html lay out a too-tight bold run that clipped the first glyph; our clean h1/h2/h3 tagStyles render it fully.
- **Dead space after the title** → strip `<div>` inline styles (kept `<span>` colors). The doc header is a web "card" (`background:linear-gradient; padding:40px; margin:30px`) whose gradient/icon don't render natively but whose padding/height reserved a big empty band; dropping the div styling collapses it so content flows.

Verified live on the iOS simulator (Doc + Doc/Architecture). tsc clean, **55 vitest**, **5/5 web e2e**.

Note: the header NodeType icons (`/static/NodeTypeIcons/*.svg`) 404 on the headless LocalMesh sidecar and aren't in the repo (the full Blazor portal serves them) — serving them from LocalMesh + rendering via react-native-svg is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)