### PR TITLE
Sub-thread 'not starting': cold-start heartbeat fix + mail routing + delegation UX

### DIFF
--- a/content/ai/Agent/Assistant.md
+++ b/content/ai/Agent/Assistant.md
@@ -12,6 +12,8 @@ delegations:
     instructions: "Deep information gathering: web search, mesh exploration across many nodes, documentation lookup, data analysis. Use when the investigation would otherwise bloat your main context window."
   - agentPath: Agent/Worker
     instructions: "Mechanical bulk writes you want kept out of the main context (e.g. create 5 child nodes in parallel, or a long iterative patch loop). For one-off small writes, do them yourself."
+  - agentPath: Agent/ExecutiveAssistant
+    instructions: "Email & calendar — read/triage the user's inbox, send or reply to mail, schedule/reschedule/cancel meetings, and manage notification channels/rules. Delegate any mail or calendar request here; it runs on the user's OWN mailbox under their identity. If the mailbox isn't connected it returns a connect link — relay that to the user."
 plugins:
   - Mesh
   - Version
@@ -62,6 +64,7 @@ Delegation is **opt-in, not default**. Reach for it in exactly two cases:
 
 1. **A specialist is clearly better at this.** Examples:
    - The task is **deep cross-mesh investigation** or **multi-source web research** → **Researcher** can run many `Search` / `Get` / `SearchWeb` calls without polluting your context.
+   - The request is about **email or the calendar** — read/triage the inbox, send or reply to mail, schedule/cancel a meeting, or notification preferences → **ExecutiveAssistant** (it acts on the user's own mailbox under their identity). If it reports the mailbox isn't connected, relay the connect link it returns.
    - A **local agent** (per-user or per-org custom agent visible in your `hierarchyAgents`) was built for exactly this domain.
 2. **You want the work out of your main context window.** Long iterative patch loops, bulk creation of many child nodes, exhaustive search-and-replace passes — anything where the *intermediate* reads/writes would bloat the conversation but the *summary* is all the user needs. Delegate, get the summary back, relay it. **Worker** is the right target for mechanical bulk writes.
 

--- a/src/MeshWeaver.AI/Delegation/DelegationHandlers.cs
+++ b/src/MeshWeaver.AI/Delegation/DelegationHandlers.cs
@@ -20,22 +20,14 @@ namespace MeshWeaver.AI.Delegation;
 /// </summary>
 internal static class DelegationHandlers
 {
-    /// <summary>Default heartbeat timeout when MeshThread.HeartbeatTimeout is null.
-    /// 10 s — well above any streaming chat client's normal delta cadence, low
-    /// enough that hung delegations are detected promptly. Tests requiring
-    /// even tighter detection override via <c>MeshThread.HeartbeatTimeout</c>.</summary>
-    public static readonly TimeSpan DefaultHeartbeatTimeout = TimeSpan.FromSeconds(10);
-
-    /// <summary>Cold-start grace from <c>ExecutionStartedAt</c>. Sub-threads
-    /// often spend the first ~5 s on agent allocation + first-token latency
-    /// without writing <c>LastActivityAt</c>; 15 s covers that without
-    /// allowing real hangs to pin the user too long.</summary>
-    public static readonly TimeSpan ColdStartGrace = TimeSpan.FromSeconds(15);
-
     /// <summary>Periodic interval for the heartbeat scanner. 1 s keeps
     /// hang-detection responsive — total worst-case latency is
     /// <c>HeartbeatInterval + HeartbeatTimeout</c>.</summary>
     public static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(1);
+
+    /// <summary>Fallback thresholds when no <see cref="DelegationHeartbeatOptions"/>
+    /// is registered (production default). Immutable — a shared read-only constant.</summary>
+    public static readonly DelegationHeartbeatOptions DefaultHeartbeatOptions = new();
 
     /// <summary>
     /// On the PARENT thread hub. Periodic scanner (every 1 s). Reads the
@@ -44,6 +36,20 @@ internal static class DelegationHandlers
     /// currently waiting on?"), reads each sub-thread's MeshNode via the
     /// process-wide cache, and applies the heartbeat predicate. On match,
     /// posts <see cref="CancelDelegationSubThread"/> back to this hub.
+    ///
+    /// <para><b>Two windows, not one.</b> A sub-thread that has produced NO activity
+    /// yet (<c>LastActivityAt == null</c>) is in FIRST-TOKEN LATENCY — agent
+    /// allocation + model time-to-first-token + first tool round-trip — which is NOT
+    /// a stalled stream. A reasoning model, a cold provider endpoint, or a slow first
+    /// tool legitimately takes far longer than the inter-activity timeout to emit its
+    /// first delta; judging that window by the short timeout cancelled a live-but-slow
+    /// sub-agent before it ever started (the "sub-thread never started" symptom this
+    /// method used to cause). Such a sub-thread is judged by
+    /// <see cref="DelegationHeartbeatOptions.FirstActivityBudget"/> instead. Only once
+    /// the sub-agent HAS stamped an activity does the inter-activity
+    /// <see cref="DelegationHeartbeatOptions.HeartbeatTimeout"/> apply. A genuinely
+    /// hung agent that never emits is still caught (after the first-activity budget),
+    /// and the parent's 10-min <c>delegate_to_agent</c> timeout is the ultimate backstop.</para>
     /// </summary>
     internal static IMessageDelivery HandleHeartbeatTick(
         IMessageHub hub, IMessageDelivery<HeartbeatTick> delivery)
@@ -55,6 +61,8 @@ internal static class DelegationHandlers
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.AI.Delegation");
         var nodeCache = hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+        var opts = hub.ServiceProvider.GetService<DelegationHeartbeatOptions>()
+                   ?? DefaultHeartbeatOptions;
         var now = DateTime.UtcNow;
 
         foreach (var subPath in chat.ActiveDelegationPaths)
@@ -70,18 +78,31 @@ internal static class DelegationHandlers
                     {
                         if (node?.Content is not MeshThread t || !t.IsExecuting)
                             return;
-                        var timeout = t.HeartbeatTimeout ?? DefaultHeartbeatTimeout;
                         var startedAt = t.ExecutionStartedAt ?? now;
-                        if (now - startedAt <= ColdStartGrace) return;
-                        var lastActivity = t.LastActivityAt ?? startedAt;
-                        if (now - lastActivity <= timeout) return;
+
+                        string reason;
+                        if (t.LastActivityAt is not { } lastActivity)
+                        {
+                            // Never active yet → still in first-token latency. Judge by the
+                            // (generous) first-activity budget, NOT the inter-activity timeout.
+                            var firstBudget = t.FirstActivityBudget ?? opts.FirstActivityBudget;
+                            if (now - startedAt <= firstBudget) return;
+                            reason = $"no first activity within {(int)firstBudget.TotalSeconds}s of start";
+                        }
+                        else
+                        {
+                            // Was active, now silent → a genuinely stalled stream. Apply the
+                            // inter-activity timeout, keeping the post-start settle grace.
+                            if (now - startedAt <= opts.ColdStartGrace) return;
+                            var timeout = t.HeartbeatTimeout ?? opts.HeartbeatTimeout;
+                            if (now - lastActivity <= timeout) return;
+                            reason = $"no activity for {(int)(now - lastActivity).TotalSeconds}s";
+                        }
 
                         logger?.LogWarning(
-                            "[DelegationHandlers] heartbeat stale sub={Path} sinceActivity={Since}s timeout={Timeout}s — cancelling",
-                            subPath,
-                            (int)(now - lastActivity).TotalSeconds, (int)timeout.TotalSeconds);
-                        hub.Post(new CancelDelegationSubThread(subPath,
-                            $"Heartbeat: no activity for {(int)(now - lastActivity).TotalSeconds}s"));
+                            "[DelegationHandlers] heartbeat stale sub={Path} — cancelling ({Reason})",
+                            subPath, reason);
+                        hub.Post(new CancelDelegationSubThread(subPath, $"Heartbeat: {reason}"));
                     },
                     _ => { /* swallow; next tick retries */ });
         }

