### PR TITLE
Plugin catalog: git-based install of content + runtime-compiled code

### DIFF
--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -110,6 +110,7 @@
     <Project Path="src/MeshWeaver.Messaging.Hub/MeshWeaver.Messaging.Hub.csproj" />
     <Project Path="src/MeshWeaver.NuGet.AzureBlob/MeshWeaver.NuGet.AzureBlob.csproj" />
     <Project Path="src/MeshWeaver.NuGet/MeshWeaver.NuGet.csproj" />
+    <Project Path="src/MeshWeaver.PluginCatalog/MeshWeaver.PluginCatalog.csproj" />
     <Project Path="src/MeshWeaver.Reflection/MeshWeaver.Reflection.csproj" />
     <Project Path="src/MeshWeaver.ServiceProvider/MeshWeaver.ServiceProvider.csproj" />
     <Project Path="src/MeshWeaver.ShortGuid/MeshWeaver.ShortGuid.csproj" />
@@ -148,6 +149,7 @@
     <Project Path="test/MeshWeaver.Maui.Integration.Test/MeshWeaver.Maui.Integration.Test.csproj" />
     <Project Path="test/MeshWeaver.Messaging.Hub.Test/MeshWeaver.Messaging.Hub.Test.csproj" />
     <Project Path="test/MeshWeaver.NodeOperations.Test/MeshWeaver.NodeOperations.Test.csproj" />
