### PR TITLE
Deck → PDF export (content-faithful download) — #423 piece 1

### DIFF
--- a/src/MeshWeaver.Graph/DeckLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/DeckLayoutAreas.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Reactive.Linq;
+using System.Text.Json;
 using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Layout;
@@ -233,7 +234,7 @@ public static class DeckLayoutAreas
     /// compatibility) or an ABSOLUTE path to a slide anywhere in the mesh (any reference
     /// containing a <c>/</c> is treated as an absolute path and returned as-is).
     /// </summary>
-    internal static string ResolveSlidePath(string deckPath, string slideRef)
+    public static string ResolveSlidePath(string deckPath, string slideRef)
     {
         var trimmed = slideRef.Trim().TrimStart('/');
         if (trimmed.Length == 0)
@@ -241,6 +242,37 @@ public static class DeckLayoutAreas
         // A reference that names a path (contains '/') points at a slide ANYWHERE — presentation
         // is decoupled from the deck's children. A bare id is a child under the deck.
         return trimmed.Contains('/') ? trimmed : $"{deckPath}/{trimmed}";
+    }
+
+    /// <summary>
+    /// Resolves a deck node's slide SELECTION — the pure (IO-free) core shared by the live
+    /// Overview/Present binding (<see cref="ObserveSlideNodes"/>) and by the PDF export template,
+    /// so a deck's order is defined in exactly ONE place. Returns either the explicit ordered
+    /// manifest (<see cref="DeckContent.Slides"/>) resolved to full paths — in which case
+    /// <c>Query</c> is <c>null</c> — or, when the manifest is empty, the live query to run
+    /// (<see cref="DeckContent.Query"/>, else the default subtree of Slide nodes under the deck)
+    /// with <c>Paths</c> empty.
+    /// </summary>
+    /// <param name="deckNode">The deck node whose <see cref="DeckContent"/> declares the selection.</param>
+    /// <param name="deckPath">The deck's mesh path, used to resolve bare-id references and the default query.</param>
+    /// <param name="options">JSON options used to read <see cref="DeckContent"/> off the node.</param>
+    /// <returns>The ordered explicit slide paths, or the query to run when the manifest is empty.</returns>
+    public static (ImmutableList<string> Paths, string? Query) ResolveDeckSelection(
+        MeshNode? deckNode, string deckPath, JsonSerializerOptions options)
+    {
+        var deck = deckNode.ContentAs<DeckContent>(options);
+        var paths = (deck?.Slides ?? ImmutableList<string>.Empty)
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .Select(r => ResolveSlidePath(deckPath, r))
+            .ToImmutableList();
+        // Empty manifest → a live query: the deck's custom Query, else the DEFAULT subtree of
+        // Slide nodes (a deck can be just "a folder of slides"; only Slide nodes count).
+        var query = paths.Count > 0
+            ? null
+            : string.IsNullOrWhiteSpace(deck?.Query)
+                ? $"path:{deckPath} nodeType:{SlideNodeType.NodeType} scope:subtree"
+                : deck!.Query!.Trim();
+        return (paths, query);
     }
 
     private static string LastSegment(string reference)
@@ -260,22 +292,7 @@ public static class DeckLayoutAreas
     internal static IObservable<IReadOnlyList<(string Path, MeshNode? Node)>> ObserveSlideNodes(
         LayoutAreaHost host, string deckPath)
         => host.Workspace.GetMeshNodeStream()
