### PR TITLE
feat(feedback): /feedback skill + Feedback type; rename create-markdown → markdown

### DIFF
--- a/content/ai/Agent/Assistant.md
+++ b/content/ai/Agent/Assistant.md
@@ -41,6 +41,21 @@ pre-flight loop (`LspCheckNode` before every `Patch`), and the compile/diagnosti
 hand-write `Source/*.cs` without loading it first. To keep heavy code work out of your context
 window, delegate it to **Worker** with instructions to load the `Skill/code` skill first.
 
+# Creating content: load the matching skill FIRST — never improvise the shape
+
+Content creation is **skill-driven**. Each kind of node has a skill that owns its correct shape — the
+proper `create` (not `update`), the icon rules, the live `@@` regions, the exact node schema. **Before you
+create one of these, you MUST load its skill and follow it** — do not hand-improvise the shape:
+
+- **A Markdown page** (or any node with a markdown body) → **`/markdown`** — `load_skill('Skill/markdown')`.
+- **A Space** (top-level container / partition) → **`/create-space`** — `load_skill('Skill/create-space')`.
+- **An access Group** (the Group + its grant + members/invites) → **`/create-group`** — `load_skill('Skill/create-group')`.
+- **User feedback** (capture the user's location + name, file it in the Feedback space) → **`/feedback`** — `load_skill('Skill/feedback')`.
+
+A **NodeType / source / data model / layout area / Script** is the **`/code`** skill (above). Load the skill
+that matches what you're about to create; when several apply across a multi-step task, load each as you reach
+that step. Read a given skill only once per thread.
+
 # When to delegate (and when not to)
 
 Delegation is **opt-in, not default**. Reach for it in exactly two cases:

--- a/content/ai/Skill/feedback.md
+++ b/content/ai/Skill/feedback.md
@@ -1,0 +1,112 @@
+---
+nodeType: Skill
+name: /feedback
+description: Capture the user's feedback together with WHERE they are (the current page) and WHO they are (name), and file it into the dedicated Feedback space so the team can review it. Type /feedback followed by the feedback.
+icon: 📣
+category: Skills
+order: 13
+autoMount: true
+---
+
+You are filing a piece of **user feedback**. The user typed `/feedback` followed by what they want to
+say. Your job: capture that text **plus the context that makes it actionable** — *where* they were and
+*who* they are — and create one **`Feedback`** node in the dedicated top-level **`Feedback`** space.
+One node per submission. Do it, then confirm in one sentence — don't interrogate the user.
+
+# 1. Capture WHO and WHERE (you already have both — do NOT ask)
+
+Both come from your prompt context, not from the user:
+
+- **WHERE (`location`)** — the **`node.path`** in the **`# Current Application Context`** block: the page
+  the user was on when they gave the feedback (e.g. `ACME/Reports/Q3`). This is the single most useful
+  field — it lets a reviewer jump straight to what the feedback is about. If there is no context node,
+  leave `location` empty.
+- **WHO** — the **`# Current User`** block: use **`User ID`** for `submittedBy` and **`Name`** for
+  `submittedByName`. (The framework also stamps the node's `CreatedBy` with the user automatically; you
+  set the content fields so the identity travels with an export and shows on the review card.)
+
+# 2. The dedicated Feedback space is platform-provided — just file into it
+
+Feedback lands in ONE shared, top-level space named **`Feedback`**. It is **seeded automatically on
+every instance** (space root + a `Public → Contributor` grant so every user — all platform admins
+included — can read the board and contribute). So in the normal case it already exists and is already
+open for contributions: **skip straight to §3**.
+
+**Only if it is genuinely missing** — e.g. a local dev mesh running WITHOUT static-repo sync — recreate
+it yourself with these two nodes (otherwise never touch them):
+
+**(a) the space** — a real `create` (never `update` a bare node into a Space; that skips partition
+provisioning). Load the **`/create-space`** skill for the full recipe; the minimum:
+
+```json
+{
+  "id": "Feedback", "namespace": "",
+  "nodeType": "Space",
+  "content": {
+    "$type": "Space",
+    "name": "Feedback",
+    "description": "What users tell us — one node per submission, with where they were and who they are.",
+    "icon": "📣",
+    "body": "Feedback filed through the `/feedback` skill lands here — each entry records the page the user was on and who they are, so we can act on it.\n\n## Contents\n\n@@(\"area/Search\")"
+  }
+}
+```
+
+**(b) let every user contribute** — one `AccessAssignment` granting the **`Public`** subject the built-in
+**`Contributor`** role (read + create, but NOT edit/delete others' entries) at the `Feedback` scope.
+Granting `Public` propagates to every authenticated user, so anyone can submit — without being able to
+tamper with someone else's feedback:
+
+```json
+{
+  "id": "Public_Access", "namespace": "Feedback/_Access", "name": "All users — Contributor",
+  "nodeType": "AccessAssignment", "mainNode": "Feedback",
+  "content": {
+    "$type": "AccessAssignment",
+    "accessObject": "Public", "displayName": "All users",
+    "roles": [ { "$type": "RoleAssignment", "role": "Contributor" } ]
+  }
+}
+```
+
+`mainNode` MUST equal the scope (`Feedback`) — an empty `mainNode` is silently ignored (see [/access](/access)).
+
+# 3. File the feedback node
+
+Create one `Feedback` node under the `Feedback` space. Give it a short, human `name` (a few words
+summarising the feedback — this is the review-list title), and fill the content:
+
+```json
+{
+  "id": "{short-slug-or-guid}", "namespace": "Feedback",
+  "name": "{a few words summarising the feedback}",
+  "nodeType": "Feedback", "icon": "📣",
+  "content": {
+    "$type": "Feedback",
+    "text": "{the user's feedback, verbatim — lightly cleaned up, never editorialised}",
+    "location": "{node.path from Current Application Context, or empty}",
+    "submittedBy": "{User ID}",
+    "submittedByName": "{Name}",
+    "category": "{optional: bug | idea | praise | question — only if obvious, else omit}",
+    "status": "New"
+  }
+}
+```
+
+- Content field names are **camelCase**; `status` serialises by name — start it at **`New`**.
+- Put the WHOLE of what the user said in `text`. Don't summarise it away — the `name` is the summary,
+  `text` is the record.
+
+# 4. Verify and confirm
+
+- `get @Feedback/{id}` → the node exists with your `text`, `location`, and `submittedByName`.
+- Reply in ONE sentence: thank them and link the entry — `Filed your feedback → [{name}](@/Feedback/{id}).`
+  Do not dump the JSON back at them.
+
+# Notes
+
+- **Never** invent a location or a name — read them from the context blocks. If a field genuinely isn't
+  available (no context node), leave it empty rather than guessing.
+- Everyone who can reach the `Feedback` space can read the entries filed there (it's a shared inbox). Don't
+  put anything in `text` the user wouldn't want other space members to see; if they flag something private,
+  tell them this is a shared space.

--- a/content/ai/Skill/markdown.md
+++ b/content/ai/Skill/markdown.md
@@ -1,6 +1,6 @@
 ---
 nodeType: Skill
-name: /create-markdown
+name: /markdown
 description: Author a Markdown node (a page) the right way — always an icon, never a title (node.Name is already the H1), live @@ region embeds, and interactive (executable) code cells.
 icon: 📝
 category: Skills

--- a/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
+++ b/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
@@ -50,6 +50,13 @@ public static class StaticRepoSyncExtensions
             if (serveFromPartition.Overlaps(AiContentSources.ContentPartitions))
                 services.AddBuiltInAiContentSources();
 
+            // The dedicated Feedback space (the /feedback inbox) ALWAYS seeds when static-repo sync is
+            // on: it is a WRITABLE platform space (Additive → user-filed feedback is never pruned), not
+            // a read-only catalog, so it has no in-memory static provider to gate against and needs no
+            // per-partition allow-list. Its Public → Contributor grant lets every user (all platform
+            // admins included) read the board and file feedback.
+            services.AddSingleton<IStaticRepoSource, MeshWeaver.Graph.Configuration.FeedbackStaticRepoSource>();
+
             // Runs after the PG schema-provisioning hosted service (registered earlier by
             // AddPartitionedPostgreSqlPersistence) — hosted services start in registration order.
             // A factory (not AddHostedService<T>) so the deploy-time per-partition mode overrides

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-11-feedback-skill.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-11-feedback-skill.md
@@ -1,0 +1,12 @@
+---
+Name: Send feedback right from chat with /feedback
+Category: What's New
+Description: A new /feedback skill files your feedback — with the page you were on and your name — into a shared Feedback space everyone can contribute to.
+Icon: Sparkle
+---
+
+# Send feedback right from chat with /feedback
+
+You can now type **`/feedback`** followed by whatever you want to tell us, and the assistant files it for you. It captures the page you were on and who you are, so we can act on it without having to ask you where or what you meant.
+
+Every submission lands in one shared **Feedback** space that provisions automatically — anyone can add feedback, and platform admins can review everything that comes in. (The old `/create-markdown` skill is now simply **`/markdown`**.)

--- a/src/MeshWeaver.Graph/Configuration/FeedbackNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/FeedbackNodeType.cs
@@ -1,0 +1,34 @@
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Provides configuration for <c>Feedback</c> nodes in the graph. Feedback nodes are standalone
+/// (NOT satellites): one node per submission, filed by the <c>/feedback</c> skill into the dedicated
+/// top-level <c>Feedback</c> space. Access is governed by that space's grants (the space grants the
+/// <c>Public</c> subject a create-capable role, so any authenticated user can contribute) — there is
+/// no bespoke satellite access rule.
+/// </summary>
+public static class FeedbackNodeType
+{
+    /// <summary>The NodeType value used to identify feedback nodes.</summary>
+    public const string NodeType = "Feedback";
+
+    /// <summary>Registers the built-in "Feedback" MeshNode on the mesh builder.</summary>
+    public static TBuilder AddFeedbackType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        return builder;
+    }
+
+    /// <summary>Creates the MeshNode type-definition for the Feedback node type.</summary>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "Feedback",
+        Icon = "📣",
+        HubConfiguration = config => config
+            .AddMeshDataSource(source => source
+                .WithContentType<Feedback>())
+    };
+}

--- a/src/MeshWeaver.Graph/Configuration/FeedbackStaticRepoSource.cs
+++ b/src/MeshWeaver.Graph/Configuration/FeedbackStaticRepoSource.cs
@@ -1,0 +1,78 @@
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Seeds the dedicated top-level <c>Feedback</c> space as a static-repo import source, so the whole
+/// feature provisions automatically on every instance (no manual create, no first-run bootstrap).
+/// Ships two things:
+/// <list type="bullet">
+///   <item>the <b>space root</b> — a Space landing page that lists the feedback filed into it; and</item>
+///   <item>one <b>AccessAssignment</b> granting the <see cref="WellKnownUsers.Public"/> subject the
+///     built-in <c>Contributor</c> role. Granting <c>Public</c> folds into <em>every</em> authenticated
+///     user in <c>PermissionEvaluator</c> — so all users (and therefore <b>all platform admins</b>, who
+///     are not data superusers and would otherwise be locked out of this partition) can read the board
+///     and file feedback, without being able to edit or delete other people's entries.</item>
+/// </list>
+/// <para>🚨 <see cref="SyncMode"/> is <see cref="PartitionSyncMode.Additive"/> because users FILE their
+/// own Feedback nodes into this partition — a re-import must NEVER prune them; only a seed node this
+/// build previously shipped and has since dropped is removed.</para>
+/// </summary>
+public sealed class FeedbackStaticRepoSource : IStaticRepoSource
+{
+    /// <summary>The dedicated Feedback space (top-level partition).</summary>
+    public const string PartitionName = "Feedback";
+
+    /// <inheritdoc />
+    public string Partition => PartitionName;
+
+    /// <inheritdoc />
+    // The seed nodes carry no meaningful version → fingerprint on content (re-imports when the seed changes).
+    public bool Versioned => false;
+
+    /// <inheritdoc />
+    // 🚨 Additive — users file feedback here; never prune their nodes on re-import.
+    public PartitionSyncMode SyncMode => PartitionSyncMode.Additive;
+
+    /// <inheritdoc />
+    public IReadOnlyList<MeshNode> EnumerateSourceNodes() =>
+    [
+        new MeshNode("Public_Access", $"{PartitionName}/_Access")
+        {
+            NodeType = "AccessAssignment",
+            Name = "All users — Contributor",
+            MainNode = PartitionName,          // MUST equal the scope, or the grant is ignored
+            State = MeshNodeState.Active,
+            Content = new AccessAssignment
+            {
+                AccessObject = WellKnownUsers.Public,
+                DisplayName = "All users",
+                Roles = [new RoleAssignment { Role = "Contributor" }],
+            },
+        },
+    ];
+
+    /// <inheritdoc />
+    public MeshNode? PartitionRoot => new(PartitionName)
+    {
+        Name = "Feedback",
+        NodeType = "Space",
+        Icon = "📣",
+        State = MeshNodeState.Active,
+        Content = new MarkdownContent { Content = WelcomeMarkdown },
+    };
+
+    /// <summary>The Feedback space landing page — a short intro plus the live contents catalog.</summary>
+    public const string WelcomeMarkdown = """
+        Feedback filed through the `/feedback` skill lands here — one entry per submission, each
+        recording the page the user was on and who they are, so the team can act on it.
+
+        Anyone can add feedback; browse what has come in below.
+
+        ## Contents
+
+        @@("area/Search")
+        """;
+}

--- a/src/MeshWeaver.Graph/Configuration/FeedbackStaticRepoSource.cs
+++ b/src/MeshWeaver.Graph/Configuration/FeedbackStaticRepoSource.cs
@@ -52,6 +52,21 @@ public sealed class FeedbackStaticRepoSource : IStaticRepoSource
                 Roles = [new RoleAssignment { Role = "Contributor" }],
             },
         },
