### PR TITLE
GitSync: sync git-committed content-collection binaries into the mesh (stop wiping course videos)

### DIFF
--- a/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
@@ -26,12 +26,119 @@ public static class ContentImportExtensions
     public static ContentImportBuilder ImportContent(this IMessageHub hub, string nodePath)
         => new(hub, nodePath);
 
+    /// <summary>Begin a fluent inline content sync targeting <paramref name="nodePath"/>'s hub.</summary>
+    public static SyncContentFilesBuilder SyncContentFiles(this IMessageHub hub, string nodePath)
+        => new(hub, nodePath);
+
     /// <summary>
-    /// Registers the <see cref="ImportContentRequest"/> handler. Wired into
-    /// <c>AddContentCollectionsInfrastructure</c> so every content-enabled node hub can receive an import.
+    /// Registers the <see cref="ImportContentRequest"/> + <see cref="SyncContentFilesRequest"/> handlers.
+    /// Wired into <c>AddContentCollectionsInfrastructure</c> so every content-enabled node hub can
+    /// receive a collection→collection import AND an inline (byte-carrying) content mirror.
     /// </summary>
     internal static MessageHubConfiguration AddContentImportHandler(this MessageHubConfiguration config)
-        => config.WithHandler<ImportContentRequest>(HandleImportContent);
+        => config
+            .WithHandler<ImportContentRequest>(HandleImportContent)
+            .WithHandler<SyncContentFilesRequest>(HandleSyncContentFiles);
+
+    private static IMessageDelivery HandleSyncContentFiles(
+        IMessageHub hub, IMessageDelivery<SyncContentFilesRequest> delivery)
+    {
+        var request = delivery.Message;
+        var contentService = hub.ServiceProvider.GetService<IContentService>();
+        if (contentService is null)
+        {
+            hub.Post(ImportContentResponse.Fail("Content collections not configured on this node"),
+                o => o.ResponseFor(delivery));
+            return delivery.Processed();
+        }
+
+        // The hub action block only subscribes + returns; every I/O leaf runs on the
+        // collection's own pool — this layer is pure reactive composition.
+        SyncFiles(contentService, request)
+            .Subscribe(
+                count => hub.Post(ImportContentResponse.Ok(count), o => o.ResponseFor(delivery)),
+                ex => hub.Post(ImportContentResponse.Fail(ex.Message), o => o.ResponseFor(delivery)));
+
+        return delivery.Processed();
+    }
+
+    /// <summary>
+    /// Writes each inline file under <c>TargetPath</c> (binary-safe — the bytes are streamed straight
+    /// into the collection, never through the text API), then — when <c>Mirror</c> — deletes any file
+    /// already under <c>TargetPath</c> that the incoming set does not carry, so the folder mirrors the
+    /// supplied set exactly. Returns the number of files written.
+    /// </summary>
+    private static IObservable<int> SyncFiles(IContentService contentService, SyncContentFilesRequest request)
+        => contentService.GetCollection(request.CollectionName)
+            .Select(target => target
+                ?? throw new InvalidOperationException($"Target content collection '{request.CollectionName}' not found"))
+            .SelectMany(target =>
+            {
+                var baseDir = (request.TargetPath ?? string.Empty).Trim('/');
+                // Full collection-relative path of an incoming file (baseDir + its relative Path).
+                string FullPath(string rel)
+                {
+                    var r = rel.Replace('\\', '/').TrimStart('/');
+                    return baseDir.Length == 0 ? r : $"{baseDir}/{r}";
+                }
+
+                var writes = request.Files.Count == 0
+                    ? Observable.Return(0)
+                    : request.Files
+                        .Select(f =>
+                        {
+                            var full = FullPath(f.Path);
+                            var slash = full.LastIndexOf('/');
+                            var dir = slash < 0 ? string.Empty : full[..slash];
+                            var name = slash < 0 ? full : full[(slash + 1)..];
+                            // Fresh MemoryStream per subscribe (SaveFile disposes it), bytes are immutable.
+                            return target.SaveFile(dir, name, () => new MemoryStream(f.Content, writable: false))
+                                .Select(_ => 1);
+                        })
+                        .Concat()
+                        .Sum();
+
+                if (!request.Mirror)
+                    return writes;
+
+                var keep = request.Files
+                    .Select(f => FullPath(f.Path))
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                // Prune AFTER writing: enumerate the folder's current files, delete those not kept.
+                // EnumerateAllFiles yields collection-relative paths; a delete of an absent file is
+                // tolerated (best-effort) so a concurrent external delete never fails the mirror.
+                return writes.SelectMany(written =>
+                    EnumerateAllFiles(target, baseDir)
+                        .Where(path => !keep.Contains(path))
+                        .Select(path => target.DeleteFile(path)
+                            .Select(_ => 0)
+                            .Catch<int, Exception>(_ => Observable.Return(0)))
+                        .Concat()
+                        .Sum()
+                        .Select(_ => written));
+            });
+
+    /// <summary>
+    /// Recursively enumerates every file at or under <paramref name="folder"/> in the collection,
+    /// yielding each file's collection-relative path. Folders are walked depth-first; the enumeration
+    /// leaves run on the collection's own pool.
+    /// </summary>
+    private static IObservable<string> EnumerateAllFiles(ContentCollection collection, string folder)
+    {
+        // A not-yet-created folder (no file has ever been written there) surfaces as a
+        // DirectoryNotFoundException on some providers — treat it as "no files", never a mirror fault.
+        var files = collection.GetFiles(folder)
+            .Select(f => NormalizePath(f.Path))
+            .Catch<string, DirectoryNotFoundException>(_ => Observable.Empty<string>());
+        var sub = collection.GetFolders(folder)
+            .Catch<FolderItem, DirectoryNotFoundException>(_ => Observable.Empty<FolderItem>())
+            .SelectMany(sf => EnumerateAllFiles(collection, NormalizePath(sf.Path)));
+        return files.Concat(sub);
+    }
+
+    /// <summary>Collection-relative path form used for compare/delete: forward slashes, no leading slash.</summary>
+    private static string NormalizePath(string path) => path.Replace('\\', '/').TrimStart('/');
 
     private static IMessageDelivery HandleImportContent(
         IMessageHub hub, IMessageDelivery<ImportContentRequest> delivery)
@@ -139,6 +246,76 @@ public sealed class ContentImportBuilder
         // Typed request-response: pre-registers the response callback by message-id BEFORE posting
         // (canonical hub.Observe<TResponse> idiom) — no manual Post returning a nullable delivery.
         // Wrapped in Defer so the post still happens on Subscribe (cold), as before.
