### PR TITLE
Persist node authorship in Postgres (created/last-modified by + date)

### DIFF
--- a/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
+++ b/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
@@ -53,6 +53,7 @@ public static class MigrationRegistry
         new V42_ReapplySpaceAuthMirrorAndBackfill(),
         new V43_FixAccessTriggerSchemaResolutionAndBackfill(),
         new V44_FixMeshNodeHistoryTriggerPerSchema(),
+        new V45_AddNodeAuthorshipColumns(),
     ];
 
     /// <summary>

--- a/memex/aspire/Memex.Database.Migration/Migrations/V45_AddNodeAuthorshipColumns.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V45_AddNodeAuthorshipColumns.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Database.Migration.Migrations;
+
+/// <summary>
+/// Adds the node-authorship columns (<c>created_by</c>, <c>last_modified_by</c>, <c>created_date</c>)
+/// to every same-schema partition's <c>mesh_nodes</c> and makes the history trigger record the
+/// modifier.
+///
+/// <para><b>Background.</b> <c>MeshNode</c> carries <c>CreatedBy</c> / <c>LastModifiedBy</c> /
+/// <c>CreatedDate</c> (stamped by the create/update handlers), but the Postgres <c>mesh_nodes</c>
+/// table never had columns for them and the adapter never wrote/read them — so on every PG-backed
+/// mesh each node round-tripped with NULL authorship (the "Created by / Updated by" line in the node
+/// header rendered blank). This adds the columns; the adapter (same change set) now persists and
+/// hydrates them.</para>
+///
+/// <para><b>Steps per same-schema partition (a schema owning both <c>mesh_nodes</c> and its own
+/// <c>mesh_node_history</c>), all idempotent:</b></para>
+/// <list type="number">
+///   <item><c>ALTER TABLE … ADD COLUMN IF NOT EXISTS</c> the three authorship columns.</item>
+///   <item><c>CREATE OR REPLACE</c> <c>{schema}.trg_mesh_node_to_history()</c> so the history
+///     snapshot's <c>changed_by</c> is populated from <c>NEW.last_modified_by</c> (schema-qualified
+///     insert via <c>TG_TABLE_SCHEMA</c>); ensure the trigger exists (belt-and-braces with V44).</item>
+/// </list>
+///
+/// <para><b>No backfill.</b> Authorship for rows written before this change was never captured and
+/// cannot be recovered; identities populate on the first write after the fix. Frozen inline SQL —
+/// matches <c>PostgreSqlSchemaInitializer.GetVersionedPartitionDdl</c> as of V45.</para>
+///
+/// <para><b>Scope.</b> Same-schema partitions only; cross-schema <c>{schema}_versions</c> layouts are
+/// left untouched (their history lives elsewhere and their trigger already schema-qualifies).</para>
+/// </summary>
+public sealed class V45_AddNodeAuthorshipColumns : IMigration
+{
+    public int Version => 45;
+    public string Description => "Add created_by/last_modified_by/created_date to mesh_nodes on every partition schema (PG dropped node authorship on write) and record changed_by in the history trigger";
+
+    public async Task RunAsync(MigrationContext ctx)
+    {
+        var schemas = new List<string>();
+        await using (var discover = ctx.DataSource.CreateCommand("""
+            SELECT n.table_schema
+            FROM information_schema.tables n
+            WHERE n.table_name = 'mesh_nodes'
+              AND n.table_schema NOT IN ('information_schema','pg_catalog','pg_toast')
+              AND n.table_schema NOT LIKE '%\_versions'
+              AND EXISTS (
+                  SELECT 1 FROM information_schema.tables h
+                  WHERE h.table_name = 'mesh_node_history'
+                    AND h.table_schema = n.table_schema)
+            ORDER BY n.table_schema
+            """))
+        await using (var rdr = await discover.ExecuteReaderAsync())
+        {
+            while (await rdr.ReadAsync())
+                schemas.Add(rdr.GetString(0));
+        }
+
+        foreach (var schema in schemas)
+        {
+            var quotedSchema = "\"" + schema.Replace("\"", "\"\"") + "\"";
+
+            // 1. Authorship columns (idempotent).
+            await using (var alter = ctx.DataSource.CreateCommand($"""
+                ALTER TABLE {quotedSchema}.mesh_nodes
+                    ADD COLUMN IF NOT EXISTS created_by       TEXT,
+                    ADD COLUMN IF NOT EXISTS last_modified_by TEXT,
+                    ADD COLUMN IF NOT EXISTS created_date     TIMESTAMPTZ
+                """))
+            {
+                await alter.ExecuteNonQueryAsync();
+            }
+
+            // 2. History trigger records changed_by = NEW.last_modified_by (schema-qualified insert).
+            await using (var trg = ctx.DataSource.CreateCommand($"""
+                CREATE OR REPLACE FUNCTION {quotedSchema}.trg_mesh_node_to_history() RETURNS TRIGGER AS $trg_history$
+                BEGIN
+                    EXECUTE format(
+                        'INSERT INTO %I.mesh_node_history (
+                            namespace, id, name, node_type, description, category, icon,
+                            display_order, last_modified, version, state, content, desired_id, main_node, changed_by
+                        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+                        ON CONFLICT (namespace, id, version) DO NOTHING',
+                        TG_TABLE_SCHEMA
+                    ) USING
+                        NEW.namespace, NEW.id, NEW.name, NEW.node_type, NEW.description,
+                        NEW.category, NEW.icon, NEW.display_order, NEW.last_modified,
+                        NEW.version, NEW.state, NEW.content, NEW.desired_id, NEW.main_node, NEW.last_modified_by;
+                    RETURN NEW;
+                END;
+                $trg_history$ LANGUAGE plpgsql;
+
+                DO $ensure_trigger$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_trigger tg
+                        JOIN pg_class c ON c.oid = tg.tgrelid
+                        JOIN pg_namespace n ON n.oid = c.relnamespace
+                        WHERE tg.tgname = 'mesh_node_copy_to_history'
+                          AND c.relname = 'mesh_nodes' AND n.nspname = '{schema.Replace("'", "''")}')
+                    THEN
+                        CREATE TRIGGER mesh_node_copy_to_history
+                            AFTER INSERT OR UPDATE ON {quotedSchema}.mesh_nodes
+                            FOR EACH ROW EXECUTE FUNCTION {quotedSchema}.trg_mesh_node_to_history();
+                    END IF;
+                END;
+                $ensure_trigger$;
+                """))
+            {
+                await trg.ExecuteNonQueryAsync();
+            }
+
+            ctx.Logger.LogInformation(
+                "Repair v45: '{Schema}' — authorship columns added; history trigger records changed_by", schema);
+        }
+
+        ctx.Logger.LogInformation(
+            "Repair v45: done — {Count} partition schema(s) now persist node authorship", schemas.Count);
+    }
+}

