### PR TITLE
AI MeshOperations: route copy fan-out to a hub that handles node ops

### DIFF
--- a/src/MeshWeaver.Graph/NodeCopyHelper.cs
+++ b/src/MeshWeaver.Graph/NodeCopyHelper.cs
@@ -34,6 +34,12 @@ public static class NodeCopyHelper
     /// <see cref="CreateOrUpdateNodeRequest"/> handler — the helper just
     /// dispatches.</para>
     ///
+    /// <para><b>Routing</b> — every per-node request is targeted at the root mesh
+    /// hub (<c>hub.GetMeshHub()</c>), where the node-operation handlers are
+    /// guaranteed to be registered. <paramref name="hub"/> may therefore be ANY
+    /// hub (an MCP/REST session hub, a per-node UI hub, the mesh hub itself); it
+    /// only supplies the caller identity and the reply address.</para>
+    ///
     /// <para><b>force semantics</b> are encoded in the upsert request: when
     /// the target path already exists, the upsert handler applies the change
     /// via <c>stream.Update</c> (requires Update permission) when
@@ -65,6 +71,25 @@ public static class NodeCopyHelper
         // FanOutDeleteSubtree does for recursive deletes.
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var callerAccessContext = accessService?.Context ?? accessService?.CircuitContext;
+
+        // 🚨 Target the per-node create/upsert requests at the ROOT mesh hub — the hub where
+        // WithNodeOperationHandlers registers the CreateNodeRequest/CreateOrUpdateNodeRequest
+        // handlers (MeshBuilder.AddMesh). An un-targeted Observe delivers to the CALLING hub,
+        // which only works when that hub happens to register the node-op handlers itself
+        // (per-node UI hubs do, via AddMeshDataSource). The MCP/REST session hub
+        // (portal/mcp-{user}-{session}, SessionHubResolver) registers only AddData — every
+        // per-node post bounced with "No handler found for message type CreateNodeRequest"
+        // (memex 2026-07-13, MCP copy tool). Same routing contract as MeshService.MeshAddress,
+        // whose comment pins the identical 2026-05-23 incident for un-walked child-hub writes.
+        var meshAddress = hub.GetMeshHub().Address;
+
+        // Shared post options for both verbs: route to the mesh hub and stamp the
+        // eagerly-captured caller identity (mirrors MeshService.ConfigurePost).
+        PostOptions ConfigurePost(PostOptions o)
+        {
+            o = o.WithTarget(meshAddress);
+            return callerAccessContext is null ? o : o.WithAccessContext(callerAccessContext);
+        }
 
         // Single Query over the source subtree — emits source + every
         // descendant in one go. Take(1) snapshots the listing for the copy