+        return Observable.Defer(() => _hub
+            .Observe(request, o => o.WithTarget(address))
+            .Select(d => d.Message)
+            .Take(1));
+    }
+}
+
+/// <summary>
+/// Fluent builder for <see cref="ContentImportExtensions.SyncContentFiles"/> — write git-committed
+/// (or otherwise in-memory) binaries into a node's content collection, carrying the BYTES inline:
+/// <code>
+/// hub.SyncContentFiles("AgenticEngineering")               // the hub where "content" resolves (the Space root)
+///    .To("content", "TDD")                                  // collection + folder (owning node's path within the Space)
+///    .Add("x.png", pngBytes)
+///    .Mirror(true)                                          // delete files under "TDD" no longer supplied
+///    .Post();                                               // IObservable&lt;ImportContentResponse&gt;
+/// </code>
+/// </summary>
+public sealed class SyncContentFilesBuilder
+{
+    private readonly IMessageHub _hub;
+    private readonly string _nodePath;
+    private string _targetCollection = ContentCollectionsExtensions.DefaultCollectionName;
+    private string _targetPath = "";
+    private bool _mirror = true;
+    private readonly List<InlineContentFile> _files = new();
+
+    internal SyncContentFilesBuilder(IMessageHub hub, string nodePath)
+    {
+        _hub = hub;
+        _nodePath = nodePath;
+    }
+
+    /// <summary>Target content collection (default <c>"content"</c>) + folder within it.</summary>
+    public SyncContentFilesBuilder To(string targetCollection, string targetPath = "")
+    {
+        _targetCollection = targetCollection;
+        _targetPath = targetPath;
+        return this;
+    }
+
+    /// <summary>Adds a file, whose <paramref name="path"/> is relative to the target folder.</summary>
+    public SyncContentFilesBuilder Add(string path, byte[] content)
+    {
+        _files.Add(new InlineContentFile(path, content));
+        return this;
+    }
+
+    /// <summary>Adds a set of inline files (paths relative to the target folder).</summary>
+    public SyncContentFilesBuilder Add(IEnumerable<InlineContentFile> files)
+    {
+        _files.AddRange(files);
+        return this;
+    }
+
+    /// <summary>Whether to delete files under the target folder that are not in the supplied set (default true).</summary>
+    public SyncContentFilesBuilder Mirror(bool mirror)
+    {
+        _mirror = mirror;
+        return this;
+    }
+
+    /// <summary>Post the sync to the target node's hub. Cold — subscribe to run.</summary>
+    public IObservable<ImportContentResponse> Post()
+    {
+        var request = new SyncContentFilesRequest(_targetCollection, _targetPath, _files.ToArray())
+        {
+            Mirror = _mirror,
+        };
+        var address = new Address(_nodePath);
         return Observable.Defer(() => _hub
             .Observe(request, o => o.WithTarget(address))
             .Select(d => d.Message)

--- a/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
@@ -75,6 +75,18 @@ public static class ContentImportExtensions
             .SelectMany(target =>
             {
                 var baseDir = (request.TargetPath ?? string.Empty).Trim('/');
+                // 🚨 Never let a caller-supplied path escape the collection root. The file-system
+                // provider joins baseDir/path onto its BasePath, so a "../" (or a rooted / segment)
+                // would write/delete OUTSIDE the collection. Reject the whole request up front rather
+                // than sanitize-and-continue — a traversal attempt is a bug or an attack, not a typo.
+                if (!IsSafeCollectionPath(baseDir))
+                    return Observable.Throw<int>(new InvalidOperationException(
+                        $"Unsafe TargetPath '{request.TargetPath}' (empty, rooted, or contains '.'/'..')."));
+                foreach (var f in request.Files)
+                    if (string.IsNullOrWhiteSpace(f.Path) || !IsSafeCollectionPath(f.Path))
+                        return Observable.Throw<int>(new InvalidOperationException(
+                            $"Unsafe content file path '{f.Path}' (empty, rooted, or contains '.'/'..')."));
+
                 // Full collection-relative path of an incoming file (baseDir + its relative Path).
                 string FullPath(string rel)
                 {
@@ -139,6 +151,23 @@ public static class ContentImportExtensions
 
     /// <summary>Collection-relative path form used for compare/delete: forward slashes, no leading slash.</summary>
     private static string NormalizePath(string path) => path.Replace('\\', '/').TrimStart('/');
+
+    /// <summary>
+    /// True when <paramref name="path"/> is a safe collection-relative path: it stays within the
+    /// collection root. An empty path is the root (allowed). Rooted paths (leading <c>/</c> or
+    /// <c>\</c>) and any <c>.</c>/<c>..</c> segment are rejected — those escape the root when joined
+    /// onto the provider's BasePath. A Windows drive/rooted path is likewise rejected.
+    /// </summary>
+    private static bool IsSafeCollectionPath(string path)
+    {
+        if (path.Length == 0)
+            return true;
+        var norm = path.Replace('\\', '/');
+        if (norm.StartsWith('/') || System.IO.Path.IsPathRooted(path))
+            return false;
+        return norm.Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .All(seg => seg is not ("." or ".."));
+    }
 
     private static IMessageDelivery HandleImportContent(
         IMessageHub hub, IMessageDelivery<ImportContentRequest> delivery)

--- a/src/MeshWeaver.GitSync/ContentAssetMapper.cs
+++ b/src/MeshWeaver.GitSync/ContentAssetMapper.cs
@@ -37,16 +37,34 @@ public static class ContentAssetMapper
     public record ContentAsset(string OwnerRelativePath, string FileRelativePath, byte[] Bytes);
 
     /// <summary>
+    /// Cheap path-only precheck: could <paramref name="repoRelativePath"/> be a content asset at all?
+    /// True iff it has a <c>content</c> path segment that is not the last segment. Lets a caller skip
+    /// materializing a file's bytes for the common case (a node file, never under <c>content/</c>).
+    /// </summary>
+    public static bool IsContentPath(string repoRelativePath)
+        => TrySplit(repoRelativePath, out _, out _);
+
+    /// <summary>
     /// Classifies a subdirectory-relative repo path as a content asset, or returns null when it is NOT
     /// under any node's <c>content/</c> folder (so it flows on to node parsing). A path whose FIRST
     /// segment is <c>content</c> belongs to the Space root; a deeper <c>content</c> segment names the
     /// owning node's folder. A path that is exactly <c>content</c> or ends right at a <c>content</c>
-    /// segment (no file after it) is not an asset.
+    /// segment (no file after it) is not an asset. The <paramref name="bytes"/> factory is invoked
+    /// ONLY when the path actually classifies — so a large repo pays no per-file byte cost for its
+    /// (majority) node files.
     /// </summary>
-    public static ContentAsset? TryClassify(string repoRelativePath, byte[] bytes)
+    public static ContentAsset? TryClassify(string repoRelativePath, Func<byte[]> bytes)
+        => TrySplit(repoRelativePath, out var owner, out var file)
+            ? new ContentAsset(owner, file, bytes())
+            : null;
+
+    /// <summary>Path-only classification: splits a content path into (owner, file) or returns false.</summary>
+    private static bool TrySplit(string repoRelativePath, out string owner, out string file)
     {
+        owner = string.Empty;
+        file = string.Empty;
         if (string.IsNullOrEmpty(repoRelativePath))
-            return null;
+            return false;
         var segments = repoRelativePath.Replace('\\', '/').Trim('/')
             .Split('/', StringSplitOptions.RemoveEmptyEntries);
         // Find the FIRST "content" segment — but never at the very end (no file follows it).
@@ -54,13 +72,14 @@ public static class ContentAssetMapper
         {
             if (!string.Equals(segments[i], ContentSegment, StringComparison.OrdinalIgnoreCase))
                 continue;
-            var owner = string.Join('/', segments.Take(i));
-            var file = string.Join('/', segments.Skip(i + 1));
-            if (file.Length == 0)
-                return null;
-            return new ContentAsset(owner, file, bytes);
+            var f = string.Join('/', segments.Skip(i + 1));
+            if (f.Length == 0)
+                return false;
+            owner = string.Join('/', segments.Take(i));
+            file = f;
+            return true;
         }
-        return null;
+        return false;
     }
 
     /// <summary>

--- a/src/MeshWeaver.GitSync/ContentAssetMapper.cs
+++ b/src/MeshWeaver.GitSync/ContentAssetMapper.cs
@@ -1,0 +1,92 @@
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// Maps a repo's git-committed <b>content-collection assets</b> — the raw files under a node's
+/// <c>content/</c> folder (<c>{node}/content/**</c>: course videos, posters, fonts, images) — onto the
+/// mesh's per-Space <c>content</c> collection, so a GitSync import can MIRROR them in (the fix for
+/// content that was never synced from git and so "disappeared" on every sync).
+///
+/// <para>The per-Space <c>content</c> collection is mounted on the partition ROOT (children inherit it)
+/// and served at <c>/static/storage/content/{nodePath}/{file}</c> — i.e. a <c>content:</c> reference on
+/// node <c>{Space}/A/B</c> resolves under collection-relative path <c>A/B/{file}</c>. So a repo file
+/// (subdirectory-relative, i.e. relative to the Space) is a content asset iff it has a path segment
+/// exactly <c>content</c>; the segments BEFORE it are the owning node's Space-relative path (which is
+/// also the collection sub-folder), and the segments AFTER it are the file's path within that folder.</para>
+///
+/// <list type="bullet">
+///   <item><c>content/videos/x.mp4</c> → owner = Space root, folder = <c>""</c>, file = <c>videos/x.mp4</c>.</item>
+///   <item><c>TDD/content/x.png</c> → owner = <c>{Space}/TDD</c>, folder = <c>TDD</c>, file = <c>x.png</c>.</item>
+/// </list>
+/// The NEAREST <c>content</c> segment wins (the first one), so a nested <c>A/content/B/content/y</c> maps
+/// to owner <c>{Space}/A</c>, file <c>B/content/y</c> — the deeper "content" is just a folder name.
+/// </summary>
+public static class ContentAssetMapper
+{
+    /// <summary>The reserved folder segment that marks a node's content-collection subtree.</summary>
+    public const string ContentSegment = "content";
+
+    /// <summary>
+    /// A single classified content asset: which node owns it, where it lives within the content
+    /// collection, and its bytes.
+    /// </summary>
+    /// <param name="OwnerRelativePath">The owning node's path relative to the Space (empty for the Space root).</param>
+    /// <param name="FileRelativePath">The file's path within the owning node's content folder (e.g. <c>videos/x.mp4</c>).</param>
+    /// <param name="Bytes">The file's raw bytes.</param>
+    public record ContentAsset(string OwnerRelativePath, string FileRelativePath, byte[] Bytes);
+
+    /// <summary>
+    /// Classifies a subdirectory-relative repo path as a content asset, or returns null when it is NOT
+    /// under any node's <c>content/</c> folder (so it flows on to node parsing). A path whose FIRST
+    /// segment is <c>content</c> belongs to the Space root; a deeper <c>content</c> segment names the
+    /// owning node's folder. A path that is exactly <c>content</c> or ends right at a <c>content</c>
+    /// segment (no file after it) is not an asset.
+    /// </summary>
+    public static ContentAsset? TryClassify(string repoRelativePath, byte[] bytes)
+    {
+        if (string.IsNullOrEmpty(repoRelativePath))
+            return null;
+        var segments = repoRelativePath.Replace('\\', '/').Trim('/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries);
+        // Find the FIRST "content" segment — but never at the very end (no file follows it).
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            if (!string.Equals(segments[i], ContentSegment, StringComparison.OrdinalIgnoreCase))
+                continue;
+            var owner = string.Join('/', segments.Take(i));
+            var file = string.Join('/', segments.Skip(i + 1));
+            if (file.Length == 0)
+                return null;
+            return new ContentAsset(owner, file, bytes);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Builds the SINGLE whole-collection <see cref="StaticContentSync"/> for a Space, ready for
+    /// <see cref="IStaticRepoSource.EnumerateInlineContentSyncs"/>. The per-Space <c>content</c>
+    /// collection is ONE physical store (mounted on the Space root, children inherit it), so the mirror
+    /// must be ONE authoritative pass over the whole collection against the FULL repo content set — not
+    /// per-owner passes, which would overlap (the root owner's pass recurses into a module owner's
+    /// folder and would prune it). Each asset keeps its full collection-relative path
+    /// <c>{owner}/{file}</c> (matching the served <c>content:</c> URL on the owning node), and
+    /// <c>TargetPath</c> is empty (the collection root). Returns an empty list when there are no assets
+    /// (so a repo carrying zero content leaves the collection completely untouched — no empty mirror
+    /// that would wipe a manually-uploaded file the repo simply doesn't track).
+    /// </summary>
+    public static IReadOnlyList<StaticContentSync> ToContentSyncs(
+        string spaceId, IEnumerable<ContentAsset> assets, string collectionName = "content")
+    {
+        var files = assets
+            .Select(a => new InlineContentFile(
+                a.OwnerRelativePath.Length == 0 ? a.FileRelativePath : $"{a.OwnerRelativePath}/{a.FileRelativePath}",
+                a.Bytes))
+            .GroupBy(f => f.Path, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToArray();
+        return files.Length == 0
+            ? []
+            : [new StaticContentSync(spaceId, files, collectionName, TargetPath: "")];
+    }
+}

--- a/src/MeshWeaver.GitSync/GitHubModels.cs
+++ b/src/MeshWeaver.GitSync/GitHubModels.cs
@@ -2,8 +2,26 @@ using System.Collections.Immutable;
 
 namespace MeshWeaver.GitSync;
 
-/// <summary>A single file in a repo tree — repo-relative <paramref name="Path"/> + UTF-8 text <paramref name="Content"/>.</summary>
-public record RepoFile(string Path, string Content);
+/// <summary>
+/// A single file in a repo tree — repo-relative <paramref name="Path"/> plus its bytes. A TEXT file
+/// carries its UTF-8 text in <paramref name="Content"/> (and <see cref="Binary"/> is null). A BINARY
+/// file (a course video/poster committed under <c>{node}/content/**</c>, a font, any non-UTF-8 blob)
+/// carries its raw bytes in <see cref="Binary"/> — <paramref name="Content"/> is then empty, because
+/// round-tripping arbitrary bytes through a UTF-8 string corrupts them (the bug that repeatedly nuked
+/// the course videos: the fetch decoded a base64 <c>.mp4</c> blob as UTF-8 and mangled it). Use
+/// <see cref="Bytes"/> to read the raw content regardless of kind.
+/// </summary>
+/// <param name="Path">The repo-relative file path.</param>
+/// <param name="Content">The file's UTF-8 text (empty for a binary file — read <see cref="Bytes"/>).</param>
+/// <param name="Binary">The file's raw bytes when it is NOT valid UTF-8 text; null for a text file.</param>
+public record RepoFile(string Path, string Content, byte[]? Binary = null)
+{
+    /// <summary>True when this file holds raw (non-text) bytes that must never pass through the text API.</summary>
+    public bool IsBinary => Binary is not null;
+
+    /// <summary>The file's raw bytes: <see cref="Binary"/> for a binary file, else the UTF-8 encoding of <see cref="Content"/>.</summary>
+    public byte[] Bytes => Binary ?? System.Text.Encoding.UTF8.GetBytes(Content);
+}
 
 /// <summary>
 /// A request to mirror a set of files into a GitHub repository as a single commit.

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -416,22 +416,36 @@ public sealed class GitHubSyncService
         return repoClient.Fetch(repoUrl, commitish, subdirectory, token).SelectMany(snapshot =>
             ParseSnapshot(snapshot, spaceId, ignore, progress).SelectMany(parsed =>
             {
-                var source = new InMemoryStaticRepoSource(spaceId, parsed.Children, parsed.Root);
+                var source = new InMemoryStaticRepoSource(
+                    spaceId, parsed.Children, parsed.Root, parsed.ContentSyncs);
                 return StaticRepoImporter.ImportSource(hub, source, logger)
                     .Select(result => (result, snapshot.CommitSha));
             }));
     }
 
-    private IObservable<(MeshNode? Root, IReadOnlyList<MeshNode> Children)> ParseSnapshot(
+    private IObservable<(MeshNode? Root, IReadOnlyList<MeshNode> Children, IReadOnlyList<StaticContentSync> ContentSyncs)> ParseSnapshot(
         RepoSnapshot snapshot, string spaceId, SyncIgnore ignore, Action<string, LogLevel>? progress = null)
     {
         if (snapshot.Files.Count == 0)
-            return Observable.Return(((MeshNode?)null, (IReadOnlyList<MeshNode>)Array.Empty<MeshNode>()));
-        return snapshot.Files
-            // The Space's ignore rules apply on import too — a repo that carries ignored paths
-            // (e.g. Release/ bookkeeping from an older export) must not re-create those nodes.
-            .Where(f => !ignore.IsIgnored(f.Path))
-            .Select(f => ParseFile(f, spaceId, progress))
+            return Observable.Return(((MeshNode?)null, (IReadOnlyList<MeshNode>)Array.Empty<MeshNode>(),
+                (IReadOnlyList<StaticContentSync>)Array.Empty<StaticContentSync>()));
+
+        // Apply the Space's ignore rules on import too — a repo that carries ignored paths (e.g.
+        // Release/ bookkeeping from an older export) must not re-create those nodes NOR re-sync their
+        // content. Then split off the git-committed content-collection assets ({node}/content/**):
+        // their raw bytes are mirrored into the owning node's content collection (never parsed as a
+        // node), so committed course videos/posters land and stop getting wiped. Everything else flows
+        // to node parsing as before.
+        var kept = snapshot.Files.Where(f => !ignore.IsIgnored(f.Path)).ToArray();
+        var classified = kept
+            .Select(f => (File: f, Asset: ContentAssetMapper.TryClassify(f.Path, f.Bytes)))
+            .ToArray();
+        var contentSyncs = ContentAssetMapper.ToContentSyncs(
+            spaceId, classified.Where(c => c.Asset is not null).Select(c => c.Asset!));
+
+        return classified
+            .Where(c => c.Asset is null)
+            .Select(c => ParseFile(c.File, spaceId, progress))
             .Merge(8)
             .Where(x => x.Node is not null)
             .ToList()
@@ -439,7 +453,7 @@ public sealed class GitHubSyncService
             {
                 var root = list.FirstOrDefault(x => x.IsRoot).Node;
                 var children = list.Where(x => !x.IsRoot).Select(x => x.Node!).ToList();
-                return (root, (IReadOnlyList<MeshNode>)children);
+                return (root, (IReadOnlyList<MeshNode>)children, contentSyncs);
             });
     }
 

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -437,8 +437,12 @@ public sealed class GitHubSyncService
         // node), so committed course videos/posters land and stop getting wiped. Everything else flows
         // to node parsing as before.
         var kept = snapshot.Files.Where(f => !ignore.IsIgnored(f.Path)).ToArray();
+        // Cheap path-only precheck first (no byte materialization for the common node file), then
+        // classify only the content paths — f.Bytes is realized ONLY for an actual content asset.
         var classified = kept
-            .Select(f => (File: f, Asset: ContentAssetMapper.TryClassify(f.Path, f.Bytes)))
+            .Select(f => (File: f, Asset: ContentAssetMapper.IsContentPath(f.Path)
+                ? ContentAssetMapper.TryClassify(f.Path, () => f.Bytes)
+                : null))
             .ToArray();
         var contentSyncs = ContentAssetMapper.ToContentSyncs(
             spaceId, classified.Where(c => c.Asset is not null).Select(c => c.Asset!));

--- a/src/MeshWeaver.GitSync/InMemoryStaticRepoSource.cs
+++ b/src/MeshWeaver.GitSync/InMemoryStaticRepoSource.cs
@@ -11,14 +11,23 @@ namespace MeshWeaver.GitSync;
 /// static-repo sources do. <see cref="Versioned"/> is false so the fingerprint hashes
 /// content (the commit's files), making a re-import at a different commit a new
 /// fingerprint that re-syncs and an identical commit a no-op.
+///
+/// <para>Beyond the node files, the repo's git-committed content-collection assets — the raw
+/// binaries under <c>{node}/content/**</c> (course videos/posters, fonts, images) — are captured
+/// as <see cref="StaticContentSync"/> groups and returned from
+/// <see cref="EnumerateInlineContentSyncs"/>, so the importer MIRRORS them into the owning node's
+/// content collection after the node upsert. Binary-safe (bytes travel intact) and mirroring, so
+/// committed content lands and stops getting wiped by a re-import.</para>
 /// </summary>
 internal sealed class InMemoryStaticRepoSource(
     string partition,
     IReadOnlyList<MeshNode> children,
-    MeshNode? root) : IStaticRepoSource
+    MeshNode? root,
+    IReadOnlyList<StaticContentSync>? contentSyncs = null) : IStaticRepoSource
 {
     public string Partition => partition;
     public bool Versioned => false;
     public IReadOnlyList<MeshNode> EnumerateSourceNodes() => children;
     public MeshNode? PartitionRoot => root;
+    public IReadOnlyList<StaticContentSync> EnumerateInlineContentSyncs() => contentSyncs ?? [];
 }

--- a/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
@@ -184,9 +184,9 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
 
                 return blobs
                     .Select(e => Http.InvokeObservable(ct => client.Git.Blob.Get(owner, repo, e.Sha))
-                        .Select(blob => new RepoFile(
+                        .Select(blob => ToRepoFile(
                             prefix.Length == 0 ? e.Path : e.Path[prefix.Length..],
-                            DecodeBlob(blob))))
+                            blob)))
                     .Merge(8)
                     .ToList()
                     .Select(list => new RepoSnapshot(head.CommitSha!, (IReadOnlyList<RepoFile>)list));
@@ -653,10 +653,45 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
             ? Http.InvokeObservable(ct => client.Git.Reference.Update(owner, repo, $"heads/{branch}", new ReferenceUpdate(commitSha)))
             : Http.InvokeObservable(ct => client.Git.Reference.Create(owner, repo, new NewReference($"refs/heads/{branch}", commitSha)));
 
-    private static string DecodeBlob(Blob blob) =>
-        string.Equals(blob.Encoding.StringValue, "base64", StringComparison.OrdinalIgnoreCase)
-            ? Encoding.UTF8.GetString(Convert.FromBase64String(blob.Content))
-            : blob.Content;
+    /// <summary>
+    /// Builds a <see cref="RepoFile"/> from a fetched blob, PRESERVING BINARY BYTES. A base64 blob is
+    /// decoded to raw bytes; if those bytes are valid UTF-8 the file is a text <see cref="RepoFile"/>
+    /// (so node/markdown parsing is unchanged), otherwise the raw bytes are carried in
+    /// <see cref="RepoFile.Binary"/>. This is the fix for the corruption that repeatedly nuked the
+    /// course videos: the old <c>DecodeBlob</c> UTF-8-decoded a base64 <c>.mp4</c>/<c>.png</c> blob
+    /// into a string, mangling every non-UTF-8 byte. A non-base64 (already-utf8) blob stays text.
+    /// </summary>
+    private static RepoFile ToRepoFile(string path, Blob blob)
+    {
+        if (!string.Equals(blob.Encoding.StringValue, "base64", StringComparison.OrdinalIgnoreCase))
+            return new RepoFile(path, blob.Content);
+        var bytes = Convert.FromBase64String(blob.Content);
+        return TryDecodeUtf8(bytes, out var text)
+            ? new RepoFile(path, text)
+            : new RepoFile(path, string.Empty, bytes);
+    }
+
+    /// <summary>
+    /// True + the decoded text when <paramref name="bytes"/> is valid UTF-8; false for binary content.
+    /// Uses a strict (throw-on-invalid) UTF-8 decoder so an arbitrary byte stream (a video, a font) is
+    /// classified binary rather than silently lossily decoded.
+    /// </summary>
+    private static bool TryDecodeUtf8(byte[] bytes, out string text)
+    {
+        try
+        {
+            text = StrictUtf8.GetString(bytes);
+            return true;
+        }
+        catch (DecoderFallbackException)
+        {
+            text = string.Empty;
+            return false;
+        }
+    }
+
+    private static readonly Encoding StrictUtf8 =
+        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
     private static string NormalizePrefix(string? subdirectory)
     {

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -658,10 +658,17 @@ public static class StaticRepoImporter
                     return pruned.SelectMany(prunedCount =>
                         // Sync content-collection files (the assets behind @@content/<file> embeds)
                         // collection→collection into each owning node — AFTER the node upsert.
-                        SyncContentImports(hub, source, logger).SelectMany(contentCount =>
+                        SyncContentImports(hub, source, logger).SelectMany(embedCount =>
+                        // Mirror inline (byte-carrying) content into each owning node's content
+                        // collection — the git-committed {Space}/content/** binaries a GitSync import
+                        // supplies. Binary-safe + mirroring (writes what the repo has, prunes what it
+                        // dropped) so committed course videos/posters land and stop getting wiped.
+                        SyncInlineContent(hub, source, logger).SelectMany(inlineCount =>
+                        {
+                        var contentCount = embedCount + inlineCount;
                         // Persist the per-node manifest LAST (after upserts + prune) so the NEXT import's
                         // diff sees exactly what's now in the partition. One write; survives prune (_Activity).
-                        WriteManifest(hub, source.Partition, nodes, hub.JsonSerializerOptions, logger).Select(_ =>
+                        return WriteManifest(hub, source.Partition, nodes, hub.JsonSerializerOptions, logger).Select(_ =>
                         {
                             // 🚨 Terminal status reflects per-file outcomes: ANY failed upsert →
                             // Warning (the ⚠ lines above pinpoint which files), all-clear →
@@ -687,6 +694,7 @@ public static class StaticRepoImporter
                                 source.Partition, count.Imported, failed, prunedCount, contentCount, fingerprint);
                             return new StaticRepoImportResult(source.Partition, fingerprint,
                                 failed > 0 ? "ImportedWithErrors" : "Imported", count.Imported);
+                        });
                         })));
                 });
             })
@@ -865,6 +873,39 @@ public static class StaticRepoImporter
                     logger?.LogWarning(ex,
                         "[StaticRepoImport] {Partition}: content import for {Node} failed (continuing).",
                         source.Partition, import.NodePath);
+                    return Observable.Return(0);
+                }))
+            .ToObservable()
+            .Merge(BatchSize)
+            .Sum();
+    }
+
+    /// <summary>
+    /// Mirrors the source's inline content syncs (<see cref="IStaticRepoSource.EnumerateInlineContentSyncs"/>)
+    /// — the byte-carrying content-collection files a GitSync import supplies (the git-committed
+    /// <c>{Space}/content/**</c> binaries). Each group is posted as a <see cref="SyncContentFilesRequest"/>
+    /// (via <see cref="ContentImportExtensions.SyncContentFiles"/>) under System to the owning node's hub,
+    /// which writes the bytes and — mirroring — prunes files the group no longer carries. Per-group failures
+    /// log and continue. Returns the total files written.
+    /// </summary>
+    private static IObservable<int> SyncInlineContent(IMessageHub hub, IStaticRepoSource source, ILogger? logger)
+    {
+        var syncs = source.EnumerateInlineContentSyncs();
+        if (syncs.Count == 0)
+            return Observable.Return(0);
+
+        return syncs
+            .Select(sync => AsSystem(hub, () => hub.SyncContentFiles(sync.NodePath)
+                    .To(sync.TargetCollection, sync.TargetPath)
+                    .Add(sync.Files)
+                    .Mirror(true)
+                    .Post())
+                .Select(r => r.Success ? r.FilesImported : 0)
+                .Catch<int, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "[StaticRepoImport] {Partition}: inline content sync for {Node} failed (continuing).",
+                        source.Partition, sync.NodePath);
                     return Observable.Return(0);
                 }))
             .ToObservable()

