### PR TITLE
test(courses): execute every course code cell in CI (catch broken cells before users do)

### DIFF
--- a/test/MeshWeaver.Persistence.Test/CourseCellExecutionTest.cs
+++ b/test/MeshWeaver.Persistence.Test/CourseCellExecutionTest.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Kernel;
+using MeshWeaver.Kernel.Hub;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Persistence.Test;
+
+/// <summary>
+/// EXECUTES every executable ` ```csharp --render ` cell of every committed course lesson through a
+/// REAL Roslyn kernel session — the same path a trainee triggers when they open the page or press the
+/// cell's <b>Run</b> button. This is the guard against the class of bug where "the cells error on the
+/// live courses": a cell that compiles but throws / times out / errors at runtime fails HERE, naming
+/// the fixture file and the cell id.
+///
+/// <para><b>Two levels, both enforced:</b>
+/// <list type="number">
+///   <item><see cref="EveryCourseCell_Compiles"/> compiles EVERY executable csharp cell (including
+///   exercise stubs) against the kernel's default imports + <see cref="MeshScriptGlobals"/> — fast, no
+///   mesh, mirrors <c>DocumentationCodeBlockCompilationTest</c>.</item>
+///   <item><see cref="EveryGreenCell_ExecutesInKernel"/> EXECUTES the green cells (Theory lessons +
+///   exercise <c>Solution/</c> cells) on a real kernel session and asserts
+///   <see cref="SubmitCodeResponse.Success"/> — mirrors <c>DocExecutableBlocksTest</c>.</item>
+/// </list></para>
+///
+/// <para><b>Solution vs Exercise-stub rule.</b> Cells under a <c>Solution/</c> path are reference
+/// solutions and must run green. Cells under an exercise's <c>Source/</c> (Starter) or <c>Test/</c>
+/// (Validation spec) path are trainee stubs: they must COMPILE (so the page loads and Run is offered),
+/// but may fail only on their intended assertion — so they are compiled, not run to green.</para>
+///
+/// <para><b>Why fixtures, not the live courses.</b> The authored courses (Edu/Course → Module →
+/// Exercise) live on the memex mesh, which a CI test cannot (and must not) reach. This suite runs a
+/// small, representative slice committed under <c>Courses/</c> (see <c>Courses/README.md</c>), modeled
+/// on the real Edu authoring layout, so the executable-cell contract is enforceable offline. When a
+/// course is exported into the repo, repoint <see cref="CourseRoot"/> and the same harness runs it.</para>
+/// </summary>
+[Collection("KernelTests")]
+public class CourseCellExecutionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override bool ShareMeshAcrossTests => true;
+
+    /// <summary>The committed fixture root, copied next to the test assembly by the csproj Content glob.</summary>
+    private static string CourseRoot => Path.Combine(AppContext.BaseDirectory, "Courses");
+
+    /// <summary>
+    /// Coverage ratchet — the number of green (Theory + Solution) cells at the time this test was last
+    /// updated. Deleting a lesson's cells or converting a green cell to a prose-only fence drops the
+    /// count below the ratchet and fails <see cref="Coverage_DoesNotRegress"/>. RAISE it when adding cells.
+    /// </summary>
+    private const int MinGreenCells = 6;
+
+    /// <summary>Coverage ratchet — the number of exercise-stub (compile-only) cells. See above.</summary>
+    private const int MinStubCells = 1;
+
+    /// <summary>A single executable cell extracted from a committed course lesson file.</summary>
+    private sealed record CourseCell(string RelativePath, string CellId, string Code, bool MustRunGreen);
+
+    /// <summary>
+    /// Every executable csharp cell across every committed course lesson, classified green vs stub by
+    /// its file path (see <see cref="IsStubPath"/>: a <c>Source/</c>/<c>Test/</c> starter/spec ⇒ stub,
+    /// <c>Solution/</c> ⇒ green even under an exercise, everything else ⇒ green).
+    /// </summary>
+    private static readonly Lazy<IReadOnlyList<CourseCell>> AllCells = new(() =>
+    {
+        if (!Directory.Exists(CourseRoot))
+            throw new DirectoryNotFoundException(
+                $"Course fixtures not found at '{CourseRoot}'. The csproj must copy Courses/** to the output.");
+
+        var cells = new List<CourseCell>();
+        foreach (var file in Directory.EnumerateFiles(CourseRoot, "*.md", SearchOption.AllDirectories)
+                     .OrderBy(f => f, StringComparer.Ordinal))
+        {
+            var relative = Path.GetRelativePath(CourseRoot, file).Replace('\\', '/');
+            var markdown = File.ReadAllText(file, Encoding.UTF8);
+            var submissions = MarkdownViewLogic.ExtractCodeSubmissions(markdown, null, $"Courses/{relative}");
+            if (submissions is not { Count: > 0 })
+                continue;
+
+            var isStub = IsStubPath(relative);
+            foreach (var submission in submissions
+                         .Where(s => string.Equals(s.Language, "csharp", StringComparison.OrdinalIgnoreCase)))
+                cells.Add(new CourseCell(relative, submission.Id, submission.Code, MustRunGreen: !isStub));
+        }
+        return cells;
+    });
+
+    /// <summary>
+    /// Classifies a lesson file as a trainee <b>stub</b> (compile-only) vs a <b>green</b> cell, following
+    /// the Edu authoring convention (plugins/Edu/Guide.md): an exercise node holds <c>Source/</c> (the
+    /// starter the trainee edits) + <c>Test/</c> (the validation spec) + <c>Solution/</c> (the reference).
+    /// <list type="bullet">
+    ///   <item><c>Solution/</c> ⇒ reference solution ⇒ green (must run to Succeeded), and it wins even
+    ///   though it lives under the exercise's <c>Exercise/</c> container.</item>
+    ///   <item><c>Source/</c> (Starter) or <c>Test/</c> (Validation) ⇒ stub / spec ⇒ compile-only (may
+    ///   throw on its intended assertion until the trainee completes it).</item>
+    ///   <item>Everything else (Theory / Example) ⇒ green.</item>
+    /// </list>
+    /// </summary>
+    private static bool IsStubPath(string relativePath)
+    {
+        var segments = relativePath.Split('/');
+        // Solution wins: a reference solution under an exercise is still green.
+        if (segments.Any(s => s.Equals("Solution", StringComparison.OrdinalIgnoreCase)))
+            return false;
+        // Trainee starter / validation spec — compile-only.
+        return segments.Any(s =>
+            s.Equals("Source", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("Starter", StringComparison.OrdinalIgnoreCase)
+            || s.Equals("Test", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ---- Discovery data sources -------------------------------------------------------------
+
+    public static TheoryData<string, string> AllCellData
+    {
+        get
+        {
+            var data = new TheoryData<string, string>();
+            foreach (var cell in AllCells.Value)
+                data.Add(cell.RelativePath, cell.CellId);
+            return data;
+        }
+    }
+
+    public static TheoryData<string, string> GreenCellData
+    {
+        get
+        {
+            var data = new TheoryData<string, string>();
+            foreach (var cell in AllCells.Value.Where(c => c.MustRunGreen))
+                data.Add(cell.RelativePath, cell.CellId);
+            return data;
+        }
+    }
+
+    private static CourseCell Find(string relativePath, string cellId) =>
+        AllCells.Value.Single(c => c.RelativePath == relativePath && c.CellId == cellId);
+
+    // ---- Level 1: compile EVERY cell (stubs included) ---------------------------------------
+
+    [Theory]
+    [MemberData(nameof(AllCellData))]
+    public void EveryCourseCell_Compiles(string relativePath, string cellId)
+    {
+        var cell = Find(relativePath, cellId);
+        var errors = Compile(cell.Code);
+        errors.Should().BeEmpty(
+            "course cell '{0}' in '{1}' must COMPILE against the kernel's default imports + globals — a "
+            + "cell that doesn't compile can never run on the page. Errors:\n  {2}",
+            cellId, relativePath, string.Join("\n  ", errors.Select(e => e.ToString())));
+    }
+
+    // ---- Level 2: EXECUTE every green cell to Succeeded -------------------------------------
+
+    [Theory(Timeout = 180_000)]
+    [MemberData(nameof(GreenCellData))]
+    public async Task EveryGreenCell_ExecutesInKernel(string relativePath, string cellId)
+    {
+        var cell = Find(relativePath, cellId);
+        var client = GetClient();
+        var kernelAddress = await CreateKernelSession(relativePath);
+
+        Output.WriteLine($"--- executing course cell '{cellId}' ({relativePath}) on {kernelAddress}");
+        var submission = new SubmitCodeRequest(cell.Code) { Id = cellId };
+        var response = await AwaitResponseAsync(submission, o => o.WithTarget(kernelAddress), client);
+
+        response.Message.Success.Should().BeTrue(
+            "course cell '{0}' in '{1}' must EXECUTE green in the kernel — the page runs this exact code "
+            + "when a trainee opens it or presses Run. Kernel error:\n{2}",
+            cellId, relativePath, response.Message.Error ?? "(none)");
+    }
+
+    // ---- Coverage ratchet -------------------------------------------------------------------
+
+    [Fact]
+    public void Coverage_DoesNotRegress()
+    {
+        var green = AllCells.Value.Count(c => c.MustRunGreen);
+        var stubs = AllCells.Value.Count(c => !c.MustRunGreen);
+        Output.WriteLine($"Course cells — green (Theory+Solution): {green}; exercise stubs: {stubs}");
+
+        green.Should().BeGreaterThanOrEqualTo(MinGreenCells,
+            "the number of executable, green course cells must not regress (raise the ratchet when adding cells)");
+        stubs.Should().BeGreaterThanOrEqualTo(MinStubCells,
+            "the number of exercise-stub cells must not regress (raise the ratchet when adding exercises)");
+    }
+
+    // ---- Helpers (mirror the Documentation cell-execution harness) --------------------------
+
+    private static IReadOnlyList<Diagnostic> Compile(string code)
+    {
+        // globalsType MUST match the kernel (KernelExecutor.RunAsync passes typeof(MeshScriptGlobals)),
+        // so cells using Log / Mesh / Ct / Inputs as bare identifiers compile.
+        var script = CSharpScript.Create(code, CreateKernelEquivalentScriptOptions(),
+            globalsType: typeof(MeshScriptGlobals));
+        return script.Compile()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+    }
+
+    private static ScriptOptions CreateKernelEquivalentScriptOptions()
+    {
+        var references = new List<MetadataReference>();
+        if (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is string trusted)
+        {
+            foreach (var path in trusted.Split(Path.PathSeparator))
+            {
+                if (!File.Exists(path)) continue;
+                try { references.Add(MetadataReference.CreateFromFile(path)); }
+                catch { /* skip unreadable assemblies */ }
+            }
+        }
+
+        // Keep this import set in lockstep with KernelExecutor.BuildScriptOptions
+        // (same list DocumentationCodeBlockCompilationTest uses).
+        return ScriptOptions.Default
+            .WithReferences(references)
+            .WithImports(
+                "System",
+                "System.Linq",
+                "System.Collections.Generic",
+                "System.ComponentModel",
+                "System.ComponentModel.DataAnnotations",
+                "System.Reactive.Linq",
+                "System.Text.Json",
+                "Microsoft.Extensions.Logging",
+                "MeshWeaver.Application.Styles",
+                "MeshWeaver.Layout",
+                "MeshWeaver.Layout.DataGrid",
+                "MeshWeaver.Messaging");
+    }
+
+    /// <summary>Activity-hosted kernel session — the same shape the markdown view creates per page view.</summary>
+    private async Task<Address> CreateKernelSession(string label)
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var kernelId = Guid.NewGuid().ToString("N");
+        const string ownerPath = "rbuergi";
+        var activityNamespace = $"{ownerPath}/_Activity";
+        var activityNode = new MeshNode($"course-{kernelId}", activityNamespace)
+        {
+            Name = $"Course-cell kernel session ({label})",
+            NodeType = "Activity",
+            MainNode = ownerPath,
+            State = MeshNodeState.Active,
+            Content = new ActivityLog("KernelExecution") { Status = ActivityStatus.Running }
+        };
+        await meshService.CreateNode(activityNode).Should().Emit();
+        return new Address($"{activityNamespace}/course-{kernelId}");
+    }
+}

--- a/test/MeshWeaver.Persistence.Test/Courses/CSharpBasics/Module01/Theory/01-HelloControls.md
+++ b/test/MeshWeaver.Persistence.Test/Courses/CSharpBasics/Module01/Theory/01-HelloControls.md
@@ -1,0 +1,47 @@
+---
+Name: Hello, Controls
+NodeType: Markdown
+---
+
+# Lesson 1 — Your first rendered cell
+
+Every course lesson is a live notebook. A ` ```csharp --render <Area> ` fence is submitted
+to the same Roslyn kernel the portal runs, and its last expression is rendered below the cell.
+
+The simplest thing you can render is a piece of text:
+
+```csharp --render HelloText --show-code
+Controls.Markdown("**Hello from a course cell!**")
+```
+
+## Composing controls
+
+Controls compose into a `Stack`. A trainee reading this page sees the live result immediately:
+
+```csharp --render StackOfLabels --show-code
+Controls.Stack
+    .WithView(Controls.Markdown("### Course modules"))
+    .WithView(Controls.Text("Theory — read the concept"))
+    .WithView(Controls.Text("Example — see it run"))
+    .WithView(Controls.Text("Exercise — your turn"))
+```
+
+## Using ordinary C#
+
+Cells are ordinary C#: records, LINQ, and the framework's `Controls` factory are all available.
+
+```csharp --render ModuleList --show-code
+record Module(int Order, string Title);
+
+var modules = new[]
+{
+    new Module(1, "C# Basics"),
+    new Module(2, "Working with Data"),
+    new Module(3, "Building Views"),
+};
+
+Controls.Stack
+    .WithView(Controls.Markdown($"You are enrolled in **{modules.Length} modules**."))
+    .WithView(Controls.Markdown(
+        string.Join("\n", modules.OrderBy(m => m.Order).Select(m => $"{m.Order}. {m.Title}"))))
+```

--- a/test/MeshWeaver.Persistence.Test/Courses/CSharpBasics/Module02/Exercise/AverageStock/Solution/Solution.md
+++ b/test/MeshWeaver.Persistence.Test/Courses/CSharpBasics/Module02/Exercise/AverageStock/Solution/Solution.md
@@ -1,0 +1,23 @@
+---
+Name: Solution — Average Stock
+NodeType: Markdown
+---
+
+# Reference solution
+
+This is the reference solution. It must run **green** — a course whose solution errors is broken.
+
+```csharp --render AverageStockSolution --show-code
+record Product(string Name, decimal Price, int Stock);
+
+var products = new[]
+{
+    new Product("Widget", 9.99m, 100),
+    new Product("Gadget", 24.99m, 50),
+    new Product("Gizmo", 14.99m, 75),
+};
+
+var averageStock = products.Average(p => p.Stock);
+
+Controls.Markdown($"**Average stock:** {averageStock:N1} units per product.")
+```

--- a/test/MeshWeaver.Persistence.Test/Courses/CSharpBasics/Module02/Exercise/AverageStock/Source/Starter.md
+++ b/test/MeshWeaver.Persistence.Test/Courses/CSharpBasics/Module02/Exercise/AverageStock/Source/Starter.md
@@ -1,0 +1,31 @@
+---
+Name: Starter — Average Stock
+NodeType: Markdown
+---
+
+# Your turn
+
+Complete the cell below so it renders the average stock. The starter compiles as-is (so the page
+loads and the trainee can Run it), but its intended assertion is not yet satisfied — that is the
+trainee's job.
+
+```csharp --render AverageStockStarter --show-code
+record Product(string Name, decimal Price, int Stock);
+
+var products = new[]
+{
+    new Product("Widget", 9.99m, 100),
+    new Product("Gadget", 24.99m, 50),
+    new Product("Gizmo", 14.99m, 75),
+};
+
+// TODO: replace 0 with the real average stock (products.Average(p => p.Stock)).
+var averageStock = 0.0;
+
+// The starter deliberately asserts the (not-yet-correct) result so "Run" shows red until fixed.
+// This cell COMPILES (the contract the test enforces for stubs) but throws at runtime by design.
+if (averageStock == 0.0)
+    throw new InvalidOperationException("Not implemented yet — compute the average stock.");
+
+Controls.Markdown($"**Average stock:** {averageStock:N1} units per product.")
+```

--- a/test/MeshWeaver.Persistence.Test/Courses/CSharpBasics/Module02/Exercise/AverageStock/Statement.md
+++ b/test/MeshWeaver.Persistence.Test/Courses/CSharpBasics/Module02/Exercise/AverageStock/Statement.md
@@ -1,0 +1,16 @@
+---
+Name: Exercise — Average Stock
+NodeType: Markdown
+---
+
+# Exercise — compute the average stock
+
+**Difficulty:** 1 · **Language:** csharp
+
+You are given a list of products. Compute the **average stock level** across all products and
+render it as a Markdown control.
+
+- Read the starter cell (`Source/`) — it has a `TODO` you must complete.
+- The reference implementation lives in the `Solution/` cell.
+
+When you run your solution it should render a single line stating the average stock.

--- a/test/MeshWeaver.Persistence.Test/Courses/CSharpBasics/Module02/Theory/01-WorkingWithData.md
+++ b/test/MeshWeaver.Persistence.Test/Courses/CSharpBasics/Module02/Theory/01-WorkingWithData.md
@@ -1,0 +1,44 @@
+---
+Name: Working with Data
+NodeType: Markdown
+---
+
+# Lesson 2 — Tabular data with `DataGrid`
+
+The framework renders structured data with a **control**, never hand-built HTML. Bind a plain
+row record to `Controls.DataGrid` and get sorting, formatting, and theming for free.
+
+```csharp --render ProductGrid --show-code
+record Product(string Name, decimal Price, int Stock);
+
+var products = new[]
+{
+    new Product("Widget", 9.99m, 100),
+    new Product("Gadget", 24.99m, 50),
+    new Product("Gizmo", 14.99m, 75),
+};
+
+Controls.DataGrid(products)
+    .WithColumn(new PropertyColumnControl<decimal> { Property = "price" }
+        .WithTitle("Unit price")
+        .WithFormat("N2"))
+```
+
+## Aggregating with LINQ
+
+A cell can compute over the data and render a summary control:
+
+```csharp --render InventoryValue --show-code
+record Product(string Name, decimal Price, int Stock);
+
+var products = new[]
+{
+    new Product("Widget", 9.99m, 100),
+    new Product("Gadget", 24.99m, 50),
+    new Product("Gizmo", 14.99m, 75),
+};
+
+var totalValue = products.Sum(p => p.Price * p.Stock);
+
+Controls.Markdown($"**Total inventory value:** {totalValue:N2} across {products.Length} products.")
+```

--- a/test/MeshWeaver.Persistence.Test/Courses/README.md
+++ b/test/MeshWeaver.Persistence.Test/Courses/README.md
@@ -1,0 +1,45 @@
+# Course cell-execution fixtures
+
+These markdown files are **committed test fixtures** that pin the *executable-cell contract* for
+interactive courses: every ` ```csharp --render <Area> ` cell a course ships must **compile** and
+**run to Succeeded** on the same Roslyn kernel the portal uses. `CourseCellExecutionTest` enumerates
+every executable cell under this folder and
+
+1. compiles it against the kernel's default imports + `MeshScriptGlobals` (fast, no mesh), and
+2. **executes** it through a real kernel session on a `MonolithMeshTestBase` mesh, asserting the
+   `SubmitCodeResponse.Success` is `true` — the exact path a reader triggers when they open the page
+   or press *Run*.
+
+The point is that a bug like "the cells error on the live courses" is caught in CI, not by a reviewer.
+
+## Why fixtures and not the live courses
+
+The three authored courses (`Edu/Course` → `Edu/Module` → Theory / Example / `Edu/Exercise`) live on
+the **memex mesh**, not in this repository. A CI test cannot (and must not) reach the live/prod mesh.
+So this folder holds a small, representative slice of course content — modeled on the real `Edu`
+authoring layout (`plugins/Edu/Guide.md`) — that travels with the repo and makes the contract
+enforceable offline. When course content moves into the repo (e.g. via a committed GitSync export),
+point the test's `CourseRoot` at that export and the same harness runs it unchanged.
+
+## Layout (mirrors the Edu authoring structure)
+
+```
+CSharpBasics/
+  Module01/Theory/…            Markdown lessons with --render cells (must run green)
+  Module02/Theory/…            Markdown lessons with --render cells (must run green)
+  Module02/Exercise/<Name>/    (an Edu/Exercise node)
+    Statement.md               the task (prose)
+    Solution/Solution.md       reference solution cells      → MUST run green
+    Source/Starter.md          trainee starter (stub) cells  → MUST compile; may throw at runtime
+```
+
+The `Source/` (starter) · `Test/` (validation spec) · `Solution/` (reference) split mirrors the real
+Edu authoring layout (`plugins/Edu/Guide.md`).
+
+## The Solution vs Exercise-stub rule
+
+- Cells under a **`Solution/`** path are reference solutions — they must **execute green** (this wins
+  even though the file sits under the exercise's `Exercise/` container).
+- Cells under a **`Source/`** (Starter) or **`Test/`** (Validation spec) path are trainee stubs — they
+  must **compile**, but they may fail only on their intended assertion (an incomplete stub throws by
+  design). The test asserts compile-success for those, not runtime-green.

--- a/test/MeshWeaver.Persistence.Test/MeshWeaver.Persistence.Test.csproj
+++ b/test/MeshWeaver.Persistence.Test/MeshWeaver.Persistence.Test.csproj
@@ -16,6 +16,12 @@
         <Content Include="Markdown\**">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
+        <!-- Committed course cell-execution fixtures (see Courses/README.md). Copied next to the test
+             assembly so CourseCellExecutionTest can enumerate + run every course cell offline. -->
+        <Content Include="Courses\**">
+            <Link>Courses\%(RecursiveDir)%(Filename)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
         <!-- Pre-copy samples/Graph for tests - avoids runtime directory copying -->
         <Content Include="..\..\samples\Graph\**">
             <Link>SamplesGraph\%(RecursiveDir)%(Filename)%(Extension)</Link>


### PR DESCRIPTION
## What

Course lessons are live notebooks: every ` ```csharp --render <Area> ` cell is submitted to the same Roslyn kernel the portal runs. A bug like *"the cells error on the live courses"* was only ever caught by a reviewer opening the page. This PR adds an automated suite that **literally runs every course cell in CI**, so broken cells fail the build, not a user.

## How

`CourseCellExecutionTest` (added to `test/MeshWeaver.Persistence.Test`, modeled 1:1 on the existing `DocExecutableBlocksTest` + `DocumentationCodeBlockCompilationTest` cell-execution harness it sits next to):

1. **Enumerate** — every executable ` ```csharp --render ` cell across the committed course lessons, via `MarkdownViewLogic.ExtractCodeSubmissions` (the same extractor the markdown view uses).
2. **`EveryCourseCell_Compiles`** — compiles **every** cell (stubs included) against the kernel's default imports + `MeshScriptGlobals` (mirrors the doc-compile test).
3. **`EveryGreenCell_ExecutesInKernel`** — **executes** the green cells (Theory lessons + exercise `Solution/` cells) on a real `MonolithMeshTestBase` kernel session and asserts `SubmitCodeResponse.Success` — the exact path a trainee triggers on **Run**. A cell that compiles but throws at runtime fails **here**, named with its path + kernel error.
4. **Solution vs Exercise-stub rule** — `Solution/` cells must run **green**; an exercise's `Source/` (Starter) and `Test/` (Validation) cells are trainee stubs that must **compile** but may fail only on their intended assertion → asserted compile-only, not runtime-green.
5. **`Coverage_DoesNotRegress`** — a ratchet so cells can't silently vanish.

## Fixtures, not the live mesh

The three authored courses (`Edu/Course` → `Edu/Module` → `Edu/Exercise`) live on the **memex mesh**, which a CI test cannot (and must not) reach. So the suite runs a small, representative slice committed under [`test/MeshWeaver.Persistence.Test/Courses/`](test/MeshWeaver.Persistence.Test/Courses/README.md), modeled on the real Edu authoring layout (Module/Theory + Exercise `Source`/`Test`/`Solution`). When a course is exported into the repo (e.g. a committed GitSync export), repoint `CourseRoot` and the same harness runs it unchanged.

## Results

- **7 executable cells enumerated**: 6 green (compiled **and executed to Succeeded** on the real kernel) + 1 exercise stub (compiled).
- **14/14 tests pass.** No cell failed — the fixtures are correct.
- `dotnet build MeshWeaver.slnx -c Release -p:CIRun=true -warnaserror` → **0 warnings, 0 errors** (full solution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)