### PR TITLE
Invite/access emails: who invited you, a real link, a branded shell

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -38,6 +38,13 @@ data:
   Graph__Storage__Type: "{{ .Values.config.memex_portal.Graph__Storage__Type }}"
   Graph__Storage__BasePath: "{{ .Values.config.memex_portal.Graph__Storage__BasePath }}"
   Mcp__BaseUrl: "{{ .Values.config.memex_portal.Mcp__BaseUrl }}"
+  # ---- Public base URL — the instance's own https host --------------------
+  # Used to build ABSOLUTE links in outbound email (access-granted notifications,
+  # invitations) — without it the "Open {space}" button is omitted and the email
+  # ships linkless (the #1 complaint: a first-contact invite with no way in). Set
+  # to the instance's public URL, e.g. https://memex.meshweaver.cloud. Read by
+  # NotificationService/InvitationEmailSender via Portal:BaseUrl.
+  Portal__BaseUrl: "{{ .Values.config.memex_portal.Portal__BaseUrl | default "" }}"
   # ---- Instance identity (tab title + favicon badge) — optional -------------
   # When InstanceName is set, the browser tab title becomes that name and the
   # favicon becomes a distinct colored badge (instance initial), so Local / Test /

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -164,6 +164,10 @@ config:
     Graph__Storage__Type: "PostgreSql"
     Graph__Storage__BasePath: "/data/graph"
     Mcp__BaseUrl: "http://memex-portal-service:8080"
+    # Public https host of THIS instance — builds the "Open" links in outbound email
+    # (invitations / access-granted). Empty = links omitted. An env overlay sets it,
+    # e.g. Portal__BaseUrl: "https://memex.meshweaver.cloud".
+    Portal__BaseUrl: ""
     # AI model catalog — empty by default. An overlay sets endpoints + model
     # lists (+ keys in secrets above) to seed the system catalog on deploy.
     Anthropic__Endpoint: ""

--- a/memex/Memex.Portal.Shared/Email/InvitationEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/InvitationEmailSender.cs
@@ -214,31 +214,20 @@ public sealed class InvitationEmailSender(
     }
 
     private static string BuildGenericHtml(string? baseUrl)
-    {
-        var link = string.IsNullOrEmpty(baseUrl)
-            ? ""
-            : $"<p style=\"margin:16px 0;\"><a href=\"{System.Net.WebUtility.HtmlEncode(baseUrl)}\" " +
-              "style=\"background:#2563eb;color:#fff;padding:10px 18px;border-radius:6px;text-decoration:none;\">"
-              + "Open Memex</a></p>"
-              + $"<p style=\"color:#888;font-size:12px;\">{System.Net.WebUtility.HtmlEncode(baseUrl)}</p>";
-        return "<p>You've been invited to Memex.</p>"
-               + "<p>Sign in with this email address to get started.</p>"
-               + link;
-    }
+        => MeshWeaver.Graph.EmailTemplate.Build(
+            heading: "You've been invited to Memex",
+            paragraphs: ["You've been invited to Memex — a shared workspace for your team's content and agents."],
+            ctaLabel: string.IsNullOrEmpty(baseUrl) ? null : "Open Memex",
+            ctaUrl: string.IsNullOrEmpty(baseUrl) ? null : baseUrl,
+            footerNote: "Sign in with this email address to get started.");
 
     private static string BuildSpaceHtml(string spaceName, string? spaceUrl)
-    {
-        var name = System.Net.WebUtility.HtmlEncode(spaceName);
-        var link = string.IsNullOrEmpty(spaceUrl)
-            ? ""
-            : $"<p style=\"margin:16px 0;\"><a href=\"{System.Net.WebUtility.HtmlEncode(spaceUrl)}\" " +
-              "style=\"background:#2563eb;color:#fff;padding:10px 18px;border-radius:6px;text-decoration:none;\">"
-              + $"Open {name}</a></p>"
-              + $"<p style=\"color:#888;font-size:12px;\">{System.Net.WebUtility.HtmlEncode(spaceUrl)}</p>";
-        return $"<p>You've been invited to <strong>{name}</strong>.</p>"
-               + "<p>Sign in with this email address to get started.</p>"
-               + link;
-    }
+        => MeshWeaver.Graph.EmailTemplate.Build(
+            heading: $"You've been invited to {spaceName}",
+            paragraphs: [$"You've been invited to \"{spaceName}\" on Memex."],
+            ctaLabel: string.IsNullOrEmpty(spaceUrl) ? null : $"Open {spaceName}",
+            ctaUrl: string.IsNullOrEmpty(spaceUrl) ? null : spaceUrl,
+            footerNote: "Sign in with this email address to get started.");
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 

