### PR TITLE
feat(activity): generic live progress + log view; wire GitHub sync operations to it

### DIFF
--- a/src/MeshWeaver.Blazor/Components/ProgressView.razor
+++ b/src/MeshWeaver.Blazor/Components/ProgressView.razor
@@ -48,7 +48,7 @@
     protected override void BindData()
     {
         base.BindData();
-        DataBind(ViewModel.Progress, x => x.Progress, defaultValue:0);
+        DataBind(ViewModel.Progress, x => x.Progress);
         DataBind(ViewModel.Min, x => x.Min, defaultValue:0);
         DataBind(ViewModel.Max, x => x.Max,defaultValue:100);
         DataBind(ViewModel.Paused, x => x.Paused, defaultValue:true);

--- a/src/MeshWeaver.GitSync/GitHubActionArea.cs
+++ b/src/MeshWeaver.GitSync/GitHubActionArea.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using MeshWeaver.Application.Styles;
+using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
@@ -68,38 +70,75 @@ public static class GitHubActionArea
             return Observable.Return<UiControl?>(Message(
                 "Sign-in required", "Could not resolve your identity for the GitHub operation.", backHref));
 
+        // The op extension calls onActivityCreated(activityPath) the moment the
+        // Activity node is created. Capture it in a ReplaySubject so we can render
+        // the LIVE activity view as soon as the path is known (and replay it to any
+        // late render subscription). This subject is per-render — NOT static — so it
+        // dies with the render and holds no cross-request state.
+        var pathSubject = new ReplaySubject<string>(1);
+        void OnCreated(string p) => pathSubject.OnNext(p);
+
         var (title, action) = op switch
         {
-            Commit => ("Committing to GitHub", host.Hub.CommitToGitHub(spacePath, userId, sourceId: sourceId)),
-            Update => ("Updating from GitHub", host.Hub.UpdateToLatestFromGitHub(spacePath, userId, sourceId: sourceId)),
-            Check => ("Checking branch state", host.Hub.CheckBranchStateOnGitHub(spacePath, userId, sourceId: sourceId)),
+            Commit => ("Committing to GitHub",
+                host.Hub.CommitToGitHub(spacePath, userId, OnCreated, sourceId)),
+            Update => ("Updating from GitHub",
+                host.Hub.UpdateToLatestFromGitHub(spacePath, userId, OnCreated, sourceId)),
+            Check => ("Checking branch state",
+                host.Hub.CheckBranchStateOnGitHub(spacePath, userId, OnCreated, sourceId)),
             _ => (null, (IObservable<string>?)null),
         };
         if (action is null)   // unknown op — don't claim an activity started
             return Observable.Return<UiControl?>(Message(
                 "Unknown operation", $"Unrecognized GitHub operation <code>{System.Net.WebUtility.HtmlEncode(op)}</code>.", backHref));
 
+        // Fire the work. The activity node it creates streams its own live progress.
         action.Subscribe(_ => { }, ex => logger?.LogWarning(ex, "GitHub action {Op} failed for {Space}", op, spacePath));
-        return Observable.Return<UiControl?>(Message(
-            title!,
-            "The operation is running as an activity — its progress and result appear in this Space's "
-            + "activity feed and your notifications.",
-            backHref));
+
+        // Render the live activity Overview as soon as the activity path arrives;
+        // until then show a "Starting…" placeholder.
+        return pathSubject
+            .Select(path => (UiControl?)BuildLiveView(title!, path, backHref))
+            .StartWith((UiControl?)BuildStarting(title!, backHref));
     }
 
