### PR TITLE
Registry: resolve GitHub App token for URL package sources (fix /api/plugins 500)

### DIFF
--- a/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
@@ -33,8 +33,14 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
 
     private IIoPool Http => ioPools.Get(IoPoolNames.Http);
 
+    // An empty token means ANONYMOUS access (a public repo, e.g. the plugin registry serving a
+    // public plugins repo with no App identity configured). Octokit's `new Credentials("")` THROWS
+    // ArgumentException "String cannot be empty (Parameter 'token')", so never hand it an empty
+    // string — build a credential-less client instead (unauthenticated, lower rate limit but valid).
     private static IObservableGitHubClient Client(string token) =>
-        new ObservableGitHubClient(new GitHubClient(Product) { Credentials = new Credentials(token) });
+        new ObservableGitHubClient(string.IsNullOrEmpty(token)
+            ? new GitHubClient(Product)
+            : new GitHubClient(Product) { Credentials = new Credentials(token) });
 
     /// <summary>Parses <c>https://github.com/owner/repo(.git)</c> into (owner, repo).</summary>
     public static (string Owner, string Repo) ParseRepoUrl(string url)

--- a/src/MeshWeaver.PluginCatalog/GitHubPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/GitHubPackageSource.cs
@@ -16,19 +16,55 @@ namespace MeshWeaver.PluginCatalog;
 /// so it needs no test double for that large interface — production passes <c>client.Fetch</c>, tests
 /// pass a stub. A public repo reads anonymously (empty token); a private one needs a token.</para>
 /// </summary>
