### PR TITLE
feat(social): publish to LinkedIn + engagement from the mesh

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -333,6 +333,12 @@ public static class MemexConfiguration
                     MeshWeaver.Mesh.INodeMenuProvider,
                     Memex.Portal.Shared.Social.LinkedInCredentialMenuProvider>());
 
+            // Add the Publish/Refresh-engagement actions to a social-media Post node's menu.
+            services.TryAddEnumerable(
+                Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+                    MeshWeaver.Mesh.INodeMenuProvider,
+                    Memex.Portal.Shared.Social.SocialPostMenuProvider>());
+
             // (Removed: SocialMediaUserMenuProvider — hardcoded a NodeType
             // ("Systemorph/SocialMediaHub") that isn't registered anywhere in
             // the codebase. NodeTypes belong in the database (NodeTypeDefinition
@@ -984,6 +990,11 @@ public static class MemexConfiguration
         // LinkedIn company-Page sync (Community Management API) — org-scope OAuth +
         // posts/statistics pull. Same ordering requirement (needs HttpContext.User).
         app.MapLinkedInPageSync();
+
+        // LinkedIn member publishing + engagement — POST /linkedin/publish (JSON API) plus
+        // GET /linkedin/publish and GET /linkedin/engagement triggers surfaced from the Post
+        // node menu (w_member_social scope). Same ordering requirement (needs HttpContext.User).
+        app.MapLinkedInPublish();
 
         // GitHub Sync — OAuth authorization-code connect endpoints (same ordering
         // requirement: needs HttpContext.User). Stores the per-user token at

--- a/memex/Memex.Portal.Shared/Social/LinkedInConnectEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/LinkedInConnectEndpoints.cs
@@ -85,13 +85,14 @@ public static class LinkedInConnectEndpoints
                 + $"&client_id={Uri.EscapeDataString(clientId!)}"
                 + $"&redirect_uri={Uri.EscapeDataString(redirectUri)}"
                 + $"&state={Uri.EscapeDataString(state)}"
-                // Keep scopes minimal: openid/profile/email is plain OIDC sign-in,
-                // which is all we need for the analytics dashboard (posts come in
-                // via CSV import since r_member_social is closed). w_member_social
-                // (publishing) is not requested — it causes LinkedIn to render
-                // "share on your behalf" on the consent screen which isn't what
-                // this flow is for today.
-                + "&scope=" + Uri.EscapeDataString("openid profile email");
+                // openid/profile/email  → OIDC sign-in + the member's `sub` (person id), which we
+                //                         persist as the credential SubjectId so publishing knows
+                //                         the author (see LinkedInPostsApi.NormalizeMemberUrn).
+                // w_member_social       → "Create, modify, and delete posts, comments, and reactions
+                //                         on your behalf" — the publishing scope the app is approved
+                //                         for. Grants the consent-screen "share on your behalf" line;
+                //                         that IS the intent now (POST /linkedin/publish → /rest/posts).
+                + "&scope=" + Uri.EscapeDataString("openid profile email w_member_social");
 
             return Results.Redirect(url);
         }).RequireAuthorization();

--- a/memex/Memex.Portal.Shared/Social/LinkedInPublishEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/LinkedInPublishEndpoints.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Social;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Social;
+
+/// <summary>
+/// Member <b>publishing + engagement</b> endpoints for the LinkedIn integration — the
+/// <c>w_member_social</c> side of the connect flow (<see cref="LinkedInConnectEndpoints"/> grants
+/// the scope; these endpoints use it):
+///
+/// <code>
+///   POST /linkedin/publish              JSON { postPath?, profilePath?, text?, visibility? } → publish a member post
+///   GET  /linkedin/publish?postPath=…   UI trigger — publish a Post node, redirect back with ?publish=ok|error
+///   GET  /linkedin/engagement?postPath=… UI trigger — refresh like/comment counts for a published Post node
+/// </code>
+///
+/// These are thin ASP.NET minimal-API adapters over <see cref="LinkedInPublishService"/> (in
+/// <c>MeshWeaver.Social</c>), which owns the credential-read → publish → node-write-back chain and its
+/// access gates. <c>async</c>/<c>HttpClient</c> is fine here (endpoint handlers are NOT hub code); the
+/// service carries the request's AccessContext through the mesh reads/writes — it NEVER runs as system,
+/// so a caller who lacks access to the post (or to the credential) is denied by the normal mesh
+/// permission checks before any LinkedIn call is made. The versioned <c>/rest/*</c> calls require the
+/// app to be granted <c>w_member_social</c> and the member to have re-consented after that scope was
+/// added; a missing scope surfaces as <c>reason=missing-w_member_social-reconnect</c>.
+/// </summary>
+public static class LinkedInPublishEndpoints
+{
+    private const string ApiVersion = LinkedInPostsApi.DefaultApiVersion;
+
+    /// <summary>Registers the publish + engagement endpoints. Call alongside <c>MapLinkedInConnect()</c>.</summary>
+    public static IEndpointRouteBuilder MapLinkedInPublish(this IEndpointRouteBuilder endpoints)
+    {
+        // 1) JSON publish API — body { postPath?, profilePath?, text?, visibility? }.
+        endpoints.MapPost("/linkedin/publish", async (
+            HttpContext http,
+            PublishRequest body,
+            IMessageHub hub,
+            IMeshService mesh,
+            IHttpClientFactory httpFactory,
+            ILoggerFactory loggers) =>
+        {
+            if (!http.User.Identity?.IsAuthenticated ?? true)
+                return Results.Unauthorized();
+
+            var svc = new LinkedInPublishService(hub, mesh, loggers.CreateLogger<LinkedInPublishService>());
+            var client = httpFactory.CreateClient();
+            var ct = http.RequestAborted;
+
+            if (!string.IsNullOrWhiteSpace(body.PostPath))
+            {
+                if (!IsSafePath(body.PostPath!))
+                    return Results.BadRequest(new { ok = false, reason = "bad-post-path" });
+                var outcome = await svc.PublishPostAsync(client, body.PostPath!, body.Text, body.Visibility, ApiVersion, ct);
+                return outcome.Success
+                    ? Results.Json(new { ok = true, urn = outcome.Urn, url = outcome.PostUrl, status = "Published" })
+                    : Results.Json(new { ok = false, reason = outcome.Reason, status = outcome.StatusCode }, statusCode: HttpStatusFor(outcome.Reason, outcome.StatusCode));
+            }
+
+            if (!string.IsNullOrWhiteSpace(body.ProfilePath) && !string.IsNullOrWhiteSpace(body.Text))
+            {
+                var outcome = await svc.PublishTextAsync(client, body.ProfilePath!, body.Text!, body.Visibility, ApiVersion, ct);
+                return outcome.Success
+                    ? Results.Json(new { ok = true, urn = outcome.Urn, url = outcome.PostUrl, status = "Published" })
+                    : Results.Json(new { ok = false, reason = outcome.Error, status = outcome.StatusCode }, statusCode: HttpStatusFor(outcome.Error, outcome.StatusCode));
+            }
+
+            return Results.BadRequest(new { ok = false, reason = "postPath-or-profilePath+text-required" });
+        }).RequireAuthorization();
+
+        // 2) UI trigger — publish a specific Post node, redirect back to it. Surfaced as a node-menu
+        //    item (SocialPostMenuProvider) whose Href is a plain GET navigation.
+        endpoints.MapGet("/linkedin/publish", async (
+            HttpContext http,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string postPath,
+            IMessageHub hub,
+            IMeshService mesh,
+            IHttpClientFactory httpFactory,
+            ILoggerFactory loggers) =>
+        {
+            if (!http.User.Identity?.IsAuthenticated ?? true)
+                return Results.Challenge(new AuthenticationProperties { RedirectUri = http.Request.Path + http.Request.QueryString });
+            if (!IsSafePath(postPath))
+                return Redirect(postPath, "publish", ok: false, "bad-post-path");
+
+            var svc = new LinkedInPublishService(hub, mesh, loggers.CreateLogger<LinkedInPublishService>());
+            var outcome = await svc.PublishPostAsync(httpFactory.CreateClient(), postPath, null, null, ApiVersion, http.RequestAborted);
+            return Redirect(postPath, "publish", outcome.Success, outcome.Reason);
+        }).RequireAuthorization();
+
+        // 3) UI trigger — refresh engagement for a published Post node, redirect back.
+        endpoints.MapGet("/linkedin/engagement", async (
+            HttpContext http,
+            [Microsoft.AspNetCore.Mvc.FromQuery] string postPath,
+            IMessageHub hub,
+            IMeshService mesh,
+            IHttpClientFactory httpFactory,
+            ILoggerFactory loggers) =>
+        {
+            if (!http.User.Identity?.IsAuthenticated ?? true)
+                return Results.Challenge(new AuthenticationProperties { RedirectUri = http.Request.Path + http.Request.QueryString });
+            if (!IsSafePath(postPath))
+                return Redirect(postPath, "engagement", ok: false, "bad-post-path");
+
+            var svc = new LinkedInPublishService(hub, mesh, loggers.CreateLogger<LinkedInPublishService>());
+            var outcome = await svc.RefreshEngagementAsync(httpFactory.CreateClient(), postPath, ApiVersion, http.RequestAborted);
+            return Redirect(postPath, "engagement", outcome.Success, outcome.Reason);
+        }).RequireAuthorization();
+
+        return endpoints;
+    }
+
+    private static int HttpStatusFor(string? reason, int upstreamStatus) => reason switch
+    {
+        "access-denied" => StatusCodes.Status403Forbidden,
+        "post-not-found" => StatusCodes.Status404NotFound,
+        "not-connected" or "missing-w_member_social-reconnect" => StatusCodes.Status409Conflict,
+        "profile-path-missing" or "empty-text" or "not-published" => StatusCodes.Status400BadRequest,
+        _ => upstreamStatus is >= 400 and < 600 ? upstreamStatus : StatusCodes.Status502BadGateway,
+    };
+
+    private static IResult Redirect(string postPath, string action, bool ok, string? reason)
+    {
+        var target = IsSafePath(postPath) ? "/" + postPath : "/";
+        var sep = target.Contains('?') ? "&" : "?";
+        var url = $"{target}{sep}{action}={(ok ? "ok" : "error")}";
+        if (!ok && !string.IsNullOrEmpty(reason))
+            url += $"&reason={Uri.EscapeDataString(reason!)}";
+        return Results.Redirect(url);
+    }
+
+    /// <summary>
+    /// A <c>postPath</c> is a mesh node path we interpolate into a Location header. Reject anything
+    /// that could turn the redirect into an open redirect (leading slash, protocol-relative, scheme,
+    /// traversal) — mirrors <see cref="LinkedInPageSyncEndpoints"/>'s guard.
+    /// </summary>
+    private static bool IsSafePath(string? path) =>
+        !string.IsNullOrWhiteSpace(path)
+        && !path.StartsWith('/')
+        && !path.Contains("//", StringComparison.Ordinal)
+        && !path.Contains("..", StringComparison.Ordinal)
+        && !path.Contains(':');
+
+    /// <summary>JSON body for <c>POST /linkedin/publish</c>.</summary>
+    public sealed record PublishRequest(string? PostPath, string? ProfilePath, string? Text, string? Visibility);
+}

