### PR TITLE
AI composer: DeepSeek-V4-Flash default (Order -1) + heal a gone selected model

### DIFF
--- a/src/MeshWeaver.AI/BuiltInLanguageModelProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInLanguageModelProvider.cs
@@ -165,6 +165,14 @@ public class BuiltInLanguageModelProvider : IStaticNodeProvider
                 if (string.IsNullOrWhiteSpace(modelId)) continue;
                 if (!seen.Add(modelId)) continue;
 
+                // Effective Order: a per-model override (ModelOrdering) wins over the source's uniform
+                // Order, so a single model within a provider can be pinned as the platform default
+                // (DeepSeek-V4-Flash → -1) without re-ordering the whole provider. Stamped onto BOTH the
+                // ModelDefinition.Order (which ToModelInfo/the picker read) AND the emitted MeshNode.Order
+                // (which ChatClientCredentialResolver.ResolveDefaultModelId reads) so the picker default
+                // and the execution-time stale-model fallback agree on the same lowest-Order model.
+                var effectiveOrder = ModelOrdering.For(modelId, source.Order);
+
                 var def = new ModelDefinition
                 {
                     Id = modelId,
@@ -178,7 +186,7 @@ public class BuiltInLanguageModelProvider : IStaticNodeProvider
                     // this pointer; context-partition ModelProvider nodes override via their
                     // own ProviderRef on child LanguageModel nodes.
                     ProviderRef = $"{ModelProviderNodeType.RootNamespace}/{source.ProviderName}",
-                    Order = source.Order,
+                    Order = effectiveOrder,
                     // Seed the published default price (USD per 1M tokens) for known
                     // model ids so the token-cost summaries show a real cost out of
                     // the box; users can override per model in the Models settings.
@@ -198,6 +206,10 @@ public class BuiltInLanguageModelProvider : IStaticNodeProvider
                     NodeType = LanguageModelNodeType.NodeType,
                     Name = modelId,
                     Category = "Models",
+                    // Stamp the effective Order on the NODE too — ResolveDefaultModelId ranks by
+                    // MeshNode.Order, so leaving it null made every catalog model rank 0 and the
+                    // execution-time default was arbitrary (diverging from the picker's def.Order default).
+                    Order = effectiveOrder,
                     // Brand logo inferred from the model id (then provider) so a model reads
                     // as its maker; the generic sparkle SVG when unknown. Fall back to the
                     // self-contained SVG URL (not the legacy "Sparkle" Fluent name, which

--- a/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
+++ b/src/MeshWeaver.AI/ChatClientCredentialResolver.cs
@@ -289,7 +289,17 @@ public sealed class ChatClientCredentialResolver : IDisposable
         var snapshot = ReadSnapshot();
         return snapshot
             .Where(n => string.Equals(n.NodeType, LanguageModelNodeType.NodeType, StringComparison.OrdinalIgnoreCase))
-            .Select(n => (Order: n.Order ?? 0, Id: ExtractContent<ModelDefinition>(n.Content)?.Id))
+            .Select(n =>
+            {
+                var def = ExtractContent<ModelDefinition>(n.Content);
+                // Rank by MeshNode.Order, falling back to the ModelDefinition's Order when the node
+                // carries none — mirrors the picker (ToModelInfo reads def.Order), so a per-model
+                // default (DeepSeek-V4-Flash → -1) is honoured whether the Order lives on the node
+                // or only on its content. Without the def fallback a BYO model that set only
+                // ModelDefinition.Order ranked 0 here while ranking correctly in the picker.
+                var order = n.Order ?? (def?.Order ?? 0);
+                return (Order: order, Id: def?.Id);
+            })
             .Where(x => !string.IsNullOrEmpty(x.Id))
             .OrderBy(x => x.Order)
             .Select(x => x.Id!)

--- a/src/MeshWeaver.AI/ModelOrdering.cs
+++ b/src/MeshWeaver.AI/ModelOrdering.cs
@@ -1,0 +1,54 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.AI;
+
+/// <summary>
+/// Per-model-id <see cref="MeshWeaver.Mesh.MeshNode.Order"/> overrides for built-in catalog models.
+///
+/// <para>The catalog's default selection is resolved purely by ORDER — the LOWEST-<c>Order</c>
+/// resolvable <c>LanguageModel</c> wins (the <c>Order = -1</c> "make this the default" convention, used
+/// by both <see cref="ChatClientCredentialResolver.ResolveDefaultModelId"/> and
+/// <see cref="AgentPickerProjection.ObserveDefaultComposer"/>). The catalog source's
+/// <see cref="LanguageModelCatalogSource.Order"/> is applied uniformly to EVERY model that source
+/// emits, so it can rank providers but cannot single out one model within a provider as the platform
+/// default. This table is that missing per-model lever: a model id listed here overrides its source's
+/// Order, so a specific model (e.g. DeepSeek's fast/cheap flash tier) can be THE default without
+/// re-ordering the whole provider.</para>
+///
+/// <para>Immutable, read-only constant lookup initialised once and never written at runtime — a
+/// constant, not a cache (see NoStaticState.md). Mirrors <see cref="ModelPricing.Defaults"/>.</para>
+/// </summary>
+public static class ModelOrdering
+{
+    /// <summary>
+    /// Model id → explicit <see cref="MeshWeaver.Mesh.MeshNode.Order"/>. A model NOT listed here keeps
+    /// its catalog source's <see cref="LanguageModelCatalogSource.Order"/>.
+    ///
+    /// <para><c>DeepSeek-V4-Flash</c> is pinned to <c>-1</c> — the fast/cheap DeepSeek tier is the
+    /// intended platform default (the lowest-cost model that resolves), so a deployment whose composer
+    /// has no explicit selection (or whose selection was removed from the catalog) falls back to it
+    /// rather than to an arbitrary catalog entry.</para>
+    /// </summary>
+    public static readonly ImmutableDictionary<string, int> Defaults =
+        new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            // The fast/cheap DeepSeek tier — the platform default. Order -1 = "make this the default".
+            ["DeepSeek-V4-Flash"] = -1,
+        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The explicit per-model Order override for <paramref name="modelId"/>, or <paramref name="fallback"/>
+    /// (the catalog source's Order) when the model is not listed. Case-insensitive; tolerates a leading
+    /// provider/path prefix by also trying the last path segment, mirroring
+    /// <see cref="ModelPricing.Default(string?)"/>.
+    /// </summary>
+    public static int For(string? modelId, int fallback)
+    {
+        if (string.IsNullOrWhiteSpace(modelId))
+            return fallback;
+        if (Defaults.TryGetValue(modelId, out var order))
+            return order;
+        var lastSegment = modelId[(modelId.LastIndexOf('/') + 1)..];
+        return Defaults.TryGetValue(lastSegment, out order) ? order : fallback;
+    }
+}

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -748,7 +748,14 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 // conversational default. The latter migrates composers a pre-sort:order picker
                 // stamped with the first (utility) agent — the "ThreadNamer pre-selected" symptom.
                 AgentName = NeedsAgentDefault(c.AgentName) ? defaults.AgentName : c.AgentName,
-                ModelName = string.IsNullOrEmpty(c.ModelName) ? defaults.ModelName : c.ModelName,
+                // Default (or RE-default) the model: empty, OR a persisted selection that no longer
+                // resolves (its provider/catalog entry was removed — the stuck "glm-5.2" case) → the
+                // order-resolved default. Coalesce-only left a stale non-empty model bound forever, so
+                // the composer showed a gone model and Send shipped it to execution where the provider
+                // 404'd "model does not exist". Re-defaulting only when `defaults.ModelName` is itself
+                // non-empty (the catalog is loaded and HAS a resolvable default) means a transient cold
+                // snapshot can never wipe a good selection.
+                ModelName = NeedsModelDefault(c.ModelName, defaults.ModelName) ? defaults.ModelName : c.ModelName,
             };
             return filled == c ? node : node with { Content = filled };
         }).Subscribe(
@@ -757,6 +764,27 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
                 "[ThreadChat:{InstanceId}] composer default-fill failed for {Path}", _instanceId, path));
 
         OpenComposerProjection(path);
