### PR TITLE
Portal: entitlement-gated course-asset endpoint (302 to GitHub download_url)

### DIFF
--- a/memex/Memex.Portal.Shared/Courses/CourseAssetEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Courses/CourseAssetEndpoints.cs
@@ -1,0 +1,180 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Blazor.Infrastructure; // PortalApplication
+using MeshWeaver.GitSync;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging; // AccessService
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Courses;
+
+/// <summary>
+/// <c>GET /assets/{Space}/{path…}</c> — the entitlement-gated course-asset endpoint.
+/// Course media (videos) live in the Space's synced GitHub repository
+/// (<c>{Space}/_GitSync</c>, <see cref="GitHubSyncConfig"/>), not in the mesh; this endpoint
+/// resolves the asset's repo file, applies the entitlement gate (<see cref="CourseAssetGate"/>)
+/// and 302-redirects to GitHub's short-lived tokenized <c>download_url</c>
+/// (<see cref="CourseAssetService"/>) — the bytes are never proxied through the portal.
+///
+/// <para><b>Gate</b>: the viewer needs <see cref="Permission.Read"/> on the Space AND — when the
+/// course is paid (its <c>{Space}/_Entitlements</c> container has entries) — an entitlement node
+/// <c>{Space}/_Entitlements/{viewer}</c>. Course admins (<see cref="Permission.Update"/> on the
+/// Space) always pass. 404 when the Space has no GitSync config or the file is not in the repo;
+/// 401 (anonymous) / 403 (authenticated) when the gate denies.</para>
+///
+/// <para><b>Shape</b>: mirrors <see cref="MeshWeaver.Hosting.Blazor">the /static endpoint</see> —
+/// the whole resolution is one <see cref="IObservable{T}"/> chain, bridged to
+/// <c>Task&lt;IResult&gt;</c> exactly once at the HTTP boundary with
+/// <c>FirstAsync().ToTask(RequestAborted)</c>. The viewer identity comes from the
+/// <c>AccessService</c> context that <c>UserContextMiddleware</c> stamped for this request
+/// (same resolution as <c>GitHubConnectEndpoints</c>); the config/entitlement reads run under
+/// the System identity (the gate itself is the protection — the satellites are not
+/// viewer-readable in general), while the permission check runs for the viewer explicitly.</para>
+/// </summary>
+public static class CourseAssetEndpoints
+{
+    /// <summary>The route prefix of the asset endpoint.</summary>
+    public const string RoutePrefix = "/assets";
+
+    /// <summary>The Space's entitlement container segment (<c>{Space}/_Entitlements/{viewer}</c>).</summary>
+    public const string EntitlementsSegment = "_Entitlements";
+
+    // Ceiling for the viewer's positive Read/Update grant to surface on the live permission
+    // stream (its first emission can be the premature empty seed — same rationale and window
+    // as AdminMenuGate.GrantWait). A viewer with no grant pays the full wait and is denied.
+    private static readonly TimeSpan GrantWait = TimeSpan.FromSeconds(5);
+
+    // Ceiling for the query Initial snapshots (config + entitlements) — a wedged provider
+    // must fail the request loudly (500 via the outer Catch), never hang it.
+    private static readonly TimeSpan SnapshotWait = TimeSpan.FromSeconds(10);
+
+    /// <summary>Maps the course-asset endpoint. Call after <c>UseAuthentication</c> (needs the resolved user).</summary>
+    public static IEndpointRouteBuilder MapCourseAssets(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet(RoutePrefix + "/{**path}", (HttpContext http, string? path) =>
+        {
+            if (!CourseAssetGate.TryParsePath(path, out var space, out var relativePath))
+                return Task.FromResult(Results.NotFound("Expected /assets/{Space}/{path…}."));
+
+            var hub = http.RequestServices.GetRequiredService<IMessageHub>();
+            var assets = http.RequestServices.GetRequiredService<CourseAssetService>();
+            var logger = http.RequestServices.GetRequiredService<ILoggerFactory>()
+                .CreateLogger(typeof(CourseAssetEndpoints));
+
+            // Viewer identity — the SAME AccessService instance UserContextMiddleware stamped
+            // (the portal hub's; mirrors GitHubConnectEndpoints.ResolveMeshUserId), captured
+            // SYNCHRONOUSLY before any async hop (the AsyncLocal does not survive SelectMany).
+            var accessService = http.RequestServices.GetService<PortalApplication>()?.Hub
+                                    .ServiceProvider.GetService<AccessService>()
+                                ?? hub.ServiceProvider.GetService<AccessService>();
+            var context = accessService?.Context ?? accessService?.CircuitContext;
+            var viewerId = context?.ObjectId;
+            var isAuthenticated = !string.IsNullOrEmpty(viewerId)
+                                  && context?.IsVirtual != true
+                                  && !string.Equals(viewerId, WellKnownUsers.Anonymous, StringComparison.Ordinal);
+            if (!isAuthenticated)
+                viewerId = WellKnownUsers.Anonymous;
+
+            return ResolveAsset(hub, assets, logger, space, relativePath, viewerId!, isAuthenticated)
+                .Catch<IResult, Exception>(ex =>
+                {
+                    logger.LogWarning(ex, "Course-asset resolution failed for {Space}/{Path}", space, relativePath);
+                    return Observable.Return(Results.Problem($"Error resolving course asset: {ex.Message}"));
+                })
+                .FirstAsync()
+                .ToTask(http.RequestAborted);
+        });
+        return endpoints;
+    }
+
+    /// <summary>
+    /// The full resolution chain: GitSync config + entitlement entries (System-identity Initial
+    /// snapshots) + the viewer's Space permissions → gate decision → tokenized download URL.
+    /// </summary>
+    private static IObservable<IResult> ResolveAsset(
+        IMessageHub hub,
+        CourseAssetService assets,
+        ILogger logger,
+        string space,
+        string relativePath,
+        string viewerId,
+        bool isAuthenticated)
+    {
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var configPath = $"{space}/{GitHubSyncService.ConfigId}";
+        var entitlementsNamespace = $"{space}/{EntitlementsSegment}";
+
+        // The Space's primary GitSync source — absent (or repo-less) means there is nothing
+        // to serve for this Space: 404, checked before the gate ("no course here" is not an
+        // access question and must not leak differently per viewer).
+        var config = InitialSnapshot(meshService, $"path:{configPath}")
+            .Select(nodes => nodes
+                .FirstOrDefault(n => string.Equals(n.Path, configPath, StringComparison.OrdinalIgnoreCase))
+                .ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions, logger));
+
+        // The entitlement entries ({Space}/_Entitlements/{userId}): any entry ⇒ the course is
+        // paid; an entry whose id matches the viewer ⇒ the viewer is entitled.
+        var entitlements = InitialSnapshot(meshService, $"namespace:{entitlementsNamespace}")
+            .Select(nodes => nodes
+                .Where(n => string.Equals(n.Namespace, entitlementsNamespace, StringComparison.OrdinalIgnoreCase))
+                .Select(n => n.Id)
+                .ToList());
+
+        // The viewer's effective permissions on the Space — wait for the positive (the stream's
+        // first emission can be the premature empty seed), bounded; no positive ⇒ None.
+        var permissions = hub.GetEffectivePermissions(space, viewerId)
+            .Where(p => p.HasFlag(Permission.Read) || p.HasFlag(Permission.Update))
+            .Take(1)
+            .Timeout(GrantWait)
+            .Catch((Exception _) => Observable.Empty<Permission>())
+            .DefaultIfEmpty(Permission.None);
+
+        return Observable
+            .CombineLatest(config, entitlements, permissions,
+                (cfg, entitled, perms) => (Config: cfg, EntitledIds: entitled, Permissions: perms))
+            .Take(1)
+            .SelectMany(t =>
+            {
+                if (t.Config?.RepositoryUrl is not { Length: > 0 } repositoryUrl)
+                    return Observable.Return(Results.NotFound(
+                        $"No course assets at '{space}' (the Space has no GitHub sync source)."));
+
+                var isPaid = t.EntitledIds.Count > 0;
+                var isEntitled = isAuthenticated && t.EntitledIds
+                    .Any(id => string.Equals(id, viewerId, StringComparison.OrdinalIgnoreCase));
+                var decision = CourseAssetGate.Decide(t.Permissions, isAuthenticated, isPaid, isEntitled);
+                if (decision == CourseAssetGate.Decision.NotAuthenticated)
+                    return Observable.Return(Results.Unauthorized());
+                if (decision == CourseAssetGate.Decision.Forbidden)
+                    return Observable.Return(Results.StatusCode(StatusCodes.Status403Forbidden));
+
+                var repoFilePath = CourseAssetGate.MapToRepoPath(t.Config.Subdirectory, relativePath);
+                return assets.GetDownloadUrl(repositoryUrl, t.Config.Branch, repoFilePath)
+                    .Select(url => url is null
+                        ? Results.NotFound($"'{relativePath}' not found in the course repository.")
+                        : Results.Redirect(url));
+            });
+    }
+
+    /// <summary>
+    /// One deterministic point-in-time query snapshot under the System identity: the
+    /// <see cref="QueryChangeType.Initial"/> (or Reset) emission of <see cref="IMeshService.Query{T}"/>.
+    /// System because the gate reads hidden satellites the viewer generally cannot Read — the
+    /// endpoint's own decision (not RLS on the satellites) is what protects the asset. Bounded
+    /// by <see cref="SnapshotWait"/>; an empty completion (no matching provider) yields an
+    /// empty snapshot (→ 404 downstream), never a hang.
+    /// </summary>
+    private static IObservable<IReadOnlyList<MeshNode>> InitialSnapshot(IMeshService meshService, string query) =>
+        meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(query, WellKnownUsers.System))
+            .Where(c => c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+            .Take(1)
+            .Timeout(SnapshotWait)
+            .Select(c => c.Items)
+            .DefaultIfEmpty([]);
+}

