### PR TITLE
Group access: resolve groups globally so a group can be licensed cross-partition

### DIFF
--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
@@ -293,33 +293,119 @@ public static class PostgreSqlSchemaInitializer
     /// </summary>
     internal const string AccessChangedTriggerFunctionBody = """
         DECLARE
-            affected_user TEXT;
+            new_subject TEXT;
+            old_subject TEXT;
+            subject_is_group BOOLEAN;
         BEGIN
-            IF TG_OP = 'DELETE' THEN
-                affected_user := OLD.content->>'accessObject';
-            ELSE
-                affected_user := NEW.content->>'accessObject';
+            IF TG_OP <> 'INSERT' THEN
+                old_subject := OLD.content->>'accessObject';
+            END IF;
+            IF TG_OP <> 'DELETE' THEN
+                new_subject := NEW.content->>'accessObject';
             END IF;
 
-            -- Schema-qualified via TG_TABLE_SCHEMA (= the partition schema): an unqualified
-            -- PERFORM resolves through the WRITING SESSION's search_path, which on the shared
-            -- base connection pool is public — silently rebuilding the WRONG schema's
-            -- permissions and leaving this partition's user_effective_permissions empty
-            -- (memex prod incident 2026-07-13).
-            IF affected_user IS NOT NULL THEN
-                EXECUTE format('SELECT %I.rebuild_user_permissions_for($1)', TG_TABLE_SCHEMA)
-                    USING affected_user;
-            ELSE
+            -- A grant whose subject is a GROUP applies to every (leaf) MEMBER of that group.
+            -- rebuild_user_permissions_for(subject) does NOT compute that — it would rebuild the
+            -- group id as if it were a user — so a group grant written before OR after its members
+            -- exist would leave them stale. Detect a group subject and fall back to a full rebuild,
+            -- so a licensed group materializes its members regardless of add-vs-grant order.
+            -- (Membership CHANGES are the mirror case, handled by the auth-mirror
+            -- zzz_group_recompute_* triggers — see GroupChangedTriggerFunctionBody.)
+            --
+            -- Every call is schema-qualified via TG_TABLE_SCHEMA (= the partition schema whose
+            -- `access` table fired the trigger): an unqualified PERFORM resolves through the WRITING
+            -- SESSION's search_path, which on the shared base connection pool is public — silently
+            -- rebuilding the WRONG schema's permissions and leaving this partition's
+            -- user_effective_permissions empty (memex prod incident 2026-07-13).
+            -- Groups mirror to the GLOBAL auth schema, so a grant to a group DEFINED IN ANOTHER
+            -- PARTITION is still detected here (cross-partition licensing) — read auth, not the
+            -- local schema. Default false so an (impossible) missing auth schema falls back to the
+            -- per-user path rather than erroring the originating grant write.
+            subject_is_group := false;
+            IF to_regclass('"auth".mesh_nodes') IS NOT NULL THEN
+                EXECUTE
+                    'SELECT EXISTS (SELECT 1 FROM "auth".mesh_nodes WHERE node_type = ''Group'''
+                    || ' AND CASE WHEN namespace = '''' THEN id ELSE namespace || ''/'' || id END'
+                    || ' IN ($1, $2))'
+                    INTO subject_is_group USING new_subject, old_subject;
+            END IF;
+
+            IF subject_is_group OR (new_subject IS NULL AND old_subject IS NULL) THEN
                 EXECUTE format('SELECT %I.rebuild_user_effective_permissions()', TG_TABLE_SCHEMA);
-            END IF;
-
-            IF TG_OP = 'UPDATE' AND OLD.content->>'accessObject' IS DISTINCT FROM NEW.content->>'accessObject' THEN
-                IF OLD.content->>'accessObject' IS NOT NULL THEN
+            ELSE
+                IF new_subject IS NOT NULL THEN
                     EXECUTE format('SELECT %I.rebuild_user_permissions_for($1)', TG_TABLE_SCHEMA)
-                        USING OLD.content->>'accessObject';
+                        USING new_subject;
+                END IF;
+                IF old_subject IS NOT NULL AND old_subject IS DISTINCT FROM new_subject THEN
+                    EXECUTE format('SELECT %I.rebuild_user_permissions_for($1)', TG_TABLE_SCHEMA)
+                        USING old_subject;
                 END IF;
             END IF;
 
+            RETURN NULL;
+        END;
+        """;
+
+    /// <summary>
+    /// Body of the <c>trg_group_changed()</c> trigger function — recomputes
+    /// <c>user_effective_permissions</c> whenever a <c>Group</c> or <c>GroupMembership</c> node
+    /// changes. Group memberships feed the group-expansion INSIDE the rebuild, but — unlike an
+    /// <c>AccessAssignment</c> — they live in <c>mesh_nodes</c>, not the <c>access</c> satellite
+    /// that <see cref="AccessChangedTriggerFunctionBody"/> watches. So without this trigger,
+    /// adding or removing a member (or renaming/deleting a group) left every affected member's
+    /// permissions STALE until an unrelated grant write or the next boot's self-heal
+    /// re-materialized them: a group licensed on a course granted its new members nothing until
+    /// something else touched the projection. Installed ONCE, on the global auth mirror — the two
+    /// <c>zzz_group_recompute_*</c> triggers on <c>auth.mesh_nodes</c> that <see cref="GetAuthMirrorSelfHealScript"/>
+    /// creates (this body becomes <c>public.trg_group_changed()</c>).
+    ///
+    /// <para><b>Cross-partition fan-out.</b> Group access is resolved GLOBALLY: memberships mirror
+    /// into <c>auth.mesh_nodes</c> and every schema's rebuild reads them from there, so a group can
+    /// be defined in one partition and licensed on a course in another. A membership change in ANY
+    /// partition therefore mirrors into <c>auth</c> and can change effective permissions in ANY
+    /// schema that grants the affected group(s) — so this body loops the partition schemas and
+    /// full-rebuilds every one that has at least one GROUP grant (a superset of the truly-affected
+    /// schemas: correct, and bounded to the partitions that actually license a group). A full
+    /// rebuild per schema (not per-user) is the right call — a membership can list several groups,
+    /// its member can itself be a group (nested groups expand recursively to leaf users), and a group
+    /// can be renamed/deleted, so the affected end-users are not knowable from the single changed
+    /// row. Group changes are infrequent admin operations, and the triggers' <c>WHEN</c> clause keeps
+    /// this off every non-group write.</para>
+    ///
+    /// <para><b>Why on auth, not per partition.</b> The membership converges in <c>auth</c> (the
+    /// global mirror), so ONE trigger there covers every partition — no per-partition copies to
+    /// double-fire, and the changed row is already in <c>auth</c> when the trigger fires (the mirror
+    /// wrote it), so no firing-order hack is needed. Every rebuild call is schema-qualified
+    /// (<c>%I</c>) so it materializes the right schema.</para>
+    /// </summary>
+    internal const string GroupChangedTriggerFunctionBody = """
+        DECLARE
+            sch text;
+            has_group_grant boolean;
+        BEGIN
+            -- A Group/GroupMembership changed. Because group access is resolved GLOBALLY (auth-
+            -- mirrored memberships; each schema's rebuild reads them), the affected users may live
+            -- in — and be granted in — ANY partition. Rebuild every schema that grants a group.
+            FOR sch IN
+                SELECT n.nspname
+                FROM pg_namespace n
+                WHERE n.nspname NOT IN ('information_schema','pg_catalog','pg_toast','auth')
+                  AND n.nspname NOT LIKE 'pg\_%'
+                  AND n.nspname NOT LIKE '%\_versions'
+                  AND to_regclass(format('%I.access', n.nspname)) IS NOT NULL
+                  AND to_regclass(format('%I.user_effective_permissions', n.nspname)) IS NOT NULL
+            LOOP
+                -- Skip schemas with no group grant — nothing there depends on group membership.
+                EXECUTE format(
+                    'SELECT EXISTS (SELECT 1 FROM %I.access a'
+                    || ' JOIN "auth".mesh_nodes g ON g.node_type = ''Group'''
+                    || ' AND g.namespace || ''/'' || g.id = a.content->>''accessObject'')', sch)
+                    INTO has_group_grant;
+                IF has_group_grant THEN
+                    EXECUTE format('SELECT %I.rebuild_user_effective_permissions()', sch);
+                END IF;
+            END LOOP;
             RETURN NULL;
         END;
         """;
