### PR TITLE
fix(graph): don't NuGet-resolve the built-in scope generator's legacy #r

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -1010,6 +1010,10 @@ internal class MeshNodeCompilationService(
             strippedSources.Add((p.Path, stripped, p.LastModifiedTicks));
         }
 
+        // A legacy `#r "nuget:MeshWeaver.BusinessRules.Generator"` must NOT reach the NuGet resolver
+        // (the generator ships built-in now) — see StripBuiltInScopeGeneratorRef.
+        StripBuiltInScopeGeneratorRef(allNugetRefs, builtInPresent: BuiltInGeneratorPaths.Count > 0);
+
         // 🚨 100% reactive — NO await, and the input assembly is NOT wrapped in
         // _ioPool.Run. The only async leaf is NuGet restore (network IO), and it runs
         // ONLY when a `#r "nuget:"` directive is present — bridged through the IoPool
@@ -1287,10 +1291,40 @@ internal class MeshNodeCompilationService(
     // generator; those add to this built-in one. Resolved once (the file is stable per process).
     private static readonly IReadOnlyList<string> BuiltInGeneratorPaths = ResolveBuiltInGenerators();
 
+    /// <summary>
+    /// NuGet package id (and, with <c>.dll</c>, assembly file name) of the BusinessRules scope
+    /// source generator. It ships BUILT-IN with the platform, so a legacy
+    /// <c>#r "nuget:MeshWeaver.BusinessRules.Generator"</c> is redundant and is filtered out of
+    /// BOTH the generator list (avoid a double-run → CS0101, see <see cref="RunSourceGenerators"/>)
+    /// and the NuGet resolve set (avoid a round-trip to the removed mesh-local feed, see
+    /// <see cref="AssembleCompilationInputs"/>).
+    /// </summary>
+    private const string BuiltInScopeGeneratorId = "MeshWeaver.BusinessRules.Generator";
+
     private static IReadOnlyList<string> ResolveBuiltInGenerators()
     {
-        var path = Path.Combine(AppContext.BaseDirectory, "MeshWeaver.BusinessRules.Generator.dll");
+        var path = Path.Combine(AppContext.BaseDirectory, BuiltInScopeGeneratorId + ".dll");
         return File.Exists(path) ? [path] : [];
+    }
+
+    /// <summary>
+    /// Removes a legacy <c>#r "nuget:MeshWeaver.BusinessRules.Generator"</c> from the NuGet resolve
+    /// set when the generator ships built-in (<paramref name="builtInPresent"/>). The generator is
+    /// now part of the platform, so that <c>#r</c> is redundant — and RESOLVING it hard-fails on a
+    /// deployed image: after <c>BakeMeshLocalFeed</c> was removed (#395) the mesh-local feed
+    /// (<c>dist/packages</c>) is gone, so NuGet throws
+    /// <c>"The local source '/app/dist/packages' doesn't exist"</c> and breaks every deployed scope
+    /// node still carrying the legacy <c>#r</c> (the atioz BalanceSheet failure). Behaviour is
+    /// unchanged: the built-in generator still emits the <c>IScope&lt;,&gt;</c> implementations, and
+    /// <see cref="RunSourceGenerators"/> already de-dups the generator itself (CS0101). When the
+    /// built-in is somehow absent the <c>#r</c> is kept so the generator can still resolve via NuGet.
+    /// Other package references are never touched.
+    /// </summary>
+    internal static void StripBuiltInScopeGeneratorRef(List<NuGetPackageReference> refs, bool builtInPresent)
+    {
+        if (builtInPresent)
+            refs.RemoveAll(r => string.Equals(
+                r.Id, BuiltInScopeGeneratorId, StringComparison.OrdinalIgnoreCase));
     }
 
     private static CSharpCompilation RunSourceGenerators(
@@ -1299,12 +1333,13 @@ internal class MeshNodeCompilationService(
         // Always include the built-in scope generator, plus any OTHER generator a node #r'd. Filter a
         // node's own `#r "nuget:MeshWeaver.BusinessRules.Generator"` OUT — otherwise the same generator
         // loads from two paths (built-in + baked) and runs twice → duplicate IScope<,> implementations
-        // → CS0101. Legacy nodes that still carry that #r keep compiling (built-in supersedes it).
+        // → CS0101. Legacy nodes that still carry that #r keep compiling (built-in supersedes it, and
+        // AssembleCompilationInputs strips the #r from the NuGet resolve set so it never round-trips).
         IReadOnlyList<string> allPaths = BuiltInGeneratorPaths.Count == 0
             ? generatorAssemblyPaths
             : [.. BuiltInGeneratorPaths,
                .. generatorAssemblyPaths.Where(p => !string.Equals(
-                   Path.GetFileName(p), "MeshWeaver.BusinessRules.Generator.dll", StringComparison.OrdinalIgnoreCase))];
+                   Path.GetFileName(p), BuiltInScopeGeneratorId + ".dll", StringComparison.OrdinalIgnoreCase))];
         if (allPaths.Count == 0)
             return compilation;
         var generators = SourceGeneratorLoader.Discover(allPaths, logger);

