### PR TITLE
Invitations: mark accepted on sign-up + show lifecycle in settings tab

### DIFF
--- a/memex/Memex.Portal.Shared/Pages/Onboarding.razor
+++ b/memex/Memex.Portal.Shared/Pages/Onboarding.razor
@@ -8,6 +8,7 @@
 @using MeshWeaver.Blazor.Infrastructure
 @using MeshWeaver.Data
 @using MeshWeaver.Graph
+@using MeshWeaver.Graph.Configuration
 @using MeshWeaver.Mesh
 @using MeshWeaver.Mesh.Security
 @using MeshWeaver.Mesh.Services
@@ -196,10 +197,15 @@ else
         var firstUserQuery = needFirstUser
             ? workspace.GetQuery("onboarding:firstUserCheck", "namespace:User limit:1")
             : Observable.Return(Enumerable.Empty<MeshNode>());
+        // PATH-scoped (path:Admin/Invitation scope:children): the PG router routes by the
+        // path's first segment, and a path-less nodeType:Invitation query fans out
+        // cross-schema — which deliberately EXCLUDES the admin schema — so it never finds
+        // invitations (see InvitationNodeType). Same shape as InvitationService /
+        // InvitationEmailSender / InvitationsSettingsTab.
         var inviteQuery = invitationOnly
             ? workspace.GetQuery(
                 $"onboarding:invite:{email}",
-                $"nodeType:Invitation content.email:{email}")
+                $"path:{InvitationNodeType.Namespace} scope:children nodeType:{InvitationNodeType.NodeType} content.email:{email}")
             : Observable.Return(Enumerable.Empty<MeshNode>());
 
         var jsonOptions = workspace.Hub.JsonSerializerOptions;
@@ -333,10 +339,14 @@ else
             $"onboarding:email:{email}",
             $"nodeType:User content.email:{email}");
         // Invitation-only allowlist: a Pending Invitation matching this verified email
-        // unlocks onboarding and is flipped to Accepted on success.
+        // unlocks onboarding and is flipped to Accepted on success. PATH-scoped
+        // (path:Admin/Invitation scope:children) — a path-less nodeType:Invitation query
+        // fans out cross-schema, which EXCLUDES the admin schema, so it finds nothing:
+        // the gate would wrongly block invited users AND MarkAccepted would never fire
+        // (invitations stayed "Pending" forever in the Invitations settings tab).
         var inviteQuery = workspace.GetQuery(
             $"onboarding:invite:{email}",
-            $"nodeType:Invitation content.email:{email}");
+            $"path:{InvitationNodeType.Namespace} scope:children nodeType:{InvitationNodeType.NodeType} content.email:{email}");
         var jsonOptions = workspace.Hub.JsonSerializerOptions;
 
         // Observable.Using holds the System-impersonation scope for the whole

--- a/memex/Memex.Portal.Shared/Settings/InvitationsSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/InvitationsSettingsTab.cs
@@ -181,6 +181,8 @@ public static class InvitationsSettingsTab
                 $"<div style=\"font-size: 0.8rem; color: var(--neutral-foreground-hint);\">" +
                 $"Invited {inv.InvitedAt:yyyy-MM-dd}" +
                 (string.IsNullOrEmpty(inv.InvitedBy) ? "" : $" by {Esc(inv.InvitedBy!)}") +
+                (inv.EmailSentAt is null ? "" : $" · Emailed {inv.EmailSentAt:yyyy-MM-dd}") +
+                (inv.AcceptedAt is null ? "" : $" · Accepted {inv.AcceptedAt:yyyy-MM-dd}") +
                 (string.IsNullOrEmpty(inv.SpacePath) ? "" : $" · Space: {Esc(inv.SpacePath!)}") +
                 (string.IsNullOrEmpty(inv.Note) ? "" : $" · {Esc(inv.Note!)}") +
                 "</div></div>"));

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-12-invitation-accepted-status.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-12-invitation-accepted-status.md
@@ -1,0 +1,10 @@
+---
+Name: Invitations now show whether they were accepted
+Category: What's New
+Description: The Invitations settings tab tracks each invitation through its life — when it was emailed and when the invitee signed up — instead of showing everything as Pending forever.
+Icon: Sparkle
+---
+
+The **Invitations** settings tab now tells you what actually happened to each invitation you sent. Every row shows when the invitation email went out and, once the invitee completes sign-up, an **Accepted** badge with the date — so you can see at a glance who is still outstanding and who is already on board.
+
+Behind the scenes, an invitation is now reliably marked accepted the moment the invited person finishes onboarding. Previously this connection was broken on hosted deployments: invitations stayed "Pending" forever even after the person had joined, and on invitation-only portals invited users could be wrongly turned away. Both are fixed — the invitation-only gate now recognises invited emails correctly.

