### PR TITLE
Foreign-language Code runs never hang when no worker is connected

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
@@ -85,6 +85,17 @@ public static class CodeNodeType
         };
 
     /// <summary>
+    /// True when <paramref name="language"/> runs on a foreign-language worker (a connected gate)
+    /// rather than in-process on the Activity hub's Roslyn kernel — i.e. when
+    /// <see cref="ResolveKernelAddress"/> routes to a stable <c>py/*</c> or <c>node/*</c> address.
+    /// The in-process C# path always writes a terminal status (its kernel calls
+    /// <c>ActivityLogLogger.Complete</c>); a foreign run reaches a terminal status ONLY if a worker
+    /// is connected, so the dispatch must reconcile the ActivityLog when one is not.
+    /// </summary>
+    private static bool IsForeignLanguage(string? language) =>
+        language?.ToLowerInvariant() is "python" or "javascript" or "typescript";
+
+    /// <summary>
     /// Runs the Code node's own script. Reads the local workspace for the node's
     /// <see cref="CodeConfiguration"/>, validates <c>IsExecutable</c>, dispatches
     /// <see cref="SubmitCodeRequest"/> to the <see cref="ResolveKernelAddress">language kernel</see>,
@@ -204,15 +215,54 @@ public static class CodeNodeType
                             // C# runs in-process on the Activity hub's Roslyn kernel; a foreign language
                             // routes to the worker that owns its runtime (see ResolveKernelAddress).
                             var submitTarget = ResolveKernelAddress(code.Language, activityPath);
-                            hub.Post(
-                                new SubmitCodeRequest(code.Code ?? string.Empty)
+                            var submit = new SubmitCodeRequest(code.Code ?? string.Empty)
+                            {
+                                Id = submissionId,
+                                ActivityLogPath = activityPath,
+                                Language = string.IsNullOrWhiteSpace(code.Language) ? "csharp" : code.Language,
+                                Inputs = request.Message.Inputs
+                            };
+
+                            if (IsForeignLanguage(code.Language))
+                            {
+                                // Foreign-language run: the script executes on a connected worker
+                                // (py/python-kernel, node/node-kernel), which patches the ActivityLog
+                                // to a terminal status when done. But submitTarget is a STREAM-ROUTED
+                                // address: on the distributed portal a post to it with NO subscriber is
+                                // silently absorbed by the Orleans memory stream (no DeliveryFailure),
+                                // so with no worker connected the run would stay Running forever — the
+                                // opposite of the "nothing hangs" promise in
+                                // Doc/Architecture/PythonCodeNodes. Fail fast on a presence miss, and
+                                // Observe the response so a monolith NotFound / a mid-flight disconnect
+                                // still reconciles the ActivityLog instead of parking.
+                                var presence = hub.ServiceProvider.GetService<IParticipantPresence>();
+                                if (presence is not null && !presence.IsConnected(submitTarget))
                                 {
-                                    Id = submissionId,
-                                    ActivityLogPath = activityPath,
-                                    Language = string.IsNullOrWhiteSpace(code.Language) ? "csharp" : code.Language,
-                                    Inputs = request.Message.Inputs
-                                },
-                                o => o.WithTarget(submitTarget));
+                                    FailActivity(hub, activityPath,
+                                        $"No {submit.Language} worker connected at '{submitTarget}'. The " +
+                                        "language gate is not running in this deployment — see " +
+                                        "Doc/Architecture/PythonCodeNodes.");
+                                }
+                                else
+                                {
+                                    hub.Observe<SubmitCodeResponse>(submit, o => o.WithTarget(submitTarget))
+                                        .Take(1)
+                                        .Subscribe(
+                                            // Success or a handled script error: the worker has already
+                                            // patched the ActivityLog to its terminal status — nothing to do.
+                                            _ => { },
+                                            // The delivery faulted (target unreachable / disconnected)
+                                            // before any terminal write — reconcile so the run ends.
+                                            ex => FailActivity(hub, activityPath,
+                                                $"{submit.Language} run failed: {ex.Message}"));
+                                }
+                            }
+                            else
+                            {
+                                // C# in-process: the Activity hub's Roslyn kernel always calls
+                                // ActivityLogLogger.Complete, so the ActivityLog can never hang here.
+                                hub.Post(submit, o => o.WithTarget(submitTarget));
+                            }
 
                             // Stamp Last{ExecutedAt,ExecutedBy,ActivityPath} onto
                             // the Code MeshNode so the Content area can show
