### PR TITLE
fix(mesh): carry caller AccessContext through cross-partition copy/move fan-out

### DIFF
--- a/src/MeshWeaver.Graph/NodeCopyHelper.cs
+++ b/src/MeshWeaver.Graph/NodeCopyHelper.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Linq;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
@@ -54,6 +55,17 @@ public static class NodeCopyHelper
         logger ??= hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.Graph.NodeCopyHelper");
 
+        // 🚨 Capture the caller's identity EAGERLY, at invocation (the click action / MCP tool /
+        // handler thread where AsyncLocal is still correct). The per-node CreateNodeRequest posts
+        // below fire from SelectMany continuations on the subtree-query's emission scheduler, where
+        // the AsyncLocal AccessContext is WIPED — so an un-stamped post would carry no identity and
+        // the PostPipeline would fail closed (only the root landing; recursive children erroring
+        // with "AccessContext must never be null … message=CreateNodeRequest" — the cross-partition
+        // copy bug). Stamp the captured context explicitly on every post, exactly as
+        // FanOutDeleteSubtree does for recursive deletes.
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var callerAccessContext = accessService?.Context ?? accessService?.CircuitContext;
+
         // Single Query over the source subtree — emits source + every
         // descendant in one go. Take(1) snapshots the listing for the copy
         // operation; subsequent edits to the source don't follow.
@@ -103,7 +115,8 @@ public static class NodeCopyHelper
                 {
                     return hub
                         .Observe<CreateOrUpdateNodeResponse>(
-                            new CreateOrUpdateNodeRequest(copiedNode))
+                            new CreateOrUpdateNodeRequest(copiedNode),
+                            o => callerAccessContext is null ? o : o.WithAccessContext(callerAccessContext))
                         .FirstAsync()
                         .Select(d => d.Message)
                         .SelectMany(resp =>
@@ -120,7 +133,8 @@ public static class NodeCopyHelper
                         });
                 }
                 return hub
