### PR TITLE
Login-first anonymous gate + data-driven user-home tabs

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-16-anonymous-paywall-gate.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-16-anonymous-paywall-gate.md
@@ -1,18 +1,21 @@
 ---
-Name: Public pages for logged-out visitors, paywall for the rest
+Name: Public covers for logged-out visitors, sign-in first everywhere else
 Category: What's New
-Description: A logged-out visitor can now open pages with an explicit Anonymous grant; every other page sends them to the partition's configured paywall page, or to sign-in.
+Description: A logged-out visitor can open pages with an explicit Anonymous grant (course covers, catalogs); every other page asks them to sign in first — and after sign-in, gated content leads to the partition's configured paywall page.
 Icon: Sparkle
 ---
 
-# Public pages for logged-out visitors, paywall for the rest
+# Public covers for logged-out visitors, sign-in first everywhere else
 
 Until now the portal sent every logged-out visitor straight to sign-in — even for pages that were
 meant to be public, like a course cover or a catalog. Now a page that carries an explicit
 **Anonymous** grant opens directly for logged-out visitors.
 
-For everything else, the partition's **redirect on denied** setting decides where the visitor goes:
-if the access policy names a page (for example a course's Subscribe page), the visitor lands there
-instead of a dead end — sign-in stays the fallback when nothing is configured. This makes public
-course funnels work end to end: the course cover is open to everyone, and every gated lesson leads
-to the subscribe page.
+Every other page keeps asking for sign-in first, and returns the visitor to the page they wanted
+afterwards. If that page is gated content in a partition with a **redirect on denied** setting
+(for example a course's Subscribe page), the signed-in visitor lands there instead of an error —
+so a public course funnel works end to end: open cover, sign in, subscribe, learn.
+
+The user home also became extensible: the tab row on your home page (Spaces, My Items, …) now
+accepts tabs published as mesh nodes, so a plugin can add its own tab — like a Courses tab with a
+"+" that opens the course catalog — without any platform change.

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -60,6 +60,7 @@ public static class GraphConfigurationExtensions
                 .AddGraphSubscriptionType()
                 .AddActivityType()
                 .AddUserActivityType()
+                .AddHomeTabType()
                 .AddKernel()
                 .AddApiTokenType()
                 .AddMeshDataSourceType()

--- a/src/MeshWeaver.Graph/Configuration/HomeTabNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/HomeTabNodeType.cs
@@ -1,0 +1,46 @@
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Provides configuration for HomeTab node types — the DATA-driven extension tabs of the user
+/// home's catalog row (Spaces, My Items, …). A HomeTab node's <c>Name</c> is the tab label and its
+/// content maps the tab's search (<c>nodeType</c>, <c>query</c>, <c>placeholder</c>) and "+" target
+/// (<c>createHref</c>); the user home's catalog area (<c>UserActivityLayoutAreas</c>) renders every
+/// readable one — a plugin adds a tab (e.g. Courses → the course catalog) by shipping a node,
+/// never by editing the framework.
+/// </summary>
+public static class HomeTabNodeType
+{
+    /// <summary>
+    /// The NodeType value used to identify home-tab nodes — one definition, shared with the
+    /// reader in <see cref="UserActivityLayoutAreas.HomeTabNodeType"/>.
+    /// </summary>
+    public const string NodeType = UserActivityLayoutAreas.HomeTabNodeType;
+
+    /// <summary>
+    /// Registers the built-in "HomeTab" MeshNode on the mesh builder.
+    /// </summary>
+    public static TBuilder AddHomeTabType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        // Tabs are UI config meant to appear on every user's home — public-readable by default;
+        // a partition can still gate an individual tab node (visibility follows readability).
+        builder.ConfigureNodeTypeAccess(a => a.WithPublicRead(NodeType));
+        return builder;
+    }
+
+    /// <summary>
+    /// Creates a MeshNode definition for the HomeTab node type.
+    /// This provides HubConfiguration for nodes with nodeType="HomeTab".
+    /// </summary>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "Home Tab",
+        Icon = "/static/NodeTypeIcons/layout.svg",
+        HubConfiguration = config => config
+            .AddDefaultLayoutAreas()
+            .AddMeshDataSource()
+    };
+}

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Application.Styles;
 using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
@@ -436,11 +439,99 @@ public static class UserActivityLayoutAreas
         return Observable.Return<UiControl?>(BuildOpenThreads(nodePath, OwnerIdOf(nodePath)));
     }
 
