### PR TITLE
Count prompt-cache tokens in the AI usage counter (all providers)

### DIFF
--- a/src/MeshWeaver.AI.AzureFoundry/AzureClaudeChatClient.cs
+++ b/src/MeshWeaver.AI.AzureFoundry/AzureClaudeChatClient.cs
@@ -17,6 +17,15 @@ public class AzureClaudeChatClient : IChatClient
     private const string AnthropicVersion = "2023-06-01";
     private const int DefaultMaxTokens = 16384;
 
+    /// <summary>
+    /// Ephemeral prompt-cache breakpoint (<c>{"type":"ephemeral"}</c>). Attached to the LAST tool and
+    /// the system prompt so Anthropic caches the large, static prefix (tool schemas + the agent's
+    /// instructions) — on a multi-round agent turn every round after the first re-reads that prefix at
+    /// the reduced cache-read rate instead of full input price. Below the model's minimum cacheable
+    /// size Anthropic simply doesn't cache (no error), so it is always safe to mark.
+    /// </summary>
+    private static readonly object EphemeralCacheControl = new { type = "ephemeral" };
+
     private readonly HttpClient httpClient;
     private readonly string endpoint;
     private readonly string apiKey;
@@ -146,6 +155,11 @@ public class AzureClaudeChatClient : IChatClient
         // once on message_start and cumulative output-tokens on message_delta).
         var inputTokens = 0;
         var outputTokens = 0;
+        // Prompt-cache counts, reported alongside input_tokens on message_start. On the
+        // Anthropic wire input_tokens EXCLUDES these, so they used to be invisible; capture
+        // them and fold into the reported total below (UsageTokens convention).
+        var cacheReadTokens = 0;
+        var cacheCreationTokens = 0;
 
         while ((line = await reader.ReadLineAsync(cancellationToken)) != null)
         {
@@ -179,6 +193,8 @@ public class AzureClaudeChatClient : IChatClient
                         // Anthropic reports cumulative output tokens on message_delta;
                         // seed with any initial value on message_start.
                         outputTokens = startUsage.OutputTokens;
+                        cacheReadTokens = startUsage.CacheReadInputTokens;
+                        cacheCreationTokens = startUsage.CacheCreationInputTokens;
                     }
                     break;
 
@@ -254,20 +270,43 @@ public class AzureClaudeChatClient : IChatClient
                 case "message_stop":
                     // Final UsageContent carries the totals — ThreadExecution stamps the
                     // response cell's InputTokens/OutputTokens/TotalTokens from this.
-                    if (inputTokens > 0 || outputTokens > 0)
+                    if (inputTokens > 0 || outputTokens > 0 || cacheReadTokens > 0 || cacheCreationTokens > 0)
                     {
                         yield return new ChatResponseUpdate(ChatRole.Assistant, [
-                            new UsageContent(new UsageDetails
-                            {
-                                InputTokenCount = inputTokens,
-                                OutputTokenCount = outputTokens,
-                                TotalTokenCount = inputTokens + outputTokens
-                            })
+                            BuildUsageContent(inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens)
                         ]);
                     }
                     break;
             }
         }
+    }
+
+    /// <summary>
+    /// Builds the final <see cref="UsageContent"/> from the Anthropic usage counters, NORMALISING to
+    /// the <see cref="UsageTokens"/> convention: Anthropic's <c>input_tokens</c> EXCLUDES cached
+    /// tokens, so the true prompt-token total is <c>input + cache_read + cache_creation</c>. That full
+    /// total becomes <see cref="UsageDetails.InputTokenCount"/> (so the "in" counter stops
+    /// under-reporting cached context), and the cache breakdown is carried in
+    /// <see cref="UsageDetails.AdditionalCounts"/> for accurate cost + the counter's cache line.
+    /// </summary>
+    private static UsageContent BuildUsageContent(int inputTokens, int outputTokens, int cacheReadTokens, int cacheCreationTokens)
+    {
+        var totalInput = inputTokens + cacheReadTokens + cacheCreationTokens;
+        var details = new UsageDetails
+        {
+            InputTokenCount = totalInput,
+            OutputTokenCount = outputTokens,
+            TotalTokenCount = totalInput + outputTokens
+        };
+        if (cacheReadTokens > 0 || cacheCreationTokens > 0)
+        {
+            details.AdditionalCounts = new AdditionalPropertiesDictionary<long>();
+            if (cacheReadTokens > 0)
+                details.AdditionalCounts[UsageTokens.CacheReadKey] = cacheReadTokens;
+            if (cacheCreationTokens > 0)
+                details.AdditionalCounts[UsageTokens.CacheWriteKey] = cacheCreationTokens;
+        }
+        return new UsageContent(details);
     }
 
     /// <inheritdoc />
@@ -384,8 +423,15 @@ public class AzureClaudeChatClient : IChatClient
         var request = new ClaudeRequest
         {
             Model = modelId,
+            // System sent as a content-block array so the agent's (large, static) instructions carry a
+            // prompt-cache breakpoint; a bare string when there's no system prompt.
+            System = string.IsNullOrEmpty(systemPrompt)
+                ? null
+                : new List<ClaudeSystemBlock>
+                {
+                    new() { Type = "text", Text = systemPrompt, CacheControl = EphemeralCacheControl }
+                },
             Messages = claudeMessages,
-            System = systemPrompt,
             MaxTokens = options?.MaxOutputTokens ?? DefaultMaxTokens,
             Temperature = options?.Temperature,
             TopP = options?.TopP,
@@ -399,6 +445,10 @@ public class AzureClaudeChatClient : IChatClient
                 .OfType<AIFunction>()
                 .Select(ConvertToClaudeTool)
                 .ToList();
+            // Cache breakpoint on the LAST tool → Anthropic caches the whole tools block (order is
+            // tools → system → messages), so tool schemas + instructions are the cached prefix.
+            if (request.Tools.Count > 0)
+                request.Tools[^1].CacheControl = EphemeralCacheControl;
         }
 
         return request;
