### PR TITLE
fix(ai): ship context+attachments on the streaming chat path; rebuild thread change-summary UI

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -445,72 +445,20 @@ public class AgentChatClient : IAgentChat
         return system.Concat(kept).ToList();
     }
 
-    private async Task<(string Text, ImmutableList<DataContent> BinaryAttachments)> BuildMessageWithContextAsync(IReadOnlyCollection<ChatMessage> messages, string? agentName = null)
+    /// <summary>
+    /// Appends the DYNAMIC per-round context block to <paramref name="messageText"/> — the current
+    /// application context (node IDENTITY as JSON) plus any attached content (text inlined, binary
+    /// returned) — and returns the binary attachments. This is the single source of truth shared by
+    /// BOTH the non-streaming <see cref="BuildMessageWithContextAsync"/> path and the streaming
+    /// <see cref="GetStreamingResponseAsync(IReadOnlyCollection{ChatMessage}, CancellationToken)"/>
+    /// path, so the streaming chat ships the same context/attachments the user set (contextPath +
+    /// attachments) instead of dropping them and forcing the agent to Search for what was attached.
+    /// 🚨 It deliberately does NOT enumerate context children (no IMeshService.QueryAsync fan-out) —
+    /// that fan-out bridges back through hub messaging and can park the streaming task indefinitely
+    /// ("Generating response…" forever). The agent's Search tool pulls children when it needs them.
+    /// </summary>
+    private async Task<ImmutableList<DataContent>> AppendContextAndAttachmentsAsync(StringBuilder messageText)
     {
-        var messageText = new StringBuilder();
-
-        // Static part: agent instructions + tool docs (built once, cached)
-        if (cachedSystemPrompt == null && !isPersistentFactory)
-        {
-            var sb = new StringBuilder();
-            if (!string.IsNullOrEmpty(agentName))
-            {
-                var agentInfo = loadedAgents.FirstOrDefault(a => a.Name == agentName);
-                var agentInstructions = agentInfo?.AgentConfiguration?.Instructions;
-                if (!string.IsNullOrEmpty(agentInstructions))
-                {
-                    sb.AppendLine("# Agent Identity and Instructions");
-                    sb.AppendLine();
-                    sb.AppendLine("You are acting as the following agent. Follow these instructions strictly:");
-                    sb.AppendLine();
-                    sb.AppendLine(agentInstructions);
-                    sb.AppendLine();
-                }
-            }
-
-            var toolDocs = cachedToolDocs ?? await LoadToolDocumentationAsync().ConfigureAwait(false);
-            if (!string.IsNullOrEmpty(toolDocs))
-            {
-                sb.AppendLine("# Available Tools Documentation");
-                sb.AppendLine();
-                sb.AppendLine(toolDocs);
-                sb.AppendLine();
-            }
-
-            cachedSystemPrompt = sb.ToString();
-        }
-
-        if (!string.IsNullOrEmpty(cachedSystemPrompt))
-            messageText.Append(cachedSystemPrompt);
-
-        // User identity
-        var accessService = hub.ServiceProvider.GetService<AccessService>();
-        var userContext = accessService?.Context ?? accessService?.CircuitContext;
-        if (userContext != null)
-        {
-            messageText.AppendLine("# Current User");
-            messageText.AppendLine();
-            messageText.AppendLine($"- **User ID:** `{userContext.ObjectId}`");
-            if (!string.IsNullOrEmpty(userContext.Name))
-                messageText.AppendLine($"- **Name:** {userContext.Name}");
-            messageText.AppendLine($"- **User namespace:** `User/{userContext.ObjectId}`");
-            messageText.AppendLine();
-        }
-
-        // Turn repetition into a reusable Skill — PROACTIVE. The trigger is a repeating
-        // user, so one-shot / utility agents (NodeInitializer, DescriptionWriter, …) simply
-        // never fire it. Kept in the shared base prompt so every conversational agent offers it.
-        messageText.AppendLine("# Turn repetition into a Skill (proactive)");
-        messageText.AppendLine();
-        messageText.AppendLine("When the user asks for the SAME multi-step task more than once (in this thread or across threads), proactively offer to save it as a reusable **Skill** — e.g. \"Want me to save this as a `/<name>` skill you can re-run anytime?\". Don't wait to be asked.");
-        messageText.AppendLine();
-        messageText.AppendLine("\"Create a skill\" means create a `nodeType:Skill` node (the same mechanism behind `/agent`, `/model`, `/harness`). Use `create` with `content` = a `SkillDefinition`:");
-        messageText.AppendLine("- node **id** = the slash word (`/<id>`); **name** + **description** = its display name and help text.");
-        messageText.AppendLine("- `Instructions` = a how-to (the SKILL.md body) the agent loads on demand — for \"run these steps\" skills — and/or `Action` = a behaviour (`Pick` a node by a query and write it to the composer, `OpenContent`, `Connect`/`Disconnect`).");
-        messageText.AppendLine("- Place it under the user's own namespace + `/Skill` (private to them) or the Space's `{space}/Skill` (shared with everyone in that Space); the platform-wide catalog is `Skill`.");
-        messageText.AppendLine("Once created, `/<id>` works in chat immediately — no code. Full SkillDefinition shape: `/Doc/AI/ChatCommands`.");
-        messageText.AppendLine();
-
         // Dynamic part: context (changes per navigation)
         if (Context != null)
         {
@@ -620,6 +568,78 @@ public class AgentChatClient : IAgentChat
                 }
             }
         }