--- a/memex/Memex.Portal.Shared/Social/SocialPostMenuProvider.cs
+++ b/memex/Memex.Portal.Shared/Social/SocialPostMenuProvider.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+
+namespace Memex.Portal.Shared.Social;
+
+/// <summary>
+/// Adds LinkedIn publish/engagement actions to the node menu of a <b>social-media Post</b> node
+/// (content <c>$type == "SocialMediaPost"</c>, platform LinkedIn):
+///
+///   - "Publish to LinkedIn" — while the post is NOT yet published (no <c>publishedUrn</c>): an
+///     <c>Href</c> to <c>GET /linkedin/publish?postPath=…</c>, which publishes via the member's
+///     stored credential and writes <c>status</c>/<c>publishedUrn</c>/<c>publishedAt</c> back.
+///   - "Refresh engagement" — once published: an <c>Href</c> to <c>GET /linkedin/engagement?postPath=…</c>,
+///     which pulls like/comment counts and writes <c>likes</c>/<c>comments</c> back.
+///
+/// The action is a plain GET navigation (same shape as <see cref="LinkedInCredentialMenuProvider"/>'s
+/// "Download past posts") — no hand-rolled HTML, no async hub code. The item self-swaps as the node's
+/// <c>publishedUrn</c> lands because the provider composes the live own-node stream. Both require Update
+/// permission, which the post owner has by definition.
+/// </summary>
+public sealed class SocialPostMenuProvider : INodeMenuProvider
+{
+    public string Context => "Node";
+
+    /// <summary>
+    /// Reactive: switches on the live own-node stream so the "Publish" ↔ "Refresh engagement" swap
+    /// happens the moment the endpoint writes <c>publishedUrn</c> back — no one-shot read. Emits an
+    /// empty slice for non-post nodes so the menu aggregator's <c>CombineLatest</c> never stalls.
+    /// </summary>
+    public IObservable<IReadOnlyCollection<NodeMenuItemDefinition>> GetItems(
+        LayoutAreaHost host, RenderingContext ctx)
+    {
+        var hubPath = host.Hub.Address.ToString();
+        return host.Workspace.GetMeshNodeStream()
+            .Select(n => (MeshNode?)n)
+            .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null))
+            .StartWith((MeshNode?)null)
+            .Select(node => BuildItems(hubPath, node));
+    }
+
+    private static IReadOnlyCollection<NodeMenuItemDefinition> BuildItems(string hubPath, MeshNode? node)
+    {
+        IReadOnlyCollection<NodeMenuItemDefinition> empty = [];
+        if (node?.Content is null || !IsLinkedInPost(node))
+            return empty;
+
+        var encoded = Uri.EscapeDataString(hubPath);
+        var publishedUrn = Prop(node, "publishedUrn");
+        var status = Prop(node, "status");
+        var isPublished = !string.IsNullOrEmpty(publishedUrn)
+            || string.Equals(status, "Published", StringComparison.OrdinalIgnoreCase);
+
+        if (!isPublished)
+            return
+            [
+                new NodeMenuItemDefinition(
+                    Label: "Publish to LinkedIn",
+                    Area: "PublishLinkedIn",
+                    Icon: "Send",
+                    RequiredPermission: Permission.Update,
+                    Order: 15,
+                    Href: $"/linkedin/publish?postPath={encoded}",
+                    Tooltip: "Publish this post to LinkedIn on your behalf"),
+            ];
+
+        return
+        [
+            new NodeMenuItemDefinition(
+                Label: "Refresh engagement",
+                Area: "RefreshLinkedInEngagement",
+                Icon: "ArrowSync",
+                RequiredPermission: Permission.Update,
+                Order: 15,
+                Href: $"/linkedin/engagement?postPath={encoded}",
+                Tooltip: "Pull the latest like + comment counts from LinkedIn"),
+        ];
+    }
+
+    private static bool IsLinkedInPost(MeshNode node)
+    {
+        var type = Prop(node, "$type");
+        var isPost = string.Equals(type, "SocialMediaPost", StringComparison.OrdinalIgnoreCase)
+            || (node.NodeType?.EndsWith("Post", StringComparison.OrdinalIgnoreCase) ?? false);
+        if (!isPost)
+            return false;
+        var platform = Prop(node, "platform");
+        return string.IsNullOrEmpty(platform)
+            || string.Equals(platform, "LinkedIn", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? Prop(MeshNode node, string name)
+    {
+        if (node.Content is null)
+            return null;
+        var je = node.Content is JsonElement e ? e : JsonSerializer.SerializeToElement(node.Content, node.Content.GetType());
+        if (je.ValueKind != JsonValueKind.Object)
+            return null;
+        if (TryString(je, name, out var v))
+            return v;
+        var pascal = char.ToUpperInvariant(name[0]) + name[1..];
+        return TryString(je, pascal, out var v2) ? v2 : null;
+    }
+
+    private static bool TryString(JsonElement obj, string name, out string? value)
+    {
+        value = null;
+        if (!obj.TryGetProperty(name, out var p))
+            return false;
+        value = p.ValueKind switch
+        {
+            JsonValueKind.String => p.GetString(),
+            JsonValueKind.Number => p.ToString(),
+            _ => null,
+        };
+        return value is not null;
+    }
+}

--- a/samples/Graph/Data/SocialMedia/Post/Source/SocialMediaPost.cs
+++ b/samples/Graph/Data/SocialMedia/Post/Source/SocialMediaPost.cs
@@ -37,4 +37,11 @@ public record SocialMediaPost
 
     [DisplayName("Media URL")]
     public string? MediaUrl { get; init; }
+
+    // Publishing lifecycle: Draft → Published (or Failed). Written back by the
+    // /linkedin/publish endpoint; drives the Post-node "Publish to LinkedIn" menu action.
+    public string Status { get; init; } = "Draft";
+
+    [DisplayName("Published URN")]
+    public string? PublishedUrn { get; init; }
 }