-    /// <summary>The catalog region — the declarative TabsControl + MeshSearches.</summary>
+    /// <summary>The catalog region — the declarative TabsControl + MeshSearches. Extension tabs
+    /// come from the mesh (<see cref="HomeTabNodeType"/> nodes) — see <see cref="ObserveHomeTabs"/>.</summary>
     internal static IObservable<UiControl?> CatalogAreaView(LayoutAreaHost host, RenderingContext _)
     {
         var nodePath = host.Hub.Address.ToString();
-        return Observable.Return<UiControl?>(BuildCatalog(nodePath, OwnerIdOf(nodePath)));
+        return ObserveHomeTabs(host)
+            .Select(tabs => (UiControl?)BuildCatalog(nodePath, OwnerIdOf(nodePath), tabs));
+    }
+
+    /// <summary>
+    /// NodeType of a home-catalog EXTENSION TAB: the home's tab list is DATA, not code. Any
+    /// partition (a plugin's synced content, an admin's config) can publish a node of this type
+    /// and it appears as a tab on every user's home — the framework knows nothing about the
+    /// domain the tab surfaces (courses, feeds, …). The node's <c>Name</c> is the tab label,
+    /// <c>Order</c> sorts among extension tabs, and its content carries the MeshSearch mapping
+    /// (all optional): <c>nodeType</c>, <c>query</c>, <c>placeholder</c> (a non-empty one shows
+    /// the search box), and <c>createHref</c> (the tab's "+" target — e.g. a catalog page).
+    /// Visibility follows node readability: a viewer who cannot read the tab node gets no tab.
+    /// </summary>
+    public const string HomeTabNodeType = "HomeTab";
+
+    /// <summary>
+    /// The live extension-tab list: every readable <see cref="HomeTabNodeType"/> node on the mesh,
+    /// ordered. Starts empty so the home paints instantly and the tabs land reactively.
+    /// </summary>
+    private static IObservable<IReadOnlyList<MeshNode>> ObserveHomeTabs(LayoutAreaHost host)
+    {
+        var mesh = host.Hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null)
+            return Observable.Return<IReadOnlyList<MeshNode>>([]);
+        return mesh
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{HomeTabNodeType} is:main"))
+            .Scan(ImmutableDictionary<string, MeshNode>.Empty,
+                (map, change) =>
+                {
+                    if (change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+                        return change.Items.ToImmutableDictionary(n => n.Path);
+                    foreach (var item in change.Items)
+                        map = change.ChangeType switch
+                        {
+                            QueryChangeType.Added or QueryChangeType.Updated => map.SetItem(item.Path, item),
+                            QueryChangeType.Removed => map.Remove(item.Path),
+                            _ => map
+                        };
+                    return map;
+                })
+            .Select(map => (IReadOnlyList<MeshNode>)map.Values
+                .OrderBy(n => n.Order ?? int.MaxValue)
+                .ThenBy(n => n.Name ?? n.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList())
+            .StartWith((IReadOnlyList<MeshNode>)[]);
+    }
+
+    /// <summary>A string field off a HomeTab node's content JSON (foreign-typed — read untyped).</summary>
+    private static string? HomeTabField(MeshNode node, string camelCaseField) =>
+        node.Content is JsonElement je && je.ValueKind == JsonValueKind.Object
+        && je.TryGetProperty(camelCaseField, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
+
+    /// <summary>
+    /// One <see cref="HomeTabNodeType"/> node → its tab: the node's Name is the label; the content
+    /// maps to a <see cref="MeshSearchControl"/> with the catalog's standard look-and-feel —
+    /// <c>nodeType</c>/<c>query</c> compose the hidden query, a non-empty <c>placeholder</c> shows
+    /// the search box, <c>createHref</c> wires the tab's "+".
+    /// </summary>
+    internal static (string Label, MeshSearchControl Search) MapHomeTab(MeshNode tab)
+    {
+        var nodeType = HomeTabField(tab, "nodeType");
+        var query = HomeTabField(tab, "query") ?? "is:main sort:LastModified-desc";
+        var placeholder = HomeTabField(tab, "placeholder");
+        var createHref = HomeTabField(tab, "createHref");
+        var hiddenQuery = string.Join(" ", new[]
+        {
+            string.IsNullOrWhiteSpace(nodeType) ? null : $"nodeType:{nodeType}",
+            query.Trim(),
+        }.Where(part => !string.IsNullOrWhiteSpace(part)));
+        var search = Controls.MeshSearch
+            .WithHiddenQuery(hiddenQuery)
+            .WithShowSearchBox(!string.IsNullOrWhiteSpace(placeholder))
+            .WithShowEmptyMessage(true)
+            .WithRenderMode(MeshSearchRenderMode.Flat)
+            .WithCollapsibleSections(false)
+            .WithSectionCounts(false)
+            .WithMaxColumns(4)
+            .WithItemLimit(50)
+            .WithMaxRows(3)
+            .WithReactiveMode(true);
+        if (!string.IsNullOrWhiteSpace(placeholder))
+            search = search.WithPlaceholder(placeholder!);
+        if (!string.IsNullOrWhiteSpace(createHref))
+            search = search.WithCreateHref(createHref!);
+        return (tab.Name ?? tab.Id, search);
     }
 
     /// <summary>
@@ -495,9 +586,14 @@ public static class UserActivityLayoutAreas
     /// label + scoped query (and create/empty-state) from what used to be the per-tab
     /// <c>Build*</c> helpers — now folded into the declarative builder. The TabsControl owns tab
     /// switching, so there is no host-data tab-state and no CSS-flex toggling.
+    /// <para>Extension tabs (<paramref name="extensionTabs"/>, the readable
+    /// <see cref="HomeTabNodeType"/> nodes) render right after Spaces — the tab list is data,
+    /// so a plugin adds a tab by shipping a node, never by editing this file.</para>
     /// </summary>
-    internal static UiControl BuildCatalog(string nodePath, string nodeOwnerId)
-        => Controls.Tabs
+    internal static UiControl BuildCatalog(
+        string nodePath, string nodeOwnerId, IReadOnlyList<MeshNode>? extensionTabs = null)
+    {
+        var tabs = Controls.Tabs
             // 100% width so the tabs + their search grids fill the home page instead of shrinking to
             // content width (the TabsControl had no Width skin before — FluentTabs defaulted to fit).
             .WithSkin(s => s.WithWidth("100%"))
@@ -515,7 +611,17 @@ public static class UserActivityLayoutAreas
                     .WithRenderMode(MeshSearchRenderMode.Flat)
                     .WithCollapsibleSections(false).WithSectionCounts(false)
                     .WithMaxColumns(4).WithItemLimit(50).WithMaxRows(3).WithReactiveMode(true)
-                    .WithCreateHref("/create?type=Space"))
+                    .WithCreateHref("/create?type=Space"));
+
+        // The data-driven tabs — same look-and-feel defaults as Spaces; the node's content
+        // supplies only the mapping (nodeType/query/placeholder/createHref).
+        foreach (var tab in extensionTabs ?? [])
+        {
+            var (label, search) = MapHomeTab(tab);
+            tabs = tabs.WithView(search, label);
+        }
+
+        return tabs
             // My Items — the owner's own partition (rbuergi.* post-v10), grouped by type.
             .WithMeshSearch(TabMyItems,
                 @namespace: nodeOwnerId,
@@ -541,6 +647,7 @@ public static class UserActivityLayoutAreas
                     .WithShowSearchBox(false).WithRenderMode(MeshSearchRenderMode.Flat)
                     .WithCollapsibleSections(false).WithSectionCounts(false)
                     .WithMaxColumns(2).WithItemLimit(50).WithMaxRows(4).WithReactiveMode(true));
+    }
 
     /// <summary>
     /// Public profile shown to visitors — UserProfileControl (rendered by Blazor)

