### PR TITLE
Derive Portal__BaseUrl from ingress.host (persist email links, no per-env config)

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -41,10 +41,18 @@ data:
   # ---- Public base URL — the instance's own https host --------------------
   # Used to build ABSOLUTE links in outbound email (access-granted notifications,
   # invitations) — without it the "Open {space}" button is omitted and the email
-  # ships linkless (the #1 complaint: a first-contact invite with no way in). Set
-  # to the instance's public URL, e.g. https://memex.meshweaver.cloud. Read by
-  # NotificationService/InvitationEmailSender via Portal:BaseUrl.
-  Portal__BaseUrl: "{{ .Values.config.memex_portal.Portal__BaseUrl | default "" }}"
+  # ships linkless (the #1 complaint: a first-contact invite with no way in). Read
+  # by NotificationService/InvitationEmailSender via Portal:BaseUrl.
+  # DERIVED by default from the ingress host (https://{ingress.host}) — the SAME
+  # host OAuth redirect_uri is built from — so every instance with a public host
+  # gets correct email links with NO per-env config. An explicit
+  # config.memex_portal.Portal__BaseUrl overrides (e.g. a vanity domain that
+  # differs from the ingress host).
+{{- $portalBaseUrl := .Values.config.memex_portal.Portal__BaseUrl }}
+{{- if and (not $portalBaseUrl) (.Values.ingress).enabled (.Values.ingress).host }}
+{{-   $portalBaseUrl = printf "https://%s" .Values.ingress.host }}
+{{- end }}
+  Portal__BaseUrl: "{{ $portalBaseUrl | default "" }}"
   # ---- Instance identity (tab title + favicon badge) — optional -------------
   # When InstanceName is set, the browser tab title becomes that name and the
   # favicon becomes a distinct colored badge (instance initial), so Local / Test /

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -165,8 +165,8 @@ config:
     Graph__Storage__BasePath: "/data/graph"
     Mcp__BaseUrl: "http://memex-portal-service:8080"
     # Public https host of THIS instance — builds the "Open" links in outbound email
-    # (invitations / access-granted). Empty = links omitted. An env overlay sets it,
-    # e.g. Portal__BaseUrl: "https://memex.meshweaver.cloud".
+    # (invitations / access-granted). Leave empty to DERIVE it from ingress.host
+    # (https://{ingress.host}); set only to override with a vanity domain.
     Portal__BaseUrl: ""
     # AI model catalog — empty by default. An overlay sets endpoints + model
     # lists (+ keys in secrets above) to seed the system catalog on deploy.


### PR DESCRIPTION
Follow-up to #452. That PR added `Portal__BaseUrl` (the base for the "Open {space}" links in invitation / access-granted email) but it had to be set per-env, and the memex.cloud value I applied was a live configmap patch that the next `helm upgrade` would revert.

This makes it durable with **no per-env config**: the config template now **derives** `Portal__BaseUrl` from `https://{ingress.host}` when it isn't set explicitly — the same host OAuth `redirect_uri` is already built from — so every instance with a public ingress host gets correct email links, surviving every `helm upgrade`. An explicit `config.memex_portal.Portal__BaseUrl` still overrides (e.g. a vanity domain ≠ ingress host).

Verified via `helm template`:
- `memex` (systemorph, `ingress.host=memex.systemorph.com`) → `https://memex.systemorph.com`
- memex-cloud (`ingress.host=memex.meshweaver.cloud`, confirmed set in its live release) → `https://memex.meshweaver.cloud`
- explicit override → honored
- no ingress (local dev) → empty (links omitted, as before)

Deploy-template only; no code change. After this ships, the live memex.cloud configmap patch is redundant — the chart sets it on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)