### PR TITLE
feat(notifications): space-aware invites + configurable delivery + access-grant alerts

### DIFF
--- a/memex/Memex.Portal.Shared/Email/InvitationEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/InvitationEmailSender.cs
@@ -3,6 +3,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.Json;
 using MeshWeaver.Blazor.Infrastructure;
+using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -41,7 +42,10 @@ public sealed class InvitationEmailSender(
     IConfiguration configuration,
     ILogger<InvitationEmailSender>? logger = null) : IHostedService, IDisposable
 {
-    private const string InviteSubject = "You've been invited to Memex";
+    private const string GenericSubject = "You've been invited to Memex";
+    // Cap on resolving the invited Space's display name for the email — a nice-to-have, so we fall
+    // back to the raw space path (never block the send) if the cross-partition read is slow.
+    private static readonly TimeSpan SpaceLookupTimeout = TimeSpan.FromSeconds(10);
     private readonly CompositeDisposable subscriptions = new();
     // In-process single-claim guard: path → claimed. Instance (mesh/process-scoped), never static.
     // Prevents the live-query snapshot lag from re-claiming+re-sending the same invitation while
@@ -74,6 +78,7 @@ public sealed class InvitationEmailSender(
             var meshService = sp.GetRequiredService<IMeshService>();
             var accessService = sp.GetRequiredService<AccessService>();
             var emailSender = sp.GetRequiredService<IEmailSender>();
+            var workspace = hub.GetWorkspace();
             var jsonOptions = hub.JsonSerializerOptions;
             var baseUrl = configuration["Portal:BaseUrl"]
                           ?? configuration["PublicBaseUrl"]
@@ -102,7 +107,7 @@ public sealed class InvitationEmailSender(
                     items =>
                     {
                         foreach (var node in items)
-                            Send(node, meshService, accessService, emailSender, jsonOptions, baseUrl);
+                            Send(node, meshService, accessService, emailSender, workspace, jsonOptions, baseUrl);
                     },
                     ex => logger?.LogWarning(ex, "InvitationEmailSender: query failed")));
         }
@@ -114,7 +119,7 @@ public sealed class InvitationEmailSender(
 
     private void Send(
         MeshNode node, IMeshService meshService, AccessService accessService,
-        IEmailSender emailSender, JsonSerializerOptions jsonOptions, string? baseUrl)
+        IEmailSender emailSender, IWorkspace workspace, JsonSerializerOptions jsonOptions, string? baseUrl)
     {
         var invitation = InvitationService.TryGetInvitation(node, jsonOptions);
         if (invitation is null
@@ -136,7 +141,12 @@ public sealed class InvitationEmailSender(
         // the rare multi-replica race — worst case one duplicate email, never a lost one.)
         var claimedAt = DateTimeOffset.UtcNow;
         SetEmailSentAt(node, invitation, claimedAt, meshService, accessService)
-            .SelectMany(_ => emailSender.SendEmail(invitation.Email!, InviteSubject, BuildInviteEmailHtml(baseUrl)))
+            .SelectMany(_ => ResolveSpaceName(invitation, workspace, accessService))
+            .SelectMany(spaceName =>
+            {
+                var (subject, html) = BuildInviteEmail(invitation, spaceName, baseUrl);
+                return emailSender.SendEmail(invitation.Email!, subject, html);
+            })
             .Subscribe(
                 ok => logger?.LogInformation(
                     "InvitationEmailSender: {Email} emailed (sent={Sent})", invitation.Email, ok),
@@ -159,7 +169,51 @@ public sealed class InvitationEmailSender(
             () => accessService.ImpersonateAsSystem(),
             _ => meshService.UpdateNode(node with { Content = current with { EmailSentAt = to } }));
 
-    private static string BuildInviteEmailHtml(string? baseUrl)
+    /// <summary>
+    /// Resolves the invited Space's display name for a space-scoped invitation (reads the Space
+    /// node's <see cref="MeshNode.Name"/> as System, since this hosted service has no user context).
+    /// Emits <c>null</c> for a deployment-wide invitation (no <see cref="Invitation.SpacePath"/>),
+    /// and falls back to the raw space path if the read is slow or the node isn't visible — the
+    /// name is cosmetic, so we never block or fail the send on it.
+    /// </summary>
+    private static IObservable<string?> ResolveSpaceName(
+        Invitation invitation, IWorkspace workspace, AccessService accessService)
+    {
+        if (string.IsNullOrWhiteSpace(invitation.SpacePath))
+            return Observable.Return<string?>(null);
+
+        var spacePath = invitation.SpacePath!.Trim();
+        return Observable.Using(
+            accessService.ImpersonateAsSystem,
+            _ => workspace.GetMeshNodeStream(spacePath)
+                .Where(n => n is not null)
+                .Select(n => string.IsNullOrWhiteSpace(n!.Name) ? spacePath : n.Name)
+                .Take(1)
+                .Timeout(SpaceLookupTimeout, Observable.Return<string?>(spacePath))
+                .Catch(Observable.Return<string?>(spacePath)));
+    }
+
+    /// <summary>
+    /// Builds the invitation email. When the invitation targets a Space
+    /// (<see cref="Invitation.SpacePath"/> set) it addresses the Space by <paramref name="spaceName"/>
+    /// (falling back to the path) and links straight to it (<c>{baseUrl}/{SpacePath}</c>); otherwise
+    /// it renders the generic deployment-wide invite. Pure + static so it is directly unit-testable.
+    /// </summary>
+    internal static (string Subject, string Html) BuildInviteEmail(
+        Invitation invitation, string? spaceName, string? baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(invitation.SpacePath))
+            return (GenericSubject, BuildGenericHtml(baseUrl));
+
+        var spacePath = invitation.SpacePath!.Trim();
+        var display = string.IsNullOrWhiteSpace(spaceName) ? spacePath : spaceName!.Trim();
+        var spaceUrl = string.IsNullOrEmpty(baseUrl)
+            ? null
+            : $"{baseUrl!.TrimEnd('/')}/{spacePath.TrimStart('/')}";
+        return ($"You've been invited to {display}", BuildSpaceHtml(display, spaceUrl));
+    }
+
+    private static string BuildGenericHtml(string? baseUrl)
     {
         var link = string.IsNullOrEmpty(baseUrl)
             ? ""
@@ -168,6 +222,20 @@ public sealed class InvitationEmailSender(
               + "Open Memex</a></p>"
               + $"<p style=\"color:#888;font-size:12px;\">{System.Net.WebUtility.HtmlEncode(baseUrl)}</p>";
         return "<p>You've been invited to Memex.</p>"
+               + "<p>Sign in with this email address to get started.</p>"
+               + link;
+    }
+
+    private static string BuildSpaceHtml(string spaceName, string? spaceUrl)
+    {
+        var name = System.Net.WebUtility.HtmlEncode(spaceName);
+        var link = string.IsNullOrEmpty(spaceUrl)
+            ? ""
+            : $"<p style=\"margin:16px 0;\"><a href=\"{System.Net.WebUtility.HtmlEncode(spaceUrl)}\" " +
+              "style=\"background:#2563eb;color:#fff;padding:10px 18px;border-radius:6px;text-decoration:none;\">"
+              + $"Open {name}</a></p>"
+              + $"<p style=\"color:#888;font-size:12px;\">{System.Net.WebUtility.HtmlEncode(spaceUrl)}</p>";
+        return $"<p>You've been invited to <strong>{name}</strong>.</p>"
                + "<p>Sign in with this email address to get started.</p>"
                + link;
     }

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -180,6 +180,10 @@ public static class MemexConfiguration
         // live via the change feed + reconciled against current state on startup so a trigger during
         // downtime still fires. Migrates any legacy ScheduledAction nodes on startup.
         services.AddHostedService<MeshWeaver.Graph.EventSubscriptionRunner>();
+        // Access-grant notifier: watches AccessAssignment creations on the change feed and notifies the
+        // granted user ("You've been given <role> access to <node>") through NotificationService.Dispatch
+        // (honours their per-category bell/email preferences). Covers every grant path in one place.
+        services.AddHostedService<MeshWeaver.Graph.AccessGrantNotifier>();
         // App-level event-log outbox: durably records every change-feed event (Postgres in prod via
         // PostgreSqlEventLogStore, else in-memory) + replays not-yet-processed entries on startup.
         services.AddMeshEventLog();
@@ -728,6 +732,8 @@ public static class MemexConfiguration
                         // per-node hub so they resolve when anchored on the type roots (/Agent/AiAgents …).
                         .AddAiCatalogLayoutAreas()
                         .AddApiTokensSettingsTab()
+                        // Per-user "Notifications" tab: choose bell/email per notification category.
+                        .AddNotificationsSettingsTab()
                         // AI menu (top bar) — replaces the retired Models + AI Settings tabs. Each entry
                         // opens mesh search grouped by namespace, so every tier (global / space / user)
                         // where the concern is defined shows as its own section. Per-item configurable

--- a/memex/Memex.Portal.Shared/Settings/InvitationsSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/InvitationsSettingsTab.cs
@@ -181,6 +181,7 @@ public static class InvitationsSettingsTab
                 $"<div style=\"font-size: 0.8rem; color: var(--neutral-foreground-hint);\">" +
                 $"Invited {inv.InvitedAt:yyyy-MM-dd}" +
                 (string.IsNullOrEmpty(inv.InvitedBy) ? "" : $" by {Esc(inv.InvitedBy!)}") +
+                (string.IsNullOrEmpty(inv.SpacePath) ? "" : $" · Space: {Esc(inv.SpacePath!)}") +
                 (string.IsNullOrEmpty(inv.Note) ? "" : $" · {Esc(inv.Note!)}") +
                 "</div></div>"));
 
@@ -205,25 +206,6 @@ public static class InvitationsSettingsTab
         }
 
         return container;
-    }
-
-    private const string InviteSubject = "You've been invited to Memex";
-
-    private static string BuildInviteEmailHtml(string? baseUrl)
-    {
-        var link = string.IsNullOrEmpty(baseUrl)
-            ? ""
-            : $"<p style=\"margin:16px 0;\"><a href=\"{Esc(baseUrl)}\" " +
-              $"style=\"background:#2563eb;color:#fff;padding:10px 18px;border-radius:6px;" +
-              $"text-decoration:none;\">Open Memex</a></p>";
-        return
-            "<div style=\"font-family:sans-serif;font-size:14px;color:#111;\">" +
-            "<h2 style=\"margin:0 0 12px 0;\">You've been invited to Memex</h2>" +
-            "<p>An administrator has invited you to join the Memex portal. " +
-            "Sign in with <strong>this email address</strong> to complete your onboarding.</p>" +
-            link +
-            "<p style=\"color:#666;font-size:12px;\">If you weren't expecting this invitation, you can ignore this email.</p>" +
-            "</div>";
     }
 
     private static string StatusBadge(InvitationStatus status)