--- a/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
+++ b/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
@@ -87,10 +87,10 @@ internal class NavigationService : INavigationService
     // is not enough. Null when the app doesn't register one — behavior then unchanged.
     private readonly PageRouteRegistry? _pageRoutes;
 
-    // The anonymous gate's decision for a resolved path — AnonymousGate.DecideAnonymousAccess
-    // in production; injectable via the internal ctor so the wiring tests drive all three
-    // outcomes (allow / paywall redirect / login) without mocking the permission stack.
-    private readonly Func<string, IObservable<AnonymousGateDecision>> _anonymousGate;
+    // The anonymous gate's decision for a resolved path — AnonymousGate.AllowAnonymous in
+    // production; injectable via the internal ctor so the wiring tests drive both outcomes
+    // (allow / login) without mocking the permission stack.
+    private readonly Func<string, IObservable<bool>> _anonymousGate;
 
     public NavigationService(
         NavigationManager navigationManager,
@@ -113,9 +113,9 @@ internal class NavigationService : INavigationService
         ICircuitContextAccessor circuitContextAccessor,
         int[] retryDelays,
         PageRouteRegistry? pageRoutes = null,
-        Func<string, IObservable<AnonymousGateDecision>>? anonymousGate = null)
+        Func<string, IObservable<bool>>? anonymousGate = null)
     {
-        _anonymousGate = anonymousGate ?? (path => AnonymousGate.DecideAnonymousAccess(hub, path));
+        _anonymousGate = anonymousGate ?? (path => AnonymousGate.AllowAnonymous(hub, path));
         _pageRoutes = pageRoutes;
         _navigationManager = navigationManager;
         _pathResolver = pathResolver;
@@ -536,14 +536,15 @@ internal class NavigationService : INavigationService
         var (area, id) = ParseRemainder(resolution.Remainder);
 
         // Anonymous gate: a logged-OUT visitor sees application content ONLY when the resolved
-        // node carries an explicit positive Anonymous grant (a public cover / catalog / landing).
-        // Everything else goes to the partition's configured paywall (PartitionAccessPolicy.
-        // RedirectOnDenied — "if no access, redirect here") when one is set, and to /login
-        // otherwise. PathResolutionService resolves under a System bypass, so EVERY existing mesh
-        // page (public or private) reaches here — the gate is the anonymous enforcement point.
+        // node carries an explicit positive Anonymous grant (a public course cover / catalog /
+        // landing). EVERYTHING else goes to /login first — sign-in is always the first step; the
+        // paywall (PartitionAccessPolicy.RedirectOnDenied) applies to the then-AUTHENTICATED
+        // visitor via the area-level access-denied redirect in NamedAreaView. PathResolutionService
+        // resolves under a System bypass, so EVERY existing mesh page (public or private) reaches
+        // here — the gate is the anonymous enforcement point.
         //
-        // The decision itself lives in AnonymousGate.DecideAnonymousAccess (Mesh.Contract) so it
-        // is integration-tested against the REAL PermissionEvaluator; it is FAIL-CLOSED: no
+        // The decision itself lives in AnonymousGate.AllowAnonymous (Mesh.Contract) so it is
+        // integration-tested against the REAL PermissionEvaluator; it is FAIL-CLOSED: no
         // EffectivePermissionsDelegate registered (RLS not installed), probe error, or timeout
         // all settle on /login — the default evaluator's Permission.All can never open content
         // to an anonymous browser. Injectable via the internal ctor for the wiring tests.
@@ -554,8 +555,7 @@ internal class NavigationService : INavigationService
         // navigation is unconditional, drops any half-built interactive circuit on the
         // gated page, and 302s during prerender. The /login?returnUrl=… target is a page
         // route (single segment + query) that ProcessLocationChange short-circuits, so
-        // this cannot loop; the paywall redirect is loop-guarded by AnonymousGate.IsSafeRedirect
-        // and the paywall page itself passes the gate via its own Anonymous grant.
+        // this cannot loop.
         //
         // userId is the EXPLICIT Anonymous well-known value (ResolveCurrentUserId normalises
         // logged-out + virtual visitors to it, captured synchronously on the inbound-activity
@@ -567,28 +567,13 @@ internal class NavigationService : INavigationService
             _anonymousGate(resolution.Prefix)
                 .Take(1)
                 .Timeout(TimeSpan.FromSeconds(10))
-                .Catch<AnonymousGateDecision, Exception>(_ =>
-                    Observable.Return(AnonymousGateDecision.Login))
-                .Subscribe(decision =>
+                .Catch<bool, Exception>(_ => Observable.Return(false))
+                .Subscribe(allowed =>
                 {
-                    if (decision.Allow)
-                    {
+                    if (allowed)
                         LoadResolved();
-                        return;
-                    }
-                    if (decision.RedirectTo is { } paywall)
-                    {
-                        _logger?.LogInformation(
-                            "Anonymous-gate: '{Prefix}' not anonymous-readable — redirecting to configured paywall '/{Paywall}'.",
-                            resolution.Prefix, paywall);
-                        IsResolving = false;
-                        Context = null;
-                        CurrentNamespace = null;
-                        _navigationContext.OnNext(null);
-                        _navigationManager.NavigateTo($"/{paywall}");
-                        return;
-                    }
-                    RedirectToLogin();
+                    else
+                        RedirectToLogin();
                 });
             return;
         }

--- a/src/MeshWeaver.Mesh.Contract/Security/AnonymousGate.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/AnonymousGate.cs
@@ -4,82 +4,39 @@ using MeshWeaver.Messaging;
 namespace MeshWeaver.Mesh.Security;
 
 /// <summary>
-/// Where a logged-OUT visitor goes for a resolved mesh path. Exactly one of three outcomes:
-/// <list type="bullet">
-/// <item><see cref="Allow"/> — the node carries an explicit positive Anonymous Read grant
-///   (a public cover / catalog / landing): load it.</item>
-/// <item><see cref="RedirectTo"/> set — the node is NOT anonymous-readable but the nearest scope's
-///   <see cref="PartitionAccessPolicy.RedirectOnDenied"/> names a public page (the paywall):
-///   navigate there instead of a dead-end.</item>
-/// <item>Neither — redirect to <c>/login</c> (the pre-existing hard-gate behavior).</item>
-/// </list>
-/// </summary>
-public sealed record AnonymousGateDecision
-{
-    /// <summary>The visitor may load the page (explicit Anonymous Read grant).</summary>
-    public bool Allow { get; init; }
-
-    /// <summary>Paywall path to navigate to instead (normalized, no leading '/'); null = /login.</summary>
-    public string? RedirectTo { get; init; }
-
-    /// <summary>The fail-closed default: not readable, no paywall — /login.</summary>
-    public static readonly AnonymousGateDecision Login = new();
-}
-
-/// <summary>
 /// The anonymous navigation gate's decision logic, separated from the Blazor wiring so it is
 /// integration-testable against the REAL <see cref="PermissionEvaluator"/> (no mocks). The Blazor
-/// <c>NavigationService</c> maps the decision to load / navigate / login.
+/// <c>NavigationService</c> maps the decision to load / login.
+///
+/// <para>A logged-OUT visitor may load a page ONLY when it carries an explicit positive Anonymous
+/// Read grant (a public course cover / catalog / landing). EVERYTHING else — including gated
+/// content whose partition configures a paywall — goes to <c>/login</c> first: sign-in is always
+/// the first step, and the paywall redirect for the then-AUTHENTICATED visitor is handled by the
+/// area-level access-denied redirect (<c>PartitionAccessPolicy.RedirectOnDenied</c> in
+/// <c>NamedAreaView</c>).</para>
 /// </summary>
 public static class AnonymousGate
 {
     /// <summary>
-    /// Decide what a logged-OUT visitor may do with <paramref name="path"/>.
+    /// True when a logged-OUT visitor may load <paramref name="path"/> — an explicit positive
+    /// Anonymous Read grant; false ⇒ redirect to /login.
     ///
     /// <para><b>Fail-closed.</b> When no <see cref="EffectivePermissionsDelegate"/> is registered
     /// (RLS not installed — the canonical check used across the hosting layer), the default
     /// evaluator would return <see cref="Permission.All"/> and silently open every page to
-    /// anonymous browsers; instead the gate returns <see cref="AnonymousGateDecision.Login"/>.
-    /// Any error in the permission probe or the policy lookup also settles on Login.</para>
+    /// anonymous browsers; instead the gate returns false. Any error in the permission probe also
+    /// settles on false.</para>
     /// </summary>
-    public static IObservable<AnonymousGateDecision> DecideAnonymousAccess(
-        IMessageHub hub, string path)
+    public static IObservable<bool> AllowAnonymous(IMessageHub hub, string path)
     {
         ArgumentNullException.ThrowIfNull(hub);
         if (hub.Configuration.Get<EffectivePermissionsDelegate>() is null)
-            return Observable.Return(AnonymousGateDecision.Login);
+            return Observable.Return(false);
 
-        // Defer: both extensions have synchronous prologues (service resolution) — any throw
+        // Defer: CheckPermission has a synchronous prologue (service resolution) — any throw
         // must surface as OnError into the Catch below, never on the caller's stack.
         return Observable.Defer(() =>
-                hub.CheckPermission(path, WellKnownUsers.Anonymous, Permission.Read)
-                    .Take(1)
-                    .SelectMany(anonymousReadable => anonymousReadable
-                        ? Observable.Return(new AnonymousGateDecision { Allow = true })
-                        : hub.GetRedirectOnDenied(path)
-                            .Take(1)
-                            .Select(target => IsSafeRedirect(path, target)
-                                ? new AnonymousGateDecision { RedirectTo = target!.TrimStart('/') }
-                                : AnonymousGateDecision.Login)))
-            .Catch<AnonymousGateDecision, Exception>(_ =>
-                Observable.Return(AnonymousGateDecision.Login));
-    }
-
-    /// <summary>
-    /// Loop-guard shared by every consumer of <see cref="PartitionAccessPolicy.RedirectOnDenied"/>:
-    /// a redirect is safe only when a target is configured AND it is not the denied path itself or
-    /// an ancestor-equal segment of it (redirecting a denied page onto itself would loop forever).
-    /// Counterpart of the Layout-side <c>AreaErrorClassifier.IsSafeRedirect</c> (same rule; that
-    /// project does not reference this one).
-    /// </summary>
-    public static bool IsSafeRedirect(string? deniedPath, string? redirectPath)
-    {
-        if (string.IsNullOrEmpty(deniedPath) || string.IsNullOrWhiteSpace(redirectPath))
-            return false;
-        var target = redirectPath.Trim().TrimStart('/');
-        if (target.Length == 0)
-            return false;
-        return !string.Equals(deniedPath, target, StringComparison.Ordinal)
-            && !deniedPath.StartsWith(target + "/", StringComparison.Ordinal);
+                hub.CheckPermission(path, WellKnownUsers.Anonymous, Permission.Read).Take(1))
+            .Catch<bool, Exception>(_ => Observable.Return(false));
     }
 }