--- a/memex/Memex.Portal.Shared/Courses/CourseAssetEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Courses/CourseAssetEndpoints.cs
@@ -127,12 +127,26 @@ public static class CourseAssetEndpoints
                 .ToList());
 
         // The viewer's effective permissions on the Space — wait for the positive (the stream's
-        // first emission can be the premature empty seed), bounded; no positive ⇒ None.
+        // first emission can be the premature empty seed), bounded; no positive ⇒ None. Failures
+        // fail CLOSED but never silently: the timeout is the expected "no positive grant"
+        // outcome (a denied viewer pays the full wait), anything else is an infrastructure
+        // failure that must leave a log signal rather than masquerade as a 401/403.
         var permissions = hub.GetEffectivePermissions(space, viewerId)
             .Where(p => p.HasFlag(Permission.Read) || p.HasFlag(Permission.Update))
             .Take(1)
             .Timeout(GrantWait)
-            .Catch((Exception _) => Observable.Empty<Permission>())
+            .Catch((Exception ex) =>
+            {
+                if (ex is TimeoutException)
+                    logger.LogDebug(
+                        "No positive grant for {Viewer} on {Space} within {Wait} — treating as no access",
+                        viewerId, space, GrantWait);
+                else
+                    logger.LogWarning(ex,
+                        "Permission stream for {Viewer} on {Space} failed — failing closed",
+                        viewerId, space);
+                return Observable.Empty<Permission>();
+            })
             .DefaultIfEmpty(Permission.None);
 
         return Observable

