### PR TITLE
Remove BakeMeshLocalFeed — mesh-local #r feed is redundant (BusinessRules in TPA)

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
+++ b/memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
@@ -27,82 +27,16 @@
     <ProjectReference Include="..\..\..\src\MeshWeaver.NuGet.AzureBlob\MeshWeaver.NuGet.AzureBlob.csproj" />
   </ItemGroup>
 
-  <!-- Bake the mesh-local #r feed into the container image. The runtime
-       `#r "nuget:MeshWeaver.*"` resolver (NuGetAssemblyResolver →
-       Settings.LoadDefaultSettings from the app dir) reads nuget.config and resolves
-       MeshWeaver.*/Memex.* against the local `dist/packages` folder source — offline,
-       no nuget.org round-trip. This is how BusinessRules / BusinessRules.Generator reach
-       node compilation now that they are no longer ProjectReferenced by the framework
-       (see MeshWeaver.Graph). nuget.config ships next to the feed so the resolver finds it. -->
+  <!-- Ship nuget.config into the image so the runtime `#r "nuget:..."` resolver can
+       resolve third-party packages a Code node references. BusinessRules /
+       BusinessRules.Generator no longer need a baked mesh-local feed: the scope generator
+       ships WITH the platform (its DLL is copied into MeshWeaver.Graph's output — see
+       BuiltInScopeGeneratorTest) and MeshWeaver.BusinessRules is in the app's TPA
+       (deps.json), so an IScope<,> node compiles with neither an `#r "nuget:…"` directive
+       nor a baked feed. -->
   <ItemGroup>
     <Content Include="..\..\..\nuget.config" Link="nuget.config" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
