### PR TITLE
Deck: default to nodeType:Slide scope:subtree; parser understands [path1, path2, …]

### DIFF
--- a/src/MeshWeaver.Graph/DeckLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/DeckLayoutAreas.cs
@@ -5,7 +5,9 @@ using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Layout;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MeshWeaver.Graph;
 
@@ -276,11 +278,51 @@ public static class DeckLayoutAreas
             .Select(node => ResolveSlidePaths(host, deckPath, node))
             .DistinctUntilChanged(paths => string.Join("\n", paths))
             .Select(paths => paths.Count == 0
-                ? Observable.Return((IReadOnlyList<(string, MeshNode?)>)ImmutableList<(string, MeshNode?)>.Empty)
+                // No explicit manifest → DEFAULT query: every Slide node under the deck, ordered by
+                // Order. A deck whose slides are simply its children needs no hardcoded array (the
+                // reported "deck has no slides yet" despite child slides existing).
+                ? ObserveDefaultSubtreeSlides(host, deckPath)
                 : Observable.CombineLatest(paths.Select(ObserveSlide(host)))
                     .Select(items => (IReadOnlyList<(string, MeshNode?)>)items.ToImmutableList()))
             .Switch()
             .StartWith((IReadOnlyList<(string, MeshNode?)>)ImmutableList<(string, MeshNode?)>.Empty);
+
+    /// <summary>
+    /// The deck's DEFAULT slide set when it carries no explicit <see cref="DeckContent.Slides"/>
+    /// manifest: the live result of <c>nodeType:Slide scope:subtree</c> under the deck path, ordered
+    /// by <see cref="MeshNode.Order"/> (null last), ties by path. This is what lets a deck be just "a
+    /// folder of slides" — presentation order falls out of the nodes' own Order, no hardcoded array.
+    /// </summary>
+    private static IObservable<IReadOnlyList<(string Path, MeshNode? Node)>> ObserveDefaultSubtreeSlides(
+        LayoutAreaHost host, string deckPath)
+    {
+        var meshService = host.Hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null)
+            return Observable.Return<IReadOnlyList<(string, MeshNode?)>>(
+                ImmutableList<(string, MeshNode?)>.Empty);
+
+        return meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"path:{deckPath} nodeType:{SlideNodeType.NodeType} scope:subtree"))
+            .Scan(ImmutableDictionary<string, MeshNode>.Empty, (map, change) =>
+            {
+                if (change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+                    return change.Items.ToImmutableDictionary(n => n.Path);
+                foreach (var item in change.Items)
+                    map = change.ChangeType switch
+                    {
+                        QueryChangeType.Added or QueryChangeType.Updated => map.SetItem(item.Path, item),
+                        QueryChangeType.Removed => map.Remove(item.Path),
+                        _ => map
+                    };
+                return map;
+            })
+            .Select(map => (IReadOnlyList<(string, MeshNode?)>)map.Values
+                .OrderBy(n => n.Order ?? int.MaxValue)
+                .ThenBy(n => n.Path, StringComparer.Ordinal)
+                .Select(n => (n.Path, (MeshNode?)n))
+                .ToImmutableList());
+    }
 
     /// <summary>One resolved slide stream: its path paired with the live node (null until it loads / if missing).</summary>
     private static Func<string, IObservable<(string Path, MeshNode? Node)>> ObserveSlide(LayoutAreaHost host)

--- a/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
+++ b/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
@@ -22,6 +22,16 @@ public partial class QueryParser
         if (string.IsNullOrWhiteSpace(query))
             return ParsedQuery.Empty;
 
+        // Explicit ORDERED path list: `[a, b, c]`. The "alternatively, specify the exact nodes
+        // in order" surface (a Deck's explicit slide manifest, vs. the default
+        // `nodeType:Slide scope:subtree`). It populates the SAME Paths list as `path:a|b|c` — so
+        // backends push it down as `WHERE path IN (...)` — but ORDER-PRESERVING, so an
+        // order-sensitive consumer (deck slide sequence) can present in the listed order. Entries
+        // are trimmed; blanks dropped. A bare bracket list is a WHOLE-query form (not composed
+        // with other qualifiers).
+        if (TryParseBracketPathList(query, out var listPaths))
+            return ParsedQuery.Empty with { Paths = listPaths, Path = listPaths[0] };
+
         var tokens = Tokenize(query);
         var (filterTokens, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths) = ExtractReservedQualifiers(tokens);
 
@@ -34,6 +44,29 @@ public partial class QueryParser
         }
 
         return new ParsedQuery(filter, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths);
+    }
+
+    /// <summary>
+    /// Recognizes a whole-query explicit path list <c>[a, b, c]</c> and returns its ordered,
+    /// trimmed, non-blank entries. Returns <c>false</c> (and null) when the query is not a
+    /// bracket list or contains no entries.
+    /// </summary>
+    private static bool TryParseBracketPathList(string query, out IReadOnlyList<string> paths)
+    {
+        paths = System.Array.Empty<string>();
+        var trimmed = query.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '[' || trimmed[^1] != ']')
+            return false;
+        var inner = trimmed[1..^1];
+        var entries = inner
+            .Split(',')
+            .Select(s => s.Trim())
+            .Where(s => s.Length > 0)
+            .ToArray();
+        if (entries.Length == 0)
+            return false;
+        paths = entries;
+        return true;
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeckLayoutAreaTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeckLayoutAreaTest.cs
@@ -202,6 +202,37 @@ public class DeckLayoutAreaTest(ITestOutputHelper output) : MonolithMeshTestBase
     }
 
     /// <summary>
