### PR TITLE
GitSync: fail loud instead of silently dropping a node from export

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
@@ -153,6 +153,46 @@ activity lock + canonical upsert + prune) — see
 > **Take-over edits survive.** A node you've edited and marked to exclude from sync is
 > not overwritten or pruned by a re-import — that's how you "claim" content locally.
 
+### Git is the source of truth — author in the repo, never only-live
+
+A sync **reconciles**: *Update to latest* and *Re-import* mirror the branch into the Space
+with **add / update / prune** — so **a node that exists live but is NOT in the repo is
+PRUNED.** That is the model's whole point (the repo is authoritative and reproducible),
+but it has one sharp edge worth stating plainly:
+
+> ⚠️ **Content created or edited *only live* — never committed — is deleted by the next
+> reconcile.** A restart, a scheduled restore, or someone clicking *Update to latest*
+> re-imports the repo baseline and prunes everything not in it. This is the single most
+> common way live work is lost. **Author in the repo.**
+
+The safe loop for anything you want to keep — the **git-first** discipline:
+
+1. **Edit in the repo** — or, if you edited live, **Sync now** (`op: commit`) *immediately*
+   to capture it in the repo; never let live-only state accumulate.
+2. **Commit / open a PR**, review, **merge**.
+3. **Update to latest** (`op: update`) — pull the merged state back into the Space.
+4. **Recycle** any node whose **type or configuration changed**. Importing new content
+   into a node that is already *running* does not swap its live views: a node that flipped
+   `Markdown → Deck`, or whose `NodeType` source recompiled, keeps its old hub until you
+   recycle it (`{node}/Recycle`, or post a `DisposeRequest`). Freshly *created* nodes get
+   the right views immediately; only a **type/config change on an existing node** needs the
+   recycle. A node whose content merely changed (same type) re-renders reactively — no
+   recycle needed.
+
+### Export never silently drops a node
+
+The export is the exact inverse of the import: **every node serializes** — through a
+per-type serializer (`*.md` / `*.cs`) or the **universal JSON fallback** (any content
+type → `*.json`, keyed on its `$type`, the inverse of the JSON import). If a node could
+ever fail to serialize, the export **fails loudly** rather than skipping it — a node
+dropped from the mirror would be pruned by the next import, i.e. **silent data loss**.
+Symmetrically, a repo file whose content is missing its `$type` is **tolerated on import**
+(the value is re-typed against the target at the read site), so a hand-edited file is not
+lost either. The only things left out of an export are the **governance satellites**
+(`_Access`, `_Activity`, `_GitSync`, … — see §8) and paths matched by the Space's
+**gitignore-style ignore rules** (`SyncIgnore`). Nothing else is excluded, and nothing is
+excluded *silently*.
+
 ---
 
 ## 5. Operations — branch, commit, checkout, pull request

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -256,14 +256,18 @@ public sealed class GitHubSyncService
         var serializer = parsers.GetSerializerFor(node);
         if (serializer is null)
         {
-            logger?.LogWarning("No serializer for node {Path} (type {Type}) — skipping.", node.Path, node.NodeType);
-            // Also surface the skip on the owning activity (a node silently missing from the
-            // export is invisible in the portal otherwise); Warning rolls the terminal status
-            // up to ActivityStatus.Warning via ActivityRunner.Finish.
-            progress?.Invoke(
-                $"No serializer for node '{node.Path}' (type {node.NodeType}) — skipped from export.",
-                LogLevel.Warning);
-            return Observable.Return<RepoFile?>(null);
+            // Every node MUST round-trip to the mirror. The registry always includes the universal
+            // JSON serializer (JsonFileParser.CanSerialize => true — any content type, the exact
+            // inverse of the JSON import), so this is unreachable in practice. If a future change
+            // ever left the registry without that fallback, FAIL LOUD rather than silently dropping
+            // the node: a dropped node is pruned by the next import — silent data loss, the very
+            // failure mode this guard exists to make impossible.
+            var message =
+                $"No serializer for node '{node.Path}' (type {node.NodeType}). Export must serialize " +
+                "every node; the universal JSON fallback is missing from the parser registry.";
+            logger?.LogError(message);
+            progress?.Invoke(message, LogLevel.Error);
+            throw new InvalidOperationException(message);
         }
         var ext = serializer.SupportedExtensions.FirstOrDefault() ?? ".json";
         var repoPath = NodeFileMapper.ToRepoPath(node.Path, partition, ext, NodeFileMapper.HasChildren(node.Path, allPaths));

