### PR TITLE
fix(security): redact User email PII on read for non-owner/non-admin (#471 RC1)

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -17,6 +17,7 @@ using MeshWeaver.Layout;
 using MeshWeaver.Domain;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Graph.Security;
 using MeshWeaver.Mesh;
 using MeshWeaver.Kernel;
 using MeshWeaver.Mesh.Security;
@@ -282,6 +283,12 @@ public class MeshOperations
     /// </summary>
     private IObservable<string> ReadNodeOrUnified(string resolvedPath)
     {
+        // Capture the caller identity synchronously: the AccessContext AsyncLocal is cleared
+        // across .Subscribe hops, so read it now (Get runs under the caller's context) and thread
+        // it into the reactive chain for the User-PII read projection below.
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var caller = accessService?.Context ?? accessService?.CircuitContext;
+
         // Single-node content read via GetDataRequest + MeshNodeReference + RegisterCallback.
         // See Doc/Architecture/CqrsAndContentAccess.md — queries are for sets only.
         return TryResolveUnifiedPath(resolvedPath)
@@ -305,12 +312,16 @@ public class MeshOperations
                         return unifiedError is not null
                             ? Observable.Return(unifiedError)
                             : GetWithBrokenNodeTypeFallback(resolvedPath);
-                    return LookupCompilationError(node)
-                        .Select(compileError => compileError != null
-                            ? JsonSerializer.Serialize(
-                                new { node, compilationError = compileError },
-                                hub.JsonSerializerOptions)
-                            : JsonSerializer.Serialize(node, hub.JsonSerializerOptions));
+                    // Redact PII (email) on a User node for a reader who is neither the subject
+                    // nor a global admin — the User node is world-readable, so its content reaches
+                    // every authenticated caller (issue #471). Non-User nodes pass through unchanged.
+                    return UserPiiRedaction.RedactEmailForReader(hub, node, caller)
+                        .SelectMany(readable => LookupCompilationError(readable)
+                            .Select(compileError => compileError != null
+                                ? JsonSerializer.Serialize(
+                                    new { node = readable, compilationError = compileError },
+                                    hub.JsonSerializerOptions)
+                                : JsonSerializer.Serialize(readable, hub.JsonSerializerOptions)));
                 });
             })
             .Catch((Exception ex) =>

--- a/src/MeshWeaver.Graph/Security/UserPiiRedaction.cs
+++ b/src/MeshWeaver.Graph/Security/UserPiiRedaction.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Graph.Security;
+
+/// <summary>
+/// Read-time redaction of the PII on <see cref="User"/> nodes. User nodes are world-readable
+/// (<c>WithPublicRead</c>), so their content is served to every authenticated caller. The email
+/// address is PII: it must be visible ONLY to the subject (the user themselves) and to global
+/// admins — never to arbitrary authenticated readers (GitHub issue #471, RC1).
+/// <para>
+/// This is a READ PROJECTION, not a storage change. The stored node keeps the real email, so the
+/// System-identity email→userId login lookup (<c>UserContextMiddleware.TryLoadMeshUser</c>, which
+/// queries <c>content.email</c> under <c>ImpersonateAsHub</c> and never routes through this helper)
+/// keeps resolving. The display <b>name</b> is never redacted — only the email.
+/// </para>
+/// <para>
+/// There is deliberately no single per-caller content-projection seam in the mesh: a single-node
+/// read via <c>GetMeshNodeStream</c> is a SHARED subscription — the owning hub broadcasts ONE node
+/// value to every subscriber on a silo, so it cannot project per-reader. Redaction is therefore
+/// applied at the read surfaces that carry the caller's identity and actually expose the email:
+/// the MCP/agent single-node read (<c>MeshOperations.Get</c>) and the GUI visitor profile
+/// (<c>UserActivityLayoutAreas.BuildVisitorProfile</c>). Search/enumeration returns only a
+/// {path,name,nodeType,version,lastModified} projection and never carries the email.
+/// </para>
+/// </summary>
+public static class UserPiiRedaction
+{
+    /// <summary>
+    /// Returns <paramref name="node"/> with <see cref="User.Email"/> nulled when it is a User node
+    /// carrying an email; a no-op for non-User nodes or an already-null email. Pure — never mutates
+    /// the input (returns a <c>with</c>-copy), so the stored/queried node is untouched.
+    /// </summary>
+    public static MeshNode RedactEmail(MeshNode node, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        if (!string.Equals(node.NodeType, UserNodeType.NodeType, StringComparison.Ordinal))
+            return node;
+        var user = node.ContentAs<User>(options);
+        if (user is null || user.Email is null)
+            return node;
+        return node with { Content = user with { Email = null } };
+    }
+
+    /// <summary>
+    /// Per-reader projection: emits <paramref name="node"/> unchanged when the reader is the subject
+    /// of the User node or a global admin; otherwise emits it with the email redacted. Non-User
+    /// nodes pass through unchanged. Single emission, reactive (no <c>await</c>).
+    /// </summary>
+    public static IObservable<MeshNode> RedactEmailForReader(
+        IMessageHub hub, MeshNode node, AccessContext? viewer)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        ArgumentNullException.ThrowIfNull(node);
+
+        var options = hub.JsonSerializerOptions;
+        if (!string.Equals(node.NodeType, UserNodeType.NodeType, StringComparison.Ordinal))
+            return Observable.Return(node);
+
+        // The subject sees their own email (same owner predicate the home page uses).
+        var ownerId = OwnerIdOf(node.Path);
+        if (UserActivityLayoutAreas.IsViewerOwner(viewer, ownerId))
+            return Observable.Return(node);
+
+        // Anonymous / virtual readers never see it.
+        var viewerId = viewer?.ObjectId;
+        if (string.IsNullOrEmpty(viewerId) || viewer?.IsVirtual == true)
+            return Observable.Return(RedactEmail(node, options));
+
+        // Global admins (Permission.All at the Admin scope) see it; everyone else gets it redacted.
+        // Fail-secure: a slow/faulted admin probe redacts rather than leaks.
+        var redacted = RedactEmail(node, options);
+        return hub.IsGlobalAdmin(viewerId)
+            .Take(1)
+            .Select(isAdmin => isAdmin ? node : redacted)
+            .Timeout(TimeSpan.FromSeconds(5), Observable.Return(redacted))
+            .Catch<MeshNode, Exception>(_ => Observable.Return(redacted));
+    }
+
+    /// <summary>Subject id from a User node path (<c>"User/Alice" → "Alice"</c>, else verbatim).</summary>
+    private static string OwnerIdOf(string? path)
+        => string.IsNullOrEmpty(path)
+            ? string.Empty
+            : path.StartsWith("User/", StringComparison.OrdinalIgnoreCase)
+                ? path["User/".Length..]
+                : path;
+}

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -144,20 +144,31 @@ public static class UserActivityLayoutAreas
 
         var syncStream = host.Workspace.GetStream(new MeshNodeReference());
 
