### PR TITLE
fix(#352): treat empty-string DiscoverModels config as absent, not a startup crash

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -122,7 +122,10 @@ data:
   # static Models[] above — a pulled model then shows up in the picker without a config edit.
   # When "true", leave Models[] empty (discovery owns this provider's child set). The embedding
   # model (Embedding__Model) is excluded from the chat catalog. Empty/false = static behaviour.
-  OpenAICompatible__DiscoverModels: "{{ .Values.config.memex_portal.OpenAICompatible__DiscoverModels | default "" }}"
+  # NOTE: this key is read as a Boolean (GetValue<bool>), so its default must be a PARSEABLE value —
+  # `default "false"`, never `default ""`. The `default ""` pattern above is only safe for keys
+  # consumed as strings; an empty string fails Boolean.Parse and crashes host startup (issue #352).
+  OpenAICompatible__DiscoverModels: "{{ .Values.config.memex_portal.OpenAICompatible__DiscoverModels | default "false" }}"
   # Tier → concrete model id (agents that declare ModelTier resolve through these).
   ModelTier__Heavy: "{{ .Values.config.memex_portal.ModelTier__Heavy }}"
   ModelTier__Standard: "{{ .Values.config.memex_portal.ModelTier__Standard }}"

--- a/deploy/homebrew/share/values.local.yaml
+++ b/deploy/homebrew/share/values.local.yaml
@@ -66,6 +66,9 @@ config:
     # ---- Local LLM via host-native Ollama (LocalColimaMac.md §10) ------------
     OpenAICompatible__Endpoint: "http://ollama:11434/v1"
     OpenAICompatible__Models__0: "qwen3.6-code"
+    # Auto-discover the endpoint's model list instead of the static Models[] above.
+    # Read as a Boolean — must be "true"/"false", never left empty (issue #352).
+    OpenAICompatible__DiscoverModels: "false"
 
     # ---- Full logging (verbose) — see header note. Declared here for
     # visibility; ALSO applied by `memex-local up` via `kubectl set env`

--- a/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
+++ b/memex/Memex.Portal.Shared/Models/OpenAICompatibleModelSync.cs
@@ -107,7 +107,7 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
         // nodes with SupportsTools=null (assume supported) → the round would send tools to a tool-less
         // local model (Mythalion → HTTP 400). The backfill probes each configured model and stamps its
         // KNOWN capability. So an endpoint alone is enough to activate this service.
-        var discover = configuration.GetValue("OpenAICompatible:DiscoverModels", false);
+        var discover = GetBool(configuration, "OpenAICompatible:DiscoverModels", false);
         var apiKey = configuration["OpenAICompatible:ApiKey"] ?? string.Empty;
         var embeddingModel = configuration["Embedding:Model"];
         // The statically-configured model ids (OpenAICompatible:Models[]) — what the boot seeder laid
@@ -115,9 +115,9 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
         var configuredModels = configuration.GetSection("OpenAICompatible:Models").Get<string[]>()
             ?? Array.Empty<string>();
         var initialDelay = TimeSpan.FromSeconds(
-            Math.Max(0, configuration.GetValue("OpenAICompatible:DiscoverInitialDelaySeconds", 20)));
+            Math.Max(0, GetInt(configuration, "OpenAICompatible:DiscoverInitialDelaySeconds", 20)));
         var period = TimeSpan.FromSeconds(
-            Math.Max(15, configuration.GetValue("OpenAICompatible:DiscoverIntervalSeconds", 120)));
+            Math.Max(15, GetInt(configuration, "OpenAICompatible:DiscoverIntervalSeconds", 120)));
 
         // 🚨 Defer EVERY mesh-cache touch (the catalog query AND the reconcile/backfill) until initialDelay
         // past startup, off any hub thread. StartAsync runs during host startup, when the Orleans stream
@@ -399,6 +399,26 @@ public sealed class OpenAICompatibleModelSync : IHostedService, IDisposable
     {
         var idx = id.IndexOf(':');
         return idx < 0 ? id : id[..idx];
+    }
+
+    // 🚨 Typed config reads must treat an EMPTY/whitespace value as ABSENT, not as a present-but-unparseable
+    // value. The Helm ConfigMap renders every allow-listed key even when unset, emitting an empty string
+    // (`OpenAICompatible__DiscoverModels: ""`). The framework's GetValue<bool>/<int> THROWS on "" before its
+    // own default applies, which kills host startup (issue #352). Reading the raw string and TryParse-ing it
+    // honours the "inert unless explicitly set" contract regardless of how the deployment surface renders an
+    // unset key — and protects every future non-string key from re-arming the same trap.
+    internal static bool GetBool(IConfiguration configuration, string key, bool defaultValue)
+    {
+        var raw = configuration[key];
+        return string.IsNullOrWhiteSpace(raw) ? defaultValue
+            : bool.TryParse(raw, out var v) ? v : defaultValue;
+    }
+
+    internal static int GetInt(IConfiguration configuration, string key, int defaultValue)
+    {
+        var raw = configuration[key];
+        return string.IsNullOrWhiteSpace(raw) ? defaultValue
+            : int.TryParse(raw, out var v) ? v : defaultValue;
     }
 
     // Construct AND subscribe under the system identity (no ambient AccessContext in a hosted service).