--- a/src/MeshWeaver.AI/Delegation/DelegationHeartbeatOptions.cs
+++ b/src/MeshWeaver.AI/Delegation/DelegationHeartbeatOptions.cs
@@ -1,0 +1,46 @@
+namespace MeshWeaver.AI.Delegation;
+
+/// <summary>
+/// Tunable thresholds for the parent-hub delegation heartbeat watcher
+/// (<see cref="DelegationHandlers.HandleHeartbeatTick"/>). Registered as a
+/// mesh-scoped singleton and resolved from the thread hub's ServiceProvider;
+/// when unregistered the watcher falls back to
+/// <see cref="DelegationHandlers.DefaultHeartbeatOptions"/> (these same defaults),
+/// so production needs no explicit registration. A test registers an instance with
+/// small values to exercise the cold-start / stall branches deterministically
+/// without long wall-clock waits.
+///
+/// <para><b>Two distinct windows.</b> Time-to-first-activity and the gap between
+/// activity stamps are different phenomena and must not share one threshold:
+/// a reasoning model, a cold provider endpoint, or a slow first tool legitimately
+/// takes tens of seconds to its FIRST delta, which is not a stall. See the branch
+/// in <see cref="DelegationHandlers.HandleHeartbeatTick"/>.</para>
+/// </summary>
+public sealed record DelegationHeartbeatOptions
+{
+    /// <summary>
+    /// Inter-activity timeout: the maximum gap BETWEEN <see cref="Thread.LastActivityAt"/>
+    /// stamps once the sub-agent has started streaming, before a silent (stalled)
+    /// stream is cancelled. Per-thread override: <see cref="Thread.HeartbeatTimeout"/>.
+    /// </summary>
+    public TimeSpan HeartbeatTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Settle grace from <see cref="Thread.ExecutionStartedAt"/> applied ONLY to the
+    /// stalled branch (a sub-thread that was active and then went silent) so a
+    /// momentary gap right after the first token is never treated as a stall.
+    /// </summary>
+    public TimeSpan ColdStartGrace { get; init; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// First-activity budget: how long a sub-thread that has produced NO activity yet
+    /// (<see cref="Thread.LastActivityAt"/> is null) may spend in first-token latency
+    /// — agent allocation + model time-to-first-token + first tool round-trip — before
+    /// it is treated as hung. Deliberately far larger than <see cref="HeartbeatTimeout"/>:
+    /// judging first-token latency by the inter-activity timeout is what killed a
+    /// live-but-slow sub-agent before it ever emitted (the "sub-thread never started"
+    /// symptom). Backstopped by the parent's 10-min delegate_to_agent timeout.
+    /// Per-thread override: <see cref="Thread.FirstActivityBudget"/>.
+    /// </summary>
+    public TimeSpan FirstActivityBudget { get; init; } = TimeSpan.FromSeconds(60);
+}

--- a/src/MeshWeaver.AI/Thread.cs
+++ b/src/MeshWeaver.AI/Thread.cs
@@ -288,25 +288,43 @@ public record Thread
     /// Wall clock of the most recent "the agent is still making progress"
     /// signal — streaming text deltas, tool-call activity, status changes.
     /// Written atomically with those events in the OWNING thread hub's
-    /// action block (no extra writes, no race). Read by the parent thread
-    /// hub's heartbeat watcher: if <c>IsExecuting=true</c> AND
-    /// <c>(now - LastActivityAt) &gt; HeartbeatTimeout</c> (with a 60 s
-    /// cold-start grace measured from <see cref="ExecutionStartedAt"/>),
-    /// the watcher sets <see cref="RequestedStatus"/> = <c>Cancelled</c> on this
-    /// sub-thread — the same primitive the GUI Stop button uses. Replaces
-    /// the hard 5-minute watchdog in <c>ExecuteDelegationAsync</c>.
+    /// action block (no extra writes, no race). <b>Null until the sub-agent
+    /// emits its first activity</b> — that null is the signal the parent's
+    /// heartbeat watcher uses to tell first-token latency apart from a stall
+    /// (see <see cref="MeshWeaver.AI.Delegation.DelegationHeartbeatOptions"/>).
+    /// Read by the parent thread hub's heartbeat watcher: once
+    /// <c>LastActivityAt</c> is non-null, <c>IsExecuting=true</c> AND
+    /// <c>(now - LastActivityAt) &gt; <see cref="HeartbeatTimeout"/></c> (past the
+    /// settle grace) sets <see cref="RequestedStatus"/> = <c>Cancelled</c> on this
+    /// sub-thread — the same primitive the GUI Stop button uses. Replaces the hard
+    /// 5-minute watchdog in <c>ExecuteDelegationAsync</c>.
     /// </summary>
     public DateTime? LastActivityAt { get; init; }
 
     /// <summary>
-    /// Per-thread override of the framework-default heartbeat timeout
-    /// (30 s). Set by an agent that legitimately makes slow progress
-    /// (e.g. non-streaming chat client with long single-shot completions).
-    /// Null → use default. The 60 s cold-start grace is applied
-    /// regardless, so the value can be aggressive without false-positives
-    /// on cold start.
+    /// Per-thread override of the INTER-ACTIVITY heartbeat timeout — the maximum gap
+    /// between <see cref="LastActivityAt"/> stamps once the sub-agent is streaming,
+    /// before a silent (stalled) stream is cancelled. Set by an agent that legitimately
+    /// makes slow BETWEEN-token progress (e.g. a non-streaming chat client with long
+    /// single-shot completions). Null → framework default
+    /// (<see cref="MeshWeaver.AI.Delegation.DelegationHeartbeatOptions.HeartbeatTimeout"/>).
+    /// This does NOT govern time-to-first-token — see <see cref="FirstActivityBudget"/>.
     /// </summary>
     public TimeSpan? HeartbeatTimeout { get; init; }
+
+    /// <summary>
+    /// Per-thread override of the FIRST-ACTIVITY budget — how long this sub-thread may
+    /// spend in first-token latency (agent allocation + model time-to-first-token +
+    /// first tool round-trip) before its first <see cref="LastActivityAt"/> stamp
+    /// without being treated as hung by the parent's heartbeat watcher. Distinct from
+    /// <see cref="HeartbeatTimeout"/> (which measures the gap between stamps once
+    /// streaming): time-to-first-token is legitimately much longer than the inter-token
+    /// gap, so it gets its own, larger budget. Null → framework default
+    /// (<see cref="MeshWeaver.AI.Delegation.DelegationHeartbeatOptions.FirstActivityBudget"/>).
+    /// Set by an agent whose first token is legitimately very slow (large reasoning
+    /// model, cold endpoint).
+    /// </summary>
+    public TimeSpan? FirstActivityBudget { get; init; }
 
     /// <summary>
     /// Control-plane request for a status transition the owning thread hub

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -953,7 +953,8 @@ internal static class ThreadExecution
             ThreadMessageStatus? status = null,
             string? summary = null,
             string? harness = null,
-            int? cacheReadTokens = null, int? cacheWriteTokens = null)
+            int? cacheReadTokens = null, int? cacheWriteTokens = null,
+            bool stampActivity = true)
         {
             // Cell already latched dead (no initial state ever arrived) — skip the write entirely.
             // Never construct/subscribe a doomed cache.Update; that is the storm. Empty completes
@@ -1124,8 +1125,17 @@ internal static class ThreadExecution
             // since the heartbeat scanner runs every 5 s and the timeout is
             // 30 s. Single source of "is this sub-thread still alive?" the
             // parent's heartbeat scanner reads via cache.GetStream(threadPath).
+            //
+            // 🚨 stampActivity=false for the framework's own "Generating response..."
+            // placeholder: it is NOT agent progress. Stamping it would set
+            // LastActivityAt at round start, so a sub-agent still in first-token
+            // latency looks "active then stalled" to the parent heartbeat and gets
+            // cancelled by the inter-activity timeout before it ever emits (the
+            // "sub-thread never started" symptom). Leaving LastActivityAt null until
+            // the FIRST real token is what lets DelegationHandlers tell first-token
+            // latency (the generous first-activity budget) apart from a genuine stall.
             var now = DateTime.UtcNow;
-            if (now - lastActivityStamped > heartbeatStampInterval)
+            if (stampActivity && now - lastActivityStamped > heartbeatStampInterval)
             {
                 lastActivityStamped = now;
                 parentHub.GetWorkspace().GetMeshNodeStream(threadPath).Update(node =>
@@ -1708,10 +1718,13 @@ internal static class ThreadExecution
                 capturedResponseText = responseText;
                 segment.ResponseText = responseText;
 
-                // Push progress: generating
+                // Push progress: generating. stampActivity:false — this framework
+                // placeholder is NOT agent progress, so it must not set LastActivityAt
+                // (else first-token latency reads as a stall to the parent heartbeat).
                 PushToResponseMessage("Generating response...", ImmutableList<ToolCallEntry>.Empty,
                     ImmutableList<NodeChangeEntry>.Empty, request.AgentName, request.ModelName,
-                    status: ThreadMessageStatus.Streaming, harness: request.Harness);
+                    status: ThreadMessageStatus.Streaming, harness: request.Harness,
+                    stampActivity: false);
 
                 // 🚦 The streaming round is an async I/O leaf and MUST run on the bounded AI
                 // I/O pool — NEVER Task.Run, NEVER inline on the hub turn. The pool offloads onto

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -361,6 +361,16 @@ else
                                             <img src="@icon" alt="" class="thread-msg-tool-delegation-icon" />
                                             <span class="thread-msg-tool-delegation-title">@title</span>
                                             <span class="thread-msg-tool-delegation-agent">@callSummary</span>
+                                            @* Live elapsed while the sub-thread runs — makes "it's running"
+                                               unmistakable in the bubble itself (not only the runtime panel).
+                                               Driven by the 1s ticker; StartedAt is the sub-thread's
+                                               ExecutionStartedAt, so it appears the moment the round is executing
+                                               and updates each second until the delegation settles. *@
+                                            @if (isPending && delHeader is { IsExecuting: true, StartedAt: { } delStarted })
+                                            {
+                                                <span class="thread-msg-tool-delegation-elapsed"
+                                                      title="Running — elapsed since the sub-thread started">@FormatElapsed(delStarted)</span>
+                                            }
                                         </a>
                                     }
                                     else
@@ -582,8 +592,8 @@ else
                                 <div class="thread-runtime-subthread-title">
                                     <span class="thread-runtime-subthread-title-text">@subTitle</span>
                                     @* Elapsed-time chip for the sub-thread — null StartedAt
-                                       means the sub-thread is in StartingExecution and
-                                       hasn't flipped LastActivityAt yet; chip auto-hides. *@
+                                       means the sub-thread is still in StartingExecution and
+                                       hasn't stamped ExecutionStartedAt yet; chip auto-hides. *@
                                     @if (header.StartedAt is { } subStarted)
                                     {
                                         <span class="thread-runtime-subthread-elapsed" title="Elapsed since sub-thread started">@FormatElapsed(subStarted)</span>

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
@@ -1400,6 +1400,16 @@ button.thread-chat-status-item {
     background: color-mix(in srgb, var(--accent-fill-rest) 14%, transparent);
 }
 
+/* Live elapsed timer on a RUNNING delegation chip — pulses in step with the
+   state icon so the bubble reads as actively working, not a static link. */
+.thread-msg-tool-delegation-elapsed {
+    font-size: 0.7rem;
+    color: var(--accent-fill-rest);
+    flex: 0 0 auto;
+    font-variant-numeric: tabular-nums;
+    animation: thread-msg-delegation-pulse-anim 1.4s ease-in-out infinite;
+}
+
 @@keyframes thread-msg-delegation-pulse-anim {
     0%, 100% { opacity: 0.4; }
     50%      { opacity: 1;   }

--- a/test/MeshWeaver.Portal.E2E.Test/ChatDelegationTest.cs
+++ b/test/MeshWeaver.Portal.E2E.Test/ChatDelegationTest.cs
@@ -56,7 +56,7 @@ public class ChatDelegationTest(PortalFixture fixture)
         "the worker returns its result, relay that result to the user in one short sentence.";
 
     [Fact(Timeout = 360_000)]
-    public async Task Coordinator_DelegatesToWorker_SubThreadSpawns_AndResultFlowsBack()
+    public async Task Coordinator_DelegatesToWorker_SubThreadSpawns_ResultFlowsBack_AndRendersWhenOpened()
     {
         Assert.SkipUnless(fixture.Available, fixture.SkipReason);
 
@@ -180,6 +180,26 @@ public class ChatDelegationTest(PortalFixture fixture)
         resultBack.Should().BeTrue(
             "the delegated worker's result must flow back into the parent thread — the delegation tool call " +
             "must resolve into its completed form (details.thread-msg-delegation-entry / .thread-msg-tool-result)");
+
+        // ── 3) OPEN the spawned sub-thread directly — the "I clicked into the sub-thread" flow the user
+        // reported ("it didn't look like starting"). Navigating to the sub-thread's own URL must render
+        // ITS conversation (the user's delegated request + the worker's assistant answer) — not an empty /
+        // idle view. A broken sub-thread ThreadChatView binding would surface here as no assistant bubble.
+        var subPage = await context.NewPageAsync();
+        await subPage.SetViewportSizeAsync(1400, 1000);
+        await subPage.GotoAsync($"{fixture.BaseUrl}/{subThreadPath}",
+            new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 90_000 });
+        subPage.Url.Should().NotContain("/login");
+
+        await subPage.Locator(".thread-msg-bubble.thread-msg-user").First
+            .WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+        var subRendered = await PollAsync(
+            async () => await subPage.Locator(".thread-msg-bubble.thread-msg-assistant").CountAsync() > 0,
+            TimeSpan.FromSeconds(90));
+        await subPage.ScreenshotAsync(new PageScreenshotOptions { Path = "/tmp/chat-subthread-open.png", FullPage = true });
+        subRendered.Should().BeTrue(
+            "opening the spawned sub-thread must render its OWN conversation (the worker's assistant bubble) " +
+            "— the 'clicked into the sub-thread, it didn't look like starting' symptom would show as an empty view");
     }
 
     // ── helpers (mirroring ClaudeCodeHarnessExecutesTest) ────────────────────────────────────────────────

--- a/test/MeshWeaver.Threading.Test/SubThreadColdStartRepro.cs
+++ b/test/MeshWeaver.Threading.Test/SubThreadColdStartRepro.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI;
+using MeshWeaver.AI.Delegation;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshThread = MeshWeaver.AI.Thread;
+
+namespace MeshWeaver.Threading.Test;
+
+/// <summary>
+/// Repro + regression guard for the prod symptom "the sub-thread did not start"
+/// (the 2026-07-15 <c>can-you-check-my-mail</c> thread): the parent's heartbeat
+/// watcher (<see cref="DelegationHandlers"/>) used a SINGLE window for both
+/// time-to-first-token and the inter-token gap, so a sub-agent still in first-token
+/// latency (agent allocation + model TTFT + a slow first tool — an inbox/Graph call,
+/// a reasoning model) was cancelled after the short cold-start grace, before it ever
+/// emitted a delta. From the user it read as a sub-thread that "didn't look like
+/// starting" — it started, sat silent during cold start, and got killed.
+///
+/// <para>The fix splits the windows: a sub-thread that has produced NO activity yet
+/// (<c>LastActivityAt == null</c>) is judged by
+/// <see cref="DelegationHeartbeatOptions.FirstActivityBudget"/>; only once it HAS
+/// stamped an activity does the inter-activity
+/// <see cref="DelegationHeartbeatOptions.HeartbeatTimeout"/> apply. Both are made
+/// small here via a registered <see cref="DelegationHeartbeatOptions"/> so the two
+/// branches are exercised in seconds, deterministically — no wall-clock guesswork.</para>
+/// </summary>
+public abstract class SubThreadHeartbeatTestBase(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected const string ContextPath = "User/TestUser";
+
+    // Small, well-separated windows so both heartbeat branches fire in seconds.
+    // FirstActivityBudget (5 s) ≫ HeartbeatTimeout (1 s): a sub-agent silent during
+    // first-token latency for longer than the inter-activity timeout, but within the
+    // first-activity budget, must survive — that IS the bug being pinned.
+    protected static readonly DelegationHeartbeatOptions FastOptions = new()
+    {
+        HeartbeatTimeout = TimeSpan.FromSeconds(1),
+        ColdStartGrace = TimeSpan.FromSeconds(1),
+        FirstActivityBudget = TimeSpan.FromSeconds(5),
+    };
+
+    /// <summary>The delegation target's chat client — the behaviour under test.</summary>
+    protected abstract IChatClient CreateSubAgent();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            // A cancelled/stalled sub-thread leaves the framework's per-emission
+            // DataChangeRequest → Observe callbacks pending until the RequestTimeout;
+            // give teardown room so leak-detection doesn't trip on expected-pending work.
+            .ConfigureHub(c => c.WithQuiesceTimeout(TimeSpan.FromSeconds(45)))
+            .ConfigureServices(services =>
+            {
+                // Register the small heartbeat windows (resolved by the parent thread hub's
+                // HandleHeartbeatTick) and the factory that routes default→parent, other→sub-agent.
+                // The factory extends ChatClientAgentFactory (so the real delegate_to_agent tool
+                // is wired) and needs the hub — resolved from the container at construction time.
+                services.AddSingleton(FastOptions);
+                services.AddSingleton<IChatClientFactory>(sp =>
+                    new HeartbeatTestSubAgentFactory(sp.GetRequiredService<IMessageHub>(), CreateSubAgent));
+                return services;
+            })
+            .AddAI()
+            .AddSampleUsers();
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddAITypes();
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    protected async Task<string> CreateThread(IMessageHub client, string text)
+    {
+        var threadNode = ThreadNodeType.BuildThreadNode(ContextPath, text, "TestUser");
+        var response = await client.Observe(new CreateNodeRequest(threadNode),
+            o => o.WithTarget(Mesh.Address)).Should().Within(15.Seconds()).Emit();
+        response.Message.Success.Should().BeTrue(response.Message.Error ?? "");
+        return response.Message.Node!.Path!;
+    }
+
+    /// <summary>
+    /// Waits for the parent's response cell to stamp a non-null <c>DelegationPath</c>
+    /// on its delegate_to_agent tool call and returns that sub-thread path.
+    /// </summary>
+    protected static async Task<string> WaitForDelegationPath(IMessageHub client, string parentPath)
+    {
+        var workspace = client.GetWorkspace();
+        var thread = await workspace.GetMeshNodeStream(parentPath)
+            .Select(n => n.Content as MeshThread)
+            .Should().Within(15.Seconds()).Match(t => t is { Messages.Count: >= 2 });
+        var respPath = $"{parentPath}/{thread!.Messages[^1]}";
+        var responseMsg = await workspace.GetMeshNodeStream(respPath)
+            .Select(n => n.Content as ThreadMessage)
+            .Should().Within(30.Seconds()).Match(m => m?.ToolCalls is { Count: > 0 }
+                && m.ToolCalls[0].DelegationPath is { Length: > 0 });
+        return responseMsg!.ToolCalls![0].DelegationPath!;
+    }
+
+    #region Harness — delegating parent + configurable sub-agent factory
+
+    /// <summary>
+    /// Parent: emits a single delegate_to_agent call on the first turn (no
+    /// FunctionResultContent yet), then plain text once the tool result is present so
+    /// the function-calling loop terminates. Target "Worker" is a built-in agent from
+    /// <c>.AddAI()</c>, so the delegation proceeds to sub-thread creation.
+    /// </summary>
+    private sealed class DelegatingParentChatClient : IChatClient
+    {
+        public ChatClientMetadata Metadata => new("DelegatingParent");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "Done")));
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var hasToolResult = false;
+            foreach (var msg in messages)
+            foreach (var content in msg.Contents)
+                if (content is FunctionResultContent) { hasToolResult = true; break; }
+
+            if (!hasToolResult)
+            {
+                yield return new ChatResponseUpdate(ChatRole.Assistant,
+                    [new FunctionCallContent("call1", "delegate_to_agent",
+                        new Dictionary<string, object?>
+                        {
+                            ["agentName"] = "Worker",
+                            ["task"] = "do the work"
+                        })]);
+                await Task.Yield();
+                yield break;
+            }
+
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "Delegation returned — finishing.");
+            await Task.Yield();
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) =>
+            serviceType == typeof(IChatClient) ? this : null;
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Routes the default agent to <see cref="DelegatingParentChatClient"/>; every
+    /// other agent (the delegation target) gets the test-supplied sub-agent. Extends
+    /// <see cref="ChatClientAgentFactory"/> so the framework wires the real
+    /// <c>delegate_to_agent</c> tool; <paramref name="hub"/> is passed to the base only,
+    /// <paramref name="subAgentFactory"/> is captured (no CS9107).
+    /// </summary>
+    private sealed class HeartbeatTestSubAgentFactory(IMessageHub hub, Func<IChatClient> subAgentFactory)
+        : ChatClientAgentFactory(hub)
+    {
+        public override string Name => "HeartbeatTestSubAgentFactory";
+        public override IReadOnlyList<string> Models => ["heartbeat-test-model"];
+        public override int Order => 0;
+
+        protected override IChatClient CreateChatClient(AgentConfiguration agentConfig)
+            => agentConfig.IsDefault ? new DelegatingParentChatClient() : subAgentFactory();
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// THE bug repro: a sub-agent that is silent through first-token latency (longer than
+/// the 1 s inter-activity timeout, but within the 5 s first-activity budget) then emits
+/// and completes must NOT be cancelled by the heartbeat. Before the fix it was cancelled
+/// during cold start and never produced anything.
+/// </summary>
+public class SubThreadColdStartRepro(ITestOutputHelper output) : SubThreadHeartbeatTestBase(output)
+{
+    private const string ColdStartDoneText = "cold start done";
+
+    protected override IChatClient CreateSubAgent()
+        => new SlowFirstTokenSubAgent(TimeSpan.FromSeconds(3), ColdStartDoneText);
+
+    [Fact]
+    public async Task SlowFirstToken_NotCancelledDuringColdStart_Completes()
+    {
+        var client = GetClient();
+        var workspace = client.GetWorkspace();
+
+        var parentPath = await CreateThread(client, "delegate to a slow-starting worker");
+        await workspace.GetMeshNodeStream(parentPath)
+            .Select(n => n.Content as MeshThread)
+            .Should().Within(10.Seconds()).Match(t => t != null);
+
+        client.SubmitMessage(parentPath, "delegate this", contextPath: ContextPath);
+
+        var subThreadPath = await WaitForDelegationPath(client, parentPath);
+        Output.WriteLine($"Sub-thread: {subThreadPath}");
+
+        // The sub-agent stays silent for 3 s (> the 1 s inter-activity timeout, < the
+        // 5 s first-activity budget), then emits "cold start done" and completes. The
+        // ONLY way the sub-thread reaches a completed assistant response carrying that
+        // text is if the heartbeat did NOT cancel it during first-token latency —
+        // exactly the behaviour the fix restores.
+        var settled = await Observable.Defer(() =>
+                workspace.GetMeshNodeStream(subThreadPath)
+                    .Select(n => n.Content as MeshThread)
+                    .Where(t => t is { IsExecuting: false, Messages.Count: >= 2 })
+                    .Take(1))
+            .Catch<MeshThread?, Exception>(_ =>
+                Observable.Empty<MeshThread?>().Delay(200.Milliseconds()))
+            .Repeat()
+            .Should().Within(20.Seconds()).Emit();
+
+        settled!.IsExecuting.Should().BeFalse();
+
+        // The response cell must carry the sub-agent's post-cold-start output — proof it
+        // ran to completion rather than being cancelled silent. Wait for the ACTUAL text
+        // (not merely non-empty: the round opens the cell with a "Generating response..."
+        // placeholder, which a wrongful cold-start cancel would leave in place forever).
+        var responseId = settled.Messages[^1];
+        var response = await workspace.GetMeshNodeStream($"{subThreadPath}/{responseId}")
+            .Select(n => n.Content as ThreadMessage)
+            .Should().Within(15.Seconds()).Match(m => m?.Text != null && m.Text.Contains(ColdStartDoneText),
+                "the sub-agent emitted its first token only AFTER the cold-start window — a " +
+                "single-window heartbeat would have cancelled it during first-token latency, " +
+                "leaving the cell stuck on the 'Generating response...' placeholder.");
+        Output.WriteLine($"Sub-thread completed with: '{response!.Text}'");
+    }
+
+    /// <summary>Silent through first-token latency, then emits + completes. Honors
+    /// cancellation so a wrongful cold-start cancel settles the round without the text.</summary>
+    private sealed class SlowFirstTokenSubAgent(TimeSpan firstTokenDelay, string doneText) : IChatClient
+    {
+        public ChatClientMetadata Metadata => new("SlowFirstTokenSubAgent");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, doneText)));
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            // No delta yet → LastActivityAt stays null (the never-active window).
+            await Task.Delay(firstTokenDelay, cancellationToken);
+            yield return new ChatResponseUpdate(ChatRole.Assistant, doneText);
+            await Task.Yield();
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) =>
+            serviceType == typeof(IChatClient) ? this : null;
+        public void Dispose() { }
+    }
+}
+
+/// <summary>
+/// Regression guard for the OTHER branch: a sub-agent that emits a first token (stamps
+/// LastActivityAt) and THEN goes silent forever is a genuine stall and MUST still be
+/// cancelled by the inter-activity timeout. Ensures the cold-start fix did not disable
+/// stall detection.
+/// </summary>
+public class SubThreadStallRepro(ITestOutputHelper output) : SubThreadHeartbeatTestBase(output)
+{
+    protected override IChatClient CreateSubAgent() => new StreamsThenStallsSubAgent();
+
+    [Fact]
+    public async Task StreamsThenStalls_IsCancelledByInterActivityTimeout()
+    {
+        var client = GetClient();
+        var workspace = client.GetWorkspace();
+
+        var parentPath = await CreateThread(client, "delegate to a worker that stalls mid-stream");
+        await workspace.GetMeshNodeStream(parentPath)
+            .Select(n => n.Content as MeshThread)
+            .Should().Within(10.Seconds()).Match(t => t != null);
+
+        client.SubmitMessage(parentPath, "delegate this", contextPath: ContextPath);
+
+        var subThreadPath = await WaitForDelegationPath(client, parentPath);
+
+        // It emits one token (→ IsExecuting, LastActivityAt stamped) then hangs forever.
+        await workspace.GetMeshNodeStream(subThreadPath)
+            .Select(n => n.Content as MeshThread)
+            .Should().Within(15.Seconds()).Match(t => t is { IsExecuting: true });
+
+        // The inter-activity timeout (1 s, past the 1 s grace) must fire and cancel it.
+        var settled = await Observable.Defer(() =>
+                workspace.GetMeshNodeStream(subThreadPath)
+                    .Select(n => n.Content as MeshThread)
+                    .Where(t => t is { IsExecuting: false })
+                    .Take(1))
+            .Catch<MeshThread?, Exception>(_ =>
+                Observable.Empty<MeshThread?>().Delay(200.Milliseconds()))
+            .Repeat()
+            .Should().Within(20.Seconds()).Emit();
+
+        settled!.IsExecuting.Should().BeFalse(
+            "a sub-agent that streamed then went silent past the inter-activity timeout " +
+            "must still be cancelled — the cold-start fix only relaxes the FIRST-token window.");
+    }
+
+    /// <summary>Emits one delta (stamps LastActivityAt) then blocks forever, honoring cancellation.</summary>
+    private sealed class StreamsThenStallsSubAgent : IChatClient
+    {
+        public ChatClientMetadata Metadata => new("StreamsThenStallsSubAgent");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+                .ContinueWith<ChatResponse>(_ => throw new TaskCanceledException(),
+                    TaskContinuationOptions.OnlyOnCanceled);
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "starting ");
+            await Task.Yield();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            yield break; // unreachable
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) =>
+            serviceType == typeof(IChatClient) ? this : null;
+        public void Dispose() { }
+    }
+}

