### PR TITLE
Chat composer UX + assistant docs/skill polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,13 @@ This file provides guidance to AI agents working with this repository.
 
 **NEVER commit or push automatically.** Always wait for the user to explicitly ask.
 
-### 🚨 Work in a dedicated git worktree — NEVER the shared primary checkout
+### 🚨🚨🚨 ABSOLUTE: NEVER work on the primary checkout — it stays on `main`, untouched. EVERYONE creates a worktree.
 
-**Every agent session works in its OWN `git worktree`, not the primary checkout (`/Users/roland/code/MeshWeaver`).** Many Claude/agent sessions run against this repo at once; the primary checkout's working tree + index are shared, so editing, committing, or `reset`ing there clobbers other sessions' uncommitted WIP (a `reset --hard` there once wiped live work across every concurrent session). Create an isolated worktree on a fresh branch and do ALL edits, commits, builds, and pushes there:
+**The primary checkout (`/Users/roland/code/MeshWeaver`) is a READ-ONLY reference, not a workspace. It must stay parked on `main` and untouched — never edit, build, commit, `checkout`, `switch`, `reset`, or `stash` there, and never leave it on a feature branch.** It is the shared base that every session's worktree is cut from; the moment you mutate it (working tree, index, or HEAD) you can clobber every concurrent session's uncommitted WIP (a `reset --hard` there once wiped live work across every session).
+
+**EVERY agent session — no exceptions — works in its OWN `git worktree` on a fresh branch, and does ALL edits, builds, commits, and pushes there.** If you find yourself about to touch a file under `/Users/roland/code/MeshWeaver` directly, STOP and create a worktree first. Many Claude/agent sessions run against this repo at once; the worktree is what keeps them isolated.
+
+Create an isolated worktree on a fresh branch and do ALL work there:
 
 ```bash
 # base on origin/main for a fresh change, or on the feature branch you're extending
@@ -19,6 +23,7 @@ git worktree remove /Users/roland/code/MW-my-change   # once merged/abandoned
 ```
 
 - `git worktree list` shows every active worktree (and which branch each holds — a branch can be checked out in only one).
+- **Keep the primary parked on `main` and clean.** If you find it on a feature branch or with a dirty tree, capture any work you care about (`git diff > patch`) and restore it — `git switch main` — before continuing in a worktree. It is the cut-point for every other session; a dirty/feature-branch primary breaks the "cut a fresh worktree off `origin/main`" flow.
 - **Never `git stash`** — the stash stack is repo-global and collides across worktrees; use `git diff > patch` + `git apply` instead.
 - Parallel PR-building sub-agents must pass `isolation: "worktree"` as a tool PARAM (a prompt-only "work in a worktree" does nothing).
 

--- a/content/ai/Agent/Assistant.md
+++ b/content/ai/Agent/Assistant.md
@@ -48,7 +48,7 @@ proper `create` (not `update`), the icon rules, the live `@@` regions, the exact
 create one of these, you MUST load its skill and follow it** — do not hand-improvise the shape:
 
 - **A Markdown page** (or any node with a markdown body) → **`/markdown`** — `load_skill('Skill/markdown')`.