--- a/memex/Memex.Portal.Shared/Settings/NotificationsSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/NotificationsSettingsTab.cs
@@ -1,0 +1,68 @@
+using System.Reactive.Linq;
+using MeshWeaver.Application.Styles;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Memex.Portal.Shared.Settings;
+
+/// <summary>
+/// Per-user "Notifications" settings tab — lets every user choose, per notification category
+/// (approvals, access grants, chat, system), whether it reaches them via the in-app bell and/or by
+/// email. Data-binds the STANDARD node-content editor directly to the user's
+/// <c>{userId}/_Settings/Notifications</c> <see cref="NotificationSettings"/> node (each checkbox
+/// writes one field through the node stream — no /data replica, no save subscription). Visible to
+/// everyone (<see cref="Permission.None"/>).
+///
+/// <para>These deterministic preferences drive <see cref="NotificationService.Dispatch"/>. The
+/// advanced AI-triage routing (<c>NotificationRule</c>/<c>NotificationChannel</c>) still layers on top
+/// for users who author routing rules; the deterministic email path defers to it for them.</para>
+/// </summary>
+public static class NotificationsSettingsTab
+{
+    public const string TabId = "Notifications";
+
+    public static MessageHubConfiguration AddNotificationsSettingsTab(this MessageHubConfiguration config)
+        => config.AddSettingsMenuItems(
+            new SettingsMenuItemDefinition(
+                Id: TabId,
+                Label: "Notifications",
+                ContentBuilder: BuildContent,
+                Group: "Preferences",
+                Icon: FluentIcons.Alert(),
+                GroupIcon: FluentIcons.Person(),
+                Order: 240,
+                RequiredPermission: Permission.None));
+
+    internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack, MeshNode? node)
+    {
+        var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
+        var userId = accessService?.Context?.ObjectId ?? accessService?.CircuitContext?.ObjectId;
+
+        stack = stack.WithView(Controls.H2("Notifications").WithStyle("margin: 0 0 8px 0;"));
+        stack = stack.WithView(Controls.Markdown(
+            "Choose where each kind of notification reaches you — the in-app **bell** and/or **email**. " +
+            "The bell is on by default for everything; email is on by default for access grants and approvals."));
+
+        if (string.IsNullOrEmpty(userId))
+        {
+            stack = stack.WithView(Controls.Markdown("_Sign in to manage your notification preferences._"));
+            return stack;
+        }
+
+        // Ensure the settings node exists (create-on-absent with defaults), then bind the standard
+        // node-content editor to it — each bool renders as a labelled checkbox that auto-saves through
+        // the node stream. No hand-rolled form, no /data copy.
+        stack = stack.WithView((h, _) => NotificationSettingsNodeType
+            .EnsureExists(h.Hub, userId!)
+            .Select(path => (UiControl?)MeshNodeContentEditorControl.ForType(path, typeof(NotificationSettings)))
+            .StartWith((UiControl?)Controls.Markdown("_Loading notification preferences…_")));
+
+        return stack;
+    }
+}

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -2525,13 +2525,17 @@ internal static class ThreadExecution
         var threadName = (hub.GetWorkspace().GetStream(new MeshNodeReference())
             as ISynchronizationStream<MeshNode>)?.Current?.Value?.Name ?? "Thread";
         var preview = Truncate(responseText, 120) ?? "";
+        // The thread lives under its owner's partition ({owner}/_Thread/{id}); the owner is the
+        // recipient whose delivery preferences (bell/email for the ChatReady category) apply.
+        var owner = threadPath.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
 
-        NotificationService.CreateNotification(
-            meshService,
+        NotificationService.Dispatch(
+            hub,
+            recipient: owner,
             mainNodePath: threadPath,
             title: $"\"{threadName}\" is ready",
             message: preview,
-            type: NotificationType.General,
+            type: NotificationType.ChatReady,
             targetNodePath: threadPath,
             // agentName arrives as a full PATH (resolution form); store the friendly short name.
             createdBy: SelectionId.IdOf(agentName) ?? "agent",

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -189,6 +189,9 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 // Keep the nav menu's sub-thread (children) list bound to the current thread.
                 if (!string.IsNullOrEmpty(value.ThreadPath))
                     SetupChildThreadsSubscription(value.ThreadPath);
+
+                // Viewing a thread clears its bell notifications (backlog + live arrivals).
+                MarkThreadNotificationsRead(value?.ThreadPath);
             }
 
             // Open per-message cache subscriptions AFTER threadPath is set —
@@ -299,6 +302,10 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     private IDisposable? myThreadsSubscription;
     private IReadOnlyList<MeshNode> childThreads = [];     // sub-threads (delegations) of THIS thread
     private IDisposable? childThreadsSubscription;
+    // While a thread is being viewed, its bell notifications are auto-marked read (backlog + any that
+    // arrive live). Re-subscribed only when the viewed thread changes; disposed with the component.
+    private IDisposable? _threadNotificationsSub;
+    private string? _notificationsThread;
 
     // Agent/model lists — fed by AgentPickerProjection; consumed by the /agent and /model
     // slash commands + @-reference agent detection. The visible harness/agent/model SELECTION
@@ -426,6 +433,8 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         {
             _templatePath = threadPath;
             OpenComposerProjection(threadPath);
+            // Opening an existing thread clears its bell notifications.
+            MarkThreadNotificationsRead(threadPath);
         }
         else if (!string.IsNullOrEmpty(_userHome))
         {
@@ -2861,6 +2870,45 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     /// not immediate children. Re-opened whenever the thread path changes.
     /// </summary>
     private string? _childThreadsPath;
+    /// <summary>
+    /// While this thread is the one being viewed, mark its bell notifications
+    /// (<c>{threadPath}/_Notification/*</c>) read — both the backlog on open and any that arrive live
+    /// (e.g. a completion notification while you're watching). Re-subscribes only when the viewed
+    /// thread changes. RLS scopes the query to the current user, so only their own notifications are
+    /// touched. Idempotent: already-read rows are skipped and the write is a no-op merge.
+    /// </summary>
+    private void MarkThreadNotificationsRead(string? path)
+    {
+        if (string.Equals(_notificationsThread, path, StringComparison.Ordinal))
+            return;                                       // already watching this thread
+        _notificationsThread = path;
+        _threadNotificationsSub?.Dispose();
+        _threadNotificationsSub = null;
+        if (string.IsNullOrEmpty(path))
+            return;
+        var cache = EnsureCache();
+        if (cache is null)
+            return;
+        _threadNotificationsSub = MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"path:{path}/_Notification scope:children nodeType:Notification"))
+            .Subscribe(
+                change =>
+                {
+                    foreach (var node in change.Items ?? [])
+                    {
+                        var n = node.ContentAs<Notification>(Hub.JsonSerializerOptions);
+                        if (n is null || n.IsRead)
+                            continue;
+                        cache.Update(node.Path, x =>
+                                x.Content is Notification cur && !cur.IsRead
+                                    ? x with { Content = cur with { IsRead = true } }
+                                    : x, Hub.JsonSerializerOptions)
+                            .Subscribe(_ => { }, _ => { });
+                    }
+                },
+                _ => { /* query error: leave notifications as-is */ });
+    }
+
     private void SetupChildThreadsSubscription(string path)
     {
         if (string.Equals(_childThreadsPath, path, StringComparison.OrdinalIgnoreCase))
@@ -3852,6 +3900,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             resumeSubscription?.Dispose();
             myThreadsSubscription?.Dispose();
             childThreadsSubscription?.Dispose();
+            _threadNotificationsSub?.Dispose();
             _navContextSubscription?.Dispose();
             composerSubscription?.Dispose();
             composerDefaultsSubscription?.Dispose();

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -2886,9 +2886,6 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         _threadNotificationsSub = null;
         if (string.IsNullOrEmpty(path))
             return;
-        var cache = EnsureCache();
-        if (cache is null)
-            return;
         _threadNotificationsSub = MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery(
                 $"path:{path}/_Notification scope:children nodeType:Notification"))
             .Subscribe(
@@ -2896,14 +2893,15 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 {
                     foreach (var node in change.Items ?? [])
                     {
-                        var n = node.ContentAs<Notification>(Hub.JsonSerializerOptions);
-                        if (n is null || n.IsRead)
+                        if (node.ContentAs<Notification>(Hub.JsonSerializerOptions) is not { IsRead: false })
                             continue;
-                        cache.Update(node.Path, x =>
-                                x.Content is Notification cur && !cur.IsRead
-                                    ? x with { Content = cur with { IsRead = true } }
-                                    : x, Hub.JsonSerializerOptions)
-                            .Subscribe(_ => { }, _ => { });
+                        // Re-establish the DURABLE circuit user: this write runs from a background query
+                        // emission where the AsyncLocal identity is cleared, so a direct stream Update
+                        // would fail closed under RLS and silently leave the notification unread.
+                        UpdateMeshNodeAsCircuitUser(node.Path, x =>
+                            x.ContentAs<Notification>(Hub.JsonSerializerOptions) is { IsRead: false } cur
+                                ? x with { Content = cur with { IsRead = true } }
+                                : x);
                     }
                 },
                 _ => { /* query error: leave notifications as-is */ });