--- a/src/MeshWeaver.Mesh.Contract/IStaticRepoSource.cs
+++ b/src/MeshWeaver.Mesh.Contract/IStaticRepoSource.cs
@@ -73,7 +73,35 @@ public interface IStaticRepoSource
     /// collection→collection, stream-to-stream. Default empty.
     /// </summary>
     IReadOnlyList<StaticContentImport> EnumerateContentImports() => [];
+
+    /// <summary>
+    /// Optional content-collection <b>files carried inline</b> (their raw bytes travel with the source,
+    /// not via an embedded source collection) that must be MIRRORED into a node's content collection.
+    /// This is how a GitSync import syncs the git-committed <c>{Space}/content/**</c> binaries (course
+    /// videos/posters) into the mesh: the fetch captures each blob's bytes, and after the node upsert
+    /// the importer posts a <see cref="SyncContentFilesRequest"/> per group (under System) to the owning
+    /// node's hub, which writes the bytes AND — mirroring — deletes files under the folder the group no
+    /// longer carries. Binary-safe (bytes never round-trip through a text/JSON string) and idempotent.
+    /// Default empty. Independent of <see cref="EnumerateContentImports"/> (collection→collection copies).
+    /// </summary>
+    IReadOnlyList<StaticContentSync> EnumerateInlineContentSyncs() => [];
 }
