### PR TITLE
Area-id hrefs: encode '/' (%9Z) so path-shaped ids survive URL routing

### DIFF
--- a/src/MeshWeaver.Data.Contract/WorkspaceReference.cs
+++ b/src/MeshWeaver.Data.Contract/WorkspaceReference.cs
@@ -9,17 +9,27 @@ namespace MeshWeaver.Data;
 public abstract record WorkspaceReference
 {
     /// <summary>
-    /// Encodes a value for safe use as a reference segment, escaping <c>.</c> as <c>%9Y</c> in strings.
+    /// Encodes a value for safe use as ONE reference/URL segment, escaping <c>.</c> as <c>%9Y</c>
+    /// and <c>/</c> as <c>%9Z</c> in strings. Escaping the slash keeps a path-shaped id (e.g. a
+    /// source Code node path in a NodeType shell's <c>{node}/Code/{id}</c> href) a SINGLE segment:
+    /// with raw slashes the URL resolver's prefix probe contains segments like <c>Source</c>/<c>Test</c>,
+    /// which the satellite-table mapping routes to the <c>code</c> table for the WHOLE probe — the
+    /// node's ancestors then match nothing and navigation dies with "Page not found"
+    /// (Chess/GambitHunt shell links, 2026-07-12). Same principle as the base64url node-bound
+    /// DataContext (<c>LayoutAreaReference.MeshNodePrefix</c>): ids must not leak path segments.
     /// </summary>
     /// <param name="value">The value to encode.</param>
     /// <returns>The encoded value (strings escaped; other values unchanged).</returns>
-    public static object Encode(object value) => value is string s ? s.Replace(".", "%9Y") : value;
+    public static object Encode(object value) =>
+        value is string s ? s.Replace(".", "%9Y").Replace("/", "%9Z") : value;
     /// <summary>
-    /// Reverses <see cref="Encode"/>, restoring <c>.</c> from <c>%9Y</c> in strings.
+    /// Reverses <see cref="Encode"/>, restoring <c>/</c> from <c>%9Z</c> and <c>.</c> from
+    /// <c>%9Y</c> in strings.
     /// </summary>
     /// <param name="value">The value to decode.</param>
     /// <returns>The decoded value (strings unescaped; other values unchanged).</returns>
-    public static object Decode(object value) => value is string s ? s.Replace("%9Y", ".") : value;
+    public static object Decode(object value) =>
+        value is string s ? s.Replace("%9Z", "/").Replace("%9Y", ".") : value;
 
 }
 

--- a/test/MeshWeaver.Layout.Test/AreaIdEncodingTest.cs
+++ b/test/MeshWeaver.Layout.Test/AreaIdEncodingTest.cs
@@ -1,0 +1,46 @@
+using MeshWeaver.Data;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Pins the reference-segment encoding contract: an area id must survive the
+/// href → route → <see cref="WorkspaceReference.Decode"/> round-trip as ONE URL
+/// segment. Slashes are the load-bearing case — a path-shaped id (a source Code
+/// node path in a NodeType shell's <c>{node}/Code/{id}</c> href) rendered with
+/// raw slashes injects segments like <c>Source</c>/<c>Test</c> into the URL
+/// resolver's prefix probe, which the satellite-table mapping routes to the
+/// <c>code</c> table for the whole probe — ancestors match nothing and navigation
+/// dies with "Page not found" (the Chess/GambitHunt shell links, 2026-07-12).
+/// </summary>
+public class AreaIdEncodingTest
+{
+    [Theory]
+    [InlineData("Chess/GambitHunt/Source/GambitHunt")]
+    [InlineData("plain")]
+    [InlineData("with.dot")]
+    [InlineData("path/with.dot/and/slashes.cs")]
+    public void Encode_RoundTrips(string id)
+    {
+        var encoded = (string)WorkspaceReference.Encode(id);
+        Assert.Equal(id, (string)WorkspaceReference.Decode(encoded));
+    }
+
+    [Fact]
+    public void Encode_ProducesSingleSegment()
+    {
+        var encoded = (string)WorkspaceReference.Encode("Chess/GambitHunt/Source/GambitHunt");
+        Assert.DoesNotContain("/", encoded);
+        Assert.DoesNotContain(".", encoded);
+    }
+
+    [Fact]
+    public void ToHref_PathShapedId_KeepsHubAreaIdAsThreeTrailingSegments()
+    {
+        var href = new LayoutAreaReference("Code") { Id = "Chess/GambitHunt/Source/GambitHunt" }
+            .ToHref("Chess/GambitHunt");
+        // hub (2 segments) + area (1) + id (1 encoded segment) — nothing the
+        // path resolver could mistake for a Source/Test satellite segment.
+        Assert.Equal("Chess/GambitHunt/Code/Chess%9ZGambitHunt%9ZSource%9ZGambitHunt", href);
+    }
+}


### PR DESCRIPTION
Clicking any source file in a NodeType shell's side menu 404s ("does not match any registered address pattern") — for every NodeType.

**Root cause:** `ToHref` renders the area id (a source Code node *path*) with raw slashes, so the URL carries `Source`/`Test` segments. `PathResolutionService` probes one query containing every URL prefix; `PostgreSqlPartitionedMeshQuery`'s satellite-table mapping sees the `Source` segment and routes the **whole probe** to the `code` table — the node's ancestors (Space/NodeType rows in `mesh_nodes`) match nothing → NotFound. Reproduced live on memex: `path:"…/Code/…/Source/X"|"Chess/GambitHunt"|"Chess"` → 0 rows, while `path:"Chess/GambitHunt"|"Chess"` → 2.

**Fix:** `WorkspaceReference.Encode` escapes `/` as `%9Z` (mirroring the existing `.` → `%9Y`); `Decode` reverses. All 6 `Encode` call sites live in `ToHref` (audited), and `AreaPage`/`ApplicationPage`/`MeshOperations` already funnel inbound area/id through `Decode` — so shell hrefs become `{node}/Code/{one-encoded-segment}`, resolve against `mesh_nodes`, and **the Code area opens inside the shell with the side menu preserved** (the requested UX: browse code without losing navigation). Same principle as the base64url node-bound DataContext: ids must not leak path segments.

**Tests:** new `AreaIdEncodingTest` (round-trip incl. dots+slashes, single-segment guarantee, exact shell-href shape); full `MeshWeaver.Layout.Test` 311/311 green.

**Note:** takes effect on memex with the next deploy (hrefs are rendered server-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)