### PR TITLE
Portal admin/UX: notification detail, Instances gate, partition status, multi-source plugin registry, GitSync export fix

### DIFF
--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -196,6 +196,18 @@ config:
 selfUpdate:
   azureClientId: ""   # set per-env from the portalIdentityClientId bicep output
 
+# --- Platform-admin Instances overview ---------------------------------------
+# memex.systemorph.com is the company/control instance — the ONE install that gets the Instances
+# admin tab (Settings ▸ Administration ▸ Instances) and the cluster-scoped read RBAC behind it.
+# clusterRead drives BOTH: the RBAC grant and Instances__Enabled (the menu item's existence).
+# Customer/public envs (atioz, memex-cloud) must NOT set this — their overlays inherit the chart
+# default (false), so the tab does not exist there at all.
+instancesAdmin:
+  clusterRead: true
+  # In-cluster Grafana (loki-stack, `monitoring` ns) has no public host yet — set this to the
+  # Grafana base URL once it is exposed to get per-instance Loki log deep links on the tab.
+  grafanaBaseUrl: ""
+
 # --- Container images -------------------------------------------------------
 # Default = pull straight from GHCR (no ACR needed). To use the private ACR,
 # `az acr import` the images (see README) and set registry to the ACR login

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -50,6 +50,16 @@ data:
   # app-relative path; empty = none. Per-install brand assets ship at
   # _content/Memex.Portal.Shared/brand/{systemorph,atioz,local}-180.png (or a mesh asset / absolute URL).
   Portal__AppleTouchIcon: "{{ .Values.config.memex_portal.Portal__AppleTouchIcon | default "" }}"
+{{- if (.Values.instancesAdmin).clusterRead }}
+  # ---- Platform-admin Instances overview (see .Values.instancesAdmin) -------
+  # The SAME flag that grants the cluster-read RBAC also enables the Settings tab, so the
+  # Instances menu item exists ONLY on the company/control instance.
+  Instances__Enabled: "true"
+{{- if (.Values.instancesAdmin).grafanaBaseUrl }}
+  # Per-instance Grafana Explore (Loki) log deep links on the Instances tab.
+  Instances__GrafanaBaseUrl: "{{ .Values.instancesAdmin.grafanaBaseUrl }}"
+{{- end }}
+{{- end }}
 {{- if (.Values.portalNext).enabled }}
   # ---- Next.js React frontend (FEATURE-FLAGGED — see .Values.portalNext) -----
   # Non-empty ReactAppUrl is what enables FrontendSelection: it shows the user

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -17,8 +17,14 @@ selfUpdate:
 # deployments/ingresses ACROSS namespaces needs a cluster-scoped read grant — enable it ONLY on the
 # company/control instance, never on public or customer instances (a tenant pod must not be able to
 # enumerate the whole cluster). Off by default; the company env sets clusterRead: true.
+# clusterRead also drives Instances__Enabled — the SAME flag both grants the RBAC and makes the
+# Settings menu item exist, so on every other instance the tab never appears at all.
 instancesAdmin:
   clusterRead: false
+  # Grafana base URL for the per-instance log deep links (Grafana Explore / Loki) on the
+  # Instances tab (→ Instances__GrafanaBaseUrl). Empty = the tab shows a configure-me hint
+  # instead of links. Only meaningful where clusterRead is true (the company instance).
+  grafanaBaseUrl: ""
 # ---- External Ollama (local self-host) ------------------------------------
 # Front a host-native Ollama with an in-cluster Service so the portal addresses
 # it by name (http://ollama:11434/v1) instead of a host-gateway IP. On macOS the

--- a/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
@@ -15,8 +15,9 @@ namespace Memex.Portal.Shared.Api;
 /// <summary>
 /// The PUBLIC plugin-registry surface — this instance acting as the distribution point for plugin
 /// modules. <c>GET /api/plugins</c> lists the catalog; <c>POST /api/plugins/files</c> returns one
-/// package's files. Both are backed by the registry's configured git <see cref="IPackageSource"/>
-/// (<c>PluginCatalog:SourceRepoPath</c> — e.g. the plugins repo via GitSync), so a consuming instance
+/// package's files. Both are backed by the registry's configured git <see cref="IPackageSource"/>s
+/// (<c>PluginCatalog:Sources:N:*</c> — e.g. the plugins repo AND an education repo — or the legacy
+/// single <c>PluginCatalog:SourceRepoPath</c>, via GitSync), so a consuming instance
 /// browses/installs over HTTP with NO git/GitHub credentials of its own: the registry's GitHub App
 /// credential stays here and is never handed out (npm/NuGet-style encapsulation). Only curated
 /// packages — each addressed by its plugin id in the configured source (node-native
@@ -44,34 +45,82 @@ public static class PluginRegistryEndpoints
         return endpoints;
     }
 
