### PR TITLE
GitSync: incremental fetch — GetHeadSha change counter + path-filtered Fetch

### DIFF
--- a/src/MeshWeaver.GitSync/IGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/IGitHubRepoClient.cs
@@ -1,3 +1,5 @@
+using System.Reactive.Linq;
+
 namespace MeshWeaver.GitSync;
 
 /// <summary>
@@ -32,6 +34,32 @@ public interface IGitHubRepoClient
     /// </summary>
     IObservable<RepoSnapshot> Fetch(
         string repositoryUrl, string commitish, string? subdirectory, string accessToken);
+
+    /// <summary>
+    /// Filtered fetch: like <see cref="Fetch(string, string, string?, string)"/> but downloads ONLY
+    /// the blobs whose subdirectory-relative path satisfies <paramref name="pathFilter"/> — e.g.
+    /// every package's <c>*/index.json</c> manifest without pulling the rest of the repo. The
+    /// default implementation fetches everything and filters afterwards (correct on any
+    /// implementation); <see cref="OctokitGitHubRepoClient"/> overrides it to filter the tree
+    /// BEFORE the per-blob reads, so a manifest scan of a large repo costs a handful of calls.
+    /// </summary>
+    IObservable<RepoSnapshot> Fetch(
+        string repositoryUrl, string commitish, string? subdirectory, string accessToken,
+        Func<string, bool> pathFilter)
+        => Fetch(repositoryUrl, commitish, subdirectory, accessToken)
+            .Select(snapshot => new RepoSnapshot(
+                snapshot.CommitSha,
+                snapshot.Files.Where(f => pathFilter(f.Path)).ToArray()));
+
+    /// <summary>
+    /// The commit SHA a commitish currently resolves to — ONE cheap API call, no tree read, no blob
+    /// reads. This is the git-history change counter: poll it and re-fetch only when it moved past
+    /// the SHA you already processed (deletions included — the snapshot at the new SHA is the full
+    /// truth). The default implementation falls back to a full fetch's SHA (correct, not cheap);
+    /// <see cref="OctokitGitHubRepoClient"/> overrides it with the single ref/commit lookup.
+    /// </summary>
+    IObservable<string> GetHeadSha(string repositoryUrl, string commitish, string accessToken)
+        => Fetch(repositoryUrl, commitish, null, accessToken).Select(snapshot => snapshot.CommitSha);
 
     /// <summary>
     /// Creates <see cref="GitHubCreateBranchRequest.NewBranch"/> from

--- a/src/MeshWeaver.GitSync/IGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/IGitHubRepoClient.cs
@@ -46,10 +46,13 @@ public interface IGitHubRepoClient
     IObservable<RepoSnapshot> Fetch(
         string repositoryUrl, string commitish, string? subdirectory, string accessToken,
         Func<string, bool> pathFilter)
-        => Fetch(repositoryUrl, commitish, subdirectory, accessToken)
+    {
+        ArgumentNullException.ThrowIfNull(pathFilter);
+        return Fetch(repositoryUrl, commitish, subdirectory, accessToken)
             .Select(snapshot => new RepoSnapshot(
                 snapshot.CommitSha,
                 snapshot.Files.Where(f => pathFilter(f.Path)).ToArray()));
+    }
 
     /// <summary>
     /// The commit SHA a commitish currently resolves to — ONE cheap API call, no tree read, no blob

--- a/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
@@ -143,6 +143,22 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
     /// <returns>An observable emitting the resolved commit SHA and its files (paths made subdirectory-relative).</returns>
     public IObservable<RepoSnapshot> Fetch(
         string repositoryUrl, string commitish, string? subdirectory, string accessToken)
+        => Fetch(repositoryUrl, commitish, subdirectory, accessToken, _ => true);
+
+    /// <summary>
+    /// Filtered fetch — the tree is filtered BEFORE the per-blob reads, so fetching every package's
+    /// <c>*/index.json</c> from a large repo costs the ref + tree lookups plus one blob read per
+    /// manifest, not one per file in the repo.
+    /// </summary>
+    /// <param name="repositoryUrl">The repository URL (https://github.com/owner/repo).</param>
+    /// <param name="commitish">Branch name or commit SHA to read at.</param>
+    /// <param name="subdirectory">Optional subtree; returned paths are relative to it.</param>
+    /// <param name="accessToken">The token to read with (empty for anonymous/public).</param>
+    /// <param name="pathFilter">Predicate over the subdirectory-relative path; only matches download.</param>
+    /// <returns>The snapshot at the resolved commit containing only the matching files.</returns>
+    public IObservable<RepoSnapshot> Fetch(
+        string repositoryUrl, string commitish, string? subdirectory, string accessToken,
+        Func<string, bool> pathFilter)
     {
         var (owner, repo) = ParseRepoUrl(repositoryUrl);
         var client = Client(accessToken);
@@ -154,6 +170,7 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
             {
                 var blobs = head.ExistingBlobs
                     .Where(e => prefix.Length == 0 || e.Path.StartsWith(prefix, StringComparison.Ordinal))
+                    .Where(e => pathFilter(prefix.Length == 0 ? e.Path : e.Path[prefix.Length..]))
                     .ToArray();
                 if (blobs.Length == 0)
                     return Observable.Return(new RepoSnapshot(head.CommitSha!, Array.Empty<RepoFile>()));
@@ -167,6 +184,23 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
                     .ToList()
                     .Select(list => new RepoSnapshot(head.CommitSha!, (IReadOnlyList<RepoFile>)list));
             });
