### PR TITLE
feat(ai): Google Custom Search web-search provider behind a swappable seam (#485 Part 1)

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -152,6 +152,16 @@ data:
   Anthropic__Order: "{{ .Values.config.memex_portal.Anthropic__Order | default "0" }}"
   AzureAIS__Endpoint: "{{ .Values.config.memex_portal.AzureAIS__Endpoint | default "" }}"
   AzureAIS__Order: "{{ .Values.config.memex_portal.AzureAIS__Order | default "0" }}"
+  # ---- Agent web search (WebSearchPlugin) — optional --------------------------
+  # SearchWeb is advertised to agents ONLY when a provider is configured; with these empty the
+  # tool is not offered at all (agents fall back to FetchWebPage on explicit URLs). The
+  # deployment supplies the Google Programmable Search credentials (API key + Search-Engine id /
+  # cx) — get them from the Google Cloud console + programmablesearchengine.google.com. Provider
+  # defaults to auto-detect ("" → Google when key+cx are set); set "Google" to force. Bing
+  # (WebSearch:Provider=Bing) is retired (API shut down 2025-08-11) and kept only for back-compat.
+  WebSearch__Provider: "{{ .Values.config.memex_portal.WebSearch__Provider | default "" }}"
+  WebSearch__Google__ApiKey: "{{ .Values.config.memex_portal.WebSearch__Google__ApiKey | default "" }}"
+  WebSearch__Google__Cx: "{{ .Values.config.memex_portal.WebSearch__Google__Cx | default "" }}"
   # ---- Observability (OTLP collector) — optional ----------------------------
   OTEL_EXPORTER_OTLP_ENDPOINT: "{{ .Values.config.memex_portal.OTEL_EXPORTER_OTLP_ENDPOINT | default "" }}"
   OTEL_EXPORTER_OTLP_PROTOCOL: "{{ .Values.config.memex_portal.OTEL_EXPORTER_OTLP_PROTOCOL | default "" }}"

--- a/src/MeshWeaver.AI/Plugins/WebSearchPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/WebSearchPlugin.cs
@@ -13,18 +13,32 @@ using Microsoft.Extensions.Options;
 namespace MeshWeaver.AI.Plugins;
 
 /// <summary>
-/// Configuration for the WebSearch plugin.
+/// Configuration for the WebSearch plugin. Bound from the <c>WebSearch</c> section.
 /// </summary>
 public class WebSearchConfiguration
 {
     /// <summary>
-    /// Bing Search API subscription key.
-    /// If not set, SearchWeb will return an error prompting configuration.
+    /// Which web-search backend to use (<c>WebSearch:Provider</c>). Defaults to
+    /// <see cref="WebSearchProviderType.None"/>, which auto-detects from whatever credentials are
+    /// present (Google first, then the retired Bing path). When no backend is configured the
+    /// <c>SearchWeb</c> tool is not advertised at all.
+    /// </summary>
+    public WebSearchProviderType Provider { get; set; } = WebSearchProviderType.None;
+
+    /// <summary>
+    /// Google Programmable Search (Custom Search JSON API) settings (<c>WebSearch:Google:*</c>).
+    /// The deployment supplies <c>ApiKey</c> and <c>Cx</c>.
+    /// </summary>
+    public GoogleWebSearchConfiguration Google { get; set; } = new();
+
+    /// <summary>
+    /// Bing Search API subscription key. RETIRED (Bing Search was shut down 2025-08-11) — present
+    /// only for back-compat; prefer <see cref="Google"/>.
     /// </summary>
     public string? BingApiKey { get; set; }
 
     /// <summary>
-    /// Bing Search API endpoint.
+    /// Bing Search API endpoint (retired).
     /// </summary>
     public string Endpoint { get; set; } = "https://api.bing.microsoft.com/v7.0/search";
 
@@ -45,15 +59,25 @@ public class WebSearchPlugin : IAgentPlugin
     private readonly ILogger<WebSearchPlugin> logger;
     private readonly IIoPool ioPool;
 
+    /// <summary>
+    /// The selected search backend, or <c>null</c>/unconfigured when no provider is set up.
+    /// When this is not configured the <c>SearchWeb</c> tool is not advertised.
+    /// </summary>
+    private readonly IWebSearchProvider? searchProvider;
+
     /// <summary>The plugin's stable identifier, <c>WebSearch</c>.</summary>
     public string Name => "WebSearch";
 
+    /// <summary>True when a search backend is configured and <c>SearchWeb</c> should be advertised.</summary>
+    private bool SearchConfigured => searchProvider is { IsConfigured: true };
+
     /// <summary>
     /// Creates the plugin, resolving the named <c>Http</c> I/O pool through which every
-    /// HTTP leaf is bridged (falls back to <c>IoPool.Unbounded</c> when no registry is supplied).
+    /// HTTP leaf is bridged (falls back to <c>IoPool.Unbounded</c> when no registry is supplied),
+    /// and selecting the web-search backend from configuration.
     /// </summary>
     /// <param name="httpClient">HTTP client used for search and page-fetch requests.</param>
-    /// <param name="options">Web-search configuration (Bing key, endpoint, fetch limit).</param>
+    /// <param name="options">Web-search configuration (provider selection, keys, fetch limit).</param>
     /// <param name="logger">Logger for diagnostics.</param>
     /// <param name="ioPoolRegistry">Optional registry supplying the bounded HTTP I/O pool.</param>
     public WebSearchPlugin(
@@ -66,19 +90,38 @@ public class WebSearchPlugin : IAgentPlugin
         this.config = options.Value;
         this.logger = logger;
         ioPool = ioPoolRegistry?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
+        searchProvider = ResolveProvider();
+    }
+
+    /// <summary>
+    /// Selects the search backend from config. An explicit <c>WebSearch:Provider</c> forces that
+    /// backend; the default (<see cref="WebSearchProviderType.None"/>) auto-detects — Google when
+    /// its key + cx are present, else the retired Bing path when a legacy key is present, else none.
+    /// </summary>
+    private IWebSearchProvider? ResolveProvider()
+    {
+        var google = new GoogleWebSearchProvider(config.Google, httpClient, ioPool, logger);
+        var bing = new BingWebSearchProvider(config.BingApiKey, config.Endpoint, httpClient, ioPool, logger);
+
+        return config.Provider switch
+        {
+            WebSearchProviderType.Google => google,
+            WebSearchProviderType.Bing => bing,
+            _ => google.IsConfigured ? google : bing.IsConfigured ? bing : null,
+        };
     }
 
     // The AIFunction surface requires Task<string> — these are the sanctioned one-line
     // boundary adapters; the bodies are reactive with the HTTP leaf bridged through the
     // IIoPool (AsynchronousCalls.md, ControlledIoPooling.md).
     /// <summary>
-    /// MCP/agent tool: searches the web via Bing and returns matching results
+    /// MCP/agent tool: searches the web via the configured provider and returns matching results
     /// (title, URL and snippet) as JSON.
     /// </summary>
     /// <param name="query">Search query string.</param>
     /// <param name="count">Number of results to return (default 5, clamped to 1..20).</param>
     /// <returns>A task resolving to the JSON result list, or a message when search is not configured or fails.</returns>
-    [Description("Searches the web using Bing and returns relevant results with titles, URLs, and snippets. Use this to find current information, documentation, or any topic on the internet.")]
+    [Description("Searches the web and returns relevant results with titles, URLs, and snippets. Use this to find current information, documentation, or any topic on the internet.")]
     public Task<string> SearchWeb(
         [Description("Search query string")] string query,
         [Description("Number of results to return (default 5, max 20)")] int count = 5)
@@ -99,45 +142,23 @@ public class WebSearchPlugin : IAgentPlugin
     {
         logger.LogInformation("SearchWeb called with query={Query}, count={Count}", query, count);
 
-        if (string.IsNullOrWhiteSpace(config.BingApiKey))
-            return Observable.Return("Web search is not configured. A Bing Search API key is required.");
+        if (searchProvider is not { IsConfigured: true } provider)
+            return Observable.Return("Web search is not configured.");
 
         var clamped = Math.Clamp(count, 1, 20);
 
-        // The HTTP round-trip is ONE pooled async leaf — async lives only inside
-        // the IIoPool bridge, never on the subscribing thread.
-        return ioPool.Invoke(async ct =>
-            {
-                using var request = new HttpRequestMessage(HttpMethod.Get,
-                    $"{config.Endpoint}?q={Uri.EscapeDataString(query)}&count={clamped}&textFormat=Plain");
-                request.Headers.Add("Ocp-Apim-Subscription-Key", config.BingApiKey);
-
-                using var response = await httpClient.SendAsync(request, ct);
-                response.EnsureSuccessStatusCode();
-
-                var json = await response.Content.ReadAsStringAsync(ct);
-                using var doc = JsonDocument.Parse(json);
-
-                var results = ImmutableList<object>.Empty;
-                if (doc.RootElement.TryGetProperty("webPages", out var webPages) &&
-                    webPages.TryGetProperty("value", out var pages))
+        // The provider bridges its single HTTP round-trip through the IIoPool — async lives only
+        // inside that bridge, never on the subscribing thread. Map the neutral results to the
+        // stable JSON shape agents already consume: [{ title, url, snippet }].
+        return provider.Search(query, clamped)
+            .Select(results => results.Count == 0
+                ? "No results found."
+                : JsonSerializer.Serialize(results.Select(r => new
                 {
-                    foreach (var page in pages.EnumerateArray())
-                    {
-                        results = results.Add(new
-                        {
-                            title = page.GetProperty("name").GetString(),
-                            url = page.GetProperty("url").GetString(),
-                            snippet = page.GetProperty("snippet").GetString()
-                        });
-                    }
-                }
-
-                if (results.Count == 0)
-                    return "No results found.";
-
-                return JsonSerializer.Serialize(results);
-            })
+                    title = r.Title,
+                    url = r.Url,
+                    snippet = r.Snippet
+                })))
             .Catch((HttpRequestException ex) =>
             {
                 logger.LogError(ex, "Web search failed for query={Query}", query);
@@ -225,15 +246,21 @@ public class WebSearchPlugin : IAgentPlugin
     }
 
     /// <summary>
-    /// Builds the <c>AITool</c> set this plugin exposes to agents — SearchWeb and FetchWebPage.
+    /// Builds the <c>AITool</c> set this plugin exposes to agents. <c>FetchWebPage</c> is always
+    /// available; <c>SearchWeb</c> is advertised ONLY when a search provider is configured — a
+    /// deployment never advertises a search tool it cannot fulfil.
     /// </summary>
     /// <returns>The web-search tools.</returns>
     public IEnumerable<AITool> CreateTools()
     {
-        return
-        [
-            AIFunctionFactory.Create(SearchWeb),
-            AIFunctionFactory.Create(FetchWebPage)
-        ];
+        var tools = ImmutableList<AITool>.Empty;
+
+        if (SearchConfigured)
+            tools = tools.Add(AIFunctionFactory.Create(SearchWeb));
+        else
+            logger.LogInformation("WebSearch: no search provider configured — SearchWeb tool not advertised.");
+
+        tools = tools.Add(AIFunctionFactory.Create(FetchWebPage));
+        return tools;
     }
 }

--- a/src/MeshWeaver.AI/Plugins/WebSearchProviders.cs
+++ b/src/MeshWeaver.AI/Plugins/WebSearchProviders.cs
@@ -1,0 +1,190 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.AI.Plugins;
+
+/// <summary>
+/// Selects which web-search backend <see cref="WebSearchPlugin"/> uses. Bound from
+/// <c>WebSearch:Provider</c>. <see cref="None"/> (the default) auto-detects from whatever
+/// credentials are present (Google first, then the retired Bing path); an explicit value
+/// forces that backend.
+/// </summary>
+public enum WebSearchProviderType
+{
+    /// <summary>No explicit selection — auto-detect from configured credentials.</summary>
+    None = 0,
+
+    /// <summary>Google Programmable Search (Custom Search JSON API).</summary>
+    Google,
+
+    /// <summary>Bing Search v7 — RETIRED by Microsoft on 2025-08-11; kept only for back-compat.</summary>
+    Bing,
+}
+
+/// <summary>
+/// One web-search hit: title, URL and snippet. The provider-neutral result shape the
+/// <see cref="IWebSearchProvider"/> seam maps every backend's payload into.
+/// </summary>
+/// <param name="Title">Result title / heading.</param>
+/// <param name="Url">Result URL.</param>
+/// <param name="Snippet">Short text excerpt.</param>
+public sealed record WebSearchResult(string Title, string Url, string Snippet);
+
+/// <summary>
+/// The swappable web-search backend seam. Implementations bridge their single HTTP round-trip
+/// through the <see cref="IoPoolNames.Http"/> <see cref="IIoPool"/> and return results reactively.
+/// A backend that lacks credentials reports <see cref="IsConfigured"/> = <c>false</c> so the
+/// plugin can decline to advertise the <c>SearchWeb</c> tool (never advertise what it can't fulfil).
+/// </summary>
+public interface IWebSearchProvider
+{
+    /// <summary>Provider identity (for logs/diagnostics).</summary>
+    WebSearchProviderType Kind { get; }
+
+    /// <summary>True when the backend has the credentials it needs to actually run a search.</summary>
+    bool IsConfigured { get; }
+
+    /// <summary>
+    /// Searches the web. Returns a cold observable that runs the HTTP leaf on the I/O pool when
+    /// subscribed and emits the mapped results once. May surface <see cref="HttpRequestException"/>
+    /// via <c>OnError</c> — the caller formats that into a user-facing message.
+    /// </summary>
+    /// <param name="query">Search query string.</param>
+    /// <param name="count">Requested result count (each provider clamps to its own maximum).</param>
+    IObservable<IReadOnlyList<WebSearchResult>> Search(string query, int count);
+}
+
+/// <summary>
+/// Google Programmable Search (Custom Search JSON API) backend configuration. The deployment
+/// supplies both keys (see the Helm ConfigMap <c>WebSearch__Google__*</c>); with either missing
+/// the provider is inert and <c>SearchWeb</c> is not advertised.
+/// </summary>
+public class GoogleWebSearchConfiguration
+{
+    /// <summary>Google API key (<c>WebSearch:Google:ApiKey</c>). Supplied by the deployment.</summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>Programmable Search Engine id / <c>cx</c> (<c>WebSearch:Google:Cx</c>). Supplied by the deployment.</summary>
+    public string? Cx { get; set; }
+
+    /// <summary>Custom Search JSON API endpoint.</summary>
+    public string Endpoint { get; set; } = "https://www.googleapis.com/customsearch/v1";
+}
+
+/// <summary>
+/// Google Custom Search JSON API provider. Calls
+/// <c>GET {endpoint}?key={key}&amp;cx={cx}&amp;q={query}&amp;num={count}</c> (num capped at 10 by
+/// Google) and maps each <c>items[]</c> entry's <c>title</c>/<c>link</c>/<c>snippet</c> to a
+/// <see cref="WebSearchResult"/>. The single HTTP round-trip is one pooled async leaf.
+/// </summary>
+internal sealed class GoogleWebSearchProvider(
+    GoogleWebSearchConfiguration config,
+    HttpClient httpClient,
+    IIoPool ioPool,
+    ILogger logger) : IWebSearchProvider
+{
+    /// <summary>Google Custom Search caps <c>num</c> at 10 per request.</summary>
+    private const int MaxResults = 10;
+
+    public WebSearchProviderType Kind => WebSearchProviderType.Google;
+
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(config.ApiKey) && !string.IsNullOrWhiteSpace(config.Cx);
+
+    public IObservable<IReadOnlyList<WebSearchResult>> Search(string query, int count)
+    {
+        var num = Math.Clamp(count, 1, MaxResults);
+
+        // The HTTP round-trip is ONE pooled async leaf — async lives only inside the
+        // IIoPool bridge, never on the subscribing thread (AsynchronousCalls.md).
+        return ioPool.Invoke(async ct =>
+        {
+            var uri = $"{config.Endpoint}?key={Uri.EscapeDataString(config.ApiKey!)}" +
+                      $"&cx={Uri.EscapeDataString(config.Cx!)}" +
+                      $"&q={Uri.EscapeDataString(query)}&num={num}";
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            using var response = await httpClient.SendAsync(request, ct);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+
+            var results = ImmutableList<WebSearchResult>.Empty;
+            if (doc.RootElement.TryGetProperty("items", out var items) &&
+                items.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in items.EnumerateArray())
+                {
+                    results = results.Add(new WebSearchResult(
+                        GetString(item, "title"),
+                        GetString(item, "link"),
+                        GetString(item, "snippet")));
+                }
+            }
+
+            logger.LogInformation("Google Custom Search returned {Count} result(s) for query={Query}", results.Count, query);
+            return (IReadOnlyList<WebSearchResult>)results;
+        });
+    }
+
+    private static string GetString(JsonElement element, string property) =>
+        element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? string.Empty
+            : string.Empty;
+}
+
+/// <summary>
+/// Bing Search v7 provider. RETIRED — Microsoft shut the Bing Search API down on 2025-08-11, so
+/// this path no longer resolves against a live service. Kept behind <c>WebSearch:Provider = Bing</c>
+/// (and only advertised when a legacy <c>BingApiKey</c> is present) purely for back-compat; new
+/// deployments use <see cref="GoogleWebSearchProvider"/>.
+/// </summary>
+internal sealed class BingWebSearchProvider(
+    string? apiKey,
+    string endpoint,
+    HttpClient httpClient,
+    IIoPool ioPool,
+    ILogger logger) : IWebSearchProvider
+{
+    public WebSearchProviderType Kind => WebSearchProviderType.Bing;
+
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(apiKey);
+
+    public IObservable<IReadOnlyList<WebSearchResult>> Search(string query, int count)
+    {
+        var clamped = Math.Clamp(count, 1, 20);
+
+        return ioPool.Invoke(async ct =>
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get,
+                $"{endpoint}?q={Uri.EscapeDataString(query)}&count={clamped}&textFormat=Plain");
+            request.Headers.Add("Ocp-Apim-Subscription-Key", apiKey);
+
+            using var response = await httpClient.SendAsync(request, ct);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+
+            var results = ImmutableList<WebSearchResult>.Empty;
+            if (doc.RootElement.TryGetProperty("webPages", out var webPages) &&
+                webPages.TryGetProperty("value", out var pages))
+            {
+                foreach (var page in pages.EnumerateArray())
+                {
+                    results = results.Add(new WebSearchResult(
+                        page.GetProperty("name").GetString() ?? string.Empty,
+                        page.GetProperty("url").GetString() ?? string.Empty,
+                        page.GetProperty("snippet").GetString() ?? string.Empty));
+                }
+            }
+
+            logger.LogInformation("Bing search returned {Count} result(s) for query={Query}", results.Count, query);
+            return (IReadOnlyList<WebSearchResult>)results;
+        });
+    }
+}