+        // Email is PII on the world-readable User node (issue #471): the visitor profile shows it
+        // ONLY to the subject or a global admin. The owner already sees their own home; every other
+        // viewer starts REDACTED (secure default) and the email is revealed only once global-admin
+        // is confirmed. IsGlobalAdmin rides the live AccessAssignment stream, so StartWith(false)
+        // renders immediately and DistinctUntilChanged drops the duplicate initial false.
+        var viewerId = capturedAccessContext?.ObjectId;
+        var canSeeEmail = isOwner || string.IsNullOrEmpty(viewerId) || capturedAccessContext?.IsVirtual == true
+            ? Observable.Return(isOwner)
+            : host.Hub.IsGlobalAdmin(viewerId).StartWith(false).DistinctUntilChanged();
+
         // The composer region (@@("area/Composer")) renders its ThreadChatControl INLINE — a pure
         // layout area with no backing node (see ComposerAreaView) — so the dashboard no longer has to
         // ensure-create a {owner}/Chat node before rendering. Nothing to gate on: bind straight to the
         // owner-node sync stream.
         return syncStream!
-            .Select(change =>
+            .CombineLatest(canSeeEmail, (change, showEmail) => (change, showEmail))
+            .Select(t =>
             {
-                var ownerNode = change.Value;
+                var ownerNode = t.change.Value;
                 var ownerName = ownerNode?.Name ?? nodeOwnerId;
 
                 if (isOwner)
                     return (UiControl?)BuildOwnerHome(nodePath, ownerName, ownerNode, host.Hub.JsonSerializerOptions);
                 else
-                    return (UiControl?)BuildVisitorProfile(nodePath, ownerName, ownerNode);
+                    return (UiControl?)BuildVisitorProfile(nodePath, ownerName, ownerNode, t.showEmail);
             })
             // The area must NEVER spin forever, but it must ALSO never tear itself down
             // while idle. Two distinct failure modes, ONE narrow guard:
@@ -651,9 +662,11 @@ public static class UserActivityLayoutAreas
 
     /// <summary>
     /// Public profile shown to visitors — UserProfileControl (rendered by Blazor)
-    /// with child nodes and recent activity below.
+    /// with child nodes and recent activity below. <paramref name="showEmail"/> gates the PII email
+    /// field: it is populated ONLY for the subject or a global admin (issue #471); every other
+    /// viewer sees the profile without the email.
     /// </summary>
-    private static UiControl BuildVisitorProfile(string nodePath, string ownerName, MeshNode? ownerNode)
+    private static UiControl BuildVisitorProfile(string nodePath, string ownerName, MeshNode? ownerNode, bool showEmail)
     {
         // Compute owner partition path (post-v10 each user has their own
         // partition; legacy /User/{userid}/... maps to {userid}/... content)
@@ -674,6 +687,10 @@ public static class UserActivityLayoutAreas
             if (je.TryGetProperty("Bio", out var bioProp) || je.TryGetProperty("bio", out bioProp))
                 bio = bioProp.GetString();
         }
+
+        // Redact the email unless the viewer is the subject or a global admin (issue #471).
+        if (!showEmail)
+            email = null;
 
         var profile = Controls.Stack
             .WithWidth("100%")

--- a/test/MeshWeaver.Security.Test/UserEmailPiiRedactionTest.cs
+++ b/test/MeshWeaver.Security.Test/UserEmailPiiRedactionTest.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Security;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// Redaction of the PII email on world-readable <see cref="User"/> nodes (GitHub issue #471, RC1).
+/// The subject and global admins see the real email; every other authenticated reader (and
+/// anonymous) sees it redacted. The display name is never redacted, and the STORED node keeps the
+/// real email so the System-identity email→userId login lookup keeps resolving.
+/// </summary>
+public class UserEmailPiiRedactionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string OwnerId = "Alice";
+    private const string OwnerEmail = "alice@example.com";
+    private const string AdminUserId = "AdminUser";
+
+    private CancellationToken Ct => new CancellationTokenSource(TimeSpan.FromSeconds(20)).Token;
+
+    // No PublicAdminAccess here — otherwise every user would resolve as a global admin and the
+    // "non-admin → redacted" case could never be exercised. Grant exactly one global admin
+    // (Admin role at the Admin scope) so IsGlobalAdmin is deterministic per identity.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(AssignmentNodeFactory.UserRole(AdminUserId, "Admin", "Admin"));
+
+    private static MeshNode UserNode() => new(OwnerId)
+    {
+        Name = "Alice Smith",
+        NodeType = "User",
+        State = MeshNodeState.Active,
+        Content = new User { FullName = "Alice Smith", Email = OwnerEmail, Role = "Developer", Bio = "Hi there" },
+    };
+
+    private User? ReadUser(MeshNode node) => node.ContentAs<User>(Mesh.JsonSerializerOptions);
+
+    // ── (a) + (e): a non-owner non-admin reader gets the email redacted; the NAME is preserved. ──
+    [Fact(Timeout = 30000)]
+    public async Task NonOwnerNonAdmin_EmailRedacted_NameKept()
+    {
+        var bob = new AccessContext { ObjectId = "Bob", Name = "Bob" };
+        var projected = await UserPiiRedaction.RedactEmailForReader(Mesh, UserNode(), bob)
+            .FirstAsync().ToTask(Ct);
+
+        ReadUser(projected)!.Email.Should().BeNull("a non-owner non-admin reader must not see the PII email");
+        // Name / display identity is NOT redacted.
+        projected.Name.Should().Be("Alice Smith");
+        ReadUser(projected)!.FullName.Should().Be("Alice Smith");
+        ReadUser(projected)!.Role.Should().Be("Developer");
+    }
+
+    // ── (b): the subject (owner) sees their own real email. ──
+    [Fact(Timeout = 30000)]
+    public async Task Owner_SeesOwnEmail()
+    {
+        var owner = new AccessContext { ObjectId = OwnerId, Name = OwnerId };
+        var projected = await UserPiiRedaction.RedactEmailForReader(Mesh, UserNode(), owner)
+            .FirstAsync().ToTask(Ct);
+
+        ReadUser(projected)!.Email.Should().Be(OwnerEmail);
+    }
+
+    // ── (c): a global admin sees the real email. ──
+    [Fact(Timeout = 30000)]
+    public async Task GlobalAdmin_SeesEmail()
+    {
+        var admin = new AccessContext { ObjectId = AdminUserId, Name = AdminUserId };
+        var projected = await UserPiiRedaction.RedactEmailForReader(Mesh, UserNode(), admin)
+            .FirstAsync().ToTask(Ct);
+
+        ReadUser(projected)!.Email.Should().Be(OwnerEmail);
+    }
+
+    // ── Anonymous readers never see it. ──
+    [Fact(Timeout = 30000)]
+    public async Task Anonymous_EmailRedacted()
+    {
+        var projected = await UserPiiRedaction.RedactEmailForReader(Mesh, UserNode(), viewer: null)
+            .FirstAsync().ToTask(Ct);
+
+        ReadUser(projected)!.Email.Should().BeNull();
+    }
+
+    // ── (d): redaction is a READ PROJECTION, never a mutation — the input/stored node is untouched,
+    //         so the System-identity email→userId login lookup (which reads the stored value) still
+    //         resolves. Non-User nodes pass through unchanged. ──
+    [Fact(Timeout = 30000)]
+    public async Task Redaction_DoesNotMutateStoredNode_And_PassesNonUserNodesThrough()
+    {
+        var stored = UserNode();
+        var bob = new AccessContext { ObjectId = "Bob", Name = "Bob" };
+
+        var projected = await UserPiiRedaction.RedactEmailForReader(Mesh, stored, bob)
+            .FirstAsync().ToTask(Ct);
+
+        // The projection returned a redacted COPY; the original (stored) node keeps the real email,
+        // so the content.email login lookup under System identity is unaffected.
+        ReadUser(projected)!.Email.Should().BeNull();
+        ReadUser(stored)!.Email.Should().Be(OwnerEmail, "redaction must not mutate the stored node");
+
+        // A non-User node is never touched (short-circuits on NodeType, returning the same instance).
+        var markdown = new MeshNode("Page") { Name = "A Page", NodeType = "Markdown" };
+        var passthrough = await UserPiiRedaction.RedactEmailForReader(Mesh, markdown, bob)
+            .FirstAsync().ToTask(Ct);
+        passthrough.Should().BeSameAs(markdown);
+    }
+}