+    /// <summary>Back button + title + a "Starting…" indeterminate progress, shown until the activity path is known.</summary>
+    private static UiControl BuildStarting(string title, string backHref)
+        => Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("padding: 24px; gap: 12px;")
+            .WithView(BuildHeader(title, backHref))
+            .WithView(Controls.Progress("Starting…", null!).WithWidth("100%").WithHideNumber(true));
+
+    /// <summary>Back button + title + the live activity Overview embed (live progress + message log).</summary>
+    private static UiControl BuildLiveView(string title, string activityPath, string backHref)
+        => Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("padding: 24px; gap: 12px;")
+            .WithView(BuildHeader(title, backHref))
+            .WithView(new LayoutAreaControl(
+                new Address(activityPath),
+                new LayoutAreaReference(ActivityLayoutAreas.OverviewArea)));
+
+    private static StackControl BuildHeader(string title, string backHref)
+        => Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithHorizontalGap(16)
+            .WithStyle("align-items: center;")
+            .WithView(Controls.Button("Back")
+                .WithAppearance(Appearance.Lightweight)
+                .WithIconStart(FluentIcons.ArrowLeft())
+                .WithNavigateToHref(backHref))
+            .WithView(Controls.H2(title).WithStyle("margin: 0;"));
+
+    // Early-return guard message (Not in a Space / Nothing to do / Sign-in required /
+    // Unknown operation). The body may contain a pre-rendered <code> snippet, so it
+    // stays a Controls.Html paragraph; the header is the shared control-based row.
     private static UiControl Message(string title, string bodyHtml, string backHref)
         => Controls.Stack
             .WithWidth("100%")
-            .WithStyle("padding: 24px;")
-            .WithView(Controls.Stack
-                .WithOrientation(Orientation.Horizontal)
-                .WithHorizontalGap(16)
-                .WithStyle("align-items: center; margin-bottom: 16px;")
-                .WithView(Controls.Button("Back")
-                    .WithAppearance(Appearance.Lightweight)
-                    .WithIconStart(FluentIcons.ArrowLeft())
-                    .WithNavigateToHref(backHref))
-                .WithView(Controls.H2(title).WithStyle("margin: 0;")))
+            .WithStyle("padding: 24px; gap: 16px;")
+            .WithView(BuildHeader(title, backHref))
             .WithView(Controls.Html(
                 $"<p style=\"color: var(--neutral-foreground-hint);\">{bodyHtml}</p>"));
 }

--- a/src/MeshWeaver.Graph/ActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/ActivityLayoutAreas.cs
@@ -51,9 +51,11 @@ public static class ActivityLayoutAreas
 
     /// <summary>
     /// Overview for an Activity node. Header (user / category / status / timestamps),