+    }
+
+    /// <summary>
+    /// The commit SHA <paramref name="commitish"/> resolves to — one ref (or commit) lookup, no
+    /// tree, no blobs. The cheap change counter for pollers: compare against the last processed
+    /// SHA and skip the fetch entirely when nothing was merged.
+    /// </summary>
+    /// <param name="repositoryUrl">The repository URL (https://github.com/owner/repo).</param>
+    /// <param name="commitish">Branch name or commit SHA.</param>
+    /// <param name="accessToken">The token to read with (empty for anonymous/public).</param>
+    /// <returns>An observable emitting the resolved commit SHA.</returns>
+    public IObservable<string> GetHeadSha(string repositoryUrl, string commitish, string accessToken)
+    {
+        var (owner, repo) = ParseRepoUrl(repositoryUrl);
+        var client = Client(accessToken);
+        var commitRef = string.IsNullOrWhiteSpace(commitish) ? "main" : commitish.Trim();
+        return ResolveRefSha(client, owner, repo, commitRef);
     }
 
     /// <summary>Creates a branch from an existing ref (branch name or SHA) resolved to its commit.</summary>

--- a/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
@@ -160,6 +160,7 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
         string repositoryUrl, string commitish, string? subdirectory, string accessToken,
         Func<string, bool> pathFilter)
     {
+        ArgumentNullException.ThrowIfNull(pathFilter);
         var (owner, repo) = ParseRepoUrl(repositoryUrl);
         var client = Client(accessToken);
         var prefix = NormalizePrefix(subdirectory);

--- a/src/MeshWeaver.PluginCatalog/GitHubPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/GitHubPackageSource.cs
@@ -7,7 +7,7 @@ namespace MeshWeaver.PluginCatalog;
 
 /// <summary>
 /// An <see cref="IPackageSource"/> that reads a REMOTE git repo at a commit/branch by reusing
-/// GitSync's fetch (<see cref="IGitHubRepoClient.Fetch"/>) — so a DEPLOYED portal, which has no
+/// GitSync's fetch (<see cref="IGitHubRepoClient.Fetch(string, string, string?, string)"/>) — so a DEPLOYED portal, which has no
 /// source tree in its container, can browse/install from the plugins repo on GitHub. Still git-based
 /// and NuGet-free: it fetches the repo tree at a ref, groups the folders that carry a
 /// <c>package.json</c>, and returns each folder's files.

--- a/test/MeshWeaver.GitSync.Test/IncrementalFetchDefaultsTest.cs
+++ b/test/MeshWeaver.GitSync.Test/IncrementalFetchDefaultsTest.cs
@@ -1,0 +1,83 @@
+using System.Collections.Immutable;
+using MeshWeaver.GitSync;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Pins the <b>incremental-fetch default interface members</b> on <see cref="IGitHubRepoClient"/>,
+/// added so pollers can (1) check a repo's head SHA with ONE call via
+/// <see cref="IGitHubRepoClient.GetHeadSha"/> and re-fetch only when it moved, and (2) download
+/// only the files a manifest scan needs via the path-filtered
+/// <see cref="IGitHubRepoClient.Fetch(string, string, string?, string, Func{string, bool})"/>
+/// overload — instead of pulling every blob in the repo on every poll (which exhausted the
+/// GitHub App rate limit).
+///
+/// <para>Both members are default interface implementations (full fetch + post-filter, resp. the
+/// full fetch's <see cref="RepoSnapshot.CommitSha"/>), so every existing implementor stays correct
+/// and source-compatible without changes. <see cref="FakeGitHubRepoClient"/> deliberately does NOT
+/// override either member — calling them through the interface exercises the DIMs themselves.</para>
+/// </summary>
+public class IncrementalFetchDefaultsTest
+{
+    private const string Repo = "https://github.com/acme/plugin-registry";
+
+    private static IObservable<GitHubPushResult> Seed(FakeGitHubRepoClient fake) =>
+        fake.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = Repo,
+            CommitMessage = "seed",
+            AuthorName = "tester",
+            AuthorEmail = "tester@example.com",
+            AccessToken = "",
+            Files = ImmutableList.Create(
+                new RepoFile("Slides/index.json", """{ "id": "Slides" }"""),
+                new RepoFile("Slides/Slide/Source/Slide.cs", "// live-compiled source"),
+                new RepoFile("Edu/index.json", """{ "id": "Edu" }"""),
+                new RepoFile("README.md", "# readme")),
+        });
+
+    [Fact]
+    public async Task FilteredFetchDefault_ReturnsOnlyMatchingFiles_AtTheSameCommit()
+    {
+        var fake = new FakeGitHubRepoClient();
+        var pushed = await Seed(fake).Should().Emit();
+        IGitHubRepoClient client = fake; // interface call => the DIM, not an override
+
+        var snapshot = await client
+            .Fetch(Repo, pushed.CommitSha, null, "",
+                path => path.EndsWith("/index.json", StringComparison.Ordinal))
+            .Should().Emit();
+
+        snapshot.CommitSha.Should().Be(pushed.CommitSha);
+        snapshot.Files.Select(f => f.Path).Should().Equal("Slides/index.json", "Edu/index.json");
+    }
+
+    [Fact]
+    public async Task FilteredFetchDefault_FilterSeesSubdirectoryRelativePaths()
+    {
+        var fake = new FakeGitHubRepoClient();
+        var pushed = await Seed(fake).Should().Emit();
+        IGitHubRepoClient client = fake;
+
+        // Within subdirectory "Slides" the manifest's relative path is exactly "index.json".
+        var snapshot = await client
+            .Fetch(Repo, pushed.CommitSha, "Slides", "", path => path == "index.json")
+            .Should().Emit();
+
+        snapshot.CommitSha.Should().Be(pushed.CommitSha);
+        snapshot.Files.Select(f => f.Path).Should().Equal("index.json");
+    }
+
+    [Fact]
+    public async Task GetHeadShaDefault_ReturnsTheFetchedCommitSha()
+    {
+        var fake = new FakeGitHubRepoClient();
+        var pushed = await Seed(fake).Should().Emit();
+        IGitHubRepoClient client = fake;
+
+        var sha = await client.GetHeadSha(Repo, "main", "").Should().Emit();
+
+        sha.Should().Be(pushed.CommitSha);
+    }
+}


