### PR TITLE
fix(pg): permissions rebuild dies on overlapping grants (21000) — prod query outage

### DIFF
--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
@@ -1102,6 +1102,8 @@ public static class PostgreSqlSchemaInitializer
 
                 -- Direct entries from AccessAssignment nodes (access satellite table)
                 INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 SELECT
                     aa.content->>'accessObject' AS user_id,
                     COALESCE(aa.main_node, aa.namespace) AS node_path_prefix,
@@ -1142,11 +1144,15 @@ public static class PostgreSqlSchemaInitializer
                 ) perm
                 WHERE aa.content->>'accessObject' IS NOT NULL
                   AND aa.content->'roles' IS NOT NULL
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
 
                 -- Group expansion: read GroupMembership MeshNodes
                 INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 WITH RECURSIVE all_members AS (
                     SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
                     FROM "auth".mesh_nodes gm
@@ -1207,18 +1213,26 @@ public static class PostgreSqlSchemaInitializer
                     ) AS permission
                 ) perm
                 WHERE aa.content->'roles' IS NOT NULL
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
 
                 -- Direct entries from access_control table (convenience methods)
                 INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 SELECT subject, node_path, permission, is_allow
                 FROM access_control
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
 
                 -- Group expansion from group_members + access_control
                 INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 WITH RECURSIVE all_members AS (
                     SELECT group_name, member_id FROM group_members
                     UNION
@@ -1233,6 +1247,8 @@ public static class PostgreSqlSchemaInitializer
                 SELECT lm.member_id, ac.node_path, ac.permission, ac.is_allow
                 FROM access_control ac
                 JOIN leaf_members lm ON lm.group_name = ac.subject
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
 
@@ -1278,7 +1294,11 @@ public static class PostgreSqlSchemaInitializer
                     NULL;
                 END;
             END;
-            $$ LANGUAGE plpgsql;
+            -- jit off: the dedup aggregate's cost estimate (inflated by jsonb SRF default row
+            -- estimates) exceeds jit_above_cost, and LLVM then spends ~450ms compiling the
+            -- unnest expressions PER STATEMENT — in a trigger path that runs on every
+            -- _Access write and once per schema in the boot self-heal sweep.
+            $$ LANGUAGE plpgsql SET jit = off;
 
             -- Access satellite table (must exist before trigger creation)
             CREATE TABLE IF NOT EXISTS access (
@@ -1323,6 +1343,8 @@ public static class PostgreSqlSchemaInitializer
 
                 -- Direct entries from AccessAssignment nodes for this user
                 INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 SELECT
                     p_user_id,
                     COALESCE(aa.main_node, aa.namespace),
@@ -1357,11 +1379,15 @@ public static class PostgreSqlSchemaInitializer
                 ) perm
                 WHERE aa.content->>'accessObject' = p_user_id
                   AND aa.content->'roles' IS NOT NULL
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
 
                 -- Group expansion for this user
                 INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 WITH RECURSIVE all_members AS (
                     SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
                     FROM "auth".mesh_nodes gm
@@ -1407,12 +1433,18 @@ public static class PostgreSqlSchemaInitializer
                     ) AS permission
                 ) perm
                 WHERE aa.content->'roles' IS NOT NULL
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
 
                 -- access_control entries for this user
                 INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 SELECT subject, node_path, permission, is_allow FROM access_control WHERE subject = p_user_id
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
 
@@ -1441,7 +1473,11 @@ public static class PostgreSqlSchemaInitializer
                 EXCEPTION WHEN undefined_table THEN NULL;
                 END;
             END;
-            $$ LANGUAGE plpgsql;
+            -- jit off: the dedup aggregate's cost estimate (inflated by jsonb SRF default row
+            -- estimates) exceeds jit_above_cost, and LLVM then spends ~450ms compiling the
+            -- unnest expressions PER STATEMENT — in a trigger path that runs on every
+            -- _Access write and once per schema in the boot self-heal sweep.
+            $$ LANGUAGE plpgsql SET jit = off;
 
             -- Trigger function: per-row, rebuilds only the affected user's permissions.
             -- Body single-sourced from AccessChangedTriggerFunctionBody: every rebuild call is
