### PR TITLE
Compile retry un-parks: route MCP compile/recycle through the release-request seam

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -2978,19 +2978,26 @@ public class MeshOperations
     {
         try
         {
-            // Trigger a fresh compile by flipping CompilationStatus = Pending on
-            // the NodeType MeshNode. The per-NodeType hub's CompileWatcher (see
-            // NodeTypeCompilationHelpers.InstallCompileWatcher) picks up the
-            // Pending flip and runs Roslyn — the MeshNode IS the cache, so we
+            // Trigger a fresh compile through the RELEASE-REQUEST seam — stamp
+            // RequestedReleaseAt (+ Force) on the NodeType MeshNode, exactly what the
+            // UI Compile button writes. The per-NodeType hub's
+            // InstallReleaseRequestWatcher UN-PARKS the type in the
+            // NodeTypeCompileParkRegistry (a deliberate retry is the single un-park
+            // trigger) and promotes the request to CompilationStatus = Pending; the
+            // CompileWatcher then runs Roslyn — the MeshNode IS the cache, so we
             // don't need a side cache to invalidate.
+            // 🚨 Never flip CompilationStatus = Pending directly: a direct flip
+            // bypasses the un-park seam, so a parked (terminally failed) type swallows
+            // the trigger in the compile watcher's parked short-circuit and wedges at
+            // Pending (2026-07-16 memex Reinsurance/Layer + BusinessRules/Scope).
             hub.GetWorkspace().GetMeshNodeStream(resolvedPath).Update(curr =>
-                    curr.Content is Graph.Configuration.NodeTypeDefinition def
-                        ? curr with { Content = def with { CompilationStatus = CompilationStatus.Pending } }
+                    IsNodeTypeNode(curr)
+                        ? WithReleaseRequest(curr, DateTimeOffset.UtcNow)
                         : curr)
                 .Subscribe(
                     _ => { },
                     ex => logger.LogWarning(ex,
-                        "Recycle: failed to flip CompilationStatus=Pending for {Path}", resolvedPath));
+                        "Recycle: failed to stamp release request for {Path}", resolvedPath));
 
             var changeFeed = hub.ServiceProvider.GetService<IMeshChangeFeed>();
             if (changeFeed != null)
@@ -3144,17 +3151,25 @@ public class MeshOperations
     }
 
     /// <summary>
-    /// Triggers a compile for a NodeType by flipping its
-    /// <see cref="NodeTypeDefinition.CompilationStatus"/> to
-    /// <see cref="CompilationStatus.Pending"/> via the canonical remote-stream
-    /// write path: <see cref="MeshNodeStreamExtensions.UpdateMeshNode"/> opens a
-    /// <c>GetRemoteStream&lt;MeshNode, MeshNodeReference&gt;</c> against the
-    /// owning per-node hub and pushes a <see cref="ChangeItem{T}"/> patch through
-    /// the synchronization protocol. The CompileWatcher (installed by
-    /// <c>AddMeshDataSource</c>) observes the Pending state on its own MeshNode
-    /// stream and runs Roslyn, then writes back <see cref="CompilationStatus.Ok"/>
-    /// or <see cref="CompilationStatus.Error"/> plus
+    /// Triggers a compile for a NodeType by stamping a RELEASE REQUEST
+    /// (<see cref="NodeTypeDefinition.RequestedReleaseAt"/> +
+    /// <see cref="NodeTypeDefinition.RequestedReleaseForce"/>) on its MeshNode via the
+    /// canonical remote-stream write path: <see cref="MeshNodeStreamExtensions"/>'
+    /// <c>GetMeshNodeStream(path).Update(...)</c> pushes a patch through the
+    /// synchronization protocol to the owning per-node hub. That is the SAME seam the
+    /// UI Compile button uses: the hub's <c>InstallReleaseRequestWatcher</c> observes
+    /// the timestamp move, UN-PARKS the type in the <c>NodeTypeCompileParkRegistry</c>
+    /// (a deliberate retry is the single un-park trigger) and promotes the request to
+    /// <see cref="CompilationStatus.Pending"/>; the CompileWatcher then runs Roslyn and
+    /// writes back <see cref="CompilationStatus.Ok"/> or
+    /// <see cref="CompilationStatus.Error"/> plus
     /// <see cref="NodeTypeDefinition.LastCompilationActivityPath"/>.
+    ///
+    /// <para>🚨 Never flip <c>CompilationStatus = Pending</c> directly from here: a
+    /// direct flip bypasses the un-park seam, so a parked (terminally failed) type
+    /// swallows the trigger in the compile watcher's parked short-circuit and wedges
+    /// at Pending forever (2026-07-16 memex Reinsurance/Layer + BusinessRules/Scope —
+    /// healed only by a pod restart).</para>
     ///
     /// <para>Why a dedicated tool over <see cref="Patch"/>: Patch requires both
     /// Read (to merge the existing node) and Update permission on the target node.
@@ -3194,88 +3209,112 @@ public class MeshOperations
                     hub.JsonSerializerOptions));
             }
 
-            // Subscribe to the NodeType's stream BEFORE flipping Pending so we
-            // don't miss the watcher's status transitions. The stream emits the
+            // Subscribe to the NodeType's stream BEFORE triggering so we don't
+            // miss the watcher's status transitions. The stream emits the
             // current node first (whatever status it's in); we wait for a
             // settled Ok/Error after the trigger.
             var stream = workspace.GetMeshNodeStream(resolvedPath);
 
