### PR TITLE
fix(docs): render @@content/<file> embeds on doc pages

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
@@ -105,25 +105,27 @@ The importer must be **idempotent over existing rows** (re-imports, eventually-c
 
 ## Scope: mesh nodes AND content-collection files
 
-The import materializes both **mesh nodes** (a node's `Content` + prerendered HTML, via the node upsert above) and the node's **content-collection files** — the assets a node references through the `content` collection, e.g. an `@@content/logo.svg` image embed or an `@@content/sample.md` include on a doc page.
+The import materializes both **mesh nodes** (a node's `Content` + prerendered HTML, via the node upsert above) and, for sources that need it, the node's **content-collection files** — the assets a node references through the `content` collection, e.g. an `@@content/logo.svg` image embed on a Space page.
 
-Those files live in a **per-node content collection**, not the node row: `ConfigureDefaultNodeHub` gives every node hub its own `content` collection rooted at `{Storage:BasePath}/content/{nodePath}`, read via `IFileContentProvider.GetFileContent("content", "<file>")` **on that node's hub**. Syncing a file is therefore a per-node-hub operation dispatched to the owning node's hub, distinct from the node upsert.
+Those files live in a **per-node content collection**, not the node row — and *where* that collection is mapped is a **host decision**, not something every node hub gets automatically. The memex portal (`MemexConfiguration.ConfigureDefaultNodeHub`) maps a **writable** `content` collection only on **Space/partition roots** (`nodePath` with no `/`), rooted at `{Storage:BasePath}/content/{nodePath}`; a read-only embedded source like **`Doc`** instead maps each node's **own embedded `Content/<subpath>` subfolder** as its read-only `content` collection (`AddDocumentation.ConfigureDefaultNodeHub`), so a doc page's `@@content/<file>` embed is served straight from the shipped assembly — no copy needed. Files are read via `IFileContentProvider.GetFileContent("content", "<file>")` **on that node's hub**.
 
 ### How content files are synced (collection → collection)
 
-1. A source ships its assets in an **embedded content collection** and declares the imports by overriding `IStaticRepoSource.EnumerateContentImports()` → `StaticContentImport(NodePath, SourceCollection, SourcePath, TargetCollection="content", TargetPath="")`. E.g. `DocumentationStaticRepoSource` ships `logo.svg` + `sample.md` under `Content/DataMesh/UnifiedPath/` (the embedded `DocContent` collection) and imports that folder into the `Doc/DataMesh/UnifiedPath` node's `content` collection.
+This copy path is for a source whose target nodes have a **writable** per-node `content` collection (e.g. a GitSync Space whose assets ship in a FileSystem source). **The built-in `Doc` partition does NOT use it** — a child doc node like `Doc/DataMesh/UnifiedPath` has no writable `content` collection (the portal maps writable `content` only on Space roots), so the copy had nowhere to land. Instead, `AddDocumentation` maps each Doc node's own embedded `Content/<subpath>` subfolder as its read-only `content` collection, and `@@content/<file>` resolves directly from the shipped assembly. Verified by `DocContentEmbedRenderTest`.
+
+1. A source that needs the copy declares its imports by overriding `IStaticRepoSource.EnumerateContentImports()` → `StaticContentImport(NodePath, SourceCollection, SourcePath, TargetCollection="content", TargetPath="")`, shipping the assets in a source content collection readable on the owning node's hub.
 2. After the node upsert the importer's `SyncContentImports` posts the **canonical `ImportContentRequest`** per entry, under `ImpersonateAsSystem`, via the fluent API in `MeshWeaver.ContentCollections`:
 
    ```csharp
    hub.ImportContent(nodePath)
-      .From("DocContent", "DataMesh/UnifiedPath")  // embedded source collection + folder
-      .To("content")                               // target collection on the node
-      .Post()                                       // → ImportContentRequest to the OWNING node's hub
+      .From("<sourceCollection>", "<sourceFolder>")  // source collection + folder
+      .To("content")                                 // WRITABLE target collection on the node
+      .Post()                                        // → ImportContentRequest to the OWNING node's hub
    ```
 
-   The handler (registered by `AddContentCollectionsInfrastructure`, so every content-enabled node hub has it) resolves both collections via `IContentService` and copies each direct-child file of the source folder **stream-to-stream** so binary assets (svg/png) survive — `GetFiles`/`GetContentAsync` on the source, `SaveFileAsync` on the target — with the **whole copy sealed in one `IIoPool` operation** (the hub action block only subscribes + returns; async never runs on the hub). The file is then served through `/static/{address}/content/<file>`. **No hand-rolled cross-hub `IFileContentProvider` write, no async on a hub path, and no second `ImportContentRequest`** (the type is wire-registered — a duplicate collides). The embedded source collection (`DocContent`) is exposed on node hubs too (`AddDocumentation`'s `ConfigureDefaultNodeHub`) so the node-hub handler can read it.
+   The handler (registered by `AddContentCollectionsInfrastructure`, so every content-enabled node hub has it) resolves both collections via `IContentService` and copies each direct-child file of the source folder **stream-to-stream** so binary assets (svg/png) survive — `GetFiles`/`GetContentAsync` on the source, `SaveFileAsync` on the target — with the **whole copy sealed in one `IIoPool` operation** (the hub action block only subscribes + returns; async never runs on the hub). The file is then served through `/static/{address}/content/<file>`. **No hand-rolled cross-hub `IFileContentProvider` write, no async on a hub path, and no second `ImportContentRequest`** (the type is wire-registered — a duplicate collides). The source collection must be exposed on the node hub (via `ConfigureDefaultNodeHub`) so the node-hub handler can read it.
 
-This is why a synced doc page's `@@content/<file>` embeds render on a fresh deployment (e.g. a FileSystem source at `/mnt/content`): the importer copies the assets into the runtime `content` collection on boot, alongside the nodes. Tests: `ContentImportSyncTest` (monolith, filesystem + embedded sources) and `OrleansContentImportSyncTest` (the distributed cross-grain path — the shape that must not deadlock).
+This is how a source with a writable target collection gets its `@@content/<file>` assets to land on a fresh deployment (e.g. a FileSystem source at `/mnt/content`): the importer copies them into the runtime `content` collection on boot, alongside the nodes. Tests: `ContentImportSyncTest` (monolith, filesystem + embedded sources) and `OrleansContentImportSyncTest` (the distributed cross-grain path — the shape that must not deadlock).
 
 ## The two primitives
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-16-doc-page-embeds-render.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-16-doc-page-embeds-render.md
@@ -1,0 +1,13 @@
+---
+Name: Documentation page embeds now render
+Category: What's New
+Description: Diagrams and inline examples embedded in documentation pages now display instead of "not found"
+Icon: Sparkle
+---
+
+# Documentation page embeds now render
+
+Documentation pages that embed a shipped asset — an architecture diagram, an inline
+markdown example, an image — now display it inline instead of showing an "Area not found"
+placeholder. The assets a page ships alongside it are served directly, so every doc page
+renders exactly as authored, on a fresh deployment and offline.

--- a/src/MeshWeaver.Documentation/DocumentationExtensions.cs
+++ b/src/MeshWeaver.Documentation/DocumentationExtensions.cs
@@ -74,16 +74,38 @@ public static class DocumentationExtensions
                 typeof(DocumentationExtensions).Assembly,
                 "Content"));
 
-        // Also expose DocContent on every node hub: the static-repo content import handler runs on
-        // the OWNING node's hub and reads DocContent as the SOURCE collection when copying assets
-        // (e.g. the Unified Path page's @@content/logo.svg + sample.md) into the node's runtime
-        // "content" collection. Without this the node hub can't resolve DocContent. See
-        // StaticRepoImport.md + DocumentationStaticRepoSource.EnumerateContentImports.
-        builder.ConfigureDefaultNodeHub(config => config
-            .AddEmbeddedResourceContentCollection(
-                "DocContent",
-                typeof(DocumentationExtensions).Assembly,
-                "Content"));
+        // Give every Doc-partition CHILD node hub a node-scoped, READ-ONLY "content" collection backed
+        // DIRECTLY by the shipped embedded assets under Content/<node-subpath>/. This is what makes a
+        // @@content/<file> embed on a doc page resolve — the Architecture diagrams
+        // (@@content/platform-overview.svg …), the Unified Path page's @@content/logo.svg + sample.md,
+        // and any future page asset.
+        //
+        // Why the DIRECT embedded collection and not the old import copy: the portal maps a WRITABLE
+        // "content" collection ONLY on partition ROOTS (content lives once per Space; children inherit
+        // via ExposeInChildren — MemexConfiguration gates on !nodePath.Contains('/')). A CHILD doc node
+        // like Doc/DataMesh/UnifiedPath therefore never had a "content" collection at all, so the
+        // import's collection→collection copy had nowhere to land and every @@content/ embed on a doc
+        // page rendered "Area/Collection not found". Mapping the node's own Content/ subfolder as its
+        // read-only "content" here fixes them uniformly — no import copy, no writable storage, works
+        // offline. AddContentCollections() (idempotent) also guarantees the $Content layout area +
+        // content service are on the hub regardless of how the node is served (DB-synced or embedded).
+        builder.ConfigureDefaultNodeHub(config =>
+        {
+            var prefix = DocumentationNodeProvider.RootNamespace + "/"; // "Doc/"
+            var address = config.Address.ToString();
+            if (!address.StartsWith(prefix, StringComparison.Ordinal))
+                return config;
+            // Node sub-path within the partition → embedded-resource prefix segment (dots, not slashes):
+            // Doc/DataMesh/UnifiedPath → "Content.DataMesh.UnifiedPath", i.e. the node's own Content/
+            // subfolder. Nodes without a Content/ subfolder just get an empty collection (never queried).
+            var subPath = address[prefix.Length..].Replace('/', '.');
+            return config
+                .AddContentCollections()
+                .AddEmbeddedResourceContentCollection(
+                    ContentCollectionsExtensions.DefaultCollectionName,
+                    typeof(DocumentationExtensions).Assembly,
+                    $"Content.{subPath}");
+        });
 
         // Doc namespace caps: read-only docs (no Create/Update/Delete) but
         // discussion + commenting allowed. Previously lived on the legacy

--- a/src/MeshWeaver.Documentation/DocumentationStaticRepoSource.cs
+++ b/src/MeshWeaver.Documentation/DocumentationStaticRepoSource.cs
@@ -33,20 +33,12 @@ public sealed class DocumentationStaticRepoSource(IServiceProvider serviceProvid
         DocumentationNodeProvider.LoadIndexableNodes(
             serviceProvider.GetRequiredService<IMessageHub>().JsonSerializerOptions);
 
-    /// <inheritdoc />
-    // The Unified Path page embeds @@content/logo.svg + @@content/sample.md. Those assets ship in
-    // the embedded DocContent collection (Content/DataMesh/UnifiedPath/*); after the node upsert the
-    // import copies that folder's direct-child files into the node's runtime "content" collection so
-    // the embeds render on a fresh deploy.
-    public IReadOnlyList<StaticContentImport> EnumerateContentImports() =>
-    [
-        new StaticContentImport(
-            NodePath: $"{Partition}/DataMesh/UnifiedPath",
-            SourceCollection: "DocContent",
-            SourcePath: "DataMesh/UnifiedPath",
-            TargetCollection: MeshWeaver.ContentCollections.ContentCollectionsExtensions.DefaultCollectionName,
-            TargetPath: ""),
-    ];
+    // NOTE: no EnumerateContentImports override. The @@content/<file> embeds on doc pages (the
+    // Architecture diagrams, the Unified Path page's logo.svg + sample.md) are served directly from
+    // the shipped embedded assets: DocumentationExtensions maps each Doc node's own Content/ subfolder
+    // as its read-only "content" collection. The old import copy targeted a per-CHILD-node writable
+    // "content" collection that the portal never provisions (content lives once per Space root), so it
+    // could never land — see DocumentationExtensions.AddDocumentation.
 
     /// <inheritdoc />
     // The /Doc landing page — a proper Space root with a curated welcome inviting the reader to

--- a/test/MeshWeaver.Content.Test/DocContentEmbedRenderTest.cs
+++ b/test/MeshWeaver.Content.Test/DocContentEmbedRenderTest.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Data;
+using MeshWeaver.Documentation;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Content.Test;
+
+/// <summary>
+/// Pins that a doc page's <c>@@content/&lt;file&gt;</c> embed renders the SHIPPED asset — the exact
+/// failure the screenshot showed ("2. Embedded Markdown" → "Area not found" for
+/// <c>@@content/sample.md</c> on the Unified Path page).
+///
+/// <para>Root cause: the portal maps a WRITABLE <c>content</c> collection only on partition ROOTS
+/// (content lives once per Space; children inherit — MemexConfiguration gates on
+/// <c>!nodePath.Contains('/')</c>). So a CHILD doc node like <c>Doc/DataMesh/UnifiedPath</c> never had
+/// a <c>content</c> collection at all, and the old import copy had nowhere to land →
+/// <c>$Content</c> resolved to "Area/Collection not found". <see cref="DocumentationExtensions"/> now
+/// maps each Doc node's own <c>Content/</c> subfolder as its read-only <c>content</c> collection, so
+/// the embedded asset resolves directly. This test renders the <c>$Content</c> area exactly as the
+/// portal does — no manually-mapped collection, only <see cref="DocumentationExtensions.AddDocumentation"/>.</para>
+/// </summary>
+public class DocContentEmbedRenderTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    // Partitioned (routing-aware) persistence is required for the embedded "Doc" partition to be
+    // SERVED — a plain non-partitioned in-memory adapter leaves the Doc namespace unreachable ("No
+    // node found"). Mirrors the render harness in MarkdownNodeIntegrationTest / the Orleans doc test.
+    // No content collection is mapped by hand here: only AddDocumentation, exactly like the portal.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => builder
+            .UseMonolithMesh()
+            .AddPartitionedInMemoryPersistence()
+            .AddDocumentation()
+            .AddGraph()
+            .ConfigureHub(c => c.WithRequestTimeout(TimeSpan.FromSeconds(60)));
+
+    // Layout-area streams require the layout client on the client hub.
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    // (node, @@content/<file>, a fragment unique to the successfully-rendered asset)
+    [Theory]
+    // The screenshot case: the Unified Path page's embedded markdown.
+    [InlineData("Doc/DataMesh/UnifiedPath", "sample.md", "Sample embedded markdown")]
+    // Same node, an inline SVG — RenderImageContent wraps it in <div class='embedded-svg'>.
+    [InlineData("Doc/DataMesh/UnifiedPath", "logo.svg", "embedded-svg")]
+    // A different node entirely: the Architecture landing page's platform diagram — proves the fix is
+    // node-scoped (Content/Architecture/…), not a one-off for UnifiedPath.
+    [InlineData("Doc/Architecture", "platform-overview.svg", "embedded-svg")]
+    public async Task ContentEmbed_RendersShippedAsset(string nodePath, string file, string fragment)
+    {
+        var workspace = GetClient().GetWorkspace();
+        // @@content/<file> → the $Content area with the file path as the reference Id.
+        var reference = new LayoutAreaReference(ContentCollectionsExtensions.ContentAreaName) { Id = file };
+
+        // The area emits a "Building layout…" placeholder first; Match() waits for the frame that
+        // actually carries the rendered asset. A regressed build (no node-scoped content collection)
+        // renders "…not found" instead — which never satisfies the predicate → the Within() trips.
+        var value = await workspace
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(nodePath), reference)
+            .Should().Within(40.Seconds())
+            .Match(v =>
+            {
+                var json = v.Value.GetRawText();
+                return json.Contains(fragment) && !json.Contains("not found");
+            }, $"@@content/{file} on {nodePath} must render the shipped asset, not a 'not found' placeholder");
+
+        var rendered = value.Value.GetRawText();
+        Output.WriteLine(rendered.Length > 800 ? rendered[..800] : rendered);
+    }
+}


### PR DESCRIPTION
## Problem

Documentation pages that embed a shipped asset render **"Area not found"** / **"Collection 'content' not found"** instead of the asset — the screenshot case being the Unified Path page's `@@content/sample.md`, plus `@@content/logo.svg` and the Architecture diagrams (`@@content/platform-overview.svg`, `data-compression.svg`, `message-flow.svg`).

## Root cause

The `@@content/<file>` embed resolves to the `$Content` area on the doc node's own hub → `GetCollection("content")`. But **the child doc node has no `content` collection at all**: the portal (`MemexConfiguration.ConfigureDefaultNodeHub`) maps a *writable* `content` collection **only on partition roots** (`!nodePath.Contains('/')` — "content lives once per Space; children inherit"). So `Doc/DataMesh/UnifiedPath` never had one, and the old `DocumentationStaticRepoSource.EnumerateContentImports` copy-into-`content` had nowhere to land — it silently failed every boot. (Confirmed on live memex: `@Doc/DataMesh/UnifiedPath/content/sample.md` → *"Content collection 'content' not found"*.)

## Fix

- **`DocumentationExtensions.AddDocumentation`** — for every Doc **child** node hub, map the node's own shipped `Content/<subpath>` embedded subfolder as its read-only `content` collection (`AddEmbeddedResourceContentCollection("content", …, "Content.<subpath>")`, dotted prefix so the embedded provider's `ResourcePrefix` matches). `@@content/<file>` now resolves straight from the assembly — no import copy, no writable storage, works offline, covers every doc page uniformly.
- **`DocumentationStaticRepoSource`** — removed the now-dead `EnumerateContentImports` override.
- **`StaticRepoImport.md`** — corrected the section that described Doc embeds rendering via the (removed) copy.

## Verification (all local — no prod mutation)

- New **`DocContentEmbedRenderTest`** renders `$Content` exactly as the portal does, with *only* `AddDocumentation()` (no hand-mapped collection). **Revert-proven**: all 3 cases fail without the fix (render "not found" → timeout), pass with it.
- **No regressions**: 21 content tests (incl. `ContentCollectionReferenceTest`, `ContentImportSyncTest`) + 11 doc-integrity tests green. Clean under `-c Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)