### PR TITLE
CI overhaul: ~30→~18 min runs, unmask 4 classes of hidden test failures, fix a prod 5s get-latency defect

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -114,8 +114,12 @@ jobs:
         find test -mindepth 2 -maxdepth 2 -type d -name bin > .build-paths.txt
         echo "Packaging $(wc -l < .build-paths.txt) test bin trees"
         # One zstd tarball (-T0 = all cores) moves through upload/download-artifact
-        # FAR faster than millions of loose files would.
-        tar -I 'zstd -T0' -cf build-output.tar.zst -T .build-paths.txt
+        # FAR faster than millions of loose files would. --long=27 (128 MiB match
+        # window) dedupes across files: the ~60 self-contained test bins each carry
+        # near-identical copies of the same framework + MeshWeaver DLLs, which a
+        # default window (8 MiB) can't see. The EXTRACT side must pass --long=27
+        # too, or zstd refuses with a window-size error.
+        tar -I 'zstd -T0 --long=27' -cf build-output.tar.zst -T .build-paths.txt
         ls -lh build-output.tar.zst
     - name: "Upload artifact: build output"
       uses: actions/upload-artifact@v6
@@ -169,7 +173,8 @@ jobs:
     - name: Extract build output
       run: |
         set -euo pipefail
-        tar -I zstd -xf build-output.tar.zst
+        # --long=27 matches the pack side (window > 8 MiB default; required to decode).
+        tar -I 'zstd --long=27' -xf build-output.tar.zst
         rm -f build-output.tar.zst
     - name: Run Tests
       env:
@@ -177,6 +182,14 @@ jobs:
         Logging__LogLevel__Default: Warning
         SHARD_INDEX: ${{ matrix.shard }}
         SHARD_TOTAL: 6
+        # Native-crash diagnosability (SIGSEGV/SIGABRT of a test host): the runtime
+        # writes a mini core dump before dying, collected into the shard artifact.
+        # First seen: FutuRe.Test exit=139 on the first native-host run — not
+        # reproducible on macOS-arm64 or linux-arm64 locally, so the dump is the
+        # only window into the runner-only crash.
+        DOTNET_DbgEnableMiniDump: 1
+        DOTNET_DbgMiniDumpType: 2
+        DOTNET_DbgMiniDumpName: /tmp/coredumps/%e-%p.dmp
       run: |
         # Only Cosmos is excluded — needs the Cosmos emulator which is heavy to
         # set up on a runner. Everything else runs (PostgreSql via Testcontainers
@@ -188,6 +201,7 @@ jobs:
         # fails the shard on anything non-zero.
         set +e
         : > test/test-results.log
+        mkdir -p /tmp/coredumps
 
         # ── Shard assignment: measured weights + greedy LPT ──────────────────
         # Weights are wall-clock seconds measured on ubuntu-latest (run
@@ -319,6 +333,12 @@ jobs:
         # find the worst leakers without wading through the full per-event trace.
         if [ -f /tmp/meshweaver-memory-delta.log ]; then
           cp /tmp/meshweaver-memory-delta.log collected-logs/_meshweaver-memory-delta.log