-            try
-            {
-                // Impersonate System for the Pending flip. Triggering a recompile is an
-                // INFRASTRUCTURE operation that fills the assembly cache — it must succeed
-                // even when the caller has no Update right on the target partition (the
-                // read-only Doc partition is the canonical case). Under the caller's identity
-                // this flip was denied → "UpdateMeshNode failed" → the compile never ran and
-                // the cache stayed empty (atioz on-demand-compile failure on Doc). The
-                // RunCompile watcher + Release-node creation already run as System; this entry
-                // flip was the straggler still on the caller's identity.
-                var accessService = hub.ServiceProvider.GetService<AccessService>();
-                using (accessService?.ImpersonateAsSystem())
-                    workspace.GetMeshNodeStream(resolvedPath).Update(node => node with
-                    {
-                        Content = WithPendingCompilationStatus(node.Content)
-                    }).Subscribe(
-                        _ => { },
-                        ex => logger.LogWarning(ex,
-                            "Compile: UpdateMeshNode failed for {Path}", resolvedPath));
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Compile trigger failed for {Path}", resolvedPath);
-                return Observable.Return(JsonSerializer.Serialize(
-                    new { status = "Error", path = resolvedPath, message = ex.Message },
-                    hub.JsonSerializerOptions));
-            }
-
-            // Wait for the watcher to write back Ok or Error (60s budget — Roslyn
-            // first compile of a moderate node is 5-15s; bigger trees can take
-            // longer; some hubs may take ~5s to emit a settled state after the
-            // initial Pending). Then return a structured result with the error
-            // body inline if Error — agents/humans get the diagnostic without a
-            // second polling round-trip.
+            // 🚨 Capture the PRE-TRIGGER snapshot FIRST. The settle-wait below only
+            // accepts a terminal Ok/Error emission produced by THIS trigger's compile
+            // run: the stream replays the current node on subscribe, so without this
+            // barrier the PREVIOUS run's terminal snapshot (still Ok/Error) could be
+            // returned as this run's result — complete with the previous run's
+            // activity path (a fabricated "Compile SUCCEEDED" for a compile that
+            // never ran).
             return stream
-                .Where(n =>
-                {
-                    var status = ReadCompilationStatusFromNode(n);
-                    return status == CompilationStatus.Ok || status == CompilationStatus.Error;
-                })
                 .Take(1)
-                .Timeout(TimeSpan.FromSeconds(60))
-                .Select(n =>
+                .Timeout(TimeSpan.FromSeconds(30))
+                .Catch<MeshNode?, Exception>(preEx =>
                 {
-                    var status = ReadCompilationStatusFromNode(n);
-                    var error = ReadCompilationError(n);
-                    var activityPath = ReadActivityPath(n);
-                    return JsonSerializer.Serialize(
-                        new
-                        {
-                            status = status?.ToString() ?? "Unknown",
-                            path = resolvedPath,
-                            error,
-                            activityPath,
-                            message = status == CompilationStatus.Ok
-                                ? "Compile SUCCEEDED."
-                                : "Compile FAILED — see `error` for Roslyn diagnostics. "
-                                  + "Full source-discovery + matched-Code-paths trace lives at "
-                                  + (activityPath ?? "(no activity log written)") + "."
-                        },
-                        hub.JsonSerializerOptions);
+                    logger.LogWarning(preEx,
+                        "Compile: could not read the pre-trigger snapshot for {Path} — proceeding without a stale-result barrier",
+                        resolvedPath);
+                    return Observable.Return<MeshNode?>(null);
                 })
-                .Catch((Exception ex) =>
+                .SelectMany(before =>
                 {
-                    logger.LogWarning(ex,
-                        "Compile: timeout / observer error waiting for {Path} to settle", resolvedPath);
-                    return Observable.Return(JsonSerializer.Serialize(
-                        new
+                    try
+                    {
+                        // Impersonate System for the trigger write. Triggering a recompile is an
+                        // INFRASTRUCTURE operation that fills the assembly cache — it must succeed
+                        // even when the caller has no Update right on the target partition (the
+                        // read-only Doc partition is the canonical case). Under the caller's identity
+                        // this write was denied → "UpdateMeshNode failed" → the compile never ran and
+                        // the cache stayed empty (atioz on-demand-compile failure on Doc). The
+                        // RunCompile watcher + Release-node creation already run as System; this entry
+                        // write was the straggler still on the caller's identity.
+                        var accessService = hub.ServiceProvider.GetService<AccessService>();
+                        using (accessService?.ImpersonateAsSystem())
+                            stream.Update(node => WithReleaseRequest(node, DateTimeOffset.UtcNow))
+                                .Subscribe(
+                                    _ => { },
+                                    ex => logger.LogWarning(ex,
+                                        "Compile: UpdateMeshNode failed for {Path}", resolvedPath));
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex, "Compile trigger failed for {Path}", resolvedPath);
+                        return Observable.Return(JsonSerializer.Serialize(
+                            new { status = "Error", path = resolvedPath, message = ex.Message },
+                            hub.JsonSerializerOptions));
+                    }
+
+                    // Wait for the watcher to write back Ok or Error (60s budget — Roslyn
+                    // first compile of a moderate node is 5-15s; bigger trees can take
+                    // longer; some hubs may take ~5s to emit a settled state after the
+                    // initial Pending). Only a terminal state from a NEW compile run is
+                    // accepted (IsNewCompileRun): every run stamps LastCompileStartedAt —
+                    // and, when the activity create lands, a fresh
+                    // LastCompilationActivityPath — at its Pending→Compiling transition,
+                    // so the pre-trigger snapshot's replayed terminal state can never be
+                    // reported as this run's result. Then return a structured result with
+                    // the error body inline if Error — agents/humans get the diagnostic
+                    // without a second polling round-trip.
+                    return stream
+                        .Where(n =>
                         {
-                            status = "Pending",
-                            path = resolvedPath,
-                            message = "Compile triggered but did not settle within the deadline. "
-                                + "Poll `get " + resolvedPath + "` for `compilationStatus` and "
-                                + "`lastCompilationActivityPath`. Underlying error: " + ex.Message
-                        },
-                        hub.JsonSerializerOptions));
+                            var status = ReadCompilationStatusFromNode(n);
+                            return (status == CompilationStatus.Ok || status == CompilationStatus.Error)
+                                && IsNewCompileRun(n, before);
+                        })
+                        .Take(1)
+                        .Timeout(TimeSpan.FromSeconds(60))
+                        .Select(n =>
+                        {
+                            var status = ReadCompilationStatusFromNode(n);
+                            var error = ReadCompilationError(n);
+                            var activityPath = ReadActivityPath(n);
+                            return JsonSerializer.Serialize(
+                                new
+                                {
+                                    status = status?.ToString() ?? "Unknown",
+                                    path = resolvedPath,
+                                    error,
+                                    activityPath,
+                                    message = status == CompilationStatus.Ok
+                                        ? "Compile SUCCEEDED."
+                                        : "Compile FAILED — see `error` for Roslyn diagnostics. "
+                                          + "Full source-discovery + matched-Code-paths trace lives at "
+                                          + (activityPath ?? "(no activity log written)") + "."
+                                },
+                                hub.JsonSerializerOptions);
+                        })
+                        .Catch((Exception ex) =>
+                        {
+                            logger.LogWarning(ex,
+                                "Compile: timeout / observer error waiting for {Path} to settle", resolvedPath);
+                            return Observable.Return(JsonSerializer.Serialize(
+                                new
+                                {
+                                    status = "Pending",
+                                    path = resolvedPath,
+                                    message = "Compile triggered but no NEW compile run settled within the deadline. "
+                                        + "Poll `get " + resolvedPath + "` for `compilationStatus` and "
+                                        + "`lastCompilationActivityPath`. Underlying error: " + ex.Message
+                                },
+                                hub.JsonSerializerOptions));
+                        });
                 });
         });
     }