--- a/src/MeshWeaver.Documentation/Data/DataMesh/SocialMedia/Post/Source/SocialMediaPost.cs
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SocialMedia/Post/Source/SocialMediaPost.cs
@@ -32,4 +32,13 @@ public record SocialMediaPost
     public int Impressions { get; init; }
 
     public int Likes { get; init; }
+
+    public int Comments { get; init; }
+
+    // Publishing lifecycle: Draft → Published (or Failed). Written back by the
+    // /linkedin/publish endpoint; drives the Post-node "Publish to LinkedIn" menu action.
+    public string Status { get; init; } = "Draft";
+
+    [DisplayName("Published URN")]
+    public string? PublishedUrn { get; init; }
 }

--- a/src/MeshWeaver.Social/LinkedInPostsApi.cs
+++ b/src/MeshWeaver.Social/LinkedInPostsApi.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MeshWeaver.Social;
+
+/// <summary>
+/// Thin, stateless wrapper over LinkedIn's <b>versioned REST</b> member-publishing surface —
+/// the <c>w_member_social</c> "create a post on your behalf" flow:
+///
+/// <list type="bullet">
+///   <item><description><c>POST https://api.linkedin.com/rest/posts</c> — publish a text share as the member.</description></item>
+///   <item><description><c>GET  https://api.linkedin.com/rest/socialActions/{urn}</c> — read like + comment counts back.</description></item>
+/// </list>
+///
+/// This is deliberately separate from <see cref="LinkedInPublisher"/> (which speaks the older
+/// <c>/v2/ugcPosts</c> UGC API used by the scheduler subsystem). The versioned <c>/rest/posts</c>
+/// endpoint is what the connect-endpoint publish path uses because it is the current, documented
+/// member-post API and returns the created post URN in the <c>x-restli-id</c> response header.
+///
+/// Every method is a pure function of (HttpClient, credential, inputs) → outcome record, so the
+/// HTTP boundary can be stubbed with a test <see cref="HttpMessageHandler"/> (no mesh, no mocking).
+/// Callers own persistence: they write the returned <see cref="LinkedInPublishOutcome.Urn"/> /
+/// counts back onto the mesh node.
+/// </summary>
+public static class LinkedInPostsApi
+{
+    /// <summary>
+    /// LinkedIn versioned-API month header value (<c>LinkedIn-Version: YYYYMM</c>). LinkedIn pins
+    /// each versioned endpoint to a month; bump this to a currently-supported version as LinkedIn
+    /// rolls the window forward. Callers may override per-call.
+    /// </summary>
+    public const string DefaultApiVersion = "202506";
+
+    private static readonly Uri PostsEndpoint = new("https://api.linkedin.com/rest/posts");
+    private const string SocialActionsBase = "https://api.linkedin.com/rest/socialActions/";
+
+    /// <summary>
+    /// Normalizes a stored subject id into a member author URN. LinkedIn's <c>sub</c> claim from
+    /// <c>/v2/userinfo</c> is the bare person id (e.g. <c>abc123</c>); the Posts API wants the full
+    /// <c>urn:li:person:abc123</c>. An already-<c>urn:</c>-prefixed value (person OR organization)
+    /// is returned unchanged.
+    /// </summary>
+    public static string NormalizeMemberUrn(string subjectId) =>
+        string.IsNullOrEmpty(subjectId)
+            ? subjectId
+            : subjectId.StartsWith("urn:", StringComparison.Ordinal)
+                ? subjectId
+                : $"urn:li:person:{subjectId}";
+
+    /// <summary>
+    /// Publishes <paramref name="text"/> as a member post via <c>POST /rest/posts</c>. Returns the
+    /// created post URN (from the <c>x-restli-id</c> header, falling back to <c>x-linkedin-id</c> or
+    /// the response body <c>id</c>). On a non-2xx status the outcome carries the upstream status code
+    /// and body verbatim — the caller surfaces it rather than swallowing.
+    /// </summary>
+    /// <param name="http">HTTP client (may be backed by a test handler).</param>
+    /// <param name="credential">The member's LinkedIn credential (access token + subject id).</param>
+    /// <param name="text">The post commentary (LinkedIn renders plain text; no markdown).</param>
+    /// <param name="visibility">Post visibility: <c>PUBLIC</c> (default) or <c>CONNECTIONS</c>.</param>
+    /// <param name="apiVersion">The <c>LinkedIn-Version</c> header value; defaults to <see cref="DefaultApiVersion"/>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public static async Task<LinkedInPublishOutcome> PublishAsync(
+        HttpClient http,
+        PlatformCredential credential,
+        string text,
+        string? visibility,
+        string? apiVersion,
+        CancellationToken ct)
+    {
+        var author = NormalizeMemberUrn(credential.SubjectId);
+        var vis = string.IsNullOrWhiteSpace(visibility) ? "PUBLIC" : visibility!.Trim();
+
+        // Verbatim keys — an anonymous object serializes its property names exactly as written
+        // (System.Text.Json applies no naming policy by default), so this is the wire body 1:1:
+        // {"author":..,"commentary":..,"visibility":"PUBLIC","distribution":{"feedDistribution":
+        //  "MAIN_FEED","targetEntities":[],"thirdPartyDistributionChannels":[]},
+        //  "lifecycleState":"PUBLISHED","isReshareDisabledByAuthor":false}
+        var body = new
+        {
+            author,
+            commentary = text ?? "",
+            visibility = vis,
+            distribution = new
+            {
+                feedDistribution = "MAIN_FEED",
+                targetEntities = Array.Empty<string>(),
+                thirdPartyDistributionChannels = Array.Empty<string>()
+            },
+            lifecycleState = "PUBLISHED",
+            isReshareDisabledByAuthor = false
+        };
+
+        using var req = new HttpRequestMessage(HttpMethod.Post, PostsEndpoint)
+        {
+            Content = JsonContent.Create(body)
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential.AccessToken);
+        req.Headers.Add("LinkedIn-Version", string.IsNullOrWhiteSpace(apiVersion) ? DefaultApiVersion : apiVersion!);
+        req.Headers.Add("X-Restli-Protocol-Version", "2.0.0");
+
+        using var resp = await http.SendAsync(req, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var err = await resp.Content.ReadAsStringAsync(ct);
+            return new LinkedInPublishOutcome(false, null, null, (int)resp.StatusCode, err);
+        }
+
+        var urn = FirstHeader(resp, "x-restli-id") ?? FirstHeader(resp, "x-linkedin-id");
+        if (urn is null)
+        {
+            // Some responses echo the id in the body instead of / in addition to the header.
+            try
+            {
+                using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(ct));
+                if (doc.RootElement.TryGetProperty("id", out var idEl) && idEl.ValueKind == JsonValueKind.String)
+                    urn = idEl.GetString();
+            }
+            catch (JsonException) { /* empty / non-JSON body — header was authoritative anyway */ }
+        }
+
+        var url = urn is null ? null : $"https://www.linkedin.com/feed/update/{urn}/";
+        return new LinkedInPublishOutcome(true, urn, url, (int)resp.StatusCode, null);
+    }
+
+    /// <summary>
+    /// Reads engagement (like + comment totals) for a previously-published post via
+    /// <c>GET /rest/socialActions/{urn}</c>. Parses <c>likesSummary.totalLikes</c> and
+    /// <c>commentsSummary.count</c> (with aggregate-field fallbacks LinkedIn has used across
+    /// versions). On non-2xx the outcome carries the upstream status + body; counts are 0.
+    /// </summary>
+    public static async Task<LinkedInEngagementOutcome> GetSocialActionsAsync(
+        HttpClient http,
+        string urn,
+        PlatformCredential credential,
+        string? apiVersion,
+        CancellationToken ct)
+    {
+        using var req = new HttpRequestMessage(
+            HttpMethod.Get,
+            new Uri(SocialActionsBase + Uri.EscapeDataString(urn)));
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential.AccessToken);
+        req.Headers.Add("LinkedIn-Version", string.IsNullOrWhiteSpace(apiVersion) ? DefaultApiVersion : apiVersion!);
+        req.Headers.Add("X-Restli-Protocol-Version", "2.0.0");
+
+        using var resp = await http.SendAsync(req, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var err = await resp.Content.ReadAsStringAsync(ct);
+            return new LinkedInEngagementOutcome(false, 0, 0, (int)resp.StatusCode, err, DateTimeOffset.UtcNow);
+        }
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(ct));
+        var root = doc.RootElement;
+        var likes = SummaryInt(root, "likesSummary", "totalLikes", "aggregatedTotalLikes");
+        var comments = SummaryInt(root, "commentsSummary", "count", "aggregatedTotalComments");
+        return new LinkedInEngagementOutcome(true, likes, comments, (int)resp.StatusCode, null, DateTimeOffset.UtcNow);
+    }
+
+    private static int SummaryInt(JsonElement root, string summaryProp, string primary, string fallback)
+    {
+        if (!root.TryGetProperty(summaryProp, out var summary) || summary.ValueKind != JsonValueKind.Object)
+            return 0;
+        if (summary.TryGetProperty(primary, out var p) && p.ValueKind == JsonValueKind.Number && p.TryGetInt32(out var v))
+            return v;
+        if (summary.TryGetProperty(fallback, out var f) && f.ValueKind == JsonValueKind.Number && f.TryGetInt32(out var v2))
+            return v2;
+        return 0;
+    }
+
+    private static string? FirstHeader(HttpResponseMessage resp, string name) =>
+        resp.Headers.TryGetValues(name, out var values)
+            ? System.Linq.Enumerable.FirstOrDefault(values)
+            : null;
+}
+
+/// <summary>
+/// Outcome of a <see cref="LinkedInPostsApi.PublishAsync"/> call. On success <see cref="Urn"/> is the
+/// created post URN; on failure <see cref="Success"/> is false and <see cref="Error"/> holds the
+/// upstream body so the caller can surface LinkedIn's own reason.
+/// </summary>
+public sealed record LinkedInPublishOutcome(
+    bool Success,
+    string? Urn,
+    string? PostUrl,
+    int StatusCode,
+    string? Error);
+
+/// <summary>
+/// Outcome of a <see cref="LinkedInPostsApi.GetSocialActionsAsync"/> call. On success the like /
+/// comment counts are populated; on failure <see cref="Success"/> is false and <see cref="Error"/>
+/// carries the upstream body.
+/// </summary>
+public sealed record LinkedInEngagementOutcome(
+    bool Success,
+    int LikeCount,
+    int CommentCount,
+    int StatusCode,
+    string? Error,
+    DateTimeOffset RetrievedAt);

