### PR TITLE
AI content sync-back: edit agents & skills in the mesh, write back to content/ai

### DIFF
--- a/src/MeshWeaver.AI/AiContentLocator.cs
+++ b/src/MeshWeaver.AI/AiContentLocator.cs
@@ -18,7 +18,7 @@ namespace MeshWeaver.AI;
 ///     shipped by the csproj <c>Content</c> item. Read-only (a container has no repo to sync back to).</item>
 /// </list>
 /// </summary>
-internal static class AiContentLocator
+public static class AiContentLocator
 {
     /// <summary>The section root (<c>content/ai</c> or the copied <c>AiContent</c>), or null → embedded.</summary>
     public static string? SectionRoot() => RepoSectionRoot() ?? OutputSectionRoot();

--- a/src/MeshWeaver.AI/BuiltInSkillProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInSkillProvider.cs
@@ -1,11 +1,6 @@
-using Markdig;
-using Markdig.Extensions.Yaml;
-using Markdig.Syntax;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace MeshWeaver.AI;
 
@@ -20,15 +15,6 @@ namespace MeshWeaver.AI;
 public class BuiltInSkillProvider : IStaticNodeProvider
 {
     private static readonly Lazy<MeshNode[]> LazyNodes = new(LoadEmbeddedNodes);
-
-    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
-        .UseYamlFrontMatter()
-        .Build();
-
-    private static readonly IDeserializer Yaml = new DeserializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .IgnoreUnmatchedProperties()
-        .Build();
 
     /// <inheritdoc />
     public IEnumerable<MeshNode> GetStaticNodes()
@@ -96,49 +82,9 @@ public class BuiltInSkillProvider : IStaticNodeProvider
         return nodes.ToArray();
     }
 
-    private static MeshNode? ParseSkillNode(string content, string id)
-    {
-        if (string.IsNullOrEmpty(id)) return null;
-
-        var document = Markdig.Markdown.Parse(content, Pipeline);
-        var yamlBlock = document.Descendants<YamlFrontMatterBlock>().FirstOrDefault();
-        if (yamlBlock == null) return null;
-
-        var fm = Yaml.Deserialize<SkillFrontMatter>(yamlBlock.Lines.ToString());
-        if (fm == null) return null;
-
-        var body = content[(yamlBlock.Span.End + 1)..].TrimStart('\r', '\n').Trim();
-
-        var definition = new SkillDefinition
-        {
-            Instructions = string.IsNullOrWhiteSpace(body) ? null : body,
-            AutoMount = fm.AutoMount,
-            LaunchesSubThread = fm.LaunchesSubThread,
-            Harness = fm.Harness,
-            Action = fm.Action is null ? null : new SkillAction
-            {
-                Kind = Enum.TryParse<SkillActionKind>(fm.Action.Kind, ignoreCase: true, out var kind)
-                    ? kind : SkillActionKind.Pick,
-                Query = fm.Action.Query,
-                Field = fm.Action.Field,
-                Title = fm.Action.Title,
-                ContentPath = fm.Action.ContentPath,
-                Provider = fm.Action.Provider,
-            },
-        };
-
-        return new MeshNode(id, SkillNodeType.RootNamespace)
-        {
-            NodeType = SkillNodeType.NodeType,
-            Name = fm.Name ?? $"/{id}",
-            Description = fm.Description,
-            Category = fm.Category ?? "Skills",
-            Icon = fm.Icon ?? "Sparkle",
-            Order = fm.Order,
-            State = MeshNodeState.Active,
-            Content = definition,
-        };
-    }
+    // The one skill md↔node conversion lives in SkillMarkdown, shared with the sync-back writer
+    // (AiContentDiskWriter serializes via SkillMarkdown.Serialize) — so read and write can never drift.
+    private static MeshNode? ParseSkillNode(string content, string id) => SkillMarkdown.Parse(content, id);
 
     private static string ResourceNameToId(string resourceName, string skillPrefix)
     {
@@ -147,27 +93,4 @@ public class BuiltInSkillProvider : IStaticNodeProvider
         return lastDot > 0 ? rest[..lastDot] : rest;
     }
 
-    private sealed class SkillFrontMatter
-    {
-        public string? NodeType { get; set; }
-        public string? Name { get; set; }
-        public string? Description { get; set; }
-        public string? Icon { get; set; }
-        public string? Category { get; set; }
-        public int Order { get; set; }
-        public bool AutoMount { get; set; } = true;
-        public bool LaunchesSubThread { get; set; }
-        public string? Harness { get; set; }
-        public SkillActionFrontMatter? Action { get; set; }
-    }
-
-    private sealed class SkillActionFrontMatter
-    {
-        public string? Kind { get; set; }
-        public string? Query { get; set; }
-        public string? Field { get; set; }
-        public string? Title { get; set; }
-        public string? ContentPath { get; set; }
-        public string? Provider { get; set; }
-    }
 }