--- a/src/MeshWeaver.Blazor.Portal/Components/NotificationCenter.razor
+++ b/src/MeshWeaver.Blazor.Portal/Components/NotificationCenter.razor
@@ -45,8 +45,16 @@
             .Subscribe(change =>
             {
                 var items = change.Items ?? Array.Empty<MeshNode>();
-                var newCount = items.Count(n =>
-                    n.ContentAs<Notification>(Hub.JsonSerializerOptions)?.IsRead == false);
+                // Count distinct SOURCES with unread notifications, not raw rows — five unread
+                // messages in one thread read as a single "1" on the bell, matching the grouped panel.
+                var newCount = items
+                    .Select(n => (node: n, notif: n.ContentAs<Notification>(Hub.JsonSerializerOptions)))
+                    .Where(x => x.notif is { IsRead: false })
+                    .Select(x => !string.IsNullOrEmpty(x.notif!.TargetNodePath)
+                        ? x.notif!.TargetNodePath!
+                        : (x.node.MainNode ?? x.node.Path))
+                    .Distinct()
+                    .Count();
                 if (newCount != unreadCount)
                 {
                     unreadCount = newCount;
@@ -70,15 +78,9 @@
             return;
         }
 
-        // Opening acknowledges the notifications — clear the badge immediately.
-        // The panel persists IsRead durably; this is the optimistic UX so the
-        // count doesn't linger while the writes propagate.
-        if (unreadCount != 0)
-        {
-            unreadCount = 0;
-            StateHasChanged();
-        }
-
+        // Opening the panel no longer marks everything read (the panel groups by source and marks a
+        // group read on click / on viewing its node), so the badge keeps reflecting the true unread
+        // count from the live query rather than being optimistically zeroed here.
         var dialog = await DialogService.ShowPanelAsync<NotificationCenterPanel>(new DialogParameters<GlobalState>()
         {
             Alignment = HorizontalAlignment.Right,

--- a/src/MeshWeaver.Blazor.Portal/Components/NotificationCenterPanel.razor
+++ b/src/MeshWeaver.Blazor.Portal/Components/NotificationCenterPanel.razor
@@ -244,8 +244,10 @@
     private void OnGroupClick(NotificationGroup g)
     {
         // Mark every unread notification in the group read, then navigate to the shared target.
+        // The synced query delivers Content as a JsonElement, so deserialize via ContentAs — a
+        // `node.Content is Notification` pattern would never match and nothing would be marked read.
         foreach (var node in g.Nodes)
-            if (node.Content is Notification n && !n.IsRead)
+            if (node.ContentAs<Notification>(Hub.JsonSerializerOptions) is { IsRead: false } n)
                 MarkRead(node, n);
         if (!string.IsNullOrEmpty(g.Key))
             NavigationManager.NavigateTo($"/{g.Key}");
@@ -277,7 +279,9 @@
         var changed = false;
         foreach (var n in notifications)
         {
-            if (n.Content is Notification notif && !notif.IsRead)
+            // Synced-query nodes carry Content as a JsonElement — deserialize via ContentAs (a
+            // `n.Content is Notification` check would never match, so nothing would be marked read).
+            if (n.ContentAs<Notification>(Hub.JsonSerializerOptions) is { IsRead: false } notif)
             {
                 MarkRead(n, notif);                                   // durable cross-hub write
                 updated.Add(n with { Content = notif with { IsRead = true } }); // optimistic

--- a/src/MeshWeaver.Blazor.Portal/Components/NotificationCenterPanel.razor
+++ b/src/MeshWeaver.Blazor.Portal/Components/NotificationCenterPanel.razor
@@ -29,16 +29,12 @@
     else
     {
         <div class="notification-list">
-            @foreach (var node in notifications)
+            @foreach (var g in Grouped())
             {
-                var notif = node.ContentAs<Notification>(Hub.JsonSerializerOptions);
-                if (notif == null) continue;
-                var isRead = notif.IsRead;
-                var targetPath = !string.IsNullOrEmpty(notif.TargetNodePath)
-                    ? notif.TargetNodePath
-                    : node.MainNode;
+                var notif = g.Newest;
+                var isRead = g.UnreadCount == 0;
                 <button class="notification-item @(isRead ? "is-read" : "is-unread")"
-                        @onclick="() => OnNotificationClick(node, notif, targetPath)" type="button">
+                        @onclick="() => OnGroupClick(g)" type="button">
                     <div class="notification-icon">
                         @if (!string.IsNullOrEmpty(notif.Icon))
                         {
@@ -50,7 +46,13 @@
                         }
                     </div>
                     <div class="notification-body">
-                        <div class="notification-title">@notif.Title</div>
+                        <div class="notification-title">
+                            @notif.Title
+                            @if (g.Count > 1)
+                            {
+                                <span class="notification-count" title="@g.Count updates">@g.Count</span>
+                            }
+                        </div>
                         @if (!string.IsNullOrEmpty(notif.Message))
                         {
                             <div class="notification-message">@notif.Message</div>
@@ -65,7 +67,7 @@
                     </div>
                     @if (!isRead)
                     {
-                        <div class="notification-unread-dot" title="Unread"></div>
+                        <div class="notification-unread-dot" title="@g.UnreadCount unread"></div>
                     }
                 </button>
             }
@@ -154,6 +156,20 @@
         margin-bottom: 2px;
         overflow-wrap: anywhere;
     }
+    .notification-count {
+        display: inline-block;
+        margin-left: 6px;
+        min-width: 18px;
+        padding: 0 5px;
+        font-size: 0.7rem;
+        font-weight: 700;
+        line-height: 16px;
+        text-align: center;
+        border-radius: 9px;
+        background: var(--accent-fill-rest);
+        color: var(--neutral-fill-rest);
+        vertical-align: middle;
+    }
     .notification-message {
         font-size: 0.82rem;
         color: var(--neutral-foreground-rest);
@@ -183,7 +199,6 @@
     [Parameter] public GlobalState Content { get; set; } = default!;
 
     private IReadOnlyList<MeshNode> notifications = Array.Empty<MeshNode>();
-    private bool markedOnOpen;
     private IDisposable? subscription;
 
     protected override void OnInitialized()
@@ -193,26 +208,51 @@
             .Subscribe(change =>
             {
                 notifications = (IReadOnlyList<MeshNode>?)change.Items?.ToList() ?? Array.Empty<MeshNode>();
-                // Opening the panel counts as seeing the notifications: flip the
-                // displayed set to read so the bell badge clears. Gate on the first
-                // populated load so notifications that arrive live while the panel
-                // is open still surface as unread.
-                if (!markedOnOpen && notifications.Count > 0)
-                {
-                    markedOnOpen = true;
-                    MarkAllRead();
-                }
+                // Note: opening the panel no longer marks everything read — that would defeat the
+                // per-source grouping + counts. A group is marked read when clicked, when its
+                // node/thread is viewed, or via the explicit "Mark all read" action.
                 InvokeAsync(StateHasChanged);
             });
     }
 
-    private void OnNotificationClick(MeshNode node, Notification notif, string? targetPath)
+    /// <summary>One notification group per source node (the thread/document/space the notifications
+    /// point at), so e.g. five new messages in a thread collapse into a single row with a count.
+    /// Keyed by <see cref="Notification.TargetNodePath"/> (fall back to <see cref="MeshNode.MainNode"/>),
+    /// newest group first.</summary>
+    private IReadOnlyList<NotificationGroup> Grouped()
     {
-        if (!notif.IsRead)
-            MarkRead(node, notif);
-        if (!string.IsNullOrEmpty(targetPath))
-            NavigationManager.NavigateTo($"/{targetPath}");
+        return notifications
+            .Select(n => (node: n, notif: n.ContentAs<Notification>(Hub.JsonSerializerOptions)))
+            .Where(x => x.notif is not null)
+            .GroupBy(x => !string.IsNullOrEmpty(x.notif!.TargetNodePath)
+                ? x.notif!.TargetNodePath!
+                : (x.node.MainNode ?? x.node.Path))
+            .Select(byKey =>
+            {
+                var ordered = byKey.OrderByDescending(x => x.notif!.CreatedAt).ToList();
+                return new NotificationGroup(
+                    Key: byKey.Key,
+                    Newest: ordered[0].notif!,
+                    Nodes: ordered.Select(x => x.node).ToList(),
+                    UnreadCount: ordered.Count(x => !x.notif!.IsRead),
+                    Count: ordered.Count);
+            })
+            .OrderByDescending(g => g.Newest.CreatedAt)
+            .ToList();
     }
+
+    private void OnGroupClick(NotificationGroup g)
+    {
+        // Mark every unread notification in the group read, then navigate to the shared target.
+        foreach (var node in g.Nodes)
+            if (node.Content is Notification n && !n.IsRead)
+                MarkRead(node, n);
+        if (!string.IsNullOrEmpty(g.Key))
+            NavigationManager.NavigateTo($"/{g.Key}");
+    }
+
+    private sealed record NotificationGroup(
+        string Key, Notification Newest, IReadOnlyList<MeshNode> Nodes, int UnreadCount, int Count);
 
     private void MarkRead(MeshNode node, Notification notif)
     {
@@ -270,6 +310,9 @@
         NotificationType.ApprovalRequired => new Icons.Regular.Size20.ShieldQuestion(),
         NotificationType.ApprovalGiven => new Icons.Regular.Size20.ShieldCheckmark(),
         NotificationType.ApprovalRejected => new Icons.Regular.Size20.ShieldDismiss(),
+        NotificationType.AccessGranted => new Icons.Regular.Size20.LockOpen(),
+        NotificationType.ChatReady => new Icons.Regular.Size20.Chat(),
+        NotificationType.System => new Icons.Regular.Size20.Warning(),
         _ => new Icons.Regular.Size20.Info()
     };
 

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingActivity.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingActivity.cs
@@ -242,24 +242,22 @@ internal static class ContentIndexingActivity
         if (meshService is null)
             return Observable.Return(Unit.Default);
 
-        // ImpersonateAsSystem is set when CreateNotification CALLS CreateNode (the write primitive
-        // snapshots the ambient AccessContext at call time and carries it through the later
-        // Subscribe — see AccessContextPropagation.md), so the cold write still runs as System.
-        using (accessService?.ImpersonateAsSystem())
-            return NotificationService.CreateNotification(
-                    meshService,
-                    "Admin",
-                    "Content indexing failed",
-                    $"The indexing activity '{activityPath}' ended in failure: {error}",
-                    NotificationType.General,
-                    targetNodePath: activityPath,
-                    createdBy: "system")
-                .Select(_ => Unit.Default)
-                .Catch<Unit, Exception>(ex =>
-                {
-                    logger?.LogWarning(ex,
-                        "Failed to emit admin notification for failed indexing activity {Path}", activityPath);
-                    return Observable.Return(Unit.Default);
-                });
+        // Dispatch runs the whole flow under the system identity itself (Admin-broadcast: no single
+        // recipient → in-app bell only, no email). System notification category.
+        return NotificationService.Dispatch(
+                hub,
+                recipient: null,
+                mainNodePath: "Admin",
+                title: "Content indexing failed",
+                message: $"The indexing activity '{activityPath}' ended in failure: {error}",
+                type: NotificationType.System,
+                targetNodePath: activityPath,
+                createdBy: "system")
+            .Catch<Unit, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "Failed to emit admin notification for failed indexing activity {Path}", activityPath);
+                return Observable.Return(Unit.Default);
+            });
     }
 }

--- a/src/MeshWeaver.Graph/AccessGrantNotifier.cs
+++ b/src/MeshWeaver.Graph/AccessGrantNotifier.cs
@@ -1,0 +1,129 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// Watches the mesh change feed for newly-created <c>AccessAssignment</c> nodes and notifies the
+/// granted user — "You've been given &lt;role&gt; access to &lt;node&gt;" — with a link to the node.
+/// This is the ONE place that reacts to grants, so it covers every grant path (the access-control
+/// tab, a Space's "Invite people" for an existing user, MCP, the event-subscription grant on
+/// sign-up) without touching each call site.
+///
+/// <para>Delivery goes through <see cref="NotificationService.Dispatch"/>, so it honours the
+/// recipient's <see cref="NotificationSettings"/> (bell and/or email for the
+/// <see cref="NotificationCategory.AccessGranted"/> category). Runs as System (the change feed has
+/// no user context). Only <b>grants</b> (a non-denied role) to a real <see cref="Mesh.Security.User"/>
+/// notify — denials and group/role subjects are skipped, and a self-grant (creator granting
+/// themselves, e.g. on space creation) is suppressed so it is never noise. Modelled on
+/// <see cref="EventSubscriptionRunner"/>.</para>
+/// </summary>
+public sealed class AccessGrantNotifier(
+    IMessageHub hub,
+    IMeshChangeFeed changeFeed,
+    AccessService accessService,
+    ILogger<AccessGrantNotifier>? logger = null) : IHostedService, IDisposable
+{
+    private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(10);
+    private IDisposable? subscription;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Live-only feed (no history replay): historical/seed grants written before this subscription
+        // never fire, so a restart does not re-notify. See EventSubscriptionRunner.
+        subscription = changeFeed.Subscribe(OnCreated, MeshChangeKind.Created);
+        logger?.LogInformation("AccessGrantNotifier: watching AccessAssignment creations");
+        return Task.CompletedTask;
+    }
+
+    private void OnCreated(MeshChangeEvent e)
+    {
+        if (!string.Equals(e.NodeType, AccessAssignmentNodeType.NodeType, StringComparison.Ordinal))
+            return;
+        AsSystem(() => hub.GetMeshNode(e.Path, ReadTimeout))
+            .SelectMany(Handle)
+            .Subscribe(
+                _ => { },
+                ex => logger?.LogWarning(ex, "AccessGrantNotifier: failed for {Path}", e.Path));
+    }
+
+    private IObservable<Unit> Handle(MeshNode? assignmentNode)
+    {
+        if (assignmentNode is null
+            || !TryResolveGrant(assignmentNode, hub.JsonSerializerOptions,
+                out var recipient, out var grantedNodePath, out var roleText))
+            return Observable.Return(Unit.Default);
+
+        // Notify only real users (a group/role subject has no User content → skip).
+        return AsSystem(() => hub.GetMeshNode(recipient, ReadTimeout)).SelectMany(userNode =>
+        {
+            if (userNode?.ContentAs<User>(hub.JsonSerializerOptions) is null)
+                return Observable.Return(Unit.Default);
+
+            return AsSystem(() => hub.GetMeshNode(grantedNodePath, ReadTimeout)).SelectMany(grantedNode =>
+            {
+                var name = string.IsNullOrWhiteSpace(grantedNode?.Name) ? grantedNodePath : grantedNode!.Name;
+                return NotificationService.Dispatch(
+                    hub,
+                    recipient: recipient,
+                    mainNodePath: recipient,
+                    title: $"You've been given access to {name}",
+                    message: $"You now have {roleText} access to \"{name}\".",
+                    type: NotificationType.AccessGranted,
+                    targetNodePath: grantedNodePath,
+                    createdBy: assignmentNode.CreatedBy,
+                    icon: "/static/NodeTypeIcons/shield.svg");
+            });
+        });
+    }
+
+    /// <summary>
+    /// Pure decision: should the created <paramref name="assignmentNode"/> raise an access-granted
+    /// notification, and to whom / for what? Returns <c>true</c> only for an actual grant (a
+    /// non-denied role) that is NOT a self-grant (creator == subject) and carries a target node.
+    /// Does not resolve whether the subject is a user (that needs a read). Pure + unit-testable.
+    /// </summary>
+    internal static bool TryResolveGrant(
+        MeshNode assignmentNode, System.Text.Json.JsonSerializerOptions options,
+        out string recipient, out string grantedNodePath, out string roleText)
+    {
+        recipient = grantedNodePath = roleText = "";
+        var assignment = assignmentNode.ContentAs<AccessAssignment>(options);
+        if (assignment is null || string.IsNullOrEmpty(assignment.AccessObject))
+            return false;
+
+        // Only actual grants (a non-denied role) — never notify about a denial.
+        var grantedRoles = (assignment.Roles ?? [])
+            .Where(r => !r.Denied && !string.IsNullOrEmpty(r.Role))
+            .Select(r => r.Role)
+            .ToList();
+        if (grantedRoles.Count == 0)
+            return false;
+
+        // Suppress self-grants (e.g. the space creator's own Admin assignment) — not noise-worthy.
+        if (string.Equals(assignmentNode.CreatedBy, assignment.AccessObject, StringComparison.Ordinal))
+            return false;
+
+        if (string.IsNullOrEmpty(assignmentNode.MainNode))
+            return false;
+
+        recipient = assignment.AccessObject;
+        grantedNodePath = assignmentNode.MainNode;
+        roleText = string.Join(", ", grantedRoles);
+        return true;
+    }
+
+    private IObservable<T> AsSystem<T>(Func<IObservable<T>> factory)
+        => Observable.Using(accessService.ImpersonateAsSystem, _ => Observable.Defer(factory));
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public void Dispose() => subscription?.Dispose();
+}

--- a/src/MeshWeaver.Graph/ApprovalLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/ApprovalLayoutAreas.cs
@@ -189,14 +189,15 @@ public static class ApprovalLayoutAreas
 
         activityWrite
             .DefaultIfEmpty()
-            .SelectMany(_ => NotificationService.CreateNotification(
-                nodeFactory,
-                approval.Requester,
-                $"Approval {newStatus}",
-                $"Your approval request for \"{approval.Purpose}\" has been {newStatus.ToString().ToLowerInvariant()}.",
-                notificationType,
-                approval.PrimaryNodePath,
-                currentUser))
+            .SelectMany(_ => NotificationService.Dispatch(
+                host.Hub,
+                recipient: approval.Requester,
+                mainNodePath: approval.Requester,
+                title: $"Approval {newStatus}",
+                message: $"Your approval request for \"{approval.Purpose}\" has been {newStatus.ToString().ToLowerInvariant()}.",
+                type: notificationType,
+                targetNodePath: approval.PrimaryNodePath,
+                createdBy: currentUser))
             .Subscribe(
                 _ => { /* fire-and-forget success */ },
                 _ => { /* errors already logged by hub */ });

--- a/src/MeshWeaver.Graph/ApprovalsView.cs
+++ b/src/MeshWeaver.Graph/ApprovalsView.cs
@@ -157,14 +157,15 @@ public static class ApprovalsView
                 };
 
                 nodeFactory.CreateNode(approvalNode)
-                    .SelectMany(_ => NotificationService.CreateNotification(
-                        nodeFactory,
-                        approver,
-                        "Approval Requested",
-                        $"{currentUser} requested your approval for \"{purpose}\".",
-                        NotificationType.ApprovalRequired,
-                        nodePath,
-                        currentUser))
+                    .SelectMany(_ => NotificationService.Dispatch(
+                        host.Hub,
+                        recipient: approver,
+                        mainNodePath: approver,
+                        title: "Approval Requested",
+                        message: $"{currentUser} requested your approval for \"{purpose}\".",
+                        type: NotificationType.ApprovalRequired,
+                        targetNodePath: nodePath,
+                        createdBy: currentUser))
                     .Subscribe(
                         _ => host.Hub.ServiceProvider.GetService<INavigationService>()
                                 ?.NavigateTo($"/{nodePath}"),

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -47,6 +47,7 @@ public static class GraphConfigurationExtensions
                 .AddGroupMembershipType()
                 .AddApprovalType()
                 .AddNotificationType()
+                .AddNotificationSettingsType()
                 .AddNotificationRuleType()
                 .AddNotificationChannelType()
                 .AddInvitationType()

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompileParkRegistry.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompileParkRegistry.cs
@@ -185,24 +185,25 @@ public sealed class NodeTypeCompileParkRegistry
             $"The node type '{nodeTypePath}' was parked after a compile failure and will not be " +
             $"retried until its source is fixed. {SummarizeError(error)}";
 
-        // Emit as System: the compile already runs as System, the recipient's bell partition
-        // (or the failing type's read-only partition, e.g. Doc) admits no ambient user write.
-        // Infrastructure observability, not a user-attributed write.
-        using (accessService?.ImpersonateAsSystem())
-            NotificationService.CreateNotification(
-                    meshService,
-                    mainNodePath,
-                    title,
-                    message,
-                    NotificationType.General,
-                    targetNodePath: nodeTypePath,
-                    createdBy: "system")
-                .Subscribe(
-                    _ => logger?.LogInformation(
-                        "Emitted compile-failure notification for {NodeTypePath} (recipient {Recipient})",
-                        nodeTypePath, mainNodePath),
-                    ex => logger?.LogWarning(ex,
-                        "Failed to emit compile-failure notification for {NodeTypePath}", nodeTypePath));
+        // Dispatch runs the whole flow as System itself (the compile runs as System; the recipient's
+        // bell partition — or the failing type's read-only partition, e.g. Doc — admits no ambient
+        // user write). Infrastructure observability under the System notification category. When
+        // recipient is null (System-driven build), it falls to the failing type (in-app only).
+        NotificationService.Dispatch(
+                hub,
+                recipient: recipient,
+                mainNodePath: mainNodePath,
+                title: title,
+                message: message,
+                type: NotificationType.System,
+                targetNodePath: nodeTypePath,
+                createdBy: "system")
+            .Subscribe(
+                _ => logger?.LogInformation(
+                    "Emitted compile-failure notification for {NodeTypePath} (recipient {Recipient})",
+                    nodeTypePath, mainNodePath),
+                ex => logger?.LogWarning(ex,
+                    "Failed to emit compile-failure notification for {NodeTypePath}", nodeTypePath));
     }
 
     private static string? NonSystem(string? userId) =>

--- a/src/MeshWeaver.Graph/Configuration/NotificationSettingsNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/NotificationSettingsNodeType.cs
@@ -1,0 +1,113 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Configuration for the <b>NotificationSettings</b> node — the per-user, deterministic delivery
+/// preferences (per <see cref="NotificationCategory"/>: in-app bell and/or email) that back the
+/// Notifications settings tab. One singleton node per user at
+/// <see cref="NotificationSettingsPaths.PathFor"/> (<c>{userId}/_Settings/Notifications</c>).
+///
+/// <para>System-managed shape (excluded from search/create/autocomplete) but user-owned — the
+/// settings tab data-binds to it and writes per-field via the node stream. Complements the advanced
+/// AI-triage layer (<see cref="NotificationRule"/> / <see cref="NotificationChannel"/>): the
+/// deterministic email path defers to triage for users who authored routing rules.</para>
+/// </summary>
+public static class NotificationSettingsNodeType
+{
+    /// <summary>The NodeType value used to identify notification-settings nodes.</summary>
+    public const string NodeType = "NotificationSettings";
+
+    /// <summary>Registers the built-in "NotificationSettings" MeshNode on the mesh builder.</summary>
+    public static TBuilder AddNotificationSettingsType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        builder.AddAutocompleteExcludedTypes(NodeType);
+        builder.ConfigureHub(config => config.WithType<NotificationSettings>(nameof(NotificationSettings)));
+        return builder;
+    }
+
+    /// <summary>Creates a MeshNode definition for the NotificationSettings node type.</summary>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "Notification Settings",
+        Icon = "/static/NodeTypeIcons/bell.svg",
+        IsSatelliteType = true,
+        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        HubConfiguration = config => config
+            .AddMeshDataSource(source => source
+                .WithContentType<NotificationSettings>())
+    };
+
+    /// <summary>
+    /// Create-on-absent (idempotent, reactive) of the <paramref name="userId"/>'s
+    /// <c>{userId}/_Settings/Notifications</c> node with default preferences, so the settings editor
+    /// binds to an existing node. Existence is read via <c>GetQuery</c> (empty-on-absent) — never a
+    /// point <c>GetMeshNodeStream</c> probe of a maybe-absent path. Emits the node path. Runs under
+    /// the caller's identity (the user owns their own partition). An existing node is left untouched.
+    /// </summary>
+    public static IObservable<string> EnsureExists(IMessageHub hub, string userId, ILogger? logger = null)
+    {
+        var path = NotificationSettingsPaths.PathFor(userId);
+        var meshService = hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null || string.IsNullOrEmpty(userId))
+            return Observable.Return(path);
+
+        MeshNode BuildNode() => new(NotificationSettingsPaths.NodeId, NotificationSettingsPaths.NamespaceFor(userId))
+        {
+            NodeType = NodeType,
+            Name = "Notification Settings",
+            State = MeshNodeState.Active,
+            Content = new NotificationSettings(),
+        };
+
+        return hub.GetWorkspace()
+            .GetQuery($"{NodeType}|{path}", $"path:{path} nodeType:{NodeType}")
+            .Take(1)
+            .SelectMany(nodes =>
+            {
+                var existing = nodes.FirstOrDefault(n =>
+                    string.Equals(n.NodeType, NodeType, StringComparison.OrdinalIgnoreCase));
+                if (existing is not null)
+                    return Observable.Return(path);
+                logger?.LogInformation("Seeding notification settings for {User}", userId);
+                return meshService.CreateNode(BuildNode())
+                    .Select(_ => path)
+                    // Idempotent: a concurrent first-writer won the create race.
+                    .Catch<string, Exception>(ex => IsAlreadyExists(ex)
+                        ? Observable.Return(path)
+                        : Observable.Throw<string>(ex));
+            });
+    }
+
+    /// <summary>Parses the settings content from a node (typed or raw <see cref="JsonElement"/>);
+    /// returns defaults when absent/unparseable.</summary>
+    public static NotificationSettings Parse(MeshNode? node, JsonSerializerOptions options) =>
+        node?.Content switch
+        {
+            NotificationSettings c => c,
+            JsonElement je => TryDeserialize(je, options) ?? new NotificationSettings(),
+            _ => new NotificationSettings(),
+        };
+
+    private static NotificationSettings? TryDeserialize(JsonElement je, JsonSerializerOptions options)
+    {
+        try { return JsonSerializer.Deserialize<NotificationSettings>(je.GetRawText(), options); }
+        catch { return null; }
+    }
+
+    private static bool IsAlreadyExists(Exception ex)
+    {
+        for (var e = ex; e is not null; e = e.InnerException)
+            if (e.Message?.Contains("already exists", StringComparison.OrdinalIgnoreCase) == true)
+                return true;
+        return false;
+    }
+}