--- a/memex/Memex.Portal.Shared/Courses/CourseAssetGate.cs
+++ b/memex/Memex.Portal.Shared/Courses/CourseAssetGate.cs
@@ -28,8 +28,10 @@ public static class CourseAssetGate
     /// Parses the catch-all route value into the Space id (first segment) and the asset's
     /// path relative to the Space's synced content (the remaining segments). Rejects
     /// paths without at least a space + one file segment, empty segments (<c>//</c>),
-    /// dot segments (<c>.</c> / <c>..</c> — path traversal), and a satellite-shaped
-    /// (<c>_</c>-prefixed) space segment.
+    /// dot segments (<c>.</c> / <c>..</c> — path traversal), segments containing
+    /// whitespace (the space segment is interpolated into mesh query strings — embedded
+    /// whitespace would break tokenization / allow query injection), and a
+    /// satellite-shaped (<c>_</c>-prefixed) space segment.
     /// </summary>
     /// <param name="path">The raw <c>{**path}</c> route value (already URL-decoded).</param>
     /// <param name="space">The Space id (first path segment).</param>
@@ -45,7 +47,7 @@ public static class CourseAssetGate
         var segments = path.Trim('/').Split('/');
         if (segments.Length < 2)
             return false;
-        if (segments.Any(s => string.IsNullOrWhiteSpace(s) || s == "." || s == ".."))
+        if (segments.Any(s => s.Length == 0 || s.Any(char.IsWhiteSpace) || s == "." || s == ".."))
             return false;
         if (segments[0].StartsWith('_'))
             return false;

--- a/memex/Memex.Portal.Shared/Courses/CourseAssetGate.cs
+++ b/memex/Memex.Portal.Shared/Courses/CourseAssetGate.cs
@@ -1,0 +1,102 @@
+using MeshWeaver.Mesh.Security;
+
+namespace Memex.Portal.Shared.Courses;
+
+/// <summary>
+/// Pure decision logic for the course-asset endpoint (<c>GET /assets/{Space}/{path…}</c>):
+/// the URL → (space, relative path) parse, the relative-path → repo-file-path mapping
+/// (through the Space's GitSync <c>Subdirectory</c>), and the entitlement gate itself.
+/// No I/O, no hub — every rule is a static function so the gate semantics are unit-testable
+/// in isolation (see <c>CourseAssetGateTest</c>).
+/// </summary>
+public static class CourseAssetGate
+{
+    /// <summary>The gate's verdict for one request.</summary>
+    public enum Decision
+    {
+        /// <summary>Serve the asset (302 to the tokenized download URL).</summary>
+        Allowed,
+
+        /// <summary>The viewer is anonymous and anonymous access does not suffice → 401.</summary>
+        NotAuthenticated,
+
+        /// <summary>The viewer is authenticated but lacks Read on the Space or the required entitlement → 403.</summary>
+        Forbidden,
+    }
+
+    /// <summary>
+    /// Parses the catch-all route value into the Space id (first segment) and the asset's
+    /// path relative to the Space's synced content (the remaining segments). Rejects
+    /// paths without at least a space + one file segment, empty segments (<c>//</c>),
+    /// dot segments (<c>.</c> / <c>..</c> — path traversal), and a satellite-shaped
+    /// (<c>_</c>-prefixed) space segment.
+    /// </summary>
+    /// <param name="path">The raw <c>{**path}</c> route value (already URL-decoded).</param>
+    /// <param name="space">The Space id (first path segment).</param>
+    /// <param name="relativePath">The asset path relative to the Space's synced subtree.</param>
+    /// <returns>True when the path has the expected <c>{Space}/{rest…}</c> shape.</returns>
+    public static bool TryParsePath(string? path, out string space, out string relativePath)
+    {
+        space = string.Empty;
+        relativePath = string.Empty;
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        var segments = path.Trim('/').Split('/');
+        if (segments.Length < 2)
+            return false;
+        if (segments.Any(s => string.IsNullOrWhiteSpace(s) || s == "." || s == ".."))
+            return false;
+        if (segments[0].StartsWith('_'))
+            return false;
+
+        space = segments[0];
+        relativePath = string.Join('/', segments.Skip(1));
+        return true;
+    }
+
+    /// <summary>
+    /// Maps the asset's Space-relative path to the file path inside the synced repository:
+    /// the Space's GitSync <c>Subdirectory</c> (when configured) prefixes the relative path,
+    /// mirroring how the sync itself lays the Space's content out in the repo.
+    /// </summary>
+    /// <param name="subdirectory">The <c>GitHubSyncConfig.Subdirectory</c> (null/empty = repository root).</param>
+    /// <param name="relativePath">The asset path relative to the Space's synced subtree.</param>
+    /// <returns>The repository file path to request from the GitHub contents API.</returns>
+    public static string MapToRepoPath(string? subdirectory, string relativePath)
+    {
+        var prefix = subdirectory?.Trim().Trim('/');
+        return string.IsNullOrEmpty(prefix) ? relativePath : $"{prefix}/{relativePath}";
+    }
+
+    /// <summary>
+    /// The entitlement gate. Course admins (<see cref="Permission.Update"/> on the Space)
+    /// always pass. Everyone else needs <see cref="Permission.Read"/> on the Space AND —
+    /// when the course is paid (its <c>{Space}/_Entitlements</c> container has entries) —
+    /// an entitlement of their own. Denials split by authentication so the endpoint can
+    /// answer 401 (log in) vs 403 (no access).
+    /// </summary>
+    /// <param name="spacePermissions">The viewer's effective permissions on the Space node.</param>
+    /// <param name="isAuthenticated">True when the viewer is a real signed-in user (not anonymous/virtual).</param>
+    /// <param name="isPaid">True when the Space's <c>_Entitlements</c> container holds any entries.</param>
+    /// <param name="isEntitled">True when an entitlement node exists for this viewer.</param>
+    /// <returns>The verdict for this request.</returns>
+    public static Decision Decide(
+        Permission spacePermissions,
+        bool isAuthenticated,
+        bool isPaid,
+        bool isEntitled)
+    {
+        // Course admins always pass — they manage the content the gate protects.
+        if (spacePermissions.HasFlag(Permission.Update))
+            return Decision.Allowed;
+
+        if (!spacePermissions.HasFlag(Permission.Read))
+            return isAuthenticated ? Decision.Forbidden : Decision.NotAuthenticated;
+
+        if (isPaid && !isEntitled)
+            return isAuthenticated ? Decision.Forbidden : Decision.NotAuthenticated;
+
+        return Decision.Allowed;
+    }
+}

