### PR TITLE
feat(portal): platform-admin Instances GUI — live cluster view, Grafana logs, guided create

### DIFF
--- a/deploy/helm/templates/memex-portal/instances-rbac.yaml
+++ b/deploy/helm/templates/memex-portal/instances-rbac.yaml
@@ -1,10 +1,12 @@
 {{- if .Values.instancesAdmin.clusterRead }}
 ---
 # Cluster-scoped READ for the platform-admin Instances overview (Doc/Architecture/Instances.md):
-# list portal deployments + ingresses + namespaces across the cluster so the company/control
-# instance can show every portal, its version and its host. Least-privilege: get/list only, and
-# ONLY created when instancesAdmin.clusterRead is set — which must be the company instance alone,
-# never a public or customer instance (else a tenant pod could enumerate the whole cluster).
+# list portal deployments + ingresses across the cluster so the company/control instance can show
+# every portal, its version and its host. Least-privilege: get/list on exactly the two resources
+# the query reads (deployments + ingresses — the namespace comes from each object's metadata, so no
+# `namespaces` grant is needed), and ONLY created when instancesAdmin.clusterRead is set — which
+# must be the company instance alone, never a public or customer instance (else a tenant pod could
+# enumerate the whole cluster).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -14,9 +16,6 @@ metadata:
     app.kubernetes.io/component: "memex-portal"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 rules:
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["get", "list"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list"]

--- a/deploy/helm/templates/memex-portal/instances-rbac.yaml
+++ b/deploy/helm/templates/memex-portal/instances-rbac.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.instancesAdmin.clusterRead }}
+---
+# Cluster-scoped READ for the platform-admin Instances overview (Doc/Architecture/Instances.md):
+# list portal deployments + ingresses + namespaces across the cluster so the company/control
+# instance can show every portal, its version and its host. Least-privilege: get/list only, and
+# ONLY created when instancesAdmin.clusterRead is set — which must be the company instance alone,
+# never a public or customer instance (else a tenant pod could enumerate the whole cluster).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ .Release.Name }}-instances-read"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "memex-portal"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ .Release.Name }}-instances-read"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "memex-portal"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "{{ .Release.Name }}-instances-read"
+subjects:
+  - kind: ServiceAccount
+    name: "memex-portal-sa"
+    namespace: "{{ .Release.Namespace }}"
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -12,6 +12,13 @@ persistDataVolume: false
 # leave empty for local/self-host (the in-cluster patch still works; ACR polling just won't auth).
 selfUpdate:
   azureClientId: ""
+# ---- Platform-admin Instances overview -------------------------------------
+# The admin "Instances" tab lists every portal on the cluster by querying the k8s API. Reading
+# deployments/ingresses ACROSS namespaces needs a cluster-scoped read grant — enable it ONLY on the
+# company/control instance, never on public or customer instances (a tenant pod must not be able to
+# enumerate the whole cluster). Off by default; the company env sets clusterRead: true.
+instancesAdmin:
+  clusterRead: false
 # ---- External Ollama (local self-host) ------------------------------------
 # Front a host-native Ollama with an in-cluster Service so the portal addresses
 # it by name (http://ollama:11434/v1) instead of a host-gateway IP. On macOS the