--- a/test/MeshWeaver.Graph.Test/BuiltInScopeGeneratorTest.cs
+++ b/test/MeshWeaver.Graph.Test/BuiltInScopeGeneratorTest.cs
@@ -1,8 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using MeshWeaver.BusinessRules;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.NuGet;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -27,6 +31,59 @@ public class BuiltInScopeGeneratorTest
 
         var generators = SourceGeneratorLoader.Discover([path], NullLogger.Instance);
         generators.Should().NotBeEmpty("the shipped DLL must expose the [Generator] ScopeCodeGenerator");
+    }
+
+    [Fact]
+    public void BuiltInGenerator_OnCustomIScopeSource_EmitsWorkingImplementation()
+    {
+        // The runtime node-compile path (MeshNodeCompilationService.RunSourceGenerators) that atioz
+        // scope nodes take: feed the SHIPPED generator DLL to Roslyn over a CUSTOM IScope<,> source
+        // — NO #r, NO project reference — and assert it emits a concrete proxy that COMPILES against
+        // the platform BusinessRules assembly. Guards "building the generator and using it on custom
+        // code" end to end, without any mesh infrastructure.
+        const string customScopeSource = """
+            using MeshWeaver.BusinessRules;
+
+            // A custom scope authored the way a mesh-node Source file declares one.
+            public interface IPensionScope : IScope<int, object>
+            {
+                int Doubled => Identity * 2;
+            }
+            """;
+
+        var generatorPath = Path.Combine(AppContext.BaseDirectory, "MeshWeaver.BusinessRules.Generator.dll");
+        var generators = SourceGeneratorLoader.Discover([generatorPath], NullLogger.Instance);
+        generators.Should().NotBeEmpty();
+
+        // Reference set = the runtime's trusted platform assemblies + the BusinessRules assembly that
+        // defines IScope<,>/ScopeBase<,,>/ScopeRegistry<> the generated proxy derives from.
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Where(p => p.Length > 0)
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .Append(MetadataReference.CreateFromFile(typeof(IScope<,>).Assembly.Location))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "CustomScopeCodegenTest",
+            [CSharpSyntaxTree.ParseText(customScopeSource)],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        CSharpGeneratorDriver.Create(generators)
+            .RunGeneratorsAndUpdateCompilation(compilation, out var updated, out _);
+
+        // 1. The generator emitted a concrete proxy for the custom interface.
+        var generatedTrees = updated.SyntaxTrees.Except(compilation.SyntaxTrees).ToList();
+        generatedTrees.Should()
+            .ContainSingle("the built-in generator must emit exactly one proxy for the custom IScope interface")
+            .Which.ToString().Should().Contain("IPensionScopeProxy");
+
+        // 2. The generated proxy COMPILES against the platform BusinessRules assembly (no errors) —
+        //    this is the codegen every deployed scope node depends on.
+        updated.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Should().BeEmpty("the generated scope proxy must compile cleanly");
     }
 
     // A legacy `#r "nuget:MeshWeaver.BusinessRules.Generator"` (authored before the generator became

--- a/test/MeshWeaver.Graph.Test/BuiltInScopeGeneratorTest.cs
+++ b/test/MeshWeaver.Graph.Test/BuiltInScopeGeneratorTest.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.NuGet;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -25,5 +27,48 @@ public class BuiltInScopeGeneratorTest
 
         var generators = SourceGeneratorLoader.Discover([path], NullLogger.Instance);
         generators.Should().NotBeEmpty("the shipped DLL must expose the [Generator] ScopeCodeGenerator");
