### PR TITLE
fix(compile): rebuild framework-stale NodeType assemblies + surface real activation errors (#464)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -393,8 +393,73 @@ internal static class NodeTypeCompilationHelpers
                         "Compile recovery: re-trigger Update failed for {HubPath}", hubPath));
             });
 
+        // 🚨 Framework-stale kickoff (issue #464, Defect 1) — PROACTIVE, level-triggered.
+        //
+        // The platform self-update case: a MeshWeaver redeploy changes FrameworkVersion (the
+        // Graph MVID), so every NodeType whose cached assembly was built against the PREVIOUS
+        // build is now ABI-stale — its bytes reference framework members that may have changed
+        // signature, and will throw MissingMethodException the moment they run on the new
+        // binaries. Such a type is still persisted as CompilationStatus=Ok with the OLD
+        // CompiledFrameworkVersion, so NOTHING re-drives it: firstBuildKickoff needs null,
+        // recoveryKickoff needs Compiling, InstallReleaseRequestWatcher needs a fresh
+        // RequestedReleaseAt. The framework-stale self-heal in NodeTypeEnrichmentHelpers only
+        // fires when an INSTANCE of the type is activated — a NodeType with no live instances
+        // stays stale (and `compile`/CreateRelease up-to-date checks could report it clean)
+        // until an operator manually rebuilds it.
+        //
+        // This subscription is the OWNER-side, proactive analogue: when the NodeType's own
+        // hub observes a SETTLED (Ok/Error) state whose cached assembly is framework-stale, it
+        // flips CompilationStatus=Pending so the compile watcher rebuilds it against the current
+        // framework — no instance activation, no user click, no MissingMethodException timebomb.
+        //
+        // Bounded & storm-safe, mirroring firstBuildKickoff/recoveryKickoff:
+        //   • Take(1) — one-shot per hub lifetime; a successful rebuild stamps the CURRENT
+        //     FrameworkVersion so the type is no longer stale and never re-matches.
+        //   • Skips PARKED types — a broken type that terminally failed stays parked (serving
+        //     its cached error); only a deliberate retry (Compile/Recycle/UI button, which
+        //     un-parks) rebuilds it. So a framework-stale type whose sources ALSO don't compile
+        //     against the new framework parks after one attempt instead of storming.
+        //   • Skips static-only types (nothing to Roslyn-compile).
+        //   • ImpersonateAsSystem — a framework-internal self-heal, exactly like the other
+        //     kickoffs (no inbound AccessContext → no "lacks Create" loop).
+        var frameworkStaleKickoffSub = ownStream
+            .Where(node => node?.Content is NodeTypeDefinition def
+                && def.CompilationStatus is CompilationStatus.Ok or CompilationStatus.Error
+                && HasStaleFrameworkBuild(def)
+                && !IsStaticOnlyNodeType(node, def)
+                && parkRegistry?.IsParked(hubPath) != true)
+            .Take(1)
+            .Subscribe(node =>
+            {
+                logger?.LogInformation(
+                    "Framework-stale kickoff: NodeType {HubPath} assembly was compiled against framework {Compiled} but the live framework is {Live} — flipping CompilationStatus=Pending to rebuild",
+                    hubPath,
+                    node.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions)?.CompiledFrameworkVersion ?? "(null)",
+                    FrameworkVersion);
+                var staleAccess = hub.ServiceProvider.GetService<AccessService>();
+                using var systemScope = staleAccess?.ImpersonateAsSystem();
+                workspace.GetMeshNodeStream().Update(curr =>
+                {
+                    if (curr?.Content is not NodeTypeDefinition def) return curr!;
+                    // Don't clobber an in-flight compile (a concurrent enrichment self-heal or
+                    // release request may already have flipped Pending/Compiling).
+                    if (def.CompilationStatus is CompilationStatus.Pending
+                                              or CompilationStatus.Compiling)
+                        return curr;
+                    // Re-check staleness inside the lambda — a genuine rebuild may have refreshed
+                    // CompiledFrameworkVersion between the outer Where and this write.
+                    if (!HasStaleFrameworkBuild(def)) return curr;
+                    return curr with
+                    {
+                        Content = def with { CompilationStatus = CompilationStatus.Pending }
+                    };
+                }).Subscribe(_ => { },
+                    ex => logger?.LogWarning(ex,
+                        "Framework-stale kickoff: Update failed for {HubPath}", hubPath));
+            });
+
         return new CompositeDisposable(
-            watcherSub, firstBuildKickoffSub, recoveryKickoffSub);
+            watcherSub, firstBuildKickoffSub, recoveryKickoffSub, frameworkStaleKickoffSub);
     }
 
     /// <summary>
