### PR TITLE
Send a deck/document to contacts (#423)

### DIFF
--- a/memex/Memex.Portal.Shared/Email/GraphEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/GraphEmailSender.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Extensions.Logging;
@@ -54,27 +55,47 @@ public sealed class GraphEmailSender : IEmailSender, IDisposable
     public void Dispose() => _http.Dispose();
 
     public IObservable<bool> SendEmail(string toAddress, string subject, string htmlBody) =>
-        _http.Run(ct => SendAsync(toAddress, subject, htmlBody, ct));
+        SendEmail(toAddress, subject, htmlBody, []);
 
-    private async Task<bool> SendAsync(string toAddress, string subject, string htmlBody, CancellationToken ct)
+    public IObservable<bool> SendEmail(
+        string toAddress, string subject, string htmlBody, IReadOnlyCollection<EmailAttachment> attachments) =>
+        _http.Run(ct => SendAsync(toAddress, subject, htmlBody, attachments, ct));
+
+    private async Task<bool> SendAsync(
+        string toAddress, string subject, string htmlBody,
+        IReadOnlyCollection<EmailAttachment> attachments, CancellationToken ct)
     {
-        var body = new SendMailPostRequestBody
+        var message = new Message
         {
-            Message = new Message
-            {
-                Subject = subject,
-                Body = new ItemBody { ContentType = BodyType.Html, Content = htmlBody },
-                ToRecipients =
-                [
-                    new Recipient { EmailAddress = new EmailAddress { Address = toAddress } }
-                ]
-            },
-            SaveToSentItems = false
+            Subject = subject,
+            Body = new ItemBody { ContentType = BodyType.Html, Content = htmlBody },
+            ToRecipients =
+            [
+                new Recipient { EmailAddress = new EmailAddress { Address = toAddress } }
+            ]
         };
 
+        if (attachments.Count > 0)
+        {
+            // Graph carries small attachments (< 3 MB total) inline as base64 fileAttachments on the
+            // message; ContentBytes takes the raw byte[] and the SDK base64-encodes it on the wire.
+            message.Attachments =
+            [
+                .. attachments.Select(a => (Attachment)new FileAttachment
+                {
+                    OdataType = "#microsoft.graph.fileAttachment",
+                    Name = a.FileName,
+                    ContentType = a.MimeType,
+                    ContentBytes = a.Content
+                })
+            ];
+        }
+
+        var body = new SendMailPostRequestBody { Message = message, SaveToSentItems = false };
+
         await _graph.Users[_options.MailboxAddress].SendMail.PostAsync(body, cancellationToken: ct).ConfigureAwait(false);
-        _logger?.LogInformation("Sent email to {To} (subject: {Subject}) as {From}",
-            toAddress, subject, _options.MailboxAddress);
+        _logger?.LogInformation("Sent email to {To} (subject: {Subject}, attachments: {Attachments}) as {From}",
+            toAddress, subject, attachments.Count, _options.MailboxAddress);
         return true;
     }
 }

--- a/memex/Memex.Portal.Shared/Email/NoOpEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/NoOpEmailSender.cs
@@ -12,10 +12,14 @@ namespace Memex.Portal.Shared.Email;
 public sealed class NoOpEmailSender(ILogger<NoOpEmailSender>? logger = null) : IEmailSender
 {
     public IObservable<bool> SendEmail(string toAddress, string subject, string htmlBody)
+        => SendEmail(toAddress, subject, htmlBody, []);
+
+    public IObservable<bool> SendEmail(
+        string toAddress, string subject, string htmlBody, IReadOnlyCollection<EmailAttachment> attachments)
     {
         logger?.LogInformation(
-            "Email disabled (Email:Enabled=false) — skipping send to {To} (subject: {Subject})",
-            toAddress, subject);
+            "Email disabled (Email:Enabled=false) — skipping send to {To} (subject: {Subject}, attachments: {Attachments})",
+            toAddress, subject, attachments.Count);
         return Observable.Return(true);
     }
 }

--- a/src/MeshWeaver.Graph/NotificationService.cs
+++ b/src/MeshWeaver.Graph/NotificationService.cs
@@ -79,7 +79,7 @@ public static class NotificationService
     /// <list type="bullet">
     ///   <item><b>In-app</b> → creates the bell <see cref="Notification"/> satellite (as
     ///     <see cref="CreateNotification"/> does).</item>
-    ///   <item><b>Email</b> → sends via <see cref="HubEmailExtensions.SendEmail"/> to the recipient's
+    ///   <item><b>Email</b> → sends via <see cref="HubEmailExtensions.SendEmail(MeshWeaver.Messaging.IMessageHub,string,string,string)"/> to the recipient's
     ///     <see cref="Mesh.Security.User.Email"/>, UNLESS the recipient authored AI routing rules
     ///     (<see cref="NotificationRule"/>) — then the advanced <c>NotificationTriageService</c> owns
     ///     escalation and we skip the deterministic email to avoid double-sending.</item>