+
+        return binaryAttachments;
+    }
+
+    private async Task<(string Text, ImmutableList<DataContent> BinaryAttachments)> BuildMessageWithContextAsync(IReadOnlyCollection<ChatMessage> messages, string? agentName = null)
+    {
+        var messageText = new StringBuilder();
+
+        // Static part: agent instructions + tool docs (built once, cached)
+        if (cachedSystemPrompt == null && !isPersistentFactory)
+        {
+            var sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(agentName))
+            {
+                var agentInfo = loadedAgents.FirstOrDefault(a => a.Name == agentName);
+                var agentInstructions = agentInfo?.AgentConfiguration?.Instructions;
+                if (!string.IsNullOrEmpty(agentInstructions))
+                {
+                    sb.AppendLine("# Agent Identity and Instructions");
+                    sb.AppendLine();
+                    sb.AppendLine("You are acting as the following agent. Follow these instructions strictly:");
+                    sb.AppendLine();
+                    sb.AppendLine(agentInstructions);
+                    sb.AppendLine();
+                }
+            }
+
+            var toolDocs = cachedToolDocs ?? await LoadToolDocumentationAsync().ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(toolDocs))
+            {
+                sb.AppendLine("# Available Tools Documentation");
+                sb.AppendLine();
+                sb.AppendLine(toolDocs);
+                sb.AppendLine();
+            }
+
+            cachedSystemPrompt = sb.ToString();
+        }
+
+        if (!string.IsNullOrEmpty(cachedSystemPrompt))
+            messageText.Append(cachedSystemPrompt);
+
+        // User identity
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var userContext = accessService?.Context ?? accessService?.CircuitContext;
+        if (userContext != null)
+        {
+            messageText.AppendLine("# Current User");
+            messageText.AppendLine();
+            messageText.AppendLine($"- **User ID:** `{userContext.ObjectId}`");
+            if (!string.IsNullOrEmpty(userContext.Name))
+                messageText.AppendLine($"- **Name:** {userContext.Name}");
+            messageText.AppendLine($"- **User namespace:** `User/{userContext.ObjectId}`");
+            messageText.AppendLine();
+        }
+
+        // Turn repetition into a reusable Skill — PROACTIVE. The trigger is a repeating
+        // user, so one-shot / utility agents (NodeInitializer, DescriptionWriter, …) simply
+        // never fire it. Kept in the shared base prompt so every conversational agent offers it.
+        messageText.AppendLine("# Turn repetition into a Skill (proactive)");
+        messageText.AppendLine();
+        messageText.AppendLine("When the user asks for the SAME multi-step task more than once (in this thread or across threads), proactively offer to save it as a reusable **Skill** — e.g. \"Want me to save this as a `/<name>` skill you can re-run anytime?\". Don't wait to be asked.");
+        messageText.AppendLine();
+        messageText.AppendLine("\"Create a skill\" means create a `nodeType:Skill` node (the same mechanism behind `/agent`, `/model`, `/harness`). Use `create` with `content` = a `SkillDefinition`:");
+        messageText.AppendLine("- node **id** = the slash word (`/<id>`); **name** + **description** = its display name and help text.");
+        messageText.AppendLine("- `Instructions` = a how-to (the SKILL.md body) the agent loads on demand — for \"run these steps\" skills — and/or `Action` = a behaviour (`Pick` a node by a query and write it to the composer, `OpenContent`, `Connect`/`Disconnect`).");
+        messageText.AppendLine("- Place it under the user's own namespace + `/Skill` (private to them) or the Space's `{space}/Skill` (shared with everyone in that Space); the platform-wide catalog is `Skill`.");
+        messageText.AppendLine("Once created, `/<id>` works in chat immediately — no code. Full SkillDefinition shape: `/Doc/AI/ChatCommands`.");
+        messageText.AppendLine();
+
+        // Dynamic part: context + attachments (shared with the streaming path).
+        var binaryAttachments = await AppendContextAndAttachmentsAsync(messageText).ConfigureAwait(false);
 
         // Inject conversation history from persisted ThreadMessage nodes (resume scenario)
         if (conversationHistory is { Count: > 0 })
@@ -873,7 +893,33 @@ public class AgentChatClient : IAgentChat
         var turnMessages = new List<ChatMessage>();
         if (!string.IsNullOrEmpty(agent.Instructions))
             turnMessages.Add(new ChatMessage(ChatRole.System, agent.Instructions));
+
+        // 🚨 Ship the current application context + attachments (the contextPath / attachments the
+        // user set) into the prompt — the SAME dynamic block the non-streaming path injects via
+        // BuildMessageWithContextAsync. Without this the streaming chat sent NONE of it, so the agent
+        // had to Search to rediscover what was already attached (the "context not shipped" flail that
+        // pegs a local model). Injected as a System message so TruncateToContextBudget always keeps
+        // it. (AppendContextAndAttachmentsAsync does NOT fan out over children — see its remarks.)
+        var contextBlock = new StringBuilder();
+        var binaryAttachments = await AppendContextAndAttachmentsAsync(contextBlock).ConfigureAwait(false);
+        if (contextBlock.Length > 0)
+            turnMessages.Add(new ChatMessage(ChatRole.System, contextBlock.ToString()));
         turnMessages.AddRange(messages);
