### PR TITLE
Deck: default to subtree (live query, ordered by MeshNode.Order) + custom Query

### DIFF
--- a/src/MeshWeaver.Documentation/Data/GUI/SlidesAndDecks.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/SlidesAndDecks.md
@@ -53,7 +53,16 @@ A **Deck** (`NodeType = "Deck"`) is a node whose `Content` is a `DeckContent` re
 
 - **`Title`** — optional display title for the welcome stage (falls back to the node name).
 - **`Description`** — optional markdown intro shown on the deck's welcome stage.
-- **`Slides`** — the **ordered list of child references**. **This IS the deck's order.** Each entry is a child id (relative — `"intro"`) or a full path.
+- **`Slides`** — an explicit **ordered list of references**. **This IS the deck's order**, kept exactly as declared (never re-sorted). Each entry is a child id (relative — `"intro"`) or a full path to a slide **anywhere** in the mesh, so the same slide can appear in many decks in different orders.
+- **`Query`** — an optional GitHub-style node query that selects the deck's slides **dynamically**, as a live (synced) set — used only when `Slides` is empty.
+
+**How a deck picks its slides — precedence:**
+
+1. **`Slides` manifest** (non-empty) → exactly those references, **in the order declared**. Use this for a curated deck, or one that draws from a shared pool that lives elsewhere.
+2. **`Query`** (when there is no manifest) → the live query result, ordered by each slide's **`MeshNode.Order`** (nulls last, ties by path).
+3. **Neither** → the deck defaults to its **own subtree** (`path:{deck} scope:descendants`), ordered by `MeshNode.Order`. So a deck whose slides are simply its children needs **no manifest at all** — reorder by editing each slide's `Order`.
+
+(Query/subtree results skip the deck node itself and any `_`-prefixed governance node.)
 
 The Deck's views are automatic:
 

--- a/src/MeshWeaver.Graph/Configuration/DeckNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/DeckNodeType.cs
@@ -89,4 +89,15 @@ public record DeckContent
     /// Present walk all follow this order. Default empty.
     /// </summary>
     public ImmutableList<string> Slides { get; init; } = ImmutableList<string>.Empty;
+
+    /// <summary>
+    /// Optional GitHub-style mesh-node query selecting the deck's slides DYNAMICALLY, as a live
+    /// (synced) set — used only when <see cref="Slides"/> is empty. The matched nodes are ordered
+    /// by <see cref="MeshNode.Order"/> (nulls last, ties by path). When BOTH this and
+    /// <see cref="Slides"/> are empty the deck defaults to <b>its own subtree</b>
+    /// (<c>path:{deck} scope:descendants</c>), so a deck with slides as children just works with no
+    /// manifest. An explicit <see cref="Slides"/> manifest always wins and is kept in its declared
+    /// order (never re-sorted). Default null.
+    /// </summary>
+    public string? Query { get; init; }
 }

--- a/src/MeshWeaver.Graph/DeckLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/DeckLayoutAreas.cs
@@ -1,11 +1,14 @@
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Reactive.Linq;
+using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MeshWeaver.Graph;
 
@@ -248,22 +251,6 @@ public static class DeckLayoutAreas
     }
 
     /// <summary>
-    /// The deck's ordered, resolved slide paths — read off the deck node's
-    /// <see cref="DeckContent.Slides"/> manifest (blanks dropped, each mapped via
-    /// <see cref="ResolveSlidePath"/>).
-    /// </summary>
-    private static ImmutableList<string> ResolveSlidePaths(
-        LayoutAreaHost host, string deckPath, MeshNode? deckNode)
-    {
-        var refs = deckNode.ContentAs<DeckContent>(host.Hub.JsonSerializerOptions)?.Slides
-                   ?? ImmutableList<string>.Empty;
-        return refs
-            .Where(r => !string.IsNullOrWhiteSpace(r))
-            .Select(r => ResolveSlidePath(deckPath, r))
-            .ToImmutableList();
-    }
-
-    /// <summary>
     /// Live observable of the deck's referenced slides, in manifest order, each resolved by PATH
     /// via <c>workspace.GetMeshNodeStream(path)</c> (the slides may live ANYWHERE — presentation
     /// is decoupled from the slide nodes). Re-subscribes the per-slide streams only when the
@@ -273,14 +260,71 @@ public static class DeckLayoutAreas
     internal static IObservable<IReadOnlyList<(string Path, MeshNode? Node)>> ObserveSlideNodes(
         LayoutAreaHost host, string deckPath)
         => host.Workspace.GetMeshNodeStream()