--- a/test/MeshWeaver.Threading.Test/SubThreadHangRepro.cs
+++ b/test/MeshWeaver.Threading.Test/SubThreadHangRepro.cs
@@ -73,6 +73,17 @@ public class SubThreadHangRepro(ITestOutputHelper output) : MonolithMeshTestBase
             .ConfigureServices(services =>
             {
                 services.AddSingleton<IChatClientFactory, HangingSubAgentFactory>();
+                // The hung sub-agent never emits a delta → it stays in the "never active"
+                // heartbeat window. Under the production first-activity budget (60 s) it would
+                // only cancel at 60 s — past this test's settle window AND the 60 s method
+                // timeout. Register small heartbeat windows so the genuine hang is still
+                // detected fast (here via the first-activity budget, since it never streams).
+                services.AddSingleton(new MeshWeaver.AI.Delegation.DelegationHeartbeatOptions
+                {
+                    HeartbeatTimeout = TimeSpan.FromSeconds(2),
+                    ColdStartGrace = TimeSpan.FromSeconds(2),
+                    FirstActivityBudget = TimeSpan.FromSeconds(8),
+                });
                 return services;
             })
             .AddAI()


### PR DESCRIPTION
Addresses the reported *"had a thread this morning to check my email — sub-thread was not starting."* Investigation (memex-cloud pod logs) showed the sub-thread **actually started in 300 ms and ran to completion** — but a real latent bug in the start path, a routing gap, and a visibility gap all fed the perception. Four focused changes:

### 1. `fix(delegation)` — don't cancel a sub-thread during first-token latency (the real bug)
The parent-hub heartbeat used **one window** for both time-to-first-token and the inter-token gap. And `LastActivityAt` was stamped at round start by the `"Generating response..."` placeholder push — so a sub-agent still in first-token latency (reasoning model, cold endpoint, slow first tool) looked *"active then stalled"* and got cancelled before it emitted anything.

- `PushToResponseMessage` gains `stampActivity`; the placeholder passes `false` (framework bookkeeping ≠ agent progress) → `LastActivityAt` stays null until the first **real** token.
- `HandleHeartbeatTick` splits the windows: `LastActivityAt == null` (first-token latency) → generous `FirstActivityBudget` (60 s); once a real token lands → inter-activity `HeartbeatTimeout`. Timings → injectable `DelegationHeartbeatOptions` (reconciles the doc-vs-code drift); per-thread `Thread.FirstActivityBudget` override.
- **`SubThreadColdStartRepro` is revert-proven** (fails on the single-window logic, passes on the fix). `SubThreadStallRepro` guards the stall branch; `SubThreadHangRepro` updated.

### 2. `feat(agent)` — route mail/calendar to ExecutiveAssistant explicitly
`Assistant.md` only listed Researcher/Worker; mail reached ExecutiveAssistant only via the implicit hierarchy fallback. Added it as a named delegation (relays the connect link when the mailbox isn't linked).

### 3. `feat(chat)` — live elapsed on the inline delegation chip
The runtime panel had a live elapsed timer; the inline bubble chip (where the user first looks) didn't. Added it (existing 1 s ticker off the sub-thread's `ExecutionStartedAt`). Also fixes a comment that misnamed `ExecutionStartedAt` as `LastActivityAt`.

### 4. `test(e2e)` — verify the opened sub-thread renders
Extends `ChatDelegationTest` to navigate **into** the spawned sub-thread (the *"clicked in, didn't look like starting"* flow) and assert its own view renders the conversation.

## Verification
- **Threading.Test: 126/126 green.** AI.Test delegation classes: 35/35 green. Blazor.Portal + E2E compile `-warnaserror`. Merged with current `main`.
- ⚠️ The E2E test (#4) was **not run live** this session — the local Colima stack boot timed out pulling `mcr.microsoft.com/dotnet/aspnet:10.0` (network). Run it with `memex-local up && memex-local e2e up && memex-local e2e test ChatDelegationTest` once the registry is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)