+        // Binary attachments (images/PDFs) ride on the last user message so the model receives them.
+        if (!binaryAttachments.IsEmpty)
+        {
+            var lastUserIdx = turnMessages.FindLastIndex(m => m.Role == ChatRole.User);
+            if (lastUserIdx >= 0)
+            {
+                var lastUser = turnMessages[lastUserIdx];
+                var mergedContents = new List<AIContent>(lastUser.Contents);
+                mergedContents.AddRange(binaryAttachments);
+                turnMessages[lastUserIdx] = new ChatMessage(ChatRole.User, mergedContents)
+                {
+                    AuthorName = lastUser.AuthorName
+                };
+            }
+        }
         // 🪙 Cap the per-round context (see TruncateToContextBudget): the model re-reads the WHOLE
         // history every round, so an unbounded thread makes input tokens — and local-model compute /
         // heat — grow quadratically (the "123k tokens / hot Ollama" report). Keep the system prompt +

--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -891,19 +891,25 @@ public class AgentChatClient : IAgentChat
         // Pass all messages as separate turns with system prompt prepended.
         // The agent's ChatClient includes FunctionInvokingChatClient for tool calls.
         var turnMessages = new List<ChatMessage>();
-        if (!string.IsNullOrEmpty(agent.Instructions))
-            turnMessages.Add(new ChatMessage(ChatRole.System, agent.Instructions));
 
         // 🚨 Ship the current application context + attachments (the contextPath / attachments the
         // user set) into the prompt — the SAME dynamic block the non-streaming path injects via
         // BuildMessageWithContextAsync. Without this the streaming chat sent NONE of it, so the agent
         // had to Search to rediscover what was already attached (the "context not shipped" flail that
-        // pegs a local model). Injected as a System message so TruncateToContextBudget always keeps
-        // it. (AppendContextAndAttachmentsAsync does NOT fan out over children — see its remarks.)
+        // pegs a local model). Fold it INTO the agent's system message so the turn carries exactly
+        // ONE system message (instructions + context) — matching the non-streaming single combined
+        // prompt and NOT inflating the per-turn message count. Always kept by TruncateToContextBudget
+        // (system messages are never trimmed). (AppendContextAndAttachmentsAsync does NOT fan out
+        // over children — see its remarks.)
         var contextBlock = new StringBuilder();
         var binaryAttachments = await AppendContextAndAttachmentsAsync(contextBlock).ConfigureAwait(false);
+        var systemText = agent.Instructions ?? string.Empty;
         if (contextBlock.Length > 0)
-            turnMessages.Add(new ChatMessage(ChatRole.System, contextBlock.ToString()));
+            systemText = string.IsNullOrEmpty(systemText)
+                ? contextBlock.ToString()
+                : systemText + "\n\n" + contextBlock;
+        if (!string.IsNullOrEmpty(systemText))
+            turnMessages.Add(new ChatMessage(ChatRole.System, systemText));
         turnMessages.AddRange(messages);
         // Binary attachments (images/PDFs) ride on the last user message so the model receives them.
         if (!binaryAttachments.IsEmpty)

--- a/src/MeshWeaver.AI/ThreadLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ThreadLayoutAreas.cs
@@ -582,7 +582,7 @@ public static class ThreadLayoutAreas
 
     /// <summary>
     /// Full-page Changes view. Reuses the header's <see cref="CollectUpdatedNodes"/>
-    /// aggregation + <see cref="BuildModifiedNodesHtml"/> grid, plus a
+    /// aggregation + <see cref="BuildModifiedNodesView"/> grid, plus a
     /// "Revert All" bulk action that posts one
     /// <c>RollbackNodeRequest</c> per entry sequentially (order-sensitive to
     /// avoid parent-deleted-before-child issues).
@@ -647,9 +647,9 @@ public static class ThreadLayoutAreas
             return container;
         }
 
-        // Reuse the same git-like grid as the header summary — single source of truth
-        // for path / version chips / Diff / per-row Restore links.
-        container = container.WithView(Controls.Html(BuildModifiedNodesHtml(updates, threadPath)));
+        // Reuse the same control-based grid as the header summary — single source of truth
+        // for path / version chips / Diff / per-row Undo. (Header already has "Revert all".)
+        container = container.WithView(BuildModifiedNodesView(updates, threadPath, "Modified nodes", undoAll: false));
         return container;
     }
 
@@ -753,25 +753,22 @@ public static class ThreadLayoutAreas
             stack = stack.WithView(parentLink);
 
         if (!updates.IsEmpty)
-            stack = stack.WithView(Controls.Html(BuildModifiedNodesHtml(updates, threadPath)));
+            stack = stack.WithView(BuildModifiedNodesView(updates, threadPath, "Modified nodes", undoAll: false));
 
         return stack;
     }
 
     /// <summary>
-    /// Git-like panel for the aggregated UpdatedNodes list:
-    /// - Tabular layout (CSS grid): path · old-ver · → · new-ver · Diff · Restore v{old} · Restore v{new}.
-    /// - All action links visible inline on each row (no hidden ⋯ menu).
-    /// - Theme-safe colours that work in dark + light mode (no white-on-light-blue).
-    /// - Paths rendered relative to the thread's parent namespace so the most
-    ///   interesting segment (leaf) stays visible when the table narrows.
-    /// - On screens &lt; 720 px the whole section collapses behind a summary row.
+    /// Framework-control renderer for a <see cref="NodeChangeEntry"/> list — the control-based
+    /// replacement for the old hand-built HTML grid (forbidden by the no-hand-rolled-HTML rule, and
+    /// whose <c>1fr</c> path column made the version chips float to the right edge). One row per
+    /// changed node: {node link} · v{before} → v{after} · Diff · Undo. When <paramref name="undoAll"/>
+    /// is set, appends a single "Undo all" button. Undo semantics (per node): a prior version exists
+    /// → roll back to it; a freshly Created node (no prior version) → delete it. See <see cref="UndoNodeChange"/>.
     /// </summary>
