### PR TITLE
feat(react-native): interactive markdown via shared server Markdig + splitRenderedHtml

### DIFF
--- a/clients/react-native/App.tsx
+++ b/clients/react-native/App.tsx
@@ -5,14 +5,17 @@ import {
   ScopeProvider,
   StaticAreaSource,
   EmbeddedAreaProvider,
+  MeshOpsProvider,
   createGrpcEmbeddedFactory,
   type AreaSource,
   type AreaSourceFactory,
+  type MeshOps,
 } from "@meshweaver/react/core";
 import { Mesh } from "@meshweaver/client-web";
 import { rnPack } from "./src/rnPack";
 import { sampleArea } from "./src/sample";
 import { createLiveSource } from "./src/live";
+import { buildMeshOps } from "./src/liveOps";
 import { NavContext, CurrentAddressContext, type NavTarget } from "./src/nav";
 import { Shell, HOME } from "./src/Shell";
 import { ensureWebStyles } from "./src/webStyles";
@@ -78,6 +81,9 @@ function AppInner() {
   const [submitter, setSubmitter] = useState<ThreadSubmitter | undefined>(undefined);
   // The factory `@@` layout-area embeds (LayoutAreaControl) open their nested area streams through.
   const [embedFactory, setEmbedFactory] = useState<AreaSourceFactory | null>(null);
+  // The MeshOps surface (interactive-markdown render + kernel, thread submit, node ops) the tree consumes
+  // via useMeshOps — built at the app level over the live connection, exactly like portal-next's adaptOps.
+  const [meshOps, setMeshOps] = useState<MeshOps | null>(null);
 
   const navigate = (t: NavTarget) => {
     setClientScreen(null);
@@ -107,6 +113,9 @@ function AppInner() {
         // AND the nested streams that `@@("area/X")` layout-area embeds open.
         setSubmitter(Mesh.from(l.connection));
         setEmbedFactory(() => createGrpcEmbeddedFactory(l.connection));
+        // The full MeshOps over the same connection — renderMarkdown (server Markdig) + the per-view kernel
+        // anchor the interactive markdown + runnable code cells; the kernel activity lives in CHAT's partition.
+        setMeshOps(buildMeshOps(l.connection, inst.url, CHAT?.namespacePath ?? ""));
       })
       .catch((e) => { console.warn("[live] connect failed:", e?.message ?? String(e)); /* shell stays on the last-good source */ });
     return () => {
@@ -142,6 +151,7 @@ function AppInner() {
     <SafeAreaView style={{ flex: 1, backgroundColor: palette.appBg }}>
       <StatusBar />
       <RegistryProvider pack={rnPack}>
+       <MeshOpsProvider ops={meshOps}>
         <EmbeddedAreaProvider factory={embedFactory}>
           <NavContext.Provider value={navigate}>
             <CurrentAddressContext.Provider value={nav.address}>
@@ -158,6 +168,7 @@ function AppInner() {
             </CurrentAddressContext.Provider>
           </NavContext.Provider>
         </EmbeddedAreaProvider>
+       </MeshOpsProvider>
       </RegistryProvider>
       {CHAT && (
         <ChatComposer

--- a/clients/react-native/src/liveOps.ts
+++ b/clients/react-native/src/liveOps.ts
@@ -1,0 +1,135 @@
+// The React-Native MeshOps — built at the APP level exactly like clients/portal-next/src/client/live.ts
+// (adaptOps), over the SAME shared building blocks: @meshweaver/client-web's `Mesh` (watch/patch/create/
+// thread) + the interactive-markdown contract from @meshweaver/react/core. The only RN-specific bits are
+// (a) it talks to the LocalMesh sidecar ANONYMOUSLY (no token mint — the sidecar is same-origin, no auth),
+// and (b) render-markdown goes over a plain fetch POST (non-streaming, so the RN global fetch is fine —
+// only the gRPC-web server-stream needs nativeStreamingFetch). renderMarkdown reuses the ONE server Markdig
+// parser; the Markdown leaf hydrates its HTML with the shared splitRenderedHtml — no bespoke parser.
+import { Mesh, type MeshWebConnection } from "@meshweaver/client-web";
+import type {
+  MarkdownCellSubmission,
+  MarkdownKernelSession,
+  MeshNodeState,
+  MeshOps,
+  RenderedMarkdown,
+  ThreadSubmitOptions,
+} from "@meshweaver/react/core";
+
+/** Server-side Markdig render (POST {baseUrl}/api/mesh/render-markdown) — the ONE markdown parser. */
+async function renderMarkdown(baseUrl: string, markdown: string, nodePath?: string): Promise<RenderedMarkdown> {
+  const resp = await fetch(`${baseUrl.replace(/\/+$/, "")}/api/mesh/render-markdown`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ markdown, nodePath: nodePath ?? null }),
+  });
+  if (!resp.ok) throw new Error(`render-markdown failed (${resp.status})`);
+  const text = await resp.text();
+  if (text.startsWith("Error:")) throw new Error(text);
+  const parsed = JSON.parse(text) as { html?: string; codeSubmissions?: MarkdownCellSubmission[] };
+  return { html: parsed.html ?? "", codeSubmissions: parsed.codeSubmissions ?? [] };
+}
+
+function newId(): string {
+  const g = globalThis as { crypto?: { randomUUID?: () => string } };
+  return (g.crypto?.randomUUID?.() ?? `${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`).replace(/-/g, "");
+}
+
+/**
+ * The per-view interactive-markdown kernel — the RN twin of portal-next's startMarkdownKernel /
+ * MarkdownViewLogic.CreateActivityAndSubmit: create the kernel Activity under `partition` (the only
+ * place the viewer can Create), wait until its per-node hub is ROUTABLE (first stream emission proves
+ * it — posting before that NotFound-storms the router), then post the cell submissions IN ORDER.
+ */
+async function startMarkdownKernel(
+  connection: MeshWebConnection,
+  mesh: Mesh,
+  partition: string,
+  cells: MarkdownCellSubmission[],
+): Promise<MarkdownKernelSession> {
+  if (!partition) throw new Error("no partition to anchor the kernel activity");
+  const kernelId = newId();
+  const ns = `${partition}/_Activity`;
+  const activityPath = `${ns}/markdown-${kernelId}`;
+
+  await mesh.create({
+    id: `markdown-${kernelId}`,
+    namespace: ns,
+    path: activityPath,
+    name: `Markdown view ${kernelId.slice(0, 8)}`,
+    nodeType: "Activity",
+    mainNode: partition,
+    state: "Active",
+    content: {
+      $type: "ActivityLog",
+      category: "MarkdownExecution",
+      id: `markdown-${kernelId}`,
+      hubPath: partition,
+      status: "Running",
+    },
+  });
+
+  // Routable gate: the activity node's own stream is served BY its per-node hub, so the first emission
+  // proves the hub is live (CreateNode completing only means PERSISTED).
+  await Promise.race([
+    (async () => {
+      for await (const node of mesh.watch(activityPath)) if (node) return;
+    })(),
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error("kernel activity did not become routable within 15s")), 15_000),
+    ),
+  ]);
+
+  const submit = (cell: MarkdownCellSubmission) =>
+    connection.observe(activityPath, "SubmitCodeRequest", {
+      code: cell.code,
+      id: cell.id,
+      language: cell.language ?? "csharp",
+    });
+
+  void (async () => {
+    for (const cell of cells) {
+      try {
+        await submit(cell);
+      } catch {
+        // an individual cell failure surfaces in its own result area; later cells still run
+      }
+    }
+  })();
+
+  return {
+    kernelAddress: activityPath,
+    submit: (cell) => void submit(cell).catch(() => undefined),
+    dispose: () => {
+      mesh.patch(activityPath, { content: { requestedStatus: "Cancelled" } });
+      void mesh.delete(activityPath).catch(() => undefined);
+    },
+  };
+}
+
+async function* watchNode(mesh: Mesh, path: string): AsyncIterable<MeshNodeState> {
+  for await (const node of mesh.watch(path)) {
+    yield { ...node.raw, path: node.path ?? path, name: node.name, nodeType: node.nodeType, content: node.content };
+  }
+}
+
+/**
+ * Build the RN MeshOps from a live connection. `partition` anchors the interactive-markdown kernel
+ * activity (the viewer's home partition — CHAT.namespacePath on the anonymous sidecar).
+ */
+export function buildMeshOps(connection: MeshWebConnection, baseUrl: string, partition: string): MeshOps {
+  const mesh = Mesh.from(connection);
+  return {
+    watch: (path: string) => watchNode(mesh, path),
+    startThread: (namespacePath: string, userText: string, opts?: ThreadSubmitOptions) =>
+      mesh.startThread(namespacePath, userText, opts),
+    submitMessage: (threadPath: string, userText: string, opts?: ThreadSubmitOptions) =>
+      mesh.submitMessage(threadPath, userText, opts),
+    patch: (path: string, fields: Record<string, unknown>) => mesh.patch(path, fields),
+    search: (query: string, basePath?: string, limit?: number) =>
+      mesh.search(query, basePath, limit).catch(() => [] as Record<string, unknown>[]),
+    renderMarkdown: (markdown: string, nodePath?: string) => renderMarkdown(baseUrl, markdown, nodePath),
+    startMarkdownKernel: (cells: MarkdownCellSubmission[]) => startMarkdownKernel(connection, mesh, partition, cells),
+    getNode: (path: string) => mesh.get(path).then((n) => n.raw as Record<string, unknown>).catch(() => null),
+    createNode: (node: Record<string, unknown>) => mesh.create(node).then(() => undefined),
+  };
+}

