### PR TITLE
Access control with redirect: "if no access ⇒ redirect here" (configurable, tested)

### DIFF
--- a/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/NamedAreaView.razor.cs
@@ -283,20 +283,17 @@ public partial class NamedAreaView
                     else
                         Logger.LogError(error, "Error in control stream for area {Area}", AreaToBeRendered);
 
-                    // "No access ⇒ course poster": a not-yet-enrolled visitor denied a page UNDER a course
-                    // ({course}/Anything) is redirected to that course's PUBLIC Overview "poster" (ad page)
-                    // instead of a dead-end "Access denied" card — so the funnel never terminates on an error.
-                    // Guards: only the page's TOP-LEVEL area redirects (an embedded gated area must never hijack
-                    // the whole page), and only when the course ROOT is actually readable by THIS viewer (its
-                    // public poster renders) — a fully-private partition, or any other denied node, falls through
-                    // to the honest error card below (which is ALSO why this can't loop: a gated root is never
-                    // readable). The probe is best-effort: its OnError path shows the original error, never a swallow.
+                    // "No access ⇒ redirect": when the denied node's access policy configures a
+                    // RedirectOnDenied page (PartitionAccessPolicy — e.g. a public course cover / sign-up),
+                    // send the viewer THERE instead of a dead-end "Access denied" card. Guards: only the
+                    // page's TOP-LEVEL area redirects (an embedded gated area must never hijack the whole
+                    // page); the target comes from the node's OWN policy (reliable, not a guess); and
+                    // IsSafeRedirect blocks redirecting the target itself (or a node under it), so it can
+                    // never loop. The lookup is best-effort + bounded: on error/timeout it shows the honest
+                    // error, never a swallow. When no RedirectOnDenied is set, it falls through to the error.
                     if (Top
-                        && AreaErrorClassifier.TryGetCoursePosterPath(error) is { } posterPath
-                        && Hub.ServiceProvider.GetService<IMeshService>() is { } meshService)
+                        && AreaErrorClassifier.TryGetAccessDeniedPath(error) is { } deniedPath)
                     {
-                        var courseRoot = posterPath[..posterPath.LastIndexOf('/')];
-
                         void ShowError() => InvokeAsync(() =>
                         {
                             if (IsViewDisposed) return;
@@ -308,27 +305,30 @@ public partial class NamedAreaView
                             catch (ObjectDisposedException) { /* renderer gone */ }
                         });
 
-                        meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{courseRoot}"))
-                            .Select(change => change.Items.Any(n => string.Equals(n.Path, courseRoot, StringComparison.Ordinal)))
+                        Hub.GetRedirectOnDenied(deniedPath)
                             .Take(1)
                             .Timeout(TimeSpan.FromSeconds(5))
                             .Subscribe(
-                                posterVisible =>
+                                redirectPath =>
                                 {
                                     if (IsViewDisposed) return;
-                                    if (!posterVisible) { ShowError(); return; }
+                                    if (!AreaErrorClassifier.IsSafeRedirect(deniedPath, redirectPath))
+                                    {
+                                        ShowError();
+                                        return;
+                                    }
                                     InvokeAsync(() =>
                                     {
                                         if (IsViewDisposed) return;
                                         try
                                         {
-                                            RootControl = new RedirectControl($"/{posterPath}");
+                                            RootControl = new RedirectControl($"/{redirectPath!.TrimStart('/')}");
                                             RequestStateChange();
                                         }
                                         catch (ObjectDisposedException) { /* renderer gone */ }
                                     });
                                 },
-                                _ => { if (!IsViewDisposed) ShowError(); }); // probe failed → honest error
+                                _ => { if (!IsViewDisposed) ShowError(); }); // lookup failed → honest error
                         return;
                     }
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-15-access-denied-redirect.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-15-access-denied-redirect.md
@@ -1,0 +1,10 @@
+---
+Name: Redirect on access denied
+Category: What's New
+Description: Send visitors without access to a page you choose, instead of a dead-end error.
+Icon: Sparkle
+---
+
+# Redirect on access denied
+
+A space can now decide where to send a visitor who doesn't have access to a page — for example a public overview or a sign-up page — instead of showing a bare "Access denied". Set a redirect target on the space's access policy and anyone who lands on a page they can't read is taken there automatically. Spaces that don't set one are unchanged.

