### PR TITLE
Content transformers: restore PDF/XLSX + describe images on save (get never returns bytes)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -639,7 +639,14 @@ public static class MemexConfiguration
                         embedderFactory: sp => new EmbeddingProviderChunkEmbedder(
                             sp.GetRequiredService<IEmbeddingProvider>(),
                             sp.GetService<IoPoolRegistry>()),
-                        summarizerFactory: _ => new ExtractiveSummarizer())
+                        summarizerFactory: _ => new ExtractiveSummarizer(),
+                        // Images have no extractable text: caption them on save with the mesh's default
+                        // (multimodal) chat model so the description is embedded for search AND written
+                        // to the file's Document node. Degrades to no-text when no vision model resolves.
+                        imageDescriberFactory: sp => new ChatClientImageDescriber(
+                            () => sp.GetRequiredService<DefaultChatClientProvider>().TryCreate(),
+                            sp.GetRequiredService<IoPoolRegistry>(),
+                            sp.GetService<ILogger<ChatClientImageDescriber>>()))
                     .AddContentSearch();
             }
 

--- a/src/MeshWeaver.AI.AzureFoundry/AzureClaudeChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI.AzureFoundry/AzureClaudeChatClientAgentFactory.cs
@@ -80,6 +80,12 @@ public class AzureClaudeChatClientAgentFactory(
             throw new InvalidOperationException(
                 "No model selected. Pick one in the chat dropdown.");
 
+        return CreateChatClientForModel(modelName);
+    }
+
+    /// <inheritdoc />
+    protected override IChatClient CreateChatClientForModel(string modelName)
+    {
         // Driver config: resolver walks parent ModelProvider → root ModelProvider
         // → legacy ModelDefinition fields. Fall back to IOptions if the resolver
         // returns Missing.
@@ -99,8 +105,8 @@ public class AzureClaudeChatClientAgentFactory(
                 $"ApiKey is missing for model '{modelName}'. Configure a ModelProvider node (e.g. Model/Anthropic) or set Anthropic:ApiKey in config.");
 
         logger.LogInformation(
-            "[AzureClaude] Creating chat client agent={AgentName} model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint}",
-            agentConfig.Id, modelName, endpoint, source, Fingerprint(apiKey));
+            "[AzureClaude] Creating chat client model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint}",
+            modelName, endpoint, source, Fingerprint(apiKey));
 
         try
         {
@@ -108,9 +114,9 @@ public class AzureClaudeChatClientAgentFactory(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to create Azure Claude chat client for agent {AgentName}", agentConfig.Id);
+            logger.LogError(ex, "Failed to create Azure Claude chat client for model {ModelName}", modelName);
             throw new InvalidOperationException(
-                $"Failed to create Azure Claude chat client for agent {agentConfig.Id}: {ex.Message}", ex);
+                $"Failed to create Azure Claude chat client for model {modelName}: {ex.Message}", ex);
         }
     }
 

--- a/src/MeshWeaver.AI.AzureFoundry/AzureFoundryChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI.AzureFoundry/AzureFoundryChatClientAgentFactory.cs
@@ -89,6 +89,12 @@ public class AzureFoundryChatClientAgentFactory(
         if (string.IsNullOrEmpty(modelName))
             throw new InvalidOperationException("At least one model must be configured in AzureFoundryConfiguration.Models");
 
+        return CreateChatClientForModel(modelName);
+    }
+
+    /// <inheritdoc />
+    protected override IChatClient CreateChatClientForModel(string modelName)
+    {
         // Resolver follows ModelDefinition.ProviderRef → ModelProvider node
         // for Endpoint + ApiKey. Falls back to IOptions configuration when
         // no provider node is present (legacy single-tenant deployments).
@@ -108,8 +114,8 @@ public class AzureFoundryChatClientAgentFactory(
                 $"ApiKey is missing for model '{modelName}'. Configure a ModelProvider node (Model/AzureFoundry) or set AzureFoundry:ApiKey in config.");
 
         logger.LogInformation(
-            "[AzureFoundry] Creating chat client agent={AgentName} model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint}",
-            agentConfig.Id, modelName, endpoint, source, Fingerprint(apiKey));
+            "[AzureFoundry] Creating chat client model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint}",
+            modelName, endpoint, source, Fingerprint(apiKey));
 
         try
         {
@@ -123,9 +129,9 @@ public class AzureFoundryChatClientAgentFactory(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to create Azure Foundry chat client for agent {AgentName}", agentConfig.Id);
+            logger.LogError(ex, "Failed to create Azure Foundry chat client for model {ModelName}", modelName);
             throw new InvalidOperationException(
-                $"Failed to create Azure Foundry chat client for agent {agentConfig.Id}: {ex.Message}", ex);
+                $"Failed to create Azure Foundry chat client for model {modelName}: {ex.Message}", ex);
         }
     }
 

--- a/src/MeshWeaver.AI.OpenAI/AzureOpenAIChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI.OpenAI/AzureOpenAIChatClientAgentFactory.cs
@@ -58,6 +58,12 @@ public class AzureOpenAIChatClientAgentFactory(
         if (string.IsNullOrEmpty(modelName))
             throw new InvalidOperationException("No model configured for Azure OpenAI");
 
+        return CreateChatClientForModel(modelName);
+    }
+
+    /// <inheritdoc />
+    protected override IChatClient CreateChatClientForModel(string modelName)
+    {
         // Resolver follows ModelDefinition.ProviderRef → ModelProvider node.
         // Falls back to IOptions when no provider node has been configured.
         var resolver = Hub.ServiceProvider.GetRequiredService<ChatClientCredentialResolver>();
@@ -75,8 +81,8 @@ public class AzureOpenAIChatClientAgentFactory(
                 $"ApiKey is missing for model '{modelName}'. Configure a ModelProvider node (Model/AzureOpenAI) or set AzureOpenAI:ApiKey in config.");
 
         logger.LogInformation(
-            "[AzureOpenAI] Creating chat client agent={AgentName} model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint}",
-            agentConfig.Id, modelName, endpoint, source, Fingerprint(apiKey));
+            "[AzureOpenAI] Creating chat client model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint}",
+            modelName, endpoint, source, Fingerprint(apiKey));
 
         // Create Azure OpenAI client and get chat client
         var azureClient = new AzureOpenAIClient(

--- a/src/MeshWeaver.AI.OpenAI/OpenAIChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI.OpenAI/OpenAIChatClientAgentFactory.cs
@@ -130,6 +130,12 @@ public class OpenAIChatClientAgentFactory(
         if (string.IsNullOrEmpty(modelName))
             throw new InvalidOperationException("No model configured for OpenAI");
 
+        return CreateChatClientForModel(modelName);
+    }
+
+    /// <inheritdoc />
+    protected override IChatClient CreateChatClientForModel(string modelName)
+    {
         var resolver = Hub.ServiceProvider.GetRequiredService<ChatClientCredentialResolver>();
         // The selection may arrive as the full LanguageModel node PATH (the composer's
         // persisted form) — canonicalise to the bare wire id the endpoint expects.
@@ -150,8 +156,8 @@ public class OpenAIChatClientAgentFactory(
                 $"ApiKey is missing for model '{modelName}'. Configure a ModelProvider node (Provider 'OpenAI') or set OpenAI:ApiKey in config.");
 
         logger.LogInformation(
-            "[OpenAI] Creating chat client agent={AgentName} model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint}",
-            agentConfig.Id, modelName, endpoint ?? "(default api.openai.com)", source, Fingerprint(apiKey));
+            "[OpenAI] Creating chat client model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint}",
+            modelName, endpoint ?? "(default api.openai.com)", source, Fingerprint(apiKey));
 
         var clientOptions = new OpenAIClientOptions();
         if (!string.IsNullOrEmpty(endpoint))

--- a/src/MeshWeaver.AI/ChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI/ChatClientAgentFactory.cs
@@ -302,6 +302,24 @@ public abstract class ChatClientAgentFactory : IChatClientFactory
     /// </summary>
     protected abstract IChatClient CreateChatClient(AgentConfiguration agentConfig);
 
+    /// <inheritdoc />
+    public IChatClient CreateChatClient(string modelName)
+    {
+        if (string.IsNullOrEmpty(modelName))
+            throw new ArgumentException("Model name is required.", nameof(modelName));
+        return CreateChatClientForModel(modelName);
+    }
+
+    /// <summary>
+    /// The STATELESS half of <see cref="CreateChatClient(AgentConfiguration)"/>: given an
+    /// already-resolved model name, resolve its credentials and construct the provider-specific
+    /// <see cref="IChatClient"/> — WITHOUT consulting or mutating <see cref="CurrentModelName"/> and
+    /// without an agent. Concrete non-persistent factories override this; the agent path also routes
+    /// through it after resolving the model. The base throws so persistent factories stay unsupported.
+    /// </summary>
+    protected virtual IChatClient CreateChatClientForModel(string modelName) =>
+        throw new NotSupportedException($"Factory '{Name}' does not support creating a bare chat client.");
+
     /// <summary>
     /// Gets tools for the specified agent configuration including both plugins and delegation functions.
     /// </summary>

--- a/src/MeshWeaver.AI/DefaultChatClientProvider.cs
+++ b/src/MeshWeaver.AI/DefaultChatClientProvider.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// Resolves a BARE <see cref="IChatClient"/> for the mesh's DEFAULT language model — the lowest-Order
+/// <c>LanguageModel</c> whose credentials resolve — WITHOUT an agent and without mutating any shared
+/// factory state. It is the headless counterpart to the chat composer's model selection: background
+/// jobs that need a one-shot model call (e.g. the content-indexing image describer) resolve their
+/// client here instead of standing up an agent.
+///
+/// <para>Client selection mirrors <c>AgentChatClient.GetFactoryForModel</c>: the default model id comes
+/// from <see cref="ChatClientCredentialResolver.ResolveDefaultModelId"/>, and the serving factory is the
+/// lowest-Order non-persistent <see cref="IChatClientFactory"/> that <see cref="IChatClientFactory.Supports"/>
+/// it. Returns <c>null</c> (never throws) when no model is configured or none resolves — callers treat a
+/// null client as "no model available" and degrade gracefully.</para>
+/// </summary>
+public sealed class DefaultChatClientProvider
+{
+    private readonly IReadOnlyList<IChatClientFactory> factories;
+    private readonly ChatClientCredentialResolver resolver;
+    private readonly ILogger<DefaultChatClientProvider> logger;
+
+    /// <summary>Initializes the provider with every registered chat-client factory and the credential resolver.</summary>
+    public DefaultChatClientProvider(
+        IEnumerable<IChatClientFactory> factories,
+        ChatClientCredentialResolver resolver,
+        ILogger<DefaultChatClientProvider>? logger = null)
+    {
+        this.factories = (factories ?? throw new ArgumentNullException(nameof(factories))).ToList();
+        this.resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        this.logger = logger ?? NullLogger<DefaultChatClientProvider>.Instance;
+    }
+
+    /// <summary>
+    /// Creates a bare <see cref="IChatClient"/> for the default resolvable model, or <c>null</c> when
+    /// no model is configured / none resolves / the serving factory can't build a bare client. Never throws.
+    /// </summary>
+    public IChatClient? TryCreate()
+    {
+        var modelId = resolver.ResolveDefaultModelId();
+        if (string.IsNullOrEmpty(modelId))
+        {
+            logger.LogDebug("No default model resolves; returning null chat client.");
+            return null;
+        }
+
+        // Only a factory that actually SUPPORTS the model — never an arbitrary fallback, which would
+        // route the id to an incompatible provider. When none supports it, return null so the caller
+        // degrades to no-description rather than calling the wrong provider.
+        var factory = factories
+            .Where(f => !f.IsPersistent)
+            .OrderBy(f => f.Order)
+            .FirstOrDefault(f => f.Supports(modelId));
+        if (factory is null)
+        {
+            logger.LogDebug("No non-persistent chat-client factory supports default model {ModelId}.", modelId);
+            return null;
+        }
+
+        try
+        {
+            return factory.CreateChatClient(modelId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to create a bare chat client for default model {ModelId} via factory {Factory}.",
+                modelId, factory.Name);
+            return null;
+        }
+    }
+}

--- a/src/MeshWeaver.AI/IChatClientFactory.cs
+++ b/src/MeshWeaver.AI/IChatClientFactory.cs
@@ -1,4 +1,5 @@
 using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
 
 namespace MeshWeaver.AI;
 
@@ -68,4 +69,15 @@ public interface IChatClientFactory
         IReadOnlyDictionary<string, ChatClientAgent> existingAgents,
         IReadOnlyList<AgentConfiguration> hierarchyAgents,
         string? modelName = null);