+        fi
+        # Native-crash mini dumps (DOTNET_DbgEnableMiniDump) — present only when a
+        # test host died on a signal; the exit-marker gate reds the shard, this is
+        # the forensic payload.
+        if compgen -G '/tmp/coredumps/*.dmp' > /dev/null; then
+          cp /tmp/coredumps/*.dmp collected-logs/
         fi
     - name: "Upload artifact: shard test results"
       uses: actions/upload-artifact@v6

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -5,13 +5,26 @@
 #   build ──▶ test (matrix shard 0..5) ──▶ collect-results
 #
 # Why this shape (vs. the old "every shard restores+builds the whole solution"):
-#   * The 50+ project solution was compiled 4× — once per shard. Building once
-#     and shipping the output to the shards removes 3 redundant full builds.
-#   * Shards run `dotnet test --no-build --no-restore` against the extracted
-#     output — they START FROM ARTIFACTS, never recompile, so a shard can only
-#     fail for a real test reason (or genuine infra failure), not a flaky build.
+#   * The 50+ project solution is compiled exactly once; shards start from the
+#     packaged TEST BIN outputs, never recompile, so a shard can only fail for
+#     a real test reason (or genuine infra failure), not a flaky build.
+#   * Shards run each test project's NATIVE xUnit v3 host (`dotnet <Name>.dll`)
+#     instead of `dotnet test --no-build`: no per-project MSBuild evaluation
+#     (seconds × ~45 projects), no obj/ or NuGet cache needed in the artifact
+#     (the tarball shrank from bin+obj+.nuget-of-everything to test bins only),
+#     and the host's exit code faithfully reports catastrophic failures that
+#     vstest used to mask (see the exit-marker gate below).
 #   * Results are published from ONE collector job → a single "Test Results"
-#     check is the pass/fail gate, instead of 4 separate per-shard checks.
+#     check is the pass/fail gate, instead of separate per-shard checks.
+#
+# Gates (a shard/run is red when ANY fires):
+#   1. trx parse — any <UnitTestResult outcome="Failed"> across shards.
+#   2. exit markers — any per-project `[CI] <name> exit=N` with N != 0. This is
+#      what catches a test host that CRASHES after streaming green results
+#      (SIGABRT/FailFast → exit 134 with an all-green trx: the 2026-07 masked
+#      Persistence.Test memory-watchdog abort), a 6m wall-clock kill (124/137),
+#      and xunit catastrophic failures ("There is no currently active test",
+#      teardown ObjectDisposedException) that leave no failed trx entry.
 
 name: MeshWeaver Build and Test
 
@@ -22,14 +35,14 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-# Pin the NuGet global-packages folder INSIDE the workspace so the build job's
-# restore output travels in the same artifact as bin/obj. ${{ github.workspace }}
-# is identical across jobs on ubuntu-latest (/home/runner/work/<repo>/<repo>),
-# so the absolute paths baked into project.assets.json / *.nuget.g.props stay
-# valid after the shards extract the tarball — that's what makes
-# `dotnet test --no-build --no-restore` resolve packages offline.
-env:
-  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+# A force-push to a PR branch obsoletes the in-flight run — cancel it instead of
+# finishing a build of dead code (runner minutes + queue latency for 8 jobs/run).
+# Runs on main (and manual dispatches) are never grouped/cancelled: every main
+# push must produce its own complete run because main-cd + the self-update gate
+# key off it (group = run_id ⇒ each run is its own group).
+concurrency:
+  group: build-test-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # publish-unit-test-result-action runs per shard AND in the collector — both need
 # checks: write to create check-runs and pull-requests: write to comment.
@@ -40,24 +53,33 @@ permissions:
 
 jobs:
   # ───────────────────────────── BUILD ─────────────────────────────
-  # Compile the whole solution exactly once and package the compiled output
-  # (every project's bin + obj) together with the NuGet global-packages folder
-  # into a single self-contained tarball the shards consume.
+  # Compile the whole solution exactly once and package every TEST project's
+  # bin output (self-contained: CopyLocal puts each test's full dependency
+  # closure + fixtures in its own bin) into one tarball the shards consume.
+  #
+  # No `dotnet workload restore`: the 2026-07-12 CI logs prove it installs
+  # NOTHING ("No workloads installed for this feature band … Successfully
+  # updated workload(s): .") and burned ~75 s per job updating advertising
+  # manifests. No project in the graph requires a workload; if one ever does,
+  # the build step here fails loudly and the restore comes back — with a cache.
+  #
+  # No mesh-local `#r` pack step: the baked feed was removed from the portal
+  # image in #395 (the scope generator ships with the platform and runs
+  # in-process — pinned by BuiltInScopeGeneratorTest; legacy
+  # `#r "nuget:MeshWeaver.BusinessRules.Generator"` directives are filtered out
+  # of the NuGet resolve set at compile). Nothing in the test suite resolves
+  # from dist/packages anymore, so packing it was pure waste.
   build:
     name: "Build solution (once)"
     timeout-minutes: 25
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    # The build job packages bin+obj of all 50+ projects PLUS the whole
-    # .nuget/packages folder into a zstd tarball — that's a multi-GB copy on top
-    # of the originals, which overflowed the default ~14 GB ("No space left on
-    # device" in the runner Worker, mid-package). Reclaim the ~25 GB of
-    # preinstalled tooling a .NET build never touches (Android SDK, Haskell/GHC,
-    # preloaded Docker images, big apt packages) — identical to what the test
-    # shards already do. NOT a band-aid for a leak: the build output is a
-    # legitimate, bounded artifact; this just removes genuinely-unused runner
-    # bloat so it fits. Keep .NET + the hosted tool cache (setup-dotnet uses them).
+    # The full-solution build outputs + the test-bin tarball overflow the
+    # default ~14 GB free. Reclaim the runner bloat a .NET build never touches.
+    # large-packages (the slowest removal, ~40-60 s of apt) is OFF since the
+    # artifact stopped carrying obj/ + the NuGet cache — the reclaimed space is
+    # no longer needed. Keep .NET + the hosted tool cache (setup-dotnet uses them).
     - name: Free disk space
       uses: jlumbroso/free-disk-space@main
       with:
@@ -65,15 +87,13 @@ jobs:
         dotnet: false
         android: true
         haskell: true
-        large-packages: true
+        large-packages: false
         docker-images: true
         swap-storage: true
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
-    - name: Restore workloads
-      run: dotnet workload restore
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -83,54 +103,19 @@ jobs:
       # the gate explicit at the CI build step. NuGet restore advisories (NU19xx vulnerabilities) stay
       # warnings (WarningsNotAsErrors in Directory.Build.props) — handled via dependency overrides.
       run: dotnet build --no-restore -c Release -p:CIRun=true -warnaserror
-    # Node Source can pull MeshWeaver libraries in via a version-LESS `#r "nuget:MeshWeaver.X"`
-    # (e.g. the BusinessRules scope generator the PensionFund sample uses). Tests resolve those
-    # from the mesh-local feed (nuget.config → dist/packages), which is git-ignored — so the
-    # build job must produce them. Pack the just-built RELEASE output at the dev-feed $(Version);
-    # dist/packages travels in the build artifact below, so the --no-build/--no-restore
-    # shards (and the runtime #r resolver inside them) can resolve them offline. These are the
-    # same Release nupkgs you'd publish directly. Self-contained: BusinessRules depends only on
-    # framework packages (already in the restored .nuget cache).
-    - name: Pack mesh-local #r packages
+    - name: Package test outputs
       run: |
         set -euo pipefail
-        # -c Release matches the Release build above. NO -p:PackageVersion override: pack at the
-        # repo's continuous dev-feed $(Version) from Directory.Build.props (= 3.0.0-rc1.ci.0 here),
-        # exactly as the portal image's BakeMeshLocalFeed target and the test's documented local
-        # repro do.
-        #
-        # 🚨 Do NOT pin -p:PackageVersion=3.0.0-preview1. nuget.org carries a STALE
-        # MeshWeaver.BusinessRules.Generator 3.0.0-preview1 (published 2026-04-16, before the
-        # generator shipped its lib/<tfm> asset) that has analyzers/dotnet/cs ONLY — no lib/. NuGet's
-        # global-packages cache is keyed solely by (id, version), so once that lib-less copy lands
-        # under .nuget/packages/meshweaver.businessrules.generator/3.0.0-preview1 the runtime #r
-        # resolver's install short-circuit reuses it and NEVER surfaces the lib/ assembly — scope
-        # nodes compile but generate nothing (PensionFund balance sheet renders empty;
-        # NuGetAssemblyResolverTest fails at the lib/ assertion). packageSourceMapping pins resolution
-        # to this feed, but it can't un-poison a colliding cache key. rc1.ci.N is never published on
-        # nuget.org, so the cache key can ONLY ever be this lib-containing local package.
-        dotnet pack src/MeshWeaver.BusinessRules/MeshWeaver.BusinessRules.csproj \
-          -c Release --no-build --no-restore -o dist/packages --nologo
-        dotnet pack src/MeshWeaver.BusinessRules.Generator/MeshWeaver.BusinessRules.Generator.csproj \
-          -c Release --no-build --no-restore -o dist/packages --nologo
-        ls -lh dist/packages
-    - name: Package build output
-      run: |
-        set -euo pipefail
-        # Collect every project's compiled output (bin) + restore graph (obj),
-        # plus the workspace-local NuGet packages folder. -prune stops find from
-        # descending once a bin/obj matches, so nested matches aren't tarred
-        # twice. .git and the packages tree are excluded from the bin/obj scan;
-        # the packages folder is appended explicitly (added whole below).
-        find . -type d \( -name bin -o -name obj \) \
-          -not -path './.git/*' -not -path './.nuget/*' -prune -print > .build-paths.txt
-        echo "./.nuget/packages" >> .build-paths.txt
-        # The mesh-local #r feed packed above — the test shards' runtime #r resolver reads it.
-        echo "./dist/packages" >> .build-paths.txt
+        # Only the TEST projects' bin trees travel to the shards. Each test bin
+        # is self-contained (dependency closure + TestData fixtures copied in),
+        # and the native xUnit v3 hosts need no obj/, no src/samples bins, and
+        # no NuGet global-packages folder (runtime NuGet-resolver tests declare
+        # themselves network-based and restore into the default cache).
+        find test -mindepth 2 -maxdepth 2 -type d -name bin > .build-paths.txt
+        echo "Packaging $(wc -l < .build-paths.txt) test bin trees"
         # One zstd tarball (-T0 = all cores) moves through upload/download-artifact
-        # FAR faster than the millions of loose bin/obj/packages files would.
+        # FAR faster than millions of loose files would.
         tar -I 'zstd -T0' -cf build-output.tar.zst -T .build-paths.txt
-        echo "Packaged build output:"
         ls -lh build-output.tar.zst
     - name: "Upload artifact: build output"
       uses: actions/upload-artifact@v6
@@ -144,13 +129,9 @@ jobs:
 
   # ───────────────────────────── TEST ──────────────────────────────
   # Matrix-sharded: the ~45 test projects are split across SHARD_TOTAL parallel
-  # runners (each runs a disjoint subset). Each shard downloads the prebuilt
-  # output and runs `dotnet test --no-build --no-restore` — NO restore, NO
-  # build. It cuts the per-runner project count (and the leftover-state / memory
-  # accumulation that made late projects flake under the old single-runner
-  # sequential loop) by ~SHARD_TOTAL×.
-  # 30 min: a single shard's ~10 projects run in ~15-20 min; headroom for one
-  # hung project burning its 6m wall-clock cap.
+  # runners by MEASURED weight (greedy LPT — see the Run Tests step). Each shard
+  # downloads the prebuilt test bins and runs each project's native xUnit v3
+  # host — NO restore, NO build, NO MSBuild.
   test:
     name: "Run tests (shard ${{ matrix.shard }})"
     needs: build
@@ -165,14 +146,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    # The ~14 GB free on a GitHub-hosted runner does not fit the extracted 50-project
-    # build output + the pgvector Testcontainers image + per-project test outputs/blame
-    # dumps + runner _diag logs — shards were dying with "No space left on device" (the
-    # runner Worker itself, mid-run). Reclaim the ~25 GB of preinstalled tooling a
-    # .NET+Postgres test run never touches (Android SDK, Haskell/GHC, preloaded Docker
-    # images, big apt packages). NOT a band-aid for a code leak — it removes genuinely
-    # unused runner bloat so the legitimate test workload fits. Keep .NET + the hosted
-    # tool cache (setup-dotnet uses them).
+    # Extracted test bins + the pgvector Testcontainers image + per-project test
+    # outputs don't fit the default ~14 GB. Same trimmed reclaim as the build job.
     - name: Free disk space
       uses: jlumbroso/free-disk-space@main
       with:
@@ -180,18 +155,13 @@ jobs:
         dotnet: false
         android: true
         haskell: true
-        large-packages: true
+        large-packages: false
         docker-images: true
         swap-storage: true
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
-    # Workloads (e.g. aspire) live in the SDK, not in the build artifact — they
-    # are needed for MSBuild to evaluate workload-referencing projects even under
-    # --no-build. This installs SDK packs only; it does NOT recompile the solution.
-    - name: Restore workloads
-      run: dotnet workload restore
     - name: "Download artifact: build output"
       uses: actions/download-artifact@v6
       with:
@@ -213,78 +183,107 @@ jobs:
         # using pre-installed Docker, Orleans via in-proc TestCluster, Acme/FutuRe
         # via dynamic Code-piece compilation).
         #
-        # set +e so a hung/aborted test host (non-zero exit) doesn't terminate
-        # the loop — we want EVERY csproj to attempt to run, then surface what
-        # broke after the loop completes. The collect-results job is the gate;
-        # this step always exits 0 so per-project failures don't mask sibling
-        # projects that still need to run.
-        #
-        # Disk hygiene: `--verbosity minimal`, no tee — trx files capture full
-        # per-test results; only the per-project exit markers are persisted to
-        # test/test-results.log.
+        # set +e so a crashed/aborted test host doesn't terminate the loop — we
+        # want EVERY project to attempt to run, then the exit-marker gate below
+        # fails the shard on anything non-zero.
         set +e
         : > test/test-results.log
-        echo "::group::Per-project test runs (shard $SHARD_INDEX/$SHARD_TOTAL)"
-        # `! -path '*/bin/*'`: the build copies sample csproj fixtures into test
-        # bin dirs (e.g. MeshWeaver.Samples.Graph.csproj under
-        # test/MeshWeaver.Acme.Test/bin/Debug/net10.0/SamplesGraph/). They match
-        # the *.csproj pattern but aren't test projects — invoking dotnet test on
-        # each wastes ~1 s × N entries per run.
-        #
-        # Shard selection (weighted): the ~7 dynamic-compilation / collectible-ALC
-        # heavyweights (Acme, AI, Content, FutuRe, Graph, Hosting.Monolith,
-        # Hosting.Orleans) dominate BOTH wall-clock AND the per-runner memory
-        # accumulation (leaked NodeType ALCs) that makes a late project GC-stall and
-        # time out. A plain `idx % SHARD_TOTAL` over the *alphabetical* list happened
-        # to drop the three worst — AI + FutuRe + Orleans — all onto shard 2, which
-        # then memory-pressured and timed out the Orleans Resubmit test at 45 s +
-        # crashed teardown. Fix: round-robin the heavies on their OWN counter so
-        # consecutive heavies always land on different shards (AI/FutuRe/Orleans →
-        # distinct shards), and round-robin the light projects on a separate counter.
-        # Net: no shard carries more than two heavies, never the three ALC-heaviest
-        # together. AI.Test.FakeCli is a helper exe, not a heavy test → stays light.
-        # SHARD_TOTAL was raised 4→6: with 7 heavies over 6 shards only ONE shard
-        # doubles up (Acme+Orleans) and the ALC-3 (AI/FutuRe/Orleans) still land on
-        # distinct shards, while the ~38 light projects spread over 6 instead of 4 —
-        # that's what cuts the old 24-min long-pole shard (its extra light projects
-        # move off it).
-        heavy_idx=0
-        light_idx=0
+
+        # ── Shard assignment: measured weights + greedy LPT ──────────────────
+        # Weights are wall-clock seconds measured on ubuntu-latest (run
+        # 29213734083, 2026-07-13). Explicit and ORDER-INDEPENDENT: the previous
+        # `counter % SHARD_TOTAL` over a sorted csproj list silently depended on
+        # locale byte order — C-locale sorts MeshWeaver.AI.Test BEFORE
+        # MeshWeaver.Acme.Test ('I' 0x49 < 'c' 0x63), which stacked AI + Orleans
+        # (two of the three ALC-heaviest projects) onto shard 0, the exact
+        # pairing the scheme existed to prevent, making shard 0 the ~19-minute
+        # long pole of every run. Greedy LPT (heaviest first onto the currently
+        # least-loaded shard, ties to the lowest shard id) balances by measured
+        # cost regardless of enumeration order.
+        # Unlisted projects default to 10 s. When a project's runtime changes
+        # materially, re-measure (the per-project markers in this step's log ARE
+        # the measurement) and update the number here.
+        declare -A WEIGHT=(
+          [MeshWeaver.AI.Test]=340
+          [MeshWeaver.Hosting.Orleans.Test]=200
+          [MeshWeaver.Hosting.Monolith.Test]=200
+          [MeshWeaver.Persistence.Test]=165
+          [MeshWeaver.Threading.Test]=105
+          [MeshWeaver.Hosting.PostgreSql.Test]=105
+          [MeshWeaver.Security.Test]=90
+          [MeshWeaver.FutuRe.Test]=60
+          [MeshWeaver.Content.Test]=60
+          [MeshWeaver.Acme.Test]=55
+          [MeshWeaver.Query.Test]=55
+          [MeshWeaver.Autocomplete.Test]=50
+          [MeshWeaver.Auth.Test]=40
+          [MeshWeaver.GitSync.Test]=35
+          [MeshWeaver.NodeOperations.Test]=35
+          [MeshWeaver.InstanceSync.Test]=30
+          [MeshWeaver.Graph.Test]=30
+          [MeshWeaver.Data.Test]=25
+          [MeshWeaver.Messaging.Hub.Test]=25
+          [MeshWeaver.Courses.Test]=20
+          [MeshWeaver.Layout.Test]=20
+          [MeshWeaver.PluginCatalog.Test]=20
+          [MeshWeaver.Markdown.Test]=20
+          [MeshWeaver.PathResolution.Test]=15
+          [MeshWeaver.PensionFund.Test]=15
+          [MeshWeaver.ContentCollections.Indexing.PostgreSql.Test]=15
+          [MeshWeaver.ContentCollections.Indexing.Graph.Test]=15
+          [MeshWeaver.MemexTemplate.Test]=15
+        )
+        DEFAULT_WEIGHT=10
+
+        assignment=$(mktemp)
         for csproj in $(find test -name '*.csproj' \
             ! -path '*Cosmos*' \
             ! -path '*/bin/*' \
             | sort); do
           name=$(basename "$csproj" .csproj)
-          case "$name" in
-            MeshWeaver.Acme.Test|MeshWeaver.AI.Test|MeshWeaver.Content.Test|MeshWeaver.FutuRe.Test|MeshWeaver.Graph.Test|MeshWeaver.Hosting.Monolith.Test|MeshWeaver.Hosting.Orleans.Test)
-              assigned=$(( heavy_idx % SHARD_TOTAL ))
-              heavy_idx=$(( heavy_idx + 1 ))
-              ;;
-            *)
-              assigned=$(( light_idx % SHARD_TOTAL ))
-              light_idx=$(( light_idx + 1 ))
-              ;;
-          esac
-          if [ "$assigned" -ne "$SHARD_INDEX" ]; then
+          w=${WEIGHT[$name]:-$DEFAULT_WEIGHT}
+          printf '%05d %s %s\n' "$w" "$name" "$csproj"
+        done | sort -k1,1nr -k2,2 > "$assignment"
+
+        declare -a loads
+        for ((i=0; i<SHARD_TOTAL; i++)); do loads[i]=0; done
+        declare -a selected=()
+        while read -r w name csproj; do
+          best=0
+          for ((i=1; i<SHARD_TOTAL; i++)); do
+            if (( loads[i] < loads[best] )); then best=$i; fi
+          done
+          loads[best]=$(( loads[best] + 10#$w ))
+          if [ "$best" -eq "$SHARD_INDEX" ]; then selected+=("$csproj"); fi
+        done < "$assignment"
+        echo "Shard $SHARD_INDEX/$SHARD_TOTAL runs ${#selected[@]} projects (weighted loads: ${loads[*]})"
+
+        # ── Run each assigned project's native xUnit v3 host ─────────────────
+        for csproj in "${selected[@]}"; do
+          name=$(basename "$csproj" .csproj)
+          dir=$(dirname "$csproj")/bin/Release/net10.0
+          # Helper projects (TestDomain, Hub.Fixture, AI.Test.FakeCli) ship no
+          # xunit.v3 host — nothing to run. Recorded so the log shows they were
+          # consciously skipped, not lost.
+          if [ ! -f "$dir/$name.dll" ] || [ ! -f "$dir/xunit.v3.core.dll" ]; then
+            echo "[CI] $name exit=0 (helper project — no xUnit v3 test host)" >> test/test-results.log
             continue
           fi
-          echo "::endgroup::"
           echo "::group::$name"
-          # `timeout 6m`: per-project wall-clock cap. blame-hang-timeout 90s only
-          # fires when xUnit considers a *test* to have stalled — fixture-init
-          # and between-class hangs slip past it. 6 min covers the slowest
-          # legitimate project today (FutuRe ~5 min) with headroom; defense-in-
-          # depth backstop in case any of the skipped Linux-hang projects gets
-          # re-enabled or another regresses to the same pattern.
-          # blame-hang-timeout: 90 s of test-runner inactivity before blame
-          # collects a hang dump and aborts the test host. 90 s gives genuine
-          # teardown room (hosted-hub / static-cache dispose) without masking real
-          # hangs (the per-project 6 m wall-clock cap is the hard backstop).
-          # --no-build --no-restore: run STRICTLY against the extracted build
-          # output — never recompile or hit the network on a test runner.
-          timeout --signal=TERM --kill-after=30s 6m \
-            dotnet test "$csproj" -c Release --no-build --no-restore --verbosity minimal -l:trx \
-              --blame-hang-timeout 90s --blame-hang-dump-type mini
+          # `timeout 8m`: per-project wall-clock cap — the hang backstop (a
+          # fixture-init or between-class hang has no in-process watchdog).
+          # Sized to the slowest legitimate project + headroom: AI.Test measures
+          # ~190 s locally post-fix (was 460 s before the hidden-failure +
+          # LookupCompilationError-timeout fixes), ≈5.5 min at the observed
+          # ~1.7× CI/local ratio. A kill here surfaces as exit=124/137 and
+          # fails the shard via the marker gate — never silently (under the old
+          # trx-only gate, AI.Test was killed at the cap and read GREEN on
+          # every run).
+          # CWD = the project's bin dir, exactly like `dotnet test` ran the
+          # host: appsettings.json + xunit.runner.json + TestData resolve there.
+          mkdir -p "$dir/TestResults"
+          ( cd "$dir" && timeout --signal=TERM --kill-after=30s 8m \
+              dotnet "$name.dll" -trx "TestResults/$name.trx" )
           rc=$?
           if [ "$rc" = "124" ] || [ "$rc" = "137" ]; then
             marker="[CI] $name exit=$rc TIMEOUT (6m wall-clock cap hit — likely fixture/init hang)"
@@ -293,8 +292,8 @@ jobs:
           fi
           echo "$marker"
           echo "$marker" >> test/test-results.log
+          echo "::endgroup::"
         done
-        echo "::endgroup::"
         exit 0
     - name: Collect test logs for artifact
       if: always()
@@ -305,8 +304,8 @@ jobs:
         # The MonolithMeshTestBase phase trace + dispose trace live in the
         # process tempdir (Path.GetTempPath() == /tmp on the runner). They
         # carry the per-class INIT_MEM / DISPOSE_MEM lines that pinpoint
-        # which test class drives the AI.Test / Autocomplete.Test / Content.Test
-        # / Hosting.Monolith.Test OOM. Copy with rename so they don't collide.
+        # which test class drives a shard's memory growth. Copy with rename so
+        # they don't collide.
         if [ -f /tmp/meshweaver-test-trace.log ]; then
           cp /tmp/meshweaver-test-trace.log collected-logs/_meshweaver-test-trace.log
         fi
@@ -325,13 +324,12 @@ jobs:
       uses: actions/upload-artifact@v6
       if: always()
       with:
-        # Unique per shard so the 4 parallel matrix legs don't clobber each
+        # Unique per shard so the parallel matrix legs don't clobber each
         # other; collect-results downloads them all by the testResults-shard* glob.
         name: testResults-shard${{ matrix.shard }}
         path: |
           test/**/*.trx
           test/test-results.log
-          test/**/blame-*.dmp
           collected-logs/
         compression-level: 9
         retention-days: 15
@@ -358,13 +356,13 @@ jobs:
           fi
         done
         if [ "$any" = "0" ]; then
-          echo "_No failed tests in trx for shard ${{ matrix.shard }} (a hang/crash would show below)._" >> "$GITHUB_STEP_SUMMARY"
+          echo "_No failed tests in trx for shard ${{ matrix.shard }} (a crashed/killed host fails via the exit-marker gate below)._" >> "$GITHUB_STEP_SUMMARY"
         else
           # 🚨 GATE (TRX-based, reporter-independent): fail the shard on any test
           # failure recorded in the trx. The Publish step below is a best-effort
-          # reporter whose GitHub-API call can be rate-limited (429 when 4 shards
+          # reporter whose GitHub-API call can be rate-limited (429 when shards
           # publish concurrently); a throttled reporter must NEVER be the pass/fail
-          # gate. This trx grep + the hang-dump check below own the gate now.
+          # gate. This trx grep + the exit-marker gate below own the gate.
           echo "::error::Shard ${{ matrix.shard }}: failing tests in trx — failing the shard."
           exit 1
         fi
