### PR TITLE
Queries cover content-satellite tables; new GitSync branches base on default HEAD

### DIFF
--- a/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
@@ -496,7 +496,16 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
             : Http.InvokeObservable(ct => client.Git.Reference.Get(owner, repo, $"heads/{commitish}"))
                 .Select(reference => reference.Object.Sha);
 
-    private sealed record HeadInfo(string? CommitSha, bool RefExists, IReadOnlyList<(string Path, string Sha)> ExistingBlobs);
+    internal sealed record HeadInfo(string? CommitSha, bool RefExists, IReadOnlyList<(string Path, string Sha)> ExistingBlobs);
+
+    /// <summary>
+    /// The missing-branch base policy: a new branch on a NON-empty repo builds on the DEFAULT
+    /// branch head — its <see cref="HeadInfo.CommitSha"/> becomes the commit's parent and its
+    /// <see cref="HeadInfo.ExistingBlobs"/> the preserved tree — while <c>RefExists</c> is forced
+    /// false so the push CREATES the target ref. Without this the commit was parent-less: an
+    /// ORPHAN branch with no common ancestor, impossible to PR/merge into the default branch.
+    /// </summary>
+    internal static HeadInfo AsNewBranchBase(HeadInfo defaultHead) => defaultHead with { RefExists = false };
 
     /// <summary>Ensures the repo exists; creates it private (under the user or the org) when missing.</summary>
     private IObservable<bool> EnsureRepo(IObservableGitHubClient client, string owner, string repo, bool createIfMissing)
@@ -540,13 +549,18 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
            || ex.StatusCode == System.Net.HttpStatusCode.Conflict;
 
     /// <summary>
-    /// Bootstraps a brand-new EMPTY repo so the Git Data API works. GitHub rejects blob/tree/commit
-    /// creation on a zero-commit repo with 409 "Git Repository is empty." — only the Contents API can
-    /// create the FIRST commit. When the branch has no head AND the repo is genuinely empty, seed a
-    /// throwaway <c>.gitkeep</c> on the branch via the Contents API (which creates the branch + first
-    /// commit), then re-read the head. The caller's mirror then reconstructs the tree from scratch,
-    /// dropping the seed, so the real content lands as the next commit. A non-empty repo that merely
-    /// lacks this branch is left untouched — the normal parent-less-commit + create-ref path handles it.
+    /// Resolves the head the mirror builds on when the target branch is missing. Two cases:
+    /// <list type="bullet">
+    ///   <item>A brand-new EMPTY repo (zero commits) rejects the Git Data API (409 "Git Repository
+    ///     is empty." — only the Contents API can create the FIRST commit), so seed a throwaway
+    ///     <c>.gitkeep</c> on the branch via the Contents API (creates the branch + first commit),
+    ///     then re-read the head. The mirror reconstructs the tree from scratch, dropping the seed.</item>
+    ///   <item>A NON-empty repo that merely lacks this branch bases the new branch on the DEFAULT
+    ///     branch head — a parent-less commit here would create an ORPHAN branch with no common
+    ///     ancestor with the default branch (observed live: an un-PR-able, un-mergeable sync
+    ///     branch). The default head's blobs become the preserved tree, so the new branch is
+    ///     "default branch + the mirrored subtree" — exactly what a review/merge needs.</item>
+    /// </list>
     /// </summary>
     private IObservable<HeadInfo> EnsureInitialCommit(
         IObservableGitHubClient client, string owner, string repo, string branch, string prefix, HeadInfo head)
@@ -557,7 +571,24 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
                         new CreateFileRequest("Initialize repository (MeshWeaver sync)",
                             "Created by MeshWeaver to initialize this repository.\n", branch)))
                     .SelectMany(_ => ReadHead(client, owner, repo, branch))