--- a/memex/Memex.Portal.Shared/Instances/ClusterInstanceService.cs
+++ b/memex/Memex.Portal.Shared/Instances/ClusterInstanceService.cs
@@ -1,0 +1,266 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Runtime.Versioning;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Instances;
+
+/// <summary>One running platform instance, as observed live from the Kubernetes API.</summary>
+public sealed record InstanceInfo
+{
+    /// <summary>The Kubernetes namespace the portal runs in (e.g. <c>memex</c>, <c>memex-cloud</c>).</summary>
+    public required string Namespace { get; init; }
+    /// <summary>The public host from the namespace's Ingress (e.g. <c>memex.systemorph.com</c>), or "" if none.</summary>
+    public string Domain { get; init; } = string.Empty;
+    /// <summary>The portal container's full image reference.</summary>
+    public string Image { get; init; } = string.Empty;
+    /// <summary>The image tag — the running platform version (e.g. <c>ci.612</c>).</summary>
+    public string Version { get; init; } = string.Empty;
+    /// <summary>Ready portal replicas.</summary>
+    public int ReadyReplicas { get; init; }
+    /// <summary>Desired portal replicas.</summary>
+    public int DesiredReplicas { get; init; }
+}
+
+/// <summary>
+/// Reads the live instance inventory from the cluster: one entry per portal Deployment (selected by
+/// the portal component label), with the running image/version, replica health, and the public host
+/// from each namespace's Ingress. An injectable seam so tests substitute a fake / feed sample JSON.
+/// </summary>
+public interface IClusterInstanceService
+{
+    /// <summary>True when this install can query the cluster (runs in Kubernetes with a projected
+    /// service-account token). False on a non-k8s host → <see cref="GetInstances"/> emits empty.</summary>
+    bool CanQuery { get; }
+
+    /// <summary>A one-shot snapshot of the instances currently running on the cluster. Reactive: the
+    /// HTTP round-trips run on the <see cref="IoPoolNames.Http"/> pool, never the subscribing thread.
+    /// On error (e.g. missing cluster-read RBAC → 403) it logs and emits empty rather than faulting.</summary>
+    IObservable<ImmutableArray<InstanceInfo>> GetInstances();
+}
+
+/// <summary>
+/// Queries the in-cluster Kubernetes API for portal instances using the projected service-account
+/// token — the read-only sibling of <see cref="KubernetesDeploymentUpdater"/>. Minimal HTTP GETs (no
+/// heavy k8s client): list portal Deployments cluster-wide by label, list Ingresses to map namespace
+/// → host. The API-server certificate is validated against the mounted cluster CA; the bearer token
+/// is read fresh per call (short-lived, auto-rotated).
+///
+/// <para>Requires cluster-read RBAC — a ClusterRole granting <c>get,list</c> on
+/// <c>namespaces</c>, <c>apps/deployments</c> and <c>networking.k8s.io/ingresses</c>, bound to the
+/// portal service account. This is granted ONLY to the company instance (the Helm
+/// <c>instancesAdmin.clusterRead</c> flag), never the public/customer instances, so a tenant pod
+/// cannot enumerate the whole cluster. Without it the LIST returns 403 → logged, empty emitted.</para>
+/// </summary>
+[UnsupportedOSPlatform("browser")]
+public sealed class KubernetesInstanceService : IClusterInstanceService
+{
+    private const string TokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+    private const string CaFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+
+    private readonly InstancesOptions _options;
+    private readonly IIoPool _httpPool;
+    private readonly ILogger<KubernetesInstanceService>? _logger;
+    private readonly string? _apiBase;
+    private readonly HttpClient? _http;
+
+    public KubernetesInstanceService(IMessageHub hub, InstancesOptions options,
+        ILogger<KubernetesInstanceService>? logger = null)
+    {
+        _options = options;
+        _logger = logger;
+        _httpPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http)
+                    ?? IoPool.Unbounded;
+        if (!HostingTarget.IsKubernetes())
+            return;
+
+        var host = Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST");
+        var port = Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_PORT_HTTPS")
+                   ?? Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_PORT")
+                   ?? "443";
+        _apiBase = $"https://{host}:{port}";
+
+        var handler = new SocketsHttpHandler();
+        var caPem = SafeRead(CaFile);
+        if (!string.IsNullOrEmpty(caPem))
+        {
+            var ca = X509Certificate2.CreateFromPem(caPem);
+            handler.SslOptions.RemoteCertificateValidationCallback = (_, cert, _, _) =>
+            {
+                if (cert is null) return false;
+                using var chain = new X509Chain();
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                chain.ChainPolicy.CustomTrustStore.Add(ca);
+                return chain.Build(X509CertificateLoader.LoadCertificate(cert.GetRawCertData()));
+            };
+        }
+        _http = new HttpClient(handler);
+    }
+
+    public bool CanQuery => _http is not null && _apiBase is not null;
+
+    public IObservable<ImmutableArray<InstanceInfo>> GetInstances()
+    {
+        if (!CanQuery)
+            return Observable.Return(ImmutableArray<InstanceInfo>.Empty);
+
+        var labelSelector = Uri.EscapeDataString($"{_options.PortalComponentLabel}={_options.PortalComponentValue}");
+        var deploymentsUrl = $"{_apiBase}/apis/apps/v1/deployments?labelSelector={labelSelector}";
+        var ingressesUrl = $"{_apiBase}/apis/networking.k8s.io/v1/ingresses";
+
+        return _httpPool.Invoke(async ct =>
+            {
+                var deploymentsJson = await GetAsync(deploymentsUrl, ct).ConfigureAwait(false);
+                var ingressesJson = await GetAsync(ingressesUrl, ct).ConfigureAwait(false);
+                return ParseInstances(deploymentsJson, ingressesJson, _options);
+            })
+            .Catch((Exception ex) =>
+            {
+                _logger?.LogWarning(ex, "[Instances] cluster query failed (missing cluster-read RBAC?)");
+                return Observable.Return(ImmutableArray<InstanceInfo>.Empty);
+            });
+    }
+
+    private async Task<string> GetAsync(string url, CancellationToken ct)
+    {
+        var token = SafeRead(TokenFile)?.Trim();
+        using var req = new HttpRequestMessage(HttpMethod.Get, url);
+        if (!string.IsNullOrEmpty(token))
+            req.Headers.Authorization = new("Bearer", token);
+        req.Headers.Accept.Add(new("application/json"));
+        using var resp = await _http!.SendAsync(req, ct).ConfigureAwait(false);
+        var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode)
+            throw new HttpRequestException($"GET {url} → {(int)resp.StatusCode} {resp.ReasonPhrase}: {body}");
+        return body;
+    }
+
+    /// <summary>
+    /// Pure parse: portal Deployments list JSON + Ingresses list JSON → one <see cref="InstanceInfo"/>
+    /// per namespace, ordered by namespace. The portal container's image tag is the version; the host
+    /// is the namespace's first Ingress rule host. Unit-tested with sample cluster JSON.
+    /// </summary>
+    public static ImmutableArray<InstanceInfo> ParseInstances(
+        string deploymentsJson, string ingressesJson, InstancesOptions options)
+    {
+        var hostByNamespace = ParseIngressHosts(ingressesJson);
+
+        using var doc = JsonDocument.Parse(deploymentsJson);
+        if (!doc.RootElement.TryGetProperty("items", out var items) || items.ValueKind != JsonValueKind.Array)
+            return ImmutableArray<InstanceInfo>.Empty;
+
+        var result = new List<InstanceInfo>();
+        foreach (var item in items.EnumerateArray())
+        {
+            var meta = item.GetProperty("metadata");
+            var ns = meta.TryGetProperty("namespace", out var nsEl) ? nsEl.GetString() ?? "" : "";
+            if (ns.Length == 0)
+                continue;
+
+            var image = FindPortalImage(item, options.PortalContainer);
+            var (ready, desired) = ReadReplicas(item);
+
+            result.Add(new InstanceInfo
+            {
+                Namespace = ns,
+                Domain = hostByNamespace.GetValueOrDefault(ns, ""),
+                Image = image,
+                Version = VersionTag(image),
+                ReadyReplicas = ready,
+                DesiredReplicas = desired,
+            });
+        }
+
+        return result.OrderBy(i => i.Namespace, StringComparer.OrdinalIgnoreCase).ToImmutableArray();
+    }
+
+    private static Dictionary<string, string> ParseIngressHosts(string ingressesJson)
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            using var doc = JsonDocument.Parse(ingressesJson);
+            if (!doc.RootElement.TryGetProperty("items", out var items) || items.ValueKind != JsonValueKind.Array)
+                return map;
+            foreach (var item in items.EnumerateArray())
+            {
+                var ns = item.GetProperty("metadata").TryGetProperty("namespace", out var nsEl)
+                    ? nsEl.GetString() ?? "" : "";
+                if (ns.Length == 0 || map.ContainsKey(ns))
+                    continue;
+                if (item.TryGetProperty("spec", out var spec)
+                    && spec.TryGetProperty("rules", out var rules)
+                    && rules.ValueKind == JsonValueKind.Array)
+                    foreach (var rule in rules.EnumerateArray())
+                        if (rule.TryGetProperty("host", out var hostEl)
+                            && hostEl.GetString() is { Length: > 0 } h)
+                        {
+                            map[ns] = h;
+                            break;
+                        }
+            }
+        }
+        catch (JsonException)
+        {
+            // A malformed/empty ingress payload just means no host mapping — instances still list.
+        }
+        return map;
+    }
+
+    private static string FindPortalImage(JsonElement deployment, string containerName)
+    {
+        if (deployment.TryGetProperty("spec", out var spec)
+            && spec.TryGetProperty("template", out var tmpl)
+            && tmpl.TryGetProperty("spec", out var podSpec)
+            && podSpec.TryGetProperty("containers", out var containers)
+            && containers.ValueKind == JsonValueKind.Array)
+        {
+            string? first = null;
+            foreach (var c in containers.EnumerateArray())
+            {
+                var img = c.TryGetProperty("image", out var imgEl) ? imgEl.GetString() : null;
+                first ??= img;
+                if (c.TryGetProperty("name", out var nameEl) && nameEl.GetString() == containerName)
+                    return img ?? "";
+            }
+            return first ?? "";
+        }
+        return "";
+    }
+
+    private static (int Ready, int Desired) ReadReplicas(JsonElement deployment)
+    {
+        var ready = 0;
+        var desired = 0;
+        if (deployment.TryGetProperty("status", out var status)
+            && status.TryGetProperty("readyReplicas", out var r) && r.ValueKind == JsonValueKind.Number)
+            ready = r.GetInt32();
+        if (deployment.TryGetProperty("spec", out var spec)
+            && spec.TryGetProperty("replicas", out var d) && d.ValueKind == JsonValueKind.Number)
+            desired = d.GetInt32();
+        return (ready, desired);
+    }
+
+    /// <summary>The image tag (after the last ':', ignoring any digest '@'), i.e. the version.</summary>
+    public static string VersionTag(string image)
+    {
+        if (string.IsNullOrEmpty(image))
+            return "";
+        var noDigest = image.Split('@')[0];
+        var colon = noDigest.LastIndexOf(':');
+        return colon >= 0 && colon < noDigest.Length - 1 ? noDigest[(colon + 1)..] : "";
+    }
+
+    private static string? SafeRead(string path)
+    {
+        try { return File.Exists(path) ? File.ReadAllText(path) : null; }
+        catch { return null; }
+    }
+}