-                    .Observe<CreateNodeResponse>(new CreateNodeRequest(copiedNode))
+                    .Observe<CreateNodeResponse>(new CreateNodeRequest(copiedNode),
+                        o => callerAccessContext is null ? o : o.WithAccessContext(callerAccessContext))
                     .FirstAsync()
                     .Select(d => d.Message)
                     .SelectMany(resp =>

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -2157,8 +2157,32 @@ public static class MeshExtensions
         var logger = hub.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("MeshWeaver.Mesh.Services.IMeshCatalog");
         var copyRequest = request.Message;
         var meshService = hub.ServiceProvider.GetRequiredService<MeshWeaver.Mesh.Services.IMeshService>();
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
         var sourcePath = copyRequest.SourcePath;
         var targetPath = copyRequest.TargetPath;
+
+        // 🚨 Capture the caller's identity at handler entry — it is live on the delivery here
+        // (MessageHub restored it from delivery.AccessContext before this body ran). The per-node
+        // CreateNode calls below are subscribed from SelectMany continuations on the workspace
+        // emission scheduler, where the AsyncLocal AccessContext is WIPED. Without re-establishing
+        // the caller's identity at each create's post site, MeshService.CaptureContext reads null,
+        // the CreateNodeRequest posts with no AccessContext, and the PostPipeline fails closed —
+        // the cross-partition copy/move bug (only the root landed; recursive children errored with
+        // "AccessContext must never be null … message=CreateNodeRequest"). Mirrors the explicit
+        // WithAccessContext stamping FanOutDeleteSubtree already does for recursive deletes.
+        var callerAccessContext = request.AccessContext
+            ?? accessService?.Context ?? accessService?.CircuitContext;
+
+        // Wraps a per-node CreateNode so its eager AccessContext capture (MeshService.CaptureContext)
+        // sees the caller's identity even though this runs on a scheduler thread. Observable.Using
+        // opens the SwitchAccessContext scope on Subscribe — exactly when the cold CreateNode's Defer
+        // reads the AsyncLocal and posts — and disposes it as the create completes.
+        IObservable<MeshNode> CreateUnderCaller(MeshNode node) =>
+            callerAccessContext is null || accessService is null
+                ? meshService.CreateNode(node)
+                : Observable.Using(
+                    () => accessService.SwitchAccessContext(callerAccessContext),
+                    _ => meshService.CreateNode(node));
 
         logger.LogDebug("[CopyNode] start source={Source} target={Target} (descendants={Desc} satellites={Sat})",
             sourcePath, targetPath, copyRequest.IncludeDescendants, copyRequest.IncludeSatellites);
@@ -2204,15 +2228,17 @@ public static class MeshExtensions
                 var satCount = others.Count - descCount;
 
                 // Create root, then create all children in parallel via Merge — Move semantics
-                // require all inserts to complete before the source is deleted.
-                return meshService.CreateNode(RetargetNode(sourceNode, sourcePath, targetPath))
+                // require all inserts to complete before the source is deleted. Every create runs
+                // under the caller's identity (CreateUnderCaller) so the routed per-descendant
+                // CreateNodeRequest carries a valid AccessContext across the scheduler hop.
+                return CreateUnderCaller(RetargetNode(sourceNode, sourcePath, targetPath))
                     .SelectMany(rootCreated =>
                     {
                         if (others.Count == 0)
                             return Observable.Return<(MeshNode Root, int Desc, int Sat)>((rootCreated, descCount, satCount));
                         return others.ToObservable()
                             .Select(n => RetargetNode(n, sourcePath, targetPath))
-                            .SelectMany(retargeted => meshService.CreateNode(retargeted))
+                            .SelectMany(retargeted => CreateUnderCaller(retargeted))
                             .ToList()
                             .Select(_ => ((MeshNode Root, int Desc, int Sat))(rootCreated, descCount, satCount));
                     });

--- a/test/MeshWeaver.AI.Test/CrossPartitionMoveCopyAccessContextTest.cs
+++ b/test/MeshWeaver.AI.Test/CrossPartitionMoveCopyAccessContextTest.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Regression guard for the production failure (memex.systemorph.com): a cross-partition
+/// <c>move</c>/<c>copy</c> of a node SUBTREE fails with
+/// <c>"AccessContext must never be null for an application post … message=CreateNodeRequest"</c>.
+///
+/// <para><b>Root cause under test.</b> <see cref="MeshOperations.Copy"/> /
+/// <see cref="MeshOperations.Move"/> recreate the subtree at the target by posting one
+/// <c>CreateNodeRequest</c> per descendant. The FIRST create (the subtree root) is posted while the
+/// caller's identity is still live on the request-scoped AsyncLocal, so it carries the caller's
+/// <see cref="AccessContext"/> and succeeds. The RECURSIVE child creates are subscribed on a
+/// workspace-emission / Rx scheduler thread where the AsyncLocal is wiped — so they post with a NULL
+/// AccessContext, the PostPipeline fails closed, and the target ends up with only the root node while
+/// the source stays intact.</para>
+///
+/// <para><b>Why cross-partition.</b> A same-partition move/copy can route the child creates through
+/// the local data source without a fresh cross-hub post; the routed cross-partition
+/// <c>CreateNodeRequest</c> is what surfaces the lost identity — exactly the production shape
+/// (<c>PartnerRe/AIConsulting -&gt; ClientPartnerRe/AIConsulting</c>).</para>
+///
+/// <para><b>Why we do NOT lean on DevLogin's persistent context.</b> <see cref="TestUsers.DevLogin"/>
+/// stamps the Admin identity via <see cref="AccessService.SetCircuitContext"/>, which also writes the
+/// process-wide <c>persistentCircuitContext</c> fallback field — that field survives scheduler hops
+/// and would MASK the very identity-loss this test must reproduce (see
+/// <c>CircuitContextIsolationTest</c>). We therefore clear it and set only the request-scoped
+/// AsyncLocal (<see cref="AccessService.SetContext"/>), which is precisely the state a live hub
+/// handler has after restoring <c>delivery.AccessContext</c> — and precisely the state that a
+/// production Blazor circuit's AsyncLocal is in (no persistent fallback there either).</para>
+/// </summary>
+public class CrossPartitionMoveCopyAccessContextTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    // Each [Fact] mints unique partition names, so the shared mesh is safe and cheaper.
+    protected override bool ShareMeshAcrossTests => true;
+
+    private static CancellationToken Ct => new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token;
+
+    private MeshOperations Ops => new(Mesh);
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    private static string Unique(string prefix) => prefix + Guid.NewGuid().ToString("N")[..8];
+
+    /// <summary>
+    /// Runs <paramref name="op"/> under the FAITHFUL production identity shape: request-scoped
+    /// AsyncLocal only (like a live handler after restoring <c>delivery.AccessContext</c>), with the
+    /// masking persistent-circuit fallback cleared so a lost-on-hop identity truly surfaces as null.
+    /// Restores DevLogin (persistent Admin) afterward so the verification READS authorise.
+    /// </summary>
+    private async Task<string> RunAsUser(AccessContext user, IObservable<string> op)
+    {
+        Access.ClearPersistentCircuitContext();
+        try
+        {
+            using (Access.SwitchAccessContext(user))
+                return await op.FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+        }
+        finally
+        {
+            // Reads below (ReadNode / WaitUntil) are access-gated — re-establish the Admin
+            // circuit identity the fixture logged in with, since we cleared the persistent
+            // fallback above to faithfully reproduce the lost-on-hop write condition.
+            TestUsers.DevLogin(Mesh);
+        }
+    }
+
+    /// <summary>Creates a Space partition root (the sanctioned top-level container; its creator is
+    /// granted Admin on it, so nested child writes authorise).</summary>
+    private Task<MeshNode> CreateSpace(string id) =>
+        MeshService.CreateNode(new MeshNode(id) { Name = id, NodeType = "Space", State = MeshNodeState.Active })
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask(Ct);
+
+    private Task<MeshNode> CreateChild(string path) =>
+        MeshService.CreateNode(MeshNode.FromPath(path) with
+        {
+            Name = path.Split('/')[^1],
+            NodeType = "Markdown",
+            Content = new MarkdownContent { Content = $"# {path}" },
+            State = MeshNodeState.Active
+        }).FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask(Ct);
+
+    /// <summary>Reads a node authoritatively; null when absent/timeout.</summary>
+    private Task<MeshNode?> Read(string path) =>
+        ReadNode(path).FirstAsync().Timeout(TimeSpan.FromSeconds(15)).ToTask(Ct);
+
+    /// <summary>Waits until the node at <paramref name="path"/> either exists or is gone.</summary>
+    private Task<MeshNode?> WaitUntil(string path, bool shouldExist) =>
+        Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => ReadNode(path))
+            .Where(n => shouldExist ? n is not null : n is null)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(20))
+            .ToTask(Ct);
+
+    // ────────────────────────────────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 120000)]
+    public async Task Copy_SubtreeCrossPartition_AllDescendantsLandAtTarget()
+    {
+        var srcSpace = Unique("SrcCopy");
+        var dstSpace = Unique("DstCopy");
+        await CreateSpace(srcSpace);
+        await CreateSpace(dstSpace);
+
+        // Subtree: parent + two children (one nested). The recursive child creates are the ones
+        // that lose AccessContext across the scheduler hop in the buggy path.
+        var root = $"{srcSpace}/Consulting";
+        await CreateChild(root);
+        await CreateChild($"{root}/Alice");
+        await CreateChild($"{root}/Team/Bob");
+
+        // Copy the subtree cross-partition (srcSpace -> dstSpace). NodeCopyHelper remaps
+        // srcSpace/Consulting -> dstSpace/Consulting, etc.
+        var result = await RunAsUser(TestUsers.Admin, Ops.Copy(root, dstSpace, force: false));
+
+        result.Should().NotContain("AccessContext",
+            "the recursive per-descendant CreateNodeRequest must carry the caller's identity — a null " +
+            "AccessContext DeliveryFailure is the production bug being guarded against");
+        result.Should().StartWith("Copied", "copy of a subtree the Admin owns must succeed");
+        // "Copied N node(s): …" — N must be 3 (root + 2 descendants). A recursive create that
+        // silently lost its AccessContext would drop children and report fewer than 3.
+        result.Should().Contain("Copied 3 node(s)",
+            "all 3 subtree nodes (root + Alice + Team/Bob) must be created at the target");
+
+        // EVERY node (root + both descendants) must exist at the TARGET.
+        (await WaitUntil($"{dstSpace}/Consulting", shouldExist: true)).Should().NotBeNull("root must be copied");
+        (await WaitUntil($"{dstSpace}/Consulting/Alice", shouldExist: true)).Should().NotBeNull("child Alice must be copied");
+        (await WaitUntil($"{dstSpace}/Consulting/Team/Bob", shouldExist: true)).Should().NotBeNull("nested child Bob must be copied");
+
+        // Copy leaves the SOURCE intact.
+        (await Read(root)).Should().NotBeNull("source root must remain after copy");
+        (await Read($"{root}/Alice")).Should().NotBeNull("source child must remain after copy");
+        (await Read($"{root}/Team/Bob")).Should().NotBeNull("source nested child must remain after copy");
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Move_SubtreeCrossPartition_AllDescendantsMoveAndSourceIsGone()
+    {
+        var srcSpace = Unique("SrcMove");
+        var dstSpace = Unique("DstMove");
+        await CreateSpace(srcSpace);
+        await CreateSpace(dstSpace);
+
+        // Move remaps sourcePath -> targetPath verbatim, so target the full destination path.
+        var source = $"{srcSpace}/Consulting";
+        var target = $"{dstSpace}/Consulting";
+        await CreateChild(source);
+        await CreateChild($"{source}/Alice");
+        await CreateChild($"{source}/Team/Bob");
+
+        var result = await RunAsUser(TestUsers.Admin, Ops.Move(source, target));
+
+        result.Should().NotContain("AccessContext",
+            "the recursive per-descendant CreateNodeRequest inside the copy-then-delete move must carry " +
+            "the caller's identity — a null AccessContext DeliveryFailure is the production bug");
+        result.Should().StartWith("Moved", "move of a subtree the Admin owns must succeed");
+
+        // EVERY node lands at the TARGET.
+        (await WaitUntil(target, shouldExist: true)).Should().NotBeNull("root must be moved to target");
+        (await WaitUntil($"{target}/Alice", shouldExist: true)).Should().NotBeNull("child Alice must be moved to target");
+        (await WaitUntil($"{target}/Team/Bob", shouldExist: true)).Should().NotBeNull("nested child Bob must be moved to target");
+
+        // NONE remain at the SOURCE.
+        (await WaitUntil(source, shouldExist: false)).Should().BeNull("source root must be gone after move");
+        (await WaitUntil($"{source}/Alice", shouldExist: false)).Should().BeNull("source child must be gone after move");
+        (await WaitUntil($"{source}/Team/Bob", shouldExist: false)).Should().BeNull("source nested child must be gone after move");
+    }
+}