-    // Builds the registry's git source + the ref it serves, from PluginCatalog config. The registry is
-    // authoritative on the ref (its configured SourceRef); a consumer's ref is advisory and ignored.
-    private static (IPackageSource? Source, string GitRef) Source(IMessageHub hub, IConfiguration config)
+    /// <summary>One configured registry source: the git package source, the ref it serves, and a
+    /// display name (for logs). The registry is authoritative on each source's ref (its configured
+    /// <c>Ref</c>/<c>SourceRef</c>); a consumer's ref is advisory and ignored.</summary>
+    private sealed record RegistrySource(IPackageSource Source, string GitRef, string Name);
+
+    // Builds the registry's git sources from PluginCatalog config. Multi-source form:
+    //   PluginCatalog:Sources:N:{RepoPath,Subdir,Ref,Format,Name}
+    // (e.g. the plugins repo AND an education repo). When no Sources list is configured, the legacy
+    // single-source keys (PluginCatalog:SourceRepoPath/SourceSubdir/SourceRef/SourceFormat) apply.
+    private static IReadOnlyList<RegistrySource> Sources(IMessageHub hub, IConfiguration config)
     {
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(typeof(PluginRegistryEndpoints));
-        var repo = config["PluginCatalog:SourceRepoPath"] ?? "";
-        var subdir = config["PluginCatalog:SourceSubdir"] ?? "catalog";
-        var gitRef = config["PluginCatalog:SourceRef"] ?? "HEAD";
-        // Default to the node-native repo format (what MeshWeaver.Plugins ships); a package.json repo
-        // can opt in with PluginCatalog:SourceFormat=package-json.
-        var format = config["PluginCatalog:SourceFormat"] ?? "node-repo";
-        var nodeRepo = !string.Equals(format, "package-json", StringComparison.OrdinalIgnoreCase);
-        return (PackageSources.FromRepo(hub, repo, subdir, logger, nodeRepo), gitRef);
+
+        RegistrySource? Build(string? repo, string? subdir, string? gitRef, string? format, string? name)
+        {
+            // Default to the node-native repo format (what MeshWeaver.Plugins ships); a package.json
+            // repo can opt in with Format=package-json.
+            var nodeRepo = !string.Equals(format ?? "node-repo", "package-json", StringComparison.OrdinalIgnoreCase);
+            var source = PackageSources.FromRepo(hub, repo, subdir, logger, nodeRepo);
+            return source is null ? null : new RegistrySource(source, gitRef ?? "HEAD", name ?? repo ?? "");
+        }
+
+        var configured = config.GetSection("PluginCatalog:Sources").GetChildren()
+            .Select(s => Build(s["RepoPath"], s["Subdir"] ?? "", s["Ref"], s["Format"], s["Name"]))
+            .Where(s => s is not null)
+            .Select(s => s!)
+            .ToList();
+        if (configured.Count > 0)
+            return configured;
+
+        var legacy = Build(
+            config["PluginCatalog:SourceRepoPath"],
+            config["PluginCatalog:SourceSubdir"] ?? "catalog",
+            config["PluginCatalog:SourceRef"],
+            config["PluginCatalog:SourceFormat"],
+            name: "registry");
+        return legacy is null ? [] : [legacy];
     }
