### PR TITLE
docs(#403): add "Designing agents" guide + two corrections

### DIFF
--- a/src/MeshWeaver.Documentation/Data/AI.md
+++ b/src/MeshWeaver.Documentation/Data/AI.md
@@ -123,6 +123,7 @@ Slash skills work too: `/agent <name>`, `/model <name>`, `/harness <name>`.
 | Topic | What you'll learn |
 |-------|------------------|
 | [Agentic AI](/Doc/AI/AgenticAI) | Philosophy, delegation vs handoff, human-agent collaboration patterns |
+| [Designing agents](/Doc/AI/AgentDesign) | Cost model, round semantics, the two-phase extract-then-write protocol, hard vs. soft enforcement |
 | [MeshPlugin Tools](/Doc/AI/Tools/MeshPlugin) | Full tool reference with call shapes and path syntax |
 | [Execute Script](/Doc/AI/ExecuteScript) | How agents run C# scripts inside the mesh kernel |
 | [MCP Authentication](/Doc/AI/McpAuthentication) | OAuth flow for external MCP clients connecting to MeshWeaver |

--- a/src/MeshWeaver.Documentation/Data/AI/AgentDesign.md
+++ b/src/MeshWeaver.Documentation/Data/AI/AgentDesign.md
@@ -1,0 +1,104 @@
+---
+NodeType: Markdown
+Name: "Designing agents"
+Abstract: "Practical, transferable patterns for building cost-effective, correct agents on MeshWeaver — the turns × context cost model, what survives a round boundary, the two-phase extract-then-write protocol, hard vs. soft enforcement, and write-phase discipline for fact/dimension models."
+Icon: "<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><rect width='24' height='24' rx='4' fill='#00695c'/><path d='M6 7h12M6 12h12M6 17h8' stroke='white' stroke-width='1.8' stroke-linecap='round'/><circle cx='18.5' cy='17' r='2.2' fill='#80cbc4'/></svg>"
+Authors:
+  - "Roland Buergi"
+Tags:
+  - "AI"
+  - "Agentic AI"
+  - "Cost"
+  - "Best Practices"
+---
+
+> **Scope:** this page is the *practices* layer — how to design an agent that is both cheap and correct. For the philosophy see [Agentic AI](/Doc/AI/AgenticAI); for the technical wiring (agent definitions, orchestration, MCP) see [Agentic AI Architecture](/Doc/Architecture/AgenticAI); for the tool call shapes see [MeshPlugin Tools](/Doc/AI/Tools/MeshPlugin).
+
+The patterns here were distilled from tuning a real document-extraction agent — one that reads a 60–80-page financial report from a content collection and writes ~60 typed fact nodes into a dimensional model. Iterating the same task from **~$14 down to under $2 per run**, with correctness *improving* at the same time, came down to a handful of framework behaviours that are easy to get wrong. They generalise well beyond extraction.
+
+## 1. The cost model: turns × context
+
+Every tool call is a model **turn**, and every turn re-sends the **entire conversation so far** — the instructions, all prior tool results, and all intermediate text. Cost is therefore multiplicative:
+
+> **cost ≈ (number of turns) × (context carried per turn)**
+
+The two levers fall straight out of that product:
+
+- **Reduce turns.** Batch tool calls; avoid per-item loops. Sixty creates issued one-per-turn is sixty turns; the same sixty creates emitted as a few parallel batches is a handful of turns.
+- **Keep heavy artifacts out of the context during high-turn phases.** A full document or a large reference table that sits in context while the agent issues sixty create calls is re-billed on *every one* of those turns.
+
+Worked example: ~60 `Create` calls issued one per turn, on top of a context that still holds a full document, re-bills that document ~60 times. The identical work with the document **absent** and the creates **batched** costs roughly a tenth as much. The next two sections are how you make the document "absent" without losing the information in it.
+
+## 2. Round semantics: what survives a round boundary
+
+When a new user message starts a **round**, MeshWeaver rebuilds the conversation the model sees from the thread's stored **message texts only** — the ordered user and assistant cell bodies (`ThreadMessage.Text`). Tool calls and tool results from the previous round are **not** replayed. (This is `LoadFullConversationHistoryFromMesh` in `ThreadExecution`: it walks the thread's `Messages`, reads each cell, and reconstructs `ChatMessage(role, text)` — nothing else.)
+
+Two consequences drive the whole design:
+
+- **Heavy tool results die at the round boundary — and that is a feature.** End the reading phase with a round boundary and the document simply stops being in context. You get the "document absent" state from §1 for free.
+- **Anything the next round needs must be written into the assistant's answer *text*.** State that lived only in a tool result — including facts the agent discovered and acted on — is gone after the boundary. If the next round depends on it, the assistant must emit it as part of its reply.
+
+Also worth knowing when you reason about cost: token usage is stamped when a round **terminates**. A round that dies mid-flight (an infrastructure error, a cancellation) may record **no usage at all**, so thread-level cost figures are a *floor*, not an exact total (see GitHub issue #369).
+
+## 3. The two-phase extract-then-write protocol
+
+For any extraction-shaped task, split the work across a round boundary:
+
+1. **Phase 1 — read.** The agent reads the source(s) and ends by emitting a **complete, self-sufficient worksheet** as its answer text. The user reviews it and replies to continue.
+2. **Phase 2 — write.** A fresh round creates all nodes strictly from the worksheet.
+
+This buys three things at once:
+
+- **The document is billed only during phase 1.** Phase 2's context is the worksheet, not the source (§1, §2).
+- **The worksheet is a human review gate** before anything is written.
+- **The worksheet is durable checkpoint state.** After a crash or an interruption, a resumed round still has it in the conversation.
+
+Corollary — **the worksheet must be genuinely self-sufficient.** The source is unreachable in phase 2, so anything phase 2 needs (including any master data required to create new dimension nodes) has to be *in* the worksheet.
+
+## 4. Hard vs. soft enforcement — affordance beats instruction
+
+The [`AgentConfiguration`](/Doc/Architecture/AgenticAI) surface gives you real, hard levers — use them instead of arguing with the model in the prompt:
+
+- **`Plugins` — the plugin whitelist.** The standard plugins (Chat, Mesh, LayoutArea, Data) are always loaded; `Plugins` adds others by name. Each entry may carry a **per-method filter**: the frontmatter form `PluginName:Method1,Method2` (parsed into `AgentPluginReference.Methods`) exposes only those methods of the plugin. Narrow the surface to exactly what the task needs.
+- **`MaxToolCallsPerRound` — the per-round tool-call cap.** Maps onto `FunctionInvokingChatClient.MaximumIterationsPerRequest`. Left unset, the default is high enough for a high-volume agent to issue hundreds of tool calls in one round. Set a small value (e.g. 20–30) to force natural break points — on reaching the cap the framework strips tools on the final iteration so the model returns a graceful answer, and you can invite the user to reply "continue" for the next batch.
+
+The design rule, learned the hard way:
+
+> **When an agent repeatedly takes a forbidden action, remove or restrict the enabling tool — do not escalate the prompt wording.**
+
+In the extraction case the model ignored three successive prompt-level prohibitions of a tool-usage pattern, each stronger and closer to the action; removing the enabling plugin from the whitelist ended it *instantly*. Prompt text competes with tool affordances and loses. And keep the two consistent: a prompt that describes a tool surface the agent doesn't actually have (or omits one it does) invites unpredictable behaviour.
+
+## 5. Writing instructions that survive rounds and failures
+
+- **Scope rules to their phase.** "Load the document exactly once" reads differently after a reset — the new round has no memory of the load, so the model reads it as "not yet done" and loads again. Bind such a rule explicitly to the phase it belongs to (§2, §3).
+- **Put the rule at the action site.** A path-derivation rule buried in a general section lost to the affordance of a search result three runs in a row; the same rule as the *first sentence of the step that performs the action* — plus a recovery clause for the observed failure signature ("if a `Get` returned only metadata you fetched the wrong node; correct the path before doing anything else") — held. See the [ContentChunkNavigation](/Doc/Architecture/ContentChunkNavigation) note on file-path vs. `Document`-node reads for exactly this failure.
+- **Make batching countable.** "Batch your calls" is ignored; "every response in this step MUST contain at least 10 parallel create calls; a response with exactly one is a protocol violation" produced real batches. Expect a compliance ceiling even so — treat instruction-level batching as an optimisation, not a guarantee.
+- **Allow a stale-state exception only where it matters.** If a checkpoint artifact can be stale (a crash between phases), permit exactly one re-verification — existence of the dimension nodes immediately before creating them — and keep everything else bound to the checkpoint.
+
+## 6. Write-phase patterns for fact/dimension models
+
+- **Deterministic ids** (`{shortKey}-{period}-{position}`) make interrupted runs resumable: a re-create collides with the existing node instead of duplicating it.
+- **The dimension node's id *is* the short key** used in fact ids and reference paths — never an invented long name. Two spellings of the same dimension split the dataset silently: facts referencing the wrong one vanish from every view keyed on the right one.
+- **Check existence by listing, not by name-substring.** Dimension counts are small — list them all in one search and match on key *and* display name. A substring search on a name variant returns a false negative and the agent then creates a duplicate.
+- **Verify with a count-check per created type plus one read-back spot check per type** — not a read per node.
+- **Do not verify through the search index immediately after writing.** The index is eventually consistent ([CQRS — Queries vs. Content Access](/Doc/Architecture/CqrsAndContentAccess)): a count-search issued right after a batch of creates can return zero, and an agent then silently *downgrades* its verification instead of failing it. With deterministic ids the robust check is a direct `Get` on the expected paths; otherwise defer the count or reconcile against the checkpoint.
+- **Reconcile writes against the checkpoint.** The closing summary should enumerate which worksheet rows were intentionally *not* written and why (e.g. values the source doesn't report). An unexplained delta between "rows in the worksheet" and "nodes created" is the signature of silent under-creation.
+
+See also the typed-content discipline in [MeshPlugin → Create](/Doc/AI/Tools/MeshPlugin): `content` field names must match the registered type exactly, or the unknown fields are silently dropped and the node renders empty.
+
+## 7. Operational notes
+
+- **Measuring true cost.** Sum every `_Usage` satellite across the whole thread tree — delegation sub-threads record separately (and may be priced as an unknown model, GitHub issue #369), and error-terminated rounds may be missing entirely (§2).
+- **Filename hygiene.** Until path canonicalisation ships (GitHub issue #364), prefer ASCII filenames for uploads: decomposed-Unicode names index fine but fail by-name reads.
+
+## Measured effect
+
+The same task shape and model class, tuned across the patterns above:
+
+| Configuration | Cost per report |
+|---|---|
+| Naive: single-phase, per-value reads, per-node creates | $14–23, frequent failures |
+| Two-phase protocol, but document re-read in phase 2 + sequential creates | ~$13.5 |
+| + full-text read via one `Get` (transformers) + chunk tools removed + batched creates | **$1.9–2.0** per clean run (~$4 when a round was interrupted and redone) |
+
+The numbers are illustrative of one task, not a benchmark — but the *shape* is the point: the big wins came from cutting turns and evicting the document from the write phase (§1–§3), and the last mile from hard enforcement and typed-write discipline (§4, §6).

--- a/src/MeshWeaver.Documentation/Data/AI/Tools/MeshPlugin.md
+++ b/src/MeshWeaver.Documentation/Data/AI/Tools/MeshPlugin.md
@@ -218,6 +218,9 @@ The node's `path` is derived as `{namespace}/{id}`, or simply `{id}` for root-le
 
 - **`name` must be a clear, descriptive title** — not just the first few words of the content body.
 - **`icon` should be an inline SVG** — a small, clean 24×24 image that visually represents the node's purpose. Use simple shapes and colours that match the content theme.
+- **🚨 `content` field names must match the registered type EXACTLY — unknown fields are silently dropped.** Deserialization ignores members it doesn't recognise (no error), so a mistyped or invented field name produces a node that reports created successfully but renders **without values** in every typed view — far harder to notice than a failure. Where the content is polymorphic, include the `$type` discriminator the schema shows. Two habits prevent it:
+  - **Copy a real node as a form template.** Before creating instances of a type you have not written before, `Get` one existing node of that type and mirror its `content` structure — exact field names, reference-field shapes, and any `$type` — rather than guessing from the schema alone.
+  - **Read back after a batch.** After creating a batch, `Get` one node per type and confirm the `$type`, the reference fields, and the value fields actually persisted. (Do **not** verify through `Search` immediately — the index is eventually consistent and can return zero right after a write; `Get` the exact path instead.)
 
 ### Discovering the content schema
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContentChunkNavigation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContentChunkNavigation.md
@@ -30,7 +30,9 @@ The `page` + `bbox` columns are **source provenance** — see [Source provenance
 There are two different jobs, and they want different granularities:
 
 - **Retrieval / context** — *find* the relevant passage and feed it to the model. Chunks are perfect: a 1000-char window is a model-sized unit of context, and similarity ranks the most relevant windows first. Use `search_chunks` + `get_chunk`.
-- **Extraction** — pull a *whole* structure (a table, a full section, a complete document) where chunk boundaries would cut a row in half. Read the whole document, not chunks. Use `Get` on the file's `Document` node (or the raw `content/` file).
+- **Extraction** — pull a *whole* structure (a table, a full section, a complete document) where chunk boundaries would cut a row in half. Read the whole document, not chunks. **Get the file path, not the `Document` node** — see the note below.
+
+> **🚨 Full text lives at the file path, not the `Document` node.** A search hit is the `Document` node at `{collectionPath}/_Documents/{slug}`, and `Get` on **that** returns only the node's metadata + the AI `Summary` (~a few hundred chars) — never the text. The complete extracted text is served by `Get` on the **file path** `{collectionPath}/{filePath}`, through the registered content transformers (#396). Derive the file path from the hit's own `collectionPath` + `filePath` fields (`search_chunks` returns both; the `Document` node carries them too) — do **not** reconstruct it by editing the node path, because `{slug}` is a lossy encoding of `filePath` (directory separators and non-ASCII collapse to `-`). Getting the `Document` node, seeing only a summary, and concluding "the full text is unavailable" is the failure that sends an agent stepping through every chunk — exactly the chunk-boundary corruption this section warns against.
 
 The chunk tools are deliberately **not** a substitute for a full-document read. If you need every row of a table, a windowed chunk is the wrong tool — it may start or end mid-table.
 
@@ -124,6 +126,6 @@ A typical agent loop:
 1. `search_chunks("accrued benefit obligation", scope: "ACME/Reports")` → a ranked list of chunk hits.
 2. Pick the top hit's `(collectionPath, filePath, chunkIndex)`.
 3. `get_chunk(...)` to read the full window, then follow `nextIndex` / `prevIndex` to read the surrounding context.
-4. If the goal is to extract a whole table rather than gather context, switch to `Get` on the hit's `documentPath` for the complete document.
+4. If the goal is to extract a whole table rather than gather context, `Get` the **file path** `{collectionPath}/{filePath}` (built from the hit's own fields) for the complete text — **not** the hit's `documentPath` (the `Document` node), which returns only metadata + summary (see the note under "Retrieval vs. extraction").
 
 Related: [CQRS — Queries vs. Content Access](../CqrsAndContentAccess) for read semantics, [Vector Search](../VectorSearch) for the node-level semantic path.


### PR DESCRIPTION
Fixes #403.

## New page — `AI/AgentDesign.md` ("Designing agents")

A practices page between the [concepts](/Doc/AI/AgenticAI) and the [tool reference](/Doc/AI/Tools/MeshPlugin), distilled from tuning a real document-extraction agent from ~$14 to under $2 per run with correctness improving:

1. **Cost model** — turns × context; the two levers (fewer turns, evict heavy artifacts).
2. **Round semantics** — history is rebuilt from stored message **texts only**; tool results are not replayed → heavy results die at the boundary (a feature), and anything the next round needs must be in the answer text.
3. **Two-phase extract-then-write** — phase 1 emits a self-sufficient worksheet; phase 2 writes from it.
4. **Hard vs. soft enforcement** — `Plugins` whitelist + per-method `Methods` filter + `MaxToolCallsPerRound`; remove the enabling tool instead of escalating the prompt.
5. **Instructions that survive rounds/failures** — scope rules to their phase, put rules at the action site, make batching countable.
6. **Write-phase patterns** for fact/dimension models — deterministic ids, dimension-id discipline, list-don't-substring existence checks, don't verify via the (eventually-consistent) index right after a write.
7. **Operational notes** — measuring true cost (`_Usage` across the tree), filename hygiene.

Linked from the AI landing index (`AI.md`).

## Correction 1 — `ContentChunkNavigation.md`

"Retrieval vs. extraction" said to `Get` the file's `Document` node for the whole document. But `Get` on the `Document` node (`{collectionPath}/_Documents/{slug}`) returns only metadata + the AI `Summary` — the full text is served by `Get` on the **file path** `{collectionPath}/{filePath}` (content transformers). Corrected here and in step 4 of "Reading a document end to end", with the robust path-derivation rule (use the hit's `collectionPath`+`filePath`; the `{slug}` is a lossy encoding, so don't reconstruct by editing the node path).

## Correction 2 — `MeshPlugin.md` → Create

Added the highest-stakes typed-content rule: `content` field names must match the registered type **exactly** — unknown fields are silently dropped, producing a node that reports created but renders empty. Plus the copy-a-real-node form-template habit and read-back verification (and "don't verify via `Search` immediately — eventually consistent").

## Verification (claims checked against source, not just the issue)

- `ThreadExecution.LoadFullConversationHistoryFromMesh` rebuilds `ChatMessage(role, ThreadMessage.Text)` from the thread's cells only — **no** tool-call/result replay.
- `AgentConfiguration.Plugins` + `AgentPluginReference.Methods` (frontmatter `Name:M1,M2`) + `MaxToolCallsPerRound` → `FunctionInvokingChatClient.MaximumIterationsPerRequest`.
- `Document.Summary` (node body) vs. `DocumentPaths.For` = `{collectionPath}/_Documents/{Slug(filePath)}`.
- `DocumentationLinkIntegrityTest` green (all `/Doc/...` links resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)