+
+/// <summary>
+/// A content-collection MIRROR shipped inline by an <see cref="IStaticRepoSource"/>: write
+/// <paramref name="Files"/> into <paramref name="TargetCollection"/>/<paramref name="TargetPath"/> on
+/// the node at <paramref name="NodePath"/>, pruning any file the folder still has that the set no longer
+/// carries. The bytes travel with the source (binary-safe). Maps onto <see cref="SyncContentFilesRequest"/>.
+/// </summary>
+/// <param name="NodePath">The full path of the node whose hub owns the target collection (the Space root for the per-Space <c>content</c> collection).</param>
+/// <param name="Files">The files to mirror, each path relative to <paramref name="TargetPath"/>.</param>
+/// <param name="TargetCollection">The target content collection (default <c>content</c>).</param>
+/// <param name="TargetPath">The folder within the collection to mirror the files under (empty for the collection root).</param>
+public record StaticContentSync(
+    string NodePath,
+    IReadOnlyList<InlineContentFile> Files,
+    string TargetCollection = "content",
+    string TargetPath = "");
 
 /// <summary>
 /// A content-collection import shipped by an <see cref="IStaticRepoSource"/>: copy the

--- a/src/MeshWeaver.Mesh.Contract/ImportDeleteRequests.cs
+++ b/src/MeshWeaver.Mesh.Contract/ImportDeleteRequests.cs
@@ -93,6 +93,39 @@ public record ImportContentResponse
     public static ImportContentResponse Fail(string error) => new() { Error = error };
 }
 
