### PR TITLE
fix(portal): breadcrumb bar placement on the nav-less memex grid

### DIFF
--- a/memex/Memex.Portal.Monolith/wwwroot/app.css
+++ b/memex/Memex.Portal.Monolith/wwwroot/app.css
@@ -64,12 +64,17 @@ div.layout > header .links,
     min-width: 200px;
 }
 
-/* Remove nav column from grid when not using left nav - use div.layout for higher specificity */
+/* Remove nav column from grid when not using left nav - use div.layout for higher specificity.
+   The "breadcrumb" row hosts PortalLayoutBase's breadcrumb bar (grid-area: breadcrumb); this
+   nav-less grid overrides the framework grid with !important, so the row must be declared HERE
+   or the bar orphans into an implicit cell (rendered bottom-right). */
 div.layout,
 div.layout[class] {
     grid-template-columns: auto 1fr !important;
+    grid-template-rows: auto auto auto 1fr !important;
     grid-template-areas:
         "icon head"
+        "breadcrumb breadcrumb"
         "messagebar messagebar"
         "main main" !important;
 }
@@ -78,8 +83,10 @@ div.layout[class] {
 div.layout.chat-visible.chat-position-right,
 div.layout[class].chat-visible.chat-position-right {
     grid-template-columns: auto 1fr var(--chat-width, 400px) !important;
+    grid-template-rows: auto auto auto 1fr !important;
     grid-template-areas:
         "icon head head"
+        "breadcrumb breadcrumb breadcrumb"
         "messagebar messagebar chat"
         "main main chat" !important;
 }
@@ -87,9 +94,10 @@ div.layout[class].chat-visible.chat-position-right {
 div.layout.chat-visible.chat-position-bottom,
 div.layout[class].chat-visible.chat-position-bottom {
     grid-template-columns: auto 1fr !important;
-    grid-template-rows: auto auto 1fr var(--chat-height, 400px) !important;
+    grid-template-rows: auto auto auto 1fr var(--chat-height, 400px) !important;
     grid-template-areas:
         "icon head"
+        "breadcrumb breadcrumb"
         "messagebar messagebar"
         "main main"
         "chat chat" !important;

--- a/memex/Memex.Portal.Shared/Layout/MainLayout.razor
+++ b/memex/Memex.Portal.Shared/Layout/MainLayout.razor
@@ -3,12 +3,17 @@
 @inherits PortalLayoutBase
 
 <style>
-    /* Override grid to remove nav column */
+    /* Override grid to remove nav column. The "breadcrumb" row hosts PortalLayoutBase's
+       breadcrumb bar (grid-area: breadcrumb); this nav-less grid overrides the framework grid
+       with !important, so the row must be declared HERE or the bar orphans into an implicit
+       cell (rendered bottom-right). */
     .layout[class],
     div.layout[class] {
         grid-template-columns: auto 1fr !important;
+        grid-template-rows: auto auto auto 1fr !important;
         grid-template-areas:
             "icon head"
+            "breadcrumb breadcrumb"
             "messagebar messagebar"
             "main main" !important;
     }

--- a/memex/aspire/Memex.Portal.Distributed/wwwroot/app.css
+++ b/memex/aspire/Memex.Portal.Distributed/wwwroot/app.css
@@ -64,12 +64,17 @@ div.layout > header .links,
     min-width: 200px;
 }
 
-/* Remove nav column from grid when not using left nav - use div.layout for higher specificity */
+/* Remove nav column from grid when not using left nav - use div.layout for higher specificity.
+   The "breadcrumb" row hosts PortalLayoutBase's breadcrumb bar (grid-area: breadcrumb); this
+   nav-less grid overrides the framework grid with !important, so the row must be declared HERE
+   or the bar orphans into an implicit cell (rendered bottom-right). */
 div.layout,
 div.layout[class] {
     grid-template-columns: auto 1fr !important;
+    grid-template-rows: auto auto auto 1fr !important;
     grid-template-areas:
         "icon head"
+        "breadcrumb breadcrumb"
         "messagebar messagebar"
         "main main" !important;
 }
@@ -78,8 +83,10 @@ div.layout[class] {
 div.layout.chat-visible.chat-position-right,
 div.layout[class].chat-visible.chat-position-right {
     grid-template-columns: auto 1fr var(--chat-width, 400px) !important;
+    grid-template-rows: auto auto auto 1fr !important;
     grid-template-areas:
         "icon head head"
+        "breadcrumb breadcrumb breadcrumb"
         "messagebar messagebar chat"
         "main main chat" !important;
 }
@@ -87,9 +94,10 @@ div.layout[class].chat-visible.chat-position-right {
 div.layout.chat-visible.chat-position-bottom,
 div.layout[class].chat-visible.chat-position-bottom {
     grid-template-columns: auto 1fr !important;
-    grid-template-rows: auto auto 1fr var(--chat-height, 400px) !important;
+    grid-template-rows: auto auto auto 1fr var(--chat-height, 400px) !important;
     grid-template-areas:
         "icon head"
+        "breadcrumb breadcrumb"
         "messagebar messagebar"
         "main main"
         "chat chat" !important;


### PR DESCRIPTION
## What

Fixes the breadcrumb bar (#404) rendering **bottom-right** instead of a full-width row under the top bar, **on the memex portal**.

## Root cause

The memex portal overrides `PortalLayoutBase`'s `.layout` grid in a global stylesheet (`memex/aspire/Memex.Portal.Distributed/wwwroot/app.css`) with a **nav-less** grid — `div.layout[class] { grid-template-areas: "icon head" "messagebar messagebar" "main main" !important }`. That `!important` grid has **no `breadcrumb` row** and beats the scoped `[b-hash].layout` grid where PR #404 added the row. So the breadcrumb bar (`grid-area: breadcrumb`) had no named area to land in and fell into an implicit bottom-right cell.

Diagnosed live: a computed-style probe on a DevLogin portal showed `.breadcrumb-bar` correctly getting `grid-area: breadcrumb`, but `.layout`'s effective `grid-template-areas` lacked the row (34px orphan track at `y:866`, bottom-right).

## Fix

Add the `"breadcrumb breadcrumb"` row (and matching `grid-template-rows`) to **all three** grid variants — base, `chat-position-right`, `chat-position-bottom` — in both `Memex.Portal.Distributed/wwwroot/app.css` and `Memex.Portal.Monolith/wwwroot/app.css`.

## Verification

CSS-only change (static `wwwroot` asset, nothing compiled). Being re-verified on a freshly-built local portal — the bar renders as a full-width row directly beneath the top bar on every page (home, doc pages). Will confirm on this PR.

## What's New

Skipped — this is a placement fix to the breadcrumb feature already announced by #404's What's New entry, not a new user-facing capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
