### PR TITLE
feat(mesh): access-controlled export/import of subtrees (ZIP via MCP)

### DIFF
--- a/src/MeshWeaver.AI/MeshExportManifest.cs
+++ b/src/MeshWeaver.AI/MeshExportManifest.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// The <c>manifest.json</c> at the root of a mesh export ZIP produced by
+/// <see cref="MeshOperations.Export"/> and consumed by <see cref="MeshOperations.Import"/>.
+///
+/// <para>It carries the full JSON of every MeshNode in the exported subtree (node Content —
+/// including Code source and Markdown bodies — rides inside each node) plus a listing of every
+/// content-collection file whose raw bytes live under the ZIP's <c>files/</c> tree. Serialized
+/// with the hub's JSON options so <c>$type</c> polymorphic node Content round-trips.</para>
+/// </summary>
+public record MeshExportManifest
+{
+    /// <summary>Manifest schema version (bump on breaking layout changes).</summary>
+    public int Version { get; init; } = 1;
+
+    /// <summary>The exported subtree's root path (e.g. <c>RtSrc</c>). Import rewrites this
+    /// prefix to the target namespace.</summary>
+    public string ExportRoot { get; init; } = string.Empty;
+
+    /// <summary>UTC timestamp the export was produced.</summary>
+    public DateTimeOffset ExportedAt { get; init; }
+
+    /// <summary>Every MeshNode in the subtree (root + descendants), with full Content.</summary>
+    public IReadOnlyList<MeshNode> Nodes { get; init; } = new List<MeshNode>();
+
+    /// <summary>Every content-collection file exported; the raw bytes live at
+    /// <c>files/{NodePath}/{Collection}/{FilePath}</c> inside the ZIP.</summary>
+    public IReadOnlyList<MeshExportFileEntry> Files { get; init; } = new List<MeshExportFileEntry>();
+}
+
+/// <summary>
+/// One content-collection file entry in a <see cref="MeshExportManifest"/>. The raw bytes are
+/// stored in the ZIP at <c>files/{NodePath}/{Collection}/{FilePath}</c>.
+/// </summary>
+/// <param name="NodePath">The owning node's path (rewritten on import).</param>
+/// <param name="Collection">The content-collection name on that node (e.g. <c>content</c>).</param>
+/// <param name="FilePath">The file's collection-relative path (e.g. <c>hello.txt</c> or
+/// <c>branding/logo.png</c>).</param>
+/// <param name="Size">The file size in bytes (informational).</param>
+public record MeshExportFileEntry(string NodePath, string Collection, string FilePath, int Size);

--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -1,9 +1,11 @@
 using System.Collections.Immutable;
 using System.IO;
+using System.IO.Compression;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Schema;
@@ -16,6 +18,7 @@ using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Kernel;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
@@ -2303,6 +2306,442 @@ public class MeshOperations
                 return Observable.Return($"Error: {ex.Message}");
             });
     }
