### PR TITLE
fix(comments): reply visibility, view, and author delete

### DIFF
--- a/src/MeshWeaver.Graph/CommentLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CommentLayoutAreas.cs
@@ -71,13 +71,35 @@ public static class CommentLayoutAreas
         var parentPath = hubPath.Contains('/') ? hubPath[..hubPath.LastIndexOf('/')] : hubPath;
         var permissionsStream = host.Hub.GetEffectivePermissions(parentPath);
 
+        // Replies are the direct-CHILD Comment nodes of THIS comment ({hubPath}/{replyId}). Discover
+        // them reactively with the SAME synced-query pattern the page-level comment list uses
+        // (CommentsView.Comments) — write path (CreateNode a child) and read path (query children)
+        // therefore agree on ONE canonical namespace. The old renderer read comment.Replies, a
+        // denormalized list nothing on the write path maintained (the ↩ form never appended to it and
+        // the sample data left it empty), so every reply was invisible (issue #473). Ordered oldest-first
+        // for natural conversation order.
+        var repliesDataId = $"commentReplies_{hubPath.Replace("/", "_")}";
+        host.UpdateData(repliesDataId, Array.Empty<LayoutAreaControl>());
+        host.Workspace.GetQuery(
+                $"replies:{hubPath}",
+                $"namespace:{hubPath} nodeType:{CommentNodeType.NodeType}")
+            .Subscribe(snapshot =>
+            {
+                var replyControls = snapshot
+                    .Where(n => n.Content is Comment)
+                    .OrderBy(n => n.ContentAs<Comment>(host.Hub.JsonSerializerOptions)!.CreatedAt)
+                    .Select(n => Controls.LayoutArea(n.Path, OverviewArea))
+                    .ToArray();
+                host.UpdateData(repliesDataId, replyControls);
+            });
+
         return host.Workspace.GetMeshNodeStream()
             .CombineLatest(permissionsStream, (node, perms) =>
             {
                 var canComment = perms.HasFlag(Permission.Comment) || perms.HasFlag(Permission.Update);
                 var canDelete = perms.HasFlag(Permission.Delete);
                 return (UiControl?)BuildOverview(host, node, hubPath, editStateId, initialized,
-                    currentUser, canComment, canDelete);
+                    currentUser, canComment, canDelete, repliesDataId);
             });
     }
 
@@ -104,7 +126,7 @@ public static class CommentLayoutAreas
 
     internal static UiControl BuildOverview(LayoutAreaHost host, MeshNode? node, string hubPath,
         string editStateId, bool[] initialized, string currentUser,
-        bool canComment = true, bool canDelete = true)
+        bool canComment = true, bool canDelete = true, string? repliesDataId = null)
     {
         // ContentAs (deserialize), not `as Comment`: this view is data-bound via CombineLatest on
         // GetMeshNodeStream, whose frames alternate typed↔JsonElement; `as` → null on JsonElement
@@ -219,8 +241,12 @@ public static class CommentLayoutAreas
             });
         }
 
-        // Replies section — data-bound from comment.Replies (same pattern as Thread.Messages)
-        if (comment.Replies.Count > 0)
+        // Replies section — data-bound from the live child-Comment query set up in Overview
+        // (repliesDataId). Each entry is a LayoutArea pointing at a reply's own path
+        // ({hubPath}/{replyId}), so a reply created through EITHER write path (the ↩ form or the
+        // CreateCommentRequest handler) renders here for every reader — the fix for issue #473. The
+        // section appears/disappears reactively with the query (no static comment.Replies gate).
+        if (repliesDataId != null)
         {
             var expandedStateId = $"replies_expanded_{hubPath.Replace("/", "_")}";
             var visibleCountStateId = $"replies_visible_{hubPath.Replace("/", "_")}";
@@ -234,12 +260,16 @@ public static class CommentLayoutAreas
                     initialized[1] = true;
                 }
 