+    }
+
+    /// <summary>
+    /// True when the composer's <c>ModelName</c> should be replaced with the order-resolved default:
+    /// it's empty, OR it no longer resolves to a usable model (its provider/catalog entry was removed —
+    /// the "stuck on a deleted glm-5.2" case) AND a resolvable default IS available to replace it with.
+    /// A stale non-empty selection was previously kept forever (coalesce-only), so the composer showed a
+    /// gone model and submit shipped it to execution where the provider 404'd. Guarded so a transient
+    /// cold catalog (no default yet, or no resolver) NEVER wipes a good selection — we only re-default
+    /// when <paramref name="resolvableDefault"/> is non-empty (the catalog is loaded and has a working
+    /// default) and the resolver actively reports the current value as unusable.
+    /// </summary>
+    private bool NeedsModelDefault(string? modelName, string? resolvableDefault)
+    {
+        if (string.IsNullOrEmpty(modelName)) return true;
+        if (string.IsNullOrEmpty(resolvableDefault)) return false; // no default to fall back to → keep as-is
+        var resolver = Hub.ServiceProvider.GetService<MeshWeaver.AI.ChatClientCredentialResolver>();
+        if (resolver is null) return false; // can't judge resolvability → trust the stored value
+        // The stored model still resolves to a usable credential → keep it. Only a genuinely gone /
+        // unconfigured model (no usable credential) is re-defaulted.
+        return !resolver.HasUsableCredential(modelName);
     }
 
     /// <summary>