--- a/src/MeshWeaver.Markdown.Export/Configuration/MarkdownExportExtensions.cs
+++ b/src/MeshWeaver.Markdown.Export/Configuration/MarkdownExportExtensions.cs
@@ -125,7 +125,8 @@ public static class MarkdownExportExtensions
             })
             .AddLayout(layout => layout
                 .WithView(ExportDocumentLayoutArea.PdfArea, ExportDocumentLayoutArea.RenderPdf)
-                .WithView(ExportDocumentLayoutArea.DocxArea, ExportDocumentLayoutArea.RenderDocx)));
+                .WithView(ExportDocumentLayoutArea.DocxArea, ExportDocumentLayoutArea.RenderDocx)
+                .WithView(SendDocumentLayoutArea.SendArea, SendDocumentLayoutArea.RenderSend)));
 
         return builder;
     }

--- a/src/MeshWeaver.Markdown.Export/Handlers/SendDocumentDispatch.cs
+++ b/src/MeshWeaver.Markdown.Export/Handlers/SendDocumentDispatch.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Markdown.Export.Configuration;
+using MeshWeaver.Markdown.Export.Messaging;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Markdown.Export.Handlers;
+
+/// <summary>
+/// "Send a deck/document to contacts" (issue #423). Reuses the SAME node ⇒ file export pipeline as
+/// the download (<c>ExportDocumentRequest → ScriptDispatch → Templates/Export/Pdf → RenderedDocument
+/// bytes on ActivityLog.ReturnValue</c>) and then emails those bytes as an attachment via
+/// <see cref="IEmailSender"/> — no bespoke upload/blob path, no new request/response for the email.
+///
+/// <para>Fully reactive: composes <see cref="IObservable{T}"/> and is driven by a single
+/// <c>.Subscribe(...)</c> at the call site (layout-area click action / test). NOT hub-reachable — it
+/// posts the export request and subscribes to the activity stream off the caller's thread, never
+/// blocking a hub action block. The caller's <c>AccessContext</c> is
+/// carried through the <c>.Subscribe</c> boundaries, so the export, the recipient reads, and the send
+/// all run under the calling user's identity — a recipient's email is resolved by READING that User
+/// node under the caller (which naturally limits sends to recipients the caller could address).</para>
+/// </summary>
+public static class SendDocumentDispatch
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Exports <paramref name="sourcePath"/> to a document and emails it as an attachment to the
+    /// resolved recipients. Recipients come from two sources, merged and de-duplicated: the
+    /// <paramref name="recipientUserPaths"/> (User node paths — their <see cref="User.Email"/> is read
+    /// under the caller's identity) and any <paramref name="rawEmails"/> typed directly.
+    /// </summary>
+    /// <param name="hub">The hub used to dispatch the export and resolve the <see cref="IEmailSender"/>.</param>
+    /// <param name="workspace">Workspace used for authoritative single-node reads (activity + users).</param>
+    /// <param name="sourcePath">Mesh path of the source (Deck / Markdown) node to export.</param>
+    /// <param name="options">Export options (format, branding, …). The Deck branch is chosen by the template.</param>
+    /// <param name="recipientUserPaths">User node paths whose email should be resolved and mailed.</param>
+    /// <param name="rawEmails">Raw email addresses to mail directly (fallback / additional recipients).</param>
+    /// <param name="subject">Email subject.</param>
+    /// <param name="htmlBody">Email HTML body.</param>
+    /// <param name="timeout">Upper bound on the export + each node read. Defaults to 2 minutes.</param>
+    /// <param name="logger">Optional logger for diagnostics.</param>
+    /// <returns>A cold observable emitting one <see cref="SendDocumentResult"/> then completing.</returns>
+    public static IObservable<SendDocumentResult> ExportAndSend(
+        IMessageHub hub,
+        IWorkspace workspace,
+        string sourcePath,
+        DocumentExportOptions options,
+        IReadOnlyCollection<string> recipientUserPaths,
+        IReadOnlyCollection<string> rawEmails,
+        string subject,
+        string htmlBody,
+        TimeSpan? timeout = null,
+        ILogger? logger = null)
+    {
+        var readTimeout = timeout ?? DefaultTimeout;
+
+        // 1. Resolve the recipient list first (caller identity) — no point exporting for nobody.
+        return ResolveRecipients(hub, workspace, recipientUserPaths, rawEmails, readTimeout, logger)
+            .SelectMany(emails =>
+            {
+                if (emails.Count == 0)
+                    return Observable.Return(new SendDocumentResult(
+                        false, null, Array.Empty<string>(),
+                        "No valid recipient email addresses could be resolved."));
+
+                // 2. Run the export through the standard pipeline → RenderedDocument bytes, then send.
+                return ExportThenSend(hub, workspace, sourcePath, options, emails, subject, htmlBody, readTimeout, logger);
+            });
+    }
+
+    private static IObservable<SendDocumentResult> ExportThenSend(
+        IMessageHub hub,
+        IWorkspace workspace,
+        string sourcePath,
+        DocumentExportOptions options,
+        IReadOnlyList<string> emails,
+        string subject,
+        string htmlBody,
+        TimeSpan readTimeout,
+        ILogger? logger)
+        => hub.Observe<ExportDocumentResponse>(
+                new ExportDocumentRequest(sourcePath, options),
+                o => o.WithTarget(new Address(sourcePath)))
+            .Take(1)
+            .SelectMany(dispatch =>
+            {
+                var msg = dispatch.Message;
+                if (!string.IsNullOrEmpty(msg.Error))
+                    return Observable.Return(new SendDocumentResult(
+                        false, null, Array.Empty<string>(), $"Export failed to start: {msg.Error}"));
+                if (string.IsNullOrEmpty(msg.ActivityPath))
+                    return Observable.Return(new SendDocumentResult(
+                        false, null, Array.Empty<string>(), "Export handler returned no activity path."));
+
+                var activityPath = msg.ActivityPath;
+
+                // Subscribe to the export activity's own node stream and wait for terminal status —
+                // the canonical "operations as scripts" subscription shape (see ActivityControlPlane.md).
+                return workspace.GetMeshNodeStream(activityPath)
+                    .Select(n => n?.ContentAs<ActivityLog>(hub.JsonSerializerOptions))
+                    .Where(log => log is not null && log.Status != ActivityStatus.Running)
+                    .Take(1)
+                    .Timeout(readTimeout)
+                    .SelectMany(log =>
+                    {
+                        if (log!.Status != ActivityStatus.Succeeded)
+                            return Observable.Return(new SendDocumentResult(
+                                false, activityPath, Array.Empty<string>(), DescribeFailure(log)));
+
+                        if (log.ReturnValue is not { } returnValue)
+                            return Observable.Return(new SendDocumentResult(
+                                false, activityPath, Array.Empty<string>(), "Export produced no output."));
+
+                        var rendered = returnValue.Deserialize<RenderedDocument>(hub.JsonSerializerOptions);
+                        if (rendered is null || rendered.Content is not { Length: > 0 })
+                            return Observable.Return(new SendDocumentResult(
+                                false, activityPath, Array.Empty<string>(), "Export produced empty content."));
+
+                        var attachment = new EmailAttachment(rendered.FileName, rendered.MimeType, rendered.Content);
+                        return SendToAll(hub, emails, subject, htmlBody, attachment, activityPath, logger);
+                    });
+            });
+
+    /// <summary>
+    /// Resolves the final recipient email set: <paramref name="rawEmails"/> as-is, plus each
+    /// <paramref name="userPaths"/> User node's <see cref="User.Email"/> read under the caller's
+    /// identity. Unreadable users / missing emails are dropped (never faulting the whole send).
+    /// De-duplicated case-insensitively.
+    /// </summary>
+    private static IObservable<IReadOnlyList<string>> ResolveRecipients(
+        IMessageHub hub,
+        IWorkspace workspace,
+        IReadOnlyCollection<string> userPaths,
+        IReadOnlyCollection<string> rawEmails,
+        TimeSpan readTimeout,
+        ILogger? logger)
+    {
+        var raw = (rawEmails ?? [])
+            .Where(e => !string.IsNullOrWhiteSpace(e))
+            .Select(e => e.Trim());
+
+        var paths = (userPaths ?? []).Where(p => !string.IsNullOrWhiteSpace(p)).ToList();
+
+        var fromUsers = paths.Count == 0
+            ? Observable.Return(Enumerable.Empty<string>())
+            : paths.ToObservable()
+                .SelectMany(path => workspace.GetMeshNodeStream(path)
+                    .Where(n => n is not null)
+                    .Take(1)
+                    .Timeout(readTimeout)
+                    .Select(n => n!.ContentAs<User>(hub.JsonSerializerOptions)?.Email)
+                    .Catch((Exception ex) =>
+                    {
+                        logger?.LogWarning(ex, "SendDocument: could not resolve email for recipient {Path}", path);
+                        return Observable.Return<string?>(null);
+                    }))
+                .Where(email => !string.IsNullOrWhiteSpace(email))
+                .Select(email => email!.Trim())
+                .ToList()
+                .Select(list => (IEnumerable<string>)list);
+
+        return fromUsers.Select(userEmails => (IReadOnlyList<string>)raw
+            .Concat(userEmails)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList());
+    }
+
+    private static IObservable<SendDocumentResult> SendToAll(
+        IMessageHub hub,
+        IReadOnlyList<string> emails,
+        string subject,
+        string htmlBody,
+        EmailAttachment attachment,
+        string activityPath,
+        ILogger? logger)
+    {
+        var attachments = new[] { attachment };
+        return emails.ToObservable()
+            .SelectMany(to => hub.SendEmail(to, subject, htmlBody, attachments)
+                .Select(ok => (to, ok))
+                .Catch((Exception ex) =>
+                {
+                    logger?.LogWarning(ex, "SendDocument: send to {To} failed", to);
+                    return Observable.Return((to, ok: false));
+                }))
+            .ToList()
+            .Select(results =>
+            {
+                var sent = results.Where(r => r.ok).Select(r => r.to).ToList();
+                var allOk = results.Count > 0 && results.All(r => r.ok);
+                return new SendDocumentResult(
+                    allOk,
+                    activityPath,
+                    sent,
+                    allOk ? null : $"Sent to {sent.Count} of {results.Count} recipient(s).");
+            });
+    }
+
+    private static string DescribeFailure(ActivityLog log)
+    {
+        var lastError = log.Messages
+            .LastOrDefault(m => m.LogLevel >= LogLevel.Warning)?.Message;
+        return lastError ?? $"Export {log.Status}.";
+    }
+}