+    <Project Path="test/MeshWeaver.PluginCatalog.Test/MeshWeaver.PluginCatalog.Test.csproj" />
     <Project Path="test/MeshWeaver.Northwind.Test/MeshWeaver.Northwind.Test.csproj" />
     <Project Path="test/MeshWeaver.Search.Test/MeshWeaver.Search.Test.csproj" />
     <Project Path="test/MeshWeaver.Security.Test/MeshWeaver.Security.Test.csproj" />

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -23,6 +23,8 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Speech\MeshWeaver.Speech.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Courses\MeshWeaver.Courses.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
+    <!-- Git-based plugin catalog / installer (the mesh's "app store"). -->
+    <ProjectReference Include="..\..\src\MeshWeaver.PluginCatalog\MeshWeaver.PluginCatalog.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.InstanceSync\MeshWeaver.InstanceSync.csproj" />
     <!-- Content → vector index (core tech): chunk/embed/store on a separate Postgres vector DB,
          per-file Document nodes, chunk-search autocomplete. Inert unless ConnectionStrings:contentindex

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -34,6 +34,7 @@ using MeshWeaver.GoogleMaps;
 using MeshWeaver.Data;
 using MeshWeaver.GitSync;
 using MeshWeaver.Graph;
+using MeshWeaver.PluginCatalog;
 using MeshWeaver.InstanceSync;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Markdown.Export.Configuration;
@@ -548,6 +549,14 @@ public static class MemexConfiguration
                 .AddRowLevelSecurity()
                 // Configure graph from the same base path
                 .AddGraph()
+                // Git-based plugin catalog: browse installable folders in a repo and install each
+                // folder's content (and runtime-compiled code) into the mesh by picking a git
+                // commit + folder. Seeds a Plugins space + catalog node pointed at
+                // PluginCatalog:SourceRepoPath (empty -> the catalog shows a "configure me" prompt).
+                .AddPluginCatalog(
+                    configuration["PluginCatalog:SourceRepoPath"] ?? "",
+                    configuration["PluginCatalog:SourceSubdir"] ?? "catalog",
+                    configuration["PluginCatalog:SourceRef"] ?? "HEAD")
                 // Register GitHub-sync content types (GitHubCredential / GitHubSyncConfig)
                 // on the mesh + per-node hubs so their config nodes (de)serialize.
                 .AddGitHubSyncTypes()

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -1,0 +1,20 @@
+# Build output
+[Bb]in/
+[Oo]bj/
+[Dd]ebug/
+[Rr]elease/
+*.user
+*.suo
+
+# Test output
+TestResults/
+*.trx
+
+# IDE
+.vs/
+.idea/
+.vscode/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/plugins/LICENSE
+++ b/plugins/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Systemorph
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,37 @@
+# MeshWeaver.Plugins — catalog packages
+
+This folder holds **installable packages** for the MeshWeaver plugin catalog. The catalog
+(`MeshWeaver.PluginCatalog`, in core) browses the folders here and installs each into a running
+mesh by picking a **git commit + folder** — no rebuild, no NuGet.
+
+Each package folder under `catalog/` carries a `package.json` manifest:
+
+```json
+{ "id": "welcome-note", "name": "Welcome Note", "kind": "content",
+  "targetPartition": "Welcome", "version": "1.0.0" }
+```
+
+- **`kind: content`** — the folder's files (markdown, JSON, agent/skill `.md`) are imported into the
+  target partition (incremental upsert, nothing else is touched).
+- **`kind: code`** — the manifest's `nodeTypeConfiguration` + `Source/*.cs` become a NodeType that the
+  mesh **compiles live** (Roslyn) via its existing compile/release flow — a custom type in a running
+  mesh, no rebuild.
+
+## Sample packages (`catalog/`)
+
+| Folder | Kind | Installs |
+|---|---|---|
+| `welcome-note`, `getting-started` | content | a markdown page into a space |
+| `echo-agent` | content | a sample Agent into the `Agent` partition |
+| `hello-skill` | content | a sample Skill into the `Skill` partition |
+| `hello-widget` | code | a runtime-compiled custom NodeType |
+
+## Configuring the catalog
+
+Point the portal at this folder via `PluginCatalog:SourceRepoPath` (the local git checkout) — the
+catalog seeds a `Plugins` space with a `Plugins/catalog` node that browses `catalog/` at `HEAD`. A
+remote GitHub repo works too (the catalog uses GitSync's fetch), so a deployed portal with no source
+tree can still browse/install.
+
+_Extracted feature modules (Courses, Speech, …) may live here as their own projects later; this PR
+ships the catalog + sample packages._

--- a/plugins/catalog/echo-agent/Echo.md
+++ b/plugins/catalog/echo-agent/Echo.md
@@ -1,0 +1,14 @@
+---
+nodeType: Agent
+name: Echo
+description: A minimal sample agent installed from the plugin catalog. Repeats back and lightly rephrases what you say.
+category: Agents
+plugins:
+  - Mesh
+---
+
+You are **Echo**, a minimal sample agent shipped as a catalog package to demonstrate installing AI
+content by git commit + folder.
+
+When the user says something, repeat the essence back in one short, friendly sentence, optionally
+tidying the phrasing. Keep it to a single line. Do not take actions or touch nodes.

--- a/plugins/catalog/echo-agent/package.json
+++ b/plugins/catalog/echo-agent/package.json
@@ -1,0 +1,8 @@
+{
+  "id": "echo-agent",
+  "name": "Echo Agent",
+  "description": "A sample AI agent installed from the catalog into the Agent partition.",
+  "kind": "content",
+  "targetPartition": "Agent",
+  "version": "1.0.0"
+}

--- a/plugins/catalog/getting-started/GettingStarted.md
+++ b/plugins/catalog/getting-started/GettingStarted.md
@@ -1,0 +1,7 @@
+# Getting Started
+
+A second sample package to show the catalog listing more than one installable item.
+
+1. Open the **Plugin Catalog**.
+2. Pick a package and press **Install**.
+3. The catalog imports that folder's content into its target partition and records the install.

--- a/plugins/catalog/getting-started/package.json
+++ b/plugins/catalog/getting-started/package.json
@@ -1,0 +1,8 @@
+{
+  "id": "getting-started",
+  "name": "Getting Started Guide",
+  "description": "A sample content package — installs a short getting-started guide into the Guide space.",
+  "kind": "content",
+  "targetPartition": "Guide",
+  "version": "1.0.0"
+}

--- a/plugins/catalog/hello-skill/Hello.md
+++ b/plugins/catalog/hello-skill/Hello.md
@@ -1,0 +1,11 @@
+---
+nodeType: Skill
+name: /hello
+description: A sample skill installed from the plugin catalog — greets the user and points at the catalog.
+category: Skills
+---
+
+A sample skill shipped as a catalog package.
+
+When invoked, greet the user warmly and mention they can install more capabilities from the
+**Plugin Catalog** by picking a git commit and folder.

--- a/plugins/catalog/hello-skill/package.json
+++ b/plugins/catalog/hello-skill/package.json
@@ -1,0 +1,8 @@
+{
+  "id": "hello-skill",
+  "name": "Hello Skill",
+  "description": "A sample skill installed from the catalog into the Skill partition.",
+  "kind": "content",
+  "targetPartition": "Skill",
+  "version": "1.0.0"
+}

--- a/plugins/catalog/hello-widget/Source/HelloWidget.cs
+++ b/plugins/catalog/hello-widget/Source/HelloWidget.cs
@@ -1,0 +1,9 @@
+// A sample runtime-compiled NodeType shipped as a code package. The mesh discovers this Code node
+// under the NodeType's Source/ subtree, compiles it with Roslyn on install, and serves nodes of
+// type "hello-widget" live — no app rebuild, no NuGet.
+public record HelloWidget
+{
+    public string Title { get; init; } = "Hello from a runtime-compiled plugin";
+
+    public string Body { get; init; } = string.Empty;
+}

--- a/plugins/catalog/hello-widget/package.json
+++ b/plugins/catalog/hello-widget/package.json
@@ -1,0 +1,9 @@
+{
+  "id": "hello-widget",
+  "name": "Hello Widget (code)",
+  "description": "A sample CODE package — a custom NodeType whose C# source is compiled live on the mesh (no app rebuild, no NuGet). Installed by picking a git commit + folder.",
+  "kind": "code",
+  "targetPartition": "type",
+  "version": "1.0.0",
+  "nodeTypeConfiguration": "config => config.WithContentType<HelloWidget>()"
+}

--- a/plugins/catalog/welcome-note/Welcome.md
+++ b/plugins/catalog/welcome-note/Welcome.md
@@ -1,0 +1,6 @@
+# Welcome
+
+This page was **installed from the plugin catalog** by picking a git commit + folder — no rebuild,
+no NuGet. The catalog imported this folder's content into the mesh.
+
+Edit a package's `package.json` to change its target partition, version, or description.

--- a/plugins/catalog/welcome-note/package.json
+++ b/plugins/catalog/welcome-note/package.json
@@ -1,0 +1,8 @@
+{
+  "id": "welcome-note",
+  "name": "Welcome Note",
+  "description": "A sample content package — installs a welcome markdown page into the Welcome space.",
+  "kind": "content",
+  "targetPartition": "Welcome",
+  "version": "1.0.0"
+}

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -227,8 +227,19 @@ public static class CatalogLayoutAreas
             return;
         }
 
+        // Capture the caller's identity NOW — the click delivery stamped AccessService.Context. The
+        // fetch runs on the Process IIoPool (GitCli), so the install continuation lands on a pool
+        // thread where that AsyncLocal is wiped; re-establish it for the install's whole lifetime via
+        // Observable.Using so the CreateOrUpdate writes run as the user and don't fail closed.
+        var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
+        var user = accessService?.Context;
+
         source.FetchPackageFiles(pkg, cfg!.SourceRef)
-            .SelectMany(files => PackageInstaller.Install(host.Hub, pkg, files, cfg.SourceRef, logger))
+            .SelectMany(files => accessService is null
+                ? PackageInstaller.Install(host.Hub, pkg, files, cfg.SourceRef, logger)
+                : Observable.Using(
+                    () => accessService.SwitchAccessContext(user),
+                    _ => PackageInstaller.Install(host.Hub, pkg, files, cfg.SourceRef, logger)))
             .Subscribe(
                 count => logger?.LogInformation("Installed {Id}: {Count} node(s).", pkg.Id, count),
                 ex => logger?.LogWarning(ex, "Install of {Id} failed.", pkg.Id));

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -1,0 +1,240 @@
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The catalog browse/install view for a <c>PluginCatalog</c> node: lists the installable packages
+/// found in the node's configured source git repo at its ref, shows each package's install status
+/// (comparing against the <c>Plugins</c> install registry), and offers an Install / Update button
+/// that runs the git-based install. Reactive end to end — after an install the registry stream
+/// re-emits and the affected card flips to "Installed" with no manual refresh.
+/// </summary>
+public static class CatalogLayoutAreas
+{
+    /// <summary>Area name for the catalog browse view.</summary>
+    public const string CatalogArea = "Catalog";
+
+    /// <summary>
+    /// Registers the <c>PluginCatalog</c> node views: the catalog browse as the default Overview,
+    /// plus the standard create/delete areas.
+    /// </summary>
+    /// <param name="configuration">The message hub configuration to register on.</param>
+    /// <returns>The configuration with the catalog views registered.</returns>
+    public static MessageHubConfiguration AddPluginCatalogViews(this MessageHubConfiguration configuration)
+        => configuration
+            .AddDefaultLayoutAreas()
+            .AddMeshDataSource(s => s.WithContentType<PluginCatalogContent>())
+            .AddLayout(layout => layout
+                .WithView(MeshNodeLayoutAreas.OverviewArea, Overview)
+                .WithView(CatalogArea, Catalog)
+                .WithView(MeshNodeLayoutAreas.CreateNodeArea, CreateLayoutArea.Create)
+                .WithView(MeshNodeLayoutAreas.DeleteArea, DeleteLayoutArea.Delete));
+
+    /// <summary>The default Overview is the catalog.</summary>
+    [Browsable(false)]
+    public static IObservable<UiControl?> Overview(LayoutAreaHost host, RenderingContext ctx) => Catalog(host, ctx);
+
+    /// <summary>
+    /// Renders the catalog: the configured source's packages (live) joined with the install
+    /// registry (live) into a list of package cards with Install / Update / Installed status.
+    /// </summary>
+    /// <param name="host">The layout area host rendering the area.</param>
+    /// <param name="_">The rendering context for the area.</param>
+    /// <returns>An observable stream of the catalog view.</returns>
+    [Browsable(false)]
+    public static IObservable<UiControl?> Catalog(LayoutAreaHost host, RenderingContext _)
+    {
+        var installed = ObserveInstalled(host);
+        return host.Workspace.GetMeshNodeStream()
+            .Select(node => node.ContentAs<PluginCatalogContent>(host.Hub.JsonSerializerOptions))
+            .Select(cfg => ObserveAvailable(host, cfg).Select(available => (Cfg: cfg, Available: available)))
+            .Switch()
+            .CombineLatest(installed, (a, inst) => (UiControl?)BuildCatalog(host, a.Cfg, a.Available, inst))
+            .StartWith((UiControl?)Controls.Markdown("*Loading catalog…*"));
+    }
+
+    // Live list of installable packages from the node's configured source (local git repo or a
+    // remote GitHub repo) at its ref.
+    private static IObservable<IReadOnlyList<PackageManifest>> ObserveAvailable(
+        LayoutAreaHost host, PluginCatalogContent? cfg)
+    {
+        var source = BuildSource(host, cfg);
+        if (source is null)
+            return Observable.Return<IReadOnlyList<PackageManifest>>([]);
+        return source.ListPackages(cfg!.SourceRef)
+            .Catch<IReadOnlyList<PackageManifest>, Exception>(ex =>
+            {
+                Logger(host)?.LogWarning(ex,
+                    "Catalog: failed to list packages from {Src}@{Ref}", cfg.SourceRepoPath, cfg.SourceRef);
+                return Observable.Return<IReadOnlyList<PackageManifest>>([]);
+            })
+            .StartWith((IReadOnlyList<PackageManifest>)[]);
+    }
+
+    // Selects the package source from the catalog config: a URL uses the GitHub-fetch source (reusing
+    // GitSync's client — anonymous for a public repo), a local path uses the git-CLI source. Both are
+    // git-based, no NuGet.
+    private static IPackageSource? BuildSource(LayoutAreaHost host, PluginCatalogContent? cfg)
+    {
+        if (cfg?.SourceRepoPath is not { Length: > 0 } src)
+            return null;
+        var subdir = cfg.SourceSubdir ?? "";
+        if (IsUrl(src))
+        {
+            var client = host.Hub.ServiceProvider.GetService<IGitHubRepoClient>();
+            if (client is null)
+            {
+                Logger(host)?.LogWarning(
+                    "Catalog source {Src} is a URL but no IGitHubRepoClient is registered.", src);
+                return null;
+            }
+            return new GitHubPackageSource(client.Fetch, src, token: "", subdir, Logger(host));
+        }
+        var git = new GitCli(host.Hub.ServiceProvider.GetRequiredService<IoPoolRegistry>());
+        return new GitPackageSource(git, src, subdir, Logger(host));
+    }
+
+    private static bool IsUrl(string s) =>
+        s.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+        || s.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+        || s.StartsWith("git@", StringComparison.Ordinal);
+
+    // Live map of installed packages (the Plugins registry children), as a list.
+    private static IObservable<IReadOnlyList<MeshNode>> ObserveInstalled(LayoutAreaHost host)
+    {
+        var mesh = host.Hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null)
+            return Observable.Return<IReadOnlyList<MeshNode>>([]);
+        return mesh
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"path:{PackageInstaller.InstalledPartition} scope:children nodeType:{PackageInstaller.PackageNodeType}"))
+            .Scan(ImmutableDictionary<string, MeshNode>.Empty, (map, change) =>
+            {
+                if (change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+                    return change.Items.ToImmutableDictionary(n => n.Path);
+                foreach (var item in change.Items)
+                    map = change.ChangeType switch
+                    {
+                        QueryChangeType.Added or QueryChangeType.Updated => map.SetItem(item.Path, item),
+                        QueryChangeType.Removed => map.Remove(item.Path),
+                        _ => map
+                    };
+                return map;
+            })
+            .Select(m => (IReadOnlyList<MeshNode>)m.Values.ToList())
+            .StartWith((IReadOnlyList<MeshNode>)[]);
+    }
+
+    private static UiControl BuildCatalog(
+        LayoutAreaHost host, PluginCatalogContent? cfg,
+        IReadOnlyList<PackageManifest> available, IReadOnlyList<MeshNode> installed)
+    {
+        var installedById = installed
+            .Select(n => n.ContentAs<PackageManifest>(host.Hub.JsonSerializerOptions))
+            .Where(m => m is not null && !string.IsNullOrEmpty(m!.Id))
+            .GroupBy(m => m!.Id, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First()!, StringComparer.Ordinal);
+
+        var container = Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("width: 100%; max-width: 900px; margin: 0 auto; padding: 16px;");
+
+        container = container.WithView(Controls.H1("Plugin Catalog").WithStyle("margin: 0 0 4px 0;"));
+
+        if (!string.IsNullOrWhiteSpace(cfg?.Description))
+            container = container.WithView(Controls.Markdown(cfg!.Description!).WithStyle("margin-bottom: 8px;"));
+
+        container = container.WithView(Controls.Body(
+                cfg?.SourceRepoPath is { Length: > 0 } p
+                    ? $"Source: {p} @ {cfg.SourceRef} — {available.Count} package(s) available."
+                    : "No source configured. Set SourceRepoPath on this catalog node.")
+            .WithStyle("color: var(--neutral-foreground-hint); margin-bottom: 16px; display: block;"));
+
+        if (available.Count == 0)
+            container = container.WithView(Controls.Markdown("*No installable packages found.*"));
+
+        var n = 0;
+        foreach (var pkg in available)
+        {
+            n++;
+            installedById.TryGetValue(pkg.Id, out var inst);
+            container = container.WithView(BuildCard(host, cfg, pkg, inst), $"pkg-{n}");
+        }
+
+        return container;
+    }
+
+    private static UiControl BuildCard(
+        LayoutAreaHost host, PluginCatalogContent? cfg, PackageManifest pkg, PackageManifest? installed)
+    {
+        var card = Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("border: 1px solid var(--neutral-stroke-rest); border-radius: 8px; " +
+                       "padding: 14px 16px; margin-bottom: 12px;");
+
+        card = card.WithView(Controls.Body(pkg.Name ?? pkg.Id)
+            .WithStyle("font-weight: 600; font-size: 16px; display: block; margin-bottom: 4px;"));
+
+        if (!string.IsNullOrWhiteSpace(pkg.Description))
+            card = card.WithView(Controls.Body(pkg.Description!).WithStyle("display: block; margin-bottom: 6px;"));
+
+        card = card.WithView(Controls.Body($"v{pkg.Version}  ·  {pkg.Kind}  ·  → {pkg.TargetPartition}")
+            .WithStyle("color: var(--neutral-foreground-hint); font-size: 12px; display: block; margin-bottom: 10px;"));
+
+        var upToDate = installed is not null
+            && string.Equals(installed.Version, pkg.Version, StringComparison.Ordinal);
+
+        if (upToDate)
+        {
+            card = card.WithView(Controls.Body($"✓ Installed v{installed!.Version}")
+                .WithStyle("color: var(--success-foreground, #107c10); font-weight: 600;"));
+        }
+        else
+        {
+            var label = installed is null ? "Install" : $"Update to v{pkg.Version}";
+            card = card.WithView(Controls.Button(label)
+                .WithAppearance(Appearance.Accent)
+                .WithClickAction(ctx =>
+                {
+                    InstallPackage(host, cfg, pkg);
+                    return Task.CompletedTask;
+                }));
+        }
+
+        return card;
+    }
+
+    // Fire the git-based install; the Plugins-registry stream re-emits on completion → card flips.
+    private static void InstallPackage(LayoutAreaHost host, PluginCatalogContent? cfg, PackageManifest pkg)
+    {
+        var logger = Logger(host);
+        var source = BuildSource(host, cfg);
+        if (source is null)
+        {
+            logger?.LogWarning("Install '{Id}' skipped: catalog has no usable source.", pkg.Id);
+            return;
+        }
+
+        source.FetchPackageFiles(pkg, cfg!.SourceRef)
+            .SelectMany(files => PackageInstaller.Install(host.Hub, pkg, files, cfg.SourceRef, logger))
+            .Subscribe(
+                count => logger?.LogInformation("Installed {Id}: {Count} node(s).", pkg.Id, count),
+                ex => logger?.LogWarning(ex, "Install of {Id} failed.", pkg.Id));
+    }
+
+    private static ILogger? Logger(LayoutAreaHost host) =>
+        host.Hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.PluginCatalog.Catalog");
+}