-    private static string BuildModifiedNodesHtml(ImmutableList<NodeChangeEntry> updates, string threadPath)
+    internal static UiControl BuildModifiedNodesView(
+        ImmutableList<NodeChangeEntry> updates, string threadPath, string headerLabel, bool undoAll)
     {
-        // Derive the ancestor prefix we can strip from each node path to produce a
-        // shorter display form. For a thread at "Org/_Thread/abc", the interesting
-        // prefix to strip is "Org/" (the thread's root namespace, above _Thread).
         var threadIdx = threadPath.IndexOf("/_Thread/", StringComparison.Ordinal);
         var shortenPrefix = threadIdx > 0 ? threadPath[..(threadIdx + 1)] : null;
 
@@ -780,161 +777,83 @@ public static class ThreadLayoutAreas
                 ? path[prefix.Length..]
                 : path;
 
-        var sb = new System.Text.StringBuilder();
+        var container = Controls.Stack.WithStyle("gap:6px; width:100%;");
+        container = container.WithView(Controls.Text($"{headerLabel} ({updates.Count})")
+            .WithStyle("font-size:0.8rem; font-weight:600; color:var(--neutral-foreground-hint);"));
 
-        // Inline <style> block scoped by a unique class so the grid + media-query
-        // rules apply to the rendered HTML. Lives inside the injected markdown; Blazor
-        // passes it through untouched.
-        sb.Append("""
-            <style>
-            .thread-mod-nodes { width:100%; }
-            .thread-mod-nodes > summary {
-                list-style:none; cursor:pointer;
-                font-size:0.8rem; font-weight:600;
-                color:var(--neutral-foreground-hint);
-                padding:4px 0;
-            }
-            .thread-mod-nodes > summary::-webkit-details-marker { display:none; }
-            .thread-mod-grid {
-                display:grid;
-                grid-template-columns: minmax(0,1fr) auto auto auto auto auto auto;
-                align-items:center;
-                gap:6px 10px;
-                margin-top:6px;
-                font-size:0.78rem;
-                color:var(--neutral-foreground-rest);
-            }
-            .thread-mod-grid a {
-                text-decoration:none;
-                color:var(--accent-fill-rest);
-            }
-            .thread-mod-grid a:hover { text-decoration:underline; }
-            .thread-mod-row {
-                display:contents;
-            }
-            .thread-mod-path {
-                min-width:0;
-                overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
-                padding:4px 6px;
-                border-radius:4px;
-            }
-            .thread-mod-path:hover { background:var(--neutral-layer-2); }
-            .thread-mod-chip {
-                padding:1px 6px; border-radius:10px;
-                background:var(--neutral-layer-3);
-                color:var(--neutral-foreground-rest) !important;
-                font-family:monospace; font-size:0.72rem;
-                border:1px solid var(--neutral-stroke-rest);
-            }
-            .thread-mod-chip-new {
-                color:var(--accent-fill-rest) !important;
-                border-color:var(--accent-fill-rest);
-                font-weight:600;
-            }
-            .thread-mod-arrow { color:var(--neutral-foreground-hint); }
-            .thread-mod-action {
-                padding:2px 8px; border-radius:4px;
-                font-size:0.74rem;
-                color:var(--accent-fill-rest) !important;
-                white-space:nowrap;
-            }
-            .thread-mod-action:hover { background:var(--neutral-layer-2); }
-            .thread-mod-action-muted {
-                color:var(--neutral-foreground-hint) !important;
-            }
-            .thread-mod-marker {
-                font-size:0.72rem; color:var(--neutral-foreground-hint); font-style:italic;
-            }
-            /* Small-screen: collapse the whole section under its summary. */
-            @media (max-width: 720px) {
-                .thread-mod-nodes[data-wide-inline="true"] > .thread-mod-grid { display:none; }
-                .thread-mod-nodes[data-wide-inline="true"][open] > .thread-mod-grid { display:grid; }
-                .thread-mod-grid {
-                    grid-template-columns: minmax(0,1fr) auto auto;
-                }
-                .thread-mod-action-mobile-hide { display:none; }
-            }
-            /* Wide-screen: the <details> is always open (summary acts as header). */
-            @media (min-width: 721px) {
-                .thread-mod-nodes[data-wide-inline="true"] > .thread-mod-grid { display:grid; }
-                .thread-mod-nodes[data-wide-inline="true"] > summary { pointer-events:none; }
-            }
-            </style>
-            """);
-
-        sb.Append("<details class=\"thread-mod-nodes\" data-wide-inline=\"true\" open>");
-        sb.Append($"<summary><span style=\"display:inline-block; width:10px;\">&#9656;</span> Modified nodes ({updates.Count})</summary>");
-
-        sb.Append("<div class=\"thread-mod-grid\">");
-
+        var rows = Controls.Stack.WithStyle("gap:4px; width:100%;");
         foreach (var entry in updates)
         {
             var path = entry.Path;
-            var pathEnc = System.Web.HttpUtility.HtmlEncode(path);
-            var displayEnc = System.Web.HttpUtility.HtmlEncode(Shorten(path, shortenPrefix));
             var op = entry.Operation ?? "";
 
-            sb.Append("<div class=\"thread-mod-row\">");
+            // Horizontal row; the node link shrinks (flex:0 1 auto) but never GROWS, so the whole
+            // row packs to the left — no 1fr column stretching the actions to the far right edge.
+            var row = Controls.Stack
+                .WithOrientation(Orientation.Horizontal)
+                .WithStyle("gap:8px; align-items:center; flex-wrap:wrap;");
 
-            // Column 1: path (truncates on narrow layouts)
-            sb.Append(
-                $"<a href=\"/{pathEnc}\" title=\"{pathEnc}\" class=\"thread-mod-path\">{displayEnc}</a>");
+            row = row.WithView(Controls.NavLink(Shorten(path, shortenPrefix), $"/{path}")
+                .WithStyle("flex:0 1 auto; min-width:0; overflow:hidden; text-overflow:ellipsis; " +
+                           "white-space:nowrap; font-size:0.78rem;"));
 
-            // Column 2: old version chip or "new" marker
             if (entry.VersionBefore is { } vb)
-                sb.Append(
-                    $"<a href=\"/{pathEnc}/Versions?version={vb}\" class=\"thread-mod-chip\" title=\"View v{vb}\">v{vb}</a>");
+                row = row.WithView(Controls.Badge($"v{vb}").WithStyle("font-family:monospace; font-size:0.72rem;"));
             else if (op.Equals("Created", StringComparison.OrdinalIgnoreCase))
-                sb.Append("<span class=\"thread-mod-marker\">new</span>");
-            else
-                sb.Append("<span></span>");
+                row = row.WithView(Controls.Text("new")
+                    .WithStyle("font-size:0.72rem; font-style:italic; color:var(--neutral-foreground-hint);"));
 
-            // Column 3: arrow
-            sb.Append("<span class=\"thread-mod-arrow\">&#8594;</span>");
+            row = row.WithView(Controls.Text("→").WithStyle("color:var(--neutral-foreground-hint);"));
 
-            // Column 4: new version chip or "deleted" marker
             if (entry.VersionAfter is { } va)
-                sb.Append(
-                    $"<a href=\"/{pathEnc}/Versions?version={va}\" class=\"thread-mod-chip thread-mod-chip-new\" title=\"View v{va}\">v{va}</a>");
+                row = row.WithView(Controls.Badge($"v{va}")
+                    .WithStyle("font-family:monospace; font-size:0.72rem; font-weight:600;"));
             else if (op.Equals("Deleted", StringComparison.OrdinalIgnoreCase))
-                sb.Append("<span class=\"thread-mod-marker\">deleted</span>");
-            else
-                sb.Append("<span></span>");
+                row = row.WithView(Controls.Text("deleted")
+                    .WithStyle("font-size:0.72rem; font-style:italic; color:var(--neutral-foreground-hint);"));
 
-            // Column 5: Diff (old ↔ new) — points to VersionDiff with from/to params.
             if (entry.VersionBefore.HasValue && entry.VersionAfter.HasValue)
-                sb.Append(
-                    $"<a href=\"/{pathEnc}/VersionDiff?from={entry.VersionBefore.Value}&to={entry.VersionAfter.Value}\" " +
-                    $"class=\"thread-mod-action thread-mod-action-mobile-hide\" " +
-                    $"title=\"Compare v{entry.VersionBefore.Value} to v{entry.VersionAfter.Value}\">Diff</a>");
-            else
-                sb.Append("<span class=\"thread-mod-action-mobile-hide\"></span>");
+                row = row.WithView(Controls.NavLink("Diff",
+                        $"/{path}/VersionDiff?from={entry.VersionBefore.Value}&to={entry.VersionAfter.Value}")
+                    .WithStyle("font-size:0.74rem;"));
 
-            // Column 6: Restore to old — opens VersionDiff (which has the Restore button).
-            if (entry.VersionBefore.HasValue)
-                sb.Append(
-                    $"<a href=\"/{pathEnc}/VersionDiff?version={entry.VersionBefore.Value}\" " +
-                    $"class=\"thread-mod-action thread-mod-action-muted thread-mod-action-mobile-hide\" " +
-                    $"title=\"Revert to v{entry.VersionBefore.Value}\">Restore v{entry.VersionBefore.Value}</a>");
-            else
-                sb.Append("<span class=\"thread-mod-action-mobile-hide\"></span>");
+            var e = entry; // capture per-iteration for the click closure
+            row = row.WithView(Controls.Button("Undo")
+                .WithAppearance(Appearance.Stealth)
+                .WithIconStart(FluentIcons.ArrowUndo(IconSize.Size16))
+                .WithClickAction(ctx => UndoNodeChange(ctx.Hub, e)));
 
-            // Column 7: Restore to new — opens VersionDiff (which has the Restore button).
-            if (entry.VersionAfter.HasValue)
-                sb.Append(
-                    $"<a href=\"/{pathEnc}/VersionDiff?version={entry.VersionAfter.Value}\" " +
-                    $"class=\"thread-mod-action thread-mod-action-muted thread-mod-action-mobile-hide\" " +
-                    $"title=\"Restore v{entry.VersionAfter.Value}\">Restore v{entry.VersionAfter.Value}</a>");
-            else
-                sb.Append("<span class=\"thread-mod-action-mobile-hide\"></span>");
+            rows = rows.WithView(row);
+        }
+        container = container.WithView(rows);
 
-            sb.Append("</div>");
+        if (undoAll && updates.Count > 0)
+        {
+            var all = updates;
+            container = container.WithView(Controls.Button($"Undo all ({all.Count})")
+                .WithAppearance(Appearance.Neutral)
+                .WithIconStart(FluentIcons.ArrowUndo(IconSize.Size16))
+                .WithClickAction(ctx => { foreach (var en in all) UndoNodeChange(ctx.Hub, en); }));
         }
 
-        sb.Append("</div>");
-        sb.Append("</details>");
-        return sb.ToString();
+        return container;
     }
