### PR TITLE
fix(space): render the Overview catalog again (colon-form @@-embed mount + default catalog)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using MeshWeaver.Application.Styles;
 using MeshWeaver.Data;
 using MeshWeaver.Layout;
@@ -244,11 +245,63 @@ public static class SpaceLayoutAreas
         if (IsSystemorph(spacePath))
             shell = shell.WithView(BuildSystemorphHighlights(spacePath));
 
-        // No hardcoded navigation/catalog section. The space body (BuildBodyContent above) owns the
-        // catalog: the standard WelcomeMarkdown template embeds it INLINE via @@("area/Search"), and
-        // an author can move/tune/remove it in the editable Body like any other content. A fixed
-        // BuildNavigation section here double-rendered the catalog for any body that embedded it.
+        // Default content catalog, pinned as a bottom section — BUT only when the body does not
+        // already embed one. The standard WelcomeMarkdown template embeds the catalog INLINE via
+        // @@("area/Search"), and an author can move/tune/remove it in the editable Body; for those
+        // bodies this section is SKIPPED so the catalog never double-renders (the reason the old
+        // unconditional BuildNavigation was removed in e03f20fac). A body that predates the embed,
+        // was authored without it, or is markdown-backed (Doc/Skill roots) carries no catalog — those
+        // would otherwise show NOTHING (issue #502, Case 1), so we append the default catalog for them.
+        if (!BodyEmbedsCatalog(EffectiveBodySource(space, node)))
+            shell = shell.WithView(BuildNavigation(spacePath));
+
         return shell;