@@ -3310,40 +3349,114 @@ public class MeshOperations
         return null;
     }
 
-    /// <summary>
-    /// Returns a new <c>Content</c> object with <c>compilationStatus</c> set to
-    /// <c>Pending</c>. Handles both strongly-typed
-    /// <see cref="Graph.Configuration.NodeTypeDefinition"/> (own hub registered
-    /// the type) and <see cref="JsonElement"/> (remote hub passed it through
-    /// untyped). Other content shapes are returned unchanged with a warning —
-    /// this method is only meaningful on a NodeType node.
-    /// </summary>
-    private object? WithPendingCompilationStatus(object? content)
+    private static DateTimeOffset? ReadCompileStartedAt(MeshNode? node)
     {
-        switch (content)
+        if (node?.Content is Graph.Configuration.NodeTypeDefinition def)
+            return def.LastCompileStartedAt;
+        if (node?.Content is JsonElement json && json.TryGetProperty("lastCompileStartedAt", out var p)
+            && p.ValueKind == JsonValueKind.String && p.TryGetDateTimeOffset(out var parsed))
+            return parsed;
+        return null;
+    }
+
+    /// <summary>
+    /// True when the settled <paramref name="node"/> carries the terminal state of a
+    /// compile run STARTED AFTER the pre-trigger snapshot <paramref name="before"/> —
+    /// the barrier that keeps <see cref="Compile"/> from reporting the PREVIOUS run's
+    /// replayed Ok/Error (with the previous run's activity path) as this trigger's
+    /// result. Every compile run stamps <c>LastCompileStartedAt</c> — and, when the
+    /// activity create lands, a fresh <c>LastCompilationActivityPath</c> — at its
+    /// Pending→Compiling transition, so a new run always advances at least one of the
+    /// two. With no baseline (the pre-trigger read failed), the first settled emission
+    /// is accepted — there is no reference point to discriminate against.
+    /// </summary>
+    private static bool IsNewCompileRun(MeshNode? node, MeshNode? before)
+    {
+        if (before is null)
+            return true;
+        var activity = ReadActivityPath(node);
+        if (activity is not null
+            && !string.Equals(activity, ReadActivityPath(before), StringComparison.Ordinal))
+            return true;
+        var beforeStartedAt = ReadCompileStartedAt(before);
+        return ReadCompileStartedAt(node) is { } startedAt
+            && (beforeStartedAt is null || startedAt > beforeStartedAt.Value);
+    }
+
+    /// <summary>
+    /// True when the node is a NodeType definition node — either strongly typed
+    /// (<see cref="Graph.Configuration.NodeTypeDefinition"/> content) or a degraded
+    /// untyped mirror recognised by <see cref="MeshNode.NodeType"/>.
+    /// </summary>
+    private static bool IsNodeTypeNode(MeshNode node) =>
+        node.Content is Graph.Configuration.NodeTypeDefinition
+        || string.Equals(node.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Returns the node with a fresh RELEASE REQUEST stamped on its content:
+    /// <see cref="NodeTypeDefinition.RequestedReleaseAt"/> = <paramref name="triggerAt"/>
+    /// and <see cref="NodeTypeDefinition.RequestedReleaseForce"/> = <c>true</c> — the
+    /// exact trigger the UI Compile button writes. The per-NodeType hub's
+    /// <c>InstallReleaseRequestWatcher</c> observes the timestamp move, un-parks the
+    /// type and promotes the request to <see cref="CompilationStatus.Pending"/>.
+    /// Handles both strongly-typed <see cref="Graph.Configuration.NodeTypeDefinition"/>
+    /// (own hub registered the type) and <see cref="JsonElement"/> / <c>null</c>
+    /// (remote hub passed it through untyped). Other content shapes are returned
+    /// unchanged with a warning — the stamp is only meaningful on a NodeType node.
+    /// </summary>
+    private MeshNode WithReleaseRequest(MeshNode node, DateTimeOffset triggerAt)
+    {
+        switch (node.Content)
         {
             case Graph.Configuration.NodeTypeDefinition def:
-                return def with { CompilationStatus = CompilationStatus.Pending };
+                return node with
+                {
+                    Content = def with
+                    {
+                        RequestedReleaseAt = triggerAt,
+                        RequestedReleaseForce = true
+                    }
+                };
 
             case JsonElement json:
             {
-                var node = JsonNode.Parse(json.GetRawText()) as JsonObject ?? new JsonObject();
-                node["compilationStatus"] = "Pending";
-                return JsonSerializer.SerializeToElement(node, hub.JsonSerializerOptions);
+                var obj = JsonNode.Parse(json.GetRawText()) as JsonObject ?? new JsonObject();
+                StampReleaseRequest(obj, triggerAt);
+                return node with
+                {
+                    Content = JsonSerializer.SerializeToElement(obj, hub.JsonSerializerOptions)
+                };
             }
 
             case null:
             {
-                var node = new JsonObject { ["compilationStatus"] = "Pending" };
-                return JsonSerializer.SerializeToElement(node, hub.JsonSerializerOptions);
+                var obj = new JsonObject();
+                StampReleaseRequest(obj, triggerAt);
+                return node with
+                {
+                    Content = JsonSerializer.SerializeToElement(obj, hub.JsonSerializerOptions)
+                };
             }
 
             default:
                 logger.LogWarning(
-                    "Compile: unexpected content type {Type} on NodeType node — wrapping",
-                    content.GetType().Name);
-                return content;
+                    "Compile: unexpected content type {Type} on NodeType node — release request not stamped",
+                    node.Content.GetType().Name);
+                return node;
         }
+    }
+
+    private void StampReleaseRequest(JsonObject obj, DateTimeOffset triggerAt)
+    {
+        var naming = hub.JsonSerializerOptions.PropertyNamingPolicy;
+        var atKey = naming?.ConvertName(
+                nameof(Graph.Configuration.NodeTypeDefinition.RequestedReleaseAt))
+            ?? nameof(Graph.Configuration.NodeTypeDefinition.RequestedReleaseAt);
+        var forceKey = naming?.ConvertName(
+                nameof(Graph.Configuration.NodeTypeDefinition.RequestedReleaseForce))
+            ?? nameof(Graph.Configuration.NodeTypeDefinition.RequestedReleaseForce);
+        obj[atKey] = JsonSerializer.SerializeToNode(triggerAt, hub.JsonSerializerOptions);
+        obj[forceKey] = true;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-16-compile-retry-unparks.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-16-compile-retry-unparks.md
@@ -1,0 +1,19 @@
+---
+Name: Compile retry now recovers types with a failed build
+Category: What's New
+Description: Retrying a compile (MCP compile/recycle tools) after fixing the source now reliably rebuilds a type whose previous compile failed — no more types stuck at Pending.
+Icon: Sparkle
+---
+
+# Compile retry now recovers types with a failed build
+
+When a node type's compile fails, the platform contains the failure so the broken type
+cannot slow down the rest of the mesh. Previously, retrying the compile through the agent
+tools (`compile` or `recycle`) after fixing the source could leave the type stuck at
+"Pending" forever — the retry was silently swallowed, and even deleting and recreating the
+type at the same path did not help.
+
+Retries now go through the same release-request path as the Compile button, so a deliberate
+retry always runs a real, fresh build. The compile tool also reports the result of *your*
+build — never a leftover status from an earlier run — and deleting a type fully clears its
+failed-build state so a recreate starts clean.

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -11,6 +11,7 @@ using MeshWeaver.Messaging;
 using MeshWeaver.NuGet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Graph.Configuration;
 
@@ -223,6 +224,14 @@ public static class GraphConfigurationExtensions
                     // user-visible notification. Instance maps only — no static state. See
                     // NodeTypeCompileParkRegistry + InstallCompileWatcher's parked short-circuit.
                     services.AddSingleton<NodeTypeCompileParkRegistry>();
+                    // 🅿️ Deleting a NodeType clears its parked compile failure — the registry is
+                    // keyed by PATH and outlives the node, so without this a delete+recreate at
+                    // the same path started parked and never compiled (only a restart healed).
+                    services.AddSingleton<INodePostDeletionHandler>(sp =>
+                        new NodeTypeUnparkPostDeletionHandler(
+                            sp.GetRequiredService<NodeTypeCompileParkRegistry>(),
+                            sp.GetService<ILoggerFactory>()
+                                ?.CreateLogger<NodeTypeUnparkPostDeletionHandler>()));
                     // Stage-1 LSP language services over a NodeType's live CSharpCompilation
                     // — hover, completion, diagnostics, speculative pre-flight checks. Consumed
                     // by the Lsp* MCP tools + the agents' Lsp plugin (the /code skill's pre-flight). SpeculativeCompilation

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -193,15 +193,52 @@ internal static class NodeTypeCompilationHelpers
                     // terminal failed state, so we do NOT re-run Roslyn — that is the
                     // containment that turns a broken type from a portal-wide recompile storm
                     // (every Pending flip = a fresh Roslyn pass on the action block) into a
-                    // single, bounded, visible failure. The only thing that flips a parked
-                    // (Error) type back to Pending is a DELIBERATE release request, and
-                    // InstallReleaseRequestWatcher un-parks before it does — so this guard never
-                    // blocks a legitimate retry, only a stray re-trigger.
+                    // single, bounded, visible failure. Every DELIBERATE retry (a release
+                    // request — the UI Compile button, the MCP compile/recycle tools) goes
+                    // through InstallReleaseRequestWatcher, which un-parks BEFORE promoting to
+                    // Pending — so this guard never blocks a legitimate retry, only a stray
+                    // re-trigger (a persisted-Compiling recovery kickoff, a legacy direct flip).
                     if (parkRegistry?.IsParked(hubPath) == true)
                     {
                         logger?.LogDebug(
                             "Compile watcher: {HubPath} is PARKED (terminal compile failure) — " +
                             "skipping recompile, serving cached error", hubPath);
+                        // 🅿️ Wedge-close: the Pending flip we refuse to dispatch was already
+                        // WRITTEN to the node. Without a settle write-back the type would sit
+                        // at Pending forever — every settle-waiter (get_diagnostics' / the
+                        // compile tool's Where(Ok|Error), WaitForLatestRelease) hangs to its
+                        // timeout and the stray trigger never reaches a sink. Re-settle
+                        // Pending → Error with the CACHED parked error so the trigger is
+                        // answered (bounded, no Roslyn) while the park stays in place. Same
+                        // fire-and-forget UpdateOwn shape as the kickoffs below; System scope
+                        // because re-settling framework state is infrastructure, not a user
+                        // write.
+                        var parkedError = parkRegistry.GetParkedError(hubPath);
+                        using (accessService?.ImpersonateAsSystem())
+                            workspace.GetMeshNodeStream().Update(curr =>
+                            {
+                                var parkedDef = curr.ContentAs<NodeTypeDefinition>(
+                                    hub.JsonSerializerOptions, logger);
+                                if (parkedDef is null) return curr;
+                                // Only re-settle the stray Pending — never clobber a state a
+                                // genuine (un-parked) compile has already moved past it.
+                                if (parkedDef.CompilationStatus != CompilationStatus.Pending)
+                                    return curr;
+                                return curr with
+                                {
+                                    Content = parkedDef with
+                                    {
+                                        CompilationStatus = CompilationStatus.Error,
+                                        CompilationError = parkedError
+                                            ?? parkedDef.CompilationError
+                                            ?? "Compilation is parked after a terminal failure; request a release (Compile) to retry."
+                                    }
+                                };
+                            }).Subscribe(
+                                _ => { },
+                                ex => logger?.LogWarning(ex,
+                                    "Compile watcher: failed to re-settle parked {HubPath} from Pending to Error",
+                                    hubPath));
                         return;
                     }
 

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeUnparkPostDeletionHandler.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeUnparkPostDeletionHandler.cs
@@ -1,0 +1,46 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// 🅿️ Clears a deleted NodeType's parked compile failure from the
+/// <see cref="NodeTypeCompileParkRegistry"/> — the deletion-side companion of the
+/// release-request un-park in <c>NodeTypeCompilationHelpers.InstallReleaseRequestWatcher</c>.
+///
+/// <para>The park registry is keyed by NodeType PATH and lives in a mesh-scoped in-memory
+/// singleton, so it outlives the node itself: without this handler, deleting a parked
+/// (terminally failed) NodeType and recreating it at the same path started PARKED — the
+/// fresh type's first-build kickoff flipped Pending straight into the compile watcher's
+/// parked short-circuit and the recreated type never compiled (delete+recreate did not
+/// heal; only a process restart cleared the registry). Runs in the owner process holding
+/// the registry singleton — the delete pipeline resolves post-deletion handlers from the
+/// same service tree the per-NodeType hubs use.</para>
+/// </summary>
+public sealed class NodeTypeUnparkPostDeletionHandler(
+    NodeTypeCompileParkRegistry parkRegistry,
+    ILogger<NodeTypeUnparkPostDeletionHandler>? logger = null) : INodePostDeletionHandler
+{
+    /// <inheritdoc />
+    public string NodeType => MeshNode.NodeTypePath;
+
+    /// <inheritdoc />
+    public IObservable<Unit> Handle(MeshNode deletedNode, string? deletedBy)
+    {
+        var path = deletedNode.Path;
+        if (!string.IsNullOrEmpty(path))
+        {
+            if (parkRegistry.IsParked(path))
+                logger?.LogInformation(
+                    "NodeType '{Path}' deleted by {User} while PARKED — clearing the parked compile " +
+                    "failure so a recreate at the same path starts clean.",
+                    path, deletedBy ?? "system");
+            // Unpark also resets the failure/attempt budgets — idempotent when not parked.
+            parkRegistry.Unpark(path);
+        }
+        return Observable.Return(Unit.Default);
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using MeshWeaver.AI;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
@@ -544,6 +546,160 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
                 && d.CompilationStatus == CompilationStatus.Ok
                 && !string.IsNullOrEmpty(d.LatestReleasePath)
                 && !d.IsDirty);
+    }
+
+    /// <summary>
+    /// The DIRECT-retry twin of
+    /// <see cref="FailedCompile_PreservesErrorLogAndDoesNotCreateRelease"/>: after a failed
+    /// compile (which PARKS the type in the <c>NodeTypeCompileParkRegistry</c> — deterministic
+    /// source errors park on the first failure), fixing the source and retrying via the MCP
+    /// <c>compile</c> tool (<see cref="MeshOperations.Compile"/>) must run a REAL fresh
+    /// compile, settle at Ok with a release, and un-park. The tool routes the trigger through
+    /// the release-request seam (RequestedReleaseAt + Force — the single un-park trigger);
+    /// before the fix it flipped CompilationStatus=Pending directly, which the compile
+    /// watcher's parked short-circuit swallowed — the type wedged at Pending and the tool's
+    /// settle-wait returned the PREVIOUS run's replayed terminal snapshot (2026-07-16 memex
+    /// Reinsurance/Layer + BusinessRules/Scope incident).
+    /// </summary>
+    [Fact(Timeout = 180000)]
+    public async Task FailedCompile_DirectCompileToolRetry_RunsFreshCompileAndCreatesRelease()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var workspace = Mesh.GetWorkspace();
+        var typePath = $"{TestPartition}/ToolRetryType";
+        var sourcePath = $"{TestPartition}/ToolRetryType/Source/code";
+        var parkRegistry = Mesh.ServiceProvider.GetRequiredService<NodeTypeCompileParkRegistry>();
+
+        await NodeFactory.CreateNode(new MeshNode("ToolRetryType", TestPartition)
+        {
+            Name = "Tool Retry Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Direct compile-tool retry regression.",
+                Configuration = "config => config.AddDefaultLayoutAreas().AddLayout(layout => layout.WithView(\"Overview\", CodeEditLayoutAreas.Overview))",
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        // Plant a deliberately uncompilable source so the first compile fails and parks.
+        await NodeFactory.CreateNode(new MeshNode("code", $"{TestPartition}/ToolRetryType/Source")
+        {
+            Name = "Code",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = "this is not valid C#;", Language = "csharp" }
+        }).Should().Within(30.Seconds()).Emit();
+
+        await TriggerRecompile(typePath, DateTimeOffset.UtcNow);
+        // Gate on LastReleaseRequestHandledAt: the first-build kickoff's failed compile can
+        // park + settle Error BEFORE the explicit trigger is processed, and the trigger's
+        // release watcher then transiently UN-parks (deliberate retry). Waiting for the
+        // handled stamp + Error means we observe the TRIGGERED run's terminal state — by
+        // then RunCompile has parked (OnCompileFailed precedes the terminal status write).
+        var failed = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(TimeSpan.FromSeconds(40))
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Error
+                && d.LastReleaseRequestHandledAt is not null);
+        var failedActivityPath = ((NodeTypeDefinition)failed.Content!).LastCompilationActivityPath;
+        parkRegistry.IsParked(typePath).Should().BeTrue(
+            "a deterministic compile error must park the type");
+
+        // Fix the source; the sources watcher flips IsDirty — parked state intact.
+        await workspace.GetMeshNodeStream(sourcePath).Update(curr =>
+            curr with { Content = new CodeConfiguration { Code = CodeV1, Language = "csharp" } })
+            .Should().Within(30.Seconds()).Emit();
+        await WaitForIsDirty(typePath, expected: true);
+        parkRegistry.IsParked(typePath).Should().BeTrue(
+            "editing the source alone must not un-park — only a deliberate retry does");
+
+        // Retry via the REAL tool surface.
+        var resultJson = await new MeshOperations(Mesh).Compile(typePath)
+            .FirstAsync().Timeout(150.Seconds()).ToTask(ct);
+        Output.WriteLine($"Compile tool returned: {resultJson}");
+
+        using (var result = JsonDocument.Parse(resultJson))
+        {
+            result.RootElement.GetProperty("status").GetString().Should().Be("Ok",
+                "the deliberate retry with fixed source must run a real compile and succeed");
+            result.RootElement.GetProperty("activityPath").GetString().Should().NotBe(failedActivityPath,
+                "the reported result must belong to THIS retry's compile run, not the failed run's snapshot");
+        }
+
+        parkRegistry.IsParked(typePath).Should().BeFalse(
+            "the deliberate retry must have un-parked the type");
+        await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(TimeSpan.FromSeconds(30))
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LatestReleasePath)
+                && !d.IsDirty);
+    }
+
+    /// <summary>
+    /// Stale-success barrier: calling the MCP <c>compile</c> tool on a type that is ALREADY
+    /// settled at Ok with UNCHANGED sources must report a NEW compile run — never fabricate
+    /// "Compile SUCCEEDED" from the previous run's replayed terminal snapshot (the stream
+    /// replays the current node on subscribe, so before the fix the settle-wait accepted the
+    /// pre-trigger Ok and returned the previous run's activity path instantly). By design the
+    /// tool stamps RequestedReleaseForce — the same as the UI Compile button — so unchanged
+    /// sources do NOT skip: a genuinely fresh Roslyn run executes, and the returned
+    /// activityPath / the node's LastCompileStartedAt must move past the pre-trigger values.
+    /// </summary>
+    [Fact(Timeout = 180000)]
+    public async Task CompileTool_UnchangedSources_ForcesFreshRun_NeverReturnsPreviousRunsSnapshot()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var typePath = $"{TestPartition}/StaleBarrierType";
+
+        await NodeFactory.CreateNode(new MeshNode("StaleBarrierType", TestPartition)
+        {
+            Name = "Stale Barrier Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Stale-success settle-wait regression.",
+                Configuration = "config => config.AddDefaultLayoutAreas().AddLayout(layout => layout.WithView(\"Overview\", CodeEditLayoutAreas.Overview))",
+            }
+        }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("code", $"{TestPartition}/StaleBarrierType/Source")
+        {
+            Name = "Code",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = CodeV1, Language = "csharp" }
+        }).Should().Within(30.Seconds()).Emit();
+
+        // First compile settles Ok; capture ITS run identity (activity path + start stamp).
+        await WaitForLatestRelease(typePath, knownRelease: null);
+        var before = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(TimeSpan.FromSeconds(15))
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LastCompilationActivityPath)
+                && d.LastCompileStartedAt is not null);
+        var beforeDef = (NodeTypeDefinition)before.Content!;
+        var beforeActivityPath = beforeDef.LastCompilationActivityPath!;
+        var beforeStartedAt = beforeDef.LastCompileStartedAt!.Value;
+
+        // Compile with UNCHANGED sources.
+        var resultJson = await new MeshOperations(Mesh).Compile(typePath)
+            .FirstAsync().Timeout(150.Seconds()).ToTask(ct);
+        Output.WriteLine($"Compile tool returned: {resultJson}");
+
+        using (var result = JsonDocument.Parse(resultJson))
+        {
+            result.RootElement.GetProperty("status").GetString().Should().Be("Ok");
+            result.RootElement.GetProperty("activityPath").GetString().Should().NotBe(beforeActivityPath,
+                "the result must correspond to a NEW compile run — never the previous run's replayed snapshot");
+        }
+
+        // The node itself must prove a fresh run happened: the start stamp advanced.
+        var after = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(TimeSpan.FromSeconds(15))
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && d.LastCompileStartedAt > beforeStartedAt);
+        ((NodeTypeDefinition)after.Content!).LastCompilationActivityPath
+            .Should().NotBe(beforeActivityPath, "the fresh run stamps its own activity path");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
@@ -2,8 +2,10 @@ using System;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using MeshWeaver.AI;
 using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -117,6 +119,194 @@ public class NodeTypeCompileParkTest(ITestOutputHelper output) : MonolithMeshTes
         await client.Observe<PingResponse>(new PingRequest(), o => o.WithTarget(new Address(healthyPath)))
             .Should().Within(30.Seconds()).Emit();
         Output.WriteLine("Healthy node answered Ping — the mesh is not wedged.");