@@ -1768,6 +1804,8 @@ public static class PostgreSqlSchemaInitializer
                 -- Direct entries from AccessAssignment nodes (access satellite table)
                 -- Unnest the roles[] array to get each role assignment
                 INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 SELECT
                     aa.content->>'accessObject' AS user_id,
                     COALESCE(aa.main_node, aa.namespace) AS node_path_prefix,
@@ -1809,12 +1847,16 @@ public static class PostgreSqlSchemaInitializer
                 ) perm
                 WHERE aa.content->>'accessObject' IS NOT NULL
                   AND aa.content->'roles' IS NOT NULL
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
 
                 -- Group expansion: read GroupMembership MeshNodes
                 -- New model: content has "member" + "groups" array of {"group":"..."}
                 INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 WITH RECURSIVE all_members AS (
                     SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
                     FROM "auth".mesh_nodes gm
@@ -1875,18 +1917,26 @@ public static class PostgreSqlSchemaInitializer
                     ) AS permission
                 ) perm
                 WHERE aa.content->'roles' IS NOT NULL
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
 
                 -- Direct entries from access_control table (convenience methods)
                 INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 SELECT subject, node_path, permission, is_allow
                 FROM access_control
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
 
                 -- Group expansion from group_members + access_control
                 INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 WITH RECURSIVE all_members AS (
                     SELECT group_name, member_id FROM group_members
                     UNION
@@ -1901,6 +1951,8 @@ public static class PostgreSqlSchemaInitializer
                 SELECT lm.member_id, ac.node_path, ac.permission, ac.is_allow
                 FROM access_control ac
                 JOIN leaf_members lm ON lm.group_name = ac.subject
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
 
@@ -1949,7 +2001,11 @@ public static class PostgreSqlSchemaInitializer
                     NULL;
                 END;
             END;
-            $$ LANGUAGE plpgsql;
+            -- jit off: the dedup aggregate's cost estimate (inflated by jsonb SRF default row
+            -- estimates) exceeds jit_above_cost, and LLVM then spends ~450ms compiling the
+            -- unnest expressions PER STATEMENT — in a trigger path that runs on every
+            -- _Access write and once per schema in the boot self-heal sweep.
+            $$ LANGUAGE plpgsql SET jit = off;
 
             -- Access satellite table (must exist before trigger creation)
             CREATE TABLE IF NOT EXISTS access (
@@ -1994,6 +2050,8 @@ public static class PostgreSqlSchemaInitializer
 
                 -- Direct entries from AccessAssignment nodes for this user
                 INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 SELECT
                     p_user_id,
                     COALESCE(aa.main_node, aa.namespace),
@@ -2028,11 +2086,15 @@ public static class PostgreSqlSchemaInitializer
                 ) perm
                 WHERE aa.content->>'accessObject' = p_user_id
                   AND aa.content->'roles' IS NOT NULL
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
 
                 -- Group expansion for this user
                 INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 WITH RECURSIVE all_members AS (
                     SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
                     FROM "auth".mesh_nodes gm
@@ -2078,12 +2140,18 @@ public static class PostgreSqlSchemaInitializer
                     ) AS permission
                 ) perm
                 WHERE aa.content->'roles' IS NOT NULL
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
 
                 -- access_control entries for this user
                 INSERT INTO user_effective_permissions (user_id, node_path_prefix, permission, is_allow)