-                : Observable.Return(head));
+                : ReadDefaultBranchHead(client, owner, repo, fallback: head));
+
+    /// <summary>
+    /// The DEFAULT branch's head with <c>RefExists=false</c> — the base for creating a new branch
+    /// with real history (the caller still CREATES the target ref; the commit just parents on the
+    /// default head and preserves its tree). Falls back to <paramref name="fallback"/> when the
+    /// default branch cannot be resolved (races with repo initialization).
+    /// </summary>
+    private IObservable<HeadInfo> ReadDefaultBranchHead(
+        IObservableGitHubClient client, string owner, string repo, HeadInfo fallback)
+        => Http.InvokeObservable(ct => client.Repository.Get(owner, repo))
+            .SelectMany(r => string.IsNullOrEmpty(r.DefaultBranch)
+                ? Observable.Return(fallback)
+                : ReadHead(client, owner, repo, r.DefaultBranch))
+            .Select(AsNewBranchBase)
+            .Catch<HeadInfo, ApiException>(ex => IsMissingOrEmptyRepo(ex)
+                ? Observable.Return(fallback)
+                : Observable.Throw<HeadInfo>(ex));
 
     /// <summary>True when the repo has no commits at all (a freshly-created repo): GitHub lists zero
     /// branches for an empty repo, and some endpoints 409 "Git Repository is empty.".</summary>

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSqlGenerator.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSqlGenerator.cs
@@ -128,6 +128,14 @@ public class PostgreSqlSqlGenerator
     }
 
     /// <summary>