-
-  <!-- 🚨 The curated #r-referenceable packages must be PACKED and SHIPPED into the image AS PART OF
-       PUBLISH — the AKS image build is `dotnet publish -t:PublishContainer` with no separate pack
-       step, so without this the image ships an EMPTY feed and a deployed portal's
-       `#r "nuget:MeshWeaver.BusinessRules.Generator"` resolves on no source (it is NOT published to
-       nuget.org) → every scope node fails to compile in prod with
-       "No NuGet package 'MeshWeaver.BusinessRules.Generator' matching '*' found on configured sources".
-       This target packs the curated set — MeshWeaver.BusinessRules (the IScope<,> surface, i.e.
-       "business processes") + MeshWeaver.BusinessRules.Generator (its scope source generator) — at
-       this build's $(Version), then injects the freshly-produced nupkgs into the publish set so they
-       land at /app/dist/packages, the relative folder nuget.config's `mesh-local` source points at.
-       In-process Pack (MSBuild task, not a nested `dotnet pack`) reuses this build's restore/output;
-       the child Pack inherits the build's global -p: props (PlatformVersion/CIRun), so the staged feed
-       carries the SAME $(Version) as the portal binary. The identical set is packed for tests by
-       .github/workflows/dotnet-test.yml ("Pack mesh-local #r packages"). -->
-  <!-- Release-only: the AKS/container image is always published `-c Release`. A Debug publish is
-       a local convenience that doesn't ship, so skip the (non-trivial) pack there. -->
-  <Target Name="BakeMeshLocalFeed" BeforeTargets="ComputeFilesToPublish"
-          Condition="'$(Configuration)' == 'Release'">
-    <!-- Pack into a CLEAN per-build staging dir under obj — NOT the repo's `dist/packages` dev
-         feed, which accumulates dozens of stale nupkgs across builds (incl. a lib-LESS
-         3.0.0-preview1 generator). Shipping that whole folder would bloat the image and let the
-         version-less `#r` resolve a stale package. RemoveDir guarantees the staged feed holds only
-         this build's curated pair. Do NOT force Version= here: the child Pack inherits the build's
-         global PlatformVersion/CIRun so it computes the SAME version the portal binary carries
-         (forcing Version=$(Version) passed an empty value and degraded the package to 1.0.0). -->
-    <PropertyGroup>
-      <_MeshLocalFeedStage>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)meshlocalfeed'))</_MeshLocalFeedStage>
-    </PropertyGroup>
-    <RemoveDir Directories="$(_MeshLocalFeedStage)" />
-    <!-- 🚨 RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers;..." is load-bearing for the MULTI-ARCH
-         publish. During a multi-RID container publish the SDK runs a per-RID inner build with a concrete
-         global RuntimeIdentifier (linux-x64, then linux-arm64). The <MSBuild> task inherits the parent's
-         global properties, so without RemoveProperties these Pack calls would inherit RuntimeIdentifier=
-         linux-x64 and try to pack the RID-AGNOSTIC BusinessRules/Generator libraries for that RID — which
-         were restored without it → NETSDK1047 "assets file doesn't have a target for 'net10.0/linux-x64'".
-         These are plain (RID-agnostic) NuGet packages; strip the RID so Pack runs RID-agnostic. -->
-    <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\..\src\MeshWeaver.BusinessRules\MeshWeaver.BusinessRules.csproj"
-             Targets="Pack"
-             RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers;SelfContained;PublishSelfContained"
-             Properties="Configuration=$(Configuration);PackageOutputPath=$(_MeshLocalFeedStage)" />
-    <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\..\src\MeshWeaver.BusinessRules.Generator\MeshWeaver.BusinessRules.Generator.csproj"
-             Targets="Pack"
-             RemoveProperties="RuntimeIdentifier;RuntimeIdentifiers;SelfContained;PublishSelfContained"
-             Properties="Configuration=$(Configuration);PackageOutputPath=$(_MeshLocalFeedStage)" />
-    <!-- Inject via ResolvedFileToPublish, NOT Content. A <Content> item added inside a
-         BeforeTargets="ComputeFilesToPublish" hook arrives TOO LATE: the SDK chain
-         ComputeFilesToPublish → ComputeResolvedFilesToPublishList → _ComputeCopyToPublishDirectoryItems
-         → GetCopyToPublishDirectoryItems runs as a DEPENDENCY (before this hook) and has already
-         frozen @(Content) into the publish set, so a late Content item is silently dropped — the
-         exact bug that shipped an empty feed to atioz. ResolvedFileToPublish is the canonical
-         publish-injection item: the SDK only ever APPENDS to it and the copy / container-layer step
-         runs later, so items added here always reach /app. The glob runs AFTER Pack (a static
-         ItemGroup evaluates before any target, capturing nothing in the just-cleaned dir).
-         RelativePath = dist/packages/<file> matches nuget.config's relative `mesh-local` source.
-         Two-step (glob into _MeshLocalNupkg, then transform with the QUALIFIED %(_MeshLocalNupkg.Filename)):
-         an UNqualified %(Filename) in a target ItemGroup does not self-batch — it expands to empty,
-         so both nupkgs would collapse to the same RelativePath `dist\packages\` and fail NETSDK1152. -->
-    <ItemGroup>
-      <_MeshLocalNupkg Include="$(_MeshLocalFeedStage)\*.nupkg" />
-      <ResolvedFileToPublish Include="@(_MeshLocalNupkg)">
-        <RelativePath>dist\packages\%(_MeshLocalNupkg.Filename)%(_MeshLocalNupkg.Extension)</RelativePath>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      </ResolvedFileToPublish>
-    </ItemGroup>
-  </Target>
 
   <ItemGroup>
     <PackageReference Include="Aspire.Azure.Npgsql" />

--- a/test/MeshWeaver.PluginImage.Test/PortalImageFacility.cs
+++ b/test/MeshWeaver.PluginImage.Test/PortalImageFacility.cs
@@ -186,18 +186,30 @@ public sealed class PortalImageFacility : IAsyncLifetime
     }
 
     /// <summary>
-    /// The image ships <c>MeshWeaver.BusinessRules.dll</c> (the <c>IScope&lt;,&gt;</c> runtime surface) in
-    /// its TPA. A live-compiled scope node resolves those types from TPA — that's why the mesh-local
-    /// <c>#r</c> feed (BakeMeshLocalFeed) could be removed. This guards that safety net: if a future
-    /// change drops the runtime lib from the portal's deps, scope nodes would silently fail to compile
-    /// in prod, and this fails first.
+    /// The image ships <c>MeshWeaver.BusinessRules.dll</c> (the <c>IScope&lt;,&gt;</c> runtime surface)
+    /// AND lists it in the app's <c>.deps.json</c> — i.e. it is part of the runtime reference set the
+    /// host turns into TRUSTED_PLATFORM_ASSEMBLIES (TPA), which IS the mesh compiler's scope-compile
+    /// reference set. That's why the mesh-local <c>#r</c> feed (BakeMeshLocalFeed) could be removed: a
+    /// live-compiled scope node resolves those types from TPA, not from a baked feed. This guards that
+    /// safety net — if a future change drops the runtime lib from the portal's published deps, scope
+    /// nodes would silently fail to compile in prod, and this fails first. File presence alone would
+    /// not prove the assembly is a resolvable reference; deps.json membership does.
     /// </summary>
     [Fact]
     public async Task InjectedImage_ShipsBusinessRulesRuntime_ForFeedlessScopeCompile()
     {
         SkipIfUnavailable();
-        var probe = await _portal!.ExecAsync(new[] { "test", "-f", "/app/MeshWeaver.BusinessRules.dll" });
-        Assert.Equal(0L, probe.ExitCode);
+
+        // (a) the runtime DLL is physically present in the image.
+        var file = await _portal!.ExecAsync(new[] { "test", "-f", "/app/MeshWeaver.BusinessRules.dll" });
+        Assert.Equal(0L, file.ExitCode);
+
+        // (b) it is listed in the published .deps.json — the runtime-assembly list the host resolves
+        //     into TPA, and thus the mesh compiler's scope-compile reference set. This is the assertion
+        //     that actually backs the "resolves from TPA, no #r feed needed" claim above.
+        var deps = await _portal!.ExecAsync(new[]
+            { "sh", "-c", "grep -q '\"MeshWeaver.BusinessRules.dll\"' /app/*.deps.json" });
+        Assert.Equal(0L, deps.ExitCode);
     }
 
     public async ValueTask DisposeAsync() => await SafeDisposeAsync();

--- a/test/MeshWeaver.PluginImage.Test/PortalImageFacility.cs
+++ b/test/MeshWeaver.PluginImage.Test/PortalImageFacility.cs
@@ -185,6 +185,21 @@ public sealed class PortalImageFacility : IAsyncLifetime
         Assert.NotEqual(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
+    /// <summary>
+    /// The image ships <c>MeshWeaver.BusinessRules.dll</c> (the <c>IScope&lt;,&gt;</c> runtime surface) in
+    /// its TPA. A live-compiled scope node resolves those types from TPA — that's why the mesh-local
+    /// <c>#r</c> feed (BakeMeshLocalFeed) could be removed. This guards that safety net: if a future
+    /// change drops the runtime lib from the portal's deps, scope nodes would silently fail to compile
+    /// in prod, and this fails first.
+    /// </summary>
+    [Fact]
+    public async Task InjectedImage_ShipsBusinessRulesRuntime_ForFeedlessScopeCompile()
+    {
+        SkipIfUnavailable();
+        var probe = await _portal!.ExecAsync(new[] { "test", "-f", "/app/MeshWeaver.BusinessRules.dll" });
+        Assert.Equal(0L, probe.ExitCode);
+    }
+
     public async ValueTask DisposeAsync() => await SafeDisposeAsync();
 
     private async ValueTask SafeDisposeAsync()


### PR DESCRIPTION
## What

Remove the `BakeMeshLocalFeed` MSBuild target from `Memex.Portal.Distributed.csproj`. That target packed `MeshWeaver.BusinessRules` + `.Generator` into a mesh-local `#r nuget` feed baked into the image so live-compiled scope / `IScope<,>` nodes could resolve their runtime offline in prod. It is now **provably redundant**.