--- a/src/MeshWeaver.Layout/AreaErrorClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaErrorClassifier.cs
@@ -199,38 +199,23 @@ public static class AreaErrorClassifier
         return null;
     }
 
-    /// <summary>The Overview area — a course's public "poster" (ad) page — that a denied course
-    /// lesson redirects to. Literal (not <c>MeshNodeLayoutAreas.OverviewArea</c>) to keep this
-    /// classifier free of a Graph dependency; pinned to that constant by a unit test.</summary>
-    public const string CoursePosterArea = "Overview";
-
     /// <summary>
-    /// The course POSTER page to send a not-yet-enrolled visitor to when they are denied a page
-    /// <em>under</em> a course — the rule <c>{course}/Anything ⇒ {course}/Overview</c>, where the
-    /// course's public Overview is its poster/ad page. Courses are top-level partitions, so the course
-    /// root is the denied path's FIRST segment; any lesson beneath it therefore resolves to the SAME
-    /// poster. Returns <c>null</c> when:
-    /// <list type="bullet">
-    ///   <item>the error is not access-denied;</item>
-    ///   <item>the denied path is the course ROOT itself (a single segment) — that IS the poster
-    ///   location, so there is nothing to redirect TO; and</item>
-    ///   <item>the denied path already IS the poster (or sits under it) — so a redirect can never
-    ///   loop, even for a non-course partition whose own root is gated.</item>
-    /// </list>
-    /// Pure — unit-tested.
+    /// Whether redirecting a viewer who was denied <paramref name="deniedPath"/> to the configured
+    /// <paramref name="redirectPath"/> ("if no access ⇒ redirect here") is SAFE — i.e. cannot loop.
+    /// True only when a target is set AND the denied node is neither the target itself nor a node under
+    /// it: redirecting the target (or its subtree) back to the target would bounce forever, so those
+    /// fall through to the honest access-denied instead. A leading '/' on the target is ignored. Pure —
+    /// unit-tested. (The redirect TARGET itself comes from the node's PartitionAccessPolicy via
+    /// <c>hub.GetRedirectOnDenied(path)</c>, not from this classifier.)
     /// </summary>
-    public static string? TryGetCoursePosterPath(Exception? ex)
+    public static bool IsSafeRedirect(string? deniedPath, string? redirectPath)
     {
-        var denied = TryGetAccessDeniedPath(ex);
-        if (string.IsNullOrEmpty(denied)) return null;
-        var slash = denied.IndexOf('/');
-        if (slash <= 0) return null; // course root itself → it IS the poster; nothing to redirect to
-        var root = denied[..slash];
-        var remainder = denied[(slash + 1)..];
-        if (string.Equals(remainder, CoursePosterArea, StringComparison.Ordinal)
-            || remainder.StartsWith(CoursePosterArea + "/", StringComparison.Ordinal))
-            return null; // already at / under the poster → no loop
-        return $"{root}/{CoursePosterArea}";
+        if (string.IsNullOrEmpty(deniedPath) || string.IsNullOrWhiteSpace(redirectPath))
+            return false;
+        var target = redirectPath.Trim().TrimStart('/');
+        if (target.Length == 0) return false;
+        return !string.Equals(deniedPath, target, StringComparison.Ordinal)
+            && !deniedPath.StartsWith(target + "/", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/HubPermissionExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubPermissionExtensions.cs
@@ -134,6 +134,19 @@ public static class HubPermissionExtensions
         return PermissionEvaluator.GetPolicy(hub, targetNamespace);
     }
 
+    /// <summary>
+    /// The mesh path to REDIRECT a viewer to when they lack access to <paramref name="targetNamespace"/>
+    /// — the nearest scope's <see cref="PartitionAccessPolicy.RedirectOnDenied"/> (normalized, no leading
+    /// '/'), or <c>null</c> if none is configured. The GUI reads this on a real access-denied to send the
+    /// viewer to a public page ("if no access, redirect here") instead of a dead-end error.
+    /// </summary>
+    public static IObservable<string?> GetRedirectOnDenied(
+        this IMessageHub hub, string targetNamespace)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        return PermissionEvaluator.GetRedirectOnDenied(hub, targetNamespace);
+    }
+
     private static EffectivePermissionsDelegate ResolveEvaluator(IMessageHub hub) =>
         hub.Configuration.Get<EffectivePermissionsDelegate>()
         ?? MessageHubPermissionExtensions.DefaultEvaluator;