@@ -525,12 +575,12 @@ public class AzureClaudeChatClient : IChatClient
         {
             FinishReason = ConvertStopReason(response.StopReason),
             ModelId = response.Model,
+            // Same normalisation as the streaming path — fold the prompt-cache counts into the
+            // input total and carry the breakdown in AdditionalCounts (UsageTokens convention).
             Usage = response.Usage != null
-                ? new UsageDetails
-                {
-                    InputTokenCount = response.Usage.InputTokens,
-                    OutputTokenCount = response.Usage.OutputTokens
-                }
+                ? BuildUsageContent(
+                    response.Usage.InputTokens, response.Usage.OutputTokens,
+                    response.Usage.CacheReadInputTokens, response.Usage.CacheCreationInputTokens).Details
                 : null
         };
     }
@@ -553,12 +603,21 @@ public class AzureClaudeChatClient : IChatClient
     {
         public string Model { get; set; } = null!;
         public List<ClaudeMessage> Messages { get; set; } = new();
-        public string? System { get; set; }
+        /// <summary>String OR a <c>List&lt;ClaudeSystemBlock&gt;</c> (blocks carry the cache breakpoint).</summary>
+        public object? System { get; set; }
         public int MaxTokens { get; set; }
         public float? Temperature { get; set; }
         public float? TopP { get; set; }
         public bool Stream { get; set; }
         public List<ClaudeTool>? Tools { get; set; }
+    }
+
+    private class ClaudeSystemBlock
+    {
+        public string Type { get; set; } = "text";
+        public string? Text { get; set; }
+        /// <summary>Serialised as <c>cache_control</c> (snake_case); omitted when null.</summary>
+        public object? CacheControl { get; set; }
     }
 
     private class ClaudeMessage
@@ -585,6 +644,8 @@ public class AzureClaudeChatClient : IChatClient
         public string Name { get; set; } = null!;
         public string? Description { get; set; }
         public object InputSchema { get; set; } = null!;
+        /// <summary>Serialised as <c>cache_control</c> (snake_case); set on the last tool to cache the tools block. Omitted when null.</summary>
+        public object? CacheControl { get; set; }
     }
 
     private class ClaudeResponse
@@ -611,6 +672,11 @@ public class AzureClaudeChatClient : IChatClient
     {
         public int InputTokens { get; set; }
         public int OutputTokens { get; set; }
+        // Prompt-cache counts (JsonOptions uses snake_case → cache_read_input_tokens /
+        // cache_creation_input_tokens). Anthropic reports these SEPARATELY from input_tokens; they
+        // used to be dropped, so the counter under-reported the real cached context.
+        public int CacheReadInputTokens { get; set; }
+        public int CacheCreationInputTokens { get; set; }
     }
 
     private class ClaudeStreamEvent

--- a/src/MeshWeaver.AI/ModelPricing.cs
+++ b/src/MeshWeaver.AI/ModelPricing.cs
@@ -11,15 +11,22 @@ namespace MeshWeaver.AI;
 /// <param name="InputPerMillion">Price per 1,000,000 input (prompt) tokens.</param>
 /// <param name="OutputPerMillion">Price per 1,000,000 output (completion) tokens.</param>
 /// <param name="Currency">ISO currency code (e.g. <c>USD</c>).</param>