+    }
+
+    private const string BrokenConfiguration = "config => this is not valid C# at all ((await (";
+    private const string ValidConfiguration = "config => config.AddDefaultLayoutAreas()";
+
+    /// <summary>
+    /// 🅿️ RETRY through the REAL tool surface un-parks. A parked type whose source has been
+    /// FIXED must recompile to Ok when retried via the MCP <c>compile</c> tool
+    /// (<see cref="MeshOperations.Compile"/>). The tool routes the trigger through the
+    /// RELEASE-REQUEST seam (RequestedReleaseAt + Force) — the single un-park trigger — never
+    /// a direct CompilationStatus=Pending flip, which the compile watcher's parked
+    /// short-circuit would swallow. Regression for the 2026-07-16 memex incident
+    /// (Reinsurance/Layer + BusinessRules/Scope wedged at Pending after one failed compile;
+    /// compile/recycle/delete+recreate all failed to heal — only a pod restart did).
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ParkedNodeType_CompileToolRetry_AfterFix_SettlesOkAndUnparks()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var workspace = Mesh.GetWorkspace();
+        var parkRegistry = Mesh.ServiceProvider.GetRequiredService<NodeTypeCompileParkRegistry>();
+        const string typePath = $"{Partition}/CompileRetry";
+
+        await CreateBrokenTypeAndAwaitParkAsync("CompileRetry");
+
+        // FIX the source of the failure (the Configuration lambda). Editing alone must NOT
+        // un-park — only a deliberate retry does.
+        await workspace.GetMeshNodeStream(typePath).Update(curr =>
+        {
+            if (curr?.Content is not NodeTypeDefinition def) return curr!;
+            return curr with { Content = def with { Configuration = ValidConfiguration } };
+        }).Should().Within(30.Seconds()).Emit();
+        parkRegistry.IsParked(typePath).Should().BeTrue(
+            "editing the source alone must not un-park — only a deliberate retry does");
+
+        // RETRY via the REAL tool surface — the exact call that wedged on memex.
+        var resultJson = await new MeshOperations(Mesh).Compile(typePath)
+            .FirstAsync().Timeout(150.Seconds()).ToTask(ct);
+        Output.WriteLine($"Compile tool returned: {resultJson}");
+
+        using (var result = JsonDocument.Parse(resultJson))
+            result.RootElement.GetProperty("status").GetString().Should().Be("Ok",
+                "a deliberate compile retry of a parked type with fixed source must run a REAL compile and succeed");
+
+        parkRegistry.IsParked(typePath).Should().BeFalse(
+            "the deliberate retry must have un-parked the type");
+        await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(30.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok);
+    }
+
+    /// <summary>
+    /// 🅿️ The recycle-path twin of the compile-tool retry: <see cref="MeshOperations.Recycle"/>
+    /// on a parked type with fixed source stamps the release request (surviving the hub bounce
+    /// on the node itself), so the reactivated hub's release watcher un-parks and drives a
+    /// fresh compile to Ok. Before the fix, recycle flipped CompilationStatus=Pending directly
+    /// — the park lives in the mesh-scoped registry, not the hub, so the bounced hub's watcher
+    /// swallowed the flip and the type stayed wedged at Pending.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ParkedNodeType_RecycleRetry_AfterFix_SettlesOkAndUnparks()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var workspace = Mesh.GetWorkspace();
+        var parkRegistry = Mesh.ServiceProvider.GetRequiredService<NodeTypeCompileParkRegistry>();
+        const string typePath = $"{Partition}/RecycleRetry";
+
+        await CreateBrokenTypeAndAwaitParkAsync("RecycleRetry");
+
+        await workspace.GetMeshNodeStream(typePath).Update(curr =>
+        {
+            if (curr?.Content is not NodeTypeDefinition def) return curr!;
+            return curr with { Content = def with { Configuration = ValidConfiguration } };
+        }).Should().Within(30.Seconds()).Emit();
+
+        var recycleJson = await new MeshOperations(Mesh).Recycle(typePath)
+            .FirstAsync().Timeout(60.Seconds()).ToTask(ct);
+        Output.WriteLine($"Recycle tool returned: {recycleJson}");
+        using (var result = JsonDocument.Parse(recycleJson))
+            result.RootElement.GetProperty("status").GetString().Should().Be("Recycled");
+
+        await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok);
+        parkRegistry.IsParked(typePath).Should().BeFalse(
+            "the recycle's release request must have un-parked the type");
+    }
+
+    /// <summary>
+    /// 🅿️ Wedge-close for the parked short-circuit: a STRAY direct CompilationStatus=Pending
+    /// flip on a parked type (NOT a release request — no un-park) must NOT leave the type
+    /// stuck at Pending forever. The compile watcher declines to dispatch Roslyn (containment
+    /// holds — no recompile) but re-settles the status to Error with the CACHED parked error,
+    /// so every settle-waiter (get_diagnostics, the compile tool, WaitForLatestRelease) gets
+    /// an answer instead of hanging to its timeout.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ParkedNodeType_StrayPendingFlip_ResettlesToError_AndStaysParked()
+    {
+        var workspace = Mesh.GetWorkspace();
+        var parkRegistry = Mesh.ServiceProvider.GetRequiredService<NodeTypeCompileParkRegistry>();
+        const string typePath = $"{Partition}/StrayFlip";
+
+        await CreateBrokenTypeAndAwaitParkAsync("StrayFlip");
+        var attemptsBefore = parkRegistry.GetCompileAttemptCount(typePath);
+
+        // A stray direct Pending flip. The Description marker is written in the SAME update so
+        // the assertion below can distinguish the POST-flip re-settled Error from the replayed
+        // PRE-flip Error frames (which carry the same status + error text but not the marker).
+        const string marker = "stray-flip-discriminator";
+        await workspace.GetMeshNodeStream(typePath).Update(curr =>
+        {
+            if (curr?.Content is not NodeTypeDefinition def) return curr!;
+            return curr with
+            {
+                Content = def with
+                {
+                    CompilationStatus = CompilationStatus.Pending,
+                    Description = marker
+                }
+            };
+        }).Should().Within(30.Seconds()).Emit();
+
+        // The stray trigger must be ANSWERED: re-settled to Error (with the cached parked
+        // error), never left hanging at Pending.
+        await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(30.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.Description == marker
+                && d.CompilationStatus == CompilationStatus.Error
+                && !string.IsNullOrEmpty(d.CompilationError));
+
+        parkRegistry.IsParked(typePath).Should().BeTrue(
+            "a stray Pending flip is not a deliberate retry — the park must hold");
+        parkRegistry.GetCompileAttemptCount(typePath).Should().Be(attemptsBefore,
+            "the parked short-circuit must answer the stray trigger WITHOUT re-running Roslyn");
+    }
+
+    /// <summary>
+    /// 🅿️ Deleting a NodeType clears its parked compile failure: the park registry is keyed
+    /// by PATH in a mesh-scoped singleton that outlives the node, so without the delete-time
+    /// un-park a delete+recreate at the same path started PARKED — the fresh type's first
+    /// compile trigger fell into the parked short-circuit and the recreated type never
+    /// compiled (part of the 2026-07-16 memex incident: delete+recreate did not heal).
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task DeletedNodeType_ClearsParkedFailure()
+    {
+        var parkRegistry = Mesh.ServiceProvider.GetRequiredService<NodeTypeCompileParkRegistry>();
+        const string typePath = $"{Partition}/DeletePark";
+
+        await CreateBrokenTypeAndAwaitParkAsync("DeletePark");
+
+        await NodeFactory.DeleteNode(typePath).Should().Within(30.Seconds()).Emit();
+
+        parkRegistry.IsParked(typePath).Should().BeFalse(
+            "deleting a NodeType must clear its parked compile failure so a recreate at the same path starts clean");
+    }
+
+    /// <summary>
+    /// Creates a NodeType with a deliberately non-compiling Configuration at
+    /// <c>{Partition}/{id}</c>, waits for the first-build compile to settle at Error and
+    /// asserts the type is parked (deterministic source errors park on the FIRST failure).
+    /// </summary>
+    private async Task CreateBrokenTypeAndAwaitParkAsync(string id)
+    {
+        var typePath = $"{Partition}/{id}";
+        await NodeFactory.CreateNode(new MeshNode(id, Partition)
+        {
+            Name = id,
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Deliberately non-compiling NodeType (park retry tests).",
+                Configuration = BrokenConfiguration
+            }
+        }).Should().Emit();
+
+        await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Error);
+        Mesh.ServiceProvider.GetRequiredService<NodeTypeCompileParkRegistry>()
+            .IsParked(typePath).Should().BeTrue(
+                "a deterministic compile error must park the type");
+        Output.WriteLine($"{typePath} settled at Error and is parked.");
     }
 
     /// <summary>