+
+    /// <summary>
+    /// Exports the subtree rooted at <paramref name="path"/> as a self-contained ZIP archive: a
+    /// <c>manifest.json</c> (the export-root path plus every descendant <see cref="MeshNode"/>'s full
+    /// JSON — Code source and Markdown bodies ride inside each node's Content) plus a <c>files/</c>
+    /// tree holding the raw bytes of every editable content-collection file. The exact inverse of
+    /// <see cref="Import"/>.
+    ///
+    /// <para>Subtree traversal reuses the same snapshot query <see cref="Copy"/> uses
+    /// (<c>path:{root} scope:subtree</c>). Each node's content collections are discovered exactly as
+    /// <see cref="Upload"/> resolves a write target (a <see cref="GetDataRequest"/> for a
+    /// <see cref="ContentCollectionReference"/> against the owning node hub), and the files are read +
+    /// zipped on the file-system <see cref="IIoPool"/> — never on the hub action block, never via
+    /// <c>Observable.FromAsync</c>.</para>
+    /// </summary>
+    /// <param name="path">The subtree root to export.</param>
+    /// <returns>A cold observable emitting the ZIP bytes. Nodes the caller lacks the
+    /// <see cref="Permission.Export"/> permission on are silently skipped (partial access → subset;
+    /// no access → an empty-manifest ZIP). A non-existent path resolves to an empty-manifest ZIP too.</returns>
+    public IObservable<byte[]> Export(string path)
+    {
+        logger.LogInformation("Export called: {Path}", path);
+
+        if (string.IsNullOrWhiteSpace(path))
+            return Observable.Throw<byte[]>(new ArgumentException("path is required.", nameof(path)));
+
+        var root = ResolvePath(path).Trim('/');
+        if (string.IsNullOrWhiteSpace(root))
+            return Observable.Throw<byte[]>(new ArgumentException("path is required.", nameof(path)));
+
+        var pool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem)
+                   ?? IoPool.Unbounded;
+
+        // Access control: Export is its OWN permission (granted by Editor + Admin). Enforce it per
+        // node against the caller's real effective permissions — never bypass as system. The check
+        // runs on the mesh hub (which carries the RowLevelSecurity evaluator; when RLS is not
+        // configured the evaluator returns Permission.All, so an unsecured host exports everything).
+        // The caller identity is captured here, on the calling thread, before any Rx scheduler hop.
+        var permissionHub = hub.ServiceProvider.GetRequiredService<IMessageHub>();
+        var callerUserId = ResolveCallerUserId();
+
+        // 1. Snapshot the subtree (root + descendants) — the same query Copy traverses. Ancestor-first
+        //    ordering so an inherited collection is attributed to its owning ancestor on dedup.
+        return mesh.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{root} scope:subtree"))
+            .Take(1)
+            .Select(change => change.Items
+                .Where(n => !string.IsNullOrEmpty(n.Path))
+                .ToList())
+            .SelectMany(allNodes =>
+                // 2. Access filter: keep only nodes the caller may Export. PARTIAL access → subset;
+                //    NO access → empty. Bounded parallel; fail-closed on error (never leak a node).
+                allNodes
+                    .Select(n => permissionHub
+                        .CheckPermission(n.Path, callerUserId, Permission.Export)
+                        .Take(1)
+                        .Timeout(TimeSpan.FromSeconds(30))
+                        .Catch((Exception ex) =>
+                        {
+                            logger.LogDebug(ex, "Export: permission check failed for {Path} — skipping", n.Path);
+                            return Observable.Return(false);
+                        })
+                        .Select(allowed => (Node: n, Allowed: allowed)))
+                    .ToObservable()
+                    .Merge(NodeCopyHelper.DefaultBatchSize)
+                    .Where(x => x.Allowed)
+                    .Select(x => x.Node)
+                    .ToList())
+            .SelectMany(permitted =>
+            {
+                // Ancestor-first so an inherited collection is attributed to its owning ancestor.
+                var nodes = permitted
+                    .OrderBy(n => n.Segments.Count)
+                    .ThenBy(n => n.Path, StringComparer.Ordinal)
+                    .ToList();
+
+                // No permitted nodes (no access, or nothing at the path) → a valid empty-manifest ZIP.
+                if (nodes.Count == 0)
+                    return pool.InvokeBlocking(_ => BuildExportZip(root, nodes, new List<ExportedFile>()));
+
+                // 3. Discover each permitted node's content collections (tolerant, bounded, parallel).
+                return nodes
+                    .Select(n => GetNodeCollectionConfigs(n.Path)
+                        .Select(configs => (NodePath: n.Path, Configs: configs)))
+                    .ToObservable()
+                    .Merge(NodeCopyHelper.DefaultBatchSize)
+                    .ToList()
+                    .SelectMany(nodeConfigs =>
+                    {
+                        // Re-establish ancestor-first order (Merge reorders) and flatten to targets.
+                        var targets = nodeConfigs
+                            .OrderBy(nc => nc.NodePath.Count(c => c == '/'))
+                            .ThenBy(nc => nc.NodePath, StringComparer.Ordinal)
+                            .SelectMany(nc => nc.Configs
+                                .Where(c => c.IsEditable && !string.IsNullOrEmpty(c.Name))
+                                .Select(c => (nc.NodePath, Config: c)))
+                            .ToList();
+
+                        // 4. Gather file bytes OFF the hub (async stream reads on the IO pool), then
+                        //    5. build the ZIP on the pool (pure CPU/memory) — never on the action block.
+                        return pool.Invoke(ct => GatherContentFilesAsync(targets, ct))
+                            .SelectMany(files =>
+                                pool.InvokeBlocking(_ => BuildExportZip(root, nodes, files)));
+                    });
+            });
+    }
+
+    /// <summary>
+    /// Resolves the caller's user id from the hub's <see cref="AccessService"/> context (the same
+    /// precedence <c>HubPermissionExtensions</c> uses), defaulting to
+    /// <see cref="WellKnownUsers.Anonymous"/> when no real identity is present.
+    /// </summary>
+    private string ResolveCallerUserId()
+    {
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var ctx = accessService?.Context ?? accessService?.CircuitContext;
+        var userId = ctx?.ObjectId;
+        if (string.IsNullOrEmpty(userId) || ctx?.IsVirtual == true)
+            userId = WellKnownUsers.Anonymous;
+        return userId;
+    }
+
+    /// <summary>
+    /// Imports a ZIP produced by <see cref="Export"/> under <paramref name="targetNamespace"/>:
+    /// unpacks the archive, recreates every MeshNode with its path rewritten from the export root to
+    /// the target (via <see cref="IMeshService.CreateNode"/>, carrying the caller's AccessContext),
+    /// then re-uploads every content-collection file through the standard <see cref="Upload"/> path.
+    /// </summary>
+    /// <param name="targetNamespace">The namespace to recreate the subtree under (the export root's
+    /// path prefix is rewritten to this).</param>
+    /// <param name="zipBytes">The ZIP archive bytes from <see cref="Export"/>.</param>
+    /// <returns>A cold observable emitting a JSON summary
+    /// <c>{status,exportRoot,targetNamespace,nodesImported,filesImported}</c> or an <c>Error: …</c>
+    /// string.</returns>
+    public IObservable<string> Import(string targetNamespace, byte[] zipBytes)
+    {
+        logger.LogInformation("Import called: target={Target} bytes={Bytes}",
+            targetNamespace, zipBytes?.Length ?? 0);
+
+        if (string.IsNullOrWhiteSpace(targetNamespace))
+            return Observable.Return("Error: targetNamespace is required.");
+        if (zipBytes is null || zipBytes.Length == 0)
+            return Observable.Return("Error: zip content is required.");
+
+        var target = ResolvePath(targetNamespace).Trim('/');
+        if (string.IsNullOrWhiteSpace(target))
+            return Observable.Return("Error: targetNamespace is required.");
+
+        var pool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem)
+                   ?? IoPool.Unbounded;
+
+        // 1. Parse the ZIP OFF the hub (pure CPU/memory on the IO pool).
+        return pool.InvokeBlocking(_ => ParseExportZip(zipBytes))
+            .SelectMany(parsed =>
+            {
+                var (manifest, fileBytes) = parsed;
+                var root = manifest.ExportRoot?.Trim('/') ?? string.Empty;
+                var nodes = (manifest.Nodes ?? new List<MeshNode>())
+                    .Where(n => !string.IsNullOrEmpty(n.Path))
+                    // Parents first — deterministic, and lets a partition root land before children.
+                    .OrderBy(n => n.Segments.Count)
+                    .ThenBy(n => n.Path, StringComparer.Ordinal)
+                    .ToList();
+
+                // 2. Recreate nodes under the target, sequentially (parent-first order preserved).
+                var createNodes = nodes
+                    .Select(n => CreateRemappedNode(n, root, target))
+                    .ToObservable()
+                    .Concat()
+                    .Sum();
+
+                return createNodes.SelectMany(createdCount =>
+                {
+                    // 3. Re-upload every content-collection file into the rewritten target node.
+                    var fileEntries = manifest.Files ?? new List<MeshExportFileEntry>();
+                    return fileEntries
+                        .Select(fe =>
+                        {
+                            var entryName = ExportFileEntryName(fe.NodePath, fe.Collection, fe.FilePath);
+                            if (!fileBytes.TryGetValue(entryName, out var bytes))
+                                return Observable.Return(0);
+                            var newNodePath = RemapExportPath(fe.NodePath, root, target);
+                            return Upload($"{newNodePath}/{fe.Collection}/{fe.FilePath}", bytes)
+                                .Select(r => r.StartsWith("Error:", StringComparison.Ordinal) ? 0 : 1);
+                        })
+                        .ToObservable()
+                        .Concat()
+                        .Sum()
+                        // Explicit JsonObject so the count keys are ALWAYS present — a 0 count (e.g.
+                        // an access-denied import that wrote nothing) would otherwise be dropped by
+                        // the hub serializer's WhenWritingDefault, breaking consumers that read them.
+                        .Select(uploadedCount => new JsonObject
+                        {
+                            ["status"] = "Imported",
+                            ["exportRoot"] = root,
+                            ["targetNamespace"] = target,
+                            ["nodesImported"] = createdCount,
+                            ["filesImported"] = uploadedCount,
+                        }.ToJsonString());
+                });
+            })
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex, "Import failed for target {Target}", target);
+                return Observable.Return($"Error: {ex.Message}");
+            });
+    }
+
+    /// <summary>
+    /// Discovers the content-collection configs on the node hub at <paramref name="nodePath"/>, unioned
+    /// from two <see cref="GetDataRequest"/>s (by name):
+    /// <list type="bullet">
+    ///   <item>an EMPTY <see cref="ContentCollectionReference"/> → <c>GetAllCollectionConfigs</c>, which
+    ///     returns only collections with <c>ExposeInChildren=true</c> (the memex portal sets this on its
+    ///     <c>content</c> collection);</item>
+    ///   <item>an explicit <see cref="ContentCollectionsExtensions.DefaultCollectionName"/> request →
+    ///     <c>GetCollectionConfig</c>, which is UNFILTERED, so a node's own default <c>content</c> store
+    ///     is captured even when <c>ExposeInChildren=false</c> (the Monolith portal leaves it false).</item>
+    /// </list>
+    /// Tolerant: a node hub without the content handler simply yields an empty list rather than faulting
+    /// the export.
+    /// </summary>
+    private IObservable<IReadOnlyList<ContentCollectionConfig>> GetNodeCollectionConfigs(string nodePath)
+    {
+        var address = new Address(nodePath);
+        return RequestCollectionConfigs(address, Array.Empty<string>())
+            .CombineLatest(
+                RequestCollectionConfigs(address, [ContentCollectionsExtensions.DefaultCollectionName]),
+                (exposed, defaults) => (IReadOnlyList<ContentCollectionConfig>)exposed
+                    .Concat(defaults)
+                    .GroupBy(c => c.Name, StringComparer.Ordinal)
+                    .Select(g => g.First())
+                    .ToList());
+    }
+
+    /// <summary>
+    /// Single <see cref="GetDataRequest"/> for a node's content-collection configs (empty
+    /// <paramref name="names"/> = all exposed; specific names = those configs, unfiltered). Tolerant:
+    /// a missing content handler or a timeout yields an empty list.
+    /// </summary>
+    private IObservable<IReadOnlyList<ContentCollectionConfig>> RequestCollectionConfigs(
+        Address address, IReadOnlyCollection<string> names)
+    {
+        return hub.Observe(
+                new GetDataRequest(new ContentCollectionReference(names)),
+                o => o.WithTarget(address))
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(20))
+            .Select(delivery =>
+            {
+                IReadOnlyCollection<ContentCollectionConfig>? configs = delivery?.Message switch
+                {
+                    GetDataResponse { Data: JsonElement je } =>
+                        JsonSerializer.Deserialize<ContentCollectionConfig[]>(je, hub.JsonSerializerOptions),
+                    GetDataResponse { Data: IReadOnlyCollection<ContentCollectionConfig> direct } => direct,
+                    _ => null
+                };
+                return (IReadOnlyList<ContentCollectionConfig>)(configs?.ToList()
+                    ?? new List<ContentCollectionConfig>());
+            })
+            .Catch((Exception ex) =>
+            {
+                logger.LogDebug(ex, "Export: content-collection lookup failed for {Address}", address);
+                return Observable.Return(
+                    (IReadOnlyList<ContentCollectionConfig>)new List<ContentCollectionConfig>());
+            });
+    }
+
+    /// <summary>
+    /// Reads every file from each (node, editable collection) target into memory. Runs on the
+    /// file-system <see cref="IIoPool"/> (async stream reads). Dedupes by resolved physical location so
+    /// an inherited collection reported by multiple descendants is exported once, attributed to the
+    /// first (ancestor) node that reported it.
+    /// </summary>
+    private async Task<List<ExportedFile>> GatherContentFilesAsync(
+        IReadOnlyList<(string NodePath, ContentCollectionConfig Config)> targets, CancellationToken ct)
+    {
+        var result = new List<ExportedFile>();
+        var contentService = hub.ServiceProvider.GetService<IContentService>();
+        if (contentService is null || targets.Count == 0)
+            return result;
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (nodePath, config) in targets)
+        {
+            var collectionName = config.Name!;
+            var qualified = $"{nodePath}/{collectionName}";
+            // Register the config on this hub's content service (same mechanism as Upload) so the
+            // collection resolves locally against its backing store (FileSystem BasePath, blob, …).
+            contentService.AddConfiguration(config with { Name = qualified, Address = new Address(nodePath) });
+            var collection = await contentService.GetCollectionAsync(qualified, ct).ConfigureAwait(false);
+            if (collection is null)
+                continue;
+
+            await foreach (var file in EnumerateAllFilesAsync(collection, string.Empty, ct).ConfigureAwait(false))
+            {
+                var rel = file.Path.TrimStart('/');
+                var dedupKey = (config.BasePath ?? qualified) + "|" + rel;
+                if (!seen.Add(dedupKey))
+                    continue;
+
+                var stream = await collection.GetContentAsync(file.Path, ct).ConfigureAwait(false);
+                if (stream is null)
+                    continue;
+                byte[] bytes;
+                await using (stream.ConfigureAwait(false))
+                {
+                    using var ms = new MemoryStream();
+                    await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
+                    bytes = ms.ToArray();
+                }
+                result.Add(new ExportedFile(nodePath, collectionName, rel, bytes));
+            }
+        }
+        return result;
+    }
+
+    /// <summary>Recursively enumerates every file under <paramref name="dir"/> in a collection
+    /// (files first at each level, then recurse into sub-folders).</summary>
+    private static async IAsyncEnumerable<FileItem> EnumerateAllFilesAsync(
+        ContentCollection collection, string dir, [EnumeratorCancellation] CancellationToken ct)
+    {
+        await foreach (var file in collection.GetFiles(dir, ct).ConfigureAwait(false))
+            yield return file;
+        await foreach (var folder in collection.GetFolders(dir, ct).ConfigureAwait(false))
+            await foreach (var file in EnumerateAllFilesAsync(collection, folder.Path, ct).ConfigureAwait(false))
+                yield return file;
+    }
+
+    /// <summary>Builds the export ZIP (manifest.json + files/ tree) from the gathered nodes and file
+    /// bytes. Pure CPU/memory — runs on the <see cref="IIoPool"/> blocking scheduler.</summary>
+    private byte[] BuildExportZip(string root, List<MeshNode> nodes, List<ExportedFile> files)
+    {
+        var manifest = new MeshExportManifest
+        {
+            ExportRoot = root,
+            ExportedAt = DateTimeOffset.UtcNow,
+            Nodes = nodes,
+            Files = files
+                .Select(f => new MeshExportFileEntry(f.NodePath, f.Collection, f.RelPath, f.Bytes.Length))
+                .ToList(),
+        };
+
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var manifestEntry = zip.CreateEntry("manifest.json", CompressionLevel.Optimal);
+            using (var writer = new StreamWriter(manifestEntry.Open()))
+                writer.Write(JsonSerializer.Serialize(manifest, hub.JsonSerializerOptions));
+
+            foreach (var f in files)
+            {
+                var entry = zip.CreateEntry(
+                    ExportFileEntryName(f.NodePath, f.Collection, f.RelPath), CompressionLevel.Optimal);
+                using var es = entry.Open();
+                es.Write(f.Bytes, 0, f.Bytes.Length);
+            }
+        }
+        return ms.ToArray();
+    }
+
+    /// <summary>Parses an export ZIP into its manifest + a map of <c>files/…</c> entry name → bytes.
+    /// Pure CPU/memory — runs on the <see cref="IIoPool"/> blocking scheduler.</summary>
+    private (MeshExportManifest Manifest, Dictionary<string, byte[]> Files) ParseExportZip(byte[] zipBytes)
+    {
+        using var ms = new MemoryStream(zipBytes);
+        using var zip = new ZipArchive(ms, ZipArchiveMode.Read);
+
+        var manifestEntry = zip.GetEntry("manifest.json")
+            ?? throw new InvalidOperationException("Invalid export: manifest.json not found in the ZIP.");
+        MeshExportManifest manifest;
+        using (var reader = new StreamReader(manifestEntry.Open()))
+            manifest = JsonSerializer.Deserialize<MeshExportManifest>(reader.ReadToEnd(), hub.JsonSerializerOptions)
+                ?? throw new InvalidOperationException("Invalid export: manifest.json did not deserialize.");
+
+        var files = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (var entry in zip.Entries)
+        {
+            if (!entry.FullName.StartsWith("files/", StringComparison.Ordinal)
+                || entry.FullName.EndsWith('/'))
+                continue;
+            using var es = entry.Open();
+            using var mem = new MemoryStream();
+            es.CopyTo(mem);
+            files[entry.FullName] = mem.ToArray();
+        }
+        return (manifest, files);
+    }
+
+    /// <summary>Recreates one exported node under the target namespace with its path rewritten.
+    /// Emits 1 on success, 0 on a per-node failure (logged) so one bad node doesn't abort the import.</summary>
+    private IObservable<int> CreateRemappedNode(MeshNode node, string root, string target)
+    {
+        var newPath = RemapExportPath(node.Path, root, target);
+        var newNode = MeshNode.FromPath(newPath) with
+        {
+            Name = node.Name,
+            Description = node.Description,
+            NodeType = node.NodeType,
+            Icon = node.Icon,
+            Category = node.Category,
+            Order = node.Order,
+            Content = node.Content,
+            PreRenderedHtml = node.PreRenderedHtml,
+            MainNode = RemapExportPath(node.MainNode, root, target),
+            State = MeshNodeState.Active,
+        };
+        return mesh.CreateNode(newNode)
+            .Select(_ => 1)
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex, "Import: create failed for {Path}", newPath);
+                return Observable.Return(0);
+            });
+    }
+
+    /// <summary>Rewrites a path from the export root prefix to the target namespace.
+    /// <c>root</c>→<c>target</c>, <c>root/x</c>→<c>target/x</c>.</summary>
+    private static string RemapExportPath(string path, string root, string target)
+    {
+        if (string.IsNullOrEmpty(path))
+            return path;
+        if (string.IsNullOrEmpty(root))
+            return string.IsNullOrEmpty(target) ? path : $"{target}/{path}";
+        if (string.Equals(path, root, StringComparison.Ordinal))
+            return target;
+        if (path.StartsWith(root + "/", StringComparison.Ordinal))
+            return $"{target}/{path[(root.Length + 1)..]}";
+        return path; // outside the export root — leave unchanged (defensive; shouldn't occur)
+    }
+
+    /// <summary>The ZIP entry name a content-collection file's bytes are stored at.</summary>
+    private static string ExportFileEntryName(string nodePath, string collection, string relPath)
+        => $"files/{nodePath}/{collection}/{relPath}";
+
+    /// <summary>A gathered content-collection file held in memory during export.</summary>
+    private sealed record ExportedFile(string NodePath, string Collection, string RelPath, byte[] Bytes);
 
     /// <summary>
     /// Recycles the hub at <paramref name="path"/> by posting a

