### PR TITLE
Complete teardown-SIGSEGV fix: MeshQuery subscribe through the drainable pool (+ #483 drain)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
@@ -427,7 +427,11 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
         // an accessor into a collectible node assembly (the exit=139 teardown crash).
         if (UnloadGcProbe)
         {
-            _logger?.LogWarning("ALC_UNLOAD_PROBE forcing GC after unloading {ContextName}", Name);
+            // Write to Console DIRECTLY, not via _logger: this runs INSIDE ServiceProvider.Dispose()
+            // where the ILogger (XUnitFileLogger.GetMinLogLevel) resolves from the already-disposed
+            // container and throws ObjectDisposedException BEFORE writing — so the probe never named
+            // the culprit. Console is the only sink alive during teardown.
+            Console.Error.WriteLine($"ALC_UNLOAD_PROBE forcing GC after unloading {Name}");
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();

--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1164,15 +1164,18 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             await WaitWithProgressAsync(testName, sw, cts.Token);
             // DisposalCompleted only drains the action blocks + message round-trips.
             // Offloaded I/O (IIoPool) runs on the ThreadPool independently and is NOT
-            // covered — wait for it here, BEFORE base.DisposeAsync tears down the
-            // service scope, so no continuation resolves a disposed Autofac scope
-            // (the unobserved "catastrophic ObjectDisposedException" class).
+            // covered — CANCEL + JOIN it here, BEFORE base.DisposeAsync tears down the
+            // service scope, so no continuation resolves a disposed Autofac scope AND no
+            // ThreadPool leaf dereferences a collectible node ALC's freed metadata after
+            // unload (the teardown use-after-unload SIGSEGV). A live change-feed leaf never
+            // completes on its own, so a WAIT-only drain would time out and let the scope
+            // dispose under it; DrainAll() cancels the leaf so it stops, then joins.
             if (ioPools is not null)
             {
-                await ioPools.WhenDrained(DisposeTimeout).FirstAsync().ToTask();
+                ioPools.DrainAll();
                 if (ioPools.TotalInFlight > 0)
                     FileOutput.WriteLine(
-                        $"[DISPOSE] {testName}: I/O pools still report {ioPools.TotalInFlight} in-flight after drain wait");
+                        $"[DISPOSE] {testName}: I/O pools still report {ioPools.TotalInFlight} in-flight after drain");
             }
             // After all the sync stuff is disposed (and everyone has enqueued their async
             // cleanup), quiesce the async dispose queue before the scope closes below.

--- a/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
@@ -112,13 +112,15 @@ public class MeshQuery : IMeshQueryCore
     public IObservable<QueryResultChange<T>> Query<T>(MeshQueryRequest request)
     {
         var matched = SelectMatchingProviders(NamespacesForRequest(request));
+        // 100% reactive — NO scheduler offload here. Each provider defers its external I/O to its
+        // own IIoPool (StorageAdapter) or is pure in-memory (StaticNode), so Subscribe never blocks
+        // the calling hub's action block. A bare SubscribeOn(TaskPoolScheduler.Default) would push
+        // the whole merge pipeline onto UNOWNED thread-pool threads whose in-flight work outlives
+        // mesh disposal and dereferences a collectible node-ALC's freed metadata after unload → the
+        // native use-after-unload SIGSEGV. The only async boundary is the provider's owned IIoPool.
         return MergeProviderObservables(
-                matched.Select(p => (p.Query<T>(request, Options), p.Name)).ToList(),
-                request)
-            // Push the upstream subscription onto the thread pool so the
-            // calling hub's action block isn't blocked while providers open
-            // their connections / start their change feeds.
-            .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default);
+            matched.Select(p => (p.Query<T>(request, Options), p.Name)).ToList(),
+            request);
     }
 
     /// <summary>
@@ -143,12 +145,10 @@ public class MeshQuery : IMeshQueryCore
         // C return. Same progressive shape as Autocomplete; the brief leading
         // all-empty frame is the cost of not waiting for the whole fan-out.
         var streams = matched.Select(p => p.Query(request, Options).StartWith(empty)).ToList();
+        // 100% reactive — no scheduler offload (see Query<T> above): the provider's own IIoPool is
+        // the sole async boundary, so no unowned thread-pool straggler can race a node-ALC unload.
         return Observable.CombineLatest(streams)
-            .Select(snapshots => MergeSnapshots(snapshots))
-            // Provider Query() opens connection-pool / change-feed
-            // subscriptions on Subscribe — keep that off the calling hub's
-            // action block.
-            .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default);
+            .Select(snapshots => MergeSnapshots(snapshots));
     }
 
     /// <summary>
@@ -334,8 +334,7 @@ public class MeshQuery : IMeshQueryCore
                     // Real user: ALWAYS hit the secured provider surface
                     // (validators apply per-result RLS for request.UserId).
                     : p.Query<T>(request, options), p.Name)).ToList(),
