### PR TITLE
Observability: pipeline errors land in their Activities; startup errors notify platform admins

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -184,6 +184,15 @@ public static class MemexConfiguration
         // granted user ("You've been given <role> access to <node>") through NotificationService.Dispatch
         // (honours their per-category bell/email preferences). Covers every grant path in one place.
         services.AddHostedService<MeshWeaver.Graph.AccessGrantNotifier>();
+        // Startup-error reporter: an extra ILoggerProvider buffers every Error/Critical logged during
+        // the startup window (host build → ApplicationStarted); once the host is up, ONE Admin-partition
+        // bell notification summarizes them so platform admins learn about a degraded boot (failed seed
+        // import, hub-initialization failure, DI fault) without reading pod logs. RLS on the Admin
+        // partition scopes the bell to platform admins. Best-effort end to end — it never fails startup.
+        services.AddSingleton<MeshWeaver.Graph.StartupErrorBuffer>();
+        services.AddSingleton<Microsoft.Extensions.Logging.ILoggerProvider,
+            MeshWeaver.Graph.StartupErrorBufferLoggerProvider>();
+        services.AddHostedService<MeshWeaver.Graph.StartupErrorNotifier>();
         // App-level event-log outbox: durably records every change-feed event (Postgres in prod via
         // PostgreSqlEventLogStore, else in-memory) + replays not-yet-processed entries on startup.
         services.AddMeshEventLog();

--- a/src/MeshWeaver.GitSync/ActivityRunner.cs
+++ b/src/MeshWeaver.GitSync/ActivityRunner.cs
@@ -225,9 +225,16 @@ public static class ActivityRunner
                     ? log.Messages
                     : log.Messages.Add(new LogMessage(finalMessage,
                         status == ActivityStatus.Failed ? LogLevel.Error : LogLevel.Information));
+                // Honour what the command reported via ctx.Log: ActivityLog.Finish computes
+                // MAX(status, roll-up from Messages) — an Error line a command appended flips
+                // a would-be Succeeded terminal to Failed, a Warning line to Warning; explicit
+                // Failed / Cancelled always stand (they are more severe in the enum order).
+                // Without this, a command that reports per-item errors but completes without
+                // throwing would end "Succeeded" with errors in its own log.
+                var finished = (log with { Messages = messages }).Finish(log.Version, status);
                 return node with
                 {
-                    Content = log with { Messages = messages, Status = status, End = DateTime.UtcNow, RequestedStatus = null }
+                    Content = finished with { RequestedStatus = null }
                 };
             }).Select(_ => Unit.Default);
         }

--- a/src/MeshWeaver.GitSync/ActivityRunner.cs
+++ b/src/MeshWeaver.GitSync/ActivityRunner.cs
@@ -202,7 +202,10 @@ public static class ActivityRunner
         {
             workspace.GetMeshNodeStream(activityPath).Update(node =>
             {
-                if (node.Content is not ActivityLog log) return node;
+                // Tolerant read (ContentAs), not a bare type test: on a cross-hub update the
+                // content can arrive as a degraded JsonElement — `is ActivityLog` would silently
+                // no-op and the progress line would never land (same read as the cancel watch).
+                if (node.ContentAs<ActivityLog>(workspace.Hub.JsonSerializerOptions, logger) is not { } log) return node;
                 return node with { Content = log with { Messages = log.Messages.Add(new LogMessage(message, level)) } };
             }).Subscribe(_ => { }, ex => logger?.LogWarning(ex, "Activity log append failed for {Path}", activityPath));
         }
