### PR TITLE
Access: materialize user_effective_permissions on grant writes + partition provisioning (with backfill)

### DIFF
--- a/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
+++ b/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
@@ -51,6 +51,7 @@ public static class MigrationRegistry
         new V40_CreateEventLogSchema(),
         new V41_RetrofitModelCatalogIcons(),
         new V42_ReapplySpaceAuthMirrorAndBackfill(),
+        new V43_FixAccessTriggerSchemaResolutionAndBackfill(),
     ];
 
     /// <summary>

--- a/memex/aspire/Memex.Database.Migration/Migrations/V43_FixAccessTriggerSchemaResolutionAndBackfill.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V43_FixAccessTriggerSchemaResolutionAndBackfill.cs
@@ -1,0 +1,148 @@
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Database.Migration.Migrations;
+
+/// <summary>
+/// Repairs the <b>wrong-schema resolution in <c>trg_access_changed()</c></b> and backfills the
+/// <c>user_effective_permissions</c> tables it left empty.
+///
+/// <para><b>Background.</b> Every partition schema carries an <c>access_changed</c> trigger on its
+/// <c>access</c> satellite table whose function re-materializes the denormalized
+/// <c>user_effective_permissions</c> whenever an AccessAssignment is written. The deployed function
+/// body called the rebuild functions UNQUALIFIED (<c>PERFORM rebuild_user_permissions_for(…)</c>),
+/// which plpgsql resolves through the CALLING SESSION's <c>search_path</c>. Production writes flow
+/// through the shared base connection pool (default <c>search_path</c> = <c>public</c>) with
+/// schema-qualified statements, so the trigger silently executed PUBLIC's rebuild functions against
+/// public's empty <c>access</c> table. The partition's <c>user_effective_permissions</c> stayed
+/// EMPTY after every grant write — partition-scoped queries failed closed (count 0) for every user
+/// while direct reads worked. Live incident: memex 2026-07-13, freshly recreated partitions
+/// (AgenticEngineering / DataModeling / RiskTransfer); older partitions only had rows because the
+/// per-boot self-heal re-materializes them schema-QUALIFIED.</para>
+///
+/// <para>Two steps per partition schema, both idempotent (frozen inline SQL — a migration must not
+/// depend on live code that keeps evolving; this body matches
+/// <c>PostgreSqlSchemaInitializer.AccessChangedTriggerFunctionBody</c> as of V43):</para>
+/// <list type="number">
+///   <item><b>Re-create <c>{schema}.trg_access_changed()</c></b> with every rebuild call qualified
+///     via <c>TG_TABLE_SCHEMA</c> (the schema of the <c>access</c> table that fired the trigger —
+///     i.e. the partition schema, independent of the caller's <c>search_path</c>).
+///     <c>CREATE OR REPLACE</c> keeps the function OID, so the existing trigger picks the fixed
+///     body up immediately; the trigger itself is re-created only where missing.</item>
+///   <item><b>Backfill</b>: run <c>{schema}.rebuild_user_effective_permissions()</c> so tables the
+///     broken trigger left empty are materialized from the intact <c>_Access</c> grants (and
+///     <c>public.partition_access</c> re-synced).</item>
+/// </list>
+///
+/// <para><b>Belt and braces.</b> The same change set makes this SELF-HEALING: the always-run schema
+/// init (<c>PostgreSqlSchemaInitializer.GetAuthMirrorSelfHealScript</c>, step 5 of
+/// <c>InitializeAsync</c>) re-installs the fixed function + trigger and re-runs the rebuild on
+/// every boot. This migration remains as the recorded, ordered repair for deployed databases (and
+/// heals DBs whose next boot predates the new initializer).</para>
+/// </summary>
+public sealed class V43_FixAccessTriggerSchemaResolutionAndBackfill : IMigration
+{
+    public int Version => 43;
+    public string Description => "Schema-qualify trg_access_changed's rebuild calls via TG_TABLE_SCHEMA (grant writes on the shared pool rebuilt public instead of the partition) and backfill empty user_effective_permissions";
+
+    public async Task RunAsync(MigrationContext ctx)
+    {
+        // Partition schemas that carry the permission machinery: an access satellite table AND
+        // the per-user rebuild function. Very old / bare schemas without them are skipped —
+        // installing the trigger there would break access writes at runtime.
+        var schemas = new List<string>();
+        await using (var discover = ctx.DataSource.CreateCommand("""
+            SELECT t.table_schema
+            FROM information_schema.tables t
+            WHERE t.table_name = 'access'
+              AND t.table_schema NOT IN
+                  ('information_schema','pg_catalog','pg_toast','admin','doc')
+              AND t.table_schema NOT LIKE '%\_versions'
+              AND EXISTS (
+                  SELECT 1 FROM pg_proc p
+                  JOIN pg_namespace pn ON pn.oid = p.pronamespace
+                  WHERE p.proname = 'rebuild_user_permissions_for'
+                    AND pn.nspname = t.table_schema)
+            ORDER BY t.table_schema
+            """))
+        await using (var rdr = await discover.ExecuteReaderAsync())
+        {
+            while (await rdr.ReadAsync())
+                schemas.Add(rdr.GetString(0));
+        }
+
+        foreach (var schema in schemas)
+        {
+            var quotedSchema = "\"" + schema.Replace("\"", "\"\"") + "\"";
+
+            // 1. Re-create the trigger function with TG_TABLE_SCHEMA-qualified rebuild calls.
+            //    CREATE OR REPLACE preserves the OID — the existing access_changed trigger
+            //    starts using the fixed body with no trigger re-creation needed.
+            await using (var fn = ctx.DataSource.CreateCommand($"""
+                CREATE OR REPLACE FUNCTION {quotedSchema}.trg_access_changed() RETURNS TRIGGER AS $trg_access$
+                DECLARE
+                    affected_user TEXT;
+                BEGIN
+                    IF TG_OP = 'DELETE' THEN
+                        affected_user := OLD.content->>'accessObject';
+                    ELSE
+                        affected_user := NEW.content->>'accessObject';
+                    END IF;
+
+                    -- Schema-qualified via TG_TABLE_SCHEMA (= the partition schema): an unqualified
+                    -- PERFORM resolves through the WRITING SESSION's search_path, which on the shared
+                    -- base connection pool is public — silently rebuilding the WRONG schema's
+                    -- permissions and leaving this partition's user_effective_permissions empty
+                    -- (memex prod incident 2026-07-13).
+                    IF affected_user IS NOT NULL THEN
+                        EXECUTE format('SELECT %I.rebuild_user_permissions_for($1)', TG_TABLE_SCHEMA)
+                            USING affected_user;
+                    ELSE
+                        EXECUTE format('SELECT %I.rebuild_user_effective_permissions()', TG_TABLE_SCHEMA);
+                    END IF;
+
+                    IF TG_OP = 'UPDATE' AND OLD.content->>'accessObject' IS DISTINCT FROM NEW.content->>'accessObject' THEN
+                        IF OLD.content->>'accessObject' IS NOT NULL THEN
+                            EXECUTE format('SELECT %I.rebuild_user_permissions_for($1)', TG_TABLE_SCHEMA)
+                                USING OLD.content->>'accessObject';
+                        END IF;
+                    END IF;
+
+                    RETURN NULL;
+                END;
+                $trg_access$ LANGUAGE plpgsql;
+
+                DO $ensure_trigger$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_trigger tg
+                        JOIN pg_class c ON c.oid = tg.tgrelid
+                        JOIN pg_namespace n ON n.oid = c.relnamespace
+                        WHERE tg.tgname = 'access_changed'
+                          AND c.relname = 'access' AND n.nspname = '{schema.Replace("'", "''")}')
+                    THEN
+                        CREATE TRIGGER access_changed
+                            AFTER INSERT OR UPDATE OR DELETE ON {quotedSchema}.access
+                            FOR EACH ROW EXECUTE FUNCTION {quotedSchema}.trg_access_changed();
+                    END IF;
+                END;
+                $ensure_trigger$;
+                """))
+            {
+                await fn.ExecuteNonQueryAsync();
+            }
+
+            // 2. Backfill: materialize user_effective_permissions (+ sync public.partition_access)
+            //    from the intact _Access grants the broken trigger never projected.
+            await using (var rebuild = ctx.DataSource.CreateCommand(
+                $"SELECT {quotedSchema}.rebuild_user_effective_permissions()"))
+            {
+                await rebuild.ExecuteNonQueryAsync();
+            }
+
+            ctx.Logger.LogInformation(
+                "Repair v43: '{Schema}' — trg_access_changed re-created (TG_TABLE_SCHEMA-qualified) and user_effective_permissions rebuilt", schema);
+        }
+
+        ctx.Logger.LogInformation("Repair v43: done — {Count} schema(s) repaired and backfilled", schemas.Count);
+    }
+}

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
@@ -266,25 +266,98 @@ public static class PostgreSqlSchemaInitializer
     }
 
     /// <summary>
