### PR TITLE
Probe local-model tool support on create + static-seed backfill

### DIFF
--- a/memex/Memex.Portal.Shared/Models/ModelProviderService.cs
+++ b/memex/Memex.Portal.Shared/Models/ModelProviderService.cs
@@ -45,7 +45,7 @@ namespace Memex.Portal.Shared.Models;
 /// the live <see cref="LanguageModelCatalogOptions.Sources"/>; callers
 /// can override.</para>
 /// </summary>
-public class ModelProviderService(IMeshService meshService, IMessageHub hub, ILogger<ModelProviderService> logger)
+public class ModelProviderService(IMeshService meshService, IMessageHub hub, ILogger<ModelProviderService> logger, ProviderModelLister? lister = null)
 {
     // Per-owner cached snapshot — feeds the Models settings UI without
     // hitting the synced query on every render. Wrapped around the live
@@ -176,6 +176,14 @@ public class ModelProviderService(IMeshService meshService, IMessageHub hub, ILo
         // identity on each model create's subscribe so CreateNode's own at-call capture picks it up.
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var ctx = accessService?.Context ?? accessService?.CircuitContext;
+        // Only OpenAI-compatible (Ollama/local) endpoints expose a capability probe (/api/show). For
+        // those, probe each model's tool-calling support BEFORE creating its node so the agent round
+        // never sends tool definitions to a model that can't handle them (a roleplay model like
+        // Mythalion returns HTTP 400 "does not support tools"). Remote providers (OpenAI, Anthropic)
+        // are left unprobed — the probe would 404 and only add a spurious external call.
+        var probeTools = lister is not null
+            && string.Equals(provider, "OpenAICompatible", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(endpoint);
         return meshService.CreateNode(providerNode)
             .SelectMany(createdProvider =>
             {
@@ -183,35 +191,45 @@ public class ModelProviderService(IMeshService meshService, IMessageHub hub, ILo
                     .Where(m => !string.IsNullOrWhiteSpace(m))
                     .Select(modelId =>
                     {
-                        var modelDef = new ModelDefinition
+                        // null = unknown → assume supported (historical behaviour); false = KNOWN
+                        // tool-less → the round omits all tools. Indeterminate probe → null.
+                        var supportsToolsProbe = probeTools
+                            ? lister!.SupportsTools(endpoint, modelId)
+                                .Timeout(TimeSpan.FromSeconds(8)) // a hung endpoint must not stall provider creation
+                                .Catch<bool?, Exception>(_ => Observable.Return<bool?>(null))
+                            : Observable.Return<bool?>(null);
+                        return supportsToolsProbe.SelectMany(supportsTools =>
                         {
-                            Id = modelId,
-                            DisplayName = modelId,
-                            Provider = provider,
-                            Endpoint = null, // resolver follows ProviderRef
-                            ApiKeySecretRef = null,
-                            ProviderRef = createdProvider.Path,
-                            Order = source?.Order ?? 0
-                        };
-                        var modelNode = new MeshNode(modelId, providerPath)
-                        {
-                            NodeType = LanguageModelNodeType.NodeType,
-                            Name = modelId,
-                            Category = "Models",
-                            State = MeshNodeState.Active,
-                            MainNode = isPlatform ? $"{providerPath}/{modelId}" : ownerPath,
-                            SyncBehavior = syncBehavior,
-                            Content = modelDef,
-                        };
-                        var createModel = accessService is null || ctx is null
-                            ? meshService.CreateNode(modelNode)
-                            : Observable.Using(() => accessService.SwitchAccessContext(ctx), _ => meshService.CreateNode(modelNode));
-                        return createModel
-                            .Catch<MeshNode, Exception>(ex =>
+                            var modelDef = new ModelDefinition
                             {
-                                logger.LogWarning(ex, "Failed to create LanguageModel {ModelId} under {Path}", modelId, providerPath);
-                                return Observable.Return<MeshNode>(null!);
-                            });
+                                Id = modelId,
+                                DisplayName = modelId,
+                                Provider = provider,
+                                Endpoint = null, // resolver follows ProviderRef
+                                ApiKeySecretRef = null,
+                                ProviderRef = createdProvider.Path,
+                                Order = source?.Order ?? 0,
+                                SupportsTools = supportsTools,
+                            };
+                            var modelNode = new MeshNode(modelId, providerPath)
+                            {
+                                NodeType = LanguageModelNodeType.NodeType,
+                                Name = modelId,
+                                Category = "Models",
+                                State = MeshNodeState.Active,
+                                MainNode = isPlatform ? $"{providerPath}/{modelId}" : ownerPath,
+                                SyncBehavior = syncBehavior,
+                                Content = modelDef,
+                            };
+                            return accessService is null || ctx is null
+                                ? meshService.CreateNode(modelNode)
+                                : Observable.Using(() => accessService.SwitchAccessContext(ctx), _ => meshService.CreateNode(modelNode));
+                        })
+                        .Catch<MeshNode, Exception>(ex =>
+                        {
+                            logger.LogWarning(ex, "Failed to create LanguageModel {ModelId} under {Path}", modelId, providerPath);
+                            return Observable.Return<MeshNode>(null!);
+                        });
                     })
                     .ToArray();
 

--- a/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
+++ b/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
@@ -76,6 +76,7 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
     private IDisposable? startupSub;
     private IDisposable? catalogSub;
     private IDisposable? timerSub;
+    private IDisposable? backfillSub;
 
     public OpenAICompatibleModelSync(
         IMessageHub hub,
@@ -96,20 +97,30 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        var discover = configuration.GetValue("OpenAICompatible:DiscoverModels", false);
         var endpoint = configuration["OpenAICompatible:Endpoint"];
-        if (!discover || string.IsNullOrWhiteSpace(endpoint))
-            return Task.CompletedTask; // inert unless explicitly enabled AND an endpoint is set
+        if (string.IsNullOrWhiteSpace(endpoint))
+            return Task.CompletedTask; // no endpoint → nothing to probe or discover
 
+        // Full add/remove discovery is opt-in (DiscoverModels=true). But even with discovery OFF we run
+        // a one-shot tool-capability BACKFILL for the statically-configured models: the boot seeder
+        // (BuiltInLanguageModelProvider) can't probe /api/show synchronously, so it stamps the model
+        // nodes with SupportsTools=null (assume supported) → the round would send tools to a tool-less
+        // local model (Mythalion → HTTP 400). The backfill probes each configured model and stamps its
+        // KNOWN capability. So an endpoint alone is enough to activate this service.
+        var discover = configuration.GetValue("OpenAICompatible:DiscoverModels", false);
         var apiKey = configuration["OpenAICompatible:ApiKey"] ?? string.Empty;
         var embeddingModel = configuration["Embedding:Model"];
+        // The statically-configured model ids (OpenAICompatible:Models[]) — what the boot seeder laid
+        // down. Empty when discovery owns the child set (discover=true).
+        var configuredModels = configuration.GetSection("OpenAICompatible:Models").Get<string[]>()
+            ?? Array.Empty<string>();
         var initialDelay = TimeSpan.FromSeconds(
             Math.Max(0, configuration.GetValue("OpenAICompatible:DiscoverInitialDelaySeconds", 20)));
         var period = TimeSpan.FromSeconds(
             Math.Max(15, configuration.GetValue("OpenAICompatible:DiscoverIntervalSeconds", 120)));
 
-        // 🚨 Defer EVERY mesh-cache touch (the catalog query AND the reconcile) until initialDelay past
-        // startup, off any hub thread. StartAsync runs during host startup, when the Orleans stream
+        // 🚨 Defer EVERY mesh-cache touch (the catalog query AND the reconcile/backfill) until initialDelay
+        // past startup, off any hub thread. StartAsync runs during host startup, when the Orleans stream
         // provider may not be ready; touching the workspace/cache then constructs the process cache hub
         // too early and NREs. The one-shot timer here does nothing but schedule BeginDiscovery later, so
         // this hosted service is inert during the fragile startup window. Wrapped so it can never wedge.
@@ -118,24 +129,39 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
             {
                 try
                 {
-                    BeginDiscovery(endpoint!, apiKey, embeddingModel, period);
+                    BeginDiscovery(endpoint!, apiKey, embeddingModel, period, discover, configuredModels);
                 }
                 catch (Exception ex)
                 {
-                    logger?.LogError(ex, "[OpenAICompatibleModelSync] failed to start discovery — disabled for this run");
+                    logger?.LogError(ex, "[OpenAICompatibleModelSync] failed to start — disabled for this run");
                 }
             });
 
-        logger?.LogInformation(
-            "[OpenAICompatibleModelSync] Ollama/OpenAI-compatible model discovery enabled (endpoint {Endpoint}, first run in {Delay}s, every {Period}s)",
-            endpoint, initialDelay.TotalSeconds, period.TotalSeconds);
+        if (discover)
+            logger?.LogInformation(
+                "[OpenAICompatibleModelSync] Ollama/OpenAI-compatible model discovery enabled (endpoint {Endpoint}, first run in {Delay}s, every {Period}s)",
+                endpoint, initialDelay.TotalSeconds, period.TotalSeconds);
+        else
+            logger?.LogInformation(
+                "[OpenAICompatibleModelSync] Ollama/OpenAI-compatible tool-capability backfill enabled (endpoint {Endpoint}, runs once in {Delay}s; discovery off)",
+                endpoint, initialDelay.TotalSeconds);
         return Task.CompletedTask;
     }
 
     // Runs once, initialDelay past startup (Orleans is up by now), off any hub thread. Sets up the live
     // catalog snapshot AND the periodic reconcile. This is the FIRST point the mesh cache is touched.
-    private void BeginDiscovery(string endpoint, string apiKey, string? embeddingModel, TimeSpan period)
+    private void BeginDiscovery(
+        string endpoint, string apiKey, string? embeddingModel, TimeSpan period,
+        bool discover, IReadOnlyList<string> configuredModels)
     {
+        if (!discover)
+        {
+            // Discovery OFF: statically-configured models. Run a one-shot tool-capability backfill only
+            // — NO live catalog snapshot, NO add/remove. Probe each configured model, stamp SupportsTools.
+            BackfillToolSupport(endpoint, configuredModels, embeddingModel);
+            return;
+        }
+
         // (a) Live snapshot of the current OpenAICompatible LanguageModel child ids (system read — the
         //     Provider partition needs an identity). Constant query id: one registry entry, no leak.
         catalogSub = AsSystem(() => hub.GetWorkspace()
@@ -167,6 +193,60 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
             .Concat()
             .Subscribe(_ => { },
                 ex => logger?.LogError(ex, "[OpenAICompatibleModelSync] discovery loop terminated"));
+    }
+
+    // One-shot capability backfill for STATICALLY-configured OpenAICompatible models (discovery off).
+    // The boot seeder can't probe /api/show, so it stamps SupportsTools=null (assume supported). Here,
+    // well past startup, probe each configured chat model and stamp its KNOWN tool capability via a
+    // NARROW stream.Update (only SupportsTools — never clobbers the seed's pricing/icon/order). No
+    // add/remove: that is discovery's job (discover=true), not this.
+    private void BackfillToolSupport(string endpoint, IReadOnlyList<string> configuredModels, string? embeddingModel)
+    {
+        var chatModels = configuredModels
+            .Where(id => !string.IsNullOrWhiteSpace(id) && !IsEmbedding(id, embeddingModel))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (chatModels.Length == 0)
+            return;
+
+        backfillSub = chatModels.ToObservable()
+            .Select(modelId => Observable.Defer(() => BackfillOne(endpoint, modelId))
+                .Catch<Unit, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "[OpenAICompatibleModelSync] tool-capability backfill for {Id} failed", modelId);
+                    return Observable.Return(Unit.Default);
+                }))
+            .Concat() // one at a time — small list, no write storm
+            .Subscribe(_ => { },
+                ex => logger?.LogWarning(ex, "[OpenAICompatibleModelSync] tool-capability backfill terminated"));
+    }
+
+    // Probe ONE statically-seeded model and stamp SupportsTools only if it actually changes.
+    private IObservable<Unit> BackfillOne(string endpoint, string modelId)
+    {
+        var path = $"{ProviderPath}/{modelId}";
+        // Authoritative live read of the seeded node (waits for the boot seed to land; NOT the lagged
+        // synced query). System read — the Provider partition needs an identity.
+        return AsSystem(() => hub.GetWorkspace().GetMeshNodeStream(path)
+                .Where(n => n?.Content is ModelDefinition)
+                .Take(1)
+                .Timeout(TimeSpan.FromSeconds(30)))
+            .SelectMany(node => lister.SupportsTools(endpoint, modelId)
+                .Catch<bool?, Exception>(_ => Observable.Return<bool?>(null))
+                .SelectMany(probed =>
+                {
+                    var def = (ModelDefinition)node.Content!;
+                    if (!ShouldBackfill(def.SupportsTools, probed))
+                        return Observable.Return(Unit.Default); // indeterminate or already correct → no write
+                    logger?.LogInformation(
+                        "[OpenAICompatibleModelSync] backfilling SupportsTools={Val} for {Id}", probed, modelId);
+                    return AsSystem(() => hub.GetWorkspace().GetMeshNodeStream(path)
+                            .Update(cur => cur.Content is ModelDefinition d
+                                ? cur with { Content = d with { SupportsTools = probed } }
+                                : cur))
+                        .Select(_ => Unit.Default);
+                }));
     }
 
     // Fetch → decide (pure ComputeDelta: drop embeddings, diff, empty-guard) → apply. Exposed internally
@@ -236,6 +316,14 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
                 // small, but a generic OpenAI-compatible endpoint could return hundreds).
                 return Observable.Concat(ops).LastOrDefaultAsync().Select(_ => Unit.Default);
             });