--- a/src/MeshWeaver.Graph/NotificationService.cs
+++ b/src/MeshWeaver.Graph/NotificationService.cs
@@ -1,7 +1,14 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
 using MeshWeaver.ShortGuid;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Unit = System.Reactive.Unit;
 
 namespace MeshWeaver.Graph;
 
@@ -61,5 +68,122 @@ public static class NotificationService
         };
 
         return nodeFactory.CreateNode(node);
+    }
+
+    private static readonly TimeSpan LookupTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Preference-aware notification dispatch — the single entry point every emitter should use.
+    /// Reads the <paramref name="recipient"/>'s <see cref="NotificationSettings"/> and, per the
+    /// notification's <see cref="NotificationCategory"/>, delivers to the enabled channels:
+    /// <list type="bullet">
+    ///   <item><b>In-app</b> → creates the bell <see cref="Notification"/> satellite (as
+    ///     <see cref="CreateNotification"/> does).</item>
+    ///   <item><b>Email</b> → sends via <see cref="HubEmailExtensions.SendEmail"/> to the recipient's
+    ///     <see cref="Mesh.Security.User.Email"/>, UNLESS the recipient authored AI routing rules
+    ///     (<see cref="NotificationRule"/>) — then the advanced <c>NotificationTriageService</c> owns
+    ///     escalation and we skip the deterministic email to avoid double-sending.</item>
+    /// </list>
+    /// Runs the whole flow under the system identity (it reads arbitrary users' settings and writes
+    /// to arbitrary partitions — a legitimate infrastructure write). Returns a cold observable;
+    /// subscribe to drive. A <c>null</c>/empty <paramref name="recipient"/> (e.g. an "Admin" broadcast)
+    /// falls back to defaults and never emails.
+    /// </summary>
+    public static IObservable<Unit> Dispatch(
+        IMessageHub hub,
+        string? recipient,
+        string mainNodePath,
+        string title,
+        string message,
+        NotificationType type,
+        string? targetNodePath = null,
+        string? createdBy = null,
+        string? icon = null)
+    {
+        var meshService = hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null)
+            return Observable.Return(Unit.Default);
+        var access = hub.ServiceProvider.GetRequiredService<AccessService>();
+        var category = type.ToCategory();
+
+        return Observable.Using(
+            access.ImpersonateAsSystem,
+            _ => ReadSettings(hub, recipient).SelectMany(settings =>
+            {
+                var ops = new List<IObservable<Unit>>(2);
+                if (settings.InApp(category))
+                    ops.Add(CreateNotification(
+                            meshService, mainNodePath, title, message, type, targetNodePath, createdBy, icon)
+                        .Select(_ => Unit.Default));
+                if (!string.IsNullOrEmpty(recipient) && settings.Email(category))
+                    ops.Add(MaybeSendEmail(hub, recipient!, title, message, targetNodePath)
+                        .Select(_ => Unit.Default));
+                return ops.Count == 0 ? Observable.Return(Unit.Default) : Observable.Merge(ops);
+            }));
+    }
+
+    /// <summary>Reads a user's deterministic notification preferences (defaults when absent/unreadable).</summary>
+    private static IObservable<NotificationSettings> ReadSettings(IMessageHub hub, string? recipient)
+    {
+        if (string.IsNullOrEmpty(recipient))
+            return Observable.Return(new NotificationSettings());
+        return hub.GetWorkspace().GetMeshNodeStream(NotificationSettingsPaths.PathFor(recipient))
+            .Take(1)
+            .Select(n => n?.ContentAs<NotificationSettings>(hub.JsonSerializerOptions) ?? new NotificationSettings())
+            .Timeout(LookupTimeout, Observable.Return(new NotificationSettings()))
+            .Catch(Observable.Return(new NotificationSettings()));
+    }
+
+    /// <summary>
+    /// Sends the deterministic notification email — unless the recipient authored AI routing rules,
+    /// in which case the triage service owns escalation (no double-send). No-op if the recipient has
+    /// no email on file or no <see cref="IEmailSender"/> is registered.
+    /// </summary>
+    private static IObservable<bool> MaybeSendEmail(
+        IMessageHub hub, string recipient, string title, string message, string? targetNodePath)
+    {
+        return HasRoutingRules(hub, recipient).SelectMany(hasRules =>
+        {
+            if (hasRules)
+                return Observable.Return(false);
+            return hub.GetMeshNode(recipient, LookupTimeout)
+                .Select(n => n?.ContentAs<User>(hub.JsonSerializerOptions)?.Email)
+                .SelectMany(email => string.IsNullOrWhiteSpace(email)
+                    ? Observable.Return(false)
+                    : hub.SendEmail(email!, title, BuildEmailHtml(hub, title, message, targetNodePath)))
+                .Catch(Observable.Return(false));
+        });
+    }
+
+    /// <summary>True when the recipient authored at least one AI routing rule (defer email to triage).</summary>
+    private static IObservable<bool> HasRoutingRules(IMessageHub hub, string recipient) =>
+        hub.ServiceProvider.GetRequiredService<IMeshService>()
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"nodeType:{NotificationRuleNodeType.NodeType} " +
+                $"namespace:{recipient}/{NotificationRuleNodeType.UserSegment} limit:1"))
+            .Where(c => c.ChangeType == QueryChangeType.Initial)
+            .Select(c => c.Items.Count > 0)
+            .Take(1)
+            .Timeout(LookupTimeout, Observable.Return(false))
+            .Catch(Observable.Return(false));
+
+    private static string BuildEmailHtml(IMessageHub hub, string title, string message, string? targetNodePath)
+    {
+        var baseUrl = ResolveBaseUrl(hub);
+        var link = (!string.IsNullOrEmpty(baseUrl) && !string.IsNullOrWhiteSpace(targetNodePath))
+            ? $"<p style=\"margin:16px 0;\"><a href=\"{System.Net.WebUtility.HtmlEncode($"{baseUrl!.TrimEnd('/')}/{targetNodePath!.TrimStart('/')}")}\" " +
+              "style=\"background:#2563eb;color:#fff;padding:10px 18px;border-radius:6px;text-decoration:none;\">Open</a></p>"
+            : "";
+        return $"<div style=\"font-family:sans-serif;font-size:14px;color:#111;\">" +
+               $"<h2 style=\"margin:0 0 12px 0;\">{System.Net.WebUtility.HtmlEncode(title)}</h2>" +
+               (string.IsNullOrEmpty(message) ? "" : $"<p>{System.Net.WebUtility.HtmlEncode(message)}</p>") +
+               link +
+               "</div>";
+    }
+
+    private static string? ResolveBaseUrl(IMessageHub hub)
+    {
+        var config = hub.ServiceProvider.GetService<IConfiguration>();
+        return config?["Portal:BaseUrl"] ?? config?["PublicBaseUrl"] ?? config?["Email:WebhookBaseUrl"];
     }
 }

