### PR TITLE
fix(#354): boot self-heal asserts served AI catalog partitions are search-indexed

### DIFF
--- a/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
+++ b/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
@@ -94,7 +94,12 @@ internal sealed class StaticRepoImportHostedService(
         // SubscribeOn moves the entire subscription cleanly off the startup thread. StartAsync
         // returns immediately (Task.CompletedTask) — no async/await, no blocking. See
         // Doc/Architecture/AsynchronousCalls.md.
-        _subscription = StaticRepoImporter.ImportAll(hub, logger, syncModeOverrides)
+        // Pass the built-in AI catalog partitions as the #354 boot-index assertion set: after the
+        // import, ImportAll verifies each SERVED catalog (Agent/Provider/Harness/Skill that a source
+        // actually backs this run) is registered in the cross-schema search index, force-re-syncing it
+        // and surfacing a startup-failure notification for any that materialized but stayed unindexed.
+        _subscription = StaticRepoImporter
+            .ImportAll(hub, logger, syncModeOverrides, AiContentSources.ContentPartitions)
             .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default)
             .Subscribe(
                 r => logger?.LogInformation(

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -8,6 +8,7 @@ using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -88,7 +89,8 @@ public static class StaticRepoImporter
     /// </summary>
     public static IObservable<StaticRepoImportResult> ImportAll(
         IMessageHub hub, ILogger? logger = null,
-        IReadOnlyDictionary<string, PartitionSyncMode>? syncModeOverrides = null)
+        IReadOnlyDictionary<string, PartitionSyncMode>? syncModeOverrides = null,
+        IReadOnlySet<string>? indexedCatalogAssertions = null)
     {
         logger ??= hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.Graph.StaticRepoImporter");
@@ -153,7 +155,108 @@ public static class StaticRepoImporter
                         {
                             logger?.LogWarning(ex, "[StaticRepoImport] source-owned partition reconcile failed.");
                             return Observable.Return(new StaticRepoImportResult("_SourceOwnedCatalogs", string.Empty, "Failed"));
-                        }))));
+                        })))
+                // 🚨 #354 boot self-heal/assert: after every source has imported, verify each SERVED
+                // catalog partition the caller flagged (indexedCatalogAssertions ∩ this run's sources)
+                // is registered in the cross-schema search index (public.searchable_schemas) — force ONE
+                // re-sync so a schema just provisioned is indexed, and surface a startup-failure
+                // notification for any served catalog still absent (materialized but unindexed → index
+                // queries return empty forever). No-op on in-memory backends / when nothing is flagged.
+                .Concat(Observable.Defer(() =>
+                    AssertCatalogPartitionsIndexed(
+                        importHub, indexedCatalogAssertions, currentSourcePartitions, logger))));
+    }
+
+    /// <summary>
+    /// Boot-time self-heal/assert that each SERVED AI-catalog partition is registered in the
+    /// cross-schema search index (#354). The served set is <paramref name="candidateCatalogs"/> (the
+    /// caller's built-in AI catalog partitions) intersected with the partitions actually backed by a
+    /// registered <see cref="IStaticRepoSource"/> this run (<paramref name="currentSourcePartitions"/>)
+    /// — a catalog served in-memory (no source registered) is left ALONE, never forced into the DB.
+    ///
+    /// <para>For the served set: FORCE one <see cref="ICrossSchemaQueryProvider.SyncSearchableSchemasAsync(bool,System.Threading.CancellationToken)"/>
+    /// rebuild — bypassing the query-hot-path throttle, because this is a one-time boot action, never a
+    /// per-query rebuild — so a schema THIS boot's import provisioned is indexed immediately; then read
+    /// <see cref="ICrossSchemaQueryProvider.GetSearchableSchemasAsync"/> back. A served catalog still
+    /// ABSENT (its PG schema was never provisioned — the "materialized but unindexed" residual, where
+    /// index queries return 0 forever while exact-path <c>get</c> still works) is surfaced LOUDLY via
+    /// <see cref="NotifyStartupFailure"/>, so an already-broken instance is visible and self-repairs on
+    /// the next boot (which re-runs the import and re-forces this sync).</para>
+    ///
+    /// <para>No-op on in-memory backends (no <see cref="ICrossSchemaQueryProvider"/> is registered —
+    /// those serve catalogs directly and have no searchable-schemas registry) and when nothing is
+    /// flagged. The PG round-trips run on the <see cref="IIoPool"/>, off the subscribing thread;
+    /// reactive end-to-end — no <c>FromAsync</c>, no <c>await</c>.</para>
+    /// </summary>
+    private static IObservable<StaticRepoImportResult> AssertCatalogPartitionsIndexed(
+        IMessageHub hub, IReadOnlySet<string>? candidateCatalogs,
+        IReadOnlyCollection<string> currentSourcePartitions, ILogger? logger)
+    {
+        if (candidateCatalogs is not { Count: > 0 })
+            return Observable.Empty<StaticRepoImportResult>();
+
+        // Only the catalogs SERVED FROM THE DB this run (a registered source owns them). A catalog
+        // legitimately served in-memory (no source) is never forced into a PG schema.
+        var served = currentSourcePartitions
+            .Where(candidateCatalogs.Contains)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (served.Length == 0)
+            return Observable.Empty<StaticRepoImportResult>();
+
+        // The cross-schema search index exists only on partitioned SQL backends (Postgres/Snowflake).
+        // In-memory serves catalogs directly — nothing to index, nothing to assert.
+        var crossSchema = hub.ServiceProvider.GetService<ICrossSchemaQueryProvider>();
+        if (crossSchema is null)
+            return Observable.Empty<StaticRepoImportResult>();
+
+        var pool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Query)
+                   ?? IoPool.Unbounded;
+
+        // Force ONE registry rebuild (bypass the throttle — boot self-heal, not the query hot path),
+        // then read the registry back to assert. Both are PG round-trips → bridged through the IoPool.
+        return pool.Invoke(ct => crossSchema.SyncSearchableSchemasAsync(force: true, ct))
+            .SelectMany(_ => pool.Invoke(ct => crossSchema.GetSearchableSchemasAsync(ct)))
+            .SelectMany(searchable =>
+            {
+                // searchable_schemas holds the LOWERCASED schema name; the catalog partition is the
+                // verbatim first segment — OrdinalIgnoreCase covers the case fold.
+                var indexed = new HashSet<string>(searchable, StringComparer.OrdinalIgnoreCase);
+                var missing = served.Where(p => !indexed.Contains(p)).ToArray();
+
+                foreach (var partition in missing)
+                {
+                    logger?.LogWarning(
+                        "[StaticRepoImport] served AI catalog partition '{Partition}' is NOT registered in "
+                        + "searchable_schemas after import — its index queries (search / children listing / "
+                        + "catalog areas) return EMPTY while exact-path reads still work (#354). Surfacing a "
+                        + "startup-failure notification; the next boot re-imports and re-forces the index sync.",
+                        partition);
+                    // The activity/notification target is the catalog partition root itself (click → the
+                    // empty catalog). Best-effort under System via the existing startup-failure path; if the
+                    // partition schema is genuinely absent the notification write logs and continues.
+                    NotifyStartupFailure(
+                        hub, partition, partition,
+                        $"AI catalog partition '{partition}' is served from the database but is not provisioned "
+                        + "into a searchable schema, so its catalog renders empty. The next restart re-imports "
+                        + "and re-indexes it.",
+                        logger);
+                }
+
+                if (missing.Length == 0)
+                    logger?.LogInformation(
+                        "[StaticRepoImport] catalog-index assert: all {Count} served AI catalog partition(s) "
+                        + "are registered in searchable_schemas.", served.Length);
+
+                return Observable.Return(new StaticRepoImportResult(
+                    "_CatalogIndexAssert", string.Empty,
+                    missing.Length > 0 ? "Unindexed" : "Indexed", missing.Length));
+            })
+            .Catch<StaticRepoImportResult, Exception>(ex =>
+            {
+                logger?.LogWarning(ex, "[StaticRepoImport] catalog-index assert failed (continuing).");
+                return Observable.Return(new StaticRepoImportResult("_CatalogIndexAssert", string.Empty, "Failed"));
+            });
     }
 
     /// <summary>Namespace under the Admin partition where one marker node per source-owned catalog

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
@@ -32,7 +32,7 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
     private int _syncInFlight;
 
     /// <summary>
