### PR TITLE
TestBase: stop started hosted services before Mesh.Dispose()

### DIFF
--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -622,6 +622,14 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     private long _instanceInitRssBytes;
     private long _instanceInitRssAnonBytes;
 
+    // The exact IHostedService instances InitializeAsync started, so DisposeAsync can stop
+    // THEM (not a fresh DI resolution) in reverse order BEFORE Mesh.Dispose() — mirroring the
+    // generic host, which stops hosted services before container teardown. Without this stop,
+    // a hosted service with an in-flight mesh request at test end (e.g. an InstanceSyncWorker
+    // drain holding a GetMeshNode callback) races disposal and trips the Quiescing
+    // leaked-callback guard (CI run 29197199611, InstanceSyncPushTest).
+    private readonly List<Microsoft.Extensions.Hosting.IHostedService> _startedHostedServices = new();
+
     // Watchdog: track when the test method actually started so DisposeAsync
     // can fail loudly on silent deadlocks. xUnit v3's [Fact(Timeout=N)] is
     // cooperative cancellation — if a test ignores the ct, the await blocks
@@ -666,6 +674,7 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
                 .GetServices<Microsoft.Extensions.Hosting.IHostedService>())
             {
                 await hosted.StartAsync(TestContext.Current.CancellationToken);
+                _startedHostedServices.Add(hosted);
             }
             TestPhaseTrace(name, "INIT_HOSTED_SERVICES_STARTED", sw.ElapsedMilliseconds);
 
@@ -1113,6 +1122,30 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
 
         try
         {
+            // Stop the hosted services InitializeAsync started — in reverse order, BEFORE
+            // Mesh.Dispose(), exactly like the generic host stops hosted services before
+            // container teardown. A still-running hosted service (change-feed listener,
+            // InstanceSync worker mid-drain, …) can hold an in-flight Observe callback on a
+            // hub; disposing the mesh underneath it leaves that callback pending and the
+            // Quiescing leaked-callback guard below fails the test for a lifecycle race the
+            // production host can never hit. Per-service catch: a failing StopAsync must not
+            // mask the disposal diagnostics that follow.
+            using (var stopCts = new CancellationTokenSource(DisposeTimeout))
+            {
+                for (var i = _startedHostedServices.Count - 1; i >= 0; i--)
+                {
+                    var hosted = _startedHostedServices[i];
+                    try { await hosted.StopAsync(stopCts.Token); }
+                    catch (Exception ex)
+                    {
+                        TestPhaseTrace(testName, "DISPOSE_HOSTED_STOP_ERROR", sw.ElapsedMilliseconds,
+                            $"{hosted.GetType().Name}: {ex.GetType().Name}: {ex.Message}");
+                    }
+                }
+                _startedHostedServices.Clear();
+            }
+            TestPhaseTrace(testName, "DISPOSE_HOSTED_SERVICES_STOPPED", sw.ElapsedMilliseconds);
+
             FileOutput.WriteLine($"[DISPOSE] {testName}: Mesh.Dispose() invoking on {Mesh.Address}");
             // Capture the mesh-scoped teardown services BEFORE disposal — once Dispose()
             // begins, resolving DI races the scope teardown. We drain them after

--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1135,7 +1135,10 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
                 for (var i = _startedHostedServices.Count - 1; i >= 0; i--)
                 {
                     var hosted = _startedHostedServices[i];
-                    try { await hosted.StopAsync(stopCts.Token); }
+                    // WaitAsync enforces the budget at the await site: a StopAsync that
+                    // ignores its cancellation token would otherwise hang DisposeAsync
+                    // forever, before the DisposeTimeout-guarded diagnostics below.
+                    try { await hosted.StopAsync(stopCts.Token).WaitAsync(stopCts.Token); }
                     catch (Exception ex)
                     {
                         TestPhaseTrace(testName, "DISPOSE_HOSTED_STOP_ERROR", sw.ElapsedMilliseconds,


### PR DESCRIPTION
## Problem

Main run 29197199611 went red on `InstanceSyncPushTest.Local_delete_propagates_to_remote` — a leaked-callback failure in `DisposeAsync`: a `GetDataRequest@delta/temp` still pending (603 ms) at the quiescing check. Nondeterministic (the identical tree passed the same shard on the PR run; 40 local iterations don't reproduce it), i.e. a CI-load race.

## Root cause

`MonolithMeshTestBase.InitializeAsync` starts every registered `IHostedService`, but `DisposeAsync` never stopped them — it disposed the mesh underneath still-running services. The generic host stops hosted services **before** container teardown; the test base skipped that ordering.

In the failing test: a trailing change-feed event for the just-deleted `delta/temp` kicked one more `InstanceSyncWorker` drain pass (50 ms test debounce). Its `GetMeshNode` posted a `GetDataRequest` to the deleted node's hub right as the test ended; the mesh disposed with the callback still registered → the Quiescing leaked-callback guard failed the test for a lifecycle race the production host can never hit.

## Fix

`InitializeAsync` records the exact hosted-service instances it started; `DisposeAsync` stops them in reverse order **before** `Mesh.Dispose()` (per-service catch + trace so a failing stop never masks disposal diagnostics). `InstanceSyncCoordinator.StopAsync` disposes its workers → any in-flight drain chain is disposed → `GetMeshNode`'s teardown deregisters the hub callback. The guard now only fires on genuine test-owned leaks.

This fixes the whole failure class for every test project using hosted services, not just InstanceSync.

## Verification

- `MeshWeaver.InstanceSync.Test`: 24/24 pass (including the coordinator stop/restart test — double stop is idempotent).
- Release `-warnaserror` build clean.
- No What's New entry: pure test-infrastructure change, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)