+
+    /// <summary>
+    /// Pure write-decision for the tool-capability backfill: stamp <c>SupportsTools</c> only when the
+    /// probe is CONCLUSIVE (non-null) AND differs from what is already on the node. An indeterminate
+    /// (<c>null</c>) probe or an already-correct value writes nothing — so an unchanged reboot never
+    /// churns the node (or bumps its version). Split out so it is deterministically testable.
+    /// </summary>
+    internal static bool ShouldBackfill(bool? current, bool? probed) => probed is not null && current != probed;
 
     /// <summary>The reconcile decision, split out as a pure function so it is deterministically testable.</summary>
     internal readonly record struct CatalogDelta(
@@ -330,5 +418,6 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
         startupSub?.Dispose();
         catalogSub?.Dispose();
         timerSub?.Dispose();
+        backfillSub?.Dispose();
     }
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
@@ -346,10 +346,15 @@ OpenAICompatible__ApiKey    = ollama
 Start Ollama on the host, bound to all interfaces so the VM's host-gateway can reach it, and alias the model to the id the config expects:
 
 ```bash
-OLLAMA_HOST=0.0.0.0:11434 ollama serve            # bind to 0.0.0.0 so the cluster can reach it
+OLLAMA_CONTEXT_LENGTH=16384 OLLAMA_HOST=0.0.0.0:11434 ollama serve   # 0.0.0.0 so the cluster can reach it; 16k ctx (see below)
 ollama pull qwen3.6                                # the Ollama-library model
 ollama cp qwen3.6 qwen3.6-code                     # alias to the id used by OpenAICompatible__Models__0
 ```