+    /// The ORDER BY column expression for an OUTER wrap around a UNION of full-row selects —
+    /// same mapping as a branch-level ORDER BY, with the <c>n.</c> alias stripped (the outer
+    /// select has no alias; mirrors <see cref="GenerateCrossSchemaSelectQuery"/>'s wrap).
+    /// </summary>
+    public static string MapOrderByForUnionWrap(string selector)
+        => MapOrderBySelector(selector).Replace("n.", "");
+
+    /// <summary>
     /// Allow-listed SQL functions usable in <c>sort:func(field)-desc</c>.
     /// Tight allow-list — no arbitrary SQL in the sort selector.
     /// </summary>

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -793,70 +793,15 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         IReadOnlyCollection<string>? excludedNodeTypes,
         [EnumeratorCancellation] CancellationToken ct)
     {
-        // Resolve the target table based on the query path or nodeType and partition definition.
-        // For satellite paths like "User/alice/_Thread", this routes to the "threads" table.
-        // For nodeType-only queries like "nodeType:Thread", resolves via nodeType-to-suffix mapping.
-        // When the path doesn't contain a satellite suffix (e.g., routing fan-out with DefaultPath="User")
-        // but the query has a nodeType filter for a satellite type, prefer the nodeType-based resolution.
-        // NOTE: We query BOTH the satellite table and mesh_nodes (via UNION ALL) because existing data
-        // may be in mesh_nodes from before satellite table routing was enabled on the write path.
-        var effectivePath = query.Path ?? basePath;
-        string rawTable;
-        if (!string.IsNullOrEmpty(effectivePath))
-        {
-            rawTable = _partitionDefinition?.ResolveTable(effectivePath) ?? "mesh_nodes";
-        }
-        else
-        {
-            rawTable = _partitionDefinition?.ResolveTableByNodeType(query.ExtractNodeType()) ?? "mesh_nodes";
-        }
-
-        // When the path resolves to mesh_nodes but nodeType maps to a satellite table,
-        // use the satellite table instead. Satellite tables are the source of truth.
-        var satelliteRedirect = false;
-        if (rawTable == "mesh_nodes" && _partitionDefinition != null)
-        {
-            var satelliteTable = _partitionDefinition.ResolveTableByNodeType(query.ExtractNodeType());
-            if (satelliteTable != null && satelliteTable != "mesh_nodes")
-            {
-                rawTable = satelliteTable;
-                satelliteRedirect = true;
-            }
-        }
-        var tableName = QualifyTable(rawTable);
-        // Resolve satellite table names for source:activity and source:accessed JOINs.
-        // Non-partitioned setups store everything in mesh_nodes (no satellite tables).
-        var activityTable = QualifyTable(_partitionDefinition?.ResolveTableByNodeType("Activity") ?? "mesh_nodes");
-        var userActivityTable = QualifyTable(_partitionDefinition?.ResolveTableByNodeType("UserActivity") ?? "mesh_nodes");
-
-        // Create a fresh generator per call — the generator has mutable state (_paramIndex, _parameters)
-        // and is NOT thread-safe. Concurrent fan-out queries share the same adapter.
-        var generator = new PostgreSqlSqlGenerator { SchemaName = _schemaName };
         var includeContent = SelectorAsksFor(query.Select, "content");
-        var (sql, parameters) = generator.GenerateSelectQuery(query, userId, activityUserId, tableName,
-            activityTable, userActivityTable, excludedNodeTypes, includeContent);
-        if (!string.IsNullOrEmpty(effectivePath) || (query.Paths is { Count: > 1 }))
-        {
-            // Multi-value `path:a|b|c` push-down → `n.path IN (...)`. Routing-layer
-            // "longest-matching-prefix" lookups go through this path. Single-path
-            // queries use the existing scope-clause generator unchanged.
-            var (scopeClause, scopeParams) = query.Paths is { Count: > 1 }
-                ? generator.GenerateScopeClause(query.Paths, query.Scope, useMainNode: satelliteRedirect, qualifiedTable: tableName)
-                : generator.GenerateScopeClause(effectivePath, query.Scope, useMainNode: satelliteRedirect, qualifiedTable: tableName);
-
-            if (!string.IsNullOrEmpty(scopeClause))
-            {
-                foreach (var (k, v) in scopeParams)
-                    parameters[k] = v;
-
-                if (sql.Contains("WHERE"))
-                    sql = sql.Replace("WHERE", $"WHERE {scopeClause} AND");
-                else if (sql.Contains("ORDER BY"))
-                    sql = sql.Replace("ORDER BY", $"WHERE {scopeClause} ORDER BY");
-                else
-                    sql += $" WHERE {scopeClause}";
-            }
-        }
+        // One branch per table this query must cover. A primary-table query means "all content",
+        // so it unions the CONTENT satellite tables (Source/Test → code) — see ResolveQueryTables.
+        var tables = ResolveQueryTables(query, basePath);
+        var (sql, parameters) = tables.Count == 1
+            ? BuildSingleQuerySql(query, options, userId, basePath, activityUserId, excludedNodeTypes,
+                includeContent, tables[0])
+            : BuildUnionAcrossTablesSql(query, options, userId, basePath, activityUserId, excludedNodeTypes,
+                includeContent, tables);
 
         if (_logger?.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug) == true)
         {
@@ -962,26 +907,33 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
 
         for (var qi = 0; qi < queries.Count; qi++)
         {
-            var (perSql, perParams) = BuildSingleQuerySql(
-                queries[qi], options, userId, basePath, activityUserId, excludedNodeTypes, includeContent);
-            // Disambiguate param names across the union: rename every @<name> token
-            // referenced in this per-query SQL to @qI_<name>. We use a single regex
-            // pass keyed on the param-name word boundary so we don't mangle adjacent
-            // tokens. A naive sequence of `string.Replace` calls is order-dependent:
-            // with params @p and @p1, replacing @p first inside an already-rewritten
-            // @q0_p1 would mangle it into @q0_q0_p1. Regex.Replace also gates on
-            // `perParams.ContainsKey` so we don't accidentally rewrite @-sigils that
-            // appear inside string literals or JSONB path expressions.
-            var prefix = $"q{qi}_";
-            var renamedSql = System.Text.RegularExpressions.Regex.Replace(
-                perSql,
-                @"@([A-Za-z_]\w*)",
-                m => perParams.ContainsKey("@" + m.Groups[1].Value)
-                    ? "@" + prefix + m.Groups[1].Value
-                    : m.Value);
-            foreach (var (k, v) in perParams)
-                unionedParams["@" + prefix + k.TrimStart('@')] = v;
-            unionedSelects.Add($"({renamedSql})");
+            // Each query expands to its table branches (primary + content satellites — see
+            // ResolveQueryTables), so the multi-query union is as complete as the single-query path.
+            var queryTables = ResolveQueryTables(queries[qi], basePath);
+            for (var ti = 0; ti < queryTables.Count; ti++)
+            {
+                var (perSql, perParams) = BuildSingleQuerySql(
+                    queries[qi], options, userId, basePath, activityUserId, excludedNodeTypes,
+                    includeContent, queryTables[ti]);
+                // Disambiguate param names across the union: rename every @<name> token
+                // referenced in this per-branch SQL to @qItJ_<name>. We use a single regex
+                // pass keyed on the param-name word boundary so we don't mangle adjacent
+                // tokens. A naive sequence of `string.Replace` calls is order-dependent:
+                // with params @p and @p1, replacing @p first inside an already-rewritten
+                // @q0_p1 would mangle it into @q0_q0_p1. Regex.Replace also gates on
+                // `perParams.ContainsKey` so we don't accidentally rewrite @-sigils that
+                // appear inside string literals or JSONB path expressions.
+                var prefix = $"q{qi}t{ti}_";
+                var renamedSql = System.Text.RegularExpressions.Regex.Replace(
+                    perSql,
+                    @"@([A-Za-z_]\w*)",
+                    m => perParams.ContainsKey("@" + m.Groups[1].Value)
+                        ? "@" + prefix + m.Groups[1].Value
+                        : m.Value);
+                foreach (var (k, v) in perParams)
+                    unionedParams["@" + prefix + k.TrimStart('@')] = v;
+                unionedSelects.Add($"({renamedSql})");
+            }
         }
 
         // UNION ALL preserves both branches' rows; DISTINCT ON (namespace, id)
@@ -1033,14 +985,12 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     /// Shared by the multi-query UNION path so per-query SQL stays
     /// bug-compatible with the single-query path.
     /// </summary>
-    private (string Sql, Dictionary<string, object> Parameters) BuildSingleQuerySql(
-        ParsedQuery query,
-        JsonSerializerOptions options,
-        string? userId,
-        string? basePath,
-        string? activityUserId,
-        IReadOnlyCollection<string>? excludedNodeTypes,
-        bool includeContent = true)
+    /// <summary>
+    /// Resolves the table a query targets: path-based satellite routing first (a "Source"/"_Thread"
+    /// segment in the path), then a nodeType-based redirect when the path resolves to mesh_nodes but
+    /// the nodeType filter maps to a satellite (satellite tables are the source of truth).
+    /// </summary>
+    private (string RawTable, bool SatelliteRedirect) ResolveQueryTable(ParsedQuery query, string? basePath)
     {
         var effectivePath = query.Path ?? basePath;
         string rawTable;
@@ -1059,6 +1009,119 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                 satelliteRedirect = true;
             }
         }
