### PR TITLE
feat(gitsync): push webhooks auto-update synced Spaces

### DIFF
--- a/memex/Memex.Portal.Shared/Social/GitHubWebhookEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/GitHubWebhookEndpoints.cs
@@ -22,9 +22,11 @@ namespace Memex.Portal.Shared.Social;
 ///
 /// <para>Register ONE webhook per repo in GitHub → Settings → Webhooks, pointing at
 /// <c>https://{host}/webhooks/github</c>, content-type <c>application/json</c>, with the same
-/// secret, subscribed to the <c>Issues</c> + <c>Issue comments</c> events. The <c>async</c> here
-/// is the sanctioned HTTP-boundary bridge (mirrors <see cref="GitHubConnectEndpoints"/>); the
-/// processing itself is reactive.</para>
+/// secret, subscribed to the <c>Issues</c> + <c>Issue comments</c> + <c>Pushes</c> events —
+/// a push triggers the headless "Update to latest" for every Space sync source matching the
+/// pushed repo/branch/subdirectory, so GitSync'd Spaces stay current without polling. The
+/// <c>async</c> here is the sanctioned HTTP-boundary bridge (mirrors
+/// <see cref="GitHubConnectEndpoints"/>); the processing itself is reactive.</para>
 /// </summary>
 public static class GitHubWebhookEndpoints
 {

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +23,16 @@ namespace MeshWeaver.GitSync;
 /// that repository, merging in the new comment on a comment event and preserving comments already
 /// synced. The write runs under the system identity (an infrastructure mirror update, the same
 /// identity model as the instance-sync pull and <c>StaticRepoImporter</c>).
+///
+/// <para><c>push</c> events keep GitSync'd Spaces CURRENT without polling: every Space whose
+/// sync config targets the pushed repository + branch — and, when the config scopes a
+/// subdirectory, whose subdirectory the push actually touched — gets the same headless
+/// "Update to latest" the GUI button and the MCP <c>git_hub_sync</c> tool run
+/// (<see cref="GitHubActivityExtensions.UpdateToLatestFromGitHub"/>, <c>force: false</c> so
+/// two-way conflict resolution still protects server-side edits). The mesh writes run under
+/// the system identity; the GitHub pull authenticates as the sync config's CREATOR (their
+/// connected credential, or the GitHub App when they have none). Register the repo webhook
+/// with the <c>Pushes</c> event next to <c>Issues</c>/<c>Issue comments</c>.</para>
 ///
 /// <para>Pull-request events are intentionally ignored: PR state is read LIVE (delegated) and
 /// never materialized, so there is no node to refresh. Reactive end-to-end — no
@@ -70,6 +81,8 @@ public sealed class GitHubWebhookProcessor
     /// </summary>
     public IObservable<int> Process(string eventType, JsonElement payload)
     {
+        if (string.Equals(eventType, "push", StringComparison.OrdinalIgnoreCase))
+            return ProcessPush(payload);
         var isIssues = string.Equals(eventType, "issues", StringComparison.OrdinalIgnoreCase);
         var isComment = string.Equals(eventType, "issue_comment", StringComparison.OrdinalIgnoreCase);
         if (!isIssues && !isComment)
@@ -102,6 +115,151 @@ public sealed class GitHubWebhookProcessor
                 .ToList()
                 .Select(list => list.Count);
         });