-/// <param name="CacheReadPerMillion">Price per 1,000,000 cache-READ (cache-hit) tokens. Null ⇒ derive as 0.1× input (Anthropic standard).</param>
-/// <param name="CacheWritePerMillion">Price per 1,000,000 cache-WRITE (cache-creation) tokens. Null ⇒ derive as 1.25× input (Anthropic 5-min TTL).</param>
-public record ModelPriceRate(
-    decimal InputPerMillion,
-    decimal OutputPerMillion,
-    string Currency,
-    decimal? CacheReadPerMillion = null,
-    decimal? CacheWritePerMillion = null)
+public record ModelPriceRate(decimal InputPerMillion, decimal OutputPerMillion, string Currency)
 {
+    /// <summary>
+    /// Price per 1,000,000 cache-READ (cache-hit) tokens. Null ⇒ derive as 0.1× input (Anthropic
+    /// standard). Init-only property (NOT a primary-ctor parameter) so adding it doesn't change the
+    /// record's <c>Deconstruct</c> arity — a source/binary break for external positional callers.
+    /// </summary>
+    public decimal? CacheReadPerMillion { get; init; }
+
+    /// <summary>
+    /// Price per 1,000,000 cache-WRITE (cache-creation) tokens. Null ⇒ derive as 1.25× input
+    /// (Anthropic 5-min TTL). Init-only property for the same API-compat reason as
+    /// <see cref="CacheReadPerMillion"/>.
+    /// </summary>
+    public decimal? CacheWritePerMillion { get; init; }
+
     /// <summary>
     /// Monetary cost of the given token counts at this rate:
     /// <c>in/1e6 × InputPerMillion + out/1e6 × OutputPerMillion</c>.

--- a/src/MeshWeaver.AI/ModelPricing.cs
+++ b/src/MeshWeaver.AI/ModelPricing.cs
@@ -11,7 +11,14 @@ namespace MeshWeaver.AI;
 /// <param name="InputPerMillion">Price per 1,000,000 input (prompt) tokens.</param>
 /// <param name="OutputPerMillion">Price per 1,000,000 output (completion) tokens.</param>
 /// <param name="Currency">ISO currency code (e.g. <c>USD</c>).</param>
-public record ModelPriceRate(decimal InputPerMillion, decimal OutputPerMillion, string Currency)
+/// <param name="CacheReadPerMillion">Price per 1,000,000 cache-READ (cache-hit) tokens. Null ⇒ derive as 0.1× input (Anthropic standard).</param>
+/// <param name="CacheWritePerMillion">Price per 1,000,000 cache-WRITE (cache-creation) tokens. Null ⇒ derive as 1.25× input (Anthropic 5-min TTL).</param>
+public record ModelPriceRate(
+    decimal InputPerMillion,
+    decimal OutputPerMillion,
+    string Currency,
+    decimal? CacheReadPerMillion = null,
+    decimal? CacheWritePerMillion = null)
 {
     /// <summary>
     /// Monetary cost of the given token counts at this rate:
@@ -20,6 +27,24 @@ public record ModelPriceRate(decimal InputPerMillion, decimal OutputPerMillion, 
     public decimal Cost(long inputTokens, long outputTokens)
         => inputTokens / 1_000_000m * InputPerMillion
          + outputTokens / 1_000_000m * OutputPerMillion;
+
+    /// <summary>
+    /// Cache-aware cost. <paramref name="inputTokens"/> is the FULL prompt-token count (cache read +
+    /// write are SUBSETS of it, per <see cref="UsageTokens"/>), so the non-cached portion is
+    /// <c>inputTokens − cacheReadTokens − cacheWriteTokens</c>, priced at the input rate; cache reads
+    /// at the reduced read rate; cache writes at the premium write rate. Read/write rates fall back to
+    /// the Anthropic-standard 0.1× / 1.25× of input when the model doesn't specify them.
+    /// </summary>
+    public decimal Cost(long inputTokens, long outputTokens, long cacheReadTokens, long cacheWriteTokens)
+    {
+        var baseInput = Math.Max(0, inputTokens - cacheReadTokens - cacheWriteTokens);
+        var readRate = CacheReadPerMillion ?? InputPerMillion * 0.1m;
+        var writeRate = CacheWritePerMillion ?? InputPerMillion * 1.25m;
+        return baseInput / 1_000_000m * InputPerMillion
+             + cacheReadTokens / 1_000_000m * readRate
+             + cacheWriteTokens / 1_000_000m * writeRate
+             + outputTokens / 1_000_000m * OutputPerMillion;
+    }
 }
 
 /// <summary>

--- a/src/MeshWeaver.AI/Thread.cs
+++ b/src/MeshWeaver.AI/Thread.cs
@@ -564,6 +564,10 @@ public record ThreadMessage
     public int? OutputTokens { get; init; }
     /// <summary>Total tokens the provider billed for this response. May exceed <see cref="InputTokens"/> + <see cref="OutputTokens"/> when cached / reasoning tokens are included.</summary>
     public int? TotalTokens { get; init; }
+    /// <summary>Cache-READ (cache-hit) prompt tokens for this response — a subset of <see cref="InputTokens"/>. Null when the provider reports no prompt caching.</summary>
+    public int? CacheReadTokens { get; init; }
+    /// <summary>Cache-WRITE (cache-creation) prompt tokens for this response — a subset of <see cref="InputTokens"/>. Null on the OpenAI wire and when the provider reports no prompt caching.</summary>
+    public int? CacheWriteTokens { get; init; }
 
     /// <summary>
     /// Wall-clock time when the assistant response finished streaming. Null while

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -932,7 +932,8 @@ internal static class ThreadExecution
             DateTime? completedAt = null,
             ThreadMessageStatus? status = null,
             string? summary = null,
-            string? harness = null)
+            string? harness = null,
+            int? cacheReadTokens = null, int? cacheWriteTokens = null)
         {
             // Re-read the segment's CURRENT target + text baseline on every push so
             // writes follow a mid-round check_inbox split to the new cell. The cell
@@ -1046,6 +1047,8 @@ internal static class ThreadExecution
                     InputTokens = inputTokens ?? current.InputTokens,
                     OutputTokens = outputTokens ?? current.OutputTokens,
                     TotalTokens = totalTokens ?? current.TotalTokens,
+                    CacheReadTokens = cacheReadTokens ?? current.CacheReadTokens,
+                    CacheWriteTokens = cacheWriteTokens ?? current.CacheWriteTokens,
                     CompletedAt = completedAt ?? current.CompletedAt,
                     Status = nextStatus,
                     Summary = summary ?? current.Summary
@@ -1725,6 +1728,12 @@ internal static class ThreadExecution
                     int? inputTokens = null;
                     int? outputTokens = null;
                     int? totalTokens = null;
+                    // Prompt-cache breakdown — SUBSETS of inputTokens (see UsageTokens). Accumulated
+                    // from UsageDetails.AdditionalCounts across rounds so the counter and the per-model
+                    // TokenUsage satellite reflect the real (billable) cached context, not just the
+                    // non-cached delta the raw "in" number used to show.
+                    int? cacheReadTokens = null;
+                    int? cacheWriteTokens = null;
                     // Total-token normalization is the static NormalizeTotal helper (below),
                     // assigned per terminal path — NOT a local function here. A mutable-capturing
                     // local function threaded through this ~1400-line method's branches exploded
@@ -1912,6 +1921,15 @@ internal static class ThreadExecution
                             outputTokens = (outputTokens ?? 0) + (int)ot;
                         if (d?.TotalTokenCount is { } tt)
                             totalTokens = (totalTokens ?? 0) + (int)tt;
+                        // Prompt-cache breakdown — provider-agnostic (OpenAI/OpenRouter put the cached
+                        // subset in AdditionalCounts["InputTokenDetails.CachedTokenCount"]; the Claude
+                        // client normalises to the same shape). Subsets of InputTokenCount; used for
+                        // accurate cost + the counter's cache line. Used to be dropped entirely.
+                        var (roundCacheRead, roundCacheWrite) = UsageTokens.SplitCache(d);
+                        if (roundCacheRead > 0)
+                            cacheReadTokens = (cacheReadTokens ?? 0) + (int)roundCacheRead;
+                        if (roundCacheWrite > 0)
+                            cacheWriteTokens = (cacheWriteTokens ?? 0) + (int)roundCacheWrite;
                     }
                     else if (content is FunctionResultContent functionResult)
                     {
@@ -2085,7 +2103,8 @@ internal static class ThreadExecution
                         inputTokens: inputTokens, outputTokens: outputTokens,
                         totalTokens: totalTokens, completedAt: DateTime.UtcNow,
                         status: ThreadMessageStatus.Completed,
-                        summary: summaryText, harness: request.Harness).Subscribe(
+                        summary: summaryText, harness: request.Harness,
+                        cacheReadTokens: cacheReadTokens, cacheWriteTokens: cacheWriteTokens).Subscribe(
                         _ => { },
                         ex => execLogger?.LogWarning(ex,
                             "PushToResponseMessage(Completed) failed for {ThreadPath}", threadPath));