--- a/src/MeshWeaver.Hosting.PostgreSql/PgMeshNodeReader.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PgMeshNodeReader.cs
@@ -28,4 +28,36 @@ internal static class PgMeshNodeReader
         }
         return SyncBehavior.Include;
     }
+
+    /// <summary>
+    /// Reads a nullable text column by name, or null when the column is absent from the
+    /// result set. Defensive (scan field names, not <c>GetOrdinal</c>) so SELECTs predating
+    /// the authorship columns keep working — used for <c>created_by</c> / <c>last_modified_by</c>.
+    /// </summary>
+    internal static string? ReadNullableString(NpgsqlDataReader reader, string column)
+    {
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            if (!string.Equals(reader.GetName(i), column, StringComparison.Ordinal))
+                continue;
+            return reader.IsDBNull(i) ? null : reader.GetString(i);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Reads a nullable timestamptz column by name as a UTC <see cref="DateTimeOffset"/>, or
+    /// null when absent/NULL. Used for <c>created_date</c>; mirrors how the adapter reads
+    /// <c>last_modified</c> (<c>new DateTimeOffset(GetDateTime(), TimeSpan.Zero)</c>).
+    /// </summary>
+    internal static DateTimeOffset? ReadNullableTimestamp(NpgsqlDataReader reader, string column)
+    {
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            if (!string.Equals(reader.GetName(i), column, StringComparison.Ordinal))
+                continue;
+            return reader.IsDBNull(i) ? null : new DateTimeOffset(reader.GetDateTime(i), TimeSpan.Zero);
+        }
+        return null;
+    }
 }

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
@@ -990,6 +990,14 @@ public static class PostgreSqlSchemaInitializer
                 icon            TEXT,
                 display_order   INTEGER,
                 last_modified   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                -- Authorship: the immutable creator + the last modifier (identity + time).
