### PR TITLE
Chat composer: slash-popup theme/width fix + price cloud [1m] model variants

### DIFF
--- a/src/MeshWeaver.AI/ModelPricing.cs
+++ b/src/MeshWeaver.AI/ModelPricing.cs
@@ -107,17 +107,41 @@ public static class ModelPricing
 
     /// <summary>
     /// The built-in default rate for a model id, or null when the model isn't in
-    /// the table. Case-insensitive; tolerates a leading provider/path prefix by
-    /// also trying the last path segment.
+    /// the table. Case-insensitive; tolerates a leading provider/path prefix (by
+    /// also trying the last path segment) AND a trailing context/variant marker
+    /// (by also stripping a <c>[…]</c> / <c>:…</c> suffix off that segment). So the
+    /// bare-id rows still price the deployed variants — e.g. <c>claude-opus-4-8[1m]</c>
+    /// (the 1M context window) and <c>llama3:latest</c> both resolve to their base
+    /// row instead of falling through to <c>$0</c>.
     /// </summary>
     public static ModelPriceRate? Default(string? modelId)
     {
         if (string.IsNullOrWhiteSpace(modelId))
             return null;
-        if (Defaults.TryGetValue(modelId, out var rate))
-            return rate;
         var lastSegment = modelId[(modelId.LastIndexOf('/') + 1)..];
-        return Defaults.TryGetValue(lastSegment, out rate) ? rate : null;
+        return Lookup(modelId)
+            ?? Lookup(lastSegment)
+            ?? Lookup(StripVariant(lastSegment));
+    }
+
+    private static ModelPriceRate? Lookup(string id)
+        => Defaults.TryGetValue(id, out var rate) ? rate : null;
+
+    /// <summary>
+    /// Strips a trailing context/variant marker off a bare id segment so a priced
+    /// base id still matches: <c>claude-opus-4-8[1m]</c> → <c>claude-opus-4-8</c>,
+    /// <c>llama3:latest</c> → <c>llama3</c>. Applied only to the LAST path segment —
+    /// a provider prefix is split on <c>/</c>, so a stray <c>:</c> earlier in the id
+    /// is never mistaken for a variant marker. (The 1M variant bills at a higher rate
+    /// above 200k tokens; the base rate is a close-enough fallback, far better than $0.)
+    /// </summary>
+    private static string StripVariant(string segment)
+    {
+        var bracket = segment.IndexOf('[');
+        if (bracket > 0) segment = segment[..bracket];
+        var colon = segment.IndexOf(':');
+        if (colon > 0) segment = segment[..colon];
+        return segment.Trim();
     }
 
     /// <summary>

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -133,12 +133,15 @@ function debounce(fn, delay) {
     const style = document.createElement('style');
     style.id = 'monaco-suggest-styles';
     style.textContent = `
-        /* Target suggest widget in overflow widgets container */
+        /* Target suggest widget in overflow widgets container. Responsive width:
+           never wider than the viewport (minus a gutter) so a narrow side-panel
+           composer doesn't get a fixed 550px popup spilling off-screen. The exact
+           per-editor clamp to the editor's own bounds is done in JS (clampSuggestWidget). */
         .overflowingContentWidgets .suggest-widget,
         .monaco-editor .suggest-widget {
-            width: 550px !important;
-            min-width: 550px !important;
-            max-width: 550px !important;
+            width: min(550px, calc(100vw - 24px)) !important;
+            min-width: 240px !important;
+            max-width: min(550px, calc(100vw - 24px)) !important;
         }
 
         /* Force the list to use full width */
@@ -214,33 +217,10 @@ function debounce(fn, delay) {
             color: #8a8a8a !important;
         }
 
-        /* Also apply dark mode via system preference as fallback */
-        @media (prefers-color-scheme: dark) {
-            .suggest-widget {
-                background-color: #252526 !important;
-                border: 1px solid #454545 !important;
-                color: #cccccc !important;
-            }
-
-            .suggest-widget .monaco-list {
-                background-color: #252526 !important;
-            }
-
-            .suggest-widget .monaco-list-row {
-                color: #cccccc !important;
-                background-color: transparent !important;
-            }
-
-            .suggest-widget .monaco-list-row.focused,
-            .suggest-widget .monaco-list-row.selected {
-                background-color: #094771 !important;
-                color: #ffffff !important;
-            }
-
-            .suggest-widget .details-label {
-                color: #8a8a8a !important;
-            }
-        }
+        /* NOTE: no @media (prefers-color-scheme: dark) block. The popup must follow the
+           APP theme (:root[data-theme=...]) — see the data-theme rules above — NOT the OS
+           setting. The old prefers-color-scheme override forced a dark popup whenever macOS
+           was in dark mode even though the app was in LIGHT theme (dark box in a white panel). */
     `;
     document.head.appendChild(style);
 })();