@@ -2109,7 +2128,8 @@ internal static class ThreadExecution
                     // never touches the round on the no-usage path.
                     TokenUsageNodeType.RecordUsage(parentHub, threadPath,
                         AgentPickerProjection.PartitionOf(threadPath),
-                        actualModel ?? request.ModelName, inputTokens, outputTokens, execLogger)
+                        actualModel ?? request.ModelName, inputTokens, outputTokens, execLogger,
+                        cacheReadTokens, cacheWriteTokens)
                     .Subscribe(
                         _ => { },
                         ex => execLogger?.LogWarning(ex,
@@ -2179,7 +2199,8 @@ internal static class ThreadExecution
                             inputTokens: inputTokens, outputTokens: outputTokens,
                             totalTokens: totalTokens,
                             completedAt: DateTime.UtcNow,
-                            status: ThreadMessageStatus.Cancelled).Subscribe(
+                            status: ThreadMessageStatus.Cancelled,
+                            cacheReadTokens: cacheReadTokens, cacheWriteTokens: cacheWriteTokens).Subscribe(
                             _ => { },
                             ex => execLogger?.LogWarning(ex,
                                 "PushToResponseMessage(Cancelled) failed for {ThreadPath}", threadPath));
@@ -2200,7 +2221,8 @@ internal static class ThreadExecution
                         // after the terminal Cancelled status). Fail-open + no-op on zero tokens.
                         TokenUsageNodeType.RecordUsage(parentHub, threadPath,
                             AgentPickerProjection.PartitionOf(threadPath),
-                            request.ModelName, inputTokens, outputTokens, execLogger)
+                            request.ModelName, inputTokens, outputTokens, execLogger,
+                            cacheReadTokens, cacheWriteTokens)
                         .Subscribe(
                             _ => { },
                             ex => execLogger?.LogWarning(ex,
@@ -2280,7 +2302,8 @@ internal static class ThreadExecution
                             inputTokens: inputTokens, outputTokens: outputTokens,
                             totalTokens: totalTokens,
                             completedAt: DateTime.UtcNow,
-                            status: ThreadMessageStatus.Error)
+                            status: ThreadMessageStatus.Error,
+                            cacheReadTokens: cacheReadTokens, cacheWriteTokens: cacheWriteTokens)
                             .Timeout(TimeSpan.FromSeconds(10));
                         var errorTextLocal = errorText;
                         var errorNodeChangesLocal = errorNodeChanges;