--- a/memex/Memex.Portal.Shared/Instances/InstanceProvisioningPlan.cs
+++ b/memex/Memex.Portal.Shared/Instances/InstanceProvisioningPlan.cs
@@ -1,0 +1,90 @@
+namespace Memex.Portal.Shared.Instances;
+
+/// <summary>
+/// Generates the vetted, copy-pasteable command sequence to provision a NEW instance on the shared
+/// AKS cluster — the "guided" create flow: it produces a plan, it does NOT mutate any infrastructure.
+/// Mirrors the runbook in Doc/Architecture/OnboardingNewEnvironment.md, parameterized by the admin's
+/// inputs. Pure + unit-tested; the layout area renders the result as a markdown code block.
+/// </summary>
+public static class InstanceProvisioningPlan
+{
+    /// <summary>k8s namespace / DNS label rules: lowercase alphanumeric + '-', 1..63, no leading/trailing '-'.</summary>
+    public static bool IsValidName(string? name) =>
+        !string.IsNullOrWhiteSpace(name)
+        && name.Length <= 63
+        && System.Text.RegularExpressions.Regex.IsMatch(name, "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$");
+
+    /// <summary>
+    /// The provisioning plan for a new instance. <paramref name="name"/> is the namespace + env id;
+    /// <paramref name="domain"/> the public host; <paramref name="databaseName"/> the DB on the
+    /// shared server (defaults to a name derived from <paramref name="name"/>). Returns markdown.
+    /// </summary>
+    public static string Generate(string? name, string? domain, string? databaseName, InstancesOptions o)
+    {
+        var problems = new List<string>();
+        if (!IsValidName(name))
+            problems.Add("- **Name** must be a valid k8s namespace: lowercase letters/digits/'-', ≤63 chars, no leading/trailing '-'.");
+        if (string.IsNullOrWhiteSpace(domain))
+            problems.Add("- **Domain** is required (the public host, e.g. `acme.meshweaver.cloud`).");
+        if (problems.Count > 0)
+            return "### Cannot generate a plan yet\n\n" + string.Join("\n", problems);
+
+        var ns = name!.Trim();
+        var host = domain!.Trim();
+        var db = string.IsNullOrWhiteSpace(databaseName)
+            ? ns.Replace("-", "")
+            : databaseName!.Trim();
+
+        return $$"""
+### Provisioning plan for instance `{{ns}}`
+
+> This is a **plan only** — nothing below runs automatically. Review each step, then execute it
+> yourself against `{{o.ClusterName}}` (RG `{{o.ResourceGroup}}`). Full reference:
+> [OnboardingNewEnvironment](/Doc/Architecture/OnboardingNewEnvironment).
+
+**Target:** namespace `{{ns}}` · host `{{host}}` · database `{{db}}` on `{{o.PostgresServer}}` · image from `{{o.Registry}}`.
+
+**1. Federated credential (bicep) — add the namespace to `portalNamespaces`:**
+```bash
+# deploy/aks/infra/main.bicep → param portalNamespaces: add '{{ns}}', then:
+az deployment group create -g {{o.ResourceGroup}} \
+  --template-file deploy/aks/infra/main.bicep \
+  --parameters portalNamespaces="['memex','memex-cloud','atioz','{{ns}}']"
+```
+
+**2. Database on the shared server:**
+```bash
+az postgres flexible-server db create \
+  -g {{o.ResourceGroup}} -s {{o.PostgresServer}} -d {{db}}
+```
+
+**3. Env values (git-ignored) — scaffold `deploy/aks/envs/{{ns}}/values.{{ns}}.yaml`:**
+```yaml
+ingress:
+  host: {{host}}
+env:
+  MEMEX_DATABASENAME: {{db}}
+selfUpdate:
+  azureClientId: <portalIdentityClientId>   # the shared UAMI client id (same for every env)
+# + TLS secretName, AI + OAuth config, resources — copy from an existing env and adjust.
+```
+
+**4. Deploy (helm install + PVCs + Key Vault SecretProviderClass + ingress + TLS):**
+```bash
+deploy/aks/envs/{{ns}}/deploy.sh
+```
+
+**5. DNS + sign-in:** point `{{host}}` at the ingress IP (zone `{{o.DnsZone}}`), then add the OAuth
+redirect URIs (`https://{{host}}/signin-microsoft`, `/signin-google`, …) and invitation/email config.
+
+**6. Verify:**
+```bash
+az aks command invoke -g {{o.ResourceGroup}} -n {{o.ClusterName}} --command \
+  "kubectl -n {{ns}} rollout status deployment/memex-portal-deployment --timeout=300s"
+curl -sS -o /dev/null -w '%{http_code}\n' https://{{host}}/   # → 200
+```
+
+Once rolled, `{{host}}` self-updates from `main` like every other instance.
+""";
+    }
+}