+    /// Body of the per-partition <c>trg_access_changed()</c> trigger function — the glue between
+    /// a write to the <c>access</c> satellite table and the (re)materialization of
+    /// <c>user_effective_permissions</c>. Single-sourced here because THREE scripts install it:
+    /// <see cref="GetMeshSchemaScript"/>, <see cref="GetVersionedPartitionDdl"/> (and through it
+    /// the <c>public.ensure_partition_schema</c> proc), and the per-boot
+    /// <see cref="GetAuthMirrorSelfHealScript"/>, which CREATE OR REPLACEs stale copies on every
+    /// existing partition.
+    ///
+    /// <para>🚨 <b>Every rebuild call MUST be schema-qualified via <c>TG_TABLE_SCHEMA</c>.</b>
+    /// Inside plpgsql an unqualified <c>PERFORM rebuild_user_permissions_for(…)</c> resolves
+    /// through the CALLING SESSION's <c>search_path</c> — and production writes flow through the
+    /// SHARED base <see cref="NpgsqlDataSource"/> (default <c>search_path</c> = <c>public</c>)
+    /// with schema-qualified statements
+    /// (<see cref="PostgreSqlPartitionStorageProvider.CreateAdapterForTable"/>). The unqualified
+    /// call therefore silently executed PUBLIC's rebuild functions against public's empty
+    /// <c>access</c> table: the partition's <c>user_effective_permissions</c> stayed EMPTY after
+    /// every grant write, so partition-scoped queries failed closed (count 0) for every user
+    /// until the next boot's self-heal re-materialized it — while direct reads kept working.
+    /// Live incident: memex 2026-07-13, freshly recreated partitions
+    /// (AgenticEngineering/DataModeling/RiskTransfer) with intact <c>_Access</c> grants and an
+    /// empty permissions table; an older partition (chess) had rows only because the previous
+    /// boot's self-heal had materialized them. <c>TG_TABLE_SCHEMA</c> — the schema of the
+    /// <c>access</c> table that fired the trigger — IS the partition schema, and makes this body
+    /// schema-agnostic (no sentinel splicing), so every install path ships one identical body.</para>
+    /// </summary>
+    internal const string AccessChangedTriggerFunctionBody = """
+        DECLARE
+            affected_user TEXT;
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                affected_user := OLD.content->>'accessObject';
+            ELSE
+                affected_user := NEW.content->>'accessObject';
+            END IF;
+
+            -- Schema-qualified via TG_TABLE_SCHEMA (= the partition schema): an unqualified
+            -- PERFORM resolves through the WRITING SESSION's search_path, which on the shared
+            -- base connection pool is public — silently rebuilding the WRONG schema's
+            -- permissions and leaving this partition's user_effective_permissions empty
+            -- (memex prod incident 2026-07-13).
+            IF affected_user IS NOT NULL THEN
+                EXECUTE format('SELECT %I.rebuild_user_permissions_for($1)', TG_TABLE_SCHEMA)
+                    USING affected_user;
+            ELSE
+                EXECUTE format('SELECT %I.rebuild_user_effective_permissions()', TG_TABLE_SCHEMA);
+            END IF;
+
+            IF TG_OP = 'UPDATE' AND OLD.content->>'accessObject' IS DISTINCT FROM NEW.content->>'accessObject' THEN
+                IF OLD.content->>'accessObject' IS NOT NULL THEN
+                    EXECUTE format('SELECT %I.rebuild_user_permissions_for($1)', TG_TABLE_SCHEMA)
+                        USING OLD.content->>'accessObject';
+                END IF;
+            END IF;
+
+            RETURN NULL;
+        END;
+        """;
+
+    /// <summary>
     /// One-shot server-side reconciliation of the auth mirror AND the permission projection:
     /// per partition schema it (a) installs the <c>mesh_node_mirror_access_objects</c> trigger