@@ -357,6 +337,49 @@ export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = fals
                     }
                 }, 50);
             });
+        }
+
+        // Keep the suggest (autocomplete) widget inside THIS editor's own horizontal bounds.
+        // Monaco renders it at document level (FixedOverflowWidgets), up to the CSS width, so in a
+        // narrow side-panel composer it otherwise spilled LEFT into the page. On each content /
+        // cursor change (which is also when the widget first appears + repositions) we cap the
+        // widget's width to min(550, editorWidth) — it may only SHRINK for a narrow editor, never
+        // grow past the 550px design cap in a wide one — and re-anchor it if it reaches past the
+        // editor's edges. Uses setProperty(..,'important') so it beats the stylesheet's `!important`
+        // width. Writing the widget's inline style does NOT fire onDidChange* — no feedback loop —
+        // and a rAF debounce coalesces bursts. Wrapped so a stray DOM state can never throw into Monaco.
+        {
+            let clampPending = false;
+            const clampSuggestWidget = () => {
+                clampPending = false;
+                try {
+                    if (!editorInstance.hasTextFocus || !editorInstance.hasTextFocus()) return;
+                    const node = editorInstance.getDomNode && editorInstance.getDomNode();
+                    if (!node) return;
+                    const widget = document.querySelector('.overflowingContentWidgets .suggest-widget.visible')
+                        || node.querySelector('.suggest-widget.visible');
+                    if (!widget) return;
+                    const rect = node.getBoundingClientRect();
+                    if (rect.width < 40) return;
+                    // Only cap — never expand beyond the 550px CSS design width.
+                    const maxW = Math.max(220, Math.min(550, Math.round(rect.width)));
+                    widget.style.setProperty('width', maxW + 'px', 'important');
+                    widget.style.setProperty('max-width', maxW + 'px', 'important');
+                    widget.style.setProperty('min-width', Math.min(220, maxW) + 'px', 'important');
+                    const wr = widget.getBoundingClientRect();
+                    if (wr.left < rect.left - 1)
+                        widget.style.left = Math.round(rect.left) + 'px';
+                    else if (wr.right > rect.right + 1)
+                        widget.style.left = Math.round(Math.max(rect.left, rect.right - wr.width)) + 'px';
+                } catch { /* never break Monaco's render loop */ }
+            };
+            const scheduleClamp = () => {
+                if (clampPending) return;
+                clampPending = true;
+                requestAnimationFrame(clampSuggestWidget);
+            };
+            editorInstance.onDidChangeModelContent(scheduleClamp);
+            editorInstance.onDidChangeCursorSelection(scheduleClamp);
         }
 
         // Handle Enter key - in code edit mode, Enter inserts newline; in chat mode, Enter submits


### PR DESCRIPTION
## What
Two small, self-contained chat-composer fixes (no `plugins/` dependency).

### 1. Slash-command / @-reference popup (Monaco suggest widget)
- **Follows the APP theme now**, not the OS. The old `@media (prefers-color-scheme: dark)` block forced a **dark popup in a light app** whenever macOS was in dark mode (reported: dark box with underlined items over a white side panel). Dropped it; the `html[data-theme=…]` rules already handle the app's real theme.
- **Stops spilling out of a narrow side panel.** The hard-coded `width: 550px` overflowed the ~350px side-panel composer into the page. Width is now responsive, plus a per-editor JS clamp caps the widget to the editor's own bounds. The clamp is `try/catch`-guarded and hooks the editor's own change events (no feedback loop) — worst case it's a no-op, it can never break Monaco.

### 2. Token-cost chip showed $0 for cloud models
`ModelPricing.Default` only stripped a `/` prefix, so `claude-opus-4-8[1m]` (the 1M-context variant) missed the `claude-opus-4-8` row and priced at **$0**. It now also strips a trailing `[…]`/`:tag` variant → base rate. Local/self-hosted models (e.g. `mythalion:latest`) correctly stay $0.

## Testing
- `MeshWeaver.AI` builds clean under `-c Release -warnaserror` (ModelPricing).
- Monaco `.razor.js` passes `node --check`.
- The popup's visual behaviour is best-effort (guarded) and will confirm on the running portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)