--- a/test/MeshWeaver.Auth.Test/InvitationServiceTests.cs
+++ b/test/MeshWeaver.Auth.Test/InvitationServiceTests.cs
@@ -3,6 +3,7 @@ using Memex.Portal.Shared.Authentication;
 using Memex.Portal.Shared.Email;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
@@ -39,9 +40,11 @@ public class InvitationServiceTests(ITestOutputHelper output) : MonolithMeshTest
         Mesh.ServiceProvider.GetRequiredService<IMeshService>();
 
     /// <summary>
-    /// CreateInvitation writes a Pending Invitation node to the Admin partition, queryable
-    /// globally by <c>nodeType:Invitation content.email:X</c> — the exact lookup the onboarding
-    /// gate runs.
+    /// CreateInvitation writes a Pending Invitation node to the Admin partition, queryable by
+    /// <c>path:Admin/Invitation scope:children nodeType:Invitation content.email:X</c> — the exact
+    /// lookup the onboarding gate runs. PATH-scoped, because the PG router routes by the path's
+    /// first segment and a path-less query fans out cross-schema, which EXCLUDES the admin schema
+    /// (a path-less lookup passes here on the in-memory monolith but finds nothing on PG).
     /// </summary>
     [Fact(Timeout = 30000)]
     public async Task CreateInvitation_WritesQueryableAdminNode()
@@ -58,10 +61,10 @@ public class InvitationServiceTests(ITestOutputHelper output) : MonolithMeshTest
         InvitationService.TryGetInvitation(created, Mesh.JsonSerializerOptions)!
             .Status.Should().Be(InvitationStatus.Pending);
 
-        // Same shape as the onboarding gate's lookup — routes nodeType:Invitation to Admin.
+        // Same shape as the onboarding gate's lookup — path-scoped to the Admin partition.
         var found = await MeshSvc
             .Query<MeshNode>(MeshQueryRequest.FromQuery(
-                $"nodeType:Invitation content.email:{email} limit:1"))
+                $"path:{InvitationNodeType.Namespace} scope:children nodeType:{InvitationNodeType.NodeType} content.email:{email} limit:1"))
             .Should().Within(10.Seconds())
             .Match(c => c.Items.Count > 0);
         found.Items.Should().ContainSingle("the onboarding gate must find the invitation by email");
@@ -83,7 +86,7 @@ public class InvitationServiceTests(ITestOutputHelper output) : MonolithMeshTest
 
         // Wait for visibility, then the pending invitation is found.
         await MeshSvc.Query<MeshNode>(MeshQueryRequest.FromQuery(
-                $"nodeType:Invitation content.email:{email} limit:1"))
+                $"path:{InvitationNodeType.Namespace} scope:children nodeType:{InvitationNodeType.NodeType} content.email:{email} limit:1"))
             .Should().Within(10.Seconds()).Match(c => c.Items.Count > 0);
 
         var pending = await Service.FindPendingInvitation(workspace, email).Should().Emit();


### PR DESCRIPTION
## Problem

The Settings → Invitations tab showed every invitation as **Pending forever**, even after the invitee had signed up — and on invitation-only deployments, invited users could be wrongly turned away with "your email has not been invited".

## Root cause

`Onboarding.razor`'s two invitation lookups were **path-less** (`nodeType:Invitation content.email:X`). The PG query router routes by the path's first segment and does not consume the `nodeType:Invitation → Admin` `QueryRoutingHints` (deliberately inert — see the note in `InvitationNodeType`), so a path-less query fans out cross-schema, which **excludes the admin schema**: it finds nothing on PG. `pendingInviteNode` was therefore always `null` → `InvitationService.MarkAccepted` never fired, and the invitation-only gate never saw the invitation.

`InvitationService`, `InvitationEmailSender`, and `InvitationsSettingsTab` were all migrated to path-scoped queries; `Onboarding.razor` was the missed straggler. It slipped through because `InvitationServiceTests` run on the in-memory monolith, where path-less queries do see admin nodes.

## Fix

- `Onboarding.razor`: both invitation queries are now `path:Admin/Invitation scope:children nodeType:Invitation content.email:{email}` — the same shape as every other invitation read.
- `InvitationsSettingsTab`: rows now show `Emailed {date}` and `Accepted {date}` alongside the status badge, so the full lifecycle of each sent invitation is visible.
- `InvitationServiceTests`: pinned to the path-scoped query shape, with a comment explaining the monolith-vs-PG asymmetry.
- What's New entry included.

## Verification

- `Memex.Portal.Shared` + `MeshWeaver.Auth.Test` build clean under Release `-warnaserror`.
- `InvitationServiceTests`: 5/5 pass.

Note: invitations accepted before this fix keep their stale Pending status (no retroactive reconcile in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)