--- a/test/MeshWeaver.Graph.Test/HomeTabExtensionTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeTabExtensionTest.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using System.Text.Json;
+using MeshWeaver.Graph;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The user home's catalog tab row is DATA-driven: any readable <c>HomeTab</c> node becomes a tab
+/// (label = node name, content maps the search + the "+" target). The framework knows nothing
+/// about the domain a tab surfaces — e.g. the Edu plugin ships a "Courses" tab node whose "+"
+/// opens the course catalog, with zero framework change.
+/// </summary>
+public class HomeTabExtensionTest
+{
+    private const string NodePath = "rbuergi";
+
+    private static MeshNode HomeTabNode(string name, object content) =>
+        MeshNode.FromPath($"Edu/{name}Tab") with
+        {
+            Name = name,
+            NodeType = UserActivityLayoutAreas.HomeTabNodeType,
+            Content = JsonSerializer.SerializeToElement(content),
+        };
+
+    [Fact]
+    public void Catalog_WithoutExtensionTabs_HasTheBuiltInsOnly()
+    {
+        var catalog = (TabsControl)UserActivityLayoutAreas.BuildCatalog(NodePath, NodePath);
+
+        catalog.Areas.Select(a => a.Id).Should().Equal("Spaces", "My Items", "Last Read", "Last Edited");
+    }
+
+    [Fact]
+    public void Catalog_WithAHomeTabNode_InsertsTheTabAfterSpaces()
+    {
+        var courses = HomeTabNode("Courses", new
+        {
+            nodeType = "Edu/Course",
+            placeholder = "Search courses…",
+            createHref = "/Courses/Catalog",
+        });
+
+        var catalog = (TabsControl)UserActivityLayoutAreas.BuildCatalog(NodePath, NodePath, [courses]);
+
+        catalog.Areas.Select(a => a.Id)
+            .Should().Equal("Spaces", "Courses", "My Items", "Last Read", "Last Edited");
+    }
+
+    [Fact]
+    public void MapHomeTab_MapsSearchQueryPlaceholderAndCreateHref()
+    {
+        var (label, search) = UserActivityLayoutAreas.MapHomeTab(HomeTabNode("Courses", new
+        {
+            nodeType = "Edu/Course",
+            placeholder = "Search courses…",
+            createHref = "/Courses/Catalog",
+        }));
+
+        label.Should().Be("Courses");
+        search.HiddenQuery!.ToString().Should().Contain("nodeType:Edu/Course");
+        search.HiddenQuery!.ToString().Should().Contain("is:main");
+        search.Placeholder.Should().Be("Search courses…");
+        search.CreateHref.Should().Be("/Courses/Catalog");
+        search.ShowSearchBox.Should().Be(true);
+    }
+
+    [Fact]
+    public void MapHomeTab_MinimalNode_DefaultsAreSafe()
+    {
+        // Only a name + empty content: a browse-everything tab with no search box and no "+".
+        var (label, search) = UserActivityLayoutAreas.MapHomeTab(HomeTabNode("Feed", new { }));
+
+        label.Should().Be("Feed");
+        search.HiddenQuery!.ToString().Should().Contain("is:main");
+        search.CreateHref.Should().BeNull();
+        search.ShowSearchBox.Should().Be(false);
+    }
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
@@ -219,23 +219,23 @@ public class NavigationServiceTest
 
     /// <summary>
     /// Creates the service with an injected anonymous-gate decision (the internal ctor seam), so
-    /// the three wiring outcomes — allow / paywall redirect / login — are each driven explicitly.
-    /// The decision LOGIC itself is integration-tested against the real PermissionEvaluator in
+    /// both wiring outcomes — allow / login — are each driven explicitly. The decision LOGIC
+    /// itself is integration-tested against the real PermissionEvaluator in
     /// MeshWeaver.Security.Test.AnonymousGateTests.
     /// </summary>
     private NavigationService CreateServiceWithGate(
-        Func<string, IObservable<AnonymousGateDecision>> gate) =>
+        Func<string, IObservable<bool>> gate) =>
         new(_navigationManager, _pathResolver, _hub, _circuitContextAccessor,
             [10, 20], null, gate);
 
     [Fact]
     public async Task AnonymousVisitor_GateAllows_LoadsThePage()
     {
-        // An explicit Anonymous grant (public cover / paywall page): the gate decides Allow and
-        // the page loads for the logged-out visitor — no /login bounce.
+        // An explicit Anonymous grant (public cover / catalog): the gate allows and the page
+        // loads for the logged-out visitor — no /login bounce.
         MakeVisitorAnonymous();
         var service = CreateServiceWithGate(_ =>
-            System.Reactive.Linq.Observable.Return(new AnonymousGateDecision { Allow = true }));
+            System.Reactive.Linq.Observable.Return(true));
         _pathResolver.ResolveNavigationPath(Arg.Any<string>())
             .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
                 new AddressResolution("PublicCourse", "Overview")));