+
+        // 🔐 Scope the public Contributor grant OUT of the access-config subtree. Contributor is
+        // inheritable, so without this the grant would also give every user Create on
+        // "Feedback/_Access" — and creating an AccessAssignment only needs Create on the parent, so a
+        // user could self-escalate by writing "Feedback/_Access/{me}_Access" granting themselves Admin.
+        // BreaksInheritance discards ancestor roles AT this scope, so nobody reaches "Feedback/_Access"
+        // via the Public grant: users can create feedback ENTRIES ("Feedback/{id}") but not touch the
+        // access config. (System import bypasses permissions, so re-seeding still works.)
+        new MeshNode("_Policy", $"{PartitionName}/_Access")
+        {
+            NodeType = "PartitionAccessPolicy",
+            Name = "Feedback access — locked",
+            State = MeshNodeState.Active,
+            Content = new PartitionAccessPolicy { BreaksInheritance = true },
+        },
     ];
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -37,6 +37,7 @@ public static class GraphConfigurationExtensions
                 .AddSlideType()
                 .AddDeckType()
                 .AddCommentType()
+                .AddFeedbackType()
                 .AddTrackedChangeType()
                 .AddAccessAssignmentType()
                 .AddPartitionAccessPolicyType()

--- a/src/MeshWeaver.Graph/Configuration/RoleNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/RoleNodeType.cs
@@ -98,6 +98,7 @@ public static class RoleNodeType
             new("Editor", "Role") { Name = "Editor", NodeType = NodeType, Icon = EditorIcon, Content = Role.Editor },
             new("Viewer", "Role") { Name = "Viewer", NodeType = NodeType, Icon = ViewerIcon, Content = Role.Viewer },
             new("Commenter", "Role") { Name = "Commenter", NodeType = NodeType, Icon = CommenterIcon, Content = Role.Commenter },