--- a/src/MeshWeaver.Graph/AccessGrantNotifier.cs
+++ b/src/MeshWeaver.Graph/AccessGrantNotifier.cs
@@ -73,9 +73,13 @@ public sealed class AccessGrantNotifier(
                 // Resolve the granter's display name so the recipient sees WHO shared it — for most
                 // invitees this email is their first contact with Memex, and "someone gave you access"
                 // with no name is exactly the anonymous, off-putting message we're fixing. A granter
-                // that can't be resolved (or is System) falls back to a name-less phrasing.
-                return AsSystem(() => hub.GetMeshNode(assignmentNode.CreatedBy ?? "", ReadTimeout))
-                    .Catch(Observable.Return<MeshNode?>(null))
+                // that can't be resolved (or is System) falls back to a name-less phrasing. Skip the
+                // lookup entirely when there is no granter id (no empty-path NotFound churn).
+                var granterLookup = string.IsNullOrEmpty(assignmentNode.CreatedBy)
+                    ? Observable.Return<MeshNode?>(null)
+                    : AsSystem(() => hub.GetMeshNode(assignmentNode.CreatedBy!, ReadTimeout))
+                        .Catch(Observable.Return<MeshNode?>(null));
+                return granterLookup
                     .SelectMany(granterNode =>
                     {
                         var granter = ResolveGranterName(granterNode, assignmentNode.CreatedBy, hub.JsonSerializerOptions);
@@ -92,7 +96,11 @@ public sealed class AccessGrantNotifier(
                             targetNodePath: grantedNodePath,
                             createdBy: assignmentNode.CreatedBy,
                             icon: "/static/NodeTypeIcons/shield.svg",
-                            emailCtaLabel: $"Open {name}");
+                            emailCtaLabel: $"Open {name}",
+                            // First-contact hint — this recipient may have never signed in. Passed
+                            // explicitly (not defaulted in NotificationService) so it never leaks onto
+                            // notifications aimed at already-signed-in users.
+                            emailFooterNote: "New to Memex? Sign in with this email address to open it.");
                     });
             });
         });
@@ -145,16 +153,22 @@ public sealed class AccessGrantNotifier(
     {
         if (granterNode is null)
             return null;
-        bool Usable(string? s) => !string.IsNullOrWhiteSpace(s)
-            && !string.Equals(s, granterId, StringComparison.Ordinal);
+        var id = granterId?.Trim();
+        // Trim BEFORE comparing so a stored name that is the ObjectId with incidental whitespace is
+        // still treated as "just the id" (never leak the raw ObjectId to the recipient).
+        string? Usable(string? s)
+        {
+            var t = s?.Trim();
+            return !string.IsNullOrEmpty(t) && !string.Equals(t, id, StringComparison.Ordinal) ? t : null;
+        }
 
-        if (Usable(granterNode.Name))
-            return granterNode.Name!.Trim();
+        if (Usable(granterNode.Name) is { } nodeName)
+            return nodeName;
         var user = granterNode.ContentAs<User>(options);
-        if (Usable(user?.FullName))
-            return user!.FullName!.Trim();
-        if (Usable(user?.Email))
-            return user!.Email!.Trim();
+        if (Usable(user?.FullName) is { } fullName)
+            return fullName;
+        if (Usable(user?.Email) is { } email)
+            return email;
         return null;
     }
 

--- a/src/MeshWeaver.Graph/AccessGrantNotifier.cs
+++ b/src/MeshWeaver.Graph/AccessGrantNotifier.cs
@@ -70,16 +70,30 @@ public sealed class AccessGrantNotifier(
             return AsSystem(() => hub.GetMeshNode(grantedNodePath, ReadTimeout)).SelectMany(grantedNode =>
             {
                 var name = string.IsNullOrWhiteSpace(grantedNode?.Name) ? grantedNodePath : grantedNode!.Name;
-                return NotificationService.Dispatch(
-                    hub,
-                    recipient: recipient,
-                    mainNodePath: recipient,
-                    title: $"You've been given access to {name}",
-                    message: $"You now have {roleText} access to \"{name}\".",
-                    type: NotificationType.AccessGranted,
-                    targetNodePath: grantedNodePath,
-                    createdBy: assignmentNode.CreatedBy,
-                    icon: "/static/NodeTypeIcons/shield.svg");
+                // Resolve the granter's display name so the recipient sees WHO shared it — for most
+                // invitees this email is their first contact with Memex, and "someone gave you access"
+                // with no name is exactly the anonymous, off-putting message we're fixing. A granter
+                // that can't be resolved (or is System) falls back to a name-less phrasing.
+                return AsSystem(() => hub.GetMeshNode(assignmentNode.CreatedBy ?? "", ReadTimeout))
+                    .Catch(Observable.Return<MeshNode?>(null))
+                    .SelectMany(granterNode =>
+                    {
+                        var granter = ResolveGranterName(granterNode, assignmentNode.CreatedBy, hub.JsonSerializerOptions);
+                        var message = granter is null
+                            ? $"You now have {roleText} access to \"{name}\"."
+                            : $"{granter} gave you {roleText} access to \"{name}\".";
+                        return NotificationService.Dispatch(
+                            hub,
+                            recipient: recipient,
+                            mainNodePath: recipient,
+                            title: $"You've been given access to {name}",
+                            message: message,
+                            type: NotificationType.AccessGranted,
+                            targetNodePath: grantedNodePath,
+                            createdBy: assignmentNode.CreatedBy,
+                            icon: "/static/NodeTypeIcons/shield.svg",
+                            emailCtaLabel: $"Open {name}");
+                    });
             });
         });
     }