--- a/src/MeshWeaver.PluginCatalog/GitHubPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/GitHubPackageSource.cs
@@ -1,0 +1,75 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.GitSync;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// An <see cref="IPackageSource"/> that reads a REMOTE git repo at a commit/branch by reusing
+/// GitSync's fetch (<see cref="IGitHubRepoClient.Fetch"/>) — so a DEPLOYED portal, which has no
+/// source tree in its container, can browse/install from the plugins repo on GitHub. Still git-based
+/// and NuGet-free: it fetches the repo tree at a ref, groups the folders that carry a
+/// <c>package.json</c>, and returns each folder's files.
+///
+/// <para>Depends on a narrow <c>fetch</c> delegate rather than the whole <see cref="IGitHubRepoClient"/>
+/// so it needs no test double for that large interface — production passes <c>client.Fetch</c>, tests
+/// pass a stub. A public repo reads anonymously (empty token); a private one needs a token.</para>
+/// </summary>
+public sealed class GitHubPackageSource(
+    Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch,
+    string repoUrl,
+    string token = "",
+    string subdir = "",
+    ILogger? logger = null) : IPackageSource
+{
+    private const string ManifestFile = "package.json";
+    private static readonly JsonSerializerOptions ManifestJson = new(JsonSerializerDefaults.Web);
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
+        fetch(repoUrl, gitRef, NullIfEmpty(subdir), token)
+            .Select(snapshot =>
+            {
+                var manifests = new List<PackageManifest>();
+                foreach (var file in snapshot.Files)
+                {
+                    if (!IsManifest(file.Path))
+                        continue;
+                    PackageManifest? manifest;
+                    try
+                    {
+                        manifest = JsonSerializer.Deserialize<PackageManifest>(file.Content, ManifestJson);
+                    }
+                    catch (JsonException ex)
+                    {
+                        logger?.LogWarning(ex, "Skipping {Path}: invalid {Manifest}", file.Path, ManifestFile);
+                        continue;
+                    }
+                    if (manifest is null || string.IsNullOrWhiteSpace(manifest.Id))
+                        continue;
+                    manifests.Add(manifest with { SourceFolder = FolderOf(file.Path) });
+                }
+                return (IReadOnlyList<PackageManifest>)manifests
+                    .OrderBy(m => m.Id, StringComparer.Ordinal).ToList();
+            });
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef) =>
+        fetch(repoUrl, gitRef, NullIfEmpty(package.SourceFolder ?? package.Id), token)
+            .Select(snapshot => (IReadOnlyList<PackageFile>)snapshot.Files
+                .Select(f => new PackageFile(f.Path, f.Content)).ToList());
+
+    private static bool IsManifest(string path) =>
+        path.EndsWith("/" + ManifestFile, StringComparison.OrdinalIgnoreCase)
+        || string.Equals(path, ManifestFile, StringComparison.OrdinalIgnoreCase);
+
+    // The repo-relative folder that directly contains the manifest (e.g. "catalog/welcome-note").
+    private static string FolderOf(string manifestPath)
+    {
+        var idx = manifestPath.LastIndexOf('/');
+        return idx < 0 ? "" : manifestPath[..idx];
+    }
+
+    private static string? NullIfEmpty(string? value) => string.IsNullOrEmpty(value) ? null : value;
+}