@@ -250,14 +250,14 @@ public class NavigationServiceTest
     }
 
     [Fact]
-    public async Task AnonymousVisitor_GateRedirects_NavigatesToThePaywall()
+    public async Task AnonymousVisitor_GateDenies_RedirectsToLogin()
     {
-        // A denied content page under a partition with RedirectOnDenied: the visitor lands on the
-        // configured paywall page instead of /login.
+        // A denied page — regardless of any configured paywall — sends the logged-out visitor to
+        // /login first (returnUrl bounces them back after sign-in; the paywall then applies to
+        // the AUTHENTICATED visitor via the area-level access-denied redirect).
         MakeVisitorAnonymous();
         var service = CreateServiceWithGate(_ =>
-            System.Reactive.Linq.Observable.Return(
-                new AnonymousGateDecision { RedirectTo = "PublicCourse/Subscribe" }));
+            System.Reactive.Linq.Observable.Return(false));
         _pathResolver.ResolveNavigationPath(Arg.Any<string>())
             .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
                 new AddressResolution("PublicCourse/Lesson1", "Overview")));
@@ -265,9 +265,9 @@ public class NavigationServiceTest
         service.Initialize();
         _navigationManager.SimulateLocationChanged("http://localhost/PublicCourse/Lesson1/Overview");
 
