### PR TITLE
feat(react-native): render NodeType icon SVGs (LocalMesh /static route + SvgUri)

### DIFF
--- a/clients/react-native/package.json
+++ b/clients/react-native/package.json
@@ -28,6 +28,7 @@
     "react-native": "0.76.5",
     "react-native-fetch-api": "^3.0.0",
     "react-native-render-html": "^6.3.4",
+    "react-native-svg": "15.8.0",
     "react-native-web": "~0.19.13",
     "text-encoding": "^0.7.0",
     "web-streams-polyfill": "^4.3.0"

--- a/clients/react-native/src/nativeHtml.native.tsx
+++ b/clients/react-native/src/nativeHtml.native.tsx
@@ -3,7 +3,9 @@
 // this .native file, while web/tsc/vitest use nativeHtml.tsx (no render-html dep). Same split as nativeFetch.
 import { useMemo } from "react";
 import RenderHtml from "react-native-render-html";
-import { View, useWindowDimensions, Platform, StyleSheet } from "react-native";
+import { SvgUri } from "react-native-svg";
+import { View, Image, useWindowDimensions, Platform, StyleSheet } from "react-native";
+import { currentInstance } from "./connection";
 
 export function NativeHtml({ html }: { html: string }) {
   const { width } = useWindowDimensions();
@@ -24,15 +26,44 @@ export function NativeHtml({ html }: { html: string }) {
         tagsStyles={TAGS}
         systemFonts={SYSTEM_FONTS}
         defaultTextProps={{ selectable: true }}
-        // RN's Image can't load SVGs or the doc's relative/about: URLs (that crashed the render), and the
-        // NodeType icons 404 on the headless mesh sidecar — drop images/SVG so text/tables/links render.
+        renderers={RENDERERS}
+        // Inline <svg>/<picture>/<source> aren't handled; <img> is (see RENDERERS.img).
         ignoredDomTags={IGNORED_TAGS}
       />
     </View>
   );
 }
 
