### PR TITLE
fix(chat): /clear replaces the side panel with a fresh composer, main pane untouched

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1746,12 +1746,20 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 RunNavigate(navRow!);
                 break;
             case MeshWeaver.AI.SkillActionKind.NewThread:
-                // "/clear" — just instantiate a fresh new-chat composer (the same path as the "+" button:
-                // OnSidePanelAction("New") clears the open thread and shows the empty new-chat composer).
-                // No navigation — the composer replaces the current thread in place.
+                // "/clear" — REPLACE whatever is showing with a fresh new-chat composer, in the SIDE PANEL,
+                // and leave the main pane alone (no navigation). This is the same target as the "+" button
+                // (PortalLayoutBase.OpenNewThreadInSidePanel): drop the open thread so ThreadSidePanelContent
+                // swaps the thread layout area for the empty composer (SetContentPath(null) drives that
+                // directly — it does not merely rely on a mounted composer reacting to RequestAction), reset
+                // any already-mounted composer's draft/mode, and open the panel if it was closed (e.g. /clear
+                // typed from a full-screen thread). The main-pane view is never touched.
                 lastCommandStatus = null;
                 lastCommandStatusIsError = false;
+                SidePanelState.SetContentPath(null);
+                SidePanelState.SetTitle(null);
                 SidePanelState.RequestAction("New");
+                if (!SidePanelState.IsVisible)
+                    SidePanelState.SetVisible(true);
                 break;
             default:
                 // Instruction skill + typed task → re-enter the normal submission path with the

