### PR TITLE
fix(courses): graceful handling for not-yet-run cell output + unconfigured agent model

### DIFF
--- a/src/MeshWeaver.AI/TrainingSimResponder.cs
+++ b/src/MeshWeaver.AI/TrainingSimResponder.cs
@@ -2,6 +2,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using MeshWeaver.Layout;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MeshWeaver.AI;
 
@@ -54,6 +55,21 @@ public static class TrainingSimResponder
 
         return prompt => Observable.Create<PromptCellResponse>(observer =>
         {
+            // 🚨 DEGRADE GRACEFULLY when no language model is configured. Submitting a doomed round
+            // would surface the raw factory error ("ApiKey is missing for model 'glm-5.2'. Configure
+            // a ModelProvider node …") inline in the training cell — hostile on a course page whose
+            // point is to DEMONSTRATE the one-prompt-in / one-cell-out shape, not to debug config.
+            // The credential resolver already answers "is any model available?" reactively from its
+            // warm catalog snapshot (ResolveDefaultModelId → null when none resolves); when there is
+            // none, emit the calm notice instead of starting a thread. NOT a fabricated model / hard-
+            // coded key — the cell just says "configure a model to run this" and stays inert.
+            if (!IsAnyModelConfigured(hub))
+            {
+                observer.OnNext(NoModelNotice());
+                observer.OnCompleted();
+                return Disposable.Empty;
+            }
+
             var replySubscription = new SerialDisposable();
             hub.StartThread(
                 namespacePath,
@@ -67,13 +83,71 @@ public static class TrainingSimResponder
                         .Subscribe(
                             reply =>
                             {
-                                observer.OnNext(Project(reply.Message));
+                                // A round that RAN but whose reply IS the model-config error (the
+                                // factory failure surfaced as the assistant's text, not as an
+                                // OnError) must also degrade to the calm notice rather than echo the
+                                // raw "ApiKey is missing" into the cell.
+                                observer.OnNext(reply.Message is null || LooksLikeMissingModel(reply.Message.Text)
+                                    ? NoModelNotice()
+                                    : Project(reply.Message));
                                 observer.OnCompleted();
                             },
-                            observer.OnError),
+                            error =>
+                            {
+                                // A round that ERRORED with the model-config failure degrades too;
+                                // any other error still surfaces to the cell's exchange pane.
+                                if (LooksLikeMissingModel(error.Message))
+                                {
+                                    observer.OnNext(NoModelNotice());
+                                    observer.OnCompleted();
+                                }
+                                else
+                                    observer.OnError(error);
+                            }),
                 onError: error => observer.OnError(new InvalidOperationException(error)));
             return replySubscription;
         });