--- a/src/MeshWeaver.AI/SkillMarkdown.cs
+++ b/src/MeshWeaver.AI/SkillMarkdown.cs
@@ -84,7 +84,13 @@ public static class SkillMarkdown
     /// </summary>
     public static string Serialize(MeshNode node)
     {
-        var def = node.Content as SkillDefinition ?? new SkillDefinition();
+        // Fail fast rather than silently serialize an empty skill — a lossy write would clobber the
+        // source file during sync-back. Callers normalise a JsonElement fallback to a typed
+        // SkillDefinition (or skip) before reaching here.
+        if (node.Content is not SkillDefinition def)
+            throw new ArgumentException(
+                $"Skill node '{node.Id}' has {node.Content?.GetType().Name ?? "null"} content, not a {nameof(SkillDefinition)}.",
+                nameof(node));
 
         var fm = new SkillFrontMatterOut
         {

--- a/src/MeshWeaver.AI/SkillMarkdown.cs
+++ b/src/MeshWeaver.AI/SkillMarkdown.cs
@@ -1,0 +1,169 @@
+using Markdig;
+using Markdig.Extensions.Yaml;
+using Markdig.Syntax;
+using MeshWeaver.Mesh;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// The one place that converts a <b>Skill</b> node ↔ its <c>.md</c> file (YAML frontmatter + a
+/// <c>SKILL.md</c> body). <see cref="Parse"/> is what <see cref="BuiltInSkillProvider"/> reads the
+/// built-in <c>content/ai/Skill</c> files with; <see cref="Serialize"/> is its exact inverse, used to
+/// write a mesh-edited skill BACK to that section (the sync-back). Keeping both here — round-trip
+/// pinned by <c>SkillMarkdownRoundTripTest</c> — is what guarantees a sync-back never corrupts a skill.
+/// </summary>
+public static class SkillMarkdown
+{
+    private static readonly MarkdownPipeline Pipeline =
+        new MarkdownPipelineBuilder().UseYamlFrontMatter().Build();
+
+    private static readonly IDeserializer YamlIn = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    // OmitNull so a null field disappears; the serialize model below uses nullable fields and sets the
+    // built-in defaults (autoMount=true, category="Skills", icon="Sparkle", name="/{id}", order=0) to
+    // null so they are omitted exactly as the hand-authored files omit them → a clean round-trip.
+    private static readonly ISerializer YamlOut = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+        .Build();
+
+    /// <summary>Parses a skill <c>.md</c> (frontmatter + body) into a <c>Skill</c> MeshNode, or null.</summary>
+    public static MeshNode? Parse(string content, string id)
+    {
+        if (string.IsNullOrEmpty(id)) return null;
+
+        var document = Markdig.Markdown.Parse(content, Pipeline);
+        var yamlBlock = document.Descendants<YamlFrontMatterBlock>().FirstOrDefault();
+        if (yamlBlock == null) return null;
+
+        var fm = YamlIn.Deserialize<SkillFrontMatter>(yamlBlock.Lines.ToString());
+        if (fm == null) return null;
+
+        var body = content[(yamlBlock.Span.End + 1)..].TrimStart('\r', '\n').Trim();
+
+        var definition = new SkillDefinition
+        {
+            Instructions = string.IsNullOrWhiteSpace(body) ? null : body,
+            AutoMount = fm.AutoMount,
+            LaunchesSubThread = fm.LaunchesSubThread,
+            Harness = fm.Harness,
+            Action = fm.Action is null ? null : new SkillAction
+            {
+                Kind = Enum.TryParse<SkillActionKind>(fm.Action.Kind, ignoreCase: true, out var kind)
+                    ? kind : SkillActionKind.Pick,
+                Query = fm.Action.Query,
+                Field = fm.Action.Field,
+                Title = fm.Action.Title,
+                ContentPath = fm.Action.ContentPath,
+                Provider = fm.Action.Provider,
+            },
+        };
+
+        return new MeshNode(id, SkillNodeType.RootNamespace)
+        {
+            NodeType = SkillNodeType.NodeType,
+            Name = fm.Name ?? $"/{id}",
+            Description = fm.Description,
+            Category = fm.Category ?? "Skills",
+            Icon = fm.Icon ?? "Sparkle",
+            Order = fm.Order,
+            State = MeshNodeState.Active,
+            Content = definition,
+        };
+    }
+
+    /// <summary>
+    /// Serializes a <c>Skill</c> node back to its <c>.md</c> text — the exact inverse of
+    /// <see cref="Parse"/> (the built-in defaults are omitted, so an unedited skill round-trips to a
+    /// byte-identical file). The node's <see cref="MeshNode.Content"/> must be a <see cref="SkillDefinition"/>.
+    /// </summary>
+    public static string Serialize(MeshNode node)
+    {
+        var def = node.Content as SkillDefinition ?? new SkillDefinition();
+
+        var fm = new SkillFrontMatterOut
+        {
+            NodeType = SkillNodeType.NodeType,
+            // Omit the fields Parse fills with defaults, so a hand-authored file round-trips unchanged.
+            Name = string.Equals(node.Name, $"/{node.Id}", StringComparison.Ordinal) ? null : node.Name,
+            Description = node.Description,
+            Icon = string.Equals(node.Icon, "Sparkle", StringComparison.Ordinal) ? null : node.Icon,
+            Category = string.Equals(node.Category, "Skills", StringComparison.Ordinal) ? null : node.Category,
+            Order = node.Order == 0 ? null : node.Order,
+            AutoMount = def.AutoMount ? null : false,               // default true → omit
+            LaunchesSubThread = def.LaunchesSubThread ? true : null, // default false → omit
+            Harness = def.Harness,
+            Action = def.Action is null ? null : new SkillActionFrontMatterOut
+            {
+                // Pick is the default enum value → omit (Parse defaults a missing kind to Pick).
+                Kind = def.Action.Kind == SkillActionKind.Pick ? null : def.Action.Kind.ToString(),
+                Query = def.Action.Query,
+                Field = def.Action.Field,
+                Title = def.Action.Title,
+                ContentPath = def.Action.ContentPath,
+                Provider = def.Action.Provider,
+            },
+        };
+
+        var yaml = YamlOut.Serialize(fm).TrimEnd('\r', '\n');
+        var body = def.Instructions?.Trim() ?? "";
+        return body.Length == 0 ? $"---\n{yaml}\n---\n" : $"---\n{yaml}\n---\n\n{body}\n";
+    }
+
+    // ── The frontmatter models ──────────────────────────────────────────────
+
+    // Read model — matches the hand-authored files (camelCase, missing fields default).
+    internal sealed class SkillFrontMatter
+    {
+        public string? NodeType { get; set; }
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+        public string? Icon { get; set; }
+        public string? Category { get; set; }
+        public int Order { get; set; }
+        public bool AutoMount { get; set; } = true;
+        public bool LaunchesSubThread { get; set; }
+        public string? Harness { get; set; }
+        public SkillActionFrontMatter? Action { get; set; }
+    }
+
+    internal sealed class SkillActionFrontMatter
+    {
+        public string? Kind { get; set; }
+        public string? Query { get; set; }
+        public string? Field { get; set; }
+        public string? Title { get; set; }
+        public string? ContentPath { get; set; }
+        public string? Provider { get; set; }
+    }
+
+    // Write model — all nullable so defaults can be OMITTED (OmitNull) for a clean round-trip.
+    private sealed class SkillFrontMatterOut
+    {
+        public string? NodeType { get; set; }
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+        public string? Icon { get; set; }
+        public string? Category { get; set; }
+        public int? Order { get; set; }
+        public bool? AutoMount { get; set; }
+        public bool? LaunchesSubThread { get; set; }
+        public string? Harness { get; set; }
+        public SkillActionFrontMatterOut? Action { get; set; }
+    }
+
+    private sealed class SkillActionFrontMatterOut
+    {
+        public string? Kind { get; set; }
+        public string? Query { get; set; }
+        public string? Field { get; set; }
+        public string? Title { get; set; }
+        public string? ContentPath { get; set; }
+        public string? Provider { get; set; }
+    }
+}

--- a/src/MeshWeaver.GitSync/AiContentDiskWriter.cs
+++ b/src/MeshWeaver.GitSync/AiContentDiskWriter.cs
@@ -99,7 +99,15 @@ public sealed class AiContentDiskWriter(
                     ? path[(partition.Length + 1)..]
                     : node!.Id;
                 var repoRel = Path.Combine(partition, rel.Replace('/', Path.DirectorySeparatorChar) + ".md");
-                var full = Path.Combine(sectionRoot, repoRel);
+                // Containment: a hostile/odd node path (traversal segments) must never let the write
+                // escape the section root and clobber arbitrary files (cf. GitWorkingTreeService.ResolveInTree).
+                var sectionFull = Path.GetFullPath(sectionRoot);
+                var full = Path.GetFullPath(Path.Combine(sectionFull, repoRel));
+                if (!full.StartsWith(sectionFull + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+                {
+                    logger?.LogWarning("AI content sync-back: skipping {Path} — resolves outside the section root.", path);
+                    return Observable.Return<string?>(null);
+                }
                 return FileSystem.InvokeBlocking<string?>(_ =>
                 {
                     Directory.CreateDirectory(Path.GetDirectoryName(full)!);

--- a/src/MeshWeaver.GitSync/AiContentDiskWriter.cs
+++ b/src/MeshWeaver.GitSync/AiContentDiskWriter.cs
@@ -1,0 +1,140 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.AI;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Persistence.Parsers;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>Outcome of an AI-content sync-back: how many Agent/Skill files were written, repo-relative.</summary>
+public sealed record AiContentSyncResult(int AgentsWritten, int SkillsWritten, IReadOnlyList<string> Files)
+{
+    /// <summary>Total files written across both partitions.</summary>
+    public int TotalWritten => AgentsWritten + SkillsWritten;
+}
+
+/// <summary>
+/// The <b>sync-back writer</b>: serializes the live <c>Agent</c> and <c>Skill</c> partitions back to
+/// the on-disk AI content section (<see cref="AiContentLocator.RepoSectionRoot"/> → <c>content/ai</c>),
+/// so an agent or skill edited in the running mesh can be committed to the repo. The inverse of the
+/// providers that READ that section (<see cref="BuiltInAgentProvider"/> / <see cref="BuiltInSkillProvider"/>):
+/// agents serialize through <see cref="AgentFileParser"/> and skills through <see cref="SkillMarkdown"/>
+/// — the SAME converters the read path uses, so a round-trip never drifts (pinned by the round-trip tests).
+///
+/// <para>🚨 Reactive + pooled — no <c>async</c>/<c>await</c>. Node content is read authoritatively from
+/// the owning per-node hub (<see cref="MeshNodeStreamHandle"/>), NOT the eventually-consistent query
+/// index, so a just-made edit is never lost (CQRS). Every file write runs on the
+/// <see cref="IoPoolNames.FileSystem"/> pool, off the hub. All methods return <b>cold</b> observables —
+/// the work runs on <c>Subscribe</c>.</para>
+///
+/// <para>Only meaningful when running from a source checkout (a deployed container has no working tree —
+/// <see cref="AiContentLocator.RepoSectionRoot"/> is null there); callers gate on that.</para>
+/// </summary>
+public sealed class AiContentDiskWriter(
+    IMessageHub hub,
+    IMeshService meshService,
+    IoPoolRegistry ioPools,
+    ILogger<AiContentDiskWriter>? logger = null)
+{
+    private readonly AgentFileParser agentParser = new();
+    private IIoPool FileSystem => ioPools.Get(IoPoolNames.FileSystem);
+
+    /// <summary>
+    /// Writes the live Agent + Skill partitions to <c>{sectionRoot}/Agent</c> and
+    /// <c>{sectionRoot}/Skill</c> as <c>.md</c> files, creating directories as needed. Emits a single
+    /// <see cref="AiContentSyncResult"/> with the counts and repo-relative paths written.
+    /// </summary>
+    public IObservable<AiContentSyncResult> WriteBack(string sectionRoot) =>
+        WritePartition(sectionRoot, AgentPartition, AgentPartition, SerializeAgent).SelectMany(agents =>
+            WritePartition(sectionRoot, SkillNodeType.RootNamespace, SkillNodeType.NodeType, SerializeSkill)
+                .Select(skills => new AiContentSyncResult(agents.Count, skills.Count, [.. agents, .. skills])));
+
+    private const string AgentPartition = "Agent";
+
+    /// <summary>The Agent partition uses the standard AgentConfiguration content type "Agent".</summary>
+    private IObservable<IReadOnlyList<string>> WritePartition(
+        string sectionRoot, string partition, string nodeType, Func<MeshNode, string?> serialize) =>
+        // Listing a partition's children is a sanctioned query use; content is (re-)read authoritatively
+        // per node in WriteOne, so a stale index only affects which nodes exist, never their content.
+        meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{partition} scope:descendants nodeType:{nodeType}"))
+            .Take(1)
+            .SelectMany(collection =>
+            {
+                var paths = collection.Items
+                    .Select(n => n.Path)
+                    .Where(p => !string.IsNullOrEmpty(p)
+                                && !p.Split('/').Skip(1).Any(s => s.StartsWith('_')))   // skip _Policy etc.
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                if (paths.Length == 0)
+                    return Observable.Return((IReadOnlyList<string>)Array.Empty<string>());
+                return paths
+                    .Select(p => WriteOne(sectionRoot, partition, p, serialize))
+                    .Merge(4)
+                    .Where(f => f is not null).Select(f => f!)
+                    .ToList()
+                    .Select(l => (IReadOnlyList<string>)l);
+            });
+
+    private IObservable<string?> WriteOne(
+        string sectionRoot, string partition, string path, Func<MeshNode, string?> serialize) =>
+        hub.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null).Take(1).Timeout(TimeSpan.FromSeconds(15))
+            .SelectMany(node =>
+            {
+                var text = serialize(node!);
+                if (text is null)
+                {
+                    logger?.LogWarning("AI content sync-back: skipping {Path} — content not serializable.", path);
+                    return Observable.Return<string?>(null);
+                }
+                // Preserve any nesting under the partition (Agent/Sub/Foo → Agent/Sub/Foo.md), not just the id.
+                var rel = path.StartsWith(partition + "/", StringComparison.Ordinal)
+                    ? path[(partition.Length + 1)..]
+                    : node!.Id;
+                var repoRel = Path.Combine(partition, rel.Replace('/', Path.DirectorySeparatorChar) + ".md");
+                var full = Path.Combine(sectionRoot, repoRel);
+                return FileSystem.InvokeBlocking<string?>(_ =>
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+                    File.WriteAllText(full, text);
+                    return repoRel.Replace(Path.DirectorySeparatorChar, '/');
+                });
+            });
+
+    // AgentFileParser already handles both typed AgentConfiguration and the JsonElement fallback.
+    private string? SerializeAgent(MeshNode node) =>
+        agentParser.CanSerialize(node) ? agentParser.Serialize(node) : null;
+
+    // SkillMarkdown.Serialize needs a typed SkillDefinition; normalise a JsonElement fallback first,
+    // and refuse (return null → skip, don't clobber) content we can't interpret.
+    private string? SerializeSkill(MeshNode node)
+    {
+        var typed = node.Content switch
+        {
+            SkillDefinition => node,
+            JsonElement je => TryTypeSkill(node, je),
+            _ => null,
+        };
+        return typed is null ? null : SkillMarkdown.Serialize(typed);
+    }
+
+    private MeshNode? TryTypeSkill(MeshNode node, JsonElement je)
+    {
+        try
+        {
+            var def = JsonSerializer.Deserialize<SkillDefinition>(je.GetRawText(), hub.JsonSerializerOptions);
+            return def is null ? null : node with { Content = def };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/MeshWeaver.GitSync/AiContentSyncArea.cs
+++ b/src/MeshWeaver.GitSync/AiContentSyncArea.cs
@@ -1,0 +1,120 @@
+using System.ComponentModel;
+using System.Reactive.Linq;
+using System.Text;
+using MeshWeaver.AI;
+using MeshWeaver.Application.Styles;
+using MeshWeaver.Graph;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// The action layout area the "Sync to repo" AI-content menu item navigates to — writes the live
+/// Agent + Skill partitions back to the on-disk <c>content/ai</c> section (via
+/// <see cref="AiContentDiskWriter"/>) and renders what was written. Navigating to it runs the op
+/// (identical to <see cref="GitHubActionArea"/>). Platform-admin + source-checkout gated: a deployed
+/// container has no working tree to write to.
+/// </summary>
+public static class AiContentSyncArea
+{
+    /// <summary>Area name for the AI-content sync-back action.</summary>
+    public const string AreaName = "AiContentSync";
+
+    /// <summary>The href a menu item uses to invoke the sync-back on the containing node.</summary>
+    public static string Href(string hubPath) => MeshNodeLayoutAreas.BuildUrl(hubPath, AreaName);
+
+    /// <summary>Runs the sync-back and renders the result.</summary>
+    [Browsable(false)]
+    public static IObservable<UiControl?> Render(LayoutAreaHost host, RenderingContext _)
+    {
+        var hubPath = host.Hub.Address.ToString();
+        var backHref = MeshNodeLayoutAreas.BuildUrl(hubPath, MeshNodeLayoutAreas.OverviewArea);
+        var logger = host.Hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(AiContentSyncArea));
+
+        return host.Hub.IsGlobalAdmin().Take(1).SelectMany(isAdmin =>
+        {
+            if (!isAdmin)
+                return Observable.Return<UiControl?>(Message("Platform admins only",
+                    "Writing the built-in agents & skills back to the repo is a platform-admin operation.", backHref));
+
+            var root = AiContentLocator.RepoSectionRoot();
+            if (root is null)
+                return Observable.Return<UiControl?>(Message("Not a source checkout",
+                    "AI content sync-back writes to <code>content/ai</code> in the repo working tree — available " +
+                    "only when the portal runs from a source checkout. A deployed container has no working tree.", backHref));
+
+            var writer = host.Hub.ServiceProvider.GetService<AiContentDiskWriter>();
+            if (writer is null)
+                return Observable.Return<UiControl?>(Message("Unavailable",
+                    "The AI content sync-back writer is not registered in this host.", backHref));
+
+            return writer.WriteBack(root)
+                .Select(result => (UiControl?)BuildResult(root, result, backHref))
+                .Catch<UiControl?, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex, "AI content sync-back failed");
+                    return Observable.Return<UiControl?>(Message("Sync failed",
+                        System.Net.WebUtility.HtmlEncode(ex.Message), backHref));
+                })
+                .StartWith((UiControl?)BuildStarting(backHref));
+        });
+    }
+
+    private static UiControl BuildStarting(string backHref)
+        => Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("padding: 24px; gap: 12px;")
+            .WithView(BuildHeader("Syncing AI content to repo", backHref))
+            .WithView(Controls.Progress("Writing agents & skills…", null!).WithWidth("100%").WithHideNumber(true));
+
+    private static UiControl BuildResult(string root, AiContentSyncResult result, string backHref)
+    {
+        // Markdown prose + a bulleted file list (a list, not tabular data — the framework markdown
+        // control, never hand-built HTML).
+        var md = new StringBuilder();
+        md.AppendLine($"Wrote **{result.AgentsWritten}** agent(s) and **{result.SkillsWritten}** skill(s) " +
+                      $"to `{root}`.");
+        md.AppendLine();
+        if (result.Files.Count == 0)
+            md.AppendLine("_No agent or skill nodes were found to write._");
+        else
+            foreach (var file in result.Files.OrderBy(f => f, StringComparer.Ordinal))
+                md.AppendLine($"- `{file}`");
+        md.AppendLine();
+        md.AppendLine("Review with `git diff content/ai` and commit to sync the changes to the repo.");
+
+        return Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("padding: 24px; gap: 12px;")
+            .WithView(BuildHeader("AI content synced to repo", backHref))
+            .WithView(Controls.Markdown(md.ToString()));
+    }
+
+    private static StackControl BuildHeader(string title, string backHref)
+        => Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithHorizontalGap(16)
+            .WithStyle("align-items: center;")
+            .WithView(Controls.Button("Back")
+                .WithAppearance(Appearance.Lightweight)
+                .WithIconStart(FluentIcons.ArrowLeft())
+                .WithNavigateToHref(backHref))
+            .WithView(Controls.H2(title).WithStyle("margin: 0;"));
+
+    // Guard message (admins-only / not-a-checkout / unavailable / failed). The body may contain a
+    // pre-rendered <code> snippet, so it stays a Controls.Html paragraph (genuinely pre-rendered rich
+    // text — not structured data).
+    private static UiControl Message(string title, string bodyHtml, string backHref)
+        => Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("padding: 24px; gap: 16px;")
+            .WithView(BuildHeader(title, backHref))
+            .WithView(Controls.Html(
+                $"<p style=\"color: var(--neutral-foreground-hint);\">{bodyHtml}</p>"));
+}

--- a/src/MeshWeaver.GitSync/AiContentSyncArea.cs
+++ b/src/MeshWeaver.GitSync/AiContentSyncArea.cs
@@ -41,7 +41,7 @@ public static class AiContentSyncArea
         {
             if (!isAdmin)
                 return Observable.Return<UiControl?>(Message("Platform admins only",
-                    "Writing the built-in agents & skills back to the repo is a platform-admin operation.", backHref));
+                    "Writing the built-in agents &amp; skills back to the repo is a platform-admin operation.", backHref));
 
             var root = AiContentLocator.RepoSectionRoot();
             if (root is null)

--- a/src/MeshWeaver.GitSync/AiContentSyncMenuProvider.cs
+++ b/src/MeshWeaver.GitSync/AiContentSyncMenuProvider.cs
@@ -1,0 +1,61 @@
+using System.Reactive.Linq;
+using MeshWeaver.AI;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// DI-registered <see cref="INodeMenuProvider"/> that contributes the "Sync to repo" entry to the NODE
+/// menu on any node in the <c>Agent</c> or <c>Skill</c> partition — the one-click way to write the
+/// agents &amp; skills edited in the mesh back to the on-disk <c>content/ai</c> section
+/// (<see cref="AiContentSyncArea"/> → <see cref="AiContentDiskWriter"/>).
+///
+/// <para>Shown only when BOTH hold: the portal runs from a source checkout
+/// (<see cref="AiContentLocator.RepoSectionRoot"/> is non-null — a deployed container has no working
+/// tree to commit to) and the viewer is a platform admin. It gates on admin, NOT on partition Update
+/// permission, because the operation READS the mesh and WRITES to disk — the built-in partitions'
+/// read-only policy does not apply to a disk write.</para>
+/// </summary>
+public sealed class AiContentSyncMenuProvider : INodeMenuProvider
+{
+    /// <inheritdoc />
+    public string Context => NodeMenuItemsExtensions.NodeMenuContext;
+
+    private static readonly string[] AiPartitions = ["Agent", SkillNodeType.RootNamespace];
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyCollection<NodeMenuItemDefinition>> GetItems(
+        LayoutAreaHost host, RenderingContext ctx)
+    {
+        IReadOnlyCollection<NodeMenuItemDefinition> none = [];
+
+        // Dev-only: a deployed container has no repo working tree to write back to.
+        if (AiContentLocator.RepoSectionRoot() is null)
+            return Observable.Return(none);
+
+        var hubPath = host.Hub.Address.ToString();
+        var top = hubPath.Split('/', 2)[0];
+        if (!AiPartitions.Contains(top, StringComparer.Ordinal))
+            return Observable.Return(none);
+
+        var item = new NodeMenuItemDefinition(
+            Label: "Sync to repo",
+            Area: AiContentSyncArea.AreaName,
+            Icon: "⬇️",
+            Order: 38,   // content/history section (Files=30, Versions=32, Synchronizations=36)
+            Href: AiContentSyncArea.Href(hubPath),
+            Tooltip: "Write the agents & skills edited here back to content/ai in the repo");
+
+        // Platform-admin gated; StartWith so a host CombineLatest fires, Catch so a permission race
+        // never breaks the whole menu.
+        return host.Hub.IsGlobalAdmin()
+            .Select(isAdmin => isAdmin ? (IReadOnlyCollection<NodeMenuItemDefinition>)[item] : none)
+            .DistinctUntilChanged()
+            .Catch<IReadOnlyCollection<NodeMenuItemDefinition>, Exception>(_ => Observable.Return(none))
+            .StartWith(none);
+    }
+}

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -63,6 +63,9 @@ public static class GitHubSyncConfiguration
             });
         services.AddSingleton<GitCli>();
         services.AddSingleton<GitWorkingTreeService>();
+        // Writes the live Agent + Skill partitions back to the repo's content/ai section — the inverse
+        // of the built-in providers that READ that section. Dev-time (source checkout) only.
+        services.AddSingleton<AiContentDiskWriter>();
         // AI-drafted PR title/body. Default delegates to the PullRequestWriter agent via the
         // existing chat surface (mirrors DescriptionGenerator); tests override with a stub.
         services.AddSingleton<IPullRequestDraftService, PullRequestDraftService>();
@@ -141,10 +144,13 @@ public static class GitHubSyncConfiguration
             .WithServices(s =>
             {
                 s.TryAddEnumerable(ServiceDescriptor.Scoped<INodeMenuProvider, GitHubSyncMenuProvider>());
+                // "Sync to repo" on Agent/Skill nodes — self-gates to a source checkout + platform admin.
+                s.TryAddEnumerable(ServiceDescriptor.Scoped<INodeMenuProvider, AiContentSyncMenuProvider>());
                 return s;
             })
             .AddLayout(layout => layout
-                .WithView(GitHubActionArea.AreaName, GitHubActionArea.Render)));
+                .WithView(GitHubActionArea.AreaName, GitHubActionArea.Render)
+                .WithView(AiContentSyncArea.AreaName, AiContentSyncArea.Render)));
         return builder;
     }
 }