@@ -2306,7 +2329,8 @@ internal static class ThreadExecution
                                 // Fail-open + no-op on zero tokens.
                                 TokenUsageNodeType.RecordUsage(parentHub, threadPath,
                                     AgentPickerProjection.PartitionOf(threadPath),
-                                    request.ModelName, inputTokens, outputTokens, execLogger)
+                                    request.ModelName, inputTokens, outputTokens, execLogger,
+                                    cacheReadTokens, cacheWriteTokens)
                                 .Subscribe(
                                     _ => { },
                                     recEx => execLogger?.LogWarning(recEx,

--- a/src/MeshWeaver.AI/TokenUsage.cs
+++ b/src/MeshWeaver.AI/TokenUsage.cs
@@ -34,15 +34,38 @@ public record TokenUsage
     /// <summary>The bare model id (e.g. <c>claude-opus-4-8</c>) — the satellite's key dimension.</summary>
     public string Model { get; init; } = string.Empty;
 
-    /// <summary>Cumulative input (prompt) tokens for this model in this thread.</summary>
+    /// <summary>
+    /// Cumulative input (prompt) tokens for this model in this thread — the FULL prompt-token
+    /// count including any cache hits/writes. <see cref="CacheReadTokens"/> and
+    /// <see cref="CacheWriteTokens"/> are SUBSETS of this (see <see cref="UsageTokens"/>).
+    /// </summary>
     public long InputTokens { get; init; }
 
     /// <summary>Cumulative output (completion) tokens for this model in this thread.</summary>
     public long OutputTokens { get; init; }
 
+    /// <summary>
+    /// Cumulative cache-READ (cache-hit) prompt tokens — a subset of <see cref="InputTokens"/>.
+    /// Billed at the reduced cache-read rate. Zero when the provider reports no prompt caching.
+    /// </summary>
+    public long CacheReadTokens { get; init; }
+
+    /// <summary>
+    /// Cumulative cache-WRITE (cache-creation) prompt tokens — a subset of <see cref="InputTokens"/>.
+    /// Billed at the premium cache-write rate. Zero on the OpenAI wire (no separate write) and when
+    /// the provider reports no prompt caching.
+    /// </summary>
+    public long CacheWriteTokens { get; init; }
+
     /// <summary>Returns a copy with the given round's counts added.</summary>
-    public TokenUsage Add(long inputTokens, long outputTokens)
-        => this with { InputTokens = InputTokens + inputTokens, OutputTokens = OutputTokens + outputTokens };
+    public TokenUsage Add(long inputTokens, long outputTokens, long cacheReadTokens = 0, long cacheWriteTokens = 0)
+        => this with
+        {
+            InputTokens = InputTokens + inputTokens,
+            OutputTokens = OutputTokens + outputTokens,
+            CacheReadTokens = CacheReadTokens + cacheReadTokens,
+            CacheWriteTokens = CacheWriteTokens + cacheWriteTokens,
+        };
 }
 
 /// <summary>
@@ -114,11 +137,14 @@ public static class TokenUsageNodeType
     /// </summary>
     public static IObservable<System.Reactive.Unit> RecordUsage(
         IMessageHub hub, string threadPath, string? userId,
-        string? modelId, int? inputTokens, int? outputTokens, ILogger? logger = null)
+        string? modelId, int? inputTokens, int? outputTokens, ILogger? logger = null,
+        int? cacheReadTokens = null, int? cacheWriteTokens = null)
     {
         long inTok = inputTokens ?? 0;
         long outTok = outputTokens ?? 0;
-        if (inTok == 0 && outTok == 0)
+        long cacheReadTok = cacheReadTokens ?? 0;
+        long cacheWriteTok = cacheWriteTokens ?? 0;
+        if (inTok == 0 && outTok == 0 && cacheReadTok == 0 && cacheWriteTok == 0)
             return Observable.Return(System.Reactive.Unit.Default); // no-token round → no-op
 
         var model = string.IsNullOrWhiteSpace(modelId) ? "(unknown)" : modelId!;
@@ -175,7 +201,7 @@ public static class TokenUsageNodeType
                 {
                     var cur = node.ContentAs<TokenUsage>(hub.JsonSerializerOptions, logger)
                               ?? new TokenUsage { UserId = userId, ThreadId = threadPath, Model = model };
-                    return node with { Content = cur.Add(inTok, outTok) };
+                    return node with { Content = cur.Add(inTok, outTok, cacheReadTok, cacheWriteTok) };
                 }))
             .Select(_ => System.Reactive.Unit.Default)
             // Subscribed as an INDEPENDENT side effect (NOT chained before the terminal status write),

--- a/src/MeshWeaver.AI/UsageTokens.cs
+++ b/src/MeshWeaver.AI/UsageTokens.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.AI;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// Canonical <see cref="UsageDetails.AdditionalCounts"/> keys and a provider-agnostic
+/// reader for prompt-cache token counts.
+///
+/// <para>Prompt caching is reported differently per provider, and the raw counters used to be
+/// dropped on the floor (the "in / out" counter under-reported the real, billable context):</para>
+/// <list type="bullet">
+///   <item><b>Anthropic wire</b> (native / Azure Foundry Claude): <c>input_tokens</c>
+///   EXCLUDES cached tokens; the cached portion is reported separately as
+///   <c>cache_read_input_tokens</c> / <c>cache_creation_input_tokens</c>. The Claude client
+///   NORMALISES to the OpenAI convention (folds cache read + creation into the input total) and
+///   writes the breakdown into <see cref="UsageDetails.AdditionalCounts"/> under the keys below.</item>
+///   <item><b>OpenAI wire</b> (OpenAI / OpenRouter / Azure OpenAI / Azure Foundry via
+///   <c>Microsoft.Extensions.AI.OpenAI</c>): <c>prompt_tokens</c> already INCLUDES cached reads, and
+///   the adapter surfaces the cached subset in <c>AdditionalCounts["InputTokenDetails.CachedTokenCount"]</c>.</item>
+/// </list>
+///
+/// <para>So after normalisation there is ONE consistent meaning everywhere: <c>InputTokenCount</c> is
+/// the FULL prompt-token count, and cache read / write are SUBSETS of it. <see cref="SplitCache"/>
+/// matches both the OpenAI adapter's key and the Claude client's keys by substring, so it works
+/// regardless of which provider produced the usage.</para>
+/// </summary>
+public static class UsageTokens
+{
+    /// <summary>Cache-READ (cache-hit) prompt tokens — a subset of <see cref="UsageDetails.InputTokenCount"/>.</summary>
+    public const string CacheReadKey = "CacheReadInputTokens";
+
+    /// <summary>Cache-WRITE (cache-creation) prompt tokens — a subset of <see cref="UsageDetails.InputTokenCount"/>.</summary>
+    public const string CacheWriteKey = "CacheCreationInputTokens";
+
+    /// <summary>
+    /// Extracts (cacheRead, cacheWrite) prompt-token counts from a provider's
+    /// <see cref="UsageDetails.AdditionalCounts"/>, matching the Claude client's keys AND the
+    /// OpenAI adapter's <c>InputTokenDetails.CachedTokenCount</c> — case-insensitively by substring.
+    /// Returns <c>(0, 0)</c> when the provider reported no cache detail.
+    /// </summary>
+    public static (long CacheRead, long CacheWrite) SplitCache(UsageDetails? details)
+    {
+        long read = 0, write = 0;
+        if (details?.AdditionalCounts is { } counts)
+        {
+            foreach (var kv in counts)
+            {
+                // Order matters: "CacheCreation"/"CacheWrite" before the generic "Cache" (which
+                // also matches OpenAI's "Cached...") so a write is never miscounted as a read.
+                if (kv.Key.Contains("CacheCreation", StringComparison.OrdinalIgnoreCase)
+                    || kv.Key.Contains("CacheWrite", StringComparison.OrdinalIgnoreCase))
+                    write += kv.Value;
+                else if (kv.Key.Contains("Cache", StringComparison.OrdinalIgnoreCase))
+                    read += kv.Value;
+            }
+        }
+        return (read, write);
+    }
+}

