### PR TITLE
feat(localmesh): kernel + Markdig render-markdown endpoint (RN interactive-markdown foundation)

### DIFF
--- a/clients/react/src/core.ts
+++ b/clients/react/src/core.ts
@@ -21,6 +21,21 @@ export {
   type GrpcAreaOptions,
 } from "./live/grpcSource.js";
 export { normalizeEntityStore } from "./live/wire.js";
+// Interactive-markdown parsing — the ONE shared, non-proprietary parser (twin of the server Markdig
+// pipeline). splitRenderedHtml hydrates the server-rendered HTML (render-markdown) into text chunks +
+// @@ area markers + code-cell toolbars; both the web pack and the RN pack render those with their own leaves.
+export {
+  splitRenderedHtml,
+  parseInteractiveMarkdown,
+  cellSubmissions,
+  KERNEL_ADDRESS_PLACEHOLDER,
+  type RenderedHtmlSegment,
+  type HtmlChunkSegment,
+  type HtmlAreaSegment,
+  type HtmlToolbarSegment,
+  type HtmlMermaidSegment,
+  type InteractiveSegment,
+} from "./controls/interactiveMarkdown.js";
 export {
   MeshOpsProvider,
   useMeshOps,

--- a/memex/Memex.LocalMesh/Program.cs
+++ b/memex/Memex.LocalMesh/Program.cs
@@ -5,6 +5,7 @@ using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Grpc;
 using MeshWeaver.Hosting.Monolith;
 using MeshWeaver.Hosting.Sqlite;
+using MeshWeaver.Markdown;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 
@@ -33,6 +34,7 @@ builder.UseMeshWeaver(
     mesh => mesh
         .AddPartitionedSqlitePersistence($"Data Source={dbPath}")
         .AddGraph()          // node types + graph
+        .AddKernel()         // C# kernel (Roslyn, MeshWeaver.Kernel.Hub) — lets doc code samples Run on the sidecar
         .AddDocumentation()  // the embedded "Doc" partition — real layout areas the client can render
         .AddGrpcHub()        // py/node stream-routed address types + the gRPC services
         .UseMonolithMesh()); // in-process single-silo runtime (NOT Orleans)
@@ -73,6 +75,23 @@ app.MapGet("/static/{**path}", async (HttpContext ctx, string path) =>
     return Results.Stream(stream, contentType);
 });
 
+// Server-side Markdig render (POST /api/mesh/render-markdown) — the ONE markdown parser (the web portal
+// exposes this via MeshApiEndpoints/MeshOperations.RenderMarkdown, but that surface is MCP-auth-gated and
+// portal-coupled). RenderMarkdown is a thin wrapper over the pure MarkdownViewLogic.Render pipeline, so the
+// headless sidecar calls it directly — anonymous, no hub round-trip. Clients (portal-next + React-Native)
+// POST {markdown, nodePath} and hydrate the returned HTML + codeSubmissions (splitRenderedHtml). This is
+// what makes interactive markdown — inline @@ embeds and runnable code cells — resolve on the RN app.
+app.MapPost("/api/mesh/render-markdown", (RenderMarkdownBody body) =>
+{
+    var result = MarkdownViewLogic.Render(body.Markdown ?? string.Empty, body.NodePath, body.NodePath);
+    return Results.Json(new
+    {
+        html = result.Html,
+        codeSubmissions = (result.CodeSubmissions ?? [])
+            .Select(sub => new { id = sub.Id, language = sub.Language, code = sub.Code }),
+    });
+});
+
 var wwwroot = app.Environment.WebRootPath ?? Path.Combine(app.Environment.ContentRootPath, "wwwroot");
 if (File.Exists(Path.Combine(wwwroot, "index.html")))
     app.MapFallbackToFile("index.html"); // SPA fallback: any non-gRPC, non-file route → the packaged app
@@ -82,3 +101,6 @@ else
         $"(http/2 bidi + gRPC-web). No web app in wwwroot; point a client at http://localhost:{port}."));
 
 app.Run();
+
+/// <summary>POST body for /api/mesh/render-markdown — mirrors MeshApiEndpoints.RenderMarkdownBody.</summary>
+internal sealed record RenderMarkdownBody(string? Markdown, string? NodePath);


### PR DESCRIPTION
Server foundation for interactive markdown + code execution on the React-Native app (which attaches to the `Memex.LocalMesh` SQLite sidecar). The RN live-layer wiring that consumes this is a focused follow-up.

- **`.AddKernel()` on LocalMesh** — wires the C# Roslyn kernel (`MeshWeaver.Kernel.Hub`) so Code nodes / doc code samples can Run on the sidecar.
- **`POST /api/mesh/render-markdown` on LocalMesh** — the ONE Markdig parser, anonymous. The portal's `MeshApiEndpoints`/`MeshOperations.RenderMarkdown` is MCP-auth-gated + portal-coupled (AI/Blazor), but `RenderMarkdown` is a thin wrapper over the **pure `MarkdownViewLogic.Render`** pipeline (already referenced via Documentation → `MeshWeaver.Markdown`), so the headless sidecar calls it directly — no hub round-trip, no AI dep. Returns `{html, codeSubmissions}`; inline `@@` embeds resolve to `<div class='layout-area' …>` markers.
- **`@meshweaver/react/core` exports `splitRenderedHtml`/`parseInteractiveMarkdown`** (already defined, just not in the barrel) so the RN pack reuses the *same* parser as the web — no bespoke markdown impl.

Verified: LocalMesh **Release `-warnaserror` clean**; render-markdown curl returns Markdig HTML with the `@@` marker; react **tsc clean + 148 vitest**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)