### PR TITLE
fix(layout): cap + centre the reader shell on ultra-wide screens

### DIFF
--- a/src/MeshWeaver.Blazor/wwwroot/standard-page-layout.css
+++ b/src/MeshWeaver.Blazor/wwwroot/standard-page-layout.css
@@ -73,6 +73,19 @@ body {
     min-height: 0;
 }
 
+/* Ultra-wide screens: keep the reader shell (nav rail + content) a comfortably
+   sized, centered block instead of letting the content pane stretch edge-to-edge.
+   Without a cap, on an ultra-wide monitor the pane is enormous and — offset by the
+   300px rail — the page's own max-width text column (max-width: 1200px; margin: 0
+   auto) centers WITHIN the pane, so it floats far right of the viewport centre
+   beside a large empty gutter. Capping + centering the whole shell keeps rail and
+   content balanced. Below the cap this is a no-op (the shell stays full width). */
+.shell-splitter {
+    width: 100%;
+    max-width: 1600px;
+    margin-inline: auto;
+}
+
 /* NOTE: the pane is a <div class="fluent-multi-splitter-pane"> (a CLASS), not a
    <fluent-multi-splitter-pane> element. The leading dot is mandatory — without it
    these rules match nothing, the pane keeps FluentUI's default


### PR DESCRIPTION
**Reported:** the course layout doesn't look good on ultra-wide screens.

**Cause:** the `.shell-splitter` reader (the course `/Learn` reader, plus the Code reader and NodeType shell) fills the full viewport width. On an ultra-wide monitor the content pane is enormous, and because it's offset by the 300px nav rail while the page's own text column is `max-width: 1200px; margin: 0 auto`, that column centres **within the pane** — so it floats far right of the viewport centre beside a big empty gutter.

**Fix:** cap the shell at `1600px` and centre it (`margin-inline: auto`), so the rail + content stay a balanced, centred block on ultra-wide. Below 1600px it's a no-op (full width, unchanged). Pure CSS, one rule in `standard-page-layout.css`.

Best confirmed on an actual ultra-wide display — @rbuergi if the exact issue was something else (e.g. the landing hero/teaser cards specifically), tell me and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)