@@ -118,6 +132,30 @@ public sealed class AccessGrantNotifier(
         grantedNodePath = assignmentNode.MainNode;
         roleText = string.Join(", ", grantedRoles);
         return true;
+    }
+
+    /// <summary>
+    /// A human display name for the granter, or <c>null</c> when none can be shown (so the message
+    /// omits the "granted by" clause rather than printing a raw ObjectId). Prefers the granter node's
+    /// display <c>Name</c>, then the <see cref="User"/>'s <c>FullName</c>/<c>Email</c>; anything that
+    /// merely echoes the <paramref name="granterId"/> ObjectId is treated as "no name".
+    /// </summary>
+    internal static string? ResolveGranterName(
+        MeshNode? granterNode, string? granterId, System.Text.Json.JsonSerializerOptions options)
+    {
+        if (granterNode is null)
+            return null;
+        bool Usable(string? s) => !string.IsNullOrWhiteSpace(s)
+            && !string.Equals(s, granterId, StringComparison.Ordinal);
+
+        if (Usable(granterNode.Name))
+            return granterNode.Name!.Trim();
+        var user = granterNode.ContentAs<User>(options);
+        if (Usable(user?.FullName))
+            return user!.FullName!.Trim();
+        if (Usable(user?.Email))
+            return user!.Email!.Trim();
+        return null;
     }
 
     private IObservable<T> AsSystem<T>(Func<IObservable<T>> factory)

