### PR TITLE
Portal header: Edu entry left of the search; search fills the header

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
@@ -23,6 +23,11 @@
             </FluentAnchor>
             <FluentSpacer />
             <div class="links">
+                @* Edu — the course portal. Sits LEFT of the search; the search fills the rest. *@
+                <FluentAnchor Appearance="Appearance.Stealth" Href="/Courses" Class="edu-link"
+                              title="Edu — the course catalog" aria-label="Edu — the course catalog">
+                    <span class="edu-hat" aria-hidden="true">🎓</span> Edu
+                </FluentAnchor>
                 <div class="search-container">
                     <SearchBar />
                 </div>

--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor.css
@@ -183,12 +183,21 @@
         gap: 8px;
     }
 
-    /* Search container in header */
+    /* Edu — the course portal entry, left of the search */
+    ::deep .edu-link {
+        white-space: nowrap;
+        font-weight: 600;
+    }
+
+    ::deep .edu-link .edu-hat {
+        margin-right: 4px;
+    }
+
+    /* Search container in header — fills the remaining header width */
     ::deep .search-container {
         flex: 1;
         display: flex;
         justify-content: flex-end;
-        max-width: 600px;
     }
 }
 


### PR DESCRIPTION
Adds a 🎓 **Edu** link to the portal's top bar (desktop header), left of the search box, navigating to `/Courses` — the course catalog. The search container loses its 600px `max-width` so the search fills the remaining header width.

Label/target are trivially switchable to a "Plugins" entry if we generalize (Edu is a form of plugin) — one line each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)