### PR DESCRIPTION
Partially fixes #471 (RC1: the urgent email-PII leak; the enumeration/feed/discovery roots are held for maintainer review — see the issue RCA).

## Problem
`User.Email` is a field on the `User` content record, and the `User` node is `WithPublicRead` (`UserAccessRule.HasAccess` grants Read to any authenticated user) with no per-field RLS. So every authenticated caller could read every user's email (GDPR-relevant PII). The email was returned by the MCP/agent single-node read and rendered in the GUI visitor profile.

## Choke point
There is **no single per-caller content-projection seam**: a single-node read via `GetMeshNodeStream` is a *shared* subscription — the owning hub broadcasts one node value to every subscriber on a silo, so it cannot project per-reader. Redaction is therefore applied via **one shared helper** (`UserPiiRedaction`) at the two read surfaces that carry the caller's identity **and** actually expose the email:

1. **MCP/agent single-node read** — `MeshOperations.Get` → `ReadNodeOrUnified` (`src/MeshWeaver.AI`).
2. **GUI visitor profile** — `UserActivityLayoutAreas.Activity` / `BuildVisitorProfile` (`src/MeshWeaver.Graph`).

Search/enumeration returns only a `{path,name,nodeType,version,lastModified}` projection and never carried the email, so it needed no change.