+        return (rawTable, satelliteRedirect);
+    }
+
+    /// <summary>
+    /// Every table branch the query must cover. A query that targets the PRIMARY table means "all
+    /// content" — it additionally covers the CONTENT satellite tables (non-underscore segments:
+    /// <c>Source</c>/<c>Test</c> → <c>code</c>), whose rows are primary content stored outside
+    /// mesh_nodes. Without this a partition-rooted <c>scope:descendants</c> query silently omits
+    /// every Code node — observed live as a Space GitSync-exported WITHOUT any of its C# sources.
+    /// Metadata satellites (<c>_Thread</c>, <c>_Activity</c>, …) stay excluded: they are
+    /// governance data reached via their own segment paths or nodeType filters. Activity/accessed
+    /// source queries keep their single JOIN-shaped branch.
+    /// </summary>
+    private IReadOnlyList<(string RawTable, bool SatelliteRedirect)> ResolveQueryTables(
+        ParsedQuery query, string? basePath)
+    {
+        var primary = ResolveQueryTable(query, basePath);
+        if (primary.RawTable != "mesh_nodes" || primary.SatelliteRedirect
+            || query.Source != QuerySource.Default
+            || _partitionDefinition?.TableMappings is not { } mappings)
+            return [primary];
+
+        var contentTables = mappings
+            .Where(kv => kv.Key.Length > 0 && kv.Key[0] != '_'
+                         && !string.Equals(kv.Value, "mesh_nodes", StringComparison.Ordinal))
+            .Select(kv => kv.Value)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (contentTables.Length == 0)
+            return [primary];
+
+        var tables = new List<(string, bool)>(1 + contentTables.Length) { primary };
+        tables.AddRange(contentTables.Select(t => (t, false)));
+        return tables;
+    }
+
+    /// <summary>
+    /// UNION ALL of the same query against several tables (the primary + the content satellites),
+    /// deduped by node identity, with the query's presentation ORDER BY / text-rank / LIMIT
+    /// re-applied on the OUTSIDE (each branch's ORDER BY is scoped inside its union arm; the
+    /// DISTINCT ON wrap re-orders by identity — same technique as
+    /// <see cref="PostgreSqlSqlGenerator.GenerateCrossSchemaSelectQuery"/>).
+    /// </summary>
+    private (string Sql, Dictionary<string, object> Parameters) BuildUnionAcrossTablesSql(
+        ParsedQuery query,
+        JsonSerializerOptions options,
+        string? userId,
+        string? basePath,
+        string? activityUserId,
+        IReadOnlyCollection<string>? excludedNodeTypes,
+        bool includeContent,
+        IReadOnlyList<(string RawTable, bool SatelliteRedirect)> tables)
+    {
+        var selects = new List<string>(tables.Count);
+        var parameters = new Dictionary<string, object>(StringComparer.Ordinal);
+        for (var ti = 0; ti < tables.Count; ti++)
+        {
+            var (perSql, perParams) = BuildSingleQuerySql(
+                query, options, userId, basePath, activityUserId, excludedNodeTypes, includeContent, tables[ti]);
+            // Disambiguate param names across branches (same regex approach as the multi-query
+            // union — see QueryNodesUnionInnerAsync for why sequential Replace calls are unsafe).
+            var prefix = $"t{ti}_";
+            var renamed = System.Text.RegularExpressions.Regex.Replace(
+                perSql,
+                @"@([A-Za-z_]\w*)",
+                m => perParams.ContainsKey("@" + m.Groups[1].Value)
+                    ? "@" + prefix + m.Groups[1].Value
+                    : m.Value);
+            foreach (var (k, v) in perParams)
+                parameters["@" + prefix + k.TrimStart('@')] = v;
+            selects.Add($"({renamed})");
+        }
+
+        var sql = $"SELECT DISTINCT ON (namespace, id) * FROM ({string.Join(" UNION ALL ", selects)}) AS unioned "
+                  + "ORDER BY namespace, id, last_modified DESC";
+
+        if (query.OrderBy != null)
+        {
+            var direction = query.OrderBy.Descending ? "DESC" : "ASC";
+            var orderCol = PostgreSqlSqlGenerator.MapOrderByForUnionWrap(query.OrderBy.Property);
+            sql = $"SELECT * FROM ({sql}) combined ORDER BY {orderCol} {direction}";
+        }
+        else if (!string.IsNullOrEmpty(query.TextSearch))
+        {
+            parameters["@u_scoreText"] = query.TextSearch;
+            sql = $"SELECT * FROM ({sql}) combined ORDER BY (CASE " +
+                  "WHEN LOWER(COALESCE(name,'')) = LOWER(@u_scoreText) THEN 1000 " +
+                  "WHEN LOWER(COALESCE(name,'')) LIKE LOWER(@u_scoreText) || '%' THEN 600 " +
+                  "WHEN LOWER(COALESCE(id,'')) LIKE LOWER(@u_scoreText) || '%' THEN 500 " +
+                  "WHEN LOWER(COALESCE(name,'')) LIKE '%' || LOWER(@u_scoreText) || '%' THEN 300 " +
+                  "WHEN LOWER(COALESCE(id,'')) LIKE '%' || LOWER(@u_scoreText) || '%' THEN 200 " +
+                  "WHEN LOWER(COALESCE(description,'')) LIKE '%' || LOWER(@u_scoreText) || '%' THEN 100 " +
+                  "ELSE 0 END) DESC, last_modified DESC NULLS LAST";
+        }
+
+        if (query.Limit.HasValue)
+            sql += $" LIMIT {query.Limit.Value}";
+
+        return (sql, parameters);
+    }
+
+    private (string Sql, Dictionary<string, object> Parameters) BuildSingleQuerySql(
+        ParsedQuery query,
+        JsonSerializerOptions options,
+        string? userId,
+        string? basePath,
+        string? activityUserId,
+        IReadOnlyCollection<string>? excludedNodeTypes,
+        bool includeContent = true,
+        (string RawTable, bool SatelliteRedirect)? table = null)
+    {
+        var effectivePath = query.Path ?? basePath;
+        var (rawTable, satelliteRedirect) = table ?? ResolveQueryTable(query, basePath);
         var tableName = QualifyTable(rawTable);
         var activityTable = QualifyTable(_partitionDefinition?.ResolveTableByNodeType("Activity") ?? "mesh_nodes");
         var userActivityTable = QualifyTable(_partitionDefinition?.ResolveTableByNodeType("UserActivity") ?? "mesh_nodes");

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -979,13 +979,6 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     }
 
     /// <summary>