--- a/memex/Memex.Portal.Shared/Courses/CourseAssetService.cs
+++ b/memex/Memex.Portal.Shared/Courses/CourseAssetService.cs
@@ -1,0 +1,180 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.GitSync;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Memex.Portal.Shared.Courses;
+
+/// <summary>
+/// Resolves a course asset's short-lived, tokenized <c>download_url</c> through the GitHub
+/// contents API (<c>GET /repos/{owner}/{repo}/contents/{path}?ref={branch}</c>), authenticated
+/// as the GitHub App installation (<see cref="GitHubAppTokenService"/>) so private course repos
+/// resolve without any per-user credential. The endpoint 302-redirects to the returned URL —
+/// the bytes are never proxied through the portal.
+///
+/// <para>🚨 Reactive end-to-end — the public surface is <see cref="IObservable{T}"/>; every HTTP
+/// leaf runs inside the <see cref="IoPoolNames.Http"/> pool (<c>Doc/Architecture/ControlledIoPooling.md</c>).
+/// Results are promise-cached per repo file for <see cref="DefaultCacheTtl"/> (30&#160;s — GitHub's tokenized
+/// URLs are short-lived, so the cache must stay well inside their validity): concurrent requests
+/// for the same file share one round-trip, a failed fetch invalidates itself so the next caller
+/// retries. The cache is an instance field on this mesh-scoped singleton — never static
+/// (<c>NoStaticState.md</c>).</para>
+/// </summary>
+public sealed class CourseAssetService
+{
+    /// <summary>How long a resolved <c>download_url</c> is reused before re-fetching.</summary>
+    public static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromSeconds(30);
+
+    /// <summary>Opportunistic prune threshold — above this entry count, stale entries are swept on access.</summary>
+    private const int PruneThreshold = 512;
+
+    private readonly HttpClient http;
+    private readonly IoPoolRegistry ioPools;
+    private readonly GitHubAppTokenService? appTokens;
+    private readonly GitHubAppOptions options;
+    private readonly ILogger? logger;
+    private readonly TimeSpan cacheTtl;
+
+    // Promise-cache (instance, never static): one eagerly-connected replay per repo file,
+    // replaced when older than the TTL, removed on error so failures don't stick.
+    private readonly ConcurrentDictionary<string, CacheEntry> cache = new();
+
+    private sealed record CacheEntry(DateTimeOffset FetchedAt, IObservable<string?> DownloadUrl);
+
+    /// <summary>Initializes the service.</summary>
+    /// <param name="ioPools">Registry the HTTP I/O pool is resolved from so every HTTP leaf runs off the hub.</param>
+    /// <param name="options">The bound <see cref="GitHubAppOptions"/> (for <see cref="GitHubAppOptions.ApiBaseUrl"/>).</param>
+    /// <param name="appTokens">The App installation-token service; null / unconfigured → unauthenticated
+    /// requests (public repositories still resolve).</param>
+    /// <param name="logger">Optional logger.</param>
+    /// <param name="httpClient">Optional <see cref="HttpClient"/> to reuse (tests); a default one is created when null.</param>
+    /// <param name="cacheTtl">Optional cache TTL override (tests); defaults to <see cref="DefaultCacheTtl"/>.</param>
+    public CourseAssetService(
+        IoPoolRegistry ioPools,
+        IOptions<GitHubAppOptions> options,
+        GitHubAppTokenService? appTokens = null,
+        ILogger<CourseAssetService>? logger = null,
+        HttpClient? httpClient = null,
+        TimeSpan? cacheTtl = null)
+    {
+        this.ioPools = ioPools;
+        this.options = options.Value;
+        this.appTokens = appTokens;
+        this.logger = logger;
+        this.cacheTtl = cacheTtl ?? DefaultCacheTtl;
+        http = httpClient ?? new HttpClient();
+        if (!http.DefaultRequestHeaders.UserAgent.Any())
+            http.DefaultRequestHeaders.UserAgent.ParseAdd("MeshWeaver-CourseAssets");
+    }
+
+    private IIoPool Http => ioPools.Get(IoPoolNames.Http);
+
+    /// <summary>
+    /// The tokenized <c>download_url</c> for one repository file — cached per file for the TTL,
+    /// shared across concurrent callers. Emits <c>null</c> when the file (or the repository ref)
+    /// does not exist; errors propagate (and self-invalidate the cache entry).
+    /// </summary>
+    /// <param name="repositoryUrl">The repo URL from the Space's <see cref="GitHubSyncConfig.RepositoryUrl"/>.</param>
+    /// <param name="branch">The branch from <see cref="GitHubSyncConfig.Branch"/> (null/blank → <c>main</c>).</param>
+    /// <param name="repoFilePath">The file path inside the repository.</param>
+    /// <returns>A single-emission observable with the download URL, or null when not found.</returns>
+    public IObservable<string?> GetDownloadUrl(string repositoryUrl, string? branch, string repoFilePath)
+    {
+        var (owner, repo) = OctokitGitHubRepoClient.ParseRepoUrl(repositoryUrl);
+        var reference = string.IsNullOrWhiteSpace(branch) ? "main" : branch.Trim();
+        var key = $"{owner}/{repo}@{reference}:{repoFilePath}";
+        var now = DateTimeOffset.UtcNow;
+
+        PruneIfOversized(now);
+
+        var entry = cache.AddOrUpdate(
+            key,
+            _ => new CacheEntry(now, CreateFetch(owner, repo, reference, repoFilePath, key)),
+            (_, existing) => now - existing.FetchedAt < cacheTtl
+                ? existing
+                : new CacheEntry(now, CreateFetch(owner, repo, reference, repoFilePath, key)));
+        return entry.DownloadUrl;
+    }
+
+    /// <summary>
+    /// One eager fetch: App token (when configured) → contents API on the HTTP pool →
+    /// replayed to every subscriber of this cache entry. A failure removes the entry
+    /// (never cache a failure) and is replayed as the error to current subscribers.
+    /// </summary>
+    private IObservable<string?> CreateFetch(
+        string owner, string repo, string reference, string repoFilePath, string cacheKey)
+    {
+        var token = appTokens is { IsConfigured: true }
+            ? appTokens.GetInstallationToken().Select(t => (string?)t)
+            : Observable.Return<string?>(null);
+
+        var fetch = token
+            .Take(1)
+            .SelectMany(t => Http.Run(ct => FetchDownloadUrlAsync(owner, repo, reference, repoFilePath, t, ct)))
+            .Catch((Exception ex) =>
+            {
+                cache.TryRemove(cacheKey, out _); // never cache a failure — the next caller retries
+                return Observable.Throw<string?>(ex);
+            })
+            .Replay(1);
+        // Eager promise: kick the (self-terminating, single-emission) fetch off once; every
+        // subscriber replays its value or error — same shape as GitHubAppTokenService's cache.
+        fetch.Connect();
+        return fetch;
+    }
+
+    /// <summary>Sweeps TTL-expired entries once the cache grows beyond <see cref="PruneThreshold"/>.</summary>
+    private void PruneIfOversized(DateTimeOffset now)
+    {
+        if (cache.Count <= PruneThreshold)
+            return;
+        foreach (var (key, entry) in cache)
+            if (now - entry.FetchedAt >= cacheTtl)
+                cache.TryRemove(key, out _);
+    }
+
+    // ── HTTP leaf (runs inside the I/O pool) ─────────────────────────────────
+
+    private async Task<string?> FetchDownloadUrlAsync(
+        string owner, string repo, string reference, string repoFilePath, string? token, CancellationToken ct)
+    {
+        var escapedPath = string.Join('/', repoFilePath.Split('/').Select(Uri.EscapeDataString));
+        var url = $"{options.ApiBaseUrl.TrimEnd('/')}/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}"
+                  + $"/contents/{escapedPath}?ref={Uri.EscapeDataString(reference)}";
+        using var req = new HttpRequestMessage(HttpMethod.Get, url);
+        // The object media type keeps download_url present for 1-100 MB files, where the
+        // default media type errors (github.com/rest/repos/contents — course videos are large).
+        req.Headers.Accept.ParseAdd("application/vnd.github.object+json");
+        if (!string.IsNullOrEmpty(token))
+            req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        using var resp = await http.SendAsync(req, ct).ConfigureAwait(false);
+        if (resp.StatusCode == HttpStatusCode.NotFound)
+            return null;
+        var json = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException(
+                $"GitHub contents request for {owner}/{repo}/{repoFilePath}@{reference} failed "
+                + $"({(int)resp.StatusCode}): {Truncate(json)}");
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        // A directory answers with an array (or type != "file") — not a servable asset.
+        if (root.ValueKind != JsonValueKind.Object
+            || (root.TryGetProperty("type", out var type) && type.GetString() != "file"))
+            return null;
+        var downloadUrl = root.TryGetProperty("download_url", out var d) && d.ValueKind == JsonValueKind.String
+            ? d.GetString()
+            : null;
+        if (downloadUrl is null)
+            logger?.LogWarning("GitHub contents response for {Owner}/{Repo}/{Path}@{Ref} carried no download_url",
+                owner, repo, repoFilePath, reference);
+        return downloadUrl;
+    }
+
+    private static string Truncate(string s) => s.Length <= 300 ? s : s[..300] + "…";
+}

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
 using Memex.Portal.Shared.Api;
 using Memex.Portal.Shared.Authentication;
