### PR TITLE
Public course funnel: anonymous-gate for Anonymous-granted nodes + access-denied ⇒ course poster

### DIFF
--- a/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
@@ -1,9 +1,14 @@
-﻿using MeshWeaver.Data;
+﻿using System;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Blazor.Components;
@@ -277,6 +282,56 @@ public partial class NamedAreaView
                             AreaToBeRendered, error.Message);
                     else
                         Logger.LogError(error, "Error in control stream for area {Area}", AreaToBeRendered);
+
+                    // "No access ⇒ course poster": a not-yet-enrolled visitor denied a page UNDER a course
+                    // ({course}/Anything) is redirected to that course's PUBLIC Overview "poster" (ad page)
+                    // instead of a dead-end "Access denied" card — so the funnel never terminates on an error.
+                    // Guards: only the page's TOP-LEVEL area redirects (an embedded gated area must never hijack
+                    // the whole page), and only when the course ROOT is actually readable by THIS viewer (its
+                    // public poster renders) — a fully-private partition, or any other denied node, falls through
+                    // to the honest error card below (which is ALSO why this can't loop: a gated root is never
+                    // readable). The probe is best-effort: its OnError path shows the original error, never a swallow.
+                    if (Top
+                        && AreaErrorClassifier.TryGetCoursePosterPath(error) is { } posterPath
+                        && Hub.ServiceProvider.GetService<IMeshService>() is { } meshService)
+                    {
+                        var courseRoot = posterPath[..posterPath.LastIndexOf('/')];
+
+                        void ShowError() => InvokeAsync(() =>
+                        {
+                            if (IsViewDisposed) return;
+                            try
+                            {
+                                RootControl = new MarkdownControl($"**Error loading area:** {error.Message}");
+                                RequestStateChange();
+                            }
+                            catch (ObjectDisposedException) { /* renderer gone */ }
+                        });
+
+                        meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{courseRoot}"))
+                            .Select(change => change.Items.Any(n => string.Equals(n.Path, courseRoot, StringComparison.Ordinal)))
+                            .Take(1)
+                            .Timeout(TimeSpan.FromSeconds(5))
+                            .Subscribe(
+                                posterVisible =>
+                                {
+                                    if (IsViewDisposed) return;
+                                    if (!posterVisible) { ShowError(); return; }
+                                    InvokeAsync(() =>
+                                    {
+                                        if (IsViewDisposed) return;
+                                        try
+                                        {
+                                            RootControl = new RedirectControl($"/{posterPath}");
+                                            RequestStateChange();
+                                        }
+                                        catch (ObjectDisposedException) { /* renderer gone */ }
+                                    });
+                                },
+                                _ => { if (!IsViewDisposed) ShowError(); }); // probe failed → honest error
+                        return;
+                    }
+
                     try
                     {
                         InvokeAsync(() =>

--- a/src/MeshWeaver.Layout/AreaErrorClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaErrorClassifier.cs
@@ -171,6 +171,69 @@ public static class AreaErrorClassifier
            && (failure.Message ?? string.Empty).StartsWith("No node found", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
+    /// The node PATH an access-denied failure names — extracted so the GUI can degrade gracefully
+    /// (e.g. redirect a not-yet-enrolled visitor to a course's public paywall) instead of showing a
+    /// raw "Access denied" card. Both access-denied banners put the path in the segment right after
+    /// <c>permission on '</c>:
+    /// <list type="bullet">
+    ///   <item>"Access denied: user 'u' lacks Read permission on 'AgenticEngineering'"</item>
+    ///   <item>"User 'u' lacks Read permission on 'AgenticEngineering/Module1'"</item>
+    /// </list>
+    /// Returns <c>null</c> when the error carries no such quoted path. A routing NotFound
+    /// ("No node found at '…'") is deliberately NOT matched — it uses a different banner. Pure —
+    /// unit-tested without a renderer or a mesh.
+    /// </summary>
+    public static string? TryGetAccessDeniedPath(Exception? ex)
+    {
+        const string marker = "permission on '";
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            var msg = e.Message ?? string.Empty;
+            var open = msg.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            if (open < 0) continue;
+            var start = open + marker.Length;
+            var end = msg.IndexOf('\'', start);
+            if (end > start)
+                return msg[start..end];
+        }
+        return null;
+    }
+
+    /// <summary>The Overview area — a course's public "poster" (ad) page — that a denied course
+    /// lesson redirects to. Literal (not <c>MeshNodeLayoutAreas.OverviewArea</c>) to keep this
+    /// classifier free of a Graph dependency; pinned to that constant by a unit test.</summary>
+    public const string CoursePosterArea = "Overview";
+
+    /// <summary>
+    /// The course POSTER page to send a not-yet-enrolled visitor to when they are denied a page
+    /// <em>under</em> a course — the rule <c>{course}/Anything ⇒ {course}/Overview</c>, where the
+    /// course's public Overview is its poster/ad page. Courses are top-level partitions, so the course
+    /// root is the denied path's FIRST segment; any lesson beneath it therefore resolves to the SAME
+    /// poster. Returns <c>null</c> when:
+    /// <list type="bullet">
+    ///   <item>the error is not access-denied;</item>
+    ///   <item>the denied path is the course ROOT itself (a single segment) — that IS the poster
+    ///   location, so there is nothing to redirect TO; and</item>
+    ///   <item>the denied path already IS the poster (or sits under it) — so a redirect can never
+    ///   loop, even for a non-course partition whose own root is gated.</item>
+    /// </list>
+    /// Pure — unit-tested.
+    /// </summary>
+    public static string? TryGetCoursePosterPath(Exception? ex)
+    {
+        var denied = TryGetAccessDeniedPath(ex);
+        if (string.IsNullOrEmpty(denied)) return null;
+        var slash = denied.IndexOf('/');
+        if (slash <= 0) return null; // course root itself → it IS the poster; nothing to redirect to
+        var root = denied[..slash];
+        var remainder = denied[(slash + 1)..];
+        if (string.Equals(remainder, CoursePosterArea, StringComparison.Ordinal)
+            || remainder.StartsWith(CoursePosterArea + "/", StringComparison.Ordinal))
+            return null; // already at / under the poster → no loop
+        return $"{root}/{CoursePosterArea}";
+    }
+
+    /// <summary>
     /// The single predicate the area subscription hands to
     /// <see cref="AreaStreamRetry.RetryAreaWithBackoff{T}"/>: retry ONLY a transient hub
     /// miss — never a teardown <see cref="ObjectDisposedException"/> (benign), never a

--- a/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
+++ b/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
@@ -1,4 +1,5 @@
 using System;
+using MeshWeaver.Graph;
 using MeshWeaver.Messaging;
 using Xunit;
 
@@ -189,4 +190,57 @@ public class AreaErrorClassifierTest
     [Fact]
     public void IsRoutingNotFoundFailure_FalseForNull()
         => AreaErrorClassifier.IsRoutingNotFoundFailure(null).Should().BeFalse();
+
+    // ── TryGetAccessDeniedPath / TryGetPaywallPath: the "no access ⇒ paywall page" fallback. A
+    //    not-yet-enrolled visitor who hits a gated course is redirected to its PUBLIC paywall instead
+    //    of a raw "Access denied" card — so the discovery funnel never dead-ends on an error. ──
+
+    [Theory]
+    [InlineData("Access denied: user 'roland.buergi' lacks Read permission on 'AgenticEngineering'", "AgenticEngineering")]
+    [InlineData("Access denied: user 'u' lacks Read permission on 'AgenticEngineering/Module1'", "AgenticEngineering/Module1")]
+    [InlineData("User 'u' lacks Read permission on 'DataModeling'", "DataModeling")]
+    public void TryGetAccessDeniedPath_ExtractsThePath(string message, string expected)
+    {
+        AreaErrorClassifier.TryGetAccessDeniedPath(Failure(message, ErrorType.Unauthorized))
+            .Should().Be(expected);
+        // Works on a plain UnauthorizedAccessException too (same banner, no DeliveryFailure wrapper).
+        AreaErrorClassifier.TryGetAccessDeniedPath(new UnauthorizedAccessException(message))
+            .Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("No node found at 'x/y'.")]                       // routing NotFound — different banner
+    [InlineData("Validation failed for field 'name'")]            // no "permission on '"
+    [InlineData("boom")]
+    public void TryGetAccessDeniedPath_NullWhenNoQuotedPath(string message)
+        => AreaErrorClassifier.TryGetAccessDeniedPath(Failure(message, ErrorType.Failed)).Should().BeNull();
+
+    [Fact]
+    public void TryGetAccessDeniedPath_NullForNull()
+        => AreaErrorClassifier.TryGetAccessDeniedPath(null).Should().BeNull();
+
+    [Theory]
+    // A LESSON under the course denied → the course's Overview poster ({course}/Anything ⇒ {course}/Overview).
+    [InlineData("Access denied: user 'u' lacks Read permission on 'AgenticEngineering/Module1'", "AgenticEngineering/Overview")]
+    // A DEEP lesson resolves to the SAME poster (first segment is the course root).
+    [InlineData("Access denied: user 'u' lacks Read permission on 'AgenticEngineering/Module1/Learn'", "AgenticEngineering/Overview")]
+    public void TryGetCoursePosterPath_ResolvesTheCoursePoster(string message, string expected)
+        => AreaErrorClassifier.TryGetCoursePosterPath(Failure(message, ErrorType.Unauthorized)).Should().Be(expected);
+
+    [Theory]
+    // The course ROOT itself being denied → no redirect (the root IS the poster location; no loop).
+    [InlineData("Access denied: user 'u' lacks Read permission on 'AgenticEngineering'")]
+    // The poster ITSELF being denied → no self-redirect …
+    [InlineData("Access denied: user 'u' lacks Read permission on 'AgenticEngineering/Overview'")]
+    // … nor a node under the poster.
+    [InlineData("Access denied: user 'u' lacks Read permission on 'AgenticEngineering/Overview/Section'")]
+    // … and a non-access-denied error yields no poster.
+    [InlineData("No node found at 'x/y'.")]
+    public void TryGetCoursePosterPath_NullWhenNoSafeRedirect(string message)
+        => AreaErrorClassifier.TryGetCoursePosterPath(Failure(message, ErrorType.Unauthorized)).Should().BeNull();
+
+    [Fact]
+    public void CoursePosterArea_MatchesTheOverviewAreaConstant()
+        // The literal is kept in sync with the framework's Overview area name.
+        => AreaErrorClassifier.CoursePosterArea.Should().Be(MeshNodeLayoutAreas.OverviewArea);
 }


### PR DESCRIPTION
Two Blazor-nav changes that make a **public course funnel** work — a logged-out visitor can see the cover, and a not-yet-enrolled visitor is sent to the cover instead of an error.

## 1. Anonymous gate (`NavigationService.ProcessResolvedPath`)
The portal hard-redirected **every** logged-out visitor to `/login`. Now, for an anonymous visitor, it checks whether the resolved node is **Anonymous-readable** (`CheckPermission(path, Anonymous, Read)`) *before* redirecting: readable → load as anonymous; not readable / probe error / timeout → `/login` (fail-safe). The check evaluates the **Anonymous** identity (no authenticated user in play), so it can't re-introduce the 2026-05-21 identity-loss false-denial. Load tail → `LoadResolved()`, redirect → `RedirectToLogin()`.

→ public cover / catalog / landing render for logged-out visitors; every gated node still requires sign-in.

## 2. Access-denied ⇒ course poster (`NamedAreaView` + `AreaErrorClassifier`)
A not-yet-enrolled visitor denied a page **under a course** (`{course}/Anything`) is redirected to the course's public **Overview poster** instead of a raw "Access denied" card. Only the page's top-level area redirects, and only when the course **root is readable** by this viewer (its public poster renders) — which also prevents loops (a gated root is never readable). Reacts to the real RLS denial (the safe layer; nav-time gating of authed users is forbidden here).

- `AreaErrorClassifier.TryGetAccessDeniedPath` / `TryGetCoursePosterPath` — pure, unit-tested.

## Tests
`AreaErrorClassifierTest` (12 cases): path extraction from both banners + plain `UnauthorizedAccessException`; `{course}/Anything → {course}/Overview` (root & deep lesson → same poster); root-itself / at-poster / not-access-denied → null; `CoursePosterArea == MeshNodeLayoutAreas.OverviewArea`. Layout suite green (50/50); Release + `-warnaserror` clean across Layout, Blazor, Hosting.Blazor.

Pairs with Systemorph/MeshWeaver.Plugins#49 (Edu-side `Decide` + `ShowStartCourse`).