### PR TITLE
GitSync: gitignore-style Ignore rules on the sync config (default: Release/)

### DIFF
--- a/src/MeshWeaver.GitSync/GitHubSyncConfig.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfig.cs
@@ -50,6 +50,16 @@ public record GitHubSyncConfig
     [Description("Create the repository (private) if it doesn't exist")]
     public bool CreateRepoIfMissing { get; init; } = true;
 
+    /// <summary>
+    /// Gitignore-style patterns for paths (relative to the Space root) that do NOT sync — neither
+    /// exported to the repo nor imported from it. Unset → <see cref="SyncIgnore.Default"/>
+    /// (<c>Release/</c>: the compile pipeline's release-request bookkeeping, one node per
+    /// recompile, forever). Set to an empty list to sync everything; <c>!pattern</c> re-includes
+    /// (last match wins); <c>*</c>/<c>**</c>/<c>?</c> globs as in <c>.gitignore</c>.
+    /// </summary>
+    [Description("Ignore patterns (gitignore-style, relative to the Space root; unset = default: Release/)")]
+    public string[]? Ignore { get; init; }
+
     /// <summary>When the last successful export completed. Set by the sync operation; not user-editable.</summary>
     [Browsable(false)]
     public DateTimeOffset? LastSyncedAt { get; init; }

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -116,7 +116,7 @@ public sealed class GitHubSyncService
             return ResolveAuth(userId).SelectMany(auth =>
             {
                 var token = auth.Token;
-                return SnapshotNodes(spacePath).SelectMany(nodes =>
+                return SnapshotNodes(spacePath, SyncIgnore.For(config)).SelectMany(nodes =>
                     SerializeAll(nodes, spacePath, progress).SelectMany(files =>
                     {
                         // App-identity exports author as the bot (no personal credential involved).
@@ -150,7 +150,7 @@ public sealed class GitHubSyncService
     }
 
     /// <summary>Root + descendants of the Space, filtered to exportable content nodes.</summary>
-    private IObservable<IReadOnlyList<MeshNode>> SnapshotNodes(string spacePath)
+    private IObservable<IReadOnlyList<MeshNode>> SnapshotNodes(string spacePath, SyncIgnore ignore)
     {
         var root = hub.GetWorkspace().GetMeshNodeStream(spacePath)
             .Where(n => n is not null).Take(1).Timeout(TimeSpan.FromSeconds(30));
@@ -168,16 +168,18 @@ public sealed class GitHubSyncService
             var all = new List<MeshNode>();
             if (r is not null) all.Add(r);
             all.AddRange(desc);
-            return Filter(all, spacePath);
+            return Filter(all, spacePath, ignore);
         });
     }
 
     /// <summary>
     /// Keeps content nodes only: drops satellite/governance subtrees (a <c>_</c>-prefixed
     /// segment after the partition root — <c>_GitSync</c>, <c>_Access</c>, <c>_Activity</c>,
-    /// threads, notifications, …) and honours <see cref="SyncBehavior"/>.
+    /// threads, notifications, …), honours <see cref="SyncBehavior"/>, and applies the Space's
+    /// gitignore-style <paramref name="ignore"/> rules (<see cref="GitHubSyncConfig.Ignore"/> /
+    /// <see cref="SyncIgnore.Default"/>) to the path relative to the partition root.
     /// </summary>
-    private static IReadOnlyList<MeshNode> Filter(List<MeshNode> all, string partition)
+    internal static IReadOnlyList<MeshNode> Filter(List<MeshNode> all, string partition, SyncIgnore ignore)
     {
         var excludedRoots = all
             .Where(n => n.SyncBehavior == SyncBehavior.ExcludeThisAndChildren)
@@ -185,12 +187,15 @@ public sealed class GitHubSyncService
             .ToArray();
         bool underExcluded(string p) =>
             excludedRoots.Any(r => p.StartsWith(r + "/", StringComparison.Ordinal));
+        string relative(string p) =>
+            p.StartsWith(partition + "/", StringComparison.Ordinal) ? p[(partition.Length + 1)..] : "";
 
         return all
             .Where(n => !string.IsNullOrEmpty(n.Path)
                         && !n.Segments.Skip(1).Any(s => s.StartsWith('_'))
                         && n.SyncBehavior == SyncBehavior.Include
-                        && !underExcluded(n.Path))
+                        && !underExcluded(n.Path)
+                        && !ignore.IsIgnored(relative(n.Path)))
             .GroupBy(n => n.Path, StringComparer.Ordinal)
             .Select(g => g.First())
             .ToList();
@@ -316,7 +321,8 @@ public sealed class GitHubSyncService
                 ? meshService.CreateNode(spaceNode)
                 : Observable.Using(() => accessService.SwitchAccessContext(ctx), _ => meshService.CreateNode(spaceNode));
             return createSpace
-                .SelectMany(_ => FetchAndImport(repositoryUrl, commitish, subdirectory, token, newSpaceId, progress))
+                .SelectMany(_ => FetchAndImport(repositoryUrl, commitish, subdirectory, token, newSpaceId,
+                    SyncIgnore.For(null), progress))
                 .Select(x => x.Result);
         });
     }
