### PR TITLE
Polished owner-editable user profile with curated Showcase

### DIFF
--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -56,6 +56,18 @@ public static class UserActivityLayoutAreas
     /// <summary>Area that clears the owner's <see cref="User.Body"/> override so the default welcome home returns.</summary>
     public const string ResetHomeArea = "ResetHome";
 
+    /// <summary>
+    /// Area name for the public profile page (<c>/{user}/Profile</c>) — the polished, read-only
+    /// showcase every visitor sees, and the owner's preview + entry point to the editor.
+    /// </summary>
+    public const string ProfileArea = "Profile";
+
+    /// <summary>
+    /// Area name for the owner-only profile editor (bio, links, showcase) — node-bound editors that
+    /// auto-persist to the User node. Access-gated on <see cref="Permission.Update"/> (self-edit only).
+    /// </summary>
+    public const string EditProfileArea = "EditProfile";
+
     /// <summary>Link to the doc page that explains the configurable Body-page + <c>@@</c>-region model.</summary>
     internal const string ConfigGuideLink = "/Doc/GUI/ConfigurablePages";
 
@@ -98,7 +110,10 @@ public static class UserActivityLayoutAreas
             // Space Body editor. See EditHome / BuildHomeBodyEditor.
             .WithView(MeshNodeLayoutAreas.EditArea, EditHome)
             // Clears User.Body → the welcome template returns; reached from the Reset menu item.
-            .WithView(ResetHomeArea, ResetHome))
+            .WithView(ResetHomeArea, ResetHome)
+            // The polished public profile (read-only showcase) and its owner-only, node-bound editor.
+            .WithView(ProfileArea, ProfileAreaView)
+            .WithView(EditProfileArea, EditProfile))
             // Re-enable Edit on the user home (the default node menu HIDES generic Edit on a
             // protected partition root) and add a Reset-to-default item once the owner has
             // authored a Body override.
@@ -127,6 +142,10 @@ public static class UserActivityLayoutAreas
         var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
         var capturedAccessContext = accessService?.Context ?? accessService?.CircuitContext;
         var isOwner = IsViewerOwner(capturedAccessContext, nodeOwnerId);
+        var options = host.Hub.JsonSerializerOptions;
+        // The visitor profile reveals email ONLY to a global admin (the owner never lands here — they
+        // get the dashboard). Fail-closed: hidden until admin status resolves.
+        var isAdminStream = ViewerIsAdmin(host.Hub, capturedAccessContext?.ObjectId);
 
         var areaLogger = host.Hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.Graph.UserActivityLayoutAreas");
@@ -149,15 +168,15 @@ public static class UserActivityLayoutAreas
         // ensure-create a {owner}/Chat node before rendering. Nothing to gate on: bind straight to the
         // owner-node sync stream.
         return syncStream!