--- a/src/MeshWeaver.Blazor.Portal/Chat/MessageBubbleState.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/MessageBubbleState.cs
@@ -28,7 +28,9 @@ internal record MessageBubbleState(
     DateTime? CompletedAt = null,
     string? Harness = null,
     int? InputTokens = null,
-    int? OutputTokens = null)
+    int? OutputTokens = null,
+    int? CacheReadTokens = null,
+    int? CacheWriteTokens = null)
 {
     /// <summary>
     /// Value equality over all bound bubble state, comparing the tool-call and updated-node lists
@@ -49,6 +51,8 @@ internal record MessageBubbleState(
                && Harness == other.Harness
                && InputTokens == other.InputTokens
                && OutputTokens == other.OutputTokens
+               && CacheReadTokens == other.CacheReadTokens
+               && CacheWriteTokens == other.CacheWriteTokens
                && SequenceEqualOrBothEmpty(ToolCalls, other.ToolCalls)
                && SequenceEqualOrBothEmpty(UpdatedNodes, other.UpdatedNodes);
     }
@@ -68,6 +72,8 @@ internal record MessageBubbleState(
         hash.Add(Harness);
         hash.Add(InputTokens);
         hash.Add(OutputTokens);
+        hash.Add(CacheReadTokens);
+        hash.Add(CacheWriteTokens);
         foreach (var tc in ToolCalls ?? [])
             hash.Add(tc);
         foreach (var un in UpdatedNodes ?? [])

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -287,7 +287,11 @@ else
                                 }
                                 @if (state.InputTokens.HasValue || state.OutputTokens.HasValue)
                                 {
-                                    <span class="thread-msg-tokens" title="Token usage">@($"{state.InputTokens ?? 0:N0} in / {state.OutputTokens ?? 0:N0} out")</span>
+                                    var cachedTok = (state.CacheReadTokens ?? 0) + (state.CacheWriteTokens ?? 0);
+                                    <span class="thread-msg-tokens"
+                                          title="@($"Token usage — {state.InputTokens ?? 0:N0} input (incl. {cachedTok:N0} cached) / {state.OutputTokens ?? 0:N0} output")">
+                                        @($"{state.InputTokens ?? 0:N0} in / {state.OutputTokens ?? 0:N0} out")@(cachedTok > 0 ? $" (⚡{cachedTok:N0})" : "")
+                                    </span>
                                 }
                             </div>
                         }

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -3492,8 +3492,12 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             ? itProp.GetInt32() : null;
         int? outputTokens = je.TryGetProperty("outputTokens", out var otProp) && otProp.ValueKind == JsonValueKind.Number
             ? otProp.GetInt32() : null;
+        int? cacheReadTokens = je.TryGetProperty("cacheReadTokens", out var crProp) && crProp.ValueKind == JsonValueKind.Number
+            ? crProp.GetInt32() : null;
+        int? cacheWriteTokens = je.TryGetProperty("cacheWriteTokens", out var cwProp) && cwProp.ValueKind == JsonValueKind.Number
+            ? cwProp.GetInt32() : null;
 
-        var newState = new MessageBubbleState(role, author, modelName, timestamp, text, toolCalls, updatedNodes, status, completedAt, harness, inputTokens, outputTokens);
+        var newState = new MessageBubbleState(role, author, modelName, timestamp, text, toolCalls, updatedNodes, status, completedAt, harness, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens);
         var prev = messageStates.GetValueOrDefault(id);
         if (Equals(prev, newState)) return;
 

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadTokenChip.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadTokenChip.razor
@@ -25,8 +25,12 @@
                 {
                     <span class="thread-token-chip-row">
                         <span class="thread-token-chip-model" title="@row.Model">@row.Model</span>
-                        <span title="Input tokens">↑@FormatCompact(row.Input)</span>
+                        <span title="Input tokens (incl. cached)">↑@FormatCompact(row.Input)</span>
                         <span title="Output tokens">↓@FormatCompact(row.Output)</span>
+                        @if (row.CacheRead > 0 || row.CacheWrite > 0)
+                        {
+                            <span title="Cached prompt tokens (read + write) — a subset of input">⚡@FormatCompact(row.CacheRead + row.CacheWrite)</span>
+                        }
                     </span>
                 }
             </span>

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadTokenChip.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadTokenChip.razor.cs
@@ -41,13 +41,19 @@ public partial class ThreadTokenChip : ComponentBase, IDisposable
 
     private long _totalInput;
     private long _totalOutput;
+    private long _totalCacheRead;
+    private long _totalCacheWrite;
     private decimal _totalCost;
     private IReadOnlyList<ModelRow> _rows = [];
 
     private bool HasData => _rows.Count > 0;
 
+    // When any prompt caching happened, surface how much of the input was cache hits — the whole
+    // point of the fix is that this used to be invisible. e.g. "↑1.2M ↓3.4k ⚡0.9M cached · $2.10".
     private string ChipLabel