+
+> **🚨 Set `OLLAMA_CONTEXT_LENGTH`.** Ollama loads every model at a default context of **4096 tokens** regardless of the model's real maximum. The agent system prompt alone is now larger than that, so a fresh thread fails with
+> `request (…tokens) exceeds the available context size (4096 tokens) … exceed_context_size_error` and the model "can't run." Ollama's OpenAI-compatible `/v1` endpoint does **not** accept a per-request `num_ctx`, so the **host** is the only lever: start `ollama serve` with `OLLAMA_CONTEXT_LENGTH=16384` (or higher — bounded by the model's trained max and your VRAM). On the Ollama macOS **app**, set it once with `launchctl setenv OLLAMA_CONTEXT_LENGTH 16384` and restart the app. Per-model alternative: a Modelfile with `PARAMETER num_ctx 16384` + `ollama create`.
+>
+> **Pick a tool-capable model.** The agent round sends tool/function definitions. A pure roleplay/completion GGUF (e.g. `hf.co/TheBloke/Mythalion-13B-GGUF:Q4_K_M`) returns HTTP 400 *"does not support tools"*. The portal now probes Ollama's `/api/show` capabilities and stamps `SupportsTools=false` on such a model (so the round sends it a plain, tool-free chat request instead of erroring) — but for agent use, prefer a model whose `capabilities` include `tools` (qwen3.6 does).
 
 > k3s v1.35 logs a deprecation warning for `Endpoints` (in favor of `EndpointSlice`), but the mirroring controller auto-creates the slice, so routing works.
 