+            new("Contributor", "Role") { Name = "Contributor", NodeType = NodeType, Icon = EditorIcon, Content = Role.Contributor },
         ];
 
         public IEnumerable<MeshNode> GetStaticNodes() => Nodes;

--- a/src/MeshWeaver.Graph/Configuration/RoleNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/RoleNodeType.cs
@@ -72,8 +72,15 @@ public static class RoleNodeType
         "<path d=\"M5 6.5A1.5 1.5 0 0 1 6.5 5h7A1.5 1.5 0 0 1 15 6.5v5A1.5 1.5 0 0 1 13.5 13H9.4l-2.8 2.3A.5.5 0 0 1 5.8 15v-2A1.5 1.5 0 0 1 4.5 11.5v-5H5Zm2.5 1.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm2.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm2.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z\" fill=\"white\"/>" +
         "</svg>";
 
+    // Contributor: teal, distinct from Editor's green — a "+" (can add, cannot modify others').
+    private const string ContributorIcon =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\">" +
+        "<rect width=\"20\" height=\"20\" rx=\"4\" fill=\"#0D9488\"/>" +
+        "<path d=\"M10 4.5a.9.9 0 0 1 .9.9v3.7h3.7a.9.9 0 1 1 0 1.8h-3.7v3.7a.9.9 0 1 1-1.8 0v-3.7H5.4a.9.9 0 1 1 0-1.8h3.7V5.4a.9.9 0 0 1 .9-.9Z\" fill=\"white\"/>" +
+        "</svg>";
+
     /// <summary>