+    }
+
+    // A legacy `#r "nuget:MeshWeaver.BusinessRules.Generator"` (authored before the generator became
+    // built-in) must never reach the NuGet resolver: after BakeMeshLocalFeed was removed (#395) the
+    // mesh-local feed (dist/packages) is gone from deployed images, so RESOLVING it hard-fails with
+    // "The local source '/app/dist/packages' doesn't exist" and breaks every deployed scope node
+    // still carrying that #r (the atioz BalanceSheet failure). StripBuiltInScopeGeneratorRef drops it.
+
+    [Fact]
+    public void StripBuiltInScopeGeneratorRef_DropsLegacyGeneratorRef_WhenBuiltInPresent()
+    {
+        var refs = new List<NuGetPackageReference>
+        {
+            new("MeshWeaver.BusinessRules.Generator", null),   // legacy #r — redundant, must be dropped
+            new("Newtonsoft.Json", "13.0.3"),                  // unrelated #r — must survive
+        };
+
+        MeshNodeCompilationService.StripBuiltInScopeGeneratorRef(refs, builtInPresent: true);
+
+        refs.Should().ContainSingle("the legacy generator #r must not reach the NuGet resolver")
+            .Which.Id.Should().Be("Newtonsoft.Json");
+    }
+
+    [Fact]
+    public void StripBuiltInScopeGeneratorRef_IsCaseInsensitive()
+    {
+        var refs = new List<NuGetPackageReference> { new("meshweaver.businessrules.GENERATOR", null) };
+
+        MeshNodeCompilationService.StripBuiltInScopeGeneratorRef(refs, builtInPresent: true);
+
+        refs.Should().BeEmpty("the built-in generator id compare is case-insensitive");
+    }
+
+    [Fact]
+    public void StripBuiltInScopeGeneratorRef_KeepsLegacyRef_WhenBuiltInAbsent()
+    {
+        // Fallback: a runtime that somehow lacks the built-in generator DLL must still resolve the
+        // generator via the #r (the pre-built-in behaviour), so the ref is preserved.
+        var refs = new List<NuGetPackageReference> { new("MeshWeaver.BusinessRules.Generator", null) };
+
+        MeshNodeCompilationService.StripBuiltInScopeGeneratorRef(refs, builtInPresent: false);
+
+        refs.Should().ContainSingle().Which.Id.Should().Be("MeshWeaver.BusinessRules.Generator");
     }
 }

--- a/test/MeshWeaver.Graph.Test/MeshWeaver.Graph.Test.csproj
+++ b/test/MeshWeaver.Graph.Test/MeshWeaver.Graph.Test.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\MeshWeaver.BusinessRules\MeshWeaver.BusinessRules.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />


### PR DESCRIPTION
## Problem

On a deployed portal, scope-based dynamic NodeTypes that still carry the legacy `#r "nuget:MeshWeaver.BusinessRules.Generator"` fail to compile with:

```
The local source '/app/dist/packages' doesn't exist.
```

Their instances then can't get a `HubConfiguration`, so the per-node grain falls into the NACK/`DeactivateOnIdle` path and layout renders surface the cryptic Orleans `… "DeactivateOnIdle was called." to invalid activation. Rejecting now.` (and `get` returns NotFound). **Observed live on atioz** — `AgenticPension/spider` (PensionRadar) and the Use-Case-3 `Dashboard` (BalanceSheet) would not load. This is NOT #325 (version regression); it is a plain NodeType compile failure surfacing through the grain NACK path.

## Root cause

The BusinessRules scope generator ships **built-in** with the platform (#387), and `BakeMeshLocalFeed` was removed (#395) so the `mesh-local` feed (`dist/packages`) no longer exists in deployed images. `RunSourceGenerators` de-dups the generator from the generator *list* (avoids CS0101), but `AssembleCompilationInputs` still folded a legacy `#r "nuget:MeshWeaver.BusinessRules.Generator"` into the NuGet **resolve** set and invoked the resolver — which hard-fails on the now-missing local feed. So "legacy nodes keep compiling" was only true for the generator list, not the resolve.

## Fix

`StripBuiltInScopeGeneratorRef` removes the built-in generator's package id from the resolve set when the built-in DLL is present, so the legacy `#r` triggers no NuGet round-trip at all. The built-in generator still emits the `IScope<,>` implementations, so node behaviour is unchanged — and **every deployed scope node still carrying the legacy `#r` heals on the next deploy** with no per-node content edit. (atioz was additionally unblocked immediately by deleting the stale `#r` from the affected NodeType sources.)

## Tests

- `StripBuiltInScopeGeneratorRef` unit tests: dropped when the built-in is present, kept as a fallback when absent, case-insensitive.
- **Dedicated end-to-end codegen guard** — run the shipped generator DLL on **custom `IScope<,>` source** (no `#r`, no project reference), the exact runtime node-compile path, and assert it emits a proxy that **compiles** against the platform BusinessRules assembly.

Built Release `-warnaserror`; Graph.Test green (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)