@@ -376,31 +374,34 @@ jobs:
       # shard publishes) can't fail the build; test failures fail via the trx gate.
       continue-on-error: true
       with:
-        # Per-shard check so the 4 matrix legs don't clobber each other's
+        # Per-shard check so the matrix legs don't clobber each other's
         # check-run; distinct from the collector's "Test Results" check.
         check_name: "Test Results (shard ${{ matrix.shard }})"
         files: |
           test/**/*.trx
-    - name: Fail on hang / aborted test run (this shard)
-      # A hang aborts the test host and writes blame-*.dmp; fail the shard loudly
-      # so it isn't masked behind a green "results published" check. Last step so
-      # the artifact upload + per-shard publish above already ran.
+    - name: Fail on non-zero project exit (this shard)
+      # A test host that ABORTS mid-run (SIGABRT/FailFast → exit 134) streams
+      # green results for every COMPLETED test and then dies: the trx shows zero
+      # failures while in-flight + not-yet-run tests silently VANISH from the
+      # count. Same for a 6m wall-clock kill (124/137) and for xunit
+      # catastrophic failures that exit 1 with an all-green trx. The
+      # per-project exit markers are the only faithful record — gate on them.
+      # Last step so the artifact upload + per-shard publish above already ran.
       if: always()
       run: |
-        hang_dumps=$(find test -name 'blame-*.dmp' 2>/dev/null | wc -l)
-        if [ "$hang_dumps" -gt 0 ]; then
-          echo "::error::Shard ${{ matrix.shard }}: a test process hung — blame-*.dmp written."
-          find test -name 'blame-*.dmp' 2>/dev/null
-          cat test/test-results.log
+        bad=$(grep -E 'exit=[1-9]' test/test-results.log || true)
+        if [ -n "$bad" ]; then
+          echo "::error::Shard ${{ matrix.shard }}: a test host exited non-zero (failure, crash, or timeout kill):"
+          echo "$bad"
           exit 1
         fi
 
   # ──────────────────────── COLLECT RESULTS ────────────────────────
   # Single fan-in: pull every shard's results and produce ONE consolidated
   # "Test Results" check plus a combined step summary. This job is the run's
-  # pass/fail gate for tests + hangs. (A shard job that infra-fails reds the run
-  # on its own — GitHub's run conclusion is failure if ANY job fails, regardless
-  # of this always() collector's own conclusion.)
+  # pass/fail gate for tests + crashed hosts. (A shard job that infra-fails reds
+  # the run on its own — GitHub's run conclusion is failure if ANY job fails,
+  # regardless of this always() collector's own conclusion.)
   collect-results:
     name: "Consolidate test results"
     needs: test
@@ -437,12 +438,12 @@ jobs:
           fi
         done
         if [ "$any" = "0" ]; then
-          echo "_No failed tests in trx (a hang/crash would show below)._" >> "$GITHUB_STEP_SUMMARY"
+          echo "_No failed tests in trx (a crashed/killed host fails via the exit-marker gate below)._" >> "$GITHUB_STEP_SUMMARY"
           echo "No failed tests found in trx across all shards."
         else
           # 🚨 GATE (TRX-based, reporter-independent): the consolidated run pass/fail
           # gate. Fail on any test failure across shards, independent of the Publish
-          # step's GitHub-API health (429-immune). Hangs are gated by the dump check.
+          # step's GitHub-API health (429-immune).
           echo "::error::Failing tests in trx across shards — failing the run."
           exit 1
         fi
@@ -458,20 +459,17 @@ jobs:
         check_name: "Test Results"
         files: |
           all-results/**/*.trx
-    - name: Fail on hang / aborted test run
-      # blame-hang aborts the test host and writes a minidump (blame-*.dmp).
-      # Test *failures* are surfaced by Publish Test Results above; this step's
-      # only job is to fail loudly on a HANG so it doesn't get masked behind a
-      # "test results published" green checkmark when a trx contains only what
-      # completed before the abort. Runs even if Publish failed (if: always).
+    - name: Fail on non-zero project exit (all shards)
+      # Defense-in-depth re-check of every shard's exit markers (each shard
+      # already gates its own). A host that crashed after streaming green
+      # results, or was killed at the 6m cap, appears ONLY here — the trx gate
+      # above cannot see it (completed tests all read Passed; the rest vanish).
       if: always()
       run: |
-        hang_dumps=$(find all-results -name 'blame-*.dmp' 2>/dev/null | wc -l)
-        if [ "$hang_dumps" -gt 0 ]; then
-          echo "::error::A test process hung — blame-*.dmp files were written."
-          echo "--- Hang dumps ---"
-          find all-results -name 'blame-*.dmp' 2>/dev/null
-          echo "--- Per-project exit codes (non-zero indicates the hung project) ---"
-          find all-results -name 'test-results.log' -exec cat {} \;
+        bad=$(find all-results -name 'test-results.log' -exec cat {} \; \
+              | grep -E 'exit=[1-9]' || true)
+        if [ -n "$bad" ]; then
+          echo "::error::A test host exited non-zero despite the trx gate (crashed or killed mid-run — completed-only results were published):"
+          echo "$bad"
           exit 1
         fi

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -14,6 +14,12 @@ name: Continuous Delivery (main)
 # commit SHA). The RELEASED channel — clean 3.0.0 NuGet packages + clean GHCR images — is a
 # SEPARATE path fired by pushing a v*.*.* tag (release-packages.yml + release-images.yml).
 # "Freeze a release" = push a tag; "merge to main" = this workflow.
+#
+# The portal and migration images build in PARALLEL jobs: the migration image is small
+# (~5 min) and used to run sequentially after the portal's ~18-minute multi-arch publish on
+# the same runner — a free ~5 min off every merge-to-deployed cycle. Each job is
+# self-contained (checkout → az login → publish); the duplicated setup (~3 min) runs
+# concurrently so it costs no wall-clock.
 on:
   workflow_run:
     workflows: ["MeshWeaver Build and Test"]
@@ -37,8 +43,11 @@ env:
 
 jobs:
   # ─────────────────────────── BUILD + PUSH IMAGES ───────────────────────────
-  images:
-    name: "Build + push images to ACR"
+  # Two parallel legs, one per image. No `dotnet workload restore` in either:
+  # CI logs prove it installs nothing ("No workloads installed for this feature
+  # band … Successfully updated workload(s): .") and burned ~75 s per run.
+  portal-image:
+    name: "Build + push portal-ai image"
     # Gate: only a SUCCESSFUL test run, from a PUSH (not a PR), on main.
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
@@ -46,8 +55,6 @@ jobs:
       github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    outputs:
-      tag: ${{ steps.vars.outputs.sha }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -97,8 +104,6 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: ACR login
         run: az acr login --name meshweaver
-      - name: Restore workloads
-        run: dotnet workload restore
       # portal-ai app image — the deployment image (aspnet + node + Claude Code/Copilot CLIs),
       # layered on the base already in ACR. The base (memex-portal-ai-base) changes rarely and is
       # rebuilt by the release path / runbook §1, NOT on every main merge.
@@ -133,6 +138,55 @@ jobs:
           -p:ContainerRepository=memex-portal-ai
           -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"'
           -p:ContainerBaseImage=${{ env.ACR }}/memex-portal-ai-base:latest
+
+  migration-image:
+    name: "Build + push migration image"
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          dotnet: false
+          android: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+      # Same $(Version) computation as the portal leg: both jobs run inside ONE
+      # workflow run, so GITHUB_RUN_NUMBER — and therefore the computed
+      # 3.0.0-ci.<n> tag — is identical across the two legs by construction.
+      - name: Compute image tags (version + short SHA)
+        id: vars
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          VERSION=$(dotnet msbuild memex/aspire/Memex.Database.Migration/Memex.Database.Migration.csproj \
+            -getProperty:Version -p:CIRun=true -nologo | tr -d '[:space:]')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Computed image version: $VERSION (run #$GITHUB_RUN_NUMBER)"
+      - name: Ensure Azure CLI
+        run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: ACR login
+        run: az acr login --name meshweaver
       # migration — lean image on the standard (already multi-arch) aspnet base; same multi-arch publish.
       # <RuntimeIdentifiers> lives in Memex.Database.Migration.csproj (project-local, same reason as above).
       - name: Build + push migration
@@ -146,8 +200,8 @@ jobs:
           -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"'
 
   # ─────────────────────────────── NO DEPLOY JOB ─────────────────────────────
-  # Deployment is PULL-BASED, not push. CI's job ends at "publish the image to ACR" (the `images`
-  # job above). Each installation — memex / atioz / memex-cloud AND every external install in the
+  # Deployment is PULL-BASED, not push. CI's job ends at "publish the image to ACR" (the image
+  # jobs above). Each installation — memex / atioz / memex-cloud AND every external install in the
   # world that prod knows nothing about — runs the in-portal self-updater
   # (memex/Memex.Portal.Shared/SelfUpdate): it polls ACR with its OWN workload identity, and, per its
   # own Admin/UpdatePolicy (Continuous/Stable/None + the CI-green gate), patches its OWN portal +

--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -92,6 +92,17 @@ public class MeshOperations
             && IsSettled(ownDef))
             return Observable.Return<string?>(ownDef.CompilationError);
 
+        // Static fast path: the NodeType is a framework-bundled built-in registered via
+        // AddMeshNodes (Markdown, Code, Thread, test AddMeshNodes types, …). There is no
+        // per-NodeType hub, no NodeTypeDefinition and no CompileWatcher, so a compilation
+        // error cannot exist — and the settle-wait below can never be satisfied: it would
+        // only ever burn the full 5 s timeout on EVERY successful Get of a node with a
+        // built-in NodeType (a 5 s latency tax on agent/MCP get in prod, and ~120 s of
+        // pure timeout across the AI.Test suite). Mirrors GetDiagnostics' FindStaticNode
+        // fast path below.
+        if (hub.ServiceProvider.FindStaticNode(nodeTypePath) is not null)
+            return Observable.Return<string?>(null);
+
         // Slow path: subscribe to the NodeType's live stream, wait for a
         // settled CompilationStatus emission, then read the CompilationError.
         return hub.GetWorkspace().GetMeshNodeStream(nodeTypePath)

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -598,6 +598,15 @@ internal static class ThreadExecution
                         .Timeout(WatchdogRescueBudget)
                         .Subscribe(_ => { }, ex =>
                         {
+                            // Disposal already tearing the hub down: this inner rescue chain's
+                            // Timeout timer is NOT owned by the outer watchdog subscription (an
+                            // inner Subscribe created in onNext survives the outer's Dispose), so
+                            // it can fire AFTER hub disposal. There is nothing left to rescue —
+                            // disposal is the escape hatch's own goal — and escalating would
+                            // resolve services from the disposed container and throw INSIDE this
+                            // OnError on a bare timer thread (process-fatal). Refuse-and-complete.
+                            if (disposed || hub.IsDisposing)
+                                return;
                             // Escalate ONLY on the landing-budget timeout — that is the proof the
                             // action block is blocked. Any other error (validation, access,
                             // serialization) fails FAST on a healthy hub: deactivating there would

--- a/src/MeshWeaver.AI/ThreadSubmission.cs
+++ b/src/MeshWeaver.AI/ThreadSubmission.cs
@@ -984,6 +984,24 @@ internal static class ThreadSubmissionServer
                     // duplicate and must not re-enter ExecuteMessageAsync.
                     if (!didCommitThisEmission) return;
 
+                    // Refuse-and-complete at the LAUNCH edge. This OnNext is a reactive
+                    // continuation that can arrive after the thread hub began disposing
+                    // (teardown racing an in-flight round — UpdateEmitsDuringRoundTest ends
+                    // mid-round by design). Launching then arms the round's 60 s
+                    // WhenInitialized timeout on the global TimerQueue with the mesh gone;
+                    // when it fires, the fault sink's cell write resolves from the disposed
+                    // container and the ObjectDisposedException escapes INSIDE OnError on a
+                    // timer thread — process-fatal (the xunit "Catastrophic failure" that
+                    // reds a green Threading.Test run). Nothing to run against — refuse.
+                    if (hub.IsDisposing)
+                    {
+                        logger?.LogWarning(
+                            "[ThreadSubmission] Thread hub {ThreadPath} is disposing — not launching round {ResponseMsgId}",
+                            threadPath, responseMsgId);
+                        onFailure?.Invoke();
+                        return;
+                    }
+
                     ThreadExecution.UpdateResponseCell(
                         hub, responsePath, threadPath, responseMsgId, mainEntity,
                         msg => msg with { Text = "Allocating agent...", Status = ThreadMessageStatus.Streaming },
@@ -997,12 +1015,26 @@ internal static class ThreadSubmissionServer
                         config => config,
                         HostedHubCreation.Always);
 
+                    // GetHostedHub refuses creation once the owning hub's disposal has
+                    // begun (HostedHubsCollection.CloseCreation) — the same
+                    // refuse-and-complete edge one hop later. Never launch on a null hub:
+                    // the old null-forgiving executionHub! turned the refusal into the
+                    // exact fault the ex-sink then fails to write.
+                    if (executionHub is null)
+                    {
+                        logger?.LogWarning(
+                            "[ThreadSubmission] _Exec hub creation refused (hub disposing) for {ThreadPath} — not launching round {ResponseMsgId}",
+                            threadPath, responseMsgId);
+                        onFailure?.Invoke();
+                        return;
+                    }
+
                     // 🚨 ExecuteMessageAsync now returns a COLD IObservable<Unit> — the round runs
                     // ONLY on Subscribe, completes when the terminal Status write lands, and faults
                     // via OnError. Subscribe here (no fire-and-forget) and own the subscription on
                     // the thread-hub workspace (the round's natural lifetime owner, matching the
                     // disposal the method used to register internally).
-                    var execSub = ThreadExecution.ExecuteMessageAsync(executionHub!,
+                    var execSub = ThreadExecution.ExecuteMessageAsync(executionHub,
                         new ThreadExecution.RoundParams(
                             ThreadPath: threadPath,
                             ResponseMessageId: responseMsgId,
@@ -1022,6 +1054,16 @@ internal static class ThreadSubmissionServer
                                 logger?.LogWarning(ex,
                                     "[ThreadSubmission] Agent round faulted for {ResponseMsgId} on {ThreadPath}",
                                     responseMsgId, threadPath);
+                                // Hub already tearing down: the terminal write below resolves
+                                // services from a container that is disposed (or about to be) —
+                                // the ObjectDisposedException would escape INSIDE this OnError on
+                                // a timer/pool thread, which is process-fatal (the Threading.Test
+                                // CI catastrophic failure). Nothing is lost by refusing: on a
+                                // real grain deactivation the stuck Executing state is recovered
+                                // by ResumeInterruptedRound on the next activation; in a test
+                                // teardown the mesh is gone entirely.
+                                if (hub.IsDisposing)
+                                    return;
                                 // 🚨 An escaped fault means the round's OWN terminal handling did
                                 // NOT run (or its terminal write failed — the gate faults on that
                                 // too). Without a terminal write here the node stays Executing

--- a/src/MeshWeaver.ContentCollections/ContentCollection.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollection.cs
@@ -256,7 +256,7 @@ public class ContentCollection : IDisposable
             if (fileName.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
             {
                 var folder = path.Trim('/');
-                UpdateArticle(folder.Length == 0 ? fileName : $"{folder}/{fileName}", caller);
+                IngestContentFile(folder.Length == 0 ? fileName : $"{folder}/{fileName}", caller);
             }
         });
     }
@@ -303,7 +303,7 @@ public class ContentCollection : IDisposable
         var parsedArticles = new Dictionary<object, object>();
         await foreach (var tuple in provider.GetStreamsAsync(MarkdownFilter, ct).WithCancellation(ct).ConfigureAwait(false))
         {
-            var article = await ParseArticleAsync(tuple.Stream, tuple.Path, tuple.LastModified, ct).ConfigureAwait(false);
+            var article = await ParseContentAsync(tuple.Stream, tuple.Path, tuple.LastModified, ct).ConfigureAwait(false);
             if (article is not null)
             {
                 var key = (object)(article.Path.EndsWith(".md", StringComparison.OrdinalIgnoreCase) ? article.Path[..^3] : article.Path);
@@ -328,8 +328,21 @@ public class ContentCollection : IDisposable
     /// Re-established around the stream update so downstream reactors (indexing sinks
     /// subscribed to the markdown stream) see the uploading user, not a bare pool thread.
     /// </param>
-    protected void UpdateArticle(string path, AccessContext? caller = null)
+    protected void IngestContentFile(string path, AccessContext? caller = null)
     {
+        // A FileSystemWatcher callback can land AFTER the owning hub began disposing
+        // (native FSEvents/inotify delivery latency races collection teardown). The very
+        // first touch below — resolving IoPoolRegistry for Pool — then throws
+        // ObjectDisposedException on the watcher's native callback thread, where nothing
+        // can catch it (process-fatal under xunit; a teardown straggler in prod logs).
+        // Close the incoming stream at the source and refuse: the collection dies with
+        // its hub, there is no live stream left to update.
+        if (Hub.IsDisposing)
+        {
+            monitorDisposable?.Dispose();
+            return;
+        }
+
         // The file read + parse is the IO leaf — pooled OFF the hub; only the parsed
         // in-memory article flows into the (synchronous) stream Update. The stream's
         // UpdateStreamRequest handler is await-free by contract.
@@ -338,7 +351,7 @@ public class ContentCollection : IDisposable
                 var tuple = await provider.GetStreamWithMetadataAsync(path, ct).ConfigureAwait(false);
                 if (tuple.Stream is null)
                     return null;
-                return await ParseArticleAsync(tuple.Stream, tuple.Path, tuple.LastModified, ct).ConfigureAwait(false);
+                return await ParseContentAsync(tuple.Stream, tuple.Path, tuple.LastModified, ct).ConfigureAwait(false);
             })
             .Subscribe(
                 article =>
@@ -362,10 +375,10 @@ public class ContentCollection : IDisposable
                 },
                 ex => Hub.ServiceProvider.GetService<ILoggerFactory>()
                     ?.CreateLogger(typeof(ContentCollection))
-                    .LogWarning(ex, "UpdateArticle failed reading {Path} in collection {Collection}", path, Collection));
+                    .LogWarning(ex, "IngestContentFile failed reading {Path} in collection {Collection}", path, Collection));
     }
 
-    private async Task<MarkdownElement?> ParseArticleAsync(Stream? stream, string path, DateTime lastModified, CancellationToken ct)
+    private async Task<MarkdownElement?> ParseContentAsync(Stream? stream, string path, DateTime lastModified, CancellationToken ct)
     {
         if (stream is null)
             return null;
@@ -382,11 +395,11 @@ public class ContentCollection : IDisposable
         );
     }
 
-    /// <summary>Subscribes the collection to backing-store change notifications, routing each to <see cref="UpdateArticle"/>.</summary>
+    /// <summary>Subscribes the collection to backing-store change notifications, routing each to <see cref="IngestContentFile"/>.</summary>
     protected void AttachMonitor()
     {
-        // External (watcher-driven) changes carry no user — UpdateArticle runs context-less.
-        monitorDisposable = provider.AttachMonitor(path => UpdateArticle(path));
+        // External (watcher-driven) changes carry no user — IngestContentFile runs context-less.
+        monitorDisposable = provider.AttachMonitor(path => IngestContentFile(path));
     }
 
     /// <summary>Creates a folder in the backing store. Cold — runs on Subscribe, on <see cref="Pool"/>, under the caller's context snapshot.</summary>

--- a/src/MeshWeaver.ContentCollections/FileSystemStreamProvider.cs
+++ b/src/MeshWeaver.ContentCollections/FileSystemStreamProvider.cs
@@ -69,7 +69,7 @@ public class FileSystemStreamProvider(string basePath) : IStreamProvider
             // tolerant share (GetStreamAsync/GetStreamWithMetadataAsync open FileShare.ReadWrite|Delete).
             // FileShare.None takes an EXCLUSIVE advisory lock on Unix (.NET emulates FileShare via
             // flock: None → LOCK_EX), which the OS refuses while a reader holds the file — and the
-            // FileSystemWatcher-driven UpdateArticle read legitimately overlaps a write. That
+            // FileSystemWatcher-driven IngestContentFile read legitimately overlaps a write. That
             // exclusive-vs-shared clash is the "file is being used by another process" IOException
             // this method threw under CI load. Content files are eventually-consistent and re-ingested
             // on change, so a write must never demand exclusivity against the readers that already
@@ -262,7 +262,7 @@ public class FileSystemStreamProvider(string basePath) : IStreamProvider
         // A brand-new file often surfaces ONLY as Created (not Changed) — notably an external
         // writer (git sync, another process) creating a .md file, and on Linux a create+write into
         // a newly-created subdirectory. Handle Created as well as Changed so those files ingest
-        // instead of staying invisible until the collection re-initializes. UpdateArticle is
+        // instead of staying invisible until the collection re-initializes. IngestContentFile is
         // idempotent, so a file that raises both Created and Changed is merged once per event
         // harmlessly. (In-process writes no longer depend on this at all — see
         // ContentCollection.SaveFileAsync's proactive ingest.)

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1936,7 +1936,7 @@ public static class DataExtensions
                     node["title"] = type.Name;
 
                     // Add description for the main type
-                    var typeDescription = type.GetXmlDocsSummary();
+                    var typeDescription = MeshWeaver.Messaging.Serialization.XmlDocs.Summary(type);
                     if (!string.IsNullOrEmpty(typeDescription))
                     {
                         node["description"] = typeDescription;
@@ -1952,7 +1952,7 @@ public static class DataExtensions
                     var actualPropertyInfo = declaringType.GetProperty(propertyName.ToPascalCase()!);
                     if (actualPropertyInfo != null)
                     {
-                        var propertyDescription = actualPropertyInfo.GetXmlDocsSummary();
+                        var propertyDescription = MeshWeaver.Messaging.Serialization.XmlDocs.Summary(actualPropertyInfo);
                         if (!string.IsNullOrEmpty(propertyDescription))
                         {
                             jsonObj["description"] = propertyDescription;

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -992,7 +992,7 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
             {
                 // Fully synchronous — the update func is a pure in-memory transform
                 // (IO-producing callers pool their IO FIRST and pass only the result,
-                // see ContentCollection.UpdateArticle). No async handler: an awaited
+                // see ContentCollection.IngestContentFile). No async handler: an awaited
                 // update on the hub action block is the deadlock class
                 // AsynchronousCalls.md exists to kill.
                 var update = request.Message.Update;

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -592,6 +592,22 @@ public class Workspace : IWorkspace
     /// <inheritdoc />
     public void AddDisposable(IDisposable disposable)
     {
+        if (isDisposing)
+        {
+            // Same contract as MessageHub.RegisterForDisposal: a registrant added after
+            // disposal has begun is disposed IMMEDIATELY. The drain loop in DisposeAsync
+            // has already run, so bagging it would leak it — and any Rx Timeout timer it
+            // roots via the global TimerQueue — past the container's lifetime (the
+            // post-teardown ObjectDisposedException straggler class).
+            try { disposable.Dispose(); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Workspace {WorkspaceId} error disposing late-registered disposable {DisposableType}",
+                    Id, disposable.GetType().Name);
+            }
+            return;
+        }
         disposables.Add(disposable);
     }
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -39,19 +39,9 @@ Pick a `<tag>` that pins the change (e.g. `bugfix-2026-06-05`). CI also builds i
 
 Every `IScope<,>` node (e.g. the PensionFund balance sheet) needs the BusinessRules scope **source generator**. That generator now **ships with the platform**: its DLL is copied into `MeshWeaver.Graph`'s runtime output (the `ShipScopeGenerator` target), flows into the published image, and `MeshNodeCompilationService` always feeds it to the compile. So a new `IScope<,>` node compiles with **no `#r` directive and no NuGet round-trip** — just declare the interface. The `IScope<,>` surface itself (`MeshWeaver.BusinessRules`) is a loaded framework assembly, so it's already in the compile references too.
 
-**Transition:** legacy nodes that still carry `#r "nuget:MeshWeaver.BusinessRules.Generator"` keep working — the compile filters that `#r`'d copy out (the built-in generator supersedes it, so it never runs twice). During the transition the `BakeMeshLocalFeed` target (in `Memex.Portal.Distributed.csproj`) still bakes the mesh-local feed so those `#r` directives *resolve*; it will be removed once no node source carries the `#r`.
+**Legacy `#r` directives:** nodes that still carry `#r "nuget:MeshWeaver.BusinessRules.Generator"` keep working — the compile filters that `#r`'d copy out of the NuGet resolve set (the built-in generator supersedes it, so it never runs twice, and no feed round-trip happens). Pinned by `BuiltInScopeGeneratorTest`.
 
-**So the `dotnet publish -t:PublishContainer` command above is self-contained — there is no separate pack step.** Notes:
-
-- `dist/packages` is git-ignored; the target (re)packs it on every Release publish, so the image always carries packages matching the built code.
-- Node Source pins **no** version (`#r "nuget:MeshWeaver.BusinessRules.Generator"`), so it resolves whatever single version the baked feed carries — the version lives in one place (`PlatformVersion`).
-- If a deployed scope node ever fails with a NuGet-resolve error, the image was built **without** this target (a `-c Debug` publish, or a `dist/packages` exclusion) — rebuild `-c Release`.
-- The same curated set is packed for the test suite by `.github/workflows/dotnet-test.yml` ("Pack mesh-local #r packages"), kept in sync with this target.
-- **`NETSDK1047` on `MeshWeaver.BusinessRules` during the publish** (`Assets file … doesn't have a target for 'net10.0/linux-x64'`): because `BusinessRules` is **decoupled** from the portal's project graph (pulled in only via `#r "nuget:"`), the publish's implicit restore doesn't cover it, so a stale local `obj` can lack the `-r linux-x64` RID target the `BakeMeshLocalFeed` pack needs. Restore it for the RID once, then re-publish:
-  ```bash
-  dotnet restore src/MeshWeaver.BusinessRules/MeshWeaver.BusinessRules.csproj -r linux-x64
-  ```
-  CI is immune (it restores from a clean checkout); this only bites incremental local builds.
+**So the `dotnet publish -t:PublishContainer` command above is self-contained — there is no pack step and no mesh-local feed.** The former `BakeMeshLocalFeed` target and the CI "Pack mesh-local #r packages" step were both removed once the generator shipped in-process: nothing resolves `MeshWeaver.*` from `dist/packages` anymore (the `mesh-local` source in `nuget.config` remains only as a packageSourceMapping guard so a typo'd `#r "nuget:MeshWeaver.X"` can never pull a same-named package from a different publisher on nuget.org).
 
 ## 2. Roll out (NS = `memex`)
 

--- a/src/MeshWeaver.Fixture/HubTestBase.cs
+++ b/src/MeshWeaver.Fixture/HubTestBase.cs
@@ -162,18 +162,29 @@ public class HubTestBase : TestBase
             var hostedHubsValue = hostedHubsProperty?.GetValue(Mesh)?.ToString() ?? "unknown";
             Logger.LogInformation("[{DisposalId}] Mesh has {HubCount} hosted hubs", disposalId, hostedHubsValue);
 
-            if (Mesh.IsDisposing)
+            if (!Mesh.IsDisposing)
             {
-                Logger.LogInformation("[{DisposalId}] Mesh is disposing, waiting for completion", disposalId);
-                // Bridge the reactive completion to a Task once, at this test-teardown edge.
-                // Catch folds a disposal fault into completion (teardown waits for "done", not why).
-                await Mesh.DisposalCompleted
-                    .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
-                    .FirstOrDefaultAsync()
-                    .ToTask()
-                    .WaitAsync(timeout.Token);
-                Logger.LogInformation("[{DisposalId}] Mesh disposal completed", disposalId);
+                // The fixture owns the mesh, so the fixture must tear it down. This initiation
+                // was lost in aad01631a ("proper await in TestFixture"); since then every
+                // HubTestBase test leaked its live mesh (hubs, layout hosts, subscriptions)
+                // past the test. A leaked debounced auto-save subscription then wrote to the
+                // finished test's raw ITestOutputHelper → xUnit "There is no currently active
+                // test." → anonymous catastrophic failure → all-green trx but exit 1
+                // (Layout.Test red on every CI run, masked by the trx-only gate).
+                Logger.LogInformation("[{DisposalId}] Initiating mesh disposal", disposalId);
+                Mesh.Dispose();
             }
+
+            Logger.LogInformation("[{DisposalId}] Mesh is disposing, waiting for completion", disposalId);
+            // Bridge the reactive completion to a Task once, at this test-teardown edge.
+            // Catch folds a disposal fault into completion (teardown waits for "done", not why).
+            // DisposalCompleted replays to late subscribers, so this is race-free.
+            await Mesh.DisposalCompleted
+                .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
+                .FirstOrDefaultAsync()
+                .ToTask()
+                .WaitAsync(timeout.Token);
+            Logger.LogInformation("[{DisposalId}] Mesh disposal completed", disposalId);
         }
         catch (OperationCanceledException)
         {

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -1215,7 +1215,13 @@ internal class MeshNodeCompilationService(
         // `#r "nuget:MeshWeaver.BusinessRules.Generator"` — no auto-injection heuristic (that forced
         // generator resolution on the compile path for any node merely mentioning IScope). Explicit
         // #r → resolved here → discovered + run by RunSourceGenerators from the resolved assemblies.
-        var (source, nugetRefs) = NuGetDirectiveParser.Extract(rawSource);
+        var (source, extractedRefs) = NuGetDirectiveParser.Extract(rawSource);
+        // 🚨 Same legacy-#r strip as AssembleCompilationInputs — this path previously lacked it
+        // (see the release-folder compile below for the full story: resolving the legacy
+        // generator #r hard-fails now that the mesh-local feed is gone).
+        var nugetRefList = extractedRefs.ToList();
+        StripBuiltInScopeGeneratorRef(nugetRefList, builtInPresent: BuiltInGeneratorPaths.Count > 0);
+        var nugetRefs = nugetRefList.ToArray();
         IEnumerable<MetadataReference> references = _references;
         IReadOnlyList<string> nugetAssemblyPaths = [];
         if (nugetRefs.Length > 0)
@@ -1556,9 +1562,17 @@ internal class MeshNodeCompilationService(
         var rawSource = _attributeGenerator.GenerateAttributeSource(node, codeConfig, release.HubConfiguration, release.ContentCollections);
 
         // Strip #r "nuget:..." directives — Roslyn compilation (unlike scripting) does not process them.
-        // Scope generator is resolved ONLY via an explicit `#r "nuget:MeshWeaver.BusinessRules.Generator"`
-        // in the node Source (no auto-inject), then discovered by RunSourceGenerators.
-        var (source, nugetRefs) = NuGetDirectiveParser.Extract(rawSource);
+        var (source, extractedRefs) = NuGetDirectiveParser.Extract(rawSource);
+        // 🚨 Same legacy-#r strip as AssembleCompilationInputs: a node Source still carrying
+        // `#r "nuget:MeshWeaver.BusinessRules.Generator"` must NOT reach the NuGet resolver —
+        // the generator ships built-in, and the mesh-local feed it used to resolve from is gone
+        // (#395), so resolving hard-fails ("The local source '…/dist/packages' doesn't exist").
+        // This RELEASE-folder compile path previously lacked the strip: the PensionFund sample
+        // (legacy #r intact) compiled green on CI only because the workflow's pack step happened
+        // to recreate the feed — the strip in the OTHER compile path never covered this one.
+        var nugetRefList = extractedRefs.ToList();
+        StripBuiltInScopeGeneratorRef(nugetRefList, builtInPresent: BuiltInGeneratorPaths.Count > 0);
+        var nugetRefs = nugetRefList.ToArray();
         IEnumerable<MetadataReference> references = _references;
         IReadOnlyList<string> probingDirs = [];
         IReadOnlyList<string> nugetAssemblyPaths = [];

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -1572,7 +1572,7 @@ public static class MeshNodeLayoutAreas
                     node["title"] = type.Name;
 
                     // Add description for the main type
-                    var typeDescription = type.GetXmlDocsSummary();
+                    var typeDescription = MeshWeaver.Messaging.Serialization.XmlDocs.Summary(type);
                     if (!string.IsNullOrEmpty(typeDescription))
                     {
                         node["description"] = typeDescription;
@@ -1588,7 +1588,7 @@ public static class MeshNodeLayoutAreas
                     var actualPropertyInfo = declaringType.GetProperty(propertyName.ToPascalCase()!);
                     if (actualPropertyInfo != null)
                     {
-                        var propertyDescription = actualPropertyInfo.GetXmlDocsSummary();
+                        var propertyDescription = MeshWeaver.Messaging.Serialization.XmlDocs.Summary(actualPropertyInfo);
                         if (!string.IsNullOrEmpty(propertyDescription))
                         {
                             jsonObj["description"] = propertyDescription;

--- a/src/MeshWeaver.Hosting.Monolith/MonolithRoutingService.cs
+++ b/src/MeshWeaver.Hosting.Monolith/MonolithRoutingService.cs
@@ -114,6 +114,22 @@ internal class MonolithRoutingService(
         return hubFactory.ResolveHubConfiguration(node)
             .Select(enriched =>
             {
+                // Re-check at EMISSION time. The IsDisposing guard at method entry only
+                // covers subscribe time — ResolveHubConfiguration can emit seconds later
+                // (NodeType probe timeout / overlay fallback / TaskPool-scheduled
+                // subscribe), by which point the mesh may have fully disposed and the
+                // root scope been torn down. Building a hub then resolves from a disposed
+                // container (the CI ObjectDisposedException teardown stragglers).
+                // Refuse-and-complete: null flows to PostNotFound, which logs the
+                // shutting-down reason and NACKs only while the mesh can still deliver.
+                if (Mesh.IsDisposing)
+                {
+                    logger.LogWarning(
+                        "[ROUTE-CREATE] Mesh began disposing while resolving hub configuration for {Address} — refusing post-dispose hub creation",
+                        address);
+                    return (IMessageHub?)null;
+                }
+
                 logger.LogDebug("[ROUTE-CREATE] ResolveHubConfiguration returned for {Address}: HubConfig={HasHubConfig}",
                     address, enriched.HubConfiguration is not null);
 

--- a/src/MeshWeaver.Layout/Domain/DataModelLayoutArea.cs
+++ b/src/MeshWeaver.Layout/Domain/DataModelLayoutArea.cs
@@ -247,7 +247,7 @@ public static class DataModelLayoutArea
             .ToDictionary(td => td.Type, td => td);
         var sb = new StringBuilder();
 
-        var typeSummary = type.GetXmlDocsSummary();
+        var typeSummary = MeshWeaver.Messaging.Serialization.XmlDocs.Summary(type);
 
         // Title with right-aligned navigation icons
         var navigationIcons = $"<a href=\"{linkBase}\" title=\"Data Model Overview\" style=\"text-decoration: none; font-size: 2em; line-height: 1;\">⧉</a>";
@@ -270,7 +270,7 @@ public static class DataModelLayoutArea
                 IsInherited = p.DeclaringType != type,
                 Declaring = p.DeclaringType?.Name ?? "Base",
                 TypeName = GetPropertyTypeDisplayName(p),
-                Summary = p.GetXmlDocsSummary()
+                Summary = MeshWeaver.Messaging.Serialization.XmlDocs.Summary(p)
             })
             .OrderByDescending(x => x.IsInherited) // inherited (from base) first; keep original declared order
             .ToList();

--- a/src/MeshWeaver.Layout/Domain/DomainCatalogLayoutArea.cs
+++ b/src/MeshWeaver.Layout/Domain/DomainCatalogLayoutArea.cs
@@ -34,7 +34,7 @@ public static class DomainCatalogLayoutArea
         var ret = Controls.Stack
             .WithView(Controls.Html(titleWithNav));
         
-        var description = typeDefinition.Type.GetXmlDocsSummary();
+        var description = MeshWeaver.Messaging.Serialization.XmlDocs.Summary(typeDefinition.Type);
         if (!string.IsNullOrWhiteSpace(description))
             ret = ret.WithView(Controls.Html($"<p>{description}</p>"));
         

--- a/src/MeshWeaver.Layout/Domain/EditLayoutArea.cs
+++ b/src/MeshWeaver.Layout/Domain/EditLayoutArea.cs
@@ -176,7 +176,7 @@ public static class EditLayoutArea
         stack = stack.WithView(header);
 
         // Description if available
-        var description = typeDefinition.Type.GetXmlDocsSummary();
+        var description = MeshWeaver.Messaging.Serialization.XmlDocs.Summary(typeDefinition.Type);
         if (!string.IsNullOrWhiteSpace(description))
             stack = stack.WithView(Controls.Html($"<p style=\"color: var(--neutral-foreground-hint); margin-bottom: 1rem;\">{description}</p>"));
 

--- a/src/MeshWeaver.Layout/EditorExtensions.cs
+++ b/src/MeshWeaver.Layout/EditorExtensions.cs
@@ -569,7 +569,7 @@ public static class EditorExtensions
             {
                 Name = propertyInfo.Name.ToCamelCase(),
                 Description = propertyInfo.GetCustomAttribute<DescriptionAttribute>()?.Description
-                              ?? propertyInfo.GetXmlDocsSummary(),
+                              ?? MeshWeaver.Messaging.Serialization.XmlDocs.Summary(propertyInfo),
                 Label = propertySkinLabel
             };
         var jsonPointerReference = GetJsonPointerReference(propertyInfo);

--- a/src/MeshWeaver.Layout/LayoutDefinitionExtensions.cs
+++ b/src/MeshWeaver.Layout/LayoutDefinitionExtensions.cs
@@ -221,7 +221,7 @@ public static class LayoutDefinitionExtensions
         if (delgate is not null)
         {
             var method = delgate.Method;
-            var doc = method.GetXmlDocsSummary();
+            var doc = MeshWeaver.Messaging.Serialization.XmlDocs.Summary(method);
             ret = ret.WithDescription(doc);
 
             // Check class-level DisplayAttribute for GroupName and fallback Order

--- a/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
+++ b/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
@@ -148,8 +148,21 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
     }
 
     private readonly object locker = new();
-    private bool IsDisposing => disposalStarted;
+    private bool IsDisposing => disposalStarted || creationClosed;
     private volatile bool disposalStarted;
+    private volatile bool creationClosed;
+
+    /// <summary>
+    /// One-way switch flipped by the OWNING hub the moment its disposal begins
+    /// (<c>MessageHub.Dispose</c>). The collection's own <see cref="Dispose"/> only runs
+    /// in the DisposeHostedHubs phase — potentially seconds later — leaving a window in
+    /// which routed messages could still create NEW hubs that race
+    /// <see cref="DisposeHubsReactive"/>'s snapshot and leak as never-disposed zombies
+    /// whose timers later detonate on the disposed container (the post-teardown
+    /// ObjectDisposedException straggler class). Existing hubs remain resolvable for the
+    /// drain; only CREATION is refused (logged, observable).
+    /// </summary>
+    public void CloseCreation() => creationClosed = true;
 
     // Reactive completion source of truth — completed exactly once (CAS-guarded) when every
     // hosted hub has finished disposing (or the 10 s cap elapses). ReplaySubject(1) so a late

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1370,6 +1370,13 @@ public sealed class MessageHub : IMessageHub
 
         }
 
+        // Close hosted-hub CREATION immediately — not only when the DisposeHostedHubs
+        // phase disposes the collection. A hub created in the Quiescing window races
+        // DisposeHubsReactive's snapshot and leaks as a zombie whose timers later
+        // detonate on the disposed container (post-dispose ObjectDisposedException
+        // stragglers). Existing hubs still resolve for the drain.
+        hostedHubs.CloseCreation();
+
         // Log all hosted hubs that will be disposed
         var hostedHubAddresses = hostedHubs.Hubs.Select(h => h.Address.ToString()).ToArray();
         if (hostedHubAddresses.Length > 0)

--- a/src/MeshWeaver.Messaging.Hub/MessageHubExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHubExtensions.cs
@@ -248,6 +248,16 @@ public static class MessageHubExtensions
         var current = hub;
         while (current != null)
         {
+            // Refuse-and-complete once disposal has begun: deactivation is a rescue for a
+            // LIVE wedged hub, and a disposing hub is already being torn down — the rescue's
+            // goal. Walking further would read Configuration.ParentHub, which RESOLVES from
+            // the hub's ServiceProvider: on a disposed container that throws
+            // ObjectDisposedException — and the callers of this method are error sinks
+            // (watchdog OnError on a bare Rx timer thread), where the throw escapes as a
+            // process-fatal unhandled exception (the Threading.Test/AI.Test CI catastrophic
+            // failures).
+            if (current.IsDisposing)
+                return false;
             var callback = current.Configuration.Get<GrainDeactivateCallback>();
             if (callback != null)
             {

--- a/src/MeshWeaver.Messaging.Hub/Serialization/TypeDefinition.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/TypeDefinition.cs
@@ -36,7 +36,7 @@ public record TypeDefinition : ITypeDefinition
 
         Key = new(() => keyFunctionBuilder.GetKeyFunction(Type)!);
         
-        Description = Type.GetXmlDocsSummary();
+        Description = XmlDocs.Summary(Type);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Messaging.Hub/Serialization/XmlDocs.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/XmlDocs.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using Namotion.Reflection;
+
+namespace MeshWeaver.Messaging.Serialization;
+
+/// <summary>
+/// Thread-safe access to Namotion.Reflection XML-docs lookups — the ONLY sanctioned way to
+/// read doc summaries anywhere in the platform (never call <c>GetXmlDocsSummary</c> directly).
+///
+/// <para>Why: Namotion caches one <c>XDocument</c> per assembly in a static
+/// <c>CachingXDocument</c>, and XLinq documents lazily materialize their node graph on FIRST
+/// enumeration. Two hubs building concurrently on pool threads (<c>TypeRegistry.WithType</c> →
+/// <c>TypeDefinition..ctor</c> → docs summary) enumerated the same cached document at the same
+/// time and tore its object graph: <c>AccessViolationException</c> in
+/// <c>XContainer.GetElements</c> → SIGSEGV (exit 139) — FutuRe.Test dying mid-fixture-init on
+/// the CI runner (and reproducibly under emulated linux-amd64), invisible on fast local
+/// hardware where the first-enumeration window is microseconds.</para>
+///
+/// <para>One process-wide lock serialises every read. Docs lookups happen on registration /
+/// catalog-render paths only, and after Namotion's per-assembly cache is warm each lookup is a
+/// dictionary hit — contention is irrelevant next to memory safety. This is a synchronous lock
+/// around a synchronous third-party call (nothing is awaited under it), not an async gate.</para>
+/// </summary>
+public static class XmlDocs
+{
+    private static readonly System.Threading.Lock Gate = new();
+
+    /// <summary>Thread-safe <c>GetXmlDocsSummary</c> for a type.</summary>
+    public static string Summary(Type type)
+    {
+        lock (Gate)
+            return type.GetXmlDocsSummary();
+    }
+
+    /// <summary>Thread-safe <c>GetXmlDocsSummary</c> for a member (property, method, field).</summary>
+    public static string Summary(MemberInfo member)
+    {
+        lock (Gate)
+            return member.GetXmlDocsSummary();
+    }
+}

--- a/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
+++ b/test/MeshWeaver.AI.Test/CodeCellOutputCaptureTest.cs
@@ -178,15 +178,38 @@ public class CodeCellOutputCaptureTest(ITestOutputHelper output) : MonolithMeshT
         var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
             new Address(activityPath), reference);
 
-        // The Progress root is a Stack whose first child is the messages Html.
+        // The Progress root is a Stack: [0] the status indicator, [1] the message
+        // log — the control-based shape ActivityLayoutAreas.Progress renders since
+        // the hand-rolled messages HTML was replaced by controls (BuildLog /
+        // BuildProgressIndicator). The old assertion demanded an HtmlControl and
+        // burned its full 30 s wait on every run — one of the hidden AI.Test
+        // failures masked by the CI 6-minute kill.
         var rootControl = (StackControl)(await stream.GetControlStream(reference.Area!)
+            .Should().Within(30.Seconds()).Match(c => c is StackControl s && s.Areas.Count >= 2))!;
+
+        // Terminal indicator: a Succeeded activity renders a "✓ Done" status line,
+        // never a spinner (pinned control-shape: ActivityProgressViewTest).
+        var indicatorArea = rootControl.Areas[0].Area!.ToString()!;
+        await stream.GetControlStream(indicatorArea)
+            .Should().Within(30.Seconds()).Match(c => c is LabelControl l
+                && l.Data is not null
+                && l.Data.ToString()!.Contains("Done"));
+
+        // The captured output line renders as one of the log rows' message labels
+        // (BuildLog: one horizontal [level-tag, message] row per LogMessage).
+        var logArea = rootControl.Areas[1].Area!.ToString()!;
+        var logStack = (StackControl)(await stream.GetControlStream(logArea)
             .Should().Within(30.Seconds()).Match(c => c is StackControl s && s.Areas.Count >= 1))!;
-        var messagesArea = rootControl.Areas.First().Area!.ToString()!;
-        await stream.GetControlStream(messagesArea)
-            .Should().Within(30.Seconds()).Match(c => c is HtmlControl h
-                && h.Data is not null
-                && h.Data.ToString()!.Contains(marker)
-                && h.Data.ToString()!.Contains("Done"));
+        await logStack.Areas
+            .Select(row => stream.GetControlStream(row.Area!.ToString()!))
+            .Merge()
+            .Where(c => c is StackControl)
+            .SelectMany(row => ((StackControl)row!).Areas
+                .Select(cell => stream.GetControlStream(cell.Area!.ToString()!))
+                .Merge())
+            .Should().Within(30.Seconds()).Match(c => c is LabelControl l
+                && l.Data is not null
+                && l.Data.ToString()!.Contains(marker));
     }
 
     [Fact(Timeout = 120000)]

--- a/test/MeshWeaver.AI.Test/PluginCatalogTest.cs
+++ b/test/MeshWeaver.AI.Test/PluginCatalogTest.cs
@@ -28,6 +28,18 @@ public class PluginCatalogTest : MonolithMeshTestBase
 {
     public PluginCatalogTest(ITestOutputHelper output) : base(output) { }
 
+    static PluginCatalogTest()
+    {
+        // The class OWNS this on-disk fixture dir, and file persistence survives the
+        // process: a rerun against the same bin (local rerun after a fix; CI bins are
+        // always freshly extracted) collided with the previous run's nodes ("Node
+        // already exists: WidgetKit/Widget"). Clean ONCE per process, before the shared
+        // mesh initializes (a per-instance clean would wipe the live store mid-class —
+        // ShareMeshAcrossTests keeps one mesh across this class's tests).
+        if (Directory.Exists(TestDataPath))
+            Directory.Delete(TestDataPath, recursive: true);
+    }
+
     protected override bool ShareMeshAcrossTests => true;
 
     private static readonly string TestDataPath = Path.Combine(AppContext.BaseDirectory, "TestData-plugincatalog");

--- a/test/MeshWeaver.AI.Test/TrainingSimResponderTest.cs
+++ b/test/MeshWeaver.AI.Test/TrainingSimResponderTest.cs
@@ -83,42 +83,38 @@ public class TrainingSimResponderTest(ITestOutputHelper output) : MonolithMeshTe
             .Which.Markdown!.ToString().Should().Contain("Just an explanation");
     }
 
-    [Fact(Timeout = 90_000)]
-    public async Task Live_Responder_Submits_Thread_With_TrainingSim_Agent()
+    /// <summary>
+    /// Model-less environment: the LIVE responder must DEGRADE GRACEFULLY — emit the calm
+    /// "configure a language model" notice and NOT submit a thread. This replaced the pre-guard
+    /// behavior (submit unconditionally, assert the thread node) when
+    /// <c>TrainingSimResponder.IsAnyModelConfigured</c> was introduced: with the credential
+    /// resolver registered and no model resolvable, <see cref="TrainingSimResponder.Live"/>
+    /// returns the notice BEFORE <c>hub.StartThread</c>. The old assertion (thread lands under
+    /// the owner) was therefore impossible and burned its full 60 s wait on every run — one of
+    /// the hidden AI.Test failures masked by the CI 6-minute kill. The submit-with-model leg is
+    /// e2e-stack territory (needs a real model).
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Live_Responder_WithoutModel_EmitsCalmNotice()
     {
         var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
         access.SetCircuitContext(TestUsers.Admin);
 
         var client = GetClient();
-        // Owner partition live (onboarded) — same precondition ThreadCreatableFromHomeTest pins.
         await client.Observe(new PingRequest(), o => o.WithTarget(new Address(OwnerId)))
             .Should().Within(30.Seconds()).Emit();
 
         var prompt = $"training-live-{Guid.NewGuid():N}";
         var responder = TrainingSimResponder.Live(client, OwnerId);
 
-        // Subscribe = submit. No model is configured here, so the REPLY may
-        // never complete — the assertion below is on the canonical submission
-        // side effect, not the round.
-        using var subscription = responder(prompt).Subscribe(_ => { }, _ => { });
+        var response = await responder(prompt)
+            .Should().Within(30.Seconds()).Emit();
 
-        // The thread node lands under {owner}/_Thread with the TrainingSim
-        // agent selected on its composer and our prompt as the queued/first
-        // user message.
-        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
-        var thread = await meshService
-            .Query<MeshNode>(MeshQueryRequest.FromQuery(
-                $"path:{OwnerId}/_Thread scope:children nodeType:{ThreadNodeType.NodeType}"))
-            .SelectMany(change => change.Items)
-            .Select(node => node.ContentAs<MeshThread>(Mesh.JsonSerializerOptions))
-            .Should().Within(60.Seconds()).Match(t => t is not null
-                && t.Composer != null
-                && t.Composer.AgentName == TrainingSimResponder.AgentName
-                && (t.PendingUserMessages.Values.Any(m => m.Text == prompt)
-                    || t.UserMessageIds.Count > 0));
-
-        thread!.Composer!.AgentName.Should().Be(TrainingSimResponder.AgentName,
-            "the LIVE adapter selects the dedicated training agent on the composer");
+        response!.Code.Should().BeEmpty("the notice keeps the code pane empty");
+        var markdown = response.Output.Should().BeOfType<MarkdownControl>()
+            .Subject.Markdown!.ToString()!;
+        markdown.Should().Contain("configure a language model",
+            "a model-less environment must show the calm notice, not a raw factory error");
     }
 }
 

--- a/test/MeshWeaver.ContentCollections.Test/ContentCollectionWriteReadRaceTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/ContentCollectionWriteReadRaceTest.cs
@@ -11,7 +11,7 @@ namespace MeshWeaver.ContentCollections.Test;
 /// <see cref="FileSystemStreamProvider.GetStreamWithMetadataAsync"/>) deliberately opens with the
 /// maximally-tolerant <c>FileShare.ReadWrite | FileShare.Delete</c> — content is eventually-consistent
 /// and re-ingested on change, so reads never block and are never blocked. The FileSystemWatcher-driven
-/// <c>ContentCollection.UpdateArticle</c> issues exactly such a read whenever a file changes, so a read
+/// <c>ContentCollection.IngestContentFile</c> issues exactly such a read whenever a file changes, so a read
 /// legitimately overlaps a write.</para>
 ///
 /// <para>The bug: the write opened with <c>FileShare.None</c>. On Unix, .NET emulates <c>FileShare</c>

--- a/test/MeshWeaver.Graph.Test/NuGetAssemblyResolverTest.cs
+++ b/test/MeshWeaver.Graph.Test/NuGetAssemblyResolverTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using MeshWeaver.Graph.Configuration;
 using MeshWeaver.NuGet;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -77,63 +76,12 @@ public class NuGetAssemblyResolverTest
         second.Should().BeSameAs(first);
     }
 
-    /// <summary>
-    /// Pins the <c>#r "nuget:MeshWeaver.BusinessRules.Generator"</c> MECHANISM that every
-    /// scope-bearing node Source (PensionFund BalanceSheet, and any <c>IScope&lt;,&gt;</c> node)
-    /// depends on. The scope SOURCE GENERATOR is deliberately NOT a framework reference — that
-    /// propagated the analyzer and bloated every build (commit ef2e756d6,
-    /// project_graph_generator_build_bloat). Instead it travels WITH the node Source via a
-    /// <c>#r</c> directive, is resolved from the <b>mesh-local feed</b> (<c>dist/packages</c>,
-    /// baked into the container image — it is NOT published to nuget.org), surfaced from
-    /// <c>lib/</c>, and discovered as a Roslyn <c>[Generator]</c>. If ANY link breaks — the local
-    /// feed not on the source list, the generator not shipped under <c>lib/</c>, or the loader
-    /// failing to see it — scope nodes compile but emit no <c>IScope</c> implementations and their
-    /// views render empty. That exact regression silently broke the PensionFund balance sheet;
-    /// this test fails loudly instead.
-    ///
-    /// <para>The reference is VERSION-LESS, exactly as the node Source declares it: the resolver
-    /// returns the highest version the feed carries, so there is ONE global version
-    /// (<c>PlatformVersion</c>) and no per-sample pin to drift.</para>
-    ///
-    /// <para>Skipped only on an unprepared clone where <c>dist/packages</c> has not been packed.
-    /// CI's "Pack mesh-local #r packages" step produces it before tests; locally run
-    /// <c>dotnet pack src/MeshWeaver.BusinessRules.Generator -c Release -o dist/packages</c>.</para>
-    /// </summary>
-    [Fact(Timeout = 120_000)]
-    public async Task ScopeGenerator_ResolvesFromMeshLocalFeed_AndIsDiscoverableAsAGenerator()
-    {
-        if (ShouldSkip) return;
-
-        // dist/packages lives at the repo root (5 levels up from bin/Debug/net10.0) and is
-        // git-ignored — populated by the CI pack step / a local `dotnet pack`. When absent,
-        // exit cleanly so a missing artefact surfaces as SKIP, not as a misleading resolver error.
-        var distPackages = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "..", "..", "dist", "packages"));
-        if (!Directory.Exists(distPackages)
-            || Directory.GetFiles(distPackages, "MeshWeaver.BusinessRules.Generator.*.nupkg").Length == 0)
-            return;
-
-        var resolver = new NuGetAssemblyResolver(NullLogger<NuGetAssemblyResolver>.Instance);
-
-        // Version-LESS resolve. If the mesh-local feed were not among the configured sources this
-        // throws "no package found" — so a green result IS the "local path is in the places we
-        // look for packages" assertion.
-        var result = await resolver.ResolveAsync(
-            [new NuGetPackageReference("MeshWeaver.BusinessRules.Generator", null)],
-            targetFramework: null,
-            ct: TestContext.Current.CancellationToken);
-
-        // The generator csproj ships its DLL under BOTH analyzers/ AND lib/netstandard2.0 precisely
-        // so this lib-only resolver surfaces it; assert that contract holds.
-        result.AssemblyPaths.Should().Contain(
-            p => p.EndsWith("MeshWeaver.BusinessRules.Generator.dll", StringComparison.OrdinalIgnoreCase),
-            "the generator package must surface its assembly from lib/ so SourceGeneratorLoader can load it");
-        result.AssemblyPaths.Should().OnlyContain(p => File.Exists(p));
-
-        // …and the resolved assembly really is a usable Roslyn source generator (ScopeCodeGenerator),
-        // so MeshNodeCompilationService.RunSourceGenerators will emit the IScope<,> implementations.
-        var generators = SourceGeneratorLoader.Discover(result.AssemblyPaths, NullLogger.Instance);
-        generators.Should().NotBeEmpty(
-            "the resolved generator assembly must expose a [Generator] — otherwise scope nodes compile but generate nothing");
-    }
+    // The former ScopeGenerator_ResolvesFromMeshLocalFeed test was DELETED with the CI
+    // "Pack mesh-local #r packages" step: the feed-resolved generator mechanism it pinned is
+    // dead — the scope generator ships WITH the platform and runs in-process (no #r, no feed,
+    // no NuGet round-trip), pinned by BuiltInScopeGeneratorTest; a legacy
+    // #r "nuget:MeshWeaver.BusinessRules.Generator" is filtered out of the resolve set at
+    // compile (also pinned there). The test only ever ran when dist/packages existed (CI's
+    // pack step / a manual local pack) and self-skipped otherwise — after the pack-step
+    // removal it would have been a permanently-skipped pin of a removed mechanism.
 }

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansClusterDisposal.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansClusterDisposal.cs
@@ -1,11 +1,13 @@
 using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Threading;
 using Orleans.TestingHost;
 
 namespace MeshWeaver.Hosting.Orleans.Test;
 
 /// <summary>
-/// Drains Orleans <see cref="TestCluster"/> disposals on a BACKGROUND pool instead of
+/// Drains Orleans <see cref="TestCluster"/> disposals on the <see cref="IIoPool"/> instead of
 /// awaiting them inline at per-class teardown.
 ///
 /// <para><b>Why.</b> Awaiting <c>Cluster.DisposeAsync()</c> on the xUnit teardown thread
@@ -16,85 +18,97 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// test class spins up and tears down its OWN cluster, one wedged teardown stalls the
 /// whole sequential run (<c>maxParallelThreads:1</c>).</para>
 ///
-/// <para><b>Fix.</b> No <c>await</c> on the teardown thread — hand the cluster to a
-/// background task ("io pool") and return immediately, so the next class's cluster starts
-/// right away and disposals drain concurrently. Every disposal is then awaited ONCE, at
-/// the very end (process exit), bounded so a genuinely-wedged silo is abandoned rather
-/// than hanging the wait. (A real mesh <c>IIoPool</c> isn't available at xUnit teardown,
-/// so the background-task pool stands in for it.)</para>
+/// <para><b>Fix.</b> No <c>async</c>/<c>await</c> and no hand-rolled <c>Task.Run</c>/<c>Task.WaitAll</c>
+/// on the teardown thread. Each cluster's ordered stop→dispose is pushed onto
+/// <see cref="IoPool.Unbounded"/> — the sanctioned async boundary — as a COLD
+/// <see cref="IObservable{T}"/>, made hot immediately (so the next class's cluster starts right away
+/// and disposals drain concurrently), and its completion replayed to the final drain. Every disposal
+/// is then awaited ONCE — SYNCHRONOUSLY, via Rx blocking — at the
+/// <see cref="OrleansDisposalDrainFixture">assembly fixture</see>'s teardown (which runs AFTER all
+/// test classes but BEFORE the native in-process runner's foreground-thread check), bounded so a
+/// genuinely-wedged silo is abandoned rather than hanging the wait.</para>
+///
+/// <para>The native xUnit v3 runner force-exits non-zero — <c>"Foreground threads were left running,
+/// forcing process exit"</c> — when a silo's shutdown threads are still draining at the check.
+/// Under vstest that check didn't run, so the leak was invisible; the assembly-fixture drain (not the
+/// old <c>ProcessExit</c> hook, which fires AFTER the check) closes it.</para>
 /// </summary>
 internal static class OrleansClusterDisposal
 {
-    private static readonly ConcurrentBag<Task> Pending = new();
+    // Each cluster's stop→dispose as a hot, replayed observable — its completion is what the final
+    // drain blocks on. Replay-backed so a disposal that finishes before the drain subscribes still
+    // replays its OnCompleted.
+    private static readonly ConcurrentBag<IObservable<Unit>> Pending = new();
 
     /// <summary>
-    /// Hand a cluster's disposal to a background pool thread — NEVER awaited on the
-    /// teardown thread. Null-safe and best-effort (the cluster is on its way down; a
-    /// shutdown-race exception is benign and swallowed).
+    /// Hand a cluster's disposal to the I/O pool — NEVER awaited on the teardown thread. Null-safe
+    /// and best-effort per leg (the cluster is on its way down; a shutdown-race exception is benign).
     ///
-    /// <para><b>Graceful stop BEFORE dispose — the root fix for the Autofac
-    /// disposed-<c>LifetimeScope</c> straggler (task #20).</b> <see cref="TestCluster.DisposeAsync"/>
-    /// disposes the Orleans CLIENT host through the generic <c>IHost.DisposeAsync()</c>, which
-    /// only disposes the service provider and NEVER runs <c>StopAsync()</c>. So the client's
-    /// connection message pump (<c>Orleans.Runtime.Messaging.Connection.ProcessIncoming</c>) keeps
-    /// deserializing in-flight messages while the client's Autofac container is being torn down;
-    /// <c>CodecProvider</c> then lazily resolves a serialization codec from the already-disposed
-    /// <c>LifetimeScope</c> and throws <see cref="ObjectDisposedException"/> ("Instances cannot be
-    /// resolved and nested lifetimes cannot be created from this LifetimeScope … already disposed").
-    /// Unobserved under CI load, that reaches <see cref="AppDomain.UnhandledException"/> — the ONLY
-    /// channel xUnit v3's in-proc console runner hooks — and is reported as an anonymous
-    /// "Catastrophic failure" that reds a 123/123-green shard. (The silos are already graceful:
-    /// <c>InProcessSiloHandle.DisposeAsync</c> runs <c>StopSiloAsync(graceful)</c> first; only the
-    /// client host skips its <c>StopAsync</c>.) The pump is purely Orleans-internal, so the mesh
-    /// drain added in #231 (<c>MeshTeardownHostedService</c>) never covered it — and because the
-    /// client's <c>StopAsync</c> is skipped, that drain never even ran on the client.</para>
-    ///
-    /// <para><b>The residual gap #244 left (task #21): the CLIENT is stopped by a DIFFERENT method.</b>
-    /// <see cref="TestCluster.StopAllSilosAsync"/> stops the SILOS only — it does NOT run the client
-    /// host's <c>StopAsync</c>. So after #244 the client connection pump was still live when
-    /// <c>DisposeAsync</c> disposed the client's Autofac container → the disposed-<c>LifetimeScope</c>
-    /// straggler kept escaping under CI load (it re-flaked shard 3 of #244 and #258). The client's
-    /// graceful stop is <see cref="TestCluster.StopClusterClientAsync"/> — the exact <c>StopAsync</c>
-    /// that <c>TestCluster.DisposeAsync</c> skips. We call it FIRST (client stops initiating), THEN
-    /// stop the silos, THEN dispose — so by dispose time NO connection pump (client or silo) is left
-    /// resolving a codec. Measured by <c>TeardownStragglerCapturer</c>: the disposed-scope throw count
-    /// per Orleans.Test run goes to 0, and stays 0 across the shard sequence (the cross-project mode).</para>
+    /// <para><b>Graceful ordered stop BEFORE dispose.</b> <see cref="TestCluster.DisposeAsync"/>
+    /// disposes the Orleans CLIENT host through the generic <c>IHost.DisposeAsync()</c>, which only
+    /// disposes the service provider and NEVER runs <c>StopAsync()</c>. So the client's connection
+    /// message pump (<c>Orleans.Runtime.Messaging.Connection.ProcessIncoming</c>) keeps deserializing
+    /// in-flight messages while the client's Autofac container is torn down; <c>CodecProvider</c> then
+    /// lazily resolves a codec from the already-disposed <c>LifetimeScope</c> and throws
+    /// <see cref="ObjectDisposedException"/>, which under CI load escapes unobserved and reds a
+    /// 123/123-green shard. The silos are already graceful (<c>InProcessSiloHandle.DisposeAsync</c>
+    /// runs <c>StopSiloAsync</c>); only the client host skips its <c>StopAsync</c>. Its graceful stop
+    /// is <see cref="TestCluster.StopClusterClientAsync"/> — which <c>DisposeAsync</c> skips and
+    /// <see cref="TestCluster.StopAllSilosAsync"/> does NOT cover. We run it FIRST (client stops
+    /// initiating), THEN the silos, THEN dispose — so by dispose time no connection pump is resolving
+    /// a codec. Pinned by <c>TeardownStragglerCapturer</c>: disposed-scope throws per run stay 0.</para>
     /// </summary>
     public static void DisposeInBackground(TestCluster? cluster)
     {
         if (cluster is null)
             return;
-        Pending.Add(Task.Run(async () =>
-        {
-            // Graceful ordered stop BEFORE any Autofac container disposes: CLIENT host first
-            // (StopClusterClientAsync — the StopAsync that TestCluster.DisposeAsync SKIPS, the exact
-            // gap that left the client pump resolving a codec from a disposing scope), THEN every silo,
-            // THEN the dispose. Each step guarded separately so a stop-race can't skip the steps that
-            // follow. All benign here — the cluster is going down; a genuinely surviving straggler is
-            // still NAMED by TeardownStragglerCapturer.
-            try { await cluster.StopClusterClientAsync(); }
-            catch { /* client stop-race on a cluster going down — the silo stop + dispose still run */ }
-            try { await cluster.StopAllSilosAsync(); }
-            catch { /* silo stop-race — DisposeAsync still completes teardown */ }
-            try { await cluster.DisposeAsync(); }
-            catch { /* shutdown-race / zombie silo — benign, the cluster is going down */ }
-        }));
+
+        // Ordered: client stop → silo stop → dispose. Each leg runs on the I/O pool (off the
+        // teardown thread, ConfigureAwait(false) inside the pool); each Catch-swallows its own
+        // stop-race so a failed leg can't skip the ones that follow. SelectMany sequences them.
+        var drain =
+            RunVoid(cluster.StopClusterClientAsync)
+                .SelectMany(_ => RunVoid(cluster.StopAllSilosAsync))
+                .SelectMany(_ => RunVoid(() => cluster.DisposeAsync().AsTask()));
+
+        // Make it hot NOW so the disposal drains concurrently with the next class booting, and
+        // replay its terminal notification to the (later) synchronous drain. Connect starts it.
+        var replayed = drain.Replay(1);
+        replayed.Connect();
+        Pending.Add(replayed);
     }
 
     /// <summary>
-    /// Wait (bounded) for every background disposal. Called once at the very end, so the
-    /// process doesn't exit mid-teardown while still leaving a wedged silo free to abandon.
+    /// Runs one <see cref="Task"/>-returning leaf on <see cref="IoPool.Unbounded"/> and projects it to
+    /// <see cref="Unit"/>, swallowing a benign shutdown-race so a failed leg completes rather than
+    /// faulting the sequence. The pool IS the async boundary — nothing is <c>await</c>ed here.
+    /// </summary>
+    private static IObservable<Unit> RunVoid(Func<Task> leaf) =>
+        IoPool.Unbounded
+            .Run(_ => leaf().ContinueWith(static _ => Unit.Default, TaskScheduler.Default))
+            .Catch(Observable.Return(Unit.Default));
+
+    /// <summary>
+    /// Block (bounded) until every pooled disposal has completed. SYNCHRONOUS — Rx blocking,
+    /// no <c>async</c>/<c>await</c>. Called from the assembly fixture's teardown so the process
+    /// doesn't reach the runner's foreground-thread check while a silo's shutdown threads are
+    /// still draining.
     /// </summary>
     public static void WaitAll(TimeSpan timeout)
     {
-        try { Task.WaitAll(Pending.ToArray(), timeout); }
-        catch { /* best-effort — a wedged silo is abandoned at process exit */ }
+        var all = Pending.ToArray();
+        if (all.Length == 0)
+            return;
+        try
+        {
+            // Merge every replayed completion; block on the merged stream's terminal notification.
+            // DefaultIfEmpty guards a leg that replays only OnCompleted (no OnNext). Timeout abandons
+            // a genuinely-wedged silo instead of hanging the run.
+            Observable.Merge(all).DefaultIfEmpty(Unit.Default).Timeout(timeout).Wait();
+        }
+        catch
+        {
+            /* best-effort — a wedged silo is abandoned; TeardownStragglerCapturer still names it */
+        }
     }
-
-    // The "very end": after all tests + collections, the test host exits → drain the pool.
-    // By now the disposals have had the whole run to complete concurrently, so this is a
-    // short final flush, not a long stall.
-    [ModuleInitializer]
-    public static void Init() =>
-        AppDomain.CurrentDomain.ProcessExit += (_, _) => WaitAll(TimeSpan.FromSeconds(20));
 }

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansDisposalDrainFixture.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansDisposalDrainFixture.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+[assembly: AssemblyFixture(typeof(MeshWeaver.Hosting.Orleans.Test.OrleansDisposalDrainFixture))]
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Assembly-scoped drain for the backgrounded <see cref="TestCluster"/> disposals
+/// (<see cref="OrleansClusterDisposal.DisposeInBackground"/>). xUnit v3 constructs this once and
+/// disposes it AFTER every test class has run its per-class teardown (backgrounding its cluster's
+/// stop→dispose onto the I/O pool) but BEFORE the native in-process runner does its foreground-thread
+/// check. A SYNCHRONOUS <see cref="IDisposable.Dispose"/> (no <c>async</c>/<c>await</c>) blocks on the
+/// pooled disposals draining, so no Orleans silo shutdown thread is still alive when the runner checks
+/// — which otherwise force-exits the whole shard non-zero with
+/// <c>"Foreground threads were left running, forcing process exit"</c> despite 123/123 green.
+///
+/// <para>Replaces the previous <c>ProcessExit</c> hook as the PRIMARY drain: <c>ProcessExit</c> fires
+/// only DURING the runner's force-exit — too late to prevent it. The 30 s bound abandons a genuinely
+/// wedged silo rather than hanging the run.</para>
+/// </summary>
+public sealed class OrleansDisposalDrainFixture : IDisposable
+{
+    public void Dispose() => OrleansClusterDisposal.WaitAll(TimeSpan.FromSeconds(30));
+}

--- a/test/MeshWeaver.Persistence.Test/DocumentationCodeBlockCompilationTest.cs
+++ b/test/MeshWeaver.Persistence.Test/DocumentationCodeBlockCompilationTest.cs
@@ -32,7 +32,8 @@ namespace MeshWeaver.Persistence.Test;
 /// those package references at runtime; that path is covered by
 /// <c>ScriptExecutionInUserHomeTest.NuGetDirective_*</c>).</para>
 /// </summary>
-public class DocumentationCodeBlockCompilationTest
+public class DocumentationCodeBlockCompilationTest(KernelScriptOptionsFixture fixture)
+    : IClassFixture<KernelScriptOptionsFixture>
 {
     public static IEnumerable<object[]> DocResources()
     {
@@ -67,7 +68,7 @@ public class DocumentationCodeBlockCompilationTest
             .Where(block => !block.SubmitCode!.Code.Contains("#r \"nuget:", StringComparison.OrdinalIgnoreCase))
             .ToList();
 
-        var options = CreateKernelEquivalentScriptOptions();
+        var options = fixture.Options;
         var failures = submissions
             .Select(block => (block, errors: Compile(block.SubmitCode!.Code, options)))
             .Where(x => x.errors.Count > 0)
@@ -86,7 +87,14 @@ public class DocumentationCodeBlockCompilationTest
         // globalsType MUST match the kernel (KernelExecutor.RunAsync passes typeof(MeshScriptGlobals))
         // so that Log / Mesh / Ct / Inputs resolve as bare identifiers in cells.
         var script = CSharpScript.Create(code, options, globalsType: typeof(MeshScriptGlobals));
-        return script.Compile()
+        // Diagnostics WITHOUT creating an executor: Script.Compile() also EMITS the script and
+        // LOADS it into a fresh InteractiveAssemblyLoader AssemblyLoadContext that is never
+        // unloaded — one leaked ALC per compiled block (alc 1→121 in the CI trace), which drove
+        // the testhost past the 6 GiB memory-watchdog FailFast (SIGABRT / exit 134). The error
+        // set is identical: Compile() itself reports GetCompilation().GetDiagnostics(); the
+        // executor is pure side effect for this compile-only guard.
+        return script.GetCompilation()
+            .GetDiagnostics()
             .Where(d => d.Severity == DiagnosticSeverity.Error)
             .ToList();
     }
@@ -107,6 +115,20 @@ public class DocumentationCodeBlockCompilationTest
         using var reader = new StreamReader(stream);
         return reader.ReadToEnd();
     }
+
+}
+
+/// <summary>
+/// ONE compile environment shared across all ~210 doc-page theory cases. Rebuilding the full
+/// trusted-platform-assembly MetadataReference set per case retained ~3.3 GiB of NATIVE
+/// metadata in a single run (invisible to the GC, freed only by finalizers) — the leak that
+/// tripped the CI memory watchdog's FailFast. xunit disposes the fixture with the class, so
+/// the references are released before the kernel-based tests (DocExecutableBlocksTest,
+/// CourseCellExecutionTest) run under the same process budget.
+/// </summary>
+public sealed class KernelScriptOptionsFixture
+{
+    public ScriptOptions Options { get; } = CreateKernelEquivalentScriptOptions();
 
     private static ScriptOptions CreateKernelEquivalentScriptOptions()
     {

--- a/test/MeshWeaver.Portal.E2E.Test/BusinessRulesBalanceSheetE2ETest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/BusinessRulesBalanceSheetE2ETest.cs
@@ -1,0 +1,185 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace MeshWeaver.Portal.E2E.Test;
+
+/// <summary>
+/// The full business-rules PROCESS, end to end, in a real browser: seed the PensionFund
+/// balance-sheet sample (NodeType definitions + their Source code — the IScope&lt;,&gt;
+/// business rules included — dimension and fact nodes, and the report instance) through the
+/// public mesh API, let the portal DYNAMICALLY compile the NodeType (Roslyn + the built-in
+/// scope generator, no NuGet feed), then open the report page and assert the SCOPE-COMPUTED
+/// numbers render in the GUI: both years balance (1'060.0 / 1'142.0) and the funding ratio
+/// evaluates (≈109.8% / ≈112.4%). A generator regression, a compile-path defect (e.g. the
+/// legacy-#r feed round-trip), a scope-fold bug, or a rendering break all fail HERE — in the
+/// same shape a user would see it.
+///
+/// <para>The in-proc twin is <c>PensionFundBalanceSheetTest</c> (kernel-level, no browser);
+/// this test covers the remaining hops: REST create → per-node hub activation → dynamic
+/// compile on the deployed image → Blazor render over SignalR.</para>
+/// </summary>
+[Collection("portal-e2e")]
+public class BusinessRulesBalanceSheetE2ETest(PortalFixture fixture, ITestOutputHelper output)
+{
+    /// <summary>Repo-relative sample root (bin/Release/net10.0 → repo root is 5 levels up).</summary>
+    private static readonly string SampleRoot = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "..", "..",
+        "samples", "Graph", "Data", "PensionFund"));
+
+    [Fact(Timeout = 600_000)]
+    public async Task BalanceSheet_ScopeComputedNumbers_RenderInBrowser()
+    {
+        Assert.SkipUnless(fixture.Available, fixture.SkipReason);
+        Assert.SkipUnless(Directory.Exists(SampleRoot),
+            $"PensionFund sample not found at {SampleRoot} — run from the repo tree.");
+
+        await using var context = await fixture.NewAuthenticatedContextAsync();
+        var token = await fixture.MintTokenAsync(context);
+
+        // ── 1. Seed the sample verbatim: type definitions first, then their Source code
+        //       (the business rules), then dimension/fact instances. The report instance
+        //       comes LAST, after the NodeType compile settles — its content declares
+        //       $type: BalanceSheetReport, a type that only EXISTS once the compile is done.
+        foreach (var typeJson in new[]
+                 { "Year.json", "Currency.json", "Position.json", "BalanceSheetEntry.json", "BalanceSheet.json" })
+            await SeedFileAsync(context, token, Path.Combine(SampleRoot, typeJson));
+
+        foreach (var typeDir in new[] { "Year", "Currency", "Position", "BalanceSheetEntry", "BalanceSheet" })
+        {
+            var sourceDir = Path.Combine(SampleRoot, typeDir, "Source");
+            if (!Directory.Exists(sourceDir))
+                continue;
+            foreach (var cs in Directory.GetFiles(sourceDir, "*.cs").OrderBy(f => f, StringComparer.Ordinal))
+                await SeedCodeAsync(context, token, typeDir, cs);
+        }
+
+        foreach (var typeDir in new[] { "Year", "Currency", "Position", "BalanceSheetEntry" })
+        foreach (var instance in Directory.GetFiles(Path.Combine(SampleRoot, typeDir), "*.json")
+                     .OrderBy(f => f, StringComparer.Ordinal))
+            await SeedFileAsync(context, token, instance);
+
+        // ── 2. Wait for the BalanceSheet NodeType's dynamic compile (5 Source files +
+        //       the built-in scope generator) to SETTLE before creating the typed instance.
+        var settled = await WaitForCompileAsync(context, token, "PensionFund/BalanceSheet",
+            TimeSpan.FromSeconds(180));
+        Assert.True(settled, "the BalanceSheet NodeType compile must settle Ok — " +
+                             "a compile error here means the scope generator / compile path broke");
+
+        await SeedFileAsync(context, token, Path.Combine(SampleRoot, "Statement.json"));
+        Assert.True(await fixture.WaitUntilReadableAsync(context, token, "PensionFund/Statement",
+            TimeSpan.FromSeconds(60)), "the seeded Statement instance must become readable");
+
+        // ── 3. Drive the GUI: the report page must render the SCOPE-COMPUTED numbers.
+        var page = await context.NewPageAsync();
+        await page.SetViewportSizeAsync(1440, 1000);
+        await page.GotoAsync($"{fixture.BaseUrl}/PensionFund/Statement",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+
+        // First activation of the per-node hub renders the statement; the funding-ratio row
+        // is the deepest computation (a Ratio position over Sum positions with negative
+        // weights) — when IT shows, the whole scope graph evaluated.
+        await page.GetByText("FundingRatio").First.WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+            Timeout = 180_000
+        });
+
+        await page.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Path = "/tmp/business-rules-balance-sheet.png",
+            FullPage = true
+        });
+
+        var body = await page.Locator("body").InnerTextAsync();
+        output.WriteLine(body.Length > 4000 ? body[..4000] : body);
+
+        // Dimension members render as rows …
+        Assert.Contains("Cash", body);
+        Assert.Contains("PensionersCapital", body);
+        // … and the computed positions fold through the PositionValue scopes:
+        // totals per year and the funding ratio (separator-tolerant: 1'060.0 / 1,060.0).
+        AssertHasNumber(body, @"1['’,]?060[.,]0", "2024 total must be 1'060.0");
+        AssertHasNumber(body, @"1['’,]?142[.,]0", "2025 total must be 1'142.0");
+        AssertHasNumber(body, @"109[.,]8", "2024 funding ratio must be ≈109.8%");
+        AssertHasNumber(body, @"112[.,]4", "2025 funding ratio must be ≈112.4%");
+    }
+
+    private static void AssertHasNumber(string body, string pattern, string because)
+        => Assert.True(System.Text.RegularExpressions.Regex.IsMatch(body, pattern),
+            $"{because} — pattern '{pattern}' not found in rendered page");
+
+    /// <summary>Seeds a sample MeshNode JSON file as-is; a node that already exists (rerun
+    /// against a kept e2e DB) is fine — the sample is immutable.</summary>
+    private async Task SeedFileAsync(IBrowserContext context, string token, string path)
+    {
+        var json = await File.ReadAllTextAsync(path);
+        try
+        {
+            await fixture.CreateNodeAsync(context, token, json);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
+        {
+            output.WriteLine($"seed {Path.GetFileName(path)}: already exists — reusing");
+        }
+    }
+
+    /// <summary>Seeds a Source .cs file as a Code node under {type}/Source — the exact shape
+    /// the filesystem persistence gives sample sources (CSharpFileParser → CodeConfiguration).</summary>
+    private async Task SeedCodeAsync(IBrowserContext context, string token, string typeDir, string csPath)
+    {
+        var id = Path.GetFileNameWithoutExtension(csPath);
+        var code = await File.ReadAllTextAsync(csPath);
+        var node = System.Text.Json.JsonSerializer.Serialize(new Dictionary<string, object?>
+        {
+            ["id"] = id,
+            ["namespace"] = $"PensionFund/{typeDir}/Source",
+            ["name"] = id,
+            ["nodeType"] = "Code",
+            ["state"] = "Active",
+            ["isPersistent"] = true,
+            ["content"] = new Dictionary<string, object?>
+            {
+                ["$type"] = "CodeConfiguration",
+                ["code"] = code,
+                ["language"] = "csharp"
+            }
+        });
+        try
+        {
+            await fixture.CreateNodeAsync(context, token, node);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
+        {
+            output.WriteLine($"seed {typeDir}/Source/{id}: already exists — reusing");
+        }
+    }
+
+    /// <summary>Polls the NodeType node via the mesh get API until its compilationStatus is Ok.</summary>
+    private async Task<bool> WaitForCompileAsync(IBrowserContext context, string token, string path, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        string last = "";
+        while (DateTime.UtcNow < deadline)
+        {
+            var resp = await context.APIRequest.PostAsync($"{fixture.BaseUrl}/api/mesh/get",
+                new APIRequestContextOptions
+                {
+                    Headers = new Dictionary<string, string> { ["authorization"] = $"Bearer {token}" },
+                    DataObject = new { Path = path }
+                });
+            last = await resp.TextAsync();
+            if (last.Contains("\"compilationStatus\"", StringComparison.OrdinalIgnoreCase)
+                && last.Contains("Ok", StringComparison.Ordinal))
+                return true;
+            if (last.Contains("\"Error\"", StringComparison.Ordinal)
+                && last.Contains("compilationError", StringComparison.OrdinalIgnoreCase))
+            {
+                output.WriteLine($"compile settled at Error:\n{last[..Math.Min(last.Length, 2000)]}");
+                return false;
+            }
+            await Task.Delay(2000);
+        }
+        output.WriteLine($"compile poll timed out; last get:\n{last[..Math.Min(last.Length, 2000)]}");
+        return false;
+    }
+}


### PR DESCRIPTION
## Why

Every CI run took ~30 min, and profiling the last four runs exposed something worse than slowness: **four classes of test failures were reading GREEN**.

| Masked failure (every run) | Mechanism |
|---|---|
| `MeshWeaver.AI.Test` killed at the 6-min cap (exit=124) | killed host leaves no failing trx → trx-only gate stays green; 3 permanently-failing tests + ~120 s of pure timeout burn hid inside |
| `Persistence.Test` SIGABRT (exit=134) after "328 passed" | memory-watchdog `FailFast` mid-run; in-flight + not-yet-run tests silently vanish from the trx (passed-count varied per run) |
| `Layout.Test` exit=1 with all-green trx | leaked debounced auto-save wrote to the finished test's `ITestOutputHelper` → xunit catastrophic |
| `Threading.Test` exit=1 with all-green trx | post-dispose Rx timer → `ObjectDisposedException` thrown inside `OnError` → process-fatal |

## Timing changes

- **Shard assignment**: measured-weight greedy LPT (order-independent). The old `counter % N` over a **C-locale-sorted** list put `AI.Test` before `Acme.Test` (`'I' < 'c'`), stacking AI+Orleans — two of the three heaviest — on shard 0: the ~19-min long pole of every run. Shards now balance to ~370 weighted seconds.
- **Native xUnit v3 hosts** (`dotnet <Name>.dll -trx`) instead of `dotnet test --no-build`: no per-project MSBuild, and the build artifact shrinks from bin+obj of 156 projects + the whole NuGet cache to **test bins only**.
- **`dotnet workload restore` deleted** from all 7 jobs (~75 s each — CI logs prove it installs *nothing*).
- **"Pack mesh-local #r packages" deleted**: the feed was removed from the image in #395 (in-process scope generator, pinned by `BuiltInScopeGeneratorTest`); nothing resolves from `dist/packages` anymore. The dead pinning test is deleted with it.
- **concurrency**: force-pushed PR branches cancel their superseded runs; main pushes are never grouped.
- **main-cd.yml**: portal + migration images build in **parallel jobs** (~5 min off merge-to-deployed).
- Free-disk step trimmed; per-project cap 6m → 8m sized to the measured slowest legit project (post-fix AI.Test ≈ 5.5 CI-min) — a kill now REDS the run via the new gate.

**New gate:** any per-project non-zero exit marker fails the shard and the collector — killed, crashed, and catastrophically-failed hosts can no longer hide behind a green trx.

## Root-cause fixes (no band-aids)

- **Prod latency defect**: `MeshOperations.LookupCompilationError` burned a **5 s settle-timeout on every successful `get` of a node with a built-in static NodeType** (no `NodeTypeDefinition`/CompileWatcher exists → the wait can never satisfy). `FindStaticNode` fast path, mirroring `GetDiagnostics`. This alone was ~120 s of AI.Test and is a live agent/MCP `get` tax in every deployment.
- **`HubTestBase.DisposeAsync` never initiated `Mesh.Dispose()`** (initiation lost in `aad01631a`) — every HubTestBase test leaked its whole live mesh. Restored.
- **`DocumentationCodeBlockCompilationTest`** leaked ~3.3 GiB (per-theory TPA `MetadataReference` rebuild × 210 doc pages + `Script.Compile()` loading one never-unloaded ALC per block) → tripped the 6 GiB watchdog `FailFast`. Shared class fixture + `GetCompilation().GetDiagnostics()` (identical error set, no executor). All 381 tests actually run now (was ~330 before the abort).
- **Route/timer-after-dispose `ObjectDisposedException` class**, refuse-and-complete at every edge: emission-time `IsDisposing` re-check in `MonolithRoutingService`; `HostedHubsCollection.CloseCreation()` flipped by the owning hub the moment disposal begins (no Quiescing-window zombie hubs); `ThreadSubmission` never launches a round on a disposing/null hub and its fault sink skips the terminal write when disposing (`ResumeInterruptedRound` recovers on re-activation); `RequestGrainDeactivation` refuses on a disposing hub; the init-watchdog's inner rescue timer refuses after disposal; `Workspace.AddDisposable` disposes late registrants immediately; `ContentCollection.IngestContentFile` (renamed from legacy `UpdateArticle`) refuses post-dispose watcher callbacks.
- **Stale assertions rewritten** (hidden failures): `TrainingSimResponderTest` (pins the `IsAnyModelConfigured` calm-notice degrade, 60 s → 1 s), `CodeCellOutputCaptureTest` (pins the control-based Progress shape that replaced the banned hand-rolled HTML, 65 s → 7 s), `PluginCatalogTest` (per-process clean of its on-disk fixture dir).

## Verification (local, Release, `CIRun=true`, `-warnaserror`, native hosts)

AI.Test **845/845 in 183 s** (was 460 s + killed), Threading 124/124 exit=0 no FATALs, Layout 311/311 exit=0, Persistence 381/381, Messaging.Hub, Data, Graph, Documentation, Hosting.Monolith, ContentCollections all green.

Known pre-existing: `PensionFund.Test` fails 4/4 **locally on origin/main too** (`$type BalanceSheetReport not registered` → renders empty); it is green on today's CI vstest path — this PR's native path will measure whether that green was also runner-masked.

Follow-up candidates (separable): `InboxToolIntegrationTest` releasable round-hold (−25 s), splitting AI.Test across shards if it grows again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)