-    /// Provides the four built-in roles as static MeshNodes
+    /// Provides the built-in roles as static MeshNodes
     /// so they appear in query results regardless of scope.
     /// </summary>
     private class BuiltInRolesProvider : IStaticNodeProvider
@@ -98,7 +105,7 @@ public static class RoleNodeType
             new("Editor", "Role") { Name = "Editor", NodeType = NodeType, Icon = EditorIcon, Content = Role.Editor },
             new("Viewer", "Role") { Name = "Viewer", NodeType = NodeType, Icon = ViewerIcon, Content = Role.Viewer },
             new("Commenter", "Role") { Name = "Commenter", NodeType = NodeType, Icon = CommenterIcon, Content = Role.Commenter },
-            new("Contributor", "Role") { Name = "Contributor", NodeType = NodeType, Icon = EditorIcon, Content = Role.Contributor },
+            new("Contributor", "Role") { Name = "Contributor", NodeType = NodeType, Icon = ContributorIcon, Content = Role.Contributor },
         ];
 
         public IEnumerable<MeshNode> GetStaticNodes() => Nodes;

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -406,6 +406,8 @@ public static class MeshNodeExtensions
         typeRegistry.WithType(typeof(TrackedChangeStatus), nameof(TrackedChangeStatus));
         typeRegistry.WithType(typeof(Notification), nameof(Notification));
         typeRegistry.WithType(typeof(NotificationType), nameof(NotificationType));