--- a/src/MeshWeaver.Markdown.Export/Layout/DeckExportMenuProvider.cs
+++ b/src/MeshWeaver.Markdown.Export/Layout/DeckExportMenuProvider.cs
@@ -56,6 +56,12 @@ public class DeckExportMenuProvider : INodeMenuProvider
                         RequiredPermission: Permission.Read,
                         Order: 27,
                         Href: MeshNodeLayoutAreas.BuildUrl(hubPath, ExportDocumentLayoutArea.PdfArea)),
+                    new NodeMenuItemDefinition(
+                        Label: SendDocumentLayoutArea.SendLabel,
+                        Area: SendDocumentLayoutArea.SendArea,
+                        RequiredPermission: Permission.Read,
+                        Order: 29,
+                        Href: MeshNodeLayoutAreas.BuildUrl(hubPath, SendDocumentLayoutArea.SendArea)),
                 ];
             });
     }

--- a/src/MeshWeaver.Markdown.Export/Layout/MarkdownExportMenuProvider.cs
+++ b/src/MeshWeaver.Markdown.Export/Layout/MarkdownExportMenuProvider.cs
@@ -65,6 +65,12 @@ public class MarkdownExportMenuProvider : INodeMenuProvider
                         RequiredPermission: Permission.Read,
                         Order: 28,
                         Href: MeshNodeLayoutAreas.BuildUrl(hubPath, ExportDocumentLayoutArea.DocxArea)),
