### PR TITLE
ContentCollections: observable, pooled surface end-to-end + AccessContext across the pool hop

### DIFF
--- a/memex/Memex.LocalMesh/Program.cs
+++ b/memex/Memex.LocalMesh/Program.cs
@@ -85,7 +85,9 @@ app.MapGet("/static/{**path}", async (HttpContext ctx, string path) =>
     var filePath = string.Join('/', path[(slash + 1)..].Split('/').Select(Uri.UnescapeDataString));
     var content = app.Services.GetRequiredService<IMessageHub>().ServiceProvider.GetService<IContentService>();
     if (content is null) return Results.NotFound();
-    var stream = await content.GetContentAsync(collection, filePath, ctx.RequestAborted);
+    // HTTP-boundary await: the read leaf runs on the collection's IIoPool; the endpoint awaits
+    // the replayed single emission only.
+    var stream = await content.GetContent(collection, filePath).Take(1);
     if (stream is null) return Results.NotFound();
     var contentType = filePath.EndsWith(".svg", StringComparison.OrdinalIgnoreCase) ? "image/svg+xml"
         : filePath.EndsWith(".png", StringComparison.OrdinalIgnoreCase) ? "image/png"

--- a/samples/Graph/Data/FutuRe/GroupAnalysis/Source/FutuReDataLoader.cs
+++ b/samples/Graph/Data/FutuRe/GroupAnalysis/Source/FutuReDataLoader.cs
@@ -81,17 +81,15 @@ public static class FutuReDataLoader
             });
 
         // CSV I/O on the bounded FileSystem IoPool — no Observable.FromAsync, no async/await.
-        // Invoke() runs the genuinely-async content fetch on the pool's semaphore-gated
-        // Scheduler.Default: the ThreadPool thread is released during the await, so the
-        // continuation can't re-enter a congested hub action block (the cause of the
-        // intermittent 50s render stall). InvokeBlocking() runs the sync StreamReader read
-        // + CSV parse on the pool's dedicated limited-concurrency scheduler, so the blocking
-        // read can't trigger ThreadPool thread-injection that starves the grain schedulers.
+        // The content fetch runs on the collection's own pool (the whole IContentService surface
+        // is pooled observables). InvokeBlocking() runs the sync StreamReader read + CSV parse on
+        // the pool's dedicated limited-concurrency scheduler, so the blocking read can't trigger
+        // ThreadPool thread-injection that starves the grain schedulers.
         // Both are cold IObservables — reactive end-to-end, no async state machine.
         var ioPool = workspace.Hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem)
                      ?? IoPool.Unbounded;
-        var csvRowsObs = ioPool
-            .Invoke(ct => contentService.GetContentAsync("attachments", "datacube.csv", ct))
+        var csvRowsObs = contentService
+            .GetContent("attachments", "datacube.csv")
             .SelectMany(stream => stream is null
                 ? Observable.Return(new List<FutuReDataCube>())
                 : ioPool.InvokeBlocking(_ =>

--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -524,21 +524,22 @@ public class AgentChatClient : IAgentChat
                         {
                             // Load binary from the node's default content collection (the
                             // `content:` UCR prefix addresses the default collection by design).
-                            var effectivePath = nodePath ?? Context?.Path;
-                            var stream = await contentService.GetContentAsync(
-                                ContentCollectionsExtensions.DefaultCollectionName, fileName).ConfigureAwait(false);
-                            if (stream != null)
+                            // The whole read runs inside the collection's IIoPool leaf; this
+                            // agent-round async context awaits the replayed emission only —
+                            // ReplaySubject-backed, so the bridge cannot deadlock.
+                            var bytes = await contentService
+                                .GetCollection(ContentCollectionsExtensions.DefaultCollectionName)
+                                .SelectMany(coll => coll is null
+                                    ? Observable.Return<byte[]?>(null)
+                                    : coll.GetContentBytes(fileName))
+                                .Take(1);
+                            if (bytes != null)
                             {
-                                using (stream)
-                                {
-                                    using var ms = new MemoryStream();
-                                    await stream.CopyToAsync(ms).ConfigureAwait(false);
-                                    var mediaType = ExtensionToMediaType.GetValueOrDefault(ext, "application/octet-stream");
-                                    binaryAttachments = binaryAttachments.Add(
-                                        new DataContent(ms.ToArray(), mediaType) { Name = fileName });
-                                    logger.LogInformation("Loaded binary attachment: {FileName} ({MediaType}, {Size} bytes)",
-                                        fileName, mediaType, ms.Length);
-                                }
+                                var mediaType = ExtensionToMediaType.GetValueOrDefault(ext, "application/octet-stream");
+                                binaryAttachments = binaryAttachments.Add(
+                                    new DataContent(bytes, mediaType) { Name = fileName });
+                                logger.LogInformation("Loaded binary attachment: {FileName} ({MediaType}, {Size} bytes)",
+                                    fileName, mediaType, bytes.Length);
                             }
                             continue;
                         }

--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -1989,32 +1989,35 @@ public class MeshOperations
                         return Observable.Return("Error: content service not configured on the hub.");
 
                     contentService.AddConfiguration(collectionConfig);
-                    var ioPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
-                    return ioPool.Run(async ct =>
-                    {
-                        var collection = await contentService.GetCollectionAsync(qualifiedCollectionName, ct).ConfigureAwait(false);
-                        if (collection == null)
-                            return $"Error: failed to initialize collection '{qualifiedCollectionName}'.";
-
-                        var dir = Path.GetDirectoryName(filePath)?.Replace('\\', '/') ?? "";
-                        var fileName = Path.GetFileName(filePath);
-                        using var ms = new MemoryStream(bytes);
-                        await collection.SaveFileAsync(dir, fileName, ms).ConfigureAwait(false);
-
-                        // Post-upload seam: notify registered observers (e.g. the content-indexing
-                        // pipeline) AFTER the save succeeds. Fire-and-forget — each observer starts its
-                        // own off-band work (an Activity), so the upload response returns immediately
-                        // and indexing never runs inline on this pooled continuation. No-op when no
-                        // observer is registered; ContentCollections itself takes no indexing/AI/pg dep.
-                        hub.RaiseContentUploaded(qualifiedCollectionName, filePath);
-
-                        return JsonSerializer.Serialize(new
+                    // Pure composition — the save leaf runs on the collection's own IIoPool.
+                    return contentService.GetCollection(qualifiedCollectionName)
+                        .SelectMany(collection =>
                         {
-                            status = "Uploaded",
-                            path = $"{resolution.Prefix}/{collectionName}/{filePath}",
-                            bytes = bytes.Length,
-                        }, hub.JsonSerializerOptions);
-                    });
+                            if (collection == null)
+                                return Observable.Return($"Error: failed to initialize collection '{qualifiedCollectionName}'.");
+
+                            var dir = Path.GetDirectoryName(filePath)?.Replace('\\', '/') ?? "";
+                            var fileName = Path.GetFileName(filePath);
+                            var ms = new MemoryStream(bytes);
+                            return collection.SaveFile(dir, fileName, ms)
+                                .Finally(ms.Dispose)
+                                .Select(_ =>
+                                {
+                                    // Post-upload seam: notify registered observers (e.g. the content-indexing
+                                    // pipeline) AFTER the save succeeds. Fire-and-forget — each observer starts its
+                                    // own off-band work (an Activity), so the upload response returns immediately
+                                    // and indexing never runs inline on this continuation. No-op when no
+                                    // observer is registered; ContentCollections itself takes no indexing/AI/pg dep.
+                                    hub.RaiseContentUploaded(qualifiedCollectionName, filePath);
+
+                                    return JsonSerializer.Serialize(new
+                                    {
+                                        status = "Uploaded",
+                                        path = $"{resolution.Prefix}/{collectionName}/{filePath}",
+                                        bytes = bytes.Length,
+                                    }, hub.JsonSerializerOptions);
+                                });
+                        });
                 });
         })
         .Catch((Exception ex) =>
@@ -2095,30 +2098,29 @@ public class MeshOperations
                         return Observable.Return("Error: content service not configured on the hub.");
 
                     contentService.AddConfiguration(collectionConfig);
-                    var ioPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
-                    return ioPool.Run(async ct =>
-                    {
-                        var collection = await contentService.GetCollectionAsync(qualifiedCollectionName, ct).ConfigureAwait(false);
-                        if (collection == null)
-                            return $"Error: failed to initialize collection '{qualifiedCollectionName}'.";
-
-                        var items = new List<object>();
-                        await foreach (var item in collection.GetCollectionItems(dir, ct).ConfigureAwait(false))
-                            items.Add(item switch
-                            {
-                                FolderItem f => (object)new { kind = "folder", name = f.Name, path = f.Path, itemCount = f.ItemCount },
-                                FileItem fi => new { kind = "file", name = fi.Name, path = fi.Path, lastModified = fi.LastModified },
-                                _ => new { kind = "unknown", name = item.Name, path = item.Path },
-                            });
-
-                        return JsonSerializer.Serialize(new
+                    // Pure composition — the listing leaf runs on the collection's own IIoPool.
+                    return contentService.GetCollection(qualifiedCollectionName)
+                        .SelectMany(collection =>
                         {
-                            collection = qualifiedCollectionName,
-                            path = dir,
-                            editable = collectionConfig.IsEditable,
-                            items,
-                        }, hub.JsonSerializerOptions);
-                    });
+                            if (collection == null)
+                                return Observable.Return($"Error: failed to initialize collection '{qualifiedCollectionName}'.");
+
+                            return collection.GetCollectionItems(dir)
+                                .Select(item => item switch
+                                {
+                                    FolderItem f => (object)new { kind = "folder", name = f.Name, path = f.Path, itemCount = f.ItemCount },
+                                    FileItem fi => new { kind = "file", name = fi.Name, path = fi.Path, lastModified = fi.LastModified },
+                                    _ => new { kind = "unknown", name = item.Name, path = item.Path },
+                                })
+                                .ToArray()
+                                .Select(items => JsonSerializer.Serialize(new
+                                {
+                                    collection = qualifiedCollectionName,
+                                    path = dir,
+                                    editable = collectionConfig.IsEditable,
+                                    items,
+                                }, hub.JsonSerializerOptions));
+                        });
                 });
         })
         .Catch((Exception ex) =>
@@ -2585,9 +2587,9 @@ public class MeshOperations
                                 .Select(c => (nc.NodePath, Config: c)))
                             .ToList();
 
-                        // 4. Gather file bytes OFF the hub (async stream reads on the IO pool), then
+                        // 4. Gather file bytes OFF the hub (the collections' own IO pools), then
                         //    5. build the ZIP on the pool (pure CPU/memory) — never on the action block.
-                        return pool.Invoke(ct => GatherContentFilesAsync(targets, ct))
+                        return GatherContentFiles(targets)
                             .SelectMany(files =>
                                 pool.InvokeBlocking(_ => BuildExportZip(root, nodes, files)));
                     });
@@ -2756,65 +2758,53 @@ public class MeshOperations
     }
 
     /// <summary>
-    /// Reads every file from each (node, editable collection) target into memory. Runs on the
-    /// file-system <see cref="IIoPool"/> (async stream reads). Dedupes by resolved physical location so
-    /// an inherited collection reported by multiple descendants is exported once, attributed to the
-    /// first (ancestor) node that reported it.
+    /// Reads every file from each (node, editable collection) target into memory — pure reactive
+    /// composition; every read leaf runs on the owning collection's <see cref="IIoPool"/>. Targets
+    /// are processed strictly sequentially (Concat) so the dedup-by-resolved-physical-location set
+    /// attributes an inherited collection (reported by multiple descendants) to the first
+    /// (ancestor) node that reported it.
     /// </summary>
-    private async Task<List<ExportedFile>> GatherContentFilesAsync(
-        IReadOnlyList<(string NodePath, ContentCollectionConfig Config)> targets, CancellationToken ct)
+    private IObservable<List<ExportedFile>> GatherContentFiles(
+        IReadOnlyList<(string NodePath, ContentCollectionConfig Config)> targets)
     {
-        var result = new List<ExportedFile>();
         var contentService = hub.ServiceProvider.GetService<IContentService>();
         if (contentService is null || targets.Count == 0)
-            return result;
+            return Observable.Return(new List<ExportedFile>());
 
         var seen = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var (nodePath, config) in targets)
-        {
-            var collectionName = config.Name!;
-            var qualified = $"{nodePath}/{collectionName}";
-            // Register the config on this hub's content service (same mechanism as Upload) so the
-            // collection resolves locally against its backing store (FileSystem BasePath, blob, …).
-            contentService.AddConfiguration(config with { Name = qualified, Address = new Address(nodePath) });
-            var collection = await contentService.GetCollectionAsync(qualified, ct).ConfigureAwait(false);
-            if (collection is null)
-                continue;
-
-            await foreach (var file in EnumerateAllFilesAsync(collection, string.Empty, ct).ConfigureAwait(false))
+        return targets
+            .Select(target => Observable.Defer(() =>
             {
-                var rel = file.Path.TrimStart('/');
-                var dedupKey = (config.BasePath ?? qualified) + "|" + rel;
-                if (!seen.Add(dedupKey))
-                    continue;
-
-                var stream = await collection.GetContentAsync(file.Path, ct).ConfigureAwait(false);
-                if (stream is null)
-                    continue;
-                byte[] bytes;
-                await using (stream.ConfigureAwait(false))
-                {
-                    using var ms = new MemoryStream();
-                    await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
-                    bytes = ms.ToArray();
-                }
-                result.Add(new ExportedFile(nodePath, collectionName, rel, bytes));
-            }
-        }
-        return result;
+                var (nodePath, config) = target;
+                var collectionName = config.Name!;
+                var qualified = $"{nodePath}/{collectionName}";
+                // Register the config on this hub's content service (same mechanism as Upload) so the
+                // collection resolves locally against its backing store (FileSystem BasePath, blob, …).
+                contentService.AddConfiguration(config with { Name = qualified, Address = new Address(nodePath) });
+                return contentService.GetCollection(qualified)
+                    .SelectMany(collection => collection is null
+                        ? Observable.Empty<ExportedFile>()
+                        : EnumerateAllFiles(collection, string.Empty)
+                            .Where(file => seen.Add((config.BasePath ?? qualified) + "|" + file.Path.TrimStart('/')))
+                            .Select(file => collection.GetContentBytes(file.Path)
+                                .Where(bytes => bytes is not null)
+                                .Select(bytes => new ExportedFile(
+                                    nodePath, collectionName, file.Path.TrimStart('/'), bytes!)))
+                            .Concat());
+            }))
+            .ToObservable()
+            .Concat()
+            .ToList()
+            .Select(files => files.ToList());
     }
 
     /// <summary>Recursively enumerates every file under <paramref name="dir"/> in a collection
-    /// (files first at each level, then recurse into sub-folders).</summary>
-    private static async IAsyncEnumerable<FileItem> EnumerateAllFilesAsync(
-        ContentCollection collection, string dir, [EnumeratorCancellation] CancellationToken ct)
-    {
-        await foreach (var file in collection.GetFiles(dir, ct).ConfigureAwait(false))
-            yield return file;
-        await foreach (var folder in collection.GetFolders(dir, ct).ConfigureAwait(false))
-            await foreach (var file in EnumerateAllFilesAsync(collection, folder.Path, ct).ConfigureAwait(false))
-                yield return file;
-    }
+    /// (files first at each level, then recurse into sub-folders, strictly sequential).</summary>
+    private static IObservable<FileItem> EnumerateAllFiles(ContentCollection collection, string dir)
+        => collection.GetFiles(dir)
+            .Concat(collection.GetFolders(dir)
+                .Select(folder => EnumerateAllFiles(collection, folder.Path))
+                .Concat());
 
     /// <summary>Builds the export ZIP (manifest.json + files/ tree) from the gathered nodes and file
     /// bytes. Pure CPU/memory — runs on the <see cref="IIoPool"/> blocking scheduler.</summary>

--- a/src/MeshWeaver.Blazor/App_Code/CreateFolderModel.cs
+++ b/src/MeshWeaver.Blazor/App_Code/CreateFolderModel.cs
@@ -1,4 +1,5 @@
-﻿using MeshWeaver.ContentCollections;
+using System.Reactive;
+using MeshWeaver.ContentCollections;
 
 namespace MeshWeaver.Blazor
 {
@@ -18,8 +19,11 @@ namespace MeshWeaver.Blazor
         public bool IsValid()
             => items.All(i => !string.Equals(i.Name, Name, StringComparison.OrdinalIgnoreCase));
 
-        /// <summary>Creates the new folder at the path formed by combining <c>currentPath</c> and <c>Name</c> in the content collection.</summary>
-        public Task CreateAsync()
-            => collection.CreateFolderAsync(Path.Combine(currentPath,Name));
+        /// <summary>
+        /// Creates the new folder at the path formed by combining <c>currentPath</c> and <c>Name</c>
+        /// in the content collection. Cold — the write runs on Subscribe, on the collection's pool.
+        /// </summary>
+        public IObservable<Unit> Create()
+            => collection.CreateFolder(Path.Combine(currentPath, Name));
     }
 }

--- a/src/MeshWeaver.Blazor/FileExplorer/CreateFolderDialog.razor
+++ b/src/MeshWeaver.Blazor/FileExplorer/CreateFolderDialog.razor
@@ -1,10 +1,15 @@
-﻿@using Appearance = Microsoft.FluentUI.AspNetCore.Components.Appearance
+﻿@using System.Reactive.Linq
+@using Appearance = Microsoft.FluentUI.AspNetCore.Components.Appearance
 @implements IDialogContentComponent<CreateFolderModel>
 <FluentTextField @ref="textField" @bind-Value="Content.Name" Placeholder="New Folder"  />
+@if (!string.IsNullOrEmpty(errorMessage))
+{
+    <FluentLabel Color="Color.Error">@errorMessage</FluentLabel>
+}
 <FluentDialogFooter>
     <FluentButton Appearance="Appearance.Accent"
                   Disabled="@(Content is null || !Content.IsValid())"
-                  OnClick="@SaveAsync">
+                  OnClick="@Save">
         Create
     </FluentButton>
     <FluentButton Appearance="Appearance.Neutral"
@@ -28,14 +33,23 @@
     }
 
 
-    private async Task SaveAsync()
+    private void Save()
     {
-        if (Content.IsValid())
-        {
-            await Content.CreateAsync();
-            await Dialog.CloseAsync(Content);
-        }
+        if (!Content.IsValid())
+            return;
+        // Subscribe-only: the create runs on the collection's pool; the dialog closes on the
+        // completion emission, marshalled back onto the circuit via InvokeAsync.
+        Content.Create().Subscribe(
+            _ => { },
+            ex => _ = InvokeAsync(() =>
+            {
+                errorMessage = ex.Message;
+                StateHasChanged();
+            }),
+            () => _ = InvokeAsync(() => Dialog.CloseAsync(Content)));
     }
+
+    private string? errorMessage;
 
     private async Task CancelAsync()
     {

--- a/src/MeshWeaver.Blazor/FileExplorer/DeleteDialog.razor
+++ b/src/MeshWeaver.Blazor/FileExplorer/DeleteDialog.razor
@@ -1,4 +1,5 @@
-﻿@using Appearance = Microsoft.FluentUI.AspNetCore.Components.Appearance
+﻿@using System.Reactive.Linq
+@using Appearance = Microsoft.FluentUI.AspNetCore.Components.Appearance
 @implements IDialogContentComponent<DeleteModel>
 
 <div class="delete-confirmation">
@@ -22,7 +23,7 @@
 <FluentDialogFooter>
     <FluentButton Appearance="Appearance.Accent"
                   Disabled="@(Content is null || !Content.HasItems)"
-                  OnClick="@DeleteAsync">
+                  OnClick="@Delete">
         Delete
     </FluentButton>
     <FluentButton Appearance="Appearance.Neutral"
@@ -38,13 +39,17 @@
     [CascadingParameter]
     public FluentDialog Dialog { get; set; } = default!;
 
-    private async Task DeleteAsync()
+    private void Delete()
     {
-        if (Content.HasItems)
-        {
-            await Content.DeleteAsync();
-            await Dialog.CloseAsync(Content);
-        }
+        if (!Content.HasItems)
+            return;
+        // Subscribe-only: the deletes run sequentially on the collection's pool. Close on the
+        // terminal emission so Content.Errors is fully populated for the caller (per-item
+        // failures are captured in the model, so onError only fires on infrastructure faults).
+        Content.Delete().Subscribe(
+            _ => { },
+            ex => _ = InvokeAsync(() => Dialog.CloseAsync(Content)),
+            () => _ = InvokeAsync(() => Dialog.CloseAsync(Content)));
     }
 
     private async Task CancelAsync()

--- a/src/MeshWeaver.Blazor/FileExplorer/DeleteModel.cs
+++ b/src/MeshWeaver.Blazor/FileExplorer/DeleteModel.cs
@@ -1,4 +1,6 @@
-﻿using MeshWeaver.ContentCollections;
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.ContentCollections;
 
 namespace MeshWeaver.Blazor.FileExplorer;
 
@@ -23,33 +25,30 @@ public class DeleteModel(ContentCollection collection, IEnumerable<CollectionIte
         ? $"Are you sure you want to delete '{ItemsToDelete.First().Name}'?"
         : $"Are you sure you want to delete {Count} items?";
 
-    /// <summary>Errors accumulated during <c>DeleteAsync</c>; one entry per item that failed to delete.</summary>
+    /// <summary>Errors accumulated during <c>Delete</c>; one entry per item that failed to delete.</summary>
     public List<string> Errors { get; } = new();
 
     /// <summary>
-    /// Iterates over <c>ItemsToDelete</c> and removes each via the collection's delete API.
-    /// Failures are captured in <c>Errors</c> rather than propagated so partial success is visible.
+    /// Deletes each item in <c>ItemsToDelete</c> sequentially (Concat) through the collection's
+    /// pooled write surface. Failures are captured in <c>Errors</c> rather than propagated so
+    /// partial success is visible. Cold — runs on Subscribe; emits one Unit when finished.
     /// </summary>
-    public async Task DeleteAsync()
+    public IObservable<Unit> Delete()
     {
         Errors.Clear();
-        foreach (var item in ItemsToDelete)
-        {
-            try
-            {
-                if (item is FolderItem folder)
+        return ItemsToDelete.ToObservable()
+            .Select(item => (item switch
                 {
-                    await collection.DeleteFolderAsync(folder.Path);
-                }
-                else if (item is FileItem file)
+                    FolderItem folder => collection.DeleteFolder(folder.Path),
+                    FileItem file => collection.DeleteFile(file.Path),
+                    _ => Observable.Return(Unit.Default),
+                })
+                .Catch((Exception ex) =>
                 {
-                    await collection.DeleteFileAsync(file.Path);
-                }
-            }
-            catch (Exception ex)
-            {
-                Errors.Add($"Failed to delete '{item.Name}': {ex.Message}");
-            }
-        }
+                    Errors.Add($"Failed to delete '{item.Name}': {ex.Message}");
+                    return Observable.Return(Unit.Default);
+                }))
+            .Concat()
+            .LastOrDefaultAsync();
     }
 }