@@ -408,6 +413,8 @@ The result: every device trusts the cert out of the box (no mkcert CA install), 
 | A route 404s for ~1 second right after a Helm upgrade or ingress patch | ingress-nginx **reload lag** — the controller is reloading its config. Retry; it clears within a second. |
 | OAuth redirect URI mismatch | The redirect URI the portal built must exactly match one registered on the app (§9). Check you're hitting the host/port whose `/signin-microsoft` is registered. |
 | Ollama unreachable from the portal | Ollama must be started with `OLLAMA_HOST=0.0.0.0:11434` (not the default loopback bind), and `ollama.external.host` must be Colima's host-gateway IP (`192.168.5.2`). |
+| Local model errors `exceed_context_size_error` / `exceeds the available context size (4096 tokens)` | Ollama loads at a 4096-token default context, smaller than the agent prompt. Restart `ollama serve` with `OLLAMA_CONTEXT_LENGTH=16384` (macOS app: `launchctl setenv OLLAMA_CONTEXT_LENGTH 16384` + restart). The `/v1` endpoint can't set `num_ctx` per request — it's a host setting. See §10. |
+| Local model errors HTTP 400 `does not support tools` | The selected model is a completion-only/roleplay GGUF. The portal auto-stamps `SupportsTools=false` (round then omits tools), but for agent work pick a model whose Ollama `capabilities` include `tools` (e.g. qwen3.6). See §10. |
 
 **Verify end-to-end** that TLS + routing + the app are all working:
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-15-local-model-tool-support.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-15-local-model-tool-support.md
@@ -1,0 +1,14 @@
+---
+Name: Local models that don't support tools now just work
+Category: What's New
+Description: Ollama/OpenAI-compatible models are checked for tool support so a completion-only model no longer errors the chat.
+Icon: Sparkle
+---
+
+# Local models that don't support tools now just work
+
+When you bring your own local model through an Ollama / OpenAI-compatible endpoint, the assistant now checks whether that model supports tool calling before it uses it. A completion-only or roleplay model (which used to fail the whole chat with a *"does not support tools"* error) is detected automatically and sent a plain chat request instead — so it works as a chat model rather than breaking the round.
+
+This check runs both when you add a provider in **Settings → Language Models** and, for models configured on the server, shortly after startup. Tool-capable models are unaffected and keep full tool access.
+
+Running a local model and seeing a *context size* error instead? Local runtimes load with a small default context window — raise it on the host (for Ollama, set `OLLAMA_CONTEXT_LENGTH`) so the full prompt fits.