-                request)
-            .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default);
+                request);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
@@ -112,15 +112,13 @@ public class MeshQuery : IMeshQueryCore
     public IObservable<QueryResultChange<T>> Query<T>(MeshQueryRequest request)
     {
         var matched = SelectMatchingProviders(NamespacesForRequest(request));
-        // 100% reactive — NO scheduler offload here. Each provider defers its external I/O to its
-        // own IIoPool (StorageAdapter) or is pure in-memory (StaticNode), so Subscribe never blocks
-        // the calling hub's action block. A bare SubscribeOn(TaskPoolScheduler.Default) would push
-        // the whole merge pipeline onto UNOWNED thread-pool threads whose in-flight work outlives
-        // mesh disposal and dereferences a collectible node-ALC's freed metadata after unload → the
-        // native use-after-unload SIGSEGV. The only async boundary is the provider's owned IIoPool.
         return MergeProviderObservables(
-            matched.Select(p => (p.Query<T>(request, Options), p.Name)).ToList(),
-            request);
+                matched.Select(p => (p.Query<T>(request, Options), p.Name)).ToList(),
+                request)
+            // Push the upstream subscription onto the thread pool so the
+            // calling hub's action block isn't blocked while providers open
+            // their connections / start their change feeds.
+            .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default);
     }
 
     /// <summary>
@@ -145,10 +143,12 @@ public class MeshQuery : IMeshQueryCore
         // C return. Same progressive shape as Autocomplete; the brief leading
         // all-empty frame is the cost of not waiting for the whole fan-out.
         var streams = matched.Select(p => p.Query(request, Options).StartWith(empty)).ToList();
-        // 100% reactive — no scheduler offload (see Query<T> above): the provider's own IIoPool is
-        // the sole async boundary, so no unowned thread-pool straggler can race a node-ALC unload.
         return Observable.CombineLatest(streams)
-            .Select(snapshots => MergeSnapshots(snapshots));
+            .Select(snapshots => MergeSnapshots(snapshots))
+            // Provider Query() opens connection-pool / change-feed
+            // subscriptions on Subscribe — keep that off the calling hub's
+            // action block.
+            .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default);
     }
 
     /// <summary>
@@ -334,7 +334,8 @@ public class MeshQuery : IMeshQueryCore
                     // Real user: ALWAYS hit the secured provider surface
                     // (validators apply per-result RLS for request.UserId).
                     : p.Query<T>(request, options), p.Name)).ToList(),
-                request);
+                request)
+            .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
@@ -33,6 +33,16 @@ public class MeshQuery : IMeshQueryCore
     private readonly IReadOnlyList<IMeshQueryProvider> providers;
     private readonly IMessageHub hub;
 
+    // The tracked, DRAINABLE pool the query SUBSCRIBE runs through (replaces a bare
+    // .SubscribeOn(TaskPoolScheduler.Default) the teardown drain couldn't reach). Running the
+    // subscribe here means teardown's IoPoolRegistry.DrainAll() cancel+joins it, so a query
+    // straggler can't create a per-node hub on the disposing Autofac scope (the teardown SIGSEGV).
+    private MeshWeaver.Mesh.Threading.IIoPool? _queryPool;
+    private MeshWeaver.Mesh.Threading.IIoPool QueryPool => _queryPool ??=
+        hub?.ServiceProvider?.GetService<MeshWeaver.Mesh.Threading.IoPoolRegistry>()
+            ?.Get(MeshWeaver.Mesh.Threading.IoPoolNames.Query)
+        ?? MeshWeaver.Mesh.Threading.IoPool.Unbounded;
+
     /// <summary>
     /// Creates the top-level query fan-out, deduplicating the registered
     /// providers by <see cref="IMeshQueryProvider.Name"/> so duplicate
@@ -112,13 +122,13 @@ public class MeshQuery : IMeshQueryCore
     public IObservable<QueryResultChange<T>> Query<T>(MeshQueryRequest request)
     {
         var matched = SelectMatchingProviders(NamespacesForRequest(request));
-        return MergeProviderObservables(
+        // Run the subscribe on the DRAINABLE Query pool (not a bare TaskPoolScheduler): keeps the
+        // calling hub's action block free while providers open their change feeds, AND makes the
+        // subscribe tracked so teardown's DrainAll cancel+joins it before the scope is disposed.
+        return QueryPool.SubscribeThroughPool(
+            MergeProviderObservables(
                 matched.Select(p => (p.Query<T>(request, Options), p.Name)).ToList(),
-                request)
-            // Push the upstream subscription onto the thread pool so the
-            // calling hub's action block isn't blocked while providers open
-            // their connections / start their change feeds.
-            .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default);
+                request));
     }
 
     /// <summary>
@@ -143,12 +153,11 @@ public class MeshQuery : IMeshQueryCore
         // C return. Same progressive shape as Autocomplete; the brief leading
         // all-empty frame is the cost of not waiting for the whole fan-out.
         var streams = matched.Select(p => p.Query(request, Options).StartWith(empty)).ToList();
-        return Observable.CombineLatest(streams)
-            .Select(snapshots => MergeSnapshots(snapshots))
-            // Provider Query() opens connection-pool / change-feed
-            // subscriptions on Subscribe — keep that off the calling hub's
-            // action block.
-            .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default);
+        // Subscribe on the DRAINABLE Query pool (see Query<T>): off the calling hub's action block
+        // AND tracked, so teardown's DrainAll cancel+joins the subscribe before the scope disposes.
+        return QueryPool.SubscribeThroughPool(
+            Observable.CombineLatest(streams)
+                .Select(snapshots => MergeSnapshots(snapshots)));
     }
 
     /// <summary>