+/// <summary>One content-collection file carried INLINE (its bytes, not a source-collection reference).</summary>
+/// <param name="Path">The file's path RELATIVE to <see cref="SyncContentFilesRequest.TargetPath"/> within the collection (e.g. <c>videos/intro.mp4</c>).</param>
+/// <param name="Content">The file's raw bytes.</param>
+public record InlineContentFile(string Path, byte[] Content);
+
+/// <summary>
+/// Writes a set of files (carried INLINE as raw bytes) into a content collection folder and, when
+/// <see cref="Mirror"/> is set, PRUNES any file already under that folder that is not in
+/// <see cref="Files"/> — so the folder ends up mirroring exactly the supplied set (add / update /
+/// delete). Handled on the hub where the target collection resolves (the Space root for the
+/// per-Space <c>content</c> collection). This is the request GitSync uses to sync git-committed
+/// <c>{Space}/content/**</c> binaries (course videos/posters) into the mesh content collection:
+/// the bytes travel with the request (binary-safe — never round-tripped through a text/JSON string),
+/// and the mirror keeps the collection matching the repo without wiping files the repo still carries.
+/// Re-posting the same set is idempotent (same bytes overwrite; nothing to prune).
+/// </summary>
+/// <param name="CollectionName">The target content collection (e.g. <c>content</c>).</param>
+/// <param name="TargetPath">The folder within the collection the files are written under (the owning node's path relative to the Space; empty for the Space root).</param>
+/// <param name="Files">The files to write, each with a path relative to <paramref name="TargetPath"/>.</param>
+[RequiresPermission(Permission.Create)]
+public record SyncContentFilesRequest(
+    string CollectionName,
+    string TargetPath,
+    IReadOnlyList<InlineContentFile> Files) : IRequest<ImportContentResponse>
+{
+    /// <summary>
+    /// When true, delete every file already directly-or-recursively under <see cref="TargetPath"/>
+    /// that is NOT present in <see cref="Files"/> (mirror the folder to the supplied set). When false,
+    /// the write is purely additive (upsert only). Default true.
+    /// </summary>
+    public bool Mirror { get; init; } = true;
+}
+
 /// <summary>
 /// Request to delete content from a content collection folder.
 /// </summary>