+
+    /// <summary>
+    /// Creates a BARE <see cref="IChatClient"/> for an EXPLICIT model — no agent, no tools, and
+    /// (critically) NO mutation of shared factory state (unlike the agent path, which stamps
+    /// <c>CurrentModelName</c> on the singleton factory). Safe to call from a background job — e.g.
+    /// the content-indexing image describer — concurrently with live chats. Persistent, server-side-thread
+    /// factories have no plain chat client, so the default throws <see cref="NotSupportedException"/>.
+    /// </summary>
+    /// <param name="modelName">The exact model id/name to target (already resolved — not a tier or path).</param>
+    IChatClient CreateChatClient(string modelName) =>
+        throw new NotSupportedException($"Factory '{Name}' does not support creating a bare chat client.");
 }

--- a/src/MeshWeaver.AI/LanguageModelNodeType.cs
+++ b/src/MeshWeaver.AI/LanguageModelNodeType.cs
@@ -80,6 +80,10 @@ public static class LanguageModelNodeType
             services.TryAddSingleton<IMasterKeyProvider, ConfigMasterKeyProvider>();
             services.TryAddSingleton<IProviderKeyProtector, ProviderKeyProtector>();
             services.TryAddSingleton<ChatClientCredentialResolver>();
+            // Headless default chat client (for background one-shot model calls, e.g. the
+            // content-indexing image describer). Resolves the lowest-Order resolvable LanguageModel
+            // and its serving factory — no agent, no shared-state mutation.
+            services.TryAddSingleton<DefaultChatClientProvider>();
             // ModelDiscoveryService MUST be a top-level singleton on the
             // mesh hub — never on a per-thread / exec hub where its
             // synced subscriptions could get stuck behind an in-flight

--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Schema;
 using MeshWeaver.ContentCollections;
+using MeshWeaver.ContentCollections.Indexing;
 using MeshWeaver.Data;
 using MeshWeaver.Markdown;
 using MeshWeaver.Layout;
@@ -246,6 +247,30 @@ public class MeshOperations
         if (TryParseAreaRoute(resolvedPath, out var areaNodePath, out var routeArea, out var routeAreaId))
             return GetAreaRoute(resolvedPath, areaNodePath, routeArea, routeAreaId);
 
+        // Image content files: return the AI description (the file's Document node) instead of the raw
+        // bytes. When the file has been indexed its Document carries {Name, Summary}; otherwise fall
+        // through to the normal read, which returns a short placeholder — never the bytes (issue #379).
+        if (TryGetContentImagePath(resolvedPath, out var imgCollectionPath, out var imgFilePath))
+        {
+            var documentPath = DocumentPaths.For(imgCollectionPath, imgFilePath);
+            // Short timeout: a missing Document (image not yet indexed, or indexing disabled) maps to
+            // null and falls through to the guarded file read — don't make an image get hang.
+            return FetchNode(documentPath, timeoutSeconds: 3)
+                .SelectMany(doc => doc is not null
+                    ? Observable.Return(JsonSerializer.Serialize(doc, hub.JsonSerializerOptions))
+                    : ReadNodeOrUnified(resolvedPath));
+        }
+
+        return ReadNodeOrUnified(resolvedPath);
+    }
+
+    /// <summary>
+    /// The core single-node / unified-reference read: resolves a UCR path (content/data/schema/area/…)
+    /// or falls back to an authoritative node read. Factored out of <see cref="Get"/> so the image
+    /// branch can reuse it as its "no Document yet" fallback.
+    /// </summary>
+    private IObservable<string> ReadNodeOrUnified(string resolvedPath)
+    {
         // Single-node content read via GetDataRequest + MeshNodeReference + RegisterCallback.
         // See Doc/Architecture/CqrsAndContentAccess.md — queries are for sets only.
         return TryResolveUnifiedPath(resolvedPath)
@@ -282,6 +307,57 @@ public class MeshOperations
                 logger.LogWarning(ex, "Error getting data at path {Path}", resolvedPath);
                 return Observable.Return($"Error: {ex.Message}");
             });