+    /// A deck with NO explicit manifest (empty <see cref="DeckContent.Slides"/>) must fall back to the
+    /// DEFAULT query <c>nodeType:Slide scope:subtree</c> — every Slide node under the deck, ordered by
+    /// <see cref="MeshNode.Order"/>. Without this, a deck whose slides live as children but that carries
+    /// no hardcoded array renders "no slides yet" even though its slides exist (the reported bug). Here
+    /// two child slides (Order 1, 2) must present in Order despite no manifest.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task DeckPresent_NoManifest_DefaultsToSubtreeSlideQuery_InOrder()
+    {
+        var space = await CreateSpaceNode();
+        var deck = $"{space}/auto";
+        await CreateDeckNode(deck, "Auto Deck", ImmutableList<string>.Empty); // NO manifest
+
+        // Two slides live as children of the deck; created out of order, Order rules.
+        await CreateSlide($"{deck}/second", "Second", 2, "# Second\n\nthe-second-body");
+        await CreateSlide($"{deck}/first", "First", 1, "# First\n\nthe-first-body");
+
+        var workspace = GetClient(c => c.AddData()).GetWorkspace();
+
+        // i=0 → lowest-Order subtree slide = First; next drives to the second.
+        await AssertDeckPresentSlide(workspace, deck, index: 0,
+            expectBody: "the-first-body", expectCounter: "Slide 1 / 2",
+            expectPrev: null, expectNext: $"/{deck}/Present?i=1");
+        await AssertDeckPresentSlide(workspace, deck, index: 1,
+            expectBody: "the-second-body", expectCounter: "Slide 2 / 2",
+            expectPrev: $"/{deck}/Present?i=0", expectNext: null);
+
+        await NodeFactory.DeleteNode(space).Should().Emit();
+    }
+
+    /// <summary>
     /// The SAME slide path, referenced by TWO decks in OPPOSITE orders, presents in each deck's own
     /// order — proving presentation order lives on the deck, not the slide. Deck1 = [X, Y] shows X
     /// first; Deck2 = [Y, X] shows Y first — from the identical two slide nodes.

--- a/test/MeshWeaver.Query.Test/QueryParserTests.cs
+++ b/test/MeshWeaver.Query.Test/QueryParserTests.cs
@@ -184,6 +184,29 @@ public class QueryParserTests
         result.Paths.Should().BeNull();
     }
 
+    [Fact]
+    public void Parse_BracketList_PopulatesOrderedPaths()
+    {
+        // The [a, b, c] surface is an EXPLICIT, ORDERED list of node paths — the
+        // "alternatively specify the exact slides" form for a Deck's manifest. It
+        // populates the SAME Paths list as path:a|b|c (so backends push it down as
+        // WHERE path IN (...)), but the ORDER is preserved in Paths for order-sensitive
+        // consumers (a deck presents its slides in the listed order).
+        var result = _parser.Parse("[foo/bar/baz, foo/bar, foo]");
+
+        result.Paths.Should().Equal("foo/bar/baz", "foo/bar", "foo");
+        result.Path.Should().Be("foo/bar/baz");
+    }
+
+    [Fact]
+    public void Parse_BracketList_SingleEntry()
+    {
+        var result = _parser.Parse("[only/one]");
+
+        result.Paths.Should().Equal("only/one");
+        result.Path.Should().Be("only/one");
+    }
+
     // ─── SQL-function selectors in sort: ───
     // `sort:length(path)-desc` — function-call syntax in the sort selector lets
     // backends emit `ORDER BY length(n.path) DESC` without hardcoding sort


### PR DESCRIPTION
## The report

A deck rendered **"This deck has no slides yet"** even though its slide nodes exist. I first mis-diagnosed this as a `ContentAs`/`JsonElement` deserialization bug and wrote a hack — that was wrong (reverted): the deck's manifest deserializes fine, and the data was never corrupt. The real gap: a deck whose slides are simply its **children** had no way to find them without a hardcoded array.

Two changes, both **test-first** (red test → implement → green):

## 1. Query parser understands `[path1, path2, …]`

An explicit **ordered** path list is now a recognized query form, populating the existing `ParsedQuery.Paths` order-preserving — so `GetQuery` / `IMeshService.Query` resolve exactly those nodes in that order. It's the array surface of the existing `path:a|b|c` alternation — the "alternatively, specify the exact slides in order" form.

Tests: `Parse_BracketList_PopulatesOrderedPaths`, `Parse_BracketList_SingleEntry`.

## 2. Deck defaults to `nodeType:Slide scope:subtree`

When a deck carries **no explicit manifest**, its slide set now defaults to the live query `nodeType:Slide scope:subtree` under the deck path, ordered by `MeshNode.Order`. A deck can be just "a folder of slides" — no hardcoded array required. An explicit manifest still rules when present.

Test: `DeckPresent_NoManifest_DefaultsToSubtreeSlideQuery_InOrder` — a deck with two child slides and no manifest was red ("no slides yet"), now presents them in Order.

## Verification

`QueryParserTests` 79/79, `DeckLayoutAreaTest` 6/6, `SlideLayoutAreaTest` 3/3; full solution builds Release `-warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)