--- a/src/MeshWeaver.GitSync/HubAiContentSyncExtensions.cs
+++ b/src/MeshWeaver.GitSync/HubAiContentSyncExtensions.cs
@@ -1,0 +1,33 @@
+using System.Reactive.Linq;
+using MeshWeaver.AI;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// The hub-extension surface for the AI-content sync-back: write the agents &amp; skills edited in the
+/// running mesh back to the repo's <c>content/ai</c> section. Used by <see cref="AiContentSyncArea"/>
+/// and by tests; the same one-liner an admin script would call.
+/// </summary>
+public static class HubAiContentSyncExtensions
+{
+    /// <summary>
+    /// Writes the live <c>Agent</c> + <c>Skill</c> partitions back to the repo working tree's
+    /// <c>content/ai</c> (<see cref="AiContentLocator.RepoSectionRoot"/>). Errors when not running from
+    /// a source checkout (a deployed container has no working tree). Cold — the work runs on Subscribe.
+    /// </summary>
+    public static IObservable<AiContentSyncResult> SyncAiContentToRepo(this IMessageHub hub)
+    {
+        var root = AiContentLocator.RepoSectionRoot();
+        if (root is null)
+            return Observable.Throw<AiContentSyncResult>(new InvalidOperationException(
+                "AI content sync-back needs a repo checkout (content/ai on disk) — it is a dev-time operation; " +
+                "a deployed portal has no working tree to write to."));
+        return hub.ServiceProvider.GetRequiredService<AiContentDiskWriter>().WriteBack(root);
+    }
+
+    /// <summary>Writes to an explicit section root — the testable overload (write to a temp dir).</summary>
+    public static IObservable<AiContentSyncResult> SyncAiContentToRepo(this IMessageHub hub, string sectionRoot) =>
+        hub.ServiceProvider.GetRequiredService<AiContentDiskWriter>().WriteBack(sectionRoot);
+}