@@ -859,6 +924,25 @@ internal static class NodeTypeCompilationHelpers
         !string.IsNullOrEmpty(def.LatestAssemblyCollection)
         && !string.IsNullOrEmpty(def.LatestAssemblyPath)
         && string.Equals(def.CompiledFrameworkVersion, FrameworkVersion, StringComparison.Ordinal);
+
+    /// <summary>
+    /// True when this NodeType has a cached compiled assembly (the durable
+    /// <see cref="NodeTypeDefinition.LatestAssemblyCollection"/> /
+    /// <see cref="NodeTypeDefinition.LatestAssemblyPath"/> pair is populated) that was built
+    /// against a DIFFERENT MeshWeaver framework than the live one — i.e. the ONLY reason
+    /// <see cref="HasUsableBuild"/> is false is the framework-version mismatch, not a missing
+    /// assembly. This is the "platform self-update left a stale assembly behind" shape
+    /// (issue #464, Defect 1): the bytes exist but are ABI-incompatible with the current
+    /// process, so they must be rebuilt — a source-clean, never-touched NodeType included.
+    ///
+    /// <para>Distinct from <see cref="HasUsableBuild"/>: a NodeType that was never compiled
+    /// (no assembly fields) is NOT "stale" — it is handled by the first-build kickoff.</para>
+    /// </summary>
+    internal static bool HasStaleFrameworkBuild(NodeTypeDefinition def) =>
+        !string.IsNullOrEmpty(def.LatestAssemblyCollection)
+        && !string.IsNullOrEmpty(def.LatestAssemblyPath)
+        && !string.IsNullOrEmpty(def.CompiledFrameworkVersion)
+        && !string.Equals(def.CompiledFrameworkVersion, FrameworkVersion, StringComparison.Ordinal);
 
     /// <summary>
     /// Compile-and-write-back loop for one NodeType. Runs Roslyn via

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1042,7 +1042,18 @@ public static class MeshDataSourceExtensions
                 // build never happens). IsDirty is the documented
                 // edit→dirty→recompile→clean signal and AwaitCompilationSettled
                 // already handed us the live def, so this needs no re-query.