--- a/src/MeshWeaver.Mesh.Contract/ImportDeleteRequests.cs
+++ b/src/MeshWeaver.Mesh.Contract/ImportDeleteRequests.cs
@@ -112,7 +112,7 @@ public record InlineContentFile(string Path, byte[] Content);
 /// <param name="CollectionName">The target content collection (e.g. <c>content</c>).</param>
 /// <param name="TargetPath">The folder within the collection the files are written under (the owning node's path relative to the Space; empty for the Space root).</param>
 /// <param name="Files">The files to write, each with a path relative to <paramref name="TargetPath"/>.</param>
-[RequiresPermission(Permission.Create)]
+[SyncContentFilesPermission]
 public record SyncContentFilesRequest(
     string CollectionName,
     string TargetPath,
@@ -124,6 +124,24 @@ public record SyncContentFilesRequest(
     /// the write is purely additive (upsert only). Default true.
     /// </summary>
     public bool Mirror { get; init; } = true;
+}
+
+/// <summary>
+/// Permission gate for <see cref="SyncContentFilesRequest"/>: always requires
+/// <see cref="Permission.Create"/> (it writes files), and ADDITIONALLY requires
+/// <see cref="Permission.Delete"/> when <see cref="SyncContentFilesRequest.Mirror"/> is set (mirroring
+/// can prune existing files). A caller with only Create cannot trigger a pruning mirror.
+/// </summary>
+public sealed class SyncContentFilesPermissionAttribute() : RequiresPermissionAttribute(Permission.Create)
+{
+    /// <inheritdoc />
+    public override IEnumerable<(string Path, Permission Permission)> GetPermissionChecks(
+        IMessageDelivery delivery, string hubPath)
+    {
+        yield return (hubPath, Permission.Create);
+        if (delivery.Message is SyncContentFilesRequest { Mirror: true })
+            yield return (hubPath, Permission.Delete);
+    }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -92,6 +92,8 @@ public static class MeshExtensions
         config.TypeRegistry.WithType(typeof(ImportNodesResponse), nameof(ImportNodesResponse));
         config.TypeRegistry.WithType(typeof(ImportContentRequest), nameof(ImportContentRequest));
         config.TypeRegistry.WithType(typeof(ImportContentResponse), nameof(ImportContentResponse));
+        config.TypeRegistry.WithType(typeof(SyncContentFilesRequest), nameof(SyncContentFilesRequest));
+        config.TypeRegistry.WithType(typeof(InlineContentFile), nameof(InlineContentFile));
         config.TypeRegistry.WithType(typeof(DeleteContentRequest), nameof(DeleteContentRequest));
         config.TypeRegistry.WithType(typeof(DeleteContentResponse), nameof(DeleteContentResponse));
 

--- a/test/MeshWeaver.GitSync.Test/ContentAssetMapperTest.cs
+++ b/test/MeshWeaver.GitSync.Test/ContentAssetMapperTest.cs
@@ -18,7 +18,7 @@ public class ContentAssetMapperTest
     [Fact]
     public void RootContentAsset_OwnedByRoot_FileTailAfterContent()
     {
-        var a = ContentAssetMapper.TryClassify("content/videos/module1-intro.mp4", Png);
+        var a = ContentAssetMapper.TryClassify("content/videos/module1-intro.mp4", () => Png);
         Assert.NotNull(a);
         Assert.Equal("", a!.OwnerRelativePath);
         Assert.Equal("videos/module1-intro.mp4", a.FileRelativePath);
@@ -28,7 +28,7 @@ public class ContentAssetMapperTest
     [Fact]
     public void NestedContentAsset_OwnedByNearestNode()
     {
-        var a = ContentAssetMapper.TryClassify("TDD/content/x.png", Png);
+        var a = ContentAssetMapper.TryClassify("TDD/content/x.png", () => Png);
         Assert.NotNull(a);
         Assert.Equal("TDD", a!.OwnerRelativePath);
         Assert.Equal("x.png", a.FileRelativePath);
@@ -38,7 +38,7 @@ public class ContentAssetMapperTest
     public void DeeperContentSegment_IsJustAFolderName()
     {
         // The FIRST "content" segment wins; a second one is a plain folder in the file's path.
-        var a = ContentAssetMapper.TryClassify("A/content/B/content/y.bin", Png);
+        var a = ContentAssetMapper.TryClassify("A/content/B/content/y.bin", () => Png);
         Assert.NotNull(a);
         Assert.Equal("A", a!.OwnerRelativePath);
         Assert.Equal("B/content/y.bin", a.FileRelativePath);
@@ -52,7 +52,10 @@ public class ContentAssetMapperTest
     [InlineData("A/content")]             // ends at content — no file
     [InlineData("README.md")]             // display file
     public void NonAssetPaths_AreNotClassified(string path)
-        => Assert.Null(ContentAssetMapper.TryClassify(path, Png));
+        {
+        Assert.Null(ContentAssetMapper.TryClassify(path, () => Png));
+        Assert.False(ContentAssetMapper.IsContentPath(path));
+    }
 
     [Fact]
     public void ToContentSyncs_SingleWholeCollectionMirror_TargetsSpaceRoot_FullPaths()

--- a/test/MeshWeaver.GitSync.Test/ContentAssetMapperTest.cs
+++ b/test/MeshWeaver.GitSync.Test/ContentAssetMapperTest.cs
@@ -1,0 +1,94 @@
+using System.Text;
+using MeshWeaver.GitSync;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Pins the fetch-layer classification that keeps git-committed content-collection assets
+/// (<c>{node}/content/**</c>) OUT of node parsing and routes them to the content collection —
+/// plus the binary-safe <see cref="RepoFile"/> that carries a video/poster's raw bytes intact
+/// (the corruption that repeatedly nuked the course videos was a UTF-8 round-trip of those bytes).
+/// </summary>
+public class ContentAssetMapperTest
+{
+    private static readonly byte[] Png =
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF, 0x42, 0x7E];
+
+    [Fact]
+    public void RootContentAsset_OwnedByRoot_FileTailAfterContent()
+    {
+        var a = ContentAssetMapper.TryClassify("content/videos/module1-intro.mp4", Png);
+        Assert.NotNull(a);
+        Assert.Equal("", a!.OwnerRelativePath);
+        Assert.Equal("videos/module1-intro.mp4", a.FileRelativePath);
+        Assert.Equal(Png, a.Bytes);
+    }
+
+    [Fact]
+    public void NestedContentAsset_OwnedByNearestNode()
+    {
+        var a = ContentAssetMapper.TryClassify("TDD/content/x.png", Png);
+        Assert.NotNull(a);
+        Assert.Equal("TDD", a!.OwnerRelativePath);
+        Assert.Equal("x.png", a.FileRelativePath);
+    }
+
+    [Fact]
+    public void DeeperContentSegment_IsJustAFolderName()
+    {
+        // The FIRST "content" segment wins; a second one is a plain folder in the file's path.
+        var a = ContentAssetMapper.TryClassify("A/content/B/content/y.bin", Png);
+        Assert.NotNull(a);
+        Assert.Equal("A", a!.OwnerRelativePath);
+        Assert.Equal("B/content/y.bin", a.FileRelativePath);
+    }
+
+    [Theory]
+    [InlineData("index.json")]            // node file
+    [InlineData("Module.json")]           // node file
+    [InlineData("Docs/Intro.md")]         // node file
+    [InlineData("content")]               // bare "content" — no file after it
+    [InlineData("A/content")]             // ends at content — no file
+    [InlineData("README.md")]             // display file
+    public void NonAssetPaths_AreNotClassified(string path)
+        => Assert.Null(ContentAssetMapper.TryClassify(path, Png));
+
+    [Fact]
+    public void ToContentSyncs_SingleWholeCollectionMirror_TargetsSpaceRoot_FullPaths()
+    {
+        var assets = new[]
+        {
+            new ContentAssetMapper.ContentAsset("", "videos/a.mp4", Png),
+            new ContentAssetMapper.ContentAsset("", "posters/a.png", Png),
+            new ContentAssetMapper.ContentAsset("TDD", "x.png", Png),
+        };
+        // ONE whole-collection mirror (not per-owner, which would overlap and prune nested content).
+        var sync = Assert.Single(ContentAssetMapper.ToContentSyncs("Course", assets));
+        Assert.Equal("Course", sync.NodePath);          // the Space root hub, where "content" resolves
+        Assert.Equal("content", sync.TargetCollection);
+        Assert.Equal("", sync.TargetPath);              // the collection root
+
+        Assert.Equal(3, sync.Files.Count);
+        // Each file carries its FULL collection-relative path {owner}/{file} (matches the served URL).
+        Assert.Contains(sync.Files, f => f.Path == "videos/a.mp4");
+        Assert.Contains(sync.Files, f => f.Path == "posters/a.png");
+        Assert.Contains(sync.Files, f => f.Path == "TDD/x.png");
+    }
+
+    [Fact]
+    public void ToContentSyncs_NoAssets_IsEmpty()
+        => Assert.Empty(ContentAssetMapper.ToContentSyncs("Course", []));
+
+    [Fact]
+    public void RepoFile_TextAndBinary_ExposeBytes()
+    {
+        var text = new RepoFile("a.md", "# Hi");
+        Assert.False(text.IsBinary);
+        Assert.Equal(Encoding.UTF8.GetBytes("# Hi"), text.Bytes);
+
+        var bin = new RepoFile("v.mp4", string.Empty, Png);
+        Assert.True(bin.IsBinary);
+        Assert.Equal(Png, bin.Bytes);
+    }
+}

--- a/test/MeshWeaver.GitSync.Test/FakeGitHubRepoClient.cs
+++ b/test/MeshWeaver.GitSync.Test/FakeGitHubRepoClient.cs
@@ -69,7 +69,7 @@ public sealed class FakeGitHubRepoClient : IGitHubRepoClient
             var prefix = Norm(request.Subdirectory);
             var existing = _head.TryGetValue(key, out var cur) ? cur : new List<RepoFile>();
 
-            var newUnder = request.Files.Select(f => new RepoFile(prefix + f.Path, f.Content)).ToList();
+            var newUnder = request.Files.Select(f => f with { Path = prefix + f.Path }).ToList();
             var exportPaths = newUnder.Select(f => f.Path).ToHashSet(StringComparer.Ordinal);
             var outside = existing
                 .Where(f => prefix.Length != 0 && !f.Path.StartsWith(prefix, StringComparison.Ordinal))
@@ -117,7 +117,7 @@ public sealed class FakeGitHubRepoClient : IGitHubRepoClient
             var prefix = Norm(subdirectory);
             var files = tree
                 .Where(f => prefix.Length == 0 || f.Path.StartsWith(prefix, StringComparison.Ordinal))
-                .Select(f => new RepoFile(prefix.Length == 0 ? f.Path : f.Path[prefix.Length..], f.Content))
+                .Select(f => f with { Path = prefix.Length == 0 ? f.Path : f.Path[prefix.Length..] })
                 .ToList();
             return Observable.Return(new RepoSnapshot(sha, files));
         }

--- a/test/MeshWeaver.GitSync.Test/GitSyncContentCollectionTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitSyncContentCollectionTest.cs
@@ -1,0 +1,158 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.GitSync;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Regression pin for the content-collection sync bug that repeatedly NUKED the course videos on
+/// memex: git-committed content-collection binaries under <c>{Space}/content/**</c> (real blobs in the
+/// repo) were never synced into the mesh content collection on a GitSync import, so they only ever
+/// existed as manual uploads and got lost. This drives the FULL import path
+/// (<see cref="GitHubSyncService.ImportFromGitHub"/> → fetch → classify → import → content mirror) over
+/// the in-memory fake repo and asserts:
+/// <list type="number">
+///   <item>a committed <c>{Space}/content/videos/x.bin</c> lands in the Space's content collection,
+///     byte-for-byte (binary-safe — never round-tripped through a text/JSON string);</item>
+///   <item>a RE-import of the same commit keeps it (idempotent);</item>
+///   <item>a binary present in the mesh but REMOVED from the repo is pruned on re-import (mirror), while
+///     a binary the repo still carries survives.</item>
+/// </list>
+/// The test mounts a per-Space filesystem <c>content</c> collection exactly as the portal does, so the
+/// assertions read the bytes straight off disk.
+/// </summary>
+public class GitSyncContentCollectionTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    // Bytes that are NOT valid UTF-8 (PNG signature + 0x00/0xFF) — the exact shape that the old
+    // UTF-8-decode-on-fetch corrupted. A course video is the same kind of non-text blob.
+    private static readonly byte[] VideoBytes =
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF, 0x42, 0x7E, 0x01, 0x02, 0x03];
+    private static readonly byte[] PosterBytes =
+        [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46];
+
+    private readonly string _contentRoot = Path.Combine(
+        Path.GetTempPath(), "GitSyncContentCollectionTest", Guid.NewGuid().ToString("N"));
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            // Mirror the portal: a per-Space writable "content" collection rooted at
+            // {contentRoot}/{spacePath}. Mounted on the partition root only (single-segment path);
+            // children inherit via ExposeInChildren.
+            .ConfigureDefaultNodeHub(config =>
+            {
+                var nodePath = config.Address.ToString();
+                if (nodePath.Contains('/'))
+                    return config;
+                return config.AddContentCollection(_ => new ContentCollectionConfig
+                {
+                    Name = ContentCollectionsExtensions.DefaultCollectionName,
+                    SourceType = "FileSystem",
+                    BasePath = Path.Combine(_contentRoot, nodePath),
+                    IsEditable = true,
+                    ExposeInChildren = true,
+                });
+            });
+
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
+        if (Directory.Exists(_contentRoot))
+            try { Directory.Delete(_contentRoot, recursive: true); }
+            catch { /* ignore cleanup errors */ }
+    }
+
+    /// <summary>Seeds an arbitrary set of files (nodes + binaries) into the fake repo as one commit.</summary>
+    private async Task<string> SeedRepo(string repo, params RepoFile[] files)
+    {
+        var result = await Fake.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = repo,
+            Branch = "main",
+            Files = files.ToImmutableList(),
+            CommitMessage = "seed",
+            AuthorName = "t", AuthorEmail = "t@t",
+            AccessToken = "ghp_test_token",
+        }).Timeout(30.Seconds()).ToTask();
+        return result.CommitSha;
+    }
+
+    /// <summary>A minimal Space-root index.json node file (so the import creates a proper Space root).</summary>
+    private static RepoFile RootIndex() =>
+        new("index.json", """{"nodeType":"Space","name":"Course","content":{"$type":"Space"}}""");
+
+    /// <summary>Reads the bytes of a file under the Space's content dir, or null if absent.</summary>
+    private byte[]? ReadContent(string spaceId, string relPath)
+    {
+        var full = Path.Combine(_contentRoot, spaceId, relPath.Replace('/', Path.DirectorySeparatorChar));
+        return File.Exists(full) ? File.ReadAllBytes(full) : null;
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Import_SyncsGitCommittedContentBinary_Idempotent_AndMirrorsPrune()
+    {
+        await Connect();
+        var repo = "https://github.com/test/course-content";
+
+        // Commit 1: a node file + two content binaries (a Space-root one and a nested-module one).
+        var c1 = await SeedRepo(repo,
+            RootIndex(),
+            new RepoFile("Module1.md", "# Module 1\n\nIntro."),
+            new RepoFile("content/videos/intro.bin", string.Empty, VideoBytes),
+            new RepoFile("content/posters/intro.jpg", string.Empty, PosterBytes),
+            new RepoFile("Module1/content/diagram.bin", string.Empty, VideoBytes));
+
+        var space = "Course" + Guid.NewGuid().ToString("N")[..8];
+        await Sync.ImportFromGitHub(repo, "main", space, "Course", subdirectory: null, UserId)
+            .Timeout(90.Seconds()).ToTask();
+        // Record the repo on the Space so ReimportAtCommit (which reads the config) can re-import.
+        await Sync.SaveConfig(space, repo, "main", subdirectory: null, createBranchIfMissing: true, createRepoIfMissing: true)
+            .Timeout(30.Seconds()).ToTask();
+
+        // The node landed…
+        Assert.NotNull(await WaitForNode($"{space}/Module1"));
+        // …and so did the content binaries, byte-for-byte, at the served collection paths.
+        await WaitForContent(space, "videos/intro.bin", VideoBytes);
+        await WaitForContent(space, "posters/intro.jpg", PosterBytes);
+        // The nested module's content is keyed by the owning node's Space-relative path.
+        Assert.Equal(VideoBytes, ReadContent(space, "Module1/diagram.bin"));
+
+        // (2) RE-import the SAME commit → content still present (idempotent, no corruption).
+        await Sync.ReimportAtCommit(space, c1, UserId).Timeout(90.Seconds()).ToTask();
+        Assert.Equal(VideoBytes, ReadContent(space, "videos/intro.bin"));
+        Assert.Equal(PosterBytes, ReadContent(space, "posters/intro.jpg"));
+
+        // (3) Commit 2 REMOVES the poster (keeps the video) → re-import mirrors: poster pruned, video kept.
+        var c2 = await SeedRepo(repo,
+            RootIndex(),
+            new RepoFile("Module1.md", "# Module 1\n\nIntro."),
+            new RepoFile("content/videos/intro.bin", string.Empty, VideoBytes),
+            new RepoFile("Module1/content/diagram.bin", string.Empty, VideoBytes));
+        Assert.NotEqual(c1, c2);
+
+        await Sync.ReimportAtCommit(space, c2, UserId).Timeout(90.Seconds()).ToTask();
+        // The video the repo still carries survives; the poster the repo dropped is pruned.
+        Assert.Equal(VideoBytes, ReadContent(space, "videos/intro.bin"));
+        Assert.Equal(VideoBytes, ReadContent(space, "Module1/diagram.bin"));
+        await WaitForContentGone(space, "posters/intro.jpg");
+    }
+
+    private async Task WaitForContent(string spaceId, string relPath, byte[] expected) =>
+        await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .Select(_ => ReadContent(spaceId, relPath))
+            .Where(b => b is not null && b.SequenceEqual(expected))
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask();
+
+    private async Task WaitForContentGone(string spaceId, string relPath) =>
+        await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .Select(_ => ReadContent(spaceId, relPath))
+            .Where(b => b is null)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask();
+}