+        typeRegistry.WithType(typeof(Feedback), nameof(Feedback));
+        typeRegistry.WithType(typeof(FeedbackStatus), nameof(FeedbackStatus));
         typeRegistry.WithType(typeof(ApiToken), nameof(ApiToken));
         typeRegistry.WithType(typeof(MeshDataSourceConfiguration), nameof(MeshDataSourceConfiguration));
         typeRegistry.WithType(typeof(PartitionDefinition), nameof(PartitionDefinition));

--- a/src/MeshWeaver.Mesh.Contract/Feedback.cs
+++ b/src/MeshWeaver.Mesh.Contract/Feedback.cs
@@ -1,0 +1,66 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using MeshWeaver.Layout;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// Triage status of a piece of <see cref="Feedback"/>.
+/// </summary>
+public enum FeedbackStatus
+{
+    /// <summary>Just submitted, not yet looked at.</summary>
+    New,
+
+    /// <summary>Acknowledged and being worked on / categorised.</summary>
+    Triaged,
+
+    /// <summary>Closed — addressed, answered, or dismissed.</summary>
+    Resolved
+}
+
+/// <summary>
+/// A single piece of user feedback, filed by the <c>/feedback</c> skill into the dedicated
+/// <c>Feedback</c> space (one node per submission). The skill captures WHERE the user was
+/// (<see cref="Location"/> — the app context node path) and WHO they are
+/// (<see cref="SubmittedBy"/> / <see cref="SubmittedByName"/>) at submission time, so a reviewer
+/// can reproduce the context without asking. Content-type of <c>nodeType = "Feedback"</c> nodes.
+/// </summary>
+public record Feedback
+{
+    /// <summary>Unique identifier for the feedback entry.</summary>
+    [Browsable(false)]
+    [Key]
+    public string Id { get; init; } = Guid.NewGuid().ToString();
+
+    /// <summary>The feedback itself (markdown supported).</summary>
+    [Markdown(EditorHeight = "150px")]
+    public string Text { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Where the user was when they gave the feedback — the app context node PATH taken from the
+    /// "Current Application Context" the agent receives each round (e.g. <c>ACME/Reports/Q3</c>).
+    /// Lets a reviewer jump straight to the page the feedback is about. Empty if given with no context.
+    /// </summary>
+    public string? Location { get; init; }
+
+    /// <summary>
+    /// Identity (ObjectId / email) of the user who submitted the feedback. Mirrors
+    /// <see cref="MeshNode.CreatedBy"/>; kept on the content so it travels with an export.
+    /// </summary>
+    [Browsable(false)]
+    public string? SubmittedBy { get; init; }
+
+    /// <summary>Display name of the submitter (for showing on the review card without a User lookup).</summary>
+    public string? SubmittedByName { get; init; }
+
+    /// <summary>Optional free-text category the submitter (or triager) assigns — e.g. "bug", "idea", "praise".</summary>
+    public string? Category { get; init; }
+
+    /// <summary>When the feedback was submitted.</summary>
+    [Browsable(false)]
+    public DateTimeOffset SubmittedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>Triage status — starts <see cref="FeedbackStatus.New"/>; reviewers advance it.</summary>
+    public FeedbackStatus Status { get; init; } = FeedbackStatus.New;
+}

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -32,6 +32,7 @@ internal static class PermissionEvaluator
         { "Editor", Role.Editor },
         { "Viewer", Role.Viewer },
         { "Commenter", Role.Commenter },
+        { "Contributor", Role.Contributor },
         { "PlatformAdmin", Role.PlatformAdmin }
     };
 

--- a/src/MeshWeaver.Mesh.Contract/Security/Role.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/Role.cs
@@ -86,6 +86,22 @@ public record Role
     };
 
     /// <summary>
+    /// Built-in Contributor role: read, plus CREATE new nodes, comment, and start threads — but NOT
+    /// update or delete existing nodes. The least-privilege "can add, can't modify others'" grant.
+    /// Can be assigned to the <c>Public</c> user to let every authenticated user contribute content
+    /// into a shared space (e.g. the dedicated Feedback space) without being able to edit or delete
+    /// other people's entries.
+    /// </summary>
+    public static Role Contributor => new()
+    {
+        Id = "Contributor",
+        DisplayName = "Contributor",
+        Description = "Can read, create new nodes, comment, and start threads (but not edit or delete existing nodes)",
+        Permissions = Permission.Read | Permission.Create | Permission.Comment | Permission.Thread | Permission.Api,
+        IsInheritable = true
+    };
+
+    /// <summary>
     /// Built-in Platform Administrator role.
     /// Grants access to platform-level settings (auth providers, admin configuration).
     /// Assigned in the Admin namespace via standard AccessAssignment nodes.