+                -- Stamped by the create/update handlers onto MeshNode.CreatedBy /
+                -- LastModifiedBy / CreatedDate; the adapter persists them here so a node
+                -- round-trips its author across restarts (previously dropped on write, so
+                -- every PG-backed node read back with null authorship).
+                last_modified_by TEXT,
+                created_date    TIMESTAMPTZ,
+                created_by      TEXT,
                 version         BIGINT      NOT NULL DEFAULT 0,
                 state           SMALLINT    NOT NULL DEFAULT 0,
                 -- node-level static-repo sync claim (0=Include, 1=ExcludeThisOnly,
@@ -1314,6 +1322,14 @@ public static class PostgreSqlSchemaInitializer
                 icon            TEXT,
                 display_order   INTEGER,
                 last_modified   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                -- Authorship: the immutable creator + the last modifier (identity + time).
+                -- Stamped by the create/update handlers onto MeshNode.CreatedBy /
+                -- LastModifiedBy / CreatedDate; the adapter persists them here so a node
+                -- round-trips its author across restarts (previously dropped on write, so
+                -- every PG-backed node read back with null authorship).
+                last_modified_by TEXT,
+                created_date    TIMESTAMPTZ,
+                created_by      TEXT,
                 version         BIGINT      NOT NULL DEFAULT 0,
                 state           SMALLINT    NOT NULL DEFAULT 0,
                 -- node-level static-repo sync claim (0=Include, 1=ExcludeThisOnly,
@@ -1610,13 +1626,13 @@ public static class PostgreSqlSchemaInitializer
                     EXECUTE format(
                         'INSERT INTO %I.mesh_node_history (
                             namespace, id, name, node_type, description, category, icon,
-                            display_order, last_modified, version, state, content, desired_id, main_node
-                        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)',
+                            display_order, last_modified, version, state, content, desired_id, main_node, changed_by
+                        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)',
                         '{{versionsSchema}}'
                     ) USING
                         NEW.namespace, NEW.id, NEW.name, NEW.node_type, NEW.description,
                         NEW.category, NEW.icon, NEW.display_order, NEW.last_modified,
-                        NEW.version, NEW.state, NEW.content, NEW.desired_id, NEW.main_node;
+                        NEW.version, NEW.state, NEW.content, NEW.desired_id, NEW.main_node, NEW.last_modified_by;
                 EXCEPTION WHEN unique_violation THEN
                     -- Already exists, skip
                 END;
@@ -1691,6 +1707,14 @@ public static class PostgreSqlSchemaInitializer
                 icon            TEXT,
                 display_order   INTEGER,
                 last_modified   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                -- Authorship: the immutable creator + the last modifier (identity + time).