-    /// where missing, (b) upserts every mirrored node type
-    /// (<c>User/Group/Role/VUser/ApiToken/Space</c>) into <c>auth.mesh_nodes</c>, and (c) re-runs
-    /// the schema's <c>rebuild_user_effective_permissions()</c> so <c>_Access</c> grants and
-    /// <c>_Policy</c> rows are projected into <c>public.partition_access</c> — the table the
-    /// cross-partition fan-out filters on. (c) is the durable fix for the 2026-07 incident where
-    /// freshly-provisioned partitions had empty projections: their Spaces were invisible in the
-    /// catalog and their content unfindable in global search despite intact grants. No matview
+    /// where missing, (a2) CREATE OR REPLACEs the schema's <c>trg_access_changed()</c> with the
+    /// current <see cref="AccessChangedTriggerFunctionBody"/> (and (a3) re-installs the
+    /// <c>access_changed</c> trigger where missing) so grant writes materialize
+    /// <c>user_effective_permissions</c> into the RIGHT schema — partitions deployed with the
+    /// pre-2026-07-13 body resolved the rebuild through the writing session's
+    /// <c>search_path</c> and silently rebuilt <c>public</c> instead, (b) upserts every mirrored
+    /// node type (<c>User/Group/Role/VUser/ApiToken/Space</c>) into <c>auth.mesh_nodes</c>, and
+    /// (c) re-runs the schema's <c>rebuild_user_effective_permissions()</c> so <c>_Access</c>
+    /// grants and <c>_Policy</c> rows are projected into <c>user_effective_permissions</c> +
+    /// <c>public.partition_access</c> — the tables every partition-scoped query and the
+    /// cross-partition fan-out filter on. (c) is both the durable fix for the 2026-07
+    /// empty-projection incidents AND the data backfill for (a2): partitions whose permission
+    /// tables stayed empty under the broken trigger converge on the next boot. No matview
     /// rebuild here — the schema script (<see cref="InitializeAsync"/> step 3) already rebuilds
     /// <c>public.top_level_index</c> on the same init, and a second DROP+CREATE under
     /// ACCESS EXCLUSIVE just adds lock contention. No-op when <c>auth.mesh_nodes</c> doesn't
     /// exist. Runs once per boot (public-schema init only, serialized across silos by an advisory
     /// xact lock) — everything converges on restart rather than relying on one-time migrations.
     /// </summary>
-    public static string GetAuthMirrorSelfHealScript() => """
+    public static string GetAuthMirrorSelfHealScript() => $$"""
         DO $auth_mirror_heal$
         DECLARE
             s text;