--- a/src/MeshWeaver.PluginCatalog/GitPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/GitPackageSource.cs
@@ -1,0 +1,99 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.GitSync;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// An <see cref="IPackageSource"/> backed by a LOCAL git repository, read at a chosen commit/branch
+/// through the <c>git</c> CLI (<see cref="GitCli"/> → the Process <c>IIoPool</c>). This is the
+/// "pick a git commit + folder" primitive with ZERO NuGet dependency: it never clones or hits a
+/// package feed — it runs <c>git ls-tree</c> / <c>git show</c> against an on-disk repo. A
+/// GitHub-fetch source (reusing GitSync's repo client) can slot in behind <see cref="IPackageSource"/>
+/// later without changing the installer.
+/// </summary>
+public sealed class GitPackageSource(GitCli git, string repoPath, string subdir = "", ILogger? logger = null)
+    : IPackageSource
+{
+    private const string ManifestFile = "package.json";
+    private static readonly JsonSerializerOptions ManifestJson = new(JsonSerializerDefaults.Web);
+
+    // Package folders live at the repo root, or under `subdir/` when configured. git ls-tree emits
+    // FULL repo-relative folder paths either way (e.g. "welcome-note" or "catalog/welcome-note"),
+    // which become the package's SourceFolder — so FetchPackageFiles needs no special-casing.
+    private string[] ListArgs(string gitRef) =>
+        string.IsNullOrEmpty(subdir)
+            ? ["ls-tree", "-d", "--name-only", gitRef]
+            : ["ls-tree", "-d", "--name-only", gitRef, "--", $"{subdir.TrimEnd('/')}/"];
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
+        git.Run(repoPath, ListArgs(gitRef))
+            .SelectMany(res =>
+            {
+                if (res.ExitCode != 0)
+                    return Observable.Throw<IReadOnlyList<PackageManifest>>(
+                        new InvalidOperationException($"git ls-tree failed ({res.ExitCode}): {res.StdErr}"));
+                var folders = SplitLines(res.StdOut);
+                if (folders.Length == 0)
+                    return Observable.Return<IReadOnlyList<PackageManifest>>([]);
+                return folders
+                    .Select(folder => ReadManifest(gitRef, folder))
+                    .Merge()
+                    .Where(m => m is not null).Select(m => m!)
+                    .ToList()
+                    .Select(list => (IReadOnlyList<PackageManifest>)
+                        list.OrderBy(m => m.Id, StringComparer.Ordinal).ToList());
+            });
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef)
+    {
+        var folder = package.SourceFolder ?? package.Id;
+        return git.Run(repoPath, ["ls-tree", "-r", "--name-only", gitRef, "--", $"{folder}/"])
+            .SelectMany(res =>
+            {
+                if (res.ExitCode != 0)
+                    return Observable.Throw<IReadOnlyList<PackageFile>>(
+                        new InvalidOperationException($"git ls-tree failed ({res.ExitCode}): {res.StdErr}"));
+                var paths = SplitLines(res.StdOut);
+                if (paths.Length == 0)
+                    return Observable.Return<IReadOnlyList<PackageFile>>([]);
+                return paths
+                    .Select(p => ShowFile(gitRef, p).Select(c => c is null ? null : new PackageFile(p, c)))
+                    .Merge()
+                    .Where(f => f is not null).Select(f => f!)
+                    .ToList()
+                    .Select(list => (IReadOnlyList<PackageFile>)list);
+            });
+    }
+
+    // Reads {folder}/package.json at the ref and deserializes it; null when the folder has no
+    // manifest (→ not an installable package) or the manifest is invalid.
+    private IObservable<PackageManifest?> ReadManifest(string gitRef, string folder) =>
+        ShowFile(gitRef, $"{folder}/{ManifestFile}")
+            .Select(content =>
+            {
+                if (content is null) return null;
+                try
+                {
+                    var manifest = JsonSerializer.Deserialize<PackageManifest>(content, ManifestJson);
+                    if (manifest is null || string.IsNullOrWhiteSpace(manifest.Id)) return null;
+                    return manifest with { SourceFolder = folder };
+                }
+                catch (JsonException ex)
+                {
+                    logger?.LogWarning(ex, "Skipping folder {Folder}: invalid {Manifest}", folder, ManifestFile);
+                    return null;
+                }
+            });
+
+    // git show <ref>:<path> — the file's content at that ref, or null when the path is absent there.
+    private IObservable<string?> ShowFile(string gitRef, string path) =>
+        git.Run(repoPath, ["show", $"{gitRef}:{path}"])
+            .Select(res => res.ExitCode == 0 ? res.StdOut : (string?)null);
+
+    private static string[] SplitLines(string s) =>
+        s.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}

--- a/src/MeshWeaver.PluginCatalog/MeshWeaver.PluginCatalog.csproj
+++ b/src/MeshWeaver.PluginCatalog/MeshWeaver.PluginCatalog.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- The mesh's "app store": browse installable folders in a git repo and install each
+       folder's content into the mesh by picking a git commit + folder. Git-based, NO NuGet.
+       References GitSync for the git CLI (GitCli) + NodeFileMapper, Graph for node types,
+       and Hosting for the markdown/json file parsers. -->
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="MeshWeaver.PluginCatalog.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
+    <ProjectReference Include="..\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
+    <ProjectReference Include="..\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MeshWeaver.PluginCatalog/Package.cs
+++ b/src/MeshWeaver.PluginCatalog/Package.cs
@@ -13,8 +13,9 @@ public enum PackageKind
     /// course material) — installed by importing the folder's nodes into a partition.</summary>
     Content,
 
-    /// <summary>Compiled capability (a NodeType renderer / layout areas) shipped as source
-    /// compiled on the mesh. Reserved for the runtime-code-load stage — not installed yet.</summary>
+    /// <summary>A capability shipped as SOURCE: the manifest's <c>nodeTypeConfiguration</c> plus the
+    /// package's <c>Source/*.cs</c> become a NodeType the mesh compiles live (Roslyn) on install via
+    /// its existing compile/release flow — no rebuild, no NuGet.</summary>
     Code,
 }
 

