### PR TITLE
Ship the BusinessRules scope generator with the platform (no NuGet for IScope nodes)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -35,15 +35,11 @@ dotnet publish memex/aspire/Memex.Database.Migration/Memex.Database.Migration.cs
 
 Pick a `<tag>` that pins the change (e.g. `bugfix-2026-06-05`). CI also builds images on push, but it lags — check `az acr repository show-tags -n meshweaver --repository memex-portal-ai --orderby time_desc --top 5` before assuming your commit is built; if it isn't, build manually as above. If only portal code changed (no migration/schema change), you can reuse the live `memex-migration` tag and skip the migration build.
 
-### The node-compile `#r` feed is auto-baked into the image (no manual pack step)
+### The scope source generator ships WITH the platform (no NuGet)
 
-Node Source pulls MeshWeaver libraries in at compile time via `#r "nuget:MeshWeaver.X"` — most importantly the scope **source generator** every `IScope<,>` node needs (e.g. the PensionFund balance sheet):
+Every `IScope<,>` node (e.g. the PensionFund balance sheet) needs the BusinessRules scope **source generator**. That generator now **ships with the platform**: its DLL is copied into `MeshWeaver.Graph`'s runtime output (the `ShipScopeGenerator` target), flows into the published image, and `MeshNodeCompilationService` always feeds it to the compile. So a new `IScope<,>` node compiles with **no `#r` directive and no NuGet round-trip** — just declare the interface. The `IScope<,>` surface itself (`MeshWeaver.BusinessRules`) is a loaded framework assembly, so it's already in the compile references too.
 