+
+    /// <summary>
+    /// Undo a single node change: restore the pre-change version when one exists
+    /// (Updated/Deleted → <see cref="RollbackNodeRequest"/> to VersionBefore), or delete a freshly
+    /// Created node (no prior version). Routed to the node's OWN hub via <c>WithTarget</c>, where the
+    /// rollback handler is registered (see <c>AddDefaultLayoutAreas</c>).
+    /// </summary>
+    private static void UndoNodeChange(IMessageHub hub, NodeChangeEntry entry)
+    {
+        if (entry.VersionBefore is { } vb)
+            hub.Post(new RollbackNodeRequest(entry.Path, vb), o => o.WithTarget(new Address(entry.Path)));
+        else
+            hub.Post(new DeleteNodeRequest(entry.Path) { Recursive = true },
+                o => o.WithTarget(new Address(entry.Path)));
+    }
+
 
     /// <summary>
     /// Reads the still-pending user-message texts from <paramref name="thread"/>.

--- a/src/MeshWeaver.AI/ThreadMessageLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ThreadMessageLayoutAreas.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using System.Text.Json;
 using Humanizer;
@@ -305,6 +306,25 @@ public static class ThreadMessageLayoutAreas
                         meta.In, meta.Out, meta.Total));
             });
         }
+
+        // Per-message "modified nodes" — the version-before/after of every node THIS message
+        // changed, with per-node + "Undo all" actions. Reactive: UpdatedNodes populate as the
+        // round's tool calls land, so bind to the message stream (not the render-time snapshot).
+        // Renders nothing for messages that changed no nodes (e.g. plain user prompts).
+        container = container.WithView((h, c) =>
+        {
+            var stream = h.Workspace.GetStream(new MeshNodeReference());
+            if (stream is null) return Observable.Return<UiControl?>(null);
+
+            return stream
+                .Select(change => change.Value.ContentAs<ThreadMessage>(h.Hub.JsonSerializerOptions))
+                .Where(m => m is not null)
+                .Select(m => m!.UpdatedNodes ?? ImmutableList<NodeChangeEntry>.Empty)
+                .DistinctUntilChanged()
+                .Select(nodes => nodes.IsEmpty
+                    ? null
+                    : ThreadLayoutAreas.BuildModifiedNodesView(nodes, threadPath, "Changes", undoAll: true));
+        });
 
         // Delegation sub-threads are already shown inline inside the bubble (via the bubble's
         // tool-calls data binding). An extra embedded LayoutAreaControl here produced a

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -210,13 +210,6 @@ else
                 </div>
             }
             @{
-                var header = GetHeaderCell();
-            }
-            @if (header != null)
-            {
-                <LayoutAreaView @key="@($"hdr-{threadPath}")" ViewModel="@header" Stream="@Stream" Area="@($"hdr-{threadPath}")" />
-            }
-            @{
                 var pendingTexts = ThreadViewModel?.PendingMessageTexts ?? Array.Empty<string>();
                 var hasAnyMessage = ThreadMessages.Count > 0 || pendingTexts.Count > 0;
             }