@@ -332,8 +418,13 @@ public static class PostgreSqlSchemaInitializer
     /// <c>access_changed</c> trigger where missing) so grant writes materialize
     /// <c>user_effective_permissions</c> into the RIGHT schema — partitions deployed with the
     /// pre-2026-07-13 body resolved the rebuild through the writing session's
-    /// <c>search_path</c> and silently rebuilt <c>public</c> instead, (b) upserts every mirrored
-    /// node type (<c>User/Group/Role/VUser/ApiToken/Space</c>) into <c>auth.mesh_nodes</c>, and
+    /// <c>search_path</c> and silently rebuilt <c>public</c> instead; it also installs (once, before
+    /// the per-schema loop) the global <c>public.trg_group_changed()</c> + the two
+    /// <c>zzz_group_recompute_*</c> triggers on <c>auth.mesh_nodes</c>
+    /// (<see cref="GroupChangedTriggerFunctionBody"/>) so a Group/GroupMembership change — which
+    /// mirrors into <c>auth</c> — recomputes every schema that grants the affected group
+    /// (cross-partition group licensing), (b) upserts every mirrored
+    /// node type (<c>User/Group/Role/VUser/ApiToken/Space/GroupMembership</c>) into <c>auth.mesh_nodes</c>, and
     /// (c) re-runs the schema's <c>rebuild_user_effective_permissions()</c> so <c>_Access</c>
     /// grants and <c>_Policy</c> rows are projected into <c>user_effective_permissions</c> +
     /// <c>public.partition_access</c> — the tables every partition-scoped query and the
@@ -362,6 +453,26 @@ public static class PostgreSqlSchemaInitializer
             IF to_regclass('"auth".mesh_nodes') IS NULL THEN
                 RETURN;
             END IF;
+
+            -- Cross-partition group recompute lives HERE, on the global auth mirror — the single
+            -- convergence point for memberships. A Group/GroupMembership change in ANY partition
+            -- mirrors into auth.mesh_nodes; this trigger then recomputes every schema that grants
+            -- the affected group(s) (trg_group_changed fans out over the partition schemas). One
+            -- trigger, not one per partition: no double-fire, and the row is already in auth when
+            -- it fires (the mirror wrote it), so no firing-order hack is needed. Idempotent.
+            CREATE OR REPLACE FUNCTION public.trg_group_changed() RETURNS TRIGGER AS $trg_group$
+        {{GroupChangedTriggerFunctionBody}}
+            $trg_group$ LANGUAGE plpgsql;
+            DROP TRIGGER IF EXISTS zzz_group_recompute_ins ON "auth".mesh_nodes;
+            CREATE TRIGGER zzz_group_recompute_ins
+                AFTER INSERT OR UPDATE ON "auth".mesh_nodes
+                FOR EACH ROW WHEN (NEW.node_type IN ('GroupMembership','Group'))
+                EXECUTE FUNCTION public.trg_group_changed();
+            DROP TRIGGER IF EXISTS zzz_group_recompute_del ON "auth".mesh_nodes;
+            CREATE TRIGGER zzz_group_recompute_del
+                AFTER DELETE ON "auth".mesh_nodes
+                FOR EACH ROW WHEN (OLD.node_type IN ('GroupMembership','Group'))
+                EXECUTE FUNCTION public.trg_group_changed();
 
             -- One heal at a time across the whole mesh (HA silos boot concurrently); the lock
             -- releases with this transaction.
@@ -432,7 +543,7 @@ public static class PostgreSqlSchemaInitializer
                     SELECT namespace, id, name, node_type, category, icon, display_order,
                            last_modified, version, state, content, desired_id, main_node
                       FROM %I.mesh_nodes
-                     WHERE node_type IN ('User','Group','Role','VUser','ApiToken','Space')
+                     WHERE node_type IN ('User','Group','Role','VUser','ApiToken','Space','GroupMembership')
                     ON CONFLICT (namespace, id) DO UPDATE SET
                         name = EXCLUDED.name,
                         node_type = EXCLUDED.node_type,
@@ -582,14 +693,14 @@ public static class PostgreSqlSchemaInitializer
             END IF;
 
             IF TG_OP = 'DELETE' THEN
