### PR TITLE
Fix EditPersistenceTest flake; name + fix the Layout.Test catastrophic straggler

### DIFF
--- a/test/MeshWeaver.Layout.Test/InlineEditingTest.cs
+++ b/test/MeshWeaver.Layout.Test/InlineEditingTest.cs
@@ -424,39 +424,55 @@ public class InlineEditingPersistenceTest(ITestOutputHelper output) : HubTestBas
 
     private void SetupAutoSave(LayoutAreaHost host, string dataId, PersistedContent originalItem)
     {
+        // ⚠️ Everything in this method runs on the HOST hub (view-definition path), re-invoked
+        // on every workspace emission — and the test service provider outlives the [Fact]
+        // (see TestBase.DisposeAsync), so these callbacks CAN fire after the test has been
+        // reported. All writes therefore go through FileOutput (which guards the underlying
+        // xUnit helper): a raw Output.WriteLine here after test completion throws xunit v3's
+        // InvalidOperationException("There is no currently active test") on an Rx thread,
+        // which escalates to an unhandled "[xUnit.net] Catastrophic failure" for the shard.
         var initialJson = JsonSerializer.Serialize(originalItem, host.Hub.JsonSerializerOptions);
-        Output.WriteLine($"SetupAutoSave: Initial JSON = {initialJson}");
+        FileOutput.WriteLine($"SetupAutoSave: Initial JSON = {initialJson}");
 
-        host.RegisterForDisposal(dataId,
+        // ReplaceDisposable, not RegisterForDisposal: the view definition re-runs per workspace
+        // emission, and RegisterForDisposal only ADDS — each re-render would stack another
+        // debounced watcher, multiplying DataChangeRequests and leaking live subscriptions.
+        host.ReplaceDisposable($"{dataId}.autosave",
             host.Stream.GetDataStream<PersistedContent>(dataId)
-                .Do(content => Output.WriteLine($"Data stream emitted: {content?.Title ?? "null"}"))
+                .Do(content => FileOutput.WriteLine($"Data stream emitted: {content?.Title ?? "null"}"))
                 .Debounce(TimeSpan.FromMilliseconds(100)) // Short debounce for testing
                 .Subscribe(updatedContent =>
                 {
                     if (updatedContent == null)
                     {
-                        Output.WriteLine("Auto-save: null content, skipping");
+                        FileOutput.WriteLine("Auto-save: null content, skipping");
                         return;
                     }
 
                     var currentJson = JsonSerializer.Serialize(updatedContent, host.Hub.JsonSerializerOptions);
-                    Output.WriteLine($"Auto-save: Comparing current={currentJson} vs initial={initialJson}");
+                    FileOutput.WriteLine($"Auto-save: Comparing current={currentJson} vs initial={initialJson}");
 
                     if (currentJson == initialJson)
                     {
-                        Output.WriteLine("Auto-save: No change detected, skipping");
+                        FileOutput.WriteLine("Auto-save: No change detected, skipping");
                         return;
                     }
 
-                    Output.WriteLine($"Auto-save: Change detected! Sending DataChangeRequest for {updatedContent.Title}");
+                    FileOutput.WriteLine($"Auto-save: Change detected! Sending DataChangeRequest for {updatedContent.Title}");
 
                     // Update initial to prevent re-sending
                     initialJson = currentJson;
 
-                    // Issue DataChangeRequest to persist the change (reactive, non-blocking)
-                    host.Hub.Observe<DataChangeResponse>(new DataChangeRequest().WithUpdates(updatedContent), o => o.WithTarget(host.Hub.Address))
-                        .Subscribe(response =>
-                            Output.WriteLine($"Auto-save: DataChangeResponse status = {response.Message.Status}"));
+                    // Issue DataChangeRequest to persist the change (reactive, non-blocking).
+                    // Observe emits exactly one response or OnError (delivery failure/timeout):
+                    // bound its lifetime to the host and handle OnError explicitly — an
+                    // unhandled Rx OnError after the test ends is the same catastrophic
+                    // unhandled-exception channel as the output-helper throw above.
+                    host.RegisterForDisposal(dataId,
+                        host.Hub.Observe<DataChangeResponse>(new DataChangeRequest().WithUpdates(updatedContent), o => o.WithTarget(host.Hub.Address))
+                            .Subscribe(
+                                response => FileOutput.WriteLine($"Auto-save: DataChangeResponse status = {response.Message.Status}"),
+                                ex => FileOutput.WriteLine($"Auto-save: DataChangeRequest failed: {ex.Message}")));
                 }));
     }
 
@@ -663,34 +679,44 @@ public class ObjectTypeAutoSaveTest(ITestOutputHelper output) : HubTestBase(outp
 
     private void SetupAutoSaveWithObjectType(LayoutAreaHost host, string dataId, TestItem originalItem)
     {
+        // ⚠️ This runs on the HOST hub (view-definition path), re-invoked per workspace emission,
+        // and the test service provider outlives the [Fact] — so these callbacks fire after the
+        // test has been reported. Writes go through FileOutput (guarded): a raw Output.WriteLine
+        // from the debounce timer after test completion throws xunit v3's
+        // InvalidOperationException("There is no currently active test") on an Rx thread, which
+        // surfaces as the shard's anonymous "[xUnit.net] Catastrophic failure". (Named by a
+        // first-chance probe: TestOutputHelper.QueueTestOutput ← this Subscribe ← Debounce timer.)
         var initialJson = JsonSerializer.Serialize(originalItem, host.Hub.JsonSerializerOptions);
-        Output.WriteLine($"SetupAutoSave (object): Initial JSON = {initialJson}");
+        FileOutput.WriteLine($"SetupAutoSave (object): Initial JSON = {initialJson}");
 
-        // Use GetDataStream<object> - same as MeshNodeLayoutAreas.cs
-        host.RegisterForDisposal(dataId,
+        // Use GetDataStream<object> - same as MeshNodeLayoutAreas.cs.
+        // ReplaceDisposable, not RegisterForDisposal: the view definition re-runs per workspace
+        // emission, and RegisterForDisposal only ADDS — each re-render would stack another
+        // debounced watcher, multiplying DataChangeRequests and leaking live subscriptions.
+        host.ReplaceDisposable($"{dataId}.autosave",
             host.Stream.GetDataStream<object>(dataId)
-                .Do(content => Output.WriteLine($"Object stream emitted: {content?.GetType().Name ?? "null"}"))
+                .Do(content => FileOutput.WriteLine($"Object stream emitted: {content?.GetType().Name ?? "null"}"))
                 .Debounce(TimeSpan.FromMilliseconds(100))
                 .Subscribe(updatedContent =>
                 {
-                    Output.WriteLine($"Auto-save (object) received: {updatedContent?.GetType().Name ?? "null"}");
+                    FileOutput.WriteLine($"Auto-save (object) received: {updatedContent?.GetType().Name ?? "null"}");
 
                     if (updatedContent == null)
                     {
-                        Output.WriteLine("Auto-save (object): null content, skipping");
+                        FileOutput.WriteLine("Auto-save (object): null content, skipping");
                         return;
                     }
 
                     var currentJson = JsonSerializer.Serialize(updatedContent, host.Hub.JsonSerializerOptions);
-                    Output.WriteLine($"Auto-save (object): Comparing current={currentJson} vs initial={initialJson}");
+                    FileOutput.WriteLine($"Auto-save (object): Comparing current={currentJson} vs initial={initialJson}");
 
                     if (currentJson == initialJson)
                     {
-                        Output.WriteLine("Auto-save (object): No change detected, skipping");
+                        FileOutput.WriteLine("Auto-save (object): No change detected, skipping");
                         return;
                     }
 
-                    Output.WriteLine($"Auto-save (object): Change detected! Sending DataChangeRequest");
+                    FileOutput.WriteLine($"Auto-save (object): Change detected! Sending DataChangeRequest");
                     initialJson = currentJson;
 
                     // Mark that auto-save was triggered
@@ -714,9 +740,15 @@ public class ObjectTypeAutoSaveTest(ITestOutputHelper output) : HubTestBase(outp
                     if (typedContent != null)
                     {
                         // Reactive, non-blocking — fire the persist request and log the response.
-                        host.Hub.Observe<DataChangeResponse>(new DataChangeRequest().WithUpdates(typedContent), o => o.WithTarget(host.Hub.Address))
-                            .Subscribe(response =>
-                                Output.WriteLine($"Auto-save (object): DataChangeResponse status = {response.Message.Status}"));
+                        // Bound to the host's lifetime and with an explicit OnError handler:
+                        // Observe emits exactly once or errors (delivery failure/timeout), and an
+                        // unhandled Rx OnError after the test ends is the same catastrophic
+                        // unhandled-exception channel as the output-helper throw above.
+                        host.RegisterForDisposal(dataId,
+                            host.Hub.Observe<DataChangeResponse>(new DataChangeRequest().WithUpdates(typedContent), o => o.WithTarget(host.Hub.Address))
+                                .Subscribe(
+                                    response => FileOutput.WriteLine($"Auto-save (object): DataChangeResponse status = {response.Message.Status}"),
+                                    ex => FileOutput.WriteLine($"Auto-save (object): DataChangeRequest failed: {ex.Message}")));
                     }
                 }));
     }

--- a/test/MeshWeaver.Layout.Test/MapToToggleableControlTest.cs
+++ b/test/MeshWeaver.Layout.Test/MapToToggleableControlTest.cs
@@ -547,6 +547,18 @@ public class EditPersistenceTest(ITestOutputHelper output) : HubTestBase(output)
 
         Output.WriteLine("Edit mode activated");
 
+        // The entity reaches /data through an asynchronous host-side subscription
+        // (workspace stream → host.UpdateData) that syncs to the client independently of
+        // the control tree, so the TextField can render before the entity exists in the
+        // client's state. UpdatePointer applies a JSON patch against the client's CURRENT
+        // state; a patch targeting /data/"persistable_entity"/count before the entity has
+        // synced fails with "Target path could not be reached" and is dropped with a
+        // warning (by design — fabricating the missing parent would write back a partial
+        // entity). Wait for the entity to be present before patching it.
+        await layoutStream
+            .GetDataStream<PersistableEntity>(new JsonPointerReference("/data/\"persistable_entity\""))
+            .Should().Within(5.Seconds()).Match(x => x is not null);
+
         // While in edit mode, trigger a data update (simulating workspace stream emit)
         Output.WriteLine("Triggering data update while in edit mode...");
         layoutStream.UpdatePointer(42, "/data/\"persistable_entity\"", new JsonPointerReference("count"));

--- a/test/MeshWeaver.Layout.Test/StartWithSynchronizationTest.cs
+++ b/test/MeshWeaver.Layout.Test/StartWithSynchronizationTest.cs
@@ -226,7 +226,10 @@ public class StartWithSynchronizationTest(ITestOutputHelper output) : HubTestBas
         // actual transition rather than a wall-clock window.
         var controlsReceived = await stream
             .GetControlStream(reference.Area!)
-            .Do(c => Output.WriteLine($"Received: {c?.GetType().Name}: {GetControlContent(c)}"))
+            // FileOutput (guarded), not the raw xunit Output: a straggling emission after
+            // the 5s window has reported the test would throw "There is no currently
+            // active test" on an Rx thread and red the shard as a catastrophic failure.
+            .Do(c => FileOutput.WriteLine($"Received: {c?.GetType().Name}: {GetControlContent(c)}"))
             .TakeUntil(c => c is HtmlControl)
             .ToArray()
             .Should().Within(5.Seconds()).Emit();


### PR DESCRIPTION
## Root causes (both pinned, not papered over)

### 1. `EditPersistenceTest.EditState_ShouldSurviveDataUpdates` flake (3/6 main runs, shard 3)
The failing run's stdout shows the real signal: after "Triggering data update while in edit mode..." a `Cannot update layout` warning with `InvalidOperationException: Target path '/data/"persistable_entity"/count' could not be reached` from Json.Patch inside `LayoutClientExtensions.UpdatePointer`.

**The race is in the test, not the product.** The entity reaches `/data` through an asynchronous host-side subscription (workspace stream → `host.UpdateData`) that syncs to the client independently of the control tree — so the edit-mode TextField can render before the entity exists in the client state. The test then fired `UpdatePointer`, whose patch targets `/data/"persistable_entity"/count` against the client's **current** state; the patch faults, is dropped with the designed warning, and the 5s wait for `count == 42` times out.

**Fix layer: test.** Wait for the entity to be present on the client data stream before patching (deterministic synchronization — no timeout raised). The product's warn+drop is the correct failure mode: auto-creating the missing parent would fabricate a partial entity and write it back — data loss.

### 2. `[xUnit.net] Catastrophic failure: InvalidOperationException: There is no currently active test`
Named empirically with a temporary first-chance probe (stack captured, then probe removed):

```
Xunit.v3.TestOutputHelper.QueueTestOutput
← ObjectTypeAutoSaveTest.SetupAutoSaveWithObjectType (InlineEditingTest.cs:692)
← Rx AnonymousObserver ← ReactiveExtensions.Debounce timer ← .NET TP worker
```

Host-hub view-definition callbacks (`SetupAutoSave` in `InlineEditingTest` **and** `ObjectTypeAutoSaveTest`) write to the **raw** xunit `ITestOutputHelper` from Debounce-timer/`Observe` subscriptions. The test SP deliberately outlives each `[Fact]` (see `TestBase.DisposeAsync`), so these fire after the test is reported and xunit v3's output-helper guard throws on an Rx thread.

**Fixes (bound the lifetime + guard the writes):**
- All callback-path writes routed through the guarded `FileOutput` (swallows post-test output-helper throws by design).
- The nested `hub.Observe<DataChangeResponse>(...).Subscribe(...)` calls were **never disposed** and had **no OnError** (an Observe timeout after test end is the same unhandled-Rx channel) — now registered for disposal on the host with explicit error handlers.
- `ReplaceDisposable` instead of `RegisterForDisposal` for the per-render autosave watchers: the view definitions re-run per workspace emission and `RegisterForDisposal` only adds, so re-renders stacked live debounced watchers.
- Same `FileOutput` guard for the `.Do` logging in `StartWithSynchronizationTest`.

## Evidence
- Pre-fix: catastrophic failure reproduced locally on the first full-suite run; probe named the thrower.
- Post-fix: **6 consecutive full-suite runs (311 tests) green**, probe captured nothing, no FATAL/catastrophic lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)