+using Memex.Portal.Shared.Courses;
 using Memex.Portal.Shared.Email;
 using Memex.Portal.Shared.Instances;
 using Memex.Portal.Shared.SelfUpdate;
@@ -288,6 +289,10 @@ public static class MemexConfiguration
         // server-side sync — the plugin registry pulling the plugins repo — logs on AS THE APP
         // (installation token), never with a user's personal credential.
         services.Configure<GitHubAppOptions>(builder.Configuration.GetSection("GitHub:App"));
+        // Course assets (GET /assets/{Space}/{path…}) — resolves an asset's tokenized
+        // download_url through the GitHub contents API with the App identity above and a
+        // short (30 s) per-file promise cache; the endpoint 302-redirects, never proxies.
+        services.AddSingleton<CourseAssetService>();
 
         // Instance sync — bidirectional Space replication to another MeshWeaver instance
         // (per-space registry at {space}/_Sync; offline changes accumulate in the durable
@@ -1052,6 +1057,11 @@ public static class MemexConfiguration
         // requirement: needs HttpContext.User). Stores the per-user token at
         // {userId}/_Provider/GitHub. See Doc/Architecture/GitHubSync.
         app.MapGitHubConnect();
+
+        // Course assets — GET /assets/{Space}/{path…}: entitlement-gated 302 to GitHub's
+        // tokenized download_url for course media living in the Space's synced repo
+        // ({Space}/_GitSync). Same ordering requirement (needs the resolved user context).
+        app.MapCourseAssets();
 
         // Instance Sync — OAuth+PKCE "connect to a remote MeshWeaver instance" endpoints
         // (/connect/instance[/callback]). Redirects to the remote's own login and stores the

