### PR TITLE
fix(chat): guarantee submission-handler release on submit failure (#380)

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1180,6 +1180,13 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             if (!submissionHandler.TryBeginSubmit(userMessageText))
                 return;
 
+            // 🛟 #380 failsafe: TryBeginSubmit latched State = Submitting. If ANY step below throws
+            // before the trailing ForceRelease, this scope's Dispose (run during stack unwind, before
+            // the catch) forces the handler back to Idle so the composer never wedges at a dead
+            // "Sending…" spinner. On the happy path the ForceRelease at the end runs first, so the
+            // scope-exit Dispose is a no-op — queueing semantics are unchanged.
+            using var submitGuard = submissionHandler.BeginSubmitScope();
+
             // EXISTING thread: clear the editor immediately — the message echoes into the
             // message list via PendingUserMessages right away, so the text is never "gone".
             // NEW thread (no threadPath yet): keep the text in the editor until the thread
@@ -1366,6 +1373,13 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
         catch (Exception ex)
         {
             Logger.LogError(ex, "[ThreadChat:{InstanceId}] SubmitMessageCore failed", _instanceId);
+            // #380: the submitGuard scope has already forced the submission handler back to Idle
+            // during unwind. Clear the co-latched allocation flag (which otherwise blocks the next
+            // submit at the top of this method) and re-render so the disabled "Sending…" spinner is
+            // replaced by the live Send button — the composer recovers WITHOUT a page refresh.
+            showSubmissionProgress = false;
+            if (!_isDisposed)
+                StateHasChanged();
         }
     }
 

--- a/src/MeshWeaver.Blazor/Components/ChatSubmissionHandler.cs
+++ b/src/MeshWeaver.Blazor/Components/ChatSubmissionHandler.cs
@@ -140,6 +140,37 @@ public class ChatSubmissionHandler : IDisposable
     }
 
     /// <summary>
+    /// Opens a failsafe scope for a submission that has just begun (i.e. immediately after
+    /// <see cref="TryBeginSubmit"/> returned <c>true</c> and latched <see cref="State"/> to
+    /// <see cref="SubmissionState.Submitting"/>). Disposing the scope — on normal <b>or</b>
+    /// exceptional block exit — forces the handler back to <see cref="SubmissionState.Idle"/>
+    /// if it is still in flight, so a throw anywhere between <c>TryBeginSubmit</c> and the
+    /// caller's trailing <see cref="ForceRelease"/> can never latch the input at "Sending…"
+    /// (GitHub issue #380: the composer becomes a dead spinner where the user cannot type a new
+    /// message until a full page refresh rebuilds the handler). On the happy path the caller has
+    /// already released before the scope exits, so <see cref="IDisposable.Dispose"/> is an
+    /// idempotent no-op and the queueing semantics are unchanged. Intended usage:
+    /// <c>using var _ = handler.BeginSubmitScope();</c> around the submit body.
+    /// </summary>
+    public IDisposable BeginSubmitScope() => new SubmitScope(this);
+
+    private sealed class SubmitScope(ChatSubmissionHandler handler) : IDisposable
+    {
+        private bool _released;
+
+        public void Dispose()
+        {
+            if (_released)
+                return;
+            _released = true;
+            // Only act when the submission is still in flight: on the happy path the caller has
+            // already transitioned to Idle, so this is a no-op that preserves existing behavior.
+            if (handler.State != SubmissionState.Idle)
+                handler.ForceRelease();
+        }
+    }
+
+    /// <summary>
     /// Marks the handler as disposed so that subsequent <c>TryBeginSubmit</c> calls
     /// return <c>false</c> without side effects.
     /// </summary>

--- a/test/MeshWeaver.Layout.Test/ChatSubmissionHandlerTest.cs
+++ b/test/MeshWeaver.Layout.Test/ChatSubmissionHandlerTest.cs
@@ -276,4 +276,68 @@ public class ChatSubmissionHandlerTest
         Assert.False(handler.TryBeginSubmit("Hello"));
         Assert.Equal(0, handler.SubmissionCount);
     }