+
+    // Lists one source's packages. With SEVERAL sources a single failing repo must not take the whole
+    // catalog down (degrade to empty + log); with exactly ONE source the failure propagates so List
+    // can surface it as a 502 (the historical single-source behavior — the consumer sees the cause).
+    private static IObservable<IReadOnlyList<PackageManifest>> ListFrom(
+        RegistrySource s, bool soleSource, ILogger? logger)
+        => soleSource
+            ? s.Source.ListPackages(s.GitRef)
+            : s.Source.ListPackages(s.GitRef).Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex, "Plugin registry: listing packages from {Name} @ {Ref} failed",
+                    s.Name, s.GitRef);
+                return Observable.Return((IReadOnlyList<PackageManifest>)[]);
+            });
+
+    // Merged catalog across all sources; on an id collision the FIRST configured source wins
+    // (the registry curates the order).
+    private static IObservable<IReadOnlyList<PackageManifest>> ListAll(
+        IReadOnlyList<RegistrySource> sources, ILogger? logger)
+        => Observable.CombineLatest(sources.Select(s => ListFrom(s, sources.Count == 1, logger)))
+            .Select(lists => (IReadOnlyList<PackageManifest>)lists
+                .SelectMany(l => l)
+                .DistinctBy(p => p.Id, StringComparer.Ordinal)
+                .ToList());
 
     private static Task<IResult> List(IMessageHub hub, IConfiguration config, CancellationToken ct)
     {
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(typeof(PluginRegistryEndpoints));
-        var (source, gitRef) = Source(hub, config);
-        if (source is null)
+        var sources = Sources(hub, config);
+        if (sources.Count == 0)
             return Task.FromResult(Results.Content(PluginRegistryPayloads.List([]), "application/json"));
-        return source.ListPackages(gitRef)
+        return ListAll(sources, logger)
             .Select(list => (IResult)Results.Content(PluginRegistryPayloads.List(list), "application/json"))
             .Catch((Exception ex) =>
             {
                 // Surface the failure (502) rather than hide it as an empty catalog — the consumer's
                 // source catches it, logs, and degrades to empty; the registry log names the cause.
-                logger?.LogWarning(ex, "Plugin registry: listing packages @ {Ref} failed", gitRef);
+                logger?.LogWarning(ex, "Plugin registry: listing packages failed");
                 return Observable.Return((IResult)Results.Json(
                     new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway));
             })
@@ -85,30 +134,34 @@ public static class PluginRegistryEndpoints
         if (string.IsNullOrWhiteSpace(body.Id))
             return Task.FromResult(Results.Json(
                 new { error = "Field 'id' is required." }, statusCode: StatusCodes.Status400BadRequest));
-        var (source, gitRef) = Source(hub, config);
-        if (source is null) // registry not configured → an empty (not erroneous) response
+        var sources = Sources(hub, config);
+        if (sources.Count == 0) // registry not configured → an empty (not erroneous) response
             return Task.FromResult(Results.Content(PluginRegistryPayloads.Files([]), "application/json"));
 
         // 🚨 Resolve the requested package from the registry's CURATED catalog by ID and fetch what THAT
         // package ships — never a client-supplied path. The logic is "the id must match a published
         // package", independent of source format; trusting a caller-provided folder would let an
         // anonymous caller read arbitrary repo files. An unknown id is 404. A security property, not a hint.
-        return source.ListPackages(gitRef)
-            .SelectMany(packages =>
+        // With several sources, the id resolves in configured order — same precedence as the merged list.
+        var perSource = sources.Select(s => ListFrom(s, sources.Count == 1, logger)
+            .Select(packages => (Source: s, Package: packages.FirstOrDefault(
+                p => string.Equals(p.Id, body.Id, StringComparison.Ordinal)))));
+        return Observable.CombineLatest(perSource)
+            .SelectMany(hits =>
             {
-                var pkg = packages.FirstOrDefault(p => string.Equals(p.Id, body.Id, StringComparison.Ordinal));
-                if (pkg is null)
+                var hit = hits.FirstOrDefault(h => h.Package is not null);
+                if (hit.Package is null)
                 {
                     logger?.LogWarning("Plugin registry: files requested for unknown package '{Id}'", body.Id);
                     return Observable.Return((IResult)Results.Json(
                         new { error = $"Unknown package '{body.Id}'" }, statusCode: StatusCodes.Status404NotFound));
                 }
-                return source.FetchPackageFiles(pkg, gitRef)
+                return hit.Source.Source.FetchPackageFiles(hit.Package, hit.Source.GitRef)
                     .Select(files => (IResult)Results.Content(PluginRegistryPayloads.Files(files), "application/json"));
             })
             .Catch((Exception ex) =>
             {
-                logger?.LogWarning(ex, "Plugin registry: fetching files for {Id} @ {Ref} failed", body.Id, gitRef);
+                logger?.LogWarning(ex, "Plugin registry: fetching files for {Id} failed", body.Id);
                 return Observable.Return((IResult)Results.Json(
                     new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway));
             })

--- a/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
@@ -142,14 +142,16 @@ public static class PluginRegistryEndpoints
         // package ships — never a client-supplied path. The logic is "the id must match a published
         // package", independent of source format; trusting a caller-provided folder would let an
         // anonymous caller read arbitrary repo files. An unknown id is 404. A security property, not a hint.
-        // With several sources, the id resolves in configured order — same precedence as the merged list.
-        var perSource = sources.Select(s => ListFrom(s, sources.Count == 1, logger)
+        // Sources resolve SEQUENTIALLY in configured order (same precedence as the merged list) and
+        // short-circuit on the first hit — later sources are never even listed when an earlier one
+        // has the package (Concat subscribes lazily; FirstOrDefaultAsync unsubscribes on the match).
+        var perSource = sources.Select(s => Observable.Defer(() => ListFrom(s, sources.Count == 1, logger)
             .Select(packages => (Source: s, Package: packages.FirstOrDefault(
-                p => string.Equals(p.Id, body.Id, StringComparison.Ordinal)))));
-        return Observable.CombineLatest(perSource)
-            .SelectMany(hits =>
+                p => string.Equals(p.Id, body.Id, StringComparison.Ordinal))))));
+        return perSource.Concat()
+            .FirstOrDefaultAsync(hit => hit.Package is not null)
+            .SelectMany(hit =>
             {
-                var hit = hits.FirstOrDefault(h => h.Package is not null);
                 if (hit.Package is null)
                 {
                     logger?.LogWarning("Plugin registry: files requested for unknown package '{Id}'", body.Id);

--- a/memex/Memex.Portal.Shared/Instances/InstancesAdminLayoutArea.cs
+++ b/memex/Memex.Portal.Shared/Instances/InstancesAdminLayoutArea.cs
@@ -56,6 +56,12 @@ public static class InstancesAdminLayoutArea
     {
         IReadOnlyList<SettingsMenuItemDefinition> none = Array.Empty<SettingsMenuItemDefinition>();
 
+        // Config-gated: the Instances tab exists ONLY where Instances:Enabled is set — the
+        // company/control instance. Everywhere else (public/customer instances) the menu item
+        // never appears, matching the cluster-read RBAC which is likewise granted only there.
+        if (!IsEnabled(host))
+            return Observable.Return(none);
+
         var viewerId = ResolveViewerId(host);
         if (string.IsNullOrEmpty(viewerId))
             return Observable.Return(none);
@@ -92,6 +98,13 @@ public static class InstancesAdminLayoutArea
 
     private static IObservable<UiControl?> BuildArea(LayoutAreaHost host)
     {
+        // Defense-in-depth mirror of the menu gate: the area renders nothing useful on an
+        // install that hasn't enabled the Instances feature.
+        if (!IsEnabled(host))
+            return Observable.Return<UiControl?>(Controls.Markdown(
+                "The Instances overview is not enabled on this install. It is available only on the "
+                + "platform's control instance (`Instances:Enabled`)."));
+
         var viewerId = ResolveViewerId(host);
         if (string.IsNullOrEmpty(viewerId))
             return Observable.Return<UiControl?>(AccessDenied());
@@ -275,6 +288,9 @@ public static class InstancesAdminLayoutArea
             .StartWith((UiControl?)Controls.Markdown("*Fill in the fields and click **Generate plan**.*")));
         return form;
     }
+
+    private static bool IsEnabled(LayoutAreaHost host)
+        => (host.Hub.ServiceProvider.GetService<InstancesOptions>() ?? new InstancesOptions()).Enabled;
 
     private static string? ResolveViewerId(LayoutAreaHost host)
     {

--- a/memex/Memex.Portal.Shared/Instances/InstancesOptions.cs
+++ b/memex/Memex.Portal.Shared/Instances/InstancesOptions.cs
@@ -10,6 +10,13 @@ namespace Memex.Portal.Shared.Instances;
 /// </summary>
 public record InstancesOptions
 {
+    /// <summary>Whether the platform-admin Instances tab is available on this install AT ALL.
+    /// Default <c>false</c> — the tab is meant ONLY for the company/control instance
+    /// (memex.systemorph.com), which is also the only install whose service account gets the
+    /// cluster-read RBAC (<c>instancesAdmin.clusterRead</c> in the Helm chart plumbs both). On every
+    /// other instance the menu item never appears. Set via <c>Instances:Enabled</c>.</summary>
+    public bool Enabled { get; init; }
+
     /// <summary>The k8s label whose value marks a portal Deployment (and Ingress). The chart stamps
     /// <c>app.kubernetes.io/component=memex-portal</c> on the portal workloads; the instance query
     /// selects on it so only portals are listed, never migrations or other pods.</summary>

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -571,11 +571,11 @@ public static class MemexConfiguration
                 // admin tab installs from PluginCatalog:RegistryUrl. The options carry the consumer's
                 // registry URL/ref (empty RegistryUrl -> the tab shows a "not configured" note).
                 .AddPluginCatalog()
-                .ConfigureServices(pcs => pcs.AddSingleton(new PluginCatalogOptions
-                {
-                    RegistryUrl = configuration["PluginCatalog:RegistryUrl"] ?? "",
-                    RegistryRef = configuration["PluginCatalog:RegistryRef"] ?? "HEAD",
-                }))
+                // Bind the whole section so the multi-registry list (PluginCatalog:Registries:N:*)
+                // binds alongside the legacy single RegistryUrl/RegistryRef pair.
+                .ConfigureServices(pcs => pcs.AddSingleton(
+                    configuration.GetSection(PluginCatalogOptions.SectionName).Get<PluginCatalogOptions>()
+                    ?? new PluginCatalogOptions()))
                 // Register GitHub-sync content types (GitHubCredential / GitHubSyncConfig)
                 // on the mesh + per-node hubs so their config nodes (de)serialize.
                 .AddGitHubSyncTypes()

--- a/src/MeshWeaver.Blazor.Portal/Components/NotificationCenterPanel.razor
+++ b/src/MeshWeaver.Blazor.Portal/Components/NotificationCenterPanel.razor
@@ -60,8 +60,10 @@
                             <div class="notification-message @(expanded ? "is-expanded" : "")">@notif.Message</div>
                             @if (IsLong(notif.Message))
                             {
-                                <span class="notification-expand" role="button"
-                                      @onclick="() => ToggleExpanded(g.Key)" @onclick:stopPropagation="true">
+                                <span class="notification-expand" role="button" tabindex="0"
+                                      aria-expanded="@(expanded ? "true" : "false")"
+                                      @onclick="() => ToggleExpanded(g.Key)" @onclick:stopPropagation="true"
+                                      @onkeydown="e => OnExpandKeyDown(e, g.Key)" @onkeydown:stopPropagation="true">
                                     @(expanded ? "Show less" : "Show more")
                                 </span>
                             }
@@ -340,6 +342,14 @@
     {
         if (!expandedGroups.Remove(key))
             expandedGroups.Add(key);
+    }
+
+    /// <summary>A span with role="button" gets no synthesized click on Enter/Space (unlike a real
+    /// button), so keyboard users need an explicit toggle for the Show more/less expander.</summary>
+    private void OnExpandKeyDown(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs e, string key)
+    {
+        if (e.Key is "Enter" or " " or "Spacebar")
+            ToggleExpanded(key);
     }
 
     /// <summary>A message long enough that the 2-line clamp hides detail (error notifications carry

--- a/src/MeshWeaver.Blazor.Portal/Components/NotificationCenterPanel.razor
+++ b/src/MeshWeaver.Blazor.Portal/Components/NotificationCenterPanel.razor
@@ -35,14 +35,15 @@
                 var isRead = g.UnreadCount == 0;
                 <button class="notification-item @(isRead ? "is-read" : "is-unread")"
                         @onclick="() => OnGroupClick(g)" type="button">
-                    <div class="notification-icon">
-                        @if (!string.IsNullOrEmpty(notif.Icon))
+                    <div class="notification-icon @(IsError(notif) ? "is-error" : "")">
+                        @if (IsIconUrl(notif.Icon))
                         {
                             <img src="@notif.Icon" alt="" />
                         }
                         else
                         {
-                            <FluentIcon Value="@DefaultIconFor(notif.NotificationType)" Color="Color.Accent" />
+                            <FluentIcon Value="@DefaultIconFor(notif.NotificationType)"
+                                        Color="@(IsError(notif) ? Color.Error : Color.Accent)" />
                         }
                     </div>
                     <div class="notification-body">
@@ -55,13 +56,25 @@
                         </div>
                         @if (!string.IsNullOrEmpty(notif.Message))
                         {
-                            <div class="notification-message">@notif.Message</div>
+                            var expanded = expandedGroups.Contains(g.Key);
+                            <div class="notification-message @(expanded ? "is-expanded" : "")">@notif.Message</div>
+                            @if (IsLong(notif.Message))
+                            {
+                                <span class="notification-expand" role="button"
+                                      @onclick="() => ToggleExpanded(g.Key)" @onclick:stopPropagation="true">
+                                    @(expanded ? "Show less" : "Show more")
+                                </span>
+                            }
                         }
                         <div class="notification-meta">
-                            <span>@FormatTime(notif.CreatedAt)</span>
+                            <span title="@notif.CreatedAt.LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss")">@FormatTime(notif.CreatedAt)</span>
                             @if (!string.IsNullOrEmpty(notif.CreatedBy))
                             {
                                 <span>· @notif.CreatedBy</span>
+                            }
+                            @if (!string.IsNullOrEmpty(g.Key))
+                            {
+                                <span class="notification-target" title="@g.Key">· @g.Key</span>
                             }
                         </div>
                     </div>
@@ -179,12 +192,35 @@
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;
     }
+    .notification-message.is-expanded {
+        display: block;
+        -webkit-line-clamp: unset;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+    }
+    .notification-expand {
+        font-size: 0.75rem;
+        color: var(--accent-foreground-rest);
+        cursor: pointer;
+    }
+    .notification-expand:hover {
+        text-decoration: underline;
+    }
+    .notification-icon.is-error {
+        background: color-mix(in srgb, var(--error, #d32f2f) 12%, transparent);
+    }
     .notification-meta {
         font-size: 0.72rem;
         color: var(--neutral-foreground-hint);
         margin-top: 4px;
         display: flex;
         gap: 4px;
+        min-width: 0;
+    }
+    .notification-target {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
     .notification-unread-dot {
         width: 8px;
@@ -200,6 +236,7 @@
 
     private IReadOnlyList<MeshNode> notifications = Array.Empty<MeshNode>();
     private IDisposable? subscription;
+    private readonly HashSet<string> expandedGroups = new();
 
     protected override void OnInitialized()
     {
@@ -299,6 +336,30 @@
         }
     }
 
+    private void ToggleExpanded(string key)
+    {
+        if (!expandedGroups.Remove(key))
+            expandedGroups.Add(key);
+    }
+
+    /// <summary>A message long enough that the 2-line clamp hides detail (error notifications carry
+    /// the full compile/import error in the message) — offer the Show more toggle.</summary>
+    private static bool IsLong(string message) => message.Length > 160 || message.Contains('\n');
+
+    /// <summary>Only a URL / app path / data URI is renderable as an <c>&lt;img&gt;</c>. Emitters have
+    /// historically written bare Fluent icon names (e.g. "ErrorCircle") into <see cref="Notification.Icon"/>
+    /// — those must fall back to the type-based icon, not render as a broken image.</summary>
+    private static bool IsIconUrl(string? icon) =>
+        !string.IsNullOrEmpty(icon)
+        && (icon.StartsWith('/') || icon.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+            || icon.StartsWith("data:", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>System notifications (import failures, compile parks, …) render with error styling.
+    /// The legacy "ErrorCircle" icon name marks pre-System-type error notifications.</summary>
+    private static bool IsError(Notification notif) =>
+        notif.NotificationType == NotificationType.System
+        || string.Equals(notif.Icon, "ErrorCircle", StringComparison.OrdinalIgnoreCase);
+
     private static string FormatTime(DateTimeOffset ts)
     {
         var delta = DateTimeOffset.UtcNow - ts;
@@ -316,7 +377,7 @@
         NotificationType.ApprovalRejected => new Icons.Regular.Size20.ShieldDismiss(),
         NotificationType.AccessGranted => new Icons.Regular.Size20.LockOpen(),
         NotificationType.ChatReady => new Icons.Regular.Size20.Chat(),
-        NotificationType.System => new Icons.Regular.Size20.Warning(),
+        NotificationType.System => new Icons.Regular.Size20.ErrorCircle(),
         _ => new Icons.Regular.Size20.Info()
     };
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/Instances.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Instances.md
@@ -89,3 +89,23 @@ provisioned with the deploy tooling, not from the running app — the company in
 > Turning the company instance into a real control plane (create / tear down instances **from the
 > UI**, calling the Azure + Helm APIs behind an admin gate) is a possible future feature, not a
 > current capability.
+
+## The admin Instances tab (company instance only)
+
+**Settings ▸ Administration ▸ Instances** lists every portal on the cluster live from the k8s API —
+domain, namespace, running version (image tag), replica health — with per-instance Grafana/Loki log
+deep links and a guided create-instance **plan** generator (commands only; nothing deploys itself).
+
+The tab exists **only on memex.systemorph.com**, doubly gated:
+
+- **`Instances:Enabled`** (config, default `false`) — the Settings menu item is not even created on
+  an install that doesn't set it. In the Helm chart, `instancesAdmin.clusterRead` drives BOTH this
+  flag and the RBAC below; `deploy/aks/values.aks.yaml` (the `memex` env overlay) sets it `true`,
+  customer/public envs inherit the default.
+- **Cluster-read RBAC** (`instancesAdmin.clusterRead`) — reading deployments/ingresses across
+  namespaces needs a cluster-scoped grant, given only to the company instance (a tenant pod must not
+  enumerate the cluster). Without it the tab (where enabled) shows "Cluster query unavailable".
+
+Log links need `Instances:GrafanaBaseUrl` (Helm: `instancesAdmin.grafanaBaseUrl`) — the Grafana
+Explore (Loki) deep link is built per namespace. Empty until the in-cluster Grafana
+(`monitoring` ns, `loki-grafana` service) is exposed on a host.

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -52,11 +52,33 @@ exposed, and the registry's own credential never leaves.
 A package is addressed by its **id** only; the registry resolves what that plugin ships from its
 configured source — the consumer never supplies a folder path.
 
-Both are backed by the registry's configured git [`IPackageSource`](/Doc/Architecture/Plugins) —
-`PluginCatalog:SourceRepoPath` (a URL → the plugins repo via GitSync's client, or a local path). The
-registry is authoritative on the git ref (`PluginCatalog:SourceRef`); a consumer's `ref` is advisory.
-The wire shapes are produced by `PluginRegistryPayloads` and parsed by `RegistryPackageSource`, one
-place each, so producer and consumer cannot drift.
+Both are backed by the registry's configured git [`IPackageSource`](/Doc/Architecture/Plugins)s. A
+registry can serve **several sources** — e.g. the plugins repo *and* an education-content repo —
+via the `PluginCatalog:Sources` list:
+
+```json
+{
+  "PluginCatalog": {
+    "Sources": [
+      { "Name": "Plugins",   "RepoPath": "https://github.com/Systemorph/MeshWeaver.Plugins", "Ref": "main" },
+      { "Name": "Education", "RepoPath": "https://github.com/Systemorph/Education",          "Ref": "main" }
+    ]
+  }
+}
+```
+
+Each entry takes `RepoPath` (a URL → via GitSync's client, or a local path), optional `Subdir`,
+`Ref` (default `HEAD`) and `Format` (`node-repo` default / `package-json`). A source lists only
+folders matching its format — the Education repo's courses (DataModeling, AgenticEngineering, …)
+appear once each course folder gains a `<Course>/index.json` Space root carrying a
+`PluginManifest`, the same node-repo convention `MeshWeaver.Plugins` uses. `GET /api/plugins`
+merges all sources' packages (on an id collision the first configured source wins); `/files`
+resolves an id in the same order. With several sources one failing repo degrades to an empty
+contribution (logged), never a broken catalog. The legacy single-source keys
+(`PluginCatalog:SourceRepoPath`/`SourceSubdir`/`SourceRef`/`SourceFormat`) keep working when no
+`Sources` list is set. The registry is authoritative on each source's git ref; a consumer's `ref`
+is advisory. The wire shapes are produced by `PluginRegistryPayloads` and parsed by
+`RegistryPackageSource`, one place each, so producer and consumer cannot drift.
 
 ## The consumer — a platform-admin tab, not a Space
 
@@ -65,10 +87,12 @@ On every installation the catalog is a **Settings tab** — `PluginCatalogSettin
 **not** a browsable `Plugins` Space: a catalog is a platform-admin feature, and a Space partition
 would (correctly) deny read to everyone else — the very "Access denied on 'Plugins'" a Space produced.
 
-The tab reads `PluginCatalog:RegistryUrl` (e.g. `https://memex.meshweaver.cloud`), lists the
-registry's packages via `RegistryPackageSource` (an `IPackageSource` over HTTP, on the mesh's Http
-I/O pool), and joins them against this instance's install registry — the `Package` nodes under the
-`Plugins` partition — to render **Install / Update / Installed** per module.
+The tab reads `PluginCatalog:RegistryUrl` (e.g. `https://memex.meshweaver.cloud`) — or, to consume
+**several registries**, a `PluginCatalog:Registries` list of `{ Name, Url, Ref }` entries, rendered
+as one titled catalog section each. It lists each registry's packages via `RegistryPackageSource`
+(an `IPackageSource` over HTTP, on the mesh's Http I/O pool), and joins them against this
+instance's install registry — the `Package` nodes under the `Plugins` partition — to render
+**Install / Update / Installed** per module.
 
 ## Installing
 

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -149,9 +149,15 @@ public sealed class GitHubSyncService
     {
         var root = hub.GetWorkspace().GetMeshNodeStream(spacePath)
             .Where(n => n is not null).Take(1).Timeout(TimeSpan.FromSeconds(30));
+        // Wait for the query's INITIAL snapshot — a bare Take(1) can capture an empty pre-Initial
+        // emission, silently exporting the Space as root-only (observed on a live instance: a
+        // commit that wrote just index.json + README.md for a Space with ~50 descendants). Same
+        // pattern as PartitionSyncAdminLayoutArea.DiscoverPartitions.
         var descendants = meshService
             .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{spacePath} scope:descendants"))
-            .Take(1).Select(c => (IEnumerable<MeshNode>)c.Items);
+            .Where(c => c.ChangeType == QueryChangeType.Initial)
+            .Take(1).Timeout(TimeSpan.FromSeconds(30))
+            .Select(c => (IEnumerable<MeshNode>)c.Items);
         return root.CombineLatest(descendants, (r, desc) =>
         {
             var all = new List<MeshNode>();

--- a/src/MeshWeaver.Graph/PartitionSyncAdminLayoutArea.cs
+++ b/src/MeshWeaver.Graph/PartitionSyncAdminLayoutArea.cs
@@ -229,7 +229,7 @@ public static class PartitionSyncAdminLayoutArea
                         Name = node?.Name ?? p.Partition,
                         Type = node?.NodeType ?? "",
                         CreatedBy = node?.CreatedBy ?? "",
-                        Status = IsSynced(node) ? "Synced" : "Not synced",
+                        Status = StatusOf(node),
                         Sources = sources,
                     }));
 
@@ -261,9 +261,20 @@ public static class PartitionSyncAdminLayoutArea
         });
     }
 
-    // Anything other than the whole-subtree exclusion is treated as Synced (null/Include/ThisOnly).
+    // Anything other than the whole-subtree exclusion is treated as Synced (Include/ThisOnly).
     private static bool IsSynced(MeshNode? node)
         => node?.SyncBehavior != SyncBehavior.ExcludeThisAndChildren;
+
+    /// <summary>
+    /// The grid's Status cell. A partition registered by a source but whose ROOT node does not
+    /// exist has never been imported/installed — that is "Not materialized", NOT "Synced" (the
+    /// old two-state status showed "Synced" for a null root, claiming sync for content that was
+    /// never mounted at all).
+    /// </summary>
+    private static string StatusOf(MeshNode? node) =>
+        node is null ? "Not materialized"
+        : IsSynced(node) ? "Synced"
+        : "Not synced";
 
     // ── View composition ───────────────────────────────────────────────────────
 

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -957,10 +957,12 @@ public static class StaticRepoImporter
                 mainNodePath: partition,
                 title: $"Startup import failed: {partition}",
                 message: string.IsNullOrWhiteSpace(error) ? "Import failed during startup." : error,
-                type: NotificationType.General,
+                // System (not General): the platform/system-event category — the bell renders it
+                // with error styling. No icon override: a bare Fluent name ("ErrorCircle") is not a
+                // URL and rendered as a broken <img>; the type-based default icon is correct.
+                type: NotificationType.System,
                 targetNodePath: activityPath,
-                createdBy: "system-security",
-                icon: "ErrorCircle"))
+                createdBy: "system-security"))
             .Subscribe(
                 _ => logger?.LogInformation(
                     "[StaticRepoImport] raised startup-failure notification for {Partition} → {ActivityPath}",

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogOptions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogOptions.cs
@@ -1,11 +1,15 @@
 namespace MeshWeaver.PluginCatalog;
 
 /// <summary>
-/// Consumer-side options for the plugin catalog: the URL of the MeshWeaver instance that acts as the
-/// plugin <b>registry</b> (exposes <c>/api/plugins</c>). Every installation reads the catalog and
-/// downloads packages from this one registry over HTTP — the registry holds the source access (the
-/// GitHub App credential), so a consumer needs no git/GitHub credentials of its own (npm/NuGet-style
-/// credential encapsulation).
+/// Consumer-side options for the plugin catalog: the registry instance(s) that expose a catalog
+/// over <c>/api/plugins</c>. Every installation reads the catalog and downloads packages from a
+/// registry over HTTP — the registry holds the source access (the GitHub App credential), so a
+/// consumer needs no git/GitHub credentials of its own (npm/NuGet-style credential encapsulation).
+///
+/// <para>An installation can consume SEVERAL registries (e.g. the platform plugin registry plus an
+/// education-content registry) via <see cref="Registries"/>; the legacy single
+/// <see cref="RegistryUrl"/>/<see cref="RegistryRef"/> pair keeps working and is folded into
+/// <see cref="EffectiveRegistries"/>.</para>
 /// </summary>
 public sealed class PluginCatalogOptions
 {
@@ -15,7 +19,8 @@ public sealed class PluginCatalogOptions
     /// <summary>
     /// Base URL of the registry instance that exposes the catalog (e.g.
     /// <c>https://memex.meshweaver.cloud</c>). Empty disables the remote catalog (the admin tab shows
-    /// a "not configured" note).
+    /// a "not configured" note) unless <see cref="Registries"/> is set. Legacy single-registry key —
+    /// prefer <see cref="Registries"/> for anything beyond one source.
     /// </summary>
     public string RegistryUrl { get; set; } = "";
 
@@ -24,4 +29,38 @@ public sealed class PluginCatalogOptions
     /// <c>PluginCatalog:SourceRef</c>) and currently ignores the consumer-supplied value — it is sent
     /// so the registry could honor a pinned rollout later without a consumer change.</summary>
     public string RegistryRef { get; set; } = "HEAD";
+
+    /// <summary>
+    /// The registries this installation consumes, in display order
+    /// (<c>PluginCatalog:Registries:0:{Name,Url,Ref}</c>, …). Empty → falls back to the legacy
+    /// <see cref="RegistryUrl"/>/<see cref="RegistryRef"/> pair.
+    /// </summary>
+    public List<PluginRegistryReference> Registries { get; set; } = [];
+
+    /// <summary>
+    /// The registries to actually consume: <see cref="Registries"/> (entries with a URL), or the
+    /// legacy <see cref="RegistryUrl"/> as a single unnamed entry, or empty when nothing is
+    /// configured (the admin tab shows a "not configured" note).
+    /// </summary>
+    public IReadOnlyList<PluginRegistryReference> EffectiveRegistries =>
+        Registries.Where(r => !string.IsNullOrWhiteSpace(r.Url)).ToList() is { Count: > 0 } configured
+            ? configured
+            : string.IsNullOrWhiteSpace(RegistryUrl)
+                ? []
+                : [new PluginRegistryReference { Url = RegistryUrl, Ref = RegistryRef }];
+}
+
+/// <summary>One registry a consumer reads its plugin catalog from (an entry of
+/// <see cref="PluginCatalogOptions.Registries"/>).</summary>
+public sealed class PluginRegistryReference
+{
+    /// <summary>Display name for the catalog section (e.g. "Plugins", "Education"). Empty → the URL
+    /// is shown instead.</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>Base URL of the registry instance (e.g. <c>https://memex.meshweaver.cloud</c>).</summary>
+    public string Url { get; set; } = "";
+
+    /// <summary>Advisory git ref (see <see cref="PluginCatalogOptions.RegistryRef"/>).</summary>
+    public string Ref { get; set; } = "HEAD";
 }

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogSettingsTab.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogSettingsTab.cs
@@ -12,10 +12,12 @@ namespace MeshWeaver.PluginCatalog;
 
 /// <summary>
 /// The platform-admin "Plugin Catalog" Settings tab — the consumer half of the plugin registry.
-/// Reads the catalog from the configured registry instance (<see cref="PluginCatalogOptions.RegistryUrl"/>)
-/// over HTTP, shows each module's install status against this instance's install registry, and offers
-/// Install / Update. It replaces the old browsable <c>Plugins</c> Space: the catalog is a
-/// platform-admin feature, not a partition anyone can navigate to.
+/// Reads the catalog from the configured registry instance(s)
+/// (<see cref="PluginCatalogOptions.EffectiveRegistries"/> — the <c>PluginCatalog:Registries</c>
+/// list or the legacy single <see cref="PluginCatalogOptions.RegistryUrl"/>) over HTTP, shows each
+/// module's install status against this instance's install registry, and offers Install / Update.
+/// It replaces the old browsable <c>Plugins</c> Space: the catalog is a platform-admin feature, not
+/// a partition anyone can navigate to.
 ///
 /// <para>Gated exactly like <c>UserNodeType</c>'s Global Administration tab — visible only when the
 /// viewer is a global admin (<c>hub.IsGlobalAdmin(userId)</c>) AND on their own settings page — and
@@ -78,18 +80,26 @@ public static class PluginCatalogSettingsTab
             "Browse and install plugin modules from the platform registry. Installing a module imports " +
             "its content and compiles its node types live on this instance — no rebuild.</p>"));
 
-        if (string.IsNullOrWhiteSpace(options.RegistryUrl))
+        var registries = options.EffectiveRegistries;
+        if (registries.Count == 0)
             return stack.WithView(Controls.Html(
                 "<p style=\"font-size:0.85rem;color:var(--neutral-foreground-hint);\">" +
                 "No plugin registry is configured. Set <code>PluginCatalog:RegistryUrl</code> (for " +
-                "example <code>https://memex.meshweaver.cloud</code>) to enable the catalog.</p>"));
+                "example <code>https://memex.meshweaver.cloud</code>) — or a list under " +
+                "<code>PluginCatalog:Registries</code> — to enable the catalog.</p>"));
 
-        var source = new RegistryPackageSource(host.Hub, options.RegistryUrl);
-
-        // Reuse the shared catalog rendering: live package list from the registry joined with this
+        // One catalog section per configured registry (e.g. the platform plugin registry plus an
+        // education registry), each reusing the shared rendering: live package list joined with this
         // instance's install registry into Install / Update / Installed cards.
-        stack = stack.WithView((h, _) => CatalogLayoutAreas.RenderFromSource(
-            h, source, options.RegistryRef, description: null, sourceLabel: options.RegistryUrl));
+        foreach (var registry in registries)
+        {
+            var label = string.IsNullOrWhiteSpace(registry.Name) ? registry.Url : registry.Name;
+            if (registries.Count > 1)
+                stack = stack.WithView(Controls.Title(label, 2));
+            var source = new RegistryPackageSource(host.Hub, registry.Url);
+            stack = stack.WithView((h, _) => CatalogLayoutAreas.RenderFromSource(
+                h, source, registry.Ref, description: null, sourceLabel: registry.Url));
+        }
         return stack;
     }
 }