--- a/src/MeshWeaver.Social/LinkedInPublishService.cs
+++ b/src/MeshWeaver.Social/LinkedInPublishService.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Social;
+
+/// <summary>
+/// The mesh-facing LinkedIn member-publish chain: read the target <c>SocialMediaPost</c> node → check
+/// the caller's access → read the caller's stored LinkedIn credential → publish via
+/// <see cref="LinkedInPostsApi"/> → write <c>Status</c>/<c>PublishedUrn</c> back onto the post node.
+/// The HTTP endpoints (<c>Memex.Portal.Shared.Social.LinkedInPublishEndpoints</c>) are thin adapters
+/// that construct this service from the request's <see cref="IMessageHub"/> + <see cref="IMeshService"/>
+/// and map its outcome to a redirect / JSON — so the whole credential-read → publish → write-back path
+/// is one testable unit (see <c>LinkedInPublishServiceTest</c>).
+///
+/// <para><b>Access control.</b> Every mesh read/write runs under the <em>caller's</em> AccessContext —
+/// this service NEVER impersonates system. Two explicit gates enforce the rules the endpoint promises:
+/// <list type="number">
+///   <item><description>the caller must have <see cref="Permission.Update"/> on the post node (they are
+///     mutating it — publishing flips its <c>Status</c>) → a user who cannot access the post is denied
+///     BEFORE any LinkedIn call is made;</description></item>
+///   <item><description>the caller must have <see cref="Permission.Read"/> on the credential node
+///     (<c>{profile}/_ApiCredentials/linkedin</c>) → a user cannot publish using someone else's stored
+///     credential.</description></item>
+/// </list>
+/// When row-level security is not configured the permission evaluator returns <see cref="Permission.All"/>
+/// for everyone (dev/single-user meshes); with RLS on, these gates deny cross-user access.</para>
+///
+/// <para>This is HTTP-edge application code (invoked from ASP.NET minimal-API handlers, exactly like
+/// <see cref="LinkedInPublisher"/>), NOT hub code — so it is <c>Task</c>-based and bridges the reactive
+/// mesh surface with <c>.FirstAsync().ToTask()</c> at its own boundary.</para>
+/// </summary>
+public sealed class LinkedInPublishService
+{
+    private readonly IMessageHub _hub;
+    private readonly IMeshService _mesh;
+    private readonly ILogger? _logger;
+
+    /// <summary>Creates the service over a request-scoped hub + mesh service.</summary>
+    public LinkedInPublishService(IMessageHub hub, IMeshService mesh, ILogger<LinkedInPublishService>? logger = null)
+    {
+        _hub = hub;
+        _mesh = mesh;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Publishes the <c>SocialMediaPost</c> at <paramref name="postPath"/> to LinkedIn and writes the
+    /// result back. <paramref name="textOverride"/> wins over the post's <c>Body</c>/<c>Text</c> when set.
+    /// Returns the outcome (including <see cref="PublishNodeOutcome.HttpAttempted"/> so callers/tests can
+    /// assert that a guarded request made no outbound LinkedIn call).
+    /// </summary>
+    public async Task<PublishNodeOutcome> PublishPostAsync(
+        HttpClient client, string postPath, string? textOverride, string? visibility, string? apiVersion, CancellationToken ct)
+    {
+        var postNode = await TryReadNodeAsync(postPath, ct);
+        if (postNode is null)
+            return PublishNodeOutcome.Fail("post-not-found");
+
+        // Gate 1: the caller must be able to UPDATE the post (we write Status/PublishedUrn back).
+        // Denied → no LinkedIn call, no write. Runs under the caller's AccessContext.
+        if (!await CanAsync(postPath, Permission.Update, ct))
+            return PublishNodeOutcome.Fail("access-denied");
+
+        var text = textOverride ?? Prop(postNode, "body") ?? Prop(postNode, "text");
+        var profilePath = Prop(postNode, "profilePath");
+        if (string.IsNullOrWhiteSpace(profilePath))
+            return PublishNodeOutcome.Fail("profile-path-missing");
+        if (string.IsNullOrWhiteSpace(text))
+            return PublishNodeOutcome.Fail("empty-text");
+
+        var credential = await ReadOwnCredentialAsync(profilePath!, ct);
+        if (credential is null)
+            return PublishNodeOutcome.Fail("not-connected");
+        if (!HasPublishScope(credential))
+            return PublishNodeOutcome.Fail("missing-w_member_social-reconnect");
+
+        var outcome = await LinkedInPostsApi.PublishAsync(client, credential, text!, visibility, apiVersion, ct);
+
+        var updates = outcome.Success
+            ? new Dictionary<string, object?>
+            {
+                ["status"] = "Published",
+                ["publishedUrn"] = outcome.Urn,
+                ["publishedAt"] = DateTimeOffset.UtcNow,
+            }
+            : new Dictionary<string, object?> { ["status"] = "Failed" };
+        await WriteBackAsync(postNode, updates, ct);
+
+        return outcome.Success
+            ? new PublishNodeOutcome(true, outcome.Urn, outcome.PostUrl, null, outcome.StatusCode, HttpAttempted: true)
+            : new PublishNodeOutcome(false, null, null, ShortReason(outcome.Error), outcome.StatusCode, HttpAttempted: true);
+    }
+
+    /// <summary>
+    /// Publishes free text for <paramref name="profilePath"/>'s member (no post node). Used by the JSON
+    /// <c>POST /linkedin/publish</c> path when only <c>profilePath</c> + <c>text</c> are supplied. Still
+    /// gated on <see cref="Permission.Read"/> of the credential node so a caller cannot borrow another
+    /// member's credential.
+    /// </summary>
+    public async Task<LinkedInPublishOutcome> PublishTextAsync(
+        HttpClient client, string profilePath, string text, string? visibility, string? apiVersion, CancellationToken ct)
+    {
+        var credential = await ReadOwnCredentialAsync(profilePath, ct);
+        if (credential is null)
+            return new LinkedInPublishOutcome(false, null, null, 0, "not-connected");
+        if (!HasPublishScope(credential))
+            return new LinkedInPublishOutcome(false, null, null, 0, "missing-w_member_social-reconnect");
+        return await LinkedInPostsApi.PublishAsync(client, credential, text, visibility, apiVersion, ct);
+    }
+
+    /// <summary>
+    /// Refreshes engagement (like/comment counts) for a published post and writes the counts back. Same
+    /// two access gates as <see cref="PublishPostAsync"/>.
+    /// </summary>
+    public async Task<EngagementNodeOutcome> RefreshEngagementAsync(
+        HttpClient client, string postPath, string? apiVersion, CancellationToken ct)
+    {
+        var postNode = await TryReadNodeAsync(postPath, ct);
+        if (postNode is null)
+            return EngagementNodeOutcome.Fail("post-not-found");
+        if (!await CanAsync(postPath, Permission.Update, ct))
+            return EngagementNodeOutcome.Fail("access-denied");
+
+        var urn = Prop(postNode, "publishedUrn");
+        if (string.IsNullOrWhiteSpace(urn))
+            return EngagementNodeOutcome.Fail("not-published");
+        var profilePath = Prop(postNode, "profilePath");
+        if (string.IsNullOrWhiteSpace(profilePath))
+            return EngagementNodeOutcome.Fail("profile-path-missing");
+
+        var credential = await ReadOwnCredentialAsync(profilePath!, ct);
+        if (credential is null)
+            return EngagementNodeOutcome.Fail("not-connected");
+
+        var outcome = await LinkedInPostsApi.GetSocialActionsAsync(client, urn!, credential, apiVersion, ct);
+        if (!outcome.Success)
+            return new EngagementNodeOutcome(false, 0, 0, ShortReason(outcome.Error), outcome.StatusCode, HttpAttempted: true);
+
+        await WriteBackAsync(postNode, new Dictionary<string, object?>
+        {
+            ["likes"] = outcome.LikeCount,
+            ["comments"] = outcome.CommentCount,
+        }, ct);
+        return new EngagementNodeOutcome(true, outcome.LikeCount, outcome.CommentCount, null, outcome.StatusCode, HttpAttempted: true);
+    }
+
+    // ---- access + mesh helpers (all under the caller's AccessContext) ----
+
+    private async Task<bool> CanAsync(string path, Permission permission, CancellationToken ct)
+    {
+        try
+        {
+            return await _hub.CheckPermission(path, permission)
+                .Timeout(TimeSpan.FromSeconds(10))
+                .FirstAsync()
+                .ToTask(ct);
+        }
+        catch (Exception ex)
+        {
+            // Fail CLOSED: an errored/timed-out permission check denies. Never publish on an
+            // indeterminate access answer.
+            _logger?.LogWarning(ex, "Permission check failed for {Path} ({Permission}) — denying", path, permission);
+            return false;
+        }
+    }
+
+    private async Task<PlatformCredential?> ReadOwnCredentialAsync(string profilePath, CancellationToken ct)
+    {
+        var credentialPath = profilePath + "/_ApiCredentials/linkedin";
+        // Gate 2: the caller must be able to READ the credential node — a user cannot publish using
+        // someone else's stored credential. (RLS + the credential's owner-only access rule enforce this.)
+        if (!await CanAsync(credentialPath, Permission.Read, ct))
+            return null;
+        var node = await TryReadNodeAsync(credentialPath, ct);
+        return AsCredential(node);
+    }
+
+    private async Task<MeshNode?> TryReadNodeAsync(string path, CancellationToken ct)
+    {
+        try
+        {
+            return await _hub.GetMeshNodeStream(path)
+                .Where(n => n?.Content is not null)
+                .Take(1)
+                .Timeout(TimeSpan.FromSeconds(10))
+                .FirstAsync()
+                .ToTask(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogInformation(ex, "No readable node at {Path}", path);
+            return null;
+        }
+    }
+
+    private async Task WriteBackAsync(MeshNode postNode, IReadOnlyDictionary<string, object?> updates, CancellationToken ct)
+    {
+        try
+        {
+            var content = ContentToDict(postNode);
+            foreach (var kv in updates)
+                content[kv.Key] = kv.Value;
+            var updated = postNode with { Content = content };
+            await _mesh.CreateOrUpdateNode(updated).FirstAsync().ToTask(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to write publish result back to {Path}", postNode.Path);
+        }
+    }
+
+    private static bool HasPublishScope(PlatformCredential credential) =>
+        string.IsNullOrEmpty(credential.Scope)
+        || credential.Scope!.Contains("w_member_social", StringComparison.OrdinalIgnoreCase);
+
+    private static PlatformCredential? AsCredential(MeshNode? node)
+    {
+        if (node?.Content is PlatformCredential typed)
+            return typed;
+        if (node?.Content is JsonElement je && je.ValueKind == JsonValueKind.Object)
+        {
+            try { return je.Deserialize<PlatformCredential>(CredentialJsonOptions); }
+            catch (JsonException) { return null; }
+        }
+        return null;
+    }
+
+    private static readonly JsonSerializerOptions CredentialJsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    private static Dictionary<string, object?> ContentToDict(MeshNode node)
+    {
+        var dict = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        if (node.Content is null)
+            return dict;
+        var je = node.Content is JsonElement e ? e : JsonSerializer.SerializeToElement(node.Content, node.Content.GetType());
+        if (je.ValueKind == JsonValueKind.Object)
+            foreach (var p in je.EnumerateObject())
+                dict[p.Name] = p.Value.Clone();
+        return dict;
+    }
+
+    private static string? Prop(MeshNode node, string name)
+    {
+        if (node.Content is null)
+            return null;
+        var je = node.Content is JsonElement e ? e : JsonSerializer.SerializeToElement(node.Content, node.Content.GetType());
+        if (je.ValueKind != JsonValueKind.Object)
+            return null;
+        if (TryString(je, name, out var v))
+            return v;
+        var pascal = char.ToUpperInvariant(name[0]) + name[1..];
+        return TryString(je, pascal, out var v2) ? v2 : null;
+    }
+
+    private static bool TryString(JsonElement obj, string name, out string? value)
+    {
+        value = null;
+        if (!obj.TryGetProperty(name, out var p))
+            return false;
+        value = p.ValueKind switch
+        {
+            JsonValueKind.String => p.GetString(),
+            JsonValueKind.Number => p.ToString(),
+            _ => null,
+        };
+        return value is not null;
+    }
+
+    private static string ShortReason(string? body)
+    {
+        if (string.IsNullOrEmpty(body)) return "linkedin-error";
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("message", out var m) && m.ValueKind == JsonValueKind.String)
+                return m.GetString() ?? "linkedin-error";
+            if (doc.RootElement.TryGetProperty("error", out var er) && er.ValueKind == JsonValueKind.String)
+                return er.GetString() ?? "linkedin-error";
+        }
+        catch (JsonException) { /* non-JSON body */ }
+        return "linkedin-error";
+    }
+}
+
+/// <summary>
+/// Outcome of a <see cref="LinkedInPublishService.PublishPostAsync"/> call. <see cref="HttpAttempted"/>
+/// is false when a pre-publish gate (access / missing profile / empty text / missing scope) short-circuited
+/// BEFORE any outbound LinkedIn call — tests assert on it to prove a guarded publish made no HTTP request.
+/// </summary>
+public sealed record PublishNodeOutcome(
+    bool Success, string? Urn, string? PostUrl, string? Reason, int StatusCode, bool HttpAttempted)
+{
+    internal static PublishNodeOutcome Fail(string reason) => new(false, null, null, reason, 0, HttpAttempted: false);
+}
+
+/// <summary>Outcome of a <see cref="LinkedInPublishService.RefreshEngagementAsync"/> call.</summary>
+public sealed record EngagementNodeOutcome(
+    bool Success, int LikeCount, int CommentCount, string? Reason, int StatusCode, bool HttpAttempted)
+{
+    internal static EngagementNodeOutcome Fail(string reason) => new(false, 0, 0, reason, 0, HttpAttempted: false);
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/LinkedInPublishAccessTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/LinkedInPublishAccessTest.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Social;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.Social;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Access-control integration tests for <see cref="LinkedInPublishService"/> against a real
+/// row-level-security mesh (no <c>PublicAdminAccess</c> — only the seeded per-user grants apply).
+/// Proves the two access rules the endpoint promises, enforced by the NORMAL mesh permission checks
+/// under the caller's AccessContext (the service never runs as system):
+///
+///   (a) a user WITHOUT Update on the post cannot publish it — no LinkedIn call, no write-back;
+///   (b) a user cannot publish using another profile's credential — the credential read is denied.
+///
+/// <para><c>bob</c> is a Viewer on <c>SpaceA</c> (read-only) and an Editor on <c>SpaceB</c>, and has
+/// no access to <c>SpaceC</c>. Setup nodes are created as system (the legitimate provisioner); the
+/// publish attempts run as <c>bob</c>.</para>
+/// </summary>
+public class LinkedInPublishAccessTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)   // ConfigureMeshBase enables AddRowLevelSecurity(); no PublicAdminAccess here.
+            .AddApiCredentialType()
+            .AddMeshNodes(SocialTestNodeTypes.PostNodeType)
+            .AddMeshNodes(
+                AssignmentNodeFactory.UserRole("bob_viewerA", "Viewer", "SpaceA", accessObject: "bob"),
+                AssignmentNodeFactory.UserRole("bob_editorB", "Editor", "SpaceB", accessObject: "bob"));
+
+    [Fact(Timeout = 60000)]
+    public async Task Publish_is_denied_for_a_user_without_update_on_the_post()
+    {
+        // bob is only a Viewer on SpaceA — he can READ the post but not UPDATE it.
+        await CreateAsSystem(Credential("SpaceA", scope: "openid profile email w_member_social"));
+        await CreateAsSystem(Post("SpaceA/posts/postA", profile: "SpaceA", body: "someone else's post"));
+
+        Login("bob");
+        var handler = new LinkedInPublishServiceTest.StubHandler(HttpStatusCode.Created, ("x-restli-id", "urn:li:share:nope"));
+        var svc = new LinkedInPublishService(Mesh, NodeFactory);
+
+        var outcome = await svc.PublishPostAsync(
+            new HttpClient(handler), "SpaceA/posts/postA", textOverride: null, visibility: null,
+            LinkedInPostsApi.DefaultApiVersion, TestContext.Current.CancellationToken);
+
+        outcome.Success.Should().BeFalse();
+        outcome.Reason.Should().Be("access-denied");
+        outcome.HttpAttempted.Should().BeFalse();
+        handler.CallCount.Should().Be(0);   // nothing was published
+
+        // Nothing was written back either — Status stays Draft (bob can still READ it).
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream("SpaceA/posts/postA")
+            .Should().Within(15.Seconds())
+            .Match(n => LinkedInPublishServiceTest.StrProp(n, "body") is not null);
+        LinkedInPublishServiceTest.StrProp(node, "status").Should().Be("Draft");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Publish_cannot_borrow_another_profiles_credential()
+    {
+        // The credential lives under SpaceC (bob has NO access). bob owns postB (Editor on SpaceB) and
+        // points it at SpaceC's profile — he can update the post but must not be able to publish with a
+        // credential he cannot read.
+        await CreateAsSystem(Credential("SpaceC", scope: "openid profile email w_member_social"));
+        await CreateAsSystem(Post("SpaceB/posts/postB", profile: "SpaceC", body: "bob borrowing a credential"));
+
+        Login("bob");
+        var handler = new LinkedInPublishServiceTest.StubHandler(HttpStatusCode.Created, ("x-restli-id", "urn:li:share:nope"));
+        var svc = new LinkedInPublishService(Mesh, NodeFactory);
+
+        var outcome = await svc.PublishPostAsync(
+            new HttpClient(handler), "SpaceB/posts/postB", textOverride: null, visibility: null,
+            LinkedInPostsApi.DefaultApiVersion, TestContext.Current.CancellationToken);
+
+        outcome.Success.Should().BeFalse();
+        outcome.Reason.Should().Be("not-connected");   // credential read denied → resolved as no credential
+        outcome.HttpAttempted.Should().BeFalse();
+        handler.CallCount.Should().Be(0);
+
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream("SpaceB/posts/postB")
+            .Should().Within(15.Seconds())
+            .Match(n => LinkedInPublishServiceTest.StrProp(n, "body") is not null);
+        LinkedInPublishServiceTest.StrProp(node, "status").Should().Be("Draft");
+    }
+
+    private void Login(string userId)
+        => Mesh.ServiceProvider.GetRequiredService<AccessService>()
+            .SetCircuitContext(new AccessContext { ObjectId = userId, Name = userId });
+
+    private Task CreateAsSystem(MeshNode node)
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        return Observable.Using(access.ImpersonateAsSystem, _ => NodeFactory.CreateNode(node))
+            .SubscribeOn(TaskPoolScheduler.Default)
+            .Timeout(TimeSpan.FromSeconds(30))
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+    }
+
+    private static MeshNode Credential(string profile, string scope) =>
+        new("linkedin", $"{profile}/_ApiCredentials")
+        {
+            Name = "LinkedIn credential",
+            NodeType = ApiCredentialNodeType.NodeType,
+            State = MeshNodeState.Active,
+            Content = new PlatformCredential
+            {
+                Platform = LinkedInPublisher.PlatformId,
+                SubjectId = "abc",
+                AccessToken = "tok",
+                Scope = scope,
+                AcquiredAt = DateTimeOffset.UtcNow,
+            }
+        };
+
+    private static MeshNode Post(string path, string profile, string body)
+    {
+        var (id, ns) = LinkedInPublishServiceTest.SplitPath(path);
+        return new MeshNode(id, ns)
+        {
+            Name = "post",
+            NodeType = "Systemorph/Post",
+            State = MeshNodeState.Active,
+            Content = new Dictionary<string, object?>
+            {
+                ["title"] = "post",
+                ["body"] = body,
+                ["profilePath"] = profile,
+                ["platform"] = "LinkedIn",
+                ["status"] = "Draft",
+            }
+        };
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/LinkedInPublishServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/LinkedInPublishServiceTest.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Social;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Social;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Integration test for <see cref="LinkedInPublishService"/> against a REAL monolith mesh — the
+/// credential-read → publish → node-write-back chain the <c>POST /linkedin/publish</c> endpoint runs.
+/// The only stub is the outbound LinkedIn <see cref="HttpClient"/> (a test message handler); the mesh
+/// (persistence, per-node hubs, AccessContext) is real and never mocked.
+/// </summary>
+public class LinkedInPublishServiceTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)                       // default: RLS + PublicAdminAccess (admin everywhere)
+            .AddApiCredentialType()                          // registers the ApiCredential NodeType + PlatformCredential
+            .AddMeshNodes(SocialTestNodeTypes.PostNodeType); // registers the (generic) Systemorph/Post NodeType
+
+    [Fact(Timeout = 60000)]
+    public async Task PublishPost_writes_Published_status_and_urn_back_to_the_node()
+    {
+        var profile = $"TestData/pub_{Guid.NewGuid():N}";
+        var postPath = $"{profile}/posts/post1";
+
+        await SeedCredentialAsync(profile, scope: "openid profile email w_member_social");
+        await SeedPostAsync(postPath, profile, body: "Hello from the mesh 👋");
+
+        // Stub LinkedIn: 201 Created + the created post URN in the x-restli-id header.
+        var handler = new StubHandler(HttpStatusCode.Created, ("x-restli-id", "urn:li:share:9001"));
+        var svc = new LinkedInPublishService(Mesh, NodeFactory);
+
+        var outcome = await svc.PublishPostAsync(
+            new HttpClient(handler), postPath, textOverride: null, visibility: null,
+            LinkedInPostsApi.DefaultApiVersion, TestContext.Current.CancellationToken);
+
+        outcome.Success.Should().BeTrue();
+        outcome.Urn.Should().Be("urn:li:share:9001");
+        outcome.HttpAttempted.Should().BeTrue();
+        handler.CallCount.Should().Be(1);
+
+        // Read the node back from the mesh (live stream) and assert the write-back landed.
+        var published = await Mesh.GetWorkspace().GetMeshNodeStream(postPath)
+            .Should().Within(30.Seconds())
+            .Match(n => StrProp(n, "status") == "Published");
+        StrProp(published, "publishedUrn").Should().Be("urn:li:share:9001");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task PublishPost_without_w_member_social_scope_makes_no_http_call()
+    {
+        var profile = $"TestData/pub_{Guid.NewGuid():N}";
+        var postPath = $"{profile}/posts/post1";
+
+        // Credential predates the widened scope — it lacks w_member_social.
+        await SeedCredentialAsync(profile, scope: "openid profile email");
+        await SeedPostAsync(postPath, profile, body: "Should never leave the mesh");
+
+        var handler = new StubHandler(HttpStatusCode.Created, ("x-restli-id", "urn:li:share:should-not-happen"));
+        var svc = new LinkedInPublishService(Mesh, NodeFactory);
+
+        var outcome = await svc.PublishPostAsync(
+            new HttpClient(handler), postPath, textOverride: null, visibility: null,
+            LinkedInPostsApi.DefaultApiVersion, TestContext.Current.CancellationToken);
+
+        // The missing-scope guard fires BEFORE any LinkedIn call, and nothing is written back.
+        outcome.Success.Should().BeFalse();
+        outcome.Reason.Should().Be("missing-w_member_social-reconnect");
+        outcome.HttpAttempted.Should().BeFalse();
+        handler.CallCount.Should().Be(0);
+
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream(postPath)
+            .Should().Within(15.Seconds())
+            .Match(n => StrProp(n, "body") is not null);
+        StrProp(node, "status").Should().Be("Draft");
+    }
+
+    private Task SeedCredentialAsync(string profile, string scope) =>
+        NodeFactory.CreateNode(new MeshNode("linkedin", $"{profile}/_ApiCredentials")
+        {
+            Name = "LinkedIn credential",
+            NodeType = ApiCredentialNodeType.NodeType,
+            State = MeshNodeState.Active,
+            Content = new PlatformCredential
+            {
+                Platform = LinkedInPublisher.PlatformId,
+                SubjectId = "abc123",
+                AccessToken = "test-token",
+                Scope = scope,
+                AcquiredAt = DateTimeOffset.UtcNow,
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+    private Task SeedPostAsync(string postPath, string profile, string body)
+    {
+        var (id, ns) = SplitPath(postPath);
+        return NodeFactory.CreateNode(new MeshNode(id, ns)
+        {
+            Name = "Test post",
+            NodeType = "Systemorph/Post",
+            State = MeshNodeState.Active,
+            Content = new Dictionary<string, object?>
+            {
+                ["title"] = "Test post",
+                ["body"] = body,
+                ["profilePath"] = profile,
+                ["platform"] = "LinkedIn",
+                ["status"] = "Draft",
+            }
+        }).Should().Within(30.Seconds()).Emit();
+    }
+
+    internal static (string Id, string Namespace) SplitPath(string path)
+    {
+        var i = path.LastIndexOf('/');
+        return (path[(i + 1)..], path[..i]);
+    }
+
+    internal static string? StrProp(MeshNode? node, string name)
+    {
+        if (node?.Content is null) return null;
+        var je = node.Content is JsonElement e ? e : JsonSerializer.SerializeToElement(node.Content, node.Content.GetType());
+        if (je.ValueKind != JsonValueKind.Object) return null;
+        if (je.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String) return p.GetString();
+        var pascal = char.ToUpperInvariant(name[0]) + name[1..];
+        return je.TryGetProperty(pascal, out var pp) && pp.ValueKind == JsonValueKind.String ? pp.GetString() : null;
+    }
+
+    /// <summary>Test LinkedIn HTTP boundary: returns a canned response and counts invocations.</summary>
+    internal sealed class StubHandler(HttpStatusCode status, params (string Name, string Value)[] responseHeaders)
+        : HttpMessageHandler
+    {
+        private int _callCount;
+        public int CallCount => _callCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _callCount);
+            var resp = new HttpResponseMessage(status)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            };
+            foreach (var (name, value) in responseHeaders)
+                resp.Headers.TryAddWithoutValidation(name, value);
+            return Task.FromResult(resp);
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/SocialTestNodeTypes.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SocialTestNodeTypes.cs
@@ -1,0 +1,24 @@
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Test-fixture NodeType registrations for the LinkedIn publish integration tests.
+/// </summary>
+internal static class SocialTestNodeTypes
+{
+    /// <summary>
+    /// Registers <c>Systemorph/Post</c> as a <b>generic</b> NodeType — a data source with no CLR content
+    /// type, so instances round-trip their <c>Dictionary</c> content as a <see cref="System.Text.Json.JsonElement"/>,
+    /// exactly as the production social-media Post nodes do (the layout areas read them as JsonElement).
+    /// </summary>
+    public static MeshNode PostNodeType => new("Post", "Systemorph")
+    {
+        Name = "Social Media Post",
+        NodeType = "NodeType",
+        Content = new NodeTypeDefinition { Description = "Social media post (test fixture)." },
+        HubConfiguration = config => config.AddMeshDataSource(),
+    };
+}

--- a/test/MeshWeaver.Social.Test/LinkedInPostsApiTest.cs
+++ b/test/MeshWeaver.Social.Test/LinkedInPostsApiTest.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Social;
+using Xunit;
+
+namespace MeshWeaver.Social.Test;
+
+/// <summary>
+/// Verifies that <see cref="LinkedInPostsApi"/> builds the exact versioned <c>/rest/posts</c> +
+/// <c>/rest/socialActions</c> requests LinkedIn's <c>w_member_social</c> API expects, and parses the
+/// created-post URN + engagement counts from the response. The HTTP boundary is stubbed with a
+/// capturing <see cref="HttpMessageHandler"/> — no live LinkedIn calls, no mesh, no mocking.
+/// </summary>
+public class LinkedInPostsApiTest
+{
+    private static PlatformCredential Credential(string subjectId = "abc", string? scope = "openid profile email w_member_social") => new()
+    {
+        Platform = "LinkedIn",
+        SubjectId = subjectId,
+        AccessToken = "test-token",
+        RefreshToken = "rt",
+        ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+        AcquiredAt = DateTimeOffset.UtcNow,
+        Scope = scope,
+    };
+
+    [Fact]
+    public async Task PublishAsync_posts_to_rest_posts_with_correct_headers_and_body()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.Created, "", ("x-restli-id", "urn:li:share:7777"));
+        var http = new HttpClient(handler);
+
+        var outcome = await LinkedInPostsApi.PublishAsync(
+            http, Credential(), "Hello from the mesh 👋", visibility: null, apiVersion: null, CancellationToken.None);
+
+        // --- endpoint + verb ---
+        handler.Method.Should().Be(HttpMethod.Post.Method);
+        handler.RequestUri.Should().Be("https://api.linkedin.com/rest/posts");
+
+        // --- headers ---
+        handler.AuthScheme.Should().Be("Bearer");
+        handler.AuthParameter.Should().Be("test-token");
+        handler.LinkedInVersion.Should().Be(LinkedInPostsApi.DefaultApiVersion); // "202506"
+        handler.RestliVersion.Should().Be("2.0.0");
+
+        // --- body shape (the exact wire contract) ---
+        using var doc = JsonDocument.Parse(handler.Body!);
+        var root = doc.RootElement;
+        root.GetProperty("author").GetString().Should().Be("urn:li:person:abc");
+        root.GetProperty("commentary").GetString().Should().Be("Hello from the mesh 👋");
+        root.GetProperty("visibility").GetString().Should().Be("PUBLIC");
+        root.GetProperty("lifecycleState").GetString().Should().Be("PUBLISHED");
+        root.GetProperty("isReshareDisabledByAuthor").GetBoolean().Should().BeFalse();
+
+        var dist = root.GetProperty("distribution");
+        dist.GetProperty("feedDistribution").GetString().Should().Be("MAIN_FEED");
+        dist.GetProperty("targetEntities").GetArrayLength().Should().Be(0);
+        dist.GetProperty("thirdPartyDistributionChannels").GetArrayLength().Should().Be(0);
+
+        // --- outcome: URN comes from the x-restli-id response header ---
+        outcome.Success.Should().BeTrue();
+        outcome.Urn.Should().Be("urn:li:share:7777");
+        outcome.PostUrl.Should().Be("https://www.linkedin.com/feed/update/urn:li:share:7777/");
+    }
+
+    [Fact]
+    public async Task PublishAsync_keeps_an_already_prefixed_author_urn_and_honors_custom_visibility()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.Created, "", ("x-restli-id", "urn:li:share:1"));
+        var http = new HttpClient(handler);
+
+        await LinkedInPostsApi.PublishAsync(
+            http, Credential(subjectId: "urn:li:person:xyz"), "hi", visibility: "CONNECTIONS", apiVersion: "202401", CancellationToken.None);
+
+        handler.LinkedInVersion.Should().Be("202401");
+        using var doc = JsonDocument.Parse(handler.Body!);
+        doc.RootElement.GetProperty("author").GetString().Should().Be("urn:li:person:xyz");
+        doc.RootElement.GetProperty("visibility").GetString().Should().Be("CONNECTIONS");
+    }
+
+    [Fact]
+    public async Task PublishAsync_surfaces_error_body_on_non_2xx()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.UnprocessableEntity,
+            "{ \"message\": \"Not enough permissions to publish\" }");
+        var http = new HttpClient(handler);
+
+        var outcome = await LinkedInPostsApi.PublishAsync(
+            http, Credential(), "hi", visibility: null, apiVersion: null, CancellationToken.None);
+
+        outcome.Success.Should().BeFalse();
+        outcome.StatusCode.Should().Be(422);
+        outcome.Urn.Should().BeNull();
+        outcome.Error!.Should().Contain("Not enough permissions");
+    }
+
+    [Fact]
+    public async Task PublishAsync_falls_back_to_response_body_id_when_no_header()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, "{ \"id\": \"urn:li:ugcPost:42\" }");
+        var http = new HttpClient(handler);
+
+        var outcome = await LinkedInPostsApi.PublishAsync(
+            http, Credential(), "hi", visibility: null, apiVersion: null, CancellationToken.None);
+
+        outcome.Success.Should().BeTrue();
+        outcome.Urn.Should().Be("urn:li:ugcPost:42");
+    }
+
+    [Fact]
+    public async Task GetSocialActionsAsync_parses_likes_and_comments()
+    {
+        var payload = """
+        {
+          "likesSummary":    { "totalLikes": 12, "aggregatedTotalLikes": 12 },
+          "commentsSummary": { "count": 5,       "aggregatedTotalComments": 5 }
+        }
+        """;
+        var handler = new CapturingHandler(HttpStatusCode.OK, payload);
+        var http = new HttpClient(handler);
+
+        var outcome = await LinkedInPostsApi.GetSocialActionsAsync(
+            http, "urn:li:share:7777", Credential(), apiVersion: null, CancellationToken.None);
+
+        handler.Method.Should().Be(HttpMethod.Get.Method);
+        handler.RequestUri.Should().Contain("/rest/socialActions/");
+        handler.LinkedInVersion.Should().Be(LinkedInPostsApi.DefaultApiVersion);
+        handler.RestliVersion.Should().Be("2.0.0");
+
+        outcome.Success.Should().BeTrue();
+        outcome.LikeCount.Should().Be(12);
+        outcome.CommentCount.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task GetSocialActionsAsync_surfaces_error_without_throwing()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.Forbidden, "{ \"message\": \"insufficient scope\" }");
+        var http = new HttpClient(handler);
+
+        var outcome = await LinkedInPostsApi.GetSocialActionsAsync(
+            http, "urn:li:share:7777", Credential(), apiVersion: null, CancellationToken.None);
+
+        outcome.Success.Should().BeFalse();
+        outcome.StatusCode.Should().Be(403);
+        outcome.LikeCount.Should().Be(0);
+        outcome.CommentCount.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData("abc", "urn:li:person:abc")]
+    [InlineData("urn:li:person:xyz", "urn:li:person:xyz")]
+    [InlineData("urn:li:organization:99", "urn:li:organization:99")]
+    public void NormalizeMemberUrn_prefixes_bare_ids_only(string input, string expected) =>
+        LinkedInPostsApi.NormalizeMemberUrn(input).Should().Be(expected);
+
+    /// <summary>
+    /// Records the outgoing request (method, URI, auth + versioned headers, body) so the test can
+    /// assert the exact wire contract, then returns a canned response with optional headers.
+    /// </summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+        private readonly (string Name, string Value)[] _responseHeaders;
+
+        public string? Method { get; private set; }
+        public string? RequestUri { get; private set; }
+        public string? AuthScheme { get; private set; }
+        public string? AuthParameter { get; private set; }
+        public string? LinkedInVersion { get; private set; }
+        public string? RestliVersion { get; private set; }
+        public string? Body { get; private set; }
+
+        public CapturingHandler(HttpStatusCode status, string body, params (string, string)[] responseHeaders)
+        {
+            _status = status;
+            _body = body;
+            _responseHeaders = responseHeaders;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Method = request.Method.Method;
+            RequestUri = request.RequestUri?.GetLeftPart(UriPartial.Path);
+            AuthScheme = request.Headers.Authorization?.Scheme;
+            AuthParameter = request.Headers.Authorization?.Parameter;
+            if (request.Headers.TryGetValues("LinkedIn-Version", out var lv))
+                LinkedInVersion = System.Linq.Enumerable.FirstOrDefault(lv);
+            if (request.Headers.TryGetValues("X-Restli-Protocol-Version", out var rv))
+                RestliVersion = System.Linq.Enumerable.FirstOrDefault(rv);
+            if (request.Content is not null)
+                Body = await request.Content.ReadAsStringAsync(ct);
+
+            var resp = new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            };
+            foreach (var (name, value) in _responseHeaders)
+                resp.Headers.TryAddWithoutValidation(name, value);
+            return resp;
+        }
+    }
+}