-            .Select(node => ResolveSlidePaths(host, deckPath, node))
-            .DistinctUntilChanged(paths => string.Join("\n", paths))
-            .Select(paths => paths.Count == 0
-                ? Observable.Return((IReadOnlyList<(string, MeshNode?)>)ImmutableList<(string, MeshNode?)>.Empty)
-                : Observable.CombineLatest(paths.Select(ObserveSlide(host)))
-                    .Select(items => (IReadOnlyList<(string, MeshNode?)>)items.ToImmutableList()))
+            .Select(node =>
+            {
+                var deck = node.ContentAs<DeckContent>(host.Hub.JsonSerializerOptions);
+                var paths = (deck?.Slides ?? ImmutableList<string>.Empty)
+                    .Where(r => !string.IsNullOrWhiteSpace(r))
+                    .Select(r => ResolveSlidePath(deckPath, r))
+                    .ToImmutableList();
+                // Empty manifest → a live query (custom, or the deck's own subtree by default).
+                var query = paths.Count > 0
+                    ? null
+                    : string.IsNullOrWhiteSpace(deck?.Query)
+                        ? $"path:{deckPath} scope:descendants"
+                        : deck!.Query!.Trim();
+                return (Paths: paths, Query: query);
+            })
+            // Re-resolve only when the selection actually changes (the ordered manifest, or the query).
+            .DistinctUntilChanged(x => string.Join("\n", x.Paths) + "" + (x.Query ?? ""))
+            .Select(x => x.Paths.Count > 0
+                // Explicit manifest: exactly these paths, in the order declared — never re-sorted.
+                ? Observable.CombineLatest(x.Paths.Select(ObserveSlide(host)))
+                    .Select(items => (IReadOnlyList<(string, MeshNode?)>)items.ToImmutableList())
+                // Query/subtree: the live match, ordered by MeshNode.Order (nulls last, ties by path).
+                : ObserveQuerySlides(host, x.Query!, deckPath))
             .Switch()
             .StartWith((IReadOnlyList<(string, MeshNode?)>)ImmutableList<(string, MeshNode?)>.Empty);
+
+    /// <summary>
+    /// A live (synced) query for a deck's slides when it has no explicit manifest: runs
+    /// <paramref name="query"/> (a custom <see cref="DeckContent.Query"/> or the default
+    /// <c>path:{deck} scope:descendants</c>), accumulates the reactive change stream, drops the deck
+    /// root itself and any <c>_</c>-prefixed governance node, and orders the result by
+    /// <see cref="MeshNode.Order"/> (nulls last, then by path). So a deck whose slides are its
+    /// children needs no manifest, and re-ordering is just editing each slide's <c>Order</c>.
+    /// </summary>
+    private static IObservable<IReadOnlyList<(string Path, MeshNode? Node)>> ObserveQuerySlides(
+        LayoutAreaHost host, string query, string deckPath)
+    {
+        var meshService = host.Hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null)
+            return Observable.Return((IReadOnlyList<(string, MeshNode?)>)ImmutableList<(string, MeshNode?)>.Empty);
+
+        return meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(query))
+            .Scan(ImmutableDictionary<string, MeshNode>.Empty, (map, change) =>
+            {
+                if (change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+                    return change.Items.ToImmutableDictionary(n => n.Path);
+                foreach (var item in change.Items)
+                    map = change.ChangeType switch
+                    {
+                        QueryChangeType.Added or QueryChangeType.Updated => map.SetItem(item.Path, item),
+                        QueryChangeType.Removed => map.Remove(item.Path),
+                        _ => map
+                    };
+                return map;
+            })
+            .Select(map => (IReadOnlyList<(string, MeshNode?)>)map.Values
+                .Where(n => !string.Equals(n.Path, deckPath, StringComparison.Ordinal)
+                            && !n.Segments.Skip(1).Any(s => s.StartsWith('_')))
+                .OrderBy(n => n.Order ?? int.MaxValue)
+                .ThenBy(n => n.Path, StringComparer.Ordinal)
+                .Select(n => (n.Path, (MeshNode?)n))
+                .ToImmutableList())
+            .StartWith((IReadOnlyList<(string, MeshNode?)>)ImmutableList<(string, MeshNode?)>.Empty);
+    }
 
     /// <summary>One resolved slide stream: its path paired with the live node (null until it loads / if missing).</summary>
     private static Func<string, IObservable<(string Path, MeshNode? Node)>> ObserveSlide(LayoutAreaHost host)

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeckLayoutAreaTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeckLayoutAreaTest.cs
@@ -234,6 +234,67 @@ public class DeckLayoutAreaTest(ITestOutputHelper output) : MonolithMeshTestBase
     }
 
     /// <summary>