-                if (!force && !def.IsDirty && !string.IsNullOrEmpty(def.LatestReleasePath))
+                // 🚨 Framework-version gate (issue #464, Defect 1): "up to date" must ALSO mean
+                // "compiled against the CURRENT framework". After a platform self-update the cached
+                // assembly's CompiledFrameworkVersion no longer matches the live FrameworkVersion —
+                // the bytes are ABI-stale and would MissingMethodException at runtime. Without this
+                // guard a source-clean, framework-stale type reports AlreadyUpToDate and never
+                // rebuilds. Treat a framework mismatch as needing a rebuild (never AlreadyUpToDate).
+                var frameworkCurrent = string.Equals(
+                    def.CompiledFrameworkVersion,
+                    NodeTypeCompilationHelpers.FrameworkVersion,
+                    StringComparison.Ordinal);
+                if (!force && !def.IsDirty && frameworkCurrent
+                    && !string.IsNullOrEmpty(def.LatestReleasePath))
                 {
                     hub.Post(new CreateReleaseResponse(true, AlreadyUpToDate: true),
                         o => o.ResponseFor(request));
@@ -1140,6 +1151,13 @@ public static class MeshDataSourceExtensions
     internal static bool IsSourcesUpToDate(NodeTypeDefinition? def, IReadOnlyList<MeshNode> currentSources)
     {
         if (def is null || def.CompiledSources is null || string.IsNullOrEmpty(def.LatestReleasePath))
+            return false;
+        // 🚨 Framework-version gate (issue #464, Defect 1): a cached assembly built against a
+        // PREVIOUS framework is not "up to date" even if every source is unchanged — its bytes are
+        // ABI-stale after a platform self-update. Report it as needing a rebuild so the UI's
+        // Create-Release affordance signals "actionable" rather than "nothing changed".
+        if (!string.Equals(def.CompiledFrameworkVersion,
+                NodeTypeCompilationHelpers.FrameworkVersion, StringComparison.Ordinal))
             return false;
         var compiled = def.CompiledSources;
         var currentPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/MeshWeaver.Hosting.Orleans/GrainActivationFailureRegistry.cs
+++ b/src/MeshWeaver.Hosting.Orleans/GrainActivationFailureRegistry.cs
@@ -1,0 +1,62 @@
+using System.Collections.Concurrent;
+
+namespace MeshWeaver.Hosting.Orleans;
+
+/// <summary>
+/// Mesh-scoped registry of the LAST activation failure observed for each per-node-hub
+/// grain, keyed by the grain's primary key (== the node's address path).
+///
+/// <para><b>The defect this closes (issue #464, Defect 3).</b> When a per-node
+/// <see cref="MessageHubGrain"/> is stuck in a <i>persistent</i> activation-fault loop —
+/// its activation faults almost instantly (a broken NodeType compile can't materialise a
+/// hub configuration), so <c>DeactivateOnIdle</c> fires and the grain's alive window is
+/// ≈ 0 — every delivery (and every one of <see cref="RoutingGrain.DeliverToGrainWithRetry"/>'s
+/// transient retries) lands in a deactivation window. Orleans then answers the raw
+/// <c>OrleansMessageRejectionException</c> ("tried to forward message … after
+/// \"DeactivateOnIdle was called.\" … Rejecting now."). The retry helper NACKs THAT raw
+/// text to the sender, so the GUI sees Orleans internals instead of the real cause
+/// ("Compilation failed for 'X': CS1501 …") — which the grain resolved into
+/// <see cref="MessageHubGrain"/>'s <c>_hubReadyRaw.OnError(ex)</c> on every activation but
+/// which never reaches the sender because <c>DeliverMessage</c> never runs in the loop.</para>
+///
+/// <para><b>How it's used.</b> <see cref="MessageHubGrain"/> records the real activation
+/// error here on every faulted / NACK-fallback activation, and clears it on a genuine
+/// successful activation. <see cref="RoutingGrain"/>, on the exhausted-retry / non-transient
+/// NACK path, falls back to the stored error for the grain key instead of the raw rejection
+/// text — so the sender's <c>Observe(...)</c> fires <c>OnError</c> with a deterministic,
+/// actionable cause and the GUI's resubscribe loop stops spinning.</para>
+///
+/// <para>Mesh-scoped singleton (registered in <c>AddOrleansMeshServices</c>): one instance
+/// shared across the silo's grains, with an instance map only — NO static state
+/// (<c>NoStaticState.md</c>). A process restart clears it, which is correct: a redeployed /
+/// recompiled fix re-activates cleanly and the stale error is gone.</para>
+/// </summary>
+public sealed class GrainActivationFailureRegistry
+{
+    // grainKey (node address path) → last activation error message. Instance, never static.
+    private readonly ConcurrentDictionary<string, string> _lastError =
+        new(StringComparer.Ordinal);
+
+    /// <summary>Record the real activation error for <paramref name="grainKey"/>.</summary>
+    public void Record(string grainKey, string error)
+    {
+        if (string.IsNullOrEmpty(grainKey) || string.IsNullOrEmpty(error))
+            return;
+        _lastError[grainKey] = error;
+    }
+
+    /// <summary>Clear a stored error after the grain activated successfully.</summary>
+    public void Clear(string grainKey)
+    {
+        if (string.IsNullOrEmpty(grainKey))
+            return;
+        _lastError.TryRemove(grainKey, out _);
+    }
+
+    /// <summary>The last recorded activation error for <paramref name="grainKey"/>, or
+    /// <c>null</c> when none is known (the grain never faulted, or activated cleanly).</summary>
+    public string? TryGet(string grainKey)
+        => !string.IsNullOrEmpty(grainKey) && _lastError.TryGetValue(grainKey, out var e)
+            ? e
+            : null;
+}

--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -32,6 +32,15 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
     private readonly IMeshNodeStreamCache streamCache =
         meshHub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
 
+    // Mesh-scoped registry (issue #464, Defect 3): records the REAL activation error for this
+    // grain key so RoutingGrain can surface it instead of the raw Orleans rejection when the
+    // grain is stuck in a persistent activation-fault loop. Resolved via meshHub.ServiceProvider
+    // (same container as streamCache) so RoutingGrain reads the SAME instance. GetService (not
+    // GetRequiredService) so a mesh that skips AddOrleansMeshServices degrades to today's
+    // behaviour (raw rejection) rather than failing activation.
+    private readonly GrainActivationFailureRegistry? activationFailures =
+        meshHub.ServiceProvider.GetService<GrainActivationFailureRegistry>();
+
     /// <summary>
     /// Hub-ready signal — a <see cref="ReplaySubject{T}"/>(buffer=1) wrapped in
     /// <see cref="Observable.Synchronize{TSource}(IObservable{TSource})"/> so observer
@@ -282,6 +291,9 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                 ex =>
                 {
                     logger.LogError(ex, "[ACTIVATE] Grain {StreamId}: activation faulted for {Path}", streamId, addressPath);
+                    // Defect 3: stash the REAL cause so a caller whose delivery only ever sees the
+                    // raw Orleans rejection (grain mid-deactivation) still gets the actionable error.
+                    activationFailures?.Record(streamId, ex.Message);
                     _hubReadyRaw.OnError(ex);
                     // Retry-on-next-access: without this the grain stays a parked
                     // corpse answering Failed until idle collection; deactivating
@@ -293,8 +305,10 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                     if (_hub is not null) return;
                     logger.LogWarning("[ACTIVATE] Grain {StreamId}: source completed with no usable node for {Path}",
                         streamId, addressPath);
-                    _hubReadyRaw.OnError(new InvalidOperationException(
-                        $"No MeshNode resolvable for address '{addressPath}'. Either the node does not exist or no query provider claims its partition."));
+                    var noNodeError =
+                        $"No MeshNode resolvable for address '{addressPath}'. Either the node does not exist or no query provider claims its partition.";
+                    activationFailures?.Record(streamId, noNodeError);
+                    _hubReadyRaw.OnError(new InvalidOperationException(noNodeError));
                     TryDeactivateOnIdle();
                 });
 
@@ -341,12 +355,22 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                     $"No hub configuration resolved for {node.Path} (NodeType: {node.NodeType ?? "(null)"}). " +
                     "The node type could not produce a hub configuration; check its registration and compilation state.";
                 logger.LogWarning("[ACTIVATE] Grain {StreamId}: {Reason} — activating NACK fallback hub", streamId, reason);
+                // Defect 3: a NACK-fallback hub means activation could not produce a usable config
+                // (the broken-NodeType case). Record the reason so a delivery that only sees the raw
+                // Orleans rejection (this hub DeactivateOnIdle's below) still gets the real cause.
+                activationFailures?.Record(streamId, reason);
                 node = node with
                 {
                     HubConfiguration = c => c.Set(
                         new UnhandledMessageNack(reason, ErrorType.NotFound, node.NodeType))
                 };
                 TryDeactivateOnIdle();
+            }
+            else
+            {
+                // Genuine, usable configuration resolved — this grain can serve. Clear any stale
+                // activation error so a later transient rejection doesn't surface an outdated cause.
+                activationFailures?.Clear(streamId);
             }
             var hub = meshHub.GetHostedHub(address, config =>
             {
@@ -383,6 +407,7 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
         catch (Exception ex)
         {
             logger.LogError(ex, "Grain {StreamId}: CompleteActivation failed", streamId);
+            activationFailures?.Record(streamId, ex.Message);
             _hubReadyRaw.OnError(ex);
             // Same retry-on-next-access semantics as the activation-fault path:
             // a grain whose hub construction threw must not linger as a corpse.

--- a/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
+++ b/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
@@ -115,6 +115,13 @@ public static class OrleansServerRegistryExtensions
         services.AddPartitionedInMemoryPersistence();
         services.TryAddSingleton<IRoutingService, OrleansRoutingService>();
 
+        // Mesh-scoped registry of the last per-grain activation failure. MessageHubGrain
+        // records the real activation error here (the same one it feeds to _hubReadyRaw.OnError);
+        // RoutingGrain falls back to it when a persistent activation-fault loop would otherwise
+        // NACK the raw Orleans rejection ("DeactivateOnIdle was called … Rejecting now") instead
+        // of the actual cause (a compilation failure). See issue #464, Defect 3.
+        services.TryAddSingleton<GrainActivationFailureRegistry>();
+
         // Register Orleans-distributed change feed (wraps local feed + Orleans streams)
         services.TryAddSingleton<InProcessMeshChangeFeed>();
         services.TryAddSingleton<IMeshChangeFeed>(sp =>

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -6,6 +6,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using MeshWeaver.Reflection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Concurrency;
 using Orleans.Streams;
@@ -37,8 +38,16 @@ internal static class RoutingGrainTrace
 internal class RoutingGrain(
     IPathResolver pathResolver,
     MeshConfiguration meshConfig,
+    IMessageHub meshHub,
     ILogger<RoutingGrain> logger) : Grain, IRoutingGrain
 {
+    // Mesh-scoped registry (issue #464, Defect 3). Resolved via meshHub.ServiceProvider so this
+    // reads the SAME instance MessageHubGrain writes to. When a persistent activation-fault loop
+    // exhausts DeliverToGrainWithRetry's transient retries, we surface the recorded activation
+    // error (e.g. the compilation failure) instead of the raw Orleans "Rejecting now" text.
+    private readonly GrainActivationFailureRegistry? activationFailures =
+        meshHub.ServiceProvider.GetService<GrainActivationFailureRegistry>();
+
     public Task<IMessageDelivery> RouteMessage(IMessageDelivery delivery)
     {
         var address = GetHostAddress(delivery.Target!);
@@ -186,7 +195,10 @@ internal class RoutingGrain(
                 // node wedged on "Subscribing to {path}…" until a portal restart (atioz 2026-06-24).
                 DeliverToGrainWithRetry(
                     () => grainFactory.GetGrain<IMessageHubGrain>(grainKey).DeliverMessage(delivery),
-                    grainKey, addressPath, delivery.Id, PostFailureToSender, logger);
+                    grainKey, addressPath, delivery.Id, PostFailureToSender, logger,
+                    resolveActivationError: activationFailures is null
+                        ? null
+                        : activationFailures.TryGet);
             },
             ex =>
             {
@@ -238,7 +250,8 @@ internal class RoutingGrain(
         ILogger logger,
         int maxRetries = 6,
         Func<int, TimeSpan>? backoff = null,
-        IScheduler? scheduler = null)
+        IScheduler? scheduler = null,
+        Func<string, string?>? resolveActivationError = null)
     {
         return DeliverToGrainObservable(grainCall, grainKey, deliveryId, logger, maxRetries, backoff, scheduler)
             .Subscribe(
@@ -260,10 +273,19 @@ internal class RoutingGrain(
                 ex =>
                 {
                     RoutingGrainTrace.Write($"RoutingGrain.RouteMessage GRAIN_CALL_FAULT id={deliveryId} grainKey={grainKey} ex={ex.Message}");
+                    // 🚨 Defect 3 (issue #464): exhausted transient retries against a grain stuck in a
+                    // persistent activation-fault loop throw the RAW Orleans rejection
+                    // ("DeactivateOnIdle was called … Rejecting now") — Orleans internals that HIDE the
+                    // real cause. The grain recorded the true activation error (a compilation failure,
+                    // a missing config) into the failure registry on each faulted activation; prefer
+                    // THAT so the sender's Observe fires OnError with an actionable, deterministic
+                    // message and the GUI resubscribe loop stops spinning on Orleans noise.
+                    var activationError = resolveActivationError?.Invoke(grainKey);
+                    var detail = string.IsNullOrEmpty(activationError) ? ex.Message : activationError;
                     logger.LogWarning(ex,
-                        "[ROUTE] Grain {GrainKey} delivery failed after transient retries (or a non-transient fault) → NACK sender",
-                        grainKey);
-                    postFailureToSender($"Delivery to '{addressPath}' failed: {ex.Message}", ErrorType.Failed);
+                        "[ROUTE] Grain {GrainKey} delivery failed after transient retries (or a non-transient fault) → NACK sender: {Detail}",
+                        grainKey, detail);
+                    postFailureToSender($"Delivery to '{addressPath}' failed: {detail}", ErrorType.Failed);
                 });
     }
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/FrameworkStaleProactiveRebuildTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/FrameworkStaleProactiveRebuildTest.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Repro for issue #464, Defect 1: after a platform self-update changes the framework version,
+/// a dynamic NodeType whose cached assembly was built against the PREVIOUS framework must be
+/// rebuilt PROACTIVELY by its OWN hub — without waiting for an instance to be activated and
+/// without a manual Compile click.
+///
+/// <para><b>Root cause.</b> A framework-stale NodeType is persisted as
+/// <see cref="CompilationStatus.Ok"/> with the OLD <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/>,
+/// so nothing re-drives it: the first-build kickoff needs a <c>null</c> status, the recovery
+/// kickoff needs <c>Compiling</c>, and the framework-stale self-heal in
+/// <c>NodeTypeEnrichmentHelpers</c> only fires when an INSTANCE of the type is activated. A
+/// NodeType with no live instances therefore stays stale (and <c>compile</c> / CreateRelease
+/// up-to-date checks report it clean) — a runtime <c>MissingMethodException</c> timebomb — until
+/// an operator manually rebuilds it.</para>
+///
+/// <para><b>The fix</b> adds an owner-side, level-triggered kickoff in
+/// <c>NodeTypeCompilationHelpers.InstallCompileWatcher</c>: when the NodeType's own hub observes
+/// a settled Ok/Error state whose cached assembly is framework-stale, it flips
+/// <see cref="CompilationStatus.Pending"/> so the compile watcher rebuilds it against the CURRENT
+/// framework. This test forces the framework-stale shape on the NodeType (NO instance activated),
+/// then requires the NodeType to re-stamp the CURRENT framework version on its own. Before the fix
+/// nothing rebuilds and the wait for convergence times out.</para>
+/// </summary>
+public class FrameworkStaleProactiveRebuildTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override bool ShareMeshAcrossTests => true;
+
+    // Two real Roslyn compiles (baseline + the proactive framework-stale rebuild) — widen the
+    // watchdog to match, like FrameworkStaleInstanceRenderTest.
+    protected override TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(90);
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(180);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddGraph();
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    [Fact(Timeout = 180_000)]
+    public async Task FrameworkStaleNodeType_ProactivelyRebuilds_WithoutInstanceActivation()
+    {
+        var typeId = $"ProactiveStale{Guid.NewGuid():N}";
+        var nodeTypePath = $"type/{typeId}";
+
+        var source = $$"""
+            public record {{typeId}} { public string Title { get; init; } = string.Empty; }
+
+            public static class {{typeId}}Config
+            {
+                public static MeshWeaver.Messaging.MessageHubConfiguration Configure(
+                    MeshWeaver.Messaging.MessageHubConfiguration config) => config;
+            }
+            """;
+
+        var typeNode = MeshNode.FromPath(nodeTypePath) with
+        {
+            Name = typeId,
+            NodeType = MeshNode.NodeTypePath,
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition
+            {
+                Configuration = $"config => config.WithContentType<{typeId}>()"
+            }
+        };
+        await MeshService.CreateNode(typeNode).Should().Emit();
+        await MeshService.CreateNode(new MeshNode("code", $"{nodeTypePath}/Source")
+        {
+            NodeType = "Code",
+            Name = "code",
+            State = MeshNodeState.Active,
+            Content = new CodeConfiguration { Code = source, Language = "csharp" }
+        }).Should().Emit();
+
+        var workspace = Mesh.GetWorkspace();
+
+        // 1. Baseline: wait for the first-build compile to settle Ok with a usable build, and
+        //    capture the REAL (live) framework version it stamped.
+        await Mesh.Observe(new GetCompilationPathRequest(), o => o.WithTarget(new Address(nodeTypePath)))
+            .Should().Within(90.Seconds()).Emit();
+        var okNode = await workspace.GetMeshNodeStream(nodeTypePath)
+            .Should().Within(60.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && d.LastCompileSucceededAt is not null
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath)
+                && !string.IsNullOrEmpty(d.CompiledFrameworkVersion));
+        var baselineDef = (NodeTypeDefinition)okNode.Content!;
+        var realFv = baselineDef.CompiledFrameworkVersion!;
+        var baselineSucceededAt = baselineDef.LastCompileSucceededAt!.Value;
+        Output.WriteLine($"Baseline compile Ok — real framework version '{realFv}', succeededAt {baselineSucceededAt:O}.");
+
+        // 2. Force the framework-stale shape: stamp a bogus CompiledFrameworkVersion while leaving
+        //    Status=Ok and the assembly fields intact — exactly what a binary redeploy leaves
+        //    behind. NO instance of the type is ever activated, so the reactive enrichment
+        //    self-heal never runs: only the proactive OWNER-side kickoff can recover this.
+        var bogusFv = $"STALE-{Guid.NewGuid():N}";
+        await workspace.GetMeshNodeStream(nodeTypePath)
+            .Update(curr => curr.Content is NodeTypeDefinition d
+                ? curr with { Content = d with { CompiledFrameworkVersion = bogusFv } }
+                : curr)
+            .Should().Emit();
+        // 🚧 Barrier: confirm the bogus stamp actually LANDED before waiting for convergence.
+        // GetMeshNodeStream replays the latest snapshot, so without this the convergence Match
+        // below could match the pre-stamp baseline Ok (still carrying realFv) and pass without
+        // any rebuild — masking a disabled kickoff. Observing bogusFv proves the stale state is
+        // the current one, so realFv can only reappear via a genuine recompile.
+        await workspace.GetMeshNodeStream(nodeTypePath)
+            .Should().Within(20.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d && d.CompiledFrameworkVersion == bogusFv);
+        Output.WriteLine($"Forced framework-stale (bogus framework version '{bogusFv}').");
+
+        // 3. The NodeType's OWN hub must proactively rebuild and re-stamp the CURRENT framework
+        //    version — Status back to Ok, a usable assembly, and a STRICTLY NEWER
+        //    LastCompileSucceededAt than the baseline (proving a genuine fresh compile, not a
+        //    replayed old Ok) — WITHOUT any instance activation. Before the fix nothing re-drives
+        //    the stale-Ok type, so this times out.
+        await workspace.GetMeshNodeStream(nodeTypePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && d.CompiledFrameworkVersion == realFv
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath)
+                && d.LastCompileSucceededAt is { } s && s > baselineSucceededAt);
+        Output.WriteLine("NodeType proactively rebuilt against the current framework version.");
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainDeliveryRetryTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainDeliveryRetryTest.cs
@@ -134,6 +134,66 @@ public class RoutingGrainDeliveryRetryTest
     }
 
     [Fact]
+    public void DeliverToGrainWithRetry_ExhaustedRetries_SurfacesRecordedActivationError_NotRawRejection()
+    {
+        // Issue #464, Defect 3: a grain stuck in a PERSISTENT activation-fault loop rejects every
+        // delivery with the raw Orleans rejection ("DeactivateOnIdle was called … Rejecting now"),
+        // which hides the actual cause. The grain records the real activation error into the
+        // GrainActivationFailureRegistry on each faulted activation; the retry helper must fall back
+        // to THAT recorded cause when transient retries are exhausted, so the sender's Observe fires
+        // OnError with an actionable message instead of Orleans internals.
+        const string realCause = "Compilation failed for 'UWDeepfield/UwAttention': CS1501 no overload for 'GetFiles' takes 2 arguments";
+        var nacks = new List<(string Message, ErrorType Type)>();
+        using var done = new ManualResetEventSlim(false);
+
+        RoutingGrain.DeliverToGrainWithRetry(
+            // Every attempt lands in a deactivation window — the persistent-fault loop.
+            grainCall: () => Task.FromException<IMessageDelivery>(InvalidActivation()),
+            grainKey: "UWDeepfield/UwAttention",
+            addressPath: "UWDeepfield/UwAttention",
+            deliveryId: "t5",
+            postFailureToSender: (m, t) => { nacks.Add((m, t)); done.Set(); },
+            logger: NullLogger.Instance,
+            maxRetries: 2,
+            backoff: NoBackoff,
+            scheduler: Scheduler.Immediate,
+            // The registry says this grain key faulted with the real compilation error.
+            resolveActivationError: gk =>
+                gk == "UWDeepfield/UwAttention" ? realCause : null);
+
+        Assert.True(done.Wait(TimeSpan.FromSeconds(5)));
+        var nack = Assert.Single(nacks);
+        Assert.Equal(ErrorType.Failed, nack.Type);
+        // The NACK must carry the REAL cause the grain recorded — not the raw rejection text.
+        Assert.Contains(realCause, nack.Message);
+    }
+
+    [Fact]
+    public void DeliverToGrainWithRetry_NoRecordedActivationError_FallsBackToRawException()
+    {
+        // When nothing was recorded for the grain key (the registry has no entry, or no registry is
+        // wired at all), behaviour is unchanged: the NACK carries the underlying exception message.
+        var nacks = new List<(string Message, ErrorType Type)>();
+        using var done = new ManualResetEventSlim(false);
+
+        RoutingGrain.DeliverToGrainWithRetry(
+            grainCall: () => Task.FromException<IMessageDelivery>(new InvalidOperationException("node type not registered")),
+            grainKey: "X",
+            addressPath: "X",
+            deliveryId: "t6",
+            postFailureToSender: (m, t) => { nacks.Add((m, t)); done.Set(); },
+            logger: NullLogger.Instance,
+            backoff: NoBackoff,
+            scheduler: Scheduler.Immediate,
+            resolveActivationError: _ => null);
+
+        Assert.True(done.Wait(TimeSpan.FromSeconds(5)));
+        var nack = Assert.Single(nacks);
+        Assert.Equal(ErrorType.Failed, nack.Type);
+        Assert.Contains("node type not registered", nack.Message);
+    }
+
+    [Fact]
     public void IsTransientFailure_ClassifiesOrleansRejectionAndTimeoutAsTransient_OthersNot()
     {
         Assert.True(RoutingGrain.IsTransientFailure(InvalidActivation()));


### PR DESCRIPTION
Partially fixes #464. Ships Defects 1 and 3; Defect 2 deferred with a plan (its core wedge is already fixed in the current tree).

## Context — the tree moved since the incident
Since #464 was filed, the tree already fixed **Defect 2's core wedge**: MCP `compile` and `recycle`, and the UI Create-Release button, now all route through the `RequestedReleaseAt` release-request seam (`WithReleaseRequest`), which **un-parks** the type in `NodeTypeCompileParkRegistry` before promoting to `Pending`. So "park never cleared across recycle → no build ever starts again" no longer reproduces (verified: `NodeTypeCompileParkTest` + `CodeEditRecompileTest` green). What remained live were **Defects 1 and 3**, plus a narrow Defect-2 source-reactivation race (deferred).

## Defect 1 — platform self-update leaves stale NodeType assemblies reporting `Ok`
**Root cause:** a NodeType compiled against the *previous* framework is persisted as `CompilationStatus=Ok` with the old `CompiledFrameworkVersion`. Nothing proactively re-drives it — the framework-stale self-heal in `NodeTypeEnrichmentHelpers` only fires on **instance activation**, and the up-to-date short-circuits didn't consult the framework version. A source-clean, framework-stale type with no live instances therefore never rebuilt (a runtime `MissingMethodException` timebomb).

**Fix:**
- `NodeTypeCompilationHelpers`: new `HasStaleFrameworkBuild` + a proactive, **level-triggered** `frameworkStaleKickoffSub` in `InstallCompileWatcher`. When the NodeType's *own* hub observes a settled `Ok`/`Error` whose cached assembly is framework-stale (and it isn't parked or static-only), it flips `CompilationStatus=Pending` so the compile watcher rebuilds it against the current framework — no instance activation, no user click. Bounded and storm-safe: `Take(1)`, **skips parked types** (preserves the park storm-containment invariant), runs as System.
- `MeshDataSource`: the `HandleCreateRelease` up-to-date short-circuit and `IsSourcesUpToDate` now also require `CompiledFrameworkVersion == FrameworkVersion` — "up to date" can never report a framework-stale assembly as clean.

**Test:** `FrameworkStaleProactiveRebuildTest` — compiles a NodeType green, stamps a bogus framework version on the live `Ok` node (**no instance activated**), and requires the owner to proactively re-stamp the *current* framework version with a **strictly-newer** compile. Revert-proven: **times out at 90s** with the kickoff disabled.

## Defect 3 — activation-fault loop surfaces the raw Orleans rejection
**Root cause:** a grain stuck in a *persistent* activation-fault loop rejects every delivery (and every retry) with the raw `OrleansMessageRejectionException` (`"DeactivateOnIdle was called … Rejecting now"`) — Orleans internals that hide the real cause (`"Compilation failed for 'X': CS…"`). The real error reaches `MessageHubGrain._hubReadyRaw.OnError` on each activation but `DeliverMessage` never runs in the loop, so it never reaches the sender.

**Fix:**
- New mesh-scoped `GrainActivationFailureRegistry` (instance singleton, registered in `AddOrleansMeshServices`). `MessageHubGrain` records the real activation error (the same one fed to `_hubReadyRaw.OnError`, plus the NACK-fallback reason) and clears it on a genuine successful activation. `RoutingGrain.DeliverToGrainWithRetry`, on the exhausted / non-transient NACK, falls back to the recorded error instead of the raw rejection text — so the sender's `Observe` fires `OnError` with an actionable, deterministic message and the GUI resubscribe loop stops spinning.

**Test:** `RoutingGrainDeliveryRetryTest` — two new cases: the exhausted-retry NACK surfaces the recorded activation error; with none recorded it falls back to the raw exception. Revert-proven (fails with the fallback removed).

## Defect 2 — deferred (core already fixed; residual race is Medium-High risk)
The core wedge is already fixed in the tree (see Context), and the proactive framework-stale kickoff above covers the incident's actual self-update trigger. The one genuinely-residual piece is **2a — the lost-on-reactivation source-version race**: a source edit racing hub re-init could leave `CurrentSourceVersions` stale until the next source emission. It has a clean user recovery today (Compile/Recycle both un-park and force). The fix touches the delicate flap-back / high-water serialization in `InstallReleaseRequestWatcher` / `InstallSourcesWatcher` that has caused wedges before, so per the conservative directive it is not shipped unproven.

**Ready-to-implement plan for 2a:** on `InstallSourcesWatcher` init, re-derive `CurrentSourceVersions` from each live per-source `GetMeshNodeStream(path)` snapshot **independent of** the `(Sources,Tests)` `DistinctUntilChanged` gate (so a change-feed emission lost during re-init still converges), keeping the write idempotent. Pin with a test that writes a source change and recycles the NodeType hub *concurrently*, then asserts `CurrentSourceVersions` converges to the store.

## Files changed
- `src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs` — `HasStaleFrameworkBuild` + `frameworkStaleKickoffSub`
- `src/MeshWeaver.Graph/MeshDataSource.cs` — framework-version gate in `HandleCreateRelease` + `IsSourcesUpToDate`
- `src/MeshWeaver.Hosting.Orleans/GrainActivationFailureRegistry.cs` (new)
- `src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs` — registry registration
- `src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs` — record/clear activation error
- `src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs` — fall back to recorded activation error
- `test/MeshWeaver.Hosting.Orleans.Test/RoutingGrainDeliveryRetryTest.cs` — +2 Defect-3 cases
- `test/MeshWeaver.Hosting.Monolith.Test/FrameworkStaleProactiveRebuildTest.cs` (new) — Defect 1

## Test results (Release, one class at a time)
- `RoutingGrainDeliveryRetryTest`: 7/7 ✓ (revert-proven)
- `FrameworkStaleProactiveRebuildTest`: ✓ (revert-proven — 90s timeout without the kickoff)
- `NodeTypeCompileParkTest` + `FrameworkStaleInstanceRenderTest`: 7/7 ✓ (park containment intact)
- `CodeEditRecompileTest` + `NodeTypeReleaseTest`: 8/8 ✓

Release `-warnaserror -p:CIRun=true` build is clean; the only build noise is the pre-existing, repo-wide `NU1902` AngleSharp advisory (nothing in this diff references AngleSharp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)