--- a/memex/Memex.Portal.Shared/Instances/InstancesAdminLayoutArea.cs
+++ b/memex/Memex.Portal.Shared/Instances/InstancesAdminLayoutArea.cs
@@ -118,6 +118,12 @@ public static class InstancesAdminLayoutArea
         var logger = host.Hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger(typeof(InstancesAdminLayoutArea));
 
+        // Seed the create-instance form ONCE (outside the refresh loop, so typed values survive a
+        // Refresh) so clicking "Generate plan" before touching any field still emits — the plan
+        // generator then returns actionable "fill in the fields" feedback instead of silence.
+        host.RegisterForDisposal(Observable.Return(new Dictionary<string, object?>())
+            .Subscribe(seed => host.UpdateData(CreateFormId, seed)));
+
         // Re-query on each Refresh click (a fresh guid retriggers the Switch).
         return host.Stream.GetDataStream<string>(RefreshId).StartWith("")
             .Select(_ =>
@@ -205,7 +211,7 @@ public static class InstancesAdminLayoutArea
             }
         }
 
-        stack = stack.WithView(BuildCreateSection(options));
+        stack = stack.WithView(BuildCreateSection(options, logger));
         return stack;
     }
 
@@ -213,7 +219,7 @@ public static class InstancesAdminLayoutArea
     /// Guided create-instance: inputs → a generated provisioning PLAN (commands), rendered below.
     /// Mutates no infrastructure — the admin runs the emitted commands themselves.
     /// </summary>
-    private static UiControl BuildCreateSection(InstancesOptions options)
+    private static UiControl BuildCreateSection(InstancesOptions options, ILogger? logger)
     {
         var form = Controls.Stack
             .WithView(Controls.Title("Create a new instance", 2))
@@ -255,7 +261,8 @@ public static class InstancesAdminLayoutArea
                         string? Get(string k) => f.GetValueOrDefault(k)?.ToString()?.Trim();
                         var plan = InstanceProvisioningPlan.Generate(Get("name"), Get("domain"), Get("database"), options);
                         ctx.Host.UpdateData(CreatePlanId, plan);
-                    });
+                    },
+                    ex => logger?.LogWarning(ex, "[Instances] reading the create-instance form failed"));
                 return Task.CompletedTask;
             }));
 