--- a/test/MeshWeaver.GitSync.Test/BidirectionalEditSyncTest.cs
+++ b/test/MeshWeaver.GitSync.Test/BidirectionalEditSyncTest.cs
@@ -1,0 +1,100 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Bidirectional EDIT propagation over the in-memory fake repo — the round-trip that matters
+/// once content already exists on both sides:
+/// <list type="bullet">
+///   <item>an edit made on the <b>mesh</b> side lands in the git mirror on the next export
+///     (<see cref="EditOnMeshSide_PropagatesToGitHub"/>), and</item>
+///   <item>an edit made on the <b>git</b> side lands on the mesh node on the next import
+///     (<see cref="EditOnGitSide_PropagatesToMesh"/>).</item>
+/// </list>
+/// Complements <see cref="GitHubExportImportTest"/> (fresh export/import + prune) by pinning that
+/// a Space configured for the default <see cref="SyncDirection.Bidirectional"/> actually carries
+/// CHANGES both ways, not just first-time content.
+/// </summary>
+public class BidirectionalEditSyncTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    [Fact(Timeout = 120000)]
+    public async Task EditOnMeshSide_PropagatesToGitHub()
+    {
+        await Connect();
+        var a = "GhEm" + Guid.NewGuid().ToString("N")[..8];
+        var repo = "https://github.com/test/bidi-mesh";
+        await CreateSpace(a, "Bidi Mesh");
+        await CreateMarkdown($"{a}/Page", "Page", "# v1\n\noriginal on mesh.");
+        await Sync.SaveConfig(a, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+
+        // Initial export — the mirror carries v1.
+        var c1 = await Sync.SyncToGitHub(a, UserId).Timeout(60.Seconds()).ToTask();
+        Assert.Contains("original on mesh.", GitFile(repo, "Page.md"));
+
+        // EDIT on the mesh side, through the documented mutation path.
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{a}/Page")
+            .Update(n => n with { Content = new MarkdownContent { Content = "# v2\n\nedited on mesh." } })
+            .Timeout(30.Seconds()).ToTask();
+        await WaitForBody($"{a}/Page", b => b.Contains("edited on mesh."));
+
+        // Re-export — the edit lands in the mirror as a NEW commit and v1 is gone.
+        var c2 = await Sync.SyncToGitHub(a, UserId).Timeout(60.Seconds()).ToTask();
+        Assert.NotEqual(c1.CommitSha, c2.CommitSha);
+        var git = GitFile(repo, "Page.md");
+        Assert.Contains("edited on mesh.", git);
+        Assert.DoesNotContain("original on mesh.", git);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task EditOnGitSide_PropagatesToMesh()
+    {
+        await Connect();
+        var a = "GhEg" + Guid.NewGuid().ToString("N")[..8];
+        var repo = "https://github.com/test/bidi-git";
+        await CreateSpace(a, "Bidi Git");
+        await CreateMarkdown($"{a}/Page", "Page", "# v1\n\noriginal in mesh.");
+        await Sync.SaveConfig(a, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+        await Sync.SyncToGitHub(a, UserId).Timeout(60.Seconds()).ToTask();
+
+        // EDIT on the git side: rewrite Page.md's body, keep the rest of the tree, push a new commit.
+        var edited = Fake.Tree(repo)
+            .Select(f => f.Path == "Page.md"
+                ? new RepoFile(f.Path, f.Content.Replace("original in mesh.", "edited in git."))
+                : f)
+            .ToImmutableList();
+        var gitCommit = await Fake.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = repo,
+            Branch = "main",
+            Subdirectory = null,
+            Files = edited,
+            CommitMessage = "Edit Page on the git side",
+            AuthorName = "Git Author",
+            AuthorEmail = "git-author@test",
+            AccessToken = "ghp_test_token",
+        }).Timeout(30.Seconds()).ToTask();
+
+        // Import that commit — the mesh node reflects the git-side edit.
+        await Sync.ReimportAtCommit(a, gitCommit.CommitSha, UserId).Timeout(90.Seconds()).ToTask();
+        await WaitForBody($"{a}/Page", b => b.Contains("edited in git."));
+        Assert.DoesNotContain("original in mesh.", MarkdownBody(await WaitForNode($"{a}/Page")));
+    }
+
+    /// <summary>Current git-side content of a mirrored file.</summary>
+    private string GitFile(string repo, string path) =>
+        Fake.Tree(repo).First(f => f.Path == path).Content;
+
+    /// <summary>Waits until the mesh node at <paramref name="path"/> has a body satisfying <paramref name="predicate"/>.</summary>
+    private async Task WaitForBody(string path, Func<string, bool> predicate) =>
+        await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => ReadNode(path))
+            .Where(n => n is not null && predicate(MarkdownBody(n!)))
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+}