--- a/test/Memex.Portal.Shared.Test/OpenAICompatibleModelSyncTest.cs
+++ b/test/Memex.Portal.Shared.Test/OpenAICompatibleModelSyncTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Memex.Portal.Shared.Models;
 using MeshWeaver.AI;
 using MeshWeaver.Mesh;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Memex.Portal.Shared.Test;
@@ -105,6 +106,48 @@ public class OpenAICompatibleModelSyncTest
         Assert.Equal(2, delta.ToAdd.Count); // "a:latest"/"A:latest" collapse to one
         Assert.Contains("b:latest", delta.ToAdd);
     }
+
+    // ── GetBool / GetInt (issue #352: empty-string config must not crash startup) ──
+
+    private static IConfiguration Config(params (string Key, string? Value)[] pairs) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(pairs.Select(p => new KeyValuePair<string, string?>(p.Key, p.Value)))
+            .Build();
+
+    [Fact]
+    public void GetBool_EmptyString_ReturnsDefault_DoesNotThrow()
+    {
+        // The Helm ConfigMap renders an unset allow-listed key as "" (issue #352). The framework's
+        // GetValue<bool> THROWS on that empty string, killing host startup. GetBool must treat it as absent.
+        var config = Config(("OpenAICompatible:DiscoverModels", ""));
+
+        Assert.False(OpenAICompatibleModelSync.GetBool(config, "OpenAICompatible:DiscoverModels", false));
+
+        // Pin the regression: the previous code path (GetValue<bool> on the same empty string) DID throw.
+        Assert.Throws<InvalidOperationException>(
+            () => config.GetValue("OpenAICompatible:DiscoverModels", false));
+    }
+
+    [Theory]
+    [InlineData(null, false, false)]     // absent key → default
+    [InlineData("", true, true)]         // empty (ConfigMap unset) → default
+    [InlineData("   ", false, false)]    // whitespace → default
+    [InlineData("true", false, true)]    // explicit true
+    [InlineData("false", true, false)]   // explicit false
+    [InlineData("TRUE", false, true)]    // case-insensitive
+    [InlineData("garbage", false, false)] // unparseable → default (inert unless explicitly enabled)
+    public void GetBool_HonoursDefaultUnlessExplicitlyParseable(string? value, bool defaultValue, bool expected)
+        => Assert.Equal(expected, OpenAICompatibleModelSync.GetBool(
+            Config(("OpenAICompatible:DiscoverModels", value)), "OpenAICompatible:DiscoverModels", defaultValue));
+
+    [Theory]
+    [InlineData(null, 20, 20)]           // absent → default
+    [InlineData("", 120, 120)]           // empty (ConfigMap unset) → default, not a crash
+    [InlineData("45", 20, 45)]           // explicit
+    [InlineData("notanint", 20, 20)]     // unparseable → default
+    public void GetInt_EmptyOrUnparseable_ReturnsDefault(string? value, int defaultValue, int expected)
+        => Assert.Equal(expected, OpenAICompatibleModelSync.GetInt(
+            Config(("OpenAICompatible:DiscoverIntervalSeconds", value)), "OpenAICompatible:DiscoverIntervalSeconds", defaultValue));
 
     // ── IsEmbedding ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #352.

## Problem

The portal ConfigMap is a fixed allow-list that renders every key even when unset, emitting an empty string:

```
OpenAICompatible__DiscoverModels: ""
```

`OpenAICompatible:DiscoverModels` is the first key consumed as a **Boolean**. `GetValue<bool>` throws `InvalidOperationException: String '' was not recognized as a valid Boolean` on an empty string — *before* its own `false` default can apply — inside `OpenAICompatibleModelSync.StartAsync`, so the host never comes up. Every fresh pod whose values overlay predates #293 crash-loops; a rolling update keeps the old pod serving, so the wedge is invisible from the endpoint until the next truly fresh start.

## Fix (defense in depth — the issue's A/B/C/D)

- **Code (root cause, B+C)** — `OpenAICompatibleModelSync` reads the raw string and `TryParse`s it: empty/whitespace/absent → the intended default. Applied to `DiscoverModels` **and** the two typed int keys (`DiscoverInitialDelaySeconds` / `DiscoverIntervalSeconds`) so the exact trap the issue flags in (C) can't re-arm on a future non-string key. Honors the "inert unless explicitly enabled" contract regardless of how the deployment surface renders an unset value (also protects non-Helm surfaces, e.g. env vars set to empty by other tooling).
- **Chart (A)** — `deploy/helm/templates/memex-portal/config.yaml`: `| default "false"` instead of `| default ""` on the Boolean key, plus a pattern-guard comment that `default ""` is only safe for string-read keys.
- **Overlay (D)** — `deploy/homebrew/share/values.local.yaml`: document the key (with its default) so newly generated local overlays know it exists.

## Verification

- `helm template memex deploy/helm | grep DiscoverModels` → `OpenAICompatible__DiscoverModels: "false"` (was `""`).
- New regression tests in `OpenAICompatibleModelSyncTest`: `GetBool`/`GetInt` honor the default on empty/whitespace/absent/unparseable without throwing, and pin that the previous `GetValue<bool>` path **did** throw on the same empty string. **38/38 green**, `dotnet build -c Release -warnaserror` clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)