--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "create-markdown", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys", "pull-request", "slide");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "create-space", "feedback", "harness", "layout-area", "markdown", "maui", "model", "navigate", "provider-keys", "pull-request", "slide");
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -29,7 +29,7 @@ public class SkillNodeTypeTest
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
         skills.Should().OnlyContain(n => n.Namespace == SkillNodeType.RootNamespace);
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "create-markdown", "create-space", "harness", "layout-area", "maui", "model", "navigate", "provider-keys", "pull-request", "slide");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "create-space", "feedback", "harness", "layout-area", "markdown", "maui", "model", "navigate", "provider-keys", "pull-request", "slide");
 
         var def = (SkillDefinition)skills.Single(n => n.Id == "model").Content!;
         def.Action!.Kind.Should().Be(SkillActionKind.Pick);

--- a/test/MeshWeaver.Graph.Test/FeedbackNodeTypeTest.cs
+++ b/test/MeshWeaver.Graph.Test/FeedbackNodeTypeTest.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Reactive.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The Feedback NodeType is wired end-to-end: a node created with <c>nodeType = "Feedback"</c> and a
+/// typed <see cref="Feedback"/> content reads back with its content STILL typed as <see cref="Feedback"/>
+/// — proving <c>AddFeedbackType</c>'s data source plus the central <c>WithType</c> registration. Every
+/// field the <c>/feedback</c> skill sets (the text, the captured <see cref="Feedback.Location"/>, the
+/// submitter, the <see cref="FeedbackStatus"/>) round-trips.
+/// </summary>
+public class FeedbackNodeTypeTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    [Fact(Timeout = 60000)]
+    public async Task FeedbackNode_RoundTrips_Typed()
+    {
+        await MeshService.CreateNode(new MeshNode("search-is-slow", "Feedback")
+        {
+            NodeType = FeedbackNodeType.NodeType,
+            Name = "Search is slow",
+            Icon = "📣",
+            Content = new Feedback
+            {
+                Text = "The search box takes ages on big spaces.",
+                Location = "ACME/Reports/Q3",
+                SubmittedBy = "rbuergi",
+                SubmittedByName = "Roland Bürgi",
+                Category = "bug",
+                Status = FeedbackStatus.New,
+            },
+        }).Should().Emit();
+
+        var node = await ReadNode("Feedback/search-is-slow")
+            .Where(n => n?.Content is Feedback)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30));
+
+        node!.NodeType.Should().Be(FeedbackNodeType.NodeType);
+        var feedback = (Feedback)node.Content!;
+        feedback.Text.Should().Be("The search box takes ages on big spaces.");
+        feedback.Location.Should().Be("ACME/Reports/Q3");   // the captured app-context path
+        feedback.SubmittedBy.Should().Be("rbuergi");
+        feedback.SubmittedByName.Should().Be("Roland Bürgi");
+        feedback.Category.Should().Be("bug");
+        feedback.Status.Should().Be(FeedbackStatus.New);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/FeedbackStaticRepoSourceTest.cs
+++ b/test/MeshWeaver.Graph.Test/FeedbackStaticRepoSourceTest.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The Feedback-space seed: the <see cref="FeedbackStaticRepoSource"/> that auto-provisions the
+/// dedicated Feedback space on every instance. Verifies the partition, the <see cref="PartitionSyncMode.Additive"/>
+/// mode (so user-filed feedback is NEVER pruned on re-import), the Space root, and the
+/// <c>Public → Contributor</c> grant that makes the board readable + contributable for every user —
+/// all platform admins included.
+/// </summary>
+public class FeedbackStaticRepoSourceTest
+{
+    private readonly FeedbackStaticRepoSource _source = new();
+
+    [Fact]
+    public void Partition_IsFeedback()
+        => _source.Partition.Should().Be("Feedback");
+
+    [Fact]
+    public void SyncMode_IsAdditive_SoUserFeedbackIsNeverPruned()
+        => _source.SyncMode.Should().Be(PartitionSyncMode.Additive);
+
+    [Fact]
+    public void PartitionRoot_IsTheFeedbackSpace()
+    {
+        var root = _source.PartitionRoot;
+        root.Should().NotBeNull();
+        root!.Id.Should().Be("Feedback");
+        root.NodeType.Should().Be("Space");
+    }
+
+    [Fact]
+    public void SeedsPublicContributorGrant_SoEveryUser_AndAllAdmins_CanContribute()
+    {
+        var grant = _source.EnumerateSourceNodes()
+            .Should().ContainSingle(n => n.NodeType == "AccessAssignment").Which;
+
+        grant.Namespace.Should().Be("Feedback/_Access");
+        grant.MainNode.Should().Be("Feedback");   // scope — an empty MainNode would be silently ignored
+
+        var assignment = grant.Content.Should().BeOfType<AccessAssignment>().Which;
+        assignment.AccessObject.Should().Be(WellKnownUsers.Public);
+        assignment.Roles.Should().ContainSingle(r => r.Role == "Contributor" && !r.Denied);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/FeedbackStaticRepoSourceTest.cs
+++ b/test/MeshWeaver.Graph.Test/FeedbackStaticRepoSourceTest.cs
@@ -47,4 +47,18 @@ public class FeedbackStaticRepoSourceTest
         assignment.AccessObject.Should().Be(WellKnownUsers.Public);
         assignment.Roles.Should().ContainSingle(r => r.Role == "Contributor" && !r.Denied);
     }
+
+    [Fact]
+    public void LocksTheAccessSubtree_SoPublicCannotSelfEscalate()
+    {
+        // A BreaksInheritance policy at Feedback/_Access keeps the inheritable Contributor grant from
+        // reaching the access-config subtree — otherwise a user's Create would let them write a
+        // self-granting AccessAssignment.
+        var policy = _source.EnumerateSourceNodes()
+            .Should().ContainSingle(n => n.NodeType == "PartitionAccessPolicy").Which;
+
+        policy.Namespace.Should().Be("Feedback/_Access");
+        policy.Content.Should().BeOfType<PartitionAccessPolicy>()
+            .Which.BreaksInheritance.Should().BeTrue();
+    }
 }