-    /// Minimum interval between actual <see cref="SyncSearchableSchemasAsync"/>
+    /// Minimum interval between actual <see cref="SyncSearchableSchemasAsync(bool, CancellationToken)"/>
     /// runs. Calls within the window are no-ops. Internal setter for tests
     /// to force re-sync without waiting.
     /// </summary>
@@ -93,18 +93,26 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
     /// class is self-contained — no <c>PostgreSqlPartitionedStoreFactory</c>
     /// dependency.
     /// </summary>
-    public async Task SyncSearchableSchemasAsync(CancellationToken ct = default)
+    public Task SyncSearchableSchemasAsync(CancellationToken ct = default)
+        => SyncSearchableSchemasAsync(force: false, ct);
+
+    /// <inheritdoc />
+    public async Task SyncSearchableSchemasAsync(bool force, CancellationToken ct = default)
     {
         // Fast path: another sync ran within SyncTtl — skip. New partitions
         // created in that window are invisible until the next sync, which is
-        // an acceptable trade for not melting the connection pool.
+        // an acceptable trade for not melting the connection pool. force=true
+        // (the one-time boot self-heal) bypasses the TTL so a schema this boot's
+        // import just provisioned is registered immediately, not up to SyncTtl later.
         var lastTicks = Interlocked.Read(ref _lastSyncTicks);
-        if (lastTicks != 0 && DateTime.UtcNow.Ticks - lastTicks < SyncTtl.Ticks)
+        if (!force && lastTicks != 0 && DateTime.UtcNow.Ticks - lastTicks < SyncTtl.Ticks)
             return;
 
         // Single-flight: only one sync runs at a time. Concurrent callers
         // (every cross-schema fan-out calls this) return immediately rather
-        // than queuing on the public-schema connection.
+        // than queuing on the public-schema connection. Honoured even under
+        // force — force bypasses the TIME throttle, never the DELETE+INSERT
+        // mutual-exclusion; a concurrent sync already rebuilds the registry.
         if (Interlocked.CompareExchange(ref _syncInFlight, 1, 0) != 0)
             return;
 
@@ -113,7 +121,7 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
             // Re-check under the flight gate: another caller may have just
             // finished while we were CAS-ing.
             lastTicks = Interlocked.Read(ref _lastSyncTicks);
-            if (lastTicks != 0 && DateTime.UtcNow.Ticks - lastTicks < SyncTtl.Ticks)
+            if (!force && lastTicks != 0 && DateTime.UtcNow.Ticks - lastTicks < SyncTtl.Ticks)
                 return;
 
             var schemas = new List<string>();

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeCrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeCrossSchemaQueryProvider.cs
@@ -59,7 +59,7 @@ public class SnowflakeCrossSchemaQueryProvider : ICrossSchemaQueryProvider
     private int _syncInFlight;
 
     /// <summary>
-    /// Minimum interval between actual <see cref="SyncSearchableSchemasAsync"/>
+    /// Minimum interval between actual <see cref="SyncSearchableSchemasAsync(bool, CancellationToken)"/>
     /// runs. Calls within the window are no-ops. Internal setter for tests
     /// to force re-sync without waiting.
     /// </summary>
@@ -129,18 +129,26 @@ public class SnowflakeCrossSchemaQueryProvider : ICrossSchemaQueryProvider
     /// <see cref="Interlocked"/> single-flight gate (no semaphore — see the field
     /// comment for the incident this prevents).
     /// </summary>
-    public async Task SyncSearchableSchemasAsync(CancellationToken ct = default)
+    public Task SyncSearchableSchemasAsync(CancellationToken ct = default)
+        => SyncSearchableSchemasAsync(force: false, ct);
+
+    /// <inheritdoc />
+    public async Task SyncSearchableSchemasAsync(bool force, CancellationToken ct = default)
     {
         // Fast path: another sync ran within SyncTtl — skip. New partitions
         // created in that window are invisible until the next sync, which is
-        // an acceptable trade for not melting the connection pool.
+        // an acceptable trade for not melting the connection pool. force=true
+        // (the one-time boot self-heal) bypasses the TTL so a schema this boot's
+        // import just provisioned is registered immediately, not up to SyncTtl later.
         var lastTicks = Interlocked.Read(ref _lastSyncTicks);
-        if (lastTicks != 0 && DateTime.UtcNow.Ticks - lastTicks < SyncTtl.Ticks)
+        if (!force && lastTicks != 0 && DateTime.UtcNow.Ticks - lastTicks < SyncTtl.Ticks)
             return;
 
         // Single-flight: only one sync runs at a time. Concurrent callers
         // (every cross-schema fan-out calls this) return immediately rather
-        // than queuing on the central-schema connection.
+        // than queuing on the central-schema connection. Honoured even under
+        // force — force bypasses the TIME throttle, never the DELETE+INSERT
+        // mutual-exclusion; a concurrent sync already rebuilds the registry.
         if (Interlocked.CompareExchange(ref _syncInFlight, 1, 0) != 0)
             return;
 
@@ -149,7 +157,7 @@ public class SnowflakeCrossSchemaQueryProvider : ICrossSchemaQueryProvider
             // Re-check under the flight gate: another caller may have just
             // finished while we were CAS-ing.
             lastTicks = Interlocked.Read(ref _lastSyncTicks);
-            if (lastTicks != 0 && DateTime.UtcNow.Ticks - lastTicks < SyncTtl.Ticks)
+            if (!force && lastTicks != 0 && DateTime.UtcNow.Ticks - lastTicks < SyncTtl.Ticks)
                 return;
 
             await using var connection = await _source.OpenAsync(ct).ConfigureAwait(false);
@@ -286,7 +294,7 @@ public class SnowflakeCrossSchemaQueryProvider : ICrossSchemaQueryProvider
     /// of <paramref name="schemas"/> containing <paramref name="tableName"/>. PG binds the
     /// schema list as <c>= ANY($2)</c>; this dialect has no array binds, so the list expands
     /// to an IN-list of individual <c>:sN</c> markers. information_schema identifiers are
-    /// deliberately UNQUOTED (see <see cref="SyncSearchableSchemasAsync"/> for why).
+    /// deliberately UNQUOTED (see <see cref="SyncSearchableSchemasAsync(bool, CancellationToken)"/> for why).
     /// </summary>
     private async Task<IReadOnlyList<string>> FilterSchemasContainingTableAsync(
         IReadOnlyList<string> schemas, string tableName, CancellationToken ct)

--- a/src/MeshWeaver.Mesh.Contract/Services/ICrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/ICrossSchemaQueryProvider.cs
@@ -21,9 +21,19 @@ public interface ICrossSchemaQueryProvider
     /// <see cref="GetSearchableSchemasAsync"/> returns the up-to-date list.
     /// Cheap (one SELECT + a batched INSERT) so fan-out callers can run it
     /// per-query to pick up partitions created mid-session without waiting
-    /// for a pg_notify cycle.
+    /// for a pg_notify cycle. Throttled: a call within the implementation's
+    /// TTL window is a no-op (the query hot path calls this per fan-out).
     /// </summary>
     Task SyncSearchableSchemasAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Rebuilds the searchable-schemas registry, bypassing the throttle window when
+    /// <paramref name="force"/> is <c>true</c> (single-flight is still honoured). Used by the
+    /// ONE-TIME boot self-heal that asserts a served catalog partition's schema is registered
+    /// right after import (see <c>StaticRepoImporter</c> · #354) — NEVER on the query hot path,
+    /// where <paramref name="force"/> stays <c>false</c> and the throttle protects the pool.
+    /// </summary>
+    Task SyncSearchableSchemasAsync(bool force, CancellationToken ct = default);
 
     /// <summary>
     /// Subset of <see cref="GetSearchableSchemasAsync"/> filtered to schemas

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CatalogPartitionIndexSelfHealTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CatalogPartitionIndexSelfHealTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Blazor.Portal;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Boot-time self-heal/assert that a SERVED AI-catalog partition (Provider / Agent / Skill / Harness)
+/// is provisioned into a PG schema AND registered in the cross-schema search index
+/// (<c>public.searchable_schemas</c>) after the static-repo import — the residual of #354.
+///
+/// <para>The primary fix (#407) removed the config-alias/allow-list drift that stopped the catalogs
+/// being imported at all. The residual: nothing at boot ASSERTED that a served catalog actually landed
+/// in the search index. Because the import's own queries are all partition-PINNED, they never trigger a
+/// <c>SyncSearchableSchemasAsync</c>, so a freshly-provisioned catalog schema stays absent from
+/// <c>searchable_schemas</c> until the first unpinned fan-out query happens to run one — meanwhile every
+/// index query (<c>search nodeType:ModelProvider</c>, children listing, the catalog areas) returns
+/// EMPTY although exact-path <c>get</c> works ("materialized but unindexed").</para>
+///
+/// <para><see cref="StaticRepoImporter.ImportAll"/> now takes the served catalog set and, after the
+/// import, FORCES one searchable-schemas rebuild for it (bypassing the query-hot-path throttle — a
+/// one-time boot action) and surfaces a startup-failure notification for any served catalog still
+/// unindexed. These tests pin: (1) the served catalog is registered + a cross-schema search finds its
+/// seeded nodes; (2) a searchable-schemas row that later goes MISSING (the "materialized but unindexed"
+/// drift) is re-registered by the next boot's self-heal, EVEN INSIDE the 30 s sync throttle window — the
+/// force=true bypass is what makes that deterministic (a non-forced sync would be throttled and leave it
+/// gone).</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class CatalogPartitionIndexSelfHealTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private readonly PostgreSqlFixture _fixture = fixture;
+
+    // Capitalized partition so the lowercase-schema invariant is observable; not in the cross-schema
+    // ExcludedSchemas set. A property (reads _source) avoids the field-order trap.
+    private readonly FakeCatalogSource _source = NewSource("Cat" + Guid.NewGuid().ToString("N")[..10]);
+    private string _partition => _source.Partition;
+
+    // The #354 served-catalog assertion set the portal boot passes (here: just this fake catalog).
+    private IReadOnlySet<string> Assertions =>
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _partition };
+
+    private static FakeCatalogSource NewSource(string partition) => new(partition)
+    {
+        Root = new MeshNode(partition)
+        {
+            Name = "Catalog", NodeType = "Space", State = MeshNodeState.Active,
+            Content = new MarkdownContent { Content = $"# {partition}\n\nCatalog root." }
+        },
+        Nodes =
+        [
+            new MeshNode("Anthropic", partition)
+            {
+                NodeType = "ModelProvider", Name = "Anthropic", State = MeshNodeState.Active,
+                Content = new MarkdownContent { Content = "Anthropic provider." }
+            },
+            new MeshNode("code", partition)
+            {
+                NodeType = "Skill", Name = "code", State = MeshNodeState.Active,
+                Content = new MarkdownContent { Content = "The code skill." }
+            }
+        ]
+    };
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
+        {
+            MaxPoolSize = 16,
+            ConnectionIdleLifetime = 10
+        };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services =>
+            {
+                services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString);
+                services.AddSingleton<IStaticRepoSource>(_source);
+                return services;
+            })
+            .AddRowLevelSecurity()
+            .AddGraph()
+            .AddSpaceType()
+            // The catalog's instance node types (mirrors the real Provider/Skill catalogs) so the import's
+            // canonical CreateOrUpdate accepts them and the cross-schema search can filter by node_type.
+            .AddMeshNodes(
+                new MeshNode("ModelProvider") { Name = "Model Provider" },
+                new MeshNode("Skill") { Name = "Skill" });
+    }
+
+    private Task<IList<StaticRepoImportResult>> Import() =>
+        StaticRepoImporter.ImportAll(Mesh, null, null, Assertions)
+            .ToList().Should().Within(120.Seconds()).Emit();
+
+    /// <summary>COUNT of <paramref name="partition"/>'s (lowercased) schema in public.searchable_schemas.</summary>
+    private Task<long> SearchableSchemaCount(string partition, CancellationToken ct) =>
+        _fixture.DataSource.ScalarLong(
+            "SELECT COUNT(*) FROM public.searchable_schemas WHERE schema_name = @s",
+            new[] { ("s", (object)partition.ToLowerInvariant()) }, ct)
+            .Should().Within(30.Seconds()).Emit();
+
+    /// <summary>
+    /// Cross-schema search for <paramref name="nodeType"/> as System (userId=null → no access filter),
+    /// over the CURRENT searchable-schemas registry — the same fan-out the AI catalog areas use.
+    /// </summary>
+    private Task<List<MeshNode>> SearchByNodeType(string nodeType, CancellationToken ct)
+    {
+        var crossSchema = Mesh.ServiceProvider.GetRequiredService<ICrossSchemaQueryProvider>();
+        return crossSchema.GetSearchableSchemasAsync(ct).Run()
+            .SelectMany(schemas => crossSchema
+                .QueryAcrossSchemasAsync(
+                    new QueryParser().Parse($"nodeType:{nodeType}"),
+                    Mesh.JsonSerializerOptions, schemas, userId: null, ct)
+                .Collect(ct))
+            .Should().Within(30.Seconds()).Emit();
+    }
+
+    /// <summary>
+    /// After the boot import, the served catalog partition is registered in searchable_schemas and a
+    /// cross-schema search finds its seeded catalog nodes — the exact index-based access #354 reported
+    /// as returning empty on affected instances.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task Import_RegistersServedCatalog_AndCrossSchemaSearchFindsNodes()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var results = await Import();
+        results.Should().Contain(r => r.Partition == _partition && r.Outcome == "Imported");
+        // The self-heal step emits its own result — all served catalogs indexed (0 missing).
+        results.Should().Contain(r => r.Partition == "_CatalogIndexAssert" && r.Outcome == "Indexed");
+
+        // (a) The core #354 fix: the served catalog's schema is now in the cross-schema search index.
+        (await SearchableSchemaCount(_partition, ct)).Should().Be(
+            1L, "the boot self-heal must register the served catalog partition in searchable_schemas");
+
+        // (b) End-to-end: the index-based access that returned empty on affected instances now finds
+        // the seeded nodes (search nodeType:ModelProvider / nodeType:Skill).
+        var providers = await SearchByNodeType("ModelProvider", ct);
+        providers.Select(n => n.Id).Should().Contain("Anthropic",
+            "search nodeType:ModelProvider must find the served catalog's provider node (#354)");
+
+        var skills = await SearchByNodeType("Skill", ct);
+        skills.Select(n => n.Id).Should().Contain("code",
+            "search nodeType:Skill must find the served catalog's skill node (#354)");
+    }
+
+    /// <summary>
+    /// Revert-proven self-heal: a served catalog whose searchable_schemas row later goes MISSING (the
+    /// "materialized but unindexed" drift — the schema + its nodes are intact, only the index registration
+    /// is gone) is re-registered by the next boot's self-heal. This works EVEN INSIDE the 30 s sync
+    /// throttle window because the self-heal forces the rebuild (force=true) — a plain throttled sync
+    /// would skip and leave the catalog unindexed. Remove the force bypass (or the self-heal) and this
+    /// fails: the row stays gone.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task Reimport_ReRegistersDroppedSearchableSchema_BypassingThrottle()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var schema = _partition.ToLowerInvariant();
+
+        // First boot: import + self-heal → the catalog schema is registered (and the throttle's
+        // last-sync timestamp is now set, so a NON-forced re-sync within 30 s would be a no-op).
+        await Import();
+        (await SearchableSchemaCount(_partition, ct)).Should().Be(1L);
+
+        // Simulate the residual drift: the schema + its nodes stay (materialized), but the index
+        // registration is dropped — index queries would now return empty for this catalog.
+        await _fixture.DataSource.ExecuteNonQuery(
+                $"DELETE FROM public.searchable_schemas WHERE schema_name = '{schema}'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        (await SearchableSchemaCount(_partition, ct)).Should().Be(0L, "the row was just deleted");
+
+        // Next boot: the content import short-circuits on the unchanged fingerprint, but the self-heal
+        // runs unconditionally and FORCE-re-syncs — re-registering the catalog despite the throttle.
+        await Import();
+        (await SearchableSchemaCount(_partition, ct)).Should().Be(
+            1L, "the boot self-heal force-re-syncs (bypassing the throttle) so a dropped searchable_schemas "
+            + "row is re-registered — a non-forced sync would be throttled within 30 s and leave it gone");
+    }
+
+    /// <summary>In-memory fake catalog: instance-typed nodes + a Space root, like the real AI catalogs.</summary>
+    private sealed class FakeCatalogSource(string partition) : IStaticRepoSource
+    {
+        public string Partition => partition;
+        public bool Versioned => false;
+        public List<MeshNode> Nodes { get; set; } = [];
+        public MeshNode? Root { get; set; }
+        public IReadOnlyList<MeshNode> EnumerateSourceNodes() => Nodes;
+        public MeshNode? PartitionRoot => Root;
+    }
+}