+                    new NodeMenuItemDefinition(
+                        Label: SendDocumentLayoutArea.SendLabel,
+                        Area: SendDocumentLayoutArea.SendArea,
+                        RequiredPermission: Permission.Read,
+                        Order: 29,
+                        Href: MeshNodeLayoutAreas.BuildUrl(hubPath, SendDocumentLayoutArea.SendArea)),
                 ];
             });
     }

--- a/src/MeshWeaver.Markdown.Export/Layout/SendDocumentLayoutArea.cs
+++ b/src/MeshWeaver.Markdown.Export/Layout/SendDocumentLayoutArea.cs
@@ -1,0 +1,182 @@
+using System.ComponentModel;
+using System.Net;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Markdown.Export.Configuration;
+using MeshWeaver.Markdown.Export.Handlers;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using MeshWeaver.ShortGuid;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Markdown.Export.Layout;
+
+/// <summary>
+/// Layout area that renders the "Send to contacts" dialog for a Deck / Markdown node (issue #423).
+/// Collects one or more recipients (a framework <see cref="MeshNodePickerControl"/> over
+/// <c>nodeType:User</c> that stores the user node PATH, plus a raw-email fallback field), a subject
+/// and a message; on send it exports the node to a PDF via the SAME node ⇒ file pipeline as the
+/// download and emails the bytes as an attachment (<see cref="SendDocumentDispatch.ExportAndSend"/>).
+///
+/// <para>Everything is composed from framework controls — no hand-rolled HTML — and the send is a
+/// pure reactive subscribe off the click action, running under the caller's identity.</para>
+/// </summary>
+[Browsable(false)]
+public static class SendDocumentLayoutArea
+{
+    /// <summary>Area name for the send-to-contacts dialog.</summary>
+    public const string SendArea = "SendDocument";
+
+    /// <summary>Menu label for the send-to-contacts item.</summary>
+    public const string SendLabel = "Send to contacts";
+
+    /// <summary>
+    /// Renders the send-to-contacts form when the caller has Read on the node; otherwise an
+    /// access-denied notice.
+    /// </summary>
+    /// <param name="host">The layout area host providing hub and workspace access.</param>
+    /// <param name="_">The rendering context (unused).</param>
+    /// <returns>An observable stream of the send dialog control.</returns>
+    [Browsable(false)]
+    public static IObservable<UiControl?> RenderSend(LayoutAreaHost host, RenderingContext _)
+    {
+        var hubPath = host.Hub.Address.ToString();
+        return host.Hub.CheckPermission(hubPath, Permission.Read)
+            .Select(canRead => canRead
+                ? (UiControl?)BuildSendForm(host, hubPath)
+                : (UiControl?)Controls.Stack.WithWidth("100%").WithStyle("padding: 24px;")
+                    .WithView(Controls.H2("Access Denied").WithStyle("margin: 0 0 16px 0;"))
+                    .WithView(Controls.Markdown("You do not have permission to send this node.")));
+    }
+
+    private static UiControl BuildSendForm(LayoutAreaHost host, string hubPath)
+    {
+        var nodeName = hubPath.Contains('/') ? hubPath[(hubPath.LastIndexOf('/') + 1)..] : hubPath;
+
+        var formId = $"send_document_form_{Guid.NewGuid().AsString()}";
+        host.UpdateData(formId, new Dictionary<string, object?>
+        {
+            ["recipient"] = "",
+            ["email"] = "",
+            ["subject"] = $"Shared with you: {nodeName}",
+            ["message"] = $"Hi,\n\nPlease find \"{nodeName}\" attached as a PDF.\n\nBest regards",
+        });
+        var dataContext = LayoutAreaReference.GetDataPointer(formId);
+
+        var stack = Controls.Stack.WithWidth("100%").WithStyle("padding: 24px; max-width: 720px;");
+        stack = stack.WithView(Controls.H2($"Send “{nodeName}” to contacts").WithStyle("margin: 0 0 8px 0;"));
+        stack = stack.WithView(Controls.Markdown(
+            "Exports this node to a PDF and emails it as an attachment. Pick a user, or type an email address.")
+            .WithStyle("margin-bottom: 16px;"));
+
+        // Recipient user picker — stores the selected User node PATH.
+        stack = stack.WithView(new MeshNodePickerControl(new JsonPointerReference("recipient"))
+        {
+            Label = "Recipient (user)",
+            Placeholder = "Search users…",
+            DataContext = dataContext
+        }.WithQueries("nodeType:User").WithMaxResults(15).WithStyle("width: 100%; margin-bottom: 12px;"));
+
+        // Raw-email fallback (for non-portal contacts, or in addition to the picked user).
+        stack = stack.WithView(new TextFieldControl(new JsonPointerReference("email"))
+        {
+            Label = "Or email address",
+            Placeholder = "name@example.com",
+            DataContext = dataContext
+        }.WithStyle("width: 100%; margin-bottom: 12px;"));
+
+        stack = stack.WithView(new TextFieldControl(new JsonPointerReference("subject"))
+        {
+            Label = "Subject",
+            DataContext = dataContext
+        }.WithStyle("width: 100%; margin-bottom: 12px;"));
+
+        stack = stack.WithView(new TextAreaControl(new JsonPointerReference("message"))
+        {
+            Label = "Message",
+            DataContext = dataContext
+        }.WithRows(5).WithStyle("width: 100%; margin-bottom: 16px;"));
+
+        stack = stack.WithView(Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithStyle("gap: 8px;")
+            .WithView(Controls.Button("Send")
+                .WithAppearance(Appearance.Accent)
+                .WithClickAction(actx => SubmitSend(actx, host, hubPath, formId)))
+            .WithView(Controls.Button("Cancel")
+                .WithAppearance(Appearance.Neutral)
+                .WithNavigateToHref(MeshNodeLayoutAreas.BuildUrl(hubPath, MeshNodeLayoutAreas.OverviewArea))));
+
+        return stack;
+    }
+
+    private static void SubmitSend(UiActionContext actx, LayoutAreaHost host, string hubPath, string formId)
+    {
+        var logger = host.Hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(SendDocumentLayoutArea).FullName!);
+
+        actx.Host.Stream.GetDataStream<Dictionary<string, object?>>(formId)
+            .Take(1)
+            .Subscribe(form =>
+            {
+                string Get(string key) => form.GetValueOrDefault(key)?.ToString()?.Trim() ?? "";
+
+                var recipient = Get("recipient");
+                var email = Get("email");
+                var subject = Get("subject");
+                var message = Get("message");
+
+                if (string.IsNullOrWhiteSpace(recipient) && string.IsNullOrWhiteSpace(email))
+                {
+                    ShowDialog(actx, "Validation Error",
+                        "Please select a recipient user or enter an email address.");
+                    return;
+                }
+                if (string.IsNullOrWhiteSpace(subject))
+                    subject = "Shared with you";
+
+                string[] userPaths = string.IsNullOrWhiteSpace(recipient) ? [] : [recipient];
+                string[] rawEmails = string.IsNullOrWhiteSpace(email) ? [] : [email];
+                var htmlBody = BuildHtmlBody(message);
+
+                var options = new DocumentExportOptions { Format = ExportFormat.Pdf };
+
+                SendDocumentDispatch.ExportAndSend(
+                        host.Hub, host.Workspace, hubPath, options,
+                        userPaths, rawEmails, subject, htmlBody, logger: logger)
+                    .Subscribe(
+                        result =>
+                        {
+                            if (result.Success)
+                                ShowDialog(actx, "Sent",
+                                    $"Sent **{hubPath.Split('/').Last()}** to:\n\n"
+                                    + string.Join("\n", result.SentTo.Select(r => $"- {r}")));
+                            else
+                                ShowDialog(actx, "Send failed", result.Error ?? "The document could not be sent.");
+                        },
+                        ex =>
+                        {
+                            logger?.LogWarning(ex, "SendDocument: send failed for {Path}", hubPath);
+                            ShowDialog(actx, "Send failed", $"The document could not be sent: {ex.Message}");
+                        });
+            });
+    }
+
+    private static string BuildHtmlBody(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return "<p>Please find the attached document.</p>";
+        // Plain-text message → minimal HTML: encode, then keep line breaks.
+        var encoded = WebUtility.HtmlEncode(message).Replace("\n", "<br/>");
+        return $"<p>{encoded}</p>";
+    }
+
+    private static void ShowDialog(UiActionContext ctx, string title, string markdown)
+        => ctx.Host.UpdateArea(DialogControl.DialogArea,
+            Controls.Dialog(Controls.Markdown(markdown), title).WithSize("M").WithClosable(true));
+}

