### PR TITLE
fix(content): resolve nested file keys in the default content collection (#474)

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1743,8 +1743,32 @@ public static class DataExtensions
     }
 
     /// <summary>
+    /// The default content-collection name. A file uploaded/indexed without an explicit collection
+    /// lands here keyed by its FULL (possibly nested) relative path — e.g. "reports/2024/summary.pdf".
+    /// This name coincides with the "content" UCR prefix, so after the prefix is stripped a nested
+    /// reference's remainder is the relative key, NOT "{collection}/{file}".
+    /// </summary>
+    private const string DefaultContentCollectionName = "content";
+
+    /// <summary>
     /// Reactive observable for a content path — resolves to a file read or a folder listing.
     /// </summary>
+    /// <remarks>
+    /// The remainder for a multi-segment path <c>A/B[/C…]</c> is ambiguous:
+    /// <list type="bullet">
+    /// <item>a NESTED key <c>A/B/C…</c> inside the default <see cref="DefaultContentCollectionName"/>
+    /// collection — how uploads/indexing actually store files (issue #474:
+    /// <c>content/reports/2024/summary.pdf</c>), or</item>
+    /// <item>a named collection <c>A</c> (optionally <c>A@partition</c>) with relative key <c>B/C…</c> —
+    /// the <c>content/{collection}/{file}</c> form.</item>
+    /// </list>
+    /// The default-collection key is resolved FIRST (the whole remainder), then the named-collection
+    /// interpretation as a fallback. The old code only ever tried the named-collection split, so any
+    /// nested read in the default collection failed with "Content collection '{firstSegment}' not
+    /// found" while the flat single-segment case worked. When BOTH miss, the default-collection error
+    /// surfaces — the same "not found in collection 'content'" a flat path yields, rather than the
+    /// misleading "collection '{firstSegment}' not found".
+    /// </remarks>
     private static IObservable<GetDataResponse> HandleContentPath(
         IMessageHub hub,
         string? remainingPath,
@@ -1753,50 +1777,63 @@ public static class DataExtensions
         remainingPath = remainingPath?.TrimEnd('/');
 
         if (string.IsNullOrEmpty(remainingPath))
-            return ListCollectionItems(hub, "content", "/");
+            return ListCollectionItems(hub, DefaultContentCollectionName, "/");
 
         var slashIndex = remainingPath.IndexOf('/');
 
+        // Single segment: a file in the default "content" collection, or the name of a collection to list.
         if (slashIndex < 0)
         {
-            var collectionForFallback = remainingPath;
-            return GetFileContent(hub, "content", collectionForFallback, numberOfRows)
-                .SelectMany(fileResult =>
-                {
-                    if (fileResult.Error == null)
-                        return Observable.Return(fileResult);
-                    return ListCollectionItems(hub, collectionForFallback, "/")
-                        .Select(listResult => listResult.Error == null ? listResult : fileResult);
-                });
+            var single = remainingPath;
+            return GetFileContent(hub, DefaultContentCollectionName, single, numberOfRows)
+                .SelectMany(fileResult => fileResult.Error == null
+                    ? Observable.Return(fileResult)
+                    : ListCollectionItems(hub, single, "/")
+                        .Select(listResult => listResult.Error == null ? listResult : fileResult));
         }
 
+        var (namedCollection, namedFile) = SplitContentCollectionSegment(remainingPath, slashIndex);
+
+        // Default collection with the WHOLE remainder as the nested key first; named collection second.
+        return ReadFileOrListFolder(hub, DefaultContentCollectionName, remainingPath, numberOfRows)
+            .SelectMany(defaultResult => defaultResult.Error == null
+                ? Observable.Return(defaultResult)
+                : ReadFileOrListFolder(hub, namedCollection, namedFile, numberOfRows)
+                    .Select(namedResult => namedResult.Error == null ? namedResult : defaultResult));
+    }
+
+    /// <summary>
+    /// Reads <paramref name="filePath"/> as a file in <paramref name="collectionName"/>; on a miss,
+    /// tries listing it as a folder. Returns the file-read error when neither resolves.
+    /// </summary>
+    private static IObservable<GetDataResponse> ReadFileOrListFolder(
+        IMessageHub hub,
+        string collectionName,
+        string filePath,
+        int? numberOfRows)
+        => GetFileContent(hub, collectionName, filePath, numberOfRows)
+            .SelectMany(fileResult => fileResult.Error == null
+                ? Observable.Return(fileResult)
+                : ListCollectionItems(hub, collectionName, "/" + filePath)
+                    .Select(folderResult => folderResult.Error == null ? folderResult : fileResult));
+
+    /// <summary>
+    /// Splits the first segment of a content remainder into (collectionName, relativeFilePath),
+    /// preserving a <c>collection@partition</c> qualifier on the collection segment.
+    /// </summary>
+    private static (string CollectionName, string FilePath) SplitContentCollectionSegment(
+        string remainingPath,
+        int slashIndex)
+    {
         var collectionPart = remainingPath[..slashIndex];
         var filePath = remainingPath[(slashIndex + 1)..];
 
         var atIndex = collectionPart.IndexOf('@');
-        string collectionName;
-        if (atIndex > 0)
-        {
-            var collection = collectionPart[..atIndex];
-            var partition = collectionPart[(atIndex + 1)..];
-            collectionName = $"{collection}@{partition}";
-        }
-        else
-        {
-            collectionName = collectionPart;
-        }
+        var collectionName = atIndex > 0
+            ? $"{collectionPart[..atIndex]}@{collectionPart[(atIndex + 1)..]}"
+            : collectionPart;
 
-        if (string.IsNullOrEmpty(filePath))
-            return ListCollectionItems(hub, collectionName, "/");
-
-        return GetFileContent(hub, collectionName, filePath, numberOfRows)
-            .SelectMany(fileResult =>
-            {
-                if (fileResult.Error == null)
-                    return Observable.Return(fileResult);
-                return ListCollectionItems(hub, collectionName, "/" + filePath)
-                    .Select(folderResult => folderResult.Error == null ? folderResult : fileResult);
-            });
+        return (collectionName, filePath);
     }
 
     /// <summary>