--- a/src/MeshWeaver.Blazor.AI/McpMeshPlugin.cs
+++ b/src/MeshWeaver.Blazor.AI/McpMeshPlugin.cs
@@ -432,6 +432,42 @@ Recommended: 'icon' as an inline SVG starting with <svg, using currentColor. 'co
         => ops.Copy(sourcePath, targetNamespace, force).FirstAsync().ToTask();
 
     /// <summary>
+    /// Exports a node and its entire subtree as a portable ZIP archive (returned base64-encoded),
+    /// bundling every descendant node's JSON plus its content-collection and code/source files.
+    /// </summary>
+    /// <param name="path">The subtree root to export.</param>
+    /// <returns>The ZIP archive as a base64 string, or an <c>Error: …</c> string.</returns>
+    [McpServerTool(Title = "Export a subtree to a ZIP", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    [Description(@"Exports a node and its ENTIRE subtree as a portable ZIP archive, returned base64-encoded. The archive contains a `manifest.json` (the export-root path + every descendant MeshNode's full JSON — Code source and Markdown bodies ride inside each node's Content) plus a `files/` tree with the raw bytes of every editable content-collection file. Feed the base64 straight back into `import` (optionally on another instance) to recreate the subtree under a new namespace. Use this to snapshot, back up, or move a whole subtree (space, project, folder) with its attachments in one shot.")]
+    public Task<string> Export(
+        [Description("Path of the subtree root to export (e.g., @ACME/Project). The node and all descendants are included.")] string path)
+        => ops.Export(path)
+            .Select(Convert.ToBase64String)
+            .Catch((Exception ex) => Observable.Return($"Error: {ex.Message}"))
+            .FirstAsync().ToTask();
+
+    /// <summary>
+    /// Imports a ZIP archive (base64-encoded, produced by <see cref="Export"/>) under a target
+    /// namespace, recreating every node with paths rewritten and re-uploading content files.
+    /// </summary>
+    /// <param name="targetNamespace">The namespace to recreate the subtree under.</param>
+    /// <param name="base64Zip">The export ZIP as a base64 string.</param>
+    /// <returns>A JSON summary of the import, or an <c>Error: …</c> string.</returns>
+    [McpServerTool(Title = "Import a subtree from a ZIP", Destructive = false, Idempotent = false, OpenWorld = false)]
+    [Description(@"Imports a ZIP archive (base64-encoded, as produced by `export`) under a target namespace. Recreates every MeshNode with its path rewritten from the export root to the target namespace (nodes via create, carrying your identity), then re-uploads every content-collection file. Use this to restore a snapshot or move a subtree between namespaces / instances. Returns JSON `{status:'Imported', exportRoot, targetNamespace, nodesImported, filesImported}` on success, or an `Error: …` string.")]
+    public Task<string> Import(
+        [Description("Target namespace to recreate the subtree under (e.g., @ACME/Restored). The export root's path prefix is rewritten to this.")] string targetNamespace,
+        [Description("The export ZIP as a base64-encoded string (no data:URI prefix; just the raw base64 payload), as returned by `export`.")] string base64Zip)
+    {
+        if (string.IsNullOrEmpty(base64Zip))
+            return Task.FromResult("Error: base64Zip is required.");
+        byte[] bytes;
+        try { bytes = Convert.FromBase64String(base64Zip); }
+        catch (FormatException ex) { return Task.FromResult($"Error: invalid base64 zip: {ex.Message}"); }
+        return ops.Import(targetNamespace, bytes).FirstAsync().ToTask();
+    }
+
+    /// <summary>
     /// Returns a browser URL to view a node in the MeshWeaver UI, shaped as
     /// <c>{baseUrl}/{path}</c>; an empty path returns the base URL alone.
     /// </summary>

--- a/test/MeshWeaver.AI.Test/ExportImportAccessControlTest.cs
+++ b/test/MeshWeaver.AI.Test/ExportImportAccessControlTest.cs
@@ -1,0 +1,168 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Access-control matrix for <see cref="MeshOperations.Export"/> / <see cref="MeshOperations.Import"/>.
+/// Export is its OWN permission (<see cref="Permission.Export"/>), which the built-in Editor and Admin
+/// roles grant but Viewer/Commenter do NOT. This fixture enforces real row-level security
+/// (<see cref="MonolithMeshTestBase.ConfigureMeshBase"/> — no <c>PublicAdminAccess</c>) and seeds a
+/// source subtree plus per-user role grants, then drives Export/Import as different users:
+/// <list type="bullet">
+///   <item>a reader WITHOUT Export (Viewer) → empty export (proves Export ≠ Read);</item>
+///   <item>a user with no grants at all → empty export;</item>
+///   <item>PARTIAL Export (Editor on one child only) → export contains ONLY the permitted node;</item>
+///   <item>FULL Export (Editor on the root, inherited) → the whole subtree;</item>
+///   <item>Import as a user without Create on the target → denied, zero nodes written.</item>
+/// </list>
+///
+/// <para>Note on <see cref="Permission.Export"/>: it exists in the permission model already and is
+/// part of <see cref="Permission.All"/> (Admin) and of the built-in <see cref="Role.Editor"/> grant —
+/// verified, not added.</para>
+/// </summary>
+public class ExportImportAccessControlTest : MonolithMeshTestBase
+{
+    private static readonly string ContentBasePath = Path.Combine(
+        Path.GetTempPath(), "ExportImportAccessTest_" + Guid.NewGuid().ToString("N"));
+
+    private const string SrcRoot = "ExpSrc";
+    private const string EditorUser = "editor-user";
+    private const string ViewerUser = "viewer-user";
+    private const string PartialUser = "partial-user";
+    private const string Stranger = "stranger-user";
+
+    public ExportImportAccessControlTest(ITestOutputHelper output) : base(output) { }
+
+    // Real RLS (ConfigureMeshBase, no PublicAdminAccess). Seed the source subtree (static config nodes,
+    // present at init) + a content collection so the export's collection-config lookup responds, and
+    // per-user role grants as AccessAssignment nodes.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        ConfigureMeshBase(builder)
+            .AddAI()
+            .ConfigureDefaultNodeHub(config =>
+            {
+                var flat = config.Address.ToString().Replace('/', '_');
+                var dir = Path.Combine(ContentBasePath, flat);
+                var content = new ContentCollectionConfig
+                {
+                    Name = "content",
+                    SourceType = "FileSystem",
+                    IsEditable = true,
+                    ExposeInChildren = true,
+                    BasePath = dir,
+                    Settings = new Dictionary<string, string> { ["BasePath"] = dir },
+                };
+                return config.AddContentCollection(_ => content);
+            })
+            .AddMeshNodes(
+                new MeshNode(SrcRoot) { Name = "Export Source", NodeType = "Markdown" },
+                new MeshNode("DocA", SrcRoot) { Name = "Doc A", NodeType = "Markdown" },
+                new MeshNode("DocB", SrcRoot) { Name = "Doc B", NodeType = "Markdown" },
+                // Grants: Editor on the whole subtree; Viewer (Read, NO Export) on the subtree;
+                // Editor on ONLY DocA (partial). Inherited downward, never upward.
+                AssignmentNodeFactory.UserRole(EditorUser, Role.Editor.Id, SrcRoot),
+                AssignmentNodeFactory.UserRole(ViewerUser, Role.Viewer.Id, SrcRoot),
+                AssignmentNodeFactory.UserRole(PartialUser, Role.Editor.Id, $"{SrcRoot}/DocA"));
+
+    private MeshOperations Ops() => new(Mesh);
+
+    private void SetUser(string userId)
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var ctx = new AccessContext { ObjectId = userId, Name = userId };
+        access.SetContext(ctx);
+        access.SetCircuitContext(ctx);
+    }
+
+    private MeshExportManifest ReadManifest(byte[] zip)
+    {
+        using var archive = new ZipArchive(new MemoryStream(zip), ZipArchiveMode.Read);
+        using var r = new StreamReader(archive.GetEntry("manifest.json")!.Open());
+        return JsonSerializer.Deserialize<MeshExportManifest>(r.ReadToEnd(), Mesh.JsonSerializerOptions)!;
+    }
+
+    // (a) Reader WITHOUT the Export permission (Viewer) — export must be empty.
+    [Fact(Timeout = 90000)]
+    public async Task Export_ReaderWithoutExportPermission_ReturnsEmpty()
+    {
+        SetUser(ViewerUser);
+        var zip = await Ops().Export(SrcRoot).Should().Within(TimeSpan.FromSeconds(60)).Emit();
+        ReadManifest(zip).Nodes.Should()
+            .BeEmpty("Viewer grants Read but NOT the Export permission — nothing may be exported");
+    }
+
+    // (a) No access at all — export must be empty.
+    [Fact(Timeout = 90000)]
+    public async Task Export_NoAccessAtAll_ReturnsEmpty()
+    {
+        SetUser(Stranger);
+        var zip = await Ops().Export(SrcRoot).Should().Within(TimeSpan.FromSeconds(60)).Emit();
+        ReadManifest(zip).Nodes.Should().BeEmpty("a user with no grants exports nothing");
+    }
+
+    // (b) PARTIAL access — Editor on ExpSrc/DocA only — export contains ONLY DocA.
+    [Fact(Timeout = 90000)]
+    public async Task Export_PartialAccess_ExportsOnlyPermittedSubset()
+    {
+        SetUser(PartialUser);
+        var zip = await Ops().Export(SrcRoot).Should().Within(TimeSpan.FromSeconds(60)).Emit();
+        var paths = ReadManifest(zip).Nodes.Select(n => n.Path).ToList();
+
+        paths.Should().Contain($"{SrcRoot}/DocA", "the caller has Export on DocA");
+        paths.Should().NotContain(SrcRoot, "no Export on the root — it must be silently skipped");
+        paths.Should().NotContain($"{SrcRoot}/DocB", "no Export on the sibling — it must not leak");
+    }
+
+    // (c) FULL access — Editor on ExpSrc (inherited) — the whole subtree.
+    [Fact(Timeout = 90000)]
+    public async Task Export_EditorFullAccess_ExportsWholeSubtree()
+    {
+        SetUser(EditorUser);
+        var zip = await Ops().Export(SrcRoot).Should().Within(TimeSpan.FromSeconds(60)).Emit();
+        var paths = ReadManifest(zip).Nodes.Select(n => n.Path).ToList();
+
+        paths.Should().Contain(new[] { SrcRoot, $"{SrcRoot}/DocA", $"{SrcRoot}/DocB" },
+            "Editor on the root grants Export across the whole subtree");
+    }
+
+    // (d) Import as a user without Create on the target — denied, zero nodes written.
+    [Fact(Timeout = 90000)]
+    public async Task Import_WithoutCreatePermission_DeniedNoPartialWrite()
+    {
+        // Produce a full export as the Editor.
+        SetUser(EditorUser);
+        var zip = await Ops().Export(SrcRoot).Should().Within(TimeSpan.FromSeconds(60)).Emit();
+        ReadManifest(zip).Nodes.Should().NotBeEmpty("the editor produced a non-empty export to import");
+
+        // Import as a stranger with no Create on the target namespace — every CreateNode is denied.
+        const string target = "ImpDst";
+        SetUser(Stranger);
+        var result = await Ops().Import(target, zip).Should().Within(TimeSpan.FromSeconds(60)).Emit();
+        Output.WriteLine(result);
+
+        var doc = JsonDocument.Parse(result).RootElement;
+        doc.GetProperty("nodesImported").GetInt32().Should()
+            .Be(0, "no Create permission on the target → no node may be written (no partial import)");
+        doc.GetProperty("filesImported").GetInt32().Should().Be(0);
+    }
+}

--- a/test/MeshWeaver.AI.Test/ExportImportRoundTripTest.cs
+++ b/test/MeshWeaver.AI.Test/ExportImportRoundTripTest.cs
@@ -1,0 +1,339 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Round-trip + hardening tests for <see cref="MeshOperations.Export"/> /
+/// <see cref="MeshOperations.Import"/> — the ZIP-based subtree export/import behind the MCP
+/// <c>export</c> / <c>import</c> tools. Covers: a flat parent+child+code round-trip; a deeper
+/// NESTED subtree (grandchild + a second content file + a second content collection); and the
+/// graceful error paths (non-existent export path, empty/corrupt import bytes).
+///
+/// <para>Fixture mirrors the per-node FileSystem content-collection pattern from
+/// <see cref="MeshOperationsUploadTest"/>, with two refinements: (1) each node's collection stores
+/// are rooted in <b>sibling, non-nested</b> directories (the <c>nodePath.Replace('/','_')</c> key)
+/// so a parent's export never recurses into a child's store (the memex portal likewise keeps ONE
+/// store per Space rather than physically nesting per-node stores); (2) a second editable
+/// <c>assets</c> collection exercises multi-collection export. No AddRowLevelSecurity — plain
+/// top-level nodes are creatable as the DevLogin admin. Access control is covered separately by
+/// <see cref="ExportImportAccessControlTest"/>.</para>
+/// </summary>
+public class ExportImportRoundTripTest : MonolithMeshTestBase
+{
+    private static readonly string TestDataPath = Path.Combine(AppContext.BaseDirectory, "TestData");
+
+    // Unique per test instance so a stale on-disk content tree from a prior run can never bleed in.
+    private static readonly string ContentBasePath = Path.Combine(
+        Path.GetTempPath(),
+        "ExportImportRoundTripTest_" + Guid.NewGuid().ToString("N"));
+
+    // Unique node-id suffix — the FileSystem persistence root (TestDataPath) is shared across runs.
+    private readonly string _tag = Guid.NewGuid().ToString("N")[..8];
+
+    public ExportImportRoundTripTest(ITestOutputHelper output) : base(output) { }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        builder
+            .UseMonolithMesh()
+            .AddFileSystemPersistence(TestDataPath)
+            .AddGraph()
+            .AddAI()
+            // Per-node editable FileSystem content collections rooted in SIBLING dirs (flattened key),
+            // so a parent node's export never recurses into a child node's store.
+            .ConfigureDefaultNodeHub(config =>
+            {
+                var nodePath = config.Address.ToString();
+                var flat = nodePath.Replace('/', '_');
+                var contentDir = Path.Combine(ContentBasePath, flat);
+                var assetsDir = Path.Combine(ContentBasePath, "_assets", flat);
+                var contentConfig = new ContentCollectionConfig
+                {
+                    Name = "content",
+                    SourceType = "FileSystem",
+                    IsEditable = true,
+                    ExposeInChildren = true,
+                    BasePath = contentDir,
+                    Settings = new Dictionary<string, string> { ["BasePath"] = contentDir },
+                };
+                var assetsConfig = new ContentCollectionConfig
+                {
+                    Name = "assets",
+                    SourceType = "FileSystem",
+                    IsEditable = true,
+                    ExposeInChildren = true,
+                    BasePath = assetsDir,
+                    Settings = new Dictionary<string, string> { ["BasePath"] = assetsDir },
+                };
+                return config
+                    .AddContentCollection(_ => contentConfig)
+                    .AddContentCollection(_ => assetsConfig)
+                    .AddDefaultLayoutAreas();
+            });
+
+    private MeshOperations Ops() => new(GetClient());
+
+    private static string ContentDisk(string nodePath, string file) =>
+        Path.Combine(ContentBasePath, nodePath.Replace('/', '_'), file);
+
+    private static string AssetsDisk(string nodePath, string file) =>
+        Path.Combine(ContentBasePath, "_assets", nodePath.Replace('/', '_'), file);
+
+    private const string CodeSource = """
+        public record Widget
+        {
+            public string Name { get; init; } = "unset";
+            public int Count { get; init; }
+        }
+        """;
+
+    // ---- 1. Flat round-trip -----------------------------------------------------------------
+
+    [Fact(Timeout = 120000)]
+    public async Task Export_Then_Import_RoundTripsSubtree()
+    {
+        var root = $"RtSrc{_tag}";
+        var target = $"RtDst{_tag}";
+        var docName = $"Doc Title {_tag}";
+        var docBody = $"doc body {_tag}";
+        var helloBytes = Encoding.UTF8.GetBytes("hi");
+
+        Directory.CreateDirectory(ContentDisk(root, ""));
+
+        await NodeFactory.CreateNode(new MeshNode(root)
+        {
+            Name = $"Source Root {_tag}",
+            NodeType = "Markdown",
+        }).Should().Emit();
+
+        await NodeFactory.CreateNode(new MeshNode("Doc", root)
+        {
+            Name = docName,
+            Description = docBody,
+            NodeType = "Markdown",
+        }).Should().Emit();
+
+        await NodeFactory.CreateNode(new MeshNode("Code1", root)
+        {
+            Name = "Code One",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = CodeSource, Language = "csharp" },
+        }).Should().Emit();
+
+        var uploadResult = await Ops().Upload($"{root}/content/hello.txt", helloBytes).Should().Emit();
+        JsonDocument.Parse(uploadResult).RootElement.GetProperty("status").GetString()
+            .Should().Be("Uploaded");
+
+        await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{root} scope:subtree"))
+            .Should().Within(TimeSpan.FromSeconds(30))
+            .Match(c => c.Items.Count(n =>
+                n.Path == root || n.Path == $"{root}/Doc" || n.Path == $"{root}/Code1") >= 3);
+
+        var zip = await Ops().Export(root).Should().Within(TimeSpan.FromSeconds(60)).Emit();
+        zip.Should().NotBeNull();
+        zip.Length.Should().BeGreaterThan(0);
+
+        using (var archive = new ZipArchive(new MemoryStream(zip), ZipArchiveMode.Read))
+        {
+            var manifestEntry = archive.GetEntry("manifest.json");
+            manifestEntry.Should().NotBeNull("the export must carry a manifest.json");
+
+            var fileEntry = archive.GetEntry($"files/{root}/content/hello.txt");
+            fileEntry.Should().NotBeNull("the content-collection file must be in the files/ tree");
+            ReadEntryBytes(fileEntry!).Should().Equal(helloBytes);
+
+            var manifest = JsonSerializer.Deserialize<MeshExportManifest>(
+                ReadEntryText(manifestEntry!), Mesh.JsonSerializerOptions)!;
+            manifest.ExportRoot.Should().Be(root);
+            manifest.Nodes.Should().Contain(n => n.Path == $"{root}/Code1");
+            manifest.Files.Should().Contain(f =>
+                f.NodePath == root && f.Collection == "content" && f.FilePath == "hello.txt");
+
+            var codeNode = manifest.Nodes.First(n => n.Path == $"{root}/Code1");
+            codeNode.ContentAs<CodeConfiguration>(Mesh.JsonSerializerOptions)!.Code.Should().Be(CodeSource);
+
+            // Manifest serialization round-trip (serialize -> deserialize -> stable).
+            var reparsed = JsonSerializer.Deserialize<MeshExportManifest>(
+                JsonSerializer.Serialize(manifest, Mesh.JsonSerializerOptions), Mesh.JsonSerializerOptions)!;
+            reparsed.ExportRoot.Should().Be(root);
+            reparsed.Nodes.Count.Should().Be(manifest.Nodes.Count);
+            reparsed.Files.Count.Should().Be(manifest.Files.Count);
+        }
+
+        var importResult = await Ops().Import(target, zip).Should().Within(TimeSpan.FromSeconds(60)).Emit();
+        Output.WriteLine(importResult);
+        var importDoc = JsonDocument.Parse(importResult).RootElement;
+        importDoc.GetProperty("status").GetString().Should().Be("Imported");
+        importDoc.GetProperty("nodesImported").GetInt32().Should().BeGreaterThanOrEqualTo(3);
+        importDoc.GetProperty("filesImported").GetInt32().Should().Be(1);
+
+        var doc = await ReadNode($"{target}/Doc").Should().Within(TimeSpan.FromSeconds(30)).Match(n => n != null);
+        doc!.Name.Should().Be(docName);
+        doc.Description.Should().Be(docBody);
+
+        var code = await ReadNode($"{target}/Code1").Should().Within(TimeSpan.FromSeconds(30)).Match(n => n != null);
+        code!.ContentAs<CodeConfiguration>(Mesh.JsonSerializerOptions)!.Code.Should().Be(CodeSource);
+
+        var importedFile = ContentDisk(target, "hello.txt");
+        File.Exists(importedFile).Should().BeTrue("the imported content file must land on disk");
+        File.ReadAllBytes(importedFile).Should().Equal(helloBytes);
+    }
+
+    // ---- 2. Deeper NESTED subtree (grandchild + 2nd content file + 2nd collection) ----------
+
+    [Fact(Timeout = 120000)]
+    public async Task Export_Then_Import_RoundTripsNestedSubtree()
+    {
+        var root = $"NestSrc{_tag}";
+        var target = $"NestDst{_tag}";
+        var subBody = $"grandchild body {_tag}";
+        var helloBytes = Encoding.UTF8.GetBytes("hi");
+        var nestedBytes = Encoding.UTF8.GetBytes("# nested\n\nchild content " + _tag);
+        var svgBytes = Encoding.UTF8.GetBytes(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 8 8\"><rect width=\"8\" height=\"8\"/></svg>");
+
+        Directory.CreateDirectory(ContentDisk(root, ""));
+        Directory.CreateDirectory(ContentDisk($"{root}/Doc", ""));
+        Directory.CreateDirectory(AssetsDisk(root, ""));
+
+        // Root -> Doc -> Doc/Sub (grandchild), plus a Code node.
+        await NodeFactory.CreateNode(new MeshNode(root)
+        { Name = $"Nested Root {_tag}", NodeType = "Markdown" }).Should().Emit();
+        await NodeFactory.CreateNode(new MeshNode("Doc", root)
+        { Name = "Doc", NodeType = "Markdown" }).Should().Emit();
+        await NodeFactory.CreateNode(new MeshNode("Sub", $"{root}/Doc")
+        { Name = "Sub", Description = subBody, NodeType = "Markdown" }).Should().Emit();
+        await NodeFactory.CreateNode(new MeshNode("Code1", root)
+        { Name = "Code One", NodeType = "Code", Content = new CodeConfiguration { Code = CodeSource, Language = "csharp" } })
+            .Should().Emit();
+
+        // hello.txt on root/content; nested.md on the CHILD Doc/content; logo.svg on root/assets.
+        (await Ops().Upload($"{root}/content/hello.txt", helloBytes).Should().Emit()).Should().Contain("Uploaded");
+        (await Ops().Upload($"{root}/Doc/content/nested.md", nestedBytes).Should().Emit()).Should().Contain("Uploaded");
+        (await Ops().Upload($"{root}/assets/logo.svg", svgBytes).Should().Emit()).Should().Contain("Uploaded");
+
+        await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{root} scope:subtree"))
+            .Should().Within(TimeSpan.FromSeconds(30))
+            .Match(c => c.Items.Count(n =>
+                n.Path == root || n.Path == $"{root}/Doc" || n.Path == $"{root}/Doc/Sub" || n.Path == $"{root}/Code1") >= 4);
+
+        var zip = await Ops().Export(root).Should().Within(TimeSpan.FromSeconds(60)).Emit();
+
+        using (var archive = new ZipArchive(new MemoryStream(zip), ZipArchiveMode.Read))
+        {
+            var manifest = JsonSerializer.Deserialize<MeshExportManifest>(
+                ReadEntryText(archive.GetEntry("manifest.json")!), Mesh.JsonSerializerOptions)!;
+            // Every level present.
+            manifest.Nodes.Select(n => n.Path).Should().Contain(new[]
+            {
+                root, $"{root}/Doc", $"{root}/Doc/Sub", $"{root}/Code1"
+            });
+            // All three files, on the right nodes/collections, with NO cross-attribution.
+            manifest.Files.Should().Contain(f => f.NodePath == root && f.Collection == "content" && f.FilePath == "hello.txt");
+            manifest.Files.Should().Contain(f => f.NodePath == $"{root}/Doc" && f.Collection == "content" && f.FilePath == "nested.md");
+            manifest.Files.Should().Contain(f => f.NodePath == root && f.Collection == "assets" && f.FilePath == "logo.svg");
+            manifest.Files.Count.Should().Be(3, "exactly the three uploaded files, none double-counted");
+
+            archive.GetEntry($"files/{root}/content/hello.txt").Should().NotBeNull();
+            archive.GetEntry($"files/{root}/Doc/content/nested.md").Should().NotBeNull();
+            archive.GetEntry($"files/{root}/assets/logo.svg").Should().NotBeNull();
+        }
+
+        var importResult = await Ops().Import(target, zip).Should().Within(TimeSpan.FromSeconds(60)).Emit();
+        Output.WriteLine(importResult);
+        var importDoc = JsonDocument.Parse(importResult).RootElement;
+        importDoc.GetProperty("nodesImported").GetInt32().Should().BeGreaterThanOrEqualTo(4);
+        importDoc.GetProperty("filesImported").GetInt32().Should().Be(3);
+
+        // Every level round-tripped with the path rewritten root -> target.
+        var sub = await ReadNode($"{target}/Doc/Sub").Should().Within(TimeSpan.FromSeconds(30)).Match(n => n != null);
+        sub!.Description.Should().Be(subBody);
+        var code = await ReadNode($"{target}/Code1").Should().Within(TimeSpan.FromSeconds(30)).Match(n => n != null);
+        code!.ContentAs<CodeConfiguration>(Mesh.JsonSerializerOptions)!.Code.Should().Be(CodeSource);
+
+        File.ReadAllBytes(ContentDisk(target, "hello.txt")).Should().Equal(helloBytes);
+        File.ReadAllBytes(ContentDisk($"{target}/Doc", "nested.md")).Should().Equal(nestedBytes);
+        File.ReadAllBytes(AssetsDisk(target, "logo.svg")).Should().Equal(svgBytes);
+    }
+
+    // ---- 3. Error / edge cases --------------------------------------------------------------
+
+    [Fact(Timeout = 60000)]
+    public async Task Export_NonExistentPath_ReturnsEmptyResultCleanly()
+    {
+        var zip = await Ops().Export($"DoesNotExist{_tag}").Should().Within(TimeSpan.FromSeconds(30)).Emit();
+        zip.Should().NotBeNull();
+        zip.Length.Should().BeGreaterThan(0, "a valid (empty-manifest) ZIP is still produced");
+
+        using var archive = new ZipArchive(new MemoryStream(zip), ZipArchiveMode.Read);
+        var manifestEntry = archive.GetEntry("manifest.json");
+        manifestEntry.Should().NotBeNull("even an empty export carries a manifest");
+        var manifest = JsonSerializer.Deserialize<MeshExportManifest>(
+            ReadEntryText(manifestEntry!), Mesh.JsonSerializerOptions)!;
+        manifest.Nodes.Should().BeEmpty("no node exists at the path");
+        manifest.Files.Should().BeEmpty();
+        archive.Entries.Should().ContainSingle("only manifest.json, no files");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Import_EmptyBytes_ReturnsErrorGracefully()
+    {
+        var result = await Ops().Import($"Whatever{_tag}", Array.Empty<byte>()).Should().Emit();
+        result.Should().StartWith("Error:");
+        result.Should().Contain("zip content is required");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Import_CorruptBytes_ReturnsErrorGracefully()
+    {
+        // Random non-ZIP bytes — ZipArchive rejects them; the failure must surface as a clean
+        // "Error: …" string, never an unhandled exception out of the observable.
+        var garbage = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x50, 0x4B, 0xFF, 0xAA, 0x10, 0x20 };
+        var result = await Ops().Import($"Whatever{_tag}", garbage)
+            .Should().Within(TimeSpan.FromSeconds(30)).Emit();
+        result.Should().StartWith("Error:", "a corrupt archive must fail gracefully, not crash");
+
+        // And nothing was written under the target.
+        (await ReadNode($"Whatever{_tag}").Should().Within(TimeSpan.FromSeconds(10)).Match(_ => true))
+            .Should().BeNull("a failed import must not create the target node");
+    }
+
+    // ---- helpers ----------------------------------------------------------------------------
+
+    private static byte[] ReadEntryBytes(ZipArchiveEntry entry)
+    {
+        using var s = entry.Open();
+        using var ms = new MemoryStream();
+        s.CopyTo(ms);
+        return ms.ToArray();
+    }
+
+    private static string ReadEntryText(ZipArchiveEntry entry)
+    {
+        using var s = entry.Open();
+        using var r = new StreamReader(s);
+        return r.ReadToEnd();
+    }
+}


### PR DESCRIPTION
## What

Adds `Export`/`Import` MCP ops for moving a node subtree between spaces/portals as a ZIP.

- **`Export(path)`** → snapshots the subtree (nodes + content-collection files + code) into a ZIP (`manifest.json` + `files/` tree), **filtered per-node by the caller's `Export` permission** — no access → empty, partial → only permitted nodes (denied never leak), full → whole subtree.
- **`Import(targetNamespace, zip)`** → unpacks + recreates under the target (path-rewritten), enforcing `Create` via the CreateNode + AccessContext path (no half-imports for the unauthorized).
- MCP tools `export`/`import` registered; all IO on `IIoPool`, reactive end-to-end (no async in hub code).

## Access control

`Export` is its own permission (`Permission.Export = 256`), already granted by `Role.Editor` (and Admin via `Permission.All`). Export enforces it **per node**; import enforces `Create`.

## Fixes

- `GetNodeCollectionConfigs` unions the exposed set with the default `content` collection so files export regardless of `ExposeInChildren` (they were invisible to export on the Monolith portal).
- Import summary uses an explicit `JsonObject` so zero counts aren't dropped by default-suppression.

## Tests (MonolithMeshTestBase, no mocking) — 10, green

- Flat + nested subtree round-trip (content + code + path rewrite)
- Error cases: missing path → empty ZIP, corrupt/empty zip → clean error
- Access matrix: no-access → empty · partial → only permitted · full → whole subtree · unauthorized import → denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