-    /// followed by the structured message log (per-message rows with log-level
-    /// colour coding), terminal-status badge, and Re-run button (when the activity
-    /// originated from an executable hub and isn't currently running).
+    /// followed by the live progress indicator (indeterminate bar while running, a
+    /// status line once terminal) and the structured message log (per-message rows
+    /// with log-level colour coding), plus a Cancel button (while running) and a
+    /// Re-run button (once terminal, when the activity originated from an
+    /// executable hub). Built entirely from framework controls — no hand-rolled HTML.
     /// </summary>
     public static IObservable<UiControl?> Overview(LayoutAreaHost host, RenderingContext _)
     {
@@ -61,12 +63,14 @@ public static class ActivityLayoutAreas
             .Select(node =>
             {
                 if (node?.Content is not ActivityLog log)
-                    return (UiControl?)Controls.Html("<div>No activity data.</div>");
+                    return (UiControl?)Controls.Label("No activity data.")
+                        .WithStyle("font-style: italic; color: var(--neutral-foreground-hint);");
 
                 var stack = Controls.Stack
                     .WithStyle("padding: 16px; gap: 12px;")
-                    .WithView(Controls.Html(BuildHeaderHtml(log)))
-                    .WithView(Controls.Html(BuildMessagesHtml(log)));
+                    .WithView(BuildHeader(log))
+                    .WithView(BuildProgressIndicator(log))
+                    .WithView(BuildLog(log));
 
                 // While running: Cancel button. Per the Activity Control Plane
                 // pattern (Doc/Architecture/ActivityControlPlane.md), cancellation
@@ -143,8 +147,8 @@ public static class ActivityLayoutAreas
     /// Compact running-progress view for embedding next to an executable Code
     /// node (or anywhere a caller wants live script feedback). Streams the same
     /// ActivityLog content as <see cref="Overview"/> but trims chrome and shows
-    /// only the messages + inline Cancel button (while running) + status badge.
-    /// No header, no Re-run.
+    /// only the live progress indicator + message log + inline Cancel button
+    /// (while running). No header, no Re-run. Built from framework controls.
     /// </summary>
     public static IObservable<UiControl?> Progress(LayoutAreaHost host, RenderingContext _)
     {
@@ -152,11 +156,13 @@ public static class ActivityLayoutAreas
             .Select(node =>
             {
                 if (node?.Content is not ActivityLog log)
-                    return (UiControl?)Controls.Html("<em>No activity yet.</em>");
+                    return (UiControl?)Controls.Label("No activity yet.")
+                        .WithStyle("font-style: italic; color: var(--neutral-foreground-hint);");
 
                 var stack = Controls.Stack
                     .WithStyle("gap: 8px;")
-                    .WithView(Controls.Html(BuildMessagesHtml(log)));
+                    .WithView(BuildProgressIndicator(log))
+                    .WithView(BuildLog(log));
 
                 // Inline Cancel: same content-patch pattern as the Overview's
                 // button. Only rendered while the activity is actually running
@@ -175,71 +181,127 @@ public static class ActivityLayoutAreas
             });
     }
 
-    private static string BuildHeaderHtml(ActivityLog log)
+    /// <summary>
+    /// The activity header row: the triggering user (bold), a status badge
+    /// coloured by <see cref="ActivityStatus"/>, and a right-aligned timestamp
+    /// hint (started / ended). Control-based — replaces the former hand-rolled
+    /// header HTML.
+    /// </summary>
+    public static StackControl BuildHeader(ActivityLog log)
     {
         var userName = log.User?.DisplayName ?? log.User?.Email ?? "System";
         var startStr = log.Start.ToString("g");
         var endStr = log.End is { } end ? end.ToString("g") : "—";
-        var statusColor = log.Status switch
-        {
-            ActivityStatus.Failed => "var(--error)",
-            ActivityStatus.Warning => "var(--warning)",
-            ActivityStatus.Running => "var(--neutral-foreground-hint)",
-            _ => "var(--accent-fill-rest)",
-        };
-        var statusLabel = log.Status.ToString();
-        Func<string, string> enc = s => System.Net.WebUtility.HtmlEncode(s);
-        return
-            "<div style=\"display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;\">" +
-                $"<span style=\"font-weight: 600; font-size: 1rem;\">{enc(userName)}</span>" +
-                $"<span style=\"font-size: 0.85rem; padding: 2px 8px; border-radius: 10px; background: {statusColor}20; color: {statusColor};\">{enc(log.Category)} · {enc(statusLabel)}</span>" +
-                $"<span style=\"font-size: 0.8rem; color: var(--neutral-foreground-hint); margin-left: auto;\">started {enc(startStr)} · ended {enc(endStr)}</span>" +
-            "</div>";
+
+        return Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithHorizontalGap(12)
+            .WithStyle("align-items: baseline; flex-wrap: wrap;")
+            .WithView(Controls.Label(userName)
+                .WithStyle("font-weight: 600; font-size: 1rem;"))
+            .WithView(Controls.Label($"{log.Category} · {log.Status}")
+                .WithStyle(
+                    "font-size: 0.85rem; padding: 2px 8px; border-radius: 10px; "
+                    + $"color: {StatusColor(log.Status)}; "
+                    + $"background: color-mix(in srgb, {StatusColor(log.Status)} 12%, transparent);"))
+            .WithView(Controls.Label($"started {startStr} · ended {endStr}")
+                .WithStyle("font-size: 0.8rem; color: var(--neutral-foreground-hint); margin-left: auto;"));
     }
 
-    private static string BuildMessagesHtml(ActivityLog log)
+    /// <summary>
+    /// The activity's progress indicator — the "progress" of the generic activity GUI.
+    /// While <see cref="ActivityStatus.Running"/> it is an INDETERMINATE (animated)
+    /// <see cref="ProgressControl"/> whose message is the latest log line (or
+    /// "Running…" if none yet). Once terminal it is a coloured status line
+    /// (✓ Done / ✗ Failed / ⚠ Completed with warnings / Cancelled) preceded by the
+    /// final message. Passing <c>null</c> as the progress value is what drives the
+    /// indeterminate FluentProgress in <c>ProgressView.razor</c>.
+    /// </summary>
+    public static UiControl BuildProgressIndicator(ActivityLog log)
     {
-        if (log.Messages.Count == 0 && log.Status == ActivityStatus.Running)
-            return "<div style=\"font-style: italic; color: var(--neutral-foreground-hint);\">Running…</div>";
+        var latest = log.Messages.Count > 0 ? log.Messages[^1].Message : null;
 
-        Func<string, string> enc = s => System.Net.WebUtility.HtmlEncode(s);
-        var sb = new System.Text.StringBuilder();
-        sb.Append("<div style=\"font-family: var(--font-monospace, ui-monospace, SFMono-Regular, monospace); font-size: 0.85rem; line-height: 1.5;\">");
+        if (log.Status == ActivityStatus.Running)
+        {
+            // Indeterminate bar: progress == null → animated FluentProgress.
+            return Controls.Progress((object?)latest ?? "Running…", null!)
+                .WithWidth("100%")
+                .WithHideNumber(true)
+                .WithMessagePosition(MessagePosition.Top);
+        }
+
+        var (glyph, label) = log.Status switch
+        {
+            ActivityStatus.Succeeded => ("✓", "Done"),
+            ActivityStatus.Failed    => ("✗", "Failed"),
+            ActivityStatus.Warning   => ("⚠", "Completed with warnings"),
+            ActivityStatus.Cancelled => ("⊘", "Cancelled"),
+            _                        => ("", log.Status.ToString()),
+        };
+
+        var text = string.IsNullOrEmpty(latest) ? $"{glyph} {label}" : $"{latest}\n{glyph} {label}";
+        return Controls.H4(text)
+            .WithStyle($"color: {StatusColor(log.Status)}; white-space: pre-wrap; margin: 0;");
+    }
+
+    /// <summary>
+    /// The activity log — one row per <see cref="LogMessage"/>: a fixed-width
+    /// level tag (INFO / WARN / ERROR / DBG, coloured by severity) beside the
+    /// message text. An empty log on a running activity renders a single
+    /// "Running…" row. Control-based (a vertical <see cref="StackControl"/> of
+    /// horizontal rows) — replaces the former hand-rolled messages HTML and is
+    /// unit-testable without a layout host.
+    /// </summary>
+    public static StackControl BuildLog(ActivityLog log)
+    {
+        var stack = Controls.Stack
+            .WithStyle(
+                "font-family: var(--font-monospace, ui-monospace, monospace); "
+                + "font-size: .85rem; gap: 2px; max-height: 320px; overflow: auto;");
+
+        if (log.Messages.Count == 0)
+        {
+            return stack.WithView(Controls.Label("Running…")
+                .WithStyle("font-style: italic; color: var(--neutral-foreground-hint);"));
+        }
+
         foreach (var msg in log.Messages)
         {
-            var (color, prefix) = msg.LogLevel switch
-            {
-                Microsoft.Extensions.Logging.LogLevel.Critical or Microsoft.Extensions.Logging.LogLevel.Error =>
-                    ("var(--error)", "ERROR"),
-                Microsoft.Extensions.Logging.LogLevel.Warning =>
-                    ("var(--warning)", "WARN"),
-                Microsoft.Extensions.Logging.LogLevel.Debug or Microsoft.Extensions.Logging.LogLevel.Trace =>
-                    ("var(--neutral-foreground-hint)", "DBG"),
-                _ => ("inherit", "INFO"),
-            };
-            sb.Append($"<div style=\"display: flex; gap: 8px; padding: 2px 0;\">");
-            sb.Append($"<span style=\"color: {color}; font-weight: 600; min-width: 40px;\">{prefix}</span>");
-            sb.Append($"<span style=\"color: {color}; flex: 1; white-space: pre-wrap;\">{enc(msg.Message)}</span>");
-            sb.Append("</div>");
+            var (color, tag) = LevelTag(msg.LogLevel);
+            stack = stack.WithView(Controls.Stack
+                .WithOrientation(Orientation.Horizontal)
+                .WithHorizontalGap(8)
+                .WithView(Controls.Label(tag)
+                    .WithStyle($"min-width: 44px; font-weight: 600; color: {color};"))
+                .WithView(Controls.Label(msg.Message)
+                    .WithStyle($"flex: 1; white-space: pre-wrap; color: {color};")));
         }
-        // Terminal-state badge.
-        var statusBadge = log.Status switch
-        {
-            ActivityStatus.Succeeded => "<div style=\"margin-top: 8px; color: var(--accent-fill-rest);\">✓ Done</div>",
-            ActivityStatus.Failed    => "<div style=\"margin-top: 8px; color: var(--error);\">✗ Failed</div>",
-            ActivityStatus.Warning   => "<div style=\"margin-top: 8px; color: var(--warning);\">⚠ Completed with warnings</div>",
-            _ => "<div style=\"margin-top: 8px; font-style: italic; color: var(--neutral-foreground-hint);\">Running…</div>",
-        };
-        sb.Append(statusBadge);
-        sb.Append("</div>");
-        return sb.ToString();
+
+        return stack;
     }
+
+    private static string StatusColor(ActivityStatus status) => status switch
+    {
+        ActivityStatus.Failed    => "var(--error)",
+        ActivityStatus.Warning   => "var(--warning)",
+        ActivityStatus.Running   => "var(--neutral-foreground-hint)",
+        ActivityStatus.Cancelled => "var(--neutral-foreground-hint)",
+        _                        => "var(--accent-fill-rest)",
+    };
+
+    private static (string Color, string Tag) LevelTag(LogLevel level) => level switch
+    {
+        LogLevel.Critical or LogLevel.Error => ("var(--error)", "ERROR"),
+        LogLevel.Warning                    => ("var(--warning)", "WARN"),
+        LogLevel.Debug or LogLevel.Trace    => ("var(--neutral-foreground-hint)", "DBG"),
+        _                                   => ("inherit", "INFO"),
+    };
 
     /// <summary>
     /// Thumbnail view — compact label for activity entries.
     /// </summary>
     public static UiControl Thumbnail(LayoutAreaHost host, RenderingContext _)
     {
-        return Controls.Html("<div>Activity</div>");
+        return Controls.Label("Activity");
     }
 }

--- a/src/MeshWeaver.Layout/ProgressControl.cs
+++ b/src/MeshWeaver.Layout/ProgressControl.cs
@@ -24,6 +24,15 @@ public record ProgressControl(object Message, object Progress)
     public object? Color { get; init; }
     /// <summary>Position of the message text relative to the progress bar. Accepts a <see cref="Layout.MessagePosition"/> value.</summary>
     public object? MessagePosition { get; init; }
+
+    /// <summary>Sets the width of the progress bar (CSS size string, e.g. "100%").</summary>
+    public ProgressControl WithWidth(object width) => this with { Width = width };
+
+    /// <summary>Hides (or shows) the numeric percentage label rendered next to the bar.</summary>
+    public ProgressControl WithHideNumber(object hideNumber) => this with { HideNumber = hideNumber };
+
+    /// <summary>Sets where the message text is rendered relative to the bar.</summary>
+    public ProgressControl WithMessagePosition(object messagePosition) => this with { MessagePosition = messagePosition };
 }
 
 /// <summary>

--- a/test/MeshWeaver.Graph.Test/ActivityProgressViewTest.cs
+++ b/test/MeshWeaver.Graph.Test/ActivityProgressViewTest.cs
@@ -1,0 +1,120 @@
+using System.Collections.Immutable;
+using MeshWeaver.Data;
+using MeshWeaver.Layout;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the generic activity GUI's control shape — the progress indicator and the
+/// message log are built from framework controls (a <see cref="ProgressControl"/>
+/// while running, a status label once terminal, and a per-message row list), NOT
+/// hand-rolled HTML. Mirrors <see cref="ActivityCancelVisibilityTest"/>: the view's
+/// builders are pure functions of the <see cref="ActivityLog"/>, so their control
+/// shape is unit-testable without spinning up a layout host.
+/// </summary>
+public class ActivityProgressViewTest
+{
+    private static ActivityLog Running(params (string Text, LogLevel Level)[] messages) =>
+        new("test")
+        {
+            Status = ActivityStatus.Running,
+            Messages = messages
+                .Select(m => new LogMessage(m.Text, m.Level))
+                .ToImmutableList(),
+        };
+
+    [Fact]
+    public void Running_ProgressIndicator_IsIndeterminateProgressBar()
+    {
+        var log = Running(("Serializing…", LogLevel.Information), ("Committing on HEAD…", LogLevel.Information));
+
+        var indicator = ActivityLayoutAreas.BuildProgressIndicator(log);
+
+        var progress = indicator.Should().BeOfType<ProgressControl>().Subject;
+        // Indeterminate: a null Progress value is what drives the animated FluentProgress.
+        progress.Progress.Should().BeNull("a running activity has no numeric percentage — the bar is indeterminate");
+        // The bar's message is the LATEST log line (the current progress message).
+        progress.Message.Should().Be("Committing on HEAD…");
+        progress.HideNumber.Should().Be(true);
+    }
+
+    [Fact]
+    public void Running_NoMessages_ProgressIndicator_ShowsRunning()
+    {
+        var indicator = ActivityLayoutAreas.BuildProgressIndicator(Running());
+
+        var progress = indicator.Should().BeOfType<ProgressControl>().Subject;
+        progress.Progress.Should().BeNull();
+        progress.Message.Should().Be("Running…");
+    }
+
+    [Fact]
+    public void Succeeded_ProgressIndicator_IsDoneStatus_NotAProgressBar()
+    {
+        var log = new ActivityLog("test")
+        {
+            Status = ActivityStatus.Succeeded,
+            Messages = ImmutableList.Create(new LogMessage("Committed abcd1234.", LogLevel.Information)),
+            End = DateTime.UtcNow,
+        };
+
+        var indicator = ActivityLayoutAreas.BuildProgressIndicator(log);
+
+        indicator.Should().NotBeOfType<ProgressControl>("a terminal activity shows a status line, not a live bar");
+        var label = indicator.Should().BeOfType<LabelControl>().Subject;
+        label.Data!.ToString().Should().Contain("Done").And.Contain("Committed abcd1234.");
+    }
+
+    [Fact]
+    public void Failed_ProgressIndicator_IsFailedStatus()
+    {
+        var log = new ActivityLog("test")
+        {
+            Status = ActivityStatus.Failed,
+            Messages = ImmutableList.Create(new LogMessage("boom", LogLevel.Error)),
+            End = DateTime.UtcNow,
+        };
+
+        var indicator = ActivityLayoutAreas.BuildProgressIndicator(log);
+
+        indicator.Should().NotBeOfType<ProgressControl>();
+        indicator.Should().BeOfType<LabelControl>()
+            .Subject.Data!.ToString().Should().Contain("Failed");
+    }
+
+    [Fact]
+    public void Log_HasOneRowPerMessage()
+    {
+        var log = Running(
+            ("Serializing…", LogLevel.Information),
+            ("A warning", LogLevel.Warning),
+            ("An error", LogLevel.Error));
+
+        var logStack = ActivityLayoutAreas.BuildLog(log);
+
+        // One rendered row (NamedArea) per log message.
+        logStack.Should().BeOfType<StackControl>();
+        logStack.Areas.Should().HaveCount(3, "the log renders one control row per message");
+    }
+
+    [Fact]
+    public void Log_EmptyRunning_HasSingleRunningRow()
+    {
+        var logStack = ActivityLayoutAreas.BuildLog(Running());
+
+        logStack.Areas.Should().HaveCount(1, "an empty running log shows a single 'Running…' row");
+    }
+
+    [Fact]
+    public void Header_RendersUserStatusAndTimestamps()
+    {
+        var log = Running(("hi", LogLevel.Information));
+
+        var header = ActivityLayoutAreas.BuildHeader(log);
+
+        // user label + status label + timestamp hint.
+        header.Areas.Should().HaveCount(3);
+    }
+}


### PR DESCRIPTION
## What

Builds the **generic activity GUI** for MeshWeaver: any command that runs as an activity now shows a live **progress indicator + current progress message + activity log**, and wires the GitHub sync operations (Sync now / Update / Check) as the first consumer so they stop dead-ending on a static message.

## Changes

### Generic `ActivityLayoutAreas` (Overview + Progress) — framework controls, no hand-rolled HTML
- **Progress indicator** (the "progress"): while `Status == Running`, an **indeterminate (animated)** `ProgressControl` whose message is the latest log line (or "Running…" if none). Once terminal, a coloured status line — `✓ Done` / `✗ Failed` / `⚠ Completed with warnings` / `⊘ Cancelled` — with the final message above it.
- **Current progress message**: surfaced prominently as the running bar's message (the latest log line).
- **Activity log**: a vertical `Controls.Stack` (monospace, scrollable) of one control row per `LogMessage` — a fixed-width level tag (`INFO`/`WARN`/`ERROR`/`DBG`, coloured by severity) beside the message. Empty + running → a single "Running…" row.
- **Header**: a control-based horizontal `Stack` (bold user + status label coloured by status + timestamp hint), replacing `BuildHeaderHtml`.
- `BuildHeaderHtml` / `BuildMessagesHtml` (the banned `StringBuilder`/`$"<div>…"` path) are **deleted**. Cancel + Re-run buttons unchanged; `IsCancelButtonVisible` predicate unchanged (its test still pins it).

### `ProgressView.razor` — indeterminate on null
`DataBind(ViewModel.Progress, x => x.Progress, defaultValue:0)` → `DataBind(ViewModel.Progress, x => x.Progress)`. A **null** `Progress` now stays null so `FluentProgress` renders indeterminate (was forced to 0). Additive: every existing caller passes a real `int` and is unaffected — only an explicit null now animates.

### `ProgressControl` — additive fluent methods
`WithWidth` / `WithHideNumber` / `WithMessagePosition` (the properties already existed).

### `GitHubActionArea` — embed the live activity
After starting the op, it now renders the **live activity Overview** (`onActivityCreated` → per-render `ReplaySubject<string>(1)` → `LayoutAreaControl(new Address(activityPath), new LayoutAreaReference(ActivityLayoutAreas.OverviewArea))`) instead of returning a static "the operation is running" message. A "Starting…" placeholder (indeterminate progress) shows until the activity path arrives. The early-return guards (Not in a Space / Nothing to do / Sign-in required / Unknown operation) are unchanged.

## Reactive / framework compliance
- End-to-end `IObservable<T>` — no `async`/`await`/`Task<T>` in view code; click actions stay `ctx => { …; return Task.CompletedTask; }`.
- Framework controls only — no HTML string building for structured content (the guard `Controls.Html` paragraph for a pre-rendered `<code>` snippet is the sole remaining, sanctioned use).
- No static state — the `ReplaySubject` is per-render.

## Tests
- `ActivityCancelVisibilityTest` — **unchanged and green** (`IsCancelButtonVisible` untouched).
- New `ActivityProgressViewTest` — pins the control shape as pure-helper assertions (no host, mirroring `IsCancelButtonVisible`'s standalone testability): indeterminate `ProgressControl` (Progress == null) while running with the latest message; a `Done`/`Failed` status label (not a `ProgressControl`) when terminal; one log row per message; single "Running…" row when empty.

**Local build** (`dotnet build -c Release -p:CIRun=true -warnaserror`): Layout, Graph, GitSync, Blazor + Graph.Test / GitSync.Test / Courses.Test all **0 warnings / 0 errors**. Activity tests: **15 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)