+                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+                FROM (
                 SELECT subject, node_path, permission, is_allow FROM access_control WHERE subject = p_user_id
+                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+                GROUP BY user_id, node_path_prefix, permission
                 ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
                     SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions.is_allow END;
 
@@ -2112,7 +2180,11 @@ public static class PostgreSqlSchemaInitializer
                 EXCEPTION WHEN undefined_table THEN NULL;
                 END;
             END;
-            $$ LANGUAGE plpgsql;
+            -- jit off: the dedup aggregate's cost estimate (inflated by jsonb SRF default row
+            -- estimates) exceeds jit_above_cost, and LLVM then spends ~450ms compiling the
+            -- unnest expressions PER STATEMENT — in a trigger path that runs on every
+            -- _Access write and once per schema in the boot self-heal sweep.
+            $$ LANGUAGE plpgsql SET jit = off;
 
             -- Trigger function: per-row, rebuilds only the affected user's permissions.
             -- Body single-sourced from AccessChangedTriggerFunctionBody: every rebuild call is

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/UserEffectivePermissionsDedupTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/UserEffectivePermissionsDedupTests.cs
@@ -1,0 +1,197 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Pins the <c>user_effective_permissions</c> rebuild against OVERLAPPING grants — the
+/// memex-cloud 2026-07-17 production outage. A single <c>INSERT … ON CONFLICT DO UPDATE</c>
+/// may not touch the same key twice (SqlState 21000, "ON CONFLICT DO UPDATE command cannot
+/// affect row a second time"), yet the rebuild's source SELECTs legitimately produce duplicate
+/// <c>(user_id, node_path_prefix, permission)</c> rows: two assignment nodes granting the same
+/// subject on the same prefix (a re-seeded grant under a different node id), one assignment
+/// with two roles whose permission bitmasks overlap (Viewer + Editor both carry Read), or a
+/// member reachable through two groups.
+///
+/// <para><b>Production failure being guarded.</b> The Store-plugin gating rollout wrote
+/// overlapping grants; from then on EVERY rebuild aborted with 21000 — and because the rebuild
+/// runs inside the <c>access</c>-write trigger, the failure also aborted the grant WRITES
+/// themselves. The last-good <c>user_effective_permissions</c> went stale, the RLS-gated
+/// cross-schema query path failed closed, and every query on the portal returned count 0 while
+/// direct node reads kept working.</para>
+///
+/// <para>The fix folds duplicates INSIDE each statement — deny-wins
+/// (<c>bool_and(is_allow)</c> over <c>GROUP BY user_id, node_path_prefix, permission</c>) —
+/// matching the cross-statement <c>ON CONFLICT</c> fold. These tests fail with the unfixed
+/// function (PostgresException 21000 out of the grant write) and pin both duplicate shapes plus
+/// the deny-wins fold.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class UserEffectivePermissionsDedupTests
+{
+    private readonly PostgreSqlFixture _fixture;
+
+    // Storage serialization MUST be camelCase — the rebuild reads camelCase JSON keys
+    // (content->>'accessObject'), same as the mesh hub's naming policy.
+    private readonly JsonSerializerOptions _options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    public UserEffectivePermissionsDedupTests(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private async Task<PostgreSqlStorageAdapter> ProvisionProdShapeAdapterAsync(
+        string space, string schema, CancellationToken ct)
+    {
+        await _fixture.DataSource.ExecuteNonQuery(
+            $"SELECT public.ensure_partition_schema('{schema}')", ct)
+            .Should().Within(60.Seconds()).Emit();
+
+        var def = new PartitionDefinition
+        {
+            Namespace = space,
+            Schema = schema,
+            TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+            NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings()
+        };
+        return new PostgreSqlStorageAdapter(_fixture.DataSource, partitionDefinition: def);
+    }
+
+    private async Task WriteSpaceRootAsync(
+        PostgreSqlStorageAdapter adapter, string space, CancellationToken ct)
+        => await adapter.WriteAsync(new MeshNode(space)
+        {
+            Name = $"{space} Inc.",
+            NodeType = SpaceNodeType.NodeType,
+            State = MeshNodeState.Active,
+            MainNode = space,
+            Content = new Space()
+        }, _options, ct);
+
+    /// <summary>
+    /// TWO assignment nodes for the SAME subject on the SAME prefix (the re-seeded-grant shape):
+    /// the second write's trigger rebuild sees a duplicate (subject, prefix, Read) in one INSERT.
+    /// Unfixed, the write itself dies with 21000; fixed, it folds to ONE allow row. A third,
+    /// DENIED assignment must fold the same key to deny (deny-wins inside the statement, same
+    /// semantics as the cross-statement ON CONFLICT fold) — and the schema-level full rebuild
+    /// must come to the identical result.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task OverlappingAssignments_SameSubjectSamePrefix_FoldInsteadOf21000()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "dedupspace";
+        const string space = "DedupSpace";
+        const string alice = "dd_alice";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+
+        // Grant 1: {space}/_Access/dd_alice_Access → Viewer for dd_alice.
+        await adapter.WriteAsync(AssignmentNodeFactory.UserRole(alice, "Viewer", space), _options, ct);
+
+        // Grant 2: a DIFFERENT node id, the SAME subject and prefix (Editor also carries Read).
+        // This write fires rebuild_user_permissions_for(dd_alice), whose first INSERT now sees
+        // (dd_alice, DedupSpace, Read) twice — the unfixed function kills THIS write with 21000.
+        await adapter.WriteAsync(
+            AssignmentNodeFactory.UserRole($"{alice}_editor", "Editor", space, accessObject: alice),
+            _options, ct);
+
+        var readRows = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".user_effective_permissions " +
+            $"WHERE user_id = '{alice}' AND node_path_prefix = '{space}' AND permission = 'Read'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        readRows.Should().Be(1, "overlapping grants fold to one row per (user, prefix, permission)");
+
+        var readAllowed = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".user_effective_permissions " +
+            $"WHERE user_id = '{alice}' AND node_path_prefix = '{space}' " +
+            "AND permission = 'Read' AND is_allow = true", ct)
+            .Should().Within(30.Seconds()).Emit();
+        readAllowed.Should().Be(1, "two allow grants fold to allow");
+
+        // Grant 3: a DENIED Viewer for the same subject/prefix — deny must win the fold.
+        await adapter.WriteAsync(
+            AssignmentNodeFactory.UserRole($"{alice}_deny", "Viewer", space, denied: true, accessObject: alice),
+            _options, ct);
+
+        var readDenied = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".user_effective_permissions " +
+            $"WHERE user_id = '{alice}' AND node_path_prefix = '{space}' " +
+            "AND permission = 'Read' AND is_allow = false", ct)
+            .Should().Within(30.Seconds()).Emit();
+        readDenied.Should().Be(1, "a denied grant folds the same key to deny (deny-wins)");
+
+        // The schema-level FULL rebuild (boot self-heal path) walks the same data — it must
+        // succeed against the duplicates and land on the identical folded state.
+        await _fixture.DataSource.ExecuteNonQuery(
+            $"SELECT \"{schema}\".rebuild_user_effective_permissions()", ct)
+            .Should().Within(60.Seconds()).Emit();
+
+        var afterFull = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".user_effective_permissions " +
+            $"WHERE user_id = '{alice}' AND node_path_prefix = '{space}' " +
+            "AND permission = 'Read' AND is_allow = false", ct)
+            .Should().Within(30.Seconds()).Emit();
+        afterFull.Should().Be(1, "the full rebuild folds duplicates identically");
+    }
+
+    /// <summary>
+    /// ONE assignment carrying TWO roles whose bitmasks overlap (Viewer + Editor both expand to
+    /// Read): the roles-array unnest alone produces the duplicate — no second node needed.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task TwoRolesOneAssignment_OverlappingBits_RebuildSucceeds()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schema = "deduproles";
+        const string space = "DedupRoles";
+        const string bob = "dr_bob";
+
+        var adapter = await ProvisionProdShapeAdapterAsync(space, schema, ct);
+        await WriteSpaceRootAsync(adapter, space, ct);
+
+        // The unfixed per-subject rebuild dies with 21000 on THIS write.
+        await adapter.WriteAsync(new MeshNode($"{bob}_Access", $"{space}/_Access")
+        {
+            NodeType = "AccessAssignment",
+            Name = $"{bob} Access",
+            MainNode = space,
+            Content = new AccessAssignment
+            {
+                AccessObject = bob,
+                DisplayName = bob,
+                Roles =
+                [
+                    new RoleAssignment { Role = "Viewer" },
+                    new RoleAssignment { Role = "Editor" }
+                ]
+            }
+        }, _options, ct);
+
+        var readAllowed = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".user_effective_permissions " +
+            $"WHERE user_id = '{bob}' AND node_path_prefix = '{space}' " +
+            "AND permission = 'Read' AND is_allow = true", ct)
+            .Should().Within(30.Seconds()).Emit();
+        readAllowed.Should().Be(1, "Viewer+Editor on one assignment fold to one Read allow row");
+
+        var updateAllowed = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM \"{schema}\".user_effective_permissions " +
+            $"WHERE user_id = '{bob}' AND node_path_prefix = '{space}' " +
+            "AND permission = 'Update' AND is_allow = true", ct)
+            .Should().Within(30.Seconds()).Emit();
+        updateAllowed.Should().Be(1, "the Editor-only permissions still materialize");
+    }
+}


