### PR TITLE
fix(ai): FetchWebPage parses RSS/Atom feeds instead of stripping their structure

### DIFF
--- a/src/MeshWeaver.AI/Plugins/WebSearchPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/WebSearchPlugin.cs
@@ -4,6 +4,8 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Text;
 using System.Text.Json;
+using System.Xml;
+using System.Xml.Linq;
 using HtmlAgilityPack;
 using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.AI;
@@ -156,7 +158,8 @@ public class WebSearchPlugin : IAgentPlugin
             {
                 using var request = new HttpRequestMessage(HttpMethod.Get, url);
                 request.Headers.Add("User-Agent", "MeshWeaver/1.0");
-                request.Headers.Add("Accept", "text/html,application/xhtml+xml,text/plain");
+                request.Headers.Add("Accept",
+                    "text/html,application/xhtml+xml,application/rss+xml,application/atom+xml,application/xml,text/plain");
 
                 using var response = await httpClient.SendAsync(request, ct);
                 response.EnsureSuccessStatusCode();
@@ -164,8 +167,15 @@ public class WebSearchPlugin : IAgentPlugin
                 var contentType = response.Content.Headers.ContentType?.MediaType ?? "";
                 var content = await response.Content.ReadAsStringAsync(ct);
 
-                // Extract text from HTML
-                if (contentType.Contains("html", StringComparison.OrdinalIgnoreCase) ||
+                // An RSS/Atom feed must be parsed as a feed BEFORE the HTML branch: running it
+                // through ExtractTextFromHtml strips all element structure, collapsing every
+                // item's title/link/description into one blob and losing the title↔link pairing
+                // (issue #485). Only genuine HTML falls through to the HTML text-extractor.
+                if (IsFeedContent(contentType, content))
+                {
+                    content = ExtractFeedItems(content);
+                }
+                else if (contentType.Contains("html", StringComparison.OrdinalIgnoreCase) ||
                     content.TrimStart().StartsWith("<", StringComparison.Ordinal))
                 {
                     content = ExtractTextFromHtml(content);
@@ -223,6 +233,109 @@ public class WebSearchPlugin : IAgentPlugin
         if (isBlock && sb.Length > 0 && sb[^1] != '\n')
             sb.AppendLine();
     }
+
+    /// <summary>
+    /// Decides whether fetched content is an RSS/Atom/XML feed that must be parsed as a feed
+    /// rather than run through the HTML text-extractor. Recognizes feeds by media type
+    /// (<c>application/rss+xml</c>, <c>application/atom+xml</c>, <c>application/xml</c>,
+    /// <c>text/xml</c>) or, when the content-type is generic/absent, by an XML/feed body prefix.
+    /// XHTML (media type ends in <c>+xml</c> but is HTML) is deliberately excluded.
+    /// </summary>
+    private static bool IsFeedContent(string contentType, string content)
+    {
+        // XHTML is HTML, not a feed, even though its media type ends in "+xml".
+        if (contentType.Contains("html", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (contentType.Contains("rss", StringComparison.OrdinalIgnoreCase) ||
+            contentType.Contains("atom", StringComparison.OrdinalIgnoreCase) ||
+            contentType.Contains("xml", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Content-type is generic (text/plain, octet-stream) or missing — sniff the body prefix.
+        var trimmed = content.AsSpan().TrimStart();
+        return trimmed.StartsWith("<?xml") || trimmed.StartsWith("<rss") ||
+               trimmed.StartsWith("<feed") || trimmed.StartsWith("<rdf:RDF");
+    }
+
+    /// <summary>
+    /// Parses an RSS 2.0 / RSS 1.0 (RDF) / Atom feed into a compact JSON list of items so each
+    /// item's <c>title</c>, <c>link</c>, <c>description</c> and <c>pubDate</c> survive as a unit
+    /// (the HTML text-extractor would flatten them into a single blob and lose the title↔link
+    /// pairing — issue #485). Falls back to the raw XML when the document is not well-formed
+    /// or is valid XML but not a recognizable feed (e.g. a sitemap), which still preserves more
+    /// structure than the HTML text-extractor would.
+    /// </summary>
+    internal static string ExtractFeedItems(string xml)
+    {
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(xml);
+        }
+        catch (XmlException)
+        {
+            // Detected as XML by content-type but not well-formed — return the raw content
+            // rather than destroying it through the HTML text-extractor.
+            return xml;
+        }
+
+        var root = doc.Root;
+        if (root is null)
+            return xml;
+
+        var items = ImmutableList<FeedItem>.Empty;
+
+        // RSS 2.0 (<rss><channel><item>) and RSS 1.0/RDF (<item> under root) — RSS is
+        // typically namespace-less, so match by local name to be namespace-robust.
+        foreach (var item in root.Descendants().Where(e => e.Name.LocalName == "item"))
+            items = items.Add(ReadRssItem(item));
+
+        // Atom (<feed><entry>).
+        foreach (var entry in root.Descendants().Where(e => e.Name.LocalName == "entry"))
+            items = items.Add(ReadAtomEntry(entry));
+
+        if (items.Count == 0)
+            // Valid XML but no feed items — hand back the raw XML so structure is preserved.
+            return xml;
+
+        return JsonSerializer.Serialize(items,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    }
+
+    private static FeedItem ReadRssItem(XElement item) => new(
+        Title: GetChildText(item, "title"),
+        Link: GetChildText(item, "link"),
+        Description: GetChildText(item, "description"),
+        PubDate: GetChildText(item, "pubDate"));
+
+    private static FeedItem ReadAtomEntry(XElement entry)
+    {
+        // Atom <link> is an element carrying the URL in its href attribute; there can be
+        // several (alternate/self/enclosure). Prefer rel="alternate", then a rel-less link,
+        // then whatever link is present.
+        var links = entry.Elements().Where(e => e.Name.LocalName == "link").ToImmutableList();
+        var link = links.FirstOrDefault(l => (string?)l.Attribute("rel") == "alternate")
+                   ?? links.FirstOrDefault(l => l.Attribute("rel") is null)
+                   ?? links.FirstOrDefault();
+        var href = link?.Attribute("href")?.Value?.Trim();
+
+        return new FeedItem(
+            Title: GetChildText(entry, "title"),
+            Link: string.IsNullOrEmpty(href) ? null : href,
+            Description: GetChildText(entry, "summary") ?? GetChildText(entry, "content"),
+            PubDate: GetChildText(entry, "updated") ?? GetChildText(entry, "published"));
+    }
+
+    private static string? GetChildText(XElement parent, string localName)
+    {
+        var element = parent.Elements().FirstOrDefault(e => e.Name.LocalName == localName);
+        var value = element?.Value.Trim();
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    /// <summary>A single parsed feed item; serialized to camelCase JSON for the agent.</summary>
+    private sealed record FeedItem(string? Title, string? Link, string? Description, string? PubDate);
 
     /// <summary>
     /// Builds the <c>AITool</c> set this plugin exposes to agents — SearchWeb and FetchWebPage.

--- a/test/MeshWeaver.AI.Test/WebSearchPluginTest.cs
+++ b/test/MeshWeaver.AI.Test/WebSearchPluginTest.cs
@@ -1,0 +1,194 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System.Net;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Text.Json;
+using MeshWeaver.AI.Plugins;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Tests for <see cref="WebSearchPlugin"/>'s content handling — specifically that RSS/Atom
+/// feeds are parsed into a structured item list (title↔link pairing preserved) instead of
+/// being flattened by the HTML text-extractor (issue #485), while genuine HTML still has its
+/// tags stripped.
+/// </summary>
+public class WebSearchPluginTest
+{
+    private const string RssFixture = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>Example Feed</title>
+            <link>https://example.com</link>
+            <description>Channel-level description (must NOT become an item)</description>
+            <item>
+              <title>First Article</title>
+              <link>https://example.com/first</link>
+              <description>Summary of the first article.</description>
+              <pubDate>Mon, 06 Jan 2025 12:00:00 GMT</pubDate>
+            </item>
+            <item>
+              <title>Second Article</title>
+              <link>https://example.com/second</link>
+              <description>Summary of the second article.</description>
+              <pubDate>Tue, 07 Jan 2025 12:00:00 GMT</pubDate>
+            </item>
+          </channel>
+        </rss>
+        """;
+
+    private const string AtomFixture = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Example Atom Feed</title>
+          <link href="https://example.com/"/>
+          <updated>2025-01-06T12:00:00Z</updated>
+          <entry>
+            <title>Atom First</title>
+            <link rel="alternate" href="https://example.com/atom-first"/>
+            <summary>Summary of atom first.</summary>
+            <updated>2025-01-06T12:00:00Z</updated>
+          </entry>
+          <entry>
+            <title>Atom Second</title>
+            <link href="https://example.com/atom-second"/>
+            <content>Content of atom second.</content>
+            <published>2025-01-05T09:00:00Z</published>
+          </entry>
+        </feed>
+        """;
+
+    private const string HtmlFixture =
+        "<!DOCTYPE html><html><head><title>Page</title></head><body>" +
+        "<h1>Hello</h1><p>Some <b>bold</b> text.</p>" +
+        "<a href=\"https://example.com\">Link</a></body></html>";
+
+    private sealed record ParsedItem(string? Title, string? Link, string? Description, string? PubDate);
+
+    private static IReadOnlyList<ParsedItem> ParseItems(string json) =>
+        JsonSerializer.Deserialize<List<ParsedItem>>(json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+        ?? new List<ParsedItem>();
+
+    // ---- ExtractFeedItems: direct parsing ----------------------------------
+
+    [Fact]
+    public void ExtractFeedItems_Rss_PreservesTitleLinkPairs()
+    {
+        var json = WebSearchPlugin.ExtractFeedItems(RssFixture);
+        var items = ParseItems(json);
+
+        items.Should().HaveCount(2);
+        items[0].Title.Should().Be("First Article");
+        items[0].Link.Should().Be("https://example.com/first");
+        items[0].Description.Should().Be("Summary of the first article.");
+        items[0].PubDate.Should().Be("Mon, 06 Jan 2025 12:00:00 GMT");
+        items[1].Title.Should().Be("Second Article");
+        items[1].Link.Should().Be("https://example.com/second");
+    }
+
+    [Fact]
+    public void ExtractFeedItems_Atom_PreservesTitleLinkPairs()
+    {
+        var json = WebSearchPlugin.ExtractFeedItems(AtomFixture);
+        var items = ParseItems(json);
+
+        items.Should().HaveCount(2);
+        // rel="alternate" href is chosen for the first entry.
+        items[0].Title.Should().Be("Atom First");
+        items[0].Link.Should().Be("https://example.com/atom-first");
+        items[0].Description.Should().Be("Summary of atom first.");
+        // Second entry: no rel attribute → first (only) link href; content→description; published→pubDate.
+        items[1].Title.Should().Be("Atom Second");
+        items[1].Link.Should().Be("https://example.com/atom-second");
+        items[1].Description.Should().Be("Content of atom second.");
+        items[1].PubDate.Should().Be("2025-01-05T09:00:00Z");
+    }
+
+    [Fact]
+    public void ExtractFeedItems_ValidXmlButNotAFeed_ReturnsRaw()
+    {
+        // A sitemap is valid XML with no <item>/<entry> — return it raw rather than
+        // stripping structure through the HTML extractor.
+        const string sitemap =
+            "<?xml version=\"1.0\"?><urlset><url><loc>https://example.com/</loc></url></urlset>";
+
+        var result = WebSearchPlugin.ExtractFeedItems(sitemap);
+
+        result.Should().Be(sitemap);
+    }
+
+    [Fact]
+    public void ExtractFeedItems_MalformedXml_ReturnsRaw()
+    {
+        const string malformed = "<?xml version=\"1.0\"?><rss><channel><item><title>Broken";
+
+        var result = WebSearchPlugin.ExtractFeedItems(malformed);
+
+        result.Should().Be(malformed);
+    }
+
+    // ---- FetchWebPageCore: end-to-end routing (feed vs HTML) ----------------
+
+    [Fact]
+    public async Task FetchWebPage_RssContentType_ReturnsStructuredItems()
+    {
+        var result = await FetchAsync(RssFixture, "application/rss+xml");
+        var items = ParseItems(result);
+
+        items.Should().HaveCount(2);
+        items[0].Title.Should().Be("First Article");
+        items[0].Link.Should().Be("https://example.com/first");
+    }
+
+    [Fact]
+    public async Task FetchWebPage_AtomContentType_ReturnsStructuredItems()
+    {
+        var result = await FetchAsync(AtomFixture, "application/atom+xml");
+        var items = ParseItems(result);
+
+        items.Should().HaveCount(2);
+        items[1].Title.Should().Be("Atom Second");
+        items[1].Link.Should().Be("https://example.com/atom-second");
+    }
+
+    [Fact]
+    public async Task FetchWebPage_Html_StripsTagsAndDoesNotParseAsFeed()
+    {
+        var result = await FetchAsync(HtmlFixture, "text/html");
+
+        // HTML branch still strips tags to readable text …
+        result.Should().Contain("Hello");
+        result.Should().Contain("bold");
+        result.Should().NotContain("<");
+        // … and must NOT have gone through the feed parser.
+        result.Should().NotContain("\"link\"");
+    }
+
+    private static Task<string> FetchAsync(string body, string mediaType)
+    {
+        var httpClient = new HttpClient(new StubHttpMessageHandler(body, mediaType));
+        var plugin = new WebSearchPlugin(
+            httpClient,
+            Options.Create(new WebSearchConfiguration()),
+            NullLogger<WebSearchPlugin>.Instance);
+
+        return plugin.FetchWebPageCore("https://feed.example.com/rss").FirstAsync().ToTask();
+    }
+
+    private sealed class StubHttpMessageHandler(string body, string mediaType) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, mediaType)
+            });
+    }
+}


### PR DESCRIPTION
Partially addresses #485 (the RSS/XML feed-parsing defect; the search-provider gap is a separate product decision).

## Problem

`WebSearchPlugin.FetchWebPageCore` ran **any** content that looked like markup through an *HTML* text-extractor:

```csharp
if (contentType.Contains("html", ...) || content.TrimStart().StartsWith("<", ...))
    content = ExtractTextFromHtml(content);   // HtmlAgilityPack: strips all tags
```

The `StartsWith("<")` guard is true for `<?xml`, `<rss`, and `<feed`, so every RSS/Atom feed was flattened by `ExtractTextFromHtml`: each `<item>`/`<entry>`'s title/link/description/pubDate collapsed into one text blob and the per-item title↔link pairing was lost. "Fetch the RSS feed directly" (the natural workaround when `SearchWeb` is unavailable) therefore handed the model structure-stripped text it could not reliably parse into `{title, link}` pairs.

## Fix

Detect XML feeds **before** the HTML branch:
- by media type — `application/rss+xml`, `application/atom+xml`, `application/xml`, `text/xml`; or
- for generic/absent content-types, by an XML/feed body prefix (`<?xml`, `<rss`, `<feed`, `<rdf:RDF`).

A detected feed is parsed into a compact camelCase JSON list (`title`, `link`, `description`, `pubDate`) via `System.Xml.Linq.XDocument` (BCL — **no new dependency**). Handles RSS 2.0 / RSS 1.0 (RDF) `<item>` and Atom `<entry>` (with `<link href>` preference for `rel="alternate"`, `<summary>`/`<content>`, `<updated>`/`<published>`).

Guard rails:
- **XHTML is deliberately excluded** (its media type ends in `+xml` but it is HTML) and still flows through the HTML text-extractor.
- **Non-feed valid XML** (e.g. a sitemap) and **malformed XML** fall back to the raw content rather than being HTML-stripped — still more structure than the extractor would leave.
- Only genuine HTML reaches `ExtractTextFromHtml`.

The reactive + `ioPool.Invoke(...)` HTTP-leaf pattern (`IoPoolNames.Http`) is untouched; the new work is pure static parsing. `Accept` now also advertises the feed media types.

## Tests

New `WebSearchPluginTest` (7 tests, all green):
- `ExtractFeedItems` on RSS and Atom fixtures — title↔link (and description/pubDate) pairs survive.
- Non-feed valid XML (sitemap) and malformed XML return the raw content.
- `FetchWebPageCore` routing via a stub `HttpMessageHandler` — RSS/Atom content-types return structured items; `text/html` still strips tags and does **not** go through the feed parser.

## Scope

Fixes **only** the RSS/XML mangling defect (gap #2 in #485). The "no web-search provider configured" gap (#1) needs a product decision (configure a key vs. document fetch-only) and is intentionally left out.

Build: `dotnet build src/MeshWeaver.AI -c Release -warnaserror -p:CIRun=true` and the test project — both 0 warnings / 0 errors. Tests: 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)