+            -- The CURRENT trg_access_changed body (single-sourced from the C# constant the
+            -- partition DDL also embeds). __mw_schema__ is replace()d per schema below;
+            -- plain replace, NOT format() — the body carries its own %I/%L format specs.
+            access_trg_fn text := $acfix$
+        CREATE OR REPLACE FUNCTION __mw_schema__.trg_access_changed() RETURNS TRIGGER AS $trg_access$
+        {{AccessChangedTriggerFunctionBody}}
+        $trg_access$ LANGUAGE plpgsql
+        $acfix$;
         BEGIN
             IF to_regclass('"auth".mesh_nodes') IS NULL THEN
                 RETURN;
@@ -317,6 +390,39 @@ public static class PostgreSqlSchemaInitializer
                         || 'FOR EACH ROW EXECUTE FUNCTION public.mirror_access_object_to_auth_schema()', s);
                 END IF;
 
+                -- (a2) Heal the access→permissions trigger FUNCTION. Partitions deployed with
+                --     the pre-2026-07-13 body called the rebuild functions UNQUALIFIED, so a
+                --     grant written through the shared base pool (search_path = public)
+                --     silently rebuilt public's permissions and left this partition's
+                --     user_effective_permissions EMPTY — every partition-scoped query failed
+                --     closed for every user (memex 2026-07-13: AgenticEngineering/
+                --     DataModeling/RiskTransfer). CREATE OR REPLACE keeps the function OID, so
+                --     the existing trigger picks the fixed body up immediately. Guarded on the
+                --     access table + rebuild function existing (very old schemas may predate them).
+                IF to_regclass(format('%I.access', s)) IS NOT NULL
+                   AND EXISTS (
+                       SELECT 1 FROM pg_proc p
+                       JOIN pg_namespace pn ON pn.oid = p.pronamespace
+                       WHERE p.proname = 'rebuild_user_permissions_for' AND pn.nspname = s)
+                THEN
+                    EXECUTE replace(access_trg_fn, '__mw_schema__', quote_ident(s));
+
+                    -- (a3) …and the TRIGGER itself, for partitions provisioned in a window
+                    --     where it was missing.
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_trigger tg
+                        JOIN pg_class c ON c.oid = tg.tgrelid
+                        JOIN pg_namespace n ON n.oid = c.relnamespace
+                        WHERE tg.tgname = 'access_changed'
+                          AND c.relname = 'access' AND n.nspname = s)
+                    THEN
+                        EXECUTE format(
+                            'CREATE TRIGGER access_changed '
+                            || 'AFTER INSERT OR UPDATE OR DELETE ON %I.access '
+                            || 'FOR EACH ROW EXECUTE FUNCTION %I.trg_access_changed()', s, s);
+                    END IF;
+                END IF;
+
                 -- (b) Reconcile mirrored rows: insert what is missing, refresh what is stale.
                 --     The WHERE guard keeps the pass write-free when everything already matches.
                 EXECUTE format($reconcile$
@@ -345,11 +451,14 @@ public static class PostgreSqlSchemaInitializer
                 $reconcile$, s);
 
                 -- (c) Re-project the partition's _Access grants + _Policy into
-                --     public.partition_access. Partitions provisioned while the projection
-                --     machinery was broken (memex, ~2026-07-06..11) had EMPTY partition_access —
-                --     the cross-partition fan-out's permission filter dropped every one of their
-                --     rows, so their Spaces were invisible in the catalog (and their content
-                --     unfindable in global search) even though grants and content were intact.
+                --     user_effective_permissions + public.partition_access. Partitions
+                --     provisioned while the projection machinery was broken (memex,
+                --     ~2026-07-06..11 partition_access; ~2026-07-13 the (a2) wrong-schema
+                --     trigger) had EMPTY projections — partition-scoped queries and the
+                --     cross-partition fan-out dropped every row, so their Spaces were
+                --     invisible and their content unreadable even though grants and content
+                --     were intact. This is also the DATA BACKFILL for (a2): tables left empty
+                --     by the broken trigger converge here on the next boot.
                 --     Guarded: very old schemas may predate the rebuild function.
                 BEGIN
                     EXECUTE format('SELECT %I.rebuild_user_effective_permissions()', s);
@@ -1224,31 +1333,12 @@ public static class PostgreSqlSchemaInitializer
             $$ LANGUAGE plpgsql;
 
             -- Trigger function: per-row, rebuilds only the affected user's permissions.