-public sealed class GitHubPackageSource(
-    Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch,
-    string repoUrl,
-    string token = "",
-    string subdir = "",
-    ILogger? logger = null) : IPackageSource
+public sealed class GitHubPackageSource : IPackageSource
 {
     private const string ManifestFile = "package.json";
     private static readonly JsonSerializerOptions ManifestJson = new(JsonSerializerDefaults.Web);
 
+    private readonly Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch;
+    private readonly string repoUrl;
+    private readonly Func<IObservable<string>> tokenProvider;
+    private readonly string subdir;
+    private readonly ILogger? logger;
+
+    /// <summary>
+    /// Creates a package.json-repo source that resolves its access token FRESH before each fetch via
+    /// <paramref name="tokenProvider"/> — so the registry hands in
+    /// <see cref="GitHubAppTokenService.GetInstallationToken"/> (re-minted transparently, never
+    /// captured stale). The provider may emit an empty string for anonymous (public-repo) access.
+    /// </summary>
+    public GitHubPackageSource(
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch,
+        string repoUrl,
+        Func<IObservable<string>> tokenProvider,
+        string subdir = "",
+        ILogger? logger = null)
+    {
+        this.fetch = fetch;
+        this.repoUrl = repoUrl;
+        this.tokenProvider = tokenProvider;
+        this.subdir = subdir;
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// Creates a package.json-repo source with a FIXED token (default empty = anonymous). Convenience
+    /// for tests and public repos; the registry uses the token-provider overload so the App
+    /// installation token stays fresh.
+    /// </summary>
+    public GitHubPackageSource(
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch,
+        string repoUrl,
+        string token = "",
+        string subdir = "",
+        ILogger? logger = null)
+        : this(fetch, repoUrl, () => Observable.Return(token), subdir, logger)
+    {
+    }
+
     /// <inheritdoc />
     public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
-        fetch(repoUrl, gitRef, NullIfEmpty(subdir), token)
+        tokenProvider().SelectMany(token => fetch(repoUrl, gitRef, NullIfEmpty(subdir), token))
             .Select(snapshot =>
             {
                 var manifests = new List<PackageManifest>();
@@ -56,7 +92,8 @@ public sealed class GitHubPackageSource(
 
     /// <inheritdoc />
     public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef) =>
-        fetch(repoUrl, gitRef, NullIfEmpty(package.SourceFolder ?? package.Id), token)
+        tokenProvider().SelectMany(token =>
+                fetch(repoUrl, gitRef, NullIfEmpty(package.SourceFolder ?? package.Id), token))
             .Select(snapshot => (IReadOnlyList<PackageFile>)snapshot.Files
                 .Select(f => new PackageFile(f.Path, f.Content)).ToList());
 

--- a/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/NodeRepoPackageSource.cs
@@ -18,17 +18,51 @@ namespace MeshWeaver.PluginCatalog;
 /// <para>A plugin's <see cref="PackageManifest.Version"/> is the repo commit sha, so a new commit
 /// surfaces as an available update; the installer then writes only the nodes that actually changed.</para>
 /// </summary>
-public sealed class NodeRepoPackageSource(
-    Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch,
-    string repoUrl,
-    string token = "",
-    ILogger? logger = null) : IPackageSource
+public sealed class NodeRepoPackageSource : IPackageSource
 {
     private const string SpaceNodeType = "Space";
 
+    private readonly Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch;
+    private readonly string repoUrl;
+    private readonly Func<IObservable<string>> tokenProvider;
+    private readonly ILogger? logger;
+
+    /// <summary>
+    /// Creates a node-repo source that resolves its access token FRESH before each fetch via
+    /// <paramref name="tokenProvider"/> — so the registry hands in
+    /// <see cref="GitHubAppTokenService.GetInstallationToken"/>, whose short-lived (1h) installation
+    /// token is re-minted transparently and never captured stale. The provider may emit an empty
+    /// string for anonymous (public-repo) access.
+    /// </summary>
+    public NodeRepoPackageSource(
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch,
+        string repoUrl,
+        Func<IObservable<string>> tokenProvider,
+        ILogger? logger = null)
+    {
+        this.fetch = fetch;
+        this.repoUrl = repoUrl;
+        this.tokenProvider = tokenProvider;
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// Creates a node-repo source with a FIXED token (default empty = anonymous). Convenience for
+    /// tests and public repos; the registry uses the token-provider overload so the App installation
+    /// token stays fresh.
+    /// </summary>
+    public NodeRepoPackageSource(
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch,
+        string repoUrl,
+        string token = "",
+        ILogger? logger = null)
+        : this(fetch, repoUrl, () => Observable.Return(token), logger)
+    {
+    }
+
     /// <inheritdoc />
     public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
-        fetch(repoUrl, gitRef, null, token)
+        tokenProvider().SelectMany(token => fetch(repoUrl, gitRef, null, token))
             .Select(snapshot =>
             {
                 var manifests = new List<PackageManifest>();
@@ -64,7 +98,7 @@ public sealed class NodeRepoPackageSource(
 
     /// <inheritdoc />
     public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef) =>
-        fetch(repoUrl, gitRef, null, token)
+        tokenProvider().SelectMany(token => fetch(repoUrl, gitRef, null, token))
             .Select(snapshot =>
             {
                 // The whole plugin — root included — lives under `<Plugin>/`.

--- a/src/MeshWeaver.PluginCatalog/PackageSources.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageSources.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Linq;
 using MeshWeaver.GitSync;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
@@ -36,12 +37,34 @@ public static class PackageSources
                 logger?.LogWarning("Catalog source {Src} is a URL but no IGitHubRepoClient is registered.", src);
                 return null;
             }
+            // The registry HOLDS the credential: resolve the GitHub App INSTALLATION token FRESH
+            // before each fetch — the same machine identity GitSync's ResolveAuth uses (its 1h token
+            // is re-minted transparently). Passing token:"" (the old behavior) made
+            // OctokitGitHubRepoClient.Client("") throw ArgumentException on Octokit's empty
+            // Credentials, so any configured URL source 500'd the /api/plugins endpoint. When the App
+            // is unconfigured (or absent) the provider yields an empty token → anonymous access to a
+            // public repo (no throw, thanks to the Client("") anonymous fallback).
+            var tokenProvider = AppInstallationTokenProvider(hub);
             return nodeRepo
-                ? new NodeRepoPackageSource(client.Fetch, src, token: "", logger)
-                : new GitHubPackageSource(client.Fetch, src, token: "", subdir, logger);
+                ? new NodeRepoPackageSource(client.Fetch, src, tokenProvider, logger)
+                : new GitHubPackageSource(client.Fetch, src, tokenProvider, subdir, logger);
         }
         var git = new GitCli(hub.ServiceProvider.GetRequiredService<IoPoolRegistry>());
         return new GitPackageSource(git, src, subdir, logger);
+    }
+
+    /// <summary>
+    /// A token provider that yields the GitHub App INSTALLATION token when the App identity is
+    /// configured (<c>GitHub:App:ClientId</c> + <c>GitHub:App:PrivateKey</c>), else an empty string
+    /// (anonymous access to a public repo). Resolved lazily on each call so a re-minted token is
+    /// always current and an unconfigured/absent service degrades gracefully rather than throwing.
+    /// </summary>
+    private static Func<IObservable<string>> AppInstallationTokenProvider(IMessageHub hub)
+    {
+        var appTokens = hub.ServiceProvider.GetService<GitHubAppTokenService>();
+        return appTokens is { IsConfigured: true }
+            ? appTokens.GetInstallationToken
+            : () => Observable.Return(string.Empty);
     }
 
     private static bool IsUrl(string s) =>

--- a/test/MeshWeaver.GitSync.Test/OctokitGitHubRepoClientEmptyTokenTest.cs
+++ b/test/MeshWeaver.GitSync.Test/OctokitGitHubRepoClientEmptyTokenTest.cs
@@ -1,0 +1,34 @@
+#pragma warning disable CS1591
+
+using System;
+using MeshWeaver.GitSync;
+using MeshWeaver.Mesh.Threading;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Regression: an EMPTY access token must mean ANONYMOUS access, not a crash.
+/// <see cref="OctokitGitHubRepoClient.Fetch(string, string, string?, string)"/> builds its Octokit
+/// client EAGERLY (at call time, before the observable is subscribed), so an empty token used to
+/// throw <c>ArgumentException("String cannot be empty (Parameter 'token')")</c> from Octokit's
+/// <c>new Credentials("")</c> right there — which is exactly what 500'd the plugin registry's
+/// <c>/api/plugins</c> when a URL source resolved no App token. The client must now build a
+/// credential-less (anonymous) client instead of throwing.
+/// </summary>
+public class OctokitGitHubRepoClientEmptyTokenTest
+{
+    [Fact]
+    public void Fetch_WithEmptyToken_DoesNotThrowOnConstruction()
+    {
+        var client = new OctokitGitHubRepoClient(new IoPoolRegistry());
+
+        // Building the Fetch pipeline (which eagerly constructs the Octokit client with the token)
+        // must not throw for an empty token — the old `new Credentials("")` ArgumentException is the
+        // registry's 500. We never subscribe, so no network call is made.
+        var ex = Record.Exception(() =>
+            _ = client.Fetch("https://github.com/acme/public-repo", "main", null, ""));
+
+        Assert.Null(ex);
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/PackageSourcesTokenTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PackageSourcesTokenTest.cs
@@ -1,0 +1,182 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// The registry serves URL sources with a RESOLVED GitHub App INSTALLATION token, never a hardcoded
+/// empty token. Regression for the <c>/api/plugins</c> 500: <c>PackageSources.FromRepo</c> built a
+/// URL source with <c>token: ""</c>, which <c>OctokitGitHubRepoClient.Client("")</c> turned into
+/// <c>new Credentials("")</c> and Octokit threw <c>ArgumentException</c> — so any configured URL
+/// source crashed the endpoint. The fix resolves the token via <see cref="GitHubAppTokenService"/>
+/// (the same machine identity GitSync uses) fresh before each fetch. This drives
+/// <see cref="PackageSources.FromRepo"/> through a real mesh hub with the App CONFIGURED and a fake
+/// repo client that captures the token it is handed.
+/// </summary>
+public class PackageSourcesAppTokenTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private readonly PackageSourcesTokenFakes.TokenCapturingRepoClient client = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            .AddPluginCatalog()
+            .ConfigureServices(services =>
+            {
+                // The registry's GitHub identity + repo client — the same seam FromRepo resolves.
+                services.AddSingleton<IGitHubRepoClient>(client);
+                services.AddSingleton(sp => new GitHubAppTokenService(
+                    sp.GetRequiredService<IoPoolRegistry>(),
+                    Options.Create(new GitHubAppOptions
+                    {
+                        ClientId = "Iv23liRegistryApp",
+                        PrivateKey = PackageSourcesTokenFakes.TestKeyPem,
+                        InstallationOwner = "Systemorph",
+                    }),
+                    logger: null,
+                    httpClient: new HttpClient(new PackageSourcesTokenFakes.FakeGitHubAppHandler())));
+                return services;
+            });
+
+    [Fact(Timeout = 120_000)]
+    public async Task UrlSource_BuildsNonNull_AndListsWithResolvedAppToken_NotEmpty()
+    {
+        client.LastToken = null;
+
+        // The exact call the registry endpoint makes for a node-repo URL source.
+        var source = PackageSources.FromRepo(
+            Mesh, "https://github.com/Systemorph/MeshWeaver.Plugins", sourceSubdir: null, nodeRepo: true);
+
+        Assert.NotNull(source);
+
+        // Listing must succeed WITHOUT throwing an empty-credential exception, and the client must
+        // have been handed the App-minted installation token — never the old empty string.
+        var packages = await source!.ListPackages("main").FirstAsync().ToTask();
+        Assert.Empty(packages); // the fake returns an empty snapshot; the point is that it did not throw
+
+        Assert.Equal("ghs_registry_installation_token", client.LastToken);
+    }
+}
+
+/// <summary>
+/// The unconfigured-App companion to <see cref="PackageSourcesAppTokenTest"/>: when the GitHub App
+/// identity is NOT configured, <see cref="PackageSources.FromRepo"/> must still build a URL source
+/// and its token provider must degrade to ANONYMOUS (empty token) — the fetch runs unauthenticated
+/// against a public repo and does NOT throw.
+/// </summary>
+public class PackageSourcesAnonymousTokenTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private readonly PackageSourcesTokenFakes.TokenCapturingRepoClient client = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            .AddPluginCatalog()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IGitHubRepoClient>(client);
+                // GitHubAppTokenService present but UNCONFIGURED (no client id / private key).
+                services.AddSingleton(sp => new GitHubAppTokenService(
+                    sp.GetRequiredService<IoPoolRegistry>(),
+                    Options.Create(new GitHubAppOptions())));
+                return services;
+            });
+
+    [Fact(Timeout = 120_000)]
+    public async Task UrlSource_WithNoAppConfigured_FallsBackToAnonymous_EmptyToken_NoThrow()
+    {
+        client.LastToken = null;
+
+        var source = PackageSources.FromRepo(
+            Mesh, "https://github.com/acme/public-plugins", sourceSubdir: null, nodeRepo: true);
+
+        Assert.NotNull(source);
+        var packages = await source!.ListPackages("main").FirstAsync().ToTask();
+        Assert.Empty(packages);
+        Assert.Equal(string.Empty, client.LastToken); // anonymous access, no throw
+    }
+}
+
+/// <summary>Shared offline fakes for the package-source token tests.</summary>
+internal static class PackageSourcesTokenFakes
+{
+    /// <summary>A test RSA key (PEM), generated once, for the App-JWT signing.</summary>
+    public static readonly string TestKeyPem = CreateKey();
+
+    private static string CreateKey()
+    {
+        using var rsa = RSA.Create(2048);
+        return rsa.ExportRSAPrivateKeyPem();
+    }
+
+    /// <summary>An <see cref="IGitHubRepoClient"/> that records the token it is handed on Fetch and
+    /// returns an empty snapshot. Only Fetch is exercised by the package sources.</summary>
+    public sealed class TokenCapturingRepoClient : IGitHubRepoClient
+    {
+        public volatile string? LastToken;
+
+        public IObservable<RepoSnapshot> Fetch(
+            string repositoryUrl, string commitish, string? subdirectory, string accessToken)
+        {
+            LastToken = accessToken;
+            return Observable.Return(new RepoSnapshot(commitish, Array.Empty<RepoFile>()));
+        }
+
+        public IObservable<GitHubPushResult> Push(GitHubPushRequest request) => throw new NotSupportedException();
+        public IObservable<GitHubBranchResult> CreateBranch(GitHubCreateBranchRequest request) => throw new NotSupportedException();
+        public IObservable<GitHubPullRequestInfo> OpenPullRequest(GitHubOpenPullRequestRequest request) => throw new NotSupportedException();
+        public IObservable<GitHubPullRequestInfo> GetPullRequestStatus(string repositoryUrl, int number, string accessToken) => throw new NotSupportedException();
+        public IObservable<IReadOnlyList<GitHubIssue>> ListIssues(string repositoryUrl, GitHubIssueState? state, string accessToken) => throw new NotSupportedException();
+        public IObservable<GitHubIssue> GetIssue(string repositoryUrl, int number, string accessToken) => throw new NotSupportedException();
+        public IObservable<GitHubIssue> CreateIssue(GitHubCreateIssueRequest request) => throw new NotSupportedException();
+        public IObservable<GitHubIssueComment> CommentIssue(string repositoryUrl, int number, string body, string accessToken) => throw new NotSupportedException();
+        public IObservable<IReadOnlyList<GitHubPullRequestSummary>> ListPullRequests(string repositoryUrl, PullRequestStatus? state, string accessToken) => throw new NotSupportedException();
+        public IObservable<GitHubPullRequestDetail> GetPullRequestDetail(string repositoryUrl, int number, string accessToken) => throw new NotSupportedException();
+        public IObservable<GitHubIssueComment> CommentPullRequest(string repositoryUrl, int number, string body, string accessToken) => throw new NotSupportedException();
+        public IObservable<GitHubMergeResult> MergePullRequest(GitHubMergePullRequestRequest request) => throw new NotSupportedException();
+    }
+
+    /// <summary>GitHub App API fake: installation discovery + token minting (offline, deterministic).</summary>
+    public sealed class FakeGitHubAppHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (request.Method == HttpMethod.Get && path == "/app/installations")
+                return Task.FromResult(Json("""[{"id": 42, "account": {"login": "Systemorph"}}]"""));
+            if (request.Method == HttpMethod.Post && path.EndsWith("/access_tokens", StringComparison.Ordinal))
+            {
+                var expires = DateTimeOffset.UtcNow.AddHours(1).ToString("o");
+                return Task.FromResult(Json($$"""{"token": "ghs_registry_installation_token", "expires_at": "{{expires}}"}"""));
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent($"unexpected {request.Method} {path}"),
+            });
+        }
+
+        private static HttpResponseMessage Json(string body) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+    }
+}


### PR DESCRIPTION
## Problem

The plugin registry's `GET /api/plugins` endpoint **500s for any configured URL source**. Root cause (confirmed on prod): `PackageSources.FromRepo` (`src/MeshWeaver.PluginCatalog/PackageSources.cs`) hardcodes `token: ""` when building a `NodeRepoPackageSource`/`GitHubPackageSource` for a URL. That empty token flows into `OctokitGitHubRepoClient.Client("")` → `new Credentials("")`, and Octokit throws:

```
System.ArgumentException: String cannot be empty (Parameter 'token')
```

So the registry — which is meant to **hold the GitHub App credential and re-serve packages credential-free** — can't authenticate to GitHub at all. On memex, `/api/plugins` returns `{"packages":[]}` only because no sources are configured; configuring URL sources surfaces the 500.

## Fix

Mirrors GitSync's canonical `GitHubSyncService.ResolveAuth` pattern (user credential → **GitHub App installation token** fallback via `GitHubAppTokenService.GetInstallationToken()`):

- **`PackageSources.FromRepo`** resolves the GitHub App installation token via `GitHubAppTokenService` (reachable from `hub.ServiceProvider`, same DI as `IGitHubRepoClient`) and passes a **token provider** (`Func<IObservable<string>>`) into the package sources. The provider is invoked **fresh before each fetch** so the short-lived (1h) installation token is re-minted transparently and never captured stale. When the App is unconfigured/absent, it yields an empty token → **anonymous** access to a public repo.
- **`NodeRepoPackageSource` / `GitHubPackageSource`** take the token provider and resolve it reactively at fetch time (`tokenProvider().SelectMany(token => fetch(...))`). The fixed-string overload is retained for tests and public repos.
- **`OctokitGitHubRepoClient.Client`** builds a credential-less (anonymous) client for an empty token instead of `new Credentials("")` — a backstop so an empty token can never crash a fetch again.

Local-path sources (`GitPackageSource` via `GitCli`, no token) and the `soleSource` vs multi-source failure semantics are **unchanged**.

## Tests

- `PackageSourcesAppTokenTest` — a URL source built by `FromRepo` (App configured, fake token service) lists **without throwing** and hands the client the **App-minted installation token**, not the empty string.
- `PackageSourcesAnonymousTokenTest` — App **unconfigured** → source still builds, token resolves to anonymous (empty), no throw.
- `OctokitGitHubRepoClientEmptyTokenTest` — an empty-token `Fetch` does not throw on construction (the exact 500 site).

All affected projects build with **0 warnings** (warnings-as-errors, net10); new + existing PluginCatalog/GitSync tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)