--- a/src/MeshWeaver.Graph/NotificationService.cs
+++ b/src/MeshWeaver.Graph/NotificationService.cs
@@ -110,14 +110,18 @@ public static class NotificationService
             access.ImpersonateAsSystem,
             _ => ReadSettings(hub, recipient).SelectMany(settings =>
             {
+                // The two channels are independent — isolate each with Catch so a transient email
+                // fault can't suppress the bell write (or vice versa).
                 var ops = new List<IObservable<Unit>>(2);
                 if (settings.InApp(category))
                     ops.Add(CreateNotification(
                             meshService, mainNodePath, title, message, type, targetNodePath, createdBy, icon)
-                        .Select(_ => Unit.Default));
+                        .Select(_ => Unit.Default)
+                        .Catch(Observable.Return(Unit.Default)));
                 if (!string.IsNullOrEmpty(recipient) && settings.Email(category))
                     ops.Add(MaybeSendEmail(hub, recipient!, title, message, targetNodePath)
-                        .Select(_ => Unit.Default));
+                        .Select(_ => Unit.Default)
+                        .Catch(Observable.Return(Unit.Default)));
                 return ops.Count == 0 ? Observable.Return(Unit.Default) : Observable.Merge(ops);
             }));
     }

--- a/src/MeshWeaver.Graph/NotificationService.cs
+++ b/src/MeshWeaver.Graph/NotificationService.cs
@@ -122,14 +122,26 @@ public static class NotificationService
             }));
     }
 
