### PR TITLE
Render timestamps in each viewer's local time zone (#455)

### DIFF
--- a/src/MeshWeaver.AI/ThreadMessageLayoutAreas.cs
+++ b/src/MeshWeaver.AI/ThreadMessageLayoutAreas.cs
@@ -291,6 +291,7 @@ public static class ThreadMessageLayoutAreas
                 var stream = h.Workspace.GetStream(new MeshNodeReference());
                 if (stream is null) return Observable.Return<UiControl?>(null);
 
+                var access = h.Hub.ServiceProvider.GetService<AccessService>();
                 return stream
                     .Select(change => change.Value.ContentAs<ThreadMessage>(h.Hub.JsonSerializerOptions))
                     .Where(m => m is not null)
@@ -302,7 +303,7 @@ public static class ThreadMessageLayoutAreas
                         Out: m.OutputTokens,
                         Total: m.TotalTokens))
                     .DistinctUntilChanged()
-                    .Select(meta => BuildAssistantMetaRow(meta.Started, meta.Completed, meta.Harness,
+                    .Select(meta => BuildAssistantMetaRow(access, meta.Started, meta.Completed, meta.Harness,
                         meta.In, meta.Out, meta.Total));
             });
         }
@@ -359,13 +360,13 @@ public static class ThreadMessageLayoutAreas
     /// Returns null when there's nothing to show (e.g. response still streaming).
     /// </summary>
     private static UiControl? BuildAssistantMetaRow(
-        DateTime started, DateTime? completed, string? harness,
+        AccessService? access, DateTime started, DateTime? completed, string? harness,
         int? input, int? output, int? total)
     {
         var parts = new List<string>();
         if (!string.IsNullOrEmpty(harness))
             parts.Add(System.Web.HttpUtility.HtmlEncode(harness));
-        parts.Add(started.ToLocalTime().ToString("HH:mm:ss"));
+        parts.Add(access.ToDisplayTime(started).ToString("HH:mm:ss"));
         if (completed.HasValue)
         {
             parts.Add(FormatDurationHms(completed.Value - started));

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor
@@ -7,6 +7,7 @@
 @using MeshWeaver.Messaging
 @using FluentAppearance = Microsoft.FluentUI.AspNetCore.Components.Appearance
 @inject NavigationManager NavigationManager
+@inject AccessService Access
 
 <div class="thread-chat-container @(ViewModel.HideEmptyState ? "compact-mode" : "") @(HasNoMessages ? "no-messages" : "")" style="@Style" data-instance="@_instanceId">
 @if (viewMode == ChatViewMode.ResumeThreads)
@@ -39,7 +40,7 @@
                          @key="@thread.Path"
                          @onclick="@(() => OnSelectThread(thread))">
                         <div class="resume-thread-name">@(thread.Name ?? thread.Id)</div>
-                        <div class="resume-thread-date">@thread.LastModified.LocalDateTime.ToString("MMM d, HH:mm")</div>
+                        <div class="resume-thread-date">@Access.ToDisplayTime(thread.LastModified).ToString("MMM d, HH:mm")</div>
                     </div>
                 }
             }

--- a/src/MeshWeaver.Blazor.Portal/Components/NotificationCenterPanel.razor
+++ b/src/MeshWeaver.Blazor.Portal/Components/NotificationCenterPanel.razor
@@ -10,6 +10,7 @@
 @inject IMeshNodeStreamCache StreamCache
 @inject NavigationManager NavigationManager
 @inject IMessageHub Hub
+@inject AccessService Access
 
 <div class="notification-panel">
     <FluentStack VerticalAlignment="VerticalAlignment.Center" Style="margin-bottom: 8px;">
@@ -69,7 +70,7 @@
                             }
                         }
                         <div class="notification-meta">