@@ -116,7 +141,7 @@ public static class NodeCopyHelper
                     return hub
                         .Observe<CreateOrUpdateNodeResponse>(
                             new CreateOrUpdateNodeRequest(copiedNode),
-                            o => callerAccessContext is null ? o : o.WithAccessContext(callerAccessContext))
+                            ConfigurePost)
                         .FirstAsync()
                         .Select(d => d.Message)
                         .SelectMany(resp =>
@@ -134,7 +159,7 @@ public static class NodeCopyHelper
                 }
                 return hub
                     .Observe<CreateNodeResponse>(new CreateNodeRequest(copiedNode),
-                        o => callerAccessContext is null ? o : o.WithAccessContext(callerAccessContext))
+                        ConfigurePost)
                     .FirstAsync()
                     .Select(d => d.Message)
                     .SelectMany(resp =>

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeCopyHelperTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeCopyHelperTest.cs
@@ -4,12 +4,14 @@ using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -178,6 +180,46 @@ public class NodeCopyHelperTest(ITestOutputHelper output) : MonolithMeshTestBase
         var target = await GetNode("dest/Doc");
         target.Should().NotBeNull();
         target!.Content.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CopyNodeTree_FromMcpShapedSessionHubWithoutNodeOperationHandlers()
+    {
+        // Regression (memex 2026-07-13): the MCP `copy` tool failed with
+        // "No handler found for message type CreateNodeRequest" while `create` worked.
+        // MeshOperations.Copy runs NodeCopyHelper.CopyNodeTree on the MCP SESSION hub
+        // (portal/mcp-{user}-{session}, SessionHubResolver), which registers only
+        // AddData() — no WithNodeOperationHandlers — and the helper posted its per-node
+        // CreateNodeRequests WITHOUT a target, i.e. to that calling hub, where they
+        // bounced with DeliveryFailure. The helper must route them to the root mesh hub
+        // (the MeshService.MeshAddress contract), so the calling hub needs no node-op
+        // handlers of its own. This hosted hub mirrors SessionHubResolver's config.
+        await CreateNode("org/Acme", "Acme Corp", "Markdown");
+        await CreateNode("org/Acme/Team1", "Team One", "Markdown");
+
+        var routingService = RoutingService;
+        var sessionHub = Mesh.GetHostedHub(
+            AddressExtensions.CreatePortalAddress("mcp-test-session"),
+            c => c
+                .AddData()
+                .WithInitialization(h => h.RegisterForDisposal(routingService.RegisterStream(h))),
+            HostedHubCreation.Always);
+        sessionHub.Should().NotBeNull();
+
+        // force=false → per-node CreateNodeRequest fan-out.
+        var copied = await NodeCopyHelper
+            .CopyNodeTree(MeshService, MeshService, sessionHub!, "org/Acme", "workspace", force: false)
+            .Should().Within(30.Seconds()).Emit();
+        copied.Should().Be(2);
+        (await GetNode("workspace/Acme"))!.Name.Should().Be("Acme Corp");
+        (await GetNode("workspace/Acme/Team1"))!.Name.Should().Be("Team One");
+
+        // force=true → per-node CreateOrUpdateNodeRequest fan-out (the helper's second
+        // verb; must route to the mesh hub for the same reason).
+        var upserted = await NodeCopyHelper
+            .CopyNodeTree(MeshService, MeshService, sessionHub!, "org/Acme", "workspace", force: true)
+            .Should().Within(30.Seconds()).Emit();
+        upserted.Should().Be(2);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

The MCP `copy` tool failed on live portals (memex, 2026-07-13) while the MCP `create` tool worked fine:

```
warn: MeshWeaver.Messaging.MessageHub[0]
      No handler found for request CreateNodeRequest (ID: ...) in portal/mcp-rbuergi-... - sending DeliveryFailure response
warn: MeshWeaver.AI.MeshOperations[0]
      Error copying AgenticEngineering/Introduction/Exercise/PredictBehaviour -> rbuergi/_CopyProbe
      MeshWeaver.Messaging.DeliveryFailureException: No handler found for message type CreateNodeRequest
```

## Root cause

`NodeCopyHelper.CopyNodeTree` posts its per-node `CreateNodeRequest` / `CreateOrUpdateNodeRequest` fan-out **without a target**, so each request is delivered to the **calling** hub:

- Per-node UI hubs (browser Copy menu, Import, copy-to-home) register `WithNodeOperationHandlers` via `AddMeshDataSource` — so the UI path worked by accident of configuration.
- The MCP/REST session hub (`portal/mcp-{user}-{session}`, `SessionHubResolver`) registers only `AddData()` — every per-node post bounced with `DeliveryFailure`.

The MCP `create` tool works because `MeshService.CreateNode` targets `hub.GetMeshHub().Address` — the root mesh hub, where `MeshBuilder.AddMesh` guarantees the node-op handlers. `MeshService.MeshAddress`'s own doc comment pins the identical failure mode from 2026-05-23 ("No handler found for message type UpdateNodeRequest" — broke every MCP write) and names walking up to the mesh hub as the documented routing contract for node CRUD from child hubs.

## Fix

Route `NodeCopyHelper`'s per-node requests to `hub.GetMeshHub().Address` — the same contract `MeshService` and `HandleCopyNodeRequest` (which fans out through `IMeshService.CreateNode`) already follow. The calling hub now only supplies the caller identity and the reply address, so **any** hub (MCP session hub, per-node UI hub, the mesh hub itself) can drive a copy.

- The eagerly-captured caller `AccessContext` is still stamped on every post (unchanged); authoritative per-target-path permission checks stay in the handlers (unchanged).
- `IMeshService.CreateNode/CreateOrUpdateNode` could not be used directly: they discard the `RejectionReason`/`WasCreated` the helper's skip-on-exists semantics depend on, and their lazy context capture would run on the emission scheduler where the AsyncLocal identity is already wiped.
- Registering `WithNodeOperationHandlers` on the session hub instead was rejected: `HandleCreateNodeRequest` fails closed without an `IStorageAdapter`/`MeshConfiguration` on the *receiving* hub, so handlers on a persistence-less session hub would ack-and-refuse rather than fix anything — and it would fork the routing contract the rest of the framework follows.

## Regression test

`NodeCopyHelperTest.CopyNodeTree_FromMcpShapedSessionHubWithoutNodeOperationHandlers` copies a small subtree cross-partition through a hosted hub configured exactly like the MCP session hub (`AddData` + `RegisterStream`, `portal/*` address, **no** node-op handlers), covering both verbs (`force=false` → `CreateNodeRequest`, `force=true` → `CreateOrUpdateNodeRequest`). Verified it reproduces the exact production error without the src change:

```
Expected the observable to emit a value within 30s, but it errored: No handler found for message type CreateNodeRequest.
```

## Testing

- `dotnet build MeshWeaver.slnx -c Release` clean; `MeshWeaver.Graph` with `-warnaserror` clean
- `NodeCopyHelperTest` (9/9), `CopyModifyCopyBackTest` + `ObserveQueryFreshnessTest` (19/19 combined), `ImportLayoutAreaTest` (5/5)
- `CrossPartitionMoveCopyAccessContextTest`, `EducationStartExerciseTest`, `ExportImportRoundTripTest`, `ExportImportAccessControlTest` (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)