### PR TITLE
fix(#435): fail fast on ephemeral content store + preserve user uploads on GitSync mirror

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -472,6 +472,51 @@ public static class MemexConfiguration
         services.AddSpeechTranscription(builder.Configuration);
     }
 
+    /// <summary>
+    /// Fails fast on the content-storage configuration that GUARANTEES silent data loss (issue #435):
+    /// a DEPLOYED (non-development) <c>FileSystem</c> content store whose <c>BasePath</c> is empty or
+    /// relative. Such a path resolves against the container's ephemeral working directory (<c>/app</c>),
+    /// so every uploaded collection file is written to disk that vanishes on the next pod restart or
+    /// grain teardown — reads succeed for minutes, then the files are gone, with no signal to the user.
+    /// We cannot verify from code that an <em>absolute</em> path is a durable mount, but we CAN reject
+    /// the empty/relative footgun outright. A local <c>Development</c> run keeps the relative-to-working-
+    /// tree convenience (the Monolith's <c>Storage:BasePath = "../../samples/Graph"</c>).
+    /// <para>Pure decision (no I/O) so it is unit-testable without spinning a mesh.</para>
+    /// </summary>
+    /// <param name="contentStorageConfig">The parsed <c>Storage</c> section, or <c>null</c> when unconfigured.</param>
+    /// <param name="isDevelopment"><c>true</c> for a local Development run (relative BasePath allowed).</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a non-development FileSystem content store has an empty or relative <c>BasePath</c>.
+    /// </exception>
+    public static void ValidateContentStorageDurability(
+        ContentCollectionConfig? contentStorageConfig, bool isDevelopment)
+    {
+        // Development resolves a relative BasePath against a stable working tree — that's the intended
+        // local convenience, not the ephemeral-container footgun. Nothing configured → nothing to guard.
+        if (isDevelopment || contentStorageConfig is null)
+            return;
+        // Only the FileSystem store roots files on a local path. AzureBlob/other stores don't use
+        // BasePath as a filesystem root (it's a blob prefix), so the durability concern doesn't apply.
+        if (!string.Equals(contentStorageConfig.SourceType, "FileSystem", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var basePath = contentStorageConfig.BasePath;
+        var isEmpty = string.IsNullOrWhiteSpace(basePath);
+        // An absolute path is the operator's chosen mount; code can't verify it's durable, so allow it.
+        if (!isEmpty && Path.IsPathRooted(basePath))
+            return;
+
+        throw new InvalidOperationException(
+            "Content storage misconfiguration (issue #435): Storage:SourceType is 'FileSystem' but "
+            + (isEmpty ? "Storage:BasePath is empty." : $"Storage:BasePath ('{basePath}') is relative.")
+            + " A FileSystem content store with an empty or relative BasePath resolves against the "
+            + "container's ephemeral working directory, so uploaded collection files are written to "
+            + "storage that is SILENTLY LOST on the next pod restart or grain teardown. Set "
+            + "Storage:BasePath to an ABSOLUTE path backed by a durable volume (e.g. '/mnt/content' on "
+            + "a PersistentVolumeClaim), or use Storage:SourceType 'AzureBlob'. Refusing to start so the "
+            + "misconfiguration surfaces now rather than after users have uploaded and lost files.");
+    }
+
     extension<TBuilder>(TBuilder builder) where TBuilder : MeshBuilder
     {
         /// <summary>
@@ -514,6 +559,11 @@ public static class MemexConfiguration
 
             // Read content collection storage config from appsettings
             var contentStorageConfig = configuration.GetSection("Storage").Get<ContentCollectionConfig>();
+            // 🚨 Fail fast on the guaranteed-silent-data-loss footgun (issue #435) BEFORE the
+            // relative→absolute resolution below would MASK it: a deployed FileSystem content store
+            // with an empty/relative BasePath resolves against the ephemeral container CWD (/app),
+            // so uploaded collection files vanish on the next pod restart / grain teardown.
+            ValidateContentStorageDurability(contentStorageConfig, isDevelopment);
             if (contentStorageConfig != null)
             {
                 // Resolve relative path to absolute

--- a/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
+++ b/src/MeshWeaver.ContentCollections/ContentImportExtensions.cs
@@ -117,12 +117,21 @@ public static class ContentImportExtensions
                     .Select(f => FullPath(f.Path))
                     .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
+                // 🚨 issue #435: when the caller declares which paths the SOURCE owns (a GitSync mirror
+                // passes the previous import's file set), prune ONLY those. A file not in that set is a
+                // user upload the source never tracked and MUST be preserved — never silently wiped by a
+                // boot re-import. A null set keeps the legacy full-mirror (prune every file not in Files).
+                var sourceOwned = request.SourceOwnedPaths is { } owned
+                    ? owned.Select(NormalizePath).ToHashSet(StringComparer.OrdinalIgnoreCase)
+                    : null;
+
                 // Prune AFTER writing: enumerate the folder's current files, delete those not kept.
                 // EnumerateAllFiles yields collection-relative paths; a delete of an absent file is
                 // tolerated (best-effort) so a concurrent external delete never fails the mirror.
                 return writes.SelectMany(written =>
                     EnumerateAllFiles(target, baseDir)
-                        .Where(path => !keep.Contains(path))
+                        .Where(path => !keep.Contains(path)
+                                       && (sourceOwned is null || sourceOwned.Contains(path)))
                         .Select(path => target.DeleteFile(path)
                             .Select(_ => 0)
                             .Catch<int, Exception>(_ => Observable.Return(0)))
@@ -300,6 +309,7 @@ public sealed class SyncContentFilesBuilder
     private string _targetCollection = ContentCollectionsExtensions.DefaultCollectionName;
     private string _targetPath = "";
     private bool _mirror = true;
+    private IReadOnlyList<string>? _sourceOwnedPaths;
     private readonly List<InlineContentFile> _files = new();
 
     internal SyncContentFilesBuilder(IMessageHub hub, string nodePath)
@@ -337,12 +347,25 @@ public sealed class SyncContentFilesBuilder
         return this;
     }
 
+    /// <summary>
+    /// Restricts a mirror's pruning to the files the SOURCE previously owned (issue #435): only a file
+    /// whose collection-relative path is in <paramref name="sourceOwnedPaths"/> may be pruned, so a user
+    /// upload the source never tracked is PRESERVED. <c>null</c> (the default) keeps the full-mirror
+    /// semantics. Paths are collection-relative (<c>{TargetPath}/{file}</c> form).
+    /// </summary>
+    public SyncContentFilesBuilder SourceOwned(IReadOnlyList<string>? sourceOwnedPaths)
+    {
+        _sourceOwnedPaths = sourceOwnedPaths;
+        return this;
+    }
+
     /// <summary>Post the sync to the target node's hub. Cold — subscribe to run.</summary>
     public IObservable<ImportContentResponse> Post()
     {
         var request = new SyncContentFilesRequest(_targetCollection, _targetPath, _files.ToArray())
         {
             Mirror = _mirror,
+            SourceOwnedPaths = _sourceOwnedPaths,
         };
         var address = new Address(_nodePath);
         return Observable.Defer(() => _hub

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -580,8 +580,15 @@ public static class StaticRepoImporter
             // before the eventually-consistent read-model catches up, or the next import silently
             // re-enables sync on the freshly-decoupled partition. CQRS: never decide on a single node's
             // content from the query. EnsureRoot already ensured the root exists, so this resolves promptly.
-            .SelectMany(existingItems => ReadClaimedRoots(hub, partitions)
-                .Select(claimedRoots => (existingItems, claimedRoots)))
+            .SelectMany(existingItems => Observable.Zip(
+                    ReadClaimedRoots(hub, partitions),
+                    // Authoritative content-manifest read (owner round-trip, NOT the lagged `existing`
+                    // query snapshot): the manifest a just-completed prior import wrote can be invisible
+                    // to the eventually-consistent query, which would leave prune with an empty owned set
+                    // and silently NOT prune a genuinely-removed source file. Same freshness guard as
+                    // ReadClaimedRoots; absent (first import) resolves promptly to an empty set (#435).
+                    ReadContentManifest(hub, source.Partition),
+                    (claimedRoots, previousContentPaths) => (existingItems, claimedRoots, previousContentPaths)))
             .SelectMany(snapshot =>
             {
                 var existing = snapshot.existingItems
@@ -597,6 +604,12 @@ public static class StaticRepoImporter
                 // changed → full import (safe). This is what makes a one-node edit re-import one node.
                 var manifest = ParseManifest(
                     existing.GetValueOrDefault(ManifestPath(source.Partition)), hub.JsonSerializerOptions);
+
+                // The content-collection file paths the source owned at the LAST import (read
+                // authoritatively above from {partition}/_Activity/content-manifest). The inline content
+                // mirror prunes ONLY these, so a user upload the source never tracked survives a boot
+                // re-import (issue #435). Empty on first import / any parse failure → prune nothing.
+                var previousContentPaths = snapshot.previousContentPaths;
 
                 // Subtrees claimed wholesale — nothing at or under these paths is synced. A claimed
                 // partition ROOT (authoritative read above) decouples its WHOLE subtree; a child claimed
@@ -729,9 +742,10 @@ public static class StaticRepoImporter
                         SyncContentImports(hub, source, logger).SelectMany(embedCount =>
                         // Mirror inline (byte-carrying) content into each owning node's content
                         // collection — the git-committed {Space}/content/** binaries a GitSync import
-                        // supplies. Binary-safe + mirroring (writes what the repo has, prunes what it
-                        // dropped) so committed course videos/posters land and stop getting wiped.
-                        SyncInlineContent(hub, source, logger).SelectMany(inlineCount =>
+                        // supplies. Binary-safe + mirroring (writes what the repo has, prunes what the
+                        // SOURCE dropped) so committed course videos/posters land and stop getting wiped,
+                        // while user uploads the source never tracked are preserved (issue #435).
+                        SyncInlineContent(hub, source, previousContentPaths, logger).SelectMany(inlineCount =>
                         {
                         var contentCount = embedCount + inlineCount;
                         // Persist the per-node manifest LAST (after upserts + prune) so the NEXT import's
@@ -955,20 +969,41 @@ public static class StaticRepoImporter
     /// — the byte-carrying content-collection files a GitSync import supplies (the git-committed
     /// <c>{Space}/content/**</c> binaries). Each group is posted as a <see cref="SyncContentFilesRequest"/>
     /// (via <see cref="ContentImportExtensions.SyncContentFiles"/>) under System to the owning node's hub,
-    /// which writes the bytes and — mirroring — prunes files the group no longer carries. Per-group failures
-    /// log and continue. Returns the total files written.
+    /// which writes the bytes and — mirroring — prunes files the SOURCE no longer carries.
+    /// <para>🚨 issue #435: the mirror prunes ONLY files the source PREVIOUSLY owned
+    /// (<paramref name="previouslyOwnedContentPaths"/> = the prior content manifest), so a user upload the
+    /// source never tracked survives a boot re-import — the content-file analogue of the per-node
+    /// <c>Additive</c>/<c>SyncBehavior</c> prune protection. After the mirror, the CURRENT source-owned
+    /// paths are persisted as the content manifest so the next import knows what it owns.</para>
+    /// Per-group failures log and continue. Returns the total files written.
     /// </summary>
-    private static IObservable<int> SyncInlineContent(IMessageHub hub, IStaticRepoSource source, ILogger? logger)
+    private static IObservable<int> SyncInlineContent(
+        IMessageHub hub, IStaticRepoSource source,
+        IReadOnlyList<string> previouslyOwnedContentPaths, ILogger? logger)
     {
         var syncs = source.EnumerateInlineContentSyncs();
         if (syncs.Count == 0)
+            // No content this import → don't touch the collection (never an empty mirror that would wipe
+            // user uploads) and leave the prior content manifest intact (conservative — a removed-to-zero
+            // source set is not pruned, matching ContentAssetMapper's zero-asset behavior).
             return Observable.Return(0);
+
+        // The full collection-relative paths this source owns THIS import. Persisted as the content
+        // manifest below so the NEXT import can tell a genuinely-removed source file (prune) from a user
+        // upload the source never tracked (preserve). Same {TargetPath}/{file} form the mirror compares.
+        var currentOwned = syncs
+            .SelectMany(s => s.Files.Select(f => CombineContentPath(s.TargetPath, f.Path)))
+            .Where(p => p.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 
         return syncs
             .Select(sync => AsSystem(hub, () => hub.SyncContentFiles(sync.NodePath)
                     .To(sync.TargetCollection, sync.TargetPath)
                     .Add(sync.Files)
                     .Mirror(true)
+                    // Prune only files the source PREVIOUSLY owned — preserves user uploads (#435).
+                    .SourceOwned(previouslyOwnedContentPaths)
                     .Post())
                 .Select(r => r.Success ? r.FilesImported : 0)
                 .Catch<int, Exception>(ex =>
@@ -980,7 +1015,25 @@ public static class StaticRepoImporter
                 }))
             .ToObservable()
             .Merge(BatchSize)
-            .Sum();
+            .Sum()
+            // Persist the current source-owned content set LAST (after the mirror) so the next import's
+            // prune preserves user uploads. Best-effort: a failed write only makes the next import prune
+            // nothing (conservative), never wrong.
+            .SelectMany(written => WriteContentManifest(hub, source.Partition, currentOwned, logger)
+                .Select(_ => written));
+    }
+
+    /// <summary>
+    /// Joins a content sync's <paramref name="targetPath"/> (the collection sub-folder) with a file's
+    /// <paramref name="filePath"/> (relative to it) into the collection-relative path the mirror compares
+    /// against — forward slashes, no leading slash. Mirrors <c>SyncFiles.FullPath</c> in the handler so the
+    /// persisted manifest lines up exactly with what the mirror enumerates and keeps.
+    /// </summary>
+    private static string CombineContentPath(string? targetPath, string? filePath)
+    {
+        var baseDir = (targetPath ?? string.Empty).Replace('\\', '/').Trim('/');
+        var rel = (filePath ?? string.Empty).Replace('\\', '/').TrimStart('/');
+        return baseDir.Length == 0 ? rel : $"{baseDir}/{rel}";
     }
 
     /// <summary>Top-level partition segment of a path (the part before the first '/').</summary>
@@ -1087,6 +1140,82 @@ public static class StaticRepoImporter
 
     /// <summary>Path of a partition's per-node import manifest (an <c>_Activity</c> node; survives prune).</summary>
     private static string ManifestPath(string partition) => $"{partition}/_Activity/{ManifestId}";
+
+    private const string ContentManifestId = "content-manifest";
+
+    /// <summary>
+    /// Path of a partition's content-file manifest — an <c>_Activity</c> node (survives prune, exempt
+    /// from governance pruning) whose <see cref="ActivityLog.ReturnValue"/> holds the collection-relative
+    /// paths the source owned at the last import. Read on the next import to prune only genuinely-removed
+    /// source files, preserving user uploads (issue #435).
+    /// </summary>
+    private static string ContentManifestPath(string partition) => $"{partition}/_Activity/{ContentManifestId}";
+
+    /// <summary>
+    /// Reads a partition's content manifest AUTHORITATIVELY (the owner round-trip via
+    /// <see cref="MeshNodeStreamExtensions.GetMeshNode"/>, NOT the eventually-consistent query snapshot
+    /// which can miss the manifest a just-completed import wrote — the same freshness guard as
+    /// <see cref="ReadClaimedRoots"/>). Absent (first import) or any read failure resolves promptly to an
+    /// empty set, so the next mirror prunes nothing rather than wrongly (issue #435).
+    /// </summary>
+    private static IObservable<IReadOnlyList<string>> ReadContentManifest(IMessageHub hub, string partition)
+        => hub.GetMeshNode(ContentManifestPath(partition), TimeSpan.FromSeconds(10))
+            .Catch((Exception _) => Observable.Return<MeshNode?>(null))
+            .Take(1)
+            .Select(node => ParseContentManifest(node, hub.JsonSerializerOptions));
+
+    /// <summary>
+    /// Parses the list of source-owned content-collection paths a prior import stored in the content
+    /// manifest node's <see cref="ActivityLog.ReturnValue"/>. Empty on absence / any parse failure → the
+    /// next import's mirror prunes nothing (conservative — never wipes a user upload), never wrong.
+    /// </summary>
+    private static IReadOnlyList<string> ParseContentManifest(MeshNode? manifestNode, JsonSerializerOptions opts)
+    {
+        if (manifestNode is null) return Array.Empty<string>();
+        try
+        {
+            var log = manifestNode.ContentAs<ActivityLog>(opts);
+            if (log?.ReturnValue is not { } rv) return Array.Empty<string>();
+            var list = rv.Deserialize<List<string>>(opts);
+            return list is null ? Array.Empty<string>() : list;
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    /// <summary>
+    /// Writes the partition's content-file manifest — an <c>_Activity</c> node whose
+    /// <see cref="ActivityLog.ReturnValue"/> is the list of collection-relative paths the CURRENT source
+    /// owns. Read back on the next import so the mirror prunes only genuinely-removed source files and
+    /// preserves user uploads (issue #435). Best-effort: a failed write only makes the next import's
+    /// mirror prune nothing, never a user upload.
+    /// </summary>
+    private static IObservable<int> WriteContentManifest(
+        IMessageHub hub, string partition, IReadOnlyList<string> ownedPaths, ILogger? logger)
+    {
+        var node = new MeshNode(ContentManifestId, $"{partition}/_Activity")
+        {
+            Name = $"Content manifest ({partition})",
+            NodeType = ActivityNodeType.NodeType,
+            MainNode = partition,
+            State = MeshNodeState.Active,
+            Content = new ActivityLog(ActivityCategory.Import)
+            {
+                Status = ActivityStatus.Succeeded,
+                ReturnValue = JsonSerializer.SerializeToElement(ownedPaths, hub.JsonSerializerOptions),
+            },
+        };
+
+        return Upsert(hub, node)
+            .Catch<int, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "[StaticRepoImport] {Partition}: content manifest write failed (next import's mirror prunes nothing).", partition);
+                return Observable.Return(0);
+            });
+    }
 
     /// <summary>
     /// Parses the <c>{path → source-token}</c> map a prior import stored in the manifest node's

--- a/src/MeshWeaver.Mesh.Contract/ImportDeleteRequests.cs
+++ b/src/MeshWeaver.Mesh.Contract/ImportDeleteRequests.cs
@@ -124,6 +124,19 @@ public record SyncContentFilesRequest(
     /// the write is purely additive (upsert only). Default true.
     /// </summary>
     public bool Mirror { get; init; } = true;
+
+    /// <summary>
+    /// When set (and <see cref="Mirror"/> is true), restricts pruning to the files the SOURCE
+    /// previously owned: a file under <see cref="TargetPath"/> that is no longer in <see cref="Files"/>
+    /// is pruned ONLY if its collection-relative path is in this set. A file NOT in this set is a
+    /// user upload the source never tracked and is PRESERVED (issue #435 — a GitSync re-import must not
+    /// wipe files a user uploaded into a source-managed space). <c>null</c> keeps the legacy full-mirror
+    /// semantics (prune every file not in <see cref="Files"/>).
+    /// <para>Paths are collection-relative — the same <c>{TargetPath}/{file}</c> form the mirror
+    /// compares against (forward slashes, no leading slash), matching <see cref="Files"/> joined onto
+    /// <see cref="TargetPath"/>.</para>
+    /// </summary>
+    public IReadOnlyList<string>? SourceOwnedPaths { get; init; }
 }
 
 /// <summary>

--- a/test/Memex.Portal.Shared.Test/ContentStorageDurabilityTest.cs
+++ b/test/Memex.Portal.Shared.Test/ContentStorageDurabilityTest.cs
@@ -1,0 +1,79 @@
+using Memex.Portal.Shared;
+using MeshWeaver.ContentCollections;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the fail-fast guard (<see cref="MemexConfiguration.ValidateContentStorageDurability"/>) that turns
+/// the silent content-data-loss footgun of issue #435 into a loud startup failure: a DEPLOYED
+/// (non-development) <c>FileSystem</c> content store with an empty or relative <c>BasePath</c> resolves
+/// against the container's ephemeral working directory and loses every uploaded file on teardown. An
+/// ABSOLUTE path is accepted (code cannot verify a mount is durable, only reject the guaranteed-loss
+/// case); a local Development run keeps the relative-to-working-tree convenience.
+/// </summary>
+public class ContentStorageDurabilityTest
+{
+    private static ContentCollectionConfig FileSystem(string? basePath) =>
+        new() { Name = "storage", SourceType = "FileSystem", BasePath = basePath };
+
+    [Fact]
+    public void NonDev_FileSystem_EmptyBasePath_FailsFast()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            MemexConfiguration.ValidateContentStorageDurability(FileSystem(""), isDevelopment: false));
+        ex.Message.Should().Contain("issue #435");
+        ex.Message.Should().Contain("empty");
+        ex.Message.Should().Contain("durable");
+    }
+
+    [Fact]
+    public void NonDev_FileSystem_NullBasePath_FailsFast()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            MemexConfiguration.ValidateContentStorageDurability(FileSystem(null), isDevelopment: false));
+        ex.Message.Should().Contain("empty");
+    }
+
+    [Fact]
+    public void NonDev_FileSystem_RelativeBasePath_FailsFast()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            MemexConfiguration.ValidateContentStorageDurability(
+                FileSystem("../../samples/Graph"), isDevelopment: false));
+        ex.Message.Should().Contain("relative");
+        ex.Message.Should().Contain("../../samples/Graph");
+    }
+
+    [Fact]
+    public void NonDev_FileSystem_AbsoluteBasePath_Accepted()
+    {
+        // Path.GetTempPath() is an absolute, rooted path on every OS the tests run on.
+        var absolute = Path.GetTempPath();
+        // Does not throw — an absolute path is the operator's chosen (presumed durable) mount.
+        MemexConfiguration.ValidateContentStorageDurability(FileSystem(absolute), isDevelopment: false);
+    }
+
+    [Fact]
+    public void NonDev_AzureBlob_EmptyBasePath_Accepted()
+    {
+        // AzureBlob does not root files on a local path — BasePath is a blob prefix, not a mount.
+        var azure = new ContentCollectionConfig { Name = "storage", SourceType = "AzureBlob", BasePath = null };
+        MemexConfiguration.ValidateContentStorageDurability(azure, isDevelopment: false);
+    }
+
+    [Fact]
+    public void Development_FileSystem_RelativeBasePath_Accepted()
+    {
+        // Local dev resolves a relative path against a stable working tree — the Monolith's
+        // Storage:BasePath = "../../samples/Graph". Must NOT fail fast.
+        MemexConfiguration.ValidateContentStorageDurability(
+            FileSystem("../../samples/Graph"), isDevelopment: true);
+    }
+
+    [Fact]
+    public void NullConfig_Accepted()
+    {
+        MemexConfiguration.ValidateContentStorageDurability(contentStorageConfig: null, isDevelopment: false);
+    }
+}

--- a/test/MeshWeaver.GitSync.Test/GitSyncContentCollectionTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitSyncContentCollectionTest.cs
@@ -140,6 +140,68 @@ public class GitSyncContentCollectionTest(ITestOutputHelper output) : GitHubSync
         await WaitForContentGone(space, "posters/intro.jpg");
     }
 
+    // Bytes for a file the USER uploads — never tracked by the source repo. Distinct from the source
+    // binaries so the assertion proves the exact file survives, not just "something is there".
+    private static readonly byte[] UserUploadBytes =
+        [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB];
+
+    /// <summary>
+    /// Issue #435 regression pin: a GitSync re-import must PRESERVE files a user uploaded into a
+    /// source-managed space's content collection (files the repo never tracked), while still pruning a
+    /// file the SOURCE genuinely removed. The old unconditional <c>Mirror(true)</c> wiped every file not
+    /// in the current repo set — including user uploads — the moment a boot re-import ran. This drives the
+    /// full import path and asserts that in ONE re-import: the removed source poster is pruned, the
+    /// still-carried source video survives, and the user-uploaded binary is preserved.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task Import_PreservesUserUpload_WhilePruningRemovedSourceFile()
+    {
+        await Connect();
+        var repo = "https://github.com/test/course-user-uploads";
+
+        // Commit 1: root + two SOURCE content binaries (a video and a poster).
+        var c1 = await SeedRepo(repo,
+            RootIndex(),
+            new RepoFile("content/videos/intro.bin", string.Empty, VideoBytes),
+            new RepoFile("content/posters/p.jpg", string.Empty, PosterBytes));
+
+        var space = "Course" + Guid.NewGuid().ToString("N")[..8];
+        await Sync.ImportFromGitHub(repo, "main", space, "Course", subdirectory: null, UserId)
+            .Timeout(90.Seconds()).ToTask();
+        await Sync.SaveConfig(space, repo, "main", subdirectory: null, createBranchIfMissing: true, createRepoIfMissing: true)
+            .Timeout(30.Seconds()).ToTask();
+
+        await WaitForContent(space, "videos/intro.bin", VideoBytes);
+        await WaitForContent(space, "posters/p.jpg", PosterBytes);
+
+        // The user uploads a file the repo NEVER tracked (additive write — no mirror), directly into the
+        // Space's content collection, exactly as the portal Files view does. It is not in any source
+        // manifest, so a naive full-mirror re-import would wipe it.
+        var upload = await GetClient().SyncContentFiles(space)
+            .To(ContentCollectionsExtensions.DefaultCollectionName, "")
+            .Add("videos/user-upload.bin", UserUploadBytes)
+            .Mirror(false)
+            .Post()
+            .Timeout(30.Seconds()).ToTask();
+        Assert.True(upload.Success, upload.Error);
+        await WaitForContent(space, "videos/user-upload.bin", UserUploadBytes);
+
+        // Commit 2 REMOVES the poster (a genuine source deletion) and keeps the video.
+        var c2 = await SeedRepo(repo,
+            RootIndex(),
+            new RepoFile("content/videos/intro.bin", string.Empty, VideoBytes));
+        Assert.NotEqual(c1, c2);
+
+        await Sync.ReimportAtCommit(space, c2, UserId).Timeout(90.Seconds()).ToTask();
+
+        // The genuinely-removed source poster is pruned (mirror still prunes what the SOURCE dropped)…
+        await WaitForContentGone(space, "posters/p.jpg");
+        // …the still-carried source video survives…
+        Assert.Equal(VideoBytes, ReadContent(space, "videos/intro.bin"));
+        // …and CRUCIALLY the user upload the repo never tracked is PRESERVED (issue #435).
+        Assert.Equal(UserUploadBytes, ReadContent(space, "videos/user-upload.bin"));
+    }
+
     [Fact(Timeout = 120000)]
     public async Task SyncContentFiles_RejectsPathTraversal()
     {


### PR DESCRIPTION
Partially fixes #435 (the in-repo code hardening: fail-fast on an ephemeral/relative FileSystem store, and stop pruning user uploads on GitSync mirror. Symptom-2/search-0 was already fixed on main; the durable-PVC deployment change is flagged for maintainer review).

## FIX 1 — fail fast instead of silently creating an ephemeral content store

`MemexConfiguration.ValidateContentStorageDurability` (called from `ConfigureMemexMesh`, before the relative→absolute resolution that would mask it) throws a clear, actionable `InvalidOperationException` at startup when a **deployed** (non-development) `FileSystem` content store has an **empty or relative** `Storage:BasePath`. Such a path resolves against the container's ephemeral working directory (`/app`), so every uploaded collection file is written to storage that vanishes on the next pod restart / grain teardown — reads succeed for minutes, then the files are gone (the exact silent-loss the issue reports).

- An **absolute** `BasePath` is allowed — code can't verify a mount is durable, only reject the empty/relative case that *guarantees* loss.
- A local **Development** run keeps the relative-to-working-tree convenience (the Monolith's `Storage:BasePath = "../../samples/Graph"`), so `dotnet run` is unaffected.
- Pure decision (no I/O), unit-tested without spinning a mesh.

## FIX 2 — stop pruning user-uploaded files on the GitSync content mirror

`StaticRepoImporter.SyncInlineContent` posted the content mirror with `.Mirror(true)`, which prunes **every** file under the collection not in the current repo set — so a boot re-import of a source-managed space **deleted** files a user had uploaded (non-manifest files).

The fix mirrors the per-node `Additive`/`SyncBehavior` prune protection, at the content-file level:

- New `SyncContentFilesRequest.SourceOwnedPaths` (+ `SyncContentFilesBuilder.SourceOwned(...)`). When set, the mirror prunes a file only if its collection-relative path is in that set (i.e. the source **previously** owned it). A file not in the set is a user upload the source never tracked → **preserved**. `null` keeps the legacy full-mirror.
- The importer persists a per-partition **content manifest** (`{partition}/_Activity/content-manifest`) of the source-owned paths, and reads it back **authoritatively** on the next import via the owner round-trip (`hub.GetMeshNode`), **not** the eventually-consistent query snapshot — the same freshness guard `ReadClaimedRoots` already uses. (Reading it from the lagged snapshot left prune with an empty owned set and silently skipped a genuine removal — caught by the existing mirror-prune regression test.)
- Genuinely-removed **source** files are still pruned; user uploads survive; first import (empty manifest) prunes nothing.

## Tests (revert-proven)

- `ContentStorageDurabilityTest` (7 cases): empty/relative FileSystem in prod → fail fast with a clear message; absolute / AzureBlob / development / null-config → accepted.
- `GitSyncContentCollectionTest.Import_PreservesUserUpload_WhilePruningRemovedSourceFile`: uploads a user file the repo never tracked, then re-imports a commit that removed a source file — asserts the removed source file is pruned, the still-carried source file survives, and the user upload is preserved.
- Full `MeshWeaver.GitSync.Test` (128) and `Graph.Test` importer suites green; Release `-warnaserror -p:CIRun=true` build clean on all touched projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)