-                return h.Stream.GetDataStream<bool>(expandedStateId)
+                return h.Stream.GetDataStream<LayoutAreaControl[]>(repliesDataId)
                     .CombineLatest(
+                        h.Stream.GetDataStream<bool>(expandedStateId),
                         h.Stream.GetDataStream<int>(visibleCountStateId),
-                        (expanded, visibleCount) =>
+                        (replyControls, expanded, visibleCount) =>
                         {
-                            var totalCount = comment.Replies.Count;
+                            var totalCount = replyControls?.Length ?? 0;
+                            if (totalCount == 0)
+                                return (UiControl)Controls.Stack;
+
                             var section = Controls.Stack.WithWidth("100%").WithStyle("margin-top: 8px;");
 
                             var headerText = expanded
@@ -259,10 +289,9 @@ public static class CommentLayoutAreas
                             var shown = Math.Min(visibleCount, totalCount);
                             for (var i = 0; i < shown; i++)
                             {
-                                var replyPath = $"{hubPath}/{comment.Replies[i]}";
                                 section = section.WithView(Controls.Stack
                                     .WithStyle("margin-left: 0; padding-left: 8px; border-left: 2px solid var(--neutral-stroke-rest); margin-top: 4px;")
-                                    .WithView(Controls.LayoutArea(replyPath, OverviewArea)));
+                                    .WithView(replyControls![i]));
                             }
 
                             if (shown < totalCount)
@@ -373,8 +402,10 @@ public static class CommentLayoutAreas
     {
         var nodeFactory = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
         var replyTextDataId = $"replyText_{replyPath.Replace("/", "_")}";
+        var replyErrorDataId = $"replyError_{replyPath.Replace("/", "_")}";
 
         host.UpdateData(replyTextDataId, new Dictionary<string, object?> { ["text"] = "" });
+        host.UpdateData(replyErrorDataId, "");
 
         var stack = Controls.Stack
             .WithStyle("margin-top: 4px; padding: 4px; padding-left: 6px; border-left: 2px solid var(--accent-fill-rest);");
@@ -389,6 +420,15 @@ public static class CommentLayoutAreas
             DataContext = LayoutAreaReference.GetDataPointer(replyTextDataId)
         };
         stack = stack.WithView(editor);
+
+        // User-visible error surface: a failed reply write (e.g. Access denied) must NOT be a
+        // server-only log line while the form closes as if it succeeded (issue #473, defect 3).
+        // The Create click writes the message here on failure and clears it on retry.
+        stack = stack.WithView((h, _) => h.Stream.GetDataStream<string>(replyErrorDataId)
+            .Select(err => string.IsNullOrEmpty(err)
+                ? (UiControl)Controls.Stack
+                : Controls.Html(
+                    $"<div style=\"color: var(--error-color, #f87171); font-size: 0.8rem; margin-top: 4px;\">{System.Web.HttpUtility.HtmlEncode(err)}</div>")));
 
         // Button row: Cancel and Create
         stack = stack.WithView(Controls.Stack
@@ -423,6 +463,10 @@ public static class CommentLayoutAreas
                                 Name = $"Reply to {comment.Author}",
                                 NodeType = CommentNodeType.NodeType,
                                 State = MeshNodeState.Active,
+                                // MainNode = the document, so SatelliteAccessRule delegates the reply's
+                                // permissions to the doc (Comment to create, author/Update to delete) —
+                                // exactly like a top-level comment.
+                                MainNode = comment.PrimaryNodePath ?? "",
                                 Content = new Comment
                                 {
                                     Id = replyId,
@@ -432,12 +476,17 @@ public static class CommentLayoutAreas
                                     Text = text
                                 }
                             };
+                            host.UpdateData(replyErrorDataId, "");
                             nodeFactory.CreateNode(replyNode).Subscribe(
                                 _ => host.UpdateData(replyPathStateId, ""),
                                 // Keep the draft form OPEN on failure (don't clear the state) so the user's
-                                // reply isn't silently lost, and log so the failure is diagnosable.
-                                ex => host.Hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>()
-                                    ?.LogWarning(ex, "Failed to create reply at {Path}", replyPath));
+                                // reply isn't silently lost; surface the error in the form AND log it.
+                                ex =>
+                                {
+                                    host.UpdateData(replyErrorDataId, $"Reply not posted: {ex.Message}");
+                                    host.Hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>()
+                                        ?.LogWarning(ex, "Failed to create reply at {Path}", replyPath);
+                                });
                         });
                     return Task.CompletedTask;
                 })));