--- a/src/MeshWeaver.Markdown.Export/Messaging/SendDocumentResult.cs
+++ b/src/MeshWeaver.Markdown.Export/Messaging/SendDocumentResult.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace MeshWeaver.Markdown.Export.Messaging;
+
+/// <summary>
+/// Outcome of <see cref="Handlers.SendDocumentDispatch.ExportAndSend"/>: the source node was
+/// exported to a document (via the same node ⇒ file pipeline the download uses) and emailed as an
+/// attachment to the resolved recipients.
+///
+/// <para>Plain value record — carried back to the caller (layout-area click action / test), never a
+/// hub message. On success <see cref="SentTo"/> lists the addresses that were successfully mailed.</para>
+/// </summary>
+/// <param name="Success">True when every resolved recipient was mailed without error.</param>
+/// <param name="ActivityPath">Path of the export <c>Activity</c> node that produced the file (for
+/// diagnostics); <c>null</c> when the export never started.</param>
+/// <param name="SentTo">The addresses that were successfully mailed.</param>
+/// <param name="Error">Human-readable reason when <see cref="Success"/> is false; <c>null</c> otherwise.</param>
+public sealed record SendDocumentResult(
+    bool Success,
+    string? ActivityPath,
+    IReadOnlyList<string> SentTo,
+    string? Error = null);