+    }
+
+    /// <summary>
+    /// The calm inline notice a training cell shows when no usable language model is configured —
+    /// empty code pane, a friendly explanation in the output pane. Keeps the one-prompt-in /
+    /// one-result-out SHAPE (a code pane + an output pane) so the cell still reads as a demo,
+    /// without a fabricated model or a hard-coded key.
+    /// </summary>
+    public static PromptCellResponse NoModelNotice() =>
+        new(string.Empty, Controls.Markdown(
+            "▶ **Live agent demo** — configure a language model to run this. "
+            + "_(This cell shows how an agent turns your prompt into one code cell.)_"));
+
+    /// <summary>
+    /// Reactive "is any model available?" check for the LIVE responder, off the same warm catalog
+    /// snapshot the credential resolver maintains: <c>ResolveDefaultModelId()</c> returns the lowest-
+    /// Order LanguageModel whose credentials actually resolve, or <c>null</c> when none does. When the
+    /// resolver isn't registered (a hub without the AI stack), assume a model MIGHT exist and let the
+    /// round proceed — the reply-text / OnError classification below still catches a config failure.
+    /// </summary>
+    private static bool IsAnyModelConfigured(IMessageHub hub)
+    {
+        var resolver = hub.ServiceProvider.GetService<ChatClientCredentialResolver>();
+        return resolver is null || resolver.ResolveDefaultModelId() is not null;
+    }
+
+    /// <summary>
+    /// True when <paramref name="text"/> carries the signature of a missing-model / model-creation
+    /// failure — the factory's "ApiKey is missing …" / "Configure a ModelProvider …" error, or the
+    /// agent client's "No AI model is available …" banner. Used to convert a raw config error (whether
+    /// it arrived as the reply text or as an OnError) into the calm <see cref="NoModelNotice"/> instead
+    /// of echoing it into a course cell. Deliberately narrow: only the model-config signatures, so a
+    /// genuine agent answer or a real runtime error is never masked.
+    /// </summary>
+    internal static bool LooksLikeMissingModel(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return false;
+        return text.Contains("ApiKey is missing", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("Configure a ModelProvider", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("No AI model is available", StringComparison.OrdinalIgnoreCase)
+               || text.Contains("creating it failed via factory", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Blazor/Infrastructure/PortalErrorSink.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/PortalErrorSink.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Subjects;
+using MeshWeaver.Layout;
 using MeshWeaver.Messaging;
 
 namespace MeshWeaver.Blazor.Infrastructure;
@@ -53,6 +54,20 @@ public static class PortalErrorReporting
         this MessageHubConfiguration config, PortalErrorSink sink)
         => config.WithHandler<DeliveryFailure>((_, delivery) =>
             {
+                // 🚨 A routing NotFound for a gone / not-yet-created node is benign infrastructure
+                // churn — NOT "Something went wrong". It reaches this un-awaited handler when a
+                // fire-and-forget post (a stream.Update write, or a subscribe/heartbeat/unsubscribe
+                // on an interactive-kernel Activity area — e.g. a course lesson's `--render` output
+                // at `{viewer}/_Activity/markdown-{id}` that the viewer has not run yet) targets an
+                // address the router cannot resolve. The NamedAreaView control-stream path already
+                // renders this as a quiet "no longer available" placeholder (via the same
+                // AreaErrorClassifier); the un-awaited copy that escapes here must be SWALLOWED, not
+                // shown verbatim in the global modal ("No node found at 'thomager12/_Activity/
+                // markdown-…'. Closest ancestor is 'thomager12' …"). Everything else still surfaces —
+                // a genuinely failed portal post must pop.
+                if (AreaErrorClassifier.IsRoutingNotFoundFailure(delivery.Message))
+                    return delivery.Processed();
+
                 sink.Report(Describe(delivery.Message));
                 return delivery.Processed();
             },

--- a/src/MeshWeaver.Layout/AreaErrorClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaErrorClassifier.cs
@@ -146,6 +146,31 @@ public static class AreaErrorClassifier
     }
 
     /// <summary>
+    /// True when a raw <see cref="DeliveryFailure"/> message (NOT wrapped in a
+    /// <see cref="DeliveryFailureException"/>) is a routing <b>NotFound</b> for a node/hub that no
+    /// longer exists — or has not yet been created. This is the <see cref="IsNodeGoneNotFound"/>
+    /// predicate at the raw-message layer, for the portal hub's un-awaited-<c>DeliveryFailure</c>
+    /// handler (<c>PortalErrorReporting</c>).
+    ///
+    /// <para>Why it needs a message-level twin: a fire-and-forget post (a <c>stream.Update</c> write,
+    /// a heartbeat/subscribe/unsubscribe on an interactive-kernel area, a run-cell re-post) whose
+    /// target has already been reaped returns to the portal hub as a bare <see cref="DeliveryFailure"/>
+    /// with NO awaiting callback to consume it. The <c>NamedAreaView</c> control-stream path already
+    /// classifies this gracefully (via <see cref="IsNodeGoneNotFound"/>) and renders a "no longer
+    /// available" placeholder — but the un-awaited copy escapes to the portal-wide error MODAL, which
+    /// reported it VERBATIM ("<c>No node found at 'thomager12/_Activity/markdown-…'. Closest ancestor
+    /// is 'thomager12' …</c>") the instant a fresh viewer opened a course lesson whose <c>--render</c>
+    /// output areas point at a not-yet-run per-viewer Activity. A routing NotFound for a gone /
+    /// not-yet-created node is benign infrastructure churn — it must be SWALLOWED from the modal, never
+    /// shown as "Something went wrong". Matched on the typed <see cref="ErrorType.NotFound"/> AND the
+    /// "No node found" banner so a genuine engineering failure with the same ErrorType is untouched.</para>
+    /// </summary>
+    public static bool IsRoutingNotFoundFailure(DeliveryFailure? failure)
+        => failure is not null
+           && failure.ErrorType == ErrorType.NotFound
+           && (failure.Message ?? string.Empty).StartsWith("No node found", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// The single predicate the area subscription hands to
     /// <see cref="AreaStreamRetry.RetryAreaWithBackoff{T}"/>: retry ONLY a transient hub
     /// miss — never a teardown <see cref="ObjectDisposedException"/> (benign), never a

--- a/test/MeshWeaver.AI.Test/TrainingSimResponderTest.cs
+++ b/test/MeshWeaver.AI.Test/TrainingSimResponderTest.cs
@@ -121,3 +121,26 @@ public class TrainingSimResponderTest(ITestOutputHelper output) : MonolithMeshTe
             "the LIVE adapter selects the dedicated training agent on the composer");
     }
 }
+
+/// <summary>
+/// Host-free coverage of the model-config classifier that lets a training cell DEGRADE GRACEFULLY
+/// (a calm "configure a model to run this" notice) instead of echoing the raw "ApiKey is missing …"
+/// factory error into a course page.
+/// </summary>
+public class TrainingSimResponderClassificationTest
+{
+    [Theory]
+    [InlineData("ApiKey is missing for model 'glm-5.2'. Configure a ModelProvider node (Provider 'OpenAI').")]
+    [InlineData("No AI model is available for this hub.")]
+    [InlineData("Selected agent 'Agent/TrainingSim' was found, but creating it failed via factory 'OpenAI' for model 'z-ai/glm-5.2'.")]
+    public void LooksLikeMissingModel_TrueForModelConfigSignatures(string text)
+        => TrainingSimResponder.LooksLikeMissingModel(text).Should().BeTrue();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Here is a DataGrid of the five orders.")]
+    [InlineData("The order total is 1,211.25.")]
+    public void LooksLikeMissingModel_FalseForRealAnswersAndEmpty(string? text)
+        => TrainingSimResponder.LooksLikeMissingModel(text).Should().BeFalse();
+}

--- a/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
+++ b/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
@@ -163,4 +163,30 @@ public class AreaErrorClassifierTest
     [Fact]
     public void ShouldRetryArea_FalseForPermanentError()
         => AreaErrorClassifier.ShouldRetryArea(new InvalidOperationException("boom")).Should().BeFalse();
+
+    // ── IsRoutingNotFoundFailure: raw-message twin the portal error sink uses to swallow a benign
+    //    routing NotFound (a not-yet-run per-viewer Activity area) from the global "Something went wrong" modal ──
+
+    [Theory]
+    [InlineData("No node found at 'u/_Activity/markdown-abc'. Closest ancestor is 'u' (remainder='_Activity/markdown-abc').")]
+    [InlineData("No node found at 'x/y'.")]
+    public void IsRoutingNotFoundFailure_TrueForRoutingNotFound(string message)
+        => AreaErrorClassifier.IsRoutingNotFoundFailure(
+                new DeliveryFailure(null!, message) { ErrorType = ErrorType.NotFound }).Should().BeTrue(
+            "a routing NotFound for a gone / not-yet-created node is benign churn — swallowed, never the modal");
+
+    [Fact]
+    public void IsRoutingNotFoundFailure_FalseForNotFoundWithoutBanner()
+        => AreaErrorClassifier.IsRoutingNotFoundFailure(
+                new DeliveryFailure(null!, "access denied") { ErrorType = ErrorType.NotFound }).Should().BeFalse();
+
+    [Fact]
+    public void IsRoutingNotFoundFailure_FalseForOtherErrorTypeWithBanner()
+        // A genuine failure that happens to start "No node found" but isn't a routing NotFound stays visible.
+        => AreaErrorClassifier.IsRoutingNotFoundFailure(
+                new DeliveryFailure(null!, "No node found") { ErrorType = ErrorType.Failed }).Should().BeFalse();
+
+    [Fact]
+    public void IsRoutingNotFoundFailure_FalseForNull()
+        => AreaErrorClassifier.IsRoutingNotFoundFailure(null).Should().BeFalse();
 }