-        => $"↑{FormatCompact(_totalInput)} ↓{FormatCompact(_totalOutput)} · {FormatCost(_totalCost)}";
+        => _totalCacheRead > 0 || _totalCacheWrite > 0
+            ? $"↑{FormatCompact(_totalInput)} ↓{FormatCompact(_totalOutput)} ⚡{FormatCompact(_totalCacheRead + _totalCacheWrite)} cached · {FormatCost(_totalCost)}"
+            : $"↑{FormatCompact(_totalInput)} ↓{FormatCompact(_totalOutput)} · {FormatCost(_totalCost)}";
 
     /// <summary>
     /// Resolves the logger for the chip. Subscription setup is deferred to
@@ -102,6 +108,8 @@ public partial class ThreadTokenChip : ComponentBase, IDisposable
     {
         long totalIn = 0;
         long totalOut = 0;
+        long totalCacheRead = 0;
+        long totalCacheWrite = 0;
         decimal cost = 0m;
         var rows = new List<ModelRow>();
         foreach (var node in nodes ?? [])
@@ -111,12 +119,20 @@ public partial class ThreadTokenChip : ComponentBase, IDisposable
                 continue;
             totalIn += usage.InputTokens;
             totalOut += usage.OutputTokens;
-            cost += ModelPricing.Default(usage.Model)?.Cost(usage.InputTokens, usage.OutputTokens) ?? 0m;
-            rows.Add(new ModelRow(usage.Model, usage.InputTokens, usage.OutputTokens));
+            totalCacheRead += usage.CacheReadTokens;
+            totalCacheWrite += usage.CacheWriteTokens;
+            // Cache-aware cost: cache reads bill at the reduced rate, writes at the premium — pricing
+            // the whole input at the standard rate would badly over-state a cache-heavy agent's cost.
+            cost += ModelPricing.Default(usage.Model)
+                ?.Cost(usage.InputTokens, usage.OutputTokens, usage.CacheReadTokens, usage.CacheWriteTokens) ?? 0m;
+            rows.Add(new ModelRow(usage.Model, usage.InputTokens, usage.OutputTokens,
+                usage.CacheReadTokens, usage.CacheWriteTokens));
         }
 
         _totalInput = totalIn;
         _totalOutput = totalOut;
+        _totalCacheRead = totalCacheRead;
+        _totalCacheWrite = totalCacheWrite;
         _totalCost = cost;
         _rows = rows
             .OrderByDescending(r => r.Input + r.Output)
@@ -174,5 +190,5 @@ public partial class ThreadTokenChip : ComponentBase, IDisposable
         _subscription = null;
     }
 
-    private sealed record ModelRow(string Model, long Input, long Output);
+    private sealed record ModelRow(string Model, long Input, long Output, long CacheRead, long CacheWrite);
 }

--- a/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadTokenUsageTest.cs
@@ -41,6 +41,10 @@ public class ThreadTokenUsageTest : AITestBase
     private const int InTokens = 137;
     private const int OutTokens = 89;
     private const int TotalTokens = InTokens + OutTokens; // 226
+    // Prompt-cache subset of InTokens (137 includes the 40 read + 25 write, per the UsageTokens
+    // convention). Distinct so a test can tell read from write.
+    private const int CacheReadTokens = 40;
+    private const int CacheWriteTokens = 25;
 
     private const string TestUser = "rbuergi@systemorph.com";
     // Streamed AFTER the usage update — when this lands on the cell, the streaming loop has
@@ -60,6 +64,7 @@ public class ThreadTokenUsageTest : AITestBase
                 services.AddSingleton<IChatClientFactory>(new UsageNoTotalChatClientFactory());
                 services.AddSingleton<IChatClientFactory>(new UsageBlockChatClientFactory());
                 services.AddSingleton<IChatClientFactory>(new UsageThrowChatClientFactory());
+                services.AddSingleton<IChatClientFactory>(new UsageCacheChatClientFactory());
                 return services;
             });
 
@@ -210,6 +215,32 @@ public class ThreadTokenUsageTest : AITestBase
         cell.TotalTokens.Should().Be(TotalTokens, "derived total = in + out");
     }
 
+    // ─── Prompt cache (pins the dropped cache-token hole across providers) ───
+
+    [Fact]
+    public async Task CompletedRound_WithPromptCache_RecordsCacheTokens_OnCellAndSatellite()
+    {
+        var threadPath = await SeedThread();
+        var client = GetClient();
+        client.SubmitMessage(threadPath, "cache me", modelName: "usage-cache-model", createdBy: TestUser);
+
+        var thread = await WaitForThread(threadPath,
+            t => t.Status == ThreadExecutionStatus.Idle && t.Messages.Count >= 2, 20_000);
+
+        // The cache read/write counts must survive from UsageDetails.AdditionalCounts (mixed provider
+        // keys) all the way onto the per-model satellite — they used to be dropped entirely.
+        var usage = await WaitForUsage(threadPath, "usage_cache_model",
+            u => u.CacheReadTokens == CacheReadTokens && u.CacheWriteTokens == CacheWriteTokens, 10_000);
+        usage.InputTokens.Should().Be(InTokens, "input is the full prompt total; cache is a subset");
+        usage.OutputTokens.Should().Be(OutTokens);
+
+        var cell = await WaitForCell(threadPath, thread.Messages[^1],
+            m => m.Status == ThreadMessageStatus.Completed, 10_000);
+        cell.CacheReadTokens.Should().Be(CacheReadTokens);
+        cell.CacheWriteTokens.Should().Be(CacheWriteTokens);
+        cell.InputTokens.Should().Be(InTokens);
+    }
+
     // ─── Helpers ───
 
     private async Task<string> SeedThread()