-    /// <summary>Reads a user's deterministic notification preferences (defaults when absent/unreadable).</summary>
+    /// <summary>
+    /// Reads a user's deterministic notification preferences (defaults when absent/unreadable).
+    /// Uses a synced <c>GetQuery</c> (empty-on-absent) rather than a <c>GetMeshNodeStream</c> point-read:
+    /// the settings node usually does NOT exist (a user only has one once they visit the Notifications
+    /// tab), and a point-read of a not-yet-present node NotFound-resubscribe-storms the owner's partition
+    /// hub — which would wedge the very hub a completing thread needs. Same rationale as
+    /// <c>NotificationSettingsNodeType.EnsureExists</c> / the AiSettings/UpdatePolicy nodes.
+    /// </summary>
     private static IObservable<NotificationSettings> ReadSettings(IMessageHub hub, string? recipient)
     {
         if (string.IsNullOrEmpty(recipient))
             return Observable.Return(new NotificationSettings());
-        return hub.GetWorkspace().GetMeshNodeStream(NotificationSettingsPaths.PathFor(recipient))
+        var path = NotificationSettingsPaths.PathFor(recipient);
+        return hub.GetWorkspace()
+            .GetQuery($"{NotificationSettingsNodeType.NodeType}|{path}",
+                $"path:{path} nodeType:{NotificationSettingsNodeType.NodeType}")
             .Take(1)
-            .Select(n => n?.ContentAs<NotificationSettings>(hub.JsonSerializerOptions) ?? new NotificationSettings())
+            .Select(nodes => nodes
+                .Select(n => n.ContentAs<NotificationSettings>(hub.JsonSerializerOptions))
+                .FirstOrDefault(s => s is not null) ?? new NotificationSettings())
             .Timeout(LookupTimeout, Observable.Return(new NotificationSettings()))
             .Catch(Observable.Return(new NotificationSettings()));
     }