--- a/test/MeshWeaver.AI.Test/BuiltInLanguageModelProviderTest.cs
+++ b/test/MeshWeaver.AI.Test/BuiltInLanguageModelProviderTest.cs
@@ -121,6 +121,55 @@ public class BuiltInLanguageModelProviderTest
     }
 
     [Fact]
+    public void DeepSeekFlash_IsPinnedToOrderMinus1_OnBothTheNodeAndTheDefinition_SoItIsThePlatformDefault()
+    {
+        // The maintainer's directive: the platform default must be DeepSeek's fast/cheap flash model.
+        // The default is resolved purely by ORDER (lowest wins), so DeepSeek-V4-Flash must carry
+        // Order -1 — BELOW its AzureFoundry source's uniform Order (2 in production) and below every
+        // other catalog model. It must land on BOTH the MeshNode.Order (which
+        // ChatClientCredentialResolver.ResolveDefaultModelId ranks by) AND the ModelDefinition.Order
+        // (which AgentPickerProjection.ToModelInfo / the picker rank by), or the picker default and
+        // the execution-time stale-model fallback disagree.
+        var provider = Build(new Dictionary<string, string?>
+        {
+            ["AzureFoundry:Models:0"] = "DeepSeek-V4-Pro",
+            ["AzureFoundry:Models:1"] = "DeepSeek-V4-Flash",
+            ["AzureFoundry:Endpoint"] = "https://foundry.example/v1",
+            ["AzureFoundry:ApiKey"] = "sk-secret",
+        }, new LanguageModelCatalogSource("AzureFoundry", "AzureFoundry", Order: 2));
+
+        var models = ModelsOf(provider);
+
+        var flash = models.Single(n => n.Name == "DeepSeek-V4-Flash");
+        flash.Order.Should().Be(-1, "DeepSeek-V4-Flash is the pinned platform default (Order -1)");
+        ((ModelDefinition)flash.Content!).Order.Should().Be(-1,
+            "the def.Order must match the node.Order so the picker and the resolver agree on the default");
+
+        // A sibling model in the SAME source keeps the source's Order — the pin is per-model, not
+        // per-provider (setting the whole provider to -1 would make an arbitrary model within it the
+        // default).
+        var pro = models.Single(n => n.Name == "DeepSeek-V4-Pro");
+        pro.Order.Should().Be(2, "a non-pinned model keeps its catalog source's Order");
+
+        // And DeepSeek-V4-Flash is the LOWEST-Order model → the one ResolveDefaultModelId would pick.
+        models.OrderBy(n => n.Order ?? 0).First().Name.Should().Be("DeepSeek-V4-Flash");
+    }
+
+    [Fact]
+    public void ModelOrdering_For_ReturnsMinus1ForDeepSeekFlash_AndTheFallbackOtherwise()
+    {
+        // The per-model Order lever: DeepSeek-V4-Flash → -1; everything else → the source's Order.
+        ModelOrdering.For("DeepSeek-V4-Flash", fallback: 2).Should().Be(-1);
+        // Case-insensitive + tolerant of a leading provider/path prefix (mirrors ModelPricing.Default).
+        ModelOrdering.For("deepseek-v4-flash", fallback: 2).Should().Be(-1);
+        ModelOrdering.For("Provider/AzureFoundry/DeepSeek-V4-Flash", fallback: 2).Should().Be(-1);
+        // A model not in the table keeps its source's Order.
+        ModelOrdering.For("DeepSeek-V4-Pro", fallback: 2).Should().Be(2);
+        ModelOrdering.For("claude-opus-4-8", fallback: 1).Should().Be(1);
+        ModelOrdering.For(null, fallback: 7).Should().Be(7);
+    }
+
+    [Fact]
     public void ToModelInfo_CarriesNodePath_SoSelectionPersistsTheNodeIdentity()
     {
         var node = new MeshNode("claude-sonnet-4", "Provider/Azure")

--- a/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
+++ b/test/MeshWeaver.AI.Test/ChatClientCredentialResolverTest.cs
@@ -501,4 +501,87 @@ public class ChatClientCredentialResolverTest : AITestBase
         provider.Should().Be("Anthropic");
         resolver.GetProviderForModel("does-not-exist").Should().BeNull();
     }