--- a/test/MeshWeaver.AI.Test/WebSearchPluginTest.cs
+++ b/test/MeshWeaver.AI.Test/WebSearchPluginTest.cs
@@ -1,0 +1,165 @@
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI.Plugins;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Parsing + advertisement tests for <see cref="WebSearchPlugin"/>'s search seam. A stub
+/// <see cref="HttpMessageHandler"/> captures the outgoing request (so we assert the Google
+/// Custom Search URL) and returns a canned body (so we assert parsing) — no network. The plugin
+/// is built with no <c>IoPoolRegistry</c>, so its HTTP leaf runs on <c>IoPool.Unbounded</c>.
+/// Covers: (a) a Google CSE payload parses title/link/snippet per item; (b) with no provider
+/// configured the <c>SearchWeb</c> tool is NOT advertised; (c) configured Google advertises it.
+/// </summary>
+public class WebSearchPluginTest
+{
+    /// <summary>Records the last outgoing request and replays a canned JSON body.</summary>
+    private sealed class CapturingHandler(string responseJson, HttpStatusCode status = HttpStatusCode.OK)
+        : HttpMessageHandler
+    {
+        public HttpRequestMessage? Last { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Last = request;
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(responseJson, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private static WebSearchPlugin MakePlugin(WebSearchConfiguration config, HttpMessageHandler handler) =>
+        new(new HttpClient(handler), Options.Create(config), NullLogger<WebSearchPlugin>.Instance);
+
+    private static WebSearchConfiguration GoogleConfig(
+        WebSearchProviderType provider = WebSearchProviderType.Google,
+        string? apiKey = "test-key",
+        string? cx = "test-cx") =>
+        new()
+        {
+            Provider = provider,
+            Google = new GoogleWebSearchConfiguration { ApiKey = apiKey, Cx = cx },
+        };
+
+    /// <summary>(a) A Google CSE JSON payload parses each item's title, link and snippet, and the
+    /// outgoing URL carries key + cx + q + num against the Custom Search endpoint.</summary>
+    [Fact]
+    public async Task Google_Configured_ParsesEachItemTitleLinkSnippet()
+    {
+        const string json = """
+        {"items":[
+          {"title":"First Result","link":"https://example.com/1","snippet":"Snippet one."},
+          {"title":"Second Result","link":"https://example.com/2","snippet":"Snippet two."}
+        ]}
+        """;
+        var handler = new CapturingHandler(json);
+        var plugin = MakePlugin(GoogleConfig(), handler);
+
+        var result = await plugin.SearchWebCore("meshweaver docs", 5)
+            .Should().Within(10.Seconds()).Emit();
+
+        // URL shaping — Google Custom Search JSON API with key, cx, q and num. AbsoluteUri keeps
+        // the wire escaping (ToString() would unescape %20 for display).
+        var uri = handler.Last!.RequestUri!.AbsoluteUri;
+        uri.Should().Contain("https://www.googleapis.com/customsearch/v1");
+        uri.Should().Contain("key=test-key");
+        uri.Should().Contain("cx=test-cx");
+        uri.Should().Contain("q=meshweaver%20docs");
+        uri.Should().Contain("num=5");
+
+        // Parsing — the per-item title <-> url <-> snippet association is preserved.
+        using var doc = JsonDocument.Parse(result);
+        var items = doc.RootElement.EnumerateArray().ToList();
+        items.Should().HaveCount(2);
+
+        items[0].GetProperty("title").GetString().Should().Be("First Result");
+        items[0].GetProperty("url").GetString().Should().Be("https://example.com/1");
+        items[0].GetProperty("snippet").GetString().Should().Be("Snippet one.");
+
+        items[1].GetProperty("title").GetString().Should().Be("Second Result");
+        items[1].GetProperty("url").GetString().Should().Be("https://example.com/2");
+        items[1].GetProperty("snippet").GetString().Should().Be("Snippet two.");
+    }
+
+    /// <summary>Google caps <c>num</c> at 10 even when a larger count is requested, and an empty
+    /// item list surfaces the friendly "No results found." message.</summary>
+    [Fact]
+    public async Task Google_ClampsNumToTen_AndReportsNoResults()
+    {
+        var handler = new CapturingHandler("""{"items":[]}""");
+        var plugin = MakePlugin(GoogleConfig(), handler);
+
+        var result = await plugin.SearchWebCore("anything", 20)
+            .Should().Within(10.Seconds()).Emit();
+
+        handler.Last!.RequestUri!.ToString().Should().Contain("num=10");
+        result.Should().Contain("No results found.");
+    }
+
+    /// <summary>(b) With no provider configured (no key/cx, no legacy Bing key) the
+    /// <c>SearchWeb</c> tool is NOT advertised — only <c>FetchWebPage</c> is.</summary>
+    [Fact]
+    public void Unconfigured_SearchWebToolNotAdvertised()
+    {
+        var plugin = MakePlugin(new WebSearchConfiguration(), new CapturingHandler("{}"));
+
+        var toolNames = plugin.CreateTools().OfType<AIFunction>().Select(t => t.Name).ToList();
+
+        toolNames.Should().NotContain("SearchWeb");
+        toolNames.Should().Contain("FetchWebPage");
+    }
+
+    /// <summary>And unconfigured <c>SearchWebCore</c> returns the "not configured" message rather
+    /// than attempting a call.</summary>
+    [Fact]
+    public async Task Unconfigured_SearchWebCore_ReturnsNotConfiguredMessage()
+    {
+        var plugin = MakePlugin(new WebSearchConfiguration(), new CapturingHandler("{}"));
+
+        var result = await plugin.SearchWebCore("query", 5)
+            .Should().Within(10.Seconds()).Emit();
+
+        result.Should().Contain("not configured");
+    }
+
+    /// <summary>(c) With Google credentials present the <c>SearchWeb</c> tool IS advertised. Uses
+    /// the default (auto-detect) provider selection so this also exercises auto-detection.</summary>
+    [Fact]
+    public void GoogleConfigured_SearchWebToolAdvertised()
+    {
+        var plugin = MakePlugin(
+            GoogleConfig(provider: WebSearchProviderType.None),
+            new CapturingHandler("{}"));
+
+        var toolNames = plugin.CreateTools().OfType<AIFunction>().Select(t => t.Name).ToList();
+
+        toolNames.Should().Contain("SearchWeb");
+        toolNames.Should().Contain("FetchWebPage");
+    }
+
+    /// <summary>Forcing <c>Provider = Google</c> without credentials keeps <c>SearchWeb</c> hidden —
+    /// selection alone never advertises an unfulfillable tool.</summary>
+    [Fact]
+    public void GoogleSelectedButNoCredentials_SearchWebToolNotAdvertised()
+    {
+        var plugin = MakePlugin(
+            GoogleConfig(provider: WebSearchProviderType.Google, apiKey: null, cx: null),
+            new CapturingHandler("{}"));
+
+        var toolNames = plugin.CreateTools().OfType<AIFunction>().Select(t => t.Name).ToList();
+
+        toolNames.Should().NotContain("SearchWeb");
+        toolNames.Should().Contain("FetchWebPage");
+    }
+}


### PR DESCRIPTION
Implements #485 Part 1 — Google Custom Search provider behind a swappable seam; tool disabled when unconfigured. Bing was retired 2025-08-11.

## What changed

`WebSearchPlugin.SearchWebCore` hard-coded Bing Search v7, which Microsoft shut down on 2025-08-11 — so agent web search was dead on the deployed portal. This adds a swappable provider seam with a working Google backend, and stops advertising `SearchWeb` when nothing is configured.

### Provider seam
- New `IWebSearchProvider` — `IObservable<IReadOnlyList<WebSearchResult>> Search(string query, int count)` (result = title, url, snippet) plus an `IsConfigured` predicate. Small and reactive; each backend bridges its single HTTP round-trip through the `IoPoolNames.Http` `IIoPool` leaf (the existing pooled pattern), reusing the injected `HttpClient`.
- `WebSearch:Provider` enum (`None` / `Google` / `Bing`) selects the backend. `None` (default) auto-detects: Google when its key + cx are present, else the legacy Bing key, else nothing.

### Google Custom Search JSON API provider
- Reads `WebSearch:Google:ApiKey` and `WebSearch:Google:Cx` (the Programmable Search Engine id).
- Calls `GET https://www.googleapis.com/customsearch/v1?key={key}&cx={cx}&q={query}&num={count}` (num capped at 10) and maps `items[].{title,link,snippet}` → results. `System.Text.Json`, no new dependency. Output preserves the existing JSON shape agents consume: `[{ title, url, snippet }]`.

### Disable when unconfigured
- `CreateTools()` advertises `SearchWeb` only when a provider `IsConfigured`; otherwise only `FetchWebPage` is offered. A deployment never advertises a search tool it can't fulfil. Unconfigured `SearchWebCore` returns a clear "Web search is not configured." message (and never makes a call).

### Config + deployment
- `WebSearchConfiguration` gains `Provider` + `Google` (`ApiKey`, `Cx`, `Endpoint`). The **deployment supplies `WebSearch:Google:ApiKey` + `Cx`**.
- Helm ConfigMap (`deploy/helm/templates/memex-portal/config.yaml`) gains `WebSearch__Provider`, `WebSearch__Google__ApiKey`, `WebSearch__Google__Cx` (string keys, default empty), following the existing `__`-delimited pattern.

### Bing
- The retired Bing code path is kept (moved into `BingWebSearchProvider`), reachable via `WebSearch:Provider=Bing` and only advertised when a legacy `BingApiKey` is present. The seam is swappable — Brave/Tavily could be added later.

## Scope
Only `SearchWebCore` + config + registration. `FetchWebPageCore` (the RSS/XML fix) is issue #514 and is untouched here.

## Tests
`test/MeshWeaver.AI.Test/WebSearchPluginTest.cs` (stub `HttpMessageHandler`, no network):
- Google CSE JSON payload → parses title/link/snippet per item, correct request URL (key/cx/q/num), num clamped to 10.
- Unconfigured → `SearchWeb` not in the tool set, and `SearchWebCore` returns the "not configured" message.
- Configured Google (incl. auto-detect) → `SearchWeb` advertised; forced `Provider=Google` without credentials stays hidden.

All 6 pass. `dotnet build src/MeshWeaver.AI` and `test/MeshWeaver.AI.Test` are clean under `-c Release -warnaserror -p:CIRun=true` (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)