-            CREATE OR REPLACE FUNCTION trg_access_changed() RETURNS TRIGGER AS $$
-            DECLARE
-                affected_user TEXT;
-            BEGIN
-                IF TG_OP = 'DELETE' THEN
-                    affected_user := OLD.content->>'accessObject';
-                ELSE
-                    affected_user := NEW.content->>'accessObject';
-                END IF;
-
-                IF affected_user IS NOT NULL THEN
-                    PERFORM rebuild_user_permissions_for(affected_user);
-                ELSE
-                    PERFORM rebuild_user_effective_permissions();
-                END IF;
-
-                IF TG_OP = 'UPDATE' AND OLD.content->>'accessObject' IS DISTINCT FROM NEW.content->>'accessObject' THEN
-                    IF OLD.content->>'accessObject' IS NOT NULL THEN
-                        PERFORM rebuild_user_permissions_for(OLD.content->>'accessObject');
-                    END IF;
-                END IF;
-
-                RETURN NULL;
-            END;
-            $$ LANGUAGE plpgsql;
+            -- Body single-sourced from AccessChangedTriggerFunctionBody: every rebuild call is
+            -- schema-qualified via TG_TABLE_SCHEMA — see the constant's doc for the 2026-07-13
+            -- wrong-schema incident an unqualified PERFORM causes on the shared base pool.
+            CREATE OR REPLACE FUNCTION trg_access_changed() RETURNS TRIGGER AS $trg_access$
+            {{AccessChangedTriggerFunctionBody}}
+            $trg_access$ LANGUAGE plpgsql;
 
             -- Drop old trigger on mesh_nodes if it exists
             DROP TRIGGER IF EXISTS mesh_node_access_changed ON mesh_nodes;
@@ -1909,31 +1999,12 @@ public static class PostgreSqlSchemaInitializer
             $$ LANGUAGE plpgsql;
 
             -- Trigger function: per-row, rebuilds only the affected user's permissions.