--- a/test/Memex.Portal.Shared.Test/CourseAssetGateTest.cs
+++ b/test/Memex.Portal.Shared.Test/CourseAssetGateTest.cs
@@ -1,0 +1,121 @@
+using Memex.Portal.Shared.Courses;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The course-asset gate's pure logic (<see cref="CourseAssetGate"/>): the
+/// <c>/assets/{Space}/{path…}</c> parse, the Subdirectory → repo-file-path mapping, and the
+/// entitlement decision matrix — admins always pass, Read is the floor, a paid course
+/// (any entitlement entries) additionally requires the viewer's own entitlement, and
+/// denials split 401 (anonymous) vs 403 (authenticated).
+/// </summary>
+public class CourseAssetGateTest
+{
+    // ── Path parsing ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TryParsePath_SplitsSpaceAndRelativePath()
+    {
+        CourseAssetGate.TryParsePath(
+                "AgenticEngineering/content/videos/Module1.mp4", out var space, out var rest)
+            .Should().BeTrue();
+        space.Should().Be("AgenticEngineering");
+        rest.Should().Be("content/videos/Module1.mp4");
+    }
+
+    [Fact]
+    public void TryParsePath_ToleratesSurroundingSlashes()
+    {
+        CourseAssetGate.TryParsePath("/Chess/openings.pgn", out var space, out var rest)
+            .Should().BeTrue();
+        space.Should().Be("Chess");
+        rest.Should().Be("openings.pgn");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("SpaceOnly")]                       // no file segment
+    [InlineData("Space//file.mp4")]                 // empty segment
+    [InlineData("Space/../secrets.txt")]            // traversal
+    [InlineData("Space/videos/./file.mp4")]         // dot segment
+    [InlineData("../Space/file.mp4")]               // traversal in the space slot
+    [InlineData("_Entitlements/file.mp4")]          // satellite-shaped space
+    public void TryParsePath_RejectsMalformedPaths(string? path)
+    {
+        CourseAssetGate.TryParsePath(path, out _, out _).Should().BeFalse();
+    }
+
+    // ── Repo-path mapping ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null, "videos/Module1.mp4", "videos/Module1.mp4")]
+    [InlineData("", "videos/Module1.mp4", "videos/Module1.mp4")]
+    [InlineData("   ", "videos/Module1.mp4", "videos/Module1.mp4")]
+    [InlineData("content", "videos/Module1.mp4", "content/videos/Module1.mp4")]
+    [InlineData("/content/", "videos/Module1.mp4", "content/videos/Module1.mp4")]
+    [InlineData("courses/advanced", "intro.mp4", "courses/advanced/intro.mp4")]
+    public void MapToRepoPath_PrefixesTheConfiguredSubdirectory(
+        string? subdirectory, string relativePath, string expected)
+    {
+        CourseAssetGate.MapToRepoPath(subdirectory, relativePath).Should().Be(expected);
+    }
+
+    // ── Entitlement decision matrix ──────────────────────────────────────────
+
+    [Fact]
+    public void Decide_CourseAdmins_AlwaysPass()
+    {
+        // Update on the Space wins regardless of paid-ness or entitlement — even
+        // without an explicit Read flag.
+        CourseAssetGate.Decide(Permission.Update, isAuthenticated: true, isPaid: true, isEntitled: false)
+            .Should().Be(CourseAssetGate.Decision.Allowed);
+        CourseAssetGate.Decide(Permission.Read | Permission.Update, true, true, false)
+            .Should().Be(CourseAssetGate.Decision.Allowed);
+    }
+
+    [Fact]
+    public void Decide_FreeCourse_ReadSuffices()
+    {
+        CourseAssetGate.Decide(Permission.Read, isAuthenticated: true, isPaid: false, isEntitled: false)
+            .Should().Be(CourseAssetGate.Decision.Allowed);
+        // Public free course: anonymous with a Read grant passes too.
+        CourseAssetGate.Decide(Permission.Read, isAuthenticated: false, isPaid: false, isEntitled: false)
+            .Should().Be(CourseAssetGate.Decision.Allowed);
+    }
+
+    [Fact]
+    public void Decide_PaidCourse_RequiresEntitlement()
+    {
+        CourseAssetGate.Decide(Permission.Read, isAuthenticated: true, isPaid: true, isEntitled: true)
+            .Should().Be(CourseAssetGate.Decision.Allowed);
+        CourseAssetGate.Decide(Permission.Read, isAuthenticated: true, isPaid: true, isEntitled: false)
+            .Should().Be(CourseAssetGate.Decision.Forbidden);
+        // Anonymous on a paid course → 401 (log in), not 403.
+        CourseAssetGate.Decide(Permission.Read, isAuthenticated: false, isPaid: true, isEntitled: false)
+            .Should().Be(CourseAssetGate.Decision.NotAuthenticated);
+    }
+
+    [Fact]
+    public void Decide_WithoutRead_DeniesByAuthentication()
+    {
+        CourseAssetGate.Decide(Permission.None, isAuthenticated: false, isPaid: false, isEntitled: false)
+            .Should().Be(CourseAssetGate.Decision.NotAuthenticated);
+        CourseAssetGate.Decide(Permission.None, isAuthenticated: true, isPaid: false, isEntitled: false)
+            .Should().Be(CourseAssetGate.Decision.Forbidden);
+        // Non-Read flags alone (e.g. Comment) don't open the gate.
+        CourseAssetGate.Decide(Permission.Comment, isAuthenticated: true, isPaid: false, isEntitled: false)
+            .Should().Be(CourseAssetGate.Decision.Forbidden);
+    }
+
+    [Fact]
+    public void Decide_EntitlementWithoutRead_StaysDenied()
+    {
+        // An entitlement never substitutes for Read on the Space itself.
+        CourseAssetGate.Decide(Permission.None, isAuthenticated: true, isPaid: true, isEntitled: true)
+            .Should().Be(CourseAssetGate.Decision.Forbidden);
+    }
+}