@@ -516,9 +565,12 @@ public static class CommentLayoutAreas
             .WithClickAction(_ =>
             {
                 var nodeFactory = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
+                // Never swallow the delete fault: a denied/failed delete must be diagnosable, not a
+                // silent no-op (issue #391). The comment stays visible on failure; the log is the sink.
                 nodeFactory.DeleteNode(hubPath).Subscribe(
                     __ => { },
-                    _ => { });
+                    ex => host.Hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>()
+                        ?.LogWarning(ex, "Failed to delete comment at {Path}", hubPath));
                 return Task.CompletedTask;
             });
     }

--- a/src/MeshWeaver.Graph/CommentsExtensions.cs
+++ b/src/MeshWeaver.Graph/CommentsExtensions.cs
@@ -106,8 +106,14 @@ public static class CommentsExtensions
                 .Catch<MeshNode, Exception>(_ => Observable.Return((MeshNode)null!))
                 .SelectMany(node =>
                 {
-                    var isReply = node?.Content is Comment;
+                    var parentComment = node?.Content as Comment;
+                    var isReply = parentComment is not null;
                     var version = node?.Version ?? 0;
+
+                    // A reply's primary document is the parent comment's document (its PrimaryNodePath),
+                    // never the parent comment path — replies delegate permissions to the doc, like a
+                    // top-level comment.
+                    var primaryNodePath = isReply ? (parentComment!.PrimaryNodePath ?? nodePath) : nodePath;
 
                     // Capture the selection as a (Start, Length) range in the document's clean text.
                     var start = -1;
@@ -125,7 +131,7 @@ public static class CommentsExtensions
                     var comment = new Comment
                     {
                         Id = markerId,
-                        PrimaryNodePath = nodePath,
+                        PrimaryNodePath = primaryNodePath,
                         MarkerId = anchored ? markerId : null,
                         HighlightedText = anchored ? selectedText : null,
                         Author = author,
@@ -137,29 +143,31 @@ public static class CommentsExtensions
                         Length = anchored ? length : 0,
                         AnchorText = anchored ? anchorText : null
                     };
-                    var commentNode = new MeshNode(markerId, $"{nodePath}/{CommentPartition}")
+
+                    // ONE canonical namespace for the created node, agreeing with the ↩ reply form and
+                    // the renderer's child query:
+                    //   • reply  → {parentCommentPath}/{id}      (direct child of the parent comment)
+                    //   • text/page comment → {doc}/_Comment/{id} (child of the doc's _Comment partition)
+                    // The old handler wrote a reply into {parentCommentPath}/_Comment/{id} and linked it
+                    // via the parent's Replies list — a THIRD namespace the renderer never read from, so
+                    // request-path replies were invisible too (issue #473).
+                    var commentNamespace = isReply ? nodePath : $"{nodePath}/{CommentPartition}";
+                    var mainNode = isReply ? primaryNodePath : nodePath;
+                    var commentNode = new MeshNode(markerId, commentNamespace)
                     {
-                        Name = $"Comment by {author}",
+                        Name = isReply ? $"Reply to {parentComment!.Author}" : $"Comment by {author}",
                         NodeType = CommentNodeType.NodeType,
-                        MainNode = nodePath,
+                        MainNode = mainNode,
                         Content = comment
                     };
 
                     logger?.LogInformation(
-                        "[CreateComment] Anchoring {Id} on {Path}: anchored={Anchored} pos={Start}+{Length} v={Version}",
-                        markerId, nodePath, anchored, start, length, version);
+                        "[CreateComment] Anchoring {Id} on {Path}: anchored={Anchored} pos={Start}+{Length} v={Version} isReply={IsReply}",
+                        markerId, nodePath, anchored, start, length, version, isReply);
 
-                    var create = meshService.CreateNode(commentNode);
-
-                    // Reply: append the reply id to the parent Comment's Replies list. (Page/text
-                    // comments on a Markdown node leave the document untouched — no parent write.)
-                    if (isReply)
-                        return create.SelectMany(_ => workspace.GetMeshNodeStream().Update(n =>
-                            n.Content is Comment parent
-                                ? n with { Content = parent with { Replies = parent.Replies.Add(markerId) } }
-                                : n));
-
-                    return create;
+                    // The reply is discovered by the parent comment's child-Comment query at render time
+                    // (CommentLayoutAreas.Overview) — no Replies-list denormalization to keep in sync.
+                    return meshService.CreateNode(commentNode);
                 })
                 .Subscribe(
                     _ => hub.Post(

--- a/src/MeshWeaver.Graph/Security/SatelliteAccessRule.cs
+++ b/src/MeshWeaver.Graph/Security/SatelliteAccessRule.cs
@@ -48,6 +48,23 @@ public class SatelliteAccessRule(string nodeType, IMessageHub hub) : INodeTypeAc
         if (string.IsNullOrEmpty(userId))
             userId = WellKnownUsers.Anonymous;
 
+        // A comment's AUTHOR may always delete their OWN comment — even with only Comment permission on
+        // the document. Without this, Comment Delete falls through to the MainNode-delegated
+        // Permission.Update below, so a commenter (no Update on the doc) sees the ✕ Delete button but the
+        // delete is denied and silently swallowed — the "no delete works" half of issue #391. Match by
+        // display Name, the SAME author identity the comment UI uses (Comment.Author is set from
+        // AccessContext.Name). Non-authors still need Update (editors/admins), so the effective rule is
+        // "author and admins can delete".
+        if (context.Operation == NodeOperation.Delete
+            && nodeType == "Comment"
+            && !string.IsNullOrEmpty(context.AccessContext?.Name))
+        {
+            var comment = context.Node.ContentAs<Comment>(hub.JsonSerializerOptions);
+            if (comment is not null
+                && string.Equals(comment.Author, context.AccessContext!.Name, StringComparison.OrdinalIgnoreCase))
+                return Observable.Return(true);
+        }
+
         var mainNodePath = context.Node.MainNode;
         // Degenerate case: no MainNode (or self-referencing). The rule has no
         // opinion — fall back to the same path-based check the validator would

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -18,6 +18,14 @@
          where cancellation matters. NOT a code-quality suppression: xUnit1031 (blocking task ops →
          deadlock risk) is deliberately NOT here and is fixed at the source instead. -->
     <NoWarn>$(NoWarn);CS1591;CS1573;CS1712;xUnit1051</NoWarn>
+    <!-- NuGet transitive-dependency ADVISORY warnings (NU1901-NU1904) must not fail the test build
+         under -warnaserror. The ROOT Directory.Build.props already carries exactly this policy for src/,
+         but this test-tree props does NOT import the root (see the doc-completeness note above), so a
+         newly-published advisory on a transitive package (e.g. AngleSharp GHSA-pgww-w46g-26qg → NU1902)
+         turned green test builds RED for every test project at once while src/ stayed a warning. Mirror
+         the central src policy here so the test tree tracks it uniformly. Vulnerability handling
+         (bump/replace) is a deliberate dependency decision, not a per-build -warnaserror gate. -->
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;$(WarningsNotAsErrors)</WarningsNotAsErrors>
     <!-- Required so the global <Using> items below (incl. MeshWeaver.Reactive.Assertions)
          are actually emitted. With ImplicitUsings disabled, <Using> is silently ignored,
          and Should()/Seconds() fail to resolve across every test file. -->

--- a/test/MeshWeaver.Content.Test/CommentDeletePermissionTest.cs
+++ b/test/MeshWeaver.Content.Test/CommentDeletePermissionTest.cs
@@ -1,0 +1,94 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Graph.Security;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Content.Test;
+
+/// <summary>
+/// Root-cause coverage for the "no delete works" half of #391, on a genuinely RESTRICTIVE partition
+/// (closed-by-default, in-memory — the file-system samples env is open-by-default and cannot model this).
+///
+/// <para>Pre-fix <see cref="SatelliteAccessRule"/> mapped Comment Delete → <c>Permission.Update</c> on the
+/// MainNode, so a commenter who holds only the <c>Commenter</c> role (Read + Comment, NO Update) was denied
+/// deleting their OWN comment — and the UI swallowed the failure. The fix lets a comment's AUTHOR delete
+/// their own comment; non-authors still need Update.</para>
+/// </summary>
+public class CommentDeletePermissionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string PermDoc = "CommentPermTest/Doc1";
+
+    // ConfigureMeshBase = in-memory + AddGraph, closed-by-default (NO PublicAdminAccess).
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder);
+
+    protected override async Task SetupAccessRightsAsync()
+    {
+        // The DevLogin admin needs a persisted Admin grant to create fixtures on a closed mesh.
+        await NodeFactory.CreateNode(AssignmentNodeFactory.UserRole(TestUsers.Admin.ObjectId, "Admin", null))
+            .Should().Within(45.Seconds()).Emit();
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task CommentAuthor_CanDeleteOwnComment_ButNonAuthorWithoutUpdateCannot()
+    {
+        // Establish the partition with a real node → closed-by-default for role-less users.
+        await NodeFactory.CreateNode(MeshNode.FromPath(PermDoc) with { Name = "Doc1", NodeType = "Markdown" })
+            .Should().Within(45.Seconds()).Emit();
+
+        // Grant "bob" ONLY the Commenter role (Read + Comment, NO Update) at the partition scope.
+        await NodeFactory.CreateNode(AssignmentNodeFactory.UserRole("bob", "Commenter", "CommentPermTest"))
+            .Should().Within(45.Seconds()).Emit();
+
+        // Confirm the exact shape the bug needs: Comment but NOT Update.
+        var bobPerms = await Mesh.GetEffectivePermissions(PermDoc, "bob")
+            .Should().Within(60.Seconds()).Match(p => p.HasFlag(Permission.Comment));
+        bobPerms.Should().HaveFlag(Permission.Comment, "Bob is a Commenter on the document");
+        bobPerms.Should().NotHaveFlag(Permission.Update, "Commenter grants no Update — the crux of #391");
+
+        var rule = new SatelliteAccessRule("Comment", Mesh);
+
+        // Bob deletes HIS OWN comment → allowed via the author short-circuit (his effective Update is None).
+        var authorAllowed = await rule.HasAccess(new NodeValidationContext
+        {
+            Operation = NodeOperation.Delete,
+            Node = new MeshNode("c1", $"{PermDoc}/_Comment")
+            {
+                NodeType = CommentNodeType.NodeType,
+                MainNode = PermDoc,
+                Content = new Comment { Id = "c1", Author = "Bob", PrimaryNodePath = PermDoc }
+            },
+            AccessContext = new AccessContext { ObjectId = "bob", Name = "Bob" }
+        }, "bob").FirstAsync().ToTask();
+        authorAllowed.Should().BeTrue(
+            "a comment's author (matched by display name) may delete their own comment even without Update (#391)");
+
+        // Bob tries to delete ALICE's comment → not the author → delegates to Update on the doc, which Bob
+        // lacks → denied. Proves the allowance is the author short-circuit, not a blanket relaxation — and
+        // that pre-fix Bob's OWN delete would have hit exactly this denial.
+        var nonAuthorDenied = await rule.HasAccess(new NodeValidationContext
+        {
+            Operation = NodeOperation.Delete,
+            Node = new MeshNode("c2", $"{PermDoc}/_Comment")
+            {
+                NodeType = CommentNodeType.NodeType,
+                MainNode = PermDoc,
+                Content = new Comment { Id = "c2", Author = "Alice", PrimaryNodePath = PermDoc }
+            },
+            AccessContext = new AccessContext { ObjectId = "bob", Name = "Bob" }
+        }, "bob").FirstAsync().ToTask();
+        nonAuthorDenied.Should().BeFalse(
+            "a non-author without Update on the document cannot delete someone else's comment");
+
+        Output.WriteLine("✅ Author can delete own comment; non-author without Update cannot.");
+    }
+}

--- a/test/MeshWeaver.Content.Test/CommentReplyDeleteViewTest.cs
+++ b/test/MeshWeaver.Content.Test/CommentReplyDeleteViewTest.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Documentation;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.ShortGuid;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Content.Test;
+
+/// <summary>
+/// Regression coverage for the two comment issues:
+/// <list type="bullet">
+///   <item>#473 — a reply created as a direct-child Comment node is invisible: the Overview rendered
+///     replies from the never-maintained <c>Comment.Replies</c> list. Fixed by discovering replies with
+///     the same child-query pattern the page-level comment list uses, so write (CreateNode a child) and
+///     read (query children) agree on ONE namespace.</item>
+///   <item>#391 — a comment can be deleted end-to-end, and a comment's AUTHOR may delete their own
+///     comment even without Update on the document (<see cref="SatelliteAccessRule"/> previously mapped
+///     Comment Delete → Update on the MainNode, locking authors out).</item>
+/// </list>
+/// </summary>
+[Collection("SamplesGraphData")]
+public class CommentReplyDeleteViewTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    protected override bool ShareMeshAcrossTests => true;
+
+    private const string DocPath = "Doc/DataMesh/CollaborativeEditing";
+    private const string CommentNs = DocPath + "/" + CommentsExtensions.CommentPartition;
+
+    private static readonly string SharedCacheDirectory = Path.Combine(
+        Path.GetTempPath(), "MeshWeaverCommentReplyDeleteViewTest", ".mesh-cache");
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var graphPath = TestPaths.SamplesGraph;
+        var dataDirectory = TestPaths.SamplesGraphData;
+        Directory.CreateDirectory(SharedCacheDirectory);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Graph:Storage:SourceType"] = "FileSystem",
+                ["Graph:Storage:BasePath"] = graphPath
+            })
+            .Build();
+
+        return builder
+            .UseMonolithMesh()
+            .AddPartitionedFileSystemPersistence(dataDirectory)
+            .AddMeshWeaverDocs()
+            .AddDoc()
+            .AddDocumentation()
+            .ConfigureServices(services =>
+            {
+                services.Configure<CompilationCacheOptions>(o =>
+                {
+                    o.CacheDirectory = SharedCacheDirectory;
+                    o.EnableDiskCache = true;
+                });
+                services.AddSingleton<IConfiguration>(configuration);
+                return services;
+            })
+            .AddGraph()
+            .ConfigureDefaultNodeHub(config => config.AddDefaultLayoutAreas());
+    }
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    // ── #473: reply visibility ───────────────────────────────────────────────
+
+    /// <summary>
+    /// A reply authored by user B on user A's comment must be visible to every reader. Pre-fix the parent
+    /// comment's Overview read <c>Comment.Replies</c> (which the write path never populated), so the reply
+    /// — a real direct-child Comment node — was never rendered. Post-fix the Overview discovers it via a
+    /// child query and shows a "Replies (1)" section.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task Reply_ByAnotherUser_IsVisibleInParentCommentOverview()
+    {
+        // User A (Alice) writes a top-level comment.
+        var commentId = Guid.NewGuid().AsString();
+        var commentPath = $"{CommentNs}/{commentId}";
+        await NodeFactory.CreateNode(new MeshNode(commentId, CommentNs)
+        {
+            Name = "Comment by Alice",
+            NodeType = CommentNodeType.NodeType,
+            MainNode = DocPath,
+            Content = new Comment
+            {
+                Id = commentId,
+                PrimaryNodePath = DocPath,
+                Author = "Alice",
+                Text = "Original comment",
+                Status = CommentStatus.Active
+            }
+        }).Should().Emit();
+
+        // User B (Bob) replies — a direct-child Comment node, exactly what the ↩ reply form writes.
+        var replyId = Guid.NewGuid().AsString();
+        await NodeFactory.CreateNode(new MeshNode(replyId, commentPath)
+        {
+            Name = "Reply to Alice",
+            NodeType = CommentNodeType.NodeType,
+            MainNode = DocPath,
+            Content = new Comment
+            {
+                Id = replyId,
+                PrimaryNodePath = DocPath,
+                Author = "Bob",
+                Text = "Bob's answer to Alice",
+                Status = CommentStatus.Active
+            }
+        }).Should().Emit();
+
+        // Render the parent comment's Overview and confirm the reply is discovered.
+        var workspace = GetClient().GetWorkspace();
+        var reference = new LayoutAreaReference(CommentLayoutAreas.OverviewArea);
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(commentPath), reference);
+
+        await WaitForStoreToContain(stream, "Replies (1)",
+            "the parent comment Overview must render a replies section once a child reply exists (#473)");
+        Output.WriteLine("✅ Reply authored by Bob is visible in Alice's comment Overview.");
+    }
+
+    /// <summary>
+    /// Zero-write repro against the shipped sample data: <c>Doc/DataMesh/CollaborativeEditing/_Comment/c1</c>
+    /// has a direct-child reply <c>c1/reply1</c> authored by a different user, but its own
+    /// <c>Comment.Replies</c> list is empty. Pre-fix that reply was invisible; post-fix the child query
+    /// surfaces it.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task SampleComment_WithChildReply_ShowsRepliesSection()
+    {
+        var workspace = GetClient().GetWorkspace();
+        var reference = new LayoutAreaReference(CommentLayoutAreas.OverviewArea);
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address($"{CommentNs}/c1"), reference);
+
+        await WaitForStoreToContain(stream, "Replies (1)",
+            "sample comment c1 has a child reply1 on disk that must render even though c1.Replies is empty (#473)");
+        Output.WriteLine("✅ Sample reply1 is discovered under c1.");
+    }
+
+    // ── #391: view after creation ────────────────────────────────────────────
+
+    /// <summary>
+    /// A written comment must be viewable/openable again: rendering its own Overview shows its text.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task Comment_CanBeViewedAfterCreation()
+    {
+        var commentId = Guid.NewGuid().AsString();
+        var commentPath = $"{CommentNs}/{commentId}";
+        const string uniqueText = "A distinctive comment body to look for";
+        await NodeFactory.CreateNode(new MeshNode(commentId, CommentNs)
+        {
+            Name = "Comment by Alice",
+            NodeType = CommentNodeType.NodeType,
+            MainNode = DocPath,
+            Content = new Comment
+            {
+                Id = commentId,
+                PrimaryNodePath = DocPath,
+                Author = "Alice",
+                Text = uniqueText,
+                Status = CommentStatus.Active
+            }
+        }).Should().Emit();
+
+        var workspace = GetClient().GetWorkspace();
+        var reference = new LayoutAreaReference(CommentLayoutAreas.OverviewArea);
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(commentPath), reference);
+
+        await WaitForStoreToContain(stream, uniqueText,
+            "a created comment must be re-openable and show its text in the Overview (#391)");
+        Output.WriteLine("✅ Comment is viewable after creation.");
+    }
+
+    // ── #391: delete ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A comment can be deleted end-to-end. The successful <c>DeleteNodeResponse</c> is the authoritative
+    /// proof that the comment was removed through the access-controlled delete pipeline (#391) — the same
+    /// assertion every delete test in the suite uses.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task Comment_CanBeDeleted_EndToEnd()
+    {
+        var commentId = Guid.NewGuid().AsString();
+        var commentPath = $"{CommentNs}/{commentId}";
+        await NodeFactory.CreateNode(new MeshNode(commentId, CommentNs)
+        {
+            Name = "Comment by Alice",
+            NodeType = CommentNodeType.NodeType,
+            MainNode = DocPath,
+            Content = new Comment { Id = commentId, PrimaryNodePath = DocPath, Author = "Alice", Text = "delete me" }
+        }).Should().Within(45.Seconds()).Emit();
+
+        await NodeFactory.DeleteNode(commentPath).Should().Within(45.Seconds()).Emit();
+        Output.WriteLine("✅ Comment deleted end-to-end.");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private async Task WaitForStoreToContain(ISynchronizationStream<JsonElement> stream, string needle, string because)
+        => (await stream
+                .Where(item => item.Value.ValueKind != JsonValueKind.Undefined
+                               && item.Value.GetRawText().Contains(needle))
+                .Should().Within(30.Seconds()).Emit())
+            .Should().NotBeNull(because);
+}