+    }
+
+    /// <summary>Raster image extensions whose <c>get</c> is routed to the file's Document node.</summary>
+    private static readonly ImmutableHashSet<string> ImageExtensions = ImmutableHashSet.Create(
+        StringComparer.OrdinalIgnoreCase,
+        ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif");
+
+    /// <summary>
+    /// Detects a <c>{node}/content/{file}</c> (or legacy <c>{node}/content:{file}</c>) path pointing at
+    /// an IMAGE in the default <c>content</c> collection, and returns the qualified collection path
+    /// (<c>{node}/content</c>) and the file path within it. These feed <see cref="DocumentPaths.For"/>
+    /// so <see cref="Get"/> can return the image's Document (name + AI description) instead of its bytes.
+    /// Scoped to the <c>content</c> collection; named collections (and the <c>_Documents</c> subtree
+    /// itself) fall through to the normal read (which still guards against dumping raw bytes).
+    /// </summary>
+    internal static bool TryGetContentImagePath(string resolvedPath, out string collectionPath, out string filePath)
+    {
+        collectionPath = string.Empty;
+        filePath = string.Empty;
+        if (string.IsNullOrWhiteSpace(resolvedPath))
+            return false;
+
+        // Locate the 'content' collection segment, in either the slash ("/content/") or the legacy
+        // colon ("/content:") form.
+        const string slashMarker = "/content/";
+        const string colonMarker = "/content:";
+        int markerIdx = resolvedPath.IndexOf(slashMarker, StringComparison.Ordinal);
+        int markerLen = slashMarker.Length;
+        if (markerIdx < 0)
+        {
+            markerIdx = resolvedPath.IndexOf(colonMarker, StringComparison.Ordinal);
+            markerLen = colonMarker.Length;
+        }
+        if (markerIdx <= 0)
+            return false;
+
+        var node = resolvedPath[..markerIdx];
+        var file = resolvedPath[(markerIdx + markerLen)..].TrimStart('/');
+        if (node.Length == 0 || file.Length == 0)
+            return false;
+
+        // Never route the Document nodes themselves back into a Document lookup.
+        if (file.StartsWith(DocumentPaths.DocumentsSubNamespace + "/", StringComparison.Ordinal))
+            return false;
+
+        if (!ImageExtensions.Contains(System.IO.Path.GetExtension(file)))
+            return false;
+
+        collectionPath = $"{node}/{ContentCollectionsExtensions.DefaultCollectionName}";
+        filePath = file;
+        return true;
     }
 
     /// <summary>

--- a/src/MeshWeaver.AI/MeshWeaver.AI.csproj
+++ b/src/MeshWeaver.AI/MeshWeaver.AI.csproj
@@ -10,8 +10,6 @@
         <PackageReference Include="Azure.Core" />
         <PackageReference Include="HtmlAgilityPack" />
         <PackageReference Include="Microsoft.Extensions.Http" />
-        <PackageReference Include="ClosedXML" />
-        <PackageReference Include="DocumentFormat.OpenXml" />
         <PackageReference Include="Microsoft.Extensions.AI" />
         <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
         <PackageReference Include="Microsoft.Agents.AI" />
@@ -19,8 +17,6 @@
         <PackageReference Include="Microsoft.Agents.AI.Workflows" />
         <PackageReference Include="Microsoft.Agents.AI.AzureAI" />
         <PackageReference Include="OpenAI" />
-        <PackageReference Include="UglyToad.PdfPig" />
-
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\MeshWeaver.Application.Styles\MeshWeaver.Application.Styles.csproj" />

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/ChatClientImageDescriber.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/ChatClientImageDescriber.cs
@@ -1,0 +1,123 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using MeshWeaver.ContentCollections.Indexing;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MeshWeaver.ContentCollections.Indexing.Graph;
+
+/// <summary>
+/// The framework <see cref="IImageDescriber"/>: a single MULTIMODAL <see cref="IChatClient"/> call that
+/// captions an image for alt-text and search. The image bytes are sent as a <see cref="DataContent"/>
+/// part alongside a text prompt; the model round-trip is ONE <see cref="IoPoolNames.Http"/> I/O-pool
+/// leaf — it takes its own slot, runs off the hub/grain scheduler, and bridges back into the reactive
+/// contract. No <c>async</c>/<c>await</c> escapes the public surface.
+///
+/// <para>The chat client is resolved LAZILY per call through the supplied factory delegate
+/// (typically the mesh's <c>DefaultChatClientProvider</c>) rather than captured at construction: the
+/// default model may not be resolvable until the mesh is warm, and it can change. When no vision model
+/// is available — or the call fails — <see cref="Describe"/> emits an EMPTY string, so the file simply
+/// indexes as no-text (exactly the behavior before a describer was wired) instead of failing the
+/// indexing activity.</para>
+/// </summary>
+public sealed class ChatClientImageDescriber : IImageDescriber
+{
+    private static readonly ImmutableHashSet<string> Extensions = ImmutableHashSet.Create(
+        StringComparer.OrdinalIgnoreCase, ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif");
+
+    private static readonly ImmutableDictionary<string, string> MediaTypes =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [".png"] = "image/png",
+            [".jpg"] = "image/jpeg",
+            [".jpeg"] = "image/jpeg",
+            [".gif"] = "image/gif",
+            [".webp"] = "image/webp",
+            [".bmp"] = "image/bmp",
+            [".tiff"] = "image/tiff",
+            [".tif"] = "image/tiff"
+        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
+
+    private readonly Func<IChatClient?> chatClientFactory;
+    private readonly IIoPool httpPool;
+    private readonly ILogger<ChatClientImageDescriber> logger;
+
+    /// <summary>The image extensions this describer handles.</summary>
+    public IReadOnlyCollection<string> SupportedExtensions => Extensions;
+
+    /// <summary>
+    /// Creates the describer. <paramref name="chatClientFactory"/> supplies a multimodal chat client
+    /// on demand (may return <c>null</c> when no default model resolves); the model round-trip runs on
+    /// the shared <see cref="IoPoolNames.Http"/> outbound-network gate.
+    /// </summary>
+    public ChatClientImageDescriber(
+        Func<IChatClient?> chatClientFactory,
+        IoPoolRegistry ioPoolRegistry,
+        ILogger<ChatClientImageDescriber>? logger = null)
+    {
+        this.chatClientFactory = chatClientFactory ?? throw new ArgumentNullException(nameof(chatClientFactory));
+        httpPool = (ioPoolRegistry ?? throw new ArgumentNullException(nameof(ioPoolRegistry))).Get(IoPoolNames.Http);
+        this.logger = logger ?? NullLogger<ChatClientImageDescriber>.Instance;
+    }
+
+    /// <inheritdoc />
+    public IObservable<string> Describe(byte[] imageBytes, string fileName)
+    {
+        var ext = System.IO.Path.GetExtension(fileName).ToLowerInvariant();
+        var mediaType = MediaTypes.GetValueOrDefault(ext, "image/png");
+
+        // The multimodal round-trip is the single IIoPool leaf — cold, bounded, off-scheduler.
+        return httpPool.Invoke(async ct =>
+        {
+            IChatClient? client;
+            try
+            {
+                client = chatClientFactory();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Resolving a vision chat client failed for image '{FileName}'; indexing it without a description.",
+                    fileName);
+                return string.Empty;
+            }
+
+            if (client is null)
+            {
+                // Debug, not Information: with no vision model configured this fires for EVERY image.
+                logger.LogDebug(
+                    "No vision chat client available; image '{FileName}' indexed without a description.", fileName);
+                return string.Empty;
+            }
+
+            var message = new ChatMessage(ChatRole.User, new List<AIContent>
+            {
+                new TextContent(BuildPrompt(fileName)),
+                new DataContent(imageBytes, mediaType)
+            });
+
+            try
+            {
+                var response = await client.GetResponseAsync([message], options: null, ct).ConfigureAwait(false);
+                return response.Text ?? string.Empty;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Vision describe failed for image '{FileName}'; indexing it without a description.", fileName);
+                return string.Empty;
+            }
+        });
+    }
+
+    /// <summary>Builds the vision prompt. <paramref name="fileName"/> is a name/format hint.</summary>
+    internal static string BuildPrompt(string fileName) =>
+        $"""
+         Describe this image in 2-4 concise sentences for use as searchable alt-text. Capture the
+         subject, any visible text, and notable details. Write plain prose — no preamble, no markdown.
+
+         File name: {fileName}
+         """;
+}

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingPipelineExtensions.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingPipelineExtensions.cs
@@ -37,7 +37,8 @@ public static class ContentIndexingPipelineExtensions
         Func<IServiceProvider, IChunkedContentVectorStore> storeFactory,
         Func<IServiceProvider, IChunkEmbedder> embedderFactory,
         Func<IServiceProvider, ISummarizer>? summarizerFactory = null,
-        ContentIndexingOptions? options = null)
+        ContentIndexingOptions? options = null,
+        Func<IServiceProvider, IImageDescriber>? imageDescriberFactory = null)
         where TBuilder : MeshBuilder
     {
         ArgumentNullException.ThrowIfNull(storeFactory);
@@ -58,6 +59,8 @@ public static class ContentIndexingPipelineExtensions
             services.AddSingleton(embedderFactory);
             if (summarizerFactory is not null)
                 services.AddSingleton(summarizerFactory);
+            if (imageDescriberFactory is not null)
+                services.AddSingleton(imageDescriberFactory);
 
             services.AddSingleton(sp => new ContentIndexingService(
                 sp.GetRequiredService<ITextExtractor>(),
@@ -68,7 +71,10 @@ public static class ContentIndexingPipelineExtensions
                 // Summarizer + sink are OPTIONAL inputs to the service: both present ⇒ the per-file
                 // Document branch runs; either absent ⇒ chunk-embed-store only.
                 sp.GetService<ISummarizer>(),
-                sp.GetService<IDocumentSink>()));
+                sp.GetService<IDocumentSink>(),
+                // Optional vision describer: when wired, image files are captioned (searchable text +
+                // Document summary) instead of extracting to empty.
+                sp.GetService<IImageDescriber>()));
 
             // The upload→Activity reactor. Registered as its concrete type so a host/GUI can resolve it
             // to call ReindexAll(...), AND forwarded to the IContentUploadObserver seam so the same

--- a/src/MeshWeaver.ContentCollections.Indexing/ContentIndexingService.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/ContentIndexingService.cs
@@ -50,6 +50,7 @@ public sealed class ContentIndexingService
     private readonly IChunkedContentVectorStore _store;
     private readonly ISummarizer? _summarizer;
     private readonly IDocumentSink? _documentSink;
+    private readonly IImageDescriber? _imageDescriber;
     private readonly ContentIndexingOptions _options;
     private readonly ILogger<ContentIndexingService> _logger;
 
@@ -63,6 +64,7 @@ public sealed class ContentIndexingService
     /// <param name="logger">Logger for the indexing pipeline; a no-op logger is used when <c>null</c>.</param>
     /// <param name="summarizer">Optional per-document summarizer; the document branch runs only when both this and <paramref name="documentSink"/> are supplied.</param>
     /// <param name="documentSink">Optional sink that persists the per-file <see cref="DocumentInfo"/>; paired with <paramref name="summarizer"/>.</param>