--- a/test/Memex.Portal.Shared.Test/CourseAssetGateTest.cs
+++ b/test/Memex.Portal.Shared.Test/CourseAssetGateTest.cs
@@ -44,6 +44,10 @@ public class CourseAssetGateTest
     [InlineData("Space/videos/./file.mp4")]         // dot segment
     [InlineData("../Space/file.mp4")]               // traversal in the space slot
     [InlineData("_Entitlements/file.mp4")]          // satellite-shaped space
+    [InlineData("My Space/file.mp4")]               // whitespace in the space slot (query injection)
+    [InlineData("Space nodeType:User/file.mp4")]    // query-injection shape
+    [InlineData("Space/my video.mp4")]              // whitespace in a file segment
+    [InlineData("Space/videos/a\tb.mp4")]           // any whitespace, not just ' '
     public void TryParsePath_RejectsMalformedPaths(string? path)
     {
         CourseAssetGate.TryParsePath(path, out _, out _).Should().BeFalse();

--- a/test/Memex.Portal.Shared.Test/CourseAssetServiceTest.cs
+++ b/test/Memex.Portal.Shared.Test/CourseAssetServiceTest.cs
@@ -1,0 +1,195 @@
+using System.Net;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Security.Cryptography;
+using System.Text;
+using Memex.Portal.Shared.Courses;
+using MeshWeaver.GitSync;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Offline coverage for <see cref="CourseAssetService"/> — the GitHub-contents-API leg of the
+/// course-asset endpoint: the tokenized <c>download_url</c> must be fetched with the object media
+/// type (so 1-100 MB videos resolve), authenticated as the App installation when one is
+/// configured, cached per file inside the TTL (one round-trip for concurrent/repeated requests),
+/// NEVER cached across a failure, and a missing file must resolve to null (→ 404), not an error.
+/// </summary>
+public class CourseAssetServiceTest
+{
+    private const string RepoUrl = "https://github.com/Systemorph/courses";
+    private const string TokenizedUrl =
+        "https://raw.githubusercontent.com/Systemorph/courses/main/content/videos/Module1.mp4?token=SHORTLIVED";
+
+    private static CourseAssetService NewService(
+        HttpMessageHandler handler,
+        GitHubAppTokenService? appTokens = null,
+        TimeSpan? cacheTtl = null) =>
+        new(new IoPoolRegistry(),
+            Options.Create(new GitHubAppOptions()),
+            appTokens,
+            httpClient: new HttpClient(handler),
+            cacheTtl: cacheTtl);
+
+    [Fact]
+    public async Task GetDownloadUrl_FetchesTheContentsApi_WithTheObjectMediaType()
+    {
+        var handler = new FakeContentsHandler();
+        var service = NewService(handler);
+
+        var url = await service.GetDownloadUrl(RepoUrl, "main", "content/videos/Module1.mp4")
+            .FirstAsync().ToTask();
+
+        url.Should().Be(TokenizedUrl);
+        handler.Requests.Should().HaveCount(1);
+        var request = handler.Requests[0];
+        request.Path.Should().Be("/repos/Systemorph/courses/contents/content/videos/Module1.mp4");
+        request.Query.Should().Be("?ref=main");
+        // download_url must stay present for 1-100 MB files → the object media type.
+        request.Accept.Should().Contain("application/vnd.github.object+json");
+        // No App configured → unauthenticated (public repos still resolve).
+        request.Authorization.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetDownloadUrl_AuthenticatesAsTheAppInstallation_WhenConfigured()
+    {
+        using var rsa = RSA.Create(2048);
+        var handler = new FakeContentsHandler();
+        var appTokens = new GitHubAppTokenService(
+            new IoPoolRegistry(),
+            Options.Create(new GitHubAppOptions
+            {
+                ClientId = "Iv23liTestApp",
+                PrivateKey = rsa.ExportRSAPrivateKeyPem(),
+                InstallationId = 77,
+            }),
+            httpClient: new HttpClient(handler));
+        var service = NewService(handler, appTokens);
+
+        var url = await service.GetDownloadUrl(RepoUrl, "main", "content/videos/Module1.mp4")
+            .FirstAsync().ToTask();
+
+        url.Should().Be(TokenizedUrl);
+        var contents = handler.Requests.Single(r => r.Path.Contains("/contents/"));
+        contents.Authorization.Should().Be("Bearer ghs_installation_token");
+    }
+
+    [Fact]
+    public async Task GetDownloadUrl_MissingFile_ResolvesToNull()
+    {
+        var handler = new FakeContentsHandler { StatusCode = HttpStatusCode.NotFound };
+        var service = NewService(handler);
+
+        var url = await service.GetDownloadUrl(RepoUrl, "main", "content/gone.mp4")
+            .FirstAsync().ToTask();
+
+        url.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetDownloadUrl_CachesPerFile_InsideTheTtl()
+    {
+        var handler = new FakeContentsHandler();
+        var service = NewService(handler);
+
+        var first = await service.GetDownloadUrl(RepoUrl, "main", "content/videos/Module1.mp4")
+            .FirstAsync().ToTask();
+        var second = await service.GetDownloadUrl(RepoUrl, "main", "content/videos/Module1.mp4")
+            .FirstAsync().ToTask();
+
+        second.Should().Be(first);
+        handler.Requests.Should().HaveCount(1, "the second request inside the TTL must replay the cached URL");
+
+        // A DIFFERENT file is its own cache entry.
+        await service.GetDownloadUrl(RepoUrl, "main", "content/videos/Module2.mp4")
+            .FirstAsync().ToTask();
+        handler.Requests.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetDownloadUrl_ExpiredTtl_Refetches()
+    {
+        var handler = new FakeContentsHandler();
+        var service = NewService(handler, cacheTtl: TimeSpan.Zero);
+
+        await service.GetDownloadUrl(RepoUrl, "main", "content/videos/Module1.mp4")
+            .FirstAsync().ToTask();
+        await service.GetDownloadUrl(RepoUrl, "main", "content/videos/Module1.mp4")
+            .FirstAsync().ToTask();
+
+        handler.Requests.Should().HaveCount(2, "a zero TTL must re-fetch on every request");
+    }
+
+    [Fact]
+    public async Task GetDownloadUrl_NeverCachesAFailure()
+    {
+        var handler = new FakeContentsHandler { StatusCode = HttpStatusCode.InternalServerError };
+        var service = NewService(handler);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.GetDownloadUrl(RepoUrl, "main", "content/videos/Module1.mp4")
+                .FirstAsync().ToTask());
+
+        // The failed entry self-invalidated — the next caller retries and succeeds.
+        handler.StatusCode = HttpStatusCode.OK;
+        var url = await service.GetDownloadUrl(RepoUrl, "main", "content/videos/Module1.mp4")
+            .FirstAsync().ToTask();
+        url.Should().Be(TokenizedUrl);
+        handler.Requests.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// GitHub API fake: answers the contents API with a tokenized <c>download_url</c> (or the
+    /// configured error status) and the App token-mint endpoint, capturing every request's
+    /// path/query/headers for assertions.
+    /// </summary>
+    private sealed class FakeContentsHandler : HttpMessageHandler
+    {
+        public sealed record Captured(string Path, string Query, string Accept, string? Authorization);
+
+        public List<Captured> Requests { get; } = [];
+        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.OK;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+
+            // GitHubAppTokenService leg (only exercised by the authenticated test).
+            if (request.Method == HttpMethod.Post && path.EndsWith("/access_tokens", StringComparison.Ordinal))
+            {
+                var expires = DateTimeOffset.UtcNow.AddHours(1).ToString("o");
+                return Task.FromResult(Json(
+                    $$"""{"token": "ghs_installation_token", "expires_at": "{{expires}}"}"""));
+            }
+
+            Requests.Add(new Captured(
+                path,
+                request.RequestUri.Query,
+                request.Headers.Accept.ToString(),
+                request.Headers.Authorization?.ToString()));
+
+            if (StatusCode == HttpStatusCode.NotFound)
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent("""{"message": "Not Found"}""", Encoding.UTF8, "application/json"),
+                });
+            if (StatusCode != HttpStatusCode.OK)
+                return Task.FromResult(new HttpResponseMessage(StatusCode)
+                {
+                    Content = new StringContent("""{"message": "boom"}""", Encoding.UTF8, "application/json"),
+                });
+
+            return Task.FromResult(Json(
+                $$"""{"type": "file", "name": "Module1.mp4", "download_url": "{{TokenizedUrl}}"}"""));
+        }
+
+        private static HttpResponseMessage Json(string body) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+    }
+}


### PR DESCRIPTION
## What

Adds `GET /assets/{Space}/{path…}` to the portal: course media (videos) live in the Space's synced GitHub repository (`{Space}/_GitSync`), not in the mesh. The endpoint resolves the asset's repo file, applies the entitlement gate, and **302-redirects to GitHub's short-lived tokenized `download_url`** — the bytes are never proxied through the portal.

## Route

`GET /assets/{Space}/{path…}` — first segment is the Space id, the rest is the asset path relative to the Space's synced subtree (the Space's GitSync `Subdirectory` is prefixed automatically). The parse rejects traversal (`.`/`..`), empty segments, and `_`-satellite-shaped space segments.