@@ -259,7 +290,7 @@ public class ThreadTokenUsageTest : AITestBase
     /// the round CTS until cancelled (→ OperationCanceledException → Cancelled path), or throw
     /// (→ Error path). <paramref name="reportTotal"/> toggles whether TotalTokenCount is reported.
     /// </summary>
-    private sealed class UsageChatClient(bool reportTotal, PostUsage mode) : IChatClient
+    private sealed class UsageChatClient(bool reportTotal, PostUsage mode, bool emitCache = false) : IChatClient
     {
         public ChatClientMetadata Metadata => new("UsageProvider");
 
@@ -274,15 +305,25 @@ public class ThreadTokenUsageTest : AITestBase
         {
             // Text first — the round is genuinely streaming past the Executing flip.
             yield return new ChatResponseUpdate(ChatRole.Assistant, "Working. ");
-            // The usage report — this is what ThreadExecution aggregates.
+            // The usage report — this is what ThreadExecution aggregates. When emitCache is set, the
+            // cache breakdown rides in AdditionalCounts under MIXED provider keys (OpenAI's
+            // "InputTokenDetails.CachedTokenCount" for read, Claude's "CacheCreationInputTokens" for
+            // write) so the test proves UsageTokens.SplitCache is provider-agnostic.
+            var details = new UsageDetails
+            {
+                InputTokenCount = InTokens,
+                OutputTokenCount = OutTokens,
+                TotalTokenCount = reportTotal ? TotalTokens : (long?)null
+            };
+            if (emitCache)
+                details.AdditionalCounts = new AdditionalPropertiesDictionary<long>
+                {
+                    ["InputTokenDetails.CachedTokenCount"] = CacheReadTokens,
+                    [UsageTokens.CacheWriteKey] = CacheWriteTokens
+                };
             yield return new ChatResponseUpdate(ChatRole.Assistant, new AIContent[]
             {
-                new UsageContent(new UsageDetails
-                {
-                    InputTokenCount = InTokens,
-                    OutputTokenCount = OutTokens,
-                    TotalTokenCount = reportTotal ? TotalTokens : (long?)null
-                })
+                new UsageContent(details)
             });
             // Post-usage marker — once it lands on the cell, the usage above was provably pulled.
             yield return new ChatResponseUpdate(ChatRole.Assistant, UsageMarker);
@@ -364,5 +405,12 @@ public class ThreadTokenUsageTest : AITestBase
         public override string Name => "UsageThrowFactory";
         public override IReadOnlyList<string> Models => ["usage-error-model"];
         protected override IChatClient CreateClient() => new UsageChatClient(reportTotal: true, PostUsage.Throw);
+    }
+
+    private sealed class UsageCacheChatClientFactory : UsageFactoryBase
+    {
+        public override string Name => "UsageCacheFactory";
+        public override IReadOnlyList<string> Models => ["usage-cache-model"];
+        protected override IChatClient CreateClient() => new UsageChatClient(reportTotal: true, PostUsage.Complete, emitCache: true);
     }
 }


### PR DESCRIPTION
## Problem

The in/out token counter in the chat UI **dropped prompt-cache tokens entirely**, so it under-reported the real, billable context — a colleague flagged an extraction agent burning millions of tokens per report while the counter showed ~100k.

Root cause is shared across every provider:
- **OpenAI / OpenRouter / Azure OpenAI / Azure Foundry** already report cached tokens in `UsageDetails.AdditionalCounts` — the central aggregator (`ThreadExecution`) never read it.
- **Native Claude** (`AzureClaudeChatClient`) dropped `cache_read_input_tokens` / `cache_creation_input_tokens` at JSON deserialization, and sent no `cache_control`, so Anthropic prompt caching wasn't even enabled.

## Change

- **`UsageTokens`** (new): canonical `AdditionalCounts` keys + provider-agnostic `SplitCache()` matching OpenAI's `…CachedTokenCount` **and** the Claude keys.
- **`ThreadExecution`**: reads cache read/write from `AdditionalCounts`, accumulates across tool-call rounds, stamps the cell + all three terminal paths (Completed / Cancelled / Error).
- **`TokenUsage` / `ThreadMessage`**: new `CacheReadTokens` / `CacheWriteTokens` (subsets of input).
- **`AzureClaudeChatClient`**: parses the cache counts, **normalizes** input to include them (one consistent convention: `Input` = full prompt total, cache = subset), emits the breakdown, and sends **`cache_control` breakpoints on tools + system** to actually enable Anthropic caching (the real cost win — cache reads bill at 0.1×).
- **`ModelPricing`**: cache-aware `Cost` overload (reads 0.1×, writes 1.25× of input by default).
- **`ThreadTokenChip` / `ThreadChatView`**: surface `⚡ cached` in the chip + per-message badge; cost priced cache-aware.
- **Test**: new end-to-end case proving mixed-provider cache keys survive to the cell + satellite.

## Design note

Normalized the Claude wire (where `input_tokens` *excludes* cache) to the OpenAI convention (`prompt_tokens` *includes* cache) so one meaning and one cost formula hold across all providers.

## Verification

- `dotnet build -c Release -warnaserror -p:CIRun=true` clean (0 warnings) for `MeshWeaver.AI`, `MeshWeaver.AI.AzureFoundry`, `MeshWeaver.Blazor.Portal`, `MeshWeaver.AI.Test`.
- `ThreadTokenUsageTest` — 6/6 pass (5 existing + new cache test).

## Not covered / flag

- The `cache_control` enablement is standard, GA, opt-in (Anthropic skips caching below the size minimum, no error), but its runtime effect wasn't verifiable without a live Anthropic/Azure Foundry endpoint — worth a smoke test post-merge.
- ClaudeCode / Copilot CLI harnesses still emit no usage at all (subscription-billed) — a separate, pre-existing gap, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)