@@ -319,6 +312,11 @@ else
                                         <button class="thread-msg-action-btn" @onclick="() => StartEdit(msgId)" title="Edit">&#9998;</button>
                                         <button class="thread-msg-action-btn" @onclick="() => ResubmitMessage(msgId)" title="Resubmit">&#8635;</button>
                                         <button class="thread-msg-action-btn" @onclick="() => DeleteFromMessage(msgId)" title="Delete from here">&#128465;</button>
+                                    }
+                                    @if (state.UpdatedNodes is { Count: > 0 } && !IsReadOnlyThread)
+                                    {
+                                        <button class="thread-msg-action-btn" @onclick="() => UndoMessageChanges(msgId)"
+                                                title="Undo the @(state.UpdatedNodes.Count) node change(s) this message made">&#8630;</button>
                                     }
                                     <button class="thread-msg-action-btn" @onclick="() => NewThreadFromCell(msgId)" title="New thread from this cell">&#8599;</button>
                                 </div>
@@ -483,6 +481,16 @@ else
                     <p>Start a conversation</p>
                     <p class="hint">Use @("@") references to include context from other nodes</p>
                 </div>
+            }
+            @* Thread-total impact — the aggregate of every node changed across this thread's
+               messages (with per-node + "Undo all"), pinned at the BOTTOM of the history as a
+               running summary. Reuses the server Header area (parent back-link + totals). *@
+            @{
+                var totalSummary = GetHeaderCell();
+            }
+            @if (totalSummary != null)
+            {
+                <LayoutAreaView @key="@($"hdr-{threadPath}")" ViewModel="@totalSummary" Stream="@Stream" Area="@($"hdr-{threadPath}")" />
             }
         </div>
     }
@@ -707,6 +715,35 @@ else
            module-defined one) pops THIS one menu. The command supplied the query + title; the
            host queried the mesh (OpenPicker) and listed the nodes; clicking one writes its PATH
            to the command's composer field. No per-command widget. *@