-- **A Space** (top-level container / partition) → **`/create-space`** — `load_skill('Skill/create-space')`.
+- **A Space** (top-level container / partition) → **`/space`** — `load_skill('Skill/space')`.
 - **An access Group** (the Group + its grant + members/invites) → **`/create-group`** — `load_skill('Skill/create-group')`.
 - **User feedback** (capture the user's location + name, file it in the Feedback space) → **`/feedback`** — `load_skill('Skill/feedback')`.
 
@@ -97,10 +97,20 @@ The complete rules — `@` path resolution, query syntax, MeshNode schemas, icon
 
 # Spaces and regions (`@@`)
 
-- **Top-level = any type; `Space` is the generic one.** A top-level node has an empty namespace (path = its id). Any partition-owning type can sit at top level, but a **Space** is the generic container — use it for a company/team/topic/project workspace. Creating one is a real **`create`** (never `update` a bare node into one) so the partition + your Admin grant get provisioned. Full recipe: load the **`/create-space`** skill.
+- **Top-level = any type; `Space` is the generic one.** A top-level node has an empty namespace (path = its id). Any partition-owning type can sit at top level, but a **Space** is the generic container — use it for a company/team/topic/project workspace. Creating one is a real **`create`** (never `update` a bare node into one) so the partition + your Admin grant get provisioned. Full recipe: load the **`/space`** skill.
 - **Embed a live area inline with `@@`.** In any markdown body, a reference at the **start of a line** either links (`@`) or **embeds** (`@@`). The contents catalog / children index of a node is its **`Search`** area — embed it with **`@@("area/Search")`** (relative to the current node), and put it at the **end of a Space body** under a `## Contents` heading. It is `Search`, NOT "Catalog" — `@@Catalog` does not render the index.
 - Other common regions: `@@("area/Overview")`, `@@("area/Threads")`, `@@("area/Files")`. Absolute form: `@@/{Path}/area/{Area}`; another node's default area: `@@Some/Node`.
 - **List a node's areas** with `Get('@{path}/layoutAreas/')` (plural). Note the standard node regions above are embeddable by name even though they don't appear in that listing (only custom/visible areas do).
+
+# Showing information: markdown and simple UIs
+
+You can **always** present something visually — never tell the user "I can't render that." Options, cheapest first:
+
+- **Markdown straight in your reply.** Your message output renders as markdown: tables, lists, headings, mesh links `[text](@/Path)`, and inline region embeds `@@("path/area/Name")` all work. For a summary, comparison table, or checklist, just write it — no node, no control needed.
+- **Markdown inside a view.** The exact same markdown can live in a **Markdown control** as part of a proper UI composition, or as a Markdown **node** you `create` and link to when it should persist and be shareable.
+- **A proper view — make it interactive with links.** You can compose a real view from framework controls and drive the interaction through **links**: a `NavLink`, or markdown links inside a Markdown control (`[Open the report](@/Path)`), let the user navigate and act without any hand-built widget. Prefer real controls (`Stack`, `LayoutGrid`, `DataGrid`, `Badge`, `Button`, `Label`, `Markdown`); 🚨 **never emit raw HTML strings** for tables or structured data — use `DataGrid`/`Stack`.
+
+**For anything more complex** — a data-bound **editable** view, a brand-new layout area, or a multi-control screen with real state — **delegate to the coder (Worker) with the `/code` (or `/layout-area`) skill.** Those skills own the framework rules (data binding, framework controls, no async) that a hand-improvised UI gets wrong. Do the markdown levels yourself; hand the complex compositions to the coder.
 
 # Version history
 
@@ -118,7 +128,7 @@ You have the Version tools directly (`GetVersions`, `GetVersion`, `RestoreVersio
 
 The in-app bell is always on; whether a notification *also* escalates to email (or, later, Teams) is decided by a triage agent from the user's own rules. Channels live at `{user}/_NotificationChannel/{id}` (`kind`: `InApp`/`Email`/`Teams`, optional `target`, `enabled`); rules at `{user}/_NotificationRule/{id}` (plain-English `ruleText`, optional `channel`, `enabled`, `order`). With **no** rules the user gets in-app only — enabling email means adding **both** an email channel and a rule.
 
-When the user asks *"email me when…"*, *"stop notifying me about…"*, or *"what are my notification settings?"* — read their current channels/rules with `Search`/`Get`, explain them plainly, `Create`/`Update` the nodes to match, confirm, and point them at the manual: **[Managing your notification preferences](@/Doc/GUI/NotificationPreferences)**.
+When the user asks *"email me when…"*, *"stop notifying me about…"*, or *"what are my notification settings?"* — read their current channels/rules with `Search`/`Get`, explain them plainly, `Create`/`Patch` the nodes to match, confirm, and point them at the manual: **[Managing your notification preferences](@/Doc/GUI/NotificationPreferences)**.
 
 # Guidelines
 
@@ -127,5 +137,6 @@ When the user asks *"email me when…"*, *"stop notifying me about…"*, or *"wh
 - When the user says "show me", "take me to", "display", "open" → call `NavigateTo`.
 - When the user says "find", "search", "list", "what's under" → call `Search`.
 - When the user asks for a simple change/edit/update/create/delete → do it yourself.
+- **Editing an existing node → `Patch` (or `EditContent` for text inside a long body), never `Update`.** `Patch` merges the fields you name and preserves the rest; `Update` overwrites the whole node and silently drops anything you omit. Reserve `Update` for importing/restoring a **complete** node verbatim. See the Tools Reference above.
 - When the user asks for complex multi-step work → understand the situation yourself (read, search), articulate completion criteria (ask the user if unclear), then choose: do it yourself, or delegate per the rules above.
 - Keep text minimal. A brief confirmation after the tool call beats a paragraph before it.

--- a/content/ai/Agent/ToolsReference.md
+++ b/content/ai/Agent/ToolsReference.md
@@ -303,7 +303,7 @@ When the user says **"create"** (a page, note, doc, list, plan, space, world, ch
 
 - **Default to `nodeType: "Markdown"`.** If you're unsure which node type fits, create a **Markdown** node — it's the general-purpose document/content node and is almost always the right answer for prose, notes, plans, and pages.
 - **For specialized nodes, load the matching skill first**, then follow it — do not guess the shape:
-  - a **Space** / company / team / project / topic workspace → load **`/create-space`**
+  - a **Space** / company / team / project / topic workspace → load **`/space`**
   - an **Agent** → **`/agent`** · a **Code** node → **`/code`** · a **model / data type** → **`/model`** · a **layout area** → **`/layout-area`** · a **slide deck** → **`/slide`**
   - Discover the rest with `Search('nodeType:Skill')` and read the one that matches before creating.
 - Every node still needs a real `name`, an inline `<svg` `icon`, and (for Markdown) a `content` body — see the schema and rules below.
@@ -362,7 +362,9 @@ Create('{"id": "NewPage", "namespace": "MyOrg", "name": "New Page", "nodeType": 
 
 ## Update
 
-Updates one or more existing nodes in the mesh. The entire MeshNode is replaced, not merged.
+Replaces one or more existing nodes in the mesh **wholesale** — the entire MeshNode is overwritten, not merged. Any field you omit is wiped.
+
+> **Prefer `Patch` (or `EditContent`) for almost every change.** `Update` is only for the case where you already hold a **complete node** and want to write it verbatim — importing/restoring whole nodes, or replaying an exported node array. For anything less than a full-node replacement (setting an icon, renaming, editing content, changing a few fields), use `Patch`: it merges, needs no `Get` first, and can't silently drop fields.
 
 ### Parameter
 
@@ -406,8 +408,8 @@ Patch('@MyOrg/MyPage', '{"content": {"text": "Updated markdown content"}}')
 ### When to use Patch vs Update vs EditContent
 
 - **EditContent**: Any change *inside* a long text — Markdown body or source code. Cheapest and safest.
-- **Patch**: Simple field changes (icon, name, category, short content). No Get needed.
-- **Update**: Complex changes to multiple fields, or when you need full control. Always Get first.
+- **Patch** (default for everything else): Any field change — icon, name, category, content, even several fields at once. Merges, so unspecified fields are preserved. No Get needed.
+- **Update**: *Only* when you are importing/restoring a **complete node** (or an array of them) verbatim — e.g. replaying exported nodes. It overwrites the whole node, so anything you omit is lost; always Get first. Not for ordinary edits — reach for Patch.
 
 ## EditContent
 

--- a/content/ai/Skill/create-group.md
+++ b/content/ai/Skill/create-group.md
@@ -148,5 +148,5 @@ rather than reporting a phantom send. Check the deployment's `Email__Enabled`.
 # Related
 
 - [/access](/access) — the AccessAssignment shape, roles, and the `mainNode` rule this builds on
-- [/create-space](/create-space) — create the space the group serves
+- [/space](/space) — create the space the group serves
 - [Granting Access via AccessAssignments](/Doc/Architecture/GrantingAccess) · [Access Control Architecture](/Doc/Architecture/AccessControl)

--- a/content/ai/Skill/space.md
+++ b/content/ai/Skill/space.md
@@ -1,6 +1,6 @@
 ---
 nodeType: Skill
-name: /create-space
+name: /space
 description: Create a Space (the generic top-level container) end-to-end — proper create, a warm body, a logo, the live @@ regions that make a page useful, and the contents catalog at the bottom.
 icon: Sparkle
 category: Skills

--- a/src/MeshWeaver.AI/ThreadLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ThreadLayoutAreas.cs
@@ -778,7 +778,7 @@ public static class ThreadLayoutAreas
                 : path;
 
         var container = Controls.Stack.WithStyle("gap:6px; width:100%;");
-        container = container.WithView(Controls.Text($"{headerLabel} ({updates.Count})")
+        container = container.WithView(Controls.Label($"{headerLabel} ({updates.Count})")
             .WithStyle("font-size:0.8rem; font-weight:600; color:var(--neutral-foreground-hint);"));
 
         var rows = Controls.Stack.WithStyle("gap:4px; width:100%;");
@@ -800,16 +800,16 @@ public static class ThreadLayoutAreas
             if (entry.VersionBefore is { } vb)
                 row = row.WithView(Controls.Badge($"v{vb}").WithStyle("font-family:monospace; font-size:0.72rem;"));
             else if (op.Equals("Created", StringComparison.OrdinalIgnoreCase))
-                row = row.WithView(Controls.Text("new")
+                row = row.WithView(Controls.Label("new")
                     .WithStyle("font-size:0.72rem; font-style:italic; color:var(--neutral-foreground-hint);"));
 
-            row = row.WithView(Controls.Text("→").WithStyle("color:var(--neutral-foreground-hint);"));
+            row = row.WithView(Controls.Label("→").WithStyle("color:var(--neutral-foreground-hint);"));
 
             if (entry.VersionAfter is { } va)
                 row = row.WithView(Controls.Badge($"v{va}")
                     .WithStyle("font-family:monospace; font-size:0.72rem; font-weight:600;"));
             else if (op.Equals("Deleted", StringComparison.OrdinalIgnoreCase))
-                row = row.WithView(Controls.Text("deleted")
+                row = row.WithView(Controls.Label("deleted")
                     .WithStyle("font-size:0.72rem; font-style:italic; color:var(--neutral-foreground-hint);"));
 
             if (entry.VersionBefore.HasValue && entry.VersionAfter.HasValue)

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -2202,7 +2202,7 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
 
                 pendingPicker = picker;
                 pickerNodes = nodes;
-                _pickerHighlight = FirstSelectablePickerIndex(); // skip a leading group title
+                _pickerHighlight = CurrentSelectionPickerIndex(picker); // pre-select the active value
                 _focusPickerOnRender = true; // move focus off Monaco onto the widget so ↑/↓ reach it
                 lastCommandStatus = null;
                 StateHasChanged();
@@ -2303,6 +2303,32 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             if (!IsPickerHeaderNode(pickerNodes[i]))
                 return i;
         return -1;
+    }
+
+    /// <summary>
+    /// Index of the picker row matching the composer's CURRENT selection for this picker's field, so
+    /// the popup opens with the active harness/agent/model highlighted instead of always item 0. Falls
+    /// back to the first selectable row when nothing is selected yet or the current value isn't listed.
+    /// </summary>
+    private int CurrentSelectionPickerIndex(NodePickerRequest picker)
+    {
+        var current = picker.ComposerField switch
+        {
+            "harness" => boundHarness,
+            "agentName" => boundAgentPath,
+            "modelName" => boundModelPath,
+            _ => null,
+        };
+        // The stored value may be a full node PATH (picked) or a bare id (default/legacy), so compare
+        // on the normalized id (last segment) — the same normalization HarnessNodeType.ResolveHarness uses.
+        var currentId = MeshWeaver.AI.SelectionId.IdOf(current);
+        if (!string.IsNullOrEmpty(currentId))
+            for (var i = 0; i < pickerNodes.Count; i++)
+                if (!IsPickerHeaderNode(pickerNodes[i])
+                    && string.Equals(MeshWeaver.AI.SelectionId.IdOf(pickerNodes[i].Path), currentId,
+                        StringComparison.OrdinalIgnoreCase))
+                    return i;
+        return FirstSelectablePickerIndex();
     }
 
     /// <summary>
@@ -2412,14 +2438,25 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
     }
 
     /// <summary>
-    /// Esc on the input cancels the in-flight round (Claude.ai pattern).
-    /// The typed text is preserved in MessageText so the user can re-send
-    /// after the cancel completes — or just hit Send to queue it as the
-    /// next round (PendingUserMessages on the thread).
+    /// Esc on the input. An OPEN picker popup takes priority — Esc dismisses it. The popup's own
+    /// <see cref="OnPickerKeyDown"/> handles Escape only while the widget holds focus; once the user
+    /// clicks back into Monaco the keystroke lands HERE instead, so the popup must be closable from
+    /// the input too. Otherwise Esc cancels the in-flight round (Claude.ai pattern): the typed text
+    /// is preserved in MessageText so the user can re-send after the cancel completes — or just hit
+    /// Send to queue it as the next round (PendingUserMessages on the thread).
     /// </summary>
     private void OnInputKeyDown(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs e)
     {
-        if (e.Key == "Escape" && ThreadViewModel?.IsExecuting == true && !isCancelling)
+        if (e.Key != "Escape")
+            return;
+
+        if (pendingPicker is not null)
+        {
+            DismissWidget();
+            return;
+        }
+
+        if (ThreadViewModel?.IsExecuting == true && !isCancelling)
         {
             CancelExecution();
         }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-15-composer-pickers-and-change-summary.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-15-composer-pickers-and-change-summary.md
@@ -1,0 +1,18 @@
+---
+Name: Smoother chat composer, cleaner change summaries
+Category: What's New
+Description: The composer's harness/model/agent pickers open on your current choice and close with Esc, and thread change summaries are read-only.
+Icon: Sparkle
+---
+
+# Smoother chat composer, cleaner change summaries
+
+When you open the harness, model, or agent picker in the chat composer, it now
+highlights the option that is currently active instead of jumping to the top of the
+list — so you can see what you're on at a glance. Pressing **Esc** now closes an open
+picker; previously it had no effect.
+
+The "Modified nodes" summary shown after an agent edits your data is now clearly
+read-only. The version transition (for example `v1 → v4`) no longer renders as an
+editable text box — it's just information about what changed, with the Diff and Undo
+actions beside it.

--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "create-space", "feedback", "harness", "layout-area", "markdown", "maui", "model", "navigate", "provider-keys", "pull-request", "slide");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "feedback", "harness", "layout-area", "markdown", "maui", "model", "navigate", "provider-keys", "pull-request", "slide", "space");
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);
@@ -52,7 +52,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         });
         // Ordering lives in the QUERY (data), not the GUI picker: `sort:order` makes the picker's
         // default-to-first land on the catalog head. This applies ONLY to PICK skills that carry a
-        // query (agent / model / harness) — command/prompt skills (code, create-space) have no pick
+        // query (agent / model / harness) — command/prompt skills (code, space) have no pick
         // Action and are exempt.
         skills.Select(n => (SkillDefinition)n.Content!)
             .Where(d => d.Action?.Query is not null)

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -29,7 +29,7 @@ public class SkillNodeTypeTest
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
         skills.Should().OnlyContain(n => n.Namespace == SkillNodeType.RootNamespace);
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "create-space", "feedback", "harness", "layout-area", "markdown", "maui", "model", "navigate", "provider-keys", "pull-request", "slide");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "create-group", "feedback", "harness", "layout-area", "markdown", "maui", "model", "navigate", "provider-keys", "pull-request", "slide", "space");
 
         var def = (SkillDefinition)skills.Single(n => n.Id == "model").Content!;
         def.Action!.Kind.Should().Be(SkillActionKind.Pick);


### PR DESCRIPTION
## Summary

A batch of small chat/assistant UX and agent-docs fixes.

### Chat composer
- **Thread "Modified nodes" summary is now read-only.** It rendered the version transition (`v1 → v4`), the header, and the `new`/`deleted` markers with `Controls.Text` — which is an *editable* `TextFieldControl` — so an empty input box appeared on read-only info. Switched those four to `Controls.Label`. Badges, Diff link, and Undo button are unchanged.
- **Composer pickers pre-select the current value.** The harness/model/agent picker always highlighted item 0; it now opens on the currently-active selection (matched via `SelectionId.IdOf`, so it works whether the stored value is a bare id or a full node path), falling back to the first row when nothing is selected.
- **Esc closes an open picker.** `OnInputKeyDown` only cancelled the running round; once focus returned to the Monaco editor, Esc did nothing to an open picker. It now dismisses the picker first.

> Harness list ordering (`sort:order`) was **already** correct in code (PR #407: `Order` stamped on harness nodes + included in the import fingerprint + `RunPicker` sorts by `Order`). A portal still showing alphabetical just needs to re-import on its next deploy — no code change here.

### Assistant docs & skills
- **Prefer `patch` over `update`** in ToolsReference + Assistant: `Update` is documented as import/restore-only (wholesale overwrite that drops omitted fields); `Patch` is the default for edits.
- **UI minimum for Assistant**: markdown in the reply / a Markdown control / a real view made interactive via links — never raw HTML for structured data — and delegate complex UIs to the coder.
- **Renamed the `/create-space` skill to `/space`** (file, frontmatter name, all references, and the two skill-list test assertions).

### Repo hygiene
- **AGENTS.md**: hardened the worktree rule — NEVER work on the primary checkout; it stays parked on `main`, untouched; every session creates its own worktree.

## Verification
- Release `-warnaserror` build of `MeshWeaver.Blazor.Portal` (covers ThreadChatView + MeshWeaver.AI + embedded content): **green (0/0)**.
- `SkillNodeTypeTest` + `SkillHarnessImportSourceTest`: **12/12 pass** (skill-list assertions updated for the rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)