+    }
+
+    // Matches a reference to the space's Search catalog — either an @@("area:Search")/@@("area/Search")/
+    // @@Search markdown embed (any quoting/parenthesising, incl. a ?query suffix), OR its already-rendered
+    // layout-area div in pre-rendered HTML (data-area='Search', or a data-raw-path ending in
+    // area/Search|area:Search). Used to decide whether the body ALREADY shows a catalog, so the default
+    // bottom catalog is appended only when it doesn't (no double-render). Case-insensitive on the area name.
+    private static readonly Regex CatalogEmbedRegex = new(
+        "@@\\s*\\(?\\s*[\"']?[^\"'()\\r\\n]*?[Ss]earch"
+        + "|(?:data-area=[\"']|area[:/])[Ss]earch",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// The body string <see cref="BuildBodyContent"/> will actually render, using the SAME priority:
+    /// pre-rendered HTML → the Space's Body → the default welcome markdown. Used to detect whether that
+    /// body already embeds the Search catalog so the default bottom catalog isn't double-rendered.
+    /// </summary>
+    internal static string EffectiveBodySource(Space? space, MeshNode? node)
+        => !string.IsNullOrWhiteSpace(node?.PreRenderedHtml) ? node!.PreRenderedHtml!
+            : !string.IsNullOrWhiteSpace(space?.Body) ? space!.Body!
+            : SpaceNodeType.WelcomeMarkdown;
+
+    internal static bool BodyEmbedsCatalog(string body)
+        => !string.IsNullOrEmpty(body) && CatalogEmbedRegex.IsMatch(body);
+
+    /// <summary>
+    /// The space's content catalog — the node's <see cref="MeshNodeLayoutAreas.SearchArea"/> — rendered
+    /// as a fixed "Contents" section at the BOTTOM of the page (the standard "browse what's in this
+    /// space" navigation), embedded via <see cref="LayoutAreaControl"/> the same way
+    /// <see cref="BuildEventCalendar"/> embeds a child area. Appended by <see cref="BuildSpaceView"/>
+    /// only when the body does not already carry its own catalog embed, so it never double-renders.
+    /// </summary>
+    private static UiControl BuildNavigation(string spacePath)
+    {
+        var heading = Controls.Markdown("## Contents")
+            .WithStyle($"{ContentInset} padding-top: 24px;");
+
+        var catalog = new LayoutAreaControl(spacePath, new LayoutAreaReference(MeshNodeLayoutAreas.SearchArea))
+            .WithShowProgress(false)
+            .WithStyle($"{ContentInset} display: block; padding-bottom: 48px; width: 100%;");
+
+        return Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("width: 100%;")
+            .WithView(heading)
+            .WithView(catalog);
     }
 
     /// <summary>
@@ -405,8 +458,9 @@ public static class SpaceLayoutAreas
     /// </summary>
     internal static UiControl BuildBodyContent(Space? space, MeshNode? node, string spacePath)
     {
-        // Bottom padding gives the in-body catalog @@-embed breathing room below it (the catalog is
-        // no longer a fixed LayoutArea — see BuildSpaceView). Top padding is deliberately small: the
+        // Bottom padding gives the in-body catalog @@-embed breathing room below it (an author-embedded
+        // catalog lives here; the default bottom catalog is appended by BuildSpaceView only when the body
+        // has none). Top padding is deliberately small: the
         // header already contributes its own padding + divider above, so a large top pad here stacked
         // into an airy ~56px gap between the description and the first body element.
         var bodyStyle = $"{ContentInset} padding-top: 12px; padding-bottom: 48px;";

--- a/src/MeshWeaver.Markdown/LayoutAreaMarkdownParser.cs
+++ b/src/MeshWeaver.Markdown/LayoutAreaMarkdownParser.cs
@@ -271,6 +271,11 @@ public class LayoutAreaMarkdownParser : BlockParser
     /// matched as the address by the resolver, so the verb branch only fires when the verb is a
     /// reference verb, not a path segment. A trailing query string (<c>?…</c>) is carried into the
     /// id, matching how areas read query params.</para>
+    /// <para>Both the SLASH keyword form (<c>area/Search</c>) and the COLON keyword form
+    /// (<c>area:Search</c>) are accepted — the parse-time <see cref="CreateBlockFromToken"/> honours
+    /// both, so this runtime mirror must too. A colon-form remainder is normalised to the slash form
+    /// before dispatch; without that a shipped <c>@@("area:Search")</c> embed mounted to a
+    /// non-existent area named literally <c>"area:Search"</c> and rendered blank (issue #502).</para>
     /// </summary>
     public static (string? Area, string? Id) ParseAreaAndId(string? remainder)
     {
@@ -289,6 +294,25 @@ public class LayoutAreaMarkdownParser : BlockParser
         var segments = remainder.Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (segments.Length == 0)
             return (null, querySuffix);
+
+        // 🐛→✅ Normalise a leading COLON-keyword segment ("area:Search", "data:Type") into the
+        // equivalent SLASH form ("area/Search", "data/Type"). The markdown parse-time resolver
+        // (LayoutAreaMarkdownParser.ParsePath / CreateBlockFromToken) accepts BOTH `keyword:value`
+        // and `keyword/value`; this runtime mirror (used by PathBasedLayoutArea's @@-embed mount
+        // re-resolution AND NavigationService) previously only split on '/', so a colon-form
+        // remainder fell through to the "bare area name" default and produced an area named
+        // literally "area:Search" — a non-existent area that mounts to nothing (issue #502). The
+        // Space WelcomeMarkdown template shipped exactly `@@("area:Search")`, so its catalog
+        // rendered blank. Splitting the first colon here makes the two resolvers agree.
+        var firstColon = segments[0].IndexOf(':');
+        if (firstColon > 0)
+        {
+            var key = segments[0][..firstColon];
+            var value = segments[0][(firstColon + 1)..];
+            segments = (string.IsNullOrEmpty(value)
+                ? new[] { key }.Concat(segments.Skip(1))
+                : new[] { key, value }.Concat(segments.Skip(1))).ToArray();
+        }
 
         string? Rest(int from) => segments.Length > from ? string.Join("/", segments.Skip(from)) : null;
 

--- a/test/MeshWeaver.Graph.Test/SpaceDefaultCatalogTest.cs
+++ b/test/MeshWeaver.Graph.Test/SpaceDefaultCatalogTest.cs
@@ -1,0 +1,72 @@
+#pragma warning disable CS1591
+
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Covers the default-catalog gate behind the Space Overview (<see cref="SpaceLayoutAreas.BuildSpaceView"/>) —
+/// the second half of the issue #502 fix. Commit <c>e03f20fac</c> removed the unconditional
+/// <c>BuildNavigation</c> catalog section, leaving spaces whose body carries no catalog embed with NO
+/// catalog at all (Case 1: a body that predates the embed, was authored without it, or is a
+/// markdown-backed Doc/Skill root). The catalog is now appended as a default bottom "Contents" section
+/// ONLY when the effective body does not already embed one — so a template/custom body that carries its
+/// own <c>@@("area:Search")</c> never double-renders (the reason the hardcoded section was removed).
+/// </summary>
+public class SpaceDefaultCatalogTest
+{
+    // ── EffectiveBodySource: the string BuildBodyContent actually renders (same priority) ──────────
+
+    [Fact]
+    public void EffectiveBodySource_PrefersPreRenderedHtml()
+    {
+        var node = new MeshNode("Acme", "") { PreRenderedHtml = "<p>prerendered</p>" };
+        var space = new Space { Body = "space body" };
+        SpaceLayoutAreas.EffectiveBodySource(space, node).Should().Be("<p>prerendered</p>");
+    }
+
+    [Fact]
+    public void EffectiveBodySource_FallsBackToSpaceBody_ThenWelcome()
+    {
+        var node = new MeshNode("Acme", "");
+        SpaceLayoutAreas.EffectiveBodySource(new Space { Body = "space body" }, node)
+            .Should().Be("space body");
+        // No body → the default welcome template (which itself embeds the catalog).
+        SpaceLayoutAreas.EffectiveBodySource(new Space(), node)
+            .Should().Be(SpaceNodeType.WelcomeMarkdown);
+    }
+
+    // ── BodyEmbedsCatalog: whether the body already shows a Search catalog (⇒ skip the default) ────
+
+    [Theory]
+    // The shipped template forms — MUST be detected so the default catalog is NOT double-rendered.
+    [InlineData("## Contents\n\n@@(\"area/Search\")")]
+    [InlineData("## Contents\n\n@@(\"area:Search\")")]
+    [InlineData("Intro\n\n@@Search")]
+    [InlineData("@@area/Search")]
+    [InlineData("@@/Acme/area/Search")]
+    [InlineData("@@(\"area:Search?groupBy=type\")")]
+    // Pre-rendered HTML form (a markdown-backed body whose catalog embed already rendered to a div).
+    [InlineData("<div class='layout-area' data-address='Acme' data-area='Search'></div>")]
+    // The default welcome template carries the embed, so it counts as embedding the catalog.
+    public void BodyEmbedsCatalog_DetectsCatalogEmbeds(string body)
+        => SpaceLayoutAreas.BodyEmbedsCatalog(body).Should().BeTrue();
+
+    [Fact]
+    public void BodyEmbedsCatalog_TrueForDefaultWelcomeTemplate()
+        => SpaceLayoutAreas.BodyEmbedsCatalog(SpaceNodeType.WelcomeMarkdown).Should().BeTrue(
+            "the default welcome body embeds @@(\"area/Search\"), so the default bottom catalog must be skipped");
+
+    [Theory]
+    // A plain body with no catalog embed → the default catalog SHOULD be appended (issue #502, Case 1).
+    [InlineData("")]
+    [InlineData("# My Space\n\nJust some prose and a [link](/Doc).")]
+    [InlineData("A table:\n\n| a | b |\n|---|---|\n| 1 | 2 |")]
+    // An embed of a DIFFERENT area is not the catalog — the default catalog is still appended.
+    [InlineData("@@(\"area/Overview\")")]
+    [InlineData("@@Events")]
+    public void BodyEmbedsCatalog_FalseWhenNoCatalog(string body)
+        => SpaceLayoutAreas.BodyEmbedsCatalog(body).Should().BeFalse();
+}

--- a/test/MeshWeaver.Markdown.Test/LayoutAreaPathParseTest.cs
+++ b/test/MeshWeaver.Markdown.Test/LayoutAreaPathParseTest.cs
@@ -28,14 +28,26 @@ public class LayoutAreaPathParseTest
     [InlineData("area/Search", "Search", null)]
     [InlineData("area/Dashboard/id1", "Dashboard", "id1")]
     [InlineData("area", null, null)]                       // bare verb → default area
+    // 🐛→✅ issue #502: the COLON keyword form must resolve IDENTICALLY to the slash form. The Space
+    // WelcomeMarkdown template shipped `@@("area:Search")`; the mount re-resolution (PathBasedLayoutArea)
+    // ran the resolver remainder "area:Search" through here — and the pre-fix code, which split only on
+    // '/', took the WHOLE "area:Search" as the area name → a non-existent area that renders BLANK (the
+    // "Contents catalog no longer renders" regression). The colon form now normalises to the slash form.
+    [InlineData("area:Search", "Search", null)]
+    [InlineData("area:Dashboard/id1", "Dashboard", "id1")]
     // 🐛→✅ data/schema/model map to the canonical framework $-areas.
     [InlineData("data/Organization", "$Data", "Organization")]
     [InlineData("data/Type/id1", "$Data", "Type/id1")]
     [InlineData("schema/MyType", "$Schema", "MyType")]
     [InlineData("model", "$Model", null)]
+    // The colon keyword form maps to the same $-areas as the slash form.
+    [InlineData("data:Organization", "$Data", "Organization")]
+    [InlineData("data:Type/id1", "$Data", "Type/id1")]
+    [InlineData("schema:MyType", "$Schema", "MyType")]
     // "content" is NOT a hardcoded area — content collections are configured and resolved by
     // name downstream, so the first segment is kept as written (not translated to "$Content").
     [InlineData("content/logo.svg", "content", "logo.svg")]
+    [InlineData("content:logo.svg", "content", "logo.svg")]
     public void ParseAreaAndId_MapsKeywordsAndBareNames(string? remainder, string? expectedArea, string? expectedId)
     {
         var (area, id) = LayoutAreaMarkdownParser.ParseAreaAndId(remainder);
@@ -49,6 +61,9 @@ public class LayoutAreaPathParseTest
     [InlineData("area/Search?q=laptop", "Search", "?q=laptop")]
     [InlineData("area/Catalog/id1?groupBy=ns", "Catalog", "id1?groupBy=ns")]
     [InlineData("data/Type?x=1", "$Data", "Type?x=1")]
+    // The colon keyword form carries the query string identically — this is the tuned catalog embed
+    // `@@("area:Search?groupBy=…")` the Space template documents.
+    [InlineData("area:Search?groupBy=type", "Search", "?groupBy=type")]
     public void ParseAreaAndId_CarriesQueryStringIntoId(string remainder, string expectedArea, string expectedId)
     {
         var (area, id) = LayoutAreaMarkdownParser.ParseAreaAndId(remainder);

--- a/test/MeshWeaver.Markdown.Test/SpaceCatalogEmbedMountTest.cs
+++ b/test/MeshWeaver.Markdown.Test/SpaceCatalogEmbedMountTest.cs
@@ -1,0 +1,111 @@
+#pragma warning disable CS1591
+
+using System.Text.RegularExpressions;
+using MeshWeaver.Graph;
+using MeshWeaver.Markdown;
+using Xunit;
+
+namespace MeshWeaver.Markdown.Test;
+
+/// <summary>
+/// Reproduces issue #502 — "Space Overview catalog (Contents) tiles no longer render" — end to end
+/// through the exact stages that run at MOUNT time for an <c>@@("area:Search")</c> catalog embed in a
+/// Space's markdown body.
+///
+/// <para>Commit <c>e03f20fac</c> removed the hardcoded <c>SpaceLayoutAreas.BuildNavigation</c> catalog
+/// section and made the catalog depend entirely on the body embed shipped in
+/// <c>SpaceNodeType.WelcomeMarkdown</c>. That template shipped the COLON keyword form
+/// <c>@@("area:Search")</c>. The markdown pipeline renders it to a mountable
+/// <c>&lt;div class='layout-area' data-raw-path='{space}/area:Search' …&gt;</c> — which the issue's
+/// pure-pipeline test confirmed healthy. But the Blazor MOUNT (<c>PathBasedLayoutArea</c>) re-resolves
+/// that raw path through <c>IPathResolver</c> (matches the longest node prefix = the space, leaving
+/// remainder <c>"area:Search"</c>) and then parses the remainder with
+/// <see cref="LayoutAreaMarkdownParser.ParseAreaAndId"/>. Pre-fix, that split only on '/', so
+/// <c>"area:Search"</c> became an area named literally <c>"area:Search"</c> — a non-existent area that
+/// mounts to nothing, rendering the catalog BLANK with no error (the catalog's MeshSearchControl ships
+/// <c>emptyMessage=false, loading=false</c>).</para>
+///
+/// <para>These tests drive the real Markdig pipeline (with the Space's NodePath, as
+/// <c>SpaceLayoutAreas.BuildBodyContent</c> sets it) and then simulate the mount's resolver step —
+/// strip the resolved space prefix from the emitted raw path and run
+/// <see cref="LayoutAreaMarkdownParser.ParseAreaAndId"/> — asserting the mount lands on the real
+/// <c>Search</c> catalog area for BOTH the colon form the template shipped and the slash form it was
+/// later switched to. Revert the <c>ParseAreaAndId</c> colon-normalisation and the colon case fails
+/// with area <c>"area:Search"</c>.</para>
+/// </summary>
+public class SpaceCatalogEmbedMountTest
+{
+    private const string SpacePath = "Acme";
+
+    // The layout-area div is emitted single-line by LayoutAreaMarkdownRenderer.GetLayoutAreaDiv, so a
+    // targeted attribute match is exact — no HTML parser dependency needed.
+    private static readonly Regex RawPathAttr =
+        new($"class='{LayoutAreaMarkdownRenderer.LayoutArea}'[^>]*?data-{LayoutAreaMarkdownRenderer.RawPath}='([^']*)'",
+            RegexOptions.Compiled);
+
+    /// <summary>
+    /// Runs the exact Markdig pipeline the Space body MarkdownControl uses (NodePath = the space path,
+    /// per <c>SpaceLayoutAreas.BuildBodyContent</c>) and returns the emitted <c>data-raw-path</c> of the
+    /// single embedded layout-area div.
+    /// </summary>
+    private static string RenderEmbedRawPath(string embedMarkdown)
+    {
+        var pipeline = MarkdownExtensions.CreateMarkdownPipeline(collection: null, currentNodePath: SpacePath);
+        var html = Markdig.Markdown.ToHtml(embedMarkdown, pipeline);
+
+        var match = RawPathAttr.Match(html);
+        match.Success.Should().BeTrue(
+            $"the @@ embed must render a layout-area div carrying a raw path; got:\n{html}");
+        return match.Groups[1].Value;
+    }
+
+    /// <summary>
+    /// Simulates the mount-time resolver step: <c>IPathResolver</c> matches the longest existing node
+    /// prefix (the space) and hands the tail to <c>PathBasedLayoutArea.ParseRemainder</c> →
+    /// <see cref="LayoutAreaMarkdownParser.ParseAreaAndId"/>. The prefix strip is exact here because
+    /// the space is the deepest real node on the raw path.
+    /// </summary>
+    private static (string? Area, string? Id) MountResolve(string rawPath)
+    {
+        var prefix = SpacePath + "/";
+        Assert.StartsWith(prefix, rawPath);
+        var remainder = rawPath[prefix.Length..];
+        return LayoutAreaMarkdownParser.ParseAreaAndId(remainder);
+    }
+
+    [Theory]
+    // The COLON form the WelcomeMarkdown template shipped (e03f20fac) — the regression case.
+    [InlineData("@@(\"area:Search\")")]
+    // The SLASH form the template was later switched to (b0acd44f1) — must keep working.
+    [InlineData("@@(\"area/Search\")")]
+    // The relative slash form an author may write directly.
+    [InlineData("@@area/Search")]
+    public void SpaceBodyCatalogEmbed_MountsToTheSearchCatalogArea(string embed)
+    {
+        var rawPath = RenderEmbedRawPath(embed);
+
+        // The embed must resolve against the space (relative @@ resolved via NodePath), never a dead
+        // unaddressed div — the raw path carries the space prefix.
+        rawPath.Should().StartWith(SpacePath + "/",
+            "the relative @@ embed must resolve against the Space's NodePath");
+
+        var (area, id) = MountResolve(rawPath);
+
+        area.Should().Be(MeshNodeLayoutAreas.SearchArea,
+            "the catalog embed must mount to the real 'Search' area — NOT a non-existent area named " +
+            "after the raw keyword token (issue #502)");
+        id.Should().BeNull();
+    }
+
+    [Fact]
+    public void SpaceBodyCatalogEmbed_TunedGroupBy_CarriesQueryIntoAreaId()
+    {
+        // The template documents `@@("area:Search?groupBy=…")` as the tuned catalog — the query must
+        // survive the mount and land on the area id, not corrupt the area name.
+        var rawPath = RenderEmbedRawPath("@@(\"area:Search?groupBy=type\")");
+        var (area, id) = MountResolve(rawPath);
+
+        area.Should().Be(MeshNodeLayoutAreas.SearchArea);
+        id.Should().Be("?groupBy=type");
+    }
+}


### PR DESCRIPTION
Fixes #502.

The Space `Overview` page stopped rendering its "Contents" catalog after commit `e03f20fac` removed the hardcoded `SpaceLayoutAreas.BuildNavigation` section and made the catalog depend entirely on a body `@@`-embed. There are **two** root causes; this PR fixes both.

## Root cause 1 — colon-form embed mounts to a non-existent area (issue's Case 2)

The `@@`-embed mount (`PathBasedLayoutArea`) and URL navigation (`NavigationService`) both re-resolve the resolver *remainder* through `LayoutAreaMarkdownParser.ParseAreaAndId` — documented as the **runtime mirror** of the parse-time `CreateBlockFromToken`. The parse-time side accepts BOTH the slash keyword form (`area/Search`) and the colon keyword form (`area:Search`); the runtime mirror only split on `/`, so a colon-form remainder `area:Search` became an area named **literally** `"area:Search"` — a non-existent area that mounts to nothing, **silently** (the catalog's `MeshSearchControl` ships `emptyMessage=false, loading=false`).

The Space `WelcomeMarkdown` template shipped exactly `@@("area:Search")` when `e03f20fac` landed (later switched to the slash form in `b0acd44f1`, but any space created in that window froze the colon form in its body, and any author writing the colon form still hits it).

**Fix:** in `ParseAreaAndId`, normalise a leading colon keyword segment (`area:Search`, `data:Type`, …) to the slash form so the two resolvers agree.

## Root cause 2 — bodies with no catalog embed show nothing (issue's Case 1)

A body that predates the embed, was authored without it, or is markdown-backed (`Doc`/`Skill` partition roots) has no catalog at all once `BuildNavigation` was removed.

**Fix:** restore the default bottom "Contents" catalog in `BuildSpaceView`, but append it **only when the effective body does not already embed one** — so a template/custom body that carries its own `@@("area:Search")` never double-renders (the reason the unconditional section was removed in `e03f20fac`). Detection covers every embed form (`@@("area:Search")`, `@@("area/Search")`, `@@Search`, `@@/Space/area/Search`, `?query` suffixes) and the pre-rendered `data-area='Search'` div form.

## Verification

- `dotnet build -c Release -warnaserror -p:CIRun=true` clean for `MeshWeaver.Markdown`, `MeshWeaver.Graph` and both test projects.
- **Revert-proven:** disabling the `ParseAreaAndId` colon-normalisation makes the new colon cases fail with `Expected "Search", but found "area:Search"`.
- Tests:
  - `LayoutAreaPathParseTest` — colon keyword cases (`area:Search`, `data:Type/id1`, `area:Search?groupBy=type`, …).
  - `SpaceCatalogEmbedMountTest` — drives the full markdown → `layout-area` div → mount re-resolution chain for both embed forms, asserting the mount lands on the real `Search` area.
  - `SpaceDefaultCatalogTest` — pins the append-only-when-absent gate and the `EffectiveBodySource` priority.
- Existing `NavigationServiceTest` (colon-free remainders) and `SpaceOverviewBodyTest` (`>= 2` view count) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)