### PR DESCRIPTION
## Problem
Cross-partition **move/copy of a node subtree** fails with
`AccessContext must never be null for an application post … message=CreateNodeRequest`.
Only the subtree **root** lands at the target; the recursive descendant creates error and the source stays intact (prod shape: `PartnerRe/AIConsulting -> ClientPartnerRe/AIConsulting`).

## Root cause
`HandleCopyNodeRequest` and `NodeCopyHelper` post one `CreateNodeRequest` per descendant from `SelectMany` continuations on the workspace emission scheduler, where the request-scoped **AsyncLocal `AccessContext` is wiped**. The first (root) create runs while the caller identity is still live and succeeds; the routed cross-partition child creates post with a null `AccessContext` and the `PostPipeline` fails closed.

## Fix
Capture the caller `AccessContext` eagerly at handler entry and re-establish it at each per-node create:
- `HandleCopyNodeRequest` wraps `CreateNode` in an `Observable.Using(SwitchAccessContext(...))` scope (`CreateUnderCaller`).
- `NodeCopyHelper` stamps `WithAccessContext(...)` on each `Observe`.

Mirrors the explicit stamping `FanOutDeleteSubtree` already does for recursive deletes. (The delete-response `ResponseFor` half of the original working-tree fix is already on `main` via #406, so it's intentionally omitted here.)

## Test
`CrossPartitionMoveCopyAccessContextTest` clears DevLogin's persistent circuit context so it reproduces the request-scoped-only identity shape of a live handler. ✅ builds Release `-warnaserror`, 2/2 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)