### PR TITLE
docs(whatsnew): steadier workspace + create-makes-real-pages

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-10-steadier-workspace-and-create.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-10-steadier-workspace-and-create.md
@@ -1,0 +1,12 @@
+---
+Name: Steadier workspace, and “create” makes real pages
+Category: What's New
+Description: Chats and deletes no longer stall the workspace, and asking to “create” something now makes a proper page.
+Icon: Sparkle
+---
+
+# Steadier workspace, and “create” makes real pages
+
+We fixed two issues that could make the workspace feel stuck. A chat response that couldn't be written now fails gracefully and ends the round, instead of retrying in a tight loop that slowed everything down. And deleting a node now returns immediately when it succeeds, instead of appearing to hang for up to a minute.
+
+We also sharpened what happens when you ask an assistant to **create** something: it now makes a proper mesh node — a Markdown page by default, or the right specialized node (a Space, agent, and so on) — rather than dropping a stray `.txt` file.


### PR DESCRIPTION
The What's New entry for #406 (I merged that PR without its step-0.5 entry — this backfills it).

One doc node under `Data/WhatsNew/` (newest-first by date prefix, no cross-PR conflict), user-facing prose covering the two reliability fixes (thread-cell storm circuit breaker + DeleteNodeResponse AccessContext drop) and the assistant `create`=mesh-node behavior.

Docs-only; no code. 🤖 Generated with [Claude Code](https://claude.com/claude-code)