--- a/src/MeshWeaver.Graph/EmailTemplate.cs
+++ b/src/MeshWeaver.Graph/EmailTemplate.cs
@@ -1,0 +1,75 @@
+using System.Text;
+using System.Net;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// Builds the branded HTML shell shared by every first-contact email (access-granted
+/// notifications, invitations). For most recipients this email is their FIRST interaction with
+/// Memex — before they have ever signed in — so it must read like a real product invitation:
+/// a wordmark, a clear heading, the body, a single prominent call-to-action button (with the raw
+/// URL shown beneath it, since email clients strip button styling and some users copy-paste), and
+/// an optional first-timer sign-in hint. All caller-supplied text is plain and HTML-encoded here;
+/// only the CTA URL is trusted (callers build it from a configured base URL + a node path).
+/// </summary>
+public static class EmailTemplate
+{
+    private const string Accent = "#2563eb";
+    private const string Ink = "#111827";
+    private const string Muted = "#6b7280";
+
+    /// <summary>
+    /// Renders the email. <paramref name="heading"/> and <paramref name="paragraphs"/> are plain
+    /// text (encoded here). A CTA button is emitted only when BOTH <paramref name="ctaLabel"/> and
+    /// <paramref name="ctaUrl"/> are set. <paramref name="footerNote"/> is the optional muted line
+    /// under the CTA (e.g. the first-time sign-in hint).
+    /// </summary>
+    public static string Build(
+        string heading,
+        IReadOnlyList<string> paragraphs,
+        string? ctaLabel = null,
+        string? ctaUrl = null,
+        string? footerNote = null)
+    {
+        var sb = new StringBuilder();
+        sb.Append(
+            "<div style=\"margin:0;padding:24px;background:#f3f4f6;\">" +
+            "<div style=\"max-width:520px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;" +
+            "border-radius:12px;overflow:hidden;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;\">" +
+            // Wordmark bar
+            $"<div style=\"padding:18px 28px;border-bottom:1px solid #f0f0f0;font-weight:700;font-size:16px;color:{Ink};\">" +
+            "Memex</div>" +
+            "<div style=\"padding:28px;\">");
+
+        sb.Append($"<h1 style=\"margin:0 0 16px 0;font-size:20px;line-height:1.3;color:{Ink};\">{Enc(heading)}</h1>");
+
+        foreach (var p in paragraphs)
+            if (!string.IsNullOrWhiteSpace(p))
+                sb.Append($"<p style=\"margin:0 0 14px 0;font-size:15px;line-height:1.55;color:{Ink};\">{Enc(p)}</p>");
+
+        if (!string.IsNullOrEmpty(ctaLabel) && !string.IsNullOrWhiteSpace(ctaUrl))
+        {
+            var url = Enc(ctaUrl!);
+            sb.Append(
+                $"<div style=\"margin:24px 0 8px 0;\"><a href=\"{url}\" " +
+                $"style=\"display:inline-block;background:{Accent};color:#ffffff;padding:12px 22px;" +
+                "border-radius:8px;text-decoration:none;font-weight:600;font-size:15px;\">" +
+                $"{Enc(ctaLabel)}</a></div>" +
+                // Raw URL under the button — survives style-stripping clients and copy-paste.
+                $"<p style=\"margin:0 0 4px 0;font-size:12px;color:{Muted};word-break:break-all;\">{url}</p>");
+        }
+
+        if (!string.IsNullOrWhiteSpace(footerNote))
+            sb.Append($"<p style=\"margin:20px 0 0 0;font-size:13px;line-height:1.5;color:{Muted};\">{Enc(footerNote)}</p>");
+
+        sb.Append(
+            "</div></div>" +
+            $"<div style=\"max-width:520px;margin:12px auto 0 auto;font-size:11px;color:{Muted};text-align:center;" +
+            "font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;\">" +
+            "You received this because someone shared content with this email address on Memex." +
+            "</div></div>");
+        return sb.ToString();
+    }
+
+    private static string Enc(string? s) => WebUtility.HtmlEncode(s ?? "");
+}

--- a/src/MeshWeaver.Graph/NotificationService.cs
+++ b/src/MeshWeaver.Graph/NotificationService.cs
@@ -194,16 +194,16 @@ public static class NotificationService
         var ctaUrl = (!string.IsNullOrEmpty(baseUrl) && !string.IsNullOrWhiteSpace(targetNodePath))
             ? $"{baseUrl!.TrimEnd('/')}/{targetNodePath!.TrimStart('/')}"
             : null;
-        // A first-time recipient (most invitees have never signed in) needs to know the link IS the
-        // way in. Show the sign-in hint whenever there's a link and no caller-supplied footer.
-        var footer = footerNote
-            ?? (ctaUrl is not null ? "New to Memex? Sign in with this email address to open it." : null);
+        // The footer is caller-supplied ONLY — the first-time "New to Memex? Sign in…" hint is a
+        // first-CONTACT concern the caller owns (AccessGrantNotifier passes it). Defaulting it here
+        // for any linked email would misfire on notifications to already-signed-in users (e.g.
+        // ChatReady: "your response is ready" is not a "New to Memex?" moment).
         return EmailTemplate.Build(
             heading: title,
             paragraphs: string.IsNullOrEmpty(message) ? [] : [message],
             ctaLabel: ctaUrl is null ? null : (string.IsNullOrWhiteSpace(ctaLabel) ? "Open" : ctaLabel),
             ctaUrl: ctaUrl,
-            footerNote: footer);
+            footerNote: footerNote);
     }
 
     private static string? ResolveBaseUrl(IMessageHub hub)