+    }
+
+    // ── push → auto-update ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// One parsed <c>push</c> event: the branch and the union of file paths the push touched.
+    /// <see cref="ChangedPaths"/> is <see langword="null"/> when the change set is UNKNOWN
+    /// (GitHub caps the <c>commits</c> array at 20 — a larger push must sync every candidate
+    /// rather than silently skipping a subdirectory it can't see).
+    /// </summary>
+    internal sealed record PushEvent(string Branch, IReadOnlyList<string>? ChangedPaths);
+
+    /// <summary>A Space sync source to update: the Space path, the source id (null = primary),
+    /// and the user whose GitHub credential authenticates the pull — the sync config's CREATOR
+    /// (the human who set the sync up; the activity-owner model), falling back to the system
+    /// identity, which <see cref="GitHubSyncService"/> resolves to the GitHub App.</summary>
+    internal sealed record PushTarget(string SpacePath, string? SourceId, string UserId);
+
+    /// <summary>
+    /// Parses a <c>push</c> payload. False for non-branch refs (tag pushes) and branch
+    /// deletions — there is nothing to import from either.
+    /// </summary>
+    internal static bool TryParsePush(JsonElement payload, out PushEvent push)
+    {
+        push = null!;
+        const string headsPrefix = "refs/heads/";
+        var @ref = GetString(payload, "ref");
+        if (@ref is null || !@ref.StartsWith(headsPrefix, StringComparison.Ordinal))
+            return false;
+        if (payload.TryGetProperty("deleted", out var del) && del.ValueKind == JsonValueKind.True)
+            return false;
+
+        IReadOnlyList<string>? changed = null;
+        if (payload.TryGetProperty("commits", out var commits) && commits.ValueKind == JsonValueKind.Array)
+        {
+            var set = new HashSet<string>(StringComparer.Ordinal);
+            var commitCount = 0;
+            foreach (var commit in commits.EnumerateArray())
+            {
+                commitCount++;
+                set.UnionWith(GetArray(commit, "added", Self));
+                set.UnionWith(GetArray(commit, "modified", Self));
+                set.UnionWith(GetArray(commit, "removed", Self));
+            }
+            // payload.size = commits in the push; the commits array is capped at 20.
+            var size = GetInt(payload, "size");
+            changed = size > commitCount ? null : set.ToList();
+        }
+        push = new PushEvent(@ref[headsPrefix.Length..], changed);
+        return true;
+
+        static string? Self(JsonElement el)
+            => el.ValueKind == JsonValueKind.String ? el.GetString() : null;
+    }
+
+    /// <summary>
+    /// Whether one sync source should update for <paramref name="push"/>: the branch must match,
+    /// the source must be allowed to import, and — when the source scopes a subdirectory and the
+    /// push's change set is known — the push must have touched that subdirectory.
+    /// </summary>
+    internal static bool ConfigMatchesPush(GitHubSyncConfig? cfg, PushEvent push)
+    {
+        if (cfg is null || cfg.Direction == SyncDirection.ExportOnly)
+            return false;
+        if (!string.Equals(cfg.Branch, push.Branch, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (push.ChangedPaths is null)
+            return true;
+        var sub = cfg.Subdirectory?.Trim('/') ?? "";
+        if (sub.Length == 0)
+            return push.ChangedPaths.Count > 0;
+        return push.ChangedPaths.Any(p =>
+            p.Equals(sub, StringComparison.OrdinalIgnoreCase)
+            || p.StartsWith(sub + "/", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// A verified <c>push</c> → the same headless "Update to latest" for every matching sync
+    /// source. TRIGGERS the updates (each runs as its own activity, fire-and-forget with error
+    /// logging) and emits the number triggered — it does NOT await the imports, so the webhook
+    /// response returns within GitHub's delivery timeout.
+    /// </summary>
+    private IObservable<int> ProcessPush(JsonElement payload)
+    {
+        if (!TryParsePush(payload, out var push) || !TryGetRepoUrl(payload, out var repoUrl))
+            return Observable.Return(0);
+
+        return MatchingSyncTargets(repoUrl, push).Select(targets =>
+        {
+            if (targets.Count == 0)
+            {
+                logger?.LogInformation(
+                    "GitHub push webhook for {Repo}@{Branch} matched no synced Space.", repoUrl, push.Branch);
+                return 0;
+            }
+            logger?.LogInformation(
+                "GitHub push webhook ({Repo}@{Branch}) → updating {Count} sync source(s) to latest.",
+                repoUrl, push.Branch, targets.Count);
+            var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+            foreach (var t in targets)
+                Observable.Using(
+                        () => accessService.ImpersonateAsSystem(),
+                        _ => hub.UpdateToLatestFromGitHub(
+                            t.SpacePath, t.UserId, sourceId: t.SourceId))
+                    .Subscribe(
+                        activity => logger?.LogInformation(
+                            "Push-triggered update of {Space} completed ({Activity}).", t.SpacePath, activity),
+                        exception => logger?.LogWarning(exception,
+                            "Push-triggered update of {Space} (source {Source}) failed.",
+                            t.SpacePath, t.SourceId ?? "(primary)"));
+            return targets.Count;
+        });
+    }
+
+    /// <summary>The distinct sync sources whose config targets <paramref name="repoUrl"/> AND
+    /// matches the push's branch + touched paths.</summary>
+    private IObservable<IReadOnlyList<PushTarget>> MatchingSyncTargets(string repoUrl, PushEvent push)
+    {
+        var target = ParseSafe(repoUrl);
+        return meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{GitHubSyncService.ConfigNodeType}"))
+            .Take(1)
+            .Select(c => (IReadOnlyList<PushTarget>)c.Items
+                .Where(n => RepoMatches(n, target))
+                .Where(n => ConfigMatchesPush(
+                    n.ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions, logger), push))
+                .Select(ToPushTarget)
+                .Where(t => t is not null)
+                .Select(t => t!)
+                .DistinctBy(t => (t.SpacePath, t.SourceId))
+                .ToList());
+    }
+
+    /// <summary>Maps a config node path (<c>{space}/_GitSync</c> or <c>{space}/_GitSync/{sourceId}</c>)
+    /// to the Space + source id it configures.</summary>
+    private static PushTarget? ToPushTarget(MeshNode configNode)
+    {
+        var parts = configNode.Path.Split('/');
+        var idx = Array.IndexOf(parts, GitHubSyncService.ConfigId);
+        if (idx <= 0)
+            return null;
+        var space = string.Join('/', parts[..idx]);
+        var sourceId = idx == parts.Length - 1 ? null : string.Join('/', parts[(idx + 1)..]);
+        var userId = configNode.CreatedBy is { Length: > 0 } creator ? creator : WellKnownUsers.System;
+        return new PushTarget(space, sourceId, userId);
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
@@ -123,4 +123,112 @@ public class GitHubWebhookProcessorTest(ITestOutputHelper output) : GitHubSyncTe
         var updated = await Webhooks.Process("issues", payload).Timeout(60.Seconds()).ToTask();
         Assert.Equal(0, updated);
     }
+
+    // ── push → auto-update ───────────────────────────────────────────────────
+
+    [Fact]
+    public void TryParsePush_BranchFilesAndTruncation()
+    {
+        // A branch push with two commits: the changed set is the union of added/modified/removed.
+        var push = ParsePush("""
+        {
+          "ref": "refs/heads/main", "size": 2,
+          "commits": [
+            { "added": ["Store/index.json"], "modified": [], "removed": [] },
+            { "added": [], "modified": ["Store/Plugin.json"], "removed": ["Old.md"] }
+          ]
+        }
+        """);
+        Assert.NotNull(push);
+        Assert.Equal("main", push!.Branch);
+        Assert.NotNull(push.ChangedPaths);
+        Assert.Equal(
+            new[] { "Old.md", "Store/Plugin.json", "Store/index.json" },
+            push.ChangedPaths!.OrderBy(p => p, StringComparer.Ordinal));
+
+        // GitHub caps the commits array at 20 — when size exceeds it, the change set is UNKNOWN.
+        Assert.Null(ParsePush("""
+        { "ref": "refs/heads/main", "size": 25,
+          "commits": [ { "added": ["A.md"], "modified": [], "removed": [] } ] }
+        """)!.ChangedPaths);
+
+        // Tag pushes and branch deletions carry nothing to import.
+        Assert.Null(ParsePush("""{ "ref": "refs/tags/v1.0", "commits": [] }"""));
+        Assert.Null(ParsePush("""{ "ref": "refs/heads/main", "deleted": true, "commits": [] }"""));
+
+        static GitHubWebhookProcessor.PushEvent? ParsePush(string json)
+            => GitHubWebhookProcessor.TryParsePush(JsonDocument.Parse(json).RootElement, out var p) ? p : null;
+    }
+
+    [Fact]
+    public void ConfigMatchesPush_BranchDirectionAndSubdirectory()
+    {
+        var main = new GitHubWebhookProcessor.PushEvent("main", ["Store/index.json", "README.md"]);
+        var cfg = new GitHubSyncConfig { RepositoryUrl = "https://github.com/o/r", Branch = "main" };
+
+        // Branch must match; export-only sources never import.
+        Assert.True(GitHubWebhookProcessor.ConfigMatchesPush(cfg, main));
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(cfg with { Branch = "develop" }, main));
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(
+            cfg with { Direction = SyncDirection.ExportOnly }, main));
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(null, main));
+
+        // A subdirectory-scoped source updates only when the push touched its subdirectory.
+        Assert.True(GitHubWebhookProcessor.ConfigMatchesPush(cfg with { Subdirectory = "Store" }, main));
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(cfg with { Subdirectory = "Chess" }, main));
+        // Prefix must be segment-aligned: "Store" must not match "StoreFront/…".
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(
+            cfg with { Subdirectory = "Store" },
+            new GitHubWebhookProcessor.PushEvent("main", ["StoreFront/index.json"])));
+
+        // UNKNOWN change set (truncated push) → every candidate syncs rather than missing one.
+        var unknown = new GitHubWebhookProcessor.PushEvent("main", null);
+        Assert.True(GitHubWebhookProcessor.ConfigMatchesPush(cfg with { Subdirectory = "Chess" }, unknown));
+
+        // An empty change set (no-op push) syncs nothing.
+        var empty = new GitHubWebhookProcessor.PushEvent("main", []);
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(cfg, empty));
+        Assert.False(GitHubWebhookProcessor.ConfigMatchesPush(cfg with { Subdirectory = "Store" }, empty));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Process_PushEvent_TriggersUpdateToLatestOnMatchingSpaces()
+    {
+        await Connect();
+        var repo = "https://github.com/test/push-auto";
+
+        // Space A authors content and commits it — the fake repo now holds the canonical files.
+        var a = "GhPa" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(a, "Push Source Space");
+        await CreateMarkdown($"{a}/Welcome", "Welcome", "# Welcome\n\nPushed content.");
+        await Sync.SaveConfig(a, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+        await Sync.SyncToGitHub(a, UserId).Timeout(60.Seconds()).ToTask();
+
+        // Space B syncs the SAME repo but has never imported — the push must update it headlessly.
+        var b = "GhPb" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(b, "Push Target Space");
+        await Sync.SaveConfig(b, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
+
+        // A push on a DIFFERENT branch matches nothing.
+        var otherBranch = JsonDocument.Parse("""
+        { "ref": "refs/heads/develop", "size": 1,
+          "repository": { "full_name": "test/push-auto" },
+          "commits": [ { "added": ["Welcome.md"], "modified": [], "removed": [] } ] }
+        """).RootElement;
+        Assert.Equal(0, await Webhooks.Process("push", otherBranch).Timeout(60.Seconds()).ToTask());
+
+        // The main-branch push triggers the headless update for BOTH sync sources.
+        var payload = JsonDocument.Parse("""
+        { "ref": "refs/heads/main", "size": 1,
+          "repository": { "full_name": "test/push-auto" },
+          "commits": [ { "added": [], "modified": ["Welcome.md"], "removed": [] } ] }
+        """).RootElement;
+        var triggered = await Webhooks.Process("push", payload).Timeout(60.Seconds()).ToTask();
+        Assert.Equal(2, triggered);
+
+        // The import runs as a background activity — observe the node landing in Space B.
+        var imported = await WaitForNode($"{b}/Welcome");
+        Assert.Equal("Markdown", imported.NodeType);
+        Assert.Contains("Pushed content.", MarkdownBody(imported));
+    }
 }


### PR DESCRIPTION
## Why

Installed plugin/course Spaces drift behind their repos: a push to `Systemorph/MeshWeaver.Plugins` or `education` only reaches a portal when someone manually runs *Update to latest* per Space (tonight's Store rollout needed 10 hand-triggered syncs).

## What

The existing HMAC-verified webhook receiver (`POST /webhooks/github`, secret `GitHub:Webhook:Secret`) now handles the **push** event:

- **`TryParsePush`** — branch pushes only (tag pushes / branch deletions ignored); changed set = union of the commits' `added`/`modified`/`removed`; when GitHub's 20-commit payload cap truncates the push, the change set is treated as UNKNOWN and every candidate syncs (never silently miss a subdirectory).
- **`ConfigMatchesPush`** — a sync source updates when repo + branch match, it may import (not `ExportOnly`), and — when it scopes a subdirectory with a known change set — the push touched that subdirectory (segment-aligned prefix: `Store` ≠ `StoreFront/…`).
- Each match triggers the **same headless `UpdateToLatestFromGitHub`** the GUI button and MCP `git_hub_sync` use (`force: false` → two-way conflict resolution keeps protecting server-side edits), fire-and-forget with error logging so the webhook responds inside GitHub's 10s delivery timeout. Mesh writes run under System; the GitHub pull authenticates as the sync config's **creator** (their connected credential, else the GitHub App).

## Verification

- Pure tests: branch/tag/deletion parsing, truncation→UNKNOWN, subdirectory alignment, direction filtering.
- End-to-end (fake repo): Space A commits; Space B syncs the same repo; a push event headlessly imports into B; a different-branch push matches nothing.
- `MeshWeaver.GitSync.Test` **130/130 green**; `dotnet build -c Release -warnaserror` clean on the touched projects.

## Rollout

After deploy, edit the existing per-repo webhook (GitHub → Settings → Webhooks → `https://memex.meshweaver.cloud/webhooks/github`) and additionally subscribe the **Pushes** event — same URL, same secret. Repos: `MeshWeaver.Plugins`, `education` (and any other GitSync'd repo that should auto-deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)