--- a/src/MeshWeaver.Mesh.Contract/EmailAttachment.cs
+++ b/src/MeshWeaver.Mesh.Contract/EmailAttachment.cs
@@ -1,0 +1,15 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// A single file attachment for an outbound email — file name, MIME type, and raw bytes.
+/// Produced from the platform's node ⇒ file export pipeline (a rendered <c>RenderedDocument</c>'s
+/// bytes) and handed to <see cref="IEmailSender.SendEmail(string,string,string,IReadOnlyCollection{EmailAttachment})"/>.
+///
+/// <para>Deliberately transport-agnostic: the concrete sender (Microsoft Graph, SMTP, …) maps it to
+/// its own attachment shape. Bytes are held in memory — this is for the small, single-artifact
+/// "send my deck/document" flow, not a bulk-mail pipeline.</para>
+/// </summary>
+/// <param name="FileName">Suggested file name including extension (e.g. <c>Pitch Deck.pdf</c>).</param>
+/// <param name="MimeType">MIME type of the content (e.g. <c>application/pdf</c>).</param>
+/// <param name="Content">Raw file bytes.</param>
+public sealed record EmailAttachment(string FileName, string MimeType, byte[] Content);

--- a/src/MeshWeaver.Mesh.Contract/HubEmailExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubEmailExtensions.cs
@@ -34,4 +34,19 @@ public static class HubEmailExtensions
             ? Observable.Return(false)
             : sender.SendEmail(toAddress, subject, htmlBody);
     }
+
+    /// <summary>
+    /// Sends an HTML email with file <paramref name="attachments"/> via the registered
+    /// <see cref="IEmailSender"/> (e.g. a deck/document exported to PDF via the node ⇒ file pipeline).
+    /// Cold observable — subscribe to drive. Emits <c>false</c> if no sender is registered.
+    /// </summary>
+    public static IObservable<bool> SendEmail(
+        this IMessageHub hub, string toAddress, string subject, string htmlBody,
+        IReadOnlyCollection<EmailAttachment> attachments)
+    {
+        var sender = hub.ServiceProvider.GetService(typeof(IEmailSender)) as IEmailSender;
+        return sender is null
+            ? Observable.Return(false)
+            : sender.SendEmail(toAddress, subject, htmlBody, attachments);
+    }
 }

--- a/src/MeshWeaver.Mesh.Contract/IEmailSender.cs
+++ b/src/MeshWeaver.Mesh.Contract/IEmailSender.cs
@@ -2,7 +2,7 @@ namespace MeshWeaver.Mesh;
 
 /// <summary>
 /// Sends outbound system email. Not hub-reachable — called from Blazor click actions, the
-/// invitation flow, and mesh scripts (via <see cref="HubEmailExtensions.SendEmail"/>) — so it
+/// invitation flow, and mesh scripts (via <see cref="HubEmailExtensions.SendEmail(MeshWeaver.Messaging.IMessageHub,string,string,string)"/>) — so it
 /// exposes a reactive shape (<see cref="IObservable{T}"/>) that composes cleanly with the rest of
 /// the codebase's reactive pipelines. Implementations bridge their async leaf (e.g. Microsoft
 /// Graph) via <c>Observable.FromAsync</c>.
@@ -18,4 +18,17 @@ public interface IEmailSender
     /// emits a single <c>true</c> on success, or surfaces the failure via OnError.
     /// </summary>
     IObservable<bool> SendEmail(string toAddress, string subject, string htmlBody);