+                -- Stamped by the create/update handlers onto MeshNode.CreatedBy /
+                -- LastModifiedBy / CreatedDate; the adapter persists them here so a node
+                -- round-trips its author across restarts (previously dropped on write, so
+                -- every PG-backed node read back with null authorship).
+                last_modified_by TEXT,
+                created_date    TIMESTAMPTZ,
+                created_by      TEXT,
                 version         BIGINT      NOT NULL DEFAULT 0,
                 state           SMALLINT    NOT NULL DEFAULT 0,
                 -- node-level static-repo sync claim (0=Include, 1=ExcludeThisOnly,
@@ -2021,6 +2045,14 @@ public static class PostgreSqlSchemaInitializer
                 icon            TEXT,
                 display_order   INTEGER,
                 last_modified   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                -- Authorship: the immutable creator + the last modifier (identity + time).
+                -- Stamped by the create/update handlers onto MeshNode.CreatedBy /
+                -- LastModifiedBy / CreatedDate; the adapter persists them here so a node
+                -- round-trips its author across restarts (previously dropped on write, so
+                -- every PG-backed node read back with null authorship).
+                last_modified_by TEXT,
+                created_date    TIMESTAMPTZ,
+                created_by      TEXT,
                 version         BIGINT      NOT NULL DEFAULT 0,
                 state           SMALLINT    NOT NULL DEFAULT 0,
                 -- node-level static-repo sync claim (0=Include, 1=ExcludeThisOnly,
@@ -2347,14 +2379,14 @@ public static class PostgreSqlSchemaInitializer
                 EXECUTE format(
                     'INSERT INTO %I.mesh_node_history (
                         namespace, id, name, node_type, description, category, icon,
-                        display_order, last_modified, version, state, content, desired_id, main_node
-                    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+                        display_order, last_modified, version, state, content, desired_id, main_node, changed_by
+                    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
                     ON CONFLICT (namespace, id, version) DO NOTHING',
                     TG_TABLE_SCHEMA
                 ) USING
                     NEW.namespace, NEW.id, NEW.name, NEW.node_type, NEW.description,
                     NEW.category, NEW.icon, NEW.display_order, NEW.last_modified,
-                    NEW.version, NEW.state, NEW.content, NEW.desired_id, NEW.main_node;
+                    NEW.version, NEW.state, NEW.content, NEW.desired_id, NEW.main_node, NEW.last_modified_by;
                 RETURN NEW;
             END;
             $$ LANGUAGE plpgsql;
@@ -2395,6 +2427,14 @@ public static class PostgreSqlSchemaInitializer
                 icon            TEXT,
                 display_order   INTEGER,
                 last_modified   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                -- Authorship: the immutable creator + the last modifier (identity + time).
+                -- Stamped by the create/update handlers onto MeshNode.CreatedBy /
+                -- LastModifiedBy / CreatedDate; the adapter persists them here so a node
+                -- round-trips its author across restarts (previously dropped on write, so
+                -- every PG-backed node read back with null authorship).
+                last_modified_by TEXT,
+                created_date    TIMESTAMPTZ,
+                created_by      TEXT,
                 version         BIGINT      NOT NULL DEFAULT 0,
                 state           SMALLINT    NOT NULL DEFAULT 0,
                 -- node-level static-repo sync claim (0=Include, 1=ExcludeThisOnly,

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -173,6 +173,13 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
             ? "sync_behavior"
             : "0 AS sync_behavior";
 
+    // Authorship columns exist only on mesh_nodes; satellite selects emit typed NULLs so
+    // ReadMeshNode finds the columns by name either way (like SyncBehaviorCol).
+    private static string AuthorCols(string qualifiedTable) =>
+        qualifiedTable.Contains("mesh_nodes", StringComparison.OrdinalIgnoreCase)
+            ? "created_by, last_modified_by, created_date"
+            : "NULL::text AS created_by, NULL::text AS last_modified_by, NULL::timestamptz AS created_date";
+
     private static string NormalizePath(string? path) =>
         path?.Trim('/') ?? "";
 
@@ -220,7 +227,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         {
             await using var cmd = _dataSource.CreateCommand(
                 $"SELECT id, namespace, name, description, node_type, category, icon, display_order, " +
-                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)} " +
+                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)}, {AuthorCols(table)} " +
                 $"FROM {table} WHERE namespace = $1 AND id = $2");
             cmd.Parameters.AddWithValue(ns);
             cmd.Parameters.AddWithValue(id);
@@ -299,7 +306,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                 Enumerable.Range(2, ids.Length).Select(i => $"${i}"));
             await using var cmd = _dataSource.CreateCommand(
                 $"SELECT id, namespace, name, description, node_type, category, icon, display_order, " +
-                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)} " +
+                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)}, {AuthorCols(table)} " +
                 $"FROM {table} WHERE namespace = $1 AND id IN ({placeholders})");
             cmd.Parameters.AddWithValue(ns);
             foreach (var id in ids)
@@ -353,11 +360,17 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         var syncInsertCol = writeSync ? ", sync_behavior" : "";
         var syncInsertVal = writeSync ? ", $16" : "";
         var syncUpdate = writeSync ? ",\n                sync_behavior = EXCLUDED.sync_behavior" : "";