## Rules
- The subject (owner) and **global admins** (`hub.IsGlobalAdmin`) see the real email; every other authenticated reader — and anonymous/virtual — gets it redacted. Secure default: hidden until owner/admin is confirmed.
- **The display name is never redacted** — only `Email`. `Bio` is left intact (it is public profile info shown in the visitor profile).
- **Read projection, not a storage change**: the stored node keeps the real email, so the System-identity `email→userId` login lookup (`UserContextMiddleware.TryLoadMeshUser`, which queries `content.email` under `ImpersonateAsHub` and never routes through the helper) is unaffected. `UserLookupByEmailTest` stays green.

## Out of scope (held for maintainer greenlight)
The public-read model, the enumeration behavior, the SQL access clauses, and a "shared with me" tab are unchanged.

## Tests
`test/MeshWeaver.Security.Test/UserEmailPiiRedactionTest.cs` (5 tests, all green), revert-proven on both sides:
- **allow**: owner sees own email; global admin sees email.
- **deny**: non-owner non-admin → `Email == null`; anonymous → `Email == null`.
- name/`FullName`/`Role` are NOT redacted; redaction never mutates the stored node (login-lookup source preserved); non-User nodes pass through untouched.

Build: `dotnet build -c Release -warnaserror -p:CIRun=true` on `MeshWeaver.AI` (+ `MeshWeaver.Graph`) and `MeshWeaver.Security.Test` — 0 CS warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)