-            .Select(change =>
+            .CombineLatest(isAdminStream, (change, isAdmin) =>
             {
                 var ownerNode = change.Value;
                 var ownerName = ownerNode?.Name ?? nodeOwnerId;
 
                 if (isOwner)
-                    return (UiControl?)BuildOwnerHome(nodePath, ownerName, ownerNode, host.Hub.JsonSerializerOptions);
-                else
-                    return (UiControl?)BuildVisitorProfile(nodePath, ownerName, ownerNode);
+                    return (UiControl?)BuildOwnerHome(nodePath, ownerName, ownerNode, options);
+                return (UiControl?)BuildProfile(nodePath, nodeOwnerId, ownerName, ownerNode,
+                    isOwner: false, canSeeEmail: isAdmin, options);
             })
             // The area must NEVER spin forever, but it must ALSO never tear itself down
             // while idle. Two distinct failure modes, ONE narrow guard:
@@ -189,7 +208,7 @@ public static class UserActivityLayoutAreas
     /// True when the viewer's <see cref="AccessContext"/> represents the same
     /// principal as the per-user partition key <paramref name="nodeOwnerId"/>
     /// — the rule that gates <see cref="BuildOwnerHome"/> vs
-    /// <see cref="BuildVisitorProfile"/>. Accepts either:
+    /// <see cref="BuildProfile"/>. Accepts either:
     /// <list type="bullet">
     ///   <item><see cref="AccessContext.ObjectId"/> equal to the partition key
     ///     — the canonical match when <c>CircuitAccessHandler</c> seeds
@@ -403,6 +422,16 @@ public static class UserActivityLayoutAreas
                 var items = new List<NodeMenuItemDefinition>();
                 if (permissions.HasFlag(Permission.Update))
                 {
+                    items.Add(new NodeMenuItemDefinition(
+                        "View public profile", ProfileArea,
+                        Icon: "👤", RequiredPermission: Permission.Update, Order: 5,
+                        Href: MeshNodeLayoutAreas.BuildUrl(hubPath, ProfileArea),
+                        Tooltip: "Preview your public profile as visitors see it"));
+                    items.Add(new NodeMenuItemDefinition(
+                        "Edit profile", EditProfileArea,
+                        Icon: "🪪", RequiredPermission: Permission.Update, Order: 6,
+                        Href: MeshNodeLayoutAreas.BuildUrl(hubPath, EditProfileArea),
+                        Tooltip: "Edit your bio, links, and showcase"));
                     items.Add(new NodeMenuItemDefinition(
                         "Edit home page", MeshNodeLayoutAreas.EditArea,
                         Icon: "✏️", RequiredPermission: Permission.Update, Order: 10,
@@ -649,55 +678,224 @@ public static class UserActivityLayoutAreas
                     .WithMaxColumns(2).WithItemLimit(50).WithMaxRows(4).WithReactiveMode(true));
     }
 
-    /// <summary>
-    /// Public profile shown to visitors — UserProfileControl (rendered by Blazor)
-    /// with child nodes and recent activity below.
-    /// </summary>
-    private static UiControl BuildVisitorProfile(string nodePath, string ownerName, MeshNode? ownerNode)
-    {
-        // Compute owner partition path (post-v10 each user has their own
-        // partition; legacy /User/{userid}/... maps to {userid}/... content)
-        var nodeOwnerId = nodePath.StartsWith("User/") ? nodePath[5..] : nodePath;
+    // ── Public profile + owner-editable showcase ───────────────────────────────────────────────────
 
-        // Extract User content fields (bio, email) if available
-        string? email = null;
-        string? bio = null;
-        if (ownerNode?.Content is User userContent)
+    /// <summary>
+    /// The public profile area (<see cref="ProfileArea"/>, <c>/{user}/Profile</c>) — the polished,
+    /// read-only showcase every viewer sees, and the owner's preview + entry point to the editor.
+    /// Reacts to the owner node so edits appear live; email is revealed only to the owner or a global
+    /// admin (fail-closed: hidden until admin status resolves).
+    /// </summary>
+    public static IObservable<UiControl?> ProfileAreaView(LayoutAreaHost host, RenderingContext _)
+    {
+        var nodePath = host.Hub.Address.ToString();
+        var nodeOwnerId = OwnerIdOf(nodePath);
+        var options = host.Hub.JsonSerializerOptions;
+
+        var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
+        var captured = accessService?.Context ?? accessService?.CircuitContext;
+        var isOwner = IsViewerOwner(captured, nodeOwnerId);
+        var isAdminStream = ViewerIsAdmin(host.Hub, captured?.ObjectId);
+        var areaLogger = host.Hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Graph.UserActivityLayoutAreas");
+
+        var syncStream = host.Workspace.GetStream(new MeshNodeReference());
+        return syncStream!
+            .CombineLatest(isAdminStream, (change, isAdmin) =>
+            {
+                var ownerNode = change.Value;
+                var ownerName = ownerNode?.Name ?? nodeOwnerId;
+                return (UiControl?)BuildProfile(nodePath, nodeOwnerId, ownerName, ownerNode,
+                    isOwner, canSeeEmail: isOwner || isAdmin, options);
+            })
+            // Same narrow guard as Activity: arm the timeout for the FIRST emission only (surface an
+            // unreachable owner hub) and disarm it thereafter (an idle data-bound view must not tear
+            // itself down between edits). A first-snapshot timeout / read denial throws, never swallows.
+            .Timeout(Observable.Timer(TimeSpan.FromSeconds(30)), _ => Observable.Never<long>())
+            .Catch<UiControl?, Exception>(ex =>
+            {
+                areaLogger?.LogWarning(ex,
+                    "[UserActivity.Profile] profile unavailable for {NodePath}", nodePath);
+                return Observable.Throw<UiControl?>(
+                    new InvalidOperationException($"Profile unavailable for '{nodePath}'.", ex));
+            });
+    }
+
+    /// <summary>
+    /// The owner-only profile editor (<see cref="EditProfileArea"/>) — node-bound markdown editors for
+    /// the bio and links plus inline showcase curation, gated on <see cref="Permission.Update"/>
+    /// (self-edit → the owner only; visitors get access-denied). Mirrors <see cref="EditHome"/>.
+    /// </summary>
+    public static IObservable<UiControl?> EditProfile(LayoutAreaHost host, RenderingContext _)
+    {
+        var hubPath = host.Hub.Address.ToString();
+        var options = host.Hub.JsonSerializerOptions;
+        return host.Workspace.GetMeshNodeStream().CombineLatest(
+            host.Hub.GetEffectivePermissions(hubPath),
+            (node, permissions) => !permissions.HasFlag(Permission.Update)
+                ? (UiControl?)MeshNodeLayoutAreas.BuildAccessDenied(hubPath)
+                : (UiControl?)BuildProfileEditor(node, hubPath, options));
+    }
+
+    /// <summary>
+    /// The profile editor body: a back link, node-bound <see cref="MarkdownEditorControl"/>s for the
+    /// bio and links (each edit is a per-field read-modify-write straight to the User node — the same
+    /// node-bound DataContext pattern as <see cref="BuildHomeBodyEditor"/>: ONE source of truth, no
+    /// <c>/data</c> replica, no save subscription), and the showcase rendered with the inline unpin
+    /// overlay so the owner curates pins in place. Built from layout-area controls only.
+    /// </summary>
+    internal static UiControl BuildProfileEditor(MeshNode? node, string hubPath, JsonSerializerOptions options)
+    {
+        if (node is null)
+            return Controls.Markdown("*Profile not found.*");
+
+        var userPath = node.Path ?? hubPath;
+        var ownerId = OwnerIdOf(userPath);
+        var contentCtx = LayoutAreaReference.GetMeshNodeDataContext(userPath, bindContent: true);
+        var pins = node.ContentAs<User>(options)?.PinnedPaths;
+
+        var container = Controls.Stack
+            .WithWidth("100%")
+            .WithStyle("gap: 20px; width: 100%; padding: 0 4px 24px;");
+
+        // Header: back to the profile + auto-save hint (Label controls, never raw HTML).
+        container = container.WithView(Controls.Stack
+            .WithOrientation(Orientation.Horizontal)
+            .WithVerticalAlignment(VerticalAlignment.Center)
+            .WithHorizontalGap(12)
+            .WithStyle("padding: 8px 0; border-bottom: 1px solid var(--neutral-stroke-rest);")
+            .WithView(Controls.Button("")
+                .WithIconStart(FluentIcons.ArrowLeft())
+                .WithAppearance(Appearance.Stealth)
+                .WithNavigateToHref($"/{userPath}/{ProfileArea}"))
+            .WithView(Controls.H3("Edit your profile").WithStyle("margin: 0; flex: 1;"))
+            .WithView(Controls.Label("Changes are saved automatically")
+                .WithStyle("color: var(--neutral-foreground-hint); font-size: 0.85rem;")));
+
+        // Bio — node-bound markdown editor (JsonPointer "bio" against the User content context).
+        container = container.WithView(BuildProfileSection("Bio", new MarkdownEditorControl
         {
-            email = userContent.Email;
-            bio = userContent.Bio;
-        }
-        else if (ownerNode?.Content is JsonElement je && je.ValueKind == JsonValueKind.Object)
+            Value = new JsonPointerReference("bio"),
+            DataContext = contentCtx,
+            Height = "160px",
+            MaxHeight = "none",
+            Placeholder = "A sentence or two about what you do…"
+        }));
+
+        // Links — node-bound markdown editor (one markdown link per line).
+        container = container.WithView(BuildProfileSection("Links", new MarkdownEditorControl
         {
-            if (je.TryGetProperty("Email", out var emailProp) || je.TryGetProperty("email", out emailProp))
-                email = emailProp.GetString();
-            if (je.TryGetProperty("Bio", out var bioProp) || je.TryGetProperty("bio", out bioProp))
-                bio = bioProp.GetString();
-        }
+            Value = new JsonPointerReference("links"),
+            DataContext = contentCtx,
+            Height = "140px",
+            MaxHeight = "none",
+            Placeholder = "One link per line, e.g. [GitHub](https://github.com/you)"
+        }));
+
+        // Showcase — pinned cards with the inline unpin overlay; a note on how to add more.
+        container = container.WithView(BuildProfileSection("Showcase",
+            Controls.Stack
+                .WithStyle("gap: 8px; width: 100%;")
+                .WithView(Controls.Markdown(
+                    "Pin any space, doc, agent, or example from its menu to feature it here — " +
+                    "hover a card to unpin it."))
+                .WithView(BuildShowcase(ownerId, pins, ownerView: true))));
+
+        return container;
+    }
+
+    /// <summary>Reactive global-admin check for the viewer; false for an unauthenticated viewer, and
+    /// <c>StartWith(false)</c> so the profile renders immediately (email hidden) and reveals only once
+    /// admin status resolves — fail-closed on the PII gate.</summary>
+    private static IObservable<bool> ViewerIsAdmin(IMessageHub hub, string? viewerId)
+        => string.IsNullOrEmpty(viewerId)
+            ? Observable.Return(false)
+            : hub.IsGlobalAdmin(viewerId).StartWith(false).DistinctUntilChanged();
+
+    /// <summary>
+    /// The polished public profile — cover/avatar + display name, an opt-in bio and links block, and a
+    /// curated "Showcase" of the owner's pinned content with a recent-public-content fallback. Rendered
+    /// read-only for everyone via layout-area controls (no hand-rolled HTML); the owner reaches the
+    /// node-bound editors via <see cref="EditProfileArea"/>. Email is shown ONLY when
+    /// <paramref name="canSeeEmail"/> (owner or global admin) — visitors never see it (#471 PII). An
+    /// empty profile (no bio, links, or pins) renders the getting-started card instead of empty sections.
+    /// Kept <c>internal</c> so the owner/visitor + empty/populated behaviour is unit-testable.
+    /// </summary>
+    internal static UiControl BuildProfile(
+        string nodePath, string ownerId, string ownerName, MeshNode? ownerNode,
+        bool isOwner, bool canSeeEmail, JsonSerializerOptions options)
+    {
+        // ContentAs (not `as User`): the owner-node stream alternates typed↔JsonElement↔null frames.
+        var user = ownerNode.ContentAs<User>(options);
+        var bio = user?.Bio;
+        var links = user?.Links;
+        var pins = user?.PinnedPaths;
+        var email = canSeeEmail ? user?.Email : null;
+        var isEmpty = string.IsNullOrWhiteSpace(bio)
+                      && string.IsNullOrWhiteSpace(links)
+                      && (pins is null || pins.Count == 0);
 
         var profile = Controls.Stack
             .WithWidth("100%")
             .WithStyle("display: flex; flex-direction: column; height: 100%; min-height: 0; overflow: hidden;");
 
-        // User profile card (rendered by Blazor UserProfilePageView)
+        // Header card (avatar + name; email only for owner/admin). Bio renders as its own markdown
+        // section below, so it is NOT passed to the header — no duplication.
         profile = profile.WithView(new UserProfileControl()
             .WithNodePath(nodePath)
             .WithDisplayName(ownerName)
             .WithIcon(ownerNode?.Icon)
             .WithEmail(email)
-            .WithBio(bio));
+            .WithBio(null));
 
-        // Scrollable content area
         var content = Controls.Stack
-            .WithStyle("padding: 0 24px; flex: 1; min-height: 0; overflow-y: auto; " + ThinScrollbar);
+            .WithStyle("padding: 0 24px 24px; flex: 1; min-height: 0; overflow-y: auto; " + ThinScrollbar);
 
-        // Recent activity by this user. Per-user content lives at the user's
-        // own partition path (post-v10: nodeOwnerId = "rbuergi"), not under
-        // the User-prefixed dashboard path. Both Items and Activity queries
-        // scope to nodeOwnerId so the legacy User/ path doesn't leak.
-        content = content.WithView(Controls.MeshSearch
+        // Owner-only inline entry to the node-bound editors.
+        if (isOwner)
+            content = content.WithView(Controls.Stack
+                .WithOrientation(Orientation.Horizontal)
+                .WithHorizontalGap(8)
+                .WithStyle("padding: 8px 0;")
+                .WithView(Controls.Button("Edit profile")
+                    .WithIconStart(FluentIcons.Edit())
+                    .WithAppearance(Appearance.Lightweight)
+                    .WithNavigateToHref($"/{nodePath}/{EditProfileArea}")));
+
+        if (isEmpty)
+        {
+            content = content.WithView(BuildGettingStarted(nodePath, ownerId, ownerName, isOwner));
+        }
+        else
+        {
+            if (!string.IsNullOrWhiteSpace(bio))
+                content = content.WithView(BuildProfileSection("About", Controls.Markdown(bio!)));
+            if (!string.IsNullOrWhiteSpace(links))
+                content = content.WithView(BuildProfileSection("Links", Controls.Markdown(links!)));
+            content = content.WithView(BuildProfileSection("Showcase",
+                BuildShowcase(ownerId, pins, ownerView: false)));
+
+            // Recent activity + items — visibility-filtered to the viewer (only public nodes for visitors).
+            content = content.WithView(BuildRecentActivity(ownerId));
+            content = content.WithView(BuildProfileItems(ownerId));
+        }
+
+        profile = profile.WithView(content);
+        return profile;
+    }
+
+    /// <summary>A titled profile section — an <c>H3</c> heading (Label control, not HTML) over its body.</summary>
+    private static UiControl BuildProfileSection(string title, UiControl body) =>
+        Controls.Stack
+            .WithStyle("gap: 8px; width: 100%; padding-top: 16px;")
+            .WithView(Controls.H3(title).WithStyle("margin: 0; font-size: 1.15rem;"))
+            .WithView(body);
+
+    /// <summary>Recent activity by the owner — visibility-filtered so a visitor sees only public nodes.</summary>
+    private static UiControl BuildRecentActivity(string ownerId) =>
+        Controls.MeshSearch
             .WithTitle("Recent Activity")
-            .WithHiddenQuery($"source:activity namespace:{nodeOwnerId} scope:subtree is:main sort:LastModified-desc")
+            .WithHiddenQuery($"source:activity namespace:{ownerId} scope:subtree is:main sort:LastModified-desc")
             .WithShowSearchBox(false)
             .WithShowEmptyMessage(true)
             .WithRenderMode(MeshSearchRenderMode.Flat)
@@ -706,12 +904,13 @@ public static class UserActivityLayoutAreas
             .WithMaxColumns(4)
             .WithItemLimit(50)
             .WithMaxRows(2)
-            .WithReactiveMode(true));
+            .WithReactiveMode(true);
 