--- a/src/MeshWeaver.Documentation/Data/AI/ChatCommands.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ChatCommands.md
@@ -37,7 +37,7 @@ public record SkillDefinition
 
 public record SkillAction
 {
-    public required SkillActionKind Kind { get; init; }   // Pick | OpenContent | Navigate | Connect | Disconnect
+    public required SkillActionKind Kind { get; init; }   // Pick | OpenContent | Navigate | Connect | Disconnect | NewThread
     public string? Query { get; init; }        // Pick: the combobox query (+ `sort:order`)
     public string? Field { get; init; }        // Pick: camelCase ThreadComposer field (harness|agentName|modelName)
     public string? Title { get; init; }        // Pick: combobox title
@@ -144,6 +144,11 @@ This guidance lives in the shared agent base prompt (`AgentChatClient`); the age
   The agent's server-side `NavigateTo` tool routes through the same resolver, so "take me there" resolves
   honestly no matter who asks. Tested by `NavigationTargetResolverTest` (the pure algorithm) and
   `MeshPluginTest` (resilient + honest resolution against the live mesh).
+- **`NewThread`** — **start a fresh chat.** Ships as the built-in **`/clear`** skill
+  (`src/MeshWeaver.AI/Data/Skill/clear.md`). It REPLACES whatever is showing in the **side panel** with an
+  empty new-chat composer and **leaves the main pane alone** — the same target as the "+" button
+  (`SidePanelState.SetContentPath(null)` drops the open thread so `ThreadSidePanelContent` swaps in the
+  composer; the panel is opened if it was closed). No navigation. Handled by `ThreadChatView.RunSkill`.
 - **`Connect` / `Disconnect`** — harness auth. Under a non-MeshWeaver harness, `/login` and `/logout` are
   owned by the harness (`IHarness.Commands`) and route to its connect flow; they take priority in dispatch.
 - **`Instructions`** (no `Action`) — a pure-instruction skill (its how-to is the markdown body). Skills are
@@ -177,9 +182,9 @@ When the user runs `/name`, the chat view (`ThreadChatView.HandleSlashCommandAsy
 1. **harness-owned command?** (`/login`, `/logout` under a non-MeshWeaver harness) → route to the harness.
 2. **otherwise** → resolve a `nodeType:Skill` **mesh node** by slash word (with namespace inheritance,
    `ResolveSkillNodeAndRun`) and run its `Action` — `Pick` pops the combobox, `OpenContent` loads the
-   content window, `Navigate` resolves the target and opens it pane-aware. A pure-instruction skill with
-   trailing text submits the task as a round with a `load_skill` directive (see above); without trailing
-   text it shows the skill's help.
+   content window, `Navigate` resolves the target and opens it pane-aware, `NewThread` (`/clear`) replaces
+   the side panel with a fresh new-chat composer. A pure-instruction skill with trailing text submits the
+   task as a round with a `load_skill` directive (see above); without trailing text it shows the skill's help.
 
 The view contains **no per-skill code** — only the generic picker + content-window callbacks. All pick
 skills write to the same `ThreadComposer`.

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -40,6 +40,10 @@ public class SkillNodeTypeTest
         // /navigate is a Navigate-action skill — the pane-aware, resilient "take me there".
         var nav = (SkillDefinition)skills.Single(n => n.Id == "navigate").Content!;
         nav.Action!.Kind.Should().Be(SkillActionKind.Navigate);
+
+        // /clear is a NewThread-action skill — replaces the side panel with a fresh new-chat composer.
+        var clear = (SkillDefinition)skills.Single(n => n.Id == "clear").Content!;
+        clear.Action!.Kind.Should().Be(SkillActionKind.NewThread);
     }
 
     [Fact]

--- a/test/MeshWeaver.Portal.E2E.Test/ChatClearSkillNewComposerTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/ChatClearSkillNewComposerTest.cs
@@ -1,0 +1,168 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E;
+
+/// <summary>
+/// Guards the <c>/clear</c> skill (<see cref="MeshWeaver.AI.SkillActionKind.NewThread"/>): typing
+/// <c>/clear</c> in a running side-panel thread must REPLACE that thread with a fresh new-chat composer
+/// IN THE SIDE PANEL, and leave the main pane alone (no navigation). The harness/agent/model selection
+/// is kept.
+///
+/// <para>Flow: open the side panel, start a thread (a user bubble appears), run <c>/clear</c>, then assert
+/// the thread's message bubbles are gone, a composer is still mounted in the SAME still-open side panel,
+/// and the main pane's URL is unchanged.</para>
+///
+/// <para>Requires a portal with a language model. Drive it:
+/// <c>memex-local e2e test ChatClearSkillNewComposerTest</c>.</para>
+/// </summary>
+[Collection("portal-e2e")]
+public class ChatClearSkillNewComposerTest(PortalFixture fixture)
+{
+    private const string FirstMessage = "Reply with exactly the word OK.";
+
+    // The user bubble appears once the thread is created + shown. /clear only needs a RUNNING thread (a user
+    // message showing) — NOT the assistant's reply, so we never wait on a model round. Generous because the
+    // FIRST message on a cold portal cold-starts several hubs before the side-panel swap renders the bubble.
+    private static readonly int BubbleMs = 90_000;
+
+    // A LanguageModel node that actually EXISTS in the catalog.
+    private static readonly string ModelPath =
+        Environment.GetEnvironmentVariable("E2E_MODEL") ?? "Provider/OpenAICompatible/qwen3.6-code:latest";
+
+    // The side panel wraps its composer in .side-panel; the main pane does not.
+    private const string SideFooter = ".side-panel .thread-chat-footer";
+
+    private string ComposerSeedJson => $$"""
+        {
+          "id": "ThreadComposer",
+          "namespace": "{{fixture.UserId}}/_Thread",
+          "name": "Chat Input",
+          "nodeType": "ThreadComposer",
+          "mainNode": "{{fixture.UserId}}",
+          "content": { "$type": "ThreadComposer" }
+        }
+        """;
+
+    [Fact(Timeout = 360_000)]
+    public async Task ClearSkill_InSidePanel_ReplacesThreadWithComposer_AndLeavesMainAlone()
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+
+        await using var context = await SeedComposerOnMeshWeaverAsync();
+        var page = await context.NewPageAsync();
+        await page.SetViewportSizeAsync(1400, 950);
+        await page.GotoAsync($"{fixture.BaseUrl}/User/{fixture.UserId}",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+        var mainUrl = page.Url;
+
+        await OpenSidePanelAsync(page);
+        await WaitComposerReadyAsync(page, SideFooter);
+        if (await SkipIfNoModelAsync(page, SideFooter)) return;
+
+        // 1) Start a real thread in the side panel: type + Send. The user's bubble appearing = a thread now
+        //    exists and is running. We do NOT wait for the assistant reply.
+        await TypeAndSendAsync(page, SideFooter, FirstMessage);
+        await page.Locator(".thread-msg-bubble.thread-msg-user").First.WaitForAsync(
+            new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = BubbleMs });
+        (await page.Locator(".thread-msg-bubble").CountAsync()).Should().BeGreaterThan(0,
+            "a thread is running in the side panel before /clear");
+
+        // 2) Run /clear in the side-panel thread.
+        await RunClearAsync(page, SideFooter);
+
+        // 3) The thread is REPLACED by a fresh composer — in the SAME, still-open side panel.
+        await Assertions.Expect(page.Locator(".thread-msg-bubble")).ToHaveCountAsync(0,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 20_000 });
+        await Assertions.Expect(page.Locator(".side-panel")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        await Assertions.Expect(page.Locator($"{SideFooter} .monaco-editor").Last).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
+
+        // 4) The main pane is LEFT ALONE — /clear does not navigate it.
+        page.Url.Should().Be(mainUrl, "/clear replaces the side panel in place and must not navigate the main pane");
+
+        // 5) The harness selection is KEPT on the fresh composer (we patched it onto MeshWeaver).
+        await Assertions.Expect(page.Locator($"{SideFooter} .thread-chat-status-item[title^='Harness']").First)
+            .ToContainTextAsync("MeshWeaver",
+                new LocatorAssertionsToContainTextOptions { Timeout = 15_000 });
+
+        await page.ScreenshotAsync(new PageScreenshotOptions { Path = "/tmp/clear-sidepanel.png", FullPage = true });
+    }
+
+    // ─── helpers ────────────────────────────────────────────────────────────────
+
+    /// <summary>Authenticated context with the per-user composer seeded and PATCHed onto MeshWeaver + a
+    /// model, and any leftover draft cleared — so the test starts from a clean new-chat composer regardless
+    /// of run order in the shared collection.</summary>
+    private async Task<IBrowserContext> SeedComposerOnMeshWeaverAsync()
+    {
+        var context = await fixture.NewAuthenticatedContextAsync();
+        var token = await fixture.MintTokenAsync(context);
+        try { await fixture.CreateNodeAsync(context, token, ComposerSeedJson); }
+        catch (InvalidOperationException) { /* already seeded — fine */ }
+        await context.APIRequest.PostAsync($"{fixture.BaseUrl}/api/mesh/patch", new APIRequestContextOptions
+        {
+            Headers = new Dictionary<string, string> { ["authorization"] = $"Bearer {token}" },
+            DataObject = new
+            {
+                Path = $"{fixture.UserId}/_Thread/ThreadComposer",
+                Fields = "{\"content\":{\"$type\":\"ThreadComposer\",\"harness\":\"Harness/MeshWeaver\","
+                       + "\"agentName\":\"Agent/Assistant\",\"modelName\":\"" + ModelPath + "\","
+                       + "\"contextPath\":\"" + fixture.UserId + "\",\"messageContent\":null,\"openThreadPath\":null}}"
+            }
+        });
+        return context;
+    }
+
+    private static async Task OpenSidePanelAsync(IPage page)
+    {
+        var toggle = page.Locator(".side-panel-toggle button, .side-panel-toggle fluent-button").First;
+        await toggle.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+        await toggle.ClickAsync();
+    }
+
+    private static async Task WaitComposerReadyAsync(IPage page, string footer)
+        => await page.Locator($"{footer} .monaco-editor").Last.WaitForAsync(
+            new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+
+    private static async Task<bool> SkipIfNoModelAsync(IPage page, string footer)
+    {
+        var noModel = page.Locator($"{footer} .thread-chat-status-msg.error");
+        if (await noModel.CountAsync() > 0
+            && (await noModel.First.InnerTextAsync()).Contains("No language model", StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Skip("No language model configured on the target portal — cannot run a round to clear.");
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>Types a plain message into the composer scoped by <paramref name="footer"/> and Sends it.
+    /// The Send button is <c>disabled</c> until <c>MessageText</c> is populated by the editor, so we wait for
+    /// the ENABLED Send (the real condition that Monaco's ValueChanged synced the text) before clicking —
+    /// no debounce guessing. This is what makes StartThread receive a non-empty first message.</summary>
+    private static async Task TypeAndSendAsync(IPage page, string footer, string text)
+    {
+        var editor = page.Locator($"{footer} .monaco-editor").Last;
+        await editor.ClickAsync();
+        await page.Keyboard.TypeAsync(text);
+        var enabledSend = page.Locator($"{footer} .selector-bar fluent-button:not([disabled])").Last;
+        await enabledSend.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 20_000 });
+        await enabledSend.ClickAsync(new LocatorClickOptions { Timeout = 30_000 });
+    }
+
+    /// <summary>Types <c>/clear</c> into the running thread's composer (scoped by <paramref name="footer"/>)
+    /// and runs it via the Send button (which dispatches the slash skill through SubmitMessageCore). Waits
+    /// for the ENABLED Send (MessageText = "/clear") before clicking; the Send click blurs Monaco and closes
+    /// its slash-autocomplete popup, so the skill is dispatched rather than a completion accepted.</summary>
+    private static async Task RunClearAsync(IPage page, string footer)
+    {
+        var editor = page.Locator($"{footer} .monaco-editor").Last;
+        await editor.ClickAsync();
+        await page.Keyboard.TypeAsync("/clear");
+        var enabledSend = page.Locator($"{footer} .selector-bar fluent-button:not([disabled])").Last;
+        await enabledSend.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 20_000 });
+        await enabledSend.ClickAsync(new LocatorClickOptions { Timeout = 30_000 });
+    }
+}

--- a/test/MeshWeaver.Portal.E2E.Test/ChatClearSkillNewComposerTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/ChatClearSkillNewComposerTest.cs
@@ -26,7 +26,11 @@ public class ChatClearSkillNewComposerTest(PortalFixture fixture)
     // FIRST message on a cold portal cold-starts several hubs before the side-panel swap renders the bubble.
     private static readonly int BubbleMs = 90_000;
 
-    // A LanguageModel node that actually EXISTS in the catalog.
+    // A LanguageModel node that actually EXISTS in the catalog (env-overridable via E2E_MODEL). NOTE: the
+    // older chat E2E tests default to "…/qwen-small", but that path has drifted to a ":latest" tag and no
+    // longer resolves — so we default to a current node. This test is robust to the model anyway: the user
+    // bubble it asserts is optimistic (StartThread does not resolve the model), and SkipIfNoModelAsync skips
+    // when the catalog is empty; the model only affects the (unawaited) assistant round.
     private static readonly string ModelPath =
         Environment.GetEnvironmentVariable("E2E_MODEL") ?? "Provider/OpenAICompatible/qwen3.6-code:latest";
 
@@ -101,17 +105,12 @@ public class ChatClearSkillNewComposerTest(PortalFixture fixture)
         var token = await fixture.MintTokenAsync(context);
         try { await fixture.CreateNodeAsync(context, token, ComposerSeedJson); }
         catch (InvalidOperationException) { /* already seeded — fine */ }
-        await context.APIRequest.PostAsync($"{fixture.BaseUrl}/api/mesh/patch", new APIRequestContextOptions
-        {
-            Headers = new Dictionary<string, string> { ["authorization"] = $"Bearer {token}" },
-            DataObject = new
-            {
-                Path = $"{fixture.UserId}/_Thread/ThreadComposer",
-                Fields = "{\"content\":{\"$type\":\"ThreadComposer\",\"harness\":\"Harness/MeshWeaver\","
-                       + "\"agentName\":\"Agent/Assistant\",\"modelName\":\"" + ModelPath + "\","
-                       + "\"contextPath\":\"" + fixture.UserId + "\",\"messageContent\":null,\"openThreadPath\":null}}"
-            }
-        });
+        // PatchNodeAsync throws on a non-success response, so setup is deterministic (never silently
+        // inherits a prior test's harness/model left on the shared composer node).
+        await fixture.PatchNodeAsync(context, token, $"{fixture.UserId}/_Thread/ThreadComposer",
+            "{\"content\":{\"$type\":\"ThreadComposer\",\"harness\":\"Harness/MeshWeaver\","
+            + "\"agentName\":\"Agent/Assistant\",\"modelName\":\"" + ModelPath + "\","
+            + "\"contextPath\":\"" + fixture.UserId + "\",\"messageContent\":null,\"openThreadPath\":null}}");
         return context;
     }
 


### PR DESCRIPTION
## What

`/clear` (the `NewThread` skill) should **replace whatever is showing in the side panel with a fresh new-chat composer, and leave the main pane alone**.

`main`'s handler only called `SidePanelState.RequestAction("New")` — it relied on a mounted composer to react, didn't drop the shown thread directly, and didn't open the side panel when `/clear` was typed from a full-screen thread. This makes the handler **replace the side panel in place**:

```csharp
SidePanelState.SetContentPath(null);   // ThreadSidePanelContent swaps the thread area → empty composer
SidePanelState.SetTitle(null);
SidePanelState.RequestAction("New");    // reset any already-mounted composer's draft/mode
if (!SidePanelState.IsVisible)
    SidePanelState.SetVisible(true);    // open the panel if /clear came from a full-screen thread
```

The main pane is never navigated or touched.

## Also

- **Playwright E2E** `ChatClearSkillNewComposerTest` — main lacked one: starts a side-panel thread, runs `/clear`, asserts the thread bubbles are gone, a composer is still mounted in the same still-open side panel, and the main-pane URL is unchanged. (Skips when E2E is off, like the other portal-e2e tests; verified locally via `memex-local e2e`.)
- **Docs** — `ChatCommands.md` now documents the `NewThread` action.
- **Unit test** — `SkillNodeTypeTest` now asserts `/clear` is a `NewThread`-action skill.

## Verification

- `dotnet build -c Release -p:CIRun=true -warnaserror` clean for `MeshWeaver.Blazor.Portal`, `MeshWeaver.AI.Test`, `MeshWeaver.Portal.E2E.Test`.
- `MeshWeaver.AI.Test` skill tests 12/12.
- Side-panel `/clear` behavior verified end-to-end on a local DevLogin portal (thread → `/clear` → composer replaces it in place, harness kept, main pane untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)