+    /// <param name="imageDescriber">Optional vision describer; when supplied, an image file (by extension) is described by it instead of the text extractor, and the description becomes both the indexed text and the Document summary.</param>
     public ContentIndexingService(
         ITextExtractor extractor,
         IChunkEmbedder embedder,
@@ -70,7 +72,8 @@ public sealed class ContentIndexingService
         ContentIndexingOptions? options = null,
         ILogger<ContentIndexingService>? logger = null,
         ISummarizer? summarizer = null,
-        IDocumentSink? documentSink = null)
+        IDocumentSink? documentSink = null,
+        IImageDescriber? imageDescriber = null)
     {
         _extractor = extractor ?? throw new ArgumentNullException(nameof(extractor));
         _embedder = embedder ?? throw new ArgumentNullException(nameof(embedder));
@@ -80,6 +83,8 @@ public sealed class ContentIndexingService
         // written only when BOTH are present.
         _summarizer = summarizer;
         _documentSink = documentSink;
+        // imageDescriber is OPTIONAL: absent ⇒ images extract to empty text (today's NoText behavior).
+        _imageDescriber = imageDescriber;
         _options = options ?? new ContentIndexingOptions();
         _logger = logger ?? NullLogger<ContentIndexingService>.Instance;
     }
@@ -136,7 +141,9 @@ public sealed class ContentIndexingService
     private IObservable<Unit> EnsureDocument(
         string collectionPath, string filePath, string fileName, byte[] bytes, string hash)
     {
-        if (_summarizer is null || _documentSink is null)
+        // Nothing to heal without a sink; a summary can still come from the summarizer OR an image
+        // describer, so do NOT gate on _summarizer here (WriteDocumentBranch decides).
+        if (_documentSink is null)
             return Observable.Return(Unit.Default);
 
         return _documentSink.DocumentExists(collectionPath, filePath)
@@ -151,21 +158,21 @@ public sealed class ContentIndexingService
                     filePath, collectionPath);
                 return _store.GetChunkCount(collectionPath, filePath)
                     .Take(1)
-                    .SelectMany(chunkCount => _extractor.ExtractText(fileName, bytes)
-                        .Take(1)
-                        .SelectMany(text => string.IsNullOrWhiteSpace(text)
+                    .SelectMany(chunkCount => ExtractIndexable(fileName, bytes)
+                        .SelectMany(extracted => string.IsNullOrWhiteSpace(extracted.Document.Text)
                             ? Observable.Return(Unit.Default)
                             : WriteDocumentBranch(
-                                collectionPath, filePath, fileName, text, bytes, hash, chunkCount)));
+                                collectionPath, filePath, fileName, extracted.Document.Text, bytes, hash, chunkCount,
+                                extracted.SummaryOverride)));
             });
     }
 
     private IObservable<IndexResult> IndexChanged(
         string collectionPath, string filePath, string fileName, byte[] bytes, string hash) =>
