### PR TITLE
Anonymous gate: explicit Anonymous grant loads, denied goes to the configured paywall

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-16-anonymous-paywall-gate.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-16-anonymous-paywall-gate.md
@@ -1,0 +1,18 @@
+---
+Name: Public pages for logged-out visitors, paywall for the rest
+Category: What's New
+Description: A logged-out visitor can now open pages with an explicit Anonymous grant; every other page sends them to the partition's configured paywall page, or to sign-in.
+Icon: Sparkle
+---
+
+# Public pages for logged-out visitors, paywall for the rest
+
+Until now the portal sent every logged-out visitor straight to sign-in — even for pages that were
+meant to be public, like a course cover or a catalog. Now a page that carries an explicit
+**Anonymous** grant opens directly for logged-out visitors.
+
+For everything else, the partition's **redirect on denied** setting decides where the visitor goes:
+if the access policy names a page (for example a course's Subscribe page), the visitor lands there
+instead of a dead end — sign-in stays the fallback when nothing is configured. This makes public
+course funnels work end to end: the course cover is open to everyone, and every gated lesson leads
+to the subscribe page.

--- a/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
+++ b/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
@@ -87,6 +87,11 @@ internal class NavigationService : INavigationService
     // is not enough. Null when the app doesn't register one — behavior then unchanged.
     private readonly PageRouteRegistry? _pageRoutes;
 
+    // The anonymous gate's decision for a resolved path — AnonymousGate.DecideAnonymousAccess
+    // in production; injectable via the internal ctor so the wiring tests drive all three
+    // outcomes (allow / paywall redirect / login) without mocking the permission stack.
+    private readonly Func<string, IObservable<AnonymousGateDecision>> _anonymousGate;
+
     public NavigationService(
         NavigationManager navigationManager,
         IPathResolver pathResolver,
@@ -99,7 +104,7 @@ internal class NavigationService : INavigationService
 
     /// <summary>
     /// Test-only overload that accepts a custom retry schedule so the
-    /// retry-exhaustion path runs fast.
+    /// retry-exhaustion path runs fast, plus an injectable anonymous-gate decision.
     /// </summary>
     internal NavigationService(
         NavigationManager navigationManager,
@@ -107,8 +112,10 @@ internal class NavigationService : INavigationService
         IMessageHub hub,
         ICircuitContextAccessor circuitContextAccessor,
         int[] retryDelays,
-        PageRouteRegistry? pageRoutes = null)
+        PageRouteRegistry? pageRoutes = null,
+        Func<string, IObservable<AnonymousGateDecision>>? anonymousGate = null)
     {
+        _anonymousGate = anonymousGate ?? (path => AnonymousGate.DecideAnonymousAccess(hub, path));
         _pageRoutes = pageRoutes;
         _navigationManager = navigationManager;
         _pathResolver = pathResolver;
@@ -528,12 +535,18 @@ internal class NavigationService : INavigationService
     {
         var (area, id) = ParseRemainder(resolution.Remainder);
 
-        // Anonymous hard-gate: a logged-OUT visitor never sees application content —
-        // not even a PublicRead node. PathResolutionService resolves under a System
-        // bypass, so EVERY existing mesh page (public or private) reaches here. We
-        // redirect the visitor DIRECTLY to /login (forceLoad), carrying the current
-        // absolute URL as returnUrl so sign-in bounces them straight back to the page
-        // they tried to open.
+        // Anonymous gate: a logged-OUT visitor sees application content ONLY when the resolved
+        // node carries an explicit positive Anonymous grant (a public cover / catalog / landing).
+        // Everything else goes to the partition's configured paywall (PartitionAccessPolicy.
+        // RedirectOnDenied — "if no access, redirect here") when one is set, and to /login
+        // otherwise. PathResolutionService resolves under a System bypass, so EVERY existing mesh
+        // page (public or private) reaches here — the gate is the anonymous enforcement point.
+        //
+        // The decision itself lives in AnonymousGate.DecideAnonymousAccess (Mesh.Contract) so it
+        // is integration-tested against the REAL PermissionEvaluator; it is FAIL-CLOSED: no
+        // EffectivePermissionsDelegate registered (RLS not installed), probe error, or timeout
+        // all settle on /login — the default evaluator's Permission.All can never open content
+        // to an anonymous browser. Injectable via the internal ctor for the wiring tests.
         //
         // We navigate here instead of emitting AccessDenied and leaving ApplicationPage's
         // <AuthorizeView><NotAuthorized><RedirectToLogin> to do it: that render-chain
@@ -541,24 +554,56 @@ internal class NavigationService : INavigationService
         // navigation is unconditional, drops any half-built interactive circuit on the
         // gated page, and 302s during prerender. The /login?returnUrl=… target is a page
         // route (single segment + query) that ProcessLocationChange short-circuits, so
-        // this cannot loop.
+        // this cannot loop; the paywall redirect is loop-guarded by AnonymousGate.IsSafeRedirect
+        // and the paywall page itself passes the gate via its own Anonymous grant.
         //
-        // The portal requires authentication for ALL mesh content; "public access" governs
-        // what an AUTHENTICATED user without an explicit grant may read — NOT what an
-        // anonymous browser may see. userId is the EXPLICIT Anonymous well-known value
-        // (ResolveCurrentUserId normalises logged-out + virtual visitors to it, captured
-        // synchronously on the inbound-activity thread), so this never misreads an
-        // authenticated visitor. AUTHENTICATED visitors are never gated here — their
-        // identity is trusted and the content stream enforces RLS, so gating them would
-        // re-introduce the 2026-05-21 identity-loss false-denial.
+        // userId is the EXPLICIT Anonymous well-known value (ResolveCurrentUserId normalises
+        // logged-out + virtual visitors to it, captured synchronously on the inbound-activity
+        // thread), so this never misreads an authenticated visitor. AUTHENTICATED visitors are
+        // never gated here — their identity is trusted and the content stream enforces RLS, so
+        // gating them would re-introduce the 2026-05-21 identity-loss false-denial.
         if (string.Equals(userId, WellKnownUsers.Anonymous, StringComparison.OrdinalIgnoreCase))
         {
-            // The anonymous hard-gate is firing → a forceLoad:true redirect to /login is a FULL page
-            // reload (the "send → page reloads / GUI vanishes" symptom). Log WHY: dump the three identity
-            // sources at the decision point so a MIS-fire on an actually-authenticated user (the
-            // 2026-05-21 identity-loss regression, where a deferred Rx continuation reads a cleared
-            // ambient context) is visible in the logs instead of silent. Warning-level so it surfaces
-            // under the default MeshWeaver=Warning cap with no config change.
+            _anonymousGate(resolution.Prefix)
+                .Take(1)
+                .Timeout(TimeSpan.FromSeconds(10))
+                .Catch<AnonymousGateDecision, Exception>(_ =>
+                    Observable.Return(AnonymousGateDecision.Login))
+                .Subscribe(decision =>
+                {
+                    if (decision.Allow)
+                    {
+                        LoadResolved();
+                        return;
+                    }
+                    if (decision.RedirectTo is { } paywall)
+                    {
+                        _logger?.LogInformation(
+                            "Anonymous-gate: '{Prefix}' not anonymous-readable — redirecting to configured paywall '/{Paywall}'.",
+                            resolution.Prefix, paywall);
+                        IsResolving = false;
+                        Context = null;
+                        CurrentNamespace = null;
+                        _navigationContext.OnNext(null);
+                        _navigationManager.NavigateTo($"/{paywall}");
+                        return;
+                    }
+                    RedirectToLogin();
+                });
+            return;
+        }
+
+        LoadResolved();
+        return;
+
+        void RedirectToLogin()
+        {
+            // The anonymous gate is bouncing to sign-in → a forceLoad:true redirect to /login is a
+            // FULL page reload (the "send → page reloads / GUI vanishes" symptom). Log WHY: dump the
+            // three identity sources at the decision point so a MIS-fire on an actually-authenticated
+            // user (the 2026-05-21 identity-loss regression, where a deferred Rx continuation reads a
+            // cleared ambient context) is visible in the logs instead of silent. Warning-level so it
+            // surfaces under the default MeshWeaver=Warning cap with no config change.
             var accessService = _hub.ServiceProvider.GetService<AccessService>();
             _logger?.LogWarning(
                 "Anonymous-gate: redirecting {Uri} → /login (forceLoad full reload), resolved path '{Prefix}'. "
@@ -573,9 +618,10 @@ internal class NavigationService : INavigationService
             _navigationContext.OnNext(null);
             var returnUrl = Uri.EscapeDataString(_navigationManager.Uri);
             _navigationManager.NavigateTo($"/login?returnUrl={returnUrl}", forceLoad: true);
-            return;
         }
 
+        void LoadResolved()
+        {
         _status.OnNext(NavigationStatus.Redirecting(resolution.Prefix, area));
         _status.OnNext(NavigationStatus.Loading(resolution.Prefix));
 
@@ -674,6 +720,7 @@ internal class NavigationService : INavigationService
             _navigationContext.OnNext(null);
             _status.OnNext(NavigationStatus.NotFound(route));
         });
+        }
     }
 
     /// <summary>
@@ -815,6 +862,14 @@ internal class NavigationService : INavigationService
         // post-"no implicit schema creation" it would 42P01 on every system-context navigation.
         // System actions are infrastructure, not user activity.
         if (string.Equals(userId, WellKnownUsers.System, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        // Anonymous visitors aren't user activity either: since the anonymous gate admits
+        // logged-out visitors to explicitly Anonymous-granted pages (public covers/catalogs),
+        // tracking would write to `Anonymous/_UserActivity/…` — a partition that is never
+        // provisioned, the same 42P01 class as the System skip above. "Recently viewed" is a
+        // signed-in feature.
+        if (string.Equals(userId, WellKnownUsers.Anonymous, StringComparison.OrdinalIgnoreCase))
             return;
 
         // Skip system/internal paths

--- a/src/MeshWeaver.Mesh.Contract/Security/AnonymousGate.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/AnonymousGate.cs
@@ -1,0 +1,85 @@
+using System.Reactive.Linq;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Mesh.Security;
+
+/// <summary>
+/// Where a logged-OUT visitor goes for a resolved mesh path. Exactly one of three outcomes:
+/// <list type="bullet">
+/// <item><see cref="Allow"/> — the node carries an explicit positive Anonymous Read grant
+///   (a public cover / catalog / landing): load it.</item>
+/// <item><see cref="RedirectTo"/> set — the node is NOT anonymous-readable but the nearest scope's
+///   <see cref="PartitionAccessPolicy.RedirectOnDenied"/> names a public page (the paywall):
+///   navigate there instead of a dead-end.</item>
+/// <item>Neither — redirect to <c>/login</c> (the pre-existing hard-gate behavior).</item>
+/// </list>
+/// </summary>
+public sealed record AnonymousGateDecision
+{
+    /// <summary>The visitor may load the page (explicit Anonymous Read grant).</summary>
+    public bool Allow { get; init; }
+
+    /// <summary>Paywall path to navigate to instead (normalized, no leading '/'); null = /login.</summary>
+    public string? RedirectTo { get; init; }
+
+    /// <summary>The fail-closed default: not readable, no paywall — /login.</summary>
+    public static readonly AnonymousGateDecision Login = new();
+}
+
+/// <summary>
+/// The anonymous navigation gate's decision logic, separated from the Blazor wiring so it is
+/// integration-testable against the REAL <see cref="PermissionEvaluator"/> (no mocks). The Blazor
+/// <c>NavigationService</c> maps the decision to load / navigate / login.
+/// </summary>
+public static class AnonymousGate
+{
+    /// <summary>
+    /// Decide what a logged-OUT visitor may do with <paramref name="path"/>.
+    ///
+    /// <para><b>Fail-closed.</b> When no <see cref="EffectivePermissionsDelegate"/> is registered
+    /// (RLS not installed — the canonical check used across the hosting layer), the default
+    /// evaluator would return <see cref="Permission.All"/> and silently open every page to
+    /// anonymous browsers; instead the gate returns <see cref="AnonymousGateDecision.Login"/>.
+    /// Any error in the permission probe or the policy lookup also settles on Login.</para>
+    /// </summary>
+    public static IObservable<AnonymousGateDecision> DecideAnonymousAccess(
+        IMessageHub hub, string path)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        if (hub.Configuration.Get<EffectivePermissionsDelegate>() is null)
+            return Observable.Return(AnonymousGateDecision.Login);
+
+        // Defer: both extensions have synchronous prologues (service resolution) — any throw
+        // must surface as OnError into the Catch below, never on the caller's stack.
+        return Observable.Defer(() =>
+                hub.CheckPermission(path, WellKnownUsers.Anonymous, Permission.Read)
+                    .Take(1)
+                    .SelectMany(anonymousReadable => anonymousReadable
+                        ? Observable.Return(new AnonymousGateDecision { Allow = true })
+                        : hub.GetRedirectOnDenied(path)
+                            .Take(1)
+                            .Select(target => IsSafeRedirect(path, target)
+                                ? new AnonymousGateDecision { RedirectTo = target!.TrimStart('/') }
+                                : AnonymousGateDecision.Login)))
+            .Catch<AnonymousGateDecision, Exception>(_ =>
+                Observable.Return(AnonymousGateDecision.Login));
+    }
+
+    /// <summary>
+    /// Loop-guard shared by every consumer of <see cref="PartitionAccessPolicy.RedirectOnDenied"/>:
+    /// a redirect is safe only when a target is configured AND it is not the denied path itself or
+    /// an ancestor-equal segment of it (redirecting a denied page onto itself would loop forever).
+    /// Counterpart of the Layout-side <c>AreaErrorClassifier.IsSafeRedirect</c> (same rule; that
+    /// project does not reference this one).
+    /// </summary>
+    public static bool IsSafeRedirect(string? deniedPath, string? redirectPath)
+    {
+        if (string.IsNullOrEmpty(deniedPath) || string.IsNullOrWhiteSpace(redirectPath))
+            return false;
+        var target = redirectPath.Trim().TrimStart('/');
+        if (target.Length == 0)
+            return false;
+        return !string.Equals(deniedPath, target, StringComparison.Ordinal)
+            && !deniedPath.StartsWith(target + "/", StringComparison.Ordinal);
+    }
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
@@ -199,11 +199,10 @@ public class NavigationServiceTest
     [Fact]
     public async Task AnonymousVisitor_PublicNode_RedirectsToLogin()
     {
-        // The fix: even a PublicRead page must NOT be shown to a logged-out visitor.
-        // PathResolutionService resolves under a System bypass, so the public node still
-        // reaches the gate — which now redirects to /login regardless of the node's
-        // public-read grant, instead of rendering its content to an anonymous browser.
-        // (Previously this resolved Ready, the reported bug.)
+        // A PublicRead page (the Public subject = baseline for AUTHENTICATED users) is still
+        // NOT shown to a logged-out visitor: only an explicit ANONYMOUS grant opens the gate,
+        // and this harness registers no EffectivePermissionsDelegate, so the fail-closed gate
+        // settles on /login. (Previously this resolved Ready, the reported bug.)
         MakeVisitorAnonymous();
 
         var service = CreateService();
@@ -213,6 +212,79 @@ public class NavigationServiceTest
 
         service.Initialize();
         _navigationManager.SimulateLocationChanged("http://localhost/Public/Welcome/Overview");
+
+        await WaitForRedirect("/login?returnUrl=");
+        _navigationManager.Uri.Should().Contain("/login?returnUrl=");
+    }
+
+    /// <summary>
+    /// Creates the service with an injected anonymous-gate decision (the internal ctor seam), so
+    /// the three wiring outcomes — allow / paywall redirect / login — are each driven explicitly.
+    /// The decision LOGIC itself is integration-tested against the real PermissionEvaluator in
+    /// MeshWeaver.Security.Test.AnonymousGateTests.
+    /// </summary>
+    private NavigationService CreateServiceWithGate(
+        Func<string, IObservable<AnonymousGateDecision>> gate) =>
+        new(_navigationManager, _pathResolver, _hub, _circuitContextAccessor,
+            [10, 20], null, gate);
+
+    [Fact]
+    public async Task AnonymousVisitor_GateAllows_LoadsThePage()
+    {
+        // An explicit Anonymous grant (public cover / paywall page): the gate decides Allow and
+        // the page loads for the logged-out visitor — no /login bounce.
+        MakeVisitorAnonymous();
+        var service = CreateServiceWithGate(_ =>
+            System.Reactive.Linq.Observable.Return(new AnonymousGateDecision { Allow = true }));
+        _pathResolver.ResolveNavigationPath(Arg.Any<string>())
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("PublicCourse", "Overview")));
+
+        service.Initialize();
+        _navigationManager.SimulateLocationChanged("http://localhost/PublicCourse/Overview");
+
+        var ctx = await service.NavigationContext.Should().Within(WaitTimeout)
+            .Match(c => c?.Namespace == "PublicCourse");
+        ctx.Should().NotBeNull();
+        _navigationManager.Uri.Should().NotContain("/login");
+    }
+
+    [Fact]
+    public async Task AnonymousVisitor_GateRedirects_NavigatesToThePaywall()
+    {
+        // A denied content page under a partition with RedirectOnDenied: the visitor lands on the
+        // configured paywall page instead of /login.
+        MakeVisitorAnonymous();
+        var service = CreateServiceWithGate(_ =>
+            System.Reactive.Linq.Observable.Return(
+                new AnonymousGateDecision { RedirectTo = "PublicCourse/Subscribe" }));
+        _pathResolver.ResolveNavigationPath(Arg.Any<string>())
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("PublicCourse/Lesson1", "Overview")));
+
+        service.Initialize();
+        _navigationManager.SimulateLocationChanged("http://localhost/PublicCourse/Lesson1/Overview");
+
+        await WaitForRedirect("/PublicCourse/Subscribe");
+        _navigationManager.Uri.Should().Contain("/PublicCourse/Subscribe");
+        _navigationManager.Uri.Should().NotContain("/login");
+    }
+
+    [Fact]
+    public async Task AnonymousVisitor_GateErrors_FailsClosedToLogin()
+    {
+        // A failing decision (evaluator error / timeout) must fail CLOSED — the logged-out
+        // visitor is bounced to /login, never through to content.
+        MakeVisitorAnonymous();
+        var service = CreateServiceWithGate(_ =>
+            System.Reactive.Linq.Observable.Throw<AnonymousGateDecision>(
+                new InvalidOperationException("permission probe failed")));
+        _pathResolver.ResolveNavigationPath(Arg.Any<string>())
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("Private/Space", "Overview")));
+
+        service.Initialize();
+        _navigationManager.SimulateLocationChanged("http://localhost/Private/Space/Overview");
 
         await WaitForRedirect("/login?returnUrl=");
         _navigationManager.Uri.Should().Contain("/login?returnUrl=");

