### PR TITLE
Composer: silently fall back to the first valid model (suppress "ApiKey is missing")

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -79,17 +79,6 @@ public class AgentChatClient : IAgentChat
     private string? lastAgentCreationError;
 
     /// <summary>
-    /// Set by <see cref="ApplyStaleModelFallback"/> when the chat-selected model no longer resolves
-    /// (deleted from the catalog / provider unconfigured — the case that used to 404 the whole
-    /// thread) and we transparently swap to the default model. Surfaced ONCE as a note prepended to
-    /// the next response so the model swap is VISIBLE to the user ("model X unavailable — using
-    /// default Y") instead of silently changing which model answered — then cleared. A genuinely
-    /// unrecoverable model failure (no working default) is surfaced separately by
-    /// <see cref="lastAgentCreationError"/> and the <c>ThreadExecution</c> error cell.
-    /// </summary>
-    private string? staleModelNotice;
-
-    /// <summary>
     /// Formats the no-agent failure into an APPROPRIATE chat output — never a crash.
     /// The common cause is "no model configured" (every agent skipped via the unconfigured
     /// catch-all factory); surface that with a clear, actionable hint plus the raw detail.
@@ -739,14 +728,6 @@ public class AgentChatClient : IAgentChat
 
         currentAgentName = agent.Name;
 
-        // Surface a transparent stale-model fallback (selected model 404'd → default stepped in)
-        // ONCE, so the swap is visible instead of silently changing which model answered.
-        if (staleModelNotice is { } modelNotice)
-        {
-            staleModelNotice = null;
-            yield return new ChatMessage(ChatRole.Assistant, modelNotice) { AuthorName = currentAgentName ?? "Assistant" };
-        }
-
         // Get or create thread for this agent
         var thread = await GetOrCreateThreadAsync(agent).ConfigureAwait(false);
 
@@ -877,14 +858,6 @@ public class AgentChatClient : IAgentChat
         }
 
         currentAgentName = agent.Name;
-
-        // Surface a transparent stale-model fallback ONCE (see GetResponseAsync) so the user sees
-        // the model swap rather than it changing silently underneath them.
-        if (staleModelNotice is { } modelNotice)
-        {
-            staleModelNotice = null;
-            yield return new ChatResponseUpdate(ChatRole.Assistant, modelNotice + "\n\n");
-        }
 
         // Get or create thread for this agent
         var thread = await GetOrCreateThreadAsync(agent).ConfigureAwait(false);
@@ -1920,40 +1893,32 @@ public class AgentChatClient : IAgentChat
         var resolver = hub.ServiceProvider.GetService<ChatClientCredentialResolver>();
         if (resolver is null)
             return;
-        // The selected model already resolves → nothing to heal. (A non-empty, resolvable selection.)
-        if (!string.IsNullOrEmpty(currentModelName)
-            && resolver.Resolve(currentModelName!) != CredentialResolution.Missing)
+        // The selected model is actually USABLE (resolves to a real key) → nothing to heal. Note this
+        // is HasUsableCredential, not `Resolve != Missing`: a keyless/endpoint-only resolution (a
+        // provider node with a gateway URL but no ApiKey — e.g. z-ai/glm-5.2 on Provider/OpenAICompatible)
+        // is non-Missing yet every factory throws "ApiKey is missing" for it. Treating keyless as
+        // usable is exactly what let that raw error reach the user.
+        if (resolver.HasUsableCredential(currentModelName))
             return;
-        // Either NO model is selected, or the selected one no longer resolves (deleted/refactored out of
-        // the catalog, or its provider is unconfigured). Seed the DEFAULT available model (lowest-Order
-        // resolvable) so the round runs on a working model instead of dead-ending on the first factory
-        // (OpenAI) with "(none selected)". When nothing resolves, `fallback` is empty → currentModelName
-        // stays as-is → the round surfaces the clear "No AI model available" message (FormatNoAgentError).
+        // Either NO model is selected, or the selected one isn't usable (deleted/refactored out of the
+        // catalog, or its provider carries no key). Seed the DEFAULT available model (lowest-Order model
+        // with a usable key) so the round runs on a working model instead of dead-ending on the first
+        // factory (OpenAI) with "(none selected)". When nothing usable exists, `fallback` is empty →
+        // currentModelName stays as-is → the round surfaces the clear "No AI model available" message.
         var fallback = resolver.ResolveDefaultModelId();
         if (string.IsNullOrEmpty(fallback)
             || string.Equals(fallback, currentModelName, StringComparison.OrdinalIgnoreCase))
             return;
         var stale = currentModelName;
         currentModelName = fallback;