--- a/test/MeshWeaver.GitSync.Test/TypedNodeExportRobustnessTest.cs
+++ b/test/MeshWeaver.GitSync.Test/TypedNodeExportRobustnessTest.cs
@@ -1,0 +1,104 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Export robustness: a node whose content type has NO bespoke (markdown / agent / C#) parser —
+/// a <see cref="DeckContent"/> deck — must still round-trip. Export serializes it through the
+/// universal JSON serializer (<c>JsonFileParser.CanSerialize =&gt; true</c> — any content type, the
+/// exact inverse of the JSON import) as a <c>.json</c> file, and import reads it back typed with
+/// its manifest intact. Pins that GitSync export serializes EVERY content type and can never
+/// silently drop a node (the failure mode that lost live-only work before).
+/// </summary>
+public class TypedNodeExportRobustnessTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    [Fact(Timeout = 120000)]
+    public async Task DeckWithManifest_RoundTripsAsJson_NothingDropped()
+    {
+        await Connect();
+        var a = "GhTk" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(a, "Deck Space");
+        await NodeFactory.CreateNode(MeshNode.FromPath($"{a}/Show") with
+        {
+            NodeType = DeckNodeType.NodeType,   // "Deck" — no markdown/agent/C# parser exists for it
+            Name = "Show",
+            State = MeshNodeState.Active,
+            Content = new DeckContent
+            {
+                Title = "The Show",
+                Description = "A shared-pool presentation.",
+                Slides = ["Slides/S01", "Slides/S02", "Slides/S03"],
+            },
+        }).Timeout(60.Seconds()).ToTask();
+
+        var repo = "https://github.com/test/deck-json";
+        await Sync.SaveConfig(a, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+        await Sync.SyncToGitHub(a, UserId).Timeout(60.Seconds()).ToTask();
+
+        // Exported via the universal JSON serializer → Show.json, with the manifest preserved.
+        var file = Fake.Tree(repo).FirstOrDefault(f => f.Path == "Show.json");
+        Assert.NotNull(file);
+        Assert.Contains("DeckContent", file!.Content);
+        Assert.Contains("Slides/S02", file.Content);
+
+        // Import into a fresh Space — the Deck round-trips TYPED with its ordered manifest intact.
+        var b = "GhTl" + Guid.NewGuid().ToString("N")[..8];
+        await Sync.ImportFromGitHub(repo, "main", b, "Deck B", null, UserId).Timeout(90.Seconds()).ToTask();
+
+        var deckNode = await WaitForNode($"{b}/Show");
+        Assert.Equal(DeckNodeType.NodeType, deckNode.NodeType);
+        var deck = deckNode.ContentAs<DeckContent>(Mesh.JsonSerializerOptions);
+        Assert.NotNull(deck);
+        Assert.Equal(new[] { "Slides/S01", "Slides/S02", "Slides/S03" }, deck!.Slides);
+    }
+
+    /// <summary>
+    /// A "broken" repo file whose content object omits the <c>$type</c> discriminator must still
+    /// import and read TYPED: the content converter degrades an absent/unknown <c>$type</c> to raw
+    /// JSON, and <c>ContentAs&lt;T&gt;</c> resolves it against the target type at the read site
+    /// (<c>$type</c> is advisory, not load-bearing, for a typed read). Pins that a hand-authored or
+    /// legacy <c>$type</c>-less deck file is not lost — it round-trips to a usable Deck.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task ContentMissingDollarType_StillImportsAndReadsTyped()
+    {
+        await Connect();
+        var a = "GhNt" + Guid.NewGuid().ToString("N")[..8];
+        var repo = "https://github.com/test/missing-type";
+        await CreateSpace(a, "Repair Space");
+        await CreateMarkdown($"{a}/Seed", "Seed", "# seed");   // seeds a valid root + tree
+        await Sync.SaveConfig(a, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+        await Sync.SyncToGitHub(a, UserId).Timeout(60.Seconds()).ToTask();
+
+        // A BROKEN file: a Deck node whose content object has NO "$type".
+        var brokenJson = """
+            {"$type":"MeshNode","id":"Show","namespace":"__NS__","path":"__NS__/Show","nodeType":"Deck","name":"Show","state":"Active","content":{"title":"Show","slides":["Slides/S01","Slides/S02"]}}
+            """.Replace("__NS__", a);
+        var tree = Fake.Tree(repo).Append(new RepoFile("Show.json", brokenJson)).ToImmutableList();
+        var commit = await Fake.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = repo,
+            Branch = "main",
+            Subdirectory = null,
+            Files = tree,
+            CommitMessage = "add a $type-less deck file",
+            AuthorName = "Git Author",
+            AuthorEmail = "git-author@test",
+            AccessToken = "ghp_test_token",
+        }).Timeout(30.Seconds()).ToTask();
+
+        await Sync.ReimportAtCommit(a, commit.CommitSha, UserId).Timeout(90.Seconds()).ToTask();
+
+        var node = await WaitForNode($"{a}/Show");
+        Assert.Equal("Deck", node.NodeType);
+        var deck = node.ContentAs<DeckContent>(Mesh.JsonSerializerOptions);
+        Assert.NotNull(deck);
+        Assert.Equal(new[] { "Slides/S01", "Slides/S02" }, deck!.Slides);
+    }
+}