-const IGNORED_TAGS = ["img", "svg", "picture", "source"];
+// Resolve a relative asset URL (e.g. "/static/NodeTypeIcons/box.svg") against the connected mesh so the
+// device can fetch it; the local monolith (Memex.LocalMesh) serves /static/{collection}/{file}.
+function resolveUrl(src: string): string {
+  if (!src || /^https?:\/\//i.test(src) || src.startsWith("data:")) return src;
+  const base = (currentInstance().url || "").replace(/\/+$/, "");
+  return base ? `${base}/${src.replace(/^\/+/, "")}` : src;
+}
+
+function px(tnode: any, attr: string, prop: string): number | undefined {
+  const a = Number(tnode?.attributes?.[attr]);
+  if (Number.isFinite(a) && a > 0) return a;
+  const m = String(tnode?.attributes?.style ?? "").match(new RegExp(`${prop}\\s*:\\s*(\\d+(?:\\.\\d+)?)\\s*px`, "i"));
+  return m ? Number(m[1]) : undefined;
+}
+
+// Custom <img>: RN's Image can't decode SVG, and relative/`about:` URLs crash the loader. Resolve the URL
+// against the mesh, render SVGs via react-native-svg (SvgUri), raster via Image; skip anything unresolvable.
+const RENDERERS = {
+  img: ({ tnode }: any) => {
+    const url = resolveUrl(String(tnode?.attributes?.src ?? ""));
+    if (!/^https?:\/\//i.test(url)) return null;
+    const w = px(tnode, "width", "width") ?? 40;
+    const h = px(tnode, "height", "height") ?? w;
+    return /\.svg(\?|$)/i.test(url)
+      ? <SvgUri uri={url} width={w} height={h} />
+      : <Image source={{ uri: url }} style={{ width: w, height: h }} resizeMode="contain" />;
+  },
+};
+
+const IGNORED_TAGS = ["svg", "picture", "source"];
 const SYSTEM_FONTS = Platform.OS === "ios" ? ["System", "Menlo"] : ["sans-serif", "monospace"];
 const BASE = { color: "#242424", fontSize: 15, lineHeight: 22 } as any;
 const TAGS = {

--- a/clients/react-native/src/polyfills.d.ts
+++ b/clients/react-native/src/polyfills.d.ts
@@ -15,3 +15,8 @@ declare module "react-native-render-html" {
   const RenderHtml: any;
   export default RenderHtml;
 }
+// Native-only SVG renderer (nativeHtml.native.tsx renders <img src="*.svg"> via SvgUri).
+declare module "react-native-svg" {
+  export const SvgUri: any;
+  export const SvgXml: any;
+}

--- a/memex/Memex.LocalMesh/Program.cs
+++ b/memex/Memex.LocalMesh/Program.cs
@@ -58,8 +58,10 @@ app.MapGet("/static/{**path}", async (HttpContext ctx, string path) =>
 {
     var slash = path.IndexOf('/');
     if (slash <= 0) return Results.NotFound();
-    var collection = Uri.UnescapeDataString(path[..slash]);   // e.g. "NodeTypeIcons"
-    var filePath = path[(slash + 1)..];                        // e.g. "box.svg"
+    // Match BlazorHostingExtensions: collection names encode '/' as '~', and file-path segments are
+    // percent-encoded - decode both so names/files with spaces or UTF-8 resolve instead of false-404ing.
+    var collection = ContentCollectionsExtensions.DecodeCollectionName(path[..slash]);   // "~" -> "/"
+    var filePath = string.Join('/', path[(slash + 1)..].Split('/').Select(Uri.UnescapeDataString));
     var content = app.Services.GetRequiredService<IMessageHub>().ServiceProvider.GetService<IContentService>();
     if (content is null) return Results.NotFound();
     var stream = await content.GetContentAsync(collection, filePath, ctx.RequestAborted);

--- a/memex/Memex.LocalMesh/Program.cs
+++ b/memex/Memex.LocalMesh/Program.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.ContentCollections;
 using MeshWeaver.Documentation;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting;
@@ -47,6 +48,28 @@ app.UseStaticFiles();
 
 app.UseMeshWeaverGrpcWeb();     // browser / React-Native gRPC-web (Connect + Deliver)
 app.MapMeshWeaverGrpc();        // the mesh gRPC service (Open + Connect + Deliver)
+
+// Serve mesh content collections at /static/{collection}/{filePath} — e.g. the NodeType icons
+// (/static/NodeTypeIcons/box.svg) the doc headers <img> reference. The full Blazor portal maps this
+// (BlazorHostingExtensions.MapStaticContent); the headless sidecar didn't, so those icons 404'd and the
+// React-Native client couldn't render them. AddGraph() already registers the NodeTypeIcons collection
+// (embedded resources) on the mesh hub — this just exposes the "known collection" pattern over HTTP.
+app.MapGet("/static/{**path}", async (HttpContext ctx, string path) =>
+{
+    var slash = path.IndexOf('/');
+    if (slash <= 0) return Results.NotFound();
+    var collection = Uri.UnescapeDataString(path[..slash]);   // e.g. "NodeTypeIcons"
+    var filePath = path[(slash + 1)..];                        // e.g. "box.svg"
+    var content = app.Services.GetRequiredService<IMessageHub>().ServiceProvider.GetService<IContentService>();
+    if (content is null) return Results.NotFound();
+    var stream = await content.GetContentAsync(collection, filePath, ctx.RequestAborted);
+    if (stream is null) return Results.NotFound();
+    var contentType = filePath.EndsWith(".svg", StringComparison.OrdinalIgnoreCase) ? "image/svg+xml"
+        : filePath.EndsWith(".png", StringComparison.OrdinalIgnoreCase) ? "image/png"
+        : filePath.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase) || filePath.EndsWith(".jpeg", StringComparison.OrdinalIgnoreCase) ? "image/jpeg"
+        : "application/octet-stream";
+    return Results.Stream(stream, contentType);
+});
 
 var wwwroot = app.Environment.WebRootPath ?? Path.Combine(app.Environment.ContentRootPath, "wwwroot");
 if (File.Exists(Path.Combine(wwwroot, "index.html")))


### PR DESCRIPTION
Follow-up to #357 — makes the doc-header NodeType icons render on the native app (they were blank because the icon assets 404'd on the headless local mesh).

**Server** — `Memex.LocalMesh` now maps `/static/{collection}/{filePath}`, the route the full Blazor portal serves (`BlazorHostingExtensions.MapStaticContent`) but the headless sidecar lacked. `AddGraph()` already registers the `NodeTypeIcons` collection (embedded resources) on the mesh hub — this exposes the "known collection" pattern over HTTP via `IContentService.GetContentAsync`. `/static/NodeTypeIcons/box.svg` → `200 image/svg+xml`. Builds clean under **Release `-warnaserror`** (0 warnings).

**Client** — added `react-native-svg` + a custom `<img>` renderer in `nativeHtml.native.tsx`: resolves the `src` against the connected mesh base, renders SVGs via `SvgUri` and raster via `<Image>`, skips anything unresolvable. Un-ignore `<img>` (inline `<svg>` still ignored). Ambient-declared for CI tsc.

Verified live on the iOS simulator — the blue NodeType chart icon renders above the doc title. tsc clean, **55 vitest**, **5/5 web e2e**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)