### PR DESCRIPTION
Fixes the two bugs behind the training courses' "Something went wrong" modals (reported from a fresh viewer opening a lesson — errors on ~every 2nd/3rd activity).

## Bug A — "No node found at '…/_Activity/markdown-…'" global modal
A lesson's `--render` cell output area is addressed at `{viewer}/_Activity/markdown-{id}`, which **doesn't exist until the viewer runs the cell**. For a fresh viewer, the fire-and-forget subscribe/heartbeat returns to the portal hub as a bare `DeliveryFailure` (routing NotFound) with no awaiting callback, and `PortalErrorReporting` reported it **verbatim** in the global "Something went wrong" modal. `NamedAreaView` already renders this gracefully (`IsNodeGoneNotFound`); the un-awaited copy escaped to the modal.
**Fix:** `AreaErrorClassifier.IsRoutingNotFoundFailure` (typed `ErrorType.NotFound` **and** the "No node found" banner) — the portal error sink swallows this benign infra churn; every genuine failure still surfaces.

## Bug B — "ApiKey is missing for model 'glm-5.2'" in agent cells
When no chat model is configured, a PromptCell "Ask the agent" cell echoed the raw factory error.
**Fix:** `TrainingSimResponder` degrades gracefully — no model resolves (or the reply/OnError carries the model-config signature) → a calm "▶ Live agent demo — configure a language model to run this" notice, keeping the demo's code-pane/output-pane shape. No fabricated model, no hard-coded key.

> Note: the underlying cause of Bug B is that **memex has no general language-model provider configured** (only a harness credential) — the live cells need an `OpenAI:ApiKey` / `ModelProvider` node to actually run; this PR just makes their absence graceful.

## Tests
`IsRoutingNotFoundFailure` (5) + `LooksLikeMissingModel` (7) — all green. Release `-warnaserror` clean for Layout/AI/Blazor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)