@@ -326,7 +335,10 @@ public class MeshQuery : IMeshQueryCore
         var coreRequest = isSystem && !string.Equals(request.UserId, WellKnownUsers.System, StringComparison.Ordinal)
             ? request with { UserId = WellKnownUsers.System }
             : request;
-        return MergeProviderObservables(
+        // Subscribe on the DRAINABLE Query pool (see Query<T>): tracked so teardown DrainAll
+        // cancel+joins the subscribe before the scope disposes.
+        return QueryPool.SubscribeThroughPool(
+            MergeProviderObservables(
                 matched.Select(p => (isSystem
                     ? (p is IMeshQueryCore core
                         ? core.Query<T>(coreRequest, options)
@@ -334,8 +346,7 @@ public class MeshQuery : IMeshQueryCore
                     // Real user: ALWAYS hit the secured provider surface
                     // (validators apply per-result RLS for request.UserId).
                     : p.Query<T>(request, options), p.Name)).ToList(),
-                request)
-            .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default);
+                request));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/MeshTeardownExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshTeardownExtensions.cs
@@ -25,8 +25,9 @@ namespace MeshWeaver.Mesh;
 ///   <see cref="IMessageHub.DisposalCompleted"/> fires), and</item>
 /// <item>I/O offloaded onto the ThreadPool through <see cref="IIoPool"/> — which
 ///   runs independently of the action block and is NOT tracked by
-///   <see cref="IMessageHub.DisposalCompleted"/>. <see cref="IoPoolRegistry.WhenDrained"/>
-///   is the wait for that.</item>
+///   <see cref="IMessageHub.DisposalCompleted"/>. <see cref="IoPoolRegistry.DrainAll"/>
+///   cancels + joins that I/O — a live change-feed leaf never completes on its own, so a
+///   wait-without-cancel would time out and let the scope dispose under it.</item>
 /// </list>
 /// </summary>
 public static class MeshTeardownExtensions
@@ -66,8 +67,8 @@ public static class MeshTeardownExtensions
     /// <item>await <see cref="IMessageHub.DisposalCompleted"/> — the synchronous/reactive
     ///   disposal: action blocks + message round-trips. Resources enqueue their async
     ///   cleanup onto the <see cref="AsyncDisposeQueue"/> during this phase.</item>
-    /// <item>drain the offloaded ThreadPool I/O the action block doesn't cover
-    ///   (<see cref="IoPoolRegistry.WhenDrained"/>).</item>
+    /// <item>cancel + join the offloaded ThreadPool I/O the action block doesn't cover
+    ///   (<see cref="IoPoolRegistry.DrainAll"/>).</item>
     /// <item>after all the sync stuff is disposed, give the
     ///   <see cref="AsyncDisposeQueue"/> a bounded quiesce budget to finish
     ///   (<see cref="AsyncDisposeQueue.DrainAsync"/>), then the caller closes the scope.</item>
@@ -83,9 +84,13 @@ public static class MeshTeardownExtensions
             .ToTask()
             .WaitAsync(timeout);
 
-        // (2) Offloaded ThreadPool I/O — the half DisposalCompleted does not cover.
-        if (ioPools is not null)
-            await ioPools.WhenDrained(timeout).FirstAsync().ToTask();
+        // (2) Offloaded ThreadPool I/O — the half DisposalCompleted does not cover. CANCEL + JOIN
+        //     synchronously: a live change-feed leaf never completes on its own, so the old
+        //     WhenDrained() (WAIT-only, polled) would time out and let the scope dispose while the
+        //     leaf still runs → its ThreadPool thread dereferences a collectible node ALC's freed
+        //     metadata after unload → native use-after-unload SIGSEGV. DrainAll() cancels every leaf
+        //     so it stops, then joins — no ToTask, no wait-without-cancel.
+        ioPools?.DrainAll();
 
         // (3) After all the sync stuff is disposed (and everyone has enqueued their
         //     async cleanup), quiesce the async dispose queue before the scope closes.