-            .Select(node =>
-            {
-                var deck = node.ContentAs<DeckContent>(host.Hub.JsonSerializerOptions);
-                var paths = (deck?.Slides ?? ImmutableList<string>.Empty)
-                    .Where(r => !string.IsNullOrWhiteSpace(r))
-                    .Select(r => ResolveSlidePath(deckPath, r))
-                    .ToImmutableList();
-                // Empty manifest → a live query: the deck's custom Query, else the DEFAULT subtree of
-                // Slide nodes (a deck can be just "a folder of slides"; only Slide nodes count).
-                var query = paths.Count > 0
-                    ? null
-                    : string.IsNullOrWhiteSpace(deck?.Query)
-                        ? $"path:{deckPath} nodeType:{SlideNodeType.NodeType} scope:subtree"
-                        : deck!.Query!.Trim();
-                return (Paths: paths, Query: query);
-            })
+            .Select(node => ResolveDeckSelection(node, deckPath, host.Hub.JsonSerializerOptions))
             // Re-resolve only when the selection actually changes (the ordered manifest, or the query).
             .DistinctUntilChanged(x => string.Join("\n", x.Paths) + "" + (x.Query ?? ""))
             .Select(x => x.Paths.Count > 0

--- a/src/MeshWeaver.Markdown.Export/Ast/DocumentBuilder.cs
+++ b/src/MeshWeaver.Markdown.Export/Ast/DocumentBuilder.cs
@@ -59,9 +59,12 @@ public class DocumentBuilder
         {
             if (!first)
             {
-                elements.Add(new ChapterBreakElement(chapterTitle));
+                // Page break FIRST, then the chapter title — so each chapter (and each deck
+                // slide) starts on a fresh page with its heading at the top, never orphaned
+                // at the foot of the previous chapter's last page.
                 if (options.PageBreakBetweenChildren)
                     elements.Add(new PageBreakElement());
+                elements.Add(new ChapterBreakElement(chapterTitle));
             }
             first = false;
 

--- a/src/MeshWeaver.Markdown.Export/Configuration/DocumentExportOptions.cs
+++ b/src/MeshWeaver.Markdown.Export/Configuration/DocumentExportOptions.cs
@@ -46,6 +46,13 @@ public record DocumentExportOptions
     /// <summary>Max descendant depth when <see cref="IncludeChildren"/> is true (0 = unlimited).</summary>
     public int MaxDepth { get; init; }
 
+    /// <summary>
+    /// Render pages in landscape (wide) orientation instead of portrait. Off by default
+    /// (markdown documents stay portrait A4); the Deck → PDF export turns this on so
+    /// 16:9 slides fill the page.
+    /// </summary>
+    public bool Landscape { get; init; }
+
     /// <summary>Optional override for footer text; falls back to the brand's footer.</summary>
     public string? FooterOverride { get; init; }
 

--- a/src/MeshWeaver.Markdown.Export/Configuration/MarkdownExportExtensions.cs
+++ b/src/MeshWeaver.Markdown.Export/Configuration/MarkdownExportExtensions.cs
@@ -118,6 +118,9 @@ public static class MarkdownExportExtensions
             {
                 services.TryAddEnumerable(
                     ServiceDescriptor.Scoped<INodeMenuProvider, MarkdownExportMenuProvider>());
+                // Deck nodes get a PDF export item (one page per slide) — self-gated on NodeType=Deck.
+                services.TryAddEnumerable(
+                    ServiceDescriptor.Scoped<INodeMenuProvider, DeckExportMenuProvider>());
                 return services;
             })
             .AddLayout(layout => layout

--- a/src/MeshWeaver.Markdown.Export/Layout/DeckExportMenuProvider.cs
+++ b/src/MeshWeaver.Markdown.Export/Layout/DeckExportMenuProvider.cs
@@ -1,0 +1,62 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Markdown.Export.Layout;
+
+/// <summary>
+/// DI-registered <see cref="INodeMenuProvider"/> that contributes "Export to PDF" to the Node
+/// menu when the focused node is a <c>Deck</c>. The deck's PDF export renders one page per slide
+/// (in the deck's manifest / query order) via the same <c>Templates/Export/Pdf</c> template — the
+/// template branches on <c>NodeType == "Deck"</c>. Only PDF is offered: a deck carries no markdown
+/// body of its own, so DOCX (which exports the node's own content) would be empty.
+/// Registered via <c>TryAddEnumerable</c> so each hub sees exactly one instance — same pattern as
+/// <see cref="MarkdownExportMenuProvider"/>.
+/// </summary>
+public class DeckExportMenuProvider : INodeMenuProvider
+{
+    /// <summary>The menu context this provider contributes to — the Node menu.</summary>
+    public string Context => NodeMenuItemsExtensions.NodeMenuContext;
+
+    /// <summary>
+    /// Reactive: combines the live own-node stream with the viewer's effective permissions and
+    /// re-projects the export item on every change. Emits an empty slice when the node isn't a
+    /// Deck or the viewer lacks Read — and re-emits (showing the item) once a runtime grant
+    /// propagates, without a reload.
+    /// </summary>
+    public IObservable<IReadOnlyCollection<NodeMenuItemDefinition>> GetItems(
+        LayoutAreaHost host, RenderingContext ctx)
+    {
+        var hubPath = host.Hub.Address.ToString();
+
+        // Own MeshNode via the canonical reducer. StartWith(null) so CombineLatest fires before
+        // the node loads; Catch degrades to "no node" on hubs without a MeshDataSource.
+        var nodeStream = host.Workspace.GetMeshNodeStream()
+            .Select(n => (MeshNode?)n)
+            .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null))
+            .StartWith((MeshNode?)null);
+
+        return nodeStream.CombineLatest(
+            host.Hub.GetEffectivePermissions(hubPath),
+            (node, perms) =>
+            {
+                if (node is null || node.NodeType != DeckNodeType.NodeType || !perms.HasFlag(Permission.Read))
+                    return (IReadOnlyCollection<NodeMenuItemDefinition>)[];
+
+                return
+                [
+                    new NodeMenuItemDefinition(
+                        Label: MarkdownExportMenuProvider.PdfLabel,
+                        Area: ExportDocumentLayoutArea.PdfArea,
+                        RequiredPermission: Permission.Read,
+                        Order: 27,
+                        Href: MeshNodeLayoutAreas.BuildUrl(hubPath, ExportDocumentLayoutArea.PdfArea)),
+                ];
+            });
+    }
+}