--- a/memex/Memex.Portal.Shared/Instances/InstancesAdminLayoutArea.cs
+++ b/memex/Memex.Portal.Shared/Instances/InstancesAdminLayoutArea.cs
@@ -1,0 +1,278 @@
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using MeshWeaver.Application.Styles;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Layout.DataGrid;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Instances;
+
+/// <summary>
+/// Platform-admin "Instances" overview. Queries the live Kubernetes cluster and lists every portal
+/// instance — its public host, namespace, running version (image tag) and replica health — with a
+/// per-instance link to the Grafana logs. A guided "Create a new instance" section turns a few
+/// inputs into the exact provisioning command sequence (a plan; it mutates NOTHING). Gated to
+/// platform admins (Admin-partition <c>Permission.All</c>), like the Partitions tab.
+/// </summary>
+public static class InstancesAdminLayoutArea
+{
+    /// <summary>Area name for the instances overview.</summary>
+    public const string InstancesArea = "Instances";
+
+    private const string SettingsTabId = "Instances";
+    private const string RefreshId = "instancesRefresh";
+    private const string CreateFormId = "instancesCreateForm";
+    private const string CreatePlanId = "instancesCreatePlan";
+
+    /// <summary>Plain row record bound into the <see cref="DataGridControl"/> (camelCased property names).</summary>
+    public sealed record InstanceRow
+    {
+        /// <summary>Public host from the namespace's Ingress.</summary>
+        public string Domain { get; init; } = string.Empty;
+        /// <summary>Kubernetes namespace.</summary>
+        public string Namespace { get; init; } = string.Empty;
+        /// <summary>Running version (portal image tag).</summary>
+        public string Version { get; init; } = string.Empty;
+        /// <summary>Replica health, "ready/desired".</summary>
+        public string Replicas { get; init; } = string.Empty;
+    }
+
+    /// <summary>Registers the global-admin "Instances" tab on the node's Settings page. The provider
+    /// yields the tab only once the viewer is confirmed a global admin; the content gates again as
+    /// defense-in-depth.</summary>
+    public static MessageHubConfiguration AddInstancesAdminSettingsTab(this MessageHubConfiguration config)
+        => config.AddSettingsMenuItems(new SettingsMenuItemProvider(GetInstancesTab));
+
+    private static IObservable<IReadOnlyList<SettingsMenuItemDefinition>> GetInstancesTab(
+        LayoutAreaHost host, RenderingContext ctx)
+    {
+        IReadOnlyList<SettingsMenuItemDefinition> none = Array.Empty<SettingsMenuItemDefinition>();
+
+        var viewerId = ResolveViewerId(host);
+        if (string.IsNullOrEmpty(viewerId))
+            return Observable.Return(none);
+
+        var tab = new SettingsMenuItemDefinition(
+            Id: SettingsTabId,
+            Label: "Instances",
+            ContentBuilder: BuildInstancesTab,
+            Group: "Administration",
+            Icon: FluentIcons.Server(),
+            GroupIcon: FluentIcons.Shield(),
+            Order: 305,
+            Keywords: ["instances", "instance", "cluster", "aks", "kubernetes", "namespaces", "deployments",
+                "version", "grafana", "logs", "infra", "infrastructure", "administration", "platform",
+                "create instance", "provision", "environment"]);
+
+        return host.Hub.IsGlobalAdmin(viewerId)
+            .Where(isAdmin => isAdmin)
+            .Take(1)
+            .Select(_ => (IReadOnlyList<SettingsMenuItemDefinition>)new[] { tab })
+            .Timeout(TimeSpan.FromSeconds(5))
+            .Catch<IReadOnlyList<SettingsMenuItemDefinition>, Exception>(_ => Observable.Return(none))
+            .StartWith(none);
+    }
+
+    private static UiControl BuildInstancesTab(LayoutAreaHost host, StackControl stack, MeshNode? node)
+        => stack.WithView(BuildArea(host));
+
+    /// <summary>The reactive Instances area, registrable via
+    /// <c>AddLayout(layout =&gt; layout.WithView(InstancesArea, InstancesOverview))</c>.</summary>
+    [Browsable(false)]
+    public static IObservable<UiControl?> InstancesOverview(LayoutAreaHost host, RenderingContext _)
+        => BuildArea(host);
+
+    private static IObservable<UiControl?> BuildArea(LayoutAreaHost host)
+    {
+        var viewerId = ResolveViewerId(host);
+        if (string.IsNullOrEmpty(viewerId))
+            return Observable.Return<UiControl?>(AccessDenied());
+
+        return host.Hub.IsGlobalAdmin(viewerId)
+            .Where(isAdmin => isAdmin)
+            .Take(1)
+            .Select(_ => true)
+            .Timeout(TimeSpan.FromSeconds(5))
+            .Catch<bool, Exception>(_ => Observable.Return(false))
+            .Select(isAdmin => isAdmin
+                ? BuildAdminView(host)
+                : Observable.Return<UiControl?>(AccessDenied()))
+            .Switch();
+    }
+
+    private static UiControl AccessDenied()
+        => Controls.Markdown("Access denied — platform admins only.");
+
+    private static IObservable<UiControl?> BuildAdminView(LayoutAreaHost host)
+    {
+        var options = host.Hub.ServiceProvider.GetService<InstancesOptions>() ?? new InstancesOptions();
+        var service = host.Hub.ServiceProvider.GetService<IClusterInstanceService>();
+        var logger = host.Hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(InstancesAdminLayoutArea));
+
+        // Re-query on each Refresh click (a fresh guid retriggers the Switch).
+        return host.Stream.GetDataStream<string>(RefreshId).StartWith("")
+            .Select(_ =>
+            {
+                if (service is null || !service.CanQuery)
+                    return Observable.Return<UiControl?>(
+                        BuildView(host, ImmutableArray<InstanceInfo>.Empty, options, canQuery: false, logger));
+                return service.GetInstances()
+                    .Select(instances => (UiControl?)BuildView(host, instances, options, canQuery: true, logger))
+                    .StartWith((UiControl?)Controls.Markdown("*Querying the cluster…*"));
+            })
+            .Switch();
+    }
+
+    private static UiControl BuildView(
+        LayoutAreaHost host, ImmutableArray<InstanceInfo> instances,
+        InstancesOptions options, bool canQuery, ILogger? logger)
+    {
+        var stack = Controls.Stack
+            .WithView(Controls.Title("Platform Instances", 1))
+            .WithView(Controls.Markdown(
+                "Live from the Kubernetes cluster — every portal instance on "
+                + $"`{options.ClusterName}`, its running version and replica health. "
+                + "Use the log links to jump to Grafana."));
+
+        // Refresh
+        stack = stack.WithView(Controls.Button("Refresh")
+            .WithAppearance(Appearance.Outline)
+            .WithIconStart(FluentIcons.ArrowClockwise())
+            .WithClickAction(ctx =>
+            {
+                ctx.Host.UpdateData(RefreshId, Guid.NewGuid().ToString("N"));
+                return Task.CompletedTask;
+            }));
+
+        if (!canQuery)
+            stack = stack.WithView(Controls.Markdown(
+                "> **Cluster query unavailable.** This install can't read the cluster — it isn't running "
+                + "in Kubernetes, or its service account lacks cluster-read RBAC. Enable "
+                + "`instancesAdmin.clusterRead` on THIS instance's Helm release (granted only to the "
+                + "company instance, never public/customer instances). See "
+                + "[Instances](/Doc/Architecture/Instances)."));
+        else if (instances.Length == 0)
+            stack = stack.WithView(Controls.Markdown("*No portal instances found on the cluster.*"));
+        else
+        {
+            var rows = instances
+                .Select(i => new InstanceRow
+                {
+                    Domain = i.Domain,
+                    Namespace = i.Namespace,
+                    Version = i.Version,
+                    Replicas = $"{i.ReadyReplicas}/{i.DesiredReplicas}",
+                })
+                .ToImmutableArray();
+
+            var id = Guid.NewGuid().ToString();
+            host.RegisterForDisposal(Observable.Return(rows).Subscribe(data => host.UpdateData(id, data)));
+
+            stack = stack.WithView(Controls.DataGrid(new JsonPointerReference(LayoutAreaReference.GetDataPointer(id)))
+                .WithColumn(new PropertyColumnControl<string>
+                    { Property = nameof(InstanceRow.Domain).ToCamelCase() }.WithTitle("Instance"))
+                .WithColumn(new PropertyColumnControl<string>
+                    { Property = nameof(InstanceRow.Namespace).ToCamelCase() }.WithTitle("Namespace"))
+                .WithColumn(new PropertyColumnControl<string>
+                    { Property = nameof(InstanceRow.Version).ToCamelCase() }.WithTitle("Version"))
+                .WithColumn(new PropertyColumnControl<string>
+                    { Property = nameof(InstanceRow.Replicas).ToCamelCase() }.WithTitle("Ready"))
+                .Resizable());
+
+            // Grafana log links — one per instance. Markdown anchors (robust for external hosts).
+            stack = stack.WithView(Controls.Title("Logs", 2));
+            if (string.IsNullOrWhiteSpace(options.GrafanaBaseUrl))
+                stack = stack.WithView(Controls.Markdown(
+                    "*Set `Instances:GrafanaBaseUrl` to enable per-instance Grafana log links.*"));
+            else
+            {
+                var links = instances.Select(i =>
+                {
+                    var label = string.IsNullOrEmpty(i.Domain) ? i.Namespace : i.Domain;
+                    var url = options.GrafanaLogsUrl(i.Namespace);
+                    return url is null ? $"- {label}" : $"- [{label} — logs]({url})";
+                });
+                stack = stack.WithView(Controls.Markdown(string.Join("\n", links)));
+            }
+        }
+
+        stack = stack.WithView(BuildCreateSection(options));
+        return stack;
+    }
+
+    /// <summary>
+    /// Guided create-instance: inputs → a generated provisioning PLAN (commands), rendered below.
+    /// Mutates no infrastructure — the admin runs the emitted commands themselves.
+    /// </summary>
+    private static UiControl BuildCreateSection(InstancesOptions options)
+    {
+        var form = Controls.Stack
+            .WithView(Controls.Title("Create a new instance", 2))
+            .WithView(Controls.Markdown(
+                "Generate the vetted provisioning command sequence for a new instance on this "
+                + "cluster. **This produces a plan only — nothing is deployed automatically.**"));
+
+        var inputs = Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithHorizontalGap(8)
+            .WithStyle("align-items: flex-end; flex-wrap: wrap;");
+        inputs = inputs.WithView(new TextFieldControl(new JsonPointerReference("name"))
+        {
+            Label = "Instance name (namespace)",
+            Placeholder = "e.g. acme",
+            DataContext = LayoutAreaReference.GetDataPointer(CreateFormId),
+        }.WithWidth("220px"));
+        inputs = inputs.WithView(new TextFieldControl(new JsonPointerReference("domain"))
+        {
+            Label = "Domain",
+            Placeholder = $"e.g. acme.{options.DnsZone}",
+            DataContext = LayoutAreaReference.GetDataPointer(CreateFormId),
+        }.WithWidth("260px"));
+        inputs = inputs.WithView(new TextFieldControl(new JsonPointerReference("database"))
+        {
+            Label = "Database (optional)",
+            Placeholder = "defaults from name",
+            DataContext = LayoutAreaReference.GetDataPointer(CreateFormId),
+        }.WithWidth("220px"));
+        inputs = inputs.WithView(Controls.Button("Generate plan")
+            .WithAppearance(Appearance.Accent)
+            .WithIconStart(FluentIcons.CloudAdd())
+            .WithClickAction(ctx =>
+            {
+                ctx.Host.Stream.GetDataStream<Dictionary<string, object?>>(CreateFormId)
+                    .Take(1)
+                    .Subscribe(f =>
+                    {
+                        string? Get(string k) => f.GetValueOrDefault(k)?.ToString()?.Trim();
+                        var plan = InstanceProvisioningPlan.Generate(Get("name"), Get("domain"), Get("database"), options);
+                        ctx.Host.UpdateData(CreatePlanId, plan);
+                    });
+                return Task.CompletedTask;
+            }));
+
+        form = form.WithView(inputs);
+        // The generated plan renders here, updating in place when "Generate plan" is clicked.
+        form = form.WithView((h, _) => h.Stream.GetDataStream<string>(CreatePlanId)
+            .Select(md => (UiControl?)Controls.Markdown(string.IsNullOrEmpty(md)
+                ? "*Fill in the fields and click **Generate plan**.*"
+                : md))
+            .StartWith((UiControl?)Controls.Markdown("*Fill in the fields and click **Generate plan**.*")));
+        return form;
+    }
+
+    private static string? ResolveViewerId(LayoutAreaHost host)
+    {
+        var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
+        return accessService?.Context?.ObjectId
+               ?? accessService?.CircuitContext?.ObjectId;
+    }
+}