--- a/test/Memex.Portal.Shared.Test/OpenAICompatibleModelSyncTest.cs
+++ b/test/Memex.Portal.Shared.Test/OpenAICompatibleModelSyncTest.cs
@@ -149,4 +149,22 @@ public class OpenAICompatibleModelSyncTest
         var def = Assert.IsType<ModelDefinition>(node.Content);
         Assert.Equal(supportsTools, def.SupportsTools);
     }
+
+    // ── ShouldBackfill (tool-capability backfill write-decision) ─────────────
+
+    [Theory]
+    // probe conclusive AND differs → write.
+    [InlineData(null, false, true)]   // statically-seeded null → known tool-less: stamp it (the Mythalion fix)
+    [InlineData(null, true, true)]    // null → known tool-capable: stamp it
+    [InlineData(true, false, true)]   // a stale "supported" corrected to tool-less
+    [InlineData(false, true, true)]   // a stale "tool-less" corrected to supported
+    // probe indeterminate → never write (assume supported, historical behaviour).
+    [InlineData(null, null, false)]
+    [InlineData(true, null, false)]
+    [InlineData(false, null, false)]
+    // already correct → no churn (an unchanged reboot must not bump the node version).
+    [InlineData(false, false, false)]
+    [InlineData(true, true, false)]
+    public void ShouldBackfill_WritesOnlyWhenTheProbeIsConclusiveAndDiffers(bool? current, bool? probed, bool expected)
+        => Assert.Equal(expected, OpenAICompatibleModelSync.ShouldBackfill(current, probed));
 }