--- a/src/MeshWeaver.Graph/NotificationService.cs
+++ b/src/MeshWeaver.Graph/NotificationService.cs
@@ -98,7 +98,9 @@ public static class NotificationService
         NotificationType type,
         string? targetNodePath = null,
         string? createdBy = null,
-        string? icon = null)
+        string? icon = null,
+        string? emailCtaLabel = null,
+        string? emailFooterNote = null)
     {
         var meshService = hub.ServiceProvider.GetService<IMeshService>();
         if (meshService is null)
@@ -119,7 +121,7 @@ public static class NotificationService
                         .Select(_ => Unit.Default)
                         .Catch(Observable.Return(Unit.Default)));
                 if (!string.IsNullOrEmpty(recipient) && settings.Email(category))
-                    ops.Add(MaybeSendEmail(hub, recipient!, title, message, targetNodePath)
+                    ops.Add(MaybeSendEmail(hub, recipient!, title, message, targetNodePath, emailCtaLabel, emailFooterNote)
                         .Select(_ => Unit.Default)
                         .Catch(Observable.Return(Unit.Default)));
                 return ops.Count == 0 ? Observable.Return(Unit.Default) : Observable.Merge(ops);
@@ -156,7 +158,8 @@ public static class NotificationService
     /// no email on file or no <see cref="IEmailSender"/> is registered.
     /// </summary>
     private static IObservable<bool> MaybeSendEmail(
-        IMessageHub hub, string recipient, string title, string message, string? targetNodePath)
+        IMessageHub hub, string recipient, string title, string message, string? targetNodePath,
+        string? ctaLabel, string? footerNote)
     {
         return HasRoutingRules(hub, recipient).SelectMany(hasRules =>
         {
@@ -166,7 +169,7 @@ public static class NotificationService
                 .Select(n => n?.ContentAs<User>(hub.JsonSerializerOptions)?.Email)
                 .SelectMany(email => string.IsNullOrWhiteSpace(email)
                     ? Observable.Return(false)
-                    : hub.SendEmail(email!, title, BuildEmailHtml(hub, title, message, targetNodePath)))
+                    : hub.SendEmail(email!, title, BuildEmailHtml(hub, title, message, targetNodePath, ctaLabel, footerNote)))
                 .Catch(Observable.Return(false));
         });
     }
@@ -183,18 +186,24 @@ public static class NotificationService
             .Timeout(LookupTimeout, Observable.Return(false))
             .Catch(Observable.Return(false));
 
-    private static string BuildEmailHtml(IMessageHub hub, string title, string message, string? targetNodePath)
+    private static string BuildEmailHtml(
+        IMessageHub hub, string title, string message, string? targetNodePath,
+        string? ctaLabel, string? footerNote)
     {
         var baseUrl = ResolveBaseUrl(hub);
-        var link = (!string.IsNullOrEmpty(baseUrl) && !string.IsNullOrWhiteSpace(targetNodePath))
-            ? $"<p style=\"margin:16px 0;\"><a href=\"{System.Net.WebUtility.HtmlEncode($"{baseUrl!.TrimEnd('/')}/{targetNodePath!.TrimStart('/')}")}\" " +
-              "style=\"background:#2563eb;color:#fff;padding:10px 18px;border-radius:6px;text-decoration:none;\">Open</a></p>"
-            : "";
-        return $"<div style=\"font-family:sans-serif;font-size:14px;color:#111;\">" +
-               $"<h2 style=\"margin:0 0 12px 0;\">{System.Net.WebUtility.HtmlEncode(title)}</h2>" +
-               (string.IsNullOrEmpty(message) ? "" : $"<p>{System.Net.WebUtility.HtmlEncode(message)}</p>") +
-               link +
-               "</div>";
+        var ctaUrl = (!string.IsNullOrEmpty(baseUrl) && !string.IsNullOrWhiteSpace(targetNodePath))
+            ? $"{baseUrl!.TrimEnd('/')}/{targetNodePath!.TrimStart('/')}"
+            : null;
+        // A first-time recipient (most invitees have never signed in) needs to know the link IS the
+        // way in. Show the sign-in hint whenever there's a link and no caller-supplied footer.
+        var footer = footerNote
+            ?? (ctaUrl is not null ? "New to Memex? Sign in with this email address to open it." : null);
+        return EmailTemplate.Build(
+            heading: title,
+            paragraphs: string.IsNullOrEmpty(message) ? [] : [message],
+            ctaLabel: ctaUrl is null ? null : (string.IsNullOrWhiteSpace(ctaLabel) ? "Open" : ctaLabel),
+            ctaUrl: ctaUrl,
+            footerNote: footer);
     }
 
     private static string? ResolveBaseUrl(IMessageHub hub)