--- a/test/MeshWeaver.Security.Test/FeedbackContributorAccessTest.cs
+++ b/test/MeshWeaver.Security.Test/FeedbackContributorAccessTest.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Graph.Security;
 using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Monolith;
@@ -30,8 +32,10 @@ public class FeedbackContributorAccessTest(ITestOutputHelper output) : MonolithM
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
         ConfigureMeshBase(builder)
             .AddRowLevelSecurity()
-            // The dedicated Feedback space grants the Public subject the Contributor role.
-            .AddMeshNodes(AssignmentNodeFactory.UserRole(WellKnownUsers.Public, "Contributor", FeedbackScope));
+            // Seed EXACTLY what the platform ships for the Feedback space — the Public → Contributor
+            // grant AND the BreaksInheritance lock on the _Access subtree — so this test exercises the
+            // real access surface, self-escalation guard included.
+            .AddMeshNodes(new FeedbackStaticRepoSource().EnumerateSourceNodes().ToArray());
 
     // Granular permissions — skip the blanket PublicAdminAccess the base seeds.
     protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
@@ -67,5 +71,15 @@ public class FeedbackContributorAccessTest(ITestOutputHelper output) : MonolithM
     {
         await Mesh.GetEffectivePermissions("SomeOtherSpace", "some-random-user")
             .Should().Match(p => p == Permission.None);
+    }
+
+    [Fact(Timeout = 20000)]
+    public async Task PublicContributorGrant_CannotSelfEscalate_ViaTheAccessSubtree()
+    {
+        // The BreaksInheritance policy at Feedback/_Access discards the inherited Contributor role
+        // there, so a user has NO Create on the access-config subtree — they cannot write a
+        // self-granting AccessAssignment. (They can still create feedback entries at Feedback/{id}.)
+        await Mesh.GetEffectivePermissions($"{FeedbackScope}/_Access", "some-random-user")
+            .Should().Match(p => (p & Permission.Create) == Permission.None);
     }
 }