--- a/memex/Memex.Portal.Shared/Instances/InstancesConfiguration.cs
+++ b/memex/Memex.Portal.Shared/Instances/InstancesConfiguration.cs
@@ -1,0 +1,33 @@
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Memex.Portal.Shared.Instances;
+
+/// <summary>
+/// Wires the platform-admin Instances feature: binds <see cref="InstancesOptions"/> from the
+/// <c>Instances:*</c> configuration section and registers the live cluster-query service. The
+/// admin-gated GUI itself is added as a Settings tab via
+/// <see cref="InstancesAdminLayoutArea.AddInstancesAdminSettingsTab"/>.
+/// </summary>
+public static class InstancesConfiguration
+{
+    /// <summary>Registers <see cref="InstancesOptions"/> (from config) and
+    /// <see cref="IClusterInstanceService"/>. The k8s query service uses X.509/TLS APIs that are
+    /// <c>[UnsupportedOSPlatform("browser")]</c>, so it is skipped on a Blazor WASM host (matching
+    /// <c>AddSelfUpdate</c>); off-cluster it simply reports it cannot query.</summary>
+    public static TBuilder AddInstancesAdmin<TBuilder>(this TBuilder builder)
+        where TBuilder : MeshBuilder
+    {
+        builder.ConfigureServices(services =>
+        {
+            services.AddSingleton(sp =>
+                sp.GetService<IConfiguration>()?.GetSection("Instances").Get<InstancesOptions>()
+                ?? new InstancesOptions());
+            if (!OperatingSystem.IsBrowser())
+                services.AddSingleton<IClusterInstanceService, KubernetesInstanceService>();
+            return services;
+        });
+        return builder;
+    }
+}

--- a/memex/Memex.Portal.Shared/Instances/InstancesOptions.cs
+++ b/memex/Memex.Portal.Shared/Instances/InstancesOptions.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+
+namespace Memex.Portal.Shared.Instances;
+
+/// <summary>
+/// Configuration for the platform-admin Instances view (<see cref="InstancesAdminLayoutArea"/>).
+/// Defaults target the standard shared-AKS topology (see Doc/Architecture/Instances.md). Override
+/// per environment via the <c>Instances:*</c> configuration section — most importantly
+/// <see cref="GrafanaBaseUrl"/>, which is empty until the environment sets its Grafana host.
+/// </summary>
+public record InstancesOptions
+{
+    /// <summary>The k8s label whose value marks a portal Deployment (and Ingress). The chart stamps
+    /// <c>app.kubernetes.io/component=memex-portal</c> on the portal workloads; the instance query
+    /// selects on it so only portals are listed, never migrations or other pods.</summary>
+    public string PortalComponentLabel { get; init; } = "app.kubernetes.io/component";
+
+    /// <summary>The <see cref="PortalComponentLabel"/> value that identifies a portal.</summary>
+    public string PortalComponentValue { get; init; } = "memex-portal";
+
+    /// <summary>The container name within a portal Deployment whose image tag IS the running version.</summary>
+    public string PortalContainer { get; init; } = "memex-portal";
+
+    /// <summary>Base URL of the Grafana that serves this platform's logs (e.g.
+    /// <c>https://grafana.systemorph.com</c>). Empty → the Instances view shows no logs link and a
+    /// hint to configure it. Set via <c>Instances:GrafanaBaseUrl</c>.</summary>
+    public string GrafanaBaseUrl { get; init; } = string.Empty;
+
+    /// <summary>Optional override for the per-instance Grafana logs URL, with <c>{base}</c> and
+    /// <c>{namespace}</c> tokens (the namespace value is URL-encoded). Set this when your Grafana
+    /// version's Explore URL format differs from the built-in default. Empty → the built-in
+    /// Grafana-Explore (Loki) deep link is used.</summary>
+    public string GrafanaLogsUrlTemplate { get; init; } = string.Empty;
+
+    // ── Displayed / used for the guided create-instance command generation (Instances.md) ──
+
+    /// <summary>AKS cluster name (display + generated commands).</summary>
+    public string ClusterName { get; init; } = "memexaks-cluster";
+
+    /// <summary>Azure resource group of the cluster + PG server (generated commands).</summary>
+    public string ResourceGroup { get; init; } = "memex-aks-rg";
+
+    /// <summary>Shared PostgreSQL Flexible Server name (generated commands).</summary>
+    public string PostgresServer { get; init; } = "memexaks-pg";
+
+    /// <summary>DNS zone new instance hosts live under (generated commands / display).</summary>
+    public string DnsZone { get; init; } = "meshweaver.cloud";
+
+    /// <summary>Container registry the portal image is pulled from (display).</summary>
+    public string Registry { get; init; } = "meshweaver.azurecr.io";
+
+    /// <summary>
+    /// The Grafana logs deep-link for a namespace, or null when <see cref="GrafanaBaseUrl"/> is
+    /// unset. Uses <see cref="GrafanaLogsUrlTemplate"/> when provided, otherwise builds a Grafana
+    /// Explore (Loki) link querying <c>{namespace="&lt;ns&gt;"}</c>. Pure — unit-tested.
+    /// </summary>
+    public string? GrafanaLogsUrl(string @namespace)
+    {
+        if (string.IsNullOrWhiteSpace(GrafanaBaseUrl))
+            return null;
+        var baseUrl = GrafanaBaseUrl.TrimEnd('/');
+        if (!string.IsNullOrWhiteSpace(GrafanaLogsUrlTemplate))
+            return GrafanaLogsUrlTemplate
+                .Replace("{base}", baseUrl)
+                .Replace("{namespace}", Uri.EscapeDataString(@namespace));
+
+        // Grafana Explore (Loki) — the `panes` schema (Grafana 10+). Built with JsonSerializer so
+        // the nested braces are never a string-literal hazard, then URL-encoded as one query param.
+        var panes = JsonSerializer.Serialize(new Dictionary<string, object>
+        {
+            ["mw"] = new
+            {
+                datasource = "loki",
+                queries = new[] { new { refId = "A", expr = $"{{namespace=\"{@namespace}\"}}" } },
+                range = new { from = "now-1h", to = "now" },
+            },
+        });
+        return $"{baseUrl}/explore?schemaVersion=1&orgId=1&panes={Uri.EscapeDataString(panes)}";
+    }
+}

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -2,6 +2,7 @@
 using Memex.Portal.Shared.Api;
 using Memex.Portal.Shared.Authentication;
 using Memex.Portal.Shared.Email;