--- a/test/MeshWeaver.AI.Test/ModelProviderServiceTest.cs
+++ b/test/MeshWeaver.AI.Test/ModelProviderServiceTest.cs
@@ -2,8 +2,11 @@
 
 using System;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Memex.Portal.Shared.Models;
@@ -47,7 +50,33 @@ public class ModelProviderServiceTest : AITestBase
                 DefaultModelIds: System.Collections.Immutable.ImmutableArray.Create(
                     "claude-opus-4-7", "claude-sonnet-4-6"),
                 RequiresApiKey: true))
-            .ConfigureServices(services => services.AddSingleton<ModelProviderService>());
+            // A ProviderModelLister backed by a stub Ollama /api/show handler: CreateProvider probes
+            // tool support for OpenAICompatible models (only) and stamps ModelDefinition.SupportsTools.
+            // Anthropic (used by the other tests) is never probed, so the stub is inert for them.
+            .ConfigureServices(services => services
+                .AddSingleton(sp => new ProviderModelLister(
+                    sp.GetRequiredService<IMessageHub>(), logger: null, httpClient: new HttpClient(new StubShowHandler())))
+                .AddSingleton<ModelProviderService>());
+
+    /// <summary>
+    /// Stubs Ollama's <c>/api/show</c> capability probe: a roleplay model (id contains "mythalion")
+    /// reports <c>[completion]</c> (tool-less); everything else reports <c>[completion, tools]</c>.
+    /// </summary>
+    private sealed class StubShowHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var body = request.Content is null ? "" : await request.Content.ReadAsStringAsync(ct);
+            var toolLess = body.Contains("mythalion", StringComparison.OrdinalIgnoreCase);
+            var json = toolLess
+                ? "{\"capabilities\":[\"completion\"]}"
+                : "{\"capabilities\":[\"completion\",\"tools\"]}";
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
 
     private ModelProviderService Service => Mesh.ServiceProvider.GetRequiredService<ModelProviderService>();
     private IWorkspace Workspace => Mesh.GetWorkspace();
@@ -81,6 +110,44 @@ public class ModelProviderServiceTest : AITestBase
             def.Provider.Should().Be("Anthropic");
             def.ProviderRef.Should().Be($"{ModelProviderNodeType.UserNamespacePath(owner)}/Anthropic");
         });