--- a/src/MeshWeaver.PluginCatalog/Package.cs
+++ b/src/MeshWeaver.PluginCatalog/Package.cs
@@ -1,0 +1,95 @@
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// What an installable package delivers into the mesh.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<PackageKind>))]
+public enum PackageKind
+{
+    /// <summary>Authored mesh content (agents, skills, model providers, docs, decks,
+    /// course material) — installed by importing the folder's nodes into a partition.</summary>
+    Content,
+
+    /// <summary>Compiled capability (a NodeType renderer / layout areas) shipped as source
+    /// compiled on the mesh. Reserved for the runtime-code-load stage — not installed yet.</summary>
+    Code,
+}
+
+/// <summary>
+/// The manifest describing one installable package. In the plugins repo each installable folder
+/// carries a <c>package.json</c> that deserializes to this record; it is also the content of the
+/// <c>Package</c> node written to the installed-packages registry so the catalog can show
+/// installed / update-available status. Kept deliberately small.
+/// </summary>
+public record PackageManifest
+{
+    /// <summary>Stable package id (e.g. <c>"data-analyst-agent"</c>). Also the installed-record id.</summary>
+    public string Id { get; init; } = "";
+
+    /// <summary>Human-readable display name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>One-line description shown in the catalog.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>What the package delivers (content today; code later).</summary>
+    public PackageKind Kind { get; init; } = PackageKind.Content;
+
+    /// <summary>The mesh partition the package installs into (e.g. <c>"Agent"</c>, <c>"Skill"</c>).</summary>
+    public string? TargetPartition { get; init; }
+
+    /// <summary>Package version string (compared to the installed record for update-available status).</summary>
+    public string? Version { get; init; }
+
+    /// <summary>The package's folder within the source repo. Set by the source while listing;
+    /// not authored in <c>package.json</c>.</summary>
+    public string? SourceFolder { get; init; }
+
+    /// <summary>
+    /// For <see cref="PackageKind.Code"/> packages only: the NodeType configuration lambda source
+    /// (e.g. <c>"config =&gt; config.WithContentType&lt;Widget&gt;().AddLayout(...)"</c>). The installer
+    /// synthesizes a <c>NodeType</c> node with this configuration and imports the package's
+    /// <c>Source/*.cs</c> files as its Code nodes; the mesh then compiles it live (Roslyn) — no
+    /// rebuild, no NuGet.
+    /// </summary>
+    public string? NodeTypeConfiguration { get; init; }
+
+    /// <summary>Ids of other packages this one depends on. Advisory for now.</summary>
+    public ImmutableList<string> Requires { get; init; } = [];
+
+    // ── install-record metadata (null on catalog entries; set when written to the registry) ──
+
+    /// <summary>The git ref (commit/branch) this package was installed from. Null until installed.</summary>
+    public string? InstalledFromRef { get; init; }
+
+    /// <summary>When the package was installed (UTC). Null until installed.</summary>
+    public DateTimeOffset? InstalledAtUtc { get; init; }
+
+    /// <summary>Number of content nodes upserted on the last install. Null until installed.</summary>
+    public int? InstalledNodeCount { get; init; }
+}
+
+/// <summary>A single file of a package folder read from the source at a git ref.</summary>
+/// <param name="RelativePath">Repo-relative path, e.g. <c>"data-analyst-agent/DataAnalyst.md"</c>.</param>
+/// <param name="Content">UTF-8 file text.</param>
+public sealed record PackageFile(string RelativePath, string Content);
+
+/// <summary>
+/// A source of installable packages — a git repo at a chosen ref. Lists the packages (folders with
+/// a manifest) and fetches a package folder's files, so <see cref="PackageInstaller"/> can import
+/// them. The one MVP implementation reads a LOCAL git repo via the <c>git</c> CLI (no NuGet); a
+/// GitHub-fetch implementation slots in behind the same interface later.
+/// </summary>
+public interface IPackageSource
+{
+    /// <summary>Lists installable packages at <paramref name="gitRef"/> (each top-level folder that
+    /// carries a <c>package.json</c>).</summary>
+    IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef);
+
+    /// <summary>Fetches every file of <paramref name="package"/>'s folder at <paramref name="gitRef"/>
+    /// (the manifest itself is included; the installer skips it).</summary>
+    IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef);
+}

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1,0 +1,199 @@
+using System.Reactive.Linq;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Persistence.Parsers;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Installs a content package's folder into the mesh: parse the folder's files into MeshNodes,
+/// rebase them under the package's target partition, and upsert them INCREMENTALLY via
+/// <see cref="CreateOrUpdateNodeRequest"/> — never through the static-repo importer, whose
+/// full-replace/prune semantics would wipe the rest of a shared partition (installing one agent
+/// must not delete every other agent). After the content lands, an install record (a
+/// <c>Package</c> node) is written under the <see cref="InstalledPartition"/> registry so the
+/// catalog can show installed / update-available status. Reactive end-to-end; Subscribe to run.
+/// </summary>
+public static class PackageInstaller
+{
+    /// <summary>Partition that holds the install records (one <c>Package</c> node per installed id).</summary>
+    public const string InstalledPartition = "Plugins";
+
+    /// <summary>The NodeType of an install record.</summary>
+    public const string PackageNodeType = "Package";
+
+    /// <summary>Bounded concurrency for the per-node upsert fan-out (mirrors <c>NodeCopyHelper</c>).</summary>
+    public const int DefaultBatchSize = 8;
+
+    /// <summary>
+    /// Installs <paramref name="manifest"/>'s content <paramref name="files"/> into its target
+    /// partition and records the install. Emits the number of content nodes upserted.
+    /// </summary>
+    public static IObservable<int> Install(
+        IMessageHub hub,
+        PackageManifest manifest,
+        IReadOnlyList<PackageFile> files,
+        string installedFromRef,
+        ILogger? logger = null,
+        int batchSize = DefaultBatchSize)
+    {
+        logger ??= hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.PluginCatalog.PackageInstaller");
+
+        if (manifest.Kind == PackageKind.Code)
+            return InstallCode(hub, manifest, files, installedFromRef, logger, batchSize);
+
+        var partition = manifest.TargetPartition;
+        if (string.IsNullOrWhiteSpace(partition))
+            return Observable.Throw<int>(new InvalidOperationException(
+                $"Package '{manifest.Id}' has no targetPartition."));
+
+        var sourceFolder = manifest.SourceFolder ?? manifest.Id;
+        var parsers = new FileFormatParserRegistry(hub.JsonSerializerOptions);
+
+        var nodes = files
+            .Where(f => !IsManifest(f.RelativePath))
+            .Select(f => ParseNode(parsers, partition!, sourceFolder, f, logger))
+            .Where(n => n is not null).Select(n => n!)
+            .ToArray();
+
+        if (nodes.Length == 0)
+            return Observable.Throw<int>(new InvalidOperationException(
+                $"Package '{manifest.Id}' has no installable content files."));
+
+        return nodes
+            .Select(n => Upsert(hub, n))
+            .ToObservable()
+            .Merge(batchSize)
+            .Sum()
+            .SelectMany(count =>
+            {
+                logger?.LogInformation(
+                    "Installed package {Id} v{Version}: {Count} node(s) into {Partition} @ {Ref}",
+                    manifest.Id, manifest.Version, count, partition, installedFromRef);
+                return WriteInstalledRecord(hub, manifest, installedFromRef, count).Select(_ => count);
+            });
+    }
+
+    private static IObservable<MeshNode> WriteInstalledRecord(
+        IMessageHub hub, PackageManifest manifest, string installedFromRef, int count)
+    {
+        var record = MeshNode.FromPath($"{InstalledPartition}/{manifest.Id}") with
+        {
+            NodeType = PackageNodeType,
+            Name = manifest.Name ?? manifest.Id,
+            State = MeshNodeState.Active,
+            Content = manifest with
+            {
+                InstalledFromRef = installedFromRef,
+                InstalledAtUtc = DateTimeOffset.UtcNow,
+                InstalledNodeCount = count,
+            },
+        };
+        return hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(record))
+            .FirstAsync().Select(d => d.Message)
+            .SelectMany(resp => resp.Success
+                ? Observable.Return(resp.Node!)
+                : Observable.Throw<MeshNode>(new InvalidOperationException(
+                    $"Recording install of '{manifest.Id}' failed: {resp.Error}")));
+    }
+
+    // Installs a Code package: synthesize the NodeType node from the manifest's configuration, import
+    // the package's Source/*.cs files as its Code nodes (rebased UNDER the NodeType so its default
+    // Sources query finds them), and record the install. Creating the NodeType + Source nodes drives
+    // the mesh's first-build Roslyn compile, so the type goes live — no rebuild, no NuGet.
+    private static IObservable<int> InstallCode(
+        IMessageHub hub, PackageManifest manifest, IReadOnlyList<PackageFile> files,
+        string installedFromRef, ILogger? logger, int batchSize)
+    {
+        if (string.IsNullOrWhiteSpace(manifest.NodeTypeConfiguration))
+            return Observable.Throw<int>(new InvalidOperationException(
+                $"Code package '{manifest.Id}' has no nodeTypeConfiguration."));
+
+        var partition = string.IsNullOrWhiteSpace(manifest.TargetPartition) ? "type" : manifest.TargetPartition!;
+        var nodeTypePath = $"{partition}/{manifest.Id}";
+        var sourceFolder = manifest.SourceFolder ?? manifest.Id;
+        var parsers = new FileFormatParserRegistry(hub.JsonSerializerOptions);
+
+        var sourceNodes = files
+            .Where(f => !IsManifest(f.RelativePath))
+            .Select(f => ParseNode(parsers, nodeTypePath, sourceFolder, f, logger))
+            .Where(n => n is not null).Select(n => n!)
+            .ToArray();
+
+        if (sourceNodes.Length == 0)
+            return Observable.Throw<int>(new InvalidOperationException(
+                $"Code package '{manifest.Id}' has no Source/*.cs files."));
+
+        var nodeTypeNode = MeshNode.FromPath(nodeTypePath) with
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Name = manifest.Name ?? manifest.Id,
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition { Configuration = manifest.NodeTypeConfiguration },
+        };
+
+        // NodeType first, then its Source Code nodes — the mesh compiles the first build automatically.
+        return Upsert(hub, nodeTypeNode)
+            .SelectMany(_ => sourceNodes.Select(n => Upsert(hub, n)).ToObservable().Merge(batchSize).Sum())
+            .SelectMany(srcCount =>
+            {
+                var total = srcCount + 1;
+                logger?.LogInformation(
+                    "Installed code package {Id} v{Version}: NodeType {Path} + {Count} source node(s) @ {Ref}",
+                    manifest.Id, manifest.Version, nodeTypePath, srcCount, installedFromRef);
+                // Trigger the compile explicitly (belt-and-suspenders — creating the NodeType +
+                // Source nodes also kicks the first build) so the installed type goes live.
+                hub.RequestNodeTypeRelease(nodeTypePath,
+                    onError: msg => logger?.LogWarning(
+                        "Release request for {Path} failed: {Msg}", nodeTypePath, msg));
+                return WriteInstalledRecord(hub, manifest, installedFromRef, total).Select(_ => total);
+            });
+    }
+
+    private static IObservable<int> Upsert(IMessageHub hub, MeshNode node) =>
+        hub.Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
+            .FirstAsync().Select(d => d.Message)
+            .SelectMany(resp => resp.Success
+                ? Observable.Return(1)
+                : Observable.Throw<int>(new InvalidOperationException(
+                    $"Install of '{node.Path}' failed: {resp.Error}")));
+
+    // Parse one package file into a node rebased under the target partition (mirrors
+    // GitHubSyncService.ParseFile). The package.json manifest is filtered out before this.
+    private static MeshNode? ParseNode(
+        FileFormatParserRegistry parsers, string partition, string sourceFolder, PackageFile file, ILogger? logger)
+    {
+        var rel = file.RelativePath;
+        var prefix = sourceFolder + "/";
+        if (rel.StartsWith(prefix, StringComparison.Ordinal))
+            rel = rel[prefix.Length..];
+
+        var ext = System.IO.Path.GetExtension(rel);
+        var parsed = parsers.TryParse(ext, rel, file.Content, rel);
+        if (parsed is null)
+        {
+            logger?.LogWarning("No parser for package file {Path}; skipped.", file.RelativePath);
+            return null;
+        }
+
+        var (id, ns) = NodeFileMapper.FromRelativePath(rel);
+        var rebasedNs = string.IsNullOrEmpty(ns) ? partition : $"{partition}/{ns}";
+        return parsed with
+        {
+            Id = id,
+            Namespace = rebasedNs,
+            MainNode = $"{rebasedNs}/{id}",
+            State = MeshNodeState.Active,
+        };
+    }
+
+    private static bool IsManifest(string relativePath) =>
+        relativePath.EndsWith("/package.json", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(relativePath, "package.json", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -1,0 +1,107 @@
+using MeshWeaver.Domain;
+using MeshWeaver.Graph;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Entry point for the MeshWeaver plugin catalog — the mesh's git-based "app store". Registers the
+/// <c>Package</c> node type (the install-record shape) and the <see cref="PackageManifest"/> content
+/// type so install records round-trip across hubs. The catalog browse/install UI + a source-configured
+/// catalog node build on top of this. Git-based end to end; NO NuGet.
+/// </summary>
+public static class PluginCatalogConfigurationExtensions
+{
+    /// <summary>The NodeType of a catalog node (source-configured browse/install view).</summary>
+    public const string CatalogNodeType = "PluginCatalog";
+
+    /// <summary>
+    /// Registers the plugin catalog on the mesh builder: the <c>Package</c> install-record node type
+    /// and the <c>PluginCatalog</c> browse node type, plus their content types on the mesh + every
+    /// per-node hub so they round-trip across hubs.
+    /// </summary>
+    /// <typeparam name="TBuilder">The concrete mesh builder type.</typeparam>
+    /// <param name="builder">The mesh builder.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    public static TBuilder AddPluginCatalog<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+        => (TBuilder)builder
+            .AddMeshNodes(CreatePackageNodeType())
+            .AddMeshNodes(CreateCatalogNodeType())
+            .ConfigureHub(config =>
+            {
+                config.TypeRegistry.AddPluginCatalogTypes();
+                return config;
+            })
+            .ConfigureDefaultNodeHub(config =>
+            {
+                config.TypeRegistry.AddPluginCatalogTypes();
+                return config;
+            });
+
+    /// <summary>
+    /// Registers the plugin catalog AND seeds a ready-to-use catalog: a <c>Plugins</c> Space (a valid
+    /// partition root — a custom type can't be one) whose <c>Plugins/catalog</c> child is a
+    /// <c>PluginCatalog</c> node pointed at <paramref name="sourceRepoPath"/>. Install records land in
+    /// the same <c>Plugins</c> partition (as siblings), so the catalog is the space's home. When
+    /// <paramref name="sourceRepoPath"/> is empty the catalog renders a "configure me" prompt.
+    /// </summary>
+    /// <typeparam name="TBuilder">The concrete mesh builder type.</typeparam>
+    /// <param name="builder">The mesh builder.</param>
+    /// <param name="sourceRepoPath">Local path to the source git repo (the plugins checkout).</param>
+    /// <param name="sourceSubdir">Subdirectory holding the package folders (default <c>"catalog"</c>).</param>
+    /// <param name="sourceRef">Git ref to browse/install from (default <c>"HEAD"</c>).</param>
+    /// <returns>The same builder, for chaining.</returns>
+    public static TBuilder AddPluginCatalog<TBuilder>(
+        this TBuilder builder, string sourceRepoPath, string sourceSubdir = "catalog", string sourceRef = "HEAD")
+        where TBuilder : MeshBuilder
+        => (TBuilder)builder
+            .AddPluginCatalog()
+            .AddMeshNodes(
+                new MeshNode(PackageInstaller.InstalledPartition)
+                {
+                    Name = "Plugins",
+                    NodeType = "Space",
+                    State = MeshNodeState.Active,
+                    Content = new MarkdownContent
+                    {
+                        Content = "# Plugins\n\nThe plugin catalog and installed packages.",
+                    },
+                },
+                new MeshNode("catalog", PackageInstaller.InstalledPartition)
+                {
+                    Name = "Plugin Catalog",
+                    NodeType = CatalogNodeType,
+                    State = MeshNodeState.Active,
+                    Content = new PluginCatalogContent
+                    {
+                        SourceRepoPath = sourceRepoPath,
+                        SourceSubdir = sourceSubdir,
+                        SourceRef = sourceRef,
+                    },
+                });
+
+    /// <summary>Registers the plugin-catalog content types under their short names.</summary>
+    /// <param name="typeRegistry">The type registry to populate.</param>
+    /// <returns>The same type registry, for chaining.</returns>
+    public static ITypeRegistry AddPluginCatalogTypes(this ITypeRegistry typeRegistry)
+        => typeRegistry
+            .WithType(typeof(PackageManifest), nameof(PackageManifest))
+            .WithType(typeof(PluginCatalogContent), nameof(PluginCatalogContent));
+
+    private static MeshNode CreatePackageNodeType() => new(PackageInstaller.PackageNodeType)
+    {
+        Name = "Package",
+        Icon = "/static/NodeTypeIcons/box.svg",
+        HubConfiguration = config => config
+            .AddDefaultLayoutAreas()
+            .AddMeshDataSource(s => s.WithContentType<PackageManifest>()),
+    };
+
+    private static MeshNode CreateCatalogNodeType() => new(CatalogNodeType)
+    {
+        Name = "Plugin Catalog",
+        Icon = "/static/NodeTypeIcons/box.svg",
+        HubConfiguration = config => config.AddPluginCatalogViews(),
+    };
+}

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogContent.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogContent.cs
@@ -1,0 +1,23 @@
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The content of a <c>PluginCatalog</c> node — points the catalog browse view at a source git
+/// repository and ref. The catalog lists that repo's installable folders (folders carrying a
+/// <c>package.json</c>) at <see cref="SourceRef"/> and offers Install / Update per package.
+/// </summary>
+public record PluginCatalogContent
+{
+    /// <summary>Local path to the source git repository (the plugins repo checkout). A GitHub-URL
+    /// source can be added behind the same catalog later.</summary>
+    public string? SourceRepoPath { get; init; }
+
+    /// <summary>The git ref (commit SHA or branch) to browse/install from. Defaults to <c>HEAD</c>.</summary>
+    public string SourceRef { get; init; } = "HEAD";
+
+    /// <summary>Optional subdirectory within the repo that holds the package folders (e.g.
+    /// <c>"catalog"</c>). When empty, package folders are read from the repo root.</summary>
+    public string? SourceSubdir { get; init; }
+
+    /// <summary>Optional markdown intro shown above the package list.</summary>
+    public string? Description { get; init; }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/CatalogRenderTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/CatalogRenderTest.cs
@@ -1,0 +1,122 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Renders the catalog browse view on a <c>PluginCatalog</c> node pointed at a throwaway local git
+/// repo, and asserts it lists the repo's packages (under a <c>catalog/</c> subdir) as cards — the
+/// GUI-side proof that the git source → list → render pipeline works, using the same
+/// <c>GetRemoteStream</c>/<c>GetControlStream</c> binding the portal uses.
+/// </summary>
+public class CatalogRenderTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddPluginCatalog();
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddPluginCatalogTypes();
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Catalog_ListsPackagesFromGitSource_AsCards()
+    {
+        var repo = CreateTempRepo();
+        try
+        {
+            var git = new GitCli(Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>());
+            WriteFile(repo, "catalog/pack-a/package.json",
+                """{"id":"pack-a","name":"Package A","description":"first","kind":"content","targetPartition":"PartA","version":"1.0.0"}""");
+            WriteFile(repo, "catalog/pack-a/A.md", "# A");
+            WriteFile(repo, "catalog/pack-b/package.json",
+                """{"id":"pack-b","name":"Package B","description":"second","kind":"content","targetPartition":"PartB","version":"2.0.0"}""");
+            WriteFile(repo, "catalog/pack-b/B.md", "# B");
+            await git.Run(repo, ["init"]).FirstAsync().ToTask();
+            await git.Run(repo, ["add", "-A"]).FirstAsync().ToTask();
+            await git.Run(repo, ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init"])
+                .FirstAsync().ToTask();
+
+            // A catalog node pointed at the repo's catalog/ subdir. Created as a child (a partition
+            // ROOT must be a Space; a custom node type can't be a root), under the admin partition.
+            const string catalogPath = "rbuergi/catalog";
+            await NodeFactory.CreateNode(MeshNode.FromPath(catalogPath) with
+            {
+                Name = "Catalog",
+                NodeType = "PluginCatalog",
+                Content = new PluginCatalogContent
+                {
+                    SourceRepoPath = repo,
+                    SourceRef = "HEAD",
+                    SourceSubdir = "catalog",
+                },
+            }).Should().Emit();
+
+            var workspace = GetClient(c => c.AddData()).GetWorkspace();
+            var reference = new LayoutAreaReference(CatalogLayoutAreas.CatalogArea);
+            var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+                new Address(catalogPath), reference);
+
+            // The catalog resolves to a stack that lists both packages as "pkg-*" card areas.
+            var stack = (StackControl)(await stream.GetControlStream(reference.Area!)
+                .Should().Within(60.Seconds()).Match(c =>
+                    c is StackControl s
+                    && s.Areas.Count(a => a.Area?.ToString()?.Contains("/pkg-") == true) == 2))!;
+
+            var cardAreas = stack.Areas
+                .Select(a => a.Area?.ToString())
+                .Where(p => p is not null && p.Contains("/pkg-"))
+                .ToList();
+            cardAreas.Count.Should().Be(2);
+
+            // Each card renders (a StackControl with content).
+            foreach (var area in cardAreas)
+                await stream.GetControlStream(area!)
+                    .Should().Within(15.Seconds()).Match(c => c is StackControl);
+
+            await NodeFactory.DeleteNode(catalogPath).Should().Emit();
+        }
+        finally
+        {
+            TryDelete(repo);
+        }
+    }
+
+    private static string CreateTempRepo()
+    {
+        var p = Path.Combine(Path.GetTempPath(), "pkgcat-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(p);
+        return p;
+    }
+
+    private static void WriteFile(string root, string relative, string content)
+    {
+        var full = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+    }
+
+    private static void TryDelete(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); }
+        catch { /* best effort */ }
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/CatalogSeedTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/CatalogSeedTest.cs
@@ -1,0 +1,37 @@
+#pragma warning disable CS1591
+
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Proves the config-seed: <c>AddPluginCatalog(sourceRepoPath)</c> materializes a <c>Plugins</c>
+/// Space with a <c>Plugins/catalog</c> catalog node on boot, so a portal shows the catalog without
+/// anyone creating a node by hand. (The source path is irrelevant to seeding the node itself.)
+/// </summary>
+public class CatalogSeedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddPluginCatalog("/plugins", "catalog", "HEAD");
+
+    [Fact(Timeout = 120000)]
+    public async Task Seed_CreatesCatalogNode_UnderPluginsSpace()
+    {
+        var catalog = await Mesh.GetWorkspace().GetMeshNodeStream("Plugins/catalog")
+            .Where(n => n is not null).FirstAsync().Timeout(30.Seconds()).ToTask();
+
+        catalog.NodeType.Should().Be(PluginCatalogConfigurationExtensions.CatalogNodeType);
+        var cfg = catalog.ContentAs<PluginCatalogContent>(Mesh.JsonSerializerOptions);
+        cfg.Should().NotBeNull();
+        cfg!.SourceRepoPath.Should().Be("/plugins");
+        cfg.SourceSubdir.Should().Be("catalog");
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/CodePackageInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/CodePackageInstallTest.cs
@@ -1,0 +1,95 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Stage 3 — runtime code-load. Installs a <c>kind=code</c> package (a NodeType configuration in the
+/// manifest + a <c>Source/*.cs</c> file) from a git repo, and asserts the mesh compiles the freshly
+/// installed NodeType LIVE (Roslyn first-build → <see cref="CompilationStatus.Ok"/>) — no app rebuild,
+/// no NuGet. This reuses the same compile/release flow that <c>CompileActivityLogTest</c> exercises.
+/// </summary>
+public class CodePackageInstallTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddGraph().AddPluginCatalog();
+
+    [Fact(Timeout = 120_000)]
+    public async Task CodePackage_InstallsNodeTypeAndSource_CompilesLive()
+    {
+        var repo = CreateTempDir();
+        try
+        {
+            var git = new GitCli(Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>());
+
+            WriteFile(repo, "catalog/widget-type/package.json",
+                """{"id":"widget-type","name":"Widget","kind":"code","targetPartition":"type","version":"1.0.0","nodeTypeConfiguration":"config => config.WithContentType<Widget>()"}""");
+            WriteFile(repo, "catalog/widget-type/Source/Widget.cs",
+                "public record Widget { public string Title { get; init; } = string.Empty; }");
+
+            await git.Run(repo, ["init"]).FirstAsync().ToTask();
+            await git.Run(repo, ["add", "-A"]).FirstAsync().ToTask();
+            await git.Run(repo, ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init"])
+                .FirstAsync().ToTask();
+
+            var source = new GitPackageSource(git, repo, "catalog");
+            var pkg = (await source.ListPackages("HEAD").FirstAsync().ToTask()).First(p => p.Id == "widget-type");
+            pkg.Kind.Should().Be(PackageKind.Code);
+            var files = await source.FetchPackageFiles(pkg, "HEAD").FirstAsync().ToTask();
+
+            var count = await PackageInstaller.Install(Mesh, pkg, files, "HEAD").FirstAsync().ToTask();
+            count.Should().Be(2); // the NodeType node + one Source Code node
+
+            // The mesh compiles the just-installed NodeType (first build) and settles Ok — the custom
+            // type is now live in a running mesh, installed purely by picking a git commit + folder.
+            var node = await Mesh.GetMeshNodeStream("type/widget-type")
+                .Should().Within(90.Seconds())
+                .Match(n => n?.Content is NodeTypeDefinition d
+                    && d.CompilationStatus is CompilationStatus.Ok or CompilationStatus.Error);
+
+            var def = (NodeTypeDefinition)node.Content!;
+            def.CompilationStatus.Should().Be(CompilationStatus.Ok,
+                $"the installed code package must compile live; error: {def.CompilationError}");
+        }
+        finally
+        {
+            TryDelete(repo);
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        var p = Path.Combine(Path.GetTempPath(), "pkgcode-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(p);
+        return p;
+    }
+
+    private static void WriteFile(string root, string relative, string content)
+    {
+        var full = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+    }
+
+    private static void TryDelete(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); }
+        catch { /* best effort */ }
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/MeshWeaver.PluginCatalog.Test.csproj
+++ b/test/MeshWeaver.PluginCatalog.Test/MeshWeaver.PluginCatalog.Test.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MeshWeaver.PluginCatalog\MeshWeaver.PluginCatalog.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/MeshWeaver.PluginCatalog.Test/PackageInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PackageInstallTest.cs
@@ -1,0 +1,182 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// End-to-end proof of the git-based install loop: a throwaway local git repo holds one content
+/// package (a folder with a <c>package.json</c> manifest + a markdown file); the catalog lists it
+/// by commit, fetches its files, and installs it INCREMENTALLY into the target partition — then an
+/// install record is written to the <c>Plugins</c> registry. No NuGet, no network.
+/// </summary>
+public class PackageInstallTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddPluginCatalog();
+
+    [Fact(Timeout = 120000)]
+    public async Task GitPackage_ListsInstalls_ContentIntoPartition_AndRecordsIt()
+    {
+        var repo = CreateTempDir();
+        try
+        {
+            var git = new GitCli(Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>());
+
+            // A single content package: manifest + one markdown file.
+            WriteFile(repo, "hello-pack/package.json",
+                """{"id":"hello-pack","name":"Hello Pack","description":"A greeting.","kind":"content","targetPartition":"CatalogTest","version":"1.0.0"}""");
+            WriteFile(repo, "hello-pack/Greeting.md", "# Hello\n\nInstalled from a git package.");
+            // A non-package folder (no manifest) must be ignored by the catalog.
+            WriteFile(repo, "notes/scratch.md", "not a package");
+
+            await git.Run(repo, ["init"]).FirstAsync().ToTask();
+            await git.Run(repo, ["add", "-A"]).FirstAsync().ToTask();
+            await git.Run(repo, ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init"])
+                .FirstAsync().ToTask();
+
+            var source = new GitPackageSource(git, repo);
+
+            // List: exactly the one folder that carries a manifest.
+            var packages = await source.ListPackages("HEAD").FirstAsync().ToTask();
+            packages.Count.Should().Be(1);
+            var pkg = packages[0];
+            pkg.Id.Should().Be("hello-pack");
+            pkg.Name.Should().Be("Hello Pack");
+            pkg.TargetPartition.Should().Be("CatalogTest");
+            pkg.SourceFolder.Should().Be("hello-pack");
+            pkg.Kind.Should().Be(PackageKind.Content);
+
+            // Fetch + install.
+            var files = await source.FetchPackageFiles(pkg, "HEAD").FirstAsync().ToTask();
+            var count = await PackageInstaller.Install(Mesh, pkg, files, "HEAD").FirstAsync().ToTask();
+            count.Should().Be(1);
+
+            // The content landed under the target partition, rebased off the package folder.
+            var installed = await Mesh.GetWorkspace().GetMeshNodeStream("CatalogTest/Greeting")
+                .Where(n => n is not null).FirstAsync().Timeout(30.Seconds()).ToTask();
+            installed.NodeType.Should().Be("Markdown");
+
+            // And the install was recorded in the Plugins registry with the source ref + version.
+            var record = await Mesh.GetWorkspace().GetMeshNodeStream("Plugins/hello-pack")
+                .Where(n => n is not null).FirstAsync().Timeout(30.Seconds()).ToTask();
+            record.NodeType.Should().Be("Package");
+            var manifest = record.ContentAs<PackageManifest>(Mesh.JsonSerializerOptions);
+            manifest.Should().NotBeNull();
+            manifest!.Version.Should().Be("1.0.0");
+            manifest.InstalledFromRef.Should().Be("HEAD");
+            manifest.InstalledNodeCount.Should().Be(1);
+        }
+        finally
+        {
+            TryDelete(repo);
+        }
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task AgentPackage_InstallsAsAgentNode()
+    {
+        var repo = CreateTempDir();
+        try
+        {
+            var git = new GitCli(Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>());
+
+            // A real AI-content package: a valid Agent .md (frontmatter nodeType: Agent), under a
+            // catalog/ subdir — exactly how the plugins repo ships it.
+            WriteFile(repo, "catalog/echo-agent/package.json",
+                """{"id":"echo-agent","name":"Echo Agent","kind":"content","targetPartition":"Agent","version":"1.0.0"}""");
+            WriteFile(repo, "catalog/echo-agent/Echo.md",
+                "---\nnodeType: Agent\nname: Echo\ndescription: A sample agent.\ncategory: Agents\n---\n\nYou are Echo, a sample agent.");
+
+            await git.Run(repo, ["init"]).FirstAsync().ToTask();
+            await git.Run(repo, ["add", "-A"]).FirstAsync().ToTask();
+            await git.Run(repo, ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init"])
+                .FirstAsync().ToTask();
+
+            var source = new GitPackageSource(git, repo, "catalog");
+            var packages = await source.ListPackages("HEAD").FirstAsync().ToTask();
+            var pkg = packages.First(p => p.Id == "echo-agent");
+            var files = await source.FetchPackageFiles(pkg, "HEAD").FirstAsync().ToTask();
+
+            await PackageInstaller.Install(Mesh, pkg, files, "HEAD").FirstAsync().ToTask();
+
+            // The Agent .md installs as a proper Agent node in the Agent partition — proving the
+            // catalog installs real AI content, not just plain markdown.
+            var agent = await Mesh.GetWorkspace().GetMeshNodeStream("Agent/Echo")
+                .Where(n => n is not null).FirstAsync().Timeout(30.Seconds()).ToTask();
+            agent.NodeType.Should().Be("Agent");
+            agent.Name.Should().Be("Echo");
+        }
+        finally
+        {
+            TryDelete(repo);
+        }
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task GitHubSource_ListsAndInstalls_FromFetchedSnapshot()
+    {
+        // The GitHub-fetch source reuses GitSync's fetch; here a stub delegate stands in for the
+        // repo client (offline, no network, no full IGitHubRepoClient double). It returns the repo
+        // tree filtered to the requested subdirectory — exactly like Octokit's client.
+        var repoFiles = new List<RepoFile>
+        {
+            new("catalog/gh-pack/package.json",
+                """{"id":"gh-pack","name":"GH Pack","kind":"content","targetPartition":"GhPart","version":"1.0.0"}"""),
+            new("catalog/gh-pack/Doc.md", "# From GitHub"),
+        };
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch = (url, gitRef, sub, token) =>
+            Observable.Return(new RepoSnapshot("sha1", repoFiles
+                .Where(f => sub is null || f.Path.StartsWith(sub, StringComparison.Ordinal))
+                .ToList()));
+
+        var source = new GitHubPackageSource(fetch, "https://github.com/acme/plugins", subdir: "catalog");
+
+        var packages = await source.ListPackages("HEAD").FirstAsync().ToTask();
+        packages.Count.Should().Be(1);
+        var pkg = packages[0];
+        pkg.Id.Should().Be("gh-pack");
+        pkg.SourceFolder.Should().Be("catalog/gh-pack");
+
+        var files = await source.FetchPackageFiles(pkg, "HEAD").FirstAsync().ToTask();
+        var count = await PackageInstaller.Install(Mesh, pkg, files, "main").FirstAsync().ToTask();
+        count.Should().Be(1);
+
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream("GhPart/Doc")
+            .Where(n => n is not null).FirstAsync().Timeout(30.Seconds()).ToTask();
+        node.NodeType.Should().Be("Markdown");
+    }
+
+    private static string CreateTempDir()
+    {
+        var p = Path.Combine(Path.GetTempPath(), "pkgcat-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(p);
+        return p;
+    }
+
+    private static void WriteFile(string root, string relative, string content)
+    {
+        var full = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+    }
+
+    private static void TryDelete(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); }
+        catch { /* best effort */ }
+    }
+}


### PR DESCRIPTION
## What

Adds **`MeshWeaver.PluginCatalog`** — the mesh's git-based "app store." Browse installable folders in a git repo and install each into a **running** mesh by picking a **git commit + folder**. No NuGet.

- **Content packages** — a folder's files (markdown, agent/skill `.md`, JSON) are imported into a target partition via incremental `CreateOrUpdate` upsert (no prune — installing one agent doesn't touch the others).
- **Code packages** — the manifest's `nodeTypeConfiguration` + `Source/*.cs` become a NodeType the mesh **compiles live** via its existing Roslyn compile/release flow (no rebuild, no `AssemblyLoadContext` plumbing).
- **Sources** — a local git repo (`git` CLI via the Process I/O pool) or a remote GitHub repo (reusing GitSync's fetch), so a deployed portal with no source tree can still browse/install.
- Browse/install layout area + a `Plugins` install registry; a config-seeded `Plugins` space + `Plugins/catalog` node (`PluginCatalog:SourceRepoPath`). Wired into the memex portal.
- Sample packages under `plugins/catalog/` (content + one runtime-compiled code sample).

## Scope

Catalog machinery only — self-contained, seam-free, no module extraction. (Extracting Courses/Speech into `plugins/` and packaging the real LinkedIn module from prod are separate follow-ups; Slides is being actively reworked on main so it stays in core.)

## Verified

- Full solution `dotnet build -c Release -warnaserror` → **0/0**.
- `MeshWeaver.PluginCatalog.Test` **6/6**: content install, agent install, GitHub source, catalog render, config-seed, and code-package **compiles live** on the mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)