### PR TITLE
fix(markdown): resolve @@ absolute node embeds (no doubling + LocalMesh node resolution)

### DIFF
--- a/memex/Memex.LocalMesh/Program.cs
+++ b/memex/Memex.LocalMesh/Program.cs
@@ -1,3 +1,8 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Documentation;
 using MeshWeaver.Graph.Configuration;
@@ -6,6 +11,7 @@ using MeshWeaver.Hosting.Grpc;
 using MeshWeaver.Hosting.Monolith;
 using MeshWeaver.Hosting.Sqlite;
 using MeshWeaver.Markdown;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 
@@ -81,16 +87,52 @@ app.MapGet("/static/{**path}", async (HttpContext ctx, string path) =>
 // headless sidecar calls it directly — anonymous, no hub round-trip. Clients (portal-next + React-Native)
 // POST {markdown, nodePath} and hydrate the returned HTML + codeSubmissions (splitRenderedHtml). This is
 // what makes interactive markdown — inline @@ embeds and runnable code cells — resolve on the RN app.
-app.MapPost("/api/mesh/render-markdown", (RenderMarkdownBody body) =>
+app.MapPost("/api/mesh/render-markdown", async (RenderMarkdownBody body, CancellationToken ct) =>
 {
     var result = MarkdownViewLogic.Render(body.Markdown ?? string.Empty, body.NodePath, body.NodePath);
+    // The pure Markdig pass can't tell `@@node/path` (a node embed) from `@@node/area/id` — it has no
+    // catalog, so it emits a POSITIONAL address/area/id split. Resolve each layout-area marker's raw-path
+    // against the mesh's IPathResolver (the same longest-node-prefix resolution the portal does at runtime):
+    // when the WHOLE raw-path is itself a node (empty remainder), rewrite to a node/default-area embed so the
+    // client subscribes to the right node. Area/content/keyword embeds (non-empty remainder) keep the parser's
+    // resolution untouched. (A CHILD node that isn't independently addressable — e.g. a Code cell — stays a
+    // remainder and is left as-is; rendering those is a separate mesh-model concern.)
+    var resolver = app.Services.GetRequiredService<IMessageHub>().ServiceProvider.GetService<IPathResolver>();
+    var html = resolver is null ? result.Html : await ResolveLayoutAreaMarkers(result.Html, resolver, ct);
     return Results.Json(new
     {
-        html = result.Html,
+        html,
         codeSubmissions = (result.CodeSubmissions ?? [])
             .Select(sub => new { id = sub.Id, language = sub.Language, code = sub.Code }),
     });
 });
+
+// Rewrite layout-area markers whose raw-path is a WHOLE node (empty remainder) to a node/default-area embed,
+// using the mesh's IPathResolver (longest-node-prefix). Leaves area/content/keyword markers as the pure
+// Markdig pass emitted them. This makes a regular `@@node` embed resolve to the right node on the client.
+static async Task<string> ResolveLayoutAreaMarkers(string html, IPathResolver resolver, CancellationToken ct)
+{
+    var matches = Regex.Matches(html, @"<div class='layout-area'[^>]*?data-raw-path='([^']*)'[^>]*?></div>");
+    if (matches.Count == 0)
+        return html;
+    var sb = new StringBuilder();
+    var last = 0;
+    foreach (Match m in matches)
+    {
+        sb.Append(html, last, m.Index - last);
+        var rawPath = HttpUtility.HtmlDecode(m.Groups[1].Value);
+        AddressResolution? res = null;
+        try { res = await resolver.ResolvePath(rawPath).FirstAsync().Timeout(TimeSpan.FromSeconds(5)).ToTask(ct); }
+        catch { /* unresolved / timed out — keep the parser's marker */ }
+        if (res is not null && !string.IsNullOrEmpty(res.Prefix) && string.IsNullOrEmpty(res.Remainder))
+            sb.Append($"<div class='layout-area' data-raw-path='{HttpUtility.HtmlAttributeEncode(rawPath)}' data-address='{HttpUtility.HtmlAttributeEncode(res.Prefix)}' data-area='' data-area-id=''></div>");
+        else
+            sb.Append(m.Value);
+        last = m.Index + m.Length;
+    }
+    sb.Append(html, last, html.Length - last);
+    return sb.ToString();
+}
 
 var wwwroot = app.Environment.WebRootPath ?? Path.Combine(app.Environment.ContentRootPath, "wwwroot");
 if (File.Exists(Path.Combine(wwwroot, "index.html")))

--- a/src/MeshWeaver.Markdown/PathUtils.cs
+++ b/src/MeshWeaver.Markdown/PathUtils.cs
@@ -28,6 +28,15 @@ public static class PathUtils
         // and everything after them. Links in satellite content should resolve relative
         // to the main entity, not the satellite path.
         var basePath = StripSatellitePartition(currentNodePath);
+
+        // Self-prefixed absolute path: the raw path already BEGINS with the base (at a segment boundary),
+        // so it's already the full path — don't prepend the base again (that doubled it: base/base/rest).
+        // E.g. `@@Doc/Architecture/PythonCodeNodes/SampleStatistics` written on the node
+        // `Doc/Architecture/PythonCodeNodes`. The trailing '/' makes it a SEGMENT match, so a sibling like
+        // `DocSomething` (relative) still resolves against the base rather than false-matching.
+        if (!string.IsNullOrEmpty(basePath) && (path == basePath || path.StartsWith(basePath + "/", StringComparison.Ordinal)))
+            return path;
+
         while (path.StartsWith("../"))
         {
             var lastSlash = basePath.LastIndexOf('/');


### PR DESCRIPTION
Makes a raw absolute-node embed like `@@/Doc/Architecture` resolve to the right node on the React-Native app (against the LocalMesh sidecar).

- **`PathUtils.ResolveRelativePath`** — a raw path already beginning with the current node's base (at a segment boundary) is already absolute; return as-is instead of prepending the base again (which **doubled** it: `base/base/rest`). Segment-boundary match keeps genuine relative siblings resolving against the base.
- **`Memex.LocalMesh` `/api/mesh/render-markdown`** — the pure Markdig pass has no catalog, so `@@a/b/c` falls back to a positional `address/area/id` split. Resolve each layout-area marker's raw-path via the mesh's **`IPathResolver`** (the same longest-node-prefix resolution the portal does at runtime); when the whole raw-path is itself a node (empty remainder), rewrite the marker to a node/default-area embed. Area/content/keyword embeds are left untouched.

Does **not** affect the already-working inline `csharp --render` cells (Run → Roslyn kernel → result). Verified: `@@/Doc/Architecture` → correct marker (curl); **104 markdown tests pass**; LocalMesh **Release `-warnaserror` clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)