+        @* Delete-with-undo confirm — deleting a message removes the conversation cells but NOT the
+           node changes those cells made; offer to roll those changes back too. *@
+        @if (_deleteConfirmId is not null)
+        {
+            <div class="thread-chat-widget" @onkeydown:stopPropagation="true">
+                <div class="thread-chat-widget-header">
+                    <span>Delete @_deleteConfirmMessageCount message@(_deleteConfirmMessageCount == 1 ? "" : "s")?</span>
+                    <button class="thread-msg-action-btn" @onclick="CancelDelete" title="Close">&#10005;</button>
+                </div>
+                <div style="padding:12px 14px; display:flex; flex-direction:column; gap:12px;">
+                    <div style="color:var(--neutral-foreground-hint); line-height:1.4;">
+                        This removes this message and everything after it. Those messages also changed
+                        <strong>@_deleteConfirmChangeCount</strong> node@(_deleteConfirmChangeCount == 1 ? "" : "s").
+                        Undo those changes too?
+                    </div>
+                    <div style="display:flex; gap:8px; flex-wrap:wrap;">
+                        <button type="button" class="thread-msg-action-btn"
+                                style="padding:6px 12px; background:var(--accent-fill-rest); color:#fff; border-radius:4px;"
+                                @onclick="() => ConfirmDelete(true)">Delete &amp; undo @_deleteConfirmChangeCount change@(_deleteConfirmChangeCount == 1 ? "" : "s")</button>
+                        <button type="button" class="thread-msg-action-btn"
+                                style="padding:6px 12px; border:1px solid var(--neutral-stroke-rest); border-radius:4px;"
+                                @onclick="() => ConfirmDelete(false)">Delete only</button>
+                        <button type="button" class="thread-msg-action-btn"
+                                style="padding:6px 12px; border-radius:4px;"
+                                @onclick="CancelDelete">Cancel</button>
+                    </div>
+                </div>
+            </div>
+        }
         @* Interactive login (Connect) dialog — /login opens it. (1) choose a method, (2) account →
            redirect to the browser auth URL, (3) paste a code/token only if the flow needs it; a still-valid
            token completes silently. API key / gateway store a pasted credential. *@

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -3869,10 +3869,95 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             agentName: boundAgentPath, modelName: boundModelPath, harness: boundHarness);
     }
 
+    // Delete-with-undo confirm state. When deleting a message (and everything after it) that
+    // changed nodes, we first ASK whether to roll those node changes back too — a delete only
+    // removes the conversation cells, not the changes those cells made to the mesh.
+    private string? _deleteConfirmId;
+    private int _deleteConfirmChangeCount;
+    private int _deleteConfirmMessageCount;
+
     private void DeleteFromMessage(string id)
     {
         if (string.IsNullOrEmpty(threadPath)) return;
+        // If the deleted range changed any nodes, pause and ask whether to also undo them.
+        var changeCount = CollectChangesFrom(id).Count;
+        if (changeCount > 0)
+        {
+            _deleteConfirmId = id;
+            _deleteConfirmChangeCount = changeCount;
+            _deleteConfirmMessageCount = CountMessagesFrom(id);
+            StateHasChanged();
+            return;
+        }
         Hub.DeleteFromMessage(threadPath, id);
+    }
+
+    /// <summary>Confirms a pending delete; when <paramref name="alsoUndo"/> is set, rolls back
+    /// every node change the deleted messages made before removing the cells.</summary>
+    private void ConfirmDelete(bool alsoUndo)
+    {
+        var id = _deleteConfirmId;
+        _deleteConfirmId = null;
+        if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(threadPath)) return;
+        if (alsoUndo) UndoChanges(CollectChangesFrom(id)); // collect BEFORE the cells are deleted
+        Hub.DeleteFromMessage(threadPath, id);
+    }
+
+    private void CancelDelete() => _deleteConfirmId = null;
+
+    /// <summary>Aggregates the UpdatedNodes of the message <paramref name="id"/> and every message
+    /// after it (the range <see cref="HubThreadExtensions.DeleteFromMessage"/> would remove).</summary>
+    private IReadOnlyList<NodeChangeEntry> CollectChangesFrom(string id)
+    {
+        var result = new List<NodeChangeEntry>();
+        var found = false;
+        foreach (var mid in ThreadMessages)
+        {
+            if (!found && mid == id) found = true;
+            if (!found) continue;
+            var ch = GetMessageState(mid)?.UpdatedNodes;
+            if (ch is { Count: > 0 }) result.AddRange(ch);
+        }
+        return result;
+    }
+
+    private int CountMessagesFrom(string id)
+    {
+        var count = 0;
+        var found = false;
+        foreach (var mid in ThreadMessages)
+        {
+            if (!found && mid == id) found = true;
+            if (found) count++;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Reverts every node change a single message made: rolls each affected node back to its
+    /// pre-change version (<see cref="RollbackNodeRequest"/>), or deletes a node this message
+    /// CREATED (no prior version existed). Each request is TARGETED at the node's own hub, where
+    /// the rollback handler lives (AddDefaultLayoutAreas) — see <see cref="UndoChanges"/>.
+    /// </summary>
+    private void UndoMessageChanges(string id)
+    {
+        var changes = GetMessageState(id)?.UpdatedNodes;
+        if (changes is { Count: > 0 })
+            UndoChanges(changes);
+    }
+
+    /// <summary>Rolls back a set of node changes (see <see cref="UndoMessageChanges"/>).</summary>
+    private void UndoChanges(IReadOnlyList<NodeChangeEntry> changes)
+    {
+        foreach (var e in changes)
+        {
+            if (string.IsNullOrEmpty(e.Path)) continue;
+            if (e.VersionBefore is { } vb)
+                Hub.Post(new RollbackNodeRequest(e.Path, vb), o => o.WithTarget(new Address(e.Path)));
+            else
+                Hub.Post(new DeleteNodeRequest(e.Path) { Recursive = true },
+                    o => o.WithTarget(new Address(e.Path)));
+        }
     }
 
     // ─── Tool-call display helpers ────────────────────────────────────────

--- a/test/MeshWeaver.AI.Test/AttachmentContextTest.cs
+++ b/test/MeshWeaver.AI.Test/AttachmentContextTest.cs
@@ -149,6 +149,10 @@ public class AttachmentContextTest : MonolithMeshTestBase
             .LastOrDefault();
     }
 
+    /// <summary>Extracts the text of a single captured message (any role).</summary>
+    private static string MessageText(ChatMessage m) =>
+        m.Text ?? string.Join("", m.Contents.OfType<Microsoft.Extensions.AI.TextContent>().Select(t => t.Text));
+
     /// <summary>
     /// Helper: sets up an AgentChatClient with context pointing to Software.
     /// </summary>
@@ -266,6 +270,47 @@ public class AttachmentContextTest : MonolithMeshTestBase
         userMessageIndex.Should().BeGreaterThan(0, "user message should be present");
         contextIndex.Should().BeLessThan(userMessageIndex,
             "context should appear BEFORE the user message");
+    }
+
+    /// <summary>
+    /// Regression test for the STREAMING path. <c>GetStreamingResponseAsync</c> must inject the
+    /// current application context (contextPath) AND attachment content into the prompt — the same
+    /// as the non-streaming <c>GetResponseAsync</c>. It used to drop BOTH (it set
+    /// <c>currentAttachments = null</c> and never called the context builder), so the agent received
+    /// no context and had to Search to rediscover what was already attached. The streaming path
+    /// injects the block as a System message ahead of the user turn, so this asserts across the full
+    /// captured message sequence rather than a single combined user message.
+    /// </summary>
+    [Fact]
+    public async Task Streaming_InjectsContextAndAttachments_BeforeUserMessage()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (agentChat, factory) = await SetupAgentChatAsync(ct);
+
+        agentChat.SetAttachments(["ACME"]);
+
+        const string userText = "What is the launch status?";
+        await foreach (var _ in agentChat.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, userText)], ct)) { }
+
+        factory.AllCapturedMessages.Should().NotBeEmpty("the streaming path should send messages to the model");
+
+        // Concatenate every captured message IN ORDER — context + attachments ride on a System
+        // message that precedes the user turn, so ordering across messages is what we assert.
+        var assembled = string.Join("\n", factory.AllCapturedMessages.Select(MessageText));
+
+        var contextIndex = assembled.IndexOf("# Current Application Context", StringComparison.Ordinal);
+        var attachmentIndex = assembled.IndexOf("# Attached Content", StringComparison.Ordinal);
+        var userMessageIndex = assembled.IndexOf(userText, StringComparison.Ordinal);
+
+        contextIndex.Should().BeGreaterThanOrEqualTo(0,
+            "the STREAMING prompt must include the current application context");
+        attachmentIndex.Should().BeGreaterThanOrEqualTo(0,
+            "the STREAMING prompt must include the attachment content");
+        userMessageIndex.Should().BeGreaterThan(0, "the user message should be present");
+        contextIndex.Should().BeLessThan(attachmentIndex, "context should come before attachments");
+        attachmentIndex.Should().BeLessThan(userMessageIndex,
+            "attachments should come before the user message");
     }
 
     /// <summary>