@@ -274,5 +324,26 @@ public static class CodeNodeType
                         });
             });
         return request.Processed();
+    }
+
+    /// <summary>
+    /// Reconcile a foreign-language run's ActivityLog to a terminal <see cref="ActivityStatus.Failed"/>
+    /// when the worker never wrote one — no worker was connected, or the submission delivery faulted.
+    /// Writes through the external-node stream handle (routes to the ActivityLog's owning hub and
+    /// carries the caller's AccessContext across the Subscribe boundary); <see cref="ActivityLog.Fail"/>
+    /// appends the error and stamps <c>End</c>, so the Output pane leaves "Running…" with the reason.
+    /// </summary>
+    private static void FailActivity(IMessageHub hub, string activityPath, string error)
+    {
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Graph.CodeNodeType");
+        hub.GetWorkspace().GetMeshNodeStream(activityPath).Update(curr =>
+            curr.Content is ActivityLog log
+                ? curr with { Content = log.Fail(error) }
+                : curr)
+            .Subscribe(
+                _ => { },
+                ex => logger?.LogWarning(ex,
+                    "CodeNodeType: failed to reconcile ActivityLog {Activity} to Failed", activityPath));
     }
 }

--- a/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
@@ -27,7 +27,7 @@ namespace MeshWeaver.Hosting.Grpc;
 /// (<see cref="IMessageDelivery.SetAccessContext"/>) — the client's claimed context is never trusted.
 /// No token ⇒ <see cref="WellKnownUsers.Anonymous"/> (writes cleanly RLS-denied, never fail-closed).</para>
 /// </summary>
-public sealed class GrpcConnectionRegistry : IDisposable
+public sealed class GrpcConnectionRegistry : IDisposable, IParticipantPresence
 {
     private readonly IMessageHub hub;
     private readonly IRoutingService routingService;
@@ -105,6 +105,14 @@ public sealed class GrpcConnectionRegistry : IDisposable
     /// <summary>The connection currently owning <paramref name="addressKey"/> (delivery-time resolution).</summary>
     private string? OwnerOf(string addressKey) =>
         addressClaims.TryGetValue(addressKey, out var claim) ? claim.Owner : null;
+
+    /// <inheritdoc />
+    /// <remarks>An address is "connected" while some connection holds its claim — i.e. between a
+    /// participant's <see cref="Connect"/> and the disconnect that releases it. Lock-free read: a
+    /// <see cref="ConcurrentDictionary{TKey,TValue}"/> membership check on the delivery-agnostic
+    /// claim map.</remarks>
+    public bool IsConnected(Address address) =>
+        address is not null && addressClaims.ContainsKey(address.ToString());
 
     /// <summary>Register the per-connection outbound channel (the <c>Open</c> call drains it to the wire).
     /// Always runs first for a connection, before <see cref="Authenticate"/> / <see cref="Connect"/>.</summary>

--- a/src/MeshWeaver.Hosting.Grpc/GrpcHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcHostingExtensions.cs
@@ -1,4 +1,5 @@
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,6 +42,10 @@ public static class GrpcHostingExtensions
     {
         services.AddGrpc();
         services.AddSingleton<GrpcConnectionRegistry>();
+        // Expose the registry's live address claims as a presence check so foreign-language Code
+        // runs can fail fast when no worker is connected (a post to a stream-routed address with no
+        // subscriber is silently absorbed — no DeliveryFailure — so the run would otherwise hang).
+        services.AddSingleton<IParticipantPresence>(sp => sp.GetRequiredService<GrpcConnectionRegistry>());
         // Grpc:TrustedPort — the loopback endpoint co-deployed gates authenticate on (GrpcOptions).
         services.AddOptions<GrpcOptions>().BindConfiguration(GrpcOptions.SectionName);
         return services;

--- a/src/MeshWeaver.Mesh.Contract/Services/IParticipantPresence.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IParticipantPresence.cs
@@ -1,0 +1,29 @@
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// Read-only presence check for stream-routed participant addresses (a co-deployed language gate on
+/// the trusted loopback endpoint, or a token-authenticated participant) connected to THIS process.
+/// </summary>
+/// <remarks>
+/// Implemented by the gRPC connection registry and resolved via
+/// <c>hub.ServiceProvider.GetService&lt;IParticipantPresence&gt;()</c> — it is <b>absent</b> when the gRPC
+/// transport is not hosted (e.g. a pure test mesh), in which case callers fall back to the normal
+/// request/<c>DeliveryFailure</c> path.
+///
+/// <para>Presence is scoped to the local process. In the co-hosted portal topology every silo pod also
+/// runs the gates as sidecars on its own loopback, so a per-node hub activated on that silo sees the
+/// gate that would serve it. This is used to <b>fail a foreign-language Code run fast</b> when no worker
+/// is connected: a post to a stream-routed address with no subscriber is silently absorbed by the
+/// Orleans memory stream (no <c>DeliveryFailure</c> is produced), so without this check the run's
+/// ActivityLog would stay <c>Running</c> forever.</para>
+/// </remarks>
+public interface IParticipantPresence
+{
+    /// <summary>
+    /// True when a participant is currently connected to this process and owns <paramref name="address"/>
+    /// (i.e. a language worker is registered at that address and can service a delivery to it).
+    /// </summary>
+    bool IsConnected(Address address);
+}

--- a/test/MeshWeaver.AI.Test/MultiLanguageCodeExecutionTest.cs
+++ b/test/MeshWeaver.AI.Test/MultiLanguageCodeExecutionTest.cs
@@ -6,11 +6,13 @@ using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Kernel;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace MeshWeaver.AI.Test;
@@ -91,25 +93,26 @@ public class MultiLanguageCodeExecutionTest(ITestOutputHelper output) : Monolith
                 && l.Messages.Any(m => m.Message.Contains("multi-lang-csharp-ran")));
     }
 
