### PR TITLE
Fix CancellationAckTest flake: stamp cancel ack from one ordered writer

### DIFF
--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -1704,6 +1704,32 @@ internal static class ThreadExecution
                     .Take(1)
                     .Subscribe(_ =>
                     {
+                        // #321 ack — stamp "stopping…" the INSTANT the cancel is observed, from THIS
+                        // hub-stream gate, via stream.Update on the own node, BEFORE tripping the CTS.
+                        // Ordering is the whole fix: because the ack Update is enqueued here — before
+                        // executionCts.Cancel() propagates to the streaming-loop catch that writes the
+                        // terminal Cancelled — the owning hub's serialized write queue applies the ack
+                        // strictly BEFORE the terminal clear. The ack and the teardown were previously two
+                        // racing writers in two different contexts (InstallCancellationWatcher on the
+                        // stream-emission thread vs the catch on the AI I/O pool), so under load the
+                        // terminal could win and the guard (`IsExecuting && RequestedStatus==Cancelled`)
+                        // would drop the ack — the CancellationAckTest timeout flake. One ordered writer
+                        // removes the race. Guarded to still-executing so it can never clobber a terminal.
+                        parentHub.GetWorkspace().GetMeshNodeStream().Update(
+                            curr => curr?.Content is MeshThread ackThread
+                                    && ackThread.Status.IsExecuting()
+                                    && ackThread.RequestedStatus == ThreadExecutionStatus.Cancelled
+                                ? curr with { Content = ackThread with { ExecutionStatus = CancellationRequestedStatus } }
+                                : curr!)
+                            .Subscribe(
+                                updated => execLogger?.LogDebug(
+                                    "[ThreadExec] Cancellation ack {Result} for {ThreadPath}",
+                                    (updated?.Content as MeshThread)?.ExecutionStatus == CancellationRequestedStatus
+                                        ? "stamped" : "skipped (already terminal)",
+                                    threadPath),
+                                ex => execLogger?.LogDebug(ex,
+                                    "[ThreadExec] Cancellation ack stamp failed for {ThreadPath}", threadPath));
+
                         try { executionCts.Cancel(); }
                         catch (ObjectDisposedException) { /* round already finished */ }
                     });
@@ -2876,23 +2902,15 @@ internal static class ThreadExecution
                 {
                     var thread = x.Thread!;
 
-                    // #321: acknowledge the Stop IMMEDIATELY. The round's own CTS self-cancel
-                    // (ExecuteMessageAsync) tears the round down only after the in-flight tool
-                    // call finishes or hits its timeout (~30s); during that window the status
-                    // line would otherwise stay frozen on the previous tool-call stamp with no
-                    // sign the Stop was received. Stamp the thread's ExecutionStatus now, guarded
-                    // to the still-executing + still-cancel-requested state so it never clobbers a
-                    // terminal write, and leaving RequestedStatus in place for the round's
-                    // terminal handler. The reasoning heartbeat is suppressed while
-                    // RequestedStatus == Cancelled, so this ack persists until the round settles.
-                    hub.GetWorkspace().GetMeshNodeStream().Update(
-                        curr => curr?.Content is MeshThread ackThread
-                                && ackThread.Status.IsExecuting()
-                                && ackThread.RequestedStatus == ThreadExecutionStatus.Cancelled
-                            ? curr with { Content = ackThread with { ExecutionStatus = CancellationRequestedStatus } }
-                            : curr!)
-                        .Subscribe(_ => { }, ex => logger?.LogDebug(ex,
-                            "[ThreadExec] Cancellation ack stamp failed for {ThreadPath}", threadPath));
+                    // #321 ack — the "stopping…" stamp lives in ExecuteMessageAsync's per-round
+                    // self-cancel gate (which fires executionCts.Cancel()), NOT here. That is the
+                    // ONE ordered writer: it enqueues the ack Update before it trips the CTS, so the
+                    // owning hub's serialized queue applies the ack before the streaming-loop catch's
+                    // terminal Cancelled. Stamping it here too would re-introduce the two-context race
+                    // (this watcher runs on the stream-emission thread; the terminal write on the AI
+                    // I/O pool) that dropped the ack under load — the CancellationAckTest flake. This
+                    // watcher now only (a) propagates the cancel to sub-threads and (b) covers the
+                    // pure claim-window case via the No-CTS fallback below.
 
                     // Propagate to every active delegation sub-thread via the
                     // canonical IMeshNodeStreamCache. The sub-thread is a


### PR DESCRIPTION
## The flake

`CancellationAckTest.Stop_ImmediatelyStampsCancellationAck_BeforeRoundTearsDown` times out under CI load (30.2s soft-watchdog; reproduced **3×** on CI, always this test). It's a genuine race, not a slow test.

## Root cause — a two-writer race on a transient field

#321's "stopping…" acknowledgement (`ExecutionStatus = CancellationRequestedStatus`) was written by **two different contexts**, both reacting to the same `RequestedStatus = Cancelled`:

- `InstallCancellationWatcher` — on the shared `IMeshNodeStreamCache` stream-emission thread — **stamped** the ack.
- the streaming-loop `catch (OperationCanceledException)` — on the AI I/O pool, after `executionCts.Cancel()` — wrote the **terminal** `Cancelled` that clears `ExecutionStatus`.

Both writes serialize through the owning hub's write queue, but nothing **ordered** them. Under load the terminal write could be enqueued first; then the ack's guard (`IsExecuting && RequestedStatus==Cancelled`) is already false, so the ack is **never stamped** and the UI/test never observe it → timeout.

## Fix — one ordered writer

Stamp the ack from the **per-round self-cancel gate** in `ExecuteMessageAsync` (the hub-stream `Where(rs==Cancelled)` subscription that trips the CTS), via `stream.Update`, **before** `executionCts.Cancel()`. Because the ack `Update` is enqueued there — before the cancel propagates to the `catch` that writes the terminal — the serialized queue applies the ack **strictly before** the terminal clear. Deterministic; the race is gone.

- Removed the racing stamp from `InstallCancellationWatcher` (it keeps sub-thread cancel propagation + the No-CTS claim-window fallback).
- Added a durable success-side `LogDebug` on the ack stamp (the path previously logged only on failure).

## Validation

- `CancellationAckTest` green in **isolation** (4s, was timing out at 30.2s) **and** in the **full `AI.Test` bulk run** (the way CI hits it — 846/852; it was previously the flaky one).
- `MeshWeaver.AI` + `AI.Test` clean under `-c Release -p:CIRun=true -warnaserror` (merged with current `main`).

The one bulk-run failure was `InboxToolIntegrationTest.CheckInbox_DrainMidExecution` — passes in isolation (13/13), a **separate pre-existing bulk-only race** in the inbox-drain path, not reachable by this cancel-path change.

_No What's New entry: this is a race-condition reliability fix for an existing feature (#321 Stop acknowledgement), not a user-facing change._

🤖 Generated with [Claude Code](https://claude.com/claude-code)