-        await WaitForRedirect("/PublicCourse/Subscribe");
-        _navigationManager.Uri.Should().Contain("/PublicCourse/Subscribe");
-        _navigationManager.Uri.Should().NotContain("/login");
+        await WaitForRedirect("/login?returnUrl=");
+        _navigationManager.Uri.Should().Contain("/login?returnUrl=");
+        _navigationManager.Uri.Should().Contain(Uri.EscapeDataString("PublicCourse/Lesson1"));
     }
 
     [Fact]
@@ -277,7 +277,7 @@ public class NavigationServiceTest
         // visitor is bounced to /login, never through to content.
         MakeVisitorAnonymous();
         var service = CreateServiceWithGate(_ =>
-            System.Reactive.Linq.Observable.Throw<AnonymousGateDecision>(
+            System.Reactive.Linq.Observable.Throw<bool>(
                 new InvalidOperationException("permission probe failed")));
         _pathResolver.ResolveNavigationPath(Arg.Any<string>())
             .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(

--- a/test/MeshWeaver.Security.Test/AnonymousGateTests.cs
+++ b/test/MeshWeaver.Security.Test/AnonymousGateTests.cs
@@ -10,17 +10,18 @@ using Xunit;
 namespace MeshWeaver.Security.Test;
 
 /// <summary>
-/// Pins <see cref="AnonymousGate.DecideAnonymousAccess"/> against the REAL
+/// Pins <see cref="AnonymousGate.AllowAnonymous"/> against the REAL
 /// <see cref="PermissionEvaluator"/> (no mocks) — the decision the Blazor navigation gate maps to
-/// load / paywall-navigate / login for a logged-OUT visitor:
+/// load / login for a logged-OUT visitor:
 /// <list type="bullet">
-/// <item>an explicit Anonymous Viewer grant ⇒ <c>Allow</c> (the public course cover / paywall page),</item>
-/// <item>denied + <see cref="PartitionAccessPolicy.RedirectOnDenied"/> ⇒ redirect to the paywall,</item>
-/// <item>denied + no policy ⇒ login,</item>
-/// <item>a self-referential redirect target ⇒ login (loop-guard), never a redirect loop.</item>
+/// <item>an explicit Anonymous Viewer grant ⇒ allowed (the public course cover / catalog),</item>
+/// <item>EVERYTHING else ⇒ /login — even when the partition configures a
+///   <see cref="PartitionAccessPolicy.RedirectOnDenied"/> paywall: sign-in is always the first
+///   step, and the paywall applies to the then-authenticated visitor via the area-level
+///   access-denied redirect (<c>NamedAreaView</c>).</item>
 /// </list>
-/// The Blazor-side wiring of the three outcomes is unit-tested in
-/// <c>NavigationServiceTest</c> (Hosting.Blazor.Test) via the injectable gate seam.
+/// The Blazor-side wiring of the outcomes is unit-tested in <c>NavigationServiceTest</c>
+/// (Hosting.Blazor.Test) via the injectable gate seam.
 /// </summary>
 public class AnonymousGateTests(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -32,7 +33,8 @@ public class AnonymousGateTests(ITestOutputHelper output) : MonolithMeshTestBase
                 AssignmentNodeFactory.UserRole(
                     WellKnownUsers.Anonymous, "Viewer", "GatedCourse",
                     accessObject: WellKnownUsers.Anonymous),
-                // The paywall config: denied pages under GatedCourse redirect to the Subscribe page.
+                // A paywall policy exists — it must NOT change the anonymous decision (login
+                // first; the paywall is the authenticated visitor's redirect).
                 new MeshNode("_Policy", "GatedCourse")
                 {
                     NodeType = SecurityCollections.PartitionAccessPolicyNodeType,
@@ -42,42 +44,33 @@ public class AnonymousGateTests(ITestOutputHelper output) : MonolithMeshTestBase
                 // grant for the Anonymous subject (deny is per-subject).
                 AssignmentNodeFactory.UserRole(
                     WellKnownUsers.Anonymous, "Viewer", "GatedCourse/Lesson1",
-                    denied: true, accessObject: WellKnownUsers.Anonymous),
-                // A partition whose RedirectOnDenied points at ITSELF — the loop-guard case.
-                new MeshNode("_Policy", "LoopCourse")
-                {
-                    NodeType = SecurityCollections.PartitionAccessPolicyNodeType,
-                    Content = new PartitionAccessPolicy { RedirectOnDenied = "LoopCourse" }
-                });
+                    denied: true, accessObject: WellKnownUsers.Anonymous));
 
     // Security tests need granular permissions — skip the PublicAdmin seed.
     protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
 
     [Fact(Timeout = 20000)]
     public async Task AnonymousGrantedNode_IsAllowed()
-        => await AnonymousGate.DecideAnonymousAccess(Mesh, "GatedCourse")
-            .Should().Match(d => d.Allow && d.RedirectTo == null);
+        => await AnonymousGate.AllowAnonymous(Mesh, "GatedCourse")
+            .Should().Match(allowed => allowed);
 
     [Fact(Timeout = 20000)]
-    public async Task DeniedNode_WithConfiguredPaywall_RedirectsThere()
-        => await AnonymousGate.DecideAnonymousAccess(Mesh, "GatedCourse/Lesson1")
-            .Should().Match(d => !d.Allow && d.RedirectTo == "GatedCourse/Subscribe");
+    public async Task DeniedNode_GoesToLogin_EvenWithAPaywallConfigured()
+        // The RedirectOnDenied paywall exists at this scope — the ANONYMOUS visitor still goes to
+        // /login first; only the signed-in-but-denied visitor is redirected to the paywall.
+        => await AnonymousGate.AllowAnonymous(Mesh, "GatedCourse/Lesson1")
+            .Should().Match(allowed => !allowed);
 
     [Fact(Timeout = 20000)]
-    public async Task DeniedNode_WithoutPolicy_FallsBackToLogin()
-        => await AnonymousGate.DecideAnonymousAccess(Mesh, "PrivateSpace/Node")
-            .Should().Match(d => !d.Allow && d.RedirectTo == null);
-
-    [Fact(Timeout = 20000)]
-    public async Task SelfReferentialRedirect_IsLoopGuarded_ToLogin()
-        => await AnonymousGate.DecideAnonymousAccess(Mesh, "LoopCourse")
-            .Should().Match(d => !d.Allow && d.RedirectTo == null);
+    public async Task UngrantedNode_GoesToLogin()
+        => await AnonymousGate.AllowAnonymous(Mesh, "PrivateSpace/Node")
+            .Should().Match(allowed => !allowed);
 
     [Fact(Timeout = 20000)]
     public async Task DeepDescendant_InheritsTheRootAnonymousGrant()
         // A deep page under GatedCourse WITHOUT its own deny inherits the root's Anonymous
         // Viewer grant (grants flow downward) — pin the inheritance so the per-child deny in
-        // DeniedNode_WithConfiguredPaywall_RedirectsThere is provably the thing doing the gating.
-        => await AnonymousGate.DecideAnonymousAccess(Mesh, "GatedCourse/Deep/Page")
-            .Should().Match(d => d.Allow);
+        // DeniedNode_GoesToLogin_EvenWithAPaywallConfigured is provably the thing doing the gating.
+        => await AnonymousGate.AllowAnonymous(Mesh, "GatedCourse/Deep/Page")
+            .Should().Match(allowed => allowed);
 }