--- a/src/MeshWeaver.Mesh.Contract/Security/AccessAssignment.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/AccessAssignment.cs
@@ -90,6 +90,16 @@ public record PartitionAccessPolicy
     public bool BreaksInheritance { get; init; }
 
     /// <summary>
+    /// Optional mesh path to REDIRECT a viewer to when they lack Read on a node at this scope (or
+    /// below) — "if no access, send them here" — instead of showing an access-denied card. Typically a
+    /// PUBLIC page (a course cover, a sign-up / paywall). <c>null</c> or empty = show the normal
+    /// access-denied. Inherited: the nearest ancestor scope that sets it wins. The redirect fires only
+    /// on a REAL denial (never a guess), and never redirects the target itself (or a node under it), so
+    /// it cannot loop — see <c>HubPermissionExtensions.GetRedirectOnDenied</c>. Leading '/' is optional.
+    /// </summary>
+    public string? RedirectOnDenied { get; init; }
+
+    /// <summary>
     /// Computes the permission cap mask from individual switches.
     /// Permissions set to false are removed; null (inherit) and true are kept.
     /// </summary>

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -274,6 +274,32 @@ internal static class PermissionEvaluator
             .Select(policies => policies.TryGetValue(ns, out var policy) ? policy : null);
     }
 
+    /// <summary>
+    /// The effective <see cref="PartitionAccessPolicy.RedirectOnDenied"/> for <paramref name="targetNamespace"/>:
+    /// the nearest scope — self, then each ancestor up to root — that sets one, normalized (no leading '/'),
+    /// or <c>null</c> if none. Reuses the exact scope-policy chain the permission evaluation reads, so a
+    /// policy set once at a partition root applies to every node beneath it.
+    /// </summary>
+    public static IObservable<string?> GetRedirectOnDenied(IMessageHub hub, string targetNamespace)
+    {
+        var ns = targetNamespace ?? "";
+        var cache = hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+        var staticPolicies = CollectStaticPolicies(hub);
+        return ObserveScopePolicies(hub, cache, ns, staticPolicies)
+            .Select(policies =>
+            {
+                // Nearest scope (self first) with a RedirectOnDenied wins; walk to root.
+                for (var s = ns; ; s = GetParentScope(s))
+                {
+                    if (policies.TryGetValue(s, out var p) && !string.IsNullOrWhiteSpace(p.RedirectOnDenied))
+                        return p.RedirectOnDenied!.TrimStart('/');
+                    if (string.IsNullOrEmpty(s)) break;
+                }
+                return (string?)null;
+            })
+            .DistinctUntilChanged();
+    }
+
     #endregion
 
     #region Static node collection

--- a/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
+++ b/test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs
@@ -1,5 +1,4 @@
 using System;
-using MeshWeaver.Graph;
 using MeshWeaver.Messaging;
 using Xunit;
 
@@ -219,28 +218,25 @@ public class AreaErrorClassifierTest
     public void TryGetAccessDeniedPath_NullForNull()
         => AreaErrorClassifier.TryGetAccessDeniedPath(null).Should().BeNull();
 