--- a/test/MeshWeaver.Security.Test/AnonymousGateTests.cs
+++ b/test/MeshWeaver.Security.Test/AnonymousGateTests.cs
@@ -1,0 +1,83 @@
+using System.Threading.Tasks;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// Pins <see cref="AnonymousGate.DecideAnonymousAccess"/> against the REAL
+/// <see cref="PermissionEvaluator"/> (no mocks) — the decision the Blazor navigation gate maps to
+/// load / paywall-navigate / login for a logged-OUT visitor:
+/// <list type="bullet">
+/// <item>an explicit Anonymous Viewer grant ⇒ <c>Allow</c> (the public course cover / paywall page),</item>
+/// <item>denied + <see cref="PartitionAccessPolicy.RedirectOnDenied"/> ⇒ redirect to the paywall,</item>
+/// <item>denied + no policy ⇒ login,</item>
+/// <item>a self-referential redirect target ⇒ login (loop-guard), never a redirect loop.</item>
+/// </list>
+/// The Blazor-side wiring of the three outcomes is unit-tested in
+/// <c>NavigationServiceTest</c> (Hosting.Blazor.Test) via the injectable gate seam.
+/// </summary>
+public class AnonymousGateTests(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddRowLevelSecurity()
+            .AddMeshNodes(
+                // The public cover: the course root carries an explicit Anonymous Viewer grant.
+                AssignmentNodeFactory.UserRole(
+                    WellKnownUsers.Anonymous, "Viewer", "GatedCourse",
+                    accessObject: WellKnownUsers.Anonymous),
+                // The paywall config: denied pages under GatedCourse redirect to the Subscribe page.
+                new MeshNode("_Policy", "GatedCourse")
+                {
+                    NodeType = SecurityCollections.PartitionAccessPolicyNodeType,
+                    Content = new PartitionAccessPolicy { RedirectOnDenied = "GatedCourse/Subscribe" }
+                },
+                // A gated content page: the per-child Anonymous DENY overrides the inherited root
+                // grant for the Anonymous subject (deny is per-subject).
+                AssignmentNodeFactory.UserRole(
+                    WellKnownUsers.Anonymous, "Viewer", "GatedCourse/Lesson1",
+                    denied: true, accessObject: WellKnownUsers.Anonymous),
+                // A partition whose RedirectOnDenied points at ITSELF — the loop-guard case.
+                new MeshNode("_Policy", "LoopCourse")
+                {
+                    NodeType = SecurityCollections.PartitionAccessPolicyNodeType,
+                    Content = new PartitionAccessPolicy { RedirectOnDenied = "LoopCourse" }
+                });
+
+    // Security tests need granular permissions — skip the PublicAdmin seed.
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    [Fact(Timeout = 20000)]
+    public async Task AnonymousGrantedNode_IsAllowed()
+        => await AnonymousGate.DecideAnonymousAccess(Mesh, "GatedCourse")
+            .Should().Match(d => d.Allow && d.RedirectTo == null);
+
+    [Fact(Timeout = 20000)]
+    public async Task DeniedNode_WithConfiguredPaywall_RedirectsThere()
+        => await AnonymousGate.DecideAnonymousAccess(Mesh, "GatedCourse/Lesson1")
+            .Should().Match(d => !d.Allow && d.RedirectTo == "GatedCourse/Subscribe");
+
+    [Fact(Timeout = 20000)]
+    public async Task DeniedNode_WithoutPolicy_FallsBackToLogin()
+        => await AnonymousGate.DecideAnonymousAccess(Mesh, "PrivateSpace/Node")
+            .Should().Match(d => !d.Allow && d.RedirectTo == null);
+
+    [Fact(Timeout = 20000)]
+    public async Task SelfReferentialRedirect_IsLoopGuarded_ToLogin()
+        => await AnonymousGate.DecideAnonymousAccess(Mesh, "LoopCourse")
+            .Should().Match(d => !d.Allow && d.RedirectTo == null);
+
+    [Fact(Timeout = 20000)]
+    public async Task DeepDescendant_InheritsTheRootAnonymousGrant()
+        // A deep page under GatedCourse WITHOUT its own deny inherits the root's Anonymous
+        // Viewer grant (grants flow downward) — pin the inheritance so the per-child deny in
+        // DeniedNode_WithConfiguredPaywall_RedirectsThere is provably the thing doing the gating.
+        => await AnonymousGate.DecideAnonymousAccess(Mesh, "GatedCourse/Deep/Page")
+            .Should().Match(d => d.Allow);
+}


