### PR TITLE
fix(#402): disable ASCII-smiley markdown conversion (corrupts colon-dense output)

### DIFF
--- a/src/MeshWeaver.Markdown/MarkdownExtensions.cs
+++ b/src/MeshWeaver.Markdown/MarkdownExtensions.cs
@@ -1,7 +1,5 @@
 using System.Collections.Concurrent;
-using System.Linq;
 using Markdig;
-using Markdig.Extensions.Emoji;
 
 namespace MeshWeaver.Markdown;
 
@@ -11,19 +9,6 @@ namespace MeshWeaver.Markdown;
 /// </summary>
 public static class MarkdownExtensions
 {
-    // Emoji + smiley mapping that keeps EVERY emoji :shortcode: and EVERY ASCII smiley
-    // EXCEPT the ones whose trigger contains '|' (`:|` and `:-|` → 😐). Those corrupt a
-    // pipe table's right/center alignment delimiter — `|---:|` becomes `|---😐`, so Markdig
-    // no longer recognises the table and renders the rows as a literal `<p>` (the
-    // 2026-06-13 "balance-sheet table shows as one inline line" bug — the 😐 in the
-    // separator was the tell). Dropping only the pipe-bearing smileys keeps `:)` → 🙂 etc.
-    // working while letting right-aligned tables render. Immutable, built once.
-    private static readonly EmojiMapping TableSafeEmojiMapping = new(
-        EmojiMapping.GetDefaultEmojiShortcodeToUnicode(),
-        EmojiMapping.GetDefaultSmileyToEmojiShortcode()
-            .Where(kv => !kv.Key.Contains('|'))
-            .ToDictionary(kv => kv.Key, kv => kv.Value));
-
     // Building a MarkdownPipeline costs ~350µs (block/inline parser registration, sort by
     // priority, etc). For small docs that's ~60% of the entire render time. Markdig is
     // explicit that pipelines are designed to be cached and reused — the parsing path
@@ -69,9 +54,14 @@ public static class MarkdownExtensions
             .UseMathematics()
             .UseAdvancedExtensions()
             .UseGenericAttributes()
-            // Custom mapping: all emoji + all smileys EXCEPT the pipe-bearing ones that
-            // break table alignment delimiters (see TableSafeEmojiMapping above).
-            .UseEmojiAndSmiley(TableSafeEmojiMapping)
+            // Emoji :shortcodes: ONLY — ASCII smileys are disabled. The smiley parser turns any
+            // colon adjacent to a trigger char (`:*`, `:D`, `:P`, `:|`, …) into an emoji, which
+            // corrupts ordinary colon-dense markdown: `:**Batch**` → 😗 + broken bold, `:Die` → 😄,
+            // and `|---:|` → 😐 broke right-aligned pipe tables (the 2026-06-13 table bug). Agent
+            // output is especially colon-heavy (`Label:` + bold/capitalized words), so these false
+            // positives are common. Disabling smileys removes the whole class in one line; real
+            // emoji still work via unambiguous `:shortcode:` (`:smile:`, `:warning:`). Issue #402.
+            .UseEmojiAndSmiley(enableSmileys: false)
             .UseYamlFrontMatter()
             .Use(new ImgPathMarkdownExtension(path => ToStaticHref(path, collection)))
             .Use(new LinkUrlCleanupExtension(currentNodePath))

--- a/test/MeshWeaver.Markdown.Test/MarkdownViewLogicTest.cs
+++ b/test/MeshWeaver.Markdown.Test/MarkdownViewLogicTest.cs
@@ -294,21 +294,47 @@ public class MarkdownViewLogicTest
         html.Should().Contain("data-area='Search'");
     }
 
+    // ---------- ASCII-smiley conversion disabled (issue #402) ----------
+    // Markdig's smiley parser turned any colon adjacent to a trigger char into an emoji, which
+    // corrupts ordinary colon-dense markdown (agent output especially). Smileys are now OFF; only
+    // unambiguous :shortcode: emoji convert.
+
     [Fact]
-    public void Render_OrdinarySmiley_StillConverts()
+    public void Render_ColonBeforeBold_KeepsColonAndBold_NoKissEmoji()
     {
-        // The fix keeps ASCII smileys — it only drops the pipe-bearing ones (:| , :-|).
+        // `:**Batch 4**` used to become 😗 + a broken `*Batch 4**` (the `:*` smiley ate the colon
+        // and one `*`). Now the colon stays and the bold renders intact.
+        var html = MarkdownViewLogic.Render("(13 Knoten):**Batch 4**", null, null).Html;
+        html.Should().NotContain("😗", "the :* ASCII smiley must not fire");
+        html.Should().Contain("(13 Knoten):", "the colon must survive");
+        html.Should().Contain("<strong>Batch 4</strong>", "the bold must render — its * was not eaten");
+    }
+
+    [Fact]
+    public void Render_ColonBeforeCapitalD_KeepsLiteralText_NoGrinEmoji()
+    {
+        // `:Die` used to match the `:D` smiley → 😄 leaving a bare `ie`. Now it stays literal.
+        var html = MarkdownViewLogic.Render("(13 Knoten):Die Knoten", null, null).Html;
+        html.Should().NotContain("😄", "the :D ASCII smiley must not fire");
+        html.Should().Contain(":Die Knoten", "the text must survive verbatim");
+    }
+
+    [Fact]
+    public void Render_OrdinarySmiley_NoLongerConverts()
+    {
+        // Trade-off of disabling smileys: a typed `:)` stays literal (use :smile: for an emoji).
         var html = MarkdownViewLogic.Render("nice :)", null, null).Html;
-        html.Should().NotContain(":)", "ordinary ASCII smileys must still convert to an emoji");
+        html.Should().Contain(":)", "ASCII smileys are disabled — `:)` stays literal");
+        html.Should().NotContain("🙂", "no auto-conversion of ASCII smileys");
     }
 
     [Fact]
     public void Render_PipeBearingSmiley_StaysLiteral()
     {
-        // `:|` is intentionally NOT converted — that conversion (→ 😐) is what corrupted
-        // table alignment delimiters. In plain text it simply stays literal.
+        // `:|` → 😐 corrupted table alignment delimiters (the 2026-06-13 bug); subsumed now that
+        // all smileys are off. In plain text it simply stays literal.
         var html = MarkdownViewLogic.Render("meh :| ok", null, null).Html;
-        html.Should().NotContain("😐", ":| must not become the neutral-face emoji anymore");
+        html.Should().NotContain("😐", ":| must not become the neutral-face emoji");
         html.Should().Contain(":|", "the pipe-bearing smiley is left as literal text");
     }
 


### PR DESCRIPTION
Fixes #402.

## Problem

Markdig's ASCII-smiley conversion turns any colon adjacent to a trigger char (`:*`, `:D`, `:P`, `:|`, `:/`, …) into an emoji, silently corrupting correct markdown:

- `(13 Knoten):**Batch 4**` → `(13 Knoten)😗*Batch 4**` — the `:*` smiley eats the colon and one `*`, so the bold breaks.
- `(13 Knoten):Die Knoten` → `(13 Knoten)😄ie Knoten` — `:D` matches, leaving a bare `ie`.
- `|---:|` → `|---😐` broke right-aligned pipe tables (the 2026-06-13 balance-sheet bug).

Agent output is especially colon-dense (`Label:` introducing bold/capitalized words), so these false positives are common. This is the **single** markdown pipeline for the whole platform (`MarkdownExtensions.CreateMarkdownPipeline`), so the corruption hit chat, docs, content collections and MAUI alike.

## Fix

```csharp
.UseEmojiAndSmiley(enableSmileys: false)   // emoji :shortcodes: only
```

Disables the entire ASCII-smiley false-positive class in one line. Unambiguous `:shortcode:` emoji (`:smile:`, `:tada:`, `:warning:`) still convert. This **subsumes** the earlier pipe-bearing-smiley workaround (`:|` is an ASCII smiley too), so `TableSafeEmojiMapping` is deleted.

**Trade-off:** a deliberately-typed `:)` no longer auto-converts (use `:smile:`). Acceptable in a technical/document context. No data loss — the stored markdown was always correct; this is a render-only fix, so it retroactively corrects all existing content.

## Verification (acceptance criteria)

New/updated tests in `MarkdownViewLogicTest`, all green (41/41), `-c Release -warnaserror` clean:

- `(13 Knoten):**Batch 4**` → `(13 Knoten):` + `<strong>Batch 4</strong>`, no 😗.
- `(13 Knoten):Die Knoten` → literal text, no 😄.
- Right-aligned pipe table still renders as `<table>`, no 😐 (earlier regression stays fixed).
- `:tada:` shortcode still → 🎉.
- `:)` now stays literal (documents the trade-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)