+
+    /// <summary>
+    /// The regression the maintainer hit: a composer/thread whose MASTER selection pins a model that no
+    /// longer exists in the catalog (the stuck "glm-5.2") must resolve to the order-resolved DEFAULT —
+    /// WITHOUT throwing "model does not exist" / tearing the composer down. <c>ObserveDefaultComposer</c>
+    /// sanitises an unusable master model (<c>ValidMasterModel</c> → the resolver reports no usable
+    /// credential → falls back to the lowest-Order resolvable model), so the composer initialises on a
+    /// working model instead of surfacing the gone one.
+    /// </summary>
+    [Fact]
+    public async Task ObserveDefaultComposer_StaleMasterModel_ResolvesToDefault_WithoutThrowing()
+    {
+        var root = ModelProviderNodeType.RootNamespace; // "Provider"
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+
+        // A working provider + a lowest-Order resolvable model — the catalog default the composer should
+        // fall back to when the pinned model is gone.
+        var providerPath = $"{root}/DefProv{suffix}";
+        await MeshService.CreateNode(new MeshNode($"DefProv{suffix}", root)
+        {
+            NodeType = ModelProviderNodeType.NodeType,
+            Name = "Default Provider",
+            State = MeshNodeState.Active,
+            Content = new ModelProviderConfiguration
+            {
+                Provider = $"DefProv{suffix}",
+                ApiKey = "sk-default-key",
+                Endpoint = "https://default.example/v1",
+            }
+        }).Should().Within(15.Seconds()).Emit();
+
+        var defaultModelId = $"default-model-{suffix}";
+        var defaultModelPath = $"{providerPath}/{defaultModelId}";
+        await MeshService.CreateNode(new MeshNode(defaultModelId, providerPath)
+        {
+            NodeType = LanguageModelNodeType.NodeType,
+            Name = defaultModelId,
+            Order = -1, // the "make this the default" convention
+            State = MeshNodeState.Active,
+            Content = new ModelDefinition
+            {
+                Id = defaultModelId,
+                Provider = $"DefProv{suffix}",
+                ProviderRef = providerPath,
+                Order = -1,
+            }
+        }).Should().Within(15.Seconds()).Emit();
+
+        // Seed the user's MASTER composer pinned to a GONE model (never created in the catalog) — the
+        // exact stuck-selection the maintainer reported.
+        var user = Mesh.ServiceProvider.GetRequiredService<AccessService>().Context?.ObjectId
+                   ?? MonolithMeshTestBase.TestPartition;
+        var masterPath = ThreadComposerNodeType.PathFor(user);
+        var goneModel = $"gone-model-{suffix}";
+        await MeshService.CreateNode(MeshNode.FromPath(masterPath) with
+        {
+            Name = "Chat Input",
+            NodeType = ThreadComposerNodeType.NodeType,
+            MainNode = masterPath,
+            State = MeshNodeState.Active,
+            Content = new ThreadComposer { ModelName = goneModel },
+        }).Should().Within(15.Seconds()).Emit();
+
+        var resolver = Mesh.ServiceProvider.GetRequiredService<ChatClientCredentialResolver>();
+        resolver.EnsureSubscription();
+        // Warm the resolver so the default model is visible before we assert the composer sanitisation.
+        await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .Select(_ => resolver.ResolveDefaultModelId())
+            .Should().Within(15.Seconds()).Match(id => id == defaultModelId);
+
+        // The composer must NOT surface the gone model, and must NOT throw — it resolves to the default.
+        var composer = await AgentPickerProjection
+            .ObserveDefaultComposer(Mesh, userPath: user)
+            .Where(c => !string.IsNullOrEmpty(c.ModelName))
+            .Take(1)
+            .Timeout(15.Seconds())
+            .ToTask();
+
+        composer.ModelName.Should().NotBe(goneModel,
+            "a pinned model that no longer resolves must be sanitised away, not shown/used as-is");
+        composer.ModelName.Should().Be(defaultModelPath,
+            "the composer falls back to the lowest-Order resolvable model (persisted as its node PATH)");
+    }
 }