--- a/src/MeshWeaver.Mesh.Contract/Threading/AsyncDisposeQueue.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/AsyncDisposeQueue.cs
@@ -28,6 +28,10 @@ namespace MeshWeaver.Mesh.Threading;
 public sealed class AsyncDisposeQueue
 {
     private readonly ActionBlock<Func<CancellationToken, Task>> _block;
+    // Cancels in-flight cleanup when the quiesce budget is exceeded, so a slow cleanup UNWINDS
+    // (and is then joined) instead of being abandoned mid-flight to run past teardown — where it
+    // would touch a collectible node ALC's compiled types AFTER the ALC unloads (use-after-unload).
+    private readonly CancellationTokenSource _cts = new();
     private long _drained;
 
     /// <summary>
@@ -42,7 +46,7 @@ public sealed class AsyncDisposeQueue
         _block = new ActionBlock<Func<CancellationToken, Task>>(
             async work =>
             {
-                try { await work(CancellationToken.None).ConfigureAwait(false); }
+                try { await work(_cts.Token).ConfigureAwait(false); }
                 catch { /* teardown best-effort — one bad cleanup must not strand the rest */ }
                 finally { Interlocked.Increment(ref _drained); }
             },
@@ -75,21 +79,31 @@ public sealed class AsyncDisposeQueue
 
     private async Task RunOrphanAsync(Func<CancellationToken, Task> work)
     {
-        try { await work(CancellationToken.None).ConfigureAwait(false); }
+        try { await work(_cts.Token).ConfigureAwait(false); }
         catch { /* best-effort */ }
         finally { Interlocked.Increment(ref _drained); }
     }
 
     /// <summary>
     /// Terminal drain: stop accepting new items and await every posted item, bounded by
-    /// <paramref name="quiesce"/>. Idempotent. A timeout means a cleanup is genuinely
-    /// wedged (a separate bug to surface from a stuck resource) — teardown proceeds
-    /// rather than hanging.
+    /// <paramref name="quiesce"/>. Idempotent. If the budget is exceeded, CANCEL the in-flight
+    /// cleanup (so it unwinds) then JOIN — no cleanup must still be running (and touching a
+    /// collectible node ALC's types) when the caller proceeds to unload those ALCs (the teardown
+    /// use-after-unload SIGSEGV). Only a cleanup that ignores its token can still wedge, and that
+    /// is a separate bug in that resource; teardown proceeds rather than hanging.
     /// </summary>
     public async Task DrainAsync(TimeSpan quiesce)
     {
         _block.Complete();
+        try
+        {
+            await _block.Completion.WaitAsync(quiesce).ConfigureAwait(false);
+            return; // clean quiesce within budget
+        }
+        catch (TimeoutException) { /* budget exceeded — cancel + join below */ }
+
+        _cts.Cancel();
         try { await _block.Completion.WaitAsync(quiesce).ConfigureAwait(false); }
-        catch (TimeoutException) { /* wedged cleanup — don't hang teardown */ }
+        catch (TimeoutException) { /* a cleanup that ignores cancellation is genuinely wedged */ }
     }
 }

--- a/src/MeshWeaver.Mesh.Contract/Threading/IIoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IIoPool.cs
@@ -79,6 +79,20 @@ public interface IIoPool
     IObservable<T> InvokeObservable<T>(Func<CancellationToken, IObservable<T>> source)
         => Invoke(ct => source(ct).ToTask(ct));
 
+    /// <summary>
+    /// Runs the SUBSCRIBE of a long-lived reactive leaf — a <c>MeshQuery</c> change-feed subscription —
+    /// through the pool. The subscribe action opens the providers and emits the initial snapshot, which
+    /// can route → create a per-node hub (Autofac <c>BeginLifetimeScope</c>); that bounded, dangerous
+    /// window holds one pool slot and counts as in-flight, so teardown's <c>Drain()</c> gate-join WAITS
+    /// for it before the owning service scope is disposed — no <c>BeginLifetimeScope</c> races the scope
+    /// teardown, which is the endemic teardown-SIGSEGV. The resulting subscription lives on and is
+    /// disposed when the pool drains. Unlike <see cref="InvokeObservable{T}"/> (one-shot — awaits
+    /// completion, emits the last value) this fits a NEVER-COMPLETING change feed. It is the tracked,
+    /// drainable replacement for a bare <c>.SubscribeOn(TaskPoolScheduler.Default)</c>, which the drain
+    /// cannot reach.
+    /// </summary>
+    IObservable<T> SubscribeThroughPool<T>(IObservable<T> source);
+
     /// <summary>Operations currently in flight through this pool. Diagnostics / tests only.</summary>
     int CurrentInFlight { get; }
 }

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
@@ -162,6 +162,56 @@ public sealed class IoPool : IIoPool, IDisposable
             });
         });
 
+    /// <inheritdoc />
+    public IObservable<T> SubscribeThroughPool<T>(IObservable<T> source) =>
+        Observable.Create<T>(observer =>
+        {
+            // The long-lived subscription the setup leaf produces; disposed on unsubscribe OR pool drain.
+            var inner = new SingleAssignmentDisposable();
+
+            // Run the SUBSCRIBE — providers opening + the initial-snapshot emission that routes →
+            // CreateHub (Autofac BeginLifetimeScope) — as a TRACKED, GATED, pool-cancellable leaf,
+            // exactly like Invoke. So while that bounded, dangerous window runs it holds a gate permit
+            // and counts in _inFlight; Drain() cancels _poolCts then RE-ACQUIRES every permit, so it
+            // BLOCKS until this subscribe has released — i.e. the owning Autofac scope is never disposed
+            // while a BeginLifetimeScope is running (the endemic teardown SIGSEGV).
+            var setup = Observable.FromAsync(async subscriberCt =>
+                {
+                    using var linked = CancellationTokenSource.CreateLinkedTokenSource(subscriberCt, _poolCts.Token);
+                    var ct = linked.Token;
+                    await _gate.WaitAsync(ct).ConfigureAwait(false);
+                    Interlocked.Increment(ref _inFlight);
+                    try
+                    {
+                        // Draining before we even subscribed → do not open providers / create hubs.
+                        ct.ThrowIfCancellationRequested();
+                        inner.Disposable = source.Subscribe(observer);
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref _inFlight);
+                        _gate.Release();
+                    }
+                    return System.Reactive.Unit.Default;
+                })
+                .SubscribeOn(TaskPoolScheduler.Default)
+                .Subscribe(
+                    _ => { },
+                    ex =>
+                    {
+                        // A drain/unsubscribe cancellation is expected teardown — swallow it; surface real faults.
+                        if (ex is not OperationCanceledException)
+                            observer.OnError(ex);
+                    });
+
+            // If the pool drains AFTER the subscribe completed, tear the live subscription down too.
+            IDisposable drainReg;
+            try { drainReg = _poolCts.Token.Register(inner.Dispose); }
+            catch (ObjectDisposedException) { drainReg = Disposable.Empty; }
+
+            return new CompositeDisposable(setup, inner, drainReg);
+        });
+
     /// <summary>
     /// Cancels every in-flight leaf and JOINS — blocks until they have all unwound — WITHOUT
     /// disposing the pool. Called before a collectible node <c>AssemblyLoadContext</c> is unloaded