-    [Theory]
-    // A LESSON under the course denied → the course's Overview poster ({course}/Anything ⇒ {course}/Overview).
-    [InlineData("Access denied: user 'u' lacks Read permission on 'AgenticEngineering/Module1'", "AgenticEngineering/Overview")]
-    // A DEEP lesson resolves to the SAME poster (first segment is the course root).
-    [InlineData("Access denied: user 'u' lacks Read permission on 'AgenticEngineering/Module1/Learn'", "AgenticEngineering/Overview")]
-    public void TryGetCoursePosterPath_ResolvesTheCoursePoster(string message, string expected)
-        => AreaErrorClassifier.TryGetCoursePosterPath(Failure(message, ErrorType.Unauthorized)).Should().Be(expected);
+    // ── IsSafeRedirect: the loop-guard for the "no access ⇒ redirect here" feature. The redirect
+    //    TARGET comes from the node's PartitionAccessPolicy (hub.GetRedirectOnDenied); this only decides
+    //    whether sending the denied node THERE can loop. ──
 
     [Theory]
-    // The course ROOT itself being denied → no redirect (the root IS the poster location; no loop).
-    [InlineData("Access denied: user 'u' lacks Read permission on 'AgenticEngineering'")]
-    // The poster ITSELF being denied → no self-redirect …
-    [InlineData("Access denied: user 'u' lacks Read permission on 'AgenticEngineering/Overview'")]
-    // … nor a node under the poster.
-    [InlineData("Access denied: user 'u' lacks Read permission on 'AgenticEngineering/Overview/Section'")]
-    // … and a non-access-denied error yields no poster.
-    [InlineData("No node found at 'x/y'.")]
-    public void TryGetCoursePosterPath_NullWhenNoSafeRedirect(string message)
-        => AreaErrorClassifier.TryGetCoursePosterPath(Failure(message, ErrorType.Unauthorized)).Should().BeNull();
-
-    [Fact]
-    public void CoursePosterArea_MatchesTheOverviewAreaConstant()
-        // The literal is kept in sync with the framework's Overview area name.
-        => AreaErrorClassifier.CoursePosterArea.Should().Be(MeshNodeLayoutAreas.OverviewArea);
+    // A gated node redirects to a DIFFERENT public page → safe.
+    [InlineData("AgenticEngineering/Introduction", "AgenticEngineering/Cover", true)]
+    // A leading '/' on the target is ignored.
+    [InlineData("AgenticEngineering/Introduction", "/AgenticEngineering/Cover", true)]
+    // The redirect TARGET itself being denied → would loop → NOT safe.
+    [InlineData("AgenticEngineering/Cover", "AgenticEngineering/Cover", false)]
+    // A node UNDER the target being denied → would loop → NOT safe.
+    [InlineData("AgenticEngineering/Cover/Sub", "AgenticEngineering/Cover", false)]
+    // No target configured → nothing to redirect to.
+    [InlineData("AgenticEngineering/Introduction", null, false)]
+    [InlineData("AgenticEngineering/Introduction", "", false)]
+    [InlineData("AgenticEngineering/Introduction", "   ", false)]
+    // No denied path → nothing to redirect.
+    [InlineData(null, "AgenticEngineering/Cover", false)]
+    public void IsSafeRedirect_LoopGuard(string? deniedPath, string? redirectPath, bool expected)
+        => AreaErrorClassifier.IsSafeRedirect(deniedPath, redirectPath).Should().Be(expected);
 }