-    /// Builds the same SELECT + scope-clause SQL that the single-query
-    /// <see cref="QueryNodesAsync(ParsedQuery, JsonSerializerOptions, string?, string?, string?, IReadOnlyCollection{string}?, CancellationToken)"/>
-    /// path emits, but returns the (sql, parameters) pair instead of executing.
-    /// Shared by the multi-query UNION path so per-query SQL stays
-    /// bug-compatible with the single-query path.
-    /// </summary>
-    /// <summary>
     /// Resolves the table a query targets: path-based satellite routing first (a "Source"/"_Thread"
     /// segment in the path), then a nodeType-based redirect when the path resolves to mesh_nodes but
     /// the nodeType filter maps to a satellite (satellite tables are the source of truth).
@@ -1110,6 +1103,13 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         return (sql, parameters);
     }
 
+    /// <summary>
+    /// Builds one table branch's SELECT + scope-clause SQL, returning the (sql, parameters) pair
+    /// instead of executing. Shared by the single-query path, the content-satellite union
+    /// (<see cref="BuildUnionAcrossTablesSql"/>) and the multi-query UNION path so per-branch SQL
+    /// stays bug-compatible everywhere. <paramref name="table"/> selects the branch's table;
+    /// null resolves it from the query (<see cref="ResolveQueryTable"/>).
+    /// </summary>
     private (string Sql, Dictionary<string, object> Parameters) BuildSingleQuerySql(
         ParsedQuery query,
         JsonSerializerOptions options,

--- a/test/MeshWeaver.GitSync.Test/NewBranchBaseTest.cs
+++ b/test/MeshWeaver.GitSync.Test/NewBranchBaseTest.cs
@@ -1,0 +1,44 @@
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Pins the missing-branch base policy in <see cref="OctokitGitHubRepoClient.AsNewBranchBase"/>:
+/// a GitSync commit to a branch that does not exist on a NON-empty repo must base the new branch
+/// on the DEFAULT branch head — parenting the commit on it and preserving its tree — instead of
+/// creating a parent-less ORPHAN commit. An orphan branch shares no history with the default
+/// branch, so it can never be PR'd or merged (observed live: a Space sync branch GitHub refused
+/// to compare). RefExists is forced false so the push still CREATES the target ref rather than
+/// trying to update a ref that is not there.
+/// </summary>
+public class NewBranchBaseTest
+{
+    [Fact]
+    public void KeepsDefaultHeadAsParent_AndItsTreeAsPreserved()
+    {
+        var defaultHead = new OctokitGitHubRepoClient.HeadInfo(
+            "abc1234def",
+            RefExists: true,
+            [("Docs/readme.md", "sha-1"), ("Other/file.json", "sha-2")]);
+
+        var basis = OctokitGitHubRepoClient.AsNewBranchBase(defaultHead);
+
+        // The commit parents on the default head → the new branch shares history with it.
+        Assert.Equal("abc1234def", basis.CommitSha);
+        // The default head's blobs are the preserved tree → the new branch is
+        // "default branch + the mirrored subtree", not just the export.
+        Assert.Equal(defaultHead.ExistingBlobs, basis.ExistingBlobs);
+    }
+
+    [Fact]
+    public void ForcesRefExistsFalse_SoTheTargetRefIsCreated()
+    {
+        var defaultHead = new OctokitGitHubRepoClient.HeadInfo("abc1234def", RefExists: true, []);
+
+        var basis = OctokitGitHubRepoClient.AsNewBranchBase(defaultHead);
+
+        // The DEFAULT branch's ref exists, but the TARGET branch's does not — the push must
+        // create refs/heads/{target}, not attempt an update of a missing ref.
+        Assert.False(basis.RefExists);
+    }
+}

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/SatelliteQueryTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/SatelliteQueryTests.cs
@@ -404,7 +404,7 @@ public class SatelliteQueryTests : IAsyncLifetime
     // ── Code ─────────────────────────────────────────────────────────────
 
     [Fact(Timeout = 30000)]
-    public async Task NodeType_Code_RequiresPathBasedResolution()
+    public async Task NodeType_Code_ResolvesViaContentSatelliteUnion()
     {
         await Write(new MeshNode("MyClass", "User/alice/project/Source")
         {
@@ -418,8 +418,89 @@ public class SatelliteQueryTests : IAsyncLifetime
         var byPath = await Query("namespace:User/alice/project/Source nodeType:Code");
         byPath.Should().NotBeEmpty("path-based query to Source should find Code nodes");
 
-        // nodeType-only query with DefaultPath falls back to mesh_nodes (Code has no NodeTypeToSuffix entry)
+        // A nodeType-only query resolves to mesh_nodes (Code has no nodeType→table entry), but the
+        // primary-table query now UNIONs the content satellites — the node_type filter matches in
+        // the code table. This was the old "expected limitation": it silently returned empty.
         var byType = await Query("nodeType:Code scope:descendants", defaultPath: "User");
-        // This returns empty because Code isn't in NodeTypeToSuffix — expected limitation
+        byType.Should().Contain(n => n.Id == "MyClass",
+            "a primary-table query unions the content-satellite code table, so nodeType:Code resolves");
+    }
+
+    // ── Content-satellite union (export-all completeness) ────────────────
+
+    [Fact(Timeout = 30000)]
+    public async Task Descendants_FromPartitionRoot_IncludeCodeNodes()
+    {
+        await Write(new MeshNode("readme", "User/alice/project")
+        {
+            Name = "Readme",
+            NodeType = "Markdown",
+            MainNode = "User/alice/project/readme",
+        });
+        await Write(new MeshNode("MyClass", "User/alice/project/Source")
+        {
+            Name = "MyClass.cs",
+            NodeType = "Code",
+            MainNode = "User/alice/project",
+        });
+
+        // The GitSync export enumerates exactly this shape (path:{space} scope:descendants). A
+        // partition-rooted path has no Source segment, so it resolves to mesh_nodes — the union
+        // with the content-satellite code table is what keeps Code nodes in the result. Before
+        // the union, a Space exported WITHOUT any of its C# sources (observed live).
+        var results = await Query("path:User/alice scope:descendants");
+        results.Should().Contain(n => n.NodeType == "Code" && n.Id == "MyClass",
+            "a partition-rooted descendants query must include content-satellite Code rows");
+        results.Should().Contain(n => n.NodeType == "Markdown" && n.Id == "readme",
+            "primary-table rows must still be returned alongside the satellite union");
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Descendants_FromPartitionRoot_StillExcludeMetadataSatellites()
+    {
+        await Write(new MeshNode("doc2", "User/bob/project")
+        {
+            Name = "Doc",
+            NodeType = "Markdown",
+            MainNode = "User/bob/project/doc2",
+        });
+        await Write(new MeshNode("t1", "User/bob/project/_Thread")
+        {
+            Name = "Discussion",
+            NodeType = "Thread",
+            MainNode = "User/bob/project",
+        });
+
+        // Metadata satellites (_Thread, _Activity, …) are governance data, not content — the
+        // content-satellite union must NOT pull them into a plain descendants query. They remain
+        // reachable via their own segment paths / nodeType filters.
+        var results = await Query("path:User/bob scope:descendants");
+        results.Should().Contain(n => n.Id == "doc2");
+        results.Should().NotContain(n => n.NodeType == "Thread",
+            "underscore metadata satellites stay out of content descendants queries");
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Descendants_UnionAcrossTables_RespectsSortAndLimit()
+    {
+        await Write(new MeshNode("Alpha", "User/carol/project/Source")
+        {
+            Name = "Alpha",
+            NodeType = "Code",
+            MainNode = "User/carol/project",
+        });
+        await Write(new MeshNode("Beta", "User/carol/project")
+        {
+            Name = "Beta",
+            NodeType = "Markdown",
+            MainNode = "User/carol/project/Beta",
+        });
+
+        // The union wrap re-applies the query's presentation ORDER BY / LIMIT on the OUTSIDE
+        // (the DISTINCT ON dedup re-orders by identity internally) — a sorted+limited query must
+        // pick the global winner ACROSS tables, not per-branch arbitrary rows.
+        var results = await Query("path:User/carol scope:descendants sort:name limit:1");
+        results.Should().ContainSingle();
+        results[0].Name.Should().Be("Alpha", "sort:name across the union must rank the code-table row first");
     }
 }


### PR DESCRIPTION
Export/import must cover **ALL** nodes (except excluded namespaces). Two gaps broke that, both observed live on the UWDeepfield space export (Systemorph/MeshWeaver.Plugins#16):

## 1. Code nodes invisible to partition-rooted queries
`Source`/`Test` rows live in the `code` **content satellite** table (path-routed), but a query resolved to the primary table only ever read `mesh_nodes`. So `path:{space} scope:descendants` — the GitSync export's enumeration, and any other root-rooted query — silently omitted every Code node, and a Space exported **without its C# sources** (53 shared + 65 per-type files had to be hand-recovered for the UW plugin). Live compilation never noticed because NodeTypeDefinitions declare *Source-rooted* source queries, which the `Source` path segment routes straight to the `code` table — only the root-rooted shape ever hit the gap.

**Fix:** a primary-table query (`QuerySource.Default`, no satellite redirect) now `UNION ALL`s the same query against every content-satellite table (non-underscore segments: `Source`/`Test` → `code`), deduped by node identity (`DISTINCT ON (namespace, id)`), with the query's presentation `ORDER BY` / text-rank / `LIMIT` re-applied **outside** the union (branch ORDER BYs stay scoped inside their arms — same technique as `GenerateCrossSchemaSelectQuery`). Both the single-query and multi-query union paths expand per table. Metadata satellites (`_Thread`, `_Activity`, …) remain excluded from content queries — governance data stays reachable via its own segments/nodeType filters. Side effect: `nodeType:Code` queries (the old *documented* "expected limitation" in `SatelliteQueryTests`) now resolve.

## 2. `createBranchIfMissing` made orphan branches
A GitSync commit to a missing branch on a non-empty repo created a **parent-less commit** — a branch with no common ancestor that GitHub cannot PR or merge (observed live: `sync/uwdeepfield`). `EnsureInitialCommit` now bases the new branch on the **default branch head**: the commit parents on it and preserves its tree outside the mirrored subdirectory; `RefExists` stays false so the target ref is still created. The empty-repo Contents-API bootstrap is unchanged.

## Tests
- `SatelliteQueryTests`: partition-rooted descendants include Code nodes (the export shape); `nodeType:Code` resolves via the union (replaces the pinned limitation test); metadata satellites stay excluded; sort+limit honored across the union.
- `NewBranchBaseTest`: pins the new-branch base policy (parent + preserved tree from the default head, `RefExists=false`).
- Full suites green locally: `MeshWeaver.Hosting.PostgreSql.Test` 521 passed / 1 pre-existing skip, `MeshWeaver.GitSync.Test` 82/82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)