--- a/test/MeshWeaver.AI.Test/UnifiedContentAccessTest.cs
+++ b/test/MeshWeaver.AI.Test/UnifiedContentAccessTest.cs
@@ -491,6 +491,71 @@ public class UnifiedContentAccessTest(ITestOutputHelper output) : HubTestBase(ou
             "the handler must respond with an error rather than letting AwaitResponse time out");
     }
 
+    /// <summary>
+    /// Regression for #474: a NESTED file in the DEFAULT "content" collection
+    /// (<c>content/subfolder/nested.txt</c>) must read like the flat case does. The "content" UCR
+    /// prefix coincides with the default collection name, so after the prefix is stripped the
+    /// remainder ("subfolder/nested.txt") is the file's relative key — NOT "{collection}/{file}".
+    /// The old resolver consumed the first sub-folder segment as a collection name and failed with
+    /// "Content collection 'subfolder' not found", while the exact same file indexed/listed fine.
+    /// This is distinct from #326/#364 (a pure-ASCII, space-free path — no percent-encoding involved).
+    /// </summary>
+    [Fact]
+    public async Task GetDataRequest_ContentSlashFormat_NestedFileInDefaultCollection_Responds()
+    {
+        var testDir = Path.Combine(Path.GetTempPath(), "MeshWeaverTest_NestedDefault_" + Guid.NewGuid().ToString("N"));
+        var subDir = Path.Combine(testDir, "subfolder");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllText(Path.Combine(subDir, "nested.txt"), "nested default-collection content");
+
+        try
+        {
+            var host = GetHostWithFileProvider(testDir, defaultCollection: true);
+            var client = GetClient();
+
+            // Slash format, default "content" collection, NESTED key — pure ASCII, no encoding.
+            var response = await client.Observe(new GetDataRequest(new UnifiedReference("content/subfolder/nested.txt")), o => o.WithTarget(CreateHostAddress())).Should().Emit();
+
+            response.Message.Error.Should().BeNull(
+                "a nested key in the default 'content' collection must resolve, not be mis-split into a collection name (#474)");
+            (response.Message.Data as string).Should().Contain("nested default-collection content");
+        }
+        finally
+        {
+            if (Directory.Exists(testDir)) Directory.Delete(testDir, true);
+        }
+    }
+
+    /// <summary>
+    /// The companion negative for #474: a MISSING nested file in the default "content" collection must
+    /// fail as a plain file-not-found WITHIN "content" (exactly as a flat miss does), never as
+    /// "Content collection '{firstSegment}' not found" — the old resolver's mis-split error template.
+    /// </summary>
+    [Fact]
+    public async Task GetDataRequest_ContentSlashFormat_MissingNestedFile_FailsWithinDefaultCollection()
+    {
+        var testDir = Path.Combine(Path.GetTempPath(), "MeshWeaverTest_NestedMissing_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(testDir);
+
+        try
+        {
+            var host = GetHostWithFileProvider(testDir, defaultCollection: true);
+            var client = GetClient();
+
+            var response = await client.Observe(new GetDataRequest(new UnifiedReference("content/subfolder/nope.pdf")), o => o.WithTarget(CreateHostAddress())).Should().Emit();
+
+            response.Message.Error.Should().NotBeNullOrEmpty();
+            response.Message.Error.Should().NotContain("collection 'subfolder'",
+                "a nested miss must not consume the first sub-folder segment as a collection name (#474)");
+            response.Message.Error.Should().Contain("content",
+                "the miss is a plain file-not-found within the 'content' collection, like the flat case");
+        }
+        finally
+        {
+            if (Directory.Exists(testDir)) Directory.Delete(testDir, true);
+        }
+    }
+
     private IMessageHub GetHostWithFileProvider(string testDir, bool defaultCollection)
     {
         // For default-collection scenarios we register the collection as "content"; for named-collection


### PR DESCRIPTION
Fixes #474.

## Root cause

The kernel/agent read path — `GetDataRequest(UnifiedReference("content/…"))` → `HandleContentPath` in `src/MeshWeaver.Data/DataExtensions.cs` (was line 1748) — split the remainder at the FIRST slash and treated the first segment as a collection name.

The default content collection is itself named `content`, which coincides with the `content` UCR prefix. After the prefix is stripped, a **nested** reference like `content/subdir/nope.pdf` leaves the remainder `subdir/nope.pdf`, and the old code consumed `subdir` as a collection → `Content collection 'subdir' not found`. Flat paths worked only because a single segment (no slash) fell into the default-collection branch (`File '…' not found in collection 'content'`). The two distinct error templates in the issue confirmed the two branches.

This is **distinct from #326/#364** (percent-encoding in the browsing/serving route): it reproduces with a pure-ASCII, space-free path, on the read/kernel path. The indexer (`ContentIndexingObserver`) already resolves nested keys correctly — collection `{node}/content`, full nested relative key — which is exactly the model the read path now follows.

## Fix

`HandleContentPath` now resolves a multi-segment remainder as a NESTED key inside the default `content` collection FIRST (the whole remainder is the relative key), then falls back to the named-collection `content/{collection}/{file}` interpretation (`@partition` qualifier preserved). When both miss, the default-collection "not found in collection 'content'" error surfaces — the same shape a flat path yields — rather than the misleading "collection '{firstSegment}' not found". Single-segment (flat), named-collection, and folder-listing behaviour are unchanged.

Two sibling parsers (`ResolveContentPath`, `CreateContentPathStream`) carry the same latent split, but routing for the `content` prefix always lands in `HandleContentPath`, so it alone governs this read path's outcome.

## Tests

Added two regression tests in `test/MeshWeaver.AI.Test/UnifiedContentAccessTest.cs` (same GetDataRequest read path the agent uses, no mocking):
- `GetDataRequest_ContentSlashFormat_NestedFileInDefaultCollection_Responds` — nested pure-ASCII file resolves.
- `GetDataRequest_ContentSlashFormat_MissingNestedFile_FailsWithinDefaultCollection` — a nested miss fails as a plain file-not-found within `content`, never "collection 'subfolder' not found".

Results (Release, `-warnaserror -p:CIRun=true`, 0 warnings):
- `MeshWeaver.Data` builds clean.
- `UnifiedContentAccessTest`: 42 passed, 0 failed.
- `ContentCollectionReferenceTest` (named-collection read path): 16 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)