--- a/test/MeshWeaver.Security.Test/RedirectOnDeniedTests.cs
+++ b/test/MeshWeaver.Security.Test/RedirectOnDeniedTests.cs
@@ -1,0 +1,53 @@
+using System.Threading.Tasks;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// Pins the "if no access ⇒ redirect here" resolution. A single
+/// <see cref="PartitionAccessPolicy.RedirectOnDenied"/> set at a partition root resolves for EVERY
+/// node beneath it (nearest ancestor wins), and returns <c>null</c> where none is configured. This is
+/// the reliable, config-driven target the GUI sends a denied viewer to — the loop-guard and the actual
+/// navigation live in <c>AreaErrorClassifier.IsSafeRedirect</c> + <c>NamedAreaView</c> (unit-tested
+/// separately). No fragile "is the target readable" probe: the target is declared, not guessed.
+/// </summary>
+public class RedirectOnDeniedTests(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddRowLevelSecurity()
+            .AddMeshNodes(
+                new MeshNode("_Policy", "RedirectCourse")
+                {
+                    NodeType = SecurityCollections.PartitionAccessPolicyNodeType,
+                    Content = new PartitionAccessPolicy { RedirectOnDenied = "RedirectCourse/Cover" }
+                });
+
+    // Security tests need granular permissions — skip the PublicAdmin seed.
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    [Fact(Timeout = 20000)]
+    public async Task RedirectOnDenied_ResolvesFromTheAncestorPolicy_ForEveryNodeBeneath()
+    {
+        // The partition root itself.
+        await Mesh.GetRedirectOnDenied("RedirectCourse")
+            .Should().Match(p => p == "RedirectCourse/Cover");
+        // A direct child (a gated module).
+        await Mesh.GetRedirectOnDenied("RedirectCourse/Introduction")
+            .Should().Match(p => p == "RedirectCourse/Cover");
+        // A deep descendant resolves the SAME partition-root policy.
+        await Mesh.GetRedirectOnDenied("RedirectCourse/Module/Lesson")
+            .Should().Match(p => p == "RedirectCourse/Cover");
+    }
+
+    [Fact(Timeout = 20000)]
+    public async Task RedirectOnDenied_IsNull_WhereNoPolicyConfigured()
+        => await Mesh.GetRedirectOnDenied("SomeOtherPartition/Node")
+            .Should().Match(p => p == null);
+}


### PR DESCRIPTION
A partition can declare **where to send a viewer who lacks access** — instead of a dead-end *Access denied* — via **`PartitionAccessPolicy.RedirectOnDenied`** (a mesh path: a public course cover, a sign-up/paywall). This replaces #484's hardcoded `{course}/Overview` convention **and** its fragile *"is the root readable"* probe (which timed out into the raw 403) with a **declared, reliable** target.

## Pieces
- **`PartitionAccessPolicy.RedirectOnDenied`** — the config, on the `_Policy` node.
- **`PermissionEvaluator.GetRedirectOnDenied` / `hub.GetRedirectOnDenied(path)`** — resolves the **nearest ancestor** scope's target (set it once at a partition root → applies to every node beneath), reusing the *same* scope-policy chain the permission evaluation reads. `null` where none.
- **`AreaErrorClassifier.IsSafeRedirect`** — pure loop-guard: never redirect the target itself (or a node under it), so it can't bounce forever.
- **`NamedAreaView`** — on a **top-level** area's *real* access-denial, look up the target and (if safe) `RedirectControl` there; otherwise the honest error card. **Reacts to the real denial**, never a nav-time permission guess (the 2026-05-21 identity-loss trap). Removed the hardcoded `TryGetCoursePosterPath`.

## Tests (green, Release + `-warnaserror`)
- **`RedirectOnDeniedTests`** (MonolithMeshTestBase): a root policy resolves for the root, a direct child, and a deep descendant; `null` where unconfigured.
- **`AreaErrorClassifierTest.IsSafeRedirect_LoopGuard`**: safe to a different page (± leading `/`); **not** safe to the target itself / under it / unset / no denied path.

## Deploy
**Opt-in, per-partition** — not wired to anything on memex. Set `RedirectOnDenied` on a partition's `_Policy` to turn it on. Nothing changes for partitions that don't set it.

Supersedes the reverted course-poster hack (see the `public-course-funnel` history).