### PR DESCRIPTION
## What
Make GitSync **export never silently drop a node**, and pin the sync round-trip both directions with dedicated tests.

## Why
`SerializeOne` returned `null` (a warning log) when no serializer matched a node — dropping it from the export. The next import then **prunes** the now-missing node from the mesh: **silent data loss** (the mechanism behind recently-lost live content).

Export already routes every node through the universal JSON serializer (`JsonFileParser.CanSerialize => true` — any content type, the exact inverse of the JSON import), and `GitHubSyncService` builds the registry **with** the mesh's serializer options — so the skip is unreachable in practice. This change makes it **fail loud** if that guarantee is ever broken, rather than quietly corrupting the mirror.

## Tests — GitSync suite 111/111 green
- **`BidirectionalEditSyncTest`** — an edit on the **mesh** side lands in git on export; an edit on the **git** side lands on the mesh on import (default `SyncDirection.Bidirectional`).
- **`TypedNodeExportRobustnessTest`** — a `Deck` (`DeckContent` has no markdown/agent/C# parser) round-trips via the universal JSON serializer as `.json`, nothing dropped; and a **`$type`-less** content file still imports and reads typed (`ContentAs<T>` resolves the raw JSON at the read site — a missing `$type` is tolerated, not data loss).

## Not changed
Happy-path export/import behavior; governance subtrees (`_Access`/`_GitSync`/`_Activity`) and the gitignore-style `SyncIgnore` rules are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)