+using Memex.Portal.Shared.Instances;
 using Memex.Portal.Shared.SelfUpdate;
 using Memex.Portal.Shared.Settings;
 using Memex.Portal.Shared.Social;
@@ -757,6 +758,9 @@ public static class MemexConfiguration
                         .AddInboxSettingsTab()
                         // Platform auto-update strategy (Admin/UpdatePolicy) — stable/continuous/none.
                         .AddUpdatePolicySettingsTab()
+                        // Platform-admin Instances overview: live cluster query (namespaces, versions,
+                        // replica health) + Grafana log links + guided create-instance plan generator.
+                        .AddInstancesAdminSettingsTab()
                         // Public privacy statement (Admin/Privacy, served anonymously at /privacy).
                         .AddPrivacySettingsTab()
                         // About — exact running build (version + git commit) with a GitHub link. Ungated.
@@ -788,7 +792,10 @@ public static class MemexConfiguration
                 // Platform self-update: the Admin/UpdatePolicy node + the poller that watches ACR and
                 // (on Kubernetes) patches the portal+migration deployments to the newest version per
                 // policy. On a non-k8s host it degrades to detect-and-notify. See ReleaseStrategy.md.
-                .AddSelfUpdate();
+                .AddSelfUpdate()
+                // Platform-admin Instances feature: binds InstancesOptions (Instances:*) and the
+                // live cluster-query service backing the admin Instances tab (see Instances.md).
+                .AddInstancesAdmin();
         }
 
         /// <summary>

