### PR TITLE
fix(portal+ai): stale home nav context, awaited-failure modal double-report, org/model wire-id mangling

### DIFF
--- a/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
+++ b/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
@@ -397,9 +397,32 @@ public sealed class ChatClientCredentialResolver : IDisposable
         // latter are warm even when the snapshot isn't).
         if (IsRegisteredModelId(snapshot, modelNameOrPath))
             return modelNameOrPath;
-        // Unresolved path (node not yet in the warm snapshot): the wire id is the LAST SEGMENT — never
-        // the whole path (sending "Provider/OpenAICompatible/qwen3.6:latest" as the model name 400s).
-        return modelNameOrPath[(modelNameOrPath.LastIndexOf('/') + 1)..];
+        // Unresolved NODE PATH (node not yet in the warm snapshot): the wire id is the LAST SEGMENT
+        // — never the whole path (sending "Provider/OpenAICompatible/qwen3.6:latest" as the model
+        // name 400s). Every LanguageModel node-path shape carries a catalog marker segment —
+        // Provider/{p}/{id}, {space}/Provider/{p}/{id}, {user}/_Memex/{p}/{id} — so ONLY those
+        // last-segment. A slash-bearing value WITHOUT a marker is an org/model wire id we simply
+        // don't know (yet) — cold snapshot, unseeded model: pass it through rather than mangle it.
+        if (LooksLikeCatalogNodePath(modelNameOrPath))
+            return modelNameOrPath[(modelNameOrPath.LastIndexOf('/') + 1)..];
+        return modelNameOrPath;
+    }
+
+    /// <summary>
+    /// True when <paramref name="value"/> is shaped like a LanguageModel node PATH: it contains a
+    /// catalog marker segment (<c>Provider</c> — <see cref="ModelProviderNodeType.RootNamespace"/> —
+    /// or the user dotfile namespace <c>_Memex</c>). Org/model wire ids ("z-ai/glm-5.2") carry
+    /// neither, so an UNRECOGNIZED slug is never last-segmented even before the snapshot warms.
+    /// </summary>
+    private static bool LooksLikeCatalogNodePath(string value)
+    {
+        foreach (var segment in value.Split('/'))
+        {
+            if (string.Equals(segment, ModelProviderNodeType.RootNamespace, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(segment, ModelProviderNodeType.UserNamespace, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
+++ b/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
@@ -7,6 +7,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -383,12 +384,60 @@ public sealed class ChatClientCredentialResolver : IDisposable
     {
         if (string.IsNullOrEmpty(modelNameOrPath) || !modelNameOrPath.Contains('/'))
             return modelNameOrPath;
-        var def = FindDefinitionByNodePath(ReadSnapshot(), modelNameOrPath);
+        var snapshot = ReadSnapshot();
+        var def = FindDefinitionByNodePath(snapshot, modelNameOrPath);
         if (def != null)
             return def.Id;
+        // A slash-bearing value that is itself a REGISTERED wire id (an org/model slug like
+        // "z-ai/glm-5.2" — OpenRouter's id shape) must pass through UNCHANGED. This is the
+        // double-normalization case: Initialize already collapsed the picker path to the bare id,
+        // and the factory calls ResolveModelId again on that id — last-segmenting it here ("glm-5.2")
+        // makes it resolve NO credentials ("ApiKey is missing for model 'glm-5.2'" on a configured
+        // deployment). Match against the catalog snapshot AND the config-seeded model lists (the
+        // latter are warm even when the snapshot isn't).
+        if (IsRegisteredModelId(snapshot, modelNameOrPath))
+            return modelNameOrPath;
         // Unresolved path (node not yet in the warm snapshot): the wire id is the LAST SEGMENT — never
         // the whole path (sending "Provider/OpenAICompatible/qwen3.6:latest" as the model name 400s).
         return modelNameOrPath[(modelNameOrPath.LastIndexOf('/') + 1)..];
+    }
+
+    /// <summary>
+    /// True when <paramref name="value"/> is a registered model wire id: a LanguageModel node in the
+    /// snapshot carries it as <see cref="ModelDefinition.Id"/>, or a configured catalog source lists it
+    /// in its <c>{Section}:Models</c> array (the exact list <c>BuiltInLanguageModelProvider</c> seeds
+    /// from — readable before the snapshot warms).
+    /// </summary>
+    private bool IsRegisteredModelId(IReadOnlyList<MeshNode> snapshot, string value)
+    {
+        foreach (var node in snapshot)
+        {
+            if (!string.Equals(node.NodeType, LanguageModelNodeType.NodeType, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (string.Equals(ExtractContent<ModelDefinition>(node.Content)?.Id, value, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        var sources = hub.ServiceProvider.GetService<LanguageModelCatalogOptions>();
+        var configuration = hub.ServiceProvider.GetService<IConfiguration>();
+        if (sources is null || configuration is null) return false;
+        foreach (var source in sources.Sources)
+        {
+            string[]? models;
+            try
+            {
+                models = configuration.GetSection($"{source.SectionName}:Models")
+                    .Get<string[]>();
+            }
+            catch
+            {
+                continue; // malformed section — same skip as the catalog seeder.
+            }
+            if (models is not null
+                && models.Any(m => string.Equals(m, value, StringComparison.OrdinalIgnoreCase)))
+                return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -1190,10 +1190,12 @@ internal static class ThreadExecution
                 {
                     AgentName = request.AgentName ?? cell!.AgentName,
                     // The persisted cell carries the COMPOSER form of the model — the full
-                    // node path ("Provider/OpenAICompatible/qwen-small"). Normalize exactly
-                    // like the entry boundary above (and like Harness on the next line):
-                    // factories/credential resolution key on the bare model id.
-                    ModelName = SelectionId.IdOf(request.ModelName ?? cell!.ModelName),
+                    // node path ("Provider/OpenAICompatible/qwen-small"). Pass it through RAW,
+                    // exactly like the normal submit path: AgentChatClient.Initialize normalizes
+                    // via the credential resolver's node-path lookup. SelectionId.IdOf here
+                    // mangled org/model-shaped wire ids ("z-ai/glm-5.2" → "glm-5.2"), which
+                    // resolve no credentials — the "ApiKey is missing" round failure.
+                    ModelName = request.ModelName ?? cell!.ModelName,
                     Harness = SelectionId.IdOf(request.Harness ?? cell!.Harness)
                 })
                 .Catch<RoundParams, Exception>(ex =>

--- a/src/MeshWeaver.Blazor/Infrastructure/PortalErrorSink.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/PortalErrorSink.cs
@@ -52,10 +52,19 @@ public static class PortalErrorReporting
     public static MessageHubConfiguration WithPortalErrorReporting(
         this MessageHubConfiguration config, PortalErrorSink sink)
         => config.WithHandler<DeliveryFailure>((_, delivery) =>
-        {
-            sink.Report(Describe(delivery.Message));
-            return delivery.Processed();
-        });
+            {
+                sink.Report(Describe(delivery.Message));
+                return delivery.Processed();
+            },
+            // AWAITED failures are excluded HERE, not just by documentation: HandleCallbacks runs
+            // first in the rule chain and stamps CallbackDispatched when it hands the failure to a
+            // live hub.Observe callback — that call site's OnError already deals with it (retry,
+            // fallback, message). Reporting it again pops the RAW failure text as a blocking modal
+            // even when the caller recovered — the "Access denied … lacks Thread permission on
+            // 'Doc'" modal shown while StartThread's user-partition fallback had already re-anchored
+            // the thread. The filter REPLACES the default target-address check; a response's target
+            // is always this hub, so the stamp is the only gate needed.
+            (_, delivery) => !delivery.Properties.ContainsKey(PostOptions.CallbackDispatched));
 
     /// <summary>The user-facing line for a failed post — the raw failure reason, or a generic fallback.</summary>
     internal static string Describe(DeliveryFailure failure)

--- a/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
+++ b/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
@@ -164,10 +164,15 @@ internal class NavigationService : INavigationService
     /// single source of truth. The synchronous _currentPathSnapshot mirror is
     /// updated via the Subscribe in the constructor, not here, so every code
     /// site that pushes a path goes through the reactive subject.
+    /// <para>The EMPTY path (the portal home "/" — the logo's Href) is published like any
+    /// other: dropping it left the previous page's <see cref="NavigationContext"/> replaying
+    /// forever, so after Doc-page → logo-click the chat composer still anchored threads on the
+    /// Doc partition ("chat does not update context"). <see cref="ProcessLocationChange"/>
+    /// resolves the empty route to the signed-in user's home partition.</para>
     /// </summary>
     private void PublishPath(string? path)
     {
-        if (string.IsNullOrEmpty(path)) return;
+        if (path is null) return;
         _pathSubject.OnNext(path);
     }
 
@@ -342,6 +347,34 @@ internal class NavigationService : INavigationService
         var target = NavigationTarget.Parse(rawPath);
         var route = target.Path;
         var args = target.Args;
+
+        // The portal HOME ("/", the logo's Href) has an EMPTY route. It shows the signed-in
+        // user's own space, so resolve it AS the user's home partition — the same target every
+        // other home navigation uses (/User/{id} rewrites there via RewriteLegacyUserHome).
+        // Before this, the empty path was silently dropped (PublishPath) and the PREVIOUS
+        // page's NavigationContext kept replaying: after Doc-page → logo-click the composer
+        // chip still showed the Doc context and StartThread anchored on Doc → "Access denied:
+        // … lacks Thread permission on 'Doc'". A visitor WITHOUT a home partition — anonymous,
+        // or a System/hub principal (test fixtures, pre-identity circuits) — clears the context
+        // like a page route instead (no stale replay; the login redirect is handled elsewhere).
+        if (string.IsNullOrEmpty(route))
+        {
+            var homeUser = ResolveCurrentUserId();
+            if (string.Equals(homeUser, WellKnownUsers.Anonymous, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(homeUser, WellKnownUsers.System, StringComparison.OrdinalIgnoreCase)
+                || AccessService.LooksLikeHubPrincipal(homeUser))
+            {
+                _resolutionSubscription?.Dispose();
+                _notFoundWatchdog?.Dispose();
+                IsResolving = false;
+                Context = null;
+                CurrentNamespace = null;
+                _status.OnNext(NavigationStatus.Idle());
+                _navigationContext.OnNext(null);
+                return;
+            }
+            route = homeUser;
+        }
 
         // 🚨 A single-segment route that carries query parameters is a parametrized Blazor
         // PAGE route (/search?q=…, /create?type=…, /login?returnUrl=…) — NEVER a mesh node.

--- a/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
+++ b/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
@@ -357,6 +357,7 @@ internal class NavigationService : INavigationService
         // … lacks Thread permission on 'Doc'". A visitor WITHOUT a home partition — anonymous,
         // or a System/hub principal (test fixtures, pre-identity circuits) — clears the context
         // like a page route instead (no stale replay; the login redirect is handled elsewhere).
+        var isHomeRoute = false;
         if (string.IsNullOrEmpty(route))
         {
             var homeUser = ResolveCurrentUserId();
@@ -374,6 +375,7 @@ internal class NavigationService : INavigationService
                 return;
             }
             route = homeUser;
+            isHomeRoute = true;
         }
 
         // 🚨 A single-segment route that carries query parameters is a parametrized Blazor
@@ -392,7 +394,10 @@ internal class NavigationService : INavigationService
         // whenever the writable provider's PartitionExists probe is indeterminate
         // (InMemory/monolith), and the anonymous hard-gate then bounces the deliberately-PUBLIC
         // page to /login — the /privacy regression. See PageRouteRegistry.
-        if (!string.IsNullOrEmpty(route) && !route.Contains('/')
+        // The home rewrite above produced a NODE route (the user's partition) by construction —
+        // never a Blazor page — so it is exempt: "/?utm=…" (home + query params) must still
+        // resolve the user's home with the args riding on the context, not clear it here.
+        if (!isHomeRoute && !string.IsNullOrEmpty(route) && !route.Contains('/')
             && (!args.IsEmpty || _pageRoutes?.IsPageRoute(route) == true))
         {
             _resolutionSubscription?.Dispose();

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1147,7 +1147,13 @@ public sealed class MessageHub : IMessageHub
         if (traceEnabled)
             logger.LogTrace("MESSAGE_FLOW: HUB_CALLBACKS_COMPLETE | {MessageType} | Hub: {Address} | MessageId: {MessageId}",
                 messageTypeName, Address, delivery.Id);
-        return Observable.Return(delivery.Processed());
+        // Stamp "a live Observe callback consumed this" so later rules can tell an AWAITED
+        // response apart from an un-awaited one. The rule chain keeps running after this rule
+        // (HandleCallbacks runs first), and the portal's DeliveryFailure→modal handler must NOT
+        // re-surface a failure the call site's OnError already handled (e.g. StartThread's
+        // user-partition fallback) — that double-report was the raw "Access denied … lacks
+        // Thread permission" modal popping despite the fallback succeeding.
+        return Observable.Return(delivery.Processed().SetProperty(PostOptions.CallbackDispatched, true));
     }
 
     Address IMessageHub.Address => Address;

--- a/src/MeshWeaver.Messaging.Hub/PostOptions.cs
+++ b/src/MeshWeaver.Messaging.Hub/PostOptions.cs
@@ -16,6 +16,17 @@ public record PostOptions(Address Sender)
     /// match a response delivery back to the request that triggered it.
     /// </summary>
     public const string RequestId = nameof(RequestId);
+
+    /// <summary>
+    /// Well-known property key stamped (value <c>true</c>) on a response delivery that
+    /// <c>MessageHub.HandleCallbacks</c> dispatched to a live <c>hub.Observe</c> callback.
+    /// Distinguishes an AWAITED response — already surfaced to its caller via
+    /// <c>OnNext</c>/<c>OnError</c> — from an un-awaited one (fire-and-forget post, or a
+    /// response whose observer is gone). Consumers like the portal's
+    /// <c>DeliveryFailure</c>-to-modal reporter use it to skip failures the call site
+    /// already handled.
+    /// </summary>
+    public const string CallbackDispatched = nameof(CallbackDispatched);
     internal Address Target { get; init; } = null!;
 
     /// <summary>

--- a/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
+++ b/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
@@ -354,6 +354,29 @@ public class ChatClientCredentialResolverTest : AITestBase
         resolver.ResolveModelId($"{root}/nope/never-{suffix}").Should().Be($"never-{suffix}");
     }
 
+    /// <summary>
+    /// Cold-start guard (Copilot review finding on #367): a slash-bearing value with NO catalog
+    /// marker segment (Provider / _Memex) is an org/model wire id we simply don't know — an
+    /// UNRECOGNIZED slug (cold snapshot, unseeded model) passes through rather than being
+    /// last-segmented into an unresolvable id. Only node-path-shaped values keep the fallback.
+    /// </summary>
+    [Fact]
+    public void ResolveModelId_UnknownOrgSlashModelSlug_PassesThrough_NodePathsStillLastSegment()
+    {
+        var resolver = Mesh.ServiceProvider.GetRequiredService<ChatClientCredentialResolver>();
+
+        // Never registered anywhere — no snapshot entry, no config seed. Must NOT be mangled.
+        resolver.ResolveModelId("some-org/some-model-nobody-seeded").Should()
+            .Be("some-org/some-model-nobody-seeded",
+                "an unrecognized org/model slug is a wire id, not a node path — mangling it can only break the round");
+
+        // Node-path-shaped values (catalog marker segment) keep the documented last-segment fallback.
+        resolver.ResolveModelId("Provider/OpenAICompatible/qwen-unseeded:latest").Should()
+            .Be("qwen-unseeded:latest");
+        resolver.ResolveModelId("someuser/_Memex/OpenRouter/own-model-unseeded").Should()
+            .Be("own-model-unseeded");
+    }
+
     [Fact]
     public async Task GetProviderForModel_LooksUpProviderStamp()
     {

--- a/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
+++ b/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
@@ -283,6 +283,77 @@ public class ChatClientCredentialResolverTest : AITestBase
             "model name 400s (ResolveModelId's documented fallback); only a bare id passes through unchanged");
     }
 
+    /// <summary>
+    /// OpenRouter-style org/model slugs ("z-ai/glm-5.2") are WIRE IDS that themselves contain
+    /// '/'. The factory re-normalizes the already-bare id through
+    /// <see cref="ChatClientCredentialResolver.ResolveModelId"/> (double normalization: the
+    /// round's Initialize collapsed the picker path first) — the unresolved-path last-segment
+    /// fallback must NOT fire on a REGISTERED slug id, else "z-ai/glm-5.2" becomes "glm-5.2",
+    /// resolves no credentials, and every round dies with "ApiKey is missing for model
+    /// 'glm-5.2'" on a fully configured deployment (memex prod, 2026-07-07).
+    /// </summary>
+    [Fact]
+    public async Task ResolveModelId_OrgSlashModelSlugId_SurvivesDoubleNormalization()
+    {
+        var root = ModelProviderNodeType.RootNamespace; // "Provider"
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var providerName = $"OpenRouter{suffix}";
+        var providerPath = $"{root}/{providerName}";
+        var modelId = $"z-ai/glm-{suffix}";            // the wire id CONTAINS '/'
+        var modelPath = $"{providerPath}/{modelId}";   // node path = Provider/{p}/z-ai/glm-…
+
+        await MeshService.CreateNode(new MeshNode(providerName, root)
+        {
+            NodeType = ModelProviderNodeType.NodeType,
+            Name = providerName,
+            State = MeshNodeState.Active,
+            Content = new ModelProviderConfiguration
+            {
+                Provider = providerName,
+                ApiKey = "sk-openrouter-key",
+                Endpoint = "https://openrouter.example/api/v1",
+            }
+        }).Should().Within(15.Seconds()).Emit();
+
+        await MeshService.CreateNode(new MeshNode(modelId, providerPath)
+        {
+            NodeType = LanguageModelNodeType.NodeType,
+            Name = modelId,
+            State = MeshNodeState.Active,
+            Content = new ModelDefinition
+            {
+                Id = modelId,
+                Provider = providerName,
+                ProviderRef = providerPath,
+            }
+        }).Should().Within(15.Seconds()).Emit();
+
+        var resolver = Mesh.ServiceProvider.GetRequiredService<ChatClientCredentialResolver>();
+        resolver.EnsureSubscription();
+
+        // Warm-gate: the slug id resolves its provider credentials once the snapshot is warm.
+        await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .Select(_ => resolver.Resolve(modelId))
+            .Should().Within(10.Seconds()).Match(r => r.ApiKey != null);
+
+        // The picker-path form collapses to the FULL slug id — never its last segment.
+        resolver.ResolveModelId(modelPath).Should().Be(modelId,
+            "the canonical wire id of a path selection is the node's ModelDefinition.Id — including its 'org/' prefix");
+
+        // 🎯 The regression: re-normalizing the ALREADY-BARE slug id (what the factory does)
+        // must pass it through unchanged, not last-segment it into an unresolvable id.
+        resolver.ResolveModelId(modelId).Should().Be(modelId,
+            "a registered wire id that itself contains '/' must survive double normalization");
+
+        // End-to-end: the (double-normalized) id still resolves the provider's credentials.
+        var resolution = resolver.Resolve(resolver.ResolveModelId(modelId)!);
+        resolution.ApiKey.Should().Be("sk-openrouter-key");
+        resolution.Endpoint.Should().Be("https://openrouter.example/api/v1");
+
+        // A genuinely unresolved path (not a registered id) keeps the documented last-segment fallback.
+        resolver.ResolveModelId($"{root}/nope/never-{suffix}").Should().Be($"never-{suffix}");
+    }
+
     [Fact]
     public async Task GetProviderForModel_LooksUpProviderStamp()
     {

--- a/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
@@ -1198,6 +1198,76 @@ public class NavigationServiceTest
 
     #endregion
 
+    #region Home Route Tests
+
+    /// <summary>
+    /// 🚨 Regression ("chat does not update context — am in user home and it thinks it's docs"):
+    /// the logo links to "/" (empty route). PublishPath used to DROP the empty path, so
+    /// ProcessLocationChange never ran and the ReplaySubject(1) NavigationContext kept replaying
+    /// the PREVIOUS page — after Doc-page → logo-click the composer chip still showed the Doc
+    /// context and StartThread anchored threads on Doc ("Access denied: … lacks Thread permission
+    /// on 'Doc'"). The home route must resolve to the signed-in user's OWN partition — the same
+    /// target every other home navigation uses (/User/{id} rewrites there).
+    /// </summary>
+    [Fact]
+    public async Task HomeRoute_ResolvesUserHomePartition_ReplacingThePreviousPageContext()
+    {
+        // Authenticated circuit shape (identity on the circuit-stable accessor, ambient cleared)
+        // — same fixture as AuthenticatedCircuit_NavigationFromClearedAmbientContext, which also
+        // keeps TrackNavigationActivity inert for the mock hub.
+        MakeAmbientContextClearedButCircuitAuthenticated("rbuergi");
+
+        var service = CreateService();
+        _pathResolver.ResolveNavigationPath("Doc/Architecture")
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("Doc/Architecture", null)));
+        _pathResolver.ResolveNavigationPath("rbuergi")
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("rbuergi", null)));
+
+        service.Initialize();
+
+        // 1. The user reads a Doc page — the context follows it.
+        _navigationManager.SimulateLocationChanged("http://localhost/Doc/Architecture");
+        await service.NavigationContext.Should().Within(WaitTimeout)
+            .Match(c => c?.Namespace == "Doc/Architecture");
+
+        // 2. Logo click → "/" — the context must flip to the user's home partition,
+        //    never keep replaying the Doc page.
+        _navigationManager.SimulateLocationChanged("http://localhost/");
+        var home = await service.NavigationContext.Should().Within(WaitTimeout)
+            .Match(c => c?.Namespace == "rbuergi");
+
+        home.Should().NotBeNull();
+        service.Context!.Namespace.Should().Be("rbuergi");
+        service.CurrentNamespace.Should().Be("rbuergi");
+        _ = _pathResolver.Received().ResolveNavigationPath("rbuergi");
+    }
+
+    /// <summary>
+    /// An anonymous visitor at "/" has no home partition: the context CLEARS (no stale replay
+    /// of the previous page) and nothing is resolved — the home page is not a node for them,
+    /// and no login redirect fires from here (that's the node-navigation gate's job).
+    /// </summary>
+    [Fact]
+    public async Task HomeRoute_Anonymous_ClearsContext_WithoutResolvingOrRedirecting()
+    {
+        MakeVisitorAnonymous();
+
+        var service = CreateService();
+        service.Initialize();
+
+        _navigationManager.SimulateLocationChanged("http://localhost/");
+        await service.NavigationContext.Should().Within(WaitTimeout).Match(ctx => ctx == null);
+
+        service.Context.Should().BeNull();
+        service.CurrentNamespace.Should().BeNull();
+        _navigationManager.Uri.Should().NotContain("/login");
+        _ = _pathResolver.DidNotReceive().ResolveNavigationPath(Arg.Any<string>());
+    }
+
+    #endregion
+
     [Fact]
     public async Task NavigationContext_ReplaysLastValueToLateSubscriber()
     {

--- a/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
@@ -1245,6 +1245,30 @@ public class NavigationServiceTest
     }
 
     /// <summary>
+    /// A home URL CARRYING QUERY PARAMS ("/?utm=…") must still resolve the user's home: the
+    /// rewritten route is single-segment WITH args, which pattern-matches the Blazor page-route
+    /// gate — but the home rewrite is a NODE route by construction, so it is exempt and the args
+    /// ride on the context (Copilot review finding on #367).
+    /// </summary>
+    [Fact]
+    public async Task HomeRoute_WithQueryParams_StillResolvesUserHome()
+    {
+        MakeAmbientContextClearedButCircuitAuthenticated("rbuergi");
+
+        var service = CreateService();
+        _pathResolver.ResolveNavigationPath("rbuergi")
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("rbuergi", null)));
+
+        service.Initialize();
+        _navigationManager.SimulateLocationChanged("http://localhost/?utm=newsletter");
+
+        var home = await service.NavigationContext.Should().Within(WaitTimeout)
+            .Match(c => c?.Namespace == "rbuergi");
+        home!.Args["utm"].Should().Be("newsletter", "query params ride on the context, never clear it");
+    }
+
+    /// <summary>
     /// An anonymous visitor at "/" has no home partition: the context CLEARS (no stale replay
     /// of the previous page) and nothing is resolved — the home page is not a node for them,
     /// and no login redirect fires from here (that's the node-navigation gate's job).

--- a/test/MeshWeaver.Hosting.Blazor.Test/PortalErrorPopupTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/PortalErrorPopupTest.cs
@@ -56,4 +56,49 @@ public class PortalErrorPopupTest(ITestOutputHelper output) : HubTestBase(output
         shown.Should().Contain("boom",
             "a failed post originating from the portal hub must surface to the GUI as a popup");
     }
+
+    record UnansweredRequest : IRequest<UnansweredResponse>;
+    record UnansweredResponse;
+
+    /// <summary>
+    /// The inverse contract: an AWAITED failure must NOT pop the modal. A
+    /// <c>hub.Observe(...)</c> caller receives the <see cref="DeliveryFailure"/> through its
+    /// own <c>OnError</c> and handles it there (retry, fallback, user message) —
+    /// <c>HandleCallbacks</c> stamps the delivery <see cref="PostOptions.CallbackDispatched"/>
+    /// and the error-reporting filter skips it. Before this filter, the raw failure text
+    /// popped as a blocking modal EVEN WHEN the caller recovered — the "Access denied: …
+    /// lacks Thread permission on 'Doc'" modal shown while StartThread's user-partition
+    /// fallback had already re-anchored the thread.
+    /// </summary>
+    [Fact]
+    public async Task AwaitedFailure_DoesNotSurfaceToTheErrorSink()
+    {
+        using var sink = new PortalErrorSink();
+        var reported = new List<string>();
+        using var _ = sink.Errors.Subscribe(reported.Add);
+
+        var portal = Mesh.GetHostedHub(new Address("portal", "2"), c => c
+            .WithPortalErrorReporting(sink));
+        // A hub with NO handler for the request: FinishDelivery answers the awaited request
+        // with a DeliveryFailure (NotFound) routed back to the portal — the awaited-failure shape.
+        var silent = Mesh.GetHostedHub(new Address("silent", "1"), c => c);
+
+        // The Observe caller consumes the failure via OnError — the per-callsite surface.
+        var observed = await portal
+            .Observe(new UnansweredRequest(), o => o.WithTarget(silent.Address))
+            .Materialize()
+            .FirstAsync()
+            .ToTask()
+            .WaitAsync(TimeSpan.FromSeconds(10));
+
+        observed.Kind.Should().Be(System.Reactive.NotificationKind.OnError,
+            "the unhandled request must come back to the Observe caller as a failure");
+        observed.Exception.Should().BeOfType<DeliveryFailureException>();
+
+        // Negative assertion: give a residual report a short window to land, then require none.
+        // (Sanctioned "confirm nothing happened" delay — there is no positive signal to await.)
+        await Task.Delay(500);
+        reported.Should().BeEmpty(
+            "an awaited failure is handled at its call site's OnError and must not ALSO pop the global error modal");
+    }
 }


### PR DESCRIPTION
Three memex-prod chat defects reported 2026-07-08 (failing threads from 2026-07-07 ~22:00Z, e.g. `rbuergi/_Thread/i-had-uploaded-a-game-where-is-this-e0bf` — `MainNode: Doc`, summary = the exact ApiKey error), root-caused and fixed:

### 1. Stale composer context after navigating home ("am in user home, it thinks it's docs")
The logo links to `/`, but `NavigationService.PublishPath` **dropped empty paths** — `ProcessLocationChange` never ran for the home URL, so the ReplaySubject(1) `NavigationContext` kept replaying the previous page. The composer chip stayed on the old partition (Doc) and `StartThread` anchored threads there → `Access denied: user 'rbuergi' lacks Thread permission on 'Doc'`.

**Fix:** publish the empty route and resolve it as the signed-in user's **home partition** — the same target every other home navigation uses (`/User/{id}` rewrites there). Anonymous / System / hub-principal identities clear the context instead. New `HomeRoute_*` tests pin both.

### 2. Raw denial modal despite the fallback having recovered
The thread WAS re-anchored in the user's partition by StartThread's user-partition fallback (`MainNode: Doc` on the prod thread proves it) — but the raw pipeline text still popped as a blocking modal. `WithPortalErrorReporting`'s `DeliveryFailure` handler ran for **awaited** responses too: `HandleCallbacks` runs first in the rule chain, dispatches the failure to the `hub.Observe` caller's `OnError`, and the chain keeps running into the reporter.

**Fix:** `HandleCallbacks` stamps `PostOptions.CallbackDispatched` on responses a live callback consumed; the portal reporter filters on the stamp. Un-awaited failures (no response subject) stay unstamped and still surface — `PortalErrorPopupTest` now pins both sides. (A `State == Submitted` filter would be wrong: un-awaited failures also arrive with a RequestId and get `Processed()` by the no-subject branch.)

### 3. `ApiKey is missing for model 'glm-5.2'` for the configured `z-ai/glm-5.2`
Regression from 6e6236293 (2026-07-06): `ResolveModelId`'s unresolved-path **last-segment fallback** fires on values that are already bare wire ids containing `/` (OpenRouter org/model slugs). The round resolves the picker path to `z-ai/glm-5.2` correctly; the factory then re-normalizes that id — it matches no node **path**, so the fallback strips it to `glm-5.2`, which matches no `ModelDefinition.Id` and no config `Models` entry → no credentials. Worked 2026-07-02 → 2026-07-06; broke when the self-update rolled the fallback out.

**Fix:** pass through any value matching a registered `ModelDefinition.Id` (catalog snapshot) or a configured `{Section}:Models` entry before last-segmenting (`IsRegisteredModelId`); the genuine unresolved-path fallback (the `qwen3.6:latest` 400 fix) is preserved. Also stop `SelectionId.IdOf`-mangling the cell's `ModelName` in ThreadExecution's crash-resume recovery — `Initialize` normalizes, same as the entry boundary.

### Verification
- Full solution `dotnet build -c Release -warnaserror` clean
- `NavigationServiceTest` + `PortalErrorPopupTest`: 38/38 (3 new regression tests)
- `ChatClientCredentialResolverTest`: 8/8 (new org/model-slug double-normalization test)
- `ThreadComposerFlowTest` + `AgentSelectionPathResolutionTest`: 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)