--- a/test/MeshWeaver.Graph.Test/AccessGrantNotifierGranterTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessGrantNotifierGranterTest.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins <see cref="AccessGrantNotifier.ResolveGranterName"/> — the "who invited me" resolution that
+/// turns an anonymous "you've been given access" into "{Granter} gave you access". The granter must
+/// be shown by a HUMAN name (node display name, then <see cref="User.FullName"/>/<c>Email</c>), and
+/// must fall back to <c>null</c> (name-less phrasing) rather than print a raw ObjectId — the exact
+/// off-putting first-contact message being fixed.
+/// </summary>
+public class AccessGrantNotifierGranterTest
+{
+    private static readonly JsonSerializerOptions Options = new();
+
+    private static MeshNode Granter(string id, string? name = null, User? content = null) =>
+        new(id, "") { Name = name, Content = content };
+
+    [Fact]
+    public void PrefersNodeDisplayName()
+    {
+        var node = Granter("obj-123", name: "Roland Bürgi");
+        Assert.Equal("Roland Bürgi", AccessGrantNotifier.ResolveGranterName(node, "obj-123", Options));
+    }
+
+    [Fact]
+    public void FallsBackToUserFullName_WhenNodeNameIsJustTheObjectId()
+    {
+        var node = Granter("obj-123", name: "obj-123", content: new User { FullName = "Markus K." });
+        Assert.Equal("Markus K.", AccessGrantNotifier.ResolveGranterName(node, "obj-123", Options));
+    }
+
+    [Fact]
+    public void FallsBackToEmail_WhenNoName()
+    {
+        var node = Granter("obj-123", content: new User { Email = "granter@acme.com" });
+        Assert.Equal("granter@acme.com", AccessGrantNotifier.ResolveGranterName(node, "obj-123", Options));
+    }
+
+    [Fact]
+    public void NullWhenGranterNodeMissing()
+        => Assert.Null(AccessGrantNotifier.ResolveGranterName(null, "obj-123", Options));
+
+    [Fact]
+    public void NullWhenOnlyTheRawObjectIdIsAvailable()
+    {
+        // Name echoes the id and there's no User content → no human name → omit the clause.
+        var node = Granter("obj-123", name: "obj-123");
+        Assert.Null(AccessGrantNotifier.ResolveGranterName(node, "obj-123", Options));
+    }
+}

--- a/test/MeshWeaver.Graph.Test/AccessGrantNotifierGranterTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessGrantNotifierGranterTest.cs
@@ -52,4 +52,12 @@ public class AccessGrantNotifierGranterTest
         var node = Granter("obj-123", name: "obj-123");
         Assert.Null(AccessGrantNotifier.ResolveGranterName(node, "obj-123", Options));
     }
+
+    [Fact]
+    public void NullWhenNameIsTheObjectIdWithIncidentalWhitespace()
+    {
+        // Trimmed comparison — a stored name that is just the id plus whitespace must NOT leak.
+        var node = Granter("obj-123", name: "  obj-123  ");
+        Assert.Null(AccessGrantNotifier.ResolveGranterName(node, "obj-123", Options));
+    }
 }