--- a/src/MeshWeaver.Graph/SpaceInviteService.cs
+++ b/src/MeshWeaver.Graph/SpaceInviteService.cs
@@ -113,7 +113,9 @@ public sealed class SpaceInviteService(
         {
             NodeType = InvitationNodeType.NodeType,
             Name = $"Invitation {email}",
-            Content = new Invitation { Email = email, InvitedBy = invitedBy, Note = note ?? $"Invited to space {spacePath}" },
+            // SpacePath (structured) drives the space-aware invite email + the settings-tab list;
+            // the grant itself lands on sign-up via the EventSubscription above.
+            Content = new Invitation { Email = email, InvitedBy = invitedBy, Note = note, SpacePath = spacePath },
         };
 
         // Both writes land in the Admin partition → system identity, constructed inside the scope.

--- a/src/MeshWeaver.Mesh.Contract/Invitation.cs
+++ b/src/MeshWeaver.Mesh.Contract/Invitation.cs
@@ -60,6 +60,17 @@ public record Invitation
     public string? Note { get; init; }
 
     /// <summary>
+    /// Optional path of the Space this person was invited to (set by
+    /// <c>SpaceInviteService</c> when inviting a not-yet-onboarded email to a specific Space).
+    /// When set, the invitation email addresses the Space by name and links straight to it
+    /// (<c>{baseUrl}/{SpacePath}</c>) instead of the generic "invited to Memex" wording; the
+    /// access grant itself lands on sign-up via the matching <c>EventSubscription</c>.
+    /// <c>null</c> = a deployment-wide invitation (the Invitations settings tab).
+    /// </summary>
+    [Browsable(false)]
+    public string? SpacePath { get; init; }
+
+    /// <summary>
     /// When the invitation email was sent (set by the node-driven
     /// <c>InvitationEmailSender</c> hosted service). <c>null</c> = not yet emailed —
     /// the sender stamps this so it never re-sends, regardless of how the invitation was

--- a/src/MeshWeaver.Mesh.Contract/Notification.cs
+++ b/src/MeshWeaver.Mesh.Contract/Notification.cs
@@ -3,7 +3,8 @@ using System.ComponentModel.DataAnnotations;
 
 namespace MeshWeaver.Mesh;
 
-/// <summary>Type of notification.</summary>
+/// <summary>Type of notification. New values are APPENDED (never inserted) so the
+/// serialized ordinals of existing rows stay stable.</summary>
 public enum NotificationType
 {
     /// <summary>An approval is required from this user.</summary>
@@ -12,8 +13,14 @@ public enum NotificationType
     ApprovalGiven,
     /// <summary>An approval was rejected.</summary>
     ApprovalRejected,
-    /// <summary>General notification.</summary>
-    General
+    /// <summary>General notification (maps to the <see cref="NotificationCategory.System"/> preference).</summary>
+    General,
+    /// <summary>A user was granted access (a role) on a node.</summary>
+    AccessGranted,
+    /// <summary>An AI thread round finished and a response is ready.</summary>
+    ChatReady,
+    /// <summary>A platform/system event (indexing/import failure, compile park, …).</summary>
+    System
 }
 
 /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/NotificationSettings.cs
+++ b/src/MeshWeaver.Mesh.Contract/NotificationSettings.cs
@@ -1,0 +1,125 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// User-facing grouping of <see cref="NotificationType"/>s for delivery preferences. Several
+/// notification types collapse into one configurable row (all three approval types → Approvals).
+/// </summary>
+public enum NotificationCategory
+{
+    /// <summary>Approval requested / given / rejected.</summary>
+    Approvals,
+    /// <summary>You were granted access (a role) on a node.</summary>
+    AccessGranted,
+    /// <summary>An AI chat thread finished a round.</summary>
+    ChatReady,
+    /// <summary>Platform/system events (failures, admin alerts).</summary>
+    System
+}
+
+/// <summary>
+/// Per-user notification delivery preferences — for each <see cref="NotificationCategory"/>,
+/// whether it is delivered in-app (the bell) and/or by email. Stored as a MeshNode
+/// (<c>NotificationSettings</c>) under the user at
+/// <see cref="NotificationSettingsPaths.PathFor"/>; the Notifications settings tab data-binds to it
+/// and <see cref="NotificationCategoryExtensions"/> maps a <see cref="NotificationType"/> to its row.
+///
+/// <para><b>Serialization:</b> every bool carries <c>[JsonIgnore(Never)]</c>. The mesh serializer
+/// uses <see cref="JsonIgnoreCondition.WhenWritingDefault"/>, which omits the CLR default
+/// (<c>false</c>) from the RFC 7396 merge patch — so an "on → off" edit would silently be dropped.
+/// Forcing <c>Never</c> makes every value round-trip. Defaults: bell on for all; email on for the
+/// two categories a user most wants pushed (access grants + approvals).</para>
+/// </summary>
+public record NotificationSettings
+{
+    /// <summary>Show approval notifications in the bell.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    [Description("Approvals — show in the notification bell")]
+    public bool ApprovalsInApp { get; init; } = true;
+
+    /// <summary>Show access-granted notifications in the bell.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    [Description("Access granted — show in the notification bell")]
+    public bool AccessGrantedInApp { get; init; } = true;
+
+    /// <summary>Show chat-ready notifications in the bell.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    [Description("Chat ready — show in the notification bell")]
+    public bool ChatReadyInApp { get; init; } = true;
+
+    /// <summary>Show system notifications in the bell.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    [Description("System — show in the notification bell")]
+    public bool SystemInApp { get; init; } = true;
+
+    /// <summary>Email approval notifications.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    [Description("Approvals — send an email")]
+    public bool ApprovalsEmail { get; init; } = true;
+
+    /// <summary>Email access-granted notifications.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    [Description("Access granted — send an email")]
+    public bool AccessGrantedEmail { get; init; } = true;
+
+    /// <summary>Email chat-ready notifications.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    [Description("Chat ready — send an email")]
+    public bool ChatReadyEmail { get; init; }
+
+    /// <summary>Email system notifications.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    [Description("System — send an email")]
+    public bool SystemEmail { get; init; }
+
+    /// <summary>Whether the given category is delivered to the bell.</summary>
+    public bool InApp(NotificationCategory category) => category switch
+    {
+        NotificationCategory.Approvals => ApprovalsInApp,
+        NotificationCategory.AccessGranted => AccessGrantedInApp,
+        NotificationCategory.ChatReady => ChatReadyInApp,
+        _ => SystemInApp,
+    };
+
+    /// <summary>Whether the given category is delivered by email.</summary>
+    public bool Email(NotificationCategory category) => category switch
+    {
+        NotificationCategory.Approvals => ApprovalsEmail,
+        NotificationCategory.AccessGranted => AccessGrantedEmail,
+        NotificationCategory.ChatReady => ChatReadyEmail,
+        _ => SystemEmail,
+    };
+}
+
+/// <summary>Maps a <see cref="NotificationType"/> to its preference <see cref="NotificationCategory"/>.</summary>
+public static class NotificationCategoryExtensions
+{
+    /// <summary>The configurable category a notification type belongs to.</summary>
+    public static NotificationCategory ToCategory(this NotificationType type) => type switch
+    {
+        NotificationType.ApprovalRequired
+            or NotificationType.ApprovalGiven
+            or NotificationType.ApprovalRejected => NotificationCategory.Approvals,
+        NotificationType.AccessGranted => NotificationCategory.AccessGranted,
+        NotificationType.ChatReady => NotificationCategory.ChatReady,
+        _ => NotificationCategory.System,
+    };
+}
+
+/// <summary>Well-known paths for the per-user <c>NotificationSettings</c> node.</summary>
+public static class NotificationSettingsPaths
+{
+    /// <summary>Path segment (satellite) that holds a user's settings nodes.</summary>
+    public const string SettingsSegment = "_Settings";
+
+    /// <summary>Node id of the notification-preferences node under a user's <c>_Settings</c>.</summary>
+    public const string NodeId = "Notifications";
+
+    /// <summary>Namespace of the settings node for <paramref name="userId"/> (<c>{userId}/_Settings</c>).</summary>
+    public static string NamespaceFor(string userId) => $"{userId}/{SettingsSegment}";
+
+    /// <summary>Full path of the notification-preferences node for <paramref name="userId"/>.</summary>
+    public static string PathFor(string userId) => $"{userId}/{SettingsSegment}/{NodeId}";
+}

--- a/test/Memex.Portal.Shared.Test/InvitationEmailTest.cs
+++ b/test/Memex.Portal.Shared.Test/InvitationEmailTest.cs
@@ -1,0 +1,54 @@
+using Memex.Portal.Shared.Email;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Unit tests for <see cref="InvitationEmailSender.BuildInviteEmail"/> — the pure email-body
+/// builder. A space-scoped invitation (<see cref="Invitation.SpacePath"/> set) addresses the
+/// Space by name and links straight to it; a deployment-wide invitation keeps the generic
+/// "invited to Memex" wording.
+/// </summary>
+public class InvitationEmailTest
+{
+    [Fact]
+    public void SpaceInvite_AddressesSpaceByName_AndLinksToTheSpace()
+    {
+        var invitation = new Invitation { Email = "carol@acme.com", SpacePath = "TeamSpace" };
+
+        var (subject, html) = InvitationEmailSender.BuildInviteEmail(
+            invitation, "Team Space", "https://memex.example.com");
+
+        Assert.Equal("You've been invited to Team Space", subject);
+        Assert.Contains("Team Space", html);
+        // Links to the Space itself, not just the portal root.
+        Assert.Contains("https://memex.example.com/TeamSpace", html);
+        Assert.DoesNotContain("invited to Memex", html);
+    }
+
+    [Fact]
+    public void SpaceInvite_FallsBackToThePath_WhenTheNameIsUnresolved()
+    {
+        var invitation = new Invitation { Email = "carol@acme.com", SpacePath = "TeamSpace" };
+
+        // Trailing slash on the base url must not double up in the link.
+        var (subject, html) = InvitationEmailSender.BuildInviteEmail(
+            invitation, spaceName: null, "https://memex.example.com/");
+
+        Assert.Equal("You've been invited to TeamSpace", subject);
+        Assert.Contains("https://memex.example.com/TeamSpace", html);
+    }
+
+    [Fact]
+    public void GlobalInvite_KeepsTheGenericMemexWording()
+    {
+        var invitation = new Invitation { Email = "dave@acme.com" };
+
+        var (subject, html) = InvitationEmailSender.BuildInviteEmail(
+            invitation, spaceName: null, "https://memex.example.com");
+
+        Assert.Equal("You've been invited to Memex", subject);
+        Assert.Contains("invited to Memex", html);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ApprovalAndNotificationTest.cs
+++ b/test/MeshWeaver.Graph.Test/ApprovalAndNotificationTest.cs
@@ -216,11 +216,14 @@ public class ApprovalAndNotificationTest
     [Fact]
     public void NotificationType_HasExpectedValues()
     {
-        Enum.GetValues<NotificationType>().Should().HaveCount(4);
+        Enum.GetValues<NotificationType>().Should().HaveCount(7);
         Enum.GetValues<NotificationType>().Should().Contain(NotificationType.ApprovalRequired);
         Enum.GetValues<NotificationType>().Should().Contain(NotificationType.ApprovalGiven);
         Enum.GetValues<NotificationType>().Should().Contain(NotificationType.ApprovalRejected);
         Enum.GetValues<NotificationType>().Should().Contain(NotificationType.General);
+        Enum.GetValues<NotificationType>().Should().Contain(NotificationType.AccessGranted);
+        Enum.GetValues<NotificationType>().Should().Contain(NotificationType.ChatReady);
+        Enum.GetValues<NotificationType>().Should().Contain(NotificationType.System);
     }
 
     #endregion

--- a/test/MeshWeaver.Graph.Test/NotificationDispatchTest.cs
+++ b/test/MeshWeaver.Graph.Test/NotificationDispatchTest.cs
@@ -1,0 +1,119 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Integration tests for <see cref="NotificationService.Dispatch"/> — the preference-aware entry
+/// point. Covers: a default recipient gets the in-app bell notification; turning the category's
+/// bell off suppresses it; and a per-field "off" preference survives the RFC 7396 merge patch
+/// (the serializer's <c>WhenWritingDefault</c> trap that <c>[JsonIgnore(Never)]</c> guards against).
+/// </summary>
+public class NotificationDispatchTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+    private System.Text.Json.JsonSerializerOptions Json => Mesh.JsonSerializerOptions;
+
+    private async Task CreateUser(string id, string email)
+    {
+        using (Access.ImpersonateAsSystem())
+            await MeshService.CreateNode(new MeshNode(id)
+            {
+                NodeType = "User",
+                Name = id,
+                Content = new User { Email = email, FullName = id },
+            }).Should().Emit();
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Dispatch_Default_CreatesInAppBellNotification()
+    {
+        const string recipient = "grantee_default";
+        await CreateUser(recipient, "grantee@acme.com");
+
+        await NotificationService.Dispatch(
+                Mesh,
+                recipient: recipient,
+                mainNodePath: recipient,
+                title: "You've been given access to TeamSpace",
+                message: "You now have Editor access to \"TeamSpace\".",
+                type: NotificationType.AccessGranted,
+                targetNodePath: "TeamSpace",
+                createdBy: "admin")
+            .Timeout(30.Seconds()).ToTask();
+
+        await Mesh.GetWorkspace()
+            .GetQuery($"notif|{recipient}", $"path:{recipient}/_Notification scope:children nodeType:Notification")
+            .Where(nodes => (nodes ?? []).Any(n =>
+                n.ContentAs<Notification>(Json) is { NotificationType: NotificationType.AccessGranted, IsRead: false }))
+            .FirstAsync().Timeout(30.Seconds());
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Dispatch_InAppDisabledForCategory_SuppressesBell()
+    {
+        const string recipient = "grantee_off";
+        await CreateUser(recipient, "off@acme.com");
+
+        // Turn the AccessGranted bell OFF (leave Approvals on as the positive control).
+        var settingsPath = await NotificationSettingsNodeType.EnsureExists(Mesh, recipient).FirstAsync().Timeout(30.Seconds());
+        await Mesh.GetWorkspace().GetMeshNodeStream(settingsPath)
+            .Update(n => n with { Content = NotificationSettingsNodeType.Parse(n, Json) with { AccessGrantedInApp = false } })
+            .FirstAsync().Timeout(30.Seconds());
+        // Wait for the flip to land so the dispatch reads the updated preference.
+        await Mesh.GetWorkspace().GetMeshNodeStream(settingsPath)
+            .Select(n => NotificationSettingsNodeType.Parse(n, Json))
+            .Where(s => !s.AccessGrantedInApp)
+            .FirstAsync().Timeout(30.Seconds());
+
+        // Dispatch a suppressed AccessGranted, then a still-enabled Approvals as the ordered control.
+        await NotificationService.Dispatch(Mesh, recipient, recipient,
+                "Access", "granted", NotificationType.AccessGranted, "TeamSpace", "admin").Timeout(30.Seconds()).ToTask();
+        await NotificationService.Dispatch(Mesh, recipient, recipient,
+                "Approval Requested", "please approve", NotificationType.ApprovalRequired, "Doc/X", "admin").Timeout(30.Seconds()).ToTask();
+
+        // The control (Approvals) bell arrives...
+        var nodes = await Mesh.GetWorkspace()
+            .GetQuery($"notif|{recipient}", $"path:{recipient}/_Notification scope:children nodeType:Notification")
+            .Where(ns => (ns ?? []).Any(n =>
+                n.ContentAs<Notification>(Json)?.NotificationType == NotificationType.ApprovalRequired))
+            .FirstAsync().Timeout(30.Seconds());
+
+        // ...but the suppressed AccessGranted bell was never created.
+        Assert.DoesNotContain(nodes, n =>
+            n.ContentAs<Notification>(Json)?.NotificationType == NotificationType.AccessGranted);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task NotificationSettings_OffValue_SurvivesMergePatch()
+    {
+        const string recipient = "prefs_user";
+        await CreateUser(recipient, "prefs@acme.com");
+
+        var path = await NotificationSettingsNodeType.EnsureExists(Mesh, recipient).FirstAsync().Timeout(30.Seconds());
+
+        // Flip a default-true bell field to false via a per-field merge-patch update.
+        await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Update(n => n with { Content = NotificationSettingsNodeType.Parse(n, Json) with { ApprovalsInApp = false } })
+            .FirstAsync().Timeout(30.Seconds());
+
+        // If the WhenWritingDefault trap were unguarded the false would be dropped and this times out.
+        var settings = await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Select(n => NotificationSettingsNodeType.Parse(n, Json))
+            .Where(s => !s.ApprovalsInApp)
+            .FirstAsync().Timeout(30.Seconds());
+
+        Assert.False(settings.ApprovalsInApp);
+        Assert.True(settings.AccessGrantedInApp);   // untouched field keeps its default
+    }
+}

--- a/test/MeshWeaver.Graph.Test/NotificationPreferencesTest.cs
+++ b/test/MeshWeaver.Graph.Test/NotificationPreferencesTest.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pure unit tests for the notification preference model + the access-grant decision. No mesh needed.
+/// </summary>
+public class NotificationPreferencesTest
+{
+    [Fact]
+    public void Defaults_BellOnForAll_EmailOnForAccessAndApprovalsOnly()
+    {
+        var s = new NotificationSettings();
+
+        // Bell (in-app) on for every category.
+        Assert.True(s.InApp(NotificationCategory.Approvals));
+        Assert.True(s.InApp(NotificationCategory.AccessGranted));
+        Assert.True(s.InApp(NotificationCategory.ChatReady));
+        Assert.True(s.InApp(NotificationCategory.System));
+
+        // Email on by default only for access grants + approvals.
+        Assert.True(s.Email(NotificationCategory.Approvals));
+        Assert.True(s.Email(NotificationCategory.AccessGranted));
+        Assert.False(s.Email(NotificationCategory.ChatReady));
+        Assert.False(s.Email(NotificationCategory.System));
+    }
+
+    [Theory]
+    [InlineData(NotificationType.ApprovalRequired, NotificationCategory.Approvals)]
+    [InlineData(NotificationType.ApprovalGiven, NotificationCategory.Approvals)]
+    [InlineData(NotificationType.ApprovalRejected, NotificationCategory.Approvals)]
+    [InlineData(NotificationType.AccessGranted, NotificationCategory.AccessGranted)]
+    [InlineData(NotificationType.ChatReady, NotificationCategory.ChatReady)]
+    [InlineData(NotificationType.System, NotificationCategory.System)]
+    [InlineData(NotificationType.General, NotificationCategory.System)]
+    public void ToCategory_MapsEachType(NotificationType type, NotificationCategory expected)
+        => Assert.Equal(expected, type.ToCategory());
+
+    [Fact]
+    public void TryResolveGrant_ValidGrant_ReturnsRecipientNodeAndRole()
+    {
+        var node = Assignment(subject: "bob", role: "Editor", denied: false, createdBy: "admin", mainNode: "TeamSpace");
+
+        var ok = AccessGrantNotifier.TryResolveGrant(node, Options, out var recipient, out var granted, out var roleText);
+
+        Assert.True(ok);
+        Assert.Equal("bob", recipient);
+        Assert.Equal("TeamSpace", granted);
+        Assert.Equal("Editor", roleText);
+    }
+
+    [Fact]
+    public void TryResolveGrant_Denial_IsIgnored()
+    {
+        var node = Assignment(subject: "bob", role: "Editor", denied: true, createdBy: "admin", mainNode: "TeamSpace");
+        Assert.False(AccessGrantNotifier.TryResolveGrant(node, Options, out _, out _, out _));
+    }
+
+    [Fact]
+    public void TryResolveGrant_SelfGrant_IsSuppressed()
+    {
+        // Creator == subject (e.g. the space creator's own Admin assignment) → no notification.
+        var node = Assignment(subject: "bob", role: "Admin", denied: false, createdBy: "bob", mainNode: "TeamSpace");
+        Assert.False(AccessGrantNotifier.TryResolveGrant(node, Options, out _, out _, out _));
+    }
+
+    [Fact]
+    public void TryResolveGrant_NoTargetNode_IsIgnored()
+    {
+        var node = Assignment(subject: "bob", role: "Editor", denied: false, createdBy: "admin", mainNode: "");
+        Assert.False(AccessGrantNotifier.TryResolveGrant(node, Options, out _, out _, out _));
+    }
+
+    private static readonly JsonSerializerOptions Options = new();
+
+    private static MeshNode Assignment(string subject, string role, bool denied, string createdBy, string mainNode) =>
+        new($"{subject}_Access", $"{mainNode}/_Access")
+        {
+            NodeType = "AccessAssignment",
+            MainNode = mainNode,
+            CreatedBy = createdBy,
+            Content = new AccessAssignment
+            {
+                AccessObject = subject,
+                Roles = [new RoleAssignment { Role = role, Denied = denied }],
+            },
+        };
+}

--- a/test/MeshWeaver.Graph.Test/SpaceInviteServiceTest.cs
+++ b/test/MeshWeaver.Graph.Test/SpaceInviteServiceTest.cs
@@ -81,9 +81,10 @@ public class SpaceInviteServiceTest(ITestOutputHelper output) : MonolithMeshTest
                 && s.MatchValue == email && s.TargetPath == Space && s.Role == "Viewer"))
             .FirstAsync().Timeout(30.Seconds());
 
-        // An Invitation node was created for the email (the InvitationEmailSender emails it).
+        // An Invitation node was created for the email (the InvitationEmailSender emails it),
+        // carrying the target Space so the email addresses it by name + links to it.
         await Mesh.GetWorkspace().GetMeshNodeStream($"{InvitationNodeType.Namespace}/{SpaceInviteService.Slug(email)}")
-            .Where(n => n?.Content is Invitation inv && inv.Email == email)
+            .Where(n => n?.Content is Invitation inv && inv.Email == email && inv.SpacePath == Space)
             .FirstAsync().Timeout(30.Seconds());
     }
 }


### PR DESCRIPTION
## What & why

Two related asks: (1) the space-invite email said the generic "You've been invited to Memex" instead of naming the Space; (2) granting access was silent and notifications weren't configurable or grouped.

### Invitations
- `Invitation.SpacePath` carries the invited Space. The space-invite email now addresses the Space **by name** and links straight to it (`{baseUrl}/{spacePath}`); global (deployment-wide) invites keep the generic wording.

### Notifications
- **`NotificationSettings`** — per-user, per-category delivery preferences (Approvals / AccessGranted / ChatReady / System × bell / email), surfaced in a new data-bound **Notifications** settings tab. Defaults: **bell on for all**, **email on for access grants + approvals**.
- **`NotificationService.Dispatch`** — the single preference-aware entry point every emitter now routes through (approvals, chat-ready, access-granted, system). The deterministic email path **defers to the existing AI-triage layer** (`NotificationRule` / `NotificationTriageService`) for users who authored routing rules, so there's no double-send.
- **`AccessGrantNotifier`** — a change-feed watcher that notifies the granted user (**"You've been given \<role\> access to \<node\>"**) on any `AccessAssignment` creation. One place covers every grant path (access tab, "Invite people" for an existing user, MCP, the sign-up grant). Skips denials, group subjects, and self-grants.
- **Grouped bell** — notifications collapse by source node (5 new thread messages → 1 row with a count); the bell counter counts distinct sources.
- **Auto-mark-read** — viewing a thread marks its notifications read (backlog + any that arrive while watching).

## Serializer note
The preference bools carry `[JsonIgnore(Condition = Never)]`: the mesh serializer uses `WhenWritingDefault`, which would drop an "on → off" edit from the RFC 7396 merge patch. A test pins this.

## Tests
- **Pure:** preference defaults, `NotificationType` → category mapping, the access-grant decision (grant vs denial vs self-grant).
- **Integration:** dispatch creates the bell / a category turned off suppresses it / an off-value survives the merge patch; the space-invite carries `SpacePath`; invite-email wording.
- Full solution builds `Release -warnaserror`; affected tests green locally.

## Note on branching
Lifted onto a fresh branch off `main` because the original working branch (`feat/extract-slides-plugin`) carries an unrelated, not-yet-wired `plugins/` submodule that would fail CI's clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