@@ -220,7 +223,10 @@ public static class ActivityRunner
         {
             return workspace.GetMeshNodeStream(activityPath).Update(node =>
             {
-                if (node.Content is not ActivityLog log) return node;
+                // Tolerant read (ContentAs), not a bare type test: on a cross-hub update the
+                // content can arrive as a degraded JsonElement — `is ActivityLog` would silently
+                // no-op and the activity would hang Running forever (same read as the cancel watch).
+                if (node.ContentAs<ActivityLog>(workspace.Hub.JsonSerializerOptions, logger) is not { } log) return node;
                 var messages = string.IsNullOrEmpty(finalMessage)
                     ? log.Messages
                     : log.Messages.Add(new LogMessage(finalMessage,
@@ -231,7 +237,9 @@ public static class ActivityRunner
                 // Failed / Cancelled always stand (they are more severe in the enum order).
                 // Without this, a command that reports per-item errors but completes without
                 // throwing would end "Succeeded" with errors in its own log.
-                var finished = (log with { Messages = messages }).Finish(log.Version, status);
+                // The hub's current version stamps the finished log — the same
+                // `(int)hub.Version` every other Finish caller records.
+                var finished = (log with { Messages = messages }).Finish((int)workspace.Hub.Version, status);
                 return node with
                 {
                     Content = finished with { RequestedStatus = null }

--- a/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
+++ b/src/MeshWeaver.GitSync/GitHubActivityExtensions.cs
@@ -38,7 +38,10 @@ public static class GitHubActivityExtensions
             ctx =>
             {
                 ctx.Log("Serializing Space content and committing on the branch HEAD…");
-                return sync.SyncToGitHub(spacePath, userId, sourceId).Select(r =>
+                // ctx.Log as the progress sink: per-node export problems (skipped nodes) land on
+                // the activity log, and ActivityRunner.Finish rolls their level into the terminal
+                // status — instead of surfacing only in the server log.
+                return sync.SyncToGitHub(spacePath, userId, sourceId, ctx.Log).Select(r =>
                 {
                     ctx.Log($"Committed {r.CommitSha[..Math.Min(8, r.CommitSha.Length)]} " +
                             $"({r.FilesWritten} written, {r.FilesDeleted} removed)" +
@@ -59,7 +62,9 @@ public static class GitHubActivityExtensions
             ctx =>
             {
                 ctx.Log("Fetching the branch HEAD from GitHub and importing the deltas…");
-                return pr.UpdateToLatest(spacePath, userId, sourceId).Select(r =>
+                // ctx.Log as the progress sink: files dropped from the import (parse failures)
+                // append an Error line here and flip the terminal status to Failed.
+                return pr.UpdateToLatest(spacePath, userId, sourceId, ctx.Log).Select(r =>
                 {
                     ctx.Log($"Imported {r.Outcome} ({r.Count} node(s)).");
                     return Unit.Default;
@@ -78,7 +83,9 @@ public static class GitHubActivityExtensions
             ctx =>
             {
                 ctx.Log($"Fetching {commitish} from GitHub and importing the deltas…");
-                return sync.ReimportAtCommit(spacePath, commitish, userId, sourceId).Select(r =>
+                // ctx.Log as the progress sink: files dropped from the import (parse failures)
+                // append an Error line here and flip the terminal status to Failed.
+                return sync.ReimportAtCommit(spacePath, commitish, userId, sourceId, ctx.Log).Select(r =>
                 {
                     ctx.Log($"Re-imported {r.Outcome} ({r.Count} node(s)) at {commitish}.");
                     return Unit.Default;

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -92,8 +92,13 @@ public sealed class GitHubSyncService
     /// commit SHA on that source's <see cref="GitHubSyncConfig"/>. Rejected when the
     /// source's <see cref="GitHubSyncConfig.Direction"/> is
     /// <see cref="SyncDirection.ImportOnly"/>. Emits the push result.
+    /// <paramref name="progress"/> (when the caller runs as an activity: <c>ctx.Log</c>)
+    /// receives per-node problems — e.g. a node skipped from the export — so they land on
+    /// the activity log instead of only in the server log.
     /// </summary>
-    public IObservable<GitHubPushResult> SyncToGitHub(string spacePath, string userId, string? sourceId = null)
+    public IObservable<GitHubPushResult> SyncToGitHub(
+        string spacePath, string userId, string? sourceId = null,
+        Action<string, LogLevel>? progress = null)
     {
         return ReadConfig(spacePath, sourceId).Take(1).SelectMany(config =>
         {
@@ -112,7 +117,7 @@ public sealed class GitHubSyncService
             {
                 var token = auth.Token;
                 return SnapshotNodes(spacePath).SelectMany(nodes =>
-                    SerializeAll(nodes, spacePath).SelectMany(files =>
+                    SerializeAll(nodes, spacePath, progress).SelectMany(files =>
                     {
                         // App-identity exports author as the bot (no personal credential involved).
                         var (name, email) = auth.Credential is null
@@ -191,13 +196,14 @@ public sealed class GitHubSyncService
             .ToList();
     }
 
-    private IObservable<IReadOnlyList<RepoFile>> SerializeAll(IReadOnlyList<MeshNode> nodes, string partition)
+    private IObservable<IReadOnlyList<RepoFile>> SerializeAll(
+        IReadOnlyList<MeshNode> nodes, string partition, Action<string, LogLevel>? progress = null)
     {
         if (nodes.Count == 0)
             return Observable.Return((IReadOnlyList<RepoFile>)Array.Empty<RepoFile>());
         var allPaths = nodes.Select(n => n.Path).ToArray();
         return nodes
-            .Select(n => SerializeOne(n, partition, allPaths))
+            .Select(n => SerializeOne(n, partition, allPaths, progress))
             .Merge(8)
             .Where(f => f is not null).Select(f => f!)
             .ToList()
@@ -239,12 +245,19 @@ public sealed class GitHubSyncService
         && e.TryGetProperty(name, out var v) && v.ValueKind == System.Text.Json.JsonValueKind.String
             ? v.GetString() : null;
 
-    private IObservable<RepoFile?> SerializeOne(MeshNode node, string partition, string[] allPaths)
+    private IObservable<RepoFile?> SerializeOne(
+        MeshNode node, string partition, string[] allPaths, Action<string, LogLevel>? progress = null)
     {
         var serializer = parsers.GetSerializerFor(node);
         if (serializer is null)
         {
             logger?.LogWarning("No serializer for node {Path} (type {Type}) — skipping.", node.Path, node.NodeType);
+            // Also surface the skip on the owning activity (a node silently missing from the
+            // export is invisible in the portal otherwise); Warning rolls the terminal status
+            // up to ActivityStatus.Warning via ActivityRunner.Finish.
+            progress?.Invoke(
+                $"No serializer for node '{node.Path}' (type {node.NodeType}) — skipped from export.",
+                LogLevel.Warning);
             return Observable.Return<RepoFile?>(null);
         }
         var ext = serializer.SupportedExtensions.FirstOrDefault() ?? ".json";
@@ -271,10 +284,13 @@ public sealed class GitHubSyncService
     /// <summary>
     /// Creates a new Space (provisioning its partition + granting the user admin) and
     /// imports all nodes from the repo at <paramref name="commitish"/> (branch or SHA).
+    /// <paramref name="progress"/> receives per-file problems (a repo file that failed to
+    /// parse and was therefore dropped) so an owning activity can surface them.
     /// </summary>
     public IObservable<StaticRepoImportResult> ImportFromGitHub(
         string repositoryUrl, string commitish, string newSpaceId, string newSpaceName,
-        string? subdirectory, string userId)
+        string? subdirectory, string userId,
+        Action<string, LogLevel>? progress = null)
     {
         // Capture identity synchronously BEFORE the async credentials.Get hop — the SelectMany
         // continuation runs without the AsyncLocal AccessContext, and the Space create below must run
@@ -300,7 +316,7 @@ public sealed class GitHubSyncService
                 ? meshService.CreateNode(spaceNode)
                 : Observable.Using(() => accessService.SwitchAccessContext(ctx), _ => meshService.CreateNode(spaceNode));
             return createSpace
-                .SelectMany(_ => FetchAndImport(repositoryUrl, commitish, subdirectory, token, newSpaceId))
+                .SelectMany(_ => FetchAndImport(repositoryUrl, commitish, subdirectory, token, newSpaceId, progress))
                 .Select(x => x.Result);
         });
     }
@@ -312,9 +328,13 @@ public sealed class GitHubSyncService
     /// Rejected when the source's <see cref="GitHubSyncConfig.Direction"/> is
     /// <see cref="SyncDirection.ExportOnly"/>. This is the "change the commit and
     /// re-import to that state" operation.
+    /// <paramref name="progress"/> (when the caller runs as an activity: <c>ctx.Log</c>)
+    /// receives per-file problems — a repo file that failed to parse and was therefore
+    /// dropped from the import — so they land on the activity log, not only in Loki.
     /// </summary>
     public IObservable<StaticRepoImportResult> ReimportAtCommit(
-        string spacePath, string commitish, string userId, string? sourceId = null)
+        string spacePath, string commitish, string userId, string? sourceId = null,
+        Action<string, LogLevel>? progress = null)
     {
         return ReadConfig(spacePath, sourceId).Take(1).SelectMany(config =>
         {
@@ -329,7 +349,7 @@ public sealed class GitHubSyncService
             {
                 var token = auth.Token;
                 logger?.LogInformation("Re-importing {Space} at {Ref}", spacePath, commitish);
-                return FetchAndImport(repoUrl, commitish, config.Subdirectory, token, spacePath)
+                return FetchAndImport(repoUrl, commitish, config.Subdirectory, token, spacePath, progress)
                     .SelectMany(x => RecordLastSync(spacePath, x.CommitSha, sourceId).Select(_ => x.Result));
             });
         });
@@ -383,10 +403,11 @@ public sealed class GitHubSyncService
                         "GitHub App identity (GitHub:App:ClientId + GitHub:App:PrivateKey).")));
 
     private IObservable<(StaticRepoImportResult Result, string CommitSha)> FetchAndImport(
-        string repoUrl, string commitish, string? subdirectory, string token, string spaceId)
+        string repoUrl, string commitish, string? subdirectory, string token, string spaceId,
+        Action<string, LogLevel>? progress = null)
     {
         return repoClient.Fetch(repoUrl, commitish, subdirectory, token).SelectMany(snapshot =>
-            ParseSnapshot(snapshot, spaceId).SelectMany(parsed =>
+            ParseSnapshot(snapshot, spaceId, progress).SelectMany(parsed =>
             {
                 var source = new InMemoryStaticRepoSource(spaceId, parsed.Children, parsed.Root);
                 return StaticRepoImporter.ImportSource(hub, source, logger)
@@ -395,12 +416,12 @@ public sealed class GitHubSyncService
     }
 
     private IObservable<(MeshNode? Root, IReadOnlyList<MeshNode> Children)> ParseSnapshot(
-        RepoSnapshot snapshot, string spaceId)
+        RepoSnapshot snapshot, string spaceId, Action<string, LogLevel>? progress = null)
     {
         if (snapshot.Files.Count == 0)
             return Observable.Return(((MeshNode?)null, (IReadOnlyList<MeshNode>)Array.Empty<MeshNode>()));
         return snapshot.Files
-            .Select(f => ParseFile(f, spaceId))
+            .Select(f => ParseFile(f, spaceId, progress))
             .Merge(8)
             .Where(x => x.Node is not null)
             .ToList()
@@ -412,7 +433,8 @@ public sealed class GitHubSyncService
             });
     }
 
-    private IObservable<(MeshNode? Node, bool IsRoot)> ParseFile(RepoFile file, string spaceId)
+    private IObservable<(MeshNode? Node, bool IsRoot)> ParseFile(
+        RepoFile file, string spaceId, Action<string, LogLevel>? progress = null)
     {
         // The top-level README.md is a GitHub display file emitted on export — never a node.
         if (string.Equals(file.Path, "README.md", StringComparison.OrdinalIgnoreCase))
@@ -420,7 +442,16 @@ public sealed class GitHubSyncService
 
         var ext = System.IO.Path.GetExtension(file.Path);
         // file.Content is already an in-memory string — the parse is pure CPU, no pool.
-        var parsed = parsers.TryParse(ext, file.Path, file.Content, file.Path);
+        // A file whose parser(s) all THREW is a malformed node file: the node it should have
+        // become is silently missing after the import. Surface it on the owning activity as an
+        // Error (ActivityRunner.Finish rolls the terminal status up to Failed) in addition to
+        // the server log. Files with no registered parser (.yml, .py, …) stay silent — repos
+        // legitimately carry non-node files.
+        var parsed = parsers.TryParse(ext, file.Path, file.Content, file.Path, (path, ex) =>
+        {
+            logger?.LogWarning(ex, "Failed to parse {Path} — file skipped on import.", path);
+            progress?.Invoke($"Failed to parse '{path}': {ex.Message} — file skipped.", LogLevel.Error);
+        });
         if (parsed is null) return Observable.Return(((MeshNode?)null, false));
         if (NodeFileMapper.IsRootIndex(file.Path))
         {

--- a/src/MeshWeaver.GitSync/PullRequestService.cs
+++ b/src/MeshWeaver.GitSync/PullRequestService.cs
@@ -102,8 +102,12 @@ public sealed class PullRequestService
     /// "Update to latest" — re-imports the Space at its configured branch HEAD (delegating
     /// to <see cref="GitHubSyncService.ReimportAtCommit"/>, which fetches + mirrors). This is
     /// the checkout operation: the working Space is brought to the latest repo state.
+    /// <paramref name="progress"/> (when the caller runs as an activity: <c>ctx.Log</c>)
+    /// receives per-file import problems so they land on the activity log.
     /// </summary>
-    public IObservable<StaticRepoImportResult> UpdateToLatest(string spacePath, string userId, string? sourceId = null)
+    public IObservable<StaticRepoImportResult> UpdateToLatest(
+        string spacePath, string userId, string? sourceId = null,
+        Action<string, LogLevel>? progress = null)
     {
         return sync.ReadConfig(spacePath, sourceId).Take(1).SelectMany(config =>
         {
@@ -112,7 +116,7 @@ public sealed class PullRequestService
                     "No GitHub repository configured for this Space."));
             var branch = string.IsNullOrWhiteSpace(config.Branch) ? "main" : config.Branch;
             logger?.LogInformation("Updating {Space} to latest on {Branch}", spacePath, branch);
-            return sync.ReimportAtCommit(spacePath, branch, userId, sourceId);
+            return sync.ReimportAtCommit(spacePath, branch, userId, sourceId, progress);
         });
     }
 

--- a/src/MeshWeaver.Graph/StartupErrorBuffer.cs
+++ b/src/MeshWeaver.Graph/StartupErrorBuffer.cs
@@ -1,0 +1,126 @@
+using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>One Error/Critical log entry captured during the startup window.</summary>
+/// <param name="Timestamp">UTC time the entry was logged.</param>
+/// <param name="Level">The log level (<see cref="LogLevel.Error"/> or <see cref="LogLevel.Critical"/>).</param>
+/// <param name="Category">The logger category that produced the entry.</param>
+/// <param name="Message">The formatted message (exception message appended when present).</param>
+public sealed record StartupError(DateTimeOffset Timestamp, LogLevel Level, string Category, string Message);
+
+/// <summary>
+/// Buffers every <see cref="LogLevel.Error"/>/<see cref="LogLevel.Critical"/> log entry recorded
+/// during the <b>startup window</b> — from logger-factory construction until the host reaches
+/// <c>ApplicationStarted</c>, when <see cref="StartupErrorNotifier"/> drains it and raises ONE
+/// Admin-partition bell notification summarizing the errors. Errors after the window closes are
+/// ignored (they belong to normal operations monitoring, not the boot report).
+///
+/// <para>An instance singleton owned by the host's DI container (never static — see
+/// <c>Doc/Architecture/NoStaticState.md</c>); the backing list is guarded by a plain lock, the
+/// same shape as <c>ActivityLogLogger</c>. Bounded: only the first <see cref="Capacity"/> entries
+/// are kept (a boot that produces hundreds of errors is summarized by its first ones plus a
+/// dropped count), so a log storm can never balloon memory.</para>
+/// </summary>
+public sealed class StartupErrorBuffer
+{
+    /// <summary>Maximum number of entries kept; later entries only increment <see cref="StartupErrorReport.Dropped"/>.</summary>
+    public const int Capacity = 100;
+
+    private readonly object gate = new();
+    private ImmutableList<StartupError> errors = [];
+    private int dropped;
+    private bool open = true;
+
+    /// <summary>True while the startup window is open (entries are still being recorded).</summary>
+    public bool IsOpen
+    {
+        get { lock (gate) return open; }
+    }
+
+    /// <summary>
+    /// Records one startup error. No-op after <see cref="CloseAndDrain"/>. Never throws — this
+    /// sits on the logging path and must not be able to break the code that logs.
+    /// </summary>
+    public void Record(LogLevel level, string category, string message)
+    {
+        if (level < LogLevel.Error)
+            return;
+        lock (gate)
+        {
+            if (!open)
+                return;
+            if (errors.Count >= Capacity)
+                dropped++;
+            else
+                errors = errors.Add(new StartupError(DateTimeOffset.UtcNow, level, category, message));
+        }
+    }
+
+    /// <summary>
+    /// Closes the startup window and returns everything recorded. Idempotent: the first call
+    /// drains; subsequent calls return an empty report (so a double-fired lifecycle callback
+    /// can never produce a second notification).
+    /// </summary>
+    public StartupErrorReport CloseAndDrain()
+    {
+        lock (gate)
+        {
+            if (!open)
+                return new StartupErrorReport([], 0);
+            open = false;
+            var report = new StartupErrorReport(errors, dropped);
+            errors = [];
+            dropped = 0;
+            return report;
+        }
+    }
+}
+
+/// <summary>The drained content of a <see cref="StartupErrorBuffer"/>.</summary>
+/// <param name="Errors">The captured entries, oldest first (at most <see cref="StartupErrorBuffer.Capacity"/>).</param>
+/// <param name="Dropped">How many further entries arrived after the buffer was full.</param>
+public sealed record StartupErrorReport(ImmutableList<StartupError> Errors, int Dropped);
+
+/// <summary>
+/// The <see cref="ILoggerProvider"/> that feeds <see cref="StartupErrorBuffer"/>: registered as an
+/// additional provider (DI: <c>AddSingleton&lt;ILoggerProvider, StartupErrorBufferLoggerProvider&gt;</c>),
+/// so every logger the factory hands out ALSO forwards its Error/Critical entries to the buffer while
+/// the startup window is open. Cheap and inert once the window closes (<see cref="ILogger.IsEnabled"/>
+/// turns false), and it never throws — a reporter fault must not take down logging.
+/// </summary>
+public sealed class StartupErrorBufferLoggerProvider(StartupErrorBuffer buffer) : ILoggerProvider
+{
+    /// <inheritdoc />
+    public ILogger CreateLogger(string categoryName) => new BufferLogger(buffer, categoryName);
+
+    /// <inheritdoc />
+    public void Dispose() { }
+
+    private sealed class BufferLogger(StartupErrorBuffer buffer, string category) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error && buffer.IsOpen;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+                return;
+            try
+            {
+                var message = formatter(state, exception);
+                if (exception is not null)
+                    message = $"{message} — {exception.GetType().Name}: {exception.Message}";
+                buffer.Record(logLevel, category, message);
+            }
+            catch
+            {
+                // Never let the startup-error capture itself become a startup error.
+            }
+        }
+    }
+}

--- a/src/MeshWeaver.Graph/StartupErrorNotifier.cs
+++ b/src/MeshWeaver.Graph/StartupErrorNotifier.cs
@@ -1,0 +1,119 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// Tells platform admins about a degraded boot. Once the host reaches <c>ApplicationStarted</c>,
+/// drains the <see cref="StartupErrorBuffer"/> (fed by <see cref="StartupErrorBufferLoggerProvider"/>
+/// with every Error/Critical logged during startup — failed seed imports, hub-initialization
+/// failures, DI faults, migration-gate diagnostics) and, when anything was captured, raises
+/// <b>ONE</b> bell <see cref="Mesh.Notification"/> anchored under the <c>Admin</c> partition.
+/// RLS on the Admin partition scopes the bell to platform admins — and only them — exactly the
+/// anchoring <c>ContentIndexingActivity.NotifyAdminsOfFailure</c> and
+/// <c>NodeTypeCompileParkRegistry.EmitFailureNotification</c> already use. A clean startup
+/// raises nothing.
+///
+/// <para>Best-effort end to end: registration, drain, and dispatch are each guarded so the
+/// reporter can NEVER fail or delay startup — a broken reporter only logs a warning. Modelled on
+/// <see cref="AccessGrantNotifier"/> (hosted service over the mesh hub) and deferred to
+/// <c>ApplicationStarted</c> (the mesh must be up before nodes can be written).</para>
+/// </summary>
+public sealed class StartupErrorNotifier(
+    IMessageHub hub,
+    StartupErrorBuffer buffer,
+    IHostApplicationLifetime lifetime,
+    ILogger<StartupErrorNotifier>? logger = null) : IHostedService, IDisposable
+{
+    /// <summary>The partition the notification is anchored under — read-scoped to platform admins by RLS.</summary>
+    public const string AdminPartition = "Admin";
+
+    /// <summary>How many error lines the notification body carries verbatim; the rest is a count.</summary>
+    private const int MaxLines = 10;
+
+    private IDisposable? subscription;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            lifetime.ApplicationStarted.Register(Report);
+        }
+        catch (Exception ex)
+        {
+            // Never fail startup over the reporter.
+            logger?.LogWarning(ex, "StartupErrorNotifier: could not register the ApplicationStarted callback");
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public void Dispose() => subscription?.Dispose();
+
+    private void Report()
+    {
+        try
+        {
+            var report = buffer.CloseAndDrain();
+            if (report.Errors.Count == 0)
+            {
+                logger?.LogInformation("StartupErrorNotifier: startup clean — no admin notification raised");
+                return;
+            }
+            subscription = ReportToAdmins(hub, report, logger)
+                .Subscribe(
+                    _ => { },
+                    ex => logger?.LogWarning(ex, "StartupErrorNotifier: failed to notify admins of startup errors"));
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "StartupErrorNotifier: startup-error report failed");
+        }
+    }
+
+    /// <summary>
+    /// Raises ONE Admin-partition bell notification summarizing <paramref name="report"/>; emits
+    /// nothing extra on a clean report (no notification is created). Best-effort: a dispatch fault
+    /// is logged and absorbed — this IS the graceful sink for boot problems, so it must never
+    /// throw. Static and hub-parameterized so tests drive it directly against a test mesh.
+    /// </summary>
+    public static IObservable<Unit> ReportToAdmins(
+        IMessageHub hub, StartupErrorReport report, ILogger? logger = null)
+    {
+        if (report.Errors.Count == 0)
+            return Observable.Return(Unit.Default);
+
+        var total = report.Errors.Count + report.Dropped;
+        var lines = report.Errors
+            .Take(MaxLines)
+            .Select(e => $"[{e.Level}] {e.Category}: {e.Message}");
+        var remainder = total - Math.Min(report.Errors.Count, MaxLines);
+        var message = string.Join("\n", lines)
+            + (remainder > 0 ? $"\n… and {remainder} more error(s) — see the server log." : "");
+
+        // Admin-broadcast (recipient: null → in-app bell only, no email), System category so the
+        // bell renders it with error styling. Dispatch runs under the system identity itself.
+        return NotificationService.Dispatch(
+                hub,
+                recipient: null,
+                mainNodePath: AdminPartition,
+                title: $"Startup completed with {total} error(s)",
+                message: message,
+                type: NotificationType.System,
+                targetNodePath: AdminPartition,
+                createdBy: "system")
+            .Catch<Unit, Exception>(ex =>
+            {
+                logger?.LogWarning(ex, "Failed to raise the startup-error admin notification");
+                return Observable.Return(Unit.Default);
+            });
+    }
+}

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/FileFormatParserRegistry.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/FileFormatParserRegistry.cs
@@ -72,20 +72,27 @@ public class FileFormatParserRegistry
     /// <summary>
     /// Attempts to parse content using parsers for the given extension.
     /// Tries each parser in priority order until one succeeds.
-    /// Exceptions from individual parsers are caught and logged, allowing fallback to next parser.
+    /// Exceptions from individual parsers are caught, allowing fallback to the next parser;
+    /// when EVERY parser for the extension failed and at least one threw, the last exception
+    /// is surfaced through <paramref name="onError"/> — so a caller running as an activity can
+    /// report the dropped file instead of silently losing it. A file whose extension simply has
+    /// no registered parser (a non-node file — <c>.yml</c>, <c>.py</c>, …) never reports.
     /// </summary>
     /// <param name="extension">File extension including the dot.</param>
     /// <param name="filePath">Full path to the file.</param>
     /// <param name="content">File content.</param>
     /// <param name="relativePath">Path relative to the data root.</param>
+    /// <param name="onError">Invoked with (<paramref name="relativePath"/>, last exception) when all parsers failed and at least one threw.</param>
     /// <returns>Parsed MeshNode or null if no parser can handle the content.</returns>
     public MeshNode? TryParse(
         string extension,
         string filePath,
         string content,
-        string relativePath)
+        string relativePath,
+        Action<string, Exception>? onError = null)
     {
         var parsers = GetParsers(extension);
+        Exception? lastError = null;
         foreach (var parser in parsers)
         {
             try
@@ -94,11 +101,15 @@ public class FileFormatParserRegistry
                 if (node != null)
                     return node;
             }
-            catch
+            catch (Exception ex)
             {
-                // Parser failed, try next parser in chain
+                // Parser failed, try next parser in chain; remember the failure so an
+                // all-parsers-failed outcome is reportable rather than silent.
+                lastError = ex;
             }
         }
+        if (lastError is not null)
+            onError?.Invoke(relativePath, lastError);
         return null;
     }
 

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/JsonFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/JsonFileParser.cs
@@ -24,16 +24,16 @@ public class JsonFileParser : IFileFormatParser
     public IReadOnlyList<string> SupportedExtensions => [".json"];
 
     /// <inheritdoc />
+    /// <remarks>
+    /// A malformed document THROWS (<see cref="JsonException"/>) rather than returning null:
+    /// <see cref="FileFormatParserRegistry.TryParse"/> catches per-parser failures and surfaces
+    /// them through its <c>onError</c> callback, so an import pipeline can report the dropped
+    /// file on its activity instead of silently losing the node (the old <c>catch → null</c>
+    /// here swallowed the error before the registry ever saw it).
+    /// </remarks>
     public MeshNode? Parse(string filePath, string content, string relativePath)
     {
-        try
-        {
-            return JsonSerializer.Deserialize<MeshNode>(content, _options);
-        }
-        catch
-        {
-            return null;
-        }
+        return JsonSerializer.Deserialize<MeshNode>(content, _options);
     }
 
     /// <inheritdoc />

--- a/test/MeshWeaver.GitSync.Test/ActivityErrorSurfacingTest.cs
+++ b/test/MeshWeaver.GitSync.Test/ActivityErrorSurfacingTest.cs
@@ -1,0 +1,144 @@
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Pins that pipeline errors land on the owning Activity node instead of only in the server log
+/// (Loki) — the observability contract for every operation run through
+/// <see cref="ActivityRunner.RunActivity"/>:
+/// <list type="bullet">
+///   <item>a command that THROWS ends the activity <see cref="ActivityStatus.Failed"/> with the
+///     exception message as an <see cref="LogLevel.Error"/> message;</item>
+///   <item>a command that reports per-item problems via <c>ctx.Log(…, Error/Warning)</c> but
+///     completes without throwing still ends <see cref="ActivityStatus.Failed"/> /
+///     <see cref="ActivityStatus.Warning"/> — <c>ActivityRunner.Finish</c> rolls the message
+///     levels into the terminal status (the <see cref="ActivityLog.Finish"/> semantics);</item>
+///   <item>the GitSync import pipeline reports a repo file it could not parse (and therefore
+///     silently dropped, previously with no trace anywhere) as an Error on its activity.</item>
+/// </list>
+/// </summary>
+public class ActivityErrorSurfacingTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    [Fact(Timeout = 120000)]
+    public async Task CommandThrows_ActivityEndsFailed_WithErrorMessage()
+    {
+        var space = "GhErr" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Error Space");
+
+        var activityPath = await Mesh.RunActivity(
+                space, ActivityCategory.DataUpdate, "Throwing operation",
+                _ => Observable.Throw<Unit>(new InvalidOperationException("boom: repository unreachable")))
+            .Timeout(60.Seconds()).ToTask();
+
+        var log = await WaitForActivity(activityPath, l => l.Status != ActivityStatus.Running);
+        Assert.Equal(ActivityStatus.Failed, log.Status);
+        Assert.Contains(log.Messages, m =>
+            m.LogLevel == LogLevel.Error && m.Message.Contains("boom: repository unreachable"));
+        Assert.NotNull(log.End);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task CommandLogsError_ButCompletes_ActivityEndsFailed()
+    {
+        var space = "GhErr2" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Error Space 2");
+
+        // The command reports a per-item error via ctx.Log and then completes normally —
+        // the terminal status must still reflect the error (Finish rolls Messages up).
+        var activityPath = await Mesh.RunActivity(
+                space, ActivityCategory.Import, "Partially failing operation",
+                ctx =>
+                {
+                    ctx.Log("Item 1 imported.");
+                    ctx.Log("Item 2 could not be imported.", LogLevel.Error);
+                    return Observable.Return(Unit.Default);
+                })
+            .Timeout(60.Seconds()).ToTask();
+
+        var log = await WaitForActivity(activityPath, l => l.Status != ActivityStatus.Running);
+        Assert.Equal(ActivityStatus.Failed, log.Status);
+        Assert.Contains(log.Messages, m =>
+            m.LogLevel == LogLevel.Error && m.Message.Contains("Item 2"));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task CommandLogsWarning_ButCompletes_ActivityEndsWarning()
+    {
+        var space = "GhErr3" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Warning Space");
+
+        var activityPath = await Mesh.RunActivity(
+                space, ActivityCategory.DataUpdate, "Operation with a warning",
+                ctx =>
+                {
+                    ctx.Log("Node X skipped from export.", LogLevel.Warning);
+                    return Observable.Return(Unit.Default);
+                })
+            .Timeout(60.Seconds()).ToTask();
+
+        var log = await WaitForActivity(activityPath, l => l.Status != ActivityStatus.Running);
+        Assert.Equal(ActivityStatus.Warning, log.Status);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Import_MalformedNodeFile_SurfacesErrorOnActivity_AndFailsIt()
+    {
+        await Connect();
+        var space = "GhErr4" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Import Space");
+        await CreateMarkdown($"{space}/Good", "Good", "# Good\n\nGood body.");
+        var repo = "https://github.com/test/malformed-import";
+        await Sync.SaveConfig(space, repo, "main", subdirectory: null,
+                createBranchIfMissing: true, createRepoIfMissing: true)
+            .Timeout(30.Seconds()).ToTask();
+
+        // Seed the repo with a real export (root index.json + Good.md), then push the same tree
+        // PLUS one malformed node JSON on top (Push mirrors, so the good files must be re-sent).
+        // The malformed file used to be dropped with NO trace anywhere (JsonFileParser swallowed
+        // the exception before even the server log saw it).
+        await Sync.SyncToGitHub(space, UserId).Timeout(60.Seconds()).ToTask();
+        var seeded = Fake.Tree(repo)
+            .Append(new RepoFile("Broken.json", "{ this is not valid json !!"))
+            .ToImmutableList();
+        await Fake.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = repo,
+            Branch = "main",
+            Files = seeded,
+            CommitMessage = "seed a malformed node file",
+            AuthorName = "test",
+            AuthorEmail = "test@test",
+            AccessToken = "t",
+        }).Timeout(30.Seconds()).ToTask();
+
+        // Run the user-facing operation (the same entry point the GUI uses).
+        var activityPath = await Mesh.ReimportFromGitHub(space, "main", UserId)
+            .Timeout(90.Seconds()).ToTask();
+
+        var log = await WaitForActivity(activityPath, l => l.Status != ActivityStatus.Running);
+        // The dropped file is an Error line naming the file — and it flips the terminal status.
+        Assert.Contains(log.Messages, m =>
+            m.LogLevel == LogLevel.Error && m.Message.Contains("Broken.json"));
+        Assert.Equal(ActivityStatus.Failed, log.Status);
+
+        // The rest of the import still went through — surfacing the error is not aborting.
+        Assert.Contains("Good body.", MarkdownBody(await WaitForNode($"{space}/Good")));
+    }
+
+    private async Task<ActivityLog> WaitForActivity(string activityPath, Func<ActivityLog, bool> predicate) =>
+        await Mesh.GetWorkspace().GetMeshNodeStream(activityPath)
+            .Select(n => n?.Content as ActivityLog)
+            .Where(l => l is not null && predicate(l))
+            .Select(l => l!)
+            .FirstAsync()
+            .Timeout(60.Seconds())
+            .ToTask();
+}

--- a/test/MeshWeaver.Graph.Test/StartupErrorNotifierTest.cs
+++ b/test/MeshWeaver.Graph.Test/StartupErrorNotifierTest.cs
@@ -1,0 +1,114 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the startup-error reporter contract: Error/Critical entries logged during the startup
+/// window are buffered (<see cref="StartupErrorBuffer"/> fed through
+/// <see cref="StartupErrorBufferLoggerProvider"/>) and, once the host is up, produce exactly
+/// ONE bell <see cref="Notification"/> anchored under the <c>Admin</c> partition
+/// (<see cref="StartupErrorNotifier.ReportToAdmins"/>) — while a clean startup produces none.
+/// </summary>
+public class StartupErrorNotifierTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private System.Text.Json.JsonSerializerOptions Json => Mesh.JsonSerializerOptions;
+
+    [Fact(Timeout = 30000)]
+    public void Provider_BuffersOnlyErrorAndCritical_AndOnlyWhileOpen()
+    {
+        var buffer = new StartupErrorBuffer();
+        var provider = new StartupErrorBufferLoggerProvider(buffer);
+        var logger = provider.CreateLogger("Test.Category");
+
+        logger.LogInformation("info — must not be captured");
+        logger.LogWarning("warning — must not be captured");
+        logger.LogError("db_version check failed");
+        logger.LogCritical(new InvalidOperationException("schema missing"), "DB schema not initialised");
+
+        var report = buffer.CloseAndDrain();
+        Assert.Equal(2, report.Errors.Count);
+        Assert.Equal(0, report.Dropped);
+        Assert.Equal(LogLevel.Error, report.Errors[0].Level);
+        Assert.Contains("db_version check failed", report.Errors[0].Message);
+        Assert.Equal(LogLevel.Critical, report.Errors[1].Level);
+        // The exception detail is folded into the message.
+        Assert.Contains("schema missing", report.Errors[1].Message);
+        Assert.Equal("Test.Category", report.Errors[1].Category);
+
+        // Window closed: later errors are ignored and a second drain is empty (idempotent —
+        // a double-fired lifecycle callback can never produce a second notification).
+        Assert.False(logger.IsEnabled(LogLevel.Error));
+        logger.LogError("after the window — must not be captured");
+        Assert.Empty(buffer.CloseAndDrain().Errors);
+    }
+
+    [Fact(Timeout = 30000)]
+    public void Buffer_IsBounded_CountsOverflowAsDropped()
+    {
+        var buffer = new StartupErrorBuffer();
+        for (var i = 0; i < StartupErrorBuffer.Capacity + 7; i++)
+            buffer.Record(LogLevel.Error, "Cat", $"error {i}");
+
+        var report = buffer.CloseAndDrain();
+        Assert.Equal(StartupErrorBuffer.Capacity, report.Errors.Count);
+        Assert.Equal(7, report.Dropped);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ReportToAdmins_WithBufferedErrors_RaisesOneAdminNotification()
+    {
+        const string marker = "startup-error-marker-1af09";
+        var buffer = new StartupErrorBuffer();
+        buffer.Record(LogLevel.Error, "Memex.Migration", $"{marker}: db_version=30 < expected 32");
+        buffer.Record(LogLevel.Critical, "MeshWeaver.Hosting", $"{marker}: hub initialization failed");
+
+        await StartupErrorNotifier.ReportToAdmins(Mesh, buffer.CloseAndDrain())
+            .Timeout(30.Seconds()).ToTask();
+
+        // ONE notification, anchored under the Admin partition (RLS scopes it to platform
+        // admins), System-typed, carrying both error lines.
+        var nodes = await Mesh.GetWorkspace()
+            .GetQuery("notif|Admin",
+                $"path:{StartupErrorNotifier.AdminPartition}/_Notification scope:children nodeType:Notification")
+            .Where(ns => (ns ?? []).Any(n =>
+                n.ContentAs<Notification>(Json)?.Message.Contains(marker) == true))
+            .FirstAsync().Timeout(30.Seconds());
+
+        var startupNotifications = nodes
+            .Select(n => n.ContentAs<Notification>(Json))
+            .Where(n => n?.Message.Contains(marker) == true)
+            .ToList();
+        var notification = Assert.Single(startupNotifications)!;
+        Assert.Equal(NotificationType.System, notification.NotificationType);
+        Assert.Contains("2 error(s)", notification.Title);
+        Assert.Contains("db_version=30", notification.Message);
+        Assert.Contains("hub initialization failed", notification.Message);
+        Assert.False(notification.IsRead);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ReportToAdmins_CleanStartup_RaisesNothing()
+    {
+        var buffer = new StartupErrorBuffer();   // nothing recorded — a clean boot
+
+        // Completes without writing: the empty report short-circuits before any dispatch.
+        await StartupErrorNotifier.ReportToAdmins(Mesh, buffer.CloseAndDrain())
+            .Timeout(30.Seconds()).ToTask();
+
+        // The Admin notification satellite holds nothing from a clean-boot report: no
+        // notification titled as a startup report exists (Initial snapshot read).
+        var nodes = await Mesh.GetWorkspace()
+            .GetQuery("notif|Admin|clean",
+                $"path:{StartupErrorNotifier.AdminPartition}/_Notification scope:children nodeType:Notification")
+            .FirstAsync().Timeout(30.Seconds());
+        Assert.DoesNotContain(nodes ?? [], n =>
+            n.ContentAs<Notification>(Json)?.Title.StartsWith("Startup completed with 0") == true);
+    }
+}


### PR DESCRIPTION
Two observability gaps closed — both cases previously logged only to ILogger (Loki), invisible in the portal.

## A) Pipeline errors land on their owning Activity

- **`ActivityRunner.Finish` honours what the command reported via `ctx.Log`**: the terminal status is now computed with `ActivityLog.Finish` — MAX(explicit status, roll-up from `Messages`). A command that reports per-item Errors/Warnings but completes without throwing ends **Failed**/**Warning** instead of a false *Succeeded*. Explicit Failed/Cancelled always stand (more severe in the enum order).
- **GitSync import** (`ReimportAtCommit` / `UpdateToLatest` / `ImportFromGitHub`) threads a progress sink (`ctx.Log`) down to the per-file parse: a repo file whose parsers all threw appends an **Error** line naming the file and flips the activity to **Failed**. Previously `JsonFileParser` swallowed the exception (`catch → null`) before even the server log saw it — the node was silently missing after the import, with no trace anywhere.
- **GitSync export** (`SyncToGitHub`) reports nodes skipped for lack of a serializer as **Warning** lines; the terminal status rolls up to **Warning**.
- **`FileFormatParserRegistry.TryParse`** gains an optional `onError` callback, fired when every parser for the extension failed and at least one threw. Files with no registered parser (`.yml`, `.py`, …) stay silent — repos legitimately carry non-node files. `JsonFileParser` now throws on malformed JSON so the registry can surface it.

All `progress` parameters are optional — every existing caller compiles and behaves unchanged.

## B) Startup errors notify platform admins — once

- **`StartupErrorBuffer`** (+ `StartupErrorBufferLoggerProvider`, registered as an additional DI `ILoggerProvider`) buffers every Error/Critical logged during the startup window (logger-factory construction → `ApplicationStarted`). Bounded at 100 entries + a dropped count; instance state behind a lock — no static state.
- **`StartupErrorNotifier`** (hosted service, modelled on `AccessGrantNotifier`) drains the buffer on `ApplicationStarted` and dispatches **ONE** System-typed bell `Notification` anchored under the **Admin partition** — RLS scopes it to platform admins, the same anchoring `ContentIndexingActivity.NotifyAdminsOfFailure` and `NodeTypeCompileParkRegistry.EmitFailureNotification` already use. A clean boot raises nothing.
- **Never crashes startup**: registration, drain, and dispatch are each guarded (`try/catch` + Rx `Catch`); a broken reporter only logs a warning. The drain is idempotent — a double-fired lifecycle callback can't produce a second notification.
- Wired in `MemexConfiguration` next to the other graph-level notifiers.

## Tests

- `ActivityErrorSurfacingTest` (GitSync.Test, 4 tests): throwing command → Failed + Error message; `ctx.Log(Error)` + normal completion → Failed; `ctx.Log(Warning)` → Warning; end-to-end malformed repo file through `ReimportFromGitHub` → Error line naming the file + Failed activity, while the healthy files still import.
- `StartupErrorNotifierTest` (Graph.Test, 4 tests): provider buffers only Error/Critical and only while the window is open; bounded buffer counts overflow as dropped; buffered errors → exactly one Admin notification carrying the error lines; clean startup → no notification.

Full `MeshWeaver.GitSync.Test` suite (81) and the importer/activity/notification slices of `MeshWeaver.Graph.Test` (96) pass; touched projects + the portal host build Release `-warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)