### PR TITLE
Auth mirror: restore 'Space' + make it self-healing; Doc space cover

### DIFF
--- a/memex/aspire/Memex.Database.Migration/Migrations/V42_ReapplySpaceAuthMirrorAndBackfill.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V42_ReapplySpaceAuthMirrorAndBackfill.cs
@@ -1,0 +1,144 @@
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Database.Migration.Migrations;
+
+/// <summary>
+/// Repairs the <b>lost <c>'Space'</c> extension of the auth mirror</b> and backfills the
+/// Space rows that went missing while it was broken.
+///
+/// <para><b>Background.</b> V28 extended <c>public.mirror_access_object_to_auth_schema()</c>
+/// to mirror <c>node_type='Space'</c> rows into <c>auth.mesh_nodes</c> — the single-schema
+/// lookup behind the Spaces catalog. But the always-run schema initializer
+/// (<c>PostgreSqlSchemaInitializer.GetAuthMirrorFunctionScript</c>) re-creates that function
+/// on every startup from its own constant, which did NOT include <c>'Space'</c> — so the very
+/// next restart silently reverted V28. Every Space created after that revert (RolePlay, X,
+/// Chess, … 2026-07) has a fully working partition, grants and content but no row in
+/// <c>auth.mesh_nodes</c> — invisible in the Spaces catalog. The initializer's constant is
+/// fixed in the same change set; this migration repairs already-deployed databases.</para>
+///
+/// <para>Two steps, both idempotent:</para>
+/// <list type="number">
+///   <item><b>Re-create the function WITH <c>'Space'</c></b> (both the upsert and the delete
+///     branch). Frozen inline SQL — a migration must not depend on live code that keeps
+///     evolving; this body matches the initializer's constant as of V42.</item>
+///   <item><b>Backfill</b>: copy every <c>node_type='Space'</c> row from every content-partition
+///     schema into <c>auth.mesh_nodes</c> (<c>ON CONFLICT … DO UPDATE</c>), mirroring V28's
+///     backfill — needed because the trigger only covers writes from now on.</item>
+/// </list>
+///
+/// <para><b>Belt and braces.</b> The same change set makes the mirror SELF-HEALING: the always-run
+/// schema init (<c>PostgreSqlSchemaInitializer.GetAuthMirrorSelfHealScript</c>, step 5 of
+/// <c>InitializeAsync</c>) re-installs missing partition triggers and reconciles missed/stale
+/// mirrored rows on every boot. This migration remains as the recorded, ordered repair for
+/// deployed databases (and heals DBs whose next boot predates the new initializer).</para>
+/// </summary>
+public sealed class V42_ReapplySpaceAuthMirrorAndBackfill : IMigration
+{
+    public int Version => 42;
+    public string Description => "Re-apply 'Space' to the auth mirror function (lost to the schema-init constant) and backfill missing Space rows into auth.mesh_nodes";
+
+    public async Task RunAsync(MigrationContext ctx)
+    {
+        // 1. Re-create the mirror function WITH 'Space' in both branches. CREATE OR REPLACE →
+        //    safe against any prior state; the fail-safe guard keeps partitions writable even
+        //    when auth isn't provisioned.
+        await using (var fn = ctx.DataSource.CreateCommand("""
+            CREATE OR REPLACE FUNCTION public.mirror_access_object_to_auth_schema()
+            RETURNS TRIGGER AS $auth_mirror$
+            BEGIN
+                IF to_regclass('"auth".mesh_nodes') IS NULL THEN
+                    RETURN COALESCE(NEW, OLD);
+                END IF;
+
+                IF TG_OP = 'DELETE' THEN
+                    IF OLD.node_type IN ('User','Group','Role','VUser','ApiToken','Space') THEN
+                        DELETE FROM "auth".mesh_nodes
+                         WHERE namespace = OLD.namespace AND id = OLD.id;
+                    END IF;
+                    RETURN OLD;
+                END IF;
+
+                IF NEW.node_type IN ('User','Group','Role','VUser','ApiToken','Space') THEN
+                    INSERT INTO "auth".mesh_nodes
+                        (namespace, id, name, node_type, category, icon, display_order,
+                         last_modified, version, state, content, desired_id, main_node)
+                    VALUES (NEW.namespace, NEW.id, NEW.name, NEW.node_type, NEW.category, NEW.icon, NEW.display_order,
+                            NEW.last_modified, NEW.version, NEW.state, NEW.content, NEW.desired_id, NEW.main_node)
+                    ON CONFLICT (namespace, id) DO UPDATE SET
+                        name = EXCLUDED.name,
+                        node_type = EXCLUDED.node_type,
+                        category = EXCLUDED.category,
+                        icon = EXCLUDED.icon,
+                        display_order = EXCLUDED.display_order,
+                        last_modified = EXCLUDED.last_modified,
+                        version = EXCLUDED.version,
+                        state = EXCLUDED.state,
+                        content = EXCLUDED.content,
+                        desired_id = EXCLUDED.desired_id,
+                        main_node = EXCLUDED.main_node;
+                END IF;
+                RETURN NEW;
+            END;
+            $auth_mirror$ LANGUAGE plpgsql;
+            """))
+        {
+            await fn.ExecuteNonQueryAsync();
+            ctx.Logger.LogInformation("Repair v42: re-created mirror_access_object_to_auth_schema WITH 'Space'");
+        }
+
+        // 2. Backfill Space rows written while the function was Space-less. Same schema
+        //    discovery as V28/V34: every schema owning a mesh_nodes table except the system
+        //    schemas; auth mirrors INTO itself by construction, so it is excluded.
+        var schemas = new List<string>();
+        await using (var discover = ctx.DataSource.CreateCommand("""
+            SELECT t.table_schema
+            FROM information_schema.tables t
+            WHERE t.table_name = 'mesh_nodes'
+              AND t.table_schema NOT IN
+                  ('information_schema','pg_catalog','pg_toast','public','admin','auth','doc')
+              AND t.table_schema NOT LIKE '%\_versions'
+            ORDER BY t.table_schema
+            """))
+        await using (var rdr = await discover.ExecuteReaderAsync())
+        {
+            while (await rdr.ReadAsync())
+                schemas.Add(rdr.GetString(0));
+        }
+
+        var backfilled = 0;
+        foreach (var schema in schemas)
+        {
+            var quotedSchema = schema.Replace("\"", "\"\"");
+            await using var copy = ctx.DataSource.CreateCommand($"""
+                INSERT INTO "auth".mesh_nodes
+                    (namespace, id, name, node_type, category, icon, display_order,
+                     last_modified, version, state, content, desired_id, main_node)
+                SELECT namespace, id, name, node_type, category, icon, display_order,
+                       last_modified, version, state, content, desired_id, main_node
+                  FROM "{quotedSchema}".mesh_nodes
+                 WHERE node_type = 'Space'
+                ON CONFLICT (namespace, id) DO UPDATE SET
+                    name = EXCLUDED.name,
+                    node_type = EXCLUDED.node_type,
+                    category = EXCLUDED.category,
+                    icon = EXCLUDED.icon,
+                    display_order = EXCLUDED.display_order,
+                    last_modified = EXCLUDED.last_modified,
+                    version = EXCLUDED.version,
+                    state = EXCLUDED.state,
+                    content = EXCLUDED.content,
+                    desired_id = EXCLUDED.desired_id,
+                    main_node = EXCLUDED.main_node
+                """);
+            var rows = await copy.ExecuteNonQueryAsync();
+            if (rows > 0)
+            {
+                ctx.Logger.LogInformation(
+                    "Repair v42: '{Schema}' backfilled {Rows} Space row(s) into auth.mesh_nodes", schema, rows);
+                backfilled += rows;
+            }
+        }
+
+        ctx.Logger.LogInformation("Repair v42: done — {Count} Space row(s) backfilled", backfilled);
+    }
+}

