### PR TITLE
docs: plugin-ops + self-update ops manuals

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -75,6 +75,32 @@ Container names are `memex-portal` and `memex-migration`; deployments are `memex
 - **Portal serves:** `curl -sS -o /dev/null -w '%{http_code}' https://<NS>.meshweaver.cloud/` → `200`.
 - **Schema/index applied** (when the change was a migration): spot-check via `az aks command invoke … "kubectl -n <NS> exec deployment/memex-portal-deployment -- …"` or an MCP query.
 
+## Self-update ops — pausing, pinning, and the rules that bite
+
+Operational facts about the in-pod updater (learned the hard way — each cost a debugging session):
+
+- **Tags must be dotted SemVer** (`3.0.0` / `3.0.0-ci.749`). The updater treats any other deployed
+  tag (a hand-built `myfix-<sha>`) as invalid and **reverts the Deployment to the newest valid ci
+  tag within minutes**. Manual rolls therefore only work with CI-built `ci.<N>` tags — ship code
+  via a merged PR, never a hand-tagged image.
+- **Pause switch** = the `Admin/UpdatePolicy` node: patch `content.policy` to `None`
+  (`Continuous`/`Stable`/`None`). BUT a **freshly booted pod races the policy read** — the poller
+  starts with the configured default (`Continuous`) and runs one check before the node's value
+  arrives, so `None` alone does not protect a roll that restarts the pod.
+- **Hard pause** (break-glass, e.g. pinning a diagnostic image): delete the RoleBinding
+  `memex-portal-self-update` (namespace-local; role + SA are both named per chart) — the updater's
+  Deployment PATCH then fails closed. Recreate the RoleBinding to resume. Always restore promptly.
+- **KeyVault CSI env timing**: a new/changed KV secret needs **two rollout restarts** — the first
+  pod's mount populates the synced k8s Secret, but that pod's `envFrom` snapshot predates it; the
+  second restart reads the populated Secret. Verify with `printenv <key> | md5sum` in the NEWEST
+  pod (sort by `creationTimestamp`).
+- **🚨 Namespace ↔ instance mapping**: this cluster hosts several instances whose Deployments all
+  share names (`memex-portal-deployment`): namespace `memex` = the systemorph.com company portal,
+  `memex-cloud` = **memex.meshweaver.cloud** (SPC `memexcloud-portal-ai-secrets`, KeyVault
+  `Systemorph`, `memexcloud-`-prefixed secret names), `atioz` = the customer portal. Before ANY
+  kubectl change, confirm the namespace matches the instance you mean — e.g. run a diagnostic on
+  the target portal that prints its pod hostname and `kubectl get pods -A | grep <hostname>`.
+
 ## Portal self-update — Workload Identity for ACR polling
 
 Steady state is **self-update** (see [ReleaseStrategy.md](/Doc/Architecture/ReleaseStrategy)): the portal polls ACR and patches its own Deployment to a newer image. The in-cluster PATCH uses the `memex-portal-sa` service-account token (RBAC ships in the Helm chart and works everywhere). **Listing the ACR tags** to discover a newer image needs an Azure credential — that is wired with **AKS Workload Identity**, mirroring the existing pgBackRest wiring (`infra/modules/storage.bicep`).

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginAuthoring.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginAuthoring.md
@@ -98,6 +98,19 @@ GitSync fetches the folder and parses every file into nodes:
 Authentication resolves user-credential-first, then the **App installation token** — so a headless
 server instance imports with no personal login at all.
 
+**Into an EXISTING Space** (the partition already has content): `ImportFromGitHub` is create-only —
+it fails with `Node already exists`. Configure the source and reimport instead:
+
+```csharp
+sync.SaveConfig(spacePath, repoUrl, branch, subdir, false, false)   // register the source
+sync.ReimportAtCommit(spacePath, branch, userId)                    // mirror add/update/prune
+```
+
+Two operational notes: a **failed** `ImportFromGitHub` (e.g. auth error) leaves an **empty orphan
+Space** behind — inspect (`version:1`, no children) and delete it before retrying; and running
+`SaveConfig` + `ReimportAtCommit` back-to-back can race the config read — a retry reads the settled
+config. Re-running a reimport is idempotent (fingerprint-matched).
+
 ## 5. Set up your own instance as a registry
 
 Any MeshWeaver instance can be the distribution point for its own plugins. One-time setup:
@@ -120,6 +133,23 @@ Any MeshWeaver instance can be the distribution point for its own plugins. One-t
 
 The App credential lives on this ONE instance; every consumer pulls over HTTP — that's the whole
 point ([Plugin Registry](/Doc/Architecture/PluginRegistry) → credential encapsulation).
+
+### App-grant gotchas (each one bites)
+
+- **The grant is TWO steps**: the App's *Permissions & events* (Contents: Read [& Write]) **and** the
+  installation's *Repository access* (which repos it can see). Either missing → API calls **404**
+  (not 403) on the repo. A permission change on an installed App may also sit **pending approval**
+  on the installation page until an org admin approves it.
+- **Installation tokens fix their permissions at mint.** Granting repos/permissions does NOT upgrade
+  already-minted tokens — and the platform caches its token until near expiry. After changing the
+  grant, **restart the portal** to drop the cached token.
+- **Client-id prefixes**: `Iv23li…` = GitHub **App**, `Ov23li…` = **OAuth App**. A client secret
+  generated on one never matches the other's client id ("client_id and/or client_secret passed are
+  incorrect" at token exchange while the authorize step succeeds).
+- **Verify from outside** (no portal involved): sign an RS256 JWT with the PEM (`iss` = client id),
+  then `GET /app/installations` → `POST /app/installations/{id}/access_tokens` → check the response
+  `permissions`, then `GET /installation/repositories` with the token — the granted repos must list
+  the plugin repo.
 
 ## 6. Push back (mesh → git)
 
@@ -144,3 +174,5 @@ Trigger it from the Space's GitHub Sync settings (Sync back) or
 | `The GitHub App has no installations` | The App exists but isn't installed on the org — App page → Install App, grant the repo. |
 | Import succeeds but the type doesn't render | Compile failed — check the NodeType's diagnostics (`get_diagnostics`/the node's Configuration tab); usual causes are the runtime-compile rules in §2.5. |
 | Push-back 403 | The App's Contents permission is Read-only — set Read & Write and re-approve the installation. |
+| `Octokit.NotFoundException` (404) on a repo that exists | The installation can't SEE the repo — repo missing from the installation's *Repository access*, or the token was minted before the grant (restart the portal to drop the cached token). |
+| `Node already exists: {space}` on import | `ImportFromGitHub` is create-only. For an existing Space use `SaveConfig` + `ReimportAtCommit` (§4). If the existing node is an empty orphan from a previously failed import, delete it and retry. |


### PR DESCRIPTION
Documents today's operational lessons where the next operator will find them:

- **PluginAuthoring**: existing-Space installs (`SaveConfig` + `ReimportAtCommit`), orphan-Space cleanup, the two-step GitHub App grant + token-mint semantics, `Iv/Ov` client-id prefixes, outside-in verification, troubleshooting rows
- **DeploymentAKS**: self-update ops — SemVer-only tags (manual rolls revert), `Admin/UpdatePolicy` pause + its boot race, RoleBinding hard-pause, KV CSI double-restart, the namespace↔instance map

Docs-only; link-integrity test 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)