-        // Visible child nodes — security service automatically filters to viewer-visible nodes
-        content = content.WithView(Controls.MeshSearch
+    /// <summary>The owner's visible child nodes — the security service filters to viewer-visible nodes.</summary>
+    private static UiControl BuildProfileItems(string ownerId) =>
+        Controls.MeshSearch
             .WithTitle("Items")
-            .WithHiddenQuery($"namespace:{nodeOwnerId} is:main context:search scope:descendants sort:LastModified-desc")
+            .WithHiddenQuery($"namespace:{ownerId} is:main context:search scope:descendants sort:LastModified-desc")
             .WithShowEmptyMessage(true)
             .WithRenderMode(MeshSearchRenderMode.Grouped)
             .WithSectionCounts(true)
@@ -719,10 +918,103 @@ public static class UserActivityLayoutAreas
             .WithMaxRows(3)
             .WithMaxColumns(4)
             .WithCollapsibleSections(true)
-            .WithReactiveMode(true));
+            .WithReactiveMode(true);
 
-        profile = profile.WithView(content);
-        return profile;
+    /// <summary>
+    /// The Showcase band: the owner's curated pins (<see cref="User.PinnedPaths"/>) rendered as cards,
+    /// or — when nothing is pinned — a fallback of the owner's recent public content so the section is
+    /// never empty. Visibility is enforced by the search itself (a visitor only ever sees pins they may
+    /// read). In the owner's editor (<paramref name="ownerView"/>) each pinned card carries the inline
+    /// unpin overlay (<see cref="PinLayoutArea.PinnedThumbnailArea"/>) so the owner can curate in place.
+    /// </summary>
+    internal static UiControl BuildShowcase(string ownerId, IReadOnlyList<string>? pins, bool ownerView)
+    {
+        if (pins is { Count: > 0 })
+        {
+            var pathsClause = string.Join(" OR ", pins);
+            var search = Controls.MeshSearch
+                .WithHiddenQuery($"path:({pathsClause}) sort:LastModified-desc")
+                .WithShowSearchBox(false)
+                .WithShowEmptyMessage(false)
+                .WithRenderMode(MeshSearchRenderMode.Flat)
+                .WithCollapsibleSections(false)
+                .WithSectionCounts(false)
+                .WithMaxColumns(4)
+                .WithGridSpacing(20)
+                .WithItemLimit(24)
+                .WithMaxRows(2)
+                .WithReactiveMode(true);
+            if (ownerView)
+                search = search.WithItemArea(PinLayoutArea.PinnedThumbnailArea);
+            return search;
+        }
+
+        // Fallback — the owner's recent public content (visibility-filtered), so the band is never bare.
+        return Controls.MeshSearch
+            .WithHiddenQuery($"namespace:{ownerId} is:main context:search scope:descendants sort:LastModified-desc")
+            .WithShowSearchBox(false)
+            .WithShowEmptyMessage(true)
+            .WithRenderMode(MeshSearchRenderMode.Flat)
+            .WithCollapsibleSections(false)
+            .WithSectionCounts(false)
+            .WithMaxColumns(4)
+            .WithItemLimit(12)
+            .WithMaxRows(2)
+            .WithReactiveMode(true);
+    }
+
+    /// <summary>Stable control id for the getting-started card — asserted by tests, stable across renders.</summary>
+    internal const string GettingStartedId = "profile-getting-started";
+
+    /// <summary>
+    /// The friendly getting-started card shown on an EMPTY profile (no bio, links, or pins) — a
+    /// persistent, self-documenting starter that renders automatically for EVERY user until they fill
+    /// their profile in. There is nothing to seed: the behaviour is inherent in the render path, so it
+    /// shows for all users, always, not as a one-time step. For the owner it explains how to add a bio,
+    /// links, and pin content, links straight to the editor, and previews their recent work as
+    /// inspiration; for a visitor it is a gentle "nothing here yet" plus the owner's recent public work.
+    /// Built entirely from layout-area controls (Stack / Markdown / Button / MeshSearch) — no HTML.
+    /// </summary>
+    internal static UiControl BuildGettingStarted(string nodePath, string ownerId, string ownerName, bool isOwner)
+    {
+        var card = Controls.Stack
+            .WithId(GettingStartedId)
+            .WithWidth("100%")
+            .WithStyle("gap: 16px; width: 100%; padding: 24px; margin-top: 8px; " +
+                       "border: 1px solid var(--neutral-stroke-rest); border-radius: 8px; " +
+                       "background: var(--neutral-fill-rest);");
+
+        var intro = isOwner
+            ? $$"""
+                ### 👋 Welcome, {{ownerName}} — let's set up your profile
+
+                Your profile is how others discover your work. Make it yours:
+
+                - **Bio** — a sentence or two about what you do.
+                - **Links** — your GitHub, site, or socials (one markdown link per line).
+                - **Showcase** — **pin** your best spaces, docs, agents, or examples to feature them here.
+
+                Use **Edit profile** to add your bio and links. Pin any node from its menu to add it to your Showcase.
+                """
+            : $"### {ownerName}\n\n{ownerName} hasn't set up their profile yet. Explore their recent public work below.";
+
+        card = card.WithView(Controls.Markdown(intro));
+
+        if (isOwner)
+            card = card.WithView(Controls.Stack
+                .WithOrientation(Orientation.Horizontal)
+                .WithHorizontalGap(8)
+                .WithView(Controls.Button("Edit profile")
+                    .WithIconStart(FluentIcons.Edit())
+                    .WithAppearance(Appearance.Accent)
+                    .WithNavigateToHref($"/{nodePath}/{EditProfileArea}")));
+
+        // Recent public content — doubles as "showcase examples" so the card is never bare.
+        card = card.WithView(BuildProfileSection(
+            isOwner ? "Your recent work" : "Recent public work",
+            BuildShowcase(ownerId, null, ownerView: false)));
+
+        return card;
     }
 
 