### PR DESCRIPTION
## Root cause

A NodeType whose compile fails deterministically is **parked** in the mesh-scoped `NodeTypeCompileParkRegistry` (bounded containment — the compile watcher's parked short-circuit refuses to re-run Roslyn). The **single un-park trigger** is a release request: `InstallReleaseRequestWatcher` calls `Unpark` before promoting `RequestedReleaseAt` to `CompilationStatus = Pending`.

But two callers flipped `CompilationStatus = Pending` **directly**, bypassing that seam:

1. MCP `compile` → `MeshOperations.Compile` (via `WithPendingCompilationStatus`)
2. MCP `recycle` → `MeshOperations.RecycleCore`

On a parked type the flip fell into the parked short-circuit, which logged and returned **without re-settling the status** — the type wedged at Pending forever. Recycle didn't heal (the park lives in the registry singleton, not the hub), delete+recreate didn't heal (parked is keyed by path; no delete-time un-park), and only a process restart cleared it. On top of that, `Compile`'s settle-wait accepted the **first** replayed Ok/Error emission, so it could fabricate "Compile SUCCEEDED" from the *previous* run's terminal snapshot (with the previous run's activity path).

**Incident (2026-07-16, memex):** `Reinsurance/Layer` + `BusinessRules/Scope` wedged after one failed compile; `compile`, `recycle` and delete+recreate all failed to heal; a pod restart did.

## The fix (five parts)

1. **`MeshOperations.Compile`** stamps the release request (`RequestedReleaseAt = UtcNow` + `RequestedReleaseForce = true` — exactly what the UI Compile button writes) instead of the direct Pending flip; handles both `NodeTypeDefinition` and degraded `JsonElement` content shapes.
2. **`MeshOperations.RecycleCore`** — same change (stamps only nodes that actually are NodeType nodes, as before).
3. **Wedge-close the parked short-circuit** (`InstallCompileWatcher`): a stray Pending flip on a parked type is now **answered** — re-settled to Error with the cached parked error (`GetParkedError`) — instead of hanging at Pending; the park (and its no-Roslyn containment) holds.
4. **Un-park on NodeType delete**: new `NodeTypeUnparkPostDeletionHandler` (`INodePostDeletionHandler` for `NodeType` nodes) clears the parked failure + retry budgets, so delete+recreate at the same path starts clean. Owner-local — runs in the process holding the registry singleton.
5. **Stale-success barrier** in `Compile`'s settle-wait: the pre-trigger snapshot is captured first, and only a settled emission from a **new** compile run is accepted (activity path changed or `LastCompileStartedAt` advanced — both stamped at every run's Pending→Compiling transition).

No retry timers, no watchdogs, no swallowed errors — deliberate retries route through the existing un-park seam.

## Tests (deterministic, verified failing-first on the unfixed code)

| Test | Red on unfixed code because |
|---|---|
| `NodeTypeCompileParkTest.ParkedNodeType_CompileToolRetry_AfterFix_SettlesOkAndUnparks` | tool returned the stale parked **Error** snapshot instantly; stayed parked |
| `…ParkedNodeType_RecycleRetry_AfterFix_SettlesOkAndUnparks` | recycle's Pending flip swallowed; never settled Ok |
| `…ParkedNodeType_StrayPendingFlip_ResettlesToError_AndStaysParked` | status stuck at Pending (30s timeout) |
| `…DeletedNodeType_ClearsParkedFailure` | park survived the delete |
| `CodeEditRecompileTest.FailedCompile_DirectCompileToolRetry_RunsFreshCompileAndCreatesRelease` | tool returned the failed run's stale snapshot; stayed parked |
| `…CompileTool_UnchangedSources_ForcesFreshRun_NeverReturnsPreviousRunsSnapshot` | tool returned "Ok" with the **pre-trigger** activity path (stale success) |

All green with the fix: `dotnet test test/MeshWeaver.Hosting.Monolith.Test -c Release --filter "FullyQualifiedName~CompilePark|FullyQualifiedName~CodeEditRecompile"` → **12/12 passed** (includes the pre-existing park + recompile suites). Adjacent suites also green: `ReleaseRequestWatcherHighWaterTest`, `NodeTypeReleaseGateTest`, `CompileActivityLogTest`, `CompileActivityNoPhantomPathTest`, `CompileFinishAndDisposeTest` (24/24), and `MeshWeaver.AI.Test` `McpReturnTimingTest`/`MeshPluginTest` (35/35). Release `-warnaserror` builds clean for MeshWeaver.Graph, MeshWeaver.AI, MeshWeaver.Mcp, MeshWeaver.Documentation and both test projects.

Includes a What's New entry (`2026-07-16-compile-retry-unparks.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)