+    }
+
+    [Fact]
+    public async Task CreateProvider_OpenAICompatible_StampsProbedToolSupportPerModel()
+    {
+        var owner = $"user-{Guid.NewGuid():N}";
+
+        var result = await Service.CreateProvider(
+                ownerPath: owner,
+                provider: "OpenAICompatible",
+                apiKey: "ollama",
+                endpointOverride: "http://ollama:11434/v1",
+                modelIdsOverride: new[] { "qwen3.6-code", "hf.co/TheBloke/Mythalion-13B-GGUF:Q4_K_M" })
+            .Should().Within(20.Seconds()).Emit();
+
+        result.ModelNodes.Should().HaveCount(2);
+        var byId = result.ModelNodes.ToDictionary(
+            n => ((ModelDefinition)n.Content!).Id, n => (ModelDefinition)n.Content!);
+
+        byId["qwen3.6-code"].SupportsTools.Should().BeTrue(
+            "Ollama /api/show reports the 'tools' capability for this model");
+        byId["hf.co/TheBloke/Mythalion-13B-GGUF:Q4_K_M"].SupportsTools.Should().BeFalse(
+            "a roleplay model reporting only [completion] must be stamped tool-less so the round omits tools");
+    }
+
+    [Fact]
+    public async Task CreateProvider_NonOllamaProvider_LeavesToolSupportUnprobed()
+    {
+        var owner = $"user-{Guid.NewGuid():N}";
+
+        // Anthropic is not an Ollama endpoint — CreateProvider must NOT probe /api/show (it would 404),
+        // so SupportsTools stays null (unknown → assume supported), the historical behaviour.
+        var result = await Service.CreateProvider(owner, "Anthropic", "sk-ant-x")
+            .Should().Within(20.Seconds()).Emit();
+
+        result.ModelNodes.Should().NotBeEmpty();
+        result.ModelNodes.Should().AllSatisfy(n =>
+            ((ModelDefinition)n.Content!).SupportsTools.Should().BeNull());
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Two failures when running local (Ollama / OpenAI-compatible) models:

1. **`does not support tools` (HTTP 400)** — a completion-only / roleplay model (e.g. `hf.co/TheBloke/Mythalion-13B-GGUF:Q4_K_M`) errors the whole round because tool definitions are sent to it. The `SupportsTools` probe (`/api/show` capabilities → `ModelDefinition.SupportsTools`) already existed and the round already omits tools when it's `false`, but the probe was only wired into **opt-in discovery**. Models added via the interactive add-provider flow, or seeded statically, kept `SupportsTools=null` ("assume supported") → tools sent → 400.
2. **`exceed_context_size_error` (prompt > 4096)** — Ollama loads models at a default `num_ctx` of 4096, smaller than the agent system prompt. The `/v1` endpoint can't set `num_ctx` per request, so the only real lever is host-side.

## Changes

- **`ModelProviderService.CreateProvider`** — probe each `OpenAICompatible` model's tool capability and stamp `SupportsTools` **before creating the node** (immediate coverage for the interactive add-provider flow — the actual Mythalion path). Remote providers (OpenAI/Anthropic) are left unprobed (the probe would 404); an 8s timeout keeps a hung endpoint from stalling provider creation (falls back to "assume supported").
- **`OpenAICompatibleModelSync`** — run a one-shot, post-boot **tool-capability backfill** whenever an endpoint is set (not just under discovery), covering the **statically-seeded** models the boot projection can't probe synchronously. Narrow `stream.Update` touching **only** `SupportsTools` (never clobbers the seed's pricing/icon/order); writes only when the probe is conclusive **and** differs (`ShouldBackfill`).
- **`LocalColimaMac.md`** — document raising the host Ollama context window (`OLLAMA_CONTEXT_LENGTH`) to fix the context error, plus troubleshooting rows for both symptoms. *(Per the chosen approach, context is a host-config/docs fix — nothing enforces it in code.)*

## Tests

- `ModelProviderServiceTest`: `CreateProvider` stamps probed tool support per model (qwen→`true`, Mythalion→`false`); non-Ollama provider left unprobed (`null`). 6/6 pass.
- `OpenAICompatibleModelSyncTest`: `ShouldBackfill` write-decision table (conclusive+differs → write; indeterminate or already-correct → no write). 26/26 pass.
- `Memex.Portal.Shared` + both test projects build clean under `-c Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)