+
+    /// <summary>
+    /// Sends an HTML email with one or more file <paramref name="attachments"/> (e.g. a deck/document
+    /// exported to PDF via the platform's node ⇒ file pipeline). Additive overload — existing
+    /// no-attachment callers are unaffected. Cold observable: the send runs on Subscribe and emits a
+    /// single <c>true</c> on success, or surfaces the failure via OnError.
+    /// </summary>
+    /// <param name="toAddress">Recipient email address.</param>
+    /// <param name="subject">Subject line.</param>
+    /// <param name="htmlBody">HTML message body.</param>
+    /// <param name="attachments">Files to attach. Empty is equivalent to the no-attachment overload.</param>
+    IObservable<bool> SendEmail(
+        string toAddress, string subject, string htmlBody, IReadOnlyCollection<EmailAttachment> attachments);
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/SendDocumentToContactsTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SendDocumentToContactsTest.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown.Export.Configuration;
+using MeshWeaver.Markdown.Export.Handlers;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// End-to-end test for <b>"send a deck/document to contacts"</b> (issue #423, piece 2). Verifies that
+/// <see cref="SendDocumentDispatch.ExportAndSend"/> reuses the SAME node ⇒ file export pipeline as the
+/// download (<c>ExportDocumentRequest → Templates/Export/Pdf → RenderedDocument bytes</c>) and then
+/// emails those bytes as a PDF <see cref="EmailAttachment"/> via the new <see cref="IEmailSender"/>
+/// attachment overload — to a recipient resolved from a User node PATH (email read under the caller's
+/// identity) AND to a raw email address. A capturing <see cref="IEmailSender"/> (no mocking) records
+/// every send so the test can assert the attachment bytes/mime/filename and the recipient.
+/// <para>Mirrors <c>DeckExportScriptRelayTest</c> for the deck/slide seeding.</para>
+/// </summary>
+public class SendDocumentToContactsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private readonly CapturingEmailSender _email = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMarkdownExport()
+            .ConfigureServices(s => s.AddSingleton<IEmailSender>(_email));
+
+    [Fact(Timeout = 180000)]
+    public async Task SendDeckToContacts_EmailsPdfAttachment_ToUserAndRawAddress()
+    {
+        // ── Seed a Space holding a Deck with three ordered Slide children (as DeckExportScriptRelayTest). ──
+        var space = $"Space{Guid.NewGuid():N}"[..16];
+        await NodeFactory.CreateNode(MeshNode.FromPath(space) with
+        {
+            Name = "Send Deck Space",
+            NodeType = SpaceNodeType.NodeType,
+            Content = new Space()
+        }).Should().Emit();
+
+        var deck = $"{space}/pitch";
+        await NodeFactory.CreateNode(MeshNode.FromPath(deck) with
+        {
+            Name = "Pitch Deck",
+            NodeType = DeckNodeType.NodeType,
+            Content = new DeckContent { Title = "Pitch Deck", Slides = [$"{deck}/intro", $"{deck}/summary"] }
+        }).Should().Emit();
+        await CreateSlide($"{deck}/intro", "Intro", 1, "# Introduction\n\nAbout ALPHAWIDGET.");
+        await CreateSlide($"{deck}/summary", "Summary", 2, "# Summary\n\nThoughts on GAMMAWIDGET.");
+
+        // ── Seed a recipient User node (top-level partition root → System-seeded) with an email. ──
+        var recipientEmail = "bob.recipient@example.com";
+        var userPath = $"user{Guid.NewGuid():N}"[..16];
+        await SeedTopLevel(MeshNode.FromPath(userPath) with
+        {
+            Name = "Bob Recipient",
+            NodeType = UserNodeType.NodeType,
+            State = MeshNodeState.Active,
+            Content = new User { Email = recipientEmail, FullName = "Bob Recipient" }
+        });
+
+        var workspace = GetClient(c => c.AddData()).GetWorkspace();
+        var options = new DocumentExportOptions { Format = ExportFormat.Pdf };
+
+        // ── Act: send the deck to the picked User (by PATH) AND a raw email address. ──
+        const string rawEmail = "carol.external@example.com";
+        const string subject = "Please review our pitch";
+        var result = await SendDocumentDispatch.ExportAndSend(
+                Mesh, workspace, deck, options,
+                recipientUserPaths: [userPath],
+                rawEmails: [rawEmail],
+                subject: subject,
+                htmlBody: "<p>Here is the deck.</p>")
+            .Should().Within(2.Minutes()).Emit();
+
+        // ── Assert: send succeeded to BOTH recipients. ──
+        result.Should().NotBeNull();
+        result.Error.Should().BeNullOrEmpty("the send should succeed. Error: " + result.Error);
+        result.Success.Should().BeTrue();
+        result.ActivityPath.Should().NotBeNullOrEmpty("the export activity path should be recorded");
+        result.SentTo.Should().Contain(recipientEmail).And.Contain(rawEmail);
+
+        _email.Sent.Should().HaveCount(2, "one email per resolved recipient");
+
+        // ── Assert the resolved-USER email carries the PDF attachment (non-empty, correct mime/name). ──
+        var toUser = _email.Sent.Single(m => m.To == recipientEmail);
+        toUser.Subject.Should().Be(subject);
+        toUser.Attachments.Should().ContainSingle();
+        var attachment = toUser.Attachments.Single();
+        attachment.MimeType.Should().Be("application/pdf");
+        attachment.FileName.Should().EndWith(".pdf");
+        attachment.Content.Should().NotBeNull().And.NotBeEmpty();
+
+        // The attachment is a real, content-faithful PDF: re-read it and prove a slide's text is present.
+        using (var pdf = PdfDocument.Open(attachment.Content))
+        {
+            var text = string.Join("\n", pdf.GetPages().Select(p => p.Text));
+            text.Should().Contain("ALPHAWIDGET", "the emailed PDF must contain the deck's rendered slide content");
+            text.Should().Contain("GAMMAWIDGET");
+        }
+
+        // ── The raw-address recipient gets the SAME attachment. ──
+        var toRaw = _email.Sent.Single(m => m.To == rawEmail);
+        toRaw.Attachments.Should().ContainSingle();
+        toRaw.Attachments.Single().Content.Should().NotBeNull().And.NotBeEmpty();
+
+        await NodeFactory.DeleteNode(space).Should().Emit();
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task NoAttachmentSendEmail_StillWorks()
+    {
+        // The additive attachment overload must not disturb existing no-attachment callers
+        // (invitation / notification email). The plain 3-arg SendEmail still sends with 0 attachments.
+        var ok = await Mesh.SendEmail("alice@example.com", "Plain notification", "<p>Hello.</p>")
+            .Should().Within(10.Seconds()).Emit();
+
+        ok.Should().BeTrue();
+        _email.Sent.Should().ContainSingle();
+        var sent = _email.Sent.Single();
+        sent.To.Should().Be("alice@example.com");
+        sent.Subject.Should().Be("Plain notification");
+        sent.Attachments.Should().BeEmpty("the no-attachment path carries no files");
+    }
+
+    private async Task CreateSlide(string path, string name, int order, string body)
+        => await NodeFactory.CreateNode(MeshNode.FromPath(path) with
+        {
+            Name = name,
+            NodeType = SlideNodeType.NodeType,
+            Order = order,
+            Content = new SlideContent { Content = body, Notes = $"Notes for {name}" }
+        }).Should().Emit();
+
+    /// <summary>Capturing <see cref="IEmailSender"/> — records every send (no mocking) for assertions.</summary>
+    private sealed class CapturingEmailSender : IEmailSender
+    {
+        public ConcurrentQueue<SentEmail> SentQueue { get; } = new();
+        public IReadOnlyList<SentEmail> Sent => SentQueue.ToArray();
+
+        public IObservable<bool> SendEmail(string toAddress, string subject, string htmlBody)
+            => SendEmail(toAddress, subject, htmlBody, []);
+
+        public IObservable<bool> SendEmail(
+            string toAddress, string subject, string htmlBody, IReadOnlyCollection<EmailAttachment> attachments)
+        {
+            SentQueue.Enqueue(new SentEmail(toAddress, subject, htmlBody, attachments.ToList()));
+            return Observable.Return(true);
+        }
+    }
+
+    private sealed record SentEmail(
+        string To, string Subject, string Body, IReadOnlyList<EmailAttachment> Attachments);
+}