--- a/src/MeshWeaver.GitSync/HubAiContentSyncExtensions.cs
+++ b/src/MeshWeaver.GitSync/HubAiContentSyncExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Linq;
 using MeshWeaver.AI;
+using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,17 +18,27 @@ public static class HubAiContentSyncExtensions
     /// <c>content/ai</c> (<see cref="AiContentLocator.RepoSectionRoot"/>). Errors when not running from
     /// a source checkout (a deployed container has no working tree). Cold — the work runs on Subscribe.
     /// </summary>
-    public static IObservable<AiContentSyncResult> SyncAiContentToRepo(this IMessageHub hub)
-    {
-        var root = AiContentLocator.RepoSectionRoot();
-        if (root is null)
-            return Observable.Throw<AiContentSyncResult>(new InvalidOperationException(
-                "AI content sync-back needs a repo checkout (content/ai on disk) — it is a dev-time operation; " +
-                "a deployed portal has no working tree to write to."));
-        return hub.ServiceProvider.GetRequiredService<AiContentDiskWriter>().WriteBack(root);
-    }
+    public static IObservable<AiContentSyncResult> SyncAiContentToRepo(this IMessageHub hub) =>
+        // Enforce the platform-admin gate HERE, not only in the UI area — this is the surface other
+        // server code / an admin script calls, so the authorization can't be bypassed by skipping the menu.
+        hub.IsGlobalAdmin().Take(1).SelectMany(isAdmin =>
+        {
+            if (!isAdmin)
+                return Observable.Throw<AiContentSyncResult>(new UnauthorizedAccessException(
+                    "AI content sync-back is a platform-admin operation."));
+            var root = AiContentLocator.RepoSectionRoot();
+            if (root is null)
+                return Observable.Throw<AiContentSyncResult>(new InvalidOperationException(
+                    "AI content sync-back needs a repo checkout (content/ai on disk) — it is a dev-time operation; " +
+                    "a deployed portal has no working tree to write to."));
+            return hub.ServiceProvider.GetRequiredService<AiContentDiskWriter>().WriteBack(root);
+        });
 