-            CREATE OR REPLACE FUNCTION trg_access_changed() RETURNS TRIGGER AS $$
-            DECLARE
-                affected_user TEXT;
-            BEGIN
-                IF TG_OP = 'DELETE' THEN
-                    affected_user := OLD.content->>'accessObject';
-                ELSE
-                    affected_user := NEW.content->>'accessObject';
-                END IF;
-
-                IF affected_user IS NOT NULL THEN
-                    PERFORM rebuild_user_permissions_for(affected_user);
-                ELSE
-                    PERFORM rebuild_user_effective_permissions();
-                END IF;
-
-                IF TG_OP = 'UPDATE' AND OLD.content->>'accessObject' IS DISTINCT FROM NEW.content->>'accessObject' THEN
-                    IF OLD.content->>'accessObject' IS NOT NULL THEN
-                        PERFORM rebuild_user_permissions_for(OLD.content->>'accessObject');
-                    END IF;
-                END IF;
-
-                RETURN NULL;
-            END;
-            $$ LANGUAGE plpgsql;
+            -- Body single-sourced from AccessChangedTriggerFunctionBody: every rebuild call is
+            -- schema-qualified via TG_TABLE_SCHEMA — see the constant's doc for the 2026-07-13
+            -- wrong-schema incident an unqualified PERFORM causes on the shared base pool.
+            CREATE OR REPLACE FUNCTION trg_access_changed() RETURNS TRIGGER AS $trg_access$
+            {{AccessChangedTriggerFunctionBody}}
+            $trg_access$ LANGUAGE plpgsql;
 
             -- Drop old trigger on mesh_nodes if it exists
             DROP TRIGGER IF EXISTS mesh_node_access_changed ON mesh_nodes;

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/AccessTriggerSchemaResolutionTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/AccessTriggerSchemaResolutionTests.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using Npgsql;
+using Xunit;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Pins <c>trg_access_changed()</c>'s schema resolution against the PRODUCTION write path —
+/// the shared base <see cref="NpgsqlDataSource"/> with schema-qualified statements
+/// (<c>PostgreSqlPartitionStorageProvider.CreateAdapterForTable</c>), whose connections keep the
+/// DEFAULT <c>search_path</c> (<c>public</c>).
+///
+/// <para><b>Production failure being guarded (memex 2026-07-13).</b> Freshly (re)created
+/// partitions (AgenticEngineering / DataModeling / RiskTransfer) had intact <c>_Access</c> grants
+/// (the <c>access</c> satellite row existed) but an EMPTY <c>user_effective_permissions</c> —
+/// every partition-scoped query failed closed (count 0) for every user while direct reads worked.
+/// Cause: the trigger function called the rebuild UNQUALIFIED
+/// (<c>PERFORM rebuild_user_permissions_for(…)</c>), which plpgsql resolves through the CALLING
+/// SESSION's <c>search_path</c>. On the shared base pool that is <c>public</c>, so every grant
+/// write silently rebuilt PUBLIC's permissions from public's empty <c>access</c> table and the
+/// partition's table never materialized. Older partitions (chess) had rows only because the
+/// per-boot self-heal re-materializes schema-QUALIFIED.</para>
+///
+/// <para>The neighbouring <see cref="PartitionAccessSyncTests"/> writes through a per-schema data
+/// source with <c>SearchPath = "{schema},public"</c> — which masks exactly this bug. These tests
+/// write through the SHARED base data source, the shape production actually uses.</para>
+///
+/// <para>Test 1 drives the fixed trigger end-to-end on the production write shape. Test 2
+/// reproduces the stale-deployed-partition state (old unqualified body), pins the failure, and
+/// asserts the per-boot self-heal (<c>GetAuthMirrorSelfHealScript</c>) replaces the body AND
+/// backfills the empty table.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class AccessTriggerSchemaResolutionTests
+{
+    private readonly PostgreSqlFixture _fixture;
+
+    // Storage serialization MUST be camelCase — the same naming policy the mesh hub uses for
+    // node content. The trigger's rebuild reads camelCase JSON keys (content->>'accessObject').
+    private readonly JsonSerializerOptions _options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    public AccessTriggerSchemaResolutionTests(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    /// <summary>
+    /// Provisions the partition EXACTLY like production (the <c>public.ensure_partition_schema</c>
+    /// stored proc on the base data source) and returns an adapter in the production
+    /// <c>CreateAdapterForTable</c> shape: the SHARED base data source (default
+    /// <c>search_path</c> = <c>public</c>) with schema-qualified statements.
+    /// </summary>
+    private async Task<PostgreSqlStorageAdapter> ProvisionProdShapeAdapterAsync(
+        string space, string schema, CancellationToken ct)
+    {
+        await _fixture.DataSource.ExecuteNonQuery(
+            $"SELECT public.ensure_partition_schema('{schema}')", ct)
+            .Should().Within(60.Seconds()).Emit();
+
+        var def = new PartitionDefinition
+        {
+            Namespace = space,
+            Schema = schema,
+            TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+            NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings()
+        };
+        return new PostgreSqlStorageAdapter(_fixture.DataSource, partitionDefinition: def);
+    }
+
+    private async Task WriteSpaceRootAsync(
+        PostgreSqlStorageAdapter adapter, string space, CancellationToken ct)
+        => await adapter.WriteAsync(new MeshNode(space)
+        {
+            Name = $"{space} Inc.",
+            NodeType = SpaceNodeType.NodeType,
+            State = MeshNodeState.Active,
+            MainNode = space,
+            Content = new Space()
+        }, _options, ct);
+
+    /// <summary>
+    /// HEAD repro of the 2026-07-13 incident: a fresh partition + an <c>_Access</c> grant written
+    /// through the SHARED base pool must materialize <c>user_effective_permissions</c> in THE
+    /// PARTITION's schema (not public's), sync <c>public.partition_access</c>, and make the Space
+    /// visible to the granted user in the permission-gated cross-schema query — and ONLY to them.
+    /// Before the TG_TABLE_SCHEMA fix this failed: the unqualified rebuild ran against public and
+    /// the partition's table stayed empty.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task GrantThroughSharedBasePool_MaterializesPartitionEffectivePermissions()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "sharedpoolspace";
+        const string space = "SharedPoolSpace";
+        const string alice = "sp_alice";
+        const string bob = "sp_bob";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+
+        // The grant write: {space}/_Access/{alice}_Access → access satellite table →
+        // access_changed trigger. The connection's search_path is the DEFAULT (public) —
+        // the trigger must still rebuild THE PARTITION's permissions.
+        var grant = AssignmentNodeFactory.UserRole(alice, "Admin", space);
+        await adapter.WriteAsync(grant, _options, ct);
+
+        // 1) The partition's user_effective_permissions materialized (the incident's tell:
+        //    this was 0 while the access row existed).
+        var accessRows = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".access", ct)
+            .Should().Within(30.Seconds()).Emit();
+        accessRows.Should().Be(1, "the grant write landed in the access satellite table");
+
+        var uepRead = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".user_effective_permissions " +
+            $"WHERE user_id = '{alice}' AND permission = 'Read' AND is_allow = true", ct)
+            .Should().Within(30.Seconds()).Emit();
+        uepRead.Should().BeGreaterThan(0,
+            "the access_changed trigger must rebuild THE PARTITION's user_effective_permissions " +
+            "even when the writing session's search_path is public (the shared base pool)");
+
+        // 2) …and NOT public's (the wrong-schema rebuild the unqualified PERFORM caused).
+        var publicUep = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM public.user_effective_permissions WHERE user_id = '{alice}'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        publicUep.Should().Be(0, "the grant is scoped to the partition, not public");
+
+        // 3) partition_access synced → the permission-gated query path sees the Space.
+        var aliceAccess = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM public.partition_access WHERE user_id = '{alice}' AND partition = '{schema}'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        aliceAccess.Should().Be(1, "rebuild_user_permissions_for syncs public.partition_access");
+
+        await PopulateSearchableSchemasAsync(new[] { schema }, ct);
+        var spaceFilter = $"LOWER(n.node_type) = '{SpaceNodeType.NodeType.ToLowerInvariant()}'";
+
+        var aliceResults = await CallSearchAcrossSchemas(spaceFilter, alice, "last_modified DESC", 50, ct);
+        aliceResults.Should().ContainSingle(n => n.Id == space,
+            "alice's grant materialized → the partition-scoped gate passes for her");
+
+        var bobResults = await CallSearchAcrossSchemas(spaceFilter, bob, "last_modified DESC", 50, ct);
+        bobResults.Should().NotContain(n => n.Id == space,
+            "bob has no grant → the gate still fails closed for him");
+    }
+
+    /// <summary>
+    /// Deployed-partition heal: a partition still carrying the PRE-FIX trigger body (unqualified
+    /// <c>PERFORM</c>) reproduces the incident — the grant lands in <c>access</c> but
+    /// <c>user_effective_permissions</c> stays EMPTY. The per-boot self-heal
+    /// (<see cref="PostgreSqlSchemaInitializer.GetAuthMirrorSelfHealScript"/>, run on every
+    /// public-schema init) must CREATE OR REPLACE the function with the TG_TABLE_SCHEMA-qualified
+    /// body AND backfill the table via the schema-level rebuild; subsequent grant writes through
+    /// the shared pool must then materialize immediately.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task StaleUnqualifiedTriggerBody_HealedAndBackfilledByBootSelfHeal()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "staletrgspace";
+        const string space = "StaleTrgSpace";
+        const string carol = "st_carol";
+        const string dave = "st_dave";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+
+        // Regress the partition to the PRE-2026-07-13 deployed state: the unqualified body
+        // that resolves the rebuild through the writing session's search_path.
+        await _fixture.DataSource.ExecuteNonQuery($"""
+            CREATE OR REPLACE FUNCTION "{schema}".trg_access_changed() RETURNS TRIGGER AS $$
+            DECLARE
+                affected_user TEXT;
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    affected_user := OLD.content->>'accessObject';
+                ELSE
+                    affected_user := NEW.content->>'accessObject';
+                END IF;
+
+                IF affected_user IS NOT NULL THEN
+                    PERFORM rebuild_user_permissions_for(affected_user);
+                ELSE
+                    PERFORM rebuild_user_effective_permissions();
+                END IF;
+
+                RETURN NULL;
+            END;
+            $$ LANGUAGE plpgsql;
+            """, ct)
+            .Should().Within(30.Seconds()).Emit();
+
+        // Grant through the shared base pool (search_path = public): the stale body "succeeds"
+        // silently against PUBLIC's rebuild functions — the partition's table stays EMPTY.
+        var grant = AssignmentNodeFactory.UserRole(carol, "Admin", space);
+        await adapter.WriteAsync(grant, _options, ct);
+
+        var uepBefore = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".user_effective_permissions WHERE user_id = '{carol}'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        uepBefore.Should().Be(0,
+            "BUG REPRODUCED: the stale unqualified body rebuilds public's permissions, " +
+            "leaving the partition's user_effective_permissions empty despite the intact grant");
+
+        // HEAL: the per-boot self-heal replaces the function body (CREATE OR REPLACE keeps the
+        // OID, so the existing trigger picks it up) and backfills via the schema-level rebuild.
+        await _fixture.DataSource.ExecuteNonQuery(
+            PostgreSqlSchemaInitializer.GetAuthMirrorSelfHealScript(), ct)
+            .Should().Within(60.Seconds()).Emit();
+
+        var uepAfter = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".user_effective_permissions " +
+            $"WHERE user_id = '{carol}' AND permission = 'Read' AND is_allow = true", ct)
+            .Should().Within(30.Seconds()).Emit();
+        uepAfter.Should().BeGreaterThan(0,
+            "the self-heal's schema-level rebuild backfills user_effective_permissions from the intact grants");
+
+        var carolAccess = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM public.partition_access WHERE user_id = '{carol}' AND partition = '{schema}'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        carolAccess.Should().Be(1, "the backfill also re-syncs public.partition_access");
+
+        // And the TRIGGER is healed going forward: a fresh grant through the shared pool
+        // materializes immediately, no further heal needed.
+        var grant2 = AssignmentNodeFactory.UserRole(dave, "Viewer", space);
+        await adapter.WriteAsync(grant2, _options, ct);
+
+        var daveUep = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".user_effective_permissions " +
+            $"WHERE user_id = '{dave}' AND permission = 'Read' AND is_allow = true", ct)
+            .Should().Within(30.Seconds()).Emit();
+        daveUep.Should().BeGreaterThan(0,
+            "after the heal, grant writes through the shared pool materialize the partition's permissions directly");
+    }
+
+    // ── Helpers (mirrored from PartitionAccessSyncTests) ─────────────────────
+
+    private Task<List<MeshNode>> CallSearchAcrossSchemas(
+        string whereClause, string? userId, string orderBy, int limit, CancellationToken ct)
+        => CallSearchAcrossSchemasAsync(whereClause, userId, orderBy, limit, ct)
+            .Run().Should().Within(30.Seconds()).Emit();
+
+    private async Task PopulateSearchableSchemasAsync(IEnumerable<string> schemas, CancellationToken ct)
+    {
+        await using (var cmd = _fixture.DataSource.CreateCommand("DELETE FROM public.searchable_schemas"))
+            await cmd.ExecuteNonQueryAsync(ct);
+
+        foreach (var schema in schemas)
+        {
+            await using var cmd = _fixture.DataSource.CreateCommand(
+                "INSERT INTO public.searchable_schemas (schema_name) VALUES ($1) ON CONFLICT DO NOTHING");
+            cmd.Parameters.AddWithValue(schema);
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+    }
+
+    private async Task<List<MeshNode>> CallSearchAcrossSchemasAsync(
+        string whereClause, string? userId, string orderBy, int limit, CancellationToken ct)
+    {
+        var results = new List<MeshNode>();
+        await using var cmd = _fixture.DataSource.CreateCommand(
+            "SELECT * FROM public.search_across_schemas(@p_where, @p_user, @p_order, @p_limit) " +
+            "AS t(id TEXT, namespace TEXT, name TEXT, node_type TEXT, category TEXT, icon TEXT, " +
+            "display_order INT, last_modified TIMESTAMPTZ, version BIGINT, state SMALLINT, " +
+            "content JSONB, desired_id TEXT, main_node TEXT)");
+        cmd.Parameters.Add(new NpgsqlParameter("@p_where", string.IsNullOrEmpty(whereClause) ? "" : whereClause));
+        cmd.Parameters.Add(new NpgsqlParameter("@p_user", (object?)userId ?? DBNull.Value));
+        cmd.Parameters.Add(new NpgsqlParameter("@p_order", orderBy));
+        cmd.Parameters.Add(new NpgsqlParameter("@p_limit", limit));
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var id = reader.GetString(0);
+            var ns = reader.IsDBNull(1) ? null : reader.GetString(1);
+            results.Add(new MeshNode(id, string.IsNullOrEmpty(ns) ? null : ns)
+            {
+                Name = reader.IsDBNull(2) ? null : reader.GetString(2),
+                MainNode = reader.IsDBNull(12) ? id : reader.GetString(12)
+            });
+        }
+        return results;
+    }
+}


