### PR TITLE
HA: Orleans AdoNet clustering + KEDA autoscaling for the portal

### DIFF
--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -246,8 +246,25 @@ resources:
 # spread. portal-ha-patch.yaml sets the same count — keep the two in sync (or
 # `kubectl scale deployment memex-portal-deployment --replicas=2`).
 replicas:
-  portal: 2        # Blazor Server: 2 replicas (zone-spread is ScheduleAnyway)
+  portal: 2        # Blazor Server: initial count; KEDA (below) owns it once installed
   postgres: 1      # self-managed pg StatefulSet stays single-writer
+
+# --- KEDA autoscaling (portal) ---------------------------------------------
+# Event-driven autoscaling for the portal. Requires the KEDA operator — enable
+# the AKS managed add-on once per cluster:
+#   az aks update -g memex-aks-rg -n memexaks-cluster --enable-keda
+# metrics-server is already present. Once the ScaledObject exists, its HPA owns
+# the replica count, so the fixed `replicas.portal` above and any env
+# portal-patch.json replica override become moot. min=2 keeps HA + seeds the
+# Orleans cluster; it scales toward 4 under a class-sized load and up to 8 at
+# peak. Scale-down is deliberately slow (stateful Blazor circuits + Orleans
+# membership churn) — see the ScaledObject template.
+keda:
+  enabled: true
+  minReplicas: 2        # baseline floor (HA + Orleans cluster seed); bursts to max under load
+  maxReplicas: 8
+  cpuTarget: 70
+  memoryTarget: 80
 
 # --- Persistence (Azure Files CSI for ReadWriteMany) ------------------------
 # Blazor Server portal replicas share every /data + /mnt/* path, so those PVCs

--- a/deploy/helm/templates/memex-migration/secrets.yaml
+++ b/deploy/helm/templates/memex-migration/secrets.yaml
@@ -11,4 +11,10 @@ stringData:
   ConnectionStrings__memex: "Host=memex-postgres-service;Port=5432;Username=postgres;Password={{ .Values.secrets.memex_migration.memex_postgres_password }};Database=memex"
   MEMEX_PASSWORD: "{{ .Values.secrets.memex_migration.memex_postgres_password }}"
   MEMEX_URI: "postgresql://postgres:{{ .Values.secrets.memex_migration.memex_postgres_password }}@memex-postgres-service:5432/memex"
+  # Orleans membership tables live in a dedicated `orleans` DB on the same server;
+  # the migration's OrleansClusteringSetup creates the DB + tables when this is
+  # set. Emitted only for AdoNet (HA) deployments — mirrors the portal gate.
+  {{- if eq (.Values.config.memex_portal.Deployment__Orleans__Clustering | default "Localhost") "AdoNet" }}
+  ConnectionStrings__orleans: "Host=memex-postgres-service;Port=5432;Username=postgres;Password={{ .Values.secrets.memex_migration.memex_postgres_password }};Database=orleans"
+  {{- end }}
 type: "Opaque"