### PR DESCRIPTION
Fixes #473. Fixes #391.

Three cooperating defects in the comments feature, fixed at the root by unifying the reply write/read model and the delete-permission gate.

## #473 — comment replies never visible to other users
- **Root cause (`CommentLayoutAreas.BuildOverview`, ~line 262):** the Overview rendered replies from `Comment.Replies`, a denormalized list nothing on the write path maintains — the ↩ form never appended to it and the sample data leaves it empty, so every reply was an orphaned node no one saw. Separately, `CommentsExtensions.HandleCreateCommentRequest` wrote a reply into a **third** namespace (`{parent}/_Comment/{id}`) that the renderer never read (write/read namespaces disagreed).
- **Fix:** the Overview now discovers replies with the same child-`Comment` synced query the page-level list uses (`namespace:{commentPath} nodeType:Comment`). Both write paths (the ↩ form and the request handler) create the reply as a direct child `{parentCommentPath}/{id}` with `MainNode` = the document. Write namespace and read namespace now agree by construction; the `Replies` denormalization is no longer relied upon. A failed reply write surfaces an error in the form instead of a server-only log line.

## #391 — cannot delete a comment; cannot view it again
- **Delete root cause (`SatelliteAccessRule`):** Comment `Delete` delegated to `Permission.Update` on the MainNode, so a commenter (Comment permission, no Update) saw the ✕ Delete button but the delete was denied and the error was swallowed. **Fix:** a comment's **author** may delete their own comment (matched by display name — the identity the comment UI already uses); non-authors still need Update, preserving "author and admins can delete". The delete click action now logs failures instead of swallowing them.
- **View:** the comment display/list already uses the observed child-`Comment` query; the reply fix makes the whole comment tree (top-level + replies) render through one coherent, verified read path. See the note below on the deployed-portal (Postgres) angle.