--- a/test/Memex.Portal.Shared.Test/InstancesServiceTest.cs
+++ b/test/Memex.Portal.Shared.Test/InstancesServiceTest.cs
@@ -89,6 +89,14 @@ public class InstancesServiceTest
         => Assert.Equal(expected, KubernetesInstanceService.VersionTag(image));
 
     [Fact]
+    public void Enabled_DefaultsFalse_TheTabExistsOnlyWhereConfigured()
+    {
+        // The Instances tab is config-gated to the company/control instance: an install that does
+        // not set Instances:Enabled (all public/customer instances) must never grow the menu item.
+        Assert.False(new InstancesOptions().Enabled);
+    }
+
+    [Fact]
     public void GrafanaLogsUrl_EmptyBase_ReturnsNull()
         => Assert.Null(new InstancesOptions().GrafanaLogsUrl("memex"));
 

--- a/test/MeshWeaver.PluginCatalog.Test/PluginCatalogOptionsTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PluginCatalogOptionsTest.cs
@@ -1,0 +1,69 @@
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins <see cref="PluginCatalogOptions.EffectiveRegistries"/> — the resolution of the consumer's
+/// registry list: the multi-registry <c>PluginCatalog:Registries</c> list wins when configured,
+/// the legacy single <c>RegistryUrl</c>/<c>RegistryRef</c> pair keeps working as a one-entry
+/// fallback, and nothing configured yields an empty list (the admin tab shows its
+/// "not configured" note).
+/// </summary>
+public class PluginCatalogOptionsTest
+{
+    [Fact]
+    public void NothingConfigured_YieldsEmpty()
+    {
+        Assert.Empty(new PluginCatalogOptions().EffectiveRegistries);
+    }
+
+    [Fact]
+    public void LegacySingleRegistry_FoldsIntoOneEntry()
+    {
+        var options = new PluginCatalogOptions
+        {
+            RegistryUrl = "https://memex.meshweaver.cloud",
+            RegistryRef = "main",
+        };
+
+        var registry = Assert.Single(options.EffectiveRegistries);
+        Assert.Equal("https://memex.meshweaver.cloud", registry.Url);
+        Assert.Equal("main", registry.Ref);
+    }
+
+    [Fact]
+    public void RegistriesList_WinsOverLegacyPair()
+    {
+        var options = new PluginCatalogOptions
+        {
+            RegistryUrl = "https://legacy.example",
+            Registries =
+            [
+                new PluginRegistryReference { Name = "Plugins", Url = "https://memex.meshweaver.cloud" },
+                new PluginRegistryReference { Name = "Education", Url = "https://edu.example", Ref = "main" },
+            ],
+        };
+
+        Assert.Collection(options.EffectiveRegistries,
+            r => Assert.Equal("https://memex.meshweaver.cloud", r.Url),
+            r =>
+            {
+                Assert.Equal("https://edu.example", r.Url);
+                Assert.Equal("Education", r.Name);
+                Assert.Equal("main", r.Ref);
+            });
+    }
+
+    [Fact]
+    public void RegistriesList_BlankUrlEntriesAreDropped_FallingBackToLegacyWhenNoneRemain()
+    {
+        var options = new PluginCatalogOptions
+        {
+            RegistryUrl = "https://legacy.example",
+            Registries = [new PluginRegistryReference { Name = "misconfigured", Url = " " }],
+        };
+
+        var registry = Assert.Single(options.EffectiveRegistries);
+        Assert.Equal("https://legacy.example", registry.Url);
+    }
+}


