### PR TITLE
fix(#458): new-chat/side-panel composer fills its slot instead of a ~80px bar

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
@@ -37,6 +37,17 @@
     display: flex;
     flex-direction: column;
 }
+/* New-chat composer fills the tall slot instead of sitting as a thin ~80px bar (issue #458).
+   The MonacoEditorView AutoGrow container carries an INLINE `height:80px; min-height:80px`
+   that is load-bearing for the with-messages case (#178 auto-grow) and the #199 hit-target
+   fix — so it wins over the `.no-messages` fill intent above. Override it to fill ONLY here,
+   scoped to `.no-messages`, keeping the inline `max-height` cap + Monaco's internal scroll.
+   `::deep` reaches the child component's root; `!important` beats the inline height (and the
+   JS grow-writes, which we don't want in the fill state anyway). The with-messages composer
+   has no `.no-messages` class, so its #178 auto-grow is completely untouched. */
+.thread-chat-container.no-messages .input-container ::deep .monaco-editor-container {
+    height: 100% !important;
+}
 
 .thread-chat-messages {
     flex: 1;


### PR DESCRIPTION
Fixes #458.

## Problem

The right-hand side panel always mounts the new-chat `ThreadChatView` in its `.no-messages` state, whose CSS deliberately intends the composer to **fill** the tall empty slot (`.input-container { flex: 1 1 auto }`, per the file's own comment). But the `MonacoEditorView` `AutoGrow` container carries an **inline** `height:80px; min-height:80px` — load-bearing for the with-messages #178 auto-grow and the #199 hit-target fix. Inline styles beat external CSS, so the box sat at ~80px at the **top** of a tall slot with empty space below (exactly the reported symptom). The #178 auto-grow sizing and the `.no-messages` fill layout were never reconciled.

## Fix

A single scoped `::deep` override in `ThreadChatView.razor.css`, gated to `.no-messages`:

```css
.thread-chat-container.no-messages .input-container ::deep .monaco-editor-container {
    height: 100% !important;
}
```

`!important` beats the inline `height:80px` (and the JS grow-writes, which we don't want in the fill state); the inline `max-height` cap and Monaco's internal scroll are kept. The with-messages composer has **no** `.no-messages` class, so #178 auto-grow is completely untouched — matching the issue's "gate the fixed-80px baseline to the with-messages state only" direction.

## Verification

- `MeshWeaver.Blazor.Portal` builds clean under `-c Release -warnaserror` (0 warnings); the scoped CSS compiles.
- This is a scoped, `.no-messages`-only cascade fix matching the issue's RCA-backed proposed direction. It cannot break the with-messages path (different class). The reviewer's confirmation step is the DOM/pixel check the issue describes: in the side-panel new chat the editable area now fills the slot rather than floating as a thin ~80px bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)