### PR TITLE
fix(#356): nav labels use available width instead of a fixed 70px-reserve cap

### DIFF
--- a/src/MeshWeaver.Blazor/Components/NavMenuView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/NavMenuView.razor.css
@@ -86,6 +86,19 @@
     color: white;
 }
 
+/* FluentUI caps every nav label at `width: calc(100% - 70px)` — a FIXED reserve for the
+   icon/chevron — so labels ellipsis-truncate while up to ~70px of empty space sits to their
+   right. It is most visible on the indented Settings sub-items ("Access Control" → "Access ...")
+   even though the panel is plainly wide enough (issue #356). Let the label flex-fill the REAL
+   remaining width instead of a hard-coded cap; `text-overflow: ellipsis` (inherited) then kicks
+   in only on genuine overflow. Specificity (.sitenav + scope-attr + .fluent-nav-text) beats
+   FluentUI's ([scope] .fluent-nav-text), so no !important is needed. */
+.sitenav ::deep .fluent-nav-text {
+    width: auto;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
 @media (min-width: 641px) {
     .navbar-toggler {
         display: none;


### PR DESCRIPTION
Fixes #356.

## Root cause

FluentUI's nav CSS caps every label:

```css
[scope] .fluent-nav-text {
    overflow: hidden;
    text-overflow: ellipsis;
    width: calc(100% - 70px);   /* fixed icon/chevron reserve */
}
```

The `70px` is a hard-coded reserve. When it exceeds what the icon actually needs, a label ellipsis-truncates while up to ~70px of empty space sits to its **right** — most visible on the indented Settings sub-items (`Access Control` → `Access ...`, `Effective Permissions` → `Effectiv...`) even though the panel is plainly wide enough. Not a MeshWeaver spacing rule — the truncation lives in the FluentUI component itself.

## Fix

A scoped override in `NavMenuView.razor.css` (the shared renderer for every `NavMenuControl`, i.e. the Settings tree **and** the main sidebar) lets the label flex-fill the real remaining width:

```css
.sitenav ::deep .fluent-nav-text {
    width: auto;
    flex: 1 1 auto;
    min-width: 0;
}
```

`text-overflow: ellipsis` (inherited) now triggers only on **genuine** overflow — labels write out in full when the panel is wide enough. Selector specificity `(.sitenav + scope-attr + .fluent-nav-text)` = `(0,3,0)` beats FluentUI's `([scope] .fluent-nav-text)` = `(0,2,0)`, so no `!important` is needed.

## Verification

- `MeshWeaver.Blazor` builds clean under `-c Release -warnaserror` (0 warnings); the scoped CSS compiles.
- Grounded in the exact offending FluentUI rule (not a guess). Layout-only, no functional change. The reviewer's confirmation step: the DOM/pixel check that the Settings sub-item labels render in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)