-        // Only NOTIFY the user when we swapped AWAY from a model they had explicitly pinned. Seeding a
-        // default for an empty selection is silent — there was no user choice to override.
-        if (!string.IsNullOrEmpty(stale))
-        {
-            logger.LogWarning(
-                "[AgentChatClient] Selected model '{Stale}' does not resolve to a live model; "
-                + "falling back to default model '{Default}'.", stale, fallback);
-            // Surface the swap (GetResponseAsync / GetStreamingResponseAsync emit it once). Without this
-            // the model silently changes under the user — they think their pinned model answered when it
-            // actually 404'd and the default stepped in.
-            staleModelNotice =
-                $"*The selected model `{stale}` is unavailable — it may have been removed from the catalog "
-                + $"or its provider is no longer configured. Using the default model `{fallback}` for this response.*";
-        }
-        else
-        {
-            logger.LogDebug(
-                "[AgentChatClient] No model was selected; seeding default model '{Default}'.", fallback);
-        }
+        // 🔇 SILENT correction (user directive 2026-07-13: "the user does not get such messages —
+        // silently correct this and take the first valid model"). We LOG the swap for operators but do
+        // NOT emit a user-facing notice: an unusable pinned model is a config/catalog problem the user
+        // can't act on mid-thread, and surfacing it read as noise. The round just runs on the default.
+        logger.LogWarning(
+            "[AgentChatClient] Selected model '{Stale}' is not usable (no resolvable key); "
+            + "silently falling back to default model '{Default}'.",
+            string.IsNullOrEmpty(stale) ? "(none selected)" : stale, fallback);
     }
 
     /// <summary>

--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -414,7 +414,7 @@ public static class AgentPickerProjection
     /// </summary>
     private static string? ValidMasterModel(string? modelPath, ChatClientCredentialResolver? credResolver)
         => !string.IsNullOrEmpty(modelPath)
-           && (credResolver is null || credResolver.Resolve(modelPath) != CredentialResolution.Missing)
+           && (credResolver is null || credResolver.HasUsableCredential(modelPath))
             ? modelPath
             : null;
 

--- a/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
+++ b/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
@@ -293,8 +293,25 @@ public sealed class ChatClientCredentialResolver : IDisposable
             .Where(x => !string.IsNullOrEmpty(x.Id))
             .OrderBy(x => x.Order)
             .Select(x => x.Id!)
-            .FirstOrDefault(id => Resolve(id) != CredentialResolution.Missing);
+            .FirstOrDefault(HasUsableCredential);
     }
+
+    /// <summary>
+    /// True when <paramref name="modelId"/> resolves to a credential the model factories can ACTUALLY
+    /// use — i.e. a NON-EMPTY ApiKey. This is the honest "is this model usable" predicate, distinct
+    /// from <see cref="Resolve"/><c> != Missing</c>: <see cref="Resolve"/> returns a KEYLESS resolution
+    /// (an endpoint-only provider — e.g. <c>Provider/OpenAICompatible</c> with a gateway URL but no key)
+    /// as non-<see cref="CredentialResolution.Missing"/>, yet every registered factory
+    /// (<c>OpenAIChatClientAgentFactory</c> et al.) throws <c>"ApiKey is missing for model '…'"</c>
+    /// without a key. Selecting such a model as a default/fallback surfaces that raw factory error to
+    /// the user (the <c>z-ai/glm-5.2</c> report). Requiring a key here means default/fallback selection
+    /// only ever lands on a model that will actually run. No working model regresses: a model whose key
+    /// comes from the factory's own config/IOptions fallback (not a provider node) already resolves
+    /// <see cref="CredentialResolution.Missing"/> today and was never eligible as a catalog default.
+    /// </summary>
+    public bool HasUsableCredential(string? modelId)
+        => !string.IsNullOrEmpty(modelId)
+           && !string.IsNullOrEmpty(Resolve(modelId!).ApiKey);
 
     /// <summary>
     /// Resolve the per-user <b>Connect</b> token for a CLI harness — the user's OWN subscription