-    /// <summary>Writes to an explicit section root — the testable overload (write to a temp dir).</summary>
+    /// <summary>
+    /// Writes to an explicit section root, WITHOUT the admin gate — the low-level seam for the UI area
+    /// (which has already gated admin) and for tests (write to a temp dir). Application code should call
+    /// the gated <see cref="SyncAiContentToRepo(IMessageHub)"/> instead.
+    /// </summary>
     public static IObservable<AiContentSyncResult> SyncAiContentToRepo(this IMessageHub hub, string sectionRoot) =>
         hub.ServiceProvider.GetRequiredService<AiContentDiskWriter>().WriteBack(sectionRoot);
 }

--- a/test/MeshWeaver.AI.Test/SkillMarkdownRoundTripTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillMarkdownRoundTripTest.cs
@@ -1,0 +1,58 @@
+#pragma warning disable CS1591
+
+using System.IO;
+using System.Linq;
+using MeshWeaver.AI;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// The sync-back writes a mesh-edited skill back to its <c>.md</c> via <see cref="SkillMarkdown.Serialize"/>,
+/// and the mesh reads it via <see cref="SkillMarkdown.Parse"/>. If those two ever disagree, a sync-back
+/// corrupts the skill. This pins <c>Serialize ∘ Parse == identity</c> for EVERY built-in skill file, so
+/// a round-trip is always lossless.
+/// </summary>
+public class SkillMarkdownRoundTripTest
+{
+    [Fact]
+    public void EveryBuiltInSkill_RoundTrips_SerializeThenParse_Lossless()
+    {
+        var root = AiContentLocator.SectionRoot();
+        Assert.NotNull(root);
+        var skillDir = Path.Combine(root!, "Skill");
+        Assert.True(Directory.Exists(skillDir), $"skill section not found: {skillDir}");
+
+        var files = Directory.EnumerateFiles(skillDir, "*.md").OrderBy(f => f).ToList();
+        Assert.NotEmpty(files);
+
+        foreach (var file in files)
+        {
+            var id = Path.GetFileNameWithoutExtension(file);
+            var original = SkillMarkdown.Parse(File.ReadAllText(file), id);
+            Assert.NotNull(original);
+
+            var reparsed = SkillMarkdown.Parse(SkillMarkdown.Serialize(original!), id);
+            Assert.NotNull(reparsed);
+
+            Assert.Equal(original!.Name, reparsed!.Name);
+            Assert.Equal(original.Description, reparsed.Description);
+            Assert.Equal(original.Category, reparsed.Category);
+            Assert.Equal(original.Icon, reparsed.Icon);
+            Assert.Equal(original.Order, reparsed.Order);
+
+            var od = Assert.IsType<SkillDefinition>(original.Content);
+            var rd = Assert.IsType<SkillDefinition>(reparsed.Content);
+            Assert.Equal(od.Instructions, rd.Instructions);
+            Assert.Equal(od.AutoMount, rd.AutoMount);
+            Assert.Equal(od.LaunchesSubThread, rd.LaunchesSubThread);
+            Assert.Equal(od.Harness, rd.Harness);
+            Assert.Equal(od.Action?.Kind, rd.Action?.Kind);
+            Assert.Equal(od.Action?.Query, rd.Action?.Query);
+            Assert.Equal(od.Action?.Field, rd.Action?.Field);
+            Assert.Equal(od.Action?.Title, rd.Action?.Title);
+            Assert.Equal(od.Action?.ContentPath, rd.Action?.ContentPath);
+            Assert.Equal(od.Action?.Provider, rd.Action?.Provider);
+        }
+    }
+}