+
+    /// <summary>
+    /// Regression for GitHub issue #380 ("the agent chat still requires refresh from time to time"):
+    /// ThreadChatView.SubmitMessageCore latches State = Submitting via TryBeginSubmit and only clears
+    /// it with the trailing ForceRelease on the happy path. Before the fix, any throw between those
+    /// two points left State latched at Submitting forever — IsInputEnabled stayed false, so the Send
+    /// button rendered as a dead "Sending…" spinner and every later TryBeginSubmit early-returned;
+    /// only a page refresh (a fresh handler) recovered. The BeginSubmitScope failsafe now guarantees
+    /// the release: disposing the scope while a submission is still in flight (exactly what the
+    /// compiler-generated `using` finally does during stack unwind) forces the handler back to Idle.
+    /// </summary>
+    [Fact]
+    public void SubmitScope_BodyThrowsAfterTryBeginSubmit_ReleasesToIdle()
+    {
+        var handler = new ChatSubmissionHandler();
+        var rethrown = false;
+
+        try
+        {
+            Assert.True(handler.TryBeginSubmit("Hello"));
+            Assert.Equal(SubmissionState.Submitting, handler.State);
+            Assert.False(handler.IsInputEnabled);
+
+            using (handler.BeginSubmitScope())
+            {
+                // Simulate a throw somewhere in the submit pipeline (ns computation, StartThread,
+                // JSON serialization, …) BEFORE the trailing ForceRelease would run.
+                throw new InvalidOperationException("simulated submit-pipeline failure");
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            rethrown = true;
+        }
+
+        Assert.True(rethrown, "the failsafe scope must not swallow the exception — the caller still logs/surfaces it");
+        Assert.Equal(SubmissionState.Idle, handler.State);
+        Assert.True(handler.IsInputEnabled);
+
+        // And the composer is usable again immediately — no refresh needed.
+        Assert.True(handler.TryBeginSubmit("Another message"));
+    }
+
+    /// <summary>
+    /// Happy path: the caller releases (ForceRelease for Claude-Code-style queueing) BEFORE the
+    /// scope exits, so disposing the scope is a no-op and leaves the queueing state untouched.
+    /// </summary>
+    [Fact]
+    public void SubmitScope_ReleasedInsideScope_DisposeIsNoOp()
+    {
+        var handler = new ChatSubmissionHandler();
+
+        Assert.True(handler.TryBeginSubmit("Hello"));
+        using (handler.BeginSubmitScope())
+        {
+            // The submit body posts the message and force-releases so the input stays enabled
+            // for queueing while the round is processed server-side.
+            handler.ForceRelease();
+            Assert.Equal(SubmissionState.Idle, handler.State);
+        }
+
+        Assert.Equal(SubmissionState.Idle, handler.State);
+        Assert.True(handler.IsInputEnabled);
+    }
 }


### PR DESCRIPTION
Partially fixes #380 (the deterministic submission-handler wedge; the Monaco-focus and dropped-sync-frame mechanisms need a live portal — see the issue RCA).

## Symptom

"The agent chat still requires refresh from time to time." The composer becomes non-responsive — you cannot type/send a new message even though the previous round finished — and a page refresh clears it.

## Root cause (this mechanism)

`ThreadChatView.SubmitMessageCore` gates Send on `ChatSubmissionHandler.IsInputEnabled` (== `State == Idle`). `TryBeginSubmit` latches `State = Submitting`; the happy path clears it with a trailing `submissionHandler.ForceRelease()`. But any throw between those two points fell through to the wrapping `catch`, which **logged but never released**. So:

- `State` stayed `Submitting` forever → `!IsInputEnabled` rendered the Send button as a disabled "Sending…" spinner, and
- every later `TryBeginSubmit` early-returned (`State != Idle`).

Only a refresh (which builds a fresh, `Idle` handler) recovered — exactly the reported behavior.

## Fix (root cause, not a band-aid)

Make the release **guaranteed** instead of relying on the happy path:

- `ChatSubmissionHandler.BeginSubmitScope()` returns a disposable failsafe. Its `Dispose` — run during stack unwind on any throw, **before** the `catch` — forces the handler back to `Idle` if a submission is still in flight.
- `SubmitMessageCore` wraps the submit body in `using var submitGuard = submissionHandler.BeginSubmitScope();`. On the happy path the trailing `ForceRelease` runs first, so scope-exit `Dispose` is an idempotent no-op — the Claude-Code-style queueing semantics are unchanged.
- The `catch` additionally clears the co-latched `showSubmissionProgress` flag and re-renders, so the live Send button returns **without a refresh**.

No `async`/`await`/`Task<T>` introduced; the change is a synchronous RAII guard on the existing handler.

## Test

`ChatSubmissionHandlerTest.SubmitScope_BodyThrowsAfterTryBeginSubmit_ReleasesToIdle` — a throw inside `BeginSubmitScope()` after `TryBeginSubmit` must leave the handler `Idle` / `IsInputEnabled` and accept the next submit. Revert-proven: fails if the `ForceRelease` is removed from `SubmitScope.Dispose`. `SubmitScope_ReleasedInsideScope_DisposeIsNoOp` pins the happy-path no-op.

Build: `dotnet build … -c Release -warnaserror -p:CIRun=true` clean (0 warnings) for `MeshWeaver.Blazor.Portal` and `MeshWeaver.Layout.Test`. All 17 `ChatSubmissionHandlerTest` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)