@@ -349,7 +355,8 @@ public sealed class GitHubSyncService
             {
                 var token = auth.Token;
                 logger?.LogInformation("Re-importing {Space} at {Ref}", spacePath, commitish);
-                return FetchAndImport(repoUrl, commitish, config.Subdirectory, token, spacePath, progress)
+                return FetchAndImport(repoUrl, commitish, config.Subdirectory, token, spacePath,
+                        SyncIgnore.For(config), progress)
                     .SelectMany(x => RecordLastSync(spacePath, x.CommitSha, sourceId).Select(_ => x.Result));
             });
         });
@@ -404,10 +411,10 @@ public sealed class GitHubSyncService
 
     private IObservable<(StaticRepoImportResult Result, string CommitSha)> FetchAndImport(
         string repoUrl, string commitish, string? subdirectory, string token, string spaceId,
-        Action<string, LogLevel>? progress = null)
+        SyncIgnore ignore, Action<string, LogLevel>? progress = null)
     {
         return repoClient.Fetch(repoUrl, commitish, subdirectory, token).SelectMany(snapshot =>
-            ParseSnapshot(snapshot, spaceId, progress).SelectMany(parsed =>
+            ParseSnapshot(snapshot, spaceId, ignore, progress).SelectMany(parsed =>
             {
                 var source = new InMemoryStaticRepoSource(spaceId, parsed.Children, parsed.Root);
                 return StaticRepoImporter.ImportSource(hub, source, logger)
@@ -416,11 +423,14 @@ public sealed class GitHubSyncService
     }
 
     private IObservable<(MeshNode? Root, IReadOnlyList<MeshNode> Children)> ParseSnapshot(
-        RepoSnapshot snapshot, string spaceId, Action<string, LogLevel>? progress = null)
+        RepoSnapshot snapshot, string spaceId, SyncIgnore ignore, Action<string, LogLevel>? progress = null)
     {
         if (snapshot.Files.Count == 0)
             return Observable.Return(((MeshNode?)null, (IReadOnlyList<MeshNode>)Array.Empty<MeshNode>()));
         return snapshot.Files
+            // The Space's ignore rules apply on import too — a repo that carries ignored paths
+            // (e.g. Release/ bookkeeping from an older export) must not re-create those nodes.
+            .Where(f => !ignore.IsIgnored(f.Path))
             .Select(f => ParseFile(f, spaceId, progress))
             .Merge(8)
             .Where(x => x.Node is not null)

--- a/src/MeshWeaver.GitSync/SyncIgnore.cs
+++ b/src/MeshWeaver.GitSync/SyncIgnore.cs
@@ -27,8 +27,9 @@ namespace MeshWeaver.GitSync;
 public sealed class SyncIgnore
 {
     /// <summary>The default rule set when a config sets none: compile release-request records
-    /// (<c>Release/</c> folders at any depth) don't sync.</summary>
-    public static readonly string[] Default = ["Release/"];
+    /// (<c>Release/</c> folders at any depth) don't sync. Immutable — a shared constant, never
+    /// written at runtime (the allowed kind of static).</summary>
+    public static readonly IReadOnlyList<string> Default = ["Release/"];
 
     private readonly List<(Regex Pattern, bool Negated)> _rules;
 

--- a/src/MeshWeaver.GitSync/SyncIgnore.cs
+++ b/src/MeshWeaver.GitSync/SyncIgnore.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// Gitignore-style ignore rules for GitHub sync. The SAME rule set is applied on export (node
+/// paths relative to the Space root) and on import (repo file paths relative to the mirrored
+/// subdirectory), so an ignored subtree never syncs in either direction. Semantics follow
+/// <c>.gitignore</c>:
+/// <list type="bullet">
+///   <item><c>*</c> matches within a path segment, <c>**</c> across segments, <c>?</c> one character;</item>
+///   <item>a pattern containing a <c>/</c> (other than a trailing one) is anchored to the Space
+///     root; otherwise it matches at ANY depth;</item>
+///   <item>a match ignores the node/file AND everything beneath it (a trailing <c>/</c> is
+///     accepted and equivalent — node paths don't distinguish files from directories);</item>
+///   <item><c>!pattern</c> re-includes; the LAST matching rule wins;</item>
+///   <item>blank lines and <c>#</c> comment lines are skipped.</item>
+/// </list>
+/// Nothing is hardcoded in the sync pipeline: the rules come from
+/// <see cref="GitHubSyncConfig.Ignore"/> on the Space's <c>_GitSync</c> config node, falling back
+/// to <see cref="Default"/> when unset. <see cref="Default"/> ignores <c>Release/</c> — the
+/// per-NodeType release-request records the compile pipeline appends on every release: machine
+/// bookkeeping (~one node per recompile, forever), not content. A Space can override by setting
+/// its own list; an explicit EMPTY list syncs everything.
+/// </summary>
+public sealed class SyncIgnore
+{
+    /// <summary>The default rule set when a config sets none: compile release-request records
+    /// (<c>Release/</c> folders at any depth) don't sync.</summary>
+    public static readonly string[] Default = ["Release/"];
+
+    private readonly List<(Regex Pattern, bool Negated)> _rules;
+
+    /// <summary>Builds the matcher from gitignore-style patterns; null → <see cref="Default"/>.</summary>
+    public SyncIgnore(IEnumerable<string>? patterns)
+        => _rules = (patterns ?? Default)
+            .Select(p => p.Trim())
+            .Where(p => p.Length > 0 && !p.StartsWith('#'))
+            .Select(p =>
+            {
+                var negated = p.StartsWith('!');
+                return (ToRegex(negated ? p[1..] : p), negated);
+            })
+            .ToList();
+
+    /// <summary>The matcher for a Space's sync config — unset config/patterns → <see cref="Default"/>.</summary>
+    public static SyncIgnore For(GitHubSyncConfig? config) => new(config?.Ignore);
+
+    /// <summary>
+    /// True when <paramref name="relativePath"/> ('/'-separated, relative to the Space root /
+    /// mirrored subdirectory, no leading slash) is ignored. Last matching rule wins; no matching
+    /// rule → not ignored. The empty path (the Space root itself) is never ignored.
+    /// </summary>
+    public bool IsIgnored(string relativePath)
+    {
+        if (string.IsNullOrEmpty(relativePath))
+            return false;
+        var ignored = false;
+        foreach (var (pattern, negated) in _rules)
+            if (pattern.IsMatch(relativePath))
+                ignored = !negated;
+        return ignored;
+    }
+
+    // Translates one gitignore-style glob into an anchored regex over relative paths.
+    private static Regex ToRegex(string pattern)
+    {
+        pattern = pattern.TrimEnd('/');
+        // A '/' anywhere else anchors the pattern to the root, like gitignore.
+        var anchored = pattern.Contains('/');
+        pattern = pattern.TrimStart('/');
+
+        var sb = new StringBuilder(anchored ? "^" : @"(^|.*/)");
+        for (var i = 0; i < pattern.Length; i++)
+        {
+            var c = pattern[i];
+            if (c == '*')
+            {
+                if (i + 1 < pattern.Length && pattern[i + 1] == '*')
+                {
+                    sb.Append(".*");
+                    i++;
+                }
+                else
+                {
+                    sb.Append("[^/]*");
+                }
+            }
+            else if (c == '?')
+                sb.Append("[^/]");
+            else
+                sb.Append(Regex.Escape(c.ToString()));
+        }
+        // The match ignores the path itself and everything beneath it.
+        sb.Append("(/.*)?$");
+        return new Regex(sb.ToString(), RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    }
+}

--- a/test/MeshWeaver.GitSync.Test/MeshNodeContentEditorTest.cs
+++ b/test/MeshWeaver.GitSync.Test/MeshNodeContentEditorTest.cs
@@ -26,7 +26,7 @@ public class MeshNodeContentEditorTest(ITestOutputHelper output) : GitHubSyncTes
 
         // The six editable properties, by camelCase key — and NOT the [Browsable(false)] last-sync fields.
         Assert.Equal(
-            new[] { "repositoryUrl", "branch", "subdirectory", "direction", "createBranchIfMissing", "createRepoIfMissing" },
+            new[] { "repositoryUrl", "branch", "subdirectory", "direction", "createBranchIfMissing", "createRepoIfMissing", "ignore" },
             keys);
         Assert.DoesNotContain("lastSyncedAt", keys);
         Assert.DoesNotContain("lastSyncCommitSha", keys);

--- a/test/MeshWeaver.GitSync.Test/SyncIgnoreTest.cs
+++ b/test/MeshWeaver.GitSync.Test/SyncIgnoreTest.cs
@@ -1,0 +1,112 @@
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Pins the gitignore-style sync-ignore rules (<see cref="SyncIgnore"/>) and their application in
+/// the export filter (<see cref="GitHubSyncService.Filter"/>). Nothing is hardcoded in the sync
+/// pipeline: the rules come from <see cref="GitHubSyncConfig.Ignore"/>, defaulting to
+/// <see cref="SyncIgnore.Default"/> (<c>Release/</c> — the compile pipeline's release-request
+/// bookkeeping, appended on every recompile, forever; observed live: 77 such records exported
+/// into the plugins repo alongside the actual content).
+/// </summary>
+public class SyncIgnoreTest
+{
+    // ── Pattern semantics ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Release/2026-abc", true)]                          // top-level Release subtree
+    [InlineData("TreatySubmission/Release/2026-abc", true)]         // any-depth Release subtree
+    [InlineData("TreatySubmission/Release/2026-abc.json", true)]    // import-side file path
+    [InlineData("TreatySubmission/index.json", false)]
+    [InlineData("Source/Role", false)]                              // content is not ignored
+    [InlineData("ReleaseNotes/2026", false)]                        // segment must match exactly
+    [InlineData("", false)]                                         // the space root itself
+    public void Default_IgnoresReleaseSubtreesAtAnyDepth(string path, bool ignored)
+        => Assert.Equal(ignored, new SyncIgnore(null).IsIgnored(path));
+
+    [Fact]
+    public void ExplicitEmptyList_SyncsEverything()
+        => Assert.False(new SyncIgnore([]).IsIgnored("Release/2026-abc"));
+
+    [Theory]
+    [InlineData("Drafts/x", true)]              // unanchored: any depth
+    [InlineData("Deep/Drafts/x", true)]
+    [InlineData("Published/x", false)]
+    public void CustomPattern_MatchesAtAnyDepth(string path, bool ignored)
+        => Assert.Equal(ignored, new SyncIgnore(["Drafts/"]).IsIgnored(path));
+
+    [Theory]
+    [InlineData("Drafts/x", true)]              // anchored by the embedded '/'
+    [InlineData("Deep/Drafts/x", false)]
+    public void SlashAnchorsToTheSpaceRoot(string path, bool ignored)
+        => Assert.Equal(ignored, new SyncIgnore(["/Drafts/"]).IsIgnored(path));
+
+    [Theory]
+    [InlineData("notes.tmp", true)]
+    [InlineData("a/b/notes.tmp", true)]
+    [InlineData("notes.md", false)]
+    public void StarGlob_MatchesWithinASegment(string path, bool ignored)
+        => Assert.Equal(ignored, new SyncIgnore(["*.tmp"]).IsIgnored(path));
+
+    [Fact]
+    public void DoubleStar_MatchesAcrossSegments()
+        => Assert.True(new SyncIgnore(["Clients/**/2023"]).IsIgnored("Clients/DragenIns/2023/x"));
+
+    [Fact]
+    public void Negation_LastMatchWins()
+    {
+        var ignore = new SyncIgnore(["Release/", "!Release/keep-this"]);
+        Assert.True(ignore.IsIgnored("Release/2026-abc"));
+        Assert.False(ignore.IsIgnored("Release/keep-this"));
+    }
+
+    [Fact]
+    public void CommentsAndBlanksAreSkipped()
+        => Assert.False(new SyncIgnore(["# just a comment", "  "]).IsIgnored("anything"));
+
+    // ── Application in the export filter ──────────────────────────────────
+
+    private static MeshNode Node(string id, string ns) => new(id, ns)
+    {
+        NodeType = "Markdown",
+        MainNode = $"{ns}/{id}",
+    };
+
+    [Fact]
+    public void Filter_DropsIgnoredSubtrees_KeepsContent()
+    {
+        var nodes = new List<MeshNode>
+        {
+            Node("readme", "UW"),
+            Node("Role", "UW/Source"),
+            Node("2026-abc", "UW/Release"),
+            Node("2026-def", "UW/TreatySubmission/Release"),
+        };
+
+        var kept = GitHubSyncService.Filter(nodes, "UW", SyncIgnore.For(new GitHubSyncConfig()));
+
+        Assert.Contains(kept, n => n.Id == "readme");
+        Assert.Contains(kept, n => n.Id == "Role");
+        Assert.DoesNotContain(kept, n => n.Id == "2026-abc");
+        Assert.DoesNotContain(kept, n => n.Id == "2026-def");
+    }
+
+    [Fact]
+    public void Filter_ConfigOverridesTheDefault()
+    {
+        var nodes = new List<MeshNode>
+        {
+            Node("2026-abc", "UW/Release"),
+            Node("draft", "UW/Drafts"),
+        };
+        var config = new GitHubSyncConfig { Ignore = ["Drafts/"] };
+
+        var kept = GitHubSyncService.Filter(nodes, "UW", SyncIgnore.For(config));
+
+        // The Space's own rules replace the default entirely: Release syncs, Drafts doesn't.
+        Assert.Contains(kept, n => n.Id == "2026-abc");
+        Assert.DoesNotContain(kept, n => n.Id == "draft");
+    }
+}


### PR DESCRIPTION
Follow-up to #441 / the UWDeepfield export work: the first complete export carried **77 `<Type>/Release/*.json` release-request records** — compile bookkeeping (one node per recompile, forever) that would churn every future sync commit.

**Nothing hardcoded**: each Space's `_GitSync` config gets an optional **`Ignore`** list of gitignore-style patterns (`*` / `**` / `?` globs, `/` anchoring, `!` re-includes with last-match-wins, `#` comments), applied to paths relative to the Space root in **both directions** — export (node paths) and import (repo file paths) — so an ignored subtree never syncs either way, exactly like `.gitignore`.

- Unset → `SyncIgnore.Default = ["Release/"]` (matches `Release/` folders at any depth).
- An explicit empty list syncs everything; a config-set list **replaces** the default.
- Editable in the standard node-content editor like the rest of `GitHubSyncConfig`.

The live Release nodes on memex.systemorph.com (82 across UWDeepfield/Slides/Edu) have been deleted; with this change new ones stay out of every export.

Tests: `SyncIgnoreTest` pins pattern semantics (default at any depth incl. import file paths, anchoring, globs, negation, comments, empty-list opt-out) and the export `Filter` application; the editor field pin gains `ignore`. Full GitSync suite 107/107 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)