## Why it's safe (redundancy proof)

1. **`MeshWeaver.BusinessRules.dll` already ships in the image's TPA.** It's in `/app` and in `deps.json` (TRUSTED_PLATFORM_ASSEMBLIES) — verified by `docker inspect` on `ci.753` and on a fresh feed-less build (14848 bytes). The mesh compile reference set is `TPA + { System.Runtime, DataAnnotations, System.Text.Json }`; it does **not** scan a baked feed. So scope nodes resolve `IScope<,>` from TPA, not from `#r nuget`.
2. **The scope source generator is built in** (#387): `Graph.csproj`'s `ShipScopeGenerator` copies `MeshWeaver.BusinessRules.Generator.dll` into the Graph output. Live compile picks it up as an analyzer without the feed.
3. **No node references the feed.** `#r nuget:MeshWeaver.BusinessRules[.Generator]` appears in **0** nodes across memex, atioz, and memex-local (grep of the live partitions).
4. Third-party `#r nuget:<pkg>` still works — the `nuget.config` ship is **kept**; only the local BusinessRules pack is dropped.

## Verification

- Feed-less container publish succeeds; the resulting image has `/app/MeshWeaver.BusinessRules.dll` and **no** `/app/dist/packages`.
- New guard test `InjectedImage_ShipsBusinessRulesRuntime_ForFeedlessScopeCompile` in the portal-image facility probes the runtime lib is present — so if a future change ever drops it from the portal deps, scope nodes would silently fail to compile in prod and this fails first.
- Portal-image facility runs **4/4 green** against the feed-less image (boots healthy, ships mesh API + plugin registry, ships BusinessRules runtime).
- `dotnet build Memex.Portal.Distributed -c Release -warnaserror` → 0 warnings, 0 errors.

Facility skips cleanly without `MW_TEST_IMAGE`, so normal CI is unaffected.