### PR DESCRIPTION
Five portal admin/UX fixes from today's memex/systemorph review session.

## Notification bell — show the detail that's already in the data
Compile-failure / startup-import notifications carry the full error, `createdAt` and `targetNodePath`, but the bell clamped the message to 2 lines, showed only a relative time, and hid the node. Now: **Show more/less** expander for long messages, absolute-time tooltip, target node path in the meta row, error styling for `System` notifications, and a guard so a bare Fluent icon name (an emitter wrote `icon: "ErrorCircle"`) falls back to the type icon instead of rendering a broken `<img>`. `StaticRepoImporter`'s startup-failure notification: `General` → `System`, bogus icon dropped.

## Instances admin tab — exists only on the company instance
New `Instances:Enabled` gate (default **false**): the Settings menu item is not created unless enabled. The Helm chart plumbs it from `instancesAdmin.clusterRead`, so ONE flag grants the cluster-read RBAC and makes the tab exist; `deploy/aks/values.aks.yaml` (memex.systemorph.com env) turns it on, customer/public envs inherit the default. `instancesAdmin.grafanaBaseUrl` → `Instances__GrafanaBaseUrl` enables the per-instance Grafana/Loki log links.

## Partitions admin — stop calling an unmaterialized partition "Synced"
Three-state Status: a partition registered by a source whose root node doesn't exist shows **Not materialized** (observed live on systemorph: empty `Agent`/`Skill` stubs claiming "Synced").