--- a/deploy/helm/templates/memex-portal/scaledobject.yaml
+++ b/deploy/helm/templates/memex-portal/scaledobject.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.keda.enabled }}
+# KEDA autoscaler for the Blazor Server portal. Requires the KEDA operator
+# (AKS managed add-on) + metrics-server, and AdoNet Orleans clustering so the
+# replicas KEDA adds actually form ONE mesh (Localhost would split-brain).
+#
+# Scale-UP is fast (shed incoming load quickly); scale-DOWN is deliberately
+# slow — a Blazor circuit is stateful (draining a pod drops its users) and
+# every silo add/remove triggers an Orleans membership rebalance, so we only
+# remove a pod after a long calm window, one at a time.
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: "memex-portal-scaler"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "memex-portal"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+spec:
+  scaleTargetRef:
+    name: "memex-portal-deployment"
+  minReplicaCount: {{ .Values.keda.minReplicas | default 2 }}
+  maxReplicaCount: {{ .Values.keda.maxReplicas | default 8 }}
+  cooldownPeriod: {{ .Values.keda.cooldownPeriod | default 300 }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 30
+          policies:
+            - type: Pods
+              value: 2
+              periodSeconds: 60
+        scaleDown:
+          stabilizationWindowSeconds: {{ .Values.keda.scaleDownStabilizationSeconds | default 600 }}
+          policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 300
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "{{ .Values.keda.cpuTarget | default 70 }}"
+    - type: memory
+      metricType: Utilization
+      metadata:
+        value: "{{ .Values.keda.memoryTarget | default 80 }}"
+{{- end }}

--- a/deploy/helm/templates/memex-portal/secrets.yaml
+++ b/deploy/helm/templates/memex-portal/secrets.yaml
@@ -13,6 +13,15 @@ stringData:
   # (content_chunks/content_files alongside each partition's mesh_nodes) — no separate connection.
   MEMEX_PASSWORD: "{{ .Values.secrets.memex_portal.memex_postgres_password }}"
   MEMEX_URI: "postgresql://postgres:{{ .Values.secrets.memex_portal.memex_postgres_password }}@memex-postgres-service:5432/memex"
+  # ---- Orleans AdoNet clustering (HA / multi-replica) ----------------------
+  # The silo THROWS at startup when Deployment:Orleans:Clustering=AdoNet but
+  # ConnectionStrings:orleans is unset — so this MUST accompany the AdoNet flag.
+  # Same Postgres server, a dedicated `orleans` database that the migration's
+  # OrleansClusteringSetup creates + seeds with the membership tables. Emitted
+  # ONLY for AdoNet; Localhost single-replica deployments omit it (no unused DB).
+  {{- if eq (.Values.config.memex_portal.Deployment__Orleans__Clustering | default "Localhost") "AdoNet" }}
+  ConnectionStrings__orleans: "Host=memex-postgres-service;Port=5432;Username=postgres;Password={{ .Values.secrets.memex_portal.memex_postgres_password }};Database=orleans"
+  {{- end }}
   # ---- AI provider keys (secret) -------------------------------------------
   # Conditionally emitted: a key is set ONLY when its value is non-empty, so the chart never
   # overwrites a value injected out-of-band (Key Vault CSI / kubectl). This matters most for

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -25,6 +25,23 @@ instancesAdmin:
   # Instances tab (→ Instances__GrafanaBaseUrl). Empty = the tab shows a configure-me hint
   # instead of links. Only meaningful where clusterRead is true (the company instance).
   grafanaBaseUrl: ""
+# ---- KEDA autoscaling (portal) --------------------------------------------
+# HA deployments autoscale the portal via a KEDA ScaledObject (templates/
+# memex-portal/scaledobject.yaml) instead of a fixed replica count. Off by
+# default (single-replica installs); the AKS overlay enables it. Scale-UP is
+# fast, scale-DOWN is deliberately slow — a Blazor Server circuit is stateful
+# (killing a pod drops its users' sessions) and every silo add/remove churns
+# the Orleans cluster, so we shed load gently. Requires the KEDA operator
+# (AKS managed add-on: `az aks update --enable-keda`) + metrics-server, and
+# AdoNet Orleans clustering (Localhost cannot span the replicas KEDA adds).
+keda:
+  enabled: false
+  minReplicas: 2          # HA floor (also the Orleans cluster seed)
+  maxReplicas: 8
+  cpuTarget: 70           # % CPU utilization — scale up past this
+  memoryTarget: 80        # % memory utilization
+  cooldownPeriod: 300     # seconds idle before scaling toward min
+  scaleDownStabilizationSeconds: 600   # 10 min of calm before removing a pod
 # ---- External Ollama (local self-host) ------------------------------------
 # Front a host-native Ollama with an in-cluster Service so the portal addresses
 # it by name (http://ollama:11434/v1) instead of a host-gateway IP. On macOS the

--- a/memex/aspire/Memex.Database.Migration/Migrations/OrleansClusteringSetup.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/OrleansClusteringSetup.cs
@@ -433,5 +433,16 @@ VALUES
         AND Status = @Status AND @Status IS NOT NULL
         AND ProxyPort > 0;
 ');
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+VALUES
+(
+    'CleanupDefunctSiloEntriesKey','
+    DELETE FROM OrleansMembershipTable
+    WHERE DeploymentId = @DeploymentId
+        AND @DeploymentId IS NOT NULL
+        AND IAmAliveTime < @IAmAliveTime
+        AND Status != 3;
+');
 ";
 }


### PR DESCRIPTION
## What

Makes the portal horizontally scalable and durable at >1 replica, and fixes a migration bug that crash-loops silos under AdoNet clustering.

### Helm chart
- **`ConnectionStrings__orleans`** emitted on the portal + migration secrets, **gated on `Deployment:Orleans:Clustering=AdoNet`** — single-replica (Localhost) installs render exactly as before (verified: base template emits 0 orleans keys / 0 ScaledObject).
- **KEDA `ScaledObject`** (`memex-portal/scaledobject.yaml`, gated by `keda.enabled`): CPU 70% / memory 80% triggers, **min 2 / max 8**, fast scale-up (+2 pods/min), deliberately slow scale-down (1 pod after a 10-min calm window) because a Blazor Server circuit is stateful and every silo add/remove rebalances the Orleans cluster.
- AKS overlay (`values.aks.yaml`) enables KEDA (min 2) — the requested baseline.

### Migration fix
- Adds the missing **`CleanupDefunctSiloEntriesKey`** query to `OrleansClusteringSetup`'s membership script. The current Orleans version requires it; without it every silo crash-loops at startup on AdoNet (`Not all required queries found. Missing are: CleanupDefunctSiloEntriesKey`).

## Why it's safe / tested
Validated end-to-end on a throwaway 4-replica k3s portal **before** the prod cutover: 4 silos formed one cluster (no split-brain), KEDA HPA read live CPU/memory, and a 100-concurrent load run served all-2xx. The missing-query bug was caught there — it would otherwise have crash-looped the memex-cloud cutover.

## Deployment note
memex-cloud was already cut over live (surgical patches) and is running 2 AdoNet-clustered silos under KEDA. This PR makes that durable on `main` and correct for standard installs. memex-cloud manages its DB secret manually (external Flexible Server), so its `orleans` connection stays a manual override — same as its existing memex connection.

## What's New
Skipped — infra/deployment change, no user-visible UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)