-    // ── no worker connected: the run must FAIL fast, never hang on "Running…" ──
+    // ── no worker connected: a foreign-language run must FAIL fast, never hang on "Running…" ──
 
-    [Fact(Timeout = 120000)]
-    public async Task PythonCodeNode_WithNoWorkerConnected_FailsTheActivity_NeverHangs()
+    [Theory(Timeout = 120000)]
+    [InlineData("python")]      // → py/python-kernel   (the reported bug)
+    [InlineData("javascript")]  // → node/node-kernel   (same defect class — js/ts route to a worker too)
+    public async Task ForeignLanguageCodeNode_WithNoWorkerConnected_FailsTheActivity_NeverHangs(string language)
     {
-        // No py/python-kernel worker is registered in this test mesh. Running a python Code node
-        // must drive its ActivityLog to a TERMINAL Failed status (with a reason) rather than parking
-        // on Running forever — the "nothing hangs" contract of Doc/Architecture/PythonCodeNodes.
-        // Before the fix the dispatch fire-and-forgot the SubmitCodeRequest; with no worker the run
-        // stayed Running indefinitely (the reported bug).
-        var id = $"python-noworker-{Guid.NewGuid():N}";
+        // No worker is registered at this language's kernel address in the test mesh. Running the node
+        // must drive its ActivityLog to a TERMINAL Failed status (with a reason) rather than parking on
+        // Running forever — the "nothing hangs" contract of Doc/Architecture/PythonCodeNodes. Before the
+        // fix the dispatch fire-and-forgot the SubmitCodeRequest and the run stayed Running indefinitely.
+        var id = $"{language}-noworker-{Guid.NewGuid():N}";
         var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
         await mesh.CreateNode(new MeshNode(id, Partition)
         {
-            Name = "python cell (no worker)", NodeType = "Code",
+            Name = $"{language} cell (no worker)", NodeType = "Code",
             Content = new CodeConfiguration
             {
-                Language = "python", IsExecutable = true,
-                Code = "print('should-not-run-without-a-worker')\n1 + 1"
+                Language = language, IsExecutable = true,
+                Code = "should-not-run-without-a-worker"
             }
         }).Should().Within(30.Seconds()).Emit();
 
@@ -124,5 +127,72 @@ public class MultiLanguageCodeExecutionTest(ITestOutputHelper output) : Monolith
             .Should().Within(60.Seconds()).Match(l => l is not null
                 && l.Status == ActivityStatus.Failed
                 && l.HasErrors());
+    }
+
+    // ── a connected worker: the run reaches Succeeded (dispatch → worker → write-back → terminal) ──
+
+    [Theory(Timeout = 120000)]
+    [InlineData("python")]      // → py/python-kernel
+    [InlineData("javascript")]  // → node/node-kernel
+    public async Task ForeignLanguageCodeNode_WithConnectedWorker_ReachesSucceeded(string language)
+    {
+        // Stand up an in-process FAKE WORKER at the language's kernel address — the same stable address
+        // a real gate registers at (CodeNodeType.ResolveKernelAddress). It patches the run's ActivityLog
+        // to Succeeded, exactly as clients/python and clients/typescript do over the wire. This pins the
+        // full .NET dispatch path end-to-end (only the interpreter is faked): the round-trip that had NO
+        // coverage — which is how "foreign-language runs don't actually complete" went unnoticed.
+        var kernelAddress = CodeNodeType.ResolveKernelAddress(language, "unused");
+        const string marker = "connected-worker-ran";
+
+        var routing = Mesh.ServiceProvider.GetRequiredService<IRoutingService>();
+        var workerHub = Mesh.GetHostedHub(kernelAddress, config =>
+        {
+            config.TypeRegistry
+                .WithType(typeof(SubmitCodeRequest), nameof(SubmitCodeRequest))
+                .WithType(typeof(SubmitCodeResponse), nameof(SubmitCodeResponse));
+            return config.WithHandler<SubmitCodeRequest>((worker, req) =>
+            {
+                // Patch the SAME Activity node every subscriber watches (the mesh-native write-back),
+                // then reply for the request/response caller — mirrors the real worker's _write_back.
+                var activityPath = req.Message.ActivityLogPath!;
+                Mesh.GetWorkspace().GetMeshNodeStream(activityPath).Update(curr =>
+                        curr.Content is ActivityLog log
+                            ? curr with
+                            {
+                                Content = log with
+                                {
+                                    Status = ActivityStatus.Succeeded,
+                                    End = DateTime.UtcNow,
+                                    Messages = log.Messages.Add(new LogMessage(marker, LogLevel.Information))
+                                }
+                            }
+                            : curr)
+                    .Subscribe(_ => { }, _ => { });
+                worker.Post(new SubmitCodeResponse(req.Message.Id, true), o => o.ResponseFor(req));
+                return req.Processed();
+            });
+        }, HostedHubCreation.Always);
+        // Make the kernel address routable to the fake worker — register it in the routing streams
+        // (LOCAL_STREAM_HIT, resolved before node lookup), exactly as a real gate/participant does.
+        // Without this the monolith router resolves 'py/…' via CreateHub → null → NotFound.
+        routing.RegisterStream(workerHub!);
+
+        var id = $"{language}-worker-{Guid.NewGuid():N}";
+        var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        await mesh.CreateNode(new MeshNode(id, Partition)
+        {
+            Name = $"{language} cell (worker)", NodeType = "Code",
+            Content = new CodeConfiguration { Language = language, IsExecutable = true, Code = "run" }
+        }).Should().Within(30.Seconds()).Emit();
+
+        var exec = (await Mesh.Observe(new ExecuteScriptRequest(), o => o.WithTarget(new Address($"{Partition}/{id}")))
+            .Should().Within(60.Seconds()).Emit()).Message;
+        exec.Success.Should().BeTrue(exec.Error ?? "exec failed");
+
+        await Mesh.GetWorkspace().GetMeshNodeStream(exec.ActivityLog!)
+            .Select(n => n?.Content as ActivityLog)
+            .Should().Within(60.Seconds()).Match(l => l is not null
+                && l.Status == ActivityStatus.Succeeded
+                && l.Messages.Any(m => m.Message.Contains(marker)));
     }
 }