-                IF OLD.node_type IN ('User','Group','Role','VUser','ApiToken','Space') THEN
+                IF OLD.node_type IN ('User','Group','Role','VUser','ApiToken','Space','GroupMembership') THEN
                     DELETE FROM "auth".mesh_nodes
                      WHERE namespace = OLD.namespace AND id = OLD.id;
                 END IF;
                 RETURN OLD;
             END IF;
 
-            IF NEW.node_type IN ('User','Group','Role','VUser','ApiToken','Space') THEN
+            IF NEW.node_type IN ('User','Group','Role','VUser','ApiToken','Space','GroupMembership') THEN
                 INSERT INTO "auth".mesh_nodes
                     (namespace, id, name, node_type, category, icon, display_order,
                      last_modified, version, state, content, desired_id, main_node)
@@ -1038,13 +1149,13 @@ public static class PostgreSqlSchemaInitializer
                 INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
                 WITH RECURSIVE all_members AS (
                     SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
-                    FROM mesh_nodes gm
+                    FROM "auth".mesh_nodes gm
                     CROSS JOIN LATERAL jsonb_array_elements(gm.content->'groups') AS group_entry
                     WHERE gm.node_type = 'GroupMembership'
                     UNION
                     SELECT am.group_path, gm.content->>'member'
                     FROM all_members am
-                    JOIN mesh_nodes gm ON gm.node_type = 'GroupMembership'
+                    JOIN "auth".mesh_nodes gm ON gm.node_type = 'GroupMembership'
                     WHERE EXISTS (
                         SELECT 1 FROM jsonb_array_elements(gm.content->'groups') g
                         WHERE g->>'group' = am.member_id
@@ -1053,7 +1164,7 @@ public static class PostgreSqlSchemaInitializer
                 leaf_members AS (
                     SELECT group_path, member_id FROM all_members
                     WHERE NOT EXISTS (
-                        SELECT 1 FROM mesh_nodes gm2
+                        SELECT 1 FROM "auth".mesh_nodes gm2
                         CROSS JOIN LATERAL jsonb_array_elements(gm2.content->'groups') AS g2
                         WHERE gm2.node_type = 'GroupMembership'
                           AND g2->>'group' = all_members.member_id
@@ -1253,13 +1364,13 @@ public static class PostgreSqlSchemaInitializer
                 INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
                 WITH RECURSIVE all_members AS (
                     SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
-                    FROM mesh_nodes gm
+                    FROM "auth".mesh_nodes gm
                     CROSS JOIN LATERAL jsonb_array_elements(gm.content->'groups') AS group_entry
                     WHERE gm.node_type = 'GroupMembership'
                     UNION
                     SELECT am.group_path, gm.content->>'member'
                     FROM all_members am
-                    JOIN mesh_nodes gm ON gm.node_type = 'GroupMembership'
+                    JOIN "auth".mesh_nodes gm ON gm.node_type = 'GroupMembership'
                     WHERE EXISTS (SELECT 1 FROM jsonb_array_elements(gm.content->'groups') g WHERE g->>'group' = am.member_id)
                 ),
                 user_groups AS (
@@ -1348,6 +1459,11 @@ public static class PostgreSqlSchemaInitializer
             CREATE TRIGGER access_changed
                 AFTER INSERT OR UPDATE OR DELETE ON access
                 FOR EACH ROW EXECUTE FUNCTION trg_access_changed();
+
+            -- Group/GroupMembership recompute is NOT installed per-partition: it is driven from the
+            -- global auth mirror (see GetAuthMirrorSelfHealScript / trg_group_changed) so a group
+            -- defined in one partition can be licensed on a course in another. A per-partition copy
+            -- would double-fire (the change mirrors to auth) and couldn't see cross-partition members.
 
             -- Simple access_control and group_members tables used by convenience methods
             CREATE TABLE IF NOT EXISTS access_control (
@@ -1701,13 +1817,13 @@ public static class PostgreSqlSchemaInitializer
                 INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
                 WITH RECURSIVE all_members AS (
                     SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
-                    FROM mesh_nodes gm
+                    FROM "auth".mesh_nodes gm
                     CROSS JOIN LATERAL jsonb_array_elements(gm.content->'groups') AS group_entry
                     WHERE gm.node_type = 'GroupMembership'
                     UNION
                     SELECT am.group_path, gm.content->>'member'
                     FROM all_members am
-                    JOIN mesh_nodes gm ON gm.node_type = 'GroupMembership'
+                    JOIN "auth".mesh_nodes gm ON gm.node_type = 'GroupMembership'
                     WHERE EXISTS (
                         SELECT 1 FROM jsonb_array_elements(gm.content->'groups') g
                         WHERE g->>'group' = am.member_id
@@ -1716,7 +1832,7 @@ public static class PostgreSqlSchemaInitializer
                 leaf_members AS (
                     SELECT group_path, member_id FROM all_members
                     WHERE NOT EXISTS (
-                        SELECT 1 FROM mesh_nodes gm2
+                        SELECT 1 FROM "auth".mesh_nodes gm2
                         CROSS JOIN LATERAL jsonb_array_elements(gm2.content->'groups') AS g2
                         WHERE gm2.node_type = 'GroupMembership'
                           AND g2->>'group' = all_members.member_id
@@ -1919,13 +2035,13 @@ public static class PostgreSqlSchemaInitializer
                 INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
                 WITH RECURSIVE all_members AS (
                     SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
-                    FROM mesh_nodes gm
+                    FROM "auth".mesh_nodes gm
                     CROSS JOIN LATERAL jsonb_array_elements(gm.content->'groups') AS group_entry
                     WHERE gm.node_type = 'GroupMembership'
                     UNION
                     SELECT am.group_path, gm.content->>'member'
                     FROM all_members am
-                    JOIN mesh_nodes gm ON gm.node_type = 'GroupMembership'
+                    JOIN "auth".mesh_nodes gm ON gm.node_type = 'GroupMembership'
                     WHERE EXISTS (SELECT 1 FROM jsonb_array_elements(gm.content->'groups') g WHERE g->>'group' = am.member_id)
                 ),
                 user_groups AS (
@@ -2014,6 +2130,11 @@ public static class PostgreSqlSchemaInitializer
             CREATE TRIGGER access_changed
                 AFTER INSERT OR UPDATE OR DELETE ON access
                 FOR EACH ROW EXECUTE FUNCTION trg_access_changed();
+
+            -- Group/GroupMembership recompute is NOT installed per-partition: it is driven from the
+            -- global auth mirror (see GetAuthMirrorSelfHealScript / trg_group_changed) so a group
+            -- defined in one partition can be licensed on a course in another. A per-partition copy
+            -- would double-fire (the change mirrors to auth) and couldn't see cross-partition members.
 
             -- Simple access_control and group_members tables used by convenience methods
             CREATE TABLE IF NOT EXISTS access_control (

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -58,6 +58,13 @@ internal static class PermissionEvaluator
     private const string RoleNodeType = "Role";
     private const string RoleQueryId = "$security-roles";
 
+    // Group access is resolved GLOBALLY — a group defined in one partition can be granted in
+    // another (cross-partition licensing), so we read EVERY GroupMembership node (as System, like
+    // the other $security-* queries) and expand the viewer's transitive group set in-memory. This
+    // mirrors the Postgres rebuild, which reads memberships from the global auth mirror.
+    private const string GroupMembershipNodeType = "GroupMembership";
+    private const string MembershipQueryId = "$security-memberships";
+
     #region Public surface
 
     public static IObservable<bool> HasPermission(IMessageHub hub, string nodePath, Permission permission)
@@ -135,12 +142,19 @@ internal static class PermissionEvaluator
         var staticOnlyDeniedScopeRoles = ComputeStaticOnlyDeniedScopeRoles(staticNodes, userId, hub.JsonSerializerOptions);
         var fast = ComputeRoleState(staticOnlyScopeRoles, nodePath, userId, capturedContext, capturedCircuitContext, staticPolicies, staticOnlyDeniedScopeRoles);
 
-        var enriched = ObserveEffectiveAssignments(hub, cache, nodePath, staticNodes)
-            .CombineLatest(
+        var enriched = Observable.CombineLatest(
+                ObserveEffectiveAssignments(hub, cache, nodePath, staticNodes),
                 ObserveScopePolicies(hub, cache, nodePath, staticPolicies),
-                (nodes, policies) =>
+                ObserveAllMembershipNodes(hub),
+                (nodes, policies, memberships) =>
                 {
-                    var (granted, denied) = ComputeScopeRoles(userId, nodes, staticNodes, hub.JsonSerializerOptions);
+                    // Match grants to the viewer OR any group they belong to (transitively). A group
+                    // grant's subject is the group path, and memberships live UNDER the group node —
+                    // off the target's scope walk, and possibly in another partition — so the group
+                    // set is resolved globally here, then folded into the subjects ComputeScopeRoles
+                    // matches on. Consistent with the Postgres rebuild's global group expansion.
+                    var subjects = ResolveUserGroups(userId, memberships, hub.JsonSerializerOptions).Add(userId);
+                    var (granted, denied) = ComputeScopeRoles(subjects, nodes, staticNodes, hub.JsonSerializerOptions);
                     return (Granted: granted, Denied: denied, RuntimePolicies: policies);
                 })
             .Select(snap => ComputeRoleState(snap.Granted, nodePath, userId, capturedContext, capturedCircuitContext, staticPolicies, snap.Denied, snap.RuntimePolicies));
@@ -473,7 +487,7 @@ internal static class PermissionEvaluator
 
     private static (ImmutableDictionary<string, ImmutableHashSet<string>> Granted,
                     ImmutableDictionary<string, ImmutableHashSet<string>> Denied) ComputeScopeRoles(
-        string userId,
+        IReadOnlySet<string> subjects,
         IEnumerable<MeshNode> allNodes,
         IReadOnlyList<MeshNode> staticAssignments,
         JsonSerializerOptions options)
@@ -493,7 +507,7 @@ internal static class PermissionEvaluator
                 return;
 
             var assignment = DeserializeAssignment(node, options);
-            if (assignment == null || assignment.AccessObject != userId)
+            if (assignment == null || !subjects.Contains(assignment.AccessObject))
                 return;
 
             foreach (var ra in assignment.Roles)
@@ -615,6 +629,18 @@ internal static class PermissionEvaluator
             .Select(arr => arr.ToArray());
     }
 
+    /// <summary>
+    /// Every <c>GroupMembership</c> node in the mesh, cached process-wide and read as System (like
+    /// the other <c>$security-*</c> queries), so group access resolves GLOBALLY — a group and its
+    /// members can live in a different partition than the grant (cross-partition licensing).
+    /// </summary>
+    private static IObservable<IEnumerable<MeshNode>> ObserveAllMembershipNodes(IMessageHub hub)
+    {
+        var cache = hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+        return cache.GetQuery(MembershipQueryId, hub.JsonSerializerOptions,
+            $"nodeType:{GroupMembershipNodeType} scope:subtree");
+    }
+
     #endregion
 
     #region Helpers
@@ -627,6 +653,66 @@ internal static class PermissionEvaluator
         if (string.IsNullOrEmpty(userId) || context?.IsVirtual == true)
             userId = WellKnownUsers.Anonymous;
         return userId;
+    }
+
+    /// <summary>
+    /// The transitive set of groups <paramref name="userId"/> belongs to, expanded from all
+    /// <c>GroupMembership</c> nodes. A membership's <c>Member</c> may itself be a group, so nested
+    /// groups are followed (BFS). Never includes <paramref name="userId"/> itself.
+    /// </summary>
+    private static ImmutableHashSet<string> ResolveUserGroups(
+        string userId, IEnumerable<MeshNode> memberships, JsonSerializerOptions options)
+    {
+        // member -> the groups it is DIRECTLY a member of.
+        var edges = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var node in memberships)
+        {
+            if (node.NodeType != GroupMembershipNodeType)
+                continue;
+            var m = DeserializeMembership(node, options);
+            if (m is null || string.IsNullOrEmpty(m.Member) || m.Groups is null)
+                continue;
+            foreach (var entry in m.Groups)
+            {
+                if (string.IsNullOrEmpty(entry.Group))
+                    continue;
+                if (!edges.TryGetValue(m.Member, out var list))
+                    edges[m.Member] = list = new List<string>();
+                list.Add(entry.Group);
+            }
+        }
+
+        var result = ImmutableHashSet<string>.Empty;
+        if (edges.Count == 0)
+            return result;
+        var visited = new HashSet<string>(StringComparer.Ordinal) { userId };
+        var queue = new Queue<string>();
+        queue.Enqueue(userId);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!edges.TryGetValue(current, out var groups))
+                continue;
+            foreach (var g in groups)
+                if (visited.Add(g))   // a group may itself be a member of another group (nesting)
+                {
+                    result = result.Add(g);
+                    queue.Enqueue(g);
+                }
+        }
+        return result;
+    }
+
+    private static GroupMembership? DeserializeMembership(MeshNode node, JsonSerializerOptions options)
+    {
+        if (node.Content is GroupMembership gm)
+            return gm;
+        if (node.Content is JsonElement je)
+        {
+            try { return JsonSerializer.Deserialize<GroupMembership>(je.GetRawText(), options); }
+            catch { return null; }
+        }
+        return null;
     }
 
     private static IEnumerable<MeshNode> UnionByPath(

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/GroupMembershipRecomputeTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/GroupMembershipRecomputeTests.cs
@@ -1,0 +1,375 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Pins that <b>modifying a group re-triggers the recompute of every access where that group is
+/// used</b> — the behaviour a group-based license (e.g. a course licensed to a cohort group) relies
+/// on. Group memberships feed the group-expansion INSIDE
+/// <c>rebuild_user_effective_permissions()</c>, but <c>Group</c>/<c>GroupMembership</c> nodes live in
+/// <c>mesh_nodes</c>, NOT the <c>access</c> satellite the <c>access_changed</c> trigger watches — so
+/// without the <c>group_changed_*</c> triggers this change adds, adding or removing a member never
+/// recomputed <c>user_effective_permissions</c>: the member's group-granted access stayed stale until
+/// an unrelated grant write or the next boot's self-heal.
+///
+/// <para>Everything is driven through the PRODUCTION write path — the shared base
+/// <see cref="Npgsql.NpgsqlDataSource"/> with schema-qualified statements, whose connections keep the
+/// DEFAULT <c>search_path</c> (<c>public</c>). This is the shape that surfaced the 2026-07-13
+/// wrong-schema incident, so it also pins that the group trigger's rebuild is schema-qualified via
+/// <c>TG_TABLE_SCHEMA</c> (materializes THE PARTITION's permissions, not public's).</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class GroupMembershipRecomputeTests
+{
+    private readonly PostgreSqlFixture _fixture;
+
+    // camelCase — the naming policy the mesh hub uses for node content. The rebuild reads camelCase
+    // JSON keys (content->>'member', content->'groups', content->>'accessObject').
+    private readonly JsonSerializerOptions _options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    public GroupMembershipRecomputeTests(PostgreSqlFixture fixture) => _fixture = fixture;
+
+    // ── Fixtures shaped exactly like production (mirrors AccessTriggerSchemaResolutionTests) ──
+
+    private async Task<PostgreSqlStorageAdapter> ProvisionProdShapeAdapterAsync(
+        string space, string schema, CancellationToken ct)
+    {
+        await _fixture.DataSource.ExecuteNonQuery(
+            $"SELECT public.ensure_partition_schema('{schema}')", ct)
+            .Should().Within(60.Seconds()).Emit();
+
+        var def = new PartitionDefinition
+        {
+            Namespace = space,
+            Schema = schema,
+            TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+            NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings()
+        };
+        return new PostgreSqlStorageAdapter(_fixture.DataSource, partitionDefinition: def);
+    }
+
+    private Task WriteSpaceRootAsync(PostgreSqlStorageAdapter adapter, string space, CancellationToken ct)
+        => adapter.WriteAsync(new MeshNode(space)
+        {
+            Name = $"{space} Inc.",
+            NodeType = SpaceNodeType.NodeType,
+            State = MeshNodeState.Active,
+            MainNode = space,
+            Content = new Space()
+        }, _options, ct);
+
+    /// <summary>A <c>Group</c> access-object node at <c>{space}/{groupId}</c> (lives in mesh_nodes).</summary>
+    private Task WriteGroupAsync(PostgreSqlStorageAdapter adapter, string space, string groupId, CancellationToken ct)
+        => adapter.WriteAsync(new MeshNode(groupId, space)
+        {
+            Name = groupId,
+            NodeType = "Group",
+            State = MeshNodeState.Active,
+            MainNode = $"{space}/{groupId}",
+            Content = new AccessObject { Description = $"{groupId} cohort" }
+        }, _options, ct);
+
+    /// <summary>A <c>GroupMembership</c> node placing <paramref name="member"/> into the group.</summary>
+    private Task WriteMembershipAsync(
+        PostgreSqlStorageAdapter adapter, string groupPath, string member, CancellationToken ct)
+        => adapter.WriteAsync(new MeshNode($"{member}_Membership", groupPath)
+        {
+            Name = $"{member} membership",
+            NodeType = "GroupMembership",
+            State = MeshNodeState.Active,
+            MainNode = $"{groupPath}/{member}_Membership",
+            Content = new GroupMembership
+            {
+                Member = member,
+                DisplayName = member,
+                Groups = [new MembershipEntry { Group = groupPath }]
+            }
+        }, _options, ct);
+
+    private Task<long> PartitionReadGrants(string schema, string user, CancellationToken ct)
+        => _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".user_effective_permissions " +
+            $"WHERE user_id = '{user}' AND permission = 'Read' AND is_allow = true", ct)
+            .Should().Within(30.Seconds()).Emit();
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// THE ask: a group is licensed (granted Viewer on the space), then a member is added. Writing
+    /// the <c>GroupMembership</c> node must, on its own, recompute the member's effective permissions
+    /// so the group grant reaches them — no manual rebuild, no reboot. And it must materialize in
+    /// THE PARTITION's schema (not public), proving the trigger's <c>TG_TABLE_SCHEMA</c> qualification.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AddingMember_ToGrantedGroup_RecomputesMemberPermissions()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "grouplic";
+        const string space = "GroupLic";
+        const string groupId = "Cohort";
+        var groupPath = $"{space}/{groupId}";
+        const string alice = "gl_alice";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+        await WriteGroupAsync(adapter, space, groupId, ct);
+
+        // License the group: a Viewer grant whose subject is the GROUP path.
+        await adapter.WriteAsync(
+            AssignmentNodeFactory.UserRole(groupPath, "Viewer", space), _options, ct);
+
+        // No members yet → alice has nothing.
+        (await PartitionReadGrants(schema, alice, ct)).Should().Be(0,
+            "alice is not in the group yet");
+
+        // The whole point: adding the membership recomputes alice's access from the group grant.
+        await WriteMembershipAsync(adapter, groupPath, alice, ct);
+
+        (await PartitionReadGrants(schema, alice, ct)).Should().BeGreaterThan(0,
+            "writing the GroupMembership must retrigger the recompute so the group's Viewer grant " +
+            "reaches its new member — with no manual rebuild");
+
+        // Schema-qualified: the partition's table was rebuilt, not public's (2026-07-13 landmine).
+        var publicRows = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM public.user_effective_permissions WHERE user_id = '{alice}'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        publicRows.Should().Be(0, "the group grant is scoped to the partition, not public");
+
+        // partition_access synced → the cross-partition permission gate lets alice in.
+        var aliceAccess = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM public.partition_access WHERE user_id = '{alice}' AND partition = '{schema}'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        aliceAccess.Should().Be(1, "the rebuild syncs public.partition_access for the new member");
+    }
+
+    /// <summary>
+    /// The inverse: removing a member from a licensed group must revoke the group-granted access
+    /// immediately (the <c>group_changed_del</c> trigger fires the recompute on the hard DELETE).
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task RemovingMember_FromGrantedGroup_RevokesMemberPermissions()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "grouprevoke";
+        const string space = "GroupRevoke";
+        const string groupId = "Cohort";
+        var groupPath = $"{space}/{groupId}";
+        const string bob = "gr_bob";
+        var membershipPath = $"{groupPath}/{bob}_Membership";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+        await WriteGroupAsync(adapter, space, groupId, ct);
+        await adapter.WriteAsync(
+            AssignmentNodeFactory.UserRole(groupPath, "Viewer", space), _options, ct);
+        await WriteMembershipAsync(adapter, groupPath, bob, ct);
+
+        (await PartitionReadGrants(schema, bob, ct)).Should().BeGreaterThan(0,
+            "precondition: bob is a member and inherits the group's Viewer grant");
+
+        // Remove bob from the group (hard delete of the GroupMembership node).
+        await adapter.DeleteAsync(membershipPath, ct);
+
+        (await PartitionReadGrants(schema, bob, ct)).Should().Be(0,
+            "removing the membership must retrigger the recompute and revoke the group-granted access");
+
+        var bobAccess = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM public.partition_access WHERE user_id = '{bob}' AND partition = '{schema}'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        bobAccess.Should().Be(0, "the recompute also drops the now-unentitled member from partition_access");
+    }
+
+    /// <summary>
+    /// Order-independence: the members are added to the group FIRST, then the group is licensed. The
+    /// grant write (subject = a group with existing members) must materialize those members — a
+    /// per-user rebuild of the group id would not (it rebuilds the group as if it were a user), so
+    /// the grant trigger falls back to a full rebuild when its subject is a group. Without that, a
+    /// cohort assembled before the course was licensed would silently get nothing.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task LicensingGroup_AfterMembersExist_MaterializesMemberPermissions()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "grouporder";
+        const string space = "GroupOrder";
+        const string groupId = "Cohort";
+        var groupPath = $"{space}/{groupId}";
+        const string carol = "go_carol";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+        await WriteGroupAsync(adapter, space, groupId, ct);
+
+        // Members first, no grant yet → carol has nothing.
+        await WriteMembershipAsync(adapter, groupPath, carol, ct);
+        (await PartitionReadGrants(schema, carol, ct)).Should().Be(0,
+            "the group is not licensed yet");
+
+        // Now license the group. The grant's subject is the group; existing members must materialize.
+        await adapter.WriteAsync(
+            AssignmentNodeFactory.UserRole(groupPath, "Viewer", space), _options, ct);
+
+        (await PartitionReadGrants(schema, carol, ct)).Should().BeGreaterThan(0,
+            "granting a group must recompute its existing members, regardless of add/grant order");
+    }
+
+    /// <summary>
+    /// Nested groups: a member added to an INNER group that is itself a member of the licensed OUTER
+    /// group must inherit the grant. The rebuild expands nesting to leaf users, and the trigger's
+    /// full rebuild (rather than a single-member recompute) is what makes the transitive member
+    /// materialize when the inner membership changes.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AddingMember_ToNestedGroup_RecomputesTransitiveMember()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "groupnest";
+        const string space = "GroupNest";
+        var outer = $"{space}/Outer";
+        var inner = $"{space}/Inner";
+        const string dave = "gn_dave";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+        await WriteGroupAsync(adapter, space, "Outer", ct);
+        await WriteGroupAsync(adapter, space, "Inner", ct);
+
+        // License the OUTER group, and nest Inner inside Outer (Inner is a MEMBER of Outer).
+        await adapter.WriteAsync(
+            AssignmentNodeFactory.UserRole(outer, "Viewer", space), _options, ct);
+        await WriteMembershipAsync(adapter, outer, inner, ct); // member = the Inner group path
+
+        (await PartitionReadGrants(schema, dave, ct)).Should().Be(0, "dave is not in Inner yet");
+
+        // Add dave to the INNER group → he is a transitive leaf member of Outer.
+        await WriteMembershipAsync(adapter, inner, dave, ct);
+
+        (await PartitionReadGrants(schema, dave, ct)).Should().BeGreaterThan(0,
+            "a member of a nested inner group inherits the outer group's grant once the membership " +
+            "change retriggers the (nesting-aware) recompute");
+    }
+
+    /// <summary>
+    /// The recompute trigger lives on the GLOBAL <c>auth</c> mirror (not per-partition). This pins
+    /// that the per-boot self-heal (<see cref="PostgreSqlSchemaInitializer.GetAuthMirrorSelfHealScript"/>)
+    /// (re)installs it on <c>auth.mesh_nodes</c> and backfills via the schema-level rebuild: with the
+    /// auth triggers dropped a membership write does not recompute; after the self-heal it does. A
+    /// <c>finally</c> restores the shared auth triggers so a failure here can't leak into other tests.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task SelfHeal_InstallsGroupRecomputeTriggerOnAuthMirror()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "groupheal";
+        const string space = "GroupHeal";
+        var groupPath = $"{space}/Cohort";
+        const string erin = "gh_erin";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+        await WriteGroupAsync(adapter, space, "Cohort", ct);
+        await adapter.WriteAsync(
+            AssignmentNodeFactory.UserRole(groupPath, "Viewer", space), _options, ct);
+
+        try
+        {
+            // Regress: drop the auth-mirror recompute triggers (a pre-feature deployment).
+            await _fixture.DataSource.ExecuteNonQuery(
+                "DROP TRIGGER IF EXISTS zzz_group_recompute_ins ON \"auth\".mesh_nodes;" +
+                "DROP TRIGGER IF EXISTS zzz_group_recompute_del ON \"auth\".mesh_nodes;", ct)
+                .Should().Within(30.Seconds()).Emit();
+
+            // The membership still MIRRORS to auth, but with the recompute triggers gone nothing
+            // rebuilds → erin stays stale.
+            await WriteMembershipAsync(adapter, groupPath, erin, ct);
+            (await PartitionReadGrants(schema, erin, ct)).Should().Be(0,
+                "with the auth recompute triggers dropped, a membership write never recomputes");
+        }
+        finally
+        {
+            // HEAL (also the restore, so a failure above can't leave auth broken for other tests):
+            // reinstalls the auth triggers AND backfills every schema via the schema-level rebuild.
+            await _fixture.DataSource.ExecuteNonQuery(
+                PostgreSqlSchemaInitializer.GetAuthMirrorSelfHealScript(), ct)
+                .Should().Within(60.Seconds()).Emit();
+        }
+
+        (await PartitionReadGrants(schema, erin, ct)).Should().BeGreaterThan(0,
+            "the self-heal reinstalls the auth recompute trigger and backfills the stale member");
+
+        // Healed going forward: a fresh membership recomputes with no further heal.
+        await WriteMembershipAsync(adapter, groupPath, "gh_frank", ct);
+        (await PartitionReadGrants(schema, "gh_frank", ct)).Should().BeGreaterThan(0,
+            "after the heal the reinstalled auth trigger recomputes membership changes directly");
+    }
+
+    /// <summary>
+    /// THE cross-partition case: a group and its memberships live in partition A (like
+    /// <c>PartnerRe/AgenticEngineering0726</c>); the group is licensed on a course in partition B
+    /// (like <c>AgenticEngineering</c>). Because memberships resolve GLOBALLY (auth-mirrored) and
+    /// the recompute trigger fans out to every schema that grants the group, a member of the A-group
+    /// must gain Read in the B partition — and membership add/remove in A must recompute B.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task CrossPartitionGroup_LicensedOnAnotherPartition_ReachesMembersAndRecomputes()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schemaA = "xpgroupsrc";
+        const string spaceA = "XpGroupSrc";       // the group's home partition (like PartnerRe)
+        const string schemaB = "xpcourse";
+        const string spaceB = "XpCourse";         // the licensed course, a DIFFERENT partition
+        var groupPath = $"{spaceA}/Cohort";
+        const string user1 = "xp_user1";
+        const string user2 = "xp_user2";
+
+        // Partition A: the group + a member (mirrors the membership into auth).
+        var adapterA = await ProvisionProdShapeAdapterAsync(spaceA, schemaA, ct);
+        await WriteSpaceRootAsync(adapterA, spaceA, ct);
+        await WriteGroupAsync(adapterA, spaceA, "Cohort", ct);
+        await WriteMembershipAsync(adapterA, groupPath, user1, ct);
+
+        // Partition B: the course, licensed to the A-group (subject = the cross-partition group path).
+        var adapterB = await ProvisionProdShapeAdapterAsync(spaceB, schemaB, ct);
+        await WriteSpaceRootAsync(adapterB, spaceB, ct);
+        await adapterB.WriteAsync(
+            AssignmentNodeFactory.UserRole(groupPath, "Viewer", spaceB), _options, ct);
+
+        // The A-group's member has Read in the B partition — resolved via global auth memberships.
+        (await PartitionReadGrants(schemaB, user1, ct)).Should().BeGreaterThan(0,
+            "a group defined in partition A, licensed on partition B, reaches its members in B");
+        // …and NOT accidentally in A (no grant there).
+        (await PartitionReadGrants(schemaA, user1, ct)).Should().Be(0,
+            "the grant lives in B only; A grants nothing");
+
+        // Adding a member in A must fan out and recompute the granting partition B.
+        await WriteMembershipAsync(adapterA, groupPath, user2, ct);
+        (await PartitionReadGrants(schemaB, user2, ct)).Should().BeGreaterThan(0,
+            "a membership added in partition A recomputes the granting partition B (cross-partition fan-out)");
+
+        // Removing that member in A must recompute B and revoke.
+        await adapterA.DeleteAsync($"{groupPath}/{user2}_Membership", ct);
+        (await PartitionReadGrants(schemaB, user2, ct)).Should().Be(0,
+            "removing the member in A recomputes B and revokes the group-granted access");
+    }
+}

--- a/test/MeshWeaver.Security.Test/GroupPermissionTests.cs
+++ b/test/MeshWeaver.Security.Test/GroupPermissionTests.cs
@@ -1,0 +1,117 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// The in-memory <c>PermissionEvaluator</c> must be GROUP-AWARE and resolve groups GLOBALLY —
+/// matching the Postgres rebuild. A grant whose subject is a <c>Group</c> reaches every (transitive)
+/// member; the group and its <c>GroupMembership</c> nodes may live in a different partition than the
+/// grant (cross-partition licensing); and adding/removing a membership updates effective permissions
+/// reactively. Before this change the evaluator matched grants only where <c>accessObject == userId</c>,
+/// so group grants were invisible to <c>HasPermission</c>/<c>GetEffectivePermissions</c>.
+/// </summary>
+public class GroupPermissionTests(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder).AddRowLevelSecurity();
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    /// <summary>A GroupMembership node placing <paramref name="member"/> (a user OR a group path) into the group.</summary>
+    private static MeshNode Membership(string member, string groupPath) =>
+        new($"{member.Replace('/', '_')}_Membership", groupPath)
+        {
+            NodeType = "GroupMembership",
+            Name = $"{member} membership",
+            MainNode = $"{groupPath}/{member.Replace('/', '_')}_Membership",
+            Content = new GroupMembership
+            {
+                Member = member,
+                Groups = [new MembershipEntry { Group = groupPath }]
+            }
+        };
+
+    [Fact(Timeout = 20000)]
+    public async Task GroupGrant_ReachesMember_ButNotNonMembers()
+    {
+        // License a GROUP (grant subject = the group PATH) on ACME.
+        await MeshService.CreateNode(
+            AssignmentNodeFactory.UserRole("ACME/Cohort", "Viewer", "ACME")).Should().Emit();
+        // alice is a member; bob is not.
+        await MeshService.CreateNode(Membership("alice", "ACME/Cohort")).Should().Emit();
+
+        await Mesh.GetEffectivePermissions("ACME/Doc", "alice")
+            .Should().Match(p => p.HasFlag(Permission.Read));
+        await Mesh.GetEffectivePermissions("ACME/Doc", "bob")
+            .Should().Match(p => p == Permission.None);
+    }
+
+    [Fact(Timeout = 20000)]
+    public async Task CrossPartitionGroup_LicensedElsewhere_ReachesMember()
+    {
+        // The group + its membership live under one root; the grant lives under a DIFFERENT root.
+        // The group set is resolved GLOBALLY, so the grant still reaches the member.
+        await MeshService.CreateNode(
+            AssignmentNodeFactory.UserRole("PartnerRe/Cohort", "Viewer", "Course")).Should().Emit();
+        await MeshService.CreateNode(Membership("carol", "PartnerRe/Cohort")).Should().Emit();
+
+        await Mesh.GetEffectivePermissions("Course/Module", "carol")
+            .Should().Match(p => p.HasFlag(Permission.Read));
+    }
+
+    [Fact(Timeout = 20000)]
+    public async Task NestedGroup_ReachesTransitiveMember()
+    {
+        await MeshService.CreateNode(
+            AssignmentNodeFactory.UserRole("Org/Outer", "Viewer", "Org")).Should().Emit();
+        // Inner is a MEMBER of Outer (nesting); dave is a member of Inner.
+        await MeshService.CreateNode(Membership("Org/Inner", "Org/Outer")).Should().Emit();
+        await MeshService.CreateNode(Membership("dave", "Org/Inner")).Should().Emit();
+
+        await Mesh.GetEffectivePermissions("Org/Doc", "dave")
+            .Should().Match(p => p.HasFlag(Permission.Read));
+    }
+
+    [Fact(Timeout = 20000)]
+    public async Task RemovingMembership_RevokesGroupAccess()
+    {
+        await MeshService.CreateNode(
+            AssignmentNodeFactory.UserRole("Team/Squad", "Viewer", "Team")).Should().Emit();
+        var membership = Membership("erin", "Team/Squad");
+        await MeshService.CreateNode(membership).Should().Emit();
+
+        await Mesh.GetEffectivePermissions("Team/Doc", "erin")
+            .Should().Match(p => p.HasFlag(Permission.Read));
+
+        // Removing the membership must revoke the group-granted access (reactively).
+        await MeshService.DeleteNode(membership.Path).Should().Emit();
+
+        await Mesh.GetEffectivePermissions("Team/Doc", "erin")
+            .Should().Match(p => p == Permission.None);
+    }
+
+    [Fact(Timeout = 20000)]
+    public async Task GroupDeny_BlocksMemberAtScope()
+    {
+        // Group granted Viewer at Space, then DENIED at a child module — the member is blocked there.
+        await MeshService.CreateNode(
+            AssignmentNodeFactory.UserRole("Space/Cohort", "Viewer", "Space")).Should().Emit();
+        await MeshService.CreateNode(
+            AssignmentNodeFactory.UserRole("Space/Cohort", "Viewer", "Space/Gated", denied: true)).Should().Emit();
+        await MeshService.CreateNode(Membership("frank", "Space/Cohort")).Should().Emit();
+
+        await Mesh.GetEffectivePermissions("Space/Intro", "frank")
+            .Should().Match(p => p.HasFlag(Permission.Read));
+        await Mesh.GetEffectivePermissions("Space/Gated", "frank")
+            .Should().Match(p => p == Permission.None);
+    }
+}


### PR DESCRIPTION
## What

Group `AccessAssignment`s (subject = a group path) now take effect for **both** the Postgres RLS/query path and the in-memory `PermissionEvaluator`, and resolve **globally** — a group defined in one partition can be licensed on a space in **another**, and add/remove of a member recomputes effective permissions everywhere the group is used.

**Motivation:** a customer group (e.g. `PartnerRe/AgenticEngineering0726`) should be able to license a shared course (`AgenticEngineering`, a different partition). Previously group grants were honored only by the Postgres search/RLS path — **not** by `HasPermission`/`GetEffectivePermissions` — and only *within a single partition schema*.

## Postgres (`PostgreSqlSchemaInitializer`)
- `GroupMembership` mirrors into the global `auth` schema (alongside User/Group/Role/…).
- Both rebuild functions (`rebuild_user_effective_permissions`, `rebuild_user_permissions_for`) expand a user's groups **transitively / nested** from `auth` and match grants in the local schema.
- Recompute is **auth-driven**: one pair of `zzz_group_recompute_*` triggers on `auth.mesh_nodes` fans out to every schema that grants the affected group — so a membership change in any partition recomputes every partition that licenses the group. Single trigger (no per-partition double-fire), and the row is already in `auth` when it fires (no ordering hack).
- `trg_access_changed` detects a group subject via `auth` (a cross-partition group grant → full rebuild).

## In-memory (`PermissionEvaluator`)
- Resolves the viewer's transitive group set globally (all `GroupMembership` nodes, read as System like the other `$security-*` queries) and matches grants to `{user} ∪ groups` — consistent with the PG rebuild.

## Tests
- **`GroupMembershipRecomputeTests`** (Postgres): group grant reaches members, remove revokes, nested groups, grant-after-members, auth self-heal, and **cross-partition licensing** (group in partition A, grant in partition B).
- **`GroupPermissionTests`** (in-memory evaluator): group grant reaches members / not non-members, cross-partition, nested, revoke, deny.
- **852 permission/access tests green** (529 `MeshWeaver.Hosting.PostgreSql.Test`, 323 `MeshWeaver.Security.Test`), no regressions.

## Pairs with
The Edu plugin's enrollment model (`IsEntitled` → `hub.CheckPermission(course, Read)`, already merged in `MeshWeaver.Plugins`) becomes group-aware with this change: granting a group `_Access` Viewer on a gated course enrolls its members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