--- a/test/MeshWeaver.GitSync.Test/GitSyncContentCollectionTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitSyncContentCollectionTest.cs
@@ -140,6 +140,29 @@ public class GitSyncContentCollectionTest(ITestOutputHelper output) : GitHubSync
         await WaitForContentGone(space, "posters/intro.jpg");
     }
 
+    [Fact(Timeout = 120000)]
+    public async Task SyncContentFiles_RejectsPathTraversal()
+    {
+        await Connect();
+        var repo = "https://github.com/test/course-traversal";
+        await SeedRepo(repo, RootIndex(), new RepoFile("content/ok.bin", string.Empty, VideoBytes));
+        var space = "Course" + Guid.NewGuid().ToString("N")[..8];
+        await Sync.ImportFromGitHub(repo, "main", space, "Course", subdirectory: null, UserId)
+            .Timeout(90.Seconds()).ToTask();
+        await WaitForContent(space, "ok.bin", VideoBytes);
+
+        // A traversal path must be REJECTED (never escape the collection root), not written.
+        var resp = await GetClient().SyncContentFiles(space)
+            .To(ContentCollectionsExtensions.DefaultCollectionName)
+            .Add("../escape.bin", VideoBytes)
+            .Post()
+            .Timeout(30.Seconds()).ToTask();
+        Assert.False(resp.Success);
+        Assert.Contains("Unsafe", resp.Error);
+        // Nothing escaped the space's content dir.
+        Assert.False(File.Exists(Path.Combine(_contentRoot, "escape.bin")));
+    }
+
     private async Task WaitForContent(string spaceId, string relPath, byte[] expected) =>
         await Observable.Interval(100.Milliseconds()).StartWith(0L)
             .Select(_ => ReadContent(spaceId, relPath))