--- a/test/MeshWeaver.AI.Test/MultiLanguageCodeExecutionTest.cs
+++ b/test/MeshWeaver.AI.Test/MultiLanguageCodeExecutionTest.cs
@@ -90,4 +90,39 @@ public class MultiLanguageCodeExecutionTest(ITestOutputHelper output) : Monolith
                 && l.Status == ActivityStatus.Succeeded
                 && l.Messages.Any(m => m.Message.Contains("multi-lang-csharp-ran")));
     }
+
+    // ── no worker connected: the run must FAIL fast, never hang on "Running…" ──
+
+    [Fact(Timeout = 120000)]
+    public async Task PythonCodeNode_WithNoWorkerConnected_FailsTheActivity_NeverHangs()
+    {
+        // No py/python-kernel worker is registered in this test mesh. Running a python Code node
+        // must drive its ActivityLog to a TERMINAL Failed status (with a reason) rather than parking
+        // on Running forever — the "nothing hangs" contract of Doc/Architecture/PythonCodeNodes.
+        // Before the fix the dispatch fire-and-forgot the SubmitCodeRequest; with no worker the run
+        // stayed Running indefinitely (the reported bug).
+        var id = $"python-noworker-{Guid.NewGuid():N}";
+        var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        await mesh.CreateNode(new MeshNode(id, Partition)
+        {
+            Name = "python cell (no worker)", NodeType = "Code",
+            Content = new CodeConfiguration
+            {
+                Language = "python", IsExecutable = true,
+                Code = "print('should-not-run-without-a-worker')\n1 + 1"
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        var exec = (await Mesh.Observe(new ExecuteScriptRequest(), o => o.WithTarget(new Address($"{Partition}/{id}")))
+            .Should().Within(60.Seconds()).Emit()).Message;
+        // The run STARTS (the ActivityLog is created); the no-worker failure surfaces on that log,
+        // exactly like an in-process C# script error does.
+        exec.Success.Should().BeTrue(exec.Error ?? "the run should start");
+
+        await Mesh.GetWorkspace().GetMeshNodeStream(exec.ActivityLog!)
+            .Select(n => n?.Content as ActivityLog)
+            .Should().Within(60.Seconds()).Match(l => l is not null
+                && l.Status == ActivityStatus.Failed
+                && l.HasErrors());
+    }
 }


### PR DESCRIPTION
## Problem

A `python` / `javascript` / `typescript` Code node routes its `SubmitCodeRequest` to a **stream-routed worker address** (`py/python-kernel`, `node/node-kernel`). `CodeNodeType.HandleExecuteScript` **fire-and-forgot** that post. On the distributed portal a post to a stream-routed address with **no subscriber is silently absorbed** by the Orleans memory stream (no `DeliveryFailure`), so with no worker connected the run's ActivityLog stayed **`Running` forever** — the exact opposite of the "nothing hangs" promise in `Doc/Architecture/PythonCodeNodes`. (The in-process C# path can't hang: its Roslyn kernel always writes a terminal status via `ActivityLogLogger.Complete`.)

Reported symptom: the runnable python example on `Doc/Architecture/PythonCodeNodes` spins on **"Running…"** indefinitely.

## Fix

Mirror the reconcile the in-process path already gets:

- **`IParticipantPresence`** (new, `Mesh.Contract`) — implemented by `GrpcConnectionRegistry`'s live address claims. `HandleExecuteScript` **fails the ActivityLog fast** (`Failed`, *"No python worker connected …"*) when the target foreign address has no participant. Deterministic, no timer.
- **`Observe<SubmitCodeResponse>`** for the foreign path so a monolith `NotFound` / a mid-flight disconnect (`DeliveryFailure`) also reconciles the ActivityLog to `Failed`.
- C# in-process dispatch unchanged.

## Test

`MultiLanguageCodeExecutionTest.PythonCodeNode_WithNoWorkerConnected_FailsTheActivity_NeverHangs` — runs a python Code node with no worker and asserts the ActivityLog reaches a terminal `Failed` status (with an error) instead of hanging. Full class green (14/14); Release + `-warnaserror` clean across the deployable portal tree.

> Note: this fixes the *hang*. Making python actually **execute** on a deployment additionally requires the `py/python-kernel` gate sidecar to be running (`deploy/python-gate/Dockerfile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)