### PR DESCRIPTION
Implements #423 send-to-contacts (email the node-exported PDF as an attachment via IEmailSender; pixel-faithful rendering still deferred).

## What ships

Builds directly on the content-faithful Deck→PDF **download** (PR #518): the same node ⇒ file pipeline — `ExportDocumentRequest → ScriptDispatch → Templates/Export/Pdf → RenderedDocument(byte[]) on ActivityLog.ReturnValue` — is reused to produce the PDF, which is then emailed as an attachment. No bespoke upload/blob-link path; no new request/response for the email.

### 1. Attachment support on `IEmailSender` (additive)
- New `EmailAttachment(FileName, MimeType, byte[] Content)` value record.
- `IEmailSender` gains a `SendEmail(to, subject, htmlBody, IReadOnlyCollection<EmailAttachment>)` overload; `HubEmailExtensions` mirrors it.
- Implemented in `GraphEmailSender` (builds Graph base64 `FileAttachment`s on the message) and `NoOpEmailSender`. The existing 3-arg overload **delegates** to the new one, so every current no-attachment caller (`InvitationEmailSender`, `OutboundEmailSender`, `NotificationService`) is untouched and keeps working — those are consumers of `IEmailSender`, not implementers, so no changes were needed there.

### 2. Send-to-contacts action (Deck + Markdown nodes)
- `SendDocumentDispatch.ExportAndSend` — fully reactive (`IObservable` + `.Subscribe`, no `async`/`await`/`Task<T>`): dispatches the export, waits for the activity's terminal `RenderedDocument`, resolves recipient emails, and emails the PDF as an attachment. Runs under the **caller's** `AccessContext`; a recipient User's email is resolved by reading that User node under the caller (which naturally limits sends to recipients the caller could address). The Graph send leaf still rides `IIoPool`.
- `SendDocumentLayoutArea` + a **"Send to contacts"** node-menu item on Deck and Markdown nodes — a framework-control form (`MeshNodePicker` over `nodeType:User` storing the node PATH, a raw-email fallback field, subject + message), **no hand-rolled HTML**. The Send click drives `ExportAndSend` and reports outcome via a dialog.

### 3. Access
The send runs under the caller's identity (AccessContext propagation through `.Subscribe` boundaries). Recipient User email is read as the caller; raw addresses are used as typed.

## Test
`SendDocumentToContactsTest` (no mocking; a capturing `IEmailSender` records every send). Seeds a Deck + slides + a User recipient, then:
- asserts the emailed PDF attachment is non-empty, `application/pdf`, `.pdf`, and **content-faithful** (re-read with PdfPig — the slides' rendered text is present),
- asserts it reaches both the resolved **User** (by path) and a **raw** address,
- asserts the no-attachment path still sends with zero attachments (invitation/notification email unchanged).

## Build / test
- `dotnet build … -c Release -warnaserror -p:CIRun=true` clean for `MeshWeaver.Markdown.Export`, `MeshWeaver.Mesh.Contract`, `MeshWeaver.Graph`, `Memex.Portal.Shared`, `Memex.Portal.Monolith`, and `MeshWeaver.Hosting.Monolith.Test` (0 warnings).
- `SendDocumentToContactsTest`: 2/2 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)