### PR TITLE
fix(settings): pages scroll normally — remove the height:100% viewport pinning

### DIFF
--- a/src/MeshWeaver.Blazor/wwwroot/standard-page-layout.css
+++ b/src/MeshWeaver.Blazor/wwwroot/standard-page-layout.css
@@ -174,9 +174,14 @@ body {
 /* No inner scroller and no min-height:0 here — the settings page scrolls as a
    whole in .body-content. flex:1 1 auto only lets a SHORT page's background
    reach the bottom of the pane; a long page sizes the pane (and the page scroll)
-   by its content. */
+   by its content. overflow-x CLIP (not hidden!) keeps wide content (tables/code)
+   from widening the whole page: `hidden` would force overflow-y to compute to
+   `auto` and quietly reintroduce the inner vertical scroller this fix removed,
+   while `clip` contains the axis without creating a scroll container (same
+   treatment as mobile .body-content). */
 .settings-content-pane {
     flex: 1 1 auto;
+    overflow-x: clip;
     padding: 32px 40px 56px;
     background: var(--neutral-layer-1);
 }

--- a/src/MeshWeaver.Blazor/wwwroot/standard-page-layout.css
+++ b/src/MeshWeaver.Blazor/wwwroot/standard-page-layout.css
@@ -61,13 +61,18 @@ body {
     padding: 16px
 }
 
-/* Side-menu splitters (Settings page, NodeType shell) — give each pane a
-   definite-height flex context so menu and content scroll INDEPENDENTLY instead
-   of the whole page overflowing. Mirrors the treatment PortalLayoutBase applies
-   to its outer .body-splitter. The splitter fills its parent
-   .layout-area-container (a flex column) rather than a viewport-minus-magic-number
-   guess. */
-.settings-splitter,
+/* Side-menu splitter (NodeType shell) — give each pane a definite-height flex
+   context so menu and content scroll INDEPENDENTLY instead of the whole page
+   overflowing. Mirrors the treatment PortalLayoutBase applies to its outer
+   .body-splitter. The splitter fills its parent .layout-area-container (a flex
+   column) rather than a viewport-minus-magic-number guess.
+
+   The SETTINGS splitter deliberately does NOT get this treatment (any more):
+   settings pages flow at their natural content height and the PAGE scrolls in
+   .body-content, like every other page. FluentMultiSplitter's own stylesheet
+   pins `.fluent-multi-splitter { height: 100% }`, so the settings skin sets an
+   inline `height: auto; flex: 1 0 auto` (SettingsLayoutArea.BuildSettingsPage)
+   — grow-to-fill short pages, never shrink-and-clip long ones. */
 .shell-splitter {
     flex: 1 1 auto;
     min-height: 0;
@@ -91,12 +96,21 @@ body {
    these rules match nothing, the pane keeps FluentUI's default
    `display:block; overflow:hidden`, and the content stack below never gets a
    definite height to scroll within (it just clips). */
-.settings-splitter .fluent-multi-splitter-pane,
 .shell-splitter .fluent-multi-splitter-pane {
     overflow: hidden;
     display: flex;
     flex-direction: column;
     min-height: 0;
+}
+
+/* Settings panes must NOT clip: the settings page flows at content height and
+   scrolls in .body-content, so the pane only needs to stop hiding overflow
+   (FluentUI's pane default is overflow:hidden). Kept a flex column so the
+   > div fill rule below still applies. */
+.settings-splitter .fluent-multi-splitter-pane {
+    overflow: visible;
+    display: flex;
+    flex-direction: column;
 }
 
 .settings-splitter .fluent-multi-splitter-pane > div,
@@ -121,10 +135,10 @@ body {
     overflow-x: hidden;
 }
 
-/* Menu pane scrolls on its own. NavMenuView ignores inline Style on its root,
+/* Shell menu pane scrolls on its own. NavMenuView ignores inline Style on its root,
    so the scroll context has to come from the stylesheet. flex:1 1 auto (not
-   height:100%) for the same indefinite-percentage-height reason as the content pane. */
-.settings-splitter .navmenu,
+   height:100%) for the same indefinite-percentage-height reason as the content pane.
+   The settings nav menu is NOT listed here: it flows with the page scroll. */
 .shell-splitter .navmenu {
     flex: 1 1 auto;
     min-height: 0;
@@ -157,11 +171,12 @@ body {
     padding: 8px 0;
 }
 
+/* No inner scroller and no min-height:0 here — the settings page scrolls as a
+   whole in .body-content. flex:1 1 auto only lets a SHORT page's background
+   reach the bottom of the pane; a long page sizes the pane (and the page scroll)
+   by its content. */
 .settings-content-pane {
     flex: 1 1 auto;
-    min-height: 0;
-    overflow-y: auto;
-    overflow-x: hidden;
     padding: 32px 40px 56px;
     background: var(--neutral-layer-1);
 }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-11-settings-page-scroll.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-11-settings-page-scroll.md
@@ -1,0 +1,8 @@
+---
+Name: Settings pages scroll like normal pages
+Category: What's New
+Description: Settings no longer pins itself to the screen height — long settings pages now scroll with the page, so nothing is clipped out of reach.
+Icon: Sparkle
+---
+
+Settings pages used to lock themselves to exactly the visible screen height and scroll inside a nested pane — which, depending on the tab, could clip the bottom of the content out of reach. That's gone: a settings page now takes its natural height and the page itself scrolls, exactly like every other page. Long tabs, short screens, zoomed-in browsers — everything is reachable by just scrolling.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-11-settings-page-scroll.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-11-settings-page-scroll.md
@@ -1,7 +1,7 @@
 ---
 Name: Settings pages scroll like normal pages
 Category: What's New
-Description: Settings no longer pins itself to the screen height — long settings pages now scroll with the page, so nothing is clipped out of reach.
+Description: Settings pages no longer pin themselves to the screen height — long settings pages now scroll with the page, so nothing is clipped out of reach.
 Icon: Sparkle
 ---
 

--- a/src/MeshWeaver.Graph/SettingsLayoutArea.cs
+++ b/src/MeshWeaver.Graph/SettingsLayoutArea.cs
@@ -70,23 +70,22 @@ public static class SettingsLayoutArea
         bool canEdit,
         IReadOnlyList<SettingsMenuItemDefinition> items)
     {
-        // `settings-splitter` (standard-page-layout.css) gives each pane a definite-height
-        // flex context so the right content pane scrolls internally — mirrors the treatment
-        // PortalLayoutBase applies to its outer `.body-splitter`. Height fills the parent
-        // `.layout-area-container` (flex column) rather than a viewport-minus-magic-number
-        // guess, which was overshooting the real header/messagebar height and clipping the
-        // bottom of the content out of reach.
-        // Do NOT set Height="100%" on the splitter skin. FluentMultiSplitter renders its pane
-        // chrome in shadow DOM, so the global `.settings-splitter` CSS can't reach the inner
-        // host; the only height the component honours is the `Height` parameter fed from this
-        // skin. An inline `height:100%` resolves against an indefinite-height ancestor → it
-        // collapses to content height, the splitter grows past the viewport, and nothing
-        // scrolls. Instead let the splitter take its height from the `flex:1 1 auto; min-height:0`
-        // it already gets via the `.settings-splitter` class inside the flex-column
-        // `.layout-area-container` — a real, bounded height the `.settings-content-pane`
-        // (overflow-y:auto) scrolls within.
+        // The settings page flows at its natural content height and the PAGE scrolls
+        // (.body-content is the scroll container) — NO viewport-pinning, NO inner scroller.
+        // FluentMultiSplitter's own stylesheet pins `.fluent-multi-splitter { height: 100% }`,
+        // which inside the flex-column `.layout-area-container` resolves to exactly the visible
+        // pane height and (with the old pane overflow:hidden) clipped everything below the fold.
+        // The inline style beats that class deterministically:
+        //   height:auto     — content decides the height, never the viewport;
+        //   flex:1 0 auto   — a SHORT page still grows to the bottom (background fills), but
+        //                     shrink:0 stops the fill-area rule (`flex:1 1 auto; min-height:0`
+        //                     on the layout area's child) from shrink-clipping a LONG page back
+        //                     to the container height. Content taller than the viewport simply
+        //                     overflows the container and .body-content scrolls — like every
+        //                     other page.
         var settingsPage = Controls.Splitter
             .WithClass("settings-splitter")
+            .WithStyle("height: auto; flex: 1 0 auto;")
             .WithSkin(s => s.WithOrientation(Orientation.Horizontal).WithWidth("100%"))
             .WithView(
                 BuildMenuPane(host, node, hubAddress, hubPath, items, tabId),
@@ -99,11 +98,11 @@ public static class SettingsLayoutArea
 
         if (!canEdit)
         {
-            // Fill the layout-area-container as a flex column: the banner takes its natural
-            // height and the splitter (flex: 1, min-height: 0) shrinks to fill the rest, so
-            // the inner content pane still scrolls.
+            // A flowing flex column: the banner takes its natural height, the splitter its
+            // content height. No height:100%, no overflow:hidden — the page scrolls as a whole
+            // (flex-shrink:0 for the same fill-area shrink-clipping reason as on the splitter).
             return Controls.Stack.WithWidth("100%")
-                .WithStyle("height: 100%; min-height: 0; display: flex; flex-direction: column; overflow: hidden;")
+                .WithStyle("display: flex; flex-direction: column; flex: 1 0 auto;")
                 .WithView(Controls.Html(
                     "<div style=\"padding: 8px 16px; background: var(--neutral-layer-3); border-bottom: 1px solid var(--neutral-stroke-rest); " +
                     "color: var(--neutral-foreground-hint); font-size: 0.85rem; text-align: center;\">Read-only — you do not have edit permissions</div>"))
@@ -231,17 +230,13 @@ public static class SettingsLayoutArea
         string tabId,
         IReadOnlyList<SettingsMenuItemDefinition> items)
     {
-        // Scroll the content pane internally via the flex-fill pattern defined in
-        // standard-page-layout.css — the same treatment PortalLayoutBase applies to its
-        // .body-splitter. FluentMultiSplitter renders each pane as LIGHT DOM — a plain
+        // No inner scroller: the content pane takes its natural height and the PAGE scrolls
+        // (.body-content). FluentMultiSplitter renders each pane as LIGHT DOM — a plain
         // <div class="fluent-multi-splitter-pane"> (verified against the FluentUI source;
         // it is NOT a web component / shadow root), so the stylesheet selector
-        // `.settings-splitter .fluent-multi-splitter-pane` reaches it: it overrides the
-        // component's default `overflow:hidden` pane into a definite-height flex column, makes the
-        // content wrapper fill it, and `.settings-content-pane` (flex:1 1 auto; min-height:0;
-        // overflow-y:auto) scrolls within. The styling therefore lives in the class — only the
-        // local padding is inline. (A prior inline `height:100%` here overrode the class and is the
-        // hack this removes.)
+        // `.settings-splitter .fluent-multi-splitter-pane` reaches it and un-hides the
+        // component's default `overflow:hidden` (standard-page-layout.css). The
+        // `.settings-content-pane` class carries only padding/background/reading-column.
         var stack = Controls.Stack
             .WithClass("settings-content-pane")
             .WithWidth("100%");


### PR DESCRIPTION
## What

Settings pages were pinning themselves to exactly the visible screen height (a `height: 100%` in the render tree) and scrolling inside a nested pane — depending on the tab, content below the fold was clipped out of reach. Settings pages now take their natural content height and the **page scrolls** in `.body-content`, like every other page.

## Root cause

FluentMultiSplitter's own component stylesheet pins `.fluent-multi-splitter { width: 100%; height: 100% }` (verified against the FluentUI source — the `Height` *parameter* defaults to null, but the class rule does not). Inside the flex-column `.layout-area-container` that resolves to exactly the visible pane height; the settings CSS then clipped the panes (`overflow: hidden`) and relied on an inner `.settings-content-pane` scroller.

## Fix

- `SettingsLayoutArea`: the settings splitter gets an inline `height: auto; flex: 1 0 auto` (inline style beats the component class deterministically; `flex-shrink: 0` stops the `fill-area` rule — `flex: 1 1 auto; min-height: 0` on the layout area's child — from shrink-clipping a long page back to container height, while `flex-grow: 1` still lets a short page's background reach the bottom). The read-only banner wrapper loses its `height: 100%`/`overflow: hidden` too.
- `standard-page-layout.css`: the viewport-fill / pane `overflow: hidden` / inner-scroller rules are now **`.shell-splitter`-only** (the NodeType reader shell deliberately keeps its independent-scroll design). Settings panes stop clipping (`overflow: visible`) and `.settings-content-pane` keeps only padding/background/reading-column.

## Verification

Playwright against the running Monolith (DevLogin, 500px viewport) on `Doc/Settings` and `Doc/Settings/Access`:

- splitter inline height is `auto`; splitter height **==** content height (1663px — previously pinned to the ~460px container),
- `.body-content` scrolls (`scrollHeight 1716 > clientHeight 635`),
- scrolled to the bottom, the last card (Timestamps) is fully visible — nothing clipped.

`MeshWeaver.Graph` + `MeshWeaver.Blazor` build clean under `-c Release -warnaserror -p:CIRun=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)