--- a/src/MeshWeaver.Mesh.Contract/Security/User.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/User.cs
@@ -12,8 +12,17 @@ public record User : AccessObject
     /// <summary>Email address (from OAuth, set during onboarding).</summary>
     public string? Email { get; init; }
 
-    /// <summary>Short biography.</summary>
+    /// <summary>Short biography. Rendered read-only as markdown on the public profile; edited via a
+    /// node-bound markdown editor (see <c>UserActivityLayoutAreas.EditProfile</c>).</summary>
     public string? Bio { get; init; }
+
+    /// <summary>
+    /// Public profile links as a markdown block — one link per line, e.g.
+    /// <c>[GitHub](https://github.com/you)</c>. Rendered read-only via <c>Controls.Markdown</c> (so the
+    /// framework renders the anchors — no hand-rolled HTML) and edited via a node-bound markdown editor.
+    /// This is opt-in public content: only what the owner writes here is shown to visitors.
+    /// </summary>
+    public string? Links { get; init; }
 
     /// <summary>Profile role (e.g. Developer, Manager, Designer).</summary>
     public string? Role { get; init; }

--- a/test/MeshWeaver.Graph.Test/UserProfileShowcaseTest.cs
+++ b/test/MeshWeaver.Graph.Test/UserProfileShowcaseTest.cs
@@ -1,0 +1,248 @@
+using System.Reflection;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Unit tests for the polished, owner-editable public profile (<see cref="UserActivityLayoutAreas"/>):
+/// the read-only showcase every visitor sees, the node-bound owner editor, the curated-pins Showcase
+/// with a recent-public-content fallback, the getting-started card on an empty profile, and the two
+/// hard constraints — email is hidden from visitors (#471 PII) and everything is built from
+/// layout-area controls, never hand-rolled HTML.
+/// </summary>
+public class UserProfileShowcaseTest
+{
+    private const string NodePath = "rbuergi";
+    private static readonly JsonSerializerOptions Options = new();
+
+    private static MeshNode UserNode(User content) =>
+        MeshNode.FromPath(NodePath) with { Name = "Roland", NodeType = "User", Content = content };
+
+    // ── (a) Owner sees editable bio / links / showcase ──────────────────────────────────────────────
+
+    [Fact]
+    public void EditProfile_Owner_HasNodeBoundBioAndLinksEditors()
+    {
+        var editor = UserActivityLayoutAreas.BuildProfileEditor(
+            UserNode(new User { PinnedPaths = ["rbuergi/SpaceA"] }), NodePath, Options);
+
+        // Both fields are node-bound markdown editors — Value is a JsonPointer into the User content,
+        // so each edit is a per-field read-modify-write straight to the node (no /data replica).
+        var boundPointers = Descendants(editor)
+            .OfType<MarkdownEditorControl>()
+            .Select(e => (e.Value as JsonPointerReference)?.Pointer)
+            .ToList();
+
+        boundPointers.Should().Contain("bio");
+        boundPointers.Should().Contain("links");
+    }
+
+    [Fact]
+    public void EditProfile_Owner_ShowcaseIsCuratableInPlace()
+    {
+        var editor = UserActivityLayoutAreas.BuildProfileEditor(
+            UserNode(new User { PinnedPaths = ["rbuergi/SpaceA", "rbuergi/DocB"] }), NodePath, Options);
+
+        // The owner's pinned cards carry the inline unpin overlay (PinnedThumbnail) so pins can be
+        // curated right on the editor — the framework Pin/Unpin surface, not a hand-rolled list editor.
+        Descendants(editor).OfType<MeshSearchControl>()
+            .Should().Contain(s => Equals(s.ItemArea, PinLayoutArea.PinnedThumbnailArea));
+    }
+
+    [Fact]
+    public void Profile_Owner_OffersEditEntryPoint()
+    {
+        var profile = UserActivityLayoutAreas.BuildProfile(
+            NodePath, NodePath, "Roland", UserNode(new User { Bio = "hi" }),
+            isOwner: true, canSeeEmail: true, Options);
+
+        Descendants(profile).OfType<ButtonControl>()
+            .Should().Contain(b => (b.Data as string) == "Edit profile");
+    }
+
+    // ── (b) Non-owner sees the profile read-only, WITHOUT email ─────────────────────────────────────
+
+    [Fact]
+    public void Profile_Visitor_IsReadOnly_AndHidesEmail_ButShowsOptInBio()
+    {
+        var node = UserNode(new User { Email = "roland@systemorph.com", Bio = "Builder of things" });
+        var profile = UserActivityLayoutAreas.BuildProfile(
+            NodePath, NodePath, "Roland", node, isOwner: false, canSeeEmail: false, Options);
+
+        // A visitor never edits.
+        Descendants(profile).OfType<MarkdownEditorControl>().Should().BeEmpty();
+        // Email is never surfaced to a visitor — the header control carries no email (#471 PII).
+        Descendants(profile).OfType<UserProfileControl>().Should().OnlyContain(c => c.Email == null);
+        // …but the opt-in bio the owner chose to publish IS shown, read-only, as markdown.
+        Descendants(profile).OfType<MarkdownControl>()
+            .Should().Contain(m => m.Markdown != null && m.Markdown.ToString() == "Builder of things");
+    }
+
+    [Fact]
+    public void Profile_OwnerOrAdmin_SeesEmail()
+    {
+        var node = UserNode(new User { Email = "roland@systemorph.com", Bio = "x" });
+
+        var asOwner = UserActivityLayoutAreas.BuildProfile(
+            NodePath, NodePath, "Roland", node, isOwner: true, canSeeEmail: true, Options);
+        Descendants(asOwner).OfType<UserProfileControl>()
+            .Should().Contain(c => c.Email == "roland@systemorph.com");
+
+        // Admin viewing another user (isOwner false, canSeeEmail true) also sees the email.
+        var asAdmin = UserActivityLayoutAreas.BuildProfile(
+            NodePath, NodePath, "Roland", node, isOwner: false, canSeeEmail: true, Options);
+        Descendants(asAdmin).OfType<UserProfileControl>()
+            .Should().Contain(c => c.Email == "roland@systemorph.com");
+    }
+
+    // ── (c) Empty profile renders the getting-started card ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Profile_Empty_RendersGettingStartedCard(bool isOwner)
+    {
+        var profile = UserActivityLayoutAreas.BuildProfile(
+            NodePath, NodePath, "Roland", UserNode(new User()), isOwner, isOwner, Options);
+
+        Descendants(profile).Should().Contain(
+            c => Equals(c.Id, UserActivityLayoutAreas.GettingStartedId),
+            "an empty profile (no bio, links, or pins) must render the getting-started card for every user");
+    }
+
+    [Fact]
+    public void Profile_Populated_DoesNotRenderGettingStartedCard()
+    {
+        var profile = UserActivityLayoutAreas.BuildProfile(
+            NodePath, NodePath, "Roland", UserNode(new User { Bio = "hi" }),
+            isOwner: false, canSeeEmail: false, Options);
+
+        Descendants(profile).Should().NotContain(c => Equals(c.Id, UserActivityLayoutAreas.GettingStartedId));
+    }
+
+    [Fact]
+    public void GettingStarted_OwnerVariant_ExplainsSetupAndLinksToEditor()
+    {
+        var card = UserActivityLayoutAreas.BuildGettingStarted(NodePath, NodePath, "Roland", isOwner: true);
+
+        card.Id.Should().Be(UserActivityLayoutAreas.GettingStartedId);
+        Descendants(card).OfType<MarkdownControl>()
+            .Select(m => m.Markdown?.ToString() ?? "")
+            .Should().Contain(md => md.Contains("set up your profile"));
+        // Owner gets a button straight into the editor; a visitor variant does not.
+        Descendants(card).OfType<ButtonControl>().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void GettingStarted_VisitorVariant_IsGentleAndHasNoEditButton()
+    {
+        var card = UserActivityLayoutAreas.BuildGettingStarted(NodePath, NodePath, "Roland", isOwner: false);
+
+        Descendants(card).OfType<MarkdownControl>()
+            .Select(m => m.Markdown?.ToString() ?? "")
+            .Should().Contain(md => md.Contains("hasn't set up their profile"));
+        Descendants(card).OfType<ButtonControl>().Should().BeEmpty();
+    }
+
+    // ── (d) Curated pins render in Showcase; no pins → recent-public fallback ────────────────────────
+
+    [Fact]
+    public void Showcase_WithPins_QueriesTheCuratedPaths()
+    {
+        var showcase = UserActivityLayoutAreas.BuildShowcase(
+            "rbuergi", ["rbuergi/SpaceA", "acme/DocB"], ownerView: false);
+
+        showcase.Should().BeOfType<MeshSearchControl>();
+        ((MeshSearchControl)showcase).HiddenQuery?.ToString()
+            .Should().Contain("path:(rbuergi/SpaceA OR acme/DocB)");
+        // A visitor's showcase has no inline unpin overlay.
+        ((MeshSearchControl)showcase).ItemArea.Should().BeNull();
+    }
+
+    [Fact]
+    public void Showcase_WithPins_OwnerView_AddsUnpinOverlay()
+    {
+        var showcase = (MeshSearchControl)UserActivityLayoutAreas.BuildShowcase(
+            "rbuergi", ["rbuergi/SpaceA"], ownerView: true);
+
+        showcase.ItemArea.Should().Be(PinLayoutArea.PinnedThumbnailArea);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Showcase_NoPins_FallsBackToRecentPublicContent(bool nullVsEmpty)
+    {
+        IReadOnlyList<string>? pins = nullVsEmpty ? null : [];
+
+        var showcase = UserActivityLayoutAreas.BuildShowcase("rbuergi", pins, ownerView: false);
+
+        showcase.Should().BeOfType<MeshSearchControl>();
+        // The fallback is the owner's recent public content (visibility-filtered), never empty.
+        ((MeshSearchControl)showcase).HiddenQuery?.ToString().Should().Contain("namespace:rbuergi");
+        ((MeshSearchControl)showcase).HiddenQuery?.ToString().Should().NotContain("path:(");
+    }
+
+    // ── (e) Rendered output is layout-area controls, never raw HTML ─────────────────────────────────
+
+    [Fact]
+    public void Profile_UsesLayoutControls_NeverRawHtml()
+    {
+        var node = UserNode(new User
+        {
+            Bio = "A bio",
+            Links = "[GitHub](https://github.com/x)",
+            PinnedPaths = ["rbuergi/SpaceA"]
+        });
+        var profile = UserActivityLayoutAreas.BuildProfile(
+            NodePath, NodePath, "Roland", node, isOwner: false, canSeeEmail: false, Options);
+
+        var all = Descendants(profile).ToList();
+        all.OfType<HtmlControl>().Should().BeEmpty(
+            "the profile must be composed from controls (Stack/Markdown/MeshSearch/…), never hand-rolled HTML");
+        all.Should().Contain(c => c is StackControl);
+        all.Should().Contain(c => c is MeshSearchControl);   // Showcase
+        all.Should().Contain(c => c is MarkdownControl);     // bio + links, rendered as markdown
+    }
+
+    [Fact]
+    public void ProfileEditor_UsesLayoutControls_NeverRawHtml()
+    {
+        var editor = UserActivityLayoutAreas.BuildProfileEditor(UserNode(new User()), NodePath, Options);
+
+        Descendants(editor).OfType<HtmlControl>().Should().BeEmpty();
+    }
+
+    // ── tree walker ─────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Yields <paramref name="root"/> and every descendant <see cref="UiControl"/> nested in a
+    /// container's (protected) <c>Views</c> list — lets a pure unit test assert on the whole control
+    /// tree (types, bindings, the absence of <see cref="HtmlControl"/>) without standing up a hub.</summary>
+    private static IEnumerable<UiControl> Descendants(UiControl root)
+    {
+        yield return root;
+        if (ViewsProperty(root.GetType())?.GetValue(root) is System.Collections.IEnumerable views)
+            foreach (var v in views)
+                if (v is UiControl child)
+                    foreach (var d in Descendants(child))
+                        yield return d;
+    }
+
+    private static PropertyInfo? ViewsProperty(Type? t)
+    {
+        for (; t is not null; t = t.BaseType)
+        {
+            var p = t.GetProperty("Views",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            if (p is not null)
+                return p;
+        }
+        return null;
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/UserActivityAreaTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/UserActivityAreaTest.cs
@@ -169,6 +169,56 @@ public class UserActivityAreaTest(ITestOutputHelper output) : MonolithMeshTestBa
     }
 
     /// <summary>
+    /// The public profile area (<c>/{user}/Profile</c>) resolves end-to-end — the polished, read-only
+    /// showcase every visitor sees. Proves <see cref="UserActivityLayoutAreas.ProfileArea"/> is wired
+    /// into the User hub's layout by AddUserActivityLayoutAreas.
+    /// </summary>
+    [Fact(Timeout = 20000)]
+    public async Task ProfileArea_CanBeResolved_ForUserRoland()
+    {
+        var client = GetClient();
+        var rolandAddress = new Address("User/TestUser");
+
+        await client.Observe(new PingRequest(), o => o.WithTarget(rolandAddress)).Should().Within(15.Seconds()).Emit();
+
+        var workspace = client.GetWorkspace();
+        var reference = new LayoutAreaReference(UserActivityLayoutAreas.ProfileArea);
+
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            rolandAddress, reference);
+
+        var value = await stream.Should().Within(TimeSpan.FromSeconds(15)).Emit();
+
+        value.Should().NotBe(default(JsonElement),
+            "the public Profile area should render for User/TestUser");
+    }
+
+    /// <summary>
+    /// The owner-only profile editor area (<c>/{user}/EditProfile</c>) resolves end-to-end — either the
+    /// node-bound bio/links/showcase editor (owner) or an access-denied card (visitor). Either way it
+    /// renders, proving <see cref="UserActivityLayoutAreas.EditProfileArea"/> is registered.
+    /// </summary>
+    [Fact(Timeout = 20000)]
+    public async Task EditProfileArea_CanBeResolved_ForUserRoland()
+    {
+        var client = GetClient();
+        var rolandAddress = new Address("User/TestUser");
+
+        await client.Observe(new PingRequest(), o => o.WithTarget(rolandAddress)).Should().Within(15.Seconds()).Emit();
+
+        var workspace = client.GetWorkspace();
+        var reference = new LayoutAreaReference(UserActivityLayoutAreas.EditProfileArea);
+
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            rolandAddress, reference);
+
+        var value = await stream.Should().Within(TimeSpan.FromSeconds(15)).Emit();
+
+        value.Should().NotBe(default(JsonElement),
+            "the EditProfile area should render (editor or access-denied) for User/TestUser");
+    }
+
+    /// <summary>
     /// Simulates the production onboarding flow: creates a User node at runtime
     /// (not pre-registered via AddMeshNodes), then verifies the Activity area resolves.
     /// This tests the path: persistence Ã¢â€ â€™ MeshCatalog.ResolvePathAsync Ã¢â€ â€™ routing Ã¢â€ â€™ hub creation.


### PR DESCRIPTION
## What this renders

Enhances the existing visitor-profile surface (`UserActivityLayoutAreas.BuildVisitorProfile`) into a **polished public profile** — it is not a rewrite or a duplicate; the old visitor path now flows through the new `BuildProfile`. The profile has these sections:

- **Header** — avatar + display name (reuses the existing `UserProfileControl`). Email is shown **only** to the owner or a global admin.
- **Bio** — an opt-in short bio, rendered read-only as markdown.
- **Links** — an opt-in markdown links block (one `[label](url)` per line), rendered via `Controls.Markdown` so the framework renders the anchors.
- **Showcase** — the owner's **curated pins** rendered as cards, **with a recent-public-content fallback** so the band is never empty.
- **Recent activity + items** — visibility-filtered so a visitor only ever sees public nodes.

Two new areas are registered on the User hub: `Profile` (`/{user}/Profile`, the read-only showcase + owner preview) and `EditProfile` (`/{user}/EditProfile`, the owner-only editor). Node-menu items ("View public profile", "Edit profile") are added for the owner, and an inline "Edit profile" button appears on the owner's profile.

## Curated pins + fallback model

The Showcase source is the User node's existing `PinnedPaths` — the same list the framework's **Pin/Unpin** surface (`PinLayoutArea`) already writes, so curation is the existing, proven, node-bound mechanism (nothing new to hand-roll). Rendering:

- **Pins present** → `Controls.MeshSearch` scoped `path:(a OR b …)`. In the owner's editor each card carries the inline **unpin** overlay (`PinnedThumbnailArea`) so pins are curated in place.
- **No pins** → fallback to the owner's recent public content (`namespace:{owner} …`), visibility-filtered — the section is never bare.

Design fork (noted per instructions): I **reused `PinnedPaths`** for the Showcase rather than adding a parallel `ShowcasePaths` field — it is already "a list of node paths on the User node's content," already owner-editable via the framework, and already visibility-filtered on render, so a visitor never sees a pinned node they cannot read. **Links** is the one new content field (`User.Links`, a markdown string).

## Getting-started card

On an **empty** profile (no bio, links, or pins) the profile renders a friendly getting-started card instead of empty sections. It explains how to add a bio, links, and pin content; for the owner it links straight to the editor and previews their recent work; for a visitor it is a gentle "nothing here yet" plus the owner's recent public work. This is **seeded for all users behaviourally** — there is nothing to store; the card is inherent in the render path and shows automatically, always, until the profile is filled in (a persistent self-documenting starter, not a one-time step).

## Owner editing (data-bound, no replica)

`EditProfile` binds **directly to the User node**: bio and links are node-bound `MarkdownEditorControl`s (`Value = JsonPointerReference("bio"/"links")`, node-bound `DataContext`), each edit a per-field read-modify-write straight to the node via `GetMeshNodeStream` — one source of truth, no `/data/{id}` replica, no save subscription. Gated on `Permission.Update` (visitors get access-denied).

## Compliance

- **Framework controls only** — composed from `Controls.Stack` / `Controls.Markdown` / `Controls.MeshSearch` / `Controls.Button` / `Controls.H3`/`Label` + the node-bound editor controls. **Zero** `Controls.Html` / string-HTML / `StringBuilder` in the new code (a test asserts no `HtmlControl` in the tree).
- **Data-bound, not hand-rolled** — reads/writes go through the node stream; no `/data` replica; no `.Take(1)` on the live binding.
- **PII (#471)** — email hidden for non-owner/non-admin viewers; fail-closed (`StartWith(false)` on the admin check).
- **No async** — everything is `IObservable<T>` + `.Subscribe`; immutable collections; no static state.

## Tests

- `UserProfileShowcaseTest` (Graph.Test, pure unit, 16 tests): owner-editable bio/links/showcase; visitor read-only **without email** (+ owner/admin sees it); empty profile → getting-started card; pins render in Showcase vs recent-public fallback; and the control tree is layout-area controls with **no** `HtmlControl`.
- `UserActivityAreaTest` (Monolith.Test, integration): the new `Profile` and `EditProfile` areas resolve end-to-end.

Build: `dotnet build -c Release -warnaserror -p:CIRun=true` clean (0 warnings) for Graph, Graph.Test, Monolith.Test. All tests green (16 + 24 unit, 9 integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)