--- a/test/Memex.Portal.Shared.Test/InstancesServiceTest.cs
+++ b/test/Memex.Portal.Shared.Test/InstancesServiceTest.cs
@@ -1,0 +1,149 @@
+using Memex.Portal.Shared.Instances;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the pure logic behind the platform-admin Instances view: the Kubernetes-API JSON parse
+/// (deployments + ingresses → instances), the version-tag extraction, the Grafana log-link builder,
+/// and the guided create-instance plan generator. All deterministic — no cluster required.
+/// </summary>
+public class InstancesServiceTest
+{
+    private const string DeploymentsJson = """
+    {
+      "items": [
+        {
+          "metadata": { "name": "memex-portal-deployment", "namespace": "memex" },
+          "spec": {
+            "replicas": 2,
+            "template": { "spec": { "containers": [
+              { "name": "memex-portal", "image": "meshweaver.azurecr.io/memex-portal-ai:ci.612" }
+            ] } }
+          },
+          "status": { "readyReplicas": 2 }
+        },
+        {
+          "metadata": { "name": "memex-portal-deployment", "namespace": "atioz" },
+          "spec": {
+            "replicas": 1,
+            "template": { "spec": { "containers": [
+              { "name": "gate-node", "image": "meshweaver.azurecr.io/node-gate:ci.612" },
+              { "name": "memex-portal", "image": "meshweaver.azurecr.io/memex-portal-ai:ci.610" }
+            ] } }
+          },
+          "status": { "readyReplicas": 0 }
+        }
+      ]
+    }
+    """;
+
+    private const string IngressesJson = """
+    {
+      "items": [
+        { "metadata": { "namespace": "memex" }, "spec": { "rules": [ { "host": "memex.systemorph.com" } ] } },
+        { "metadata": { "namespace": "atioz" }, "spec": { "rules": [ { "host": "portal.atioz.example" } ] } }
+      ]
+    }
+    """;
+
+    [Fact]
+    public void ParseInstances_MapsNamespaceVersionHostAndReplicas_OrderedByNamespace()
+    {
+        var instances = KubernetesInstanceService.ParseInstances(DeploymentsJson, IngressesJson, new InstancesOptions());
+
+        Assert.Equal(2, instances.Length);
+
+        // Ordered by namespace (case-insensitive): atioz before memex.
+        var atioz = instances[0];
+        Assert.Equal("atioz", atioz.Namespace);
+        Assert.Equal("portal.atioz.example", atioz.Domain);
+        // Picks the memex-portal container's image, NOT the gate container's.
+        Assert.Equal("ci.610", atioz.Version);
+        Assert.Equal(0, atioz.ReadyReplicas);
+        Assert.Equal(1, atioz.DesiredReplicas);
+
+        var memex = instances[1];
+        Assert.Equal("memex", memex.Namespace);
+        Assert.Equal("memex.systemorph.com", memex.Domain);
+        Assert.Equal("ci.612", memex.Version);
+        Assert.Equal(2, memex.ReadyReplicas);
+        Assert.Equal(2, memex.DesiredReplicas);
+    }
+
+    [Fact]
+    public void ParseInstances_NoIngress_LeavesDomainEmpty_ButStillLists()
+    {
+        var instances = KubernetesInstanceService.ParseInstances(DeploymentsJson, """{ "items": [] }""", new InstancesOptions());
+        Assert.Equal(2, instances.Length);
+        Assert.All(instances, i => Assert.Equal(string.Empty, i.Domain));
+    }
+
+    [Theory]
+    [InlineData("meshweaver.azurecr.io/memex-portal-ai:ci.612", "ci.612")]
+    [InlineData("memex-portal-ai:latest", "latest")]
+    [InlineData("registry:5000/repo:tag", "tag")]
+    [InlineData("repo@sha256:abcdef", "")]
+    [InlineData("", "")]
+    public void VersionTag_ExtractsTagAfterLastColon_IgnoringDigest(string image, string expected)
+        => Assert.Equal(expected, KubernetesInstanceService.VersionTag(image));
+
+    [Fact]
+    public void GrafanaLogsUrl_EmptyBase_ReturnsNull()
+        => Assert.Null(new InstancesOptions().GrafanaLogsUrl("memex"));
+
+    [Fact]
+    public void GrafanaLogsUrl_WithBase_EncodesNamespaceQuery()
+    {
+        var url = new InstancesOptions { GrafanaBaseUrl = "https://grafana.example/" }.GrafanaLogsUrl("memex-cloud");
+        Assert.NotNull(url);
+        Assert.StartsWith("https://grafana.example/explore?", url);
+        // The namespace ends up inside the URL-encoded Loki query.
+        Assert.Contains("memex-cloud", Uri.UnescapeDataString(url!));
+        Assert.Contains("loki", Uri.UnescapeDataString(url!));
+    }
+
+    [Fact]
+    public void GrafanaLogsUrl_TemplateOverride_SubstitutesTokens()
+    {
+        var opts = new InstancesOptions
+        {
+            GrafanaBaseUrl = "https://g.example",
+            GrafanaLogsUrlTemplate = "{base}/logs?ns={namespace}",
+        };
+        Assert.Equal("https://g.example/logs?ns=memex", opts.GrafanaLogsUrl("memex"));
+    }
+
+    [Theory]
+    [InlineData("acme", true)]
+    [InlineData("memex-cloud", true)]
+    [InlineData("Acme", false)]      // uppercase not allowed
+    [InlineData("-acme", false)]     // leading dash
+    [InlineData("acme-", false)]     // trailing dash
+    [InlineData("ac me", false)]     // space
+    [InlineData("", false)]
+    public void IsValidName_EnforcesK8sNamespaceRules(string name, bool expected)
+        => Assert.Equal(expected, InstanceProvisioningPlan.IsValidName(name));
+
+    [Fact]
+    public void Generate_ValidInputs_EmitsParameterizedCommandPlan()
+    {
+        var plan = InstanceProvisioningPlan.Generate("acme", "acme.meshweaver.cloud", null, new InstancesOptions());
+
+        Assert.Contains("Provisioning plan for instance `acme`", plan);
+        Assert.Contains("acme.meshweaver.cloud", plan);
+        // Database defaults from the name (dashes stripped) when not given.
+        Assert.Contains("db create", plan);
+        Assert.Contains("-d acme", plan);
+        Assert.Contains("portalNamespaces", plan);
+        Assert.Contains("deploy/aks/envs/acme/deploy.sh", plan);
+    }
+
+    [Fact]
+    public void Generate_InvalidName_ReturnsCannotGenerate_NotCommands()
+    {
+        var plan = InstanceProvisioningPlan.Generate("Bad Name", "x.example", null, new InstancesOptions());
+        Assert.Contains("Cannot generate a plan yet", plan);
+        Assert.DoesNotContain("deploy.sh", plan);
+    }
+}


### PR DESCRIPTION
Requested by @rbuergi: an admin GUI that queries the live AKS config, shows the instances, links to Grafana logs, and (guided) helps create a new instance. Available to **all platform admins**.

## What it does
A new **Instances** tab on the Settings page (Administration group), gated to platform admins exactly like the Partitions tab (Admin-partition `Permission.All`, reactive gate + defense-in-depth).

- **Live cluster view** — queries the in-cluster Kubernetes API (read-only sibling of the self-updater's `KubernetesDeploymentUpdater`: same projected SA token + cluster-CA validation). Lists every portal Deployment (by `app.kubernetes.io/component=memex-portal`) with its **running version** (image tag), **ready/desired replicas**, and the **public host** from each namespace's Ingress. Rendered in a `DataGrid`. All IO bridged through `IIoPool` (Http pool); the layout area is fully reactive (no async/await).
- **Grafana logs** — a per-instance log link (`Instances:GrafanaBaseUrl`, optional `GrafanaLogsUrlTemplate`). Empty base → a configure hint. A **Refresh** button re-queries.
- **Guided create-instance** (the "guided: plan + commands" option chosen) — name/domain/db inputs → the exact vetted provisioning command sequence (bicep namespace add, DB create, `values.<env>.yaml` scaffold, `deploy.sh`, DNS/OAuth, verify) from `OnboardingNewEnvironment.md`. **Generates a plan only — mutates no infrastructure.**

## Security (important)
Reading deployments/ingresses **across namespaces** needs a cluster-scoped read grant. That `ClusterRole`+`ClusterRoleBinding` is gated behind Helm **`instancesAdmin.clusterRead` (default `false`)** so **only the company/control instance** (memex.systemorph.com) gets it — never the public or customer instances (a tenant pod must not enumerate the whole cluster). Absent grant → query 403s → logged, empty shown, no crash. Enable it in the company env's values.

## Tests / validation
- Pure logic unit-tested — **19 tests** in `Memex.Portal.Shared.Test/InstancesServiceTest.cs`: k8s JSON parse (deployments+ingresses → instances, picks the portal container not gates, orders by namespace), version-tag extraction, Grafana URL builder (+ template override), and the plan generator (valid → parameterized commands; invalid name → refuses).
- `Memex.Portal.Shared` builds clean under **Release / `-warnaserror`**.
- `helm template` renders the ClusterRole only when `clusterRead=true`, absent by default.

## Notes
- The live cluster query + admin-tab visibility need a running portal **in-cluster** to exercise end-to-end; I verified everything locally-verifiable (build, unit logic, helm render) and mirrored the proven in-pod k8s-API client. Please confirm on the company instance after enabling `instancesAdmin.clusterRead` + setting `Instances:GrafanaBaseUrl`.
- Links to `Instances.md` / `DatabaseBackups.md` from #376 (docs). Merge #376 first (or together) so those `/Doc/Architecture/...` links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)