### PR DESCRIPTION
## Motivation

Manifest polling burned through the GitHub App installation rate limit on memex today. The only read primitive GitSync exposes is the full-tree `Fetch`, which costs **one API call per blob — including binaries** — on every poll, even when nothing changed and even when the consumer only needs each package's `*/index.json` manifest.

This PR adds the two incremental primitives so consumers can be cheap:

- **Poll cheaply:** check the head SHA with ONE API call and re-fetch only when it moved past the SHA already processed (deletions included — the snapshot at the new SHA is the full truth).
- **Fetch narrowly:** a manifest scan downloads only the blobs matching a path filter (e.g. every `*/index.json`) instead of every file in the repo.

## API shape

Two new members on `IGitHubRepoClient`, both with **default interface implementations** so every existing implementor (including test fakes) keeps compiling unchanged:

```csharp
// Filtered fetch — DIM: full Fetch, then filter the snapshot's files (correct anywhere).
IObservable<RepoSnapshot> Fetch(
    string repositoryUrl, string commitish, string? subdirectory, string accessToken,
    Func<string, bool> pathFilter);

// Cheap change counter — DIM: falls back to a full fetch's CommitSha (correct, not cheap).
IObservable<string> GetHeadSha(string repositoryUrl, string commitish, string accessToken);
```

`OctokitGitHubRepoClient` overrides both for the real savings:

- The 4-arg `Fetch` now delegates to the 5-arg with `_ => true` (behavior unchanged).
- The 5-arg `Fetch` filters the tree's blobs by their **subdirectory-relative** path **before** the per-blob content reads — so fetching every package's `index.json` from a large repo costs the ref + tree lookups plus one blob read per manifest, not one per file in the repo.
- `GetHeadSha` is `ParseRepoUrl` + `Client` + `ResolveRefSha` — a single ref/commit lookup, no tree, no blobs.

## Compatibility

- DIMs keep existing implementors compiling: `FakeGitHubRepoClient` in `MeshWeaver.GitSync.Test` needed **no changes** and now doubles as the DIM test vehicle.
- One cref in `MeshWeaver.PluginCatalog/GitHubPackageSource.cs` disambiguated to the 4-arg overload (the new overload made `IGitHubRepoClient.Fetch` ambiguous under warnings-as-errors).

## Tests

`IncrementalFetchDefaultsTest` pins the DIMs through the interface (the fake does not override them):

- filtered-Fetch default returns only the matching files at the same `CommitSha`;
- the filter sees **subdirectory-relative** paths;
- `GetHeadSha` default returns the fetch's SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