### PR DESCRIPTION
## What

Two course-funnel design refinements:

1. **Anonymous = login first.** `AnonymousGate.AllowAnonymous`: a logged-out visitor loads ONLY explicitly Anonymous-granted pages (covers/catalogs); everything else → `/login?returnUrl=…` — even when a `RedirectOnDenied` paywall is configured. The paywall applies to the then-authenticated visitor via the existing `NamedAreaView` redirect. Fail-closed unchanged.
2. **User-home tabs are data, not code.** The home catalog tab row accepts extension tabs published as `HomeTab` mesh nodes (Name = label; content maps `nodeType`/`query`/`placeholder`/`createHref` = the "+" target; `Order` sorts; visibility follows node readability). A plugin ships a "Courses" tab node whose "+" opens the course catalog — zero framework knowledge of the domain.

## Tests

- `AnonymousGateTests` 4/4 (real `PermissionEvaluator`): granted ⇒ allow; denied ⇒ login even with paywall configured; ungranted ⇒ login; root grant inherits deep.
- `NavigationServiceTest` 40/40 (wiring: allow / deny→login+returnUrl / error→fail-closed login).
- `HomeTabExtensionTest` 4/4 (built-in tab order pinned; extension tab after Spaces; content mapping; safe defaults).
- Release `-warnaserror` clean; What's New updated.

Follow-ups landing separately: `Edu/Course` type work in MeshWeaver.Plugins (Subscribe area + auto-gating via `CourseGate.SeedGating`), education-repo course retyping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)