### PR TITLE
fix(#494): honor Retry-After in AzureClaudeChatClient; add retry to non-streaming path

### DIFF
--- a/src/MeshWeaver.AI.AzureFoundry/AzureClaudeChatClient.cs
+++ b/src/MeshWeaver.AI.AzureFoundry/AzureClaudeChatClient.cs
@@ -6,6 +6,8 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 
+[assembly: InternalsVisibleTo("MeshWeaver.AI.Test")]
+
 namespace MeshWeaver.AI.AzureFoundry;
 
 /// <summary>
@@ -109,35 +111,8 @@ public class AzureClaudeChatClient : IChatClient
     {
         var request = BuildRequest(messages, options, stream: true);
 
-        // Retry on transient failures (500, 502, 503, 429)
-        HttpResponseMessage? response = null;
-        for (var attempt = 0; attempt < 3; attempt++)
-        {
-            var httpRequest = CreateHttpRequest(request);
-            response = await httpClient.SendAsync(
-                httpRequest,
-                HttpCompletionOption.ResponseHeadersRead,
-                cancellationToken);
-
-            if (response.IsSuccessStatusCode)
-                break;
-
-            var status = (int)response.StatusCode;
-            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
-            logger?.LogWarning("Azure AI API {Status} on attempt {Attempt}: {Body}",
-                status, attempt + 1, errorBody?.Length > 500 ? errorBody[..500] : errorBody);
-
-            if (status is 500 or 502 or 503 or 429 && attempt < 2)
-            {
-                var delay = status == 429 ? 5000 : 1000 * (attempt + 1);
-                response.Dispose();
-                await Task.Delay(delay, cancellationToken);
-                continue;
-            }
-            response.EnsureSuccessStatusCode(); // throws
-        }
-
-        response!.EnsureSuccessStatusCode();
+        using var response = await SendWithRetryAsync(
+            request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 
         using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
         using var reader = new StreamReader(stream);
@@ -514,21 +489,87 @@ public class AzureClaudeChatClient : IChatClient
 
     private async Task<ClaudeResponse> SendRequestAsync(ClaudeRequest request, CancellationToken cancellationToken)
     {
-        using var httpRequest = CreateHttpRequest(request);
-        using var response = await httpClient.SendAsync(httpRequest, cancellationToken);
+        // Non-streaming shares the same transient-failure retry as streaming. Previously this did a single
+        // send with no retry, so a lone 429 killed the round outright (issue #494).
+        using var response = await SendWithRetryAsync(
+            request, HttpCompletionOption.ResponseContentRead, cancellationToken);
 
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            logger?.LogError("Azure Claude API error: {StatusCode} - {Body}", response.StatusCode, responseBody);
-            throw new HttpRequestException($"Azure Claude API error: {response.StatusCode} - {responseBody}");
-        }
-
         logger?.LogDebug("Received response from Azure Claude: {Json}", responseBody);
 
         return JsonSerializer.Deserialize<ClaudeResponse>(responseBody, JsonOptions)
             ?? throw new InvalidOperationException("Failed to deserialize Claude response");
+    }
+
+    private const int MaxAttempts = 3;
+
+    /// <summary>
+    /// Sends the request with a shared transient-failure retry (500/502/503/429), used by BOTH the
+    /// streaming and non-streaming paths. On success returns the (undisposed) response for the caller to
+    /// read; after <see cref="MaxAttempts"/> attempts, or on a non-retryable status, throws via
+    /// <c>EnsureSuccessStatusCode</c>. Backoff is computed by <see cref="ComputeRetryDelay"/> — the
+    /// server's <c>Retry-After</c> is authoritative; absent it, exponential backoff capped at 30s.
+    /// </summary>
+    private async Task<HttpResponseMessage> SendWithRetryAsync(
+        ClaudeRequest request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            // A fresh HttpRequestMessage per attempt — a request message can only be sent once.
+            var httpRequest = CreateHttpRequest(request);
+            var response = await httpClient.SendAsync(httpRequest, completionOption, cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+                return response;
+
+            var status = (int)response.StatusCode;
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            logger?.LogWarning("Azure AI API {Status} on attempt {Attempt}: {Body}",
+                status, attempt + 1, errorBody.Length > 500 ? errorBody[..500] : errorBody);
+
+            var retryable = status is 500 or 502 or 503 or 429;
+            if (retryable && attempt < MaxAttempts - 1)
+            {
+                var delay = ComputeRetryDelay(response, attempt, DateTimeOffset.UtcNow);
+                response.Dispose();
+                if (delay > TimeSpan.Zero)
+                    await Task.Delay(delay, cancellationToken);
+                continue;
+            }
+
+            // Non-retryable, or the last attempt failed → surface the error (throws).
+            try
+            {
+                response.EnsureSuccessStatusCode();
+            }
+            finally
+            {
+                response.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The backoff before the next retry attempt. The server's <c>Retry-After</c> header is authoritative
+    /// — honored as delta-seconds OR an HTTP-date resolved against <paramref name="utcNow"/>. A present but
+    /// non-positive value (e.g. <c>Retry-After: 0</c> or a past date) means "retry now"
+    /// (<see cref="TimeSpan.Zero"/>). With no usable header, falls back to exponential backoff
+    /// (1s × 2^<paramref name="attempt"/>) capped at 30s. Pure + internal so it is deterministically testable.
+    /// </summary>
+    internal static TimeSpan ComputeRetryDelay(HttpResponseMessage response, int attempt, DateTimeOffset utcNow)
+    {
+        var retryAfter = response.Headers.RetryAfter;
+        if (retryAfter is not null)
+        {
+            TimeSpan? fromHeader = retryAfter.Delta
+                ?? (retryAfter.Date is { } date ? date - utcNow : null);
+            if (fromHeader is { } value)
+                return value > TimeSpan.Zero ? value : TimeSpan.Zero;
+        }
+
+        // No usable Retry-After → exponential backoff (1s, 2s, 4s, …), capped at 30s.
+        var seconds = Math.Min(30d, Math.Pow(2, attempt));
+        return TimeSpan.FromSeconds(seconds);
     }
 
     private static ChatResponse ConvertToResponse(ClaudeResponse response)

--- a/test/MeshWeaver.AI.Test/AzureClaudeRetryTest.cs
+++ b/test/MeshWeaver.AI.Test/AzureClaudeRetryTest.cs
@@ -1,0 +1,206 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI.AzureFoundry;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Regression tests for <see cref="AzureClaudeChatClient"/>'s transient-failure retry (issue #494):
+/// the backoff must honor the server's <c>Retry-After</c> header (delta-seconds AND HTTP-date), a
+/// non-positive value means "retry now", and with no header the backoff is exponential + capped. The
+/// non-streaming path must now retry too (it previously did a single send). Deterministic — a stub
+/// <see cref="HttpMessageHandler"/>, no network, <c>Retry-After: 0</c> keeps the loop tests instant.
+/// </summary>
+public class AzureClaudeRetryTest
+{
+    // ── ComputeRetryDelay: Retry-After is authoritative ──────────────────────
+
+    [Fact]
+    public void ComputeRetryDelay_HonorsDeltaSeconds()
+    {
+        using var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        resp.Headers.Add("Retry-After", "30");
+
+        // attempt is irrelevant when the server dictates the wait.
+        var delay = AzureClaudeChatClient.ComputeRetryDelay(resp, attempt: 0, DateTimeOffset.UtcNow);
+
+        Assert.Equal(TimeSpan.FromSeconds(30), delay);
+    }
+
+    [Fact]
+    public void ComputeRetryDelay_HonorsHttpDate()
+    {
+        var utcNow = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        using var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        resp.Headers.Add("Retry-After", utcNow.AddSeconds(30).ToString("R")); // RFC1123 HTTP-date
+
+        var delay = AzureClaudeChatClient.ComputeRetryDelay(resp, attempt: 0, utcNow);
+
+        Assert.InRange(delay.TotalSeconds, 29.0, 31.0);
+    }
+
+    [Fact]
+    public void ComputeRetryDelay_NonPositiveDelta_MeansRetryImmediately()
+    {
+        using var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        resp.Headers.Add("Retry-After", "0");
+
+        var delay = AzureClaudeChatClient.ComputeRetryDelay(resp, attempt: 2, DateTimeOffset.UtcNow);
+
+        Assert.Equal(TimeSpan.Zero, delay); // not the attempt-2 exponential value — the server said "now"
+    }
+
+    [Fact]
+    public void ComputeRetryDelay_PastHttpDate_MeansRetryImmediately()
+    {
+        var utcNow = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        using var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        resp.Headers.Add("Retry-After", utcNow.AddSeconds(-30).ToString("R")); // already elapsed
+
+        var delay = AzureClaudeChatClient.ComputeRetryDelay(resp, attempt: 0, utcNow);
+
+        Assert.Equal(TimeSpan.Zero, delay);
+    }
+
+    // ── ComputeRetryDelay: no header → exponential backoff, capped ───────────
+
+    [Theory]
+    [InlineData(0, 1)]   // 2^0
+    [InlineData(1, 2)]   // 2^1
+    [InlineData(2, 4)]   // 2^2
+    [InlineData(3, 8)]   // 2^3
+    public void ComputeRetryDelay_NoHeader_IsExponential(int attempt, int expectedSeconds)
+    {
+        using var resp = new HttpResponseMessage(HttpStatusCode.InternalServerError); // no Retry-After
+
+        var delay = AzureClaudeChatClient.ComputeRetryDelay(resp, attempt, DateTimeOffset.UtcNow);
+
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), delay);
+    }
+
+    [Fact]
+    public void ComputeRetryDelay_NoHeader_IsCappedAt30Seconds()
+    {
+        using var resp = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable); // no Retry-After
+
+        var delay = AzureClaudeChatClient.ComputeRetryDelay(resp, attempt: 10, DateTimeOffset.UtcNow); // 2^10 = 1024
+
+        Assert.Equal(TimeSpan.FromSeconds(30), delay);
+    }
+
+    // ── Loop behavior (non-streaming path — previously NO retry at all) ──────
+
+    [Fact]
+    public async Task GetResponseAsync_RetriesThenSucceeds_On429ThenOk()
+    {
+        // Retry-After: 0 → the retry is immediate, so this proves the non-streaming path now retries.
+        var handler = new StubHandler(TooManyRequests, OkJson);
+        var client = NewClient(handler);
+
+        var response = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+
+        Assert.Equal(2, handler.CallCount);                 // one 429 + one success
+        Assert.Contains("ok", response.Text);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_Persistent429_ThrowsAfterThreeAttempts()
+    {
+        var handler = new StubHandler(TooManyRequests); // every call 429
+        var client = NewClient(handler);
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]));
+
+        Assert.Equal(3, handler.CallCount); // attempt count unchanged (3), then it gives up
+    }
+
+    // ── Loop behavior (streaming path) ───────────────────────────────────────
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_Persistent429_ThrowsAfterThreeAttempts()
+    {
+        var handler = new StubHandler(TooManyRequests);
+        var client = NewClient(handler);
+
+        await Assert.ThrowsAsync<HttpRequestException>(async () =>
+        {
+            await foreach (var _ in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "hi")]))
+            {
+                // drain — the throw happens while establishing the response, before any update
+            }
+        });
+
+        Assert.Equal(3, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_RetriesThenSucceeds_On429ThenOk()
+    {
+        var handler = new StubHandler(TooManyRequests, OkSse);
+        var client = NewClient(handler);
+
+        await foreach (var _ in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "hi")]))
+        {
+            // an empty SSE stream ([DONE]) — no updates, just confirm it completes without throwing
+        }
+
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static AzureClaudeChatClient NewClient(StubHandler handler) =>
+        new("https://api.anthropic.com", "test-key", "claude-test", new HttpClient(handler));
+
+    private static HttpResponseMessage TooManyRequests()
+    {
+        var r = new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+        {
+            Content = new StringContent("{\"error\":\"rate_limited\"}", Encoding.UTF8, "application/json")
+        };
+        r.Headers.Add("Retry-After", "0"); // immediate — keeps the test instant
+        return r;
+    }
+
+    private static HttpResponseMessage OkJson() =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                "{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}],\"stop_reason\":\"end_turn\"}",
+                Encoding.UTF8, "application/json")
+        };
+
+    private static HttpResponseMessage OkSse() =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("data: [DONE]\n\n", Encoding.UTF8, "text/event-stream")
+        };
+
+    /// <summary>
+    /// Returns queued responses in order; once the last one is reached it is re-created on every
+    /// subsequent call (so a single <see cref="TooManyRequests"/> factory yields a fresh 429 each attempt).
+    /// </summary>
+    private sealed class StubHandler(params Func<HttpResponseMessage>[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpResponseMessage>> queue = new(responses);
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            var factory = queue.Count > 1 ? queue.Dequeue() : queue.Peek();
+            return Task.FromResult(factory());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #494.

## Problem

`AzureClaudeChatClient` (Claude via Azure AI Foundry **and** direct Anthropic) retried transient failures with a **fixed 5s delay for 429 / linear for 5xx** and **never read the server's `Retry-After` header**. It gave up after 3 attempts (~10s), so a 429 whose window resets later surfaced as a hard `HttpRequestException` and wedged the agent round. The non-streaming `GetResponseAsync` path had **no retry at all** — a lone 429 killed the round.

## Fix

- **`ComputeRetryDelay(response, attempt, utcNow)`** — `Retry-After` is authoritative: honored as **delta-seconds** OR **HTTP-date** (resolved against `utcNow`). A present-but-non-positive value (`Retry-After: 0`, past date) → retry immediately. With **no** usable header → exponential backoff (`1s × 2^attempt`) capped at 30s.
- **`SendWithRetryAsync`** — one shared retry loop used by **both** the streaming and the (previously retry-less) non-streaming paths. Attempt count unchanged (3).

## Design

Stays entirely inside the sanctioned `IChatClient` async I/O leaf (`Doc/Architecture/ControlledIoPooling.md`). Honoring the server's declared backoff is the **root-cause** fix — the retry/attempt bounds were **not** widened (no band-aid).

## Verification

New `AzureClaudeRetryTest` (13 cases, all green; `-c Release -warnaserror` clean, 0 warnings) using a stub `HttpMessageHandler`:
- `Retry-After` delta-seconds + HTTP-date honored; non-positive / past date → immediate; header-less → exponential and capped at 30s.
- Loop behavior on **both** paths: `429 → 200` succeeds (proving the non-streaming path now retries); persistent `429` throws after exactly 3 attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)