### PR DESCRIPTION
## Problem

The AI composer wedged on a model that no longer exists — the maintainer's stuck **`glm-5.2`**:

- The composer **never noticed the model was gone**, kept showing it, and shipped it to execution where the provider returned *"model does not exist"* (and could crash the round).
- The intended platform default (**DeepSeek's fast/cheap flash tier**) was not actually selected because the default couldn't be pinned to one model within a provider.

## Root causes & fixes

### 1. Make `DeepSeek-V4-Flash` the platform default (Order -1)

The catalog default is resolved purely by `Order` (lowest wins), but a catalog **source's** `Order` is applied **uniformly** to every model it emits — it can rank *providers* but can't single out one *model* as the default.

- New `ModelOrdering` — a per-model-id `Order` override table (mirrors `ModelPricing`) — pins **`DeepSeek-V4-Flash` → -1** (the cheapest DeepSeek tier; the fast/cheap one).
- The effective Order is stamped onto **both** `ModelDefinition.Order` (which the picker / `ToModelInfo` read) **and** the emitted `MeshNode.Order` (which `ChatClientCredentialResolver.ResolveDefaultModelId` reads). Previously the node's `Order` was left `null`, so **every** catalog model ranked `0` and the execution-time default was arbitrary — diverging from the picker.
- `ResolveDefaultModelId` also falls back to `def.Order` when `node.Order` is null (belt-and-suspenders for BYO models).

### 2. Composer must not wedge on a gone selected model at **init**

`ThreadChatView.FillDefaultsAndProject` was **coalesce-only** for `ModelName`, so a stale *non-empty* selection (`glm-5.2`) was kept forever. New `NeedsModelDefault` re-defaults the model when the persisted selection **no longer resolves to a usable credential** (its provider/catalog entry was removed) **and** a resolvable default is available — guarded so a transient cold catalog can **never** wipe a good selection.

The execution path (`AgentChatClient.ApplyStaleModelFallback`) and the master-composer read (`AgentPickerProjection.ObserveDefaultComposer` → `ValidMasterModel`) already sanitise a gone model on `main`; this closes the composer-**INIT** path the maintainer hit.

## Tests (`MeshWeaver.AI.Test`)

- `DeepSeekFlash_IsPinnedToOrderMinus1_OnBothTheNodeAndTheDefinition_...` — the model carries `Order -1` on node **and** def, siblings keep the source Order, and it's the lowest-Order catalog model.
- `ModelOrdering_For_ReturnsMinus1ForDeepSeekFlash_AndTheFallbackOtherwise` — override + fallback, case/prefix tolerant.
- `ObserveDefaultComposer_StaleMasterModel_ResolvesToDefault_WithoutThrowing` — a composer whose master model is unknown resolves to the order default **without throwing** (the regression the maintainer hit).

Full `MeshWeaver.AI.Test`: **844 passed, 0 failed, 5 skipped** (skips are gated real-CLI/e2e). Built Release `-warnaserror` clean (incl. `MeshWeaver.Blazor.Portal`).

## Rollout

Rides the **next portal image roll** (one is already queued) — no portal roll in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)