--- a/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
+++ b/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
@@ -214,6 +214,99 @@ public class ChatClientCredentialResolverTest : AITestBase
     }
 
     /// <summary>
+    /// A KEYLESS model — a provider node with an Endpoint but NO ApiKey (the <c>z-ai/glm-5.2</c> on
+    /// <c>Provider/OpenAICompatible</c> shape) — must NEVER be picked as the default/fallback, even at
+    /// the LOWEST Order. It <see cref="ChatClientCredentialResolver.Resolve"/>s to a non-Missing
+    /// (endpoint-only) resolution, so the old <c>Resolve != Missing</c> predicate chose it — and then
+    /// every factory threw <c>"ApiKey is missing for model '…'"</c> straight at the user. The default
+    /// selection now gates on <see cref="ChatClientCredentialResolver.HasUsableCredential"/> (a real
+    /// key), so it skips the keyless model and lands on the keyed one that will actually run.
+    /// </summary>
+    [Fact]
+    public async Task ResolveDefaultModelId_SkipsKeylessModel_EvenAtLowestOrder()
+    {
+        var root = ModelProviderNodeType.RootNamespace;
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+
+        // KEYLESS provider — endpoint only, no ApiKey (the gateway-without-key shape).
+        var keylessProviderPath = $"{root}/KeylessProv{suffix}";
+        await MeshService.CreateNode(new MeshNode($"KeylessProv{suffix}", root)
+        {
+            NodeType = ModelProviderNodeType.NodeType,
+            Name = "Keyless Provider",
+            State = MeshNodeState.Active,
+            Content = new ModelProviderConfiguration
+            {
+                Provider = $"KeylessProv{suffix}",
+                Endpoint = "https://gateway.example/v1", // endpoint present, ApiKey absent
+            }
+        }).Should().Within(15.Seconds()).Emit();
+
+        // The keyless model sits at the LOWEST Order — the old predicate would have picked it.
+        var keylessModelId = $"keyless-model-{suffix}";
+        await MeshService.CreateNode(new MeshNode(keylessModelId, keylessProviderPath)
+        {
+            NodeType = LanguageModelNodeType.NodeType,
+            Name = keylessModelId,
+            Order = -5000,
+            State = MeshNodeState.Active,
+            Content = new ModelDefinition
+            {
+                Id = keylessModelId,
+                Provider = $"KeylessProv{suffix}",
+                ProviderRef = keylessProviderPath,
+            }
+        }).Should().Within(15.Seconds()).Emit();
+
+        // A KEYED model at a higher Order — the one that should actually be chosen.
+        var keyedProviderPath = $"{root}/KeyedProv{suffix}";
+        await MeshService.CreateNode(new MeshNode($"KeyedProv{suffix}", root)
+        {
+            NodeType = ModelProviderNodeType.NodeType,
+            Name = "Keyed Provider",
+            State = MeshNodeState.Active,
+            Content = new ModelProviderConfiguration
+            {
+                Provider = $"KeyedProv{suffix}",
+                ApiKey = "sk-keyed-key",
+                Endpoint = "https://keyed.example/v1",
+            }
+        }).Should().Within(15.Seconds()).Emit();
+
+        var keyedModelId = $"keyed-model-{suffix}";
+        await MeshService.CreateNode(new MeshNode(keyedModelId, keyedProviderPath)
+        {
+            NodeType = LanguageModelNodeType.NodeType,
+            Name = keyedModelId,
+            Order = 100,
+            State = MeshNodeState.Active,
+            Content = new ModelDefinition
+            {
+                Id = keyedModelId,
+                Provider = $"KeyedProv{suffix}",
+                ProviderRef = keyedProviderPath,
+            }
+        }).Should().Within(15.Seconds()).Emit();
+
+        var resolver = Mesh.ServiceProvider.GetRequiredService<ChatClientCredentialResolver>();
+        resolver.EnsureSubscription();
+
+        // The default is the KEYED model — the keyless (lower-Order) one is skipped despite winning Order.
+        var defaultId = await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .Select(_ => resolver.ResolveDefaultModelId())
+            .Should().Within(10.Seconds()).Match(id => id == keyedModelId);
+        defaultId.Should().Be(keyedModelId,
+            "the keyless lowest-Order model is not usable — the default must skip it for the keyed one");
+
+        // The bug shape: the keyless model DOES resolve (endpoint-only, non-Missing) — which is exactly
+        // why the old `Resolve != Missing` predicate wrongly chose it — but it is NOT usable.
+        resolver.Resolve(keylessModelId).Should().NotBe(CredentialResolution.Missing);
+        resolver.HasUsableCredential(keylessModelId).Should().BeFalse(
+            "an endpoint-only provider carries no key, so no factory can create it");
+        resolver.HasUsableCredential(keyedModelId).Should().BeTrue();
+    }
+
+    /// <summary>
     /// The composer persists the model as the full LanguageModel node PATH
     /// (<c>Provider/{provider}/{modelId}</c> — <c>AgentPickerProjection.ToModelInfo</c>'s
     /// Path-carrying contract). The resolver must resolve that form exactly like the bare id:


### PR DESCRIPTION
## The report

A user's chat surfaced the raw factory error:

> Selected agent 'Agent/Assistant' was found, but creating it failed via factory 'OpenAI' for model 'z-ai/glm-5.2': ApiKey is missing for model 'glm-5.2'. Configure a ModelProvider node (Provider 'OpenAI') or set OpenAI:ApiKey in config.

The composer was pinned to a model whose provider has an **endpoint but no API key**. The ask: *the user should not get such messages — silently correct this and take the first valid model.*

## Root cause

`ChatClientCredentialResolver.Resolve()` returns a **keyless** resolution (endpoint present, `ApiKey` null) as **non-`Missing`**. But every registered factory (`OpenAIChatClientAgentFactory` and friends) throws `"ApiKey is missing"` without a key. Both selection gates —
- the composer projection `AgentPickerProjection.ValidMasterModel`, and
- the execution-time self-heal `AgentChatClient.ApplyStaleModelFallback` —

used `Resolve() != Missing`, so a keyless model was treated as valid and the factory then threw the error straight at the user.

## Fix

New `ChatClientCredentialResolver.HasUsableCredential(modelId)` — the honest "is this model usable" predicate: it resolves to a **non-empty key**, which is exactly what every factory requires. `ResolveDefaultModelId`, `ValidMasterModel`, and `ApplyStaleModelFallback` now all gate on it, so default/fallback selection only ever lands on a model that will actually run — **silently taking the first valid (keyed) model**.

No working model regresses: a model keyed only via factory config/`IOptions` (no provider node) already resolved `Missing` and was never eligible as a catalog default, so this only excludes the genuinely-broken keyless case.

Per the "no such messages" directive, the user-facing `staleModelNotice` is dropped entirely — the swap is logged for operators, not shown mid-thread (removed the now-unused field + its two emit blocks).

## Already correct (verified, unchanged)

- **MeshWeaver harness wins** — `Order = -1, IsDefault = true` (`DefaultHarnessIsMeshWeaverTest`).
- **Composer validates harness → agent → model and defaults stale selections** — `AgentPickerProjection.ObserveDefaultComposer` already resets a stale harness/agent via `ValidOrDefault`; this PR fixes the model leg's predicate.
- **ClaudeCode** takes its model from the CLI probe and effort from `settings.json`/`/effort` (`ClaudeCodeRuntimeProbe`), never the mesh catalog.

## Deferred (separate, on already-working paths)

Making the composer's agent/model validation **harness-specific** (filter the valid agent/model set by the selected harness — the "second two are harness-specific" refinement). ClaudeCode already ignores the mesh model selection (passes `modelName: null`), so a stale mesh model on a ClaudeCode composer doesn't break its rounds today — this is picker-cleanliness, not a live bug. Happy to do it as a follow-up.

## Verification

- New test `ResolveDefaultModelId_SkipsKeylessModel_EvenAtLowestOrder`: a keyless lowest-Order model is skipped for the keyed one; `HasUsableCredential` is false for keyless, true for keyed.
- `ChatClientCredentialResolverTest` (10/10) + `ThreadSelectionPersistenceTest` (4/4) green.
- Full solution builds Release `-warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)