-        _extractor.ExtractDocument(fileName, bytes)
-            .Take(1)
-            .SelectMany(document =>
+        ExtractIndexable(fileName, bytes)
+            .SelectMany(extracted =>
             {
+                var (document, summaryOverride) = extracted;
                 var chunks = TextChunker.ChunkPositioned(document, _options.ChunkSize, _options.ChunkOverlap);
                 if (chunks.Count == 0)
                 {
@@ -190,29 +197,64 @@ public sealed class ContentIndexingService
                 // otherwise it's a no-op that emits a single Unit so the Zip below still completes
                 // — giving exactly today's behavior when either is absent. The summarize call is
                 // its own IIoPool leaf inside the ISummarizer impl; the orchestration holds no slot.
+                // For an image, summaryOverride carries the vision description → used verbatim as the
+                // summary (the describe call already happened once in ExtractIndexable).
                 return chunkBranch.SelectMany(storedCount =>
-                    WriteDocumentBranch(collectionPath, filePath, fileName, document.Text, bytes, hash, storedCount)
+                    WriteDocumentBranch(collectionPath, filePath, fileName, document.Text, bytes, hash, storedCount, summaryOverride)
                         .Select(_ => IndexResult.Indexed(storedCount)));
             });
 
     /// <summary>
-    /// Summarizes the document (once) and writes the per-file <see cref="DocumentInfo"/> through the
-    /// sink — but ONLY when both <see cref="ISummarizer"/> and <see cref="IDocumentSink"/> are wired.
-    /// When either is absent this is a no-op emitting a single <see cref="Unit"/>, so the caller's
-    /// composition completes identically to the original (chunk-only) flow.
+    /// Produces the file's indexable document plus an optional summary override, dispatched by
+    /// extension: a normal file goes through <see cref="ITextExtractor.ExtractDocument"/> (no override —
+    /// the summarizer produces the Document summary); an IMAGE (a describer is wired and its extension
+    /// matches) goes through <see cref="IImageDescriber"/>, whose description is wrapped as positionless
+    /// text and is BOTH the indexable content AND the summary (ONE model call, no re-summarize). With no
+    /// describer, images fall to the extractor → empty → NoText, exactly today's behavior.
+    /// </summary>
+    private IObservable<(ExtractedDocument Document, string? SummaryOverride)> ExtractIndexable(
+        string fileName, byte[] bytes)
+    {
+        var ext = System.IO.Path.GetExtension(fileName).ToLowerInvariant();
+        if (_imageDescriber is not null && _imageDescriber.SupportedExtensions.Contains(ext))
+            return _imageDescriber.Describe(bytes, fileName)
+                .Take(1)
+                .Select(description => (
+                    ExtractedDocument.PlainText(description ?? string.Empty),
+                    string.IsNullOrWhiteSpace(description) ? (string?)null : description));
+
+        return _extractor.ExtractDocument(fileName, bytes)
+            .Take(1)
+            .Select(document => (document, (string?)null));
+    }
+
+    /// <summary>
+    /// Writes the per-file <see cref="DocumentInfo"/> through the sink, deriving the summary from
+    /// <paramref name="summaryOverride"/> when present (e.g. an image's vision description, used
+    /// verbatim) or otherwise from the <see cref="ISummarizer"/> condensing the extracted text. A
+    /// no-op emitting a single <see cref="Unit"/> when there is no sink, or no way to produce a summary
+    /// (no override and no summarizer) — so the caller's composition completes identically to the
+    /// original (chunk-only) flow when the document branch isn't wired.
     /// </summary>
     private IObservable<Unit> WriteDocumentBranch(
         string collectionPath, string filePath, string fileName, string text, byte[] bytes,
-        string hash, int chunkCount)
+        string hash, int chunkCount, string? summaryOverride = null)
     {
-        if (_summarizer is null || _documentSink is null)
+        if (_documentSink is null)
             return Observable.Return(Unit.Default);
 
-        var summarizer = _summarizer;
-        var documentSink = _documentSink;
+        // Summary source: an override (image description) is used verbatim; otherwise the summarizer
+        // condenses the extracted text. With neither, there is nothing to write.
+        IObservable<string> summarySource;
+        if (summaryOverride is not null)
+            summarySource = Observable.Return(summaryOverride);
+        else if (_summarizer is not null)
+            summarySource = _summarizer.Summarize(text, fileName).Take(1);
+        else
+            return Observable.Return(Unit.Default);
 
-        return summarizer.Summarize(text, fileName)
-            .Take(1)
+        var documentSink = _documentSink;
+        return summarySource
             .SelectMany(summary => documentSink.WriteDocument(new DocumentInfo(
                 CollectionPath: collectionPath,
                 FilePath: filePath,

--- a/src/MeshWeaver.ContentCollections.Indexing/IImageDescriber.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing/IImageDescriber.cs
@@ -1,0 +1,32 @@
+namespace MeshWeaver.ContentCollections.Indexing;
+
+/// <summary>
+/// Produces a natural-language description of an IMAGE file — the vision counterpart to
+/// <see cref="ITextExtractor"/>. An image carries no extractable text, so without a describer it
+/// indexes to nothing; with one, its description becomes the file's indexable content (chunked +
+/// embedded for search) AND its <c>Document</c> summary. Owned by the storage-agnostic indexing core
+/// as a thin abstraction so the core takes NO heavy AI dependency — the real, multimodal
+/// <c>IChatClient</c>-backed implementation lives in a hosting/AI project; tests supply a fake.
+/// </summary>
+/// <remarks>
+/// Reactive contract (no <c>async</c>/<c>await</c>/<c>Task</c>): the real implementation wraps a single
+/// multimodal chat-completion call through <c>IIoPool.Invoke(...)</c> — ONE I/O-pool leaf that takes
+/// its OWN slot. <see cref="ContentIndexingService"/> composes it with <c>.SelectMany</c> and never
+/// awaits it. Called at most ONCE per image. Emits a single description string (empty when the model
+/// is unavailable — the file then indexes as no-text, exactly today's behavior) then completes.
+/// </remarks>
+public interface IImageDescriber
+{
+    /// <summary>
+    /// File extensions this describer handles (e.g. <c>.png</c>, <c>.jpg</c>). The indexing service
+    /// routes a file to the describer instead of the text extractor when its extension is in this set.
+    /// </summary>
+    IReadOnlyCollection<string> SupportedExtensions { get; }
+
+    /// <summary>
+    /// Describes the image in <paramref name="imageBytes"/>. <paramref name="fileName"/> is a prompt
+    /// hint (name / format cue). Emits exactly one description then completes; emits empty when no
+    /// vision model is available so the caller degrades to no-text.
+    /// </summary>
+    IObservable<string> Describe(byte[] imageBytes, string fileName);
+}

--- a/src/MeshWeaver.ContentCollections/ClosedXmlContentTransformer.cs
+++ b/src/MeshWeaver.ContentCollections/ClosedXmlContentTransformer.cs
@@ -1,0 +1,95 @@
+using System.Collections.Immutable;
+using System.Text;
+using ClosedXML.Excel;
+
+namespace MeshWeaver.ContentCollections;
+
+/// <summary>
+/// Transforms .xlsx / .xls spreadsheets to Markdown tables using ClosedXML — one table per
+/// worksheet, rows keyed by their Excel row number and columns by their Excel letter.
+/// Registered as IContentTransformer via DI. Restores the reader that the old agent
+/// <c>ContentPlugin.ReadExcelFile</c> provided before the read path was consolidated onto the
+/// content-collection transformer seam (only <c>.docx</c> survived that move). Without this, a
+/// spreadsheet read through the content-collection file path falls through to the raw StreamReader
+/// and returns the binary OpenXML zip bytes decoded as UTF-8.
+/// </summary>
+public class ClosedXmlContentTransformer : IContentTransformer
+{
+    private static readonly ImmutableHashSet<string> Extensions =
+        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, ".xlsx", ".xls");
+
+    /// <summary>The file extensions this transformer handles (<c>.xlsx</c>, <c>.xls</c>).</summary>
+    public IReadOnlyCollection<string> SupportedExtensions => Extensions;
+
+    /// <summary>Renders every worksheet of a spreadsheet stream as a Markdown table.</summary>
+    /// <param name="input">The spreadsheet stream to convert.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The workbook rendered as Markdown, one <c>## Sheet: {name}</c> section per worksheet.</returns>
+    public async Task<string> TransformToMarkdownAsync(Stream input, CancellationToken ct = default)
+    {
+        // ClosedXML needs random access — buffer first so a non-seekable source stream
+        // (e.g. an Azure blob read stream) parses correctly.
+        using var buffer = new MemoryStream();
+        await input.CopyToAsync(buffer, ct).ConfigureAwait(false);
+        buffer.Position = 0;
+
+        using var workbook = new XLWorkbook(buffer);
+        var sb = new StringBuilder();
+
+        foreach (var ws in workbook.Worksheets)
+        {
+            ct.ThrowIfCancellationRequested();
+            sb.AppendLine($"## Sheet: {ws.Name}");
+            sb.AppendLine();
+
+            var used = ws.RangeUsed();
+            if (used is null)
+            {
+                sb.AppendLine("(No data)");
+                sb.AppendLine();
+                continue;
+            }
+
+            var firstRow = used.FirstRow().RowNumber();
+            var lastRow = used.LastRow().RowNumber();
+            var lastCol = used.LastColumn().ColumnNumber();
+
+            var columnHeaders = new List<string> { "Row" };
+            for (var c = 1; c <= lastCol; c++)
+                columnHeaders.Add(GetExcelColumnLetter(c));
+
+            sb.AppendLine("| " + string.Join(" | ", columnHeaders) + " |");
+            sb.AppendLine("|" + string.Concat(columnHeaders.Select(_ => "---:|")));
+
+            for (var r = firstRow; r <= lastRow; r++)
+            {
+                var rowVals = new List<string> { r.ToString() };
+                for (var c = 1; c <= lastCol; c++)
+                {
+                    var raw = ws.Cell(r, c).GetValue<string>();
+                    var val = raw?.Replace('\n', ' ').Replace('\r', ' ').Replace("|", "\\|").Trim();
+                    rowVals.Add(string.IsNullOrEmpty(val) ? "" : val);
+                }
+
+                sb.AppendLine("| " + string.Join(" | ", rowVals) + " |");
+            }
+
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>Converts a 1-based column number to its Excel letter (1=A, 27=AA).</summary>
+    private static string GetExcelColumnLetter(int columnNumber)
+    {
+        var columnLetter = "";
+        while (columnNumber > 0)
+        {
+            var modulo = (columnNumber - 1) % 26;
+            columnLetter = Convert.ToChar('A' + modulo) + columnLetter;
+            columnNumber = (columnNumber - 1) / 26;
+        }
+        return columnLetter;
+    }
+}

--- a/src/MeshWeaver.ContentCollections/ContentCollectionsExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollectionsExtensions.cs
@@ -374,6 +374,8 @@ public static class ContentCollectionsExtensions
                 .AddScoped<IContentService, ContentService>()
                 .AddScoped<Data.IFileContentProvider, FileContentProvider>()
                 .AddSingleton<IContentTransformer, DocSharpContentTransformer>()
+                .AddSingleton<IContentTransformer, PdfPigContentTransformer>()
+                .AddSingleton<IContentTransformer, ClosedXmlContentTransformer>()
                 .AddKeyedScoped<IStreamProviderFactory, FileSystemStreamProviderFactory>(FileSystemStreamProvider.SourceType)
                 .AddKeyedScoped<IStreamProviderFactory, EmbeddedResourceStreamProviderFactory>(EmbeddedResourceStreamProvider.SourceType)
                 .AddKeyedScoped<IStreamProviderFactory, HubStreamProviderFactory>(HubStreamProviderFactory.SourceType);

--- a/src/MeshWeaver.ContentCollections/FileContentProvider.cs
+++ b/src/MeshWeaver.ContentCollections/FileContentProvider.cs
@@ -18,6 +18,24 @@ public class FileContentProvider : IFileContentProvider
     private readonly IIoPool _ioPool;
 
     /// <summary>
+    /// Raster image extensions → media type. A file with one of these and no registered
+    /// <see cref="IContentTransformer"/> is guarded (a descriptive placeholder is returned) rather than
+    /// having its raw bytes decoded as text. Read-only constant lookup — never mutated at runtime.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> ImageMediaTypes =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [".png"] = "image/png",
+            [".jpg"] = "image/jpeg",
+            [".jpeg"] = "image/jpeg",
+            [".gif"] = "image/gif",
+            [".webp"] = "image/webp",
+            [".bmp"] = "image/bmp",
+            [".tiff"] = "image/tiff",
+            [".tif"] = "image/tiff"
+        };
+
+    /// <summary>
     /// Initializes the provider with the content service, the available document transformers,
     /// and the file-system I/O pool used to run file access off the hub.
     /// </summary>
@@ -63,6 +81,28 @@ public class FileContentProvider : IFileContentProvider
 
                 var markdown = await transformer.TransformToMarkdownAsync(stream, ct).ConfigureAwait(false);
                 return FileContentResult.Ok(markdown);
+            }
+
+            if (ImageMediaTypes.TryGetValue(ext, out var imageMediaType))
+            {
+                // A binary image has no text transformer. NEVER decode its bytes as text (issue #379 —
+                // multi-MB of binary floods a model context and fails the next request with 400). Return
+                // a short descriptive placeholder instead. When content indexing is enabled, an AI
+                // description of the image is surfaced through the file's Document node.
+                long? size = null;
+                await using (var probe = await collection.GetContentAsync(filePath, ct).ConfigureAwait(false))
+                {
+                    if (probe == null)
+                        return FileContentResult.Fail($"File '{filePath}' not found in collection '{collectionName}'");
+                    if (probe.CanSeek)
+                        size = probe.Length;
+                }
+
+                var sizeText = size is { } s ? $", {s} bytes" : string.Empty;
+                return FileContentResult.Ok(
+                    $"[image: {Path.GetFileName(filePath)} ({imageMediaType}{sizeText})] "
+                    + "Binary image content is not returned as text. When content indexing is enabled, an "
+                    + "AI-generated description is available on the file's Document node.");
             }
 
             await using var textStream = await collection.GetContentAsync(filePath, ct).ConfigureAwait(false);

--- a/src/MeshWeaver.ContentCollections/MeshWeaver.ContentCollections.csproj
+++ b/src/MeshWeaver.ContentCollections/MeshWeaver.ContentCollections.csproj
@@ -5,8 +5,10 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="ClosedXML" />
     <PackageReference Include="DocSharp.Markdown" />
     <PackageReference Include="Markdig" />
+    <PackageReference Include="UglyToad.PdfPig" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
   </ItemGroup>

--- a/src/MeshWeaver.ContentCollections/PdfPigContentTransformer.cs
+++ b/src/MeshWeaver.ContentCollections/PdfPigContentTransformer.cs
@@ -1,0 +1,46 @@
+using System.Collections.Immutable;
+using System.Text;
+using UglyToad.PdfPig;
+
+namespace MeshWeaver.ContentCollections;
+
+/// <summary>
+/// Transforms .pdf documents to plain text using UglyToad.PdfPig, one page's text per line group.
+/// Registered as IContentTransformer via DI. Without this, a PDF read through the content-collection
+/// file path falls through to the raw StreamReader and returns the binary <c>%PDF-…FlateDecode…</c>
+/// bytes decoded as UTF-8 (the reported "get returned the full PDF" bug).
+/// </summary>
+public class PdfPigContentTransformer : IContentTransformer
+{
+    private static readonly ImmutableHashSet<string> Extensions =
+        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, ".pdf");
+
+    /// <summary>The file extensions this transformer handles (<c>.pdf</c>).</summary>
+    public IReadOnlyCollection<string> SupportedExtensions => Extensions;
+
+    /// <summary>Extracts the page text from a <c>.pdf</c> document stream.</summary>
+    /// <param name="input">The document stream to read.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The concatenated page text.</returns>
+    public async Task<string> TransformToMarkdownAsync(Stream input, CancellationToken ct = default)
+    {
+        // PdfPig needs random access (xref table) — buffer first so a non-seekable source
+        // stream (e.g. an Azure blob read stream) parses correctly. Open the seekable buffer
+        // directly (rewound) rather than copying it to a byte[] — lower peak memory on big PDFs.
+        using var buffer = new MemoryStream();
+        await input.CopyToAsync(buffer, ct).ConfigureAwait(false);
+        buffer.Position = 0;
+
+        using var document = PdfDocument.Open(buffer);
+        var sb = new StringBuilder();
+        foreach (var page in document.GetPages())
+        {
+            ct.ThrowIfCancellationRequested();
+            if (sb.Length > 0)
+                sb.Append('\n');
+            sb.Append(page.Text);
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/DataMesh/UnifiedPath.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/UnifiedPath.md
@@ -133,12 +133,17 @@ Writing goes through `upload` with the mirror shape `{nodePath}/{collection}/{fi
 | Extension | Behavior |
 |---|---|
 | `.docx` | Converted to **markdown** (DocSharp transformer) |
+| `.pdf` | Extracted to **page text** (PdfPig transformer) |
+| `.xlsx`, `.xls` | Converted to **markdown tables**, one per worksheet (ClosedXML transformer) |
 | `.md`, `.csv`, `.txt`, source files | Returned as text verbatim |
-| `.xlsx`, `.pdf`, images | **No transformer yet** — bytes are decoded as text and arrive corrupted (binary is not JSON-safe) |
+| images (`.png`, `.jpg`, `.gif`, `.webp`, `.tif`/`.tiff`, …) | **Never returned as bytes.** `get` returns the image's `Document` node (name + AI description) when content indexing has captioned it; otherwise a short placeholder (name, media type, size). |
+| other binaries | **No transformer** — bytes would decode as corrupted text (binary is not JSON-safe); do not `get` these into an agent context |
 
-For `.xlsx` / `.pdf` content, two reliable patterns until transformers ship:
+The transformer seam is a single registration (`AddContentService`), so the agent `Get` tool and the MCP `get` tool return byte-for-byte the same text for a given file — there is no second code path.
 
-1. **Server-side executable Code node** ([ExecuteScript](/Doc/AI/ExecuteScript)): resolve `IContentService`, open the stream, and parse in-process — an `.xlsx` is a ZIP, so `System.IO.Compression.ZipArchive` + `XDocument` over `xl/worksheets/sheet1.xml` and `xl/sharedStrings.xml` needs no NuGet package. Print rows to the activity log or create mesh nodes directly.
+For a binary format with no transformer, two reliable patterns:
+
+1. **Server-side executable Code node** ([ExecuteScript](/Doc/AI/ExecuteScript)): resolve `IContentService`, open the stream, and parse in-process — no bytes cross the agent boundary. Print results to the activity log or create mesh nodes directly.
 2. **Lossless export through the collection**: a script converts the file to Base64 text and saves it back via `collection.SaveFileAsync(...)`; `get` on the resulting `.b64` file is lossless text, which the client decodes back to the original bytes.
 
 A note on collection resolution inside scripts: the kernel's `IContentService` does not know node-scoped collections by their plain name. Fetch the node's collection config first and register it under a qualified name — the same handshake `upload` performs:

--- a/test/MeshWeaver.AI.Test/ContentImagePathParsingTest.cs
+++ b/test/MeshWeaver.AI.Test/ContentImagePathParsingTest.cs
@@ -1,0 +1,46 @@
+using MeshWeaver.AI;
+using MeshWeaver.ContentCollections.Indexing;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Unit coverage for <see cref="MeshOperations.TryGetContentImagePath"/> — the parse that routes a
+/// <c>get</c> on an image in the default <c>content</c> collection to the file's Document node (name +
+/// AI description) instead of returning raw bytes. It must recognise image files in the content
+/// collection (slash and legacy colon forms), and must NOT fire for non-images, other path shapes, or
+/// the <c>_Documents</c> subtree itself (which would recurse).
+/// </summary>
+public class ContentImagePathParsingTest
+{
+    [Theory]
+    [InlineData("AgenticPension/content/chart.png", "AgenticPension/content", "chart.png")]
+    [InlineData("Space/content/sub/dir/photo.jpeg", "Space/content", "sub/dir/photo.jpeg")]
+    [InlineData("A/B/content/logo.WEBP", "A/B/content", "logo.WEBP")]
+    [InlineData("Space/content:diagram.gif", "Space/content", "diagram.gif")]
+    public void Recognises_Image_Content_Paths(string path, string expectedCollection, string expectedFile)
+    {
+        MeshOperations.TryGetContentImagePath(path, out var collectionPath, out var filePath)
+            .Should().BeTrue();
+        collectionPath.Should().Be(expectedCollection);
+        filePath.Should().Be(expectedFile);
+
+        // The derived Document path is stable and under the collection's _Documents subtree.
+        DocumentPaths.For(collectionPath, filePath)
+            .Should().StartWith($"{expectedCollection}/{DocumentPaths.DocumentsSubNamespace}/");
+    }
+
+    [Theory]
+    [InlineData("AgenticPension/content/contract.pdf")]   // has a transformer — not an image
+    [InlineData("AgenticPension/content/notes.txt")]      // text
+    [InlineData("AgenticPension/content/data.xlsx")]      // has a transformer
+    [InlineData("Space/content/_Documents/chart.png")]    // the Document node itself — must not recurse
+    [InlineData("Space/Files/chart.png")]                 // named (non-'content') collection — out of scope
+    [InlineData("Space/chart.png")]                       // not under a collection
+    [InlineData("content/chart.png")]                     // no owning node before the collection
+    [InlineData("")]
+    public void Ignores_Non_Image_Content_Paths(string path)
+    {
+        MeshOperations.TryGetContentImagePath(path, out _, out _).Should().BeFalse();
+    }
+}

--- a/test/MeshWeaver.ContentCollections.Indexing.Graph.Test/ChatClientImageDescriberTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Graph.Test/ChatClientImageDescriberTest.cs
@@ -1,0 +1,98 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Indexing.Graph.Test;
+
+/// <summary>
+/// Focused tests for <see cref="ChatClientImageDescriber"/>: the description comes from a single
+/// MULTIMODAL <see cref="IChatClient"/> completion whose message carries the image bytes as a
+/// <see cref="DataContent"/> part (correct media type) plus a text prompt; the client is resolved
+/// lazily and a null client (or a failing call) degrades to an empty description rather than throwing.
+/// </summary>
+public class ChatClientImageDescriberTest
+{
+    private static readonly byte[] SampleBytes = [0x89, 0x50, 0x4E, 0x47, 0x01, 0x02, 0x03];
+
+    [Fact(Timeout = 30_000)]
+    public async Task Describe_SendsImageAsDataContent_AndReturnsModelText()
+    {
+        var chat = new RecordingChatClient("A bar chart of quarterly revenue.");
+        var describer = new ChatClientImageDescriber(() => chat, new IoPoolRegistry());
+
+        var description = await describer.Describe(SampleBytes, "chart.jpg").FirstAsync().ToTask();
+
+        description.Should().Be("A bar chart of quarterly revenue.");
+        chat.LastPrompt.Should().Contain("chart.jpg", "the file name is a prompt hint");
+        chat.LastImage.Should().NotBeNull("the image is sent as a DataContent part");
+        chat.LastImage!.MediaType.Should().Be("image/jpeg", ".jpg maps to image/jpeg");
+        chat.LastImage.Data.ToArray().Should().Equal(SampleBytes);
+    }
+
+    [Fact]
+    public async Task Describe_NoClient_ReturnsEmpty()
+    {
+        var describer = new ChatClientImageDescriber(() => null, new IoPoolRegistry());
+
+        var description = await describer.Describe(SampleBytes, "chart.png").FirstAsync().ToTask();
+
+        description.Should().BeEmpty("no vision model available → the image indexes as no-text");
+    }
+
+    [Fact]
+    public async Task Describe_ClientThrows_ReturnsEmpty()
+    {
+        var chat = new RecordingChatClient("unused", onInvoke: () => throw new InvalidOperationException("boom"));
+        var describer = new ChatClientImageDescriber(() => chat, new IoPoolRegistry());
+
+        var description = await describer.Describe(SampleBytes, "chart.png").FirstAsync().ToTask();
+
+        description.Should().BeEmpty("a failed describe call must not fail the indexing activity");
+    }
+
+    [Fact]
+    public void SupportedExtensions_CoverCommonRasterImages()
+    {
+        var describer = new ChatClientImageDescriber(() => null, new IoPoolRegistry());
+        describer.SupportedExtensions.Should().Contain([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
+    }
+
+    /// <summary>
+    /// Minimal multimodal <see cref="IChatClient"/> test double: records the last text prompt and the
+    /// last image <see cref="DataContent"/> part, returns a fixed response, and optionally runs a hook
+    /// (e.g. to throw) inside the call.
+    /// </summary>
+    private sealed class RecordingChatClient(string response, Action? onInvoke = null) : IChatClient
+    {
+        public string? LastPrompt { get; private set; }
+        public DataContent? LastImage { get; private set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var all = messages.SelectMany(m => m.Contents).ToList();
+            LastPrompt = string.Concat(all.OfType<TextContent>().Select(t => t.Text));
+            LastImage = all.OfType<DataContent>().FirstOrDefault(d => d.MediaType?.StartsWith("image/") == true);
+            onInvoke?.Invoke();
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, response)));
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var resp = await GetResponseAsync(messages, options, cancellationToken);
+            yield return new ChatResponseUpdate(ChatRole.Assistant, resp.Text);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}

--- a/test/MeshWeaver.ContentCollections.Indexing.Test/FakeImageDescriber.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Test/FakeImageDescriber.cs
@@ -1,0 +1,33 @@
+using System.Reactive.Linq;
+using MeshWeaver.ContentCollections.Indexing;
+
+namespace MeshWeaver.ContentCollections.Indexing.Test;
+
+/// <summary>
+/// Deterministic in-process <see cref="IImageDescriber"/> for tests: "describes" any image by echoing
+/// a fixed sentence that embeds the file name, so a test can assert the exact description that flowed
+/// into the chunk store and the Document summary. Counts calls so a test can prove the describer ran
+/// (once) for an image and the text summarizer did NOT. No network, no AI dependency.
+/// </summary>
+public sealed class FakeImageDescriber : IImageDescriber
+{
+    private int _calls;
+
+    /// <summary>Number of times <see cref="Describe"/> was invoked (subscribed).</summary>
+    public int Calls => Volatile.Read(ref _calls);
+
+    /// <summary>Handles the common raster image extensions.</summary>
+    public IReadOnlyCollection<string> SupportedExtensions { get; } =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".png", ".jpg", ".jpeg", ".gif", ".webp" };
+
+    public IObservable<string> Describe(byte[] imageBytes, string fileName) =>
+        Observable.Defer(() =>
+        {
+            Interlocked.Increment(ref _calls);
+            return Observable.Return(Expected(fileName));
+        });
+
+    /// <summary>The exact description this fake produces for <paramref name="fileName"/>.</summary>
+    public static string Expected(string fileName) =>
+        $"A chart titled quarterly revenue by region, from {fileName}.";
+}

--- a/test/MeshWeaver.ContentCollections.Indexing.Test/ImageDescriptionIndexingTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Test/ImageDescriptionIndexingTest.cs
@@ -1,0 +1,124 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using MeshWeaver.ContentCollections.Indexing;
+using MeshWeaver.Mesh.Threading;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Indexing.Test;
+
+/// <summary>
+/// Image indexing: with an <see cref="IImageDescriber"/> wired, an image file (which has NO extractable
+/// text) is captioned by the describer, and that description flows through the SAME pipeline as text —
+/// it is embedded into the chunk store (so the image becomes vector-searchable) AND written verbatim as
+/// the file's <see cref="DocumentInfo.Summary"/> (ONE describe call, no re-summarize). With no describer,
+/// the same image indexes as NoText (today's behavior).
+/// </summary>
+public class ImageDescriptionIndexingTest : IDisposable
+{
+    private const string Collection = "rbuergi/MyContent";
+
+    private readonly string _tempDir;
+    private readonly InMemoryChunkedContentVectorStore _store = new();
+    private readonly FakeEmbedder _embedder = new();
+    private readonly FakeSummarizer _summarizer = new();
+    private readonly FakeDocumentSink _sink = new();
+    private readonly FakeImageDescriber _describer = new();
+
+    public ImageDescriptionIndexingTest()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "mw-image-indexing-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    private ContentIndexingService Service(IImageDescriber? describer) =>
+        new(
+            new TextExtractor(IoPool.Unbounded),
+            _embedder,
+            _store,
+            new ContentIndexingOptions { ChunkSize = 120, ChunkOverlap = 20 },
+            logger: null,
+            summarizer: _summarizer,
+            documentSink: _sink,
+            imageDescriber: describer);
+
+    private string WriteImage(string name)
+    {
+        // Content need not be a valid image: the describer is faked and the text extractor is never
+        // reached for an image extension when a describer is wired.
+        var path = Path.Combine(_tempDir, name);
+        File.WriteAllBytes(path, Encoding.UTF8.GetBytes("PNG\r\n\n binary image bytes"));
+        return path;
+    }
+
+    private async Task<IndexResult> Index(ContentIndexingService service, string filePath, string fileName) =>
+        await service.IndexFile(Collection, filePath, fileName, File.ReadAllBytes(filePath))
+            .FirstAsync().ToTask();
+
+    [Fact]
+    public async Task Image_WithDescriber_EmbedsDescriptionAndWritesDocumentSummary()
+    {
+        var filePath = WriteImage("chart.png");
+
+        var result = await Index(Service(_describer), filePath, "chart.png");
+
+        // Indexed with at least one chunk — the description became embeddable text.
+        result.Status.Should().Be(IndexStatus.Indexed);
+        result.ChunkCount.Should().BeGreaterThan(0);
+
+        // The describer ran once; the TEXT summarizer did NOT (the description is the summary verbatim).
+        _describer.Calls.Should().Be(1);
+        _summarizer.Calls.Should().Be(0);
+
+        // The stored chunk carries the description → the image is now vector-searchable.
+        var stored = await _store.Search(Collection, await _embedder.Embed("chart").FirstAsync().ToTask(), 1000)
+            .FirstAsync().ToTask();
+        stored.Should().HaveCount(result.ChunkCount);
+        stored.Should().Contain(c => c.Text.Contains("quarterly revenue"));
+
+        // The Document summary is the description, used verbatim.
+        _sink.Writes.Should().Be(1);
+        var doc = _sink.LastDocument;
+        doc.Should().NotBeNull();
+        doc!.FileName.Should().Be("chart.png");
+        doc.Summary.Should().Be(FakeImageDescriber.Expected("chart.png"));
+        doc.ChunkCount.Should().Be(result.ChunkCount);
+    }
+
+    [Fact]
+    public async Task Image_WithoutDescriber_IndexesAsNoText()
+    {
+        var filePath = WriteImage("photo.png");
+
+        var result = await Index(Service(describer: null), filePath, "photo.png");
+
+        // No describer → the text extractor yields empty for a .png → NoText, no chunks, no Document.
+        result.Status.Should().Be(IndexStatus.NoText);
+        result.ChunkCount.Should().Be(0);
+        _describer.Calls.Should().Be(0);
+        _summarizer.Calls.Should().Be(0);
+        _sink.Writes.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NonImage_WithDescriber_StillUsesTextExtractorAndSummarizer()
+    {
+        // A describer being wired must NOT hijack a text file: .txt goes through the extractor + the
+        // text summarizer exactly as before.
+        var path = Path.Combine(_tempDir, "notes.txt");
+        File.WriteAllText(path, "Plain text about pensions and risk.", new UTF8Encoding(false));
+
+        var result = await Index(Service(_describer), path, "notes.txt");
+
+        result.Status.Should().Be(IndexStatus.Indexed);
+        _describer.Calls.Should().Be(0);
+        _summarizer.Calls.Should().Be(1);
+        _sink.LastDocument!.Summary.Should().Be(FakeSummarizer.Expected("Plain text about pensions and risk."));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best-effort temp cleanup */ }
+    }
+}

--- a/test/MeshWeaver.ContentCollections.Test/ImageContentGuardTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/ImageContentGuardTest.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reactive;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Test;
+
+/// <summary>
+/// The image guard in <see cref="FileContentProvider"/>: a binary image with no text transformer is
+/// NEVER decoded into text — reading it returns a short, informative placeholder (name + media type +
+/// size), never the raw bytes. This is the safety net behind issue #379 (raw multi-MB binary flooding a
+/// model context and failing the next request with 400).
+/// </summary>
+public class ImageContentGuardTest : HubTestBase
+{
+    private readonly string _contentBasePath = Path.Combine(AppContext.BaseDirectory, "Files", "ImageGuardTest");
+
+    public ImageContentGuardTest(ITestOutputHelper output) : base(output)
+    {
+        Directory.CreateDirectory(_contentBasePath);
+        // Content need not be a valid image; the guard keys on the extension. The leading PNG magic
+        // bytes prove the guard does NOT decode/return them.
+        File.WriteAllBytes(
+            Path.Combine(_contentBasePath, "photo.png"),
+            [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x01, 0x02, 0xFF]);
+    }
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        return base.ConfigureClient(configuration)
+            .AddContentCollection(_ => new ContentCollectionConfig
+            {
+                Name = "content",
+                SourceType = "FileSystem",
+                IsEditable = true,
+                ExposeInChildren = true,
+                BasePath = _contentBasePath,
+                Settings = new Dictionary<string, string> { ["BasePath"] = _contentBasePath }
+            });
+    }
+
+    [Fact]
+    public async Task FileContentProvider_Guards_Image_Returns_Placeholder_Not_Bytes()
+    {
+        var hub = GetClient();
+        var fileContentProvider = hub.ServiceProvider.GetRequiredService<IFileContentProvider>();
+
+        var result = await fileContentProvider.GetFileContent("content", "photo.png")
+            .Should().Emit();
+
+        Output.WriteLine($"Image content result:\n{result.Content}");
+        result.Success.Should().BeTrue();
+        // A short, informative placeholder — NEVER the raw image bytes (issue #379).
+        result.Content.Should().Contain("[image: photo.png");
+        result.Content.Should().Contain("image/png");
+        result.Content.Should().NotContain("�", "raw binary must not be decoded into replacement chars");
+    }
+}

--- a/test/MeshWeaver.ContentCollections.Test/PdfXlsxConversionTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/PdfXlsxConversionTest.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using ClosedXML.Excel;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reactive;
+using Microsoft.Extensions.DependencyInjection;
+using UglyToad.PdfPig.Core;
+using UglyToad.PdfPig.Fonts.Standard14Fonts;
+using UglyToad.PdfPig.Writer;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Test;
+
+/// <summary>
+/// Tests for the PDF (<see cref="PdfPigContentTransformer"/>) and XLSX
+/// (<see cref="ClosedXmlContentTransformer"/>) readers restored to the shared
+/// <see cref="IContentTransformer"/> seam (issue #379). The key guarantee is that a binary
+/// document read through the content-collection file path — the SINGLE path both the agent
+/// <c>Get</c> tool (<c>MeshPlugin.Get</c>) and the MCP <c>get</c> tool (<c>McpMeshPlugin.Get</c>)
+/// flow through via <c>MeshOperations.Get</c> → <see cref="IFileContentProvider"/> — returns
+/// extracted text, never the raw <c>%PDF…</c> / OpenXML-zip bytes.
+/// </summary>
+public class PdfXlsxConversionTest : HubTestBase
+{
+    private readonly string _contentBasePath = Path.Combine(AppContext.BaseDirectory, "Files", "PdfXlsxTest");
+
+    public PdfXlsxConversionTest(ITestOutputHelper output) : base(output)
+    {
+        // Create fixtures in the ctor (not ConfigureClient): the direct-transformer tests never
+        // build a hub, so the files must exist regardless of whether GetClient() ran — mirrors
+        // the ordering fix documented in DocxConversionTest.
+        Directory.CreateDirectory(_contentBasePath);
+        File.WriteAllBytes(
+            Path.Combine(_contentBasePath, "report.pdf"),
+            OnePagePdf("Quarterly report", "Revenue grew across all regions."));
+        File.WriteAllBytes(
+            Path.Combine(_contentBasePath, "figures.xlsx"),
+            OneSheetXlsx("Figures",
+                ["Region", "Revenue"],
+                ["EMEA", "1000"],
+                ["APAC", "2500"]));
+    }
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        return base.ConfigureClient(configuration)
+            .AddContentCollection(_ => new ContentCollectionConfig
+            {
+                Name = "content",
+                SourceType = "FileSystem",
+                IsEditable = true,
+                ExposeInChildren = true,
+                BasePath = _contentBasePath,
+                Settings = new Dictionary<string, string> { ["BasePath"] = _contentBasePath }
+            });
+    }
+
+    [Fact]
+    public async Task PdfPigContentTransformer_Converts_Pdf_To_Text()
+    {
+        var transformer = new PdfPigContentTransformer();
+        transformer.SupportedExtensions.Should().Contain(".pdf");
+
+        await using var stream = File.OpenRead(Path.Combine(_contentBasePath, "report.pdf"));
+        var text = await transformer.TransformToMarkdownAsync(stream, TestContext.Current.CancellationToken);
+
+        Output.WriteLine($"Extracted PDF text:\n{text}");
+        text.Should().Contain("Quarterly report");
+        text.Should().Contain("Revenue grew across all regions");
+        text.Should().NotContain("%PDF", "the raw PDF byte stream must never leak through");
+    }
+
+    [Fact]
+    public async Task ClosedXmlContentTransformer_Converts_Xlsx_To_Markdown()
+    {
+        var transformer = new ClosedXmlContentTransformer();
+        transformer.SupportedExtensions.Should().Contain(".xlsx");
+
+        await using var stream = File.OpenRead(Path.Combine(_contentBasePath, "figures.xlsx"));
+        var markdown = await transformer.TransformToMarkdownAsync(stream, TestContext.Current.CancellationToken);
+
+        Output.WriteLine($"Converted XLSX markdown:\n{markdown}");
+        markdown.Should().Contain("## Sheet: Figures");
+        markdown.Should().Contain("Region");
+        markdown.Should().Contain("Revenue");
+        markdown.Should().Contain("EMEA");
+        markdown.Should().Contain("2500");
+        // Column-letter header row proves the markdown-table shape, not a raw dump.
+        markdown.Should().Contain("| Row | A | B |");
+    }
+
+    [Fact]
+    public async Task FileContentProvider_Auto_Converts_Pdf()
+    {
+        var hub = GetClient();
+        var fileContentProvider = hub.ServiceProvider.GetRequiredService<IFileContentProvider>();
+
+        var result = await fileContentProvider.GetFileContent("content", "report.pdf")
+            .Should().Emit();
+
+        Output.WriteLine($"PDF content result:\n{result.Content}");
+        result.Success.Should().BeTrue();
+        result.Content.Should().Contain("Quarterly report");
+        result.Content.Should().NotContain("%PDF", "the file-read seam must serve text, not raw bytes");
+    }
+
+    [Fact]
+    public async Task FileContentProvider_Auto_Converts_Xlsx()
+    {
+        var hub = GetClient();
+        var fileContentProvider = hub.ServiceProvider.GetRequiredService<IFileContentProvider>();
+
+        var result = await fileContentProvider.GetFileContent("content", "figures.xlsx")
+            .Should().Emit();
+
+        Output.WriteLine($"XLSX content result:\n{result.Content}");
+        result.Success.Should().BeTrue();
+        result.Content.Should().Contain("## Sheet: Figures");
+        result.Content.Should().Contain("EMEA");
+    }
+
+    [Fact]
+    public async Task GetDataRequest_Content_Prefix_Returns_Text_For_Pdf()
+    {
+        // The unified path content:content/report.pdf is exactly what MeshOperations.Get posts
+        // for both the agent and the MCP Get — asserting here proves the end-to-end route.
+        var hub = GetClient();
+
+        var response = await hub.Observe(
+            new GetDataRequest(new UnifiedReference("content:content/report.pdf")),
+            o => o.WithTarget(hub.Address)).Should().Within(10.Seconds()).Emit();
+
+        var dataResponse = response.Message;
+        dataResponse.Error.Should().BeNull();
+        dataResponse.Data.Should().NotBeNull();
+        dataResponse.Data!.ToString().Should().Contain("Quarterly report");
+        dataResponse.Data!.ToString().Should().NotContain("%PDF");
+    }
+
+    [Fact]
+    public void The_Binary_Document_Extensions_Are_Each_Covered_By_Exactly_One_Transformer()
+    {
+        // Encodes the "defined once" guarantee: the read path is a single shared seam
+        // (IContentTransformer resolved from DI), so the agent Get and MCP get behave 1:1.
+        var hub = GetClient();
+        var transformers = hub.ServiceProvider.GetServices<IContentTransformer>().ToList();
+
+        foreach (var ext in new[] { ".pdf", ".docx", ".xlsx" })
+            transformers.Count(t => t.SupportedExtensions.Contains(ext))
+                .Should().Be(1, $"exactly one transformer should own '{ext}'");
+    }
+
+    private static byte[] OnePagePdf(params string[] lines)
+    {
+        var builder = new PdfDocumentBuilder();
+        var font = builder.AddStandard14Font(Standard14Font.Helvetica);
+        var page = builder.AddPage(595, 842); // A4 in points.
+
+        var y = 800;
+        foreach (var line in lines)
+        {
+            page.AddText(line, 12, new PdfPoint(50, y), font);
+            y -= 20;
+        }
+
+        return builder.Build();
+    }
+
+    private static byte[] OneSheetXlsx(string sheetName, params string[][] rows)
+    {
+        using var workbook = new XLWorkbook();
+        var ws = workbook.AddWorksheet(sheetName);
+        for (var r = 0; r < rows.Length; r++)
+            for (var c = 0; c < rows[r].Length; c++)
+                ws.Cell(r + 1, c + 1).Value = rows[r][c];
+
+        using var ms = new MemoryStream();
+        workbook.SaveAs(ms);
+        return ms.ToArray();
+    }
+}


### PR DESCRIPTION
## Why

A `get` on a content-collection file that isn't `.docx` returned **raw binary decoded as text**: PDFs/spreadsheets came back as `%PDF…FlateDecode…`, and images flooded the agent context and failed the next model request with `400` (issue #379). Only `.docx` had survived the move to the content-collection `IContentTransformer` seam.

This restores the missing readers and adds machine-readable image content, all at the **single shared seam** both the agent `Get` tool and the MCP `get` tool flow through — so they return identical results.

## Commit 1 — restore PDF + XLSX transformers

- `PdfPigContentTransformer` (`.pdf` → page text) and `ClosedXmlContentTransformer` (`.xlsx`/`.xls` → one markdown table per worksheet), registered once in `AddContentService`.
- Removes the now-dead `ClosedXML`/`OpenXml`/`PdfPig` refs from `MeshWeaver.AI` (leftovers from the old reader).

## Commit 2 — describe images on save; `get` returns the description

- **On save**, an image is captioned by the mesh's default multimodal model via a new `IImageDescriber` leaf. The description flows through the **existing** indexing pipeline: embedded for vector search **and** written as the file's `Document` summary. One model call per image; wrapped via `ExtractedDocument.PlainText` so it rides the positioned-chunk pipeline unchanged. Degrades to no-text when no vision model resolves.
- **`get` on an image** returns the file's `Document` node (name + AI description). `FileContentProvider` also guards every image read with a short placeholder, so raw bytes never reach a model context regardless of entry point (the robust #379 fix).
- Adds a stateless `IChatClientFactory.CreateChatClient(model)` seam + `DefaultChatClientProvider` so a background job can resolve a bare chat client with **no agent and no shared-factory-state mutation** (also removes a latent race on the singleton factory's `CurrentModelName`).

## Tests

New: `PdfXlsxConversionTest`, `ImageContentGuardTest`, `ImageDescriptionIndexingTest` (+ `FakeImageDescriber`), `ChatClientImageDescriberTest`, `ContentImagePathParsingTest`. Existing indexing/summarizer tests unchanged and green. Full solution `Release -warnaserror` (CI flags) build is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)