### PR TITLE
Fix RN-connector typecheck (splitRenderedHtml export + grpc-web fetch seam)

### DIFF
--- a/clients/grpc-web/src/connection.ts
+++ b/clients/grpc-web/src/connection.ts
@@ -19,8 +19,14 @@ export interface ConnectOptions {
   /** Sink for background send/stream faults that have no awaiting caller (default `console.error`). */
   onError?: (error: unknown) => void;
   /**
-   * Inject the Connect transport instead of the default gRPC-web one. Use to supply a custom `fetch`
-   * (e.g. a streaming-fetch polyfill on React Native) or an in-memory transport for tests. When set,
+   * Custom `fetch` threaded into the DEFAULT gRPC-web transport — e.g. a streaming-fetch polyfill on
+   * React Native (Hermes can't stream the Connect server-stream). Auth still flows through `token`.
+   * For full transport control (e.g. an in-memory transport in tests) use `transport` instead.
+   */
+  fetch?: typeof globalThis.fetch;
+  /**
+   * Inject the Connect transport instead of the default gRPC-web one — e.g. an in-memory transport for
+   * tests. Overrides `fetch`. When set,
    * `token` is ignored — add your own auth interceptor to the transport.
    */
   transport?: Transport;
@@ -57,7 +63,7 @@ export class MeshWebConnection {
     const address = opts.address ?? `node/${newId()}`;
     const transport =
       opts.transport ??
-      createGrpcWebTransport({ baseUrl: url, interceptors: opts.token ? [bearer(opts.token)] : [] });
+      createGrpcWebTransport({ baseUrl: url, fetch: opts.fetch, interceptors: opts.token ? [bearer(opts.token)] : [] });
     const conn = new MeshWebConnection(address, createClient(Mesh, transport), opts.onError ?? console.error);
     return conn.open();
   }

--- a/clients/react/src/core.ts
+++ b/clients/react/src/core.ts
@@ -44,3 +44,5 @@ export {
 } from "./render/embeddedArea.js";
 export { getPointer, setPointer, mergePatch, resolve, bindingPointer } from "./area/pointer.js";
 export type { AreaSource, AreaTree, UiControl, Skin, NamedArea, MeshEvent, Json } from "./area/types.js";
+// Pure (import-free) markdown-HTML splitter — the RN leaf pack hydrates interactive markdown with it.
+export { splitRenderedHtml, type RenderedHtmlSegment } from "./controls/interactiveMarkdown.js";


### PR DESCRIPTION
Fixes the pre-existing **RN connector (typecheck + test)** CI job, which was red on 4 errors unrelated to any feature work.

## Root causes

1. **`splitRenderedHtml` not re-exported from `@meshweaver/react/core`.** The RN leaf pack (`rnPack.tsx`) imports it for interactive-markdown hydration, but `clients/react/src/core.ts` never re-exported it (it lives in the import-free `controls/interactiveMarkdown.ts`). Exporting it — plus `RenderedHtmlSegment` — fixes the missing-member error **and** the cascading `TS7006` implicit-any on `segments.map((seg, i) => …)` (the params were `any` only because the import's type was `any`).

2. **`ConnectOptions` lost the `fetch` seam the RN live source needs.** `react-native/src/live.ts` passes `{ token, fetch: nativeStreamingFetch() }` (Hermes can't stream the Connect server-stream without the polyfill), but `ConnectOptions` had moved to `transport`-only. Since `react-native` doesn't depend on `@connectrpc/connect-web`, the clean fix is to re-add `fetch?` and thread it into the default gRPC-web transport inside grpc-web — `token`-based auth is unchanged, `transport` still overrides. `live.ts` is untouched.

## Verification

`react-native`, `grpc-web`, and `react` all `tsc --noEmit` clean; `grpc-web` tests 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)