-```csharp
-#r "nuget:MeshWeaver.BusinessRules.Generator"
-```
-
-These resolve **offline from a feed baked into the image**, never from nuget.org (they are not published there). The portal publish above runs the `BakeMeshLocalFeed` MSBuild target (in `Memex.Portal.Distributed.csproj`; **Release-only**, `BeforeTargets="ComputeFilesToPublish"`): it packs the curated set — `MeshWeaver.BusinessRules` (the `IScope<,>` surface) + `MeshWeaver.BusinessRules.Generator` (its scope generator) — into `dist/packages` at the single global `$(Version)` from `Directory.Build.props`, then copies that folder next to `nuget.config` into `/app`. At runtime `NuGetAssemblyResolver` reads `nuget.config` from the app dir and resolves `MeshWeaver.*` against that local folder.
+**Transition:** legacy nodes that still carry `#r "nuget:MeshWeaver.BusinessRules.Generator"` keep working — the compile filters that `#r`'d copy out (the built-in generator supersedes it, so it never runs twice). During the transition the `BakeMeshLocalFeed` target (in `Memex.Portal.Distributed.csproj`) still bakes the mesh-local feed so those `#r` directives *resolve*; it will be removed once no node source carries the `#r`.
 
 **So the `dotnet publish -t:PublishContainer` command above is self-contained — there is no separate pack step.** Notes:
 

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -1279,18 +1279,30 @@ internal class MeshNodeCompilationService(
     /// scopes framework: declare the interface, the compiler generates the
     /// proxy, and <c>services.AddBusinessRules(assembly)</c> discovers it.
     /// </summary>
+    // The BusinessRules scope generator ships WITH the platform — its DLL is copied into the Graph
+    // runtime output (see MeshWeaver.Graph.csproj) and always fed to the compile. So an IScope<,>
+    // node compiles with NO `#r "nuget:MeshWeaver.BusinessRules.Generator"` and NO NuGet round-trip
+    // (no mesh-local feed, no BakeMeshLocalFeed). It runs as a build TOOL only — never a project
+    // analyzer, so it does NOT propagate to downstream builds. A node may still `#r` a DIFFERENT
+    // generator; those add to this built-in one. Resolved once (the file is stable per process).
+    private static readonly IReadOnlyList<string> BuiltInGeneratorPaths = ResolveBuiltInGenerators();
+
+    private static IReadOnlyList<string> ResolveBuiltInGenerators()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "MeshWeaver.BusinessRules.Generator.dll");
+        return File.Exists(path) ? [path] : [];
+    }
+
     private static CSharpCompilation RunSourceGenerators(
         CSharpCompilation compilation, IReadOnlyList<string> generatorAssemblyPaths, ILogger logger, CancellationToken ct)
     {
-        // The scope generator is supplied EXPLICITLY: only nodes whose Source declares
-        // `#r "nuget:MeshWeaver.BusinessRules.Generator"` resolve it (into generatorAssemblyPaths)
-        // — there is NO auto-inject heuristic. The generator is never a framework reference (that
-        // propagated the analyzer and bloated every build). Nothing #r'd → nothing to discover →
-        // pass through unchanged (a scope source that forgot the #r fails to compile and surfaces
-        // the error on the Progress page; it never hangs).
-        if (generatorAssemblyPaths.Count == 0)
+        // Always include the built-in scope generator, plus any generator a node #r'd explicitly.
+        IReadOnlyList<string> allPaths = BuiltInGeneratorPaths.Count == 0
+            ? generatorAssemblyPaths
+            : [.. BuiltInGeneratorPaths, .. generatorAssemblyPaths];
+        if (allPaths.Count == 0)
             return compilation;
-        var generators = SourceGeneratorLoader.Discover(generatorAssemblyPaths, logger);
+        var generators = SourceGeneratorLoader.Discover(allPaths, logger);
         if (generators.IsDefaultOrEmpty)
             return compilation;
         var driver = CSharpGeneratorDriver.Create(generators);

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -1296,10 +1296,15 @@ internal class MeshNodeCompilationService(
     private static CSharpCompilation RunSourceGenerators(
         CSharpCompilation compilation, IReadOnlyList<string> generatorAssemblyPaths, ILogger logger, CancellationToken ct)
     {
-        // Always include the built-in scope generator, plus any generator a node #r'd explicitly.
+        // Always include the built-in scope generator, plus any OTHER generator a node #r'd. Filter a
+        // node's own `#r "nuget:MeshWeaver.BusinessRules.Generator"` OUT — otherwise the same generator
+        // loads from two paths (built-in + baked) and runs twice → duplicate IScope<,> implementations
+        // → CS0101. Legacy nodes that still carry that #r keep compiling (built-in supersedes it).
         IReadOnlyList<string> allPaths = BuiltInGeneratorPaths.Count == 0
             ? generatorAssemblyPaths
-            : [.. BuiltInGeneratorPaths, .. generatorAssemblyPaths];
+            : [.. BuiltInGeneratorPaths,
+               .. generatorAssemblyPaths.Where(p => !string.Equals(
+                   Path.GetFileName(p), "MeshWeaver.BusinessRules.Generator.dll", StringComparison.OrdinalIgnoreCase))];
         if (allPaths.Count == 0)
             return compilation;
         var generators = SourceGeneratorLoader.Discover(allPaths, logger);

--- a/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
+++ b/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
@@ -48,6 +48,11 @@
        NOT propagate to downstream builds). We MSBuild it (no ProjectReference — that would re-add it
        as an analyzer) and copy the DLL as a runtime item that flows to every consumer's output. -->
   <Target Name="ShipScopeGenerator" BeforeTargets="AssignTargetPaths">
+    <!-- Restore first (separate invocation — Restore+Build in one MSBuild call is unreliable):
+         a fresh checkout building Graph alone has no assets file for the generator, since it is
+         invoked as a build TOOL here, not referenced (so no transitive restore). -->
+    <MSBuild Projects="..\MeshWeaver.BusinessRules.Generator\MeshWeaver.BusinessRules.Generator.csproj"
+             Targets="Restore" Properties="Configuration=$(Configuration)" />
     <MSBuild Projects="..\MeshWeaver.BusinessRules.Generator\MeshWeaver.BusinessRules.Generator.csproj"
              Targets="Build" Properties="Configuration=$(Configuration)" />
     <ItemGroup>

--- a/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
+++ b/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
@@ -42,4 +42,21 @@
     <ProjectReference Include="..\MeshWeaver.NuGet\MeshWeaver.NuGet.csproj" />
   </ItemGroup>
 
+  <!-- Ship the BusinessRules scope generator DLL WITH the platform, so IScope<,> node types compile
+       with NO `#r "nuget:MeshWeaver.BusinessRules.Generator"` and NO mesh-local NuGet feed. It is
+       loaded by MeshNodeCompilationService as a build TOOL only (never a project analyzer, so it does
+       NOT propagate to downstream builds). We MSBuild it (no ProjectReference — that would re-add it
+       as an analyzer) and copy the DLL as a runtime item that flows to every consumer's output. -->
+  <Target Name="ShipScopeGenerator" BeforeTargets="AssignTargetPaths">
+    <MSBuild Projects="..\MeshWeaver.BusinessRules.Generator\MeshWeaver.BusinessRules.Generator.csproj"
+             Targets="Build" Properties="Configuration=$(Configuration)" />
+    <ItemGroup>
+      <None Include="..\MeshWeaver.BusinessRules.Generator\bin\$(Configuration)\netstandard2.0\MeshWeaver.BusinessRules.Generator.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>MeshWeaver.BusinessRules.Generator.dll</Link>
+        <Visible>false</Visible>
+      </None>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/test/MeshWeaver.Graph.Test/BuiltInScopeGeneratorTest.cs
+++ b/test/MeshWeaver.Graph.Test/BuiltInScopeGeneratorTest.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using MeshWeaver.Graph.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the "no NuGet for business rules" contract: the BusinessRules scope generator ships WITH the
+/// platform (its DLL copied into the Graph runtime output, flowing to every consumer) and is
+/// discoverable as a Roslyn generator — so <c>MeshNodeCompilationService</c> always feeds it to the
+/// compile and an <c>IScope&lt;,&gt;</c> node type compiles with NO
+/// <c>#r "nuget:MeshWeaver.BusinessRules.Generator"</c> and NO mesh-local NuGet feed / BakeMeshLocalFeed.
+/// </summary>
+public class BuiltInScopeGeneratorTest
+{
+    [Fact]
+    public void ScopeGenerator_ShipsWithPlatform_AndIsDiscoverable()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "MeshWeaver.BusinessRules.Generator.dll");
+        File.Exists(path).Should().BeTrue(
+            "the BusinessRules scope generator must ship in the runtime output so IScope<,> nodes " +
+            "compile without any #r \"nuget:...\" directive");
+
+        var generators = SourceGeneratorLoader.Discover([path], NullLogger.Instance);
+        generators.Should().NotBeEmpty("the shipped DLL must expose the [Generator] ScopeCodeGenerator");
+    }
+}


### PR DESCRIPTION
Cherry-picks the built-in scope generator from the feature branch (verified there since 2026-07-08):

- The generator DLL is copied into `MeshWeaver.Graph`'s runtime output (flows to every consumer) and `MeshNodeCompilationService` always feeds it to `RunSourceGenerators` — an `IScope<,>` node compiles with **no** `#r "nuget:MeshWeaver.BusinessRules.Generator"` and **no** mesh-local NuGet feed.
- Legacy nodes that still `#r` the generator are deduped (built-in supersedes) — no CS0101 double-run.
- Loaded as a build TOOL only (never a project analyzer, no build propagation). Non-breaking.
- `ShipScopeGenerator` target restores the generator explicitly (fresh-checkout single-project builds worked only via the solution restore before).

Pinned by `BuiltInScopeGeneratorTest` (DLL ships + discoverable). This unblocks migrating prod scope nodes off `#r` and then deleting `BakeMeshLocalFeed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)