### PR TITLE
Fix #364: URL-decode content-collection path segments (files/folders with spaces)

### DIFF
--- a/src/MeshWeaver.ContentCollections/CollectionNamedLayoutArea.cs
+++ b/src/MeshWeaver.ContentCollections/CollectionNamedLayoutArea.cs
@@ -47,7 +47,9 @@ public static class CollectionNamedLayoutArea
     {
         var collectionName = ContentCollectionsExtensions.DecodeCollectionName(context.Area);
         var idString = host.Reference.Id?.ToString() ?? "";
-        var path = idString.Split('?')[0].Trim('/');
+        // The URL id is percent-encoded by the browser; decode each segment before it becomes a
+        // collection path so names with spaces (or other reserved chars) match the stored items.
+        var path = ContentCollectionsExtensions.DecodeCollectionPath(idString.Split('?')[0].Trim('/'));
 
         var contentService = host.Hub.GetContentService();
         var ioPool = ContentLayoutArea.GetIoPool(host.Hub);

--- a/src/MeshWeaver.ContentCollections/ContentCollectionsExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollectionsExtensions.cs
@@ -48,6 +48,20 @@ public static class ContentCollectionsExtensions
     public static string DecodeCollectionName(string encodedName) => encodedName.Replace('~', '/');
 
     /// <summary>
+    /// Percent-decodes each segment of a collection path taken from a URL id so it matches the
+    /// provider's stored item names. Browsers percent-encode segments that contain spaces or other
+    /// reserved characters (a folder <c>Data Extraction</c> arrives as <c>Data%20Extraction</c>,
+    /// a file <c>my report.md</c> as <c>my%20report.md</c>), while the collection's real item names
+    /// carry the decoded characters — so the raw URL form never matches and the resolver falls
+    /// through to "not found". Splits on '/' first so the separators between segments are preserved,
+    /// then <see cref="Uri.UnescapeDataString(string)"/>s each segment. This mirrors the re-encoding
+    /// <see cref="ContentLayoutArea.RenderFile"/> performs (<see cref="Uri.EscapeDataString(string)"/>
+    /// per segment), and is idempotent for paths that contain no encoded characters.
+    /// </summary>
+    public static string DecodeCollectionPath(string path) =>
+        string.Join('/', path.Split('/').Select(Uri.UnescapeDataString));
+
+    /// <summary>
     /// Area name for unified content references. Uses $ prefix to avoid name collisions.
     /// </summary>
     public const string ContentAreaName = "$Content";

--- a/src/MeshWeaver.ContentCollections/ContentLayoutArea.cs
+++ b/src/MeshWeaver.ContentCollections/ContentLayoutArea.cs
@@ -297,6 +297,11 @@ public static class ContentLayoutArea
             filePath = contentPath[(firstSlash + 1)..];
         }
 
+        // The URL id is percent-encoded by the browser; decode each segment of the file path
+        // before it is matched against the collection's stored item names (RenderFile re-encodes
+        // it with Uri.EscapeDataString when building the static URL — this is its inverse).
+        filePath = ContentCollectionsExtensions.DecodeCollectionPath(filePath);
+
         if (string.IsNullOrEmpty(filePath))
             return Observable.Return<UiControl?>(new MarkdownControl($"Empty file path in: {contentPath}"));
 

--- a/test/MeshWeaver.ContentCollections.Test/NodeHubContentCollectionTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/NodeHubContentCollectionTest.cs
@@ -195,4 +195,73 @@ public class NodeHubContentCollectionTest(ITestOutputHelper output) : HubTestBas
             await collection!.DeleteFileAsync("/sub/hello.md");
         }
     }