+        // Authorship columns live only on mesh_nodes (like sync_behavior). created_by /
+        // created_date are IMMUTABLE — set once at INSERT, never in the ON CONFLICT SET —
+        // so an update preserves the original creator; only last_modified_by is refreshed.
+        var authorInsertCol = writeSync ? ", created_by, last_modified_by, created_date" : "";
+        var authorInsertVal = writeSync ? ", $17, $18, $19" : "";
+        var authorUpdate = writeSync ? ",\n                last_modified_by = EXCLUDED.last_modified_by" : "";
         await using var cmd = _dataSource.CreateCommand(
             $"""
             INSERT INTO {table} (namespace, id, name, description, node_type, category, icon, display_order,
-                                    last_modified, version, state, content, desired_id, embedding, main_node{syncInsertCol})
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15{syncInsertVal})
+                                    last_modified, version, state, content, desired_id, embedding, main_node{syncInsertCol}{authorInsertCol})
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15{syncInsertVal}{authorInsertVal})
             ON CONFLICT (namespace, id) DO UPDATE SET
                 name = EXCLUDED.name,
                 description = EXCLUDED.description,
@@ -371,7 +384,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                 content = EXCLUDED.content,
                 desired_id = EXCLUDED.desired_id,
                 embedding = EXCLUDED.embedding,
-                main_node = EXCLUDED.main_node{syncUpdate}
+                main_node = EXCLUDED.main_node{syncUpdate}{authorUpdate}
             """);
 
         cmd.Parameters.AddWithValue(ns);
@@ -395,9 +408,14 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
 
         cmd.Parameters.AddWithValue(node.MainNode);
 
-        // $16 — only bound when the target is mesh_nodes (see writeSync above).
+        // $16–$19 — only bound when the target is mesh_nodes (see writeSync above).
         if (writeSync)
+        {
             cmd.Parameters.AddWithValue((short)node.SyncBehavior);
+            cmd.Parameters.AddWithValue((object?)node.CreatedBy ?? DBNull.Value);
+            cmd.Parameters.AddWithValue((object?)node.LastModifiedBy ?? DBNull.Value);
+            cmd.Parameters.AddWithValue(node.CreatedDate == default ? DBNull.Value : node.CreatedDate);
+        }
 
         await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
@@ -508,7 +526,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         var table = ResolveTable(normalizedPath);
         await using var cmd = _dataSource.CreateCommand(
             $"SELECT id, namespace, name, description, node_type, category, icon, display_order, " +
-            $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)} " +
+            $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)}, {AuthorCols(table)} " +
             $"FROM {table} WHERE $1 = path OR $1 LIKE path || '/%' " +
             $"ORDER BY LENGTH(path) DESC LIMIT 1");
         cmd.Parameters.AddWithValue(normalizedPath);
@@ -568,7 +586,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                 : $"\"{_schemaName}\".\"{t}\"";
             unionBranches.Add(
                 $"SELECT id, namespace, name, description, node_type, category, icon, display_order, " +
-                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(qualified)} " +
+                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(qualified)}, {AuthorCols(qualified)} " +
                 $"FROM {qualified} " +
                 $"WHERE $1 = path OR $1 LIKE path || '/%'");
         }
@@ -1330,6 +1348,9 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
             Icon = reader.IsDBNull(reader.GetOrdinal("icon")) ? null : reader.GetString(reader.GetOrdinal("icon")),
             Order = reader.IsDBNull(reader.GetOrdinal("display_order")) ? null : reader.GetInt32(reader.GetOrdinal("display_order")),
             LastModified = new DateTimeOffset(reader.GetDateTime(reader.GetOrdinal("last_modified")), TimeSpan.Zero),