### PR DESCRIPTION
## Prod incident (memex-cloud, 2026-07-17 ~22:00 UTC)

Every query on the portal returns **count 0** (search, nav, the /Store catalog's live plugin feed) while direct node reads work. Portal logs show 26×/h:

```
SqlState 21000: ON CONFLICT DO UPDATE command cannot affect row a second time
  at PostgreSqlStorageAdapter.WriteAsyncCore …
[PluginGating] seeding failed for AgenticEngineering / DataModeling / RiskTransfer
```

**Root cause:** the `user_effective_permissions` rebuild's `INSERT…ON CONFLICT` statements abort when the source SELECT yields the same `(user, prefix, permission)` twice — which overlapping grants legitimately produce (two assignment nodes for one subject+prefix; one assignment with Viewer+Editor whose bitmasks both carry Read; a member reachable via two groups). The Store gating rollout wrote grants alongside pre-existing enrollment grants → duplicates → every rebuild aborts → and because the rebuild runs **inside the access-write trigger**, the grant writes themselves abort too. The RLS projection goes stale; the gated query path fails closed portal-wide.

## Fix (both parts root-cause)

1. **Deny-wins dedup inside each statement** — wrap each source SELECT in a derived table, fold with `bool_and(is_allow)` `GROUP BY user_id, node_path_prefix, permission` (identical semantics to the cross-statement `ON CONFLICT` fold). All 4 function copies, 14 statements.
2. **`SET jit = off` on the four rebuild functions** — the dedup aggregate's cost estimate (inflated by jsonb SRF default row estimates) exceeds `jit_above_cost`; LLVM then burns ~450 ms compiling the unnest expressions **per statement, per schema** (measured: `JIT Total 443 ms` of a 452 ms statement on 3 rows). The boot self-heal sweeps every schema → 30 s+, tripping the Npgsql command timeout. Tiny OLTP queries in a hot trigger path; JIT can never pay off there.

## Verification
- `UserEffectivePermissionsDedupTests` (new) — revert-proven: both tests fail with the exact prod exception (21000 out of `WriteAsyncCore`) against the unfixed SQL; pass with the fix; pin deny-wins folding and full-rebuild equivalence.
- Full `MeshWeaver.Hosting.PostgreSql.Test`: **534 passed, 48 s** (main parity; before the jit fix the suite ran 91 s with 5 bulk failures from the self-heal timeout).
- `dotnet build -c Release -warnaserror` clean on the touched projects.
- Snowflake unaffected — its C# projection dedupes via a keyed `Dictionary`.

## Rollout
Existing schemas heal on deploy without a migration: the per-boot self-heal `CREATE OR REPLACE`s the functions on every partition schema and re-runs the full rebuild, rebuilding the stale projections from the intact grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)