--- a/test/MeshWeaver.Graph.Test/EmailTemplateTest.cs
+++ b/test/MeshWeaver.Graph.Test/EmailTemplateTest.cs
@@ -1,0 +1,63 @@
+using MeshWeaver.Graph;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Unit tests for <see cref="EmailTemplate"/> — the branded first-contact email shell (invitations
+/// and access-granted notifications). Pins the parts an invitee actually needs: the heading, the
+/// body, a real CTA button carrying the URL (present only when a URL is supplied), the raw URL shown
+/// beneath it, the optional sign-in hint, and HTML-encoding of caller text.
+/// </summary>
+public class EmailTemplateTest
+{
+    [Fact]
+    public void WithLink_RendersHeadingBodyButtonAndRawUrl()
+    {
+        var html = EmailTemplate.Build(
+            heading: "You've been given access to Gate Test",
+            paragraphs: ["Roland Bürgi gave you Admin access to \"Gate Test\"."],
+            ctaLabel: "Open Gate Test",
+            ctaUrl: "https://memex.meshweaver.cloud/GateTest",
+            footerNote: "New to Memex? Sign in with this email address to open it.");
+
+        // Heading + body text present (apostrophe/non-ASCII are HTML-encoded, so assert on the
+        // ASCII-safe fragments that carry the meaning).
+        Assert.Contains("been given access to Gate Test", html);
+        Assert.Contains("gave you Admin access", html);
+        // A real anchor to the target, plus the raw URL shown for style-stripping clients.
+        Assert.Contains("href=\"https://memex.meshweaver.cloud/GateTest\"", html);
+        Assert.Contains(">Open Gate Test</a>", html);
+        Assert.Contains("Sign in with this email address to open it.", html);
+    }
+
+    [Fact]
+    public void NoUrl_OmitsTheButtonEntirely()
+    {
+        var html = EmailTemplate.Build(
+            heading: "You've been given access to Gate Test",
+            paragraphs: ["You now have Admin access."],
+            ctaLabel: "Open Gate Test",
+            ctaUrl: null);
+
+        // No URL configured → no anchor at all (rather than a dead button).
+        Assert.DoesNotContain("<a href", html);
+        Assert.Contains("been given access to Gate Test", html);
+    }
+
+    [Fact]
+    public void EncodesCallerText_ButNotTheTrustedUrl()
+    {
+        var html = EmailTemplate.Build(
+            heading: "Access to <Team> & \"Space\"",
+            paragraphs: ["<script>alert(1)</script> gave you access."],
+            ctaLabel: "Open",
+            ctaUrl: "https://x/y?a=1&b=2");
+
+        Assert.DoesNotContain("<script>alert(1)</script>", html);
+        Assert.Contains("&lt;script&gt;", html);
+        Assert.Contains("&lt;Team&gt;", html);
+        // The URL is caller-trusted (built from configured base + node path) and kept intact in href.
+        Assert.Contains("href=\"https://x/y?a=1&amp;b=2\"", html);
+    }
+}


### PR DESCRIPTION
Roland received an access-grant email on memex.cloud and was (fairly) disappointed: it doesn't say **who** invited him, has **no link**, and reads like a chewed-up system message. That email is most invitees' **first contact with Memex** — before they've ever signed in — so it's the whole first impression.

### 1. Who invited you
`AccessGrantNotifier` now resolves the granter's display name (node name → `User.FullName` → `Email`) and puts it in the message: **"Roland Bürgi gave you Admin access to \"Gate Test\"."** When the granter can't be resolved it falls back to name-less phrasing — never a raw ObjectId.

### 2. The link (root cause)
`Portal__BaseUrl` was **never plumbed into the chart**, so `ResolveBaseUrl` returned null on memex.cloud (confirmed: the configmap has `Email__Enabled=true` but no base-URL key) and the "Open" button was omitted from **every** notification and invitation email. Added `Portal__BaseUrl` to the config template + `values.yaml`; an env overlay sets the instance's public https host and the CTA renders. *(The env-overlay value + memex.cloud's live configmap are being set alongside this.)*

### 3. Make it nice
New shared `EmailTemplate` — a branded shell (wordmark, heading, body, one prominent CTA button with the raw URL beneath it for style-stripping clients, an optional first-time sign-in hint, a footer). **Both** first-contact emails now use it: access-granted notifications (`NotificationService`) and invitations (`InvitationEmailSender`), so they read like a real product invite with clear guidance for people who've never logged in.

### Tests
- `EmailTemplateTest` — heading/body/CTA/raw-URL, HTML-encoding of caller text vs. trusted URL, button omitted when no URL.
- `AccessGrantNotifierGranterTest` — granter name resolution + the ObjectId→null fallback.
- Existing `InvitationEmailTest` still green (assertions preserved).
- Full `MeshWeaver.Graph.Test` (531) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)