--- a/src/MeshWeaver.Documentation/DocumentationStaticRepoSource.cs
+++ b/src/MeshWeaver.Documentation/DocumentationStaticRepoSource.cs
@@ -56,34 +56,89 @@ public sealed class DocumentationStaticRepoSource(IServiceProvider serviceProvid
     {
         Name = "MeshWeaver Documentation",
         NodeType = "Space",
-        Icon = "/static/NodeTypeIcons/document.svg",
+        Icon = DocIcon,
         State = MeshNodeState.Active,
         Content = new MarkdownContent { Content = WelcomeMarkdown }
     };
 
     /// <summary>
-    /// The Doc partition landing page. Two clear invitations: browse the documentation, or just
-    /// chat. The Space Overview renders a chat input below this body that creates a new thread.
+    /// The Doc space icon: a mesh of nodes above an open book — the docs ARE nodes in the mesh.
+    /// Inline SVG (renderable wherever a node icon appears; never a bare Fluent icon name).
+    /// </summary>
+    public const string DocIcon =
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'>"
+        + "<rect width='48' height='48' rx='10' fill='#1a2744'/>"
+        + "<path d='M10 33c4-2 9-2 13 0 4-2 9-2 13 0V17c-4-2-9-2-13 0-4-2-9-2-13 0z' fill='none' stroke='#9fb6dd' stroke-width='2' stroke-linejoin='round'/>"
+        + "<path d='M23 17v16' stroke='#9fb6dd' stroke-width='2'/>"
+        + "<path d='M15 12 24 7l9 5' fill='none' stroke='#5c8fd6' stroke-width='1.6'/>"
+        + "<circle cx='15' cy='12' r='3' fill='#7cc0ff'/><circle cx='24' cy='7' r='3' fill='#fff'/><circle cx='33' cy='12' r='3' fill='#7cc0ff'/>"
+        + "</svg>";
+
+    /// <summary>
+    /// The Doc partition landing page — a cover that teases the documentation: a hero, one card
+    /// per doc section, the most-read pages, and the chat invitation. Raw HTML blocks pass
+    /// through Markdig; styles use the theme variables so dark and light mode both work.
     /// </summary>
     public const string WelcomeMarkdown = """
-        # MeshWeaver Documentation
+        <div style="border-radius:18px;padding:36px 40px;margin:4px 0 22px;
+                    background:linear-gradient(135deg,#1a2744 0%,#24406e 55%,#2e5a9e 100%);color:#fff;">
+          <div style="font-size:13px;letter-spacing:.14em;text-transform:uppercase;opacity:.75;">MeshWeaver</div>
+          <h1 style="margin:6px 0 10px;font-size:34px;line-height:1.15;color:#fff;">Documentation</h1>
+          <p style="margin:0;max-width:640px;font-size:16px;line-height:1.55;opacity:.92;">
+            Everything in MeshWeaver is a <strong>node in a mesh</strong> — data, views, agents, even
+            these docs. Learn how hubs pass messages, how layout areas render reactively, and how a
+            NodeType compiles live from source.
+          </p>
+          <p style="margin:18px 0 0;">
+            <a href="/Doc/Architecture" style="display:inline-block;background:#fff;color:#1a2744;font-weight:600;
+               padding:9px 18px;border-radius:8px;text-decoration:none;">Start with Architecture →</a>
+            <a href="/Doc/DataMesh/CreatingNodeTypes" style="display:inline-block;margin-left:10px;color:#fff;font-weight:600;
+               padding:9px 14px;border:1px solid rgba(255,255,255,.5);border-radius:8px;text-decoration:none;">Build a NodeType</a>
+          </p>
+        </div>
 
-        Welcome to the MeshWeaver platform documentation.
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:14px;margin:0 0 24px;">
+          <a href="/Doc/Architecture" style="text-decoration:none;color:inherit;background:var(--neutral-layer-2);
+             border:1px solid var(--neutral-stroke-rest);border-radius:14px;padding:18px 20px;display:block;">
+            <div style="font-size:24px;">🏛️</div>
+            <div style="font-weight:700;margin:6px 0 4px;">Architecture</div>
+            <div style="font-size:13px;color:var(--neutral-foreground-hint);line-height:1.5;">
+              The actor-model message hub, partitions &amp; routing, access control, persistence, deployment.</div>
+          </a>
+          <a href="/Doc/DataMesh" style="text-decoration:none;color:inherit;background:var(--neutral-layer-2);
+             border:1px solid var(--neutral-stroke-rest);border-radius:14px;padding:18px 20px;display:block;">
+            <div style="font-size:24px;">🕸️</div>
+            <div style="font-weight:700;margin:6px 0 4px;">Data Mesh</div>
+            <div style="font-size:13px;color:var(--neutral-foreground-hint);line-height:1.5;">
+              Nodes, node types, the unified path, query syntax, CRUD — the data model behind everything.</div>
+          </a>
+          <a href="/Doc/GUI" style="text-decoration:none;color:inherit;background:var(--neutral-layer-2);
+             border:1px solid var(--neutral-stroke-rest);border-radius:14px;padding:18px 20px;display:block;">
+            <div style="font-size:24px;">🎛️</div>
+            <div style="font-weight:700;margin:6px 0 4px;">GUI</div>
+            <div style="font-size:13px;color:var(--neutral-foreground-hint);line-height:1.5;">
+              Layout areas, controls, data binding — reactive views streamed from node state.</div>
+          </a>
+          <a href="/Doc/AI" style="text-decoration:none;color:inherit;background:var(--neutral-layer-2);
+             border:1px solid var(--neutral-stroke-rest);border-radius:14px;padding:18px 20px;display:block;">
+            <div style="font-size:24px;">🤖</div>
+            <div style="font-weight:700;margin:6px 0 4px;">AI</div>
+            <div style="font-size:13px;color:var(--neutral-foreground-hint);line-height:1.5;">
+              Agents, threads, skills and MCP — chat with any node, automate with the mesh tools.</div>
+          </a>
+        </div>
 
-        ## Explore
+        ## Most-read pages
 
-        Browse the guides from the menu — start with the architecture overview, the data mesh,
-        the GUI, or AI integration:
+        - **[Plugins](@/Doc/Architecture/Plugins)** — node-native modules the mesh compiles live; no rebuild, no NuGet.
+        - **[NodeType Compilation & Releases](@/Doc/Architecture/NodeTypeCompilation)** — what triggers a compile, how releases activate.
+        - **[Data Binding](@/Doc/GUI/DataBinding)** — the one right way to bind, edit and persist node data in views.
+        - **[Asynchronous Calls](@/Doc/Architecture/AsynchronousCalls)** — why it's `IObservable<T>` end to end, and where I/O belongs.
+        - **[Creating Node Types](@/Doc/DataMesh/CreatingNodeTypes)** — from content record to layout areas, step by step.
 
-        - **[Architecture](@/Doc/Architecture)** — the actor-model message hub, access control,
-          persistence, and deployment.
-        - **[Data Mesh](@/Doc/DataMesh)** — node types, query syntax, paths, and CRUD.
-        - **[GUI](@/Doc/GUI)** — layout areas, controls, data binding, and reactive views.
-        - **[AI](@/Doc/AI)** — agents, MCP, and the MeshPlugin tools.
+        ## Or just ask
 
-        ## Or just chat
-
-        Not sure where to look? Ask a question in the chat box below — it starts a new thread, and
-        the assistant will search the docs and answer directly.
+        Not sure where to look? Ask in the chat box below — it starts a new thread, and the
+        assistant searches these docs and answers with sources.
         """;
 }

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
@@ -239,7 +239,96 @@ public static class PostgreSqlSchemaInitializer
         {
             await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
+
+        // Step 5: SELF-HEAL the auth mirror. Step 2.5 heals the trigger FUNCTION on every init;
+        // this heals the TRIGGERS and the DATA, so the mirror converges on every boot instead of
+        // depending on a one-time migration: (a) any partition schema missing the
+        // mesh_node_mirror_access_objects trigger (provisioned during a bad window) gets it,
+        // (b) mirrored rows that were missed or went stale while the function/trigger was wrong
+        // are reconciled into auth.mesh_nodes, (c) the top-level matview is rebuilt so catalog
+        // surfaces see the healed rows. One server-side pass, idempotent, fail-safe (skips when
+        // auth isn't provisioned yet — e.g. a bare test fixture). This is the durable answer to
+        // the 2026-07 "spaces invisible in the catalog" incident: even if the mirror breaks
+        // again, the next restart repairs both trigger topology and data.
+        await using (var cmd = dataSource.CreateCommand(GetAuthMirrorSelfHealScript()))
+        {
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
     }
+
+    /// <summary>
+    /// One-shot server-side reconciliation of the auth mirror: installs the
+    /// <c>mesh_node_mirror_access_objects</c> trigger on every partition schema that lacks it and
+    /// upserts every mirrored node type (<c>User/Group/Role/VUser/ApiToken/Space</c>) from every
+    /// partition into <c>auth.mesh_nodes</c>, then rebuilds <c>public.top_level_index</c>.
+    /// No-op when <c>auth.mesh_nodes</c> doesn't exist. Runs at every init (<see cref="InitializeAsync"/>
+    /// step 5) — the mirror self-heals on restart rather than relying on one-time migrations.
+    /// </summary>
+    public static string GetAuthMirrorSelfHealScript() => """
+        DO $auth_mirror_heal$
+        DECLARE
+            s text;
+        BEGIN
+            IF to_regclass('"auth".mesh_nodes') IS NULL THEN
+                RETURN;
+            END IF;
+
+            FOR s IN
+                SELECT t.table_schema
+                FROM information_schema.tables t
+                WHERE t.table_name = 'mesh_nodes'
+                  AND t.table_schema NOT IN
+                      ('information_schema','pg_catalog','pg_toast','public','admin','auth')
+                  AND t.table_schema NOT LIKE '%\_versions'
+            LOOP
+                -- (a) Trigger present on every partition table (auth itself excluded above —
+                --     it is the mirror target, mirroring into itself would loop).
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_trigger tg
+                    JOIN pg_class c ON c.oid = tg.tgrelid
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                    WHERE tg.tgname = 'mesh_node_mirror_access_objects'
+                      AND c.relname = 'mesh_nodes' AND n.nspname = s)
+                THEN
+                    EXECUTE format(
+                        'CREATE TRIGGER mesh_node_mirror_access_objects '
+                        || 'AFTER INSERT OR UPDATE OR DELETE ON %I.mesh_nodes '
+                        || 'FOR EACH ROW EXECUTE FUNCTION public.mirror_access_object_to_auth_schema()', s);
+                END IF;
+
+                -- (b) Reconcile mirrored rows: insert what is missing, refresh what is stale.
+                --     The WHERE guard keeps the pass write-free when everything already matches.
+                EXECUTE format($reconcile$
+                    INSERT INTO "auth".mesh_nodes
+                        (namespace, id, name, node_type, category, icon, display_order,
+                         last_modified, version, state, content, desired_id, main_node)
+                    SELECT namespace, id, name, node_type, category, icon, display_order,
+                           last_modified, version, state, content, desired_id, main_node
+                      FROM %I.mesh_nodes
+                     WHERE node_type IN ('User','Group','Role','VUser','ApiToken','Space')
+                    ON CONFLICT (namespace, id) DO UPDATE SET
+                        name = EXCLUDED.name,
+                        node_type = EXCLUDED.node_type,
+                        category = EXCLUDED.category,
+                        icon = EXCLUDED.icon,
+                        display_order = EXCLUDED.display_order,
+                        last_modified = EXCLUDED.last_modified,
+                        version = EXCLUDED.version,
+                        state = EXCLUDED.state,
+                        content = EXCLUDED.content,
+                        desired_id = EXCLUDED.desired_id,
+                        main_node = EXCLUDED.main_node
+                    WHERE "auth".mesh_nodes.version < EXCLUDED.version
+                       OR "auth".mesh_nodes.node_type IS DISTINCT FROM EXCLUDED.node_type
+                       OR "auth".mesh_nodes.last_modified < EXCLUDED.last_modified
+                $reconcile$, s);
+            END LOOP;
+
+            -- (c) Catalog surfaces read the healed rows.
+            PERFORM public.rebuild_top_level_index();
+        END
+        $auth_mirror_heal$;
+        """;
 
     /// <summary>
     /// Builds the <c>CREATE OR REPLACE FUNCTION public.ensure_partition_schema(partition_name text)</c>
@@ -313,8 +402,8 @@ public static class PostgreSqlSchemaInitializer
     /// <summary>
     /// DDL for <c>public.mirror_access_object_to_auth_schema()</c> — the AFTER
     /// INSERT/UPDATE/DELETE trigger function that mirrors every access-object node
-    /// (<c>User</c>, <c>Group</c>, <c>Role</c>, <c>VUser</c>, <c>ApiToken</c>) from a
-    /// partition's <c>mesh_nodes</c> into the central <c>auth.mesh_nodes</c> lookup mirror.
+    /// (<c>User</c>, <c>Group</c>, <c>Role</c>, <c>VUser</c>, <c>ApiToken</c>, <c>Space</c>)
+    /// from a partition's <c>mesh_nodes</c> into the central <c>auth.mesh_nodes</c> lookup mirror.
     /// The per-partition DDL (<see cref="GetVersionedPartitionDdl"/>) installs the trigger
     /// that calls this function — but only when this function already exists, so it must be
     /// created on the always-run init path (and by the V32 repair for legacy partitions).
@@ -327,6 +416,17 @@ public static class PostgreSqlSchemaInitializer
     /// <para><b>Single-sourced.</b> <see cref="InitializeAsync"/> runs this, and the
     /// <c>V32_RepairAuthMirrorTriggerAndBackfill</c> migration calls it for legacy DBs whose
     /// partitions predate the trigger. Idempotent (<c>CREATE OR REPLACE</c>).</para>
+    ///
+    /// <para>🚨 <b>The node-type list below is THE live list — keep it complete.</b> Because this
+    /// script re-runs on every startup/schema-init (and V32 replays it), it silently OVERWRITES any
+    /// list extension a later migration made to the deployed function. That is exactly how V28's
+    /// <c>'Space'</c> extension was lost in production: V28 patched the function inline, this
+    /// constant re-created it without <c>'Space'</c> on the next restart, and every Space created
+    /// since then never reached <c>auth.mesh_nodes</c> — invisible in the Spaces catalog while its
+    /// partition, grants and content all worked (RolePlay/X/Chess, 2026-07). When a new node type
+    /// must mirror, extend THIS list (both branches) and add a backfill migration
+    /// (<c>V42_ReapplySpaceAuthMirrorAndBackfill</c> is the model); never patch the deployed
+    /// function from a migration alone.</para>
     /// </summary>
     public static string GetAuthMirrorFunctionScript() => """
         CREATE OR REPLACE FUNCTION public.mirror_access_object_to_auth_schema()
@@ -339,14 +439,14 @@ public static class PostgreSqlSchemaInitializer
             END IF;
 
             IF TG_OP = 'DELETE' THEN
-                IF OLD.node_type IN ('User','Group','Role','VUser','ApiToken') THEN
+                IF OLD.node_type IN ('User','Group','Role','VUser','ApiToken','Space') THEN
                     DELETE FROM "auth".mesh_nodes
                      WHERE namespace = OLD.namespace AND id = OLD.id;
                 END IF;
                 RETURN OLD;
             END IF;
 
-            IF NEW.node_type IN ('User','Group','Role','VUser','ApiToken') THEN
+            IF NEW.node_type IN ('User','Group','Role','VUser','ApiToken','Space') THEN
                 INSERT INTO "auth".mesh_nodes
                     (namespace, id, name, node_type, category, icon, display_order,
                      last_modified, version, state, content, desired_id, main_node)

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/AuthMirrorTriggerTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/AuthMirrorTriggerTests.cs
@@ -64,41 +64,12 @@ public class AuthMirrorTriggerTests
         await using var authDs = dsBuilder.Build();
         await PostgreSqlSchemaInitializer.InitializeAsync(authDs, opts);
 
-        await using (var cmd = _fixture.DataSource.CreateCommand("""
-            CREATE OR REPLACE FUNCTION public.mirror_access_object_to_auth_schema()
-            RETURNS TRIGGER AS $$
-            BEGIN
-                IF TG_OP = 'DELETE' THEN
-                    IF OLD.node_type IN ('User','Group','Role','VUser','ApiToken') THEN
-                        DELETE FROM "auth".mesh_nodes
-                         WHERE namespace = OLD.namespace AND id = OLD.id;
-                    END IF;
-                    RETURN OLD;
-                END IF;
-
-                IF NEW.node_type IN ('User','Group','Role','VUser','ApiToken') THEN
-                    INSERT INTO "auth".mesh_nodes
-                        (namespace, id, name, node_type, category, icon, display_order,
-                         last_modified, version, state, content, desired_id, main_node)
-                    VALUES (NEW.namespace, NEW.id, NEW.name, NEW.node_type, NEW.category, NEW.icon, NEW.display_order,
-                            NEW.last_modified, NEW.version, NEW.state, NEW.content, NEW.desired_id, NEW.main_node)
-                    ON CONFLICT (namespace, id) DO UPDATE SET
-                        name = EXCLUDED.name,
-                        node_type = EXCLUDED.node_type,
-                        category = EXCLUDED.category,
-                        icon = EXCLUDED.icon,
-                        display_order = EXCLUDED.display_order,
-                        last_modified = EXCLUDED.last_modified,
-                        version = EXCLUDED.version,
-                        state = EXCLUDED.state,
-                        content = EXCLUDED.content,
-                        desired_id = EXCLUDED.desired_id,
-                        main_node = EXCLUDED.main_node;
-                END IF;
-                RETURN NEW;
-            END;
-            $$ LANGUAGE plpgsql;
-            """))
+        // Single-source the trigger function from the initializer's constant — the same script
+        // every startup runs. An inline copy here is exactly how the V28 'Space' extension was
+        // silently lost in production (three hand-maintained copies drifting apart); the test
+        // must exercise THE deployed function body, not its own fork.
+        await using (var cmd = _fixture.DataSource.CreateCommand(
+            PostgreSqlSchemaInitializer.GetAuthMirrorFunctionScript()))
         {
             await cmd.ExecuteNonQueryAsync();
         }
@@ -214,6 +185,92 @@ public class AuthMirrorTriggerTests
 
         await ExistsInAuthAsync("", "rbuergi").Run()
             .Should().Within(30.Seconds()).Be(true);
+    }
+
+    /// <summary>
+    /// A Space root (partition root: namespace = "", id = space id) must mirror into
+    /// <c>auth.mesh_nodes</c> — that mirror IS the Spaces catalog. Pins the V28 'Space'
+    /// extension against the drift that dropped it in production (spaces created after a
+    /// restart never appeared in the catalog): the initializer's script, which this test
+    /// installs verbatim, must mirror Space on insert AND remove it on delete.
+    /// </summary>
+    [Fact]
+    public async Task SpaceInsert_MirrorsIntoAuthSchema_AndDeleteRemoves()
+    {
+        await _fixture.CleanData().Should().Within(60.Seconds()).Emit();
+        await EnsureMirrorInstalledAsync().Run().Should().Within(60.Seconds()).Emit();
+
+        var space = new MeshNode("Chess", "")
+        {
+            Name = "Chess",
+            NodeType = "Space"
+        };
+        await _fixture.StorageAdapter.Write(space, new()).Should().Within(30.Seconds()).Emit();
+
+        await ExistsInAuthAsync("", "Chess").Run()
+            .Should().Within(30.Seconds()).Be(true);
+        await ReadNameFromAuthAsync("", "Chess").Run()
+            .Should().Within(30.Seconds()).Be("Chess");
+
+        await _fixture.StorageAdapter.Delete("Chess").Should().Within(30.Seconds()).Emit();
+
+        await ExistsInAuthAsync("", "Chess").Run()
+            .Should().Within(30.Seconds()).Be(false);
+    }
+
+    /// <summary>
+    /// The auth mirror SELF-HEALS: <c>GetAuthMirrorSelfHealScript</c> (run by
+    /// <c>InitializeAsync</c> step 5 on every boot) re-installs a dropped partition trigger and
+    /// reconciles rows that were missed while the trigger/function was broken. Pins the durable
+    /// fix for the 2026-07 "spaces invisible in the catalog" incident: damage the mirror both
+    /// ways (drop the trigger, delete a mirrored row, write a row while the trigger is absent),
+    /// heal, and assert everything converged.
+    /// </summary>
+    [Fact]
+    public async Task SelfHeal_ReinstallsTriggerAndReconcilesRows()
+    {
+        await _fixture.CleanData().Should().Within(60.Seconds()).Emit();
+        await EnsureMirrorInstalledAsync().Run().Should().Within(60.Seconds()).Emit();
+
+        // A real partition schema (the heal sweep deliberately skips 'public').
+        await using (var proc = _fixture.DataSource.CreateCommand(
+            "SELECT public.ensure_partition_schema('healtest')"))
+            await proc.ExecuteNonQueryAsync();
+
+        // Baseline: a Space root in the partition mirrors into auth via the trigger.
+        await using (var ins = _fixture.DataSource.CreateCommand(
+            """INSERT INTO "healtest".mesh_nodes (namespace, id, name, node_type, state) VALUES ('', 'HealMe', 'Heal Me', 'Space', 2) ON CONFLICT (namespace, id) DO NOTHING"""))
+            await ins.ExecuteNonQueryAsync();
+        await ExistsInAuthAsync("", "HealMe").Run().Should().Within(30.Seconds()).Be(true);
+
+        // Damage 1: the trigger disappears (bad provisioning window).
+        await using (var drop = _fixture.DataSource.CreateCommand(
+            """DROP TRIGGER IF EXISTS mesh_node_mirror_access_objects ON "healtest".mesh_nodes"""))
+            await drop.ExecuteNonQueryAsync();
+        // Damage 2: an already-mirrored row is lost from auth.
+        await using (var del = _fixture.DataSource.CreateCommand(
+            """DELETE FROM "auth".mesh_nodes WHERE namespace = '' AND id = 'HealMe'"""))
+            await del.ExecuteNonQueryAsync();
+        // Damage 3: a row written while the trigger is absent never mirrors.
+        await using (var ins2 = _fixture.DataSource.CreateCommand(
+            """INSERT INTO "healtest".mesh_nodes (namespace, id, name, node_type, state) VALUES ('', 'HealMe2', 'Heal Me Too', 'Space', 2) ON CONFLICT (namespace, id) DO NOTHING"""))
+            await ins2.ExecuteNonQueryAsync();
+        await ExistsInAuthAsync("", "HealMe2").Run().Should().Within(30.Seconds()).Be(false);
+
+        // Heal — the exact script InitializeAsync runs at every boot.
+        await using (var heal = _fixture.DataSource.CreateCommand(
+            PostgreSqlSchemaInitializer.GetAuthMirrorSelfHealScript()))
+            await heal.ExecuteNonQueryAsync();
+
+        // Both rows reconciled…
+        await ExistsInAuthAsync("", "HealMe").Run().Should().Within(30.Seconds()).Be(true);
+        await ExistsInAuthAsync("", "HealMe2").Run().Should().Within(30.Seconds()).Be(true);
+
+        // …and the trigger is back: a fresh write mirrors again without another heal.
+        await using (var ins3 = _fixture.DataSource.CreateCommand(
+            """INSERT INTO "healtest".mesh_nodes (namespace, id, name, node_type, state) VALUES ('', 'HealMe3', 'Healed Live', 'Space', 2) ON CONFLICT (namespace, id) DO NOTHING"""))
+            await ins3.ExecuteNonQueryAsync();
+        await ExistsInAuthAsync("", "HealMe3").Run().Should().Within(30.Seconds()).Be(true);
     }
 
     [Fact]


### PR DESCRIPTION
## Root cause ("spaces invisible in the Spaces catalog", memex 2026-07-11)

`PostgreSqlSchemaInitializer.GetAuthMirrorFunctionScript()` re-creates the `mirror_access_object_to_auth_schema()` trigger function at **every startup** — and its node-type list was missing `'Space'`, silently reverting migration V28's extension on the next restart. Every space created since (RolePlay, X, Chess) had a working partition, grants and content, but never mirrored into `auth.mesh_nodes`, so the Spaces catalog never listed it. (Live-repaired on memex via an in-mesh script on 2026-07-11; this PR makes the fix durable and self-healing.)

## Changes

1. **Initializer** — `'Space'` restored to both branches of the mirror function, plus a 🚨 comment marking the list as THE live list (extending it in a migration alone gets overwritten on the next boot — extend here and ship a backfill migration together).
2. **Self-healing (new step 5 of `InitializeAsync`)** — `GetAuthMirrorSelfHealScript()` runs on every init: installs the mirror trigger on any partition schema missing it, reconciles missing/stale mirrored rows (`User/Group/Role/VUser/ApiToken/Space`) into `auth.mesh_nodes`, and rebuilds `public.top_level_index`. The mirror converges on every restart — no migration dependency.
3. **`V42_ReapplySpaceAuthMirrorAndBackfill`** — the recorded, ordered repair for deployed databases (re-apply function + backfill Space rows), belt-and-braces alongside the self-heal.
4. **Tests** — `AuthMirrorTriggerTests` previously carried a *third* inline copy of the function (the drift disease itself); it now single-sources the initializer's script and adds: Space root (namespace `''`) insert-mirrors/delete-removes, and a self-heal regression (drop trigger + delete mirrored row + write-while-broken → one heal pass converges everything, live mirroring resumes). **518/518 PostgreSql tests green** against real Postgres.
5. **Doc space** — real icon (mesh-over-book inline SVG) and a proper cover page (hero, section cards, most-read pages, chat invitation) in `DocumentationStaticRepoSource`, replacing the generic document icon and plain-text welcome.

## Notes for reviewers

- The self-heal DO-block is fail-safe (no-ops when `auth.mesh_nodes` doesn't exist) and write-free when everything already matches (guarded `ON CONFLICT … DO UPDATE … WHERE`).
- Found along the way, **not** fixed here: `public.searchable_schemas` on memex contains junk partition schemas (`login?error=auth_failed`, `search?q=…`, an email address) — partition-name validation deserves a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)