--- a/test/MeshWeaver.GitSync.Test/AiContentSyncBackTest.cs
+++ b/test/MeshWeaver.GitSync.Test/AiContentSyncBackTest.cs
@@ -1,0 +1,62 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.AI;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// End-to-end sync-back: the <see cref="AiContentDiskWriter"/> enumerates the live Skill partition
+/// (served here by the in-memory <c>BuiltInSkillProvider</c>), reads each node authoritatively, and
+/// writes it back to a <c>content/ai</c>-shaped folder as a <c>.md</c> file. Proves the query → stream
+/// → serialize → disk plumbing; serialization correctness itself is pinned by the SkillMarkdown
+/// round-trip test. Writes to a temp dir (never the repo working tree).
+/// </summary>
+public class AiContentSyncBackTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddSkillType()   // serves the built-in skills (Skill/*), the enumeration target
+            .ConfigureServices(s =>
+            {
+                s.AddGitHubSyncServices();   // registers AiContentDiskWriter
+                return s;
+            });
+
+    [Fact]
+    public async Task WriteBack_WritesTheLiveSkillPartition_ToDisk()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-aicontent-syncback-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var result = await Mesh.SyncAiContentToRepo(dir).Timeout(TimeSpan.FromSeconds(60)).ToTask();
+
+            // The built-in provider serves ~15 skills; every one should have been written.
+            Assert.True(result.SkillsWritten >= 10, $"skills written: {result.SkillsWritten}");
+            Assert.Equal(result.SkillsWritten,
+                result.Files.Count(f => f.StartsWith("Skill/", StringComparison.Ordinal)));
+
+            // Each written file re-parses to a valid Skill node (round-trip through the mesh + disk).
+            var skillDir = Path.Combine(dir, "Skill");
+            Assert.True(Directory.Exists(skillDir), $"expected {skillDir}");
+            foreach (var file in Directory.EnumerateFiles(skillDir, "*.md"))
+            {
+                var id = Path.GetFileNameWithoutExtension(file);
+                var text = await File.ReadAllTextAsync(file);
+                Assert.StartsWith("---", text);   // has YAML frontmatter
+                var node = SkillMarkdown.Parse(text, id);
+                Assert.NotNull(node);
+                Assert.Equal(id, node!.Id);
+                Assert.IsType<SkillDefinition>(node.Content);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## What

Follow-up to #414 (which factored the built-in Agent/Skill nodes into the editable repo section `content/ai`). This adds the **inverse of the read path**: edit an agent or skill in the running mesh, then write it back to `content/ai` to commit.

The private plugins repo can't serve the default AI content offline, so it stays in the MeshWeaver repo — but in a section we can round-trip: mesh → disk → git.

## How

- **`SkillMarkdown`** — the one Skill node ↔ `.md` converter (`Parse` + `Serialize`, exact inverse). `BuiltInSkillProvider` now delegates its parse to it, so read and write can never drift. Round-trip pinned by `SkillMarkdownRoundTripTest` (lossless for every built-in skill).
- **`AiContentDiskWriter`** (GitSync) — serializes the live **Agent** partition (`AgentFileParser`) and **Skill** partition (`SkillMarkdown`) back to `content/ai` via the `FileSystem` IoPool. Reads each node's content **authoritatively** from its owning hub (`GetMeshNodeStream`), never the eventually-consistent query index, so a just-made edit is never lost.
- **Trigger** — a "Sync to repo" node-menu item on Agent/Skill nodes (`AiContentSyncMenuProvider`) → `AiContentSyncArea` runs the write-back and renders the result. Gated on a **source checkout** (`AiContentLocator.RepoSectionRoot() != null` — a deployed container has no working tree) **+ platform admin**. `hub.SyncAiContentToRepo()` is the programmatic surface.
- `AiContentLocator` made public (GitSync resolves `RepoSectionRoot`).

## Reactive / framework compliance

- No `async`/`await`/`Task<T>`: everything is `IObservable<T>` + `Subscribe`; every disk write goes through `IIoPool` (`InvokeBlocking`), never `Observable.FromAsync`.
- Content read authoritatively via `GetMeshNodeStream` (CQRS), not `QueryAsync` — query is used only to *list* the partition's nodes.
- Trigger is a framework node-menu + layout area (modeled on the existing `GitHubActionArea`), no hand-rolled UI/HTML.

## Tests

- `SkillMarkdownRoundTripTest` — `Serialize ∘ Parse == identity` for every built-in skill.
- `AiContentSyncBackTest` — end-to-end: the writer enumerates the live Skill partition, reads each node, and writes `.md` files that re-parse to valid Skill nodes (proves the query → stream → serialize → disk plumbing). Writes to a temp dir.

Green locally: `dotnet build -c Release -warnaserror` on the touched projects + their test projects; the two new tests pass.

## Follow-up (out of scope)

The built-in Agent/Skill partitions are read-only by policy (prod safety). Making them editable-in-dev so the built-ins themselves can be round-tripped through the UI is a separate policy decision; this PR ships the sync-back mechanism, which already works for any editable agent/skill node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)