### PR DESCRIPTION
Fixes the live residual of #354 (the config drift was already fixed by #407; this adds the boot-time self-heal/assert that served AI catalog partitions are provisioned + indexed).

## The residual

On affected instances the global AI catalog partitions (`Provider`/`Agent`/`Skill`/`Harness`) are **materialized but missing from the search index**: exact-path `get @Provider/Anthropic` works, but every index-based access (`search nodeType:ModelProvider`, `@Provider/*` children listing, the AI-menu catalog areas) returns empty. #407 fixed the config-alias/allow-list drift that stopped the catalogs being imported. What remained: **nothing at boot asserted that a served catalog actually landed in `public.searchable_schemas`.**

Root cause of the residual: the static-repo import's own queries are all partition-**pinned**, so they never trigger a `SyncSearchableSchemasAsync`. A freshly-provisioned catalog schema therefore stays absent from `searchable_schemas` until the first *unpinned* fan-out query happens to run one — until then the cross-schema UNION skips it and index queries return 0 forever.

## Fix (additive, idempotent, reactive)

- **`StaticRepoImporter.ImportAll`** now takes the served catalog set and, after the import, runs `AssertCatalogPartitionsIndexed`: for each catalog partition **actually backed by a registered source this run** (candidate ∩ current sources — an in-memory-served or non-served catalog is left alone), it **forces one `searchable_schemas` rebuild** (bypassing the query-hot-path throttle — this is a one-time boot action, *not* a per-query rebuild), reads the registry back, and surfaces a **startup-failure notification** (existing `NotifyStartupFailure` path) for any served catalog still absent. So an already-broken instance self-repairs on restart and the failure is visible. No-op on in-memory backends (no `ICrossSchemaQueryProvider`). PG round-trips run on the `IIoPool`; no `Observable.FromAsync`, no `await`.
- **`ICrossSchemaQueryProvider`** gains `SyncSearchableSchemasAsync(bool force, ct)`; the PostgreSQL + Snowflake implementations bypass the TTL when `force=true` (single-flight mutual-exclusion is still honoured). Existing callers are unchanged (the old `(ct)` overload delegates with `force:false`).
- **Portal boot** passes `AiContentSources.ContentPartitions` as the assertion set.

## Test

`test/MeshWeaver.Hosting.PostgreSql.Test/CatalogPartitionIndexSelfHealTests` (PG Testcontainers, `pgvector/pgvector:pg17`):
1. after `ImportAll`, the served catalog is registered in `searchable_schemas` **and** a cross-schema search finds its seeded `ModelProvider`/`Skill` nodes;
2. revert-proven: a `searchable_schemas` row that later goes missing (the "materialized but unindexed" drift) is re-registered by the next boot's self-heal **even inside the 30 s throttle window** — the `force=true` bypass is exactly what makes that deterministic (a plain throttled sync would skip and leave it gone).

Ran locally via Testcontainers — **2/2 green**. Release `-warnaserror -p:CIRun=true` build of every touched project is clean (the only diagnostics are the pre-existing repo-wide `NU1902` AngleSharp advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)