--- a/src/MeshWeaver.Markdown.Export/Pdf/PdfDocumentRenderer.cs
+++ b/src/MeshWeaver.Markdown.Export/Pdf/PdfDocumentRenderer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using MeshWeaver.Markdown.Export.Branding;
+using MeshWeaver.Markdown.Export.Configuration;
 using MeshWeaver.Markdown.Export.Model;
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
@@ -31,9 +32,16 @@ public class PdfDocumentRenderer
         }).GeneratePdf();
     }
 
+    /// <summary>
+    /// Applies the page size honouring the document's orientation option — A4 portrait by
+    /// default, A4 landscape when <see cref="DocumentExportOptions.Landscape"/> is set (decks).
+    /// </summary>
+    private static void ApplyPageSize(PageDescriptor page, Document document)
+        => page.Size(document.Options.Landscape ? PageSizes.A4.Landscape() : PageSizes.A4);
+
     private static void ComposeCover(PageDescriptor page, Document document)
     {
-        page.Size(PageSizes.A4);
+        ApplyPageSize(page, document);
         page.Margin(2, Unit.Centimetre);
         page.DefaultTextStyle(x => x.FontFamily(document.Branding.FontFamily));
 
@@ -72,7 +80,7 @@ public class PdfDocumentRenderer
 
     private static void ComposeToc(PageDescriptor page, Document document)
     {
-        page.Size(PageSizes.A4);
+        ApplyPageSize(page, document);
         page.Margin(2, Unit.Centimetre);
         page.DefaultTextStyle(x => x.FontFamily(document.Branding.FontFamily));
         ApplyHeader(page, document);
@@ -105,7 +113,7 @@ public class PdfDocumentRenderer
 
     private static void ComposeBody(PageDescriptor page, Document document)
     {
-        page.Size(PageSizes.A4);
+        ApplyPageSize(page, document);
         page.Margin(2, Unit.Centimetre);
         page.DefaultTextStyle(x => x.FontFamily(document.Branding.FontFamily).FontSize(11));
         ApplyHeader(page, document);

--- a/src/MeshWeaver.Markdown.Export/Templates/ExportPdf.csx
+++ b/src/MeshWeaver.Markdown.Export/Templates/ExportPdf.csx
@@ -1,6 +1,7 @@
-// Built-in export template — renders a Markdown node (and optional descendants)
-// to PDF. Triggered via ExecuteScriptRequest with Inputs:
-//   sourcePath:     string  (required) — mesh path of the markdown source
+// Built-in export template — renders a Markdown node (and optional descendants), OR a
+// Deck node (one chapter per slide, in the deck's manifest/query order), to PDF.
+// Triggered via ExecuteScriptRequest with Inputs:
+//   sourcePath:     string  (required) — mesh path of the markdown / deck source
 //   title:          string  (optional) — document title; defaults to node.Name
 //   brandNodePath:  string  (optional) — CorporateIdentity / Organization path
 //   options:        object  (optional) — DocumentExportOptions JSON (IncludeChildren, MaxDepth, …)
@@ -15,6 +16,8 @@ using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading;
 using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Markdown;
 using MeshWeaver.Markdown.Export;
 using MeshWeaver.Markdown.Export.Ast;
@@ -42,53 +45,121 @@ var explicitTitle = Inputs.TryGetValue("title", out var t) && t.ValueKind == Jso
     ? t.GetString()
     : null;
 
-Log.LogInformation("Loading source markdown {Path}", sourcePath);
+Log.LogInformation("Loading source {Path}", sourcePath);
 var rootNode = await Mesh.GetMeshNode(sourcePath, TimeSpan.FromSeconds(15)).ToTask(Ct);
 if (rootNode is null)
     throw new InvalidOperationException("Source node not found: " + sourcePath);
 
-var title = explicitTitle ?? options.Title ?? rootNode.Name ?? rootNode.Id;
+var jsonOptions = Mesh.JsonSerializerOptions;
+
+List<(string, string)> chapters;
+DocumentExportOptions effectiveOptions;
+string title;
+
+if (rootNode.NodeType == DeckNodeType.NodeType)
+{
+    // ── Deck → PDF: one chapter per slide, in the deck's own order ──────────────
+    var deck = rootNode.ContentAs<DeckContent>(jsonOptions);
+    title = explicitTitle ?? options.Title ?? deck?.Title ?? rootNode.Name ?? rootNode.Id;
+
+    // Resolve the deck's slide SELECTION with the SAME logic the live Overview/Present
+    // binding uses — the manifest (ordered paths) or, when empty, the deck's query / the
+    // default Slide subtree. One source of truth for a deck's order.
+    var (paths, query) = DeckLayoutAreas.ResolveDeckSelection(rootNode, sourcePath, jsonOptions);
+
+    var slideNodes = new List<MeshNode>();
+    if (paths.Count > 0)
+    {
+        foreach (var slidePath in paths)
+        {
+            var slide = await Mesh.GetMeshNode(slidePath, TimeSpan.FromSeconds(15)).ToTask(Ct);
+            if (slide is not null)
+                slideNodes.Add(slide);
+        }
+    }
+    else if (!string.IsNullOrWhiteSpace(query))
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var matched = new List<MeshNode>();
+        var enumerator = meshService.QueryAsync<MeshNode>(query).GetAsyncEnumerator(Ct);
+        try
+        {
+            while (await enumerator.MoveNextAsync())
+            {
+                var n = enumerator.Current;
+                // Drop the deck root itself and any '_'-prefixed governance node — same
+                // filtering the live query binding applies (see DeckLayoutAreas.ObserveQuerySlides).
+                if (string.Equals(n.Path, sourcePath, StringComparison.Ordinal)) continue;
+                if (n.Segments.Skip(1).Any(s => s.StartsWith('_'))) continue;
+                matched.Add(n);
+            }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync();
+        }
+        slideNodes = matched
+            .OrderBy(n => n.Order ?? int.MaxValue)
+            .ThenBy(n => n.Path, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    Log.LogInformation("Deck export: {Count} slides", slideNodes.Count);
+    chapters = slideNodes
+        .Select(s => (s.Name ?? s.Id, ExtractSlideMarkdown(s, jsonOptions)))
+        .ToList();
+    if (chapters.Count == 0)
+        chapters.Add((title, "*This deck has no slides yet.*"));
+
+    // 16:9 slides read best in landscape, and every slide starts on its own page.
+    effectiveOptions = options with { Landscape = true, PageBreakBetweenChildren = true };
+}
+else
+{
+    // ── Markdown → PDF: the node's own body plus optional descendant chapters ───
+    title = explicitTitle ?? options.Title ?? rootNode.Name ?? rootNode.Id;
+    effectiveOptions = options;
+    chapters = new List<(string, string)>
+    {
+        (title, ExtractMarkdown(rootNode))
+    };
+    if (options.IncludeChildren)
+    {
+        Log.LogInformation("Collecting descendants");
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var rootDepth = sourcePath.Count(c => c == '/');
+        var enumerator = meshService
+            .QueryAsync<MeshNode>("path:" + sourcePath + " scope:descendants")
+            .GetAsyncEnumerator(Ct);
+        try
+        {
+            while (await enumerator.MoveNextAsync())
+            {
+                var desc = enumerator.Current;
+                if (options.MaxDepth > 0)
+                {
+                    var depth = desc.Path.Count(c => c == '/') - rootDepth;
+                    if (depth > options.MaxDepth) continue;
+                }
+                var md = ExtractMarkdown(desc);
+                if (!string.IsNullOrWhiteSpace(md))
+                    chapters.Add((desc.Name ?? desc.Id, md));
+            }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync();
+        }
+        Log.LogInformation("Collected {Count} chapters", chapters.Count);
+    }
+}
 
 Log.LogInformation("Resolving branding");
 var brandingResolver = Mesh.ServiceProvider.GetRequiredService<BrandingResolver>();
 var branding = await brandingResolver.Resolve(brandPath).FirstAsync().ToTask(Ct);
 
-var chapters = new List<(string, string)>
-{
-    (title, ExtractMarkdown(rootNode))
-};
-if (options.IncludeChildren)
-{
-    Log.LogInformation("Collecting descendants");
-    var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
-    var rootDepth = sourcePath.Count(c => c == '/');
-    var enumerator = meshService
-        .QueryAsync<MeshNode>("path:" + sourcePath + " scope:descendants")
-        .GetAsyncEnumerator(Ct);
-    try
-    {
-        while (await enumerator.MoveNextAsync())
-        {
-            var desc = enumerator.Current;
-            if (options.MaxDepth > 0)
-            {
-                var depth = desc.Path.Count(c => c == '/') - rootDepth;
-                if (depth > options.MaxDepth) continue;
-            }
-            var md = ExtractMarkdown(desc);
-            if (!string.IsNullOrWhiteSpace(md))
-                chapters.Add((desc.Name ?? desc.Id, md));
-        }
-    }
-    finally
-    {
-        await enumerator.DisposeAsync();
-    }
-    Log.LogInformation("Collected {Count} chapters", chapters.Count);
-}
-
 Log.LogInformation("Rendering PDF");
-var document = new DocumentBuilder().Build(title, chapters, options, branding);
+var document = new DocumentBuilder().Build(title, chapters, effectiveOptions, branding);
 var bytes = new PdfDocumentRenderer().Render(document);
 Log.LogInformation("Rendered {Bytes} bytes", bytes.Length);
 
@@ -103,6 +174,13 @@ static string ExtractMarkdown(MeshNode node)
     if (node.Content is MarkdownContent mc) return mc.Content ?? "";
     if (node.Content is string s) return s;
     return "";
+}
+
+static string ExtractSlideMarkdown(MeshNode node, JsonSerializerOptions options)
+{
+    var slide = node.ContentAs<SlideContent>(options);
+    if (slide?.Content is { } content) return content;
+    return ExtractMarkdown(node);
 }
 
 static string Sanitize(string s)

--- a/test/MeshWeaver.Hosting.Monolith.Test/DeckExportScriptRelayTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DeckExportScriptRelayTest.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown.Export.Configuration;
+using MeshWeaver.Markdown.Export.Messaging;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// End-to-end test for the <b>Deck → PDF</b> export (issue #423, piece 1). Verifies that
+/// posting an <see cref="ExportDocumentRequest"/> at a <c>Deck</c> node routes through the SAME
+/// script-templated pipeline as the markdown export (<c>Templates/Export/Pdf</c>), but the
+/// template's <c>NodeType == "Deck"</c> branch resolves the deck's ordered slides and renders
+/// ONE page per slide — content-faithful (each slide's text present) and landscape (16:9).
+/// <para>Mirrors <see cref="ExportDocumentScriptRelayTest"/> for the dispatch/terminal shape and
+/// <c>DeckLayoutAreaTest</c> for the deck/slide seeding; re-reads the PDF bytes with PdfPig
+/// (the trick <c>PdfXlsxConversionTest</c> uses) to assert the rendered content.</para>
+/// </summary>
+public class DeckExportScriptRelayTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMarkdownExport();
+
+    [Fact(Timeout = 120000)]
+    public async Task DeckExport_RendersOnePagePerSlide_ContentFaithful_Landscape()
+    {
+        // ── Seed a Space partition holding a Deck with three ordered Slide children. Each
+        // slide carries a UNIQUE single-word token (contiguous glyphs survive PDF text
+        // extraction intact) so we can prove every slide's content made it into the PDF. ──
+        var space = $"Space{Guid.NewGuid():N}"[..16];
+        await NodeFactory.CreateNode(MeshNode.FromPath(space) with
+        {
+            Name = "Deck Export Space",
+            NodeType = SpaceNodeType.NodeType,
+            Content = new Space()
+        }).Should().Emit();
+
+        var deck = $"{space}/pitch";
+        var s1 = $"{deck}/intro";
+        var s2 = $"{deck}/metrics";
+        var s3 = $"{deck}/summary";
+        await NodeFactory.CreateNode(MeshNode.FromPath(deck) with
+        {
+            Name = "Pitch Deck",
+            NodeType = DeckNodeType.NodeType,
+            Content = new DeckContent { Title = "Pitch Deck", Slides = [s1, s2, s3] }
+        }).Should().Emit();
+
+        await CreateSlide(s1, "Intro", 1, "# Introduction\n\nThis opening slide is about ALPHAWIDGET.");
+        // A markdown table exercises the structured-content path (tables must render, not dump).
+        await CreateSlide(s2, "Metrics", 2,
+            "## Metrics\n\n| Region | Value |\n|---|---|\n| NORTHREGION | 42 |\n| SOUTHREGION | 17 |\n");
+        await CreateSlide(s3, "Summary", 3, "# Summary\n\nFinal thoughts on GAMMAWIDGET.");
+
+        // ── Dispatch the deck export. Handler returns immediately with the activity path
+        // (no wait-for-terminal in the hub); format stays PDF, the DECK branch is chosen by
+        // the template from the node's NodeType, not by the request. ──
+        var request = new ExportDocumentRequest(deck, new DocumentExportOptions
+        {
+            Format = ExportFormat.Pdf,
+            CoverPage = false,      // deterministic page count — body pages only
+            TableOfContents = false
+        });
+
+        var dispatch = await Mesh
+            .Observe<ExportDocumentResponse>(request, o => o.WithTarget(new Address(deck)))
+            .Should().Within(30.Seconds()).Emit();
+
+        dispatch.Message.Error.Should().BeNullOrEmpty("the deck export should start successfully");
+        dispatch.Message.ActivityPath.Should().NotBeNullOrEmpty(
+            "the response should carry the running activity's path");
+
+        // ── Wait for the script to reach terminal status on its own activity node stream. ──
+        var workspace = GetClient(c => c.AddData()).GetWorkspace();
+        var terminal = await workspace
+            .GetMeshNodeStream(dispatch.Message.ActivityPath)
+            .Select(node => node?.Content as ActivityLog)
+            .Should().Within(2.Minutes())
+            .Match(log => log is not null && log.Status != ActivityStatus.Running);
+
+        terminal!.Status.Should().Be(ActivityStatus.Succeeded,
+            because: "the deck should render to PDF without errors. Messages:\n  "
+                     + string.Join("\n  ", terminal.Messages.Select(m => $"[{m.LogLevel}] {m.Message}")));
+
+        terminal.ReturnValue.Should().NotBeNull("the script should record its rendered output");
+        var rendered = terminal.ReturnValue!.Value.Deserialize<RenderedDocument>(Mesh.JsonSerializerOptions);
+        rendered.Should().NotBeNull("ActivityLog.ReturnValue should deserialise to RenderedDocument");
+        rendered!.Format.Should().Be(ExportFormat.Pdf);
+        rendered.MimeType.Should().Be("application/pdf");
+        rendered.FileName.Should().EndWith(".pdf");
+        rendered.Content.Should().NotBeNull().And.NotBeEmpty();
+
+        // ── Re-read the produced PDF and assert content faithfulness + layout. ──
+        using var pdf = PdfDocument.Open(rendered.Content);
+        var text = string.Join("\n", pdf.GetPages().Select(p => p.Text));
+        Output.WriteLine($"Deck PDF pages={pdf.NumberOfPages}\n{text}");
+
+        // Every slide's unique token must appear — the deck exported ALL slides' content.
+        text.Should().Contain("ALPHAWIDGET", "slide 1's paragraph text must be in the PDF");
+        text.Should().Contain("NORTHREGION", "slide 2's TABLE cell must render into the PDF");
+        text.Should().Contain("SOUTHREGION", "slide 2's second table row must render too");
+        text.Should().Contain("GAMMAWIDGET", "slide 3's paragraph text must be in the PDF");
+
+        // One page per slide (page break between slides).
+        pdf.NumberOfPages.Should().BeGreaterThanOrEqualTo(3,
+            "each of the three slides starts on its own page");
+
+        // Landscape orientation (16:9): A4 landscape is wider than tall.
+        var firstPage = pdf.GetPage(1);
+        firstPage.Width.Should().BeGreaterThan(firstPage.Height,
+            "the deck export defaults to landscape so 16:9 slides fill the page");
+
+        await NodeFactory.DeleteNode(space).Should().Emit();
+    }
+
+    private async Task CreateSlide(string path, string name, int order, string body)
+        => await NodeFactory.CreateNode(MeshNode.FromPath(path) with
+        {
+            Name = name,
+            NodeType = SlideNodeType.NodeType,
+            Order = order,
+            Content = new SlideContent { Content = body, Notes = $"Notes for {name}" }
+        }).Should().Emit();
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshWeaver.Hosting.Monolith.Test.csproj
@@ -12,6 +12,8 @@
         <PackageReference Include="Azure.Storage.Blobs" />
         <PackageReference Include="Namotion.Reflection" />
         <PackageReference Include="NSubstitute" />
+        <!-- Re-reads exported PDF bytes to assert content faithfulness (DeckExportScriptRelayTest). -->
+        <PackageReference Include="UglyToad.PdfPig" />
     </ItemGroup>
     <ItemGroup>
         <Content Include="Markdown\**">

--- a/test/MeshWeaver.Security.Test/MarkdownExportMenuTest.cs
+++ b/test/MeshWeaver.Security.Test/MarkdownExportMenuTest.cs
@@ -29,6 +29,7 @@ public class MarkdownExportMenuTest(ITestOutputHelper output) : MonolithMeshTest
     protected override bool ShareMeshAcrossTests => true;
 
     private const string MarkdownNodePath = "TestOrg/TestMarkdown";
+    private const string DeckNodePath = "TestOrg/TestDeck";
 
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder)
@@ -38,6 +39,12 @@ public class MarkdownExportMenuTest(ITestOutputHelper output) : MonolithMeshTest
                 {
                     Name = "Test Markdown",
                     NodeType = MarkdownNodeType.NodeType
+                },
+                new MeshNode("TestDeck", "TestOrg")
+                {
+                    Name = "Test Deck",
+                    NodeType = DeckNodeType.NodeType,
+                    Content = new DeckContent { Title = "Test Deck" }
                 }
             )
             .AddMarkdownExport()
@@ -96,5 +103,29 @@ public class MarkdownExportMenuTest(ITestOutputHelper output) : MonolithMeshTest
         var docxItem = items.First(i => i.Label == MarkdownExportMenuProvider.DocxLabel);
         docxItem.Area.Should().Be(ExportDocumentLayoutArea.DocxArea,
             "DOCX item must navigate to the DOCX export layout area");
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task DeckNode_NodeMenu_ContainsPdfExportItem_NotDocx()
+    {
+        var client = GetClient();
+        var nodeAddress = new Address(DeckNodePath);
+
+        var items = await FetchNodeMenuItems(client, nodeAddress);
+
+        Output.WriteLine($"Node menu items for Deck node: {items.Count}");
+        foreach (var item in items)
+            Output.WriteLine($"  {item.Label} (Area={item.Area}, Order={item.Order})");
+
+        items.Select(i => i.Label).Should().Contain(MarkdownExportMenuProvider.PdfLabel,
+            "DeckExportMenuProvider should contribute 'Export to PDF' for nodes with NodeType=Deck");
+        // A deck carries no markdown body of its own, so DOCX export (which renders the node's own
+        // content) is deliberately NOT offered.
+        items.Select(i => i.Label).Should().NotContain(MarkdownExportMenuProvider.DocxLabel,
+            "a Deck exposes PDF export only — DOCX would render the deck's (empty) own body");
+
+        var pdfItem = items.First(i => i.Label == MarkdownExportMenuProvider.PdfLabel);
+        pdfItem.Area.Should().Be(ExportDocumentLayoutArea.PdfArea,
+            "PDF item must navigate to the PDF export layout area");
     }
 }