-                            <span title="@notif.CreatedAt.LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss")">@FormatTime(notif.CreatedAt)</span>
+                            <span title="@Access.ToDisplayTime(notif.CreatedAt).ToString("yyyy-MM-dd HH:mm:ss")">@FormatTime(notif.CreatedAt)</span>
                             @if (!string.IsNullOrEmpty(notif.CreatedBy))
                             {
                                 <span>· @notif.CreatedBy</span>
@@ -370,14 +371,14 @@
         notif.NotificationType == NotificationType.System
         || string.Equals(notif.Icon, "ErrorCircle", StringComparison.OrdinalIgnoreCase);
 
-    private static string FormatTime(DateTimeOffset ts)
+    private string FormatTime(DateTimeOffset ts)
     {
         var delta = DateTimeOffset.UtcNow - ts;
         if (delta.TotalSeconds < 60) return "just now";
         if (delta.TotalMinutes < 60) return $"{(int)delta.TotalMinutes}m ago";
         if (delta.TotalHours < 24) return $"{(int)delta.TotalHours}h ago";
         if (delta.TotalDays < 7) return $"{(int)delta.TotalDays}d ago";
-        return ts.LocalDateTime.ToString("MMM d, HH:mm");
+        return Access.ToDisplayTime(ts).ToString("MMM d, HH:mm");
     }
 
     private static Icon DefaultIconFor(NotificationType type) => type switch

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -497,6 +497,8 @@ public static class MeshNodeLayoutAreas
             .WithOrientation(Orientation.Horizontal)
             .WithStyle("align-items: center; gap: 24px; flex-wrap: wrap; font-size: 0.85rem; color: var(--neutral-foreground-hint);");
 
+        var access = host.Hub.ServiceProvider.GetService<AccessService>();
+
         if (node != null && !string.IsNullOrEmpty(node.NodeType) && node.NodeType != MeshNode.NodeTypePath)
         {
             var typeHref = BuildUrl(node.NodeType, NodeTypeLayoutAreas.ConfigurationArea);
@@ -510,14 +512,14 @@ public static class MeshNodeLayoutAreas
 
         if (node != null && node.CreatedDate != default)
         {
-            var created = node.CreatedDate.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
+            var created = access.ToDisplayTime(node.CreatedDate).ToString("yyyy-MM-dd HH:mm");
             var createdBy = string.IsNullOrEmpty(node.CreatedBy) ? "" : $" by {System.Web.HttpUtility.HtmlEncode(node.CreatedBy)}";
             row = row.WithView(Controls.Html($"<span><span style=\"color: var(--neutral-foreground-rest);\">Created:</span> {created}{createdBy}</span>"));
         }
 
         if (node != null && node.LastModified != default)
         {
-            var modified = node.LastModified.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
+            var modified = access.ToDisplayTime(node.LastModified).ToString("yyyy-MM-dd HH:mm");
             var modifiedBy = string.IsNullOrEmpty(node.LastModifiedBy) ? "" : $" by {System.Web.HttpUtility.HtmlEncode(node.LastModifiedBy)}";
             row = row.WithView(Controls.Html($"<span><span style=\"color: var(--neutral-foreground-rest);\">Updated:</span> {modified}{modifiedBy}</span>"));
         }

--- a/src/MeshWeaver.Graph/VersionLayoutArea.cs
+++ b/src/MeshWeaver.Graph/VersionLayoutArea.cs
@@ -38,6 +38,7 @@ public static class VersionLayoutArea
     {
         var hubPath = host.Hub.Address.ToString();
         var versionQuery = host.Hub.ServiceProvider.GetService<IVersionQuery>();
+        var access = host.Hub.ServiceProvider.GetService<AccessService>();
 
         if (versionQuery == null)
         {
@@ -73,7 +74,7 @@ public static class VersionLayoutArea
 
             foreach (var version in versions)
             {
-                var timeStr = version.LastModified.LocalDateTime.ToString("g");
+                var timeStr = access.ToDisplayTime(version.LastModified).ToString("g");
                 var changedBy = version.ChangedBy ?? "—";
                 var name = version.Name ?? "";
 

--- a/src/MeshWeaver.Hosting.Blazor/CircuitAccessHandler.cs
+++ b/src/MeshWeaver.Hosting.Blazor/CircuitAccessHandler.cs
@@ -240,10 +240,18 @@ public class CircuitAccessHandler : CircuitHandler
                 var meshUser = TryLoadMeshUser(email);
                 if (meshUser != null)
                 {
+                    // Resolve the viewer's display time zone from their profile ONCE here,
+                    // where the context is built. It then rides on the AccessContext to every
+                    // render path — the Blazor circuit AND server-side hub layout areas — so
+                    // stored-UTC timestamps display in the viewer's local time via
+                    // AccessService.ToDisplayTime. Unset (never signed in on a browser yet) →
+                    // stays null → renders UTC.
+                    var timeZoneId = meshUser.ContentAs<User>(_hub.JsonSerializerOptions)?.TimeZoneId;
                     context = context with
                     {
                         ObjectId = meshUser.Id,
-                        Name = meshUser.Name ?? meshUser.Id
+                        Name = meshUser.Name ?? meshUser.Id,
+                        TimeZoneId = string.IsNullOrWhiteSpace(timeZoneId) ? context.TimeZoneId : timeZoneId
                     };
                 }
             }

--- a/src/MeshWeaver.Mesh.Contract/Security/User.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/User.cs
@@ -18,6 +18,16 @@ public record User : AccessObject
     /// <summary>Profile role (e.g. Developer, Manager, Designer).</summary>
     public string? Role { get; init; }
 
+    /// <summary>
+    /// The user's preferred display time zone as a named IANA zone id (e.g.
+    /// <c>Europe/Zurich</c>, <c>America/New_York</c>). Timestamp STORAGE stays UTC —
+    /// this drives the per-viewer DISPLAY conversion only (see
+    /// <c>AccessService.ToDisplayTime</c>). Named zones (never fixed offsets) so DST is
+    /// applied automatically and per-region. Empty/null → the viewer sees UTC. Populated
+    /// once from the browser on first sign-in and overridable in user settings.
+    /// </summary>
+    public string? TimeZoneId { get; init; }
+
     /// <summary>Ordered list of node paths the user has pinned to their dashboard.</summary>
     public IReadOnlyList<string> PinnedPaths { get; init; } = [];
 

--- a/src/MeshWeaver.Messaging.Contract/AccessContext.cs
+++ b/src/MeshWeaver.Messaging.Contract/AccessContext.cs
@@ -31,6 +31,16 @@ public record AccessContext
     public bool IsVirtual { get; init; }
 
     /// <summary>
+    /// The principal's preferred display time zone as a named IANA zone id (e.g.
+    /// <c>Europe/Zurich</c>, <c>America/New_York</c>), resolved from the user's profile
+    /// when the context is built. Rides on the identity so every render path — Blazor
+    /// circuit AND server-side hub layout areas that have no browser — can convert stored
+    /// UTC timestamps to the viewer's local time via <c>AccessService.ToDisplayTime</c>.
+    /// Null/empty → display in UTC. Never a fixed offset (DST would then be wrong).
+    /// </summary>
+    public string? TimeZoneId { get; init; }
+
+    /// <summary>
     /// When set, indicates that this context is impersonated by another identity
     /// (e.g., a portal hub acting on behalf of a virtual user).
     /// The impersonator's identity is used for authorization when the

--- a/src/MeshWeaver.Messaging.Hub/DisplayTimeExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/DisplayTimeExtensions.cs
@@ -1,0 +1,84 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// The single seam that converts a stored UTC instant into the <b>current viewer's</b>
+/// local wall-clock time for DISPLAY. Storage, serialization, versioning, sorting and
+/// logging all stay UTC — only rendering routes through here.
+///
+/// <para>The viewer's zone rides on their <see cref="AccessContext.TimeZoneId"/> (a named
+/// IANA zone, resolved from the user's profile when the context is built), so the same
+/// seam is correct on the Blazor circuit AND on server-side hub render paths that have no
+/// browser. Conversion is fully synchronous — safe to call on the render path — and uses
+/// named zones so DST is applied automatically and per-region.</para>
+/// </summary>
+public static class DisplayTimeExtensions
+{
+    /// <summary>
+    /// Converts a UTC <see cref="DateTimeOffset"/> to the given named IANA zone. A null,
+    /// empty, unknown or invalid zone falls back to UTC (the display is never wrong, just
+    /// un-localized). Pure and deterministic — independent of the host machine's zone.
+    /// </summary>
+    public static DateTimeOffset ToDisplayTime(DateTimeOffset utc, string? timeZoneId)
+    {
+        var zone = ResolveZone(timeZoneId);
+        return zone is null ? utc.ToUniversalTime() : TimeZoneInfo.ConvertTime(utc, zone);
+    }
+
+    /// <summary>
+    /// Converts a <see cref="DateTime"/> that represents a UTC instant to the given named
+    /// IANA zone and returns the zone's wall-clock time. <see cref="DateTimeKind.Unspecified"/>
+    /// is treated as UTC (stored timestamps are UTC). Null/invalid zone → UTC.
+    /// </summary>
+    public static DateTime ToDisplayTime(DateTime utc, string? timeZoneId)
+    {
+        var instant = utc.Kind == DateTimeKind.Local
+            ? new DateTimeOffset(utc).ToUniversalTime()
+            : new DateTimeOffset(DateTime.SpecifyKind(utc, DateTimeKind.Utc));
+        return ToDisplayTime(instant, timeZoneId).DateTime;
+    }
+
+    /// <summary>
+    /// Converts a UTC instant to the CURRENT viewer's display zone, resolved from the
+    /// live <see cref="AccessContext"/> (request-scoped <see cref="AccessService.Context"/>
+    /// first, then the per-circuit <see cref="AccessService.CircuitContext"/>). No profile
+    /// lookup and no async on the render path — the zone was resolved when the context was
+    /// built. Unknown viewer / unset zone → UTC.
+    /// </summary>
+    public static DateTimeOffset ToDisplayTime(this AccessService? accessService, DateTimeOffset utc)
+        => ToDisplayTime(utc, ResolveViewerZoneId(accessService));
+
+    /// <summary>
+    /// <see cref="DateTime"/> overload of <see cref="ToDisplayTime(AccessService, DateTimeOffset)"/>.
+    /// </summary>
+    public static DateTime ToDisplayTime(this AccessService? accessService, DateTime utc)
+        => ToDisplayTime(utc, ResolveViewerZoneId(accessService));
+
+    private static string? ResolveViewerZoneId(AccessService? accessService)
+    {
+        var fromRequest = accessService?.Context?.TimeZoneId;
+        if (!string.IsNullOrWhiteSpace(fromRequest))
+            return fromRequest;
+        return accessService?.CircuitContext?.TimeZoneId;
+    }
+
+    private static TimeZoneInfo? ResolveZone(string? timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+            return null;
+        try
+        {
+            // .NET 6+ FindSystemTimeZoneById accepts IANA ids on every platform
+            // (Windows ids are converted automatically), so named zones work in CI,
+            // in the UTC deployment container, and on developer machines alike.
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            return null;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            return null;
+        }
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/DisplayTimeTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisplayTimeTest.cs
@@ -1,0 +1,97 @@
+using System;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Pins the per-viewer timestamp display seam (<see cref="DisplayTimeExtensions"/>): a
+/// single stored UTC instant renders in each viewer's own named IANA zone, with DST applied
+/// automatically. Fully deterministic — the assertions are independent of the host machine's
+/// time zone (the whole point of storing UTC + converting through named zones).
+/// </summary>
+public class DisplayTimeTest
+{
+    // Same stored instant, one in summer (DST active) and one in winter (standard time).
+    private static readonly DateTimeOffset SummerUtc = new(2026, 7, 13, 16, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset WinterUtc = new(2026, 1, 13, 16, 0, 0, TimeSpan.Zero);
+
+    [Theory]
+    // Europe/Zurich: CEST (+2) in summer, CET (+1) in winter.
+    [InlineData("Europe/Zurich", true, 18, 0)]
+    [InlineData("Europe/Zurich", false, 17, 0)]
+    // America/New_York: EDT (-4) in summer, EST (-5) in winter.
+    [InlineData("America/New_York", true, 12, 0)]
+    [InlineData("America/New_York", false, 11, 0)]
+    // America/Los_Angeles: a DIFFERENT US zone — "US time" is the viewer's specific zone.
+    [InlineData("America/Los_Angeles", true, 9, 0)]
+    [InlineData("America/Los_Angeles", false, 8, 0)]
+    public void ConvertsToNamedZone_WithDst(string zoneId, bool summer, int expectedHour, int expectedMinute)
+    {
+        var utc = summer ? SummerUtc : WinterUtc;
+
+        var display = DisplayTimeExtensions.ToDisplayTime(utc, zoneId);
+
+        display.Hour.Should().Be(expectedHour);
+        display.Minute.Should().Be(expectedMinute);
+        display.Date.Should().Be(utc.UtcDateTime.Date); // no day rollover for these cases
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Not/A/Zone")]
+    public void UnsetOrInvalidZone_FallsBackToUtc(string? zoneId)
+    {
+        var display = DisplayTimeExtensions.ToDisplayTime(SummerUtc, zoneId);
+
+        display.Offset.Should().Be(TimeSpan.Zero);
+        display.Hour.Should().Be(16);
+    }
+
+    [Fact]
+    public void DateTimeOverload_TreatsUnspecifiedAsUtc()
+    {
+        var unspecified = new DateTime(2026, 7, 13, 16, 0, 0, DateTimeKind.Unspecified);
+
+        var display = DisplayTimeExtensions.ToDisplayTime(unspecified, "Europe/Zurich");
+
+        display.Hour.Should().Be(18);
+    }
+
+    [Fact]
+    public void AccessServiceExtension_ResolvesZoneFromRequestContext()
+    {
+        var access = new AccessService();
+        using (access.SwitchAccessContext(new AccessContext { ObjectId = "u", TimeZoneId = "America/New_York" }))
+        {
+            access.ToDisplayTime(SummerUtc).Hour.Should().Be(12);
+        }
+    }
+
+    [Fact]
+    public void AccessServiceExtension_FallsBackToCircuitContext()
+    {
+        var access = new AccessService();
+        access.SetCircuitContext(new AccessContext { ObjectId = "u", TimeZoneId = "Europe/Zurich" });
+        try
+        {
+            // No request-scoped context set → resolves from the circuit context.
+            access.ToDisplayTime(SummerUtc).Hour.Should().Be(18);
+        }
+        finally
+        {
+            access.SetCircuitContext(null);
+        }
+    }
+
+    [Fact]
+    public void AccessServiceExtension_NullServiceOrNoZone_IsUtc()
+    {
+        AccessService? none = null;
+        none.ToDisplayTime(SummerUtc).Offset.Should().Be(TimeSpan.Zero);
+
+        var access = new AccessService();
+        access.ToDisplayTime(SummerUtc).Offset.Should().Be(TimeSpan.Zero);
+    }
+}


### PR DESCRIPTION
Fixes #455.

## Problem

Timestamps rendered in **UTC** for everyone. The display code called `.ToLocalTime()` / `.LocalDateTime`, but under Blazor Server "local" resolves to the **server process** zone, and the deployment container runs UTC — so the conversion was a no-op. Storage was, and stays, UTC.

## Approach — store UTC, display per-user, one central seam

Named IANA zones only (never fixed offsets) so DST is automatic and per-region; the zone follows the **viewer**, not the author or the server.

- **`User.TimeZoneId`** (IANA, e.g. `Europe/Zurich`) — stored source of truth on the User node. Auditable, cross-device, deterministically testable, available anywhere the identity is.
- **`AccessContext.TimeZoneId`** — resolved from the user's profile **once**, where the context is built (`CircuitAccessHandler.ResolveUserContextAsync`, already loads the mesh User node). It then rides on the identity to **every** render path — the Blazor circuit **and** server-side hub layout areas that have no browser.
- **`AccessService.ToDisplayTime(...)`** (`DisplayTimeExtensions`) — the single seam. Fully **synchronous**, no profile lookup and no async on the render path (the zone was resolved at context-build time). Unknown viewer / unset / invalid zone → UTC (never wrong, just un-localized).

### Render sites routed through the seam (7)
| File | Was |
|---|---|
| `MeshWeaver.AI/ThreadMessageLayoutAreas.cs` | `started.ToLocalTime()` |
| `MeshWeaver.Graph/VersionLayoutArea.cs` | `version.LastModified.LocalDateTime` |
| `MeshWeaver.Graph/MeshNodeLayoutAreas.cs` ×2 | `node.CreatedDate/LastModified.ToLocalTime()` |
| `MeshWeaver.Blazor.Portal/Components/NotificationCenterPanel.razor` ×2 | `.LocalDateTime` |
| `MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor` | `thread.LastModified.LocalDateTime` |

**MAUI (`MauiViewPack.cs`) intentionally unchanged**: it is a native client where `ToLocalTime()` already resolves to the real **device** zone — routing it through a per-profile zone would regress on-device correctness when the profile is unset. Storage, serialization, versioning, sorting and logging all stay UTC.

## Test

`DisplayTimeTest` (pure, deterministic — independent of the host machine's zone): a single stored UTC instant renders `18:00`/`17:00` for `Europe/Zurich` (summer/winter) and `12:00`/`11:00` for `America/New_York`, plus `America/Los_Angeles` to show "US time" is the viewer's **specific** zone; DST is applied via named zones with no code change. 14/14 pass. Build clean under `-c Release -warnaserror -p:CIRun=true`.

## Follow-up (deliberately not in this PR)

The seam is complete and correct; a zone set via the standard node editor renders immediately. The **population UX** is the piece with a design decision (where to source the browser tz) and touches the circuit/onboarding lifecycle, so it is split out:

1. **Browser detection** — on first sign-in, when `User.TimeZoneId` is empty, read `Intl.DateTimeFormat().resolvedOptions().timeZone` via JS interop in `OnAfterRenderAsync` (the sanctioned DOM-side async carve-out) and write it **once** to the profile via `GetMeshNodeStream(userPath).Update(...)` (reactive `.Subscribe`, not awaited). "Write only if empty" so a travelling device never overwrites a chosen home zone.
2. **Settings picker** — a `TimeZoneId` field in user settings; an explicit setting always wins.
3. **Configured default** (`Display:TimeZone` → UTC) — best applied at population time, keeping the render seam pure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)