## Tests (no mocking, `MonolithMeshTestBase`)
- `CommentReplyDeleteViewTest` — a reply authored by another user is visible in the parent comment's Overview (both a write-based case and the shipped `Doc/DataMesh/CollaborativeEditing/_Comment/c1/reply1` sample, whose parent `Replies` is empty); a written comment is viewable again; a comment can be deleted end-to-end.
- `CommentDeletePermissionTest` — on a restrictive (closed-by-default) partition, a `Commenter`-only **author** can delete their own comment, while a non-author without Update cannot.

All comment/reply tests green: `Content.Test` (34), `Graph.Test` comment tests (12), `Markdown.Collaboration.Test` comment tests (54). Changed projects build clean under `-c Release -warnaserror -p:CIRun=true`.

## Note — Postgres satellite-scope caveat (separate, feature-wide)
On the Postgres backend, a satellite query `namespace:{doc}/_Comment nodeType:Comment` is scoped by `main_node` subtree of `{doc}/_Comment`, but comments carry `main_node = {doc}` — so that specific list query can under-return on PG. This is a **pre-existing, feature-wide** satellite-query-semantics issue (it affects the page comment list independently of this PR) and is not reproducible in the file-system monolith test harness (which matches satellites by namespace/path). This PR's reply rendering is **path-addressed** (each reply is a `LayoutArea` at its exact path) so it is provider-agnostic; the delete fix is provider-agnostic. The PG list-query scope is flagged here for a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)