### PR TITLE
MessageHub: RunLevel=Dead before SignalDisposalCompleted (teardown flake)

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1834,11 +1834,22 @@ public sealed class MessageHub : IMessageHub
                 {
                     logger.LogError("Error during shutdown of hub {address} after {elapsed}ms (total disposal time: {totalElapsed}ms): {exception}",
                         Address, shutdownStopwatch.ElapsedMilliseconds, disposalStopwatch.ElapsedMilliseconds, e);
+                    // Dead BEFORE signalling on the FAULT path too — TeardownAsync catches
+                    // DisposalCompleted errors and continues, so a faulted-signal waiter reads
+                    // RunLevel exactly like a completed-signal waiter does.
+                    lock (locker)
+                    {
+                        RunLevel = MessageHubRunLevel.Dead;
+                    }
                     SignalDisposalFaulted(e);
                 }
                 finally
                 {
-                    RunLevel = MessageHubRunLevel.Dead;
+                    // Backstop only — both signal paths above already terminalized under the lock.
+                    lock (locker)
+                    {
+                        RunLevel = MessageHubRunLevel.Dead;
+                    }
                     disposalStopwatch.Stop();
                     // Tidy the disposal-phase subscriptions (each has already self-completed:
                     // the watchdog cancelled via TakeUntil when SignalDisposalCompleted fired,

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1813,6 +1813,17 @@ public sealed class MessageHub : IMessageHub
                     logger.LogDebug("[DISPOSE-TRACE] {address}: messageService.Dispose() done in {elapsed}ms",
                         Address, shutdownStopwatch.ElapsedMilliseconds);
 
+                    // Dead BEFORE signalling — callers awaiting DisposalCompleted must observe the
+                    // terminal state, never a mid-teardown ShutDown snapshot. The force-teardown
+                    // path already orders it this way; here Dead was only set in the FINALLY, so a
+                    // StopAsync waiter woken by the signal could finish its (fast) IoPool +
+                    // AsyncDisposeQueue drains and read RunLevel == ShutDown — the flaky
+                    // MeshHostBuilderTeardownOrderingTest failure on loaded CI shards. The finally
+                    // keeps its (now redundant on success) assignment for the faulted path.
+                    lock (locker)
+                    {
+                        RunLevel = MessageHubRunLevel.Dead;
+                    }
                     // Signal completion through the reactive source (idempotent CAS — no
                     // InvalidOperationException to guard, unlike TaskCompletionSource).
                     SignalDisposalCompleted();


### PR DESCRIPTION
Fixes the flaky `MeshHostBuilderTeardownOrderingTest.StopAsync_DrainsTheMeshRootHub_BeforeTheHostDisposesItsAutofacScope` (CI run 29237278565 shard 4: `Expected Dead … but found ShutDown`; the rerun on the same commit passed).

**The race is a product bug, not a test bug.** In the normal disposal path, `SignalDisposalCompleted()` fired while `RunLevel` was still `ShutDown` — `Dead` was only assigned in the `finally` afterwards. Anyone awaiting `DisposalCompleted` (exactly what `MeshTeardownExtensions.TeardownAsync` → `MeshTeardownHostedService.StopAsync` does) can wake on the signal, finish the remaining (fast) IoPool + AsyncDisposeQueue drains, return from `StopAsync`, and read a mid-teardown `ShutDown` snapshot. Only loaded CI shards lose the race — 40 local pre-fix runs stayed green.

The force-teardown path already orders it correctly and documents the rule ("**Dead BEFORE signalling** — callers awaiting DisposalCompleted must observe the terminal state, never a mid-teardown snapshot"); the normal path now follows the same contract, flipping `RunLevel = Dead` under the lock immediately before `SignalDisposalCompleted()`. The `finally` keeps its assignment for the faulted path.

**Verified:** 25/25 repeated runs of the teardown test on the fixed build (via the xUnit v3 exe's `-method` filter — note `dotnet test --filter` doesn't reach this Testing-Platform project), plus full `MeshWeaver.Hosting.Test` (75) and `MeshWeaver.Messaging.Hub.Test` (88) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)