### PR DESCRIPTION
## What

A logged-out visitor can now open pages that carry an **explicit Anonymous grant** (public course covers, catalogs, paywall pages). Every other page routes to the partition's configured **`PartitionAccessPolicy.RedirectOnDenied`** paywall when one is set — `/login` stays the fallback.

## Why

The anonymous hard-gate sent every logged-out visitor to `/login`, making public course funnels impossible: the cover was unreachable and a denied lesson could never reach the Subscribe page. This is the deferred follow-up to #490 (which added `RedirectOnDenied` + the authenticated-side redirect in `NamedAreaView`).

## How

- **`AnonymousGate.DecideAnonymousAccess`** (Mesh.Contract, next to `GetRedirectOnDenied`) — the decision, **fail-closed end to end**: no `EffectivePermissionsDelegate` registered (RLS not installed) / probe error / timeout ⇒ login. This is exactly the fail-open (`Permission.All` default evaluator) that sank the first attempt.
- **`NavigationService`** maps the decision to load / paywall-navigate / login; decision injectable via the internal ctor for wiring tests. Authenticated visitors remain un-gated (2026-05-21 identity-loss rule).
- **`TrackNavigationActivity`** now also skips the Anonymous identity — an admitted logged-out visitor would otherwise write `Anonymous/_UserActivity/…` into a never-provisioned partition (same 42P01 class as the System skip).
- Loop-guard: `AnonymousGate.IsSafeRedirect` (counterpart of `AreaErrorClassifier.IsSafeRedirect`); the paywall page itself passes the gate via its own Anonymous grant.

## Tests

- `AnonymousGateTests` (Security.Test, **real PermissionEvaluator**, 5 new): grant ⇒ allow · deny+policy ⇒ paywall · no policy ⇒ login · self-referential target ⇒ loop-guarded · root grant inherits deep.
- `NavigationServiceTest` (3 new wiring tests): allow ⇒ loads · redirect ⇒ lands on paywall · gate error ⇒ fail-closed to login. Existing 37 unchanged-green (fail-closed keeps the mock-hub default at /login).
- Release `-warnaserror` clean; What's New entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)