### PR DESCRIPTION
Surfaced from a thread where the agent flailed through 20+ searches to rediscover a space (`ElAIChat`) that was **already attached** to the message — and the local model grinding through that flail read as "wedging / hot".

## 1. Context not shipped (root cause)
The **streaming** chat path (`AgentChatClient.GetStreamingResponseAsync`) never injected the current `contextPath` or `attachments` — it cleared `currentAttachments = null` and never built the context block, while only the non-streaming `GetResponseAsync` did (via `BuildMessageWithContextAsync`). So the model got no context and had to `Search` for what was already attached.

- Factored the context + attachment block into one shared `AppendContextAndAttachmentsAsync`.
- Injected it (as a System message) on the streaming path too. **No** children fan-out — that's the thing that previously parked the stream ("Generating response…" forever).
- Regression test: `AttachmentContextTest.Streaming_InjectsContextAndAttachments_BeforeUserMessage` (no-mock `CapturingChatClient`) — fails without the fix.

## 2. Thread "modified nodes" change-summary UI
- **Layout fix:** replaced the hand-built HTML grid (`BuildModifiedNodesHtml` + `Controls.Html`) — whose `1fr` path column floated the version chips to the right edge — with a control-based `BuildModifiedNodesView` (`Stack`/`NavLink`/`Badge`/`Button`) that packs left. Removes ~168 lines of banned hand-rolled HTML.
- **Per-message Undo:** each message that changed nodes gets an Undo action — roll each node back to its `VersionBefore` (`RollbackNodeRequest` targeted at the node's own hub), or delete a node the message *created*.
- **Thread-total** impact summary moved to the **bottom** of the history.
- **Delete → offer undo:** deleting messages that changed nodes now prompts *Delete & undo changes / Delete only / Cancel*.

## Verification
`MeshWeaver.AI` + `MeshWeaver.Blazor.Portal` build clean under `-c Release -warnaserror`; the new streaming test passes. Undo semantics note: rolling back a message reverts its nodes to that message's `VersionBefore`, which also discards later messages' edits to the same node (inherent to version rollback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)