+
+    /// <summary>
+    /// Regression for #364: clicking a file or folder whose name contains a space (or any other
+    /// character the browser percent-encodes) navigated to a percent-encoded URL — the collection
+    /// browser lists such items correctly but opening them returned
+    /// <c>'my%20report.md' not found in collection 'content'</c>, because the raw URL id
+    /// (<c>Data%20Extraction/my%20report.md</c>) was matched directly against the stored item names
+    /// (<c>Data Extraction/my report.md</c>). The layout-area boundaries now URL-decode each path
+    /// segment first, so the encoded id renders the same content/folder as the decoded one.
+    /// </summary>
+    [Fact]
+    public async Task CollectionNamedArea_UrlDecodesEncodedPathSegments()
+    {
+        var client = GetClient();
+        var contentService = client.ServiceProvider.GetRequiredService<IContentService>();
+        var ct = TestContext.Current.CancellationToken;
+        var collection = await contentService.GetCollectionAsync("content", ct);
+        collection.Should().NotBeNull();
+
+        // A folder AND a file whose names both contain a space — the exact shape the browser
+        // percent-encodes into "Data%20Extraction/my%20report.md".
+        var bytes = "# Quarterly report with a space in its name"u8.ToArray();
+        using (var stream = new MemoryStream(bytes))
+            await collection!.SaveFileAsync("/Data Extraction", "my report.md", stream);
+
+        try
+        {
+            // A hub cannot GetRemoteStream its own address — subscribe from the HOST hub.
+            var workspace = GetHost().GetWorkspace();
+
+            // File → the PERCENT-ENCODED id must resolve to the file's content, not "not found".
+            var fileControl = await workspace
+                .GetRemoteStream<System.Text.Json.JsonElement, LayoutAreaReference>(
+                    client.Address,
+                    new LayoutAreaReference("content") { Id = "Data%20Extraction/my%20report.md" })
+                .GetControlStream("content")
+                .Should().Within(30.Seconds())
+                .Match(c => c != null && c.ToString()!.Contains("Quarterly report with a space in its name"));
+            var fileJson = fileControl!.ToString()!;
+            fileJson.Should().NotContain("not found", "the encoded path must be decoded before matching");
+            fileJson.Should().NotContain("%20", "the literal encoded form must never reach the item match");
+
+            // Folder → the PERCENT-ENCODED id must open the browser scoped to the decoded folder.
+            var folderControl = await workspace
+                .GetRemoteStream<System.Text.Json.JsonElement, LayoutAreaReference>(
+                    client.Address,
+                    new LayoutAreaReference("content") { Id = "Data%20Extraction" })
+                .GetControlStream("content")
+                .Should().Within(30.Seconds()).Match(c => c != null && c.ToString()!.Contains("FileBrowser"));
+            folderControl!.ToString().Should().Contain("/Data Extraction",
+                "the browser is scoped to the DECODED folder path");
+
+            // Same guarantee via the unified $Content area (the second decode boundary).
+            var unifiedControl = await workspace
+                .GetRemoteStream<System.Text.Json.JsonElement, LayoutAreaReference>(
+                    client.Address,
+                    new LayoutAreaReference(ContentCollectionsExtensions.ContentAreaName)
+                        { Id = "content/Data%20Extraction/my%20report.md" })
+                .GetControlStream(ContentCollectionsExtensions.ContentAreaName)
+                .Should().Within(30.Seconds())
+                .Match(c => c != null && c.ToString()!.Contains("Quarterly report with a space in its name"));
+            unifiedControl!.ToString().Should().NotContain("%20",
+                "the $Content boundary must decode the file path too");
+        }
+        finally
+        {
+            await collection!.DeleteFileAsync("/Data Extraction/my report.md");
+        }
+    }
 }


### PR DESCRIPTION
Fixes #364.

## Problem
Clicking a file or folder whose name contains a space (or any character the browser percent-encodes) in a content collection returned:

```
'my%20report.md' not found in collection 'content'.
```

The collection browser lists such items correctly, but opening them fails — note the literal `%20` in the message.

## Root cause
The content-collection layout areas take the path from the raw URL id (`host.Reference.Id`) and match it against the collection's real item names **without URL-decoding it**. The stored name has a real space (`my report.md`) while the URL path is `my%20report.md`, so the case-insensitive match never succeeds and the "not found" fallback is returned. `WorkspaceReference.Decode` only reverses the custom `~`/`%9Y` escaping — nothing touches `%20`.

## Fix
Decode each path segment (`Uri.UnescapeDataString`, splitting on `/` first so separators are preserved) at the two boundaries where the URL id becomes a content-collection path:

- `CollectionNamedLayoutArea.RenderCore` — `/{node}/{collection}/…` navigation
- `ContentLayoutArea.UnifiedContentCore` — `$Content` / `@@…` unified references

The new `ContentCollectionsExtensions.DecodeCollectionPath` helper is the exact inverse of the `Uri.EscapeDataString` re-encoding that `RenderFile`/`RenderPdf` already perform when building static URLs — confirming the internal contract expects an already-decoded path. The collection-name segment is left untouched (it uses `~`/`@` encoding, never percent-encoding). The helper is idempotent for names with no encoded characters.

## Test
`CollectionNamedArea_UrlDecodesEncodedPathSegments` writes a folder **and** file that both contain spaces, then renders them via their **percent-encoded** ids through both boundaries (collection-named area + `$Content`). It asserts the real content/folder renders and that no literal `%20` reaches the item match.

Proven to pin the bug: with the decode neutered the test fails at 30s with the exact "not found" symptom; with the fix all 7 tests in `NodeHubContentCollectionTest` pass under Release / `-warnaserror`.

## Impact
Pure code fix in the shared codebase — resolves the issue on both **memex** and **atioz** once their images self-update from `main`. It's the enabler for uploading files whose names contain spaces (e.g. the PartnerRe files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)