### PR DESCRIPTION
## Problem

Git-committed content-collection assets under `{Space}/content/**` — the real blobs in the repo (course videos, posters, fonts, images) — were **never synced into the mesh content collection** on a GitSync import. They only ever existed as manual uploads and disappeared on every sync (this has repeatedly nuked all course videos on memex).

### Root cause (three-fold)

1. **`RepoFile.Content` was a `string`** and `OctokitGitHubRepoClient.DecodeBlob` UTF-8-decoded every base64 blob — **corrupting any non-text blob** (a `.mp4`/`.png` byte stream is not valid UTF-8; round-tripping it through a UTF-8 string mangles it).
2. **`GitHubSyncService.ParseSnapshot`/`ParseFile`** treated only `*.json`/`*.md` as nodes and dropped everything else — the `content/**` binaries were discarded before they reached the importer.
3. **`InMemoryStaticRepoSource`** (the source every GitHub sync uses) never captured the raw content blobs nor overrode the content-import hook, so nothing synced them, and the import's node-prune left the content unrepresented.

## Fix (end to end)

- **Binary-safe fetch.** `RepoFile` now carries raw bytes for non-UTF-8 blobs (`Binary`, plus `Bytes`/`IsBinary`). The Octokit fetch classifies each base64 blob **strictly** — valid UTF-8 → text, otherwise raw bytes — so a committed video survives byte-for-byte.
- **Owning-node resolution.** `ContentAssetMapper` classifies `{node}/content/**` paths: `content/videos/x.mp4` → owner = Space root; `TDD/content/x.png` → owner = `{Space}/TDD` (nearest node whose folder holds a `content/` dir; nested owners supported). The per-Space `content` collection is **one physical store** (mounted on the Space root, children inherit it), so it builds **one whole-collection `StaticContentSync`** — a single authoritative mirror, not overlapping per-owner mirrors that would prune nested content.
- **Sync + mirror.** New `SyncContentFilesRequest` (+ handler + fluent `hub.SyncContentFiles`) writes inline bytes into a node's content collection and **mirrors** the folder (add/update + prune stale) — binary-safe, idempotent. `IStaticRepoSource.EnumerateInlineContentSyncs` + `StaticRepoImporter.SyncInlineContent` drive it after the node upsert, under System.
- **Result:** after a GitSync import the content collection contains **exactly** the repo's `content/**` (added/updated/deleted); re-importing the same commit is a no-op; content the repo still carries is never pruned.

Reactive throughout (I/O only inside the collection's own pool leaves), immutable, warnings-as-errors, net10.

## Tests (regression pin)

- **`ContentAssetMapperTest`** — path classification, owning-node resolution, single whole-collection grouping, and `RepoFile` text/binary byte fidelity.
- **`GitSyncContentCollectionTest`** — the full `ImportFromGitHub` path over the in-memory fake repo: a committed `{Space}/content/videos/x.bin` lands byte-for-byte, a re-import of the same commit keeps it, and a binary removed from the repo is pruned while one still present survives (incl. nested-module content).

Verified locally: full solution builds in Release with `-warnaserror` (0 warnings); GitSync suite (121), Graph static-repo import (13), and Content import (18) tests all green.

## Deploy note

This is a core change — a **portal image roll is needed** to make it live. After the roll, a single `git_hub_sync {course} update` will restore + keep the videos from git (no more manual `upload-videos.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)