### PR DESCRIPTION
Partially implements #423 (Piece 1: content-faithful Deck→PDF download; send-to-contacts and pixel-faithful rendering deferred — see the issue).

## What

Adds a content-faithful **Deck → PDF** export that renders a slide deck to a single PDF (one page per slide) and downloads it, reusing the existing QuestPDF export pipeline unchanged. No new request/response type: a deck exports through the same `ExportDocumentRequest → ScriptDispatch → Templates/Export/Pdf → DocumentBuilder / PdfDocumentRenderer → ActivityLog.ReturnValue` path the markdown export uses. The PDF template branches on `NodeType == "Deck"`.

## Changes

- **`ExportPdf.csx`** — new `NodeType == "Deck"` branch: resolves the deck's ordered slides with the SAME logic the live Overview/Present binding uses (`DeckLayoutAreas.ResolveDeckSelection` — the explicit `Slides` manifest, else the deck's `Query` / default `nodeType:Slide scope:subtree`), loads each `SlideContent`, and builds one chapter per slide (title = slide name, body = slide markdown). The markdown export path is untouched.
- **`DeckLayoutAreas`** — extracted the pure (IO-free) `ResolveDeckSelection` helper (and made `ResolveSlidePath` public) so a deck's order lives in ONE place shared by the live binding and the export; `ObserveSlideNodes` now delegates to it.
- **`DocumentExportOptions.Landscape`** + **`PdfDocumentRenderer`** honours it. The deck export defaults to landscape (16:9); markdown export stays portrait A4.
- **`DocumentBuilder`** — the page break now precedes the chapter title, so each slide (and each markdown chapter) starts at the top of a fresh page instead of orphaning the heading at the foot of the previous page.
- **`DeckExportMenuProvider`** — contributes "Export to PDF" for `Deck` nodes (self-gated on `NodeType == "Deck"`, registered via `TryAddEnumerable` on the default node hub). PDF only: a deck has no markdown body of its own, so DOCX (which renders the node's own content) is deliberately not offered. The existing `ExportDocumentLayoutArea`/`ExportDocumentView` are reused unchanged — they already live on every per-node hub via `ConfigureDefaultNodeHub`.

## Tests

- **`DeckExportScriptRelayTest`** (new) — seeds a Space + Deck + 3 Slides (one with a markdown table), runs the deck export end-to-end, and re-reads the produced PDF with **PdfPig** to assert every slide's text (including a table cell) is present, page count ≥ number of slides, and landscape orientation.
- **`MarkdownExportMenuTest`** — added a Deck case: "Export to PDF" present, "Export to DOCX" absent.
- Regression: `DocumentBuilderTests` (19/19), `DeckLayoutAreaTest` + `SlideLayoutAreaTest` (11/11), `ExportDocumentScriptRelayTest` all green after the shared-helper refactor.

Local build: `dotnet build -c Release -warnaserror -p:CIRun=true` clean (0 warnings) for every touched project and both test projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)