### PR DESCRIPTION
## What

Publish to LinkedIn (and pull engagement) directly from the mesh, using the `w_member_social` scope the app already has.

- **Scope widened** → `openid profile email w_member_social` (author = your `urn:li:person:{sub}`, captured at connect as `PlatformCredential.SubjectId`).
- **`LinkedInPostsApi`** — `/rest/posts` publish + `/rest/socialActions` engagement (versioned headers).
- **`LinkedInPublishService`** — one code path: credential-read → access-check → publish → write `Status`/`PublishedUrn` back to the `SocialMediaPost`, all under the caller's AccessContext.
- **Endpoints** `POST /linkedin/publish` + `/linkedin/engagement` (thin adapters over the service).
- **Node menu** — "Publish to LinkedIn" (Draft) → self-swaps to "Refresh engagement" once published.
- `SocialMediaPost` gains `Status`/`PublishedUrn`/`Comments`.

## Access control (no system bypass, fail-closed)

- Publish requires **`Update`** on the post node (mutating its status) → a user can't publish a post they can't update.
- Requires **`Read`** on the caller's **own** credential node → a user can't borrow another profile's credential.
- Missing `w_member_social` → friendly reconnect guard, **no HTTP call**.

## Tests (MonolithMeshTestBase, no mocking; LinkedIn HttpClient stubbed) — 24 green

- Request-shape units (URL/verb/headers/body, URN extraction, error surfacing, socialActions parsing)
- Integration: publish writes `Status=Published`+URN back; missing-scope makes no HTTP call
- Access: denied without `Update`; cannot borrow another profile's credential

## Going live (post-merge)

Deploy, then **re-run `/connect/linkedin` once** — the new scope only applies on fresh consent. Text-only publish for now (media upload is a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