## Gate semantics

| Viewer | Free course (no `_Entitlements` entries) | Paid course (has entries) |
|---|---|---|
| Course admin (`Update` on the Space) | ✅ allowed | ✅ allowed |
| `Read` on the Space + own `{Space}/_Entitlements/{viewer}` | ✅ | ✅ |
| `Read` on the Space, no entitlement | ✅ | 🚫 403 (401 if anonymous) |
| No `Read` | 🚫 403 (401 if anonymous) | 🚫 403 (401 if anonymous) |

404 when the Space has no GitSync source or the file is not in the repo — checked before the gate so "no course here" doesn't leak differently per viewer.

## How

- **`CourseAssetGate`** — pure, static decision logic (parse, subdirectory mapping, decision matrix); fully unit-tested in isolation.
- **`CourseAssetService`** — GitHub contents API (`GET /repos/{owner}/{repo}/contents/{path}?ref=`) with the `application/vnd.github.object+json` media type (keeps `download_url` present for 1-100 MB files), authenticated as the GitHub App installation via `GitHubAppTokenService` so private course repos resolve without per-user credentials. Per-file 30 s promise cache (well inside the tokenized URL validity); failures self-invalidate. HTTP leaves run on the `IoPoolNames.Http` pool; public surface is `IObservable` end to end.
- **`CourseAssetEndpoints`** — one reactive resolution chain (GitSync config + entitlement snapshot under the System identity; the viewer's effective Space permissions for the viewer), bridged to `Task<IResult>` exactly once at the HTTP boundary. Viewer identity comes from the same `AccessService` context `UserContextMiddleware` stamps (mirrors `GitHubConnectEndpoints`).
- **Wiring** — `AddSingleton<CourseAssetService>()` + `app.MapCourseAssets()` after authentication, next to `MapGitHubConnect` in `MemexConfiguration`.

## Tests

- `CourseAssetGateTest` — parse/traversal rejection, subdirectory mapping, the full decision matrix (admin bypass, free-course Read floor, paid-course entitlement, 401 vs 403 splits).
- `CourseAssetServiceTest` — offline `HttpMessageHandler` fake: object media type + path/ref shape, App-installation Bearer auth when configured, 404 → null, per-file TTL caching (one round-trip for repeats, separate entry per file), zero-TTL refetch, failures never cached.

All 28 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)