+            CreatedBy = PgMeshNodeReader.ReadNullableString(reader, "created_by"),
+            LastModifiedBy = PgMeshNodeReader.ReadNullableString(reader, "last_modified_by"),
+            CreatedDate = PgMeshNodeReader.ReadNullableTimestamp(reader, "created_date") ?? default,
             Version = reader.GetInt64(reader.GetOrdinal("version")),
             State = (MeshNodeState)reader.GetInt16(reader.GetOrdinal("state")),
             SyncBehavior = PgMeshNodeReader.ReadSyncBehavior(reader),

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/NodeAuthorshipPersistenceTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/NodeAuthorshipPersistenceTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Regression: a node's authorship — <see cref="MeshNode.CreatedBy"/>,
+/// <see cref="MeshNode.LastModifiedBy"/>, <see cref="MeshNode.CreatedDate"/> — must survive a
+/// round-trip through the Postgres storage adapter.
+///
+/// <para>Before this change <c>mesh_nodes</c> had no authorship columns and the adapter never
+/// wrote or read them, so every PG-backed node reloaded with NULL authorship — the node header's
+/// "Created by / Updated by" line rendered blank on every instance. (FileSystem/SQLite were
+/// unaffected — they serialize the whole node as JSON — so this only reproduces against
+/// Postgres.)</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class NodeAuthorshipPersistenceTests
+{
+    private readonly PostgreSqlFixture _fixture;
+
+    public NodeAuthorshipPersistenceTests(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Authorship_SurvivesReloadFromStorage()
+    {
+        await _fixture.CleanDataAsync();
+        var adapter = _fixture.StorageAdapter;
+        var created = new DateTimeOffset(2026, 7, 18, 9, 30, 0, TimeSpan.Zero);
+
+        var node = new MeshNode("AuthoredNode")
+        {
+            Name = "Authored",
+            NodeType = "Markdown",
+            CreatedBy = "alice@example.com",
+            LastModifiedBy = "alice@example.com",
+            CreatedDate = created,
+        };
+
+        await adapter.Write(node, JsonSerializerOptions.Default).Should().Within(30.Seconds()).Emit();
+
+        var reloaded = await adapter
+            .Read("AuthoredNode", JsonSerializerOptions.Default)
+            .Should().Within(30.Seconds()).Emit();
+
+        reloaded.Should().NotBeNull("the node was just written");
+        reloaded!.CreatedBy.Should().Be("alice@example.com", "creator identity must round-trip");
+        reloaded.LastModifiedBy.Should().Be("alice@example.com", "modifier identity must round-trip");
+        reloaded.CreatedDate.Should().Be(created, "creation timestamp must round-trip");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Update_PreservesCreator_RefreshesModifier()
+    {
+        await _fixture.CleanDataAsync();
+        var adapter = _fixture.StorageAdapter;
+        var created = new DateTimeOffset(2026, 7, 18, 9, 30, 0, TimeSpan.Zero);
+
+        await adapter.Write(new MeshNode("Doc")
+        {
+            Name = "Doc", NodeType = "Markdown",
+            CreatedBy = "alice@example.com", LastModifiedBy = "alice@example.com", CreatedDate = created,
+        }, JsonSerializerOptions.Default).Should().Within(30.Seconds()).Emit();
+
+        // A later writer (with a DIFFERENT would-be creator) updates the node. created_by /
+        // created_date are immutable — the ON CONFLICT SET must not overwrite them — while
+        // last_modified_by is refreshed.
+        await adapter.Write(new MeshNode("Doc")
+        {
+            Name = "Doc v2", NodeType = "Markdown",
+            CreatedBy = "mallory@example.com", LastModifiedBy = "bob@example.com",
+            CreatedDate = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero),
+        }, JsonSerializerOptions.Default).Should().Within(30.Seconds()).Emit();
+
+        var reloaded = await adapter
+            .Read("Doc", JsonSerializerOptions.Default)
+            .Should().Within(30.Seconds()).Emit();
+
+        reloaded.Should().NotBeNull();
+        reloaded!.CreatedBy.Should().Be("alice@example.com", "the original creator is immutable across updates");
+        reloaded.CreatedDate.Should().Be(created, "the original creation timestamp is immutable across updates");
+        reloaded.LastModifiedBy.Should().Be("bob@example.com", "the last modifier is refreshed on update");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task NodeWithoutAuthorship_ReadsBackNull()
+    {
+        await _fixture.CleanDataAsync();
+        var adapter = _fixture.StorageAdapter;
+
+        await adapter
+            .Write(new MeshNode("Plain") { Name = "plain", NodeType = "Markdown" }, JsonSerializerOptions.Default)
+            .Should().Within(30.Seconds()).Emit();
+
+        var reloaded = await adapter
+            .Read("Plain", JsonSerializerOptions.Default)
+            .Should().Within(30.Seconds()).Emit();
+
+        reloaded.Should().NotBeNull();
+        reloaded!.CreatedBy.Should().BeNull();
+        reloaded.LastModifiedBy.Should().BeNull();
+        reloaded.CreatedDate.Should().Be(default);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task HistoryTrigger_RecordsModifierAsChangedBy()
+    {
+        await _fixture.CleanDataAsync();
+        var adapter = _fixture.StorageAdapter;
+
+        await adapter.Write(new MeshNode("Tracked")
+        {
+            Name = "Tracked", NodeType = "Markdown", LastModifiedBy = "carol@example.com",
+        }, JsonSerializerOptions.Default).Should().Within(30.Seconds()).Emit();
+
+        // The AFTER INSERT/UPDATE trigger snapshots the row into mesh_node_history with
+        // changed_by = NEW.last_modified_by, so version history can attribute each version.
+        await using var cmd = _fixture.DataSource.CreateCommand(
+            "SELECT changed_by FROM public.mesh_node_history WHERE id = 'Tracked' ORDER BY version DESC LIMIT 1");
+        var changedBy = await cmd.ExecuteScalarAsync() as string;
+
+        changedBy.Should().Be("carol@example.com",
+            "the history trigger must copy last_modified_by into changed_by so version history shows who made each version");
+    }
+}


### PR DESCRIPTION
> **Stacked on #528** (base = `fix/pg-version-history-reader`). Review/merge #528 first; GitHub retargets this to `main` on merge.

## What & why
`MeshNode` carries `CreatedBy` / `LastModifiedBy` / `CreatedDate` (stamped by the create/update handlers), but the Postgres `mesh_nodes` table had **no columns** for them and `PostgreSqlStorageAdapter` never wrote or read them. So on every PG-backed mesh each node round-tripped with **NULL authorship** — the node header's "Created by / Updated by" line rendered blank on every instance (reported on `systemorph.com/PartnerRe/EslLifeCycleProcess`). FileSystem/SQLite round-trip the whole node as JSON, which is why existing tests never caught it.

## Changes
- **Schema**: add `created_by` / `last_modified_by` / `created_date` to `mesh_nodes` in all three DDL blocks (same-schema, cross-schema, unversioned).
- **Adapter**: INSERT/UPSERT persists them (mesh_nodes-only, mirroring `sync_behavior`). `created_by` / `created_date` are **immutable** — set once at INSERT, never in the `ON CONFLICT SET` — so an update preserves the original creator and only refreshes `last_modified_by`. The four SELECT lists carry the columns (`AuthorCols` emits typed `NULL`s for satellite tables); `ReadMeshNode` hydrates via tolerant by-name reads.
- **History trigger** now copies `NEW.last_modified_by` into `mesh_node_history.changed_by` (both same-schema and cross-schema variants), so version history attributes each version (`ChangedBy`).
- **`V45` migration**: `ADD COLUMN IF NOT EXISTS` on every existing same-schema partition + reinstall the trigger with `changed_by`.

**No backfill** — authorship for pre-fix rows was never captured and can't be recovered; identities populate on the first write after the fix. Historical versions stay author-less.

## Tests (Testcontainers, real Postgres)
`NodeAuthorshipPersistenceTests`:
- authorship round-trips through the adapter;
- update **preserves creator / created_date**, refreshes `last_modified_by`;
- unauthored node reads back null;
- the history trigger records `changed_by` from `last_modified_by`.

Broad adapter regression net (`StorageAdapter`, `Satellite*`, `PgOnlyProdShape`, `PartitionLifecycle`, `AccessControl`, `Query`, `CrossPartitionSearch`, `SyncBehavior`) — **155 tests green**.

## Notes
- Aggregated views served by `PostgreSqlCrossSchemaQueryProvider` (search/activity fan-out) don't yet select the author columns, so author may be null there; the node page header (per-schema adapter read) is fully covered. Easy follow-up if wanted.

## Deploy note
Ships to every instance on redeploy; `V45` runs once per instance DB after `V44`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)