--- a/clients/react-native/src/rnPack.tsx
+++ b/clients/react-native/src/rnPack.tsx
@@ -10,16 +10,19 @@ import {
   ControlRenderer,
   RenderArea,
   ScopeProvider,
+  splitRenderedHtml,
   useAreaSourceFactory,
   useAreaState,
   useBindingPointer,
   useChildAreas,
   useEmit,
+  useMeshOps,
   useResolve,
   useScope,
   type ControlComponent,
   type EmbeddedAreaHandle,
   type LeafPack,
+  type MarkdownKernelSession,
   type SkinComponent,
 } from "@meshweaver/react/core";
 
@@ -205,37 +208,92 @@ const DataGrid: ControlComponent = ({ control }) => {
 // components (react-native-render-html) on a device, a stripped-text fallback in tests (see nativeHtml).
 const Html: ControlComponent = ({ control }) => <NativeHtml html={s(useResolve(control.data))} />;
 
-// Markdown / collaborative-markdown (read-only). CollaborativeMarkdownControl carries its markdown in
-// `value`; the plain Markdown control uses `data`. Convert markdown → HTML, then render via NativeHtml.
+// Markdown / collaborative-markdown. The ONE parser is server-side Markdig (meshOps.renderMarkdown): it
+// resolves inline @@ embeds + runnable code cells into markers the SHARED splitRenderedHtml hydrates. We
+// render HTML chunks via NativeHtml, area markers via <AreaEmbed>, code-cell toolbars as a Run button wired
+// to the per-view kernel. Without a MeshOps host (offline/tests) fall back to the plain `marked` render.
 const Markdown: ControlComponent = ({ control }) => {
   const md = s(useResolve(control.value ?? control.data ?? control.content ?? control.markdown));
-  return <NativeHtml html={marked.parse(md, { async: false }) as string} />;
+  const nodePath = s((control as any).nodePath ?? (control as any).hubAddress) || undefined;
+  const ops = useMeshOps();
+  return ops?.renderMarkdown
+    ? <InteractiveMarkdown markdown={md} nodePath={nodePath} />
+    : <NativeHtml html={marked.parse(md, { async: false }) as string} />;
 };
 
-// A nested layout area on another address — the `@@("area/X")` embed (LayoutAreaControl). Opens a SECOND
-// area stream via the host's AreaSourceFactory (App wires createGrpcEmbeddedFactory on the live connection)
-// and renders that tree in its own scope — the native mirror of the web LayoutAreaView. Without a factory
-// (offline / tests) it falls back to a labelled marker.
-const LayoutAreaEmbed: ControlComponent = ({ control }) => {
-  const factory = useAreaSourceFactory();
-  const rawAddress = useResolve(control.address);
-  const address = typeof rawAddress === "string" ? rawAddress : s((rawAddress as any)?.address ?? (rawAddress as any)?.path);
-  const ref = (control.reference ?? {}) as any;
-  const area = s(ref.area ?? ref.Area ?? "");
-  const id = ref.id ?? ref.Id;
-  const layout = ref.layout ?? ref.Layout;
-  // Progress options mirror the web LayoutAreaView: ShowProgress (default true) suppressed either by a
-  // false ShowProgress or SpinnerType "None".
-  const showProgress = useResolve(control.showProgress) !== false && s(control.spinnerType) !== "None";
-  const key = `${address}|${area}|${id == null ? "" : s(id)}|${s(layout)}`;
+// Interactive markdown: server Markdig render → shared splitRenderedHtml → native segment leaves. A single
+// per-view kernel (meshOps.startMarkdownKernel) hosts every runnable cell's result area + Run affordance —
+// the RN twin of the web MarkdownView (clients/react/src/controls/display.tsx).
+function InteractiveMarkdown({ markdown, nodePath }: { markdown: string; nodePath?: string }) {
+  const ops = useMeshOps();
+  const [segments, setSegments] = useState<ReturnType<typeof splitRenderedHtml> | null>(null);
+  const [subs, setSubs] = useState<{ id: string; code: string; language?: string }[]>([]);
+  const [kernel, setKernel] = useState<MarkdownKernelSession | null>(null);
+  useEffect(() => {
+    let live = true;
+    let session: MarkdownKernelSession | null = null;
+    ops?.renderMarkdown?.(markdown, nodePath)
+      .then((r) => {
+        if (!live) return;
+        setSegments(splitRenderedHtml(r.html));
+        setSubs(r.codeSubmissions);
+        if (r.codeSubmissions.length && ops.startMarkdownKernel)
+          ops.startMarkdownKernel(r.codeSubmissions)
+            .then((sess) => { if (live) { session = sess; setKernel(sess); } })
+            .catch(() => { /* kernel unavailable — cells still render, Run stays disabled */ });
+      })
+      .catch(() => { if (live) setSegments([{ kind: "html", html: `<p>${markdown}</p>` }]); });
+    return () => { live = false; session?.dispose?.(); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [markdown, nodePath]);
 
+  if (!segments) return <ActivityIndicator />;
+  return (
+    <>
+      {segments.map((seg, i) => {
+        if (seg.kind === "html") return <NativeHtml key={i} html={seg.html} />;
+        if (seg.kind === "area") {
+          const address = seg.isKernel ? kernel?.kernelAddress : (seg.address ?? seg.rawPath);
+          if (!address) return null; // kernel result area before its session is live
+          return <AreaEmbed key={i} address={address} area={s(seg.area ?? "")} id={seg.id} />;
+        }
+        if (seg.kind === "toolbar") {
+          const sub = subs.find((x) => x.id === seg.submissionId);
+          return <RunCell key={i} kernel={kernel} submission={sub ?? { id: seg.submissionId, code: "", language: seg.language }} />;
+        }
+        return null; // mermaidHtml — not rendered natively (yet)
+      })}
+    </>
+  );
+}
+
+// The Run affordance for a --render code cell: re-submits the cell's code to the per-view kernel; the output
+// streams into the sibling kernel result AreaEmbed. Disabled until the kernel session is live.
+function RunCell({ kernel, submission }: { kernel: MarkdownKernelSession | null; submission: { id: string; code: string; language?: string } }) {
+  return (
+    <Pressable
+      style={[styles.button, styles.runCell, !kernel && { opacity: 0.5 }]}
+      onPress={() => kernel?.submit(submission)}
+      disabled={!kernel}
+    >
+      <Text style={styles.buttonText}>▶ Run</Text>
+    </Pressable>
+  );
+}
+
+// A nested layout area on another address — the shared embed under `@@` macros (LayoutAreaControl), the
+// interactive-markdown segment embeds, and kernel result areas. Opens a SECOND area stream via the host's
+// AreaSourceFactory (App wires createGrpcEmbeddedFactory on the live connection) and renders it in its own
+// scope — the native mirror of the web LayoutAreaView. Without a factory (offline/tests) → a labelled marker.
+function AreaEmbed({ address, area, id, layout, showProgress = true }: { address: string; area: string; id?: unknown; layout?: unknown; showProgress?: boolean }) {
+  const factory = useAreaSourceFactory();
+  const key = `${address}|${area}|${id == null ? "" : s(id)}|${s(layout)}`;
   const [handle, setHandle] = useState<EmbeddedAreaHandle | null>(null);
   useEffect(() => {
     if (!factory || !address) return;
     const h = factory(address, { area: area || undefined, id, layout: layout ? String(layout) : undefined });
     setHandle(h);
     return () => { h?.dispose?.(); setHandle(null); };
-    // key captures address/area/id/layout; factory identity change re-opens the nested subscription.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [factory, key]);
 
@@ -248,6 +306,15 @@ const LayoutAreaEmbed: ControlComponent = ({ control }) => {
       <EmbeddedAreaBody rootArea={rootArea} showProgress={showProgress} />
     </ScopeProvider>
   );
+}
+
+// The @@("area/X") embed control (LayoutAreaControl) → the shared <AreaEmbed>.
+const LayoutAreaEmbed: ControlComponent = ({ control }) => {
+  const rawAddress = useResolve(control.address);
+  const address = typeof rawAddress === "string" ? rawAddress : s((rawAddress as any)?.address ?? (rawAddress as any)?.path);
+  const ref = (control.reference ?? {}) as any;
+  const showProgress = useResolve(control.showProgress) !== false && s(control.spinnerType) !== "None";
+  return <AreaEmbed address={address} area={s(ref.area ?? ref.Area ?? "")} id={ref.id ?? ref.Id} layout={ref.layout ?? ref.Layout} showProgress={showProgress} />;
 };
 
 // Inside the NESTED source's scope: spin (unless progress is suppressed) until the embedded root area
@@ -644,6 +711,7 @@ const styles = StyleSheet.create({
   badge: { alignSelf: "flex-start", backgroundColor: "#0f6cbd", borderRadius: 10, paddingHorizontal: 8, paddingVertical: 2 },
   badgeText: { color: "white", fontSize: 12 },
   button: { backgroundColor: "#0f6cbd", paddingVertical: 10, paddingHorizontal: 14, borderRadius: 6, alignItems: "center" },
+  runCell: { alignSelf: "flex-start", marginVertical: 8, paddingVertical: 6, paddingHorizontal: 12 },
   buttonText: { color: "white", fontWeight: "600" },
   input: { borderWidth: 1, borderColor: "#ccc", borderRadius: 4, padding: 8, fontSize: 14 },
   row: { flexDirection: "row" },


### PR DESCRIPTION
Makes the RN app render interactive markdown the **same way the web does** — reusing the shared pieces, no bespoke parser (follow-up to #359).

- **`src/liveOps.ts`** — builds the RN `MeshOps` at the **app level**, exactly like portal-next's `adaptOps`, over the SAME shared blocks: `@meshweaver/client-web`'s `Mesh` + the interactive-markdown contract from `@meshweaver/react/core`. `renderMarkdown` POSTs to the LocalMesh `/api/mesh/render-markdown` Markdig endpoint (anonymous — the sidecar is same-origin); `startMarkdownKernel` creates the per-view kernel Activity + submits cells.
- **`App.tsx`** — wraps the tree in `MeshOpsProvider` (also unlocks ThreadChat/Search later, same contract).
- **rnPack Markdown leaf → `InteractiveMarkdown`** — `meshOps.renderMarkdown` → the **shared `splitRenderedHtml`** → native segment leaves (`NativeHtml` chunks, a factored `<AreaEmbed>` for `@@`/kernel areas, a Run button wired to the kernel). `marked` kept only as the offline/test fallback.

**Verified on the iOS simulator**: `Doc/Architecture/PythonCodeNodes` renders through the server Markdig pipeline — bold, inline code, links, headings, fenced code blocks, lists, blockquotes, Comments area all correct. tsc clean, **55 vitest**, **5/5 web e2e**.

Known follow-up: an ABSOLUTE `@@Doc/…` embed inside a CollaborativeMarkdown resolves relative to `nodePath` (path doubling) — a pre-existing server-side `@@` resolution nuance, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)