## Plugin catalog — multiple sources / multiple registries
Registry side: `PluginCatalog:Sources:N:{RepoPath,Subdir,Ref,Format,Name}` — `/api/plugins` merges all sources (first-source-wins on id collision; with several sources one failing repo degrades to an empty contribution instead of a 502). Consumer side: `PluginCatalog:Registries:N:{Name,Url,Ref}` — one catalog section per registry. Legacy single-source keys keep working (pinned by `PluginCatalogOptionsTest`). Use case: serving `Systemorph/Education` alongside `MeshWeaver.Plugins`. Docs updated (`PluginRegistry.md`, `Instances.md`).

## GitSync export race — a Space exported as root-only
`GitHubSyncService.SnapshotNodes` took the descendants query's FIRST emission instead of waiting for the `Initial` snapshot — a cold query exported just `index.json` + README for a Space with ~50 descendants (reproduced live twice on systemorph's UWDeepfield). Now filters to `QueryChangeType.Initial` with a 30s timeout, the same pattern `PartitionSyncAdminLayoutArea.DiscoverPartitions` uses.

## Tests
- `PluginCatalogOptionsTest` — `EffectiveRegistries` resolution (legacy fallback, list precedence, blank-URL filtering).
- `InstancesServiceTest.Enabled_DefaultsFalse_TheTabExistsOnlyWhereConfigured` — pins the off-by-default gate.
- Full `Memex.Portal.Shared.Test`, `MeshWeaver.PluginCatalog.Test`, and GitSync/importer-filtered `MeshWeaver.Graph.Test` suites green locally; helm chart templated with and without `instancesAdmin.clusterRead`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)