+    /// DEFAULT selection: a Deck with an EMPTY manifest presents its own subtree as a LIVE query,
+    /// ordered by <see cref="MeshNode.Order"/> (nulls last, ties by path). Children created out of
+    /// order with Order 1/2/3 walk intro → mid → end — so a deck whose slides are its children just
+    /// works with no manifest to maintain.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task EmptyManifest_DefaultsToSubtree_OrderedByNodeOrder()
+    {
+        var space = await CreateSpaceNode();
+        var deck = $"{space}/auto";
+        await CreateDeckNode(deck, "Auto Deck", ImmutableList<string>.Empty);   // no manifest
+        // Children created OUT of order; MeshNode.Order (1,2,3) must rule the walk.
+        await CreateSlide($"{deck}/end", "End", 3, "# End\n\nthe-end-body");
+        await CreateSlide($"{deck}/intro", "Intro", 1, "# Intro\n\nthe-intro-body");
+        await CreateSlide($"{deck}/mid", "Mid", 2, "# Mid\n\nthe-mid-body");
+
+        var workspace = GetClient(c => c.AddData()).GetWorkspace();
+
+        await AssertDeckPresentSlide(workspace, deck, index: 0,
+            expectBody: "the-intro-body", expectCounter: "Slide 1 / 3",
+            expectPrev: null, expectNext: $"/{deck}/Present?i=1");
+        await AssertDeckPresentSlide(workspace, deck, index: 2,
+            expectBody: "the-end-body", expectCounter: "Slide 3 / 3",
+            expectPrev: $"/{deck}/Present?i=1", expectNext: null);
+
+        await NodeFactory.DeleteNode(space).Should().Emit();
+    }
+
+    /// <summary>
+    /// A Deck with a custom <see cref="DeckContent.Query"/> (and no manifest) selects its slides
+    /// LIVE from that query, ordered by <see cref="MeshNode.Order"/> — here two slides that live
+    /// under the space (NOT under the deck), matched by a nodeType query.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task CustomQuery_SelectsMatchingSlides_OrderedByNodeOrder()
+    {
+        var space = await CreateSpaceNode();
+        await CreateSlide($"{space}/s1", "One", 1, "# One\n\nbody-one");
+        await CreateSlide($"{space}/s2", "Two", 2, "# Two\n\nbody-two");
+
+        var deck = $"{space}/qdeck";
+        await NodeFactory.CreateNode(MeshNode.FromPath(deck) with
+        {
+            Name = "Query Deck",
+            NodeType = DeckNodeType.NodeType,
+            Content = new DeckContent { Title = "Q", Query = $"namespace:{space} nodeType:Slide" }
+        }).Should().Emit();
+
+        var workspace = GetClient(c => c.AddData()).GetWorkspace();
+
+        await AssertDeckPresentSlide(workspace, deck, index: 0,
+            expectBody: "body-one", expectCounter: "Slide 1 / 2",
+            expectPrev: null, expectNext: $"/{deck}/Present?i=1");
+        await AssertDeckPresentSlide(workspace, deck, index: 1,
+            expectBody: "body-two", expectCounter: "Slide 2 / 2",
+            expectPrev: $"/{deck}/Present?i=0", expectNext: null);
+
+        await NodeFactory.DeleteNode(space).Should().Emit();
+    }
+
+    /// <summary>
     /// Renders a deck's Present area at a given <c>?i</c> and asserts the shown slide body, the
     /// counter, and the keyboard driver's prev/next hrefs — all sourced from the DECK's manifest.
     /// </summary>


### PR DESCRIPTION
## What
A `Deck` no longer needs a manifest. Resolution precedence in `DeckLayoutAreas.ObserveSlideNodes`:

1. **`DeckContent.Slides` manifest** (non-empty) → exactly those paths, **in declared order — never re-sorted** (decoupled: a slide may live anywhere and appear in many decks in different orders). *(unchanged)*
2. **`DeckContent.Query`** (new, when no manifest) → a live/synced GitHub-style node query, ordered by `MeshNode.Order`.
3. **Neither** → default to the deck's **own subtree** (`path:{deck} scope:descendants`), ordered by `MeshNode.Order` (nulls last, ties by path).

Query results drop the deck root itself and any `_`-prefixed governance node. So "a deck whose slides are its children" just works, and re-ordering is editing each slide's `Order` — while a curated cross-pool deck stays an explicit ordered manifest.

## Why
Presentations are an *ordered selection of shared slides*. The manifest covered the curated/cross-pool case; this adds the common "all my slides, in Order" case without hand-maintaining a list, and a query for dynamic selections.

## Tests — Monolith Deck suite 7/7 green
- `EmptyManifest_DefaultsToSubtree_OrderedByNodeOrder`
- `CustomQuery_SelectsMatchingSlides_OrderedByNodeOrder`
- existing manifest-order / decoupled-path / non-Deck-parent tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)