--- a/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor
+++ b/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor
@@ -66,12 +66,12 @@
                     <FluentInputFile @ref="@myFileByStream"
                                      AnchorId="MyUploadStream"
                                      DragDropZoneVisible="false"
-                                     Mode="InputFileMode.Stream"
+                                     Mode="InputFileMode.SaveToTemporaryFolder"
                                      Multiple="true"
                                      MaximumFileCount="1000"
                                      MaximumFileSize="@(20 * 1024 * 1024)"
                                      ProgressPercentChanged="@(p => progressPercent = p)"
-                                     OnFileUploaded="@OnFileUploadedAsync"
+                                     OnFileUploaded="@OnFileUploaded"
                                      OnCompleted="@OnCompleted" />
                     if (ShowNewArticle)
                     {

--- a/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor.cs
+++ b/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor.cs
@@ -1,4 +1,7 @@
-﻿using MeshWeaver.ContentCollections;
+﻿using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.ContentCollections;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -11,8 +14,12 @@ namespace MeshWeaver.Blazor.FileExplorer;
 /// <summary>
 /// Blazor component that displays and manages files and folders within a named content collection.
 /// Supports browsing, uploading, downloading, creating folders, and deleting items.
+/// All collection I/O is observable end-to-end: the leaves run on the collection's
+/// <c>IIoPool</c> — never on this circuit's thread — and the component merely subscribes.
+/// A slow SMB/blob store can therefore never block the circuit (the "files disappeared"
+/// SignalR flapping this replaced).
 /// </summary>
-public partial class FileBrowser
+public partial class FileBrowser : IDisposable
 {
     [Inject] private IDialogService DialogService { get; set; } = null!;
     private IContentService ContentService => Hub.ServiceProvider.GetRequiredService<IContentService>();
@@ -46,57 +53,85 @@ public partial class FileBrowser
     [Parameter] public bool IsReadOnly { get; set; }
     private IReadOnlyCollection<CollectionItem> CollectionItems { get; set; } = [];
     FluentInputFile myFileByStream = default!;
+    private IDisposable? loadSubscription;
+
     /// <summary>
-    /// Runs after each parameter update: registers any new collection configuration, loads the collection by name,
-    /// optionally creates <c>CurrentPath</c>, and refreshes the displayed items.
+    /// Runs after each parameter update: registers any new collection configuration, then
+    /// (re)subscribes the load pipeline — resolve the collection, optionally create
+    /// <c>CurrentPath</c>, list the items. Everything I/O runs on the collection's pool; this
+    /// method only wires the subscription and returns.
     /// </summary>
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
-        await base.OnParametersSetAsync();
+        base.OnParametersSet();
 
         // Initialize collection if configuration is provided and collection doesn't exist
         if (CollectionConfiguration is not null)
             ContentService.AddConfiguration(CollectionConfiguration);
 
-        // Try to get the collection
-        Collection = CollectionName is null ? null : await ContentService.GetCollectionAsync(CollectionName);
-
-        if (CreatePath && Collection is not null && CurrentPath is not null)
-            await Collection.CreateFolderAsync(CurrentPath);
-        await RefreshContentAsync();
+        RefreshContent();
     }
-
-
 
     private const string Root = "/";
 
-    private async Task RefreshContentAsync()
+    /// <summary>
+    /// (Re)subscribes the resolve → ensure-folder → list pipeline and pushes the result into the
+    /// rendered state. Replaces any in-flight load (the previous subscription is disposed).
+    /// </summary>
+    private void RefreshContent()
     {
-        CurrentPath ??= "/";
-        if (Collection is null)
+        CurrentPath ??= Root;
+        loadSubscription?.Dispose();
+        if (CollectionName is null)
+        {
+            Collection = null;
+            CollectionItems = [];
+            SelectedItems = [];
             return;
+        }
 
-        var items = new List<CollectionItem>();
-        await foreach (var item in Collection.GetCollectionItems(CurrentPath!))
-            items.Add(item);
-        CollectionItems = items;
-        SelectedItems = [];
+        var name = CollectionName;
+        loadSubscription = ContentService.GetCollection(name)
+            .SelectMany(collection =>
+            {
+                if (collection is null)
+                    return Observable.Return<(ContentCollection? Collection, IList<CollectionItem> Items)>((null, []));
+                var ensureFolder = CreatePath && CurrentPath is not null
+                    ? collection.CreateFolder(CurrentPath)
+                    : Observable.Return(Unit.Default);
+                return ensureFolder
+                    .SelectMany(_ => collection.GetCollectionItems(CurrentPath!).ToList())
+                    .Select(items => ((ContentCollection? Collection, IList<CollectionItem> Items))(collection, items));
+            })
+            .Subscribe(
+                result =>
+                {
+                    Collection = result.Collection;
+                    CollectionItems = [.. result.Items];
+                    SelectedItems = [];
+                    InvokeAsync(StateHasChanged);
+                },
+                ex =>
+                {
+                    ToastService.ShowError($"Error loading collection '{name}': {ex.Message}");
+                    InvokeAsync(StateHasChanged);
+                });
     }
 
-
-
-
-    private async Task CollectionChanged(string collection)
+    private void CollectionChanged(string collection)
     {
         if (collection == CollectionName)
             return;
         CollectionName = collection;
-
-        Collection = CollectionName is null ? null : await ContentService.GetCollectionAsync(CollectionName);
-        await RefreshContentAsync();
-        await InvokeAsync(StateHasChanged);
+        RefreshContent();
     }
 
+    /// <summary>Disposes the in-flight load subscription with the circuit.</summary>
+    public void Dispose()
+    {
+        loadSubscription?.Dispose();
+        loadSubscription = null;
+    }
 
     private ContentCollection? Collection { get; set; }
     private IEnumerable<CollectionItem> SelectedItems { get; set; } = new List<CollectionItem>();
@@ -118,7 +153,7 @@ public partial class FileBrowser
         var dialog = await DialogService.ShowDialogAsync<CreateFolderDialog, CreateFolderModel>(new CreateFolderModel(Collection!, CurrentPath!, CollectionItems), parameters);
         var result = await dialog.Result;
         if (!result.Cancelled)
-            await RefreshContentAsync();
+            RefreshContent();
     }
     private Task NewArticleAsync(MouseEventArgs arg)
     {
@@ -143,7 +178,7 @@ public partial class FileBrowser
         var result = await dialog.Result;
         if (!result.Cancelled)
         {
-            await RefreshContentAsync();
+            RefreshContent();
 
             // Show errors if any occurred
             if (deleteModel.Errors.Any())
@@ -241,34 +276,56 @@ public partial class FileBrowser
     int progressPercent;
     string progressTitle = "";
 
-    private async Task OnFileUploadedAsync(FluentInputFileEventArgs file)
+    private void OnFileUploaded(FluentInputFileEventArgs file)
     {
         progressPercent = file.ProgressPercent;
         progressTitle = file.ProgressTitle;
+        if (Collection is null || file.LocalFile is null)
+            return;
+
+        var fileName = file.Name;
+        var tempPath = file.LocalFile.FullName;
+        // The upload was buffered to a local temp file (InputFileMode.SaveToTemporaryFolder).
+        // The factory overload opens it INSIDE the pool leaf — no I/O on the circuit, no await:
+        // subscribe-only, per the reactive rules.
+        Collection.SaveFile(CurrentPath!, fileName, () => File.OpenRead(tempPath))
+            .Finally(() => TryDeleteTempFile(tempPath))
+            .Subscribe(
+                _ => { },
+                ex => InvokeAsync(() =>
+                {
+                    ToastService.ShowError($"Error uploading {fileName}: {ex.Message}");
+                    StateHasChanged();
+                }),
+                () => InvokeAsync(() =>
+                {
+                    progressPercent = 100;
+
+                    // Post-upload seam: raise the SAME observer the MCP upload path raises
+                    // (MeshOperations.Upload → hub.RaiseContentUploaded) so a GUI upload
+                    // auto-indexes like any other upload. Fire-and-forget by contract — the
+                    // indexing runs as its own Activity and never blocks the upload (#170).
+                    // CurrentPath can carry '\' separators on Windows (the Embed breadcrumb
+                    // builds it via Path.Combine) — normalize so the seam always gets the
+                    // MCP shape (forward-slash, collection-relative, no leading slash).
+                    var folder = (CurrentPath ?? "").Replace('\\', '/').Trim('/');
+                    var relativePath = string.IsNullOrEmpty(folder) ? fileName : $"{folder}/{fileName}";
+                    Hub.RaiseContentUploaded(QualifiedCollectionPath, relativePath);
+
+                    ToastService.ShowSuccess($"File {fileName} successfully uploaded.");
+                    RefreshContent();
+                }));
+    }
+
+    private void TryDeleteTempFile(string tempPath)
+    {
         try
         {
-            if (Collection != null)
-            {
-                await Collection.SaveFileAsync(CurrentPath!, file.Name, file.Stream!);
-                progressPercent = 100;
-
-                // Post-upload seam: raise the SAME observer the MCP upload path raises
-                // (MeshOperations.Upload → hub.RaiseContentUploaded) so a GUI upload
-                // auto-indexes like any other upload. Fire-and-forget by contract — the
-                // indexing runs as its own Activity and never blocks the upload (#170).
-                // CurrentPath can carry '\' separators on Windows (the Embed breadcrumb
-                // builds it via Path.Combine) — normalize so the seam always gets the
-                // MCP shape (forward-slash, collection-relative, no leading slash).
-                var folder = (CurrentPath ?? "").Replace('\\', '/').Trim('/');
-                var relativePath = string.IsNullOrEmpty(folder) ? file.Name : $"{folder}/{file.Name}";
-                Hub.RaiseContentUploaded(QualifiedCollectionPath, relativePath);
-
-                ToastService.ShowSuccess($"File {file.Name} successfully uploaded.");
-            }
+            File.Delete(tempPath);
         }
-        catch (Exception e)
+        catch (IOException)
         {
-            ToastService.ShowError($"Error uploading {file.Name}: {e.Message}");
+            // Best-effort temp-file cleanup; the OS temp folder reclaims leftovers.
         }
     }
 
@@ -291,17 +348,17 @@ public partial class FileBrowser
         }
     }
 
-    private async Task OnCompleted(IEnumerable<FluentInputFileEventArgs> files)
+    private void OnCompleted(IEnumerable<FluentInputFileEventArgs> files)
     {
         progressPercent = 0;
         progressTitle = "";
-        await RefreshContentAsync();
+        RefreshContent();
     }
 
-    private async Task ChangePath(string path)
+    private void ChangePath(string path)
     {
         CurrentPath = path;
-        await RefreshContentAsync();
+        RefreshContent();
     }
 
     private async Task HandleFileClick(FileItem file)

--- a/src/MeshWeaver.Blazor/FileExplorer/FileBrowserView.razor
+++ b/src/MeshWeaver.Blazor/FileExplorer/FileBrowserView.razor
@@ -1,6 +1,8 @@
+@using System.Reactive.Linq
 @using MeshWeaver.ContentCollections
 @using MeshWeaver.Messaging
 @using Microsoft.Extensions.DependencyInjection
+@using Microsoft.Extensions.Logging
 @inherits BlazorView<FileBrowserControl,FileBrowserView>
 
 <FileBrowser Address="Stream?.Owner" CollectionName="@Collection" CurrentPath="@Path" CreatePath="@PathCreation" TopLevelPath="@TopLevelPath" CollectionConfiguration="@CollectionConfiguration" IsReadOnly="@IsReadOnly" Embed="@true" UrlBasePath="@UrlBasePath"></FileBrowser>
@@ -33,9 +35,9 @@
         DataBind(ViewModel.CollectionSettings, x => x.CollectionSettings);
     }
 
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
-        await base.OnParametersSetAsync();
+        base.OnParametersSet();
 
         // Reconstruct CollectionConfiguration from string properties if it didn't survive serialization
         if (CollectionConfiguration is null && !string.IsNullOrEmpty(SourceType) && !string.IsNullOrEmpty(Collection))
@@ -61,7 +63,12 @@
         {
             var contentService = Hub.ServiceProvider.GetRequiredService<IContentService>();
             contentService.AddConfiguration(CollectionConfiguration);
-            await contentService.GetCollectionAsync(Collection, CancellationToken.None);
+            // Warm the (ReplaySubject-cached) collection so the embedded browser resolves it
+            // instantly; the initialization leaf runs on the collection's pool. Cold → Subscribe.
+            var name = Collection;
+            AddBinding(contentService.GetCollection(name).Subscribe(
+                _ => { },
+                ex => Logger.LogWarning(ex, "Warming content collection '{Collection}' failed", name)));
         }
     }
 }

--- a/src/MeshWeaver.Blazor/Pages/CollectionsPage.razor
+++ b/src/MeshWeaver.Blazor/Pages/CollectionsPage.razor
@@ -1,4 +1,5 @@
 ﻿@page "/collections/{**FullPath}"
+@using System.Reactive.Linq
 @using Microsoft.AspNetCore.Components.Authorization
 @using MeshWeaver.Blazor.FileExplorer
 @using MeshWeaver.ContentCollections
@@ -23,9 +24,9 @@
     private string? Collection { get; set; } = "";
     private string? Path { get; set; } = "";
 
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
-        await base.OnParametersSetAsync();
+        base.OnParametersSet();
         if (!string.IsNullOrEmpty(FullPath))
         {
             var split = FullPath!.Split('/');
@@ -34,14 +35,16 @@
         }
         else
         {
-            // Redirect to first available collection if no collection specified
-            var collections = await ContentService.GetCollectionsAsync().ToArrayAsync();
-            var firstCollection = collections.FirstOrDefault();
-            if (firstCollection != null)
+            // Redirect to the first available collection when none is specified.
+            // Subscribe-only: the enumeration replays instantiated (pool-initialized)
+            // collections; navigation is marshalled back onto the circuit.
+            ContentService.GetCollections().ToArray().Take(1).Subscribe(collections =>
             {
-                NavigationManager.NavigateTo($"/collections/{firstCollection.Collection}");
-                return;
-            }
+                var firstCollection = collections.FirstOrDefault();
+                if (firstCollection != null)
+                    _ = InvokeAsync(() =>
+                        NavigationManager.NavigateTo($"/collections/{firstCollection.Collection}"));
+            });
         }
     }
 

--- a/src/MeshWeaver.Blazor/Pages/ContentPage.razor.cs
+++ b/src/MeshWeaver.Blazor/Pages/ContentPage.razor.cs
@@ -55,11 +55,8 @@ public partial class ContentPage : ComponentBase, IDisposable
     [Inject] public PortalApplication PortalApplication { get; set; } = null!;
     private IContentService ContentService => PortalApplication.Hub.ServiceProvider.GetRequiredService<IContentService>();
 
-    [Inject] private IoPoolRegistry? IoPoolRegistry { get; set; }
 
     // FileSystem I/O pool — keeps the genuine file/content I/O off the Blazor circuit
-    // thread. Property named Pool (not IoPool) to avoid clashing with the IoPool type.
-    private IIoPool Pool => IoPoolRegistry?.Get(IoPoolNames.FileSystem) ?? global::MeshWeaver.Mesh.Threading.IoPool.Unbounded;
 
     /// <summary>
     /// Parses the <c>FullPath</c> route parameter and initiates content loading by resolving the
@@ -141,9 +138,9 @@ public partial class ContentPage : ComponentBase, IDisposable
             });
         }
 