--- a/test/MeshWeaver.Security.Test/FeedbackContributorAccessTest.cs
+++ b/test/MeshWeaver.Security.Test/FeedbackContributorAccessTest.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Security;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// The built-in <see cref="Role.Contributor"/> role and the public-contribute grant that backs the
+/// dedicated Feedback space. Contributor is read + CREATE (not update/delete); granting it to the
+/// <see cref="WellKnownUsers.Public"/> subject at a scope makes EVERY authenticated user able to file
+/// there — via the Public permission fold in <c>PermissionEvaluator</c> — without being able to edit
+/// or delete other people's entries. This is exactly how <c>/feedback</c> opens the Feedback space.
+/// </summary>
+public class FeedbackContributorAccessTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string FeedbackScope = "Feedback";
+
+    private static readonly Permission ContributorPerms =
+        Permission.Read | Permission.Create | Permission.Comment | Permission.Thread | Permission.Api;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        ConfigureMeshBase(builder)
+            .AddRowLevelSecurity()
+            // The dedicated Feedback space grants the Public subject the Contributor role.
+            .AddMeshNodes(AssignmentNodeFactory.UserRole(WellKnownUsers.Public, "Contributor", FeedbackScope));
+
+    // Granular permissions — skip the blanket PublicAdminAccess the base seeds.
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void Contributor_Role_IsReadPlusCreate_NotUpdateOrDelete()
+    {
+        Role.Contributor.Permissions.Should().Be(ContributorPerms);
+        Role.Contributor.Permissions.Should().NotHaveFlag(Permission.Update);
+        Role.Contributor.Permissions.Should().NotHaveFlag(Permission.Delete);
+    }
+
+    [Fact(Timeout = 20000)]
+    public async Task PublicContributorGrant_LetsAnyUser_ContributeToFeedbackSpace()
+    {
+        // A user with NO explicit grant anywhere still gets Contributor at the Feedback scope,
+        // purely from the Public → Contributor assignment (the Public fold).
+        await Mesh.GetEffectivePermissions(FeedbackScope, "some-random-user")
+            .Should().Match(p => p == ContributorPerms);
+    }
+
+    [Fact(Timeout = 20000)]
+    public async Task PublicContributorGrant_Inherits_ToFeedbackEntries_ButNotUpdateOrDelete()
+    {
+        await Mesh.GetEffectivePermissions($"{FeedbackScope}/entry-123", "another-user")
+            .Should().Match(p => (p & Permission.Create) == Permission.Create
+                                 && (p & Permission.Update) == Permission.None
+                                 && (p & Permission.Delete) == Permission.None);
+    }
+
+    [Fact(Timeout = 20000)]
+    public async Task PublicContributorGrant_DoesNotLeak_ToOtherScopes()
+    {
+        await Mesh.GetEffectivePermissions("SomeOtherSpace", "some-random-user")
+            .Should().Match(p => p == Permission.None);
+    }
+}


### PR DESCRIPTION
## What & why

Adds a **`/feedback`** capability and renames a skill, per request.

### 1. Rename `create-markdown` → `markdown`
`content/ai/Skill/create-markdown.md` → `markdown.md` (`name: /markdown`), both skill-catalog test assertions re-sorted.

### 2. Assistant mandates the create-skills
`Assistant.md` now instructs the main agent to **load the matching skill first** before creating content (`/markdown`, `/create-space`, `/create-group`, `/feedback`) — never improvise the node shape.

### 3. `Feedback` type + `/feedback` skill
- **`Feedback` NodeType** — content record (`Feedback` + `FeedbackStatus`), registered in `AddGraph()` and the central type registry.
- **`/feedback` skill** — captures the user's **location** (the app-context node path the agent already receives) + **name** (from the `# Current User` prompt block) and files **one `Feedback` node per submission** into the dedicated **`Feedback`** space.

### 4. Dedicated `Feedback` space — auto-provisioned on every instance
- **`FeedbackStaticRepoSource`** seeds the top-level `Feedback` space (space root + a `Public → Contributor` grant), registered in `StaticRepoSyncExtensions`. **`SyncMode = Additive`** so user-filed feedback is never pruned on re-import; the importer provisions the writable PG partition.
- Result: the whole feature is **zero-touch after deploy** — no first-run bootstrap.

## 🔐 Access model (please eyeball)
- New built-in **`Contributor`** role = `Read | Create | Comment | Thread | Api` — **not** Update/Delete/Compile. It's a strict subset of `Editor` and grants nothing until an `AccessAssignment` references it.
- The `Feedback` space grants **`Public → Contributor`**, which folds into every authenticated user via `PermissionEvaluator` (same mechanism `Commenter` uses for public commenting). So **all users — including all platform admins** (who aren't data superusers and would otherwise be locked out) — can read the shared board and file feedback, but cannot edit/delete others' entries.
- **Note:** this is the shared-inbox model (everyone can read the board). If admins-**only** review is wanted, that's a follow-up (submit-only public role + admin-scoped read grant, or homing the inbox under the `Admin` partition).

## Tests
- Skill-catalog lists (rename + new `feedback`).
- `FeedbackNodeTypeTest` — typed round-trip proving registration.
- `FeedbackContributorAccessTest` — Contributor perms; the Public grant lets any user contribute but not update/delete; doesn't leak to other scopes.
- `FeedbackStaticRepoSourceTest` — partition, Additive mode, Space root, the `Public → Contributor` grant.

Full solution `dotnet build -c Release -p:CIRun=true -warnaserror` → **0 warnings, 0 errors**; all four affected test suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