@@ -232,5 +282,9 @@ public sealed class IoPool : IIoPool, IDisposable
 
         public IObservable<T> InvokeBlocking<T>(Func<CancellationToken, T> work)
             => Observable.FromAsync(ct => Task.Run(() => work(ct), ct)).SubscribeOn(TaskPoolScheduler.Default);
+
+        // No pool → no drain to coordinate with; the historical bare-threadpool behaviour.
+        public IObservable<T> SubscribeThroughPool<T>(IObservable<T> source)
+            => source.SubscribeOn(TaskPoolScheduler.Default);
     }
 }

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
@@ -15,7 +15,16 @@ public sealed class IoPool : IIoPool, IDisposable
 {
     private readonly SemaphoreSlim _gate;
     private readonly TaskFactory _blockingFactory;
+    private readonly int _maxConcurrency;
+    // Pool-wide cancellation, linked into every leaf's token. Drain()/Dispose() cancel it so all
+    // in-flight leaves unwind promptly — the join then knows they will release their gate permits.
+    private readonly CancellationTokenSource _poolCts = new();
     private int _inFlight;
+    private volatile bool _disposed;
+
+    // Teardown safety net for the drain join: cancellation makes in-flight leaves release in ms,
+    // so this is effectively never hit — it only bounds a hang if a leaf ignores its token.
+    private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Creates a pool whose async gate and sync-blocking scheduler are both capped at
@@ -27,6 +36,7 @@ public sealed class IoPool : IIoPool, IDisposable
     {
         if (maxConcurrency < 1)
             throw new ArgumentOutOfRangeException(nameof(maxConcurrency));
+        _maxConcurrency = maxConcurrency;
         _gate = new SemaphoreSlim(maxConcurrency, maxConcurrency);
         _blockingFactory = new TaskFactory(
             CancellationToken.None,
@@ -50,8 +60,13 @@ public sealed class IoPool : IIoPool, IDisposable
         // never runs on the calling hub/grain scheduler. (FromAsync's own
         // scheduler arg only affects notification delivery, not where the
         // function is invoked — hence the SubscribeOn, matching MeshQuery.)
-        => Observable.FromAsync(async ct =>
+        => Observable.FromAsync(async subscriberCt =>
         {
+            // Link the subscriber's token with the pool-wide token so Drain()/Dispose()
+            // cancels this leaf too — the teardown join relies on every running leaf
+            // unwinding and releasing its gate permit once the pool is cancelled.
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(subscriberCt, _poolCts.Token);
+            var ct = linked.Token;
             // WaitAsync(ct) makes acquisition itself cancellable — a dispose
             // before the slot is granted throws here, before the increment, so
             // no slot is ever leaked. The ThreadPool thread is released during
@@ -76,8 +91,10 @@ public sealed class IoPool : IIoPool, IDisposable
     /// <param name="source">The cancellable async sequence to enumerate once the gate grants a slot.</param>
     /// <returns>A cold observable that, on subscribe, enumerates the source and emits each element.</returns>
     public IObservable<T> InvokeStream<T>(Func<CancellationToken, IAsyncEnumerable<T>> source)
-        => Observable.Create<T>(async (observer, ct) =>
+        => Observable.Create<T>(async (observer, subscriberCt) =>
         {
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(subscriberCt, _poolCts.Token);
+            var ct = linked.Token;
             await _gate.WaitAsync(ct).ConfigureAwait(false);
             Interlocked.Increment(ref _inFlight);
             try
@@ -103,7 +120,8 @@ public sealed class IoPool : IIoPool, IDisposable
     public IObservable<T> InvokeBlocking<T>(Func<CancellationToken, T> work)
         => Observable.Create<T>(observer =>
         {
-            var cts = new CancellationTokenSource();
+            // Linked to the pool token so Drain()/Dispose() cancels blocking work too.
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(_poolCts.Token);
             _blockingFactory.StartNew(() =>
                 {
                     // _inFlight increments only once the scheduler grants a slot —
@@ -144,8 +162,48 @@ public sealed class IoPool : IIoPool, IDisposable
             });
         });
 
-    /// <summary>Disposes the underlying concurrency gate; called when the owning mesh is torn down.</summary>
-    public void Dispose() => _gate.Dispose();
+    /// <summary>
+    /// Cancels every in-flight leaf and JOINS — blocks until they have all unwound — WITHOUT
+    /// disposing the pool. Called before a collectible node <c>AssemblyLoadContext</c> is unloaded
+    /// so no pool thread is still executing (or about to dereference) that ALC's compiled types
+    /// when it is torn down (the teardown use-after-unload SIGSEGV). TERMINAL — it cancels the
+    /// pool token, so any leaf issued after Drain is cancelled immediately; idempotent (a second
+    /// call is a safe no-op join). This is a teardown operation; the pool is not reused afterwards.
+    /// </summary>
+    /// <remarks>
+    /// The join uses the gate we already own — no poll, no sleep, no extra signal. A running leaf
+    /// holds one permit until its <c>finally</c> releases it; once <see cref="_poolCts"/> is
+    /// cancelled every waiting leaf's <c>WaitAsync</c> throws, so no NEW leaf can take a permit.
+    /// Re-acquiring all <see cref="_maxConcurrency"/> permits therefore blocks precisely until the
+    /// last running leaf has released, then we release them back so the pool stays usable/idempotent.
+    /// </remarks>
+    public void Drain()
+    {
+        if (_disposed) return; // gate + cts already gone; nothing in flight to join
+        _poolCts.Cancel();
+        var acquired = 0;
+        for (var i = 0; i < _maxConcurrency; i++)
+        {
+            if (_gate.Wait(DrainTimeout)) acquired++;
+            else break; // safety net: a leaf ignored its token — don't hang teardown forever
+        }
+        if (acquired > 0)
+            _gate.Release(acquired);
+    }
+
+    /// <summary>
+    /// Drains in-flight work (see <see cref="Drain"/>) then disposes the gate and cancellation
+    /// source. Synchronous by design: when it returns, no pool thread is running, so the caller may
+    /// safely unload the node ALCs whose types that work referenced. Called when the mesh is torn down.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        Drain();
+        _poolCts.Dispose();
+        _gate.Dispose();
+    }
 
     /// <summary>
     /// A stateless, unbounded fallback pool used when no mesh-scoped pool is

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolOptions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolOptions.cs
@@ -25,6 +25,15 @@ public static class IoPoolNames
     /// </summary>
     public const string Ai = "Ai";
 
+    /// <summary>
+    /// MeshQuery change-feed subscribe leaves (<see cref="IIoPool.SubscribeThroughPool{T}"/>). Exists
+    /// so the query SUBSCRIBE — which opens providers + emits the initial snapshot and can route →
+    /// create a per-node hub — is TRACKED and DRAINABLE at teardown (the endemic teardown SIGSEGV was a
+    /// query straggler creating a hub on the disposing Autofac scope). Generous cap: it's a drain hook,
+    /// not a throttle (the slot is held only for the bounded subscribe window).
+    /// </summary>
+    public const string Query = "Query";
+
     /// <summary>CPU-bound compilation (Roslyn compile/script). Wave 3.</summary>
     public const string Compile = "Compile";
 
@@ -102,6 +111,13 @@ public sealed record IoPoolOptions
     /// </summary>
     public int Ai { get; init; } = 256;
 
+    /// <summary>
+    /// Concurrent MeshQuery change-feed subscribes (the <c>Query</c> pool). A drain hook, not a
+    /// throttle — the slot is held only for the bounded subscribe window — so the cap is generous
+    /// (256) to never bottleneck query fan-out.
+    /// </summary>
+    public int Query { get; init; } = 256;
+
     /// <summary>Concurrent compilations. CPU-bound; defaults to the processor count.</summary>
     public int Compile { get; init; } = Environment.ProcessorCount;
 
@@ -148,6 +164,7 @@ public sealed record IoPoolOptions
             IoPoolNames.Blob => Blob,
             IoPoolNames.Http => Http,
             IoPoolNames.Ai => Ai,
+            IoPoolNames.Query => Query,
             IoPoolNames.Compile => Compile,
             IoPoolNames.Process => Process,
             _ => Default,

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
@@ -66,6 +66,20 @@ public sealed class IoPoolRegistry : IDisposable
             .Timeout(timeout)
             .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default));
 
+    /// <summary>
+    /// Synchronously drains every created pool: cancels all in-flight leaves and JOINS (blocks until
+    /// they have unwound) — see <see cref="IoPool.Drain"/>. Unlike <see cref="WhenDrained"/> (which
+    /// only WAITS, so a live change-feed subscription never reaches zero and it times out), this
+    /// CANCELS the work so it actually stops. Call it between the hub's <c>DisposalCompleted</c>
+    /// and service-scope disposal so no pooled I/O thread is still executing a collectible node ALC's
+    /// compiled types when that scope disposes and unloads them (the teardown use-after-unload SIGSEGV).
+    /// </summary>
+    public void DrainAll()
+    {
+        foreach (var pool in _pools.Values)
+            pool.Drain();
+    }
+
     /// <summary>Disposes every created pool and clears the registry; called when the mesh is torn down.</summary>
     public void Dispose()
     {

--- a/test/MeshWeaver.Hosting.Test/AsyncDisposeQueueTest.cs
+++ b/test/MeshWeaver.Hosting.Test/AsyncDisposeQueueTest.cs
@@ -36,6 +36,34 @@ public class AsyncDisposeQueueTest
         ran.Should().Be(items);
     }
 
+    // The teardown-SIGSEGV fix: a cleanup that overruns the quiesce budget must be CANCELLED
+    // (so it unwinds) and JOINED — never abandoned mid-flight to run past teardown, where it
+    // would touch a collectible node ALC's compiled types after the ALC unloads.
+    [Fact]
+    public async Task DrainAsync_cancels_a_wedged_cleanup_then_joins_within_budget()
+    {
+        var queue = new AsyncDisposeQueue();
+        var before = queue.DrainedVersion;
+        var cancelled = false;
+        var entered = new TaskCompletionSource();
+
+        // A cleanup that never completes on its own (like an in-flight stream / flush).
+        queue.Enqueue(async ct =>
+        {
+            entered.TrySetResult();
+            try { await Task.Delay(System.Threading.Timeout.Infinite, ct); }
+            catch (OperationCanceledException) { cancelled = true; throw; }
+        });
+
+        await entered.Task.WaitAsync(Quiesce, TestContext.Current.CancellationToken);
+
+        // Budget expires with the cleanup still running → DrainAsync cancels it, then joins.
+        await queue.DrainAsync(TimeSpan.FromMilliseconds(200));
+
+        cancelled.Should().BeTrue("DrainAsync cancels a cleanup that overran the quiesce budget");
+        queue.DrainedVersion.Should().Be(before + 1, "the cancelled cleanup is JOINED, not abandoned");
+    }
+
     [Fact]
     public async Task Enqueue_from_sync_caller_drains_on_the_background_loop()
     {

--- a/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
@@ -31,7 +31,7 @@ public class IoPoolTest
     // that is in-flight holds a slot, and Drain() BLOCKS until it releases — i.e. the scope can never
     // be torn down while a BeginLifetimeScope is running.
     [Fact]
-    public void SubscribeThroughPool_holds_a_slot_and_Drain_joins_the_in_flight_subscribe()
+    public async Task SubscribeThroughPool_holds_a_slot_and_Drain_joins_the_in_flight_subscribe()
     {
         using var pool = new IoPool(4);
         var subscribeEntered = new ManualResetEventSlim();
@@ -56,12 +56,14 @@ public class IoPoolTest
 
         // Drain() must JOIN: block until the in-flight subscribe releases its slot.
         var drainDone = Task.Run(() => pool.Drain());
-        Assert.False(SpinWait.SpinUntil(() => drainDone.IsCompleted, TimeSpan.FromMilliseconds(200)),
-            "Drain MUST block while the subscribe holds a slot (the owning scope must not dispose yet)");
+        // Confirm Drain does NOT complete while the subscribe still holds a slot (the owning scope must
+        // not dispose yet) — a "wait to confirm nothing happened" negative check.
+        var winner = await Task.WhenAny(drainDone, Task.Delay(TimeSpan.FromMilliseconds(200)));
+        Assert.NotSame(drainDone, winner);
 
         releaseSubscribe.Set();
 
-        Assert.True(drainDone.Wait(Timeout5), "Drain should complete once the subscribe releases");
+        await drainDone.WaitAsync(Timeout5);
         Assert.True(subscribeFinished, "Drain must have JOINED the in-flight subscribe before returning");
         Assert.Equal(0, pool.CurrentInFlight);
     }

--- a/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
@@ -151,6 +151,46 @@ public class IoPoolTest
             .Should().BeTrue("disposing the subscription must release the held slot");
     }
 
+    // The teardown-SIGSEGV fix: Drain must CANCEL every in-flight leaf (a live change-feed
+    // subscription never completes on its own, so a WAIT-only drain — the old WhenDrained —
+    // would time out and let the caller unload the node ALCs while the leaf still runs on a
+    // ThreadPool thread → native use-after-unload) AND JOIN synchronously, so the instant
+    // Drain returns no pool thread is executing any ALC-compiled code.
+    [Fact]
+    public async Task Drain_cancels_in_flight_leaves_and_joins_synchronously()
+    {
+        using var pool = new IoPool(2);
+        using var entered = new ManualResetEventSlim(false);
+        var cancelled = false;
+
+        pool.Invoke(async ct =>
+        {
+            entered.Set();
+            try { await Task.Delay(System.Threading.Timeout.Infinite, ct); } // never completes on its own
+            catch (OperationCanceledException) { cancelled = true; throw; }
+            return 0;
+        }).Subscribe(_ => { }, _ => { });
+
+        entered.Wait(Timeout5, TestContext.Current.CancellationToken).Should().BeTrue();
+        pool.CurrentInFlight.Should().Be(1);
+
+        pool.Drain(); // cancel the leaf + JOIN — returns only once it has unwound
+
+        pool.CurrentInFlight.Should().Be(0,
+            "Drain joins synchronously — no spin: when it returns every in-flight leaf has unwound");
+        cancelled.Should().BeTrue("Drain cancels in-flight leaves so a never-completing one actually stops");
+
+        // Drain is TERMINAL (it cancels the pool token) — new work issued after Drain is
+        // cancelled immediately; there is no in-flight leaf left to reference an unloading ALC.
+        Func<Task> afterDrain = () =>
+            pool.Invoke(_ => Task.FromResult(7)).ToTask(TestContext.Current.CancellationToken);
+        await afterDrain.Should().ThrowAsync<OperationCanceledException>();
+
+        // Idempotent: a second Drain is a safe no-op join.
+        pool.Drain();
+        pool.CurrentInFlight.Should().Be(0);
+    }
+
     [Fact]
     public void Unbounded_fallback_runs_the_leaf_on_the_threadpool()
     {

--- a/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
@@ -22,6 +22,50 @@ public class IoPoolTest
     private static readonly TimeSpan Timeout5 = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan Timeout10 = TimeSpan.FromSeconds(10);
 
+    // 🚨 PIN for the endemic teardown SIGSEGV (Hosting.Monolith.Test exit=139). Root cause: a
+    // MeshQuery straggler whose SUBSCRIBE (initial emission → route → CreateHub → Autofac
+    // BeginLifetimeScope) ran on an UNTRACKED TaskPoolScheduler.Default, so teardown's drain never
+    // waited for it and the Autofac scope was disposed mid-construction → native use-after-free.
+    // The fix routes the subscribe through IIoPool.SubscribeThroughPool, so it's TRACKED and Drain()
+    // JOINS it. This test pins that guarantee DETERMINISTICALLY (no flaky ~50% CI repro): a subscribe
+    // that is in-flight holds a slot, and Drain() BLOCKS until it releases — i.e. the scope can never
+    // be torn down while a BeginLifetimeScope is running.
+    [Fact]
+    public void SubscribeThroughPool_holds_a_slot_and_Drain_joins_the_in_flight_subscribe()
+    {
+        using var pool = new IoPool(4);
+        var subscribeEntered = new ManualResetEventSlim();
+        var releaseSubscribe = new ManualResetEventSlim();
+        var subscribeFinished = false;
+
+        // A source whose SUBSCRIBE blocks — stands in for the initial-emission → CreateHub window.
+        var source = Observable.Create<int>(obs =>
+        {
+            subscribeEntered.Set();
+            releaseSubscribe.Wait(Timeout5);
+            subscribeFinished = true;
+            obs.OnNext(1);
+            return System.Reactive.Disposables.Disposable.Empty;
+        });
+
+        using var sub = pool.SubscribeThroughPool(source).Subscribe(_ => { });
+
+        Assert.True(subscribeEntered.Wait(Timeout5), "the subscribe must run on the pool");
+        Assert.True(SpinWait.SpinUntil(() => pool.CurrentInFlight == 1, Timeout5),
+            "the subscribe must hold a pool slot (tracked) for its duration — else the drain can't see it");
+
+        // Drain() must JOIN: block until the in-flight subscribe releases its slot.
+        var drainDone = Task.Run(() => pool.Drain());
+        Assert.False(SpinWait.SpinUntil(() => drainDone.IsCompleted, TimeSpan.FromMilliseconds(200)),
+            "Drain MUST block while the subscribe holds a slot (the owning scope must not dispose yet)");
+
+        releaseSubscribe.Set();
+
+        Assert.True(drainDone.Wait(Timeout5), "Drain should complete once the subscribe releases");
+        Assert.True(subscribeFinished, "Drain must have JOINED the in-flight subscribe before returning");
+        Assert.Equal(0, pool.CurrentInFlight);
+    }
+
     [Fact]
     public async Task Invoke_caps_in_flight_at_the_pool_bound()
     {


### PR DESCRIPTION
**The complete fix for the endemic `Hosting.Monolith.Test exit=139`** (reds ~half of all PRs). Builds on #483's teardown cancel+join by adding the missing half.

## Root cause
A `MeshQuery` change-feed **subscribe** (initial-snapshot emission → route → `CreateHub` → Autofac `BeginLifetimeScope`) ran on an **untracked** `TaskPoolScheduler.Default`. #483 added a cancel+join drain (`IoPoolRegistry.DrainAll`) at teardown, but MeshQuery still used `TaskPoolScheduler`, so the drain never reached it → the Autofac scope was disposed **mid-construction** → native use-after-free SIGSEGV.

## Fix (this PR = #483 + the missing half)
- **New `IIoPool.SubscribeThroughPool<T>`** — runs a long-lived reactive leaf's subscribe as a **tracked, gated, pool-cancellable** op (holds a slot for the bounded subscribe window, counts in `CurrentInFlight`, disposed on drain). Fits a never-completing change feed (unlike the one-shot `InvokeObservable`).
- **MeshQuery's 3 subscribe sites** now go through a drainable **`Query`** pool instead of `TaskPoolScheduler.Default`.
- Inherits **#483's `DrainAll` cancel+join** — which now *reaches* the query work, so the scope disposes only after every in-flight subscribe/`BeginLifetimeScope` finishes.

## Deterministic pin
`IoPoolTest.SubscribeThroughPool_holds_a_slot_and_Drain_joins_the_in_flight_subscribe` proves `Drain()` **blocks** until an in-flight subscribe releases its slot — reliable red/green, not the flaky ~50% crash. **Passes locally.**

Verified additionally by the `alc-unload-probe` workflow (aggressive forced-GC stress) + this PR's normal full-suite CI. Supersedes #483 (includes its commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)