-        // ContentService.GetCollectionAsync is a content-I/O leaf; run it on the
-        // FileSystem I/O pool so it never executes on the Blazor circuit thread.
-        Pool.Run(ct => ContentService.GetCollectionAsync(ResolvedCollection!, ct))
+        // The collection surface is observable end-to-end — its I/O leaves run on the
+        // collection's own pool, never on the Blazor circuit thread; this just subscribes.
+        ContentService.GetCollection(ResolvedCollection!)
             .Subscribe(collection =>
             {
                 if (collection is null)
@@ -167,7 +164,7 @@ public partial class ContentPage : ComponentBase, IDisposable
                 }
                 else if (ContentType != "text/markdown")
                 {
-                    Pool.Run(ct => collection.GetContentAsync(ResolvedPath!, ct))
+                    collection.GetContent(ResolvedPath!)
                         .Subscribe(content =>
                         {
                             Content = content;

--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingObserver.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/ContentIndexingObserver.cs
@@ -27,7 +27,6 @@ public sealed class ContentIndexingObserver : IContentUploadObserver
 {
     private readonly IMessageHub hub;
     private readonly ContentIndexingService indexingService;
-    private readonly IIoPool fileSystemPool;
     private readonly ILogger<ContentIndexingObserver> logger;
 
     /// <summary>
@@ -47,8 +46,6 @@ public sealed class ContentIndexingObserver : IContentUploadObserver
         this.logger = logger ?? hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger<ContentIndexingObserver>()
             ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ContentIndexingObserver>.Instance;
-        this.fileSystemPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem)
-            ?? IoPool.Unbounded;
     }
 
     /// <summary>
@@ -128,7 +125,7 @@ public sealed class ContentIndexingObserver : IContentUploadObserver
             hub,
             PartitionOf(collectionPath),
             $"Index {fileName}",
-            ctx => RegisterCollection(collectionPath).SelectMany(contentService => ReadBytes(contentService, collectionPath, filePath, ctx.CancellationToken)
+            ctx => RegisterCollection(collectionPath).SelectMany(contentService => ReadBytes(contentService, collectionPath, filePath)
                 .SelectMany(bytes =>
                 {
                     if (bytes is null)
@@ -219,14 +216,14 @@ public sealed class ContentIndexingObserver : IContentUploadObserver
         Observable.Defer(() =>
         {
             ctx.Log($"Scanning collection '{collectionPath}'.");
-            return RegisterCollection(collectionPath).SelectMany(contentService => EnumerateFiles(contentService, collectionPath, ctx.CancellationToken)
+            return RegisterCollection(collectionPath).SelectMany(contentService => EnumerateFiles(contentService, collectionPath)
                 // Sequentially index each file (Concat): each IndexFile leaf takes its own pool slots;
                 // serialising the walk keeps the activity log ordered and embed concurrency bounded.
                 // Each file emits its failure count (0 = indexed/skipped/no-text, 1 = failed).
                 .Select(filePath => Observable.Defer(() =>
                 {
                     ctx.CancellationToken.ThrowIfCancellationRequested();
-                    return ReadBytes(contentService, collectionPath, filePath, ctx.CancellationToken)
+                    return ReadBytes(contentService, collectionPath, filePath)
                         .SelectMany(bytes =>
                         {
                             if (bytes is null)
@@ -254,63 +251,38 @@ public sealed class ContentIndexingObserver : IContentUploadObserver
         });
 
     /// <summary>
-    /// Reads a file's bytes back from the collection via the FileSystem I/O-pool leaf (never inline on
-    /// the hub thread). Emits null when the file/collection is absent.
+    /// Reads a file's bytes back from the collection. The read leaf runs on the collection's own
+    /// I/O pool (never inline on the hub thread); cancellation propagates by unsubscribing the
+    /// chain (the activity teardown disposes it). Emits null when the file/collection is absent.
     /// </summary>
-    private IObservable<byte[]?> ReadBytes(
-        IContentService contentService, string collectionPath, string filePath, CancellationToken ct) =>
-        fileSystemPool.Invoke<byte[]?>(async token =>
-        {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, token);
-            var stream = await contentService.GetContentAsync(collectionPath, filePath.TrimStart('/'), linked.Token)
-                .ConfigureAwait(false);
-            if (stream is null)
-                return null;
-            await using (stream)
-            {
-                using var ms = new MemoryStream();
-                await stream.CopyToAsync(ms, linked.Token).ConfigureAwait(false);
-                return ms.ToArray();
-            }
-        });
+    private static IObservable<byte[]?> ReadBytes(
+        IContentService contentService, string collectionPath, string filePath) =>
+        contentService.GetCollection(collectionPath)
+            .SelectMany(collection => collection is null
+                ? Observable.Return<byte[]?>(null)
+                : collection.GetContentBytes(filePath.TrimStart('/')));
 
     /// <summary>
     /// Recursively enumerates every file path (relative to the collection root) in
-    /// <paramref name="collectionPath"/>. Each walk step runs on the FileSystem I/O-pool leaf.
+    /// <paramref name="collectionPath"/>. Each walk step runs on the collection's I/O pool.
     /// </summary>
-    private IObservable<string> EnumerateFiles(
-        IContentService contentService, string collectionPath, CancellationToken ct) =>
-        fileSystemPool.InvokeStream(token => WalkFiles(contentService, collectionPath, ct, token));
+    private static IObservable<string> EnumerateFiles(
+        IContentService contentService, string collectionPath) =>
+        contentService.GetCollection(collectionPath)
+            .SelectMany(collection => collection is null
+                ? Observable.Empty<string>()
+                : WalkDir(collection, "/"));
 
-    private async IAsyncEnumerable<string> WalkFiles(
-        IContentService contentService,
-        string collectionPath,
-        CancellationToken outerCt,
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken poolCt)
-    {
-        using var linked = CancellationTokenSource.CreateLinkedTokenSource(outerCt, poolCt);
-        var collection = await contentService.GetCollectionAsync(collectionPath, linked.Token).ConfigureAwait(false);
-        if (collection is null)
-            yield break;
-
-        var pending = new Queue<string>();
-        pending.Enqueue("/");
-        while (pending.Count > 0)
-        {
-            linked.Token.ThrowIfCancellationRequested();
-            var dir = pending.Dequeue();
-
-            await foreach (var folder in collection.GetFolders(dir, linked.Token).ConfigureAwait(false))
-                pending.Enqueue(folder.Path);
-
-            await foreach (var file in collection.GetFiles(dir, linked.Token).ConfigureAwait(false))
-                // Normalise OS directory separators to '/': on Windows the provider yields
-                // backslash paths (e.g. "a\one.txt"), but the whole mesh — chunk keys, Document
-                // node paths (DocumentPaths.For), the upload path — uses forward slashes. Without
-                // this, a re-indexed file keys differently from the same file uploaded.
-                yield return file.Path.TrimStart('/', '\\').Replace('\\', '/');
-        }
-    }
+    private static IObservable<string> WalkDir(ContentCollection collection, string dir) =>
+        collection.GetFiles(dir)
+            // Normalise OS directory separators to '/': on Windows the provider yields
+            // backslash paths (e.g. "a\one.txt"), but the whole mesh — chunk keys, Document
+            // node paths (DocumentPaths.For), the upload path — uses forward slashes. Without
+            // this, a re-indexed file keys differently from the same file uploaded.
+            .Select(file => file.Path.TrimStart('/', '\\').Replace('\\', '/'))
+            .Concat(collection.GetFolders(dir)
+                .Select(folder => WalkDir(collection, folder.Path))
+                .Concat());
 
     /// <summary>
     /// The partition root the activity is rooted at — the node that owns the collection (the collection

--- a/src/MeshWeaver.ContentCollections/CollectionNamedLayoutArea.cs
+++ b/src/MeshWeaver.ContentCollections/CollectionNamedLayoutArea.cs
@@ -52,9 +52,9 @@ public static class CollectionNamedLayoutArea
         var path = ContentCollectionsExtensions.DecodeCollectionPath(idString.Split('?')[0].Trim('/'));
 
         var contentService = host.Hub.GetContentService();
-        var ioPool = ContentLayoutArea.GetIoPool(host.Hub);
-        return ioPool
-            .Invoke(ct => contentService.GetCollectionAsync(collectionName, ct))
+        // No pool wrapping here — the collection surface is observable end-to-end and pools its
+        // own provider leaves; this layer is pure composition.
+        return contentService.GetCollection(collectionName)
             .SelectMany(collection =>
             {
                 if (collection is null)
@@ -69,15 +69,10 @@ public static class CollectionNamedLayoutArea
                 // an extension heuristic.
                 var lastSlash = path.LastIndexOf('/');
                 var parent = lastSlash < 0 ? "/" : $"/{path[..lastSlash]}";
-                return ioPool
-                    .Invoke<CollectionItem?>(async ct =>
-                    {
-                        await foreach (var item in collection.GetCollectionItems(parent, ct).ConfigureAwait(false))
-                            // Item paths can carry '\' separators on Windows (FileSystem provider).
-                            if (string.Equals(item.Path.Replace('\\', '/').Trim('/'), path, StringComparison.OrdinalIgnoreCase))
-                                return item;
-                        return null;
-                    })
+                return collection.GetCollectionItems(parent)
+                    // Item paths can carry '\' separators on Windows (FileSystem provider).
+                    .Where(item => string.Equals(item.Path.Replace('\\', '/').Trim('/'), path, StringComparison.OrdinalIgnoreCase))
+                    .FirstOrDefaultAsync()
                     .SelectMany(item => item switch
                     {
                         FolderItem => Observable.Return<UiControl?>(

--- a/src/MeshWeaver.ContentCollections/Completion/ContentAutocompleteProvider.cs
+++ b/src/MeshWeaver.ContentCollections/Completion/ContentAutocompleteProvider.cs
@@ -12,17 +12,13 @@ namespace MeshWeaver.ContentCollections.Completion;
 /// scores high — e.g., "two" matches "one two three.docx", "thr" matches "three" word.
 /// Priority scale: word-boundary fuzzy matches score in the thousands; proximity boost +1000 for local content.
 /// <para>Fully reactive — the collection load and the recursive file walk compose via
-/// <c>SelectMany</c>/<c>Merge</c>; the genuine I/O leaves (<c>GetCollectionAsync</c>,
-/// <c>GetFiles</c>/<c>GetFolders</c>) bridge through the <see cref="IIoPool"/> (no bare
-/// <c>Observable.FromAsync</c>, no provider-level async-enumerable). Dedup by insert text
-/// across collections is <c>Observable.Distinct</c>.</para>
+/// <c>SelectMany</c>/<c>Merge</c>; the genuine I/O leaves run inside the collection's own
+/// <see cref="IIoPool"/> (the whole <see cref="ContentCollection"/> surface is pooled
+/// observables). Dedup by insert text across collections is <c>Observable.Distinct</c>.</para>
 /// </summary>
-public class ContentAutocompleteProvider(
-    IContentService contentService,
-    IoPoolRegistry? ioPoolRegistry = null) : IAutocompleteProvider
+public class ContentAutocompleteProvider(IContentService contentService) : IAutocompleteProvider
 {
     private static readonly FuzzyScorer Scorer = new();
-    private readonly IIoPool _ioPool = ioPoolRegistry?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
 
     /// <inheritdoc />
     public string? Prefix => "content";
@@ -32,7 +28,7 @@ public class ContentAutocompleteProvider(
     {
         var searchText = ExtractSearchText(query);
         var items = contentService.GetAllCollectionConfigs().ToObservable()
-            .SelectMany(config => _ioPool.Run(ct => contentService.GetCollectionAsync(config.Name!, ct)))
+            .SelectMany(config => contentService.GetCollection(config.Name!))
             .Where(collection => collection is not null)
             .SelectMany(collection => WalkCollection(collection!, "/", searchText, contextPath))
             // Same file can surface via multiple collections (parent/child hierarchy,
@@ -45,15 +41,15 @@ public class ContentAutocompleteProvider(
         ContentCollection collection, string path, string searchText, string? contextPath)
     {
         // Files at this level + a recursive walk of every folder, merged. Each leaf
-        // enumeration is bridged through the pool and Catch-guarded so a path that
+        // enumeration runs on the collection's pool and is Catch-guarded so a path that
         // fails to enumerate is skipped rather than tearing down the whole stream.
-        var files = _ioPool.InvokeStream(ct => collection.GetFiles(path, ct))
+        var files = collection.GetFiles(path)
             .Select(file => ScoreFile(collection, file, searchText, contextPath))
             .Where(item => item is not null)
             .Select(item => item!)
             .Catch<AutocompleteItem, Exception>(_ => Observable.Empty<AutocompleteItem>());
 
-        var folders = _ioPool.InvokeStream(ct => collection.GetFolders(path, ct))
+        var folders = collection.GetFolders(path)
             .SelectMany(folder => WalkCollection(collection, folder.Path, searchText, contextPath))
             .Catch<AutocompleteItem, Exception>(_ => Observable.Empty<AutocompleteItem>());
 

--- a/src/MeshWeaver.ContentCollections/ContentCollection.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Linq;
+﻿using System.Reactive;
+using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using MeshWeaver.Data;
@@ -38,6 +39,12 @@ public class ContentCollection : IDisposable
         Config = config;
         this.provider = provider;
         markdownStream = CreateStream();
+        // ReplaySubject-backed promise cache (Pool.Run) behind a Lazy: nothing runs at
+        // construction or config registration — the FIRST actual load (Initialize() access)
+        // kicks the parse off on the pool, and every subscriber, first or late, replays
+        // the same completion.
+        initialized = new Lazy<IObservable<InstanceCollection>>(
+            () => Pool.Run(ct => InitializeCoreAsync(ct)));
     }
 
     private ISynchronizationStream<InstanceCollection> CreateStream()
@@ -54,6 +61,29 @@ public class ContentCollection : IDisposable
 
     /// <summary>The message hub that owns this collection's synchronization stream.</summary>
     public IMessageHub Hub { get; }
+
+    /// <summary>
+    /// The I/O pool every provider leaf is bridged through. All public read/write surface on this
+    /// class is <see cref="IObservable{T}"/>; the Task-shaped <see cref="IStreamProvider"/> leaves
+    /// run inside this pool, never on the subscriber's thread (hub action block / Blazor circuit).
+    /// Blob-backed collections gate on the Blob pool, everything else on the FileSystem pool.
+    /// </summary>
+    private IIoPool Pool =>
+        Hub.ServiceProvider.GetService<IoPoolRegistry>()
+            ?.Get(string.Equals(Config.SourceType, "AzureBlob", StringComparison.OrdinalIgnoreCase)
+                ? IoPoolNames.Blob
+                : IoPoolNames.FileSystem)
+        ?? IoPool.Unbounded;
+
+    private AccessService? AccessService => Hub.ServiceProvider.GetService<AccessService>();
+
+    /// <summary>
+    /// Snapshots the calling user's <see cref="AccessContext"/> on the CALLING thread. The pool hop
+    /// wipes the AsyncLocal, so every write leaf re-establishes this snapshot via
+    /// <see cref="AccessService.SwitchAccessContext"/> — the write stays attributed to the caller,
+    /// not to whatever identity happens to sit on the pool thread.
+    /// </summary>
+    private AccessContext? SnapshotCallerContext() => AccessService?.Context;
     /// <summary>The collection's unique name (from <see cref="ContentCollectionConfig.Name"/>).</summary>
     public string Collection => Config.Name!;
     /// <summary>Human-friendly display name; falls back to a word-split of <see cref="Collection"/> when none is configured.</summary>
@@ -75,19 +105,61 @@ public class ContentCollection : IDisposable
 
 
     /// <summary>
-    /// Opens a read stream for the raw file at <paramref name="path"/>, or <c>null</c> if it does not exist.
+    /// Opens a read stream for the raw file at <paramref name="path"/>, or emits <c>null</c> if it
+    /// does not exist. The provider leaf runs on <see cref="Pool"/>, never on the subscriber thread.
     /// </summary>
     /// <param name="path">The file path within the collection.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>A readable stream, or <c>null</c> when the file is not found.</returns>
-    public Task<Stream?> GetContentAsync(string path, CancellationToken ct = default)
-        => provider.GetStreamAsync(path, ct);
+    /// <returns>A single-emission observable of the readable stream, or <c>null</c> when not found.</returns>
+    public IObservable<Stream?> GetContent(string path)
+        => Pool.Invoke(ct => provider.GetStreamAsync(path, ct));
+
+    /// <summary>
+    /// Reads the raw file at <paramref name="path"/> fully into memory on <see cref="Pool"/> and
+    /// emits its bytes, or <c>null</c> when the file does not exist. Use this instead of
+    /// <see cref="GetContent"/> when the consumer would otherwise read the stream on its own
+    /// thread — the whole read stays inside the pool leaf.
+    /// </summary>
+    /// <param name="path">The file path within the collection.</param>
+    public IObservable<byte[]?> GetContentBytes(string path)
+        => Pool.Invoke<byte[]?>(async ct =>
+        {
+            var stream = await provider.GetStreamAsync(path, ct).ConfigureAwait(false);
+            if (stream is null)
+                return null;
+            await using (stream.ConfigureAwait(false))
+            {
+                using var ms = new MemoryStream();
+                await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
+                return ms.ToArray();
+            }
+        });
+
+    /// <summary>
+    /// Probes the file at <paramref name="path"/> on <see cref="Pool"/>: emits <c>null</c> when it
+    /// does not exist, the byte size when the backing stream is seekable, and <c>-1</c> when the
+    /// file exists but its size is unknown. Never reads the content.
+    /// </summary>
+    /// <param name="path">The file path within the collection.</param>
+    public IObservable<long?> GetContentSize(string path)
+        => Pool.Invoke<long?>(async ct =>
+        {
+            var stream = await provider.GetStreamAsync(path, ct).ConfigureAwait(false);
+            if (stream is null)
+                return null;
+            await using (stream.ConfigureAwait(false))
+                return stream.CanSeek ? stream.Length : -1;
+        });
 
     /// <summary>
     /// Returns content as text/markdown. For supported binary formats (.docx, .pptx, .xlsx),
-    /// converts to markdown via registered IContentTransformer. For text files, reads as-is.
+    /// converts to markdown via registered IContentTransformer. For text files, reads as-is —
+    /// optionally only the first <paramref name="maxLines"/> lines. The read + transform leaf
+    /// runs on <see cref="Pool"/>.
     /// </summary>
-    public async Task<string?> GetContentAsTextAsync(string path, IEnumerable<IContentTransformer>? transformers = null, CancellationToken ct = default)
+    public IObservable<string?> GetContentAsText(string path, IEnumerable<IContentTransformer>? transformers = null, int? maxLines = null)
+        => Pool.Invoke(ct => GetContentAsTextCoreAsync(path, transformers, maxLines, ct));
+
+    private async Task<string?> GetContentAsTextCoreAsync(string path, IEnumerable<IContentTransformer>? transformers, int? maxLines, CancellationToken ct)
     {
         var ext = System.IO.Path.GetExtension(path).ToLowerInvariant();
 
@@ -96,19 +168,30 @@ public class ContentCollection : IDisposable
             t.SupportedExtensions.Contains(ext));
         if (transformer != null)
         {
-            var stream = await GetContentAsync(path, ct);
+            var stream = await provider.GetStreamAsync(path, ct).ConfigureAwait(false);
             if (stream == null) return null;
             using (stream)
-                return await transformer.TransformToMarkdownAsync(stream, ct);
+                return await transformer.TransformToMarkdownAsync(stream, ct).ConfigureAwait(false);
         }
 
         // Fallback: read as text
-        var textStream = await GetContentAsync(path, ct);
+        var textStream = await provider.GetStreamAsync(path, ct).ConfigureAwait(false);
         if (textStream == null) return null;
         using (textStream)
         {
             using var reader = new StreamReader(textStream);
-            return await reader.ReadToEndAsync(ct);
+            if (maxLines is not { } limit)
+                return await reader.ReadToEndAsync(ct).ConfigureAwait(false);
+
+            var sb = new System.Text.StringBuilder();
+            for (var linesRead = 0; linesRead < limit; linesRead++)
+            {
+                var line = await reader.ReadLineAsync(ct).ConfigureAwait(false);
+                if (line is null)
+                    break;
+                sb.AppendLine(line);
+            }
+            return sb.ToString();
         }
     }
 
@@ -121,54 +204,80 @@ public class ContentCollection : IDisposable
         markdownStream.Dispose();
     }
 
-    /// <summary>Streams the immediate sub-folders at <paramref name="path"/> from the backing store.</summary>
+    /// <summary>Streams the immediate sub-folders at <paramref name="path"/> from the backing store, off the subscriber thread via <see cref="Pool"/>.</summary>
     /// <param name="path">The folder path within the collection.</param>
-    /// <param name="ct">Cancellation token.</param>
-    public IAsyncEnumerable<FolderItem> GetFolders(string path, CancellationToken ct = default)
-        => provider.GetFolders(path, ct);
+    public IObservable<FolderItem> GetFolders(string path)
+        => Pool.InvokeStream(ct => provider.GetFolders(path, ct));
 
-    /// <summary>Streams the files directly under <paramref name="path"/> from the backing store.</summary>
+    /// <summary>Streams the files directly under <paramref name="path"/> from the backing store, off the subscriber thread via <see cref="Pool"/>.</summary>
     /// <param name="path">The folder path within the collection.</param>
-    /// <param name="ct">Cancellation token.</param>
-    public IAsyncEnumerable<FileItem> GetFiles(string path, CancellationToken ct = default)
-        => provider.GetFiles(path, ct);
+    public IObservable<FileItem> GetFiles(string path)
+        => Pool.InvokeStream(ct => provider.GetFiles(path, ct));
 
-    /// <summary>Saves <paramref name="openReadStream"/> as a file in the backing store.</summary>
+    /// <summary>
+    /// Saves <paramref name="openReadStream"/> as a file in the backing store. Cold — the write
+    /// runs on Subscribe, on <see cref="Pool"/>, attributed to the caller's snapshot of the
+    /// <see cref="AccessContext"/> taken at call time.
+    /// </summary>
     /// <param name="path">The destination folder path within the collection.</param>
     /// <param name="fileName">The file name to write.</param>
     /// <param name="openReadStream">The content to persist.</param>
-    public async Task SaveFileAsync(string path, string fileName, Stream openReadStream)
-    {
-        await provider.SaveFileAsync(path, fileName, openReadStream);
+    public IObservable<Unit> SaveFile(string path, string fileName, Stream openReadStream)
+        => SaveFile(path, fileName, () => openReadStream);
 
-        // 🚨 Read-after-write for the collection's OWN writes must NOT depend on the file-system
-        // watcher. The watcher (AttachMonitor) is the only thing that feeds a post-init write into
-        // markdownStream — but on Linux inotify DROPS the event for a file written into a
-        // just-created subdirectory (the recursive watch on the new dir isn't registered before the
-        // write), so the article never lands and a content render stays "not found" until the
-        // collection re-initializes. That is the CI-only CollectionNamedArea flake AND the prod
-        // "upload a file then open it → shows nothing" bug this test class was written for. macOS
-        // FSEvents watches the whole tree so it never misses — which is why it only ever flaked on
-        // the Linux runner. Ingest our own write directly; the watcher remains for EXTERNAL changes.
-        if (fileName.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+    /// <summary>
+    /// Saves the stream produced by <paramref name="openStream"/> as a file in the backing store.
+    /// The factory runs INSIDE the pool leaf — use this when opening the source is itself I/O
+    /// (e.g. a temp file from an upload), so not even the open touches the subscriber's thread.
+    /// The stream is disposed after the write.
+    /// </summary>
+    /// <param name="path">The destination folder path within the collection.</param>
+    /// <param name="fileName">The file name to write.</param>
+    /// <param name="openStream">Factory producing the content stream; invoked on the pool.</param>
+    public IObservable<Unit> SaveFile(string path, string fileName, Func<Stream> openStream)
+    {
+        var caller = SnapshotCallerContext();
+        return Pool.Invoke(async ct =>
         {
-            var folder = path.Trim('/');
-            UpdateArticle(folder.Length == 0 ? fileName : $"{folder}/{fileName}");
-        }
+            using var _ = AccessService?.SwitchAccessContext(caller);
+            var openReadStream = openStream();
+            await using var __ = openReadStream.ConfigureAwait(false);
+            await provider.SaveFileAsync(path, fileName, openReadStream, ct).ConfigureAwait(false);
+
+            // 🚨 Read-after-write for the collection's OWN writes must NOT depend on the file-system
+            // watcher. The watcher (AttachMonitor) is the only thing that feeds a post-init write into
+            // markdownStream — but on Linux inotify DROPS the event for a file written into a
+            // just-created subdirectory (the recursive watch on the new dir isn't registered before the
+            // write), so the article never lands and a content render stays "not found" until the
+            // collection re-initializes. That is the CI-only CollectionNamedArea flake AND the prod
+            // "upload a file then open it → shows nothing" bug this test class was written for. macOS
+            // FSEvents watches the whole tree so it never misses — which is why it only ever flaked on
+            // the Linux runner. Ingest our own write directly; the watcher remains for EXTERNAL changes.
+            if (fileName.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                var folder = path.Trim('/');
+                UpdateArticle(folder.Length == 0 ? fileName : $"{folder}/{fileName}", caller);
+            }
+        });
     }
 
     /// <summary>
-    /// Streams folders + files at <paramref name="currentPath"/> as a single async enumerable.
-    /// Folders first, then files. Pure await foreach — no Task-bridging on the hot path.
+    /// Streams folders + files at <paramref name="currentPath"/> — folders first, then files —
+    /// with the enumeration leaf on <see cref="Pool"/>, never the subscriber thread. On the SMB
+    /// content mount every directory metadata call is a network round-trip; running it on a Blazor
+    /// circuit blocked the circuit under latency spikes (the "files disappeared" flapping).
     /// </summary>
-    public async IAsyncEnumerable<CollectionItem> GetCollectionItems(
+    public IObservable<CollectionItem> GetCollectionItems(string currentPath)
+        => Pool.InvokeStream(ct => GetCollectionItemsCore(currentPath, ct));
+
+    private async IAsyncEnumerable<CollectionItem> GetCollectionItemsCore(
         string currentPath,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
-        await foreach (var folder in provider.GetFolders(currentPath, ct))
+        await foreach (var folder in provider.GetFolders(currentPath, ct).ConfigureAwait(false))
             yield return folder;
 
-        await foreach (var file in provider.GetFiles(currentPath, ct))
+        await foreach (var file in provider.GetFiles(currentPath, ct).ConfigureAwait(false))
             yield return file;
     }
 
@@ -178,18 +287,23 @@ public class ContentCollection : IDisposable
     protected static bool MarkdownFilter(string name)
         => name.EndsWith(".md", StringComparison.OrdinalIgnoreCase);
 
+    private readonly Lazy<IObservable<InstanceCollection>> initialized;
+
     /// <summary>
     /// Parses every markdown file in the backing store into the synchronization stream and
-    /// attaches the change monitor. Call once before reading from the collection.
+    /// attaches the change monitor. Promise-cached: the first subscriber kicks the parse off on
+    /// <see cref="Pool"/>, every later subscriber replays the cached completion — the store is
+    /// scanned exactly once per collection instance.
     /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The initial collection of parsed articles.</returns>
-    public virtual async Task<InstanceCollection> InitializeAsync(CancellationToken ct)
+    /// <returns>A single-emission observable of the initial parsed articles.</returns>
+    public IObservable<InstanceCollection> Initialize() => initialized.Value;
+
+    private async Task<InstanceCollection> InitializeCoreAsync(CancellationToken ct)
     {
         var parsedArticles = new Dictionary<object, object>();
-        await foreach (var tuple in provider.GetStreamsAsync(MarkdownFilter, ct).WithCancellation(ct))
+        await foreach (var tuple in provider.GetStreamsAsync(MarkdownFilter, ct).WithCancellation(ct).ConfigureAwait(false))
         {
-            var article = await ParseArticleAsync(tuple.Stream, tuple.Path, tuple.LastModified, ct);
+            var article = await ParseArticleAsync(tuple.Stream, tuple.Path, tuple.LastModified, ct).ConfigureAwait(false);
             if (article is not null)
             {
                 var key = (object)(article.Path.EndsWith(".md", StringComparison.OrdinalIgnoreCase) ? article.Path[..^3] : article.Path);
@@ -208,19 +322,23 @@ public class ContentCollection : IDisposable
     /// Invoked by the change monitor when a file is created or modified.
     /// </summary>
     /// <param name="path">The path of the changed markdown file.</param>
-    protected void UpdateArticle(string path)
+    /// <param name="caller">
+    /// The originating user's context snapshot when the update is caused by a caller write
+    /// (SaveFile); <c>null</c> for watcher-driven external changes, which carry no user.
+    /// Re-established around the stream update so downstream reactors (indexing sinks
+    /// subscribed to the markdown stream) see the uploading user, not a bare pool thread.
+    /// </param>
+    protected void UpdateArticle(string path, AccessContext? caller = null)
     {
         // The file read + parse is the IO leaf — pooled OFF the hub; only the parsed
         // in-memory article flows into the (synchronous) stream Update. The stream's
         // UpdateStreamRequest handler is await-free by contract.
-        var ioPool = Hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem)
-                     ?? IoPool.Unbounded;
-        ioPool.Invoke(async ct =>
+        Pool.Invoke(async ct =>
             {
-                var tuple = await provider.GetStreamWithMetadataAsync(path, ct);
+                var tuple = await provider.GetStreamWithMetadataAsync(path, ct).ConfigureAwait(false);
                 if (tuple.Stream is null)
                     return null;
-                return await ParseArticleAsync(tuple.Stream, tuple.Path, tuple.LastModified, ct);
+                return await ParseArticleAsync(tuple.Stream, tuple.Path, tuple.LastModified, ct).ConfigureAwait(false);
             })
             .Subscribe(
                 article =>
@@ -230,6 +348,7 @@ public class ContentCollection : IDisposable
                     var key = article.Path.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
                         ? article.Path[..^3]
                         : article.Path;
+                    using var _ = caller is null ? null : AccessService?.SwitchAccessContext(caller);
                     markdownStream.Update(
                         x => new ChangeItem<InstanceCollection>(x!.SetItem(key, article), markdownStream.StreamId, Hub.Version),
                         ex =>
@@ -266,23 +385,39 @@ public class ContentCollection : IDisposable
     /// <summary>Subscribes the collection to backing-store change notifications, routing each to <see cref="UpdateArticle"/>.</summary>
     protected void AttachMonitor()
     {
-        monitorDisposable = provider.AttachMonitor(UpdateArticle);
+        // External (watcher-driven) changes carry no user — UpdateArticle runs context-less.
+        monitorDisposable = provider.AttachMonitor(path => UpdateArticle(path));
     }
 
-    /// <summary>Creates a folder in the backing store.</summary>
+    /// <summary>Creates a folder in the backing store. Cold — runs on Subscribe, on <see cref="Pool"/>, under the caller's context snapshot.</summary>
     /// <param name="folderPath">The folder path to create within the collection.</param>
-    public Task CreateFolderAsync(string folderPath)
-        => provider.CreateFolderAsync(folderPath);
+    public IObservable<Unit> CreateFolder(string folderPath)
+        => WriteOnPool(ct => provider.CreateFolderAsync(folderPath));
 
-    /// <summary>Deletes a folder (and its contents) from the backing store.</summary>
+    /// <summary>Deletes a folder (and its contents) from the backing store. Cold — runs on Subscribe, on <see cref="Pool"/>, under the caller's context snapshot.</summary>
     /// <param name="folderPath">The folder path to delete within the collection.</param>
-    public Task DeleteFolderAsync(string folderPath)
-        => provider.DeleteFolderAsync(folderPath);
+    public IObservable<Unit> DeleteFolder(string folderPath)
+        => WriteOnPool(ct => provider.DeleteFolderAsync(folderPath));
 
-    /// <summary>Deletes a single file from the backing store.</summary>
+    /// <summary>Deletes a single file from the backing store. Cold — runs on Subscribe, on <see cref="Pool"/>, under the caller's context snapshot.</summary>
     /// <param name="filePath">The file path to delete within the collection.</param>
-    public Task DeleteFileAsync(string filePath)
-        => provider.DeleteFileAsync(filePath);
+    public IObservable<Unit> DeleteFile(string filePath)
+        => WriteOnPool(ct => provider.DeleteFileAsync(filePath));
+
+    /// <summary>
+    /// Runs a provider write leaf on <see cref="Pool"/> with the caller's
+    /// <see cref="AccessContext"/> snapshot (taken NOW, on the calling thread) re-established
+    /// inside the leaf — the pool hop wipes the AsyncLocal otherwise.
+    /// </summary>
+    private IObservable<Unit> WriteOnPool(Func<CancellationToken, Task> write)
+    {
+        var caller = SnapshotCallerContext();
+        return Pool.Invoke(async ct =>
+        {
+            using var _ = AccessService?.SwitchAccessContext(caller);
+            await write(ct).ConfigureAwait(false);
+        });
+    }
 
     /// <summary>
     /// Resolves the MIME content type for a file path from its extension, defaulting to

--- a/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
@@ -1,6 +1,5 @@
 using System.Reactive.Linq;
 using MeshWeaver.Mesh;
-using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -12,10 +11,11 @@ namespace MeshWeaver.ContentCollections;
 /// node's target content collection (e.g. <c>content</c>) — collection to collection, no disk staging.
 /// <para>
 /// The request is posted to the OWNING node's hub, the only hub where the per-node <c>content</c>
-/// collection resolves. The whole copy is sealed inside ONE <see cref="IIoPool"/> operation — async
-/// lives only there (the sanctioned boundary), never on the hub action block, which merely subscribes
-/// and returns. The copy is stream-to-stream so binary assets (svg/png) survive intact; the text
-/// content API (<c>IFileContentProvider.GetFileContent</c>) would corrupt them.
+/// collection resolves. The copy composes on the pooled observable <see cref="ContentCollection"/>
+/// surface — async lives only inside the collections' I/O-pool leaves, never on the hub action
+/// block, which merely subscribes and returns. The copy is stream-to-stream so binary assets
+/// (svg/png) survive intact; the text content API (<c>IFileContentProvider.GetFileContent</c>)
+/// would corrupt them.
 /// </para>
 /// Reuse this for the static-repo content sync; do NOT hand-roll a cross-hub write or add a second
 /// <see cref="ImportContentRequest"/> (the type is wire-registered — a duplicate collides).
@@ -52,10 +52,9 @@ public static class ContentImportExtensions
             return delivery.Processed();
         }
 
-        var pool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem)
-                   ?? IoPool.Unbounded;
-        // The hub action block only subscribes + returns; the copy runs on the file-system pool.
-        pool.Run(ct => CopyAsync(contentService, request, ct))
+        // The hub action block only subscribes + returns; every I/O leaf runs on the
+        // collections' own pools — this layer is pure reactive composition.
+        Copy(contentService, request)
             .Subscribe(
                 count => hub.Post(ImportContentResponse.Ok(count), o => o.ResponseFor(delivery)),
                 ex => hub.Post(ImportContentResponse.Fail(ex.Message), o => o.ResponseFor(delivery)));
@@ -63,27 +62,30 @@ public static class ContentImportExtensions
         return delivery.Processed();
     }
 
-    private static async Task<int> CopyAsync(
-        IContentService contentService, ImportContentRequest request, CancellationToken ct)
-    {
-        var source = await contentService.GetCollectionAsync(request.SourceCollection!, ct).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Source content collection '{request.SourceCollection}' not found");
-        var target = await contentService.GetCollectionAsync(request.CollectionName, ct).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Target content collection '{request.CollectionName}' not found");
-
-        var targetDir = (request.TargetPath ?? string.Empty).Trim('/');
-        var count = 0;
-        await foreach (var file in source.GetFiles(request.SourcePath, ct).WithCancellation(ct).ConfigureAwait(false))
-        {
-            var stream = await source.GetContentAsync(file.Path, ct).ConfigureAwait(false);
-            if (stream is null)
-                continue;
-            await using (stream.ConfigureAwait(false))
-                await target.SaveFileAsync(targetDir, file.Name, stream).ConfigureAwait(false);
-            count++;
-        }
-        return count;
-    }
+    private static IObservable<int> Copy(IContentService contentService, ImportContentRequest request)
+        => contentService.GetCollection(request.SourceCollection!)
+            .Select(source => source
+                ?? throw new InvalidOperationException($"Source content collection '{request.SourceCollection}' not found"))
+            .Zip(
+                contentService.GetCollection(request.CollectionName)
+                    .Select(target => target
+                        ?? throw new InvalidOperationException($"Target content collection '{request.CollectionName}' not found")),
+                (source, target) => (source, target))
+            .SelectMany(pair =>
+            {
+                var targetDir = (request.TargetPath ?? string.Empty).Trim('/');
+                // Concat keeps the copies strictly sequential (one file in flight at a time),
+                // matching the previous await-foreach semantics.
+                return pair.source.GetFiles(request.SourcePath)
+                    .Select(file => pair.source.GetContent(file.Path)
+                        .SelectMany(stream => stream is null
+                            ? Observable.Return(0)
+                            : pair.target.SaveFile(targetDir, file.Name, stream)
+                                .Select(_ => 1)
+                                .Finally(stream.Dispose)))
+                    .Concat()
+                    .Sum();
+            });
 }
 
 /// <summary>

--- a/src/MeshWeaver.ContentCollections/ContentLayoutArea.cs
+++ b/src/MeshWeaver.ContentCollections/ContentLayoutArea.cs
@@ -88,8 +88,7 @@ public static class ContentLayoutArea
                                  host.Reference.GetParameterValue("presentation")?.ToLower() == "true";
 
         var articleService = host.Hub.GetContentService();
-        return GetIoPool(host.Hub)
-            .Invoke(ct => articleService.GetCollectionAsync(split[0], ct))
+        return articleService.GetCollection(split[0])
             .SelectMany(collection =>
             {
                 if (collection is null)
@@ -128,17 +127,11 @@ public static class ContentLayoutArea
         if (transformer == null)
             return Observable.Return<UiControl?>(new MarkdownControl($"No converter available for {ext} files"));
 
-        // The file stream + document→markdown transform is ONE pooled async leaf —
-        // async lives only inside the IIoPool bridge, never on the subscribing thread.
-        return ioPool.Invoke<UiControl?>(async ct =>
-            {
-                await using var stream = await collection.GetContentAsync(filePath, ct);
-                if (stream == null)
-                    return new MarkdownControl($"Document not found: {filePath}");
-
-                var markdown = await transformer.TransformToMarkdownAsync(stream, ct);
-                return new MarkdownControl(markdown);
-            })
+        // The file read + document→markdown transform run inside the collection's pooled leaf.
+        return collection.GetContentAsText(filePath, [transformer])
+            .Select(markdown => (UiControl?)(markdown is null
+                ? new MarkdownControl($"Document not found: {filePath}")
+                : new MarkdownControl(markdown)))
             .Catch((Exception ex) => Observable.Return<UiControl?>(
                 new MarkdownControl($"Error converting document {filePath}: {ex.Message}")));
     }
@@ -149,25 +142,23 @@ public static class ContentLayoutArea
         string filePath,
         string extension)
     {
-        // The file stream read + base64 conversion is ONE pooled async leaf.
-        return ioPool.Invoke<UiControl?>(async ct =>
+        // The full file read happens inside the collection's pooled leaf; only the (CPU-cheap)
+        // base64/text conversion runs on the emission.
+        return collection.GetContentBytes(filePath)
+            .Select(bytes =>
             {
-                await using var stream = await collection.GetContentAsync(filePath, ct);
-                if (stream == null)
-                    return new MarkdownControl($"Image not found: {filePath}");
+                if (bytes is null)
+                    return (UiControl?)new MarkdownControl($"Image not found: {filePath}");
 
                 if (extension == ".svg")
                 {
                     // SVG can be embedded as text
-                    using var reader = new StreamReader(stream);
-                    var svgContent = await reader.ReadToEndAsync(ct);
+                    var svgContent = System.Text.Encoding.UTF8.GetString(bytes);
                     return new HtmlControl($"<div class='embedded-svg'>{svgContent}</div>");
                 }
 
                 // For binary images, convert to base64 data URI
-                using var memoryStream = new MemoryStream();
-                await stream.CopyToAsync(memoryStream, ct);
-                var base64 = Convert.ToBase64String(memoryStream.ToArray());
+                var base64 = Convert.ToBase64String(bytes);
                 var mimeType = GetMimeType(extension);
                 var imgHtml = $"<img src='data:{mimeType};base64,{base64}' alt='{Path.GetFileName(filePath)}' style='max-width: 100%;' />";
                 return new HtmlControl(imgHtml);
@@ -307,9 +298,7 @@ public static class ContentLayoutArea
 
         // Get the collection (collectionPart may include @partition)
         var articleService = host.Hub.GetContentService();
-        var ioPool = GetIoPool(host.Hub);
-        return ioPool
-            .Invoke(ct => articleService.GetCollectionAsync(collectionPart, ct))
+        return articleService.GetCollection(collectionPart)
             .SelectMany(collection =>
             {
                 if (collection is null)

--- a/src/MeshWeaver.ContentCollections/ContentService.cs
+++ b/src/MeshWeaver.ContentCollections/ContentService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Reactive.Linq;
 using MeshWeaver.Messaging;
 using MeshWeaver.Reactive;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,8 +18,11 @@ public class ContentService : IContentService
     private readonly IMessageHub hub;
     private readonly AccessService accessService;
     private readonly ConcurrentDictionary<string, ContentCollectionConfig> collectionConfigs;
-    private readonly Dictionary<string, Task<ContentCollection?>> collections = new();
-    private readonly Lock initializeLock = new();
+    // Promise cache: each entry is a ReplaySubject-backed one-shot (ContentCollection.Initialize
+    // via Pool.Run) — the first subscriber triggers creation, every later one replays it.
+    // Values are observables, never resolved single values, so late subscribers and concurrent
+    // first-callers share exactly one initialization.
+    private readonly ConcurrentDictionary<string, IObservable<ContentCollection?>> collections = new();
 
     // Cache for resolved mapped configs
     private readonly ConcurrentDictionary<string, ContentCollectionConfig> resolvedMappedConfigs = new();
@@ -166,32 +170,30 @@ public class ContentService : IContentService
         return resolvedConfig;
     }
 
-    private async Task<ContentCollection?> CreateCollectionAsync(ContentCollectionConfig config, CancellationToken cancellationToken)
+    /// <summary>
+    /// Composes provider creation + collection initialization as a cold observable — no async
+    /// bridging. <see cref="ContentCollection.Initialize"/> is itself the ReplaySubject-backed,
+    /// pool-run promise cache, so the parse runs only when this pipeline is first subscribed.
+    /// </summary>
+    private IObservable<ContentCollection?> CreateCollection(ContentCollectionConfig config)
     {
         var factory = hub.ServiceProvider.GetKeyedService<IStreamProviderFactory>(config.SourceType);
         if (factory is null)
-            throw new ArgumentException($"Unknown source type {config.SourceType}");
+            return Observable.Throw<ContentCollection?>(
+                new ArgumentException($"Unknown source type {config.SourceType}"));
 
-        // Bridge the IObservable<IStreamProvider> into the cached Task<ContentCollection?>
-        // surface via await foreach + early return — this is a one-shot creation, the
-        // Task is the framework's caching boundary (Dictionary<string, Task<...>>).
-        ContentCollection? collection = null;
-        await foreach (var provider in factory.Create(config).ToAsyncEnumerableSequence(cancellationToken))
-        {
-            collection = new ContentCollection(config, provider, hub);
-            await collection.InitializeAsync(cancellationToken);
-            return collection;
-        }
-        return collection;
+        return factory.Create(config)
+            .Take(1)
+            .Select(provider => new ContentCollection(config, provider, hub))
+            .SelectMany(collection => collection.Initialize().Select(_ => (ContentCollection?)collection));
     }
 
-
     /// <inheritdoc />
-    public async Task<ContentCollection?> GetCollectionAsync(string collection, CancellationToken ct)
+    public IObservable<ContentCollection?> GetCollection(string collection)
     {
         // Try local collections first (matches GetCollectionConfig's local-first pattern)
         if (collections.TryGetValue(collection, out var localCollection))
-            return await localCollection;
+            return localCollection;
 
         var config = collectionConfigs.GetValueOrDefault(collection);
         if (config is not null)
@@ -201,45 +203,36 @@ public class ContentService : IContentService
             {
                 config = ResolveMappedConfig(config);
                 if (config == null)
-                    return null;
+                    return Observable.Return<ContentCollection?>(null);
             }
-            return await InitializeCollectionAsync(config, ct);
+            return InitializeCollection(config);
         }
 
         // Delegate to parent if not found locally
         var parent = GetParentContentService();
         if (parent is not null)
-            return await parent.GetCollectionAsync(collection, ct);
+            return parent.GetCollection(collection);
 
-        return null;
+        return Observable.Return<ContentCollection?>(null);
     }
 
-
-    private Task<ContentCollection?> InitializeCollectionAsync(ContentCollectionConfig config, CancellationToken cancellationToken = default)
+    private IObservable<ContentCollection?> InitializeCollection(ContentCollectionConfig config)
     {
-
-        Task<ContentCollection?>? initTask;
-        lock (initializeLock)
-        {
-            if (collections.TryGetValue(config.Name, out var localCollection))
-                return localCollection;
-            collectionConfigs[config.Name] = config;
-            // Check again inside lock
-            if (collections.TryGetValue(config.Name, out var existing))
-                return existing;
-
-            lock (initializeLock)
-            {
-                if (collections.TryGetValue(config.Name, out existing))
-                    return existing;
-
-                // Create a new initialization task
-                initTask = InstantiateCollectionAsync(config, cancellationToken);
-                collections[config.Name] = initTask;
-                return initTask;
-            }
-        }
-
+        collectionConfigs[config.Name] = config;
+        // Per-name single-flight via GetOrAdd; the entry replays creation to every subscriber.
+        // A failed creation logs, evicts its cache entry (so the next access retries with a
+        // fresh pipeline) and resolves null — callers see "collection not found", not a fault
+        // replayed forever.
+        return collections.GetOrAdd(config.Name, name =>
+            CreateCollection(config)
+                .Catch((Exception ex) =>
+                {
+                    logger.LogWarning(ex, "Creating content collection '{Collection}' failed", name);
+                    collections.TryRemove(name, out _);
+                    return Observable.Return<ContentCollection?>(null);
+                })
+                .Replay(1)
+                .AutoConnect(1));
     }
 
     /// <inheritdoc />
@@ -306,42 +299,21 @@ public class ContentService : IContentService
         if (existing != null
             && !string.IsNullOrEmpty(contentCollectionConfig.BasePath)
             && existing.BasePath != contentCollectionConfig.BasePath)
-            this.collections.Remove(name);
-    }
-
-    private Task<ContentCollection?> InstantiateCollectionAsync(ContentCollectionConfig config, CancellationToken cancellationToken)
-    {
-        try
-        {
-            // Use the async factory to create the collection
-            var newCollection = CreateCollectionAsync(config, cancellationToken);
-
-            // Register it
-            collections[config.Name] = newCollection;
-
-            return newCollection;
-        }
-        catch
-        {
-            return Task.FromResult<ContentCollection?>(null);
-        }
-    }
-
-
-
-    /// <inheritdoc />
-    public async Task<Stream?> GetContentAsync(string collection, string path, CancellationToken ct = default)
-    {
-        var coll = await GetCollectionAsync(collection, ct);
-        if (coll == null)
-            throw new ArgumentException($"Collection '{collection}' not found");
-        return await coll.GetContentAsync(path, ct);
+            this.collections.TryRemove(name, out _);
     }
 
     /// <inheritdoc />
-    public IAsyncEnumerable<ContentCollection> GetCollectionsAsync()
-    {
-        return collections.Values.ToAsyncEnumerable().Select(async x => await x).OfType<ContentCollection>();
-    }
+    public IObservable<Stream?> GetContent(string collection, string path)
+        => GetCollection(collection)
+            .SelectMany(coll => coll is null
+                ? Observable.Throw<Stream?>(new ArgumentException($"Collection '{collection}' not found"))
+                : coll.GetContent(path));
+
+    /// <inheritdoc />
+    public IObservable<ContentCollection> GetCollections()
+        => collections.Values.ToArray()
+            .Merge()
+            .Where(c => c is not null)
+            .Select(c => c!);
 
 }

--- a/src/MeshWeaver.ContentCollections/FileContentProvider.cs
+++ b/src/MeshWeaver.ContentCollections/FileContentProvider.cs
@@ -1,21 +1,18 @@
-using System.Text;
+using System.Reactive.Linq;
 using MeshWeaver.Data;
-using MeshWeaver.Mesh.Threading;
 
 namespace MeshWeaver.ContentCollections;
 
 /// <summary>
 /// Implementation of <see cref="IFileContentProvider"/> that uses <see cref="IContentService"/> to access file content.
 /// Automatically converts binary documents (.docx, .pptx, etc.) to markdown via <see cref="IContentTransformer"/>.
-/// All public methods return <see cref="IObservable{T}"/>; the I/O leaf is pushed onto the file-system
-/// <see cref="IIoPool"/> (see <see cref="IoPoolExtensions.Run{T}"/>) so the await continuations resume on the
-/// pool — never on a captured/blocking subscriber scheduler — and cannot deadlock under a blocking consumer.
+/// Pure reactive composition over the (pooled) observable <see cref="ContentCollection"/> surface —
+/// every I/O leaf runs on the collection's own <c>IIoPool</c>, never on the subscriber's thread.
 /// </summary>
 public class FileContentProvider : IFileContentProvider
 {
     private readonly IContentService contentService;
     private readonly IEnumerable<IContentTransformer> transformers;
-    private readonly IIoPool _ioPool;
 
     /// <summary>
     /// Raster image extensions → media type. A file with one of these and no registered
@@ -36,20 +33,16 @@ public class FileContentProvider : IFileContentProvider
         };
 
     /// <summary>
-    /// Initializes the provider with the content service, the available document transformers,
-    /// and the file-system I/O pool used to run file access off the hub.
+    /// Initializes the provider with the content service and the available document transformers.
     /// </summary>
     /// <param name="contentService">The service used to resolve collections and file streams.</param>
     /// <param name="transformers">Transformers that convert binary documents to markdown.</param>
-    /// <param name="ioPoolRegistry">Registry supplying the file-system I/O pool; falls back to an unbounded pool when <c>null</c>.</param>
     public FileContentProvider(
         IContentService contentService,
-        IEnumerable<IContentTransformer> transformers,
-        IoPoolRegistry? ioPoolRegistry = null)
+        IEnumerable<IContentTransformer> transformers)
     {
         this.contentService = contentService;
         this.transformers = transformers;
-        _ioPool = ioPoolRegistry?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
     }
 
     /// <inheritdoc />
@@ -57,180 +50,94 @@ public class FileContentProvider : IFileContentProvider
         string collectionName,
         string filePath,
         int? numberOfRows = null) =>
-        _ioPool.Run(ct => GetFileContentCore(collectionName, filePath, numberOfRows, ct));
-
-    private async Task<FileContentResult> GetFileContentCore(
-        string collectionName,
-        string filePath,
-        int? numberOfRows,
-        CancellationToken ct)
-    {
-        try
-        {
-            var collection = await contentService.GetCollectionAsync(collectionName, ct).ConfigureAwait(false);
-            if (collection == null)
-                return FileContentResult.Fail($"Content collection '{collectionName}' not found");
-
-            var ext = Path.GetExtension(filePath).ToLowerInvariant();
-            var transformer = transformers.FirstOrDefault(t => t.SupportedExtensions.Contains(ext));
-            if (transformer != null)
+        contentService.GetCollection(collectionName)
+            .SelectMany(collection =>
             {
-                await using var stream = await collection.GetContentAsync(filePath, ct).ConfigureAwait(false);
-                if (stream == null)
-                    return FileContentResult.Fail($"File '{filePath}' not found in collection '{collectionName}'");
+                if (collection == null)
+                    return Observable.Return(
+                        FileContentResult.Fail($"Content collection '{collectionName}' not found"));
 
-                var markdown = await transformer.TransformToMarkdownAsync(stream, ct).ConfigureAwait(false);
-                return FileContentResult.Ok(markdown);
-            }
+                var ext = Path.GetExtension(filePath).ToLowerInvariant();
+                var transformer = transformers.FirstOrDefault(t => t.SupportedExtensions.Contains(ext));
+                if (transformer != null)
+                    return collection.GetContentAsText(filePath, [transformer])
+                        .Select(markdown => markdown is null
+                            ? FileContentResult.Fail($"File '{filePath}' not found in collection '{collectionName}'")
+                            : FileContentResult.Ok(markdown));
 
-            if (ImageMediaTypes.TryGetValue(ext, out var imageMediaType))
-            {
-                // A binary image has no text transformer. NEVER decode its bytes as text (issue #379 —
-                // multi-MB of binary floods a model context and fails the next request with 400). Return
-                // a short descriptive placeholder instead. When content indexing is enabled, an AI
-                // description of the image is surfaced through the file's Document node.
-                long? size = null;
-                await using (var probe = await collection.GetContentAsync(filePath, ct).ConfigureAwait(false))
-                {
-                    if (probe == null)
-                        return FileContentResult.Fail($"File '{filePath}' not found in collection '{collectionName}'");
-                    if (probe.CanSeek)
-                        size = probe.Length;
-                }
+                if (ImageMediaTypes.TryGetValue(ext, out var imageMediaType))
+                    // A binary image has no text transformer. NEVER decode its bytes as text (issue #379 —
+                    // multi-MB of binary floods a model context and fails the next request with 400). Return
+                    // a short descriptive placeholder instead. When content indexing is enabled, an AI
+                    // description of the image is surfaced through the file's Document node.
+                    return collection.GetContentSize(filePath)
+                        .Select(size =>
+                        {
+                            if (size is null)
+                                return FileContentResult.Fail($"File '{filePath}' not found in collection '{collectionName}'");
+                            var sizeText = size >= 0 ? $", {size} bytes" : string.Empty;
+                            return FileContentResult.Ok(
+                                $"[image: {Path.GetFileName(filePath)} ({imageMediaType}{sizeText})] "
+                                + "Binary image content is not returned as text. When content indexing is enabled, an "
+                                + "AI-generated description is available on the file's Document node.");
+                        });
 
-                var sizeText = size is { } s ? $", {s} bytes" : string.Empty;
-                return FileContentResult.Ok(
-                    $"[image: {Path.GetFileName(filePath)} ({imageMediaType}{sizeText})] "
-                    + "Binary image content is not returned as text. When content indexing is enabled, an "
-                    + "AI-generated description is available on the file's Document node.");
-            }
-
-            await using var textStream = await collection.GetContentAsync(filePath, ct).ConfigureAwait(false);
-            if (textStream == null)
-                return FileContentResult.Fail($"File '{filePath}' not found in collection '{collectionName}'");
-
-            using var reader = new StreamReader(textStream);
-            string content;
-            if (numberOfRows.HasValue)
-            {
-                var sb = new StringBuilder();
-                var linesRead = 0;
-                while (linesRead < numberOfRows.Value)
-                {
-                    var line = await reader.ReadLineAsync(ct).ConfigureAwait(false);
-                    if (line is null)
-                        break;
-                    sb.AppendLine(line);
-                    linesRead++;
-                }
-                content = sb.ToString();
-            }
-            else
-            {
-                content = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
-            }
-
-            return FileContentResult.Ok(content);
-        }
-        catch (FileNotFoundException)
-        {
-            return FileContentResult.Fail($"File '{filePath}' not found in collection '{collectionName}'");
-        }
-        catch (Exception ex)
-        {
-            return FileContentResult.Fail($"Error accessing file '{filePath}' from collection '{collectionName}': {ex.Message}");
-        }
-    }
+                return collection.GetContentAsText(filePath, null, numberOfRows)
+                    .Select(content => content is null
+                        ? FileContentResult.Fail($"File '{filePath}' not found in collection '{collectionName}'")
+                        : FileContentResult.Ok(content));
+            })
+            .Catch((FileNotFoundException _) => Observable.Return(
+                FileContentResult.Fail($"File '{filePath}' not found in collection '{collectionName}'")))
+            .Catch((Exception ex) => Observable.Return(
+                FileContentResult.Fail($"Error accessing file '{filePath}' from collection '{collectionName}': {ex.Message}")));
 
     /// <inheritdoc />
     public IObservable<FileOperationResult> SaveFileContent(
         string collectionName,
         string filePath,
         Stream content) =>
-        _ioPool.Run(ct => SaveFileContentCore(collectionName, filePath, content, ct));
+        contentService.GetCollection(collectionName)
+            .SelectMany(collection =>
+            {
+                if (collection == null)
+                    return Observable.Return(
+                        FileOperationResult.Fail($"Content collection '{collectionName}' not found"));
 
-    private async Task<FileOperationResult> SaveFileContentCore(
-        string collectionName,
-        string filePath,
-        Stream content,
-        CancellationToken ct)
-    {
-        try
-        {
-            var collection = await contentService.GetCollectionAsync(collectionName, ct).ConfigureAwait(false);
-            if (collection == null)
-                return FileOperationResult.Fail($"Content collection '{collectionName}' not found");
-
-            var directory = Path.GetDirectoryName(filePath)?.Replace('\\', '/') ?? "";
-            var fileName = Path.GetFileName(filePath);
-
-            await collection.SaveFileAsync(directory, fileName, content).ConfigureAwait(false);
-            return FileOperationResult.Ok();
-        }
-        catch (Exception ex)
-        {
-            return FileOperationResult.Fail($"Error saving file '{filePath}' to collection '{collectionName}': {ex.Message}");
-        }
-    }
+                var directory = Path.GetDirectoryName(filePath)?.Replace('\\', '/') ?? "";
+                var fileName = Path.GetFileName(filePath);
+                return collection.SaveFile(directory, fileName, content)
+                    .Select(_ => FileOperationResult.Ok());
+            })
+            .Catch((Exception ex) => Observable.Return(
+                FileOperationResult.Fail($"Error saving file '{filePath}' to collection '{collectionName}': {ex.Message}")));
 
     /// <inheritdoc />
     public IObservable<FileOperationResult> DeleteFile(
         string collectionName,
         string filePath) =>
-        _ioPool.Run(ct => DeleteFileCore(collectionName, filePath, ct));
-
-    private async Task<FileOperationResult> DeleteFileCore(
-        string collectionName,
-        string filePath,
-        CancellationToken ct)
-    {
-        try
-        {
-            var collection = await contentService.GetCollectionAsync(collectionName, ct).ConfigureAwait(false);
-            if (collection == null)
-                return FileOperationResult.Fail($"Content collection '{collectionName}' not found");
-
-            await collection.DeleteFileAsync(filePath).ConfigureAwait(false);
-            return FileOperationResult.Ok();
-        }
-        catch (Exception ex)
-        {
-            return FileOperationResult.Fail($"Error deleting file '{filePath}' from collection '{collectionName}': {ex.Message}");
-        }
-    }
+        contentService.GetCollection(collectionName)
+            .SelectMany(collection => collection == null
+                ? Observable.Return(FileOperationResult.Fail($"Content collection '{collectionName}' not found"))
+                : collection.DeleteFile(filePath).Select(_ => FileOperationResult.Ok()))
+            .Catch((Exception ex) => Observable.Return(
+                FileOperationResult.Fail($"Error deleting file '{filePath}' from collection '{collectionName}': {ex.Message}")));
 
     /// <inheritdoc />
     public IObservable<CollectionListingResult> ListCollectionItems(
         string collectionName,
         string path) =>
-        _ioPool.Run(ct => ListCollectionItemsCore(collectionName, path, ct));
-
-    private async Task<CollectionListingResult> ListCollectionItemsCore(
-        string collectionName,
-        string path,
-        CancellationToken ct)
-    {
-        try
-        {
-            var collection = await contentService.GetCollectionAsync(collectionName, ct).ConfigureAwait(false);
-            if (collection == null)
-                return CollectionListingResult.Fail($"Content collection '{collectionName}' not found");
-
-            var items = new List<CollectionItemInfo>();
-            await foreach (var item in collection.GetCollectionItems(path, ct).ConfigureAwait(false))
-            {
-                items.Add(new CollectionItemInfo(
-                    item.Path,
-                    item.Name,
-                    item is FolderItem,
-                    item is FileItem fileItem ? fileItem.LastModified : null));
-            }
-
-            return CollectionListingResult.Ok(items);
-        }
-        catch (Exception ex)
-        {
-            return CollectionListingResult.Fail($"Error listing collection '{collectionName}' at path '{path}': {ex.Message}");
-        }
-    }
+        contentService.GetCollection(collectionName)
+            .SelectMany(collection => collection == null
+                ? Observable.Return(CollectionListingResult.Fail($"Content collection '{collectionName}' not found"))
+                : collection.GetCollectionItems(path)
+                    .Select(item => new CollectionItemInfo(
+                        item.Path,
+                        item.Name,
+                        item is FolderItem,
+                        item is FileItem fileItem ? fileItem.LastModified : null))
+                    .ToArray()
+                    .Select(items => CollectionListingResult.Ok(items)))
+            .Catch((Exception ex) => Observable.Return(
+                CollectionListingResult.Fail($"Error listing collection '{collectionName}' at path '{path}': {ex.Message}")));
 }

--- a/src/MeshWeaver.ContentCollections/HubStreamProviderFactory.cs
+++ b/src/MeshWeaver.ContentCollections/HubStreamProviderFactory.cs
@@ -30,11 +30,14 @@ public class HubStreamProviderFactory(IMessageHub hub) : IStreamProviderFactory
         var collectionName = config.Settings?.GetValueOrDefault("CollectionName") ?? config.Name;
 
         // Query the remote hub for the collection configuration via GetDataRequest+ContentCollectionReference.
-        var delivery = hub.Post(
-            new GetDataRequest(new ContentCollectionReference([collectionName])),
-            o => o.WithTarget(config.Address))!;
-
-        return hub.Observe(delivery)
+        // 🚨 Canonical observe-BEFORE-post (hub.Observe(request, …) pre-registers the response
+        // callback by message-id, then posts on Subscribe). The previous post-then-Observe(delivery)
+        // shape raced: the Post fired at Create() call time while the callback only registered at
+        // subscription — a fast response landed unobserved and the observable NEVER emitted, which
+        // a promise-cached collection entry then pins forever (silence, not an error).
+        return hub.Observe(
+                new GetDataRequest(new ContentCollectionReference([collectionName])),
+                o => o.WithTarget(config.Address))
             .SelectMany(callbackResponse =>
             {
                 if (callbackResponse.Message is not GetDataResponse responseMsg)

--- a/src/MeshWeaver.ContentCollections/IContentService.cs
+++ b/src/MeshWeaver.ContentCollections/IContentService.cs
@@ -1,27 +1,28 @@
-﻿namespace MeshWeaver.ContentCollections;
+namespace MeshWeaver.ContentCollections;
 
 /// <summary>
 /// Provides access to content collections and their configurations for a hub, including
 /// reading raw file content and resolving collections from the local hub or its parents.
+/// The whole surface is reactive: every method that touches the backing store returns a
+/// (replayed) <see cref="IObservable{T}"/> whose I/O leaf runs on the appropriate
+/// <c>IIoPool</c>, never on the subscriber's thread.
 /// </summary>
 public interface IContentService
 {
     /// <summary>Opens a read stream for a file within a collection.</summary>
     /// <param name="collection">The collection name.</param>
     /// <param name="path">The file path within the collection.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>A readable stream, or <c>null</c> when the file does not exist.</returns>
-    Task<Stream?> GetContentAsync(string collection, string path, CancellationToken ct = default);
+    /// <returns>A single-emission observable of the readable stream, or <c>null</c> when the file does not exist; errors when the collection is unknown.</returns>
+    IObservable<Stream?> GetContent(string collection, string path);
 
-    /// <summary>Enumerates the content collections currently instantiated on this service.</summary>
-    /// <returns>An async sequence of live collections.</returns>
-    IAsyncEnumerable<ContentCollection> GetCollectionsAsync();
+    /// <summary>Emits the content collections whose initialization has been requested on this service.</summary>
+    /// <returns>An observable sequence of the live collections (each entry replays its one-shot initialization).</returns>
+    IObservable<ContentCollection> GetCollections();
 
     /// <summary>Resolves (and lazily instantiates) a collection by name, falling back to parent services.</summary>
     /// <param name="collectionName">The collection name.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The collection, or <c>null</c> when it cannot be found.</returns>
-    Task<ContentCollection?> GetCollectionAsync(string collectionName, CancellationToken ct = default);
+    /// <returns>A single-emission observable of the collection, or <c>null</c> when it cannot be found.</returns>
+    IObservable<ContentCollection?> GetCollection(string collectionName);
 
     /// <summary>Gets the configuration for a collection (resolving mapped configs), or <c>null</c> if unknown.</summary>
     /// <param name="collection">The collection name.</param>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-13-files-tab-reliability.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-13-files-tab-reliability.md
@@ -1,0 +1,12 @@
+---
+Name: File browsing and uploads no longer freeze the page
+Category: What's New
+Description: The Files tab now does all its file work in the background — listing, uploading, creating folders and deleting can no longer stall the page or make files appear to vanish.
+Icon: Sparkle
+---
+
+Uploading and browsing files in a node's **Files** tab is now fully decoupled from the page you are looking at. Previously, listing a folder or saving an upload ran on the same thread that drives your browser session — on hosted deployments, where file storage sits on a network share, a slow moment in storage could freeze the page, drop the connection and make freshly uploaded files look like they had disappeared. The files were always safe on disk; only the view broke.
+
+All file operations — listing folders, opening files, uploading, creating folders and deleting — now run on a dedicated background I/O lane and stream their results to the page as they complete. A slow storage response can no longer block the page, and the file list refreshes itself once an upload finishes.
+
+Uploads are also attributed correctly: the file write and the follow-up indexing run under the account of the person who uploaded, so permissions and activity records reflect the real author.

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -243,14 +243,12 @@ public static class BlazorHostingExtensions
                     return Observable.Return(Results.NotFound("Content service not configured"));
 
                 portalContentService.AddConfiguration(collectionConfig);
-                return (mainHub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded)
-                    .Run(async ct =>
-                    {
-                        var contentCollection = await portalContentService.GetCollectionAsync(qualifiedCollectionName, context.RequestAborted).ConfigureAwait(false);
-                        if (contentCollection == null)
-                            return Results.NotFound($"Content collection '{addressCollectionName}' not found");
-                        return await ServeFile(context, contentCollection, addressFilePath).ConfigureAwait(false);
-                    });
+                // Pure composition — collection resolution and the file read both run on the
+                // collection's own IIoPool; ServeFile only shapes the (already-read) result.
+                return portalContentService.GetCollection(qualifiedCollectionName)
+                    .SelectMany(contentCollection => contentCollection == null
+                        ? Observable.Return(Results.NotFound($"Content collection '{addressCollectionName}' not found"))
+                        : ServeFile(context, contentCollection, addressFilePath));
             });
         });
     }
@@ -276,59 +274,60 @@ public static class BlazorHostingExtensions
             return Results.NotFound("Content service not configured");
         }
 
-        var contentCollection = await contentService.GetCollectionAsync(collectionName, context.RequestAborted);
-        if (contentCollection == null)
-        {
-            return Results.NotFound($"Content collection '{collectionName}' not found");
-        }
-
-        return await ServeFile(context, contentCollection, filePath);
+        // HTTP-boundary await of the composed pipeline — every leaf runs on the collection's pool.
+        return await contentService.GetCollection(collectionName)
+            .SelectMany(contentCollection => contentCollection == null
+                ? Observable.Return(Results.NotFound($"Content collection '{collectionName}' not found"))
+                : ServeFile(context, contentCollection, filePath))
+            .Take(1);
     }
 
     /// <summary>
-    /// Serves a file from a content collection with proper caching headers.
+    /// Serves a file from a content collection with proper caching headers. Composition — every
+    /// read (including the small-file buffering for the ETag hash) runs on the collection's pool;
+    /// this layer only shapes the HTTP result on the emissions.
     /// </summary>
-    private static async Task<IResult> ServeFile(HttpContext context, ContentCollection contentCollection, string filePath)
-    {
-        var stream = await contentCollection.GetContentAsync(filePath, context.RequestAborted);
-        if (stream == null)
-        {
-            return Results.NotFound("File not found");
-        }
+    private static IObservable<IResult> ServeFile(HttpContext context, ContentCollection contentCollection, string filePath)
+        => contentCollection.GetContent(filePath)
+            .SelectMany(stream =>
+            {
+                if (stream == null)
+                    return Observable.Return(Results.NotFound("File not found"));
 
-        var contentType = GetContentType(filePath);
-        var fileName = Path.GetFileName(filePath);
+                var contentType = GetContentType(filePath);
+                var fileName = Path.GetFileName(filePath);
 
-        // Check if download is requested via query parameter
-        var isDownload = context.Request.Query.ContainsKey("download");
-        if (isDownload)
-        {
-            context.Response.Headers.ContentDisposition = $"attachment; filename=\"{fileName}\"";
-        }
+                // Check if download is requested via query parameter
+                var isDownload = context.Request.Query.ContainsKey("download");
+                if (isDownload)
+                    context.Response.Headers.ContentDisposition = $"attachment; filename=\"{fileName}\"";
 
-        // Configure caching headers for small files
-        if (stream.Length < 10_000_000) // Only compute hash for files smaller than 10MB
-        {
-            var cacheDuration = TimeSpan.FromDays(30);
-            context.Response.Headers.CacheControl = $"public, max-age={cacheDuration.TotalSeconds}, immutable";
-            context.Response.Headers.Expires = DateTime.UtcNow.AddDays(30).ToString("R");
+                // Small files: re-read fully buffered through the collection's pooled leaf so the
+                // ETag hash never buffers on this thread.
+                if (stream.CanSeek && stream.Length < 10_000_000) // Only compute hash for files smaller than 10MB
+                {
+                    stream.Dispose();
+                    return contentCollection.GetContentBytes(filePath)
+                        .Select(bytes =>
+                        {
+                            if (bytes is null)
+                                return Results.NotFound("File not found");
+                            var cacheDuration = TimeSpan.FromDays(30);
+                            context.Response.Headers.CacheControl = $"public, max-age={cacheDuration.TotalSeconds}, immutable";
+                            context.Response.Headers.Expires = DateTime.UtcNow.AddDays(30).ToString("R");
+                            var hash = Convert.ToBase64String(System.Security.Cryptography.SHA256.HashData(bytes));
+                            context.Response.Headers.ETag = $"\"{hash}\"";
+                            return Results.File(bytes, contentType, fileName);
+                        });
+                }
 
-            // Add ETag for cache
-            using var ms = new MemoryStream();
-            await stream.CopyToAsync(ms, context.RequestAborted);
-            ms.Position = 0;
-            var hash = Convert.ToBase64String(System.Security.Cryptography.SHA256.HashData(ms.ToArray()));
-            context.Response.Headers.ETag = $"\"{hash}\"";
-            return Results.File(ms.ToArray(), contentType, fileName);
-        }
-
-        // Return the stream directly without loading it all into memory
-        return Results.Stream(
-            stream,
-            contentType,
-            fileName,
-            enableRangeProcessing: true);
-    }
+                // Return the stream directly without loading it all into memory
+                return Observable.Return(Results.Stream(
+                    stream,
+                    contentType,
+                    fileName,
+                    enableRangeProcessing: true));
+            });
 
     /// <summary>
     /// Decodes a collection name from a URL by replacing '~' back to '/'.

--- a/src/MeshWeaver.Import/Configuration/ImportBuilder.cs
+++ b/src/MeshWeaver.Import/Configuration/ImportBuilder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
+using System.Reactive.Linq;
 using System.Reflection;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Data;
@@ -170,7 +171,11 @@ public record ImportBuilder
         if (contentService == null)
             throw new ImportException("IContentService is not registered. Ensure ContentCollections are configured.");
 
-        var stream = await contentService.GetContentAsync(collectionSource.Collection, collectionSource.Path);
+        // The read leaf runs on the collection's IIoPool; this Task-shaped stream-provider leaf
+        // (the import pipeline's own contract, already off the hub) only awaits the replayed
+        // emission — cannot deadlock.
+        var stream = await contentService.GetContent(collectionSource.Collection, collectionSource.Path)
+            .Take(1);
         if (stream == null)
             throw new ImportException($"Could not find content at collection '{collectionSource.Collection}' path '{collectionSource.Path}'");
 

--- a/src/MeshWeaver.Markdown.Export/Branding/BrandingResolver.cs
+++ b/src/MeshWeaver.Markdown.Export/Branding/BrandingResolver.cs
@@ -2,7 +2,6 @@ using System.Reactive.Linq;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Data;
 using MeshWeaver.Mesh;
-using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -21,7 +20,6 @@ public class BrandingResolver
     private readonly IMessageHub hub;
     private readonly ExportTemplateResolver templateResolver;
     private readonly ILogger<BrandingResolver> logger;
-    private readonly IIoPool _ioPool;
 
     /// <summary>
     /// Initializes a new instance of the <c>BrandingResolver</c> class.
@@ -29,20 +27,14 @@ public class BrandingResolver
     /// <param name="hub">Message hub used to read brand mesh nodes and resolve services.</param>
     /// <param name="templateResolver">Resolves export template assets (logo, fonts, DOCX template).</param>
     /// <param name="logger">Logger for resolution warnings and diagnostics.</param>
-    /// <param name="ioPoolRegistry">
-    /// Optional I/O pool registry; the file-system pool drives logo and template loads, falling
-    /// back to the unbounded pool when not supplied.
-    /// </param>
     public BrandingResolver(
         IMessageHub hub,
         ExportTemplateResolver templateResolver,
-        ILogger<BrandingResolver> logger,
-        IoPoolRegistry? ioPoolRegistry = null)
+        ILogger<BrandingResolver> logger)
     {
         this.hub = hub;
         this.templateResolver = templateResolver;
         this.logger = logger;
-        _ioPool = ioPoolRegistry?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
     }
 
     /// <summary>
@@ -88,7 +80,7 @@ public class BrandingResolver
     private IObservable<BrandingOptions> FromCorporateIdentity(CorporateIdentity ci)
     {
         var logoObs = LoadLogo(ci.LogoPath);
-        var templateObs = _ioPool.Run(ct => templateResolver.LoadAsync(ci.TemplatePath, ct));
+        var templateObs = templateResolver.Load(ci.TemplatePath);
 
         return logoObs.Zip(templateObs, (logo, template) => new BrandingOptions
         {
@@ -125,61 +117,45 @@ public class BrandingResolver
         });
     }
 
-    // File-I/O kernel kept as async Task internally — wrapped into IObservable at the
-    // single boundary below. This is the "non-hub I/O" exception per the reactive rules.
-    private IObservable<LogoImage?> LoadLogo(string? path) =>
-        _ioPool.Run(ct => LoadLogoInternalAsync(path, ct));
-
-    private async Task<LogoImage?> LoadLogoInternalAsync(string? path, CancellationToken ct)
+    // Pure reactive composition: the content read runs on the collection's own I/O pool,
+    // and this layer only selects the (CPU-cheap) LogoImage projection on the emission.
+    private IObservable<LogoImage?> LoadLogo(string? path)
     {
         if (string.IsNullOrWhiteSpace(path))
-            return null;
+            return Observable.Return<LogoImage?>(null);
 
-        try
+        // content:... paths and the conventional /static/storage/content/{collection}/{path}
+        // shape both resolve through the content service; anything else is skipped.
+        const string staticPrefix = "/static/storage/content/";
+        var rel = path.StartsWith("content:", StringComparison.OrdinalIgnoreCase)
+            ? path["content:".Length..]
+            : path.StartsWith(staticPrefix, StringComparison.OrdinalIgnoreCase)
+                ? path[staticPrefix.Length..]
+                : null;
+        if (rel is null)
         {
-            // content:... paths go through the content service.
-            if (path.StartsWith("content:", StringComparison.OrdinalIgnoreCase))
-            {
-                var rel = path["content:".Length..];
-                var (collection, subPath) = SplitCollection(rel);
-                var contentSvc = hub.ServiceProvider.GetService<IContentService>();
-                if (contentSvc is null) return null;
-                await using var stream = await contentSvc.GetContentAsync(collection, subPath, ct).ConfigureAwait(false);
-                if (stream is null) return null;
-                using var ms = new MemoryStream();
-                await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
-                return new LogoImage(ms.ToArray(), InferMime(path));
-            }
-
-            // Portal-relative paths like /static/storage/content/Systemorph/logo_t.png
-            // are served by the host; for the export we resolve them via the content service
-            // when they follow the conventional /static/storage/content/{collection}/{path} shape.
-            const string staticPrefix = "/static/storage/content/";
-            if (path.StartsWith(staticPrefix, StringComparison.OrdinalIgnoreCase))
-            {
-                var rel = path[staticPrefix.Length..];
-                var (collection, subPath) = SplitCollection(rel);
-                var contentSvc = hub.ServiceProvider.GetService<IContentService>();
-                if (contentSvc is null) return null;
-                await using var stream = await contentSvc.GetContentAsync(collection, subPath, ct).ConfigureAwait(false);
-                if (stream is null) return null;
-                using var ms = new MemoryStream();
-                await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
-                return new LogoImage(ms.ToArray(), InferMime(path));
-            }
-
             // Unsupported path shape — either an absolute URL or a relative path we can't resolve server-side.
             if (Uri.TryCreate(path, UriKind.Absolute, out _))
                 logger.LogInformation("Logo path '{Path}' is an absolute URL; skipping.", path);
             else
                 logger.LogInformation("Logo path '{Path}' is an unsupported relative path; skipping.", path);
-            return null;
+            return Observable.Return<LogoImage?>(null);
         }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to load logo '{Path}'; continuing without", path);
-            return null;
-        }
+
+        var (collection, subPath) = SplitCollection(rel);
+        var contentSvc = hub.ServiceProvider.GetService<IContentService>();
+        if (contentSvc is null)
+            return Observable.Return<LogoImage?>(null);
+        return contentSvc.GetCollection(collection)
+            .SelectMany(coll => coll is null
+                ? Observable.Return<byte[]?>(null)
+                : coll.GetContentBytes(subPath))
+            .Select(bytes => bytes is null ? null : new LogoImage(bytes, InferMime(path)))
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex, "Failed to load logo '{Path}'; continuing without", path);
+                return Observable.Return<LogoImage?>(null);
+            });
     }
 
     private static (string Collection, string Path) SplitCollection(string rel)

--- a/src/MeshWeaver.Markdown.Export/Branding/ExportTemplateResolver.cs
+++ b/src/MeshWeaver.Markdown.Export/Branding/ExportTemplateResolver.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Reactive.Linq;
 using System.Xml.Linq;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Messaging;
@@ -21,23 +22,22 @@ public class ExportTemplateResolver(IMessageHub hub, ILogger<ExportTemplateResol
     /// <summary>
     /// Loads the template bytes and inspects the inner OpenXML package to pull out the
     /// first embedded raster image (used as a logo) and the major font name.
-    /// Returns null when the path does not resolve.
+    /// Emits null when the path does not resolve. The content read runs on the collection's
+    /// I/O pool; the (pure CPU) package inspection runs on its emission — pure composition,
+    /// no async state machine.
     /// </summary>
-    public async Task<ExportTemplate?> LoadAsync(string? templatePath, CancellationToken ct = default)
+    public IObservable<ExportTemplate?> Load(string? templatePath)
     {
         if (string.IsNullOrWhiteSpace(templatePath))
-            return null;
+            return Observable.Return<ExportTemplate?>(null);
 
-        var bytes = await LoadBytesAsync(templatePath, ct).ConfigureAwait(false);
-        if (bytes is null)
-            return null;
-
-        return InspectBytes(bytes, templatePath, logger);
+        return LoadBytes(templatePath!)
+            .Select(bytes => bytes is null ? null : InspectBytes(bytes, templatePath, logger));
     }
 
     /// <summary>
     /// Pure function: given raw .docx bytes, produce the <see cref="ExportTemplate"/>.
-    /// Exposed for unit tests — production code goes through <see cref="LoadAsync"/>.
+    /// Exposed for unit tests — production code goes through <see cref="Load"/>.
     /// </summary>
     public static ExportTemplate InspectBytes(byte[] bytes, string? sourceLabel = null, ILogger? logger = null)
     {
@@ -121,37 +121,33 @@ public class ExportTemplateResolver(IMessageHub hub, ILogger<ExportTemplateResol
         return null;
     }
 
-    private async Task<byte[]?> LoadBytesAsync(string path, CancellationToken ct)
+    private IObservable<byte[]?> LoadBytes(string path)
     {
-        try
+        const string staticPrefix = "/static/storage/content/";
+        var rel = path.StartsWith("content:", StringComparison.OrdinalIgnoreCase)
+            ? path["content:".Length..]
+            : path.StartsWith(staticPrefix, StringComparison.OrdinalIgnoreCase)
+                ? path[staticPrefix.Length..]
+                : null;
+        if (rel is null)
         {
-            if (path.StartsWith("content:", StringComparison.OrdinalIgnoreCase))
-                return await LoadFromContentAsync(path["content:".Length..], ct).ConfigureAwait(false);
-
-            const string staticPrefix = "/static/storage/content/";
-            if (path.StartsWith(staticPrefix, StringComparison.OrdinalIgnoreCase))
-                return await LoadFromContentAsync(path[staticPrefix.Length..], ct).ConfigureAwait(false);
-
             logger.LogInformation("Template path '{Path}' is not a content path; skipping", path);
-            return null;
+            return Observable.Return<byte[]?>(null);
         }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to load template bytes from '{Path}'; continuing without template", path);
-            return null;
-        }
-    }
 
-    private async Task<byte[]?> LoadFromContentAsync(string rel, CancellationToken ct)
-    {
         var (collection, subPath) = SplitCollection(rel);
         var contentSvc = hub.ServiceProvider.GetService<IContentService>();
-        if (contentSvc is null) return null;
-        await using var stream = await contentSvc.GetContentAsync(collection, subPath, ct).ConfigureAwait(false);
-        if (stream is null) return null;
-        using var ms = new MemoryStream();
-        await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
-        return ms.ToArray();
+        if (contentSvc is null)
+            return Observable.Return<byte[]?>(null);
+        return contentSvc.GetCollection(collection)
+            .SelectMany(coll => coll is null
+                ? Observable.Return<byte[]?>(null)
+                : coll.GetContentBytes(subPath))
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex, "Failed to load template bytes from '{Path}'; continuing without template", path);
+                return Observable.Return<byte[]?>(null);
+            });
     }
 
     private static (string Collection, string Path) SplitCollection(string rel)

--- a/test/MeshWeaver.AI.Test/MeshPluginTest.cs
+++ b/test/MeshWeaver.AI.Test/MeshPluginTest.cs
@@ -658,11 +658,11 @@ public class MeshPluginTest : MonolithMeshTestBase
     {
         var hub = GetContentHub();
         var contentService = hub.ServiceProvider.GetRequiredService<IContentService>();
-        var collection = await contentService.GetCollectionAsync("test-content", TestContext.Current.CancellationToken);
+        var collection = await contentService.GetCollection("test-content").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         collection.Should().NotBeNull();
 
         var ct = TestContext.Current.CancellationToken;
-        var files = await collection!.GetFiles("/", ct).ToListAsync(ct);
+        var files = await collection!.GetFiles("/").ToList().FirstAsync().ToTask(ct);
         files.Should().Contain(f => f.Name == "readme.md");
         files.Should().Contain(f => f.Name == "data.json");
     }
@@ -673,10 +673,10 @@ public class MeshPluginTest : MonolithMeshTestBase
         var hub = GetContentHub();
         var contentService = hub.ServiceProvider.GetRequiredService<IContentService>();
         var ct = TestContext.Current.CancellationToken;
-        var collection = await contentService.GetCollectionAsync("test-content", ct);
+        var collection = await contentService.GetCollection("test-content").FirstAsync().ToTask(ct);
         collection.Should().NotBeNull();
 
-        var folders = await collection!.GetFolders("/", ct).ToListAsync(ct);
+        var folders = await collection!.GetFolders("/").ToList().FirstAsync().ToTask(ct);
         folders.Should().Contain(f => f.Name == "images");
     }
 
@@ -686,10 +686,10 @@ public class MeshPluginTest : MonolithMeshTestBase
         var hub = GetContentHub();
         var contentService = hub.ServiceProvider.GetRequiredService<IContentService>();
         var ct = TestContext.Current.CancellationToken;
-        var collection = await contentService.GetCollectionAsync("test-content", ct);
+        var collection = await contentService.GetCollection("test-content").FirstAsync().ToTask(ct);
         collection.Should().NotBeNull();
 
-        var files = await collection!.GetFiles("/images", ct).ToListAsync(ct);
+        var files = await collection!.GetFiles("/images").ToList().FirstAsync().ToTask(ct);
         files.Should().Contain(f => f.Name == "logo.svg");
     }
 
@@ -698,21 +698,21 @@ public class MeshPluginTest : MonolithMeshTestBase
     {
         var hub = GetContentHub();
         var contentService = hub.ServiceProvider.GetRequiredService<IContentService>();
-        var collection = await contentService.GetCollectionAsync("test-content", TestContext.Current.CancellationToken);
+        var collection = await contentService.GetCollection("test-content").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         collection.Should().NotBeNull();
 
         // Upload a new file
         var content = "uploaded content"u8.ToArray();
         using var stream = new MemoryStream(content);
-        await collection!.SaveFileAsync("/", "uploaded.txt", stream);
+        await collection!.SaveFile("/", "uploaded.txt", stream).ToTask(TestContext.Current.CancellationToken);
 
         // Verify it shows up in browsing
         var ct = TestContext.Current.CancellationToken;
-        var files = await collection.GetFiles("/", ct).ToListAsync(ct);
+        var files = await collection.GetFiles("/").ToList().FirstAsync().ToTask(ct);
         files.Should().Contain(f => f.Name == "uploaded.txt");
 
         // Clean up
-        await collection.DeleteFileAsync("/uploaded.txt");
+        await collection.DeleteFile("/uploaded.txt").ToTask(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -722,7 +722,7 @@ public class MeshPluginTest : MonolithMeshTestBase
         var contentService = hub.ServiceProvider.GetRequiredService<IContentService>();
 
         // Read file content directly via service
-        await using var stream = await contentService.GetContentAsync("test-content", "/readme.md", TestContext.Current.CancellationToken);
+        await using var stream = await contentService.GetContent("test-content", "/readme.md").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         stream.Should().NotBeNull();
 
         using var reader = new StreamReader(stream!);
@@ -737,7 +737,7 @@ public class MeshPluginTest : MonolithMeshTestBase
         var hub = GetContentHub();
         var contentService = hub.ServiceProvider.GetRequiredService<IContentService>();
 
-        await using var stream = await contentService.GetContentAsync("test-content", "/images/logo.svg", TestContext.Current.CancellationToken);
+        await using var stream = await contentService.GetContent("test-content", "/images/logo.svg").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         stream.Should().NotBeNull();
 
         using var reader = new StreamReader(stream!);

--- a/test/MeshWeaver.Content.Test/ContentAutocompleteInChatTest.cs
+++ b/test/MeshWeaver.Content.Test/ContentAutocompleteInChatTest.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using MeshWeaver.Reactive;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.ContentCollections.Completion;
@@ -98,7 +100,7 @@ public class ContentAutocompleteInChatTest(ITestOutputHelper output) : MonolithM
 
         // Verify we can instantiate at least one collection
         var firstConfig = configs.First();
-        var collection = await contentService.GetCollectionAsync(firstConfig.Name);
+        var collection = await contentService.GetCollection(firstConfig.Name).FirstAsync().ToTask();
         collection.Should().NotBeNull($"collection '{firstConfig.Name}' should be instantiatable");
         Output.WriteLine($"Instantiated collection: {collection!.Collection} ({collection.DisplayName})");
     }
@@ -112,10 +114,10 @@ public class ContentAutocompleteInChatTest(ITestOutputHelper output) : MonolithM
         configs.Should().NotBeEmpty();
 
         var firstConfig = configs.First();
-        var collection = await contentService.GetCollectionAsync(firstConfig.Name);
+        var collection = await contentService.GetCollection(firstConfig.Name).FirstAsync().ToTask();
         collection.Should().NotBeNull();
 
-        var files = await collection!.GetFiles("/").ToListAsync(TestContext.Current.CancellationToken);
+        var files = await collection!.GetFiles("/").ToList().FirstAsync().ToTask(TestContext.Current.CancellationToken);
         Output.WriteLine($"Collection '{collection.Collection}' has {files.Count} files:");
         foreach (var f in files.Take(10))
             Output.WriteLine($"  - {f.Path} ({f.Name})");
@@ -137,7 +139,7 @@ public class ContentAutocompleteInChatTest(ITestOutputHelper output) : MonolithM
             var contentService = Mesh.ServiceProvider.GetRequiredService<IContentService>();
             var configs = contentService.GetAllCollectionConfigs();
             configs.Should().NotBeEmpty();
-            var collection = await contentService.GetCollectionAsync(configs.First().Name);
+            var collection = await contentService.GetCollection(configs.First().Name).FirstAsync().ToTask();
             collection.Should().NotBeNull();
             return;
         }
@@ -166,17 +168,17 @@ public class ContentAutocompleteInChatTest(ITestOutputHelper output) : MonolithM
         configs.Should().NotBeEmpty();
 
         var firstConfig = configs.First();
-        var collection = await contentService.GetCollectionAsync(firstConfig.Name);
+        var collection = await contentService.GetCollection(firstConfig.Name).FirstAsync().ToTask();
         collection.Should().NotBeNull();
 
-        var folders = await collection!.GetFolders("/").ToListAsync(TestContext.Current.CancellationToken);
+        var folders = await collection!.GetFolders("/").ToList().FirstAsync().ToTask(TestContext.Current.CancellationToken);
         Output.WriteLine($"Root folders in '{collection.Collection}': {string.Join(", ", folders.Select(f => f.Name))}");
 
         // If there are folders, verify we can browse into them
         if (folders.Count > 0)
         {
             var firstFolder = folders.First();
-            var subItems = await collection.GetCollectionItems($"/{firstFolder.Name}").ToListAsync(TestContext.Current.CancellationToken);
+            var subItems = await collection.GetCollectionItems($"/{firstFolder.Name}").ToList().FirstAsync().ToTask(TestContext.Current.CancellationToken);
             Output.WriteLine($"Items in '{firstFolder.Name}': {subItems.Count}");
             subItems.Should().NotBeNull();
         }
@@ -206,12 +208,12 @@ public class ContentAutocompleteInChatTest(ITestOutputHelper output) : MonolithM
         configs.Should().NotBeEmpty();
 
         var firstConfig = configs.First();
-        var collection = await contentService.GetCollectionAsync(firstConfig.Name);
+        var collection = await contentService.GetCollection(firstConfig.Name).FirstAsync().ToTask();
         collection.Should().NotBeNull();
 
         // After user selects "content:", they should see files and/or folders
-        var files = await collection!.GetFiles("/").ToListAsync(TestContext.Current.CancellationToken);
-        var folders = await collection.GetFolders("/").ToListAsync(TestContext.Current.CancellationToken);
+        var files = await collection!.GetFiles("/").ToList().FirstAsync().ToTask(TestContext.Current.CancellationToken);
+        var folders = await collection.GetFolders("/").ToList().FirstAsync().ToTask(TestContext.Current.CancellationToken);
 
         Output.WriteLine($"Items after '{firstConfig.Name}:' -> {files.Count} files, {folders.Count} folders");
         (files.Count + folders.Count).Should().BeGreaterThan(0,
@@ -228,10 +230,10 @@ public class ContentAutocompleteInChatTest(ITestOutputHelper output) : MonolithM
 
         foreach (var config in configs)
         {
-            var collection = await contentService.GetCollectionAsync(config.Name);
+            var collection = await contentService.GetCollection(config.Name).FirstAsync().ToTask();
             if (collection == null) continue;
 
-            var files = await collection.GetFiles("/").ToListAsync(TestContext.Current.CancellationToken);
+            var files = await collection.GetFiles("/").ToList().FirstAsync().ToTask(TestContext.Current.CancellationToken);
             foreach (var file in files.Take(5))
             {
                 var filePath = file.Path.TrimStart('/');
@@ -254,10 +256,10 @@ public class ContentAutocompleteInChatTest(ITestOutputHelper output) : MonolithM
         var contentService = Mesh.ServiceProvider.GetRequiredService<IContentService>();
         var configs = contentService.GetAllCollectionConfigs();
         var firstConfig = configs.First();
-        var collection = await contentService.GetCollectionAsync(firstConfig.Name);
+        var collection = await contentService.GetCollection(firstConfig.Name).FirstAsync().ToTask();
         collection.Should().NotBeNull();
 
-        var allFiles = await collection!.GetFiles("/").ToListAsync(TestContext.Current.CancellationToken);
+        var allFiles = await collection!.GetFiles("/").ToList().FirstAsync().ToTask(TestContext.Current.CancellationToken);
         if (allFiles.Count == 0)
         {
             Output.WriteLine("No files in collection — skipping filter test");
@@ -285,10 +287,10 @@ public class ContentAutocompleteInChatTest(ITestOutputHelper output) : MonolithM
         var contentService = Mesh.ServiceProvider.GetRequiredService<IContentService>();
         var configs = contentService.GetAllCollectionConfigs();
         var firstConfig = configs.First();
-        var collection = await contentService.GetCollectionAsync(firstConfig.Name);
+        var collection = await contentService.GetCollection(firstConfig.Name).FirstAsync().ToTask();
         collection.Should().NotBeNull();
 
-        var rootFolders = await collection!.GetFolders("/").ToListAsync(TestContext.Current.CancellationToken);
+        var rootFolders = await collection!.GetFolders("/").ToList().FirstAsync().ToTask(TestContext.Current.CancellationToken);
         if (rootFolders.Count == 0)
         {
             Output.WriteLine("No folders in root — skipping scoping test");
@@ -296,8 +298,8 @@ public class ContentAutocompleteInChatTest(ITestOutputHelper output) : MonolithM
         }
 
         var folder = rootFolders.First();
-        var subFiles = await collection.GetFiles($"/{folder.Name}").ToListAsync(TestContext.Current.CancellationToken);
-        var subFolders = await collection.GetFolders($"/{folder.Name}").ToListAsync(TestContext.Current.CancellationToken);
+        var subFiles = await collection.GetFiles($"/{folder.Name}").ToList().FirstAsync().ToTask(TestContext.Current.CancellationToken);
+        var subFolders = await collection.GetFolders($"/{folder.Name}").ToList().FirstAsync().ToTask(TestContext.Current.CancellationToken);
 
         Output.WriteLine($"Browsing '{folder.Name}/': {subFiles.Count} files, {subFolders.Count} folders");
 

--- a/test/MeshWeaver.Content.Test/ContentCollectionReferenceTest.cs
+++ b/test/MeshWeaver.Content.Test/ContentCollectionReferenceTest.cs
@@ -387,11 +387,11 @@ public class ContentCollectionReferenceTest(ITestOutputHelper output) : Monolith
         Output.WriteLine($"Added Systemorph config with qualified name: {systemorphQualifiedConfig.Name}");
 
         // Verify we can get both collections separately
-        var acmeCollection = await MeshWeaver.Mesh.Threading.IoPool.Unbounded.Invoke(ct => contentService.GetCollectionAsync($"{acmeAddress}/attachments", ct)).Should().Emit();
+        var acmeCollection = await contentService.GetCollection($"{acmeAddress}/attachments").Should().Emit();
         acmeCollection.Should().NotBeNull("ACME attachments collection should be retrievable");
         Output.WriteLine($"ACME collection retrieved: {acmeCollection?.Collection}");
 
-        var systemorphCollection = await MeshWeaver.Mesh.Threading.IoPool.Unbounded.Invoke(ct => contentService.GetCollectionAsync($"{systemorphAddress}/attachments", ct)).Should().Emit();
+        var systemorphCollection = await contentService.GetCollection($"{systemorphAddress}/attachments").Should().Emit();
         systemorphCollection.Should().NotBeNull("Systemorph attachments collection should be retrievable");
         Output.WriteLine($"Systemorph collection retrieved: {systemorphCollection?.Collection}");
 

--- a/test/MeshWeaver.ContentCollections.Indexing.Graph.Test/ContentIndexingPipelineTest.cs
+++ b/test/MeshWeaver.ContentCollections.Indexing.Graph.Test/ContentIndexingPipelineTest.cs
@@ -67,16 +67,17 @@ public class ContentIndexingPipelineTest(ITestOutputHelper output) : MonolithMes
 
     private static string Sha256Hex(byte[] bytes) => Convert.ToHexStringLower(SHA256.HashData(bytes));
 
-    /// <summary>Saves a file into the collection exactly as the upload handler does (via the collection's SaveFileAsync).</summary>
+    /// <summary>Saves a file into the collection exactly as the upload handler does (via the collection's SaveFile).</summary>
     private async Task SaveFile(string filePath, byte[] bytes)
     {
         var contentService = Mesh.ServiceProvider.GetRequiredService<IContentService>();
-        var collection = await contentService.GetCollectionAsync(Collection, TestContext.Current.CancellationToken);
+        var collection = await contentService.GetCollection(Collection)
+            .FirstAsync().ToTask(TestContext.Current.CancellationToken);
         collection.Should().NotBeNull();
         var dir = Path.GetDirectoryName(filePath)?.Replace('\\', '/') ?? "";
         var fileName = Path.GetFileName(filePath);
         using var ms = new MemoryStream(bytes);
-        await collection!.SaveFileAsync(dir, fileName, ms);
+        await collection!.SaveFile(dir, fileName, ms).ToTask(TestContext.Current.CancellationToken);
     }
 
     /// <summary>Reads the Document node back, polling until the typed content lands (write is debounced/persisted).</summary>

--- a/test/MeshWeaver.ContentCollections.Test/ContentCollectionWriteIngestTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/ContentCollectionWriteIngestTest.cs
@@ -21,7 +21,7 @@ namespace MeshWeaver.ContentCollections.Test;
 ///
 /// <para>Here the watcher is NEUTERED (<see cref="NoMonitorProvider"/> never fires
 /// <c>onChanged</c>), so the article can only reach <c>markdownStream</c> via
-/// <see cref="ContentCollection.SaveFileAsync"/>'s proactive ingest. This makes the guarantee
+/// <see cref="ContentCollection.SaveFile"/>'s proactive ingest. This makes the guarantee
 /// deterministic and OS-independent: without the ingest the read never resolves (fails fast at the
 /// 10s timeout instead of flaking); with it the article is readable at once.</para>
 /// </summary>
@@ -31,7 +31,7 @@ public class ContentCollectionWriteIngestTest(ITestOutputHelper output) : HubTes
         => base.ConfigureHost(configuration).AddContentCollections();
 
     [Fact]
-    public async Task SaveFileAsync_ingests_the_article_without_the_watcher()
+    public async Task SaveFile_ingests_the_article_without_the_watcher()
     {
         var ct = TestContext.Current.CancellationToken;
         var dir = Path.Combine(AppContext.BaseDirectory, "Files", "WriteIngest", Guid.NewGuid().ToString("N"));
@@ -47,13 +47,13 @@ public class ContentCollectionWriteIngestTest(ITestOutputHelper output) : HubTes
             },
             new NoMonitorProvider(new FileSystemStreamProvider(dir)),
             GetHost());
-        await collection.InitializeAsync(ct);
+        await collection.Initialize().FirstAsync().ToTask(ct);
 
         // Write into a NESTED, freshly-created subdirectory — the exact shape whose inotify event
         // the Linux runner dropped. With the watcher neutered this can ONLY resolve via the
         // collection's own proactive ingest on write.
         using (var stream = new MemoryStream("# Hello ingest"u8.ToArray()))
-            await collection.SaveFileAsync("/sub", "hello.md", stream);
+            await collection.SaveFile("/sub", "hello.md", stream).ToTask(ct);
 
         // GetMarkdown is the SAME content read the file render uses (ContentLayoutArea.RenderFile).
         // Without the fix this stays null (the watcher never fires) and the wait times out — the

--- a/test/MeshWeaver.ContentCollections.Test/ContentServiceDelegationTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/ContentServiceDelegationTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using MeshWeaver.Fixture;
 using MeshWeaver.Messaging;
@@ -51,7 +53,7 @@ public class ContentServiceDelegationTest(ITestOutputHelper output) : HubTestBas
             Output.WriteLine($"    Has ContentService: {cs != null}");
             if (cs != null)
             {
-                var colls = await cs.GetCollectionsAsync().ToArrayAsync(TestContext.Current.CancellationToken);
+                var colls = await cs.GetCollections().ToArray().FirstAsync().ToTask(TestContext.Current.CancellationToken);
                 Output.WriteLine($"    Collections: {string.Join(", ", colls.Select(c => c.Collection))}");
             }
             Output.WriteLine($"    ParentHub: {current.Configuration.ParentHub?.Address}");
@@ -71,34 +73,34 @@ public class ContentServiceDelegationTest(ITestOutputHelper output) : HubTestBas
         Output.WriteLine($"ContentServices are same: {ReferenceEquals(parentContentService, childContentService)}");
 
         // Debug: Check what collections each service has
-        var parentCollections = await parentContentService.GetCollectionsAsync().ToArrayAsync(TestContext.Current.CancellationToken);
-        var childCollections = await childContentService.GetCollectionsAsync().ToArrayAsync(TestContext.Current.CancellationToken);
+        var parentCollections = await parentContentService.GetCollections().ToArray().FirstAsync().ToTask(TestContext.Current.CancellationToken);
+        var childCollections = await childContentService.GetCollections().ToArray().FirstAsync().ToTask(TestContext.Current.CancellationToken);
         Output.WriteLine($"Parent content service has {parentCollections.Length} collections: {string.Join(", ", parentCollections.Select(c => c.Collection))}");
         Output.WriteLine($"Child content service has {childCollections.Length} collections: {string.Join(", ", childCollections.Select(c => c.Collection))}");
 
         // Act & Assert - Parent hub can only reach ParentCollection
-        var parentCollectionFromParent = await parentContentService.GetCollectionAsync("ParentCollection", TestContext.Current.CancellationToken);
+        var parentCollectionFromParent = await parentContentService.GetCollection("ParentCollection").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         Output.WriteLine($"Parent collection from parent: {parentCollectionFromParent?.Collection}");
         parentCollectionFromParent.Should().NotBeNull("parent hub should have ParentCollection");
 
-        var childCollectionFromParent = await parentContentService.GetCollectionAsync("ChildCollection", TestContext.Current.CancellationToken);
+        var childCollectionFromParent = await parentContentService.GetCollection("ChildCollection").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         Output.WriteLine($"Child collection from parent: {childCollectionFromParent?.Collection}");
         childCollectionFromParent.Should().BeNull("parent hub should NOT have ChildCollection");
 
         // Act & Assert - Child hub can reach both collections
         Output.WriteLine($"About to get ParentCollection from child...");
-        var parentCollectionFromChild = await childContentService.GetCollectionAsync("ParentCollection", TestContext.Current.CancellationToken);
+        var parentCollectionFromChild = await childContentService.GetCollection("ParentCollection").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         Output.WriteLine($"Parent collection from child: {parentCollectionFromChild?.Collection}");
         Output.WriteLine($"  Got from child, hash: {parentCollectionFromChild?.GetHashCode()}");
 
         // Also try getting it directly from parent to compare
-        var directFromParent = await parentContentService.GetCollectionAsync("ParentCollection", TestContext.Current.CancellationToken);
+        var directFromParent = await parentContentService.GetCollection("ParentCollection").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         Output.WriteLine($"  Got directly from parent, hash: {directFromParent?.GetHashCode()}");
         Output.WriteLine($"  Are they the same: {ReferenceEquals(parentCollectionFromChild, directFromParent)}");
 
         parentCollectionFromChild.Should().NotBeNull("child hub should have ParentCollection via delegation");
 
-        var childCollectionFromChild = await childContentService.GetCollectionAsync("ChildCollection", TestContext.Current.CancellationToken);
+        var childCollectionFromChild = await childContentService.GetCollection("ChildCollection").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         childCollectionFromChild.Should().NotBeNull("child hub should have its own ChildCollection");
 
         // Debug: Check instance details
@@ -111,7 +113,7 @@ public class ContentServiceDelegationTest(ITestOutputHelper output) : HubTestBas
             "child hub should get a ParentCollection with the same name as parent's");
 
         // Act & Assert - Verify we can actually read content from the collections
-        var parentContent = await parentContentService.GetContentAsync("ParentCollection", "test.txt", TestContext.Current.CancellationToken);
+        var parentContent = await parentContentService.GetContent("ParentCollection", "test.txt").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         parentContent.Should().NotBeNull("parent collection should have test.txt");
         using (var reader = new StreamReader(parentContent!))
         {
@@ -119,7 +121,7 @@ public class ContentServiceDelegationTest(ITestOutputHelper output) : HubTestBas
             content.Should().Contain("Parent collection test file");
         }
 
-        var childContent = await childContentService.GetContentAsync("ChildCollection", "test.txt", TestContext.Current.CancellationToken);
+        var childContent = await childContentService.GetContent("ChildCollection", "test.txt").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         childContent.Should().NotBeNull("child collection should have test.txt");
         using (var reader = new StreamReader(childContent!))
         {
@@ -128,7 +130,7 @@ public class ContentServiceDelegationTest(ITestOutputHelper output) : HubTestBas
         }
 
         // Act & Assert - Child can read parent's files via delegation
-        var parentContentFromChild = await childContentService.GetContentAsync("ParentCollection", "test.txt", TestContext.Current.CancellationToken);
+        var parentContentFromChild = await childContentService.GetContent("ParentCollection", "test.txt").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         parentContentFromChild.Should().NotBeNull("child should be able to read from ParentCollection via delegation");
         using (var reader = new StreamReader(parentContentFromChild!))
         {

--- a/test/MeshWeaver.ContentCollections.Test/NodeHubContentCollectionTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/NodeHubContentCollectionTest.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using MeshWeaver.Fixture;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Client;
@@ -83,7 +85,7 @@ public class NodeHubContentCollectionTest(ITestOutputHelper output) : HubTestBas
         var hub = GetClient();
         var contentService = hub.ServiceProvider.GetRequiredService<IContentService>();
 
-        var collection = await contentService.GetCollectionAsync("content", TestContext.Current.CancellationToken);
+        var collection = await contentService.GetCollection("content").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         collection.Should().NotBeNull("content collection should resolve to a usable IContentCollection");
     }
 
@@ -93,21 +95,21 @@ public class NodeHubContentCollectionTest(ITestOutputHelper output) : HubTestBas
         var hub = GetClient();
         var contentService = hub.ServiceProvider.GetRequiredService<IContentService>();
 
-        var collection = await contentService.GetCollectionAsync("content", TestContext.Current.CancellationToken);
+        var collection = await contentService.GetCollection("content").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         collection.Should().NotBeNull();
 
         // Create a test file
         var testContent = "Hello from unit test"u8.ToArray();
         using var stream = new MemoryStream(testContent);
-        await collection!.SaveFileAsync("/", "test.txt", stream);
+        await collection!.SaveFile("/", "test.txt", stream).ToTask(TestContext.Current.CancellationToken);
 
         // Verify it was saved
         var ct = TestContext.Current.CancellationToken;
-        var items = await collection.GetCollectionItems("/", ct).ToListAsync(ct);
+        var items = await collection.GetCollectionItems("/").ToList().FirstAsync().ToTask(ct);
         items.Should().Contain(i => i.Name == "test.txt");
 
         // Clean up
-        await collection.DeleteFileAsync("/test.txt");
+        await collection.DeleteFile("/test.txt").ToTask(ct);
     }
 
     [Fact]
@@ -155,13 +157,13 @@ public class NodeHubContentCollectionTest(ITestOutputHelper output) : HubTestBas
         var client = GetClient();
         var contentService = client.ServiceProvider.GetRequiredService<IContentService>();
         var ct = TestContext.Current.CancellationToken;
-        var collection = await contentService.GetCollectionAsync("content", ct);
+        var collection = await contentService.GetCollection("content").FirstAsync().ToTask(ct);
         collection.Should().NotBeNull();
 
         // A nested file so folder and file rendering are distinguishable.
         var bytes = "# Hello from the collection area"u8.ToArray();
         using (var stream = new MemoryStream(bytes))
-            await collection!.SaveFileAsync("/sub", "hello.md", stream);
+            await collection!.SaveFile("/sub", "hello.md", stream).ToTask(ct);
 
         try
         {
@@ -192,7 +194,7 @@ public class NodeHubContentCollectionTest(ITestOutputHelper output) : HubTestBas
         }
         finally
         {
-            await collection!.DeleteFileAsync("/sub/hello.md");
+            await collection!.DeleteFile("/sub/hello.md").ToTask(ct);
         }
     }
 
@@ -211,14 +213,14 @@ public class NodeHubContentCollectionTest(ITestOutputHelper output) : HubTestBas
         var client = GetClient();
         var contentService = client.ServiceProvider.GetRequiredService<IContentService>();
         var ct = TestContext.Current.CancellationToken;
-        var collection = await contentService.GetCollectionAsync("content", ct);
+        var collection = await contentService.GetCollection("content").FirstAsync().ToTask(ct);
         collection.Should().NotBeNull();
 
         // A folder AND a file whose names both contain a space — the exact shape the browser
         // percent-encodes into "Data%20Extraction/my%20report.md".
         var bytes = "# Quarterly report with a space in its name"u8.ToArray();
         using (var stream = new MemoryStream(bytes))
-            await collection!.SaveFileAsync("/Data Extraction", "my report.md", stream);
+            await collection!.SaveFile("/Data Extraction", "my report.md", stream).ToTask(ct);
 
         try
         {
@@ -261,7 +263,7 @@ public class NodeHubContentCollectionTest(ITestOutputHelper output) : HubTestBas
         }
         finally
         {
-            await collection!.DeleteFileAsync("/Data Extraction/my report.md");
+            await collection!.DeleteFile("/Data Extraction/my report.md").ToTask(ct);
         }
     }
 }

--- a/test/MeshWeaver.ContentCollections.Test/ObservableCollectionSurfaceTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/ObservableCollectionSurfaceTest.cs
@@ -1,0 +1,190 @@
+using System.Collections.Immutable;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Test;
+
+/// <summary>
+/// Pins the observable, pooled <see cref="ContentCollection"/> surface — the contract the
+/// FileBrowser "files disappeared" incident (2026-07-12) exposed as untested:
+/// <list type="number">
+///   <item><b>Upload → list → read</b> works end-to-end through the observable surface: a file
+///     saved via <see cref="ContentCollection.SaveFile"/> is visible in the very next
+///     <see cref="ContentCollection.GetCollectionItems"/> listing and readable via
+///     <see cref="ContentCollection.GetContentBytes"/>.</item>
+///   <item><b>The I/O leaves run OFF the subscriber's thread</b> — the provider is never entered
+///     on the thread that subscribes (a Blazor circuit / hub action block stand-in). This is what
+///     keeps a slow SMB mount from blocking the circuit.</item>
+///   <item><b>The caller's <see cref="AccessContext"/> crosses the pool hop</b>: the write leaf
+///     observes the identity that was ambient when <c>SaveFile</c> was CALLED, not an empty
+///     pool-thread context.</item>
+/// </list>
+/// </summary>
+public class ObservableCollectionSurfaceTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration).AddContentCollections();
+
+    private ContentCollection CreateCollection(out CapturingProvider provider)
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "Files", "ObservableSurface", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        provider = new CapturingProvider(new FileSystemStreamProvider(dir), GetHost());
+        return new ContentCollection(
+            new ContentCollectionConfig
+            {
+                Name = "content",
+                SourceType = "FileSystem",
+                IsEditable = true,
+                BasePath = dir,
+            },
+            provider,
+            GetHost());
+    }
+
+    [Fact]
+    public async Task Upload_then_list_then_read_roundtrips_through_the_observable_surface()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var collection = CreateCollection(out _);
+        await collection.Initialize().FirstAsync().ToTask(ct);
+
+        using (var stream = new MemoryStream("hello files"u8.ToArray()))
+            await collection.SaveFile("/", "hello.txt", stream).ToTask(ct);
+
+        // The very next listing must show the uploaded file — this is the FileBrowser
+        // refresh-after-upload path that had no test when the Files tab "lost" uploads.
+        var items = await collection.GetCollectionItems("/").ToList().FirstAsync().ToTask(ct);
+        items.Should().Contain(i => i.Name == "hello.txt",
+            "a file saved through the collection must be visible in the immediately following listing");
+
+        var bytes = await collection.GetContentBytes("/hello.txt").FirstAsync().ToTask(ct);
+        bytes.Should().NotBeNull();
+        System.Text.Encoding.UTF8.GetString(bytes!).Should().Be("hello files");
+
+        var size = await collection.GetContentSize("/hello.txt").FirstAsync().ToTask(ct);
+        size.Should().Be((long)bytes!.Length);
+
+        await collection.DeleteFile("/hello.txt").ToTask(ct);
+        var afterDelete = await collection.GetCollectionItems("/").ToList().FirstAsync().ToTask(ct);
+        afterDelete.Should().NotContain(i => i.Name == "hello.txt");
+    }
+
+    [Fact]
+    public async Task Provider_leaves_never_run_on_the_subscribing_thread()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var collection = CreateCollection(out var provider);
+        await collection.Initialize().FirstAsync().ToTask(ct);
+
+        // Subscribe from a DEDICATED thread and BLOCK it until the pipeline completes. This pins
+        // the decoupling property that broke in prod: a subscriber that blocks its own thread (a
+        // Blazor circuit stand-in) must never deadlock the leaf, because the leaf runs on the
+        // I/O pool. A dedicated thread's id can never coincide with a pool thread's while alive,
+        // so the thread-inequality assertion is race-free (an awaiting xUnit thread would not be —
+        // the ThreadPool may reuse it for the leaf).
+        var subscriberThread = 0;
+        Exception? error = null;
+        var thread = new Thread(() =>
+        {
+            subscriberThread = Environment.CurrentManagedThreadId;
+            try
+            {
+                collection.SaveFile("/", "pooled.txt", () => new MemoryStream("pooled"u8.ToArray())).Wait();
+                collection.GetCollectionItems("/").ToList().Wait();
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+            }
+        });
+        thread.Start();
+        thread.Join(TimeSpan.FromSeconds(30)).Should().BeTrue(
+            "a blocking subscriber must never deadlock the pooled leaves");
+        error.Should().BeNull();
+
+        provider.SaveThreadId.Should().NotBeNull();
+        provider.SaveThreadId.Should().NotBe(subscriberThread,
+            "the write leaf must run on the I/O pool, never the subscriber's thread (a blocked "
+            + "circuit was the 'files disappeared' SignalR flapping)");
+        provider.ListThreadId.Should().NotBeNull();
+        provider.ListThreadId.Should().NotBe(subscriberThread,
+            "the listing leaf must run on the I/O pool, never the subscriber's thread");
+    }
+
+    [Fact]
+    public async Task SaveFile_carries_the_callers_AccessContext_across_the_pool_hop()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var collection = CreateCollection(out var provider);
+        await collection.Initialize().FirstAsync().ToTask(ct);
+
+        var accessService = GetHost().ServiceProvider.GetRequiredService<AccessService>();
+        var caller = new AccessContext { ObjectId = "test-user-object-id", Name = "Test User" };
+
+        using (accessService.SwitchAccessContext(caller))
+        using (var stream = new MemoryStream("who am I"u8.ToArray()))
+            await collection.SaveFile("/", "identity.txt", stream).ToTask(ct);
+
+        provider.SaveAccessContext.Should().NotBeNull(
+            "the caller's AccessContext snapshot must be re-established inside the pool leaf — "
+            + "the AsyncLocal is wiped by the pool hop otherwise");
+        provider.SaveAccessContext!.ObjectId.Should().Be("test-user-object-id",
+            "the write must stay attributed to the CALLING user, not the pool thread's ambient identity");
+    }
+
+    /// <summary>
+    /// Delegates to a real provider while capturing, per operation, the managed thread id and the
+    /// ambient <see cref="AccessContext"/> at the moment the leaf executes.
+    /// </summary>
+    private sealed class CapturingProvider(IStreamProvider inner, IMessageHub hub) : IStreamProvider
+    {
+        private AccessService? AccessService => hub.ServiceProvider.GetService<AccessService>();
+
+        public int? SaveThreadId { get; private set; }
+        public int? ListThreadId { get; private set; }
+        public AccessContext? SaveAccessContext { get; private set; }
+
+        public string ProviderType => inner.ProviderType;
+        public IDisposable? AttachMonitor(Action<string> onChanged) => Disposable.Empty;
+
+        public Task<Stream?> GetStreamAsync(string reference, CancellationToken ct = default)
+            => inner.GetStreamAsync(reference, ct);
+        public Task<(Stream? Stream, string Path, DateTime LastModified)> GetStreamWithMetadataAsync(
+            string path, CancellationToken ct = default) => inner.GetStreamWithMetadataAsync(path, ct);
+        public Task WriteStreamAsync(string reference, Stream content, CancellationToken ct = default)
+            => inner.WriteStreamAsync(reference, content, ct);
+        public IAsyncEnumerable<(Stream? Stream, string Path, DateTime LastModified)> GetStreamsAsync(
+            Func<string, bool> filter, CancellationToken ct = default) => inner.GetStreamsAsync(filter, ct);
+
+        public IAsyncEnumerable<FolderItem> GetFolders(string path, CancellationToken ct = default)
+        {
+            ListThreadId = Environment.CurrentManagedThreadId;
+            return inner.GetFolders(path, ct);
+        }
+
+        public IAsyncEnumerable<FileItem> GetFiles(string path, CancellationToken ct = default)
+        {
+            ListThreadId = Environment.CurrentManagedThreadId;
+            return inner.GetFiles(path, ct);
+        }
+
+        public Task SaveFileAsync(string path, string fileName, Stream content, CancellationToken ct = default)
+        {
+            SaveThreadId = Environment.CurrentManagedThreadId;
+            SaveAccessContext = AccessService?.Context;
+            return inner.SaveFileAsync(path, fileName, content, ct);
+        }
+
+        public Task CreateFolderAsync(string folderPath) => inner.CreateFolderAsync(folderPath);
+        public Task DeleteFolderAsync(string folderPath) => inner.DeleteFolderAsync(folderPath);
+        public Task DeleteFileAsync(string filePath) => inner.DeleteFileAsync(filePath);
+        public Task<ImmutableDictionary<string, Author>> LoadAuthorsAsync(CancellationToken ct = default)
+            => inner.LoadAuthorsAsync(ct);
+    }
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/ContentPathDecodingTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/ContentPathDecodingTest.cs
@@ -1,5 +1,7 @@
 using System.IO;
 using System.Text;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using MeshWeaver.ContentCollections;
 using MeshWeaver.Fixture;
 using MeshWeaver.Messaging;
@@ -55,7 +57,7 @@ public class ContentPathDecodingTest(ITestOutputHelper output) : HubTestBase(out
         await File.WriteAllBytesAsync(fullPath, pdfBytes, TestContext.Current.CancellationToken);
 
         var contentService = Mesh.ServiceProvider.GetRequiredService<IContentService>();
-        var collection = await contentService.GetCollectionAsync("content", TestContext.Current.CancellationToken);
+        var collection = await contentService.GetCollection("content").FirstAsync().ToTask(TestContext.Current.CancellationToken);
         collection.Should().NotBeNull();
 
         // The path as it reaches the /static/{**path} endpoint: each segment percent-encoded
@@ -63,7 +65,7 @@ public class ContentPathDecodingTest(ITestOutputHelper output) : HubTestBase(out
         var encodedPath = "Reports/Data%20Extraction/%C3%9Cbersicht%202025.pdf";
 
         // Act 1 — the raw encoded path misses (this is the reported bug).
-        await using (var missed = await collection!.GetContentAsync(encodedPath, TestContext.Current.CancellationToken))
+        await using (var missed = await collection!.GetContent(encodedPath).FirstAsync().ToTask(TestContext.Current.CancellationToken))
         {
             missed.Should().BeNull("the percent-encoded path does not match the stored file — this is the #326 defect");
         }
@@ -73,7 +75,7 @@ public class ContentPathDecodingTest(ITestOutputHelper output) : HubTestBase(out
         decodedPath.Should().Be(storedPath);
 
         // ...and the decoded path resolves the file with its bytes intact.
-        await using var stream = await collection.GetContentAsync(decodedPath, TestContext.Current.CancellationToken);
+        await using var stream = await collection.GetContent(decodedPath).FirstAsync().ToTask(TestContext.Current.CancellationToken);
         stream.Should().NotBeNull("the decoded path matches the stored file");
         using var ms = new MemoryStream();
         await stream!.CopyToAsync(ms, TestContext.Current.CancellationToken);

--- a/test/MeshWeaver.Persistence.Test/MapContentCollectionTest.cs
+++ b/test/MeshWeaver.Persistence.Test/MapContentCollectionTest.cs
@@ -216,13 +216,13 @@ public class MapContentCollectionTest(ITestOutputHelper output) : MonolithMeshTe
 
         // Act - get the content collection and read the file via mapped name
         var contentService = client.ServiceProvider.GetRequiredService<IContentService>();
-        var collection = await contentService.GetCollectionAsync("content", TestContext.Current.CancellationToken);
+        var collection = await contentService.GetCollection("content").FirstAsync().ToTask(TestContext.Current.CancellationToken);
 
         collection.Should().NotBeNull("Content collection should be resolved");
 
         // Read "logo.svg" via the mapped "content" collection
         // This should resolve to TestStorage:images/logo.svg
-        await using var stream = await collection!.GetContentAsync("logo.svg", TestContext.Current.CancellationToken);
+        await using var stream = await collection!.GetContent("logo.svg").FirstAsync().ToTask(TestContext.Current.CancellationToken);
 
         stream.Should().NotBeNull("Content should be found via mapped path");
 
@@ -257,12 +257,12 @@ public class MapContentCollectionTest(ITestOutputHelper output) : MonolithMeshTe
 
         // Act - read nested file via mapped collection
         var contentService = client.ServiceProvider.GetRequiredService<IContentService>();
-        var collection = await contentService.GetCollectionAsync("content", TestContext.Current.CancellationToken);
+        var collection = await contentService.GetCollection("content").FirstAsync().ToTask(TestContext.Current.CancellationToken);
 
         collection.Should().NotBeNull();
 
         // Access "icons/app.txt" which should resolve to "TestStorage:media/icons/app.txt"
-        await using var stream = await collection!.GetContentAsync("icons/app.txt", TestContext.Current.CancellationToken);
+        await using var stream = await collection!.GetContent("icons/app.txt").FirstAsync().ToTask(TestContext.Current.CancellationToken);
 
         stream.Should().NotBeNull("Nested content should be found via mapped path");
 
@@ -297,12 +297,12 @@ public class MapContentCollectionTest(ITestOutputHelper output) : MonolithMeshTe
         // Act - get the content service and try to resolve "logo.svg" directly
         // This simulates what happens when UCR parses "content:logo.svg" (no slash)
         var contentService = client.ServiceProvider.GetRequiredService<IContentService>();
-        var collection = await contentService.GetCollectionAsync("content", TestContext.Current.CancellationToken);
+        var collection = await contentService.GetCollection("content").FirstAsync().ToTask(TestContext.Current.CancellationToken);
 
         collection.Should().NotBeNull("Content collection should be resolved");
 
         // Read "logo.svg" via the "content" collection
-        await using var stream = await collection!.GetContentAsync("logo.svg", TestContext.Current.CancellationToken);
+        await using var stream = await collection!.GetContent("logo.svg").FirstAsync().ToTask(TestContext.Current.CancellationToken);
 
         stream.Should().NotBeNull("Content should be found when using default collection");
 
@@ -338,12 +338,12 @@ public class MapContentCollectionTest(ITestOutputHelper output) : MonolithMeshTe
 
         // Act - get the "other" collection
         var contentService = client.ServiceProvider.GetRequiredService<IContentService>();
-        var collection = await contentService.GetCollectionAsync("other", TestContext.Current.CancellationToken);
+        var collection = await contentService.GetCollection("other").FirstAsync().ToTask(TestContext.Current.CancellationToken);
 
         collection.Should().NotBeNull("Other collection should be resolved");
 
         // Read "data.json" from the "other" collection
-        await using var stream = await collection!.GetContentAsync("data.json", TestContext.Current.CancellationToken);
+        await using var stream = await collection!.GetContent("data.json").FirstAsync().ToTask(TestContext.Current.CancellationToken);
 
         stream.Should().NotBeNull("Content should be found in 'other' collection");
 


### PR DESCRIPTION
## Root cause

The 2026-07-12 "files disappeared" incident on memex.systemorph.com (`PartnerRe/EslLifeCycleProcess/Files`): the Blazor `FileBrowser` did its file I/O — listing AND upload — as raw `async`/`await` **on the circuit thread**, and `FileSystemStreamProvider.GetFolders/GetFiles` are synchronous `Directory.Enumerate*` calls dressed as async iterators. On the AKS portal the content collection lives on an Azure Files SMB mount, where every directory-metadata call is a network round-trip: a latency spike blocked the circuit → SignalR pings timed out → connection flapping (visible in the pod logs) → the Files tab rendered stale/empty. The files were on disk the whole time.

## Fix — the content-collection surface is now observable end-to-end

Per `AsynchronousCalls.md` / `ControlledIoPooling.md`:

- **`ContentCollection` public API returns `IObservable<T>` only** — `GetContent`, `GetContentBytes`, `GetContentSize`, `GetContentAsText`, `GetCollectionItems`, `GetFolders`, `GetFiles`, `SaveFile` (incl. a `Func<Stream>` overload that opens the source inside the leaf), `CreateFolder`, `DeleteFolder`, `DeleteFile`, `Initialize`. Every provider leaf is bridged through the collection's `IIoPool` (`Blob` pool for AzureBlob-backed collections, `FileSystem` otherwise) — never the subscriber's thread. `IStreamProvider` stays the Task-shaped leaf layer, as sanctioned.
- **`IContentService` is observable**: `GetCollection`, `GetContent`, `GetCollections`. The collection cache is a **ReplaySubject-backed promise cache** (`ConcurrentDictionary<string, IObservable<ContentCollection?>>`, entries `Replay(1).AutoConnect(1)`): creation runs once, only when actually loaded (first subscription), and replays to every later subscriber; a failed creation logs, evicts its entry (next access retries) and resolves null. The old nested-lock `Dictionary<string, Task<…>>` is gone. `ContentCollection.Initialize()` itself is a `Lazy` + `Pool.Run` promise cache — the markdown parse runs once, on first load, on the pool.
- **AccessContext crosses the pool hop**: every write (`SaveFile`, `Delete*`, `CreateFolder`) snapshots `AccessService.Context` on the calling thread and re-establishes it (`SwitchAccessContext`) inside the pool leaf, so writes and the save-triggered markdown ingest stay attributed to the calling user — not a bare pool thread. (Watcher-driven external changes remain context-less, as before.)
- **All callers converted to composition + Subscribe** — no `async`/`await`, no `FirstAsync().ToTask()` bridges added anywhere in `src/`:
  - Blazor `FileBrowser`: subscription-managed load pipeline (resolve → ensure-folder → list) with `IDisposable` cleanup; upload switched to `InputFileMode.SaveToTemporaryFolder` so the save opens the temp file **inside** the pool leaf (subscribe-only, no stream-lifetime await); dialogs close on the completion emission.
  - `CollectionNamedLayoutArea`, `ContentLayoutArea`, `ContentPage`, `CollectionsPage`, `FileBrowserView`, autocomplete, content import, indexing observer, `FileContentProvider`, `MeshOperations` (upload/list/export gather), `BrandingResolver`/`ExportTemplateResolver`, FutuRe sample loader: pure reactive composition on the new surface (several redundant local pool wrappers deleted — the surface pools itself).
  - HTTP boundaries (`BlazorHostingExtensions` static content, `Memex.LocalMesh` static endpoint) and Task-contract leaves (import stream provider, agent-round attachment load) await the replayed single emission (`await pipeline.Take(1)`) — ReplaySubject-backed, cannot deadlock; no `ToTask`.

## Tests (new — this path had none, which is how the regression shipped)

`ObservableCollectionSurfaceTest` pins the contract:
1. **Upload → list → read** roundtrips through the observable surface (the exact FileBrowser refresh-after-upload path).
2. **Provider leaves never run on the subscribing thread** (capturing provider asserts the pool hop for save and list).
3. **`SaveFile` carries the caller's `AccessContext` across the pool hop** (capturing provider asserts the write executes under the calling user's context, not empty).

Existing `ContentCollections` tests converted to the new surface (test-side `ToTask` bridges only, per the testing rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
