### PR TITLE
Plugin catalog: discover node-repo roots at <Plugin>/index.json

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -39,7 +39,7 @@ Two endpoints, mapped by `PluginRegistryEndpoints` (`memex/Memex.Portal.Shared/A
 authenticated `/api/mesh/*` surface, these are **anonymous** — a plugin registry is meant to be
 pulled by any installation. That is safe because the registry only exposes **curated plugins**:
 by default the node-native repos the [`MeshWeaver.Plugins`](/Doc/Architecture/Plugins) repo ships —
-top-level `<Plugin>.json` **Space** roots carrying a `PluginManifest`, node-per-file — via a
+`<Plugin>/index.json` **Space** roots carrying a `PluginManifest`, node-per-file — via a
 `NodeRepoPackageSource` (`PluginCatalog:SourceFormat=node-repo`, the default). A `package.json`-manifest
 repo can be served instead with `SourceFormat=package-json`. Nothing outside a published plugin is
 exposed, and the registry's own credential never leaves.

--- a/src/MeshWeaver.Documentation/Data/Architecture/Plugins.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Plugins.md
@@ -22,15 +22,19 @@ A node repo is exactly the on-disk shape the sample partitions use — a `*.json
 `Source/` (and `Test/`) C# — e.g. the Slide type:
 
 ```text
-Slides.json                       the plugin's top-level Space node (the "package node")
+Slides/index.json                 the plugin's Space root (the "package node") — INSIDE the folder
 Slides/Slide.json                 a NodeType node (Content = NodeTypeDefinition{ configuration })
 Slides/Slide/Source/*.cs          the content type + layout areas — compiled live
 Slides/Slide/Test/*.cs            the type's own tests — compiled together with Source
 ```
 
+The plugin folder is the unit of import, so its partition root lives **inside** it as `index.json`
+(the `NodeFileMapper` mapping GitSync uses) — a sibling `<Plugin>.json` outside the folder would not
+be part of the partition.
+
 | Concept | Where it lives (node-native) |
 |---|---|
-| The "manifest" | the plugin's **top-level Space node** — its Content carries e.g. `minMeshVersion` |
+| The "manifest" | the plugin's **Space root** (`<Plugin>/index.json`) — its Content carries e.g. `minMeshVersion` |
 | The "kind" (content vs code) | the child's **NodeType** — a NodeType-with-`Source/` vs plain content |
 | The "version" | the **node's version**, mesh-tracked, bumped on every change — nobody hand-bumps a field |
 | The "installer" | **GitSync** — `GitHubSyncService.ImportFromGitHub` / `StaticRepoImporter` |
@@ -59,7 +63,7 @@ configured git source (the plugins repo):
 
 | Verb | Returns |
 |---|---|
-| `GET /api/plugins` | `{ packages:[PackageManifest…] }` — the curated modules from the configured source (node-native `<Plugin>.json` Space roots by default) |
+| `GET /api/plugins` | `{ packages:[PackageManifest…] }` — the curated modules from the configured source (node-native `<Plugin>/index.json` Space roots by default) |
 | `POST /api/plugins/files` `{id}` | `{ files:[{relativePath, content}…] }` — the files that plugin (by id) ships |
 
 A consuming instance browses this from its **Plugin Catalog** admin tab (Settings ▸ Administration,

--- a/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
@@ -7,11 +7,13 @@ namespace MeshWeaver.PluginCatalog;
 
 /// <summary>
 /// An <see cref="IPackageSource"/> for NODE-NATIVE plugin repos — the shape the
-/// <c>MeshWeaver.Plugins</c> repo ships (node-per-file, "the node is the manifest"). Each top-level
-/// <c>&lt;Plugin&gt;.json</c> is a Space root carrying a <c>PluginManifest</c>, and its sibling
-/// <c>&lt;Plugin&gt;/</c> folder holds the <c>NodeType</c> nodes, their <c>Source/*.cs</c> and docs —
-/// every file already a MeshNode at its CANONICAL path (no per-partition rebase). Reuses GitSync's
-/// fetch so a deployed portal reads the repo over HTTP.
+/// <c>MeshWeaver.Plugins</c> repo ships (node-per-file, "the node is the manifest"). Each
+/// <c>&lt;Plugin&gt;/</c> folder is one plugin — a mesh partition: <c>&lt;Plugin&gt;/index.json</c>
+/// is its Space root carrying a <c>PluginManifest</c> (the partition root lives INSIDE the folder,
+/// the same <c>NodeFileMapper</c> mapping GitSync uses), and the rest of the folder holds the
+/// <c>NodeType</c> nodes, their <c>Source/*.cs</c> and docs — every file already a MeshNode at its
+/// CANONICAL path (no per-partition rebase). Reuses GitSync's fetch so a deployed portal reads the
+/// repo over HTTP.
 ///
 /// <para>A plugin's <see cref="PackageManifest.Version"/> is the repo commit sha, so a new commit
 /// surfaces as an available update; the installer then writes only the nodes that actually changed.</para>
@@ -32,14 +34,17 @@ public sealed class NodeRepoPackageSource(
                 var manifests = new List<PackageManifest>();
                 foreach (var file in snapshot.Files)
                 {
-                    // A plugin root is a TOP-LEVEL `<Plugin>.json` (no '/') whose node is a Space.
-                    if (file.Path.Contains('/', StringComparison.Ordinal)
-                        || !file.Path.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                    // A plugin root is `<Plugin>/index.json` — the partition root INSIDE its folder
+                    // (the folder is the unit of import; NodeFileMapper maps root ↔ index.json) —
+                    // whose node is a Space.
+                    var segments = file.Path.Split('/');
+                    if (segments.Length != 2
+                        || !string.Equals(segments[1], "index.json", StringComparison.OrdinalIgnoreCase))
                         continue;
                     var (nodeType, name, description) = Peek(file.Content, file.Path);
                     if (!string.Equals(nodeType, SpaceNodeType, StringComparison.Ordinal))
                         continue;
-                    var id = file.Path[..^".json".Length];
+                    var id = segments[0];
                     manifests.Add(new PackageManifest
                     {
                         Id = id,
@@ -60,12 +65,10 @@ public sealed class NodeRepoPackageSource(
         fetch(repoUrl, gitRef, null, token)
             .Select(snapshot =>
             {
-                var id = package.Id;
-                var rootFile = id + ".json";
-                var folderPrefix = id + "/";
+                // The whole plugin — root included — lives under `<Plugin>/`.
+                var folderPrefix = package.Id + "/";
                 return (IReadOnlyList<PackageFile>)snapshot.Files
-                    .Where(f => string.Equals(f.Path, rootFile, StringComparison.Ordinal)
-                        || f.Path.StartsWith(folderPrefix, StringComparison.Ordinal))
+                    .Where(f => f.Path.StartsWith(folderPrefix, StringComparison.Ordinal))
                     .Select(f => new PackageFile(f.Path, f.Content))
                     .ToList();
             });

--- a/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
@@ -36,15 +36,17 @@ public sealed class NodeRepoPackageSource(
                 {
                     // A plugin root is `<Plugin>/index.json` — the partition root INSIDE its folder
                     // (the folder is the unit of import; NodeFileMapper maps root ↔ index.json) —
-                    // whose node is a Space.
-                    var segments = file.Path.Split('/');
-                    if (segments.Length != 2
-                        || !string.Equals(segments[1], "index.json", StringComparison.OrdinalIgnoreCase))
+                    // whose node is a Space. Checked allocation-free: exactly one '/' and an
+                    // `index.json` tail; only a match slices out the id.
+                    var slash = file.Path.IndexOf('/');
+                    if (slash <= 0
+                        || file.Path.IndexOf('/', slash + 1) >= 0
+                        || !file.Path.AsSpan(slash + 1).Equals("index.json", StringComparison.OrdinalIgnoreCase))
                         continue;
                     var (nodeType, name, description) = Peek(file.Content, file.Path);
                     if (!string.Equals(nodeType, SpaceNodeType, StringComparison.Ordinal))
                         continue;
-                    var id = segments[0];
+                    var id = file.Path[..slash];
                     manifests.Add(new PackageManifest
                     {
                         Id = id,

--- a/src/MeshWeaver.PluginCatalog/PackageSources.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageSources.cs
@@ -18,7 +18,7 @@ public static class PackageSources
     /// Builds a package source for <paramref name="sourceRepoPath"/> (a URL or local path), or
     /// <c>null</c> when the path is empty / a URL source has no <see cref="IGitHubRepoClient"/>.
     /// <paramref name="nodeRepo"/> selects the format for a URL source: <c>true</c> (the default the
-    /// registry uses) reads a node-native repo — <c>&lt;Plugin&gt;.json</c> Space roots, node-per-file
+    /// registry uses) reads a node-native repo — <c>&lt;Plugin&gt;/index.json</c> Space roots, node-per-file
     /// (<see cref="NodeRepoPackageSource"/>); <c>false</c> reads a <c>package.json</c>-manifest repo
     /// (<see cref="GitHubPackageSource"/>). A local path always uses the git-CLI package.json source.
     /// </summary>

--- a/test/MeshWeaver.PluginCatalog.Test/NodeRepoInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/NodeRepoInstallTest.cs
@@ -19,7 +19,8 @@ namespace MeshWeaver.PluginCatalog.Test;
 
 /// <summary>
 /// The node-native path (the shape <c>MeshWeaver.Plugins</c> ships): a <see cref="NodeRepoPackageSource"/>
-/// lists top-level <c>&lt;Plugin&gt;.json</c> Space roots and fetches a plugin's node tree; the installer
+/// lists <c>&lt;Plugin&gt;/index.json</c> Space roots (the partition root lives INSIDE the plugin
+/// folder — the folder is the unit of import) and fetches a plugin's node tree; the installer
 /// imports the nodes at their CANONICAL paths (no rebase) and the mesh compiles the NodeType live. A
 /// re-install of the unchanged repo writes nothing (checksum).
 /// </summary>
@@ -28,12 +29,14 @@ public class NodeRepoInstallTest(ITestOutputHelper output) : MonolithMeshTestBas
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder).AddGraph().AddPluginCatalog();
 
-    // A minimal node-native plugin repo: a Space root carrying a PluginManifest, one NodeType with a
-    // Configuration lambda, and that type's Source. Plus a README (a display file, never a node) and
-    // an unrelated non-top-level json (must NOT be listed as a plugin).
+    // A minimal node-native plugin repo: a `Widget/index.json` Space root carrying a PluginManifest
+    // (the partition root lives INSIDE the folder), one NodeType with a Configuration lambda, and
+    // that type's Source. Plus a README (a display file, never a node), an unrelated nested json
+    // that is no index.json, and a LEGACY top-level `<Plugin>.json` (the pre-index.json layout —
+    // must NOT be listed as a plugin).
     private static readonly IReadOnlyList<RepoFile> Repo = new List<RepoFile>
     {
-        new("Widget.json",
+        new("Widget/index.json",
             """{"$type":"MeshNode","id":"Widget","namespace":"","path":"Widget","mainNode":"Widget","name":"Widget Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"A widget plugin.","minMeshVersion":"1.0.0"}}"""),
         new("Widget/Thing.json",
             """{"$type":"MeshNode","id":"Thing","namespace":"Widget","path":"Widget/Thing","mainNode":"Widget/Thing","name":"Thing","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A thing.","configuration":"config => config.WithContentType<Thing>()","includeGlobalTypes":true}}"""),
@@ -41,6 +44,8 @@ public class NodeRepoInstallTest(ITestOutputHelper output) : MonolithMeshTestBas
             "public record Thing { public string Name { get; init; } = string.Empty; }"),
         new("README.md", "# Plugins"),
         new("Notes/scratch.json", """{"$type":"MeshNode","id":"scratch","nodeType":"Markdown"}"""),
+        new("Legacy.json",
+            """{"$type":"MeshNode","id":"Legacy","namespace":"","path":"Legacy","mainNode":"Legacy","name":"Legacy","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"Old sibling-manifest layout — not a plugin root any more."}}"""),
     };
 
     private static NodeRepoPackageSource Source()
@@ -51,11 +56,12 @@ public class NodeRepoInstallTest(ITestOutputHelper output) : MonolithMeshTestBas
     }
 
     [Fact(Timeout = 120_000)]
-    public async Task ListsTopLevelSpaces_InstallsAtCanonicalPaths_Compiles_ReinstallIdempotent()
+    public async Task ListsIndexJsonRoots_InstallsAtCanonicalPaths_Compiles_ReinstallIdempotent()
     {
         var source = Source();
 
-        // List: exactly the one top-level Space (README + the nested Notes json are not plugins).
+        // List: exactly the one `<Plugin>/index.json` Space root (README, the nested non-index
+        // json, and the legacy top-level `Legacy.json` are not plugins).
         var packages = await source.ListPackages("HEAD").FirstAsync().ToTask();
         packages.Count.Should().Be(1);
         var widget = packages[0];
@@ -64,7 +70,8 @@ public class NodeRepoInstallTest(ITestOutputHelper output) : MonolithMeshTestBas
         widget.Kind.Should().Be(PackageKind.NodeRepo);
         widget.Version.Should().Be("commit-abc"); // the commit sha → update detection
 
-        // Fetch: the plugin's own files only (root + folder), README/Notes excluded.
+        // Fetch: the plugin's own files only (everything under `Widget/`, root included) —
+        // README/Notes/Legacy excluded.
         var files = await source.FetchPackageFiles(widget, "HEAD").FirstAsync().ToTask();
         files.Count.Should().Be(3);
 


### PR DESCRIPTION
## Why

Systemorph/MeshWeaver.Plugins moved every Space root inside its plugin folder (MeshWeaver.Plugins#8) — the folder is the unit of import, so the partition root lives at `<Plugin>/index.json` (the `NodeFileMapper` mapping GitSync already uses) and the sibling `<Plugin>.json` files no longer exist. `NodeRepoPackageSource` still discovered plugins from top-level `<Plugin>.json` files, so the registry catalog (`GET /api/plugins`) lists **zero plugins** from the new layout until this lands and deploys.

## What

- `NodeRepoPackageSource.ListPackages`: a plugin root is `<Plugin>/index.json` — a Space node exactly one folder deep.
- `NodeRepoPackageSource.FetchPackageFiles`: the whole plugin — root included — lives under `<Plugin>/`; the legacy root-file clause is gone.
- `NodeRepoInstallTest`: fixture moved to the new layout; additionally pins that a legacy top-level `<Plugin>.json` Space manifest is NOT listed.
- `Plugins.md` / `PluginRegistry.md`: document the `<Plugin>/index.json` convention and why the root lives inside the folder.

## Verification

- `dotnet build test/MeshWeaver.PluginCatalog.Test -c Release -warnaserror` — green.
- `NodeRepoInstallTest` — 1/1 passed (list → fetch → install at canonical paths → live compile → idempotent re-install).
- `DocumentationLinkIntegrityTest` — passed after the doc edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)