### PR DESCRIPTION
## The incident (memex, 2026-07-13)

Freshly (re)created partitions (AgenticEngineering / DataModeling / RiskTransfer) had a working `access` row and intact `_Access` grants, but `{schema}.user_effective_permissions` stayed **EMPTY** — every partition-scoped query failed closed (count 0) for **all** users while direct reads worked. An older partition (chess) had 10 rows per user. Production was unblocked by hand-inserting rows; this PR is the real fix.

## Root cause

`trg_access_changed()` (the AFTER trigger on each partition's `access` satellite table) called the rebuild **unqualified**:

```sql
PERFORM rebuild_user_permissions_for(affected_user);
```

plpgsql resolves unqualified names through the **calling session's `search_path`**. Production writes flow through the **shared base `NpgsqlDataSource`** (default `search_path` = `public`) with schema-qualified statements (`PostgreSqlPartitionStorageProvider.CreateAdapterForTable` — the connection-pool-leak fix that replaced per-(schema,table) pools with per-statement qualification). So every grant write fired the partition's trigger, which then silently executed **`public`'s** rebuild functions against public's empty `access` table. The partition's `user_effective_permissions` never materialized.

Why chess had rows: the per-boot auth-mirror self-heal runs `SELECT "{schema}".rebuild_user_effective_permissions()` **schema-qualified** — partitions existing at the last restart got materialized; partitions created after boot stayed broken until the next restart.

Why no test caught it: the existing `PartitionAccessSyncTests` write through a per-schema data source with `SearchPath = "{schema},public"`, which masks exactly this resolution bug.

## The fix (SQL layer — the role→permission expansion already lives in the plpgsql rebuild functions; only the trigger glue was broken)

1. **`trg_access_changed()` schema-qualifies every rebuild call via `TG_TABLE_SCHEMA`** (the schema of the `access` table that fired the trigger = the partition schema, independent of the caller's `search_path`). The body is single-sourced as `AccessChangedTriggerFunctionBody` and embedded by all three install paths (`GetMeshSchemaScript`, `GetVersionedPartitionDdl` / `public.ensure_partition_schema`, and the self-heal) — one identical, schema-agnostic body everywhere.
2. **Per-boot self-heal extended** (`GetAuthMirrorSelfHealScript`): (a2) `CREATE OR REPLACE` each partition's `trg_access_changed` with the fixed body (OID preserved — the existing trigger picks it up immediately, no trigger re-creation), (a3) re-install the `access_changed` trigger where missing, and the existing step (c) rebuild doubles as the **data backfill** for tables the broken trigger left empty. Deployed meshes converge on the next restart.
3. **`V43_FixAccessTriggerSchemaResolutionAndBackfill`** (registered in `MigrationRegistry.All`, mirroring the V42 pattern): the recorded, ordered repair for deployed DBs — re-creates the function per schema (frozen inline SQL) and backfills via `rebuild_user_effective_permissions()`.

## Tests

`AccessTriggerSchemaResolutionTests` pins the bug on the **production write shape** (shared base pool + `ensure_partition_schema` provisioning):

- `GrantThroughSharedBasePool_MaterializesPartitionEffectivePermissions` — fresh partition + grant through the shared pool ⇒ the **partition's** `user_effective_permissions` materializes (not public's), `public.partition_access` syncs, and the permission-gated cross-schema query returns the Space for the granted user only. **Fails on main** with the exact incident signature (count 0); passes with the fix.
- `StaleUnqualifiedTriggerBody_HealedAndBackfilledByBootSelfHeal` — a partition carrying the pre-fix body reproduces the incident (grant lands, uep stays empty), then the boot self-heal replaces the body AND backfills; subsequent grants materialize directly.

## Verification

- Repro test confirmed red against main's DDL, green with the fix (deterministic pin).
- Full `MeshWeaver.Hosting.PostgreSql.Test`: 523 passed / 0 failed / 1 pre-existing skip.
- `MeshWeaver.Security.Test` RLS/permission slices: 31 passed.
- Full solution `dotnet build -c Release -warnaserror`: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)