### PR TITLE
feat(groups): bulk-invite a list of emails to a group with a role

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/EventSubscriptions.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/EventSubscriptions.md
@@ -32,7 +32,7 @@ Because the mesh node is the durable source of truth (Postgres), durability is *
 | NodeChange | `TriggerNodeType`, `TriggerKind`, `MatchField`, `MatchValue` | fire when a node of this type is created/updated/deleted and its field matches |
 | Timer | `FireAt` | fire once at/after this instant (a past time fires on the next boot) |
 | NodeStatus | `WatchPath`, `StatusField`, `RestingValues`, `RequireActiveFirst` | fire when the watched node's status enters a resting value |
-| **Effect** | `ContinuationType` | `GrantSpaceAccess` \| `PostThreadMessage` |
+| **Effect** | `ContinuationType` | `GrantSpaceAccess` \| `AddToGroup` \| `PostThreadMessage` |
 | | `TargetPath`, `SubjectId`, `Role`, `Pin` | what the continuation does (and to whom) |
 | **Lifecycle** | `Status`, `CreatedBy`, `CreatedAt`, `FiredAt`, `LastError` | runner-managed (`Pending → Fired \| Failed \| Cancelled`) |
 
@@ -59,6 +59,8 @@ EventSubscriptionOps.CreateSubscription(meshService, subscription).Subscribe();
 ```
 
 When the invitee onboards, their `User` node is created → the change feed fires the subscription live; the reconcile path is the safety net if the sign-up happened during downtime. The continuation (`GrantSpaceAccess`) creates the `{space}/_Access/{user}_Access` assignment and pins the Space — both idempotent create-or-updates, so live + reconcile can never double-grant. The subject is the **triggering node's id** (a `User` node's path IS the userId).
+
+The group twin is `AddToGroup` (written by `GroupInviteExtensions.InviteToGroup` / the bulk `InviteAllToGroup` behind the group's "Invite by Email" dialog): on sign-up it creates the `{group}/{user}_Membership` node, and — when the invite chose a `Role` — additionally the `{group}/_Access/{user}_Access` assignment (groups are not publicly readable, so the grant is what lets the new member see the group; `Admin` makes them a group manager). Same idempotent upserts, same deterministic id per invitee+group.
 
 ## Trigger 2 — react to a timer
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/GrantingAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GrantingAccess.md
@@ -69,6 +69,8 @@ The picker loads the subject set once (capped at 500 nodes) and filters **in-mem
 
 **Not-yet-provisioned users — grant by email.** A `User` node is created at first login/onboarding, so a person who has never signed in has no node to *pick*. The **Add** row therefore also takes an **email**: leave the subject picker empty and type the address instead. If an account already exists it is granted the selected role immediately; otherwise the person is invited and a durable deferred grant — an `EventSubscription` (see [EventSubscriptions](/Doc/Architecture/EventSubscriptions)) — lands the **same role at this exact `{scope}/_Access`** the moment they sign up. The scheduled grant is byte-identical to the immediate one, so the invitee ends up with exactly the assignment an already-provisioned subject would. (You can still grant by principal via MCP — Recipe 3 below with the exact login userId — for a fully headless setup.)
 
+**Bulk-inviting a whole list into a group.** A Group node's **Edit** area has an **Invite by Email** button: paste a list of emails (newline / comma / semicolon separated; `Name <email>` entries work) and pick a role. Every entry becomes a group member with that role granted on the group — existing accounts immediately, everyone else via invitation email + the same deferred `EventSubscription` mechanics (`AddToGroup` carrying the role), landing membership + grant the moment they register. Junk tokens are skipped and reported, and re-running a list is idempotent.
+
 ---
 
 ## Anatomy of an AccessAssignment

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-11-group-bulk-invite.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-11-group-bulk-invite.md
@@ -1,0 +1,10 @@
+---
+Name: Invite a whole list of emails to a group
+Category: What's New
+Description: Groups now have an "Invite by Email" button — paste a list of addresses, pick a role, and everyone is added now or the moment they register.
+Icon: Sparkle
+---
+
+Bringing a whole team into a group no longer means adding people one by one. Every group's Edit page now has an **Invite by Email** button: paste a list of email addresses (one per line, comma-separated, or straight from your mail client as `Name <email>`), pick the role they should get, and hit Invite.
+
+People who already have an account become members right away. Everyone else receives an invitation email and is added to the group — with the chosen role — automatically the moment they register. Duplicates are folded, anything that isn't an email address is skipped and reported, and re-running the same list is always safe.

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -261,9 +261,16 @@ public sealed class EventSubscriptionRunner(
                     .SelectMany(g => subscription.Pin
                         ? AsSystem(() => EventSubscriptionOps.Pin(hub, userId, subscription.TargetPath!)).Select(_ => g)
                         : Observable.Return(g)),
+            // Membership, plus — when the invite chose a role — the matching AccessAssignment on the group
+            // (groups aren't publicly readable; the grant is what lets the new member see the group).
             EventContinuationType.AddToGroup
                 when subscription is { TargetPath.Length: > 0 } && !string.IsNullOrEmpty(userId) =>
-                AsSystem(() => EventSubscriptionOps.AddToGroup(meshService, userId, subscription.TargetPath!)),
+                AsSystem(() => EventSubscriptionOps.AddToGroup(meshService, userId, subscription.TargetPath!))
+                    .SelectMany(m => subscription.Role is { Length: > 0 }
+                        ? AsSystem(() => EventSubscriptionOps.Grant(
+                                meshService, userId, subscription.TargetPath!, subscription.Role!))
+                            .Select(_ => m)
+                        : Observable.Return(m)),
             _ => Observable.Throw<MeshNode>(new InvalidOperationException(
                 $"Unsupported or incomplete event subscription {subscription.Id}")),
         };

--- a/src/MeshWeaver.Graph/GroupInviteExtensions.cs
+++ b/src/MeshWeaver.Graph/GroupInviteExtensions.cs
@@ -18,6 +18,36 @@ public enum GroupInviteOutcome
     Invited,
 }
 
+/// <summary>Per-email status inside a <see cref="GroupBulkInviteResult"/>.</summary>
+public enum GroupBulkInviteStatus
+{
+    /// <summary>Existing account — added to the group (and granted the role) immediately.</summary>
+    Added,
+    /// <summary>No account yet — invitation email + deferred add-on-sign-up scheduled.</summary>
+    Invited,
+    /// <summary>The entry is not an email address — skipped (reported back to the caller).</summary>
+    Invalid,
+}
+
+/// <summary>One entry of a bulk group invite: the parsed email (or raw token) and what happened to it.</summary>
+public record GroupBulkInviteEntry(string Email, GroupBulkInviteStatus Status);
+
+/// <summary>The aggregated result of <see cref="GroupInviteExtensions.InviteAllToGroup"/>.</summary>
+public record GroupBulkInviteResult
+{
+    /// <summary>Per-email outcomes — valid emails in input order, then the skipped invalid tokens.</summary>
+    public IReadOnlyList<GroupBulkInviteEntry> Entries { get; init; } = [];
+    /// <summary>Existing accounts added (and granted the role) immediately.</summary>
+    public int AddedCount => Entries.Count(e => e.Status == GroupBulkInviteStatus.Added);
+    /// <summary>Not-yet-registered emails invited; membership + role land on sign-up.</summary>
+    public int InvitedCount => Entries.Count(e => e.Status == GroupBulkInviteStatus.Invited);
+    /// <summary>Tokens that were not email-shaped and were skipped.</summary>
+    public int InvalidCount => Entries.Count(e => e.Status == GroupBulkInviteStatus.Invalid);
+    /// <summary>The skipped tokens, for reporting back to the admin.</summary>
+    public IEnumerable<string> InvalidEmails
+        => Entries.Where(e => e.Status == GroupBulkInviteStatus.Invalid).Select(e => e.Email);
+}
+
 /// <summary>
 /// Invites a person (by email) to a <b>group</b> — the group twin of <see cref="SpaceInviteService"/>,
 /// composed from existing pieces. Stateless, so a static extension rather than a DI service: the two deps
@@ -36,13 +66,24 @@ public enum GroupInviteOutcome
 /// <c>accessObject</c> is the group path); every member then inherits it — membership resolves through the
 /// permission matview's group-expansion CTE. Keep the group, its memberships, and its grant under the same
 /// partition (the matview resolves group access within a schema).
+///
+/// <para>The optional per-member <b>role</b> is the member's role ON THE GROUP NODE itself (an
+/// <c>AccessAssignment</c> at <c>{groupPath}/_Access/{member}_Access</c> — exactly what Settings → Access
+/// Control on the group creates): <c>Viewer</c> = a regular member who can see the group,
+/// <c>Admin</c> = a group manager who can add/remove members. It does NOT change what the group grants
+/// its members elsewhere — that stays the group-level assignment above.</para>
 /// </summary>
 public static class GroupInviteExtensions
 {
     /// <summary>Invites <paramref name="email"/> to the group at <paramref name="groupPath"/>. Adds the
-    /// user now if they already exist, otherwise invites + schedules the durable add-on-sign-up.</summary>
+    /// user now if they already exist, otherwise invites + schedules the durable add-on-sign-up.
+    /// When <paramref name="role"/> is set, the member is ALSO granted that role on the group node
+    /// (an <c>AccessAssignment</c> at <c>{groupPath}/_Access</c> — the same node Settings → Access Control
+    /// creates): groups are not publicly readable, so the grant is what lets a member see the group at all,
+    /// and role <c>Admin</c> makes them a group manager. The deferred path carries the role on the
+    /// <see cref="EventSubscription"/>, so an invitee lands the identical membership + grant on sign-up.</summary>
     public static IObservable<GroupInviteOutcome> InviteToGroup(
-        this IMessageHub hub, string groupPath, string email, string? invitedBy)
+        this IMessageHub hub, string groupPath, string email, string? invitedBy, string? role = null)
     {
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
@@ -58,13 +99,85 @@ public static class GroupInviteExtensions
                 var existing = users.FirstOrDefault(u => EmailMatches(hub, u, normalizedEmail));
                 return existing is not null
                     ? EventSubscriptionOps.AddToGroup(meshService, existing.Id, groupPath)
+                        .SelectMany(m => role is { Length: > 0 }
+                            ? EventSubscriptionOps.Grant(meshService, existing.Id, groupPath, role).Select(_ => m)
+                            : Observable.Return(m))
                         .Select(_ => GroupInviteOutcome.Added)
-                    : ScheduleAndInvite(meshService, accessService, groupPath, normalizedEmail, invitedBy);
+                    : ScheduleAndInvite(meshService, accessService, groupPath, normalizedEmail, invitedBy, role);
             });
     }
 
+    /// <summary>
+    /// Bulk-invites a pasted list of emails (newline / comma / semicolon separated;
+    /// <c>Display Name &lt;email&gt;</c> entries are unwrapped) to the group at <paramref name="groupPath"/>,
+    /// each with <paramref name="role"/> — sequentially, via <see cref="InviteToGroup"/> per email, so a
+    /// long list can't stampede the store. Duplicates are folded case-insensitively; tokens that aren't
+    /// email-shaped are skipped and reported as <see cref="GroupBulkInviteStatus.Invalid"/>. Every
+    /// per-email effect is an idempotent upsert, so re-running the same list after a mid-list failure is
+    /// safe and completes the remainder.
+    /// </summary>
+    public static IObservable<GroupBulkInviteResult> InviteAllToGroup(
+        this IMessageHub hub, string groupPath, string emailList, string? invitedBy, string? role = null)
+    {
+        var (valid, invalid) = ParseEmails(emailList);
+        var invalidEntries = invalid
+            .Select(token => new GroupBulkInviteEntry(token, GroupBulkInviteStatus.Invalid))
+            .ToArray();
+        if (valid.Count == 0)
+            return Observable.Return(new GroupBulkInviteResult { Entries = invalidEntries });
+
+        return valid
+            .Select(email => Observable.Defer(() => hub.InviteToGroup(groupPath, email, invitedBy, role)
+                .Select(outcome => new GroupBulkInviteEntry(email, outcome == GroupInviteOutcome.Added
+                    ? GroupBulkInviteStatus.Added
+                    : GroupBulkInviteStatus.Invited))))
+            .Concat()
+            .ToArray()
+            .Select(entries => new GroupBulkInviteResult { Entries = [.. entries, .. invalidEntries] });
+    }
+
+    private static readonly char[] EntrySeparators = [',', ';', '\n', '\r'];
+    private static readonly char[] WhitespaceSeparators = [' ', '\t'];
+
+    /// <summary>
+    /// Parses a pasted email list into email-shaped tokens and skipped junk. Entries split on
+    /// newline / comma / semicolon; a <c>Display Name &lt;email&gt;</c> entry (the Outlook copy-paste shape)
+    /// is unwrapped to the address, otherwise an entry is further split on whitespace. Deduped
+    /// case-insensitively, first occurrence wins; input order preserved.
+    /// </summary>
+    public static (IReadOnlyList<string> Valid, IReadOnlyList<string> Invalid) ParseEmails(string? emailList)
+    {
+        var tokens = (emailList ?? string.Empty)
+            .Split(EntrySeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .SelectMany(entry =>
+            {
+                var open = entry.LastIndexOf('<');
+                var close = entry.LastIndexOf('>');
+                return open >= 0 && close > open
+                    ? [entry[(open + 1)..close].Trim()]
+                    : entry.Split(WhitespaceSeparators,
+                        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            })
+            .Where(t => t.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return (tokens.Where(IsEmailShaped).ToArray(), tokens.Where(t => !IsEmailShaped(t)).ToArray());
+    }
+
+    /// <summary>A pragmatic shape check (not full RFC 5322): one <c>@</c> with a non-empty local part and
+    /// a dotted domain — enough to catch names, stray words, and truncated addresses in a pasted list.</summary>
+    private static bool IsEmailShaped(string token)
+    {
+        var at = token.IndexOf('@');
+        if (at <= 0 || at != token.LastIndexOf('@') || at == token.Length - 1)
+            return false;
+        var domain = token[(at + 1)..];
+        return domain.Contains('.') && !domain.StartsWith('.') && !domain.EndsWith('.');
+    }
+
     private static IObservable<GroupInviteOutcome> ScheduleAndInvite(
-        IMeshService meshService, AccessService accessService, string groupPath, string email, string? invitedBy)
+        IMeshService meshService, AccessService accessService, string groupPath, string email, string? invitedBy,
+        string? role)
     {
         var subscription = new EventSubscription
         {
@@ -77,13 +190,24 @@ public static class GroupInviteExtensions
             MatchValue = email,
             ContinuationType = EventContinuationType.AddToGroup,
             TargetPath = groupPath,
+            Role = role,
             CreatedBy = invitedBy,
         };
         var invitation = new MeshNode(SpaceInviteService.Slug(email), InvitationNodeType.Namespace)
         {
             NodeType = InvitationNodeType.NodeType,
             Name = $"Invitation {email}",
-            Content = new Invitation { Email = email, InvitedBy = invitedBy, Note = $"Invited to group {groupPath}" },
+            // SpacePath = the group: the invitation email then addresses the group by name and links to it
+            // (the invitee can open it — the role grant lands with the membership on sign-up).
+            Content = new Invitation
+            {
+                Email = email,
+                InvitedBy = invitedBy,
+                Note = role is { Length: > 0 }
+                    ? $"Invited to group {groupPath} as {role}"
+                    : $"Invited to group {groupPath}",
+                SpacePath = groupPath,
+            },
         };
 
         // Both writes land in the Admin partition → system identity, constructed inside the scope. Both are

--- a/src/MeshWeaver.Graph/GroupLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/GroupLayoutAreas.cs
@@ -156,14 +156,24 @@ public static class GroupLayoutAreas
                         })));
             }
 
-            stack = stack.WithView(Controls.Button("Add Member")
-                .WithAppearance(Appearance.Accent)
-                .WithIconStart(FluentIcons.PersonAdd())
-                .WithClickAction(ctx =>
-                {
-                    ShowAddMemberDialog(ctx, hubPath);
-                    return Task.CompletedTask;
-                }));
+            stack = stack.WithView(Controls.Stack
+                .WithOrientation(Orientation.Horizontal)
+                .WithStyle("gap: 8px;")
+                .WithView(Controls.Button("Add Member")
+                    .WithAppearance(Appearance.Accent)
+                    .WithIconStart(FluentIcons.PersonAdd())
+                    .WithClickAction(ctx =>
+                    {
+                        ShowAddMemberDialog(ctx, hubPath);
+                        return Task.CompletedTask;
+                    }))
+                .WithView(Controls.Button("Invite by Email")
+                    .WithIconStart(FluentIcons.Mail())
+                    .WithClickAction(ctx =>
+                    {
+                        ShowBulkInviteDialog(ctx, hubPath);
+                        return Task.CompletedTask;
+                    })));
 
             return (UiControl?)stack;
         });
@@ -263,4 +273,95 @@ public static class GroupLayoutAreas
 
         ctx.Host.UpdateArea(DialogControl.DialogArea, dialog);
     }
+
+    /// <summary>
+    /// The bulk "Invite by Email" dialog: paste a list of emails (newline / comma / semicolon separated),
+    /// pick the role every invitee gets on the group, and invite. Existing accounts become members (with
+    /// the role granted on the group) immediately; unknown emails receive an invitation email and land the
+    /// identical membership + role the moment they register — via <see cref="GroupInviteExtensions.InviteAllToGroup"/>.
+    /// </summary>
+    private static void ShowBulkInviteDialog(UiActionContext ctx, string groupPath)
+    {
+        var formId = $"bulk_invite_{Guid.NewGuid().AsString()}";
+        ctx.Host.UpdateData(formId, new Dictionary<string, object?>
+        {
+            ["emails"] = "",
+            ["role"] = Role.Viewer.Id,
+        });
+        var dataContext = LayoutAreaReference.GetDataPointer(formId);
+
+        var formContent = Controls.Stack.WithStyle("gap: 16px; padding: 16px;")
+            .WithView((new TextAreaControl(new JsonPointerReference("emails"))
+                {
+                    Label = "Email addresses",
+                    Placeholder = "anna@example.com, ben@example.com — one per line or comma-separated",
+                    DataContext = dataContext,
+                }).WithRows(8))
+            .WithView(new SelectControl(new JsonPointerReference("role"), Array.Empty<object>())
+                    .WithOptions(new[] { Role.Admin.Id, Role.Editor.Id, Role.Viewer.Id, Role.Commenter.Id })
+                with { Label = "Role", DataContext = dataContext })
+            .WithView(Controls.Markdown(
+                    "Everyone on the list becomes a member with the selected role on this group. "
+                    + "Existing accounts are added right away; everyone else receives an invitation email "
+                    + "and is added automatically the moment they register.")
+                .WithStyle("font-size: 12px; opacity: .75;"))
+            .WithView(Controls.Stack
+                .WithOrientation(Orientation.Horizontal)
+                .WithStyle("justify-content: flex-end; gap: 8px;")
+                .WithView(Controls.Button("Invite")
+                    .WithAppearance(Appearance.Accent)
+                    .WithIconStart(FluentIcons.Mail())
+                    .WithClickAction(inviteCtx =>
+                    {
+                        inviteCtx.Host.Stream.GetDataStream<Dictionary<string, object?>>(formId)
+                            .Take(1)
+                            .Subscribe(form =>
+                            {
+                                var emailList = form.GetValueOrDefault("emails")?.ToString() ?? "";
+                                var role = form.GetValueOrDefault("role")?.ToString()?.Trim();
+                                if (string.IsNullOrEmpty(role))
+                                    role = Role.Viewer.Id;
+
+                                var (valid, invalid) = GroupInviteExtensions.ParseEmails(emailList);
+                                if (valid.Count == 0)
+                                {
+                                    ShowDialogMessage(inviteCtx, invalid.Count == 0
+                                            ? "Please enter at least one **email address**."
+                                            : "No valid email address found. Not email-shaped: "
+                                              + string.Join(", ", invalid.Select(t => $"`{t}`")),
+                                        "Validation Error");
+                                    return;
+                                }
+
+                                var accessService = inviteCtx.Hub.ServiceProvider.GetRequiredService<AccessService>();
+                                var invitedBy = accessService.Context?.ObjectId;
+                                inviteCtx.Hub.InviteAllToGroup(groupPath, emailList, invitedBy, role)
+                                    .Subscribe(
+                                        result => ShowDialogMessage(inviteCtx, BuildInviteSummary(result, role),
+                                            "Invitations"),
+                                        ex => ShowDialogMessage(inviteCtx, $"Inviting failed: {ex.Message}", "Error"));
+                            });
+                        return Task.CompletedTask;
+                    })));
+
+        var dialog = Controls.Dialog(formContent, "Invite by Email")
+            .WithSize("M")
+            .WithClosable(true);
+
+        ctx.Host.UpdateArea(DialogControl.DialogArea, dialog);
+    }
+
+    private static string BuildInviteSummary(GroupBulkInviteResult result, string role)
+    {
+        var summary = $"**{result.AddedCount}** added now · **{result.InvitedCount}** invited "
+                      + $"(added when they register) · role **{role}**.";
+        if (result.InvalidCount > 0)
+            summary += "\n\nSkipped (not email-shaped): "
+                       + string.Join(", ", result.InvalidEmails.Select(t => $"`{t}`"));
+        return summary;
+    }
+
+    private static void ShowDialogMessage(UiActionContext ctx, string markdown, string title) =>
+        ctx.Host.UpdateArea(DialogControl.DialogArea,
+            Controls.Dialog(Controls.Markdown(markdown), title).WithSize("S").WithClosable(true));
 }

--- a/test/MeshWeaver.Graph.Test/GroupBulkInviteTest.cs
+++ b/test/MeshWeaver.Graph.Test/GroupBulkInviteTest.cs
@@ -1,0 +1,221 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Tests <see cref="GroupInviteExtensions.ParseEmails"/> — the pasted-list parser behind the bulk
+/// group invite. Pure static, no mesh needed.
+/// </summary>
+public class GroupBulkInviteParseTest
+{
+    [Fact]
+    public void ParseEmails_SplitsOnSeparators_DedupesCaseInsensitively_PreservesOrder()
+    {
+        var (valid, invalid) = GroupInviteExtensions.ParseEmails(
+            "anna@acme.com, ben@acme.com;carol@acme.com\nANNA@acme.com\r\n  dave@acme.com  ");
+        Assert.Equal(["anna@acme.com", "ben@acme.com", "carol@acme.com", "dave@acme.com"], valid);
+        Assert.Empty(invalid);
+    }
+
+    [Fact]
+    public void ParseEmails_UnwrapsDisplayNameAngleBracketEntries()
+    {
+        // The Outlook copy-paste shape: "Display Name <email>" — the display name is NOT junk.
+        var (valid, invalid) = GroupInviteExtensions.ParseEmails(
+            "Anna Ammann <anna@acme.com>, Ben Berger <ben@acme.com>");
+        Assert.Equal(["anna@acme.com", "ben@acme.com"], valid);
+        Assert.Empty(invalid);
+    }
+
+    [Theory]
+    [InlineData("not-an-email")]      // no @
+    [InlineData("@acme.com")]         // empty local part
+    [InlineData("anna@")]             // empty domain
+    [InlineData("anna@acmecom")]      // undotted domain (the classic truncated paste)
+    [InlineData("anna@@acme.com")]    // double @
+    [InlineData("anna@.acme.com.")]   // leading/trailing dot in domain
+    public void ParseEmails_FlagsJunkTokensAsInvalid(string junk)
+    {
+        var (valid, invalid) = GroupInviteExtensions.ParseEmails($"good@acme.com\n{junk}");
+        Assert.Equal(["good@acme.com"], valid);
+        Assert.Equal([junk], invalid);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  \n , ; ")]
+    public void ParseEmails_EmptyInput_YieldsNothing(string? input)
+    {
+        var (valid, invalid) = GroupInviteExtensions.ParseEmails(input);
+        Assert.Empty(valid);
+        Assert.Empty(invalid);
+    }
+}
+
+/// <summary>
+/// Tests <see cref="GroupInviteExtensions.InviteAllToGroup"/> — the bulk "invite a pasted list of
+/// emails to a group with a role" feature behind the group's "Invite by Email" dialog:
+/// <list type="bullet">
+///   <item>An existing account is added immediately — a <c>GroupMembership</c> node PLUS the selected
+///     role as an <c>AccessAssignment</c> on the group (groups aren't publicly readable, so the grant is
+///     what lets the member see the group).</item>
+///   <item>An unknown email gets an <c>Invitation</c> (emailed by <c>InvitationEmailSender</c>, addressing
+///     the group by name via <c>SpacePath</c>) and a durable <see cref="EventSubscription"/> carrying the
+///     role — fired by <see cref="EventSubscriptionRunner"/> on sign-up, landing the identical
+///     membership + grant.</item>
+///   <item>Junk tokens are skipped and reported, never written.</item>
+/// </list>
+/// </summary>
+public class GroupBulkInviteTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Space = "BulkSpace";
+    private const string GroupPath = Space + "/Crew";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(new MeshNode(Space) { Name = "Bulk Space", NodeType = "Space" });
+
+    private async Task SeedGroupAsync()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode("Crew", Space)
+            {
+                NodeType = "Group",
+                Name = "Crew",
+                Content = new AccessObject { Description = "Bulk-invited crew" },
+            }).Should().Emit();
+    }
+
+    private async Task SeedUserAsync(string userId, string email)
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode(userId)
+            {
+                NodeType = "User",
+                Name = userId,
+                Content = new User { Email = email, FullName = userId },
+            }).Should().Emit();
+
+        // Wait until the account is queryable by email (the invite looks it up that way).
+        await meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:User content.email:{email}"))
+            .Where(c => c.ChangeType == QueryChangeType.Initial && c.Items.Any(n => n.Id == userId))
+            .FirstAsync().Timeout(30.Seconds());
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task BulkInvite_MixedList_AddsExisting_InvitesUnknown_SkipsJunk_DedupesRepeats()
+    {
+        const string existingEmail = "bob@acme.com";
+        const string existingId = "bob";
+        const string newEmail = "carol@acme.com";
+
+        await SeedGroupAsync();
+        await SeedUserAsync(existingId, existingEmail);
+
+        // One existing account, one unknown email (repeated in Outlook shape → deduped), one junk token.
+        var result = await Mesh.InviteAllToGroup(GroupPath,
+                $"{existingEmail}\n{newEmail}\nnot-an-email\nCarol <{newEmail}>",
+                invitedBy: "admin", role: Role.Editor.Id)
+            .FirstAsync().Timeout(30.Seconds());
+
+        Assert.Equal(1, result.AddedCount);
+        Assert.Equal(1, result.InvitedCount);
+        Assert.Equal(1, result.InvalidCount);
+        Assert.Equal(["not-an-email"], result.InvalidEmails.ToArray());
+        Assert.Equal(3, result.Entries.Count);
+        Assert.Equal(GroupBulkInviteStatus.Added,
+            result.Entries.Single(e => e.Email == existingEmail).Status);
+        Assert.Equal(GroupBulkInviteStatus.Invited,
+            result.Entries.Single(e => e.Email == newEmail).Status);
+
+        // The existing user landed BOTH the membership and the selected role on the group.
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{GroupPath}/{existingId}_Membership")
+            .Where(n => n?.Content is GroupMembership gm
+                        && gm.Member == existingId
+                        && gm.Groups.Any(e => e.Group == GroupPath))
+            .FirstAsync().Timeout(20.Seconds());
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{GroupPath}/_Access/{existingId}_Access")
+            .Where(n => n?.Content is AccessAssignment a
+                        && a.AccessObject == existingId
+                        && a.Roles.Any(r => r.Role == Role.Editor.Id && !r.Denied))
+            .FirstAsync().Timeout(20.Seconds());
+
+        // The unknown email got an Invitation addressing the group (SpacePath drives the invite email)…
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{InvitationNodeType.Namespace}/{SpaceInviteService.Slug(newEmail)}")
+            .Where(n => n?.Content is Invitation inv
+                        && inv.Email == newEmail
+                        && inv.SpacePath == GroupPath)
+            .FirstAsync().Timeout(30.Seconds());
+
+        // …and a deferred subscription carrying the SELECTED role, so sign-up lands the identical grant.
+        await Mesh.GetWorkspace().GetQuery("bulk-inv-subs",
+                $"path:{EventSubscriptionNodeType.Namespace} scope:children nodeType:{EventSubscriptionNodeType.NodeType}")
+            .Where(nodes => (nodes ?? []).Any(n => n.Content is EventSubscription s
+                && s.TriggerType == EventTriggerType.NodeChange
+                && s.ContinuationType == EventContinuationType.AddToGroup
+                && s.MatchValue == newEmail
+                && s.TargetPath == GroupPath
+                && s.Role == Role.Editor.Id))
+            .FirstAsync().Timeout(30.Seconds());
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task BulkInvitedEmail_SignsUp_MembershipAndRoleLand()
+    {
+        const string email = "dave@acme.com";
+        const string userId = "dave";
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var changeFeed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        await SeedGroupAsync();
+
+        // Arm the runner BEFORE the triggering write so the live change-feed path fires the continuation.
+        using var runner = new EventSubscriptionRunner(Mesh, changeFeed, meshService, accessService,
+            Mesh.ServiceProvider.GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>());
+        await runner.StartAsync(default);
+
+        var result = await Mesh.InviteAllToGroup(GroupPath, email, invitedBy: "admin", role: Role.Editor.Id)
+            .FirstAsync().Timeout(30.Seconds());
+        Assert.Equal(1, result.InvitedCount);
+
+        // The invitee signs up — their User node is created (as onboarding does).
+        await SeedUserAsync(userId, email);
+
+        // Wait for the subscription's terminal state first (race-free: both writes complete BEFORE the
+        // Fired write, so once Fired is observed the membership + grant already exist).
+        var subId = $"addgroup_{SpaceInviteService.Slug(email)}_{SpaceInviteService.Slug(GroupPath)}";
+        var final = await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subId))
+            .Select(n => n?.Content as EventSubscription)
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.True(final!.Status == EventSubscriptionStatus.Fired,
+            $"subscription ended {final.Status}: {final.LastError}");
+
+        // Membership + the selected role landed — identical to what an immediate add would have written.
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{GroupPath}/{userId}_Membership")
+            .Where(n => n?.Content is GroupMembership gm
+                        && gm.Member == userId
+                        && gm.Groups.Any(e => e.Group == GroupPath))
+            .FirstAsync().Timeout(20.Seconds());
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{GroupPath}/_Access/{userId}_Access")
+            .Where(n => n?.Content is AccessAssignment a
+                        && a.AccessObject == userId
+                        && a.Roles.Any(r => r.Role == Role.Editor.Id && !r.Denied))
+            .FirstAsync().Timeout(20.Seconds());
+    }
+}


### PR DESCRIPTION
## What

Groups get a **bulk invite** feature: the group's **Edit** area now has an **Invite by Email** button. Paste a long list of email addresses (one per line, comma/semicolon separated, or straight from a mail client as `Name <email>`), pick a **role**, and invite. Each person is added to the group with that role — immediately if they already have an account, otherwise the moment they register.

## How it works — composed from existing pieces, nothing new invented

Per email, `IMessageHub.InviteAllToGroup` (new) → `InviteToGroup` (extended with `role`):

- **Account exists** → `GroupMembership` node (`EventSubscriptionOps.AddToGroup`) **plus** the selected role as an `AccessAssignment` on the group node (`{group}/_Access/{member}_Access` — byte-identical to what Settings → Access Control on the group creates). Groups are not publicly readable, so the grant is what lets a member see the group at all; `Admin` makes them a group manager. Runs under the inviting admin's identity.
- **No account yet** → an `Invitation` (the existing `InvitationEmailSender` emails it; `SpacePath` = the group path, so the email addresses the group by name and links to it) **plus** the existing durable `AddToGroup` `EventSubscription`, now carrying `Role`. `EventSubscriptionRunner`'s `AddToGroup` continuation applies membership + grant when the matching `User` node is created — restart-safe via the runner's live + reconcile paths, both idempotent upserts with deterministic ids (`addgroup_{email}_{group}`), so a re-invite upserts instead of duplicating.
- **Junk tokens** (not email-shaped) are skipped and reported back in the summary dialog; duplicates fold case-insensitively; `Display Name <email>` unwraps. Invites run **sequentially** (`Concat`) so a long list can't stampede the store, and because every effect is an idempotent upsert, re-running a partially-applied list is safe.

Role semantics: the per-member role is the member's role **on the group node itself** (see it / manage it). What the group grants its members elsewhere stays the group-level `AccessAssignment` (`accessObject` = group path) — unchanged.

## Files

- `src/MeshWeaver.Graph/GroupInviteExtensions.cs` — `InviteToGroup(role)`, bulk `InviteAllToGroup`, `ParseEmails`, result types.
- `src/MeshWeaver.Graph/EventSubscriptionRunner.cs` — `AddToGroup` continuation also grants when `Role` is set (role-less subscriptions behave exactly as before).
- `src/MeshWeaver.Graph/GroupLayoutAreas.cs` — "Invite by Email" button + dialog (TextArea + role select + summary), standard form-data pattern, reactive `.Subscribe(...)` only.
- `test/MeshWeaver.Graph.Test/GroupBulkInviteTest.cs` — parse-level tests (separators, Outlook shape, junk flagging, dedupe, empty input) + mesh integration: mixed list (existing user added with role; unknown email → invitation with `SpacePath` + role-carrying subscription; junk reported), and end-to-end sign-up (runner armed → user created → subscription `Fired` → membership + grant land).
- Docs: `EventSubscriptions.md` (continuation table + `AddToGroup` role note), `GrantingAccess.md` (bulk-invite section), What's New entry.

## Verification

- Full solution `dotnet build MeshWeaver.slnx -c Release -warnaserror -p:CIRun=true`: 0 warnings, 0 errors.
- New tests 13/13 green; regression suites (`GroupInviteExtensionsTest`, `SpaceInviteServiceTest`, `SpaceInviteMenuTest`, `AccessControlGrantByEmailTest`, `EventSubscriptionRunnerTest`) 13/13 green.
- `DocumentationLinkIntegrityTest` green.
- Branch is up to date with `origin/main` (0 behind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)