### PR TITLE
fix(access): cross-partition public-read feed leak (RC3) + Shared-with-me nav (RC4)

### DIFF
--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -65,6 +65,7 @@ public static class UserActivityLayoutAreas
     // the declaration order there is the tab order. Open threads are NOT a tab here — they have their
     // own region above the catalog (see ThreadsAreaView); the catalog is the broader "browse" surface.
     private const string TabSpaces = "Spaces";
+    private const string TabSharedWithMe = "Shared with me";
     private const string TabMyItems = "My Items";
     private const string TabLastRead = "Last Read";
     private const string TabLastEdited = "Last Edited";
@@ -444,9 +445,69 @@ public static class UserActivityLayoutAreas
     internal static IObservable<UiControl?> CatalogAreaView(LayoutAreaHost host, RenderingContext _)
     {
         var nodePath = host.Hub.Address.ToString();
+        var ownerId = OwnerIdOf(nodePath);
+        // Combine the data-driven extension tabs with the caller's cross-partition grants
+        // (#385 "Shared with me"). Both start empty so the home paints instantly.
         return ObserveHomeTabs(host)
-            .Select(tabs => (UiControl?)BuildCatalog(nodePath, OwnerIdOf(nodePath), tabs));
+            .CombineLatest(ObserveSharedTargets(host, ownerId),
+                (tabs, shared) => (UiControl?)BuildCatalog(nodePath, ownerId, tabs, shared));
     }
+
+    /// <summary>
+    /// The cross-partition scopes the owner has been granted access to — an invited module living in
+    /// ANOTHER partition, reachable by URL but otherwise invisible in nav (the #385 symptom). Sourced
+    /// from the owner's <c>AccessAssignment</c> satellites (<c>content.accessObject == ownerId</c>),
+    /// fanned out cross-partition and access-filtered, each resolved to its governed target scope
+    /// (<see cref="MeshNode.MainNode"/>). Starts empty so the home paints instantly; grants land
+    /// reactively. No security surface changes — it only READS the caller's own readable grants.
+    /// </summary>
+    private static IObservable<IReadOnlyList<string>> ObserveSharedTargets(LayoutAreaHost host, string ownerId)
+    {
+        var mesh = host.Hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null || string.IsNullOrEmpty(ownerId))
+            return Observable.Return<IReadOnlyList<string>>([]);
+        return mesh
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                $"nodeType:AccessAssignment content.accessObject:{ownerId}"))
+            .Scan(ImmutableDictionary<string, MeshNode>.Empty,
+                (map, change) =>
+                {
+                    if (change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+                        return change.Items.ToImmutableDictionary(n => n.Path);
+                    foreach (var item in change.Items)
+                        map = change.ChangeType switch
+                        {
+                            QueryChangeType.Added or QueryChangeType.Updated => map.SetItem(item.Path, item),
+                            QueryChangeType.Removed => map.Remove(item.Path),
+                            _ => map
+                        };
+                    return map;
+                })
+            .Select(map => SharedTargetPaths(map.Values, ownerId))
+            .StartWith((IReadOnlyList<string>)[]);
+    }
+
+    /// <summary>
+    /// Pure projection: the distinct CROSS-PARTITION target scopes from a set of the owner's
+    /// <c>AccessAssignment</c> nodes — each assignment's <see cref="MeshNode.MainNode"/> (the governed
+    /// scope; falling back to the scope derived from the node path), keeping only targets that live
+    /// OUTSIDE the owner's own partition and are non-empty.
+    /// </summary>
+    internal static IReadOnlyList<string> SharedTargetPaths(IEnumerable<MeshNode> assignments, string ownerId)
+        => assignments
+            // Normalise via ScopeOfAssignment: MainNode may hold the governed scope directly OR the
+            // satellite path (MeshNode.MainNode defaults to the node's own path). ScopeOfAssignment
+            // strips a trailing …/_Access/… segment and returns a plain scope unchanged; fall back to
+            // the node path when MainNode is unset.
+            .Select(a => AccessSubjectQueries.ScopeOfAssignment(
+                string.IsNullOrEmpty(a.MainNode) ? a.Path : a.MainNode)?.Trim('/'))
+            .Where(scope => !string.IsNullOrEmpty(scope))
+            .Select(scope => scope!)
+            .Where(scope => !string.Equals(
+                AccessSubjectQueries.Partition(scope), ownerId, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
     /// <summary>
     /// NodeType of a home-catalog EXTENSION TAB: the home's tab list is DATA, not code. Any
@@ -591,7 +652,8 @@ public static class UserActivityLayoutAreas
     /// so a plugin adds a tab by shipping a node, never by editing this file.</para>
     /// </summary>
     internal static UiControl BuildCatalog(
-        string nodePath, string nodeOwnerId, IReadOnlyList<MeshNode>? extensionTabs = null)
+        string nodePath, string nodeOwnerId, IReadOnlyList<MeshNode>? extensionTabs = null,
+        IReadOnlyList<string>? sharedTargets = null)
     {
         var tabs = Controls.Tabs
             // 100% width so the tabs + their search grids fill the home page instead of shrinking to
@@ -612,6 +674,22 @@ public static class UserActivityLayoutAreas
                     .WithCollapsibleSections(false).WithSectionCounts(false)
                     .WithMaxColumns(4).WithItemLimit(50).WithMaxRows(3).WithReactiveMode(true)
                     .WithCreateHref("/create?type=Space"));
+
+        // Shared with me (#385) — cross-partition modules the caller was invited into. Rendered
+        // right after Spaces so an invited module in another partition is discoverable in nav; the
+        // target scopes come from the caller's OWN readable AccessAssignments (no security change).
+        // The `path:a|b|c` alternation resolves each target node, access-filtered by the mesh.
+        if (sharedTargets is { Count: > 0 })
+        {
+            var pathList = string.Join("|", sharedTargets);
+            tabs = tabs.WithMeshSearch(TabSharedWithMe,
+                query: $"path:{pathList} is:main sort:LastModified-desc",
+                configure: s => s
+                    .WithShowSearchBox(false).WithShowEmptyMessage(true)
+                    .WithRenderMode(MeshSearchRenderMode.Flat)
+                    .WithCollapsibleSections(false).WithSectionCounts(false)
+                    .WithMaxColumns(4).WithItemLimit(50).WithMaxRows(3).WithReactiveMode(true));
+        }
 
         // The data-driven tabs — same look-and-feel defaults as Spaces; the node's content
         // supplies only the mapping (nodeType/query/placeholder/createHref).

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSqlGenerator.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSqlGenerator.cs
@@ -694,11 +694,43 @@ public class PostgreSqlSqlGenerator
                 LIMIT 1) = true
             """;
 
-        if (!string.IsNullOrEmpty(publicReadClause))
+        // 🔒 #471/#385 RC3 — the documented invariant (AccessControl.md, search_across_schemas,
+        // and the schema-qualified GenerateAccessControlClause) is
+        //   partition_access AND (public_read OR node)
+        // — public_read SKIPS the node-level check but NEVER the partition gate, so a partition's
+        // public-read content (Markdown, Threads, …) does not leak into another tenant's unscoped
+        // fan-out feed. BuildPerSchemaAccessClause was the lone outlier that OR'd public_read
+        // OUTSIDE the partition gate, so cross-partition public-read rows leaked into the
+        // "Last Edited" (source:activity) feed → the "listed but access-denied on open" symptom.
+        //
+        // EXCEPTION — the 'auth' mirror is the GLOBAL public identity directory (User/Group/Role/
+        // VUser replicated across every tenant). It is deliberately EXCLUDED from the tenant fan-out
+        // (PostgreSqlCrossSchemaQueryProvider.ExcludedSchemas) and reached ONLY by the pinned
+        // identity routes (e.g. nodeType:User → auth). Its public-read identity nodes MUST stay
+        // resolvable to every authenticated user regardless of partition_access — display-name
+        // resolution, invites, @-mentions, the subject picker and login all depend on it, and NO
+        // user holds a partition_access row for 'auth'. Non-public node types in auth (e.g.
+        // ApiToken) still fall through to the node-level check, so this exemption exposes only the
+        // public identity directory it is meant to. Because auth is never part of the feed fan-out,
+        // this cannot reopen the cross-partition leak.
+        if (string.Equals(schema, PublicDirectorySchema, StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrEmpty(publicReadClause))
             return $"({publicReadClause} OR ({partitionAccessExists} AND ({nodeAccess})))";
+
+        if (!string.IsNullOrEmpty(publicReadClause))
+            return $"({partitionAccessExists} AND ({publicReadClause} OR ({nodeAccess})))";
 
         return $"({partitionAccessExists} AND ({nodeAccess}))";
     }
+
+    /// <summary>
+    /// The global public identity directory schema — the cross-tenant mirror of User/Group/Role/
+    /// VUser/ApiToken nodes. It is excluded from the tenant fan-out and reached only by pinned
+    /// identity routes; its public-read identity nodes stay resolvable to all authenticated users
+    /// regardless of partition_access (see <see cref="BuildPerSchemaAccessClause"/>). Kept in
+    /// lock-step with <c>PostgreSqlCrossSchemaQueryProvider.ExcludedSchemas</c>.
+    /// </summary>
+    private const string PublicDirectorySchema = "auth";
 
     /// <summary>
     /// SQL that replicates <c>DocumentPaths.Slug</c> (MeshWeaver.ContentCollections.Indexing) for a

--- a/src/MeshWeaver.Hosting.Snowflake/SnowflakeSqlGenerator.cs
+++ b/src/MeshWeaver.Hosting.Snowflake/SnowflakeSqlGenerator.cs
@@ -792,11 +792,30 @@ public class SnowflakeSqlGenerator
 
         var nodeAccess = BuildNodeAccessPredicate(uepTable, marker, userList);
 
-        if (!string.IsNullOrEmpty(publicReadClause))
+        // 🔒 #471/#385 RC3 — mirror of PostgreSqlSqlGenerator.BuildPerSchemaAccessClause. The
+        // invariant is partition_access AND (public_read OR node): public_read skips the node-level
+        // check but NEVER the partition gate, so a partition's public-read content does not leak
+        // into another tenant's unscoped fan-out. The lone EXCEPTION is the global public identity
+        // directory ('auth' mirror) — excluded from the tenant fan-out and reached only by pinned
+        // identity routes — whose public-read identity nodes must stay resolvable to all
+        // authenticated users regardless of partition_access (display-name resolution / invites /
+        // subject picker / login). See the PG generator for the full rationale.
+        if (string.Equals(schema, PublicDirectorySchema, StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrEmpty(publicReadClause))
             return $"({publicReadClause} OR ({partitionAccessExists} AND ({nodeAccess})))";
+
+        if (!string.IsNullOrEmpty(publicReadClause))
+            return $"({partitionAccessExists} AND ({publicReadClause} OR ({nodeAccess})))";
 
         return $"({partitionAccessExists} AND ({nodeAccess}))";
     }
+
+    /// <summary>
+    /// The global public identity directory schema (cross-tenant User/Group/Role/VUser/ApiToken
+    /// mirror). Kept in lock-step with the PostgreSQL generator and
+    /// <c>PostgreSqlCrossSchemaQueryProvider.ExcludedSchemas</c>.
+    /// </summary>
+    private const string PublicDirectorySchema = "auth";
 
     /// <summary>
     /// The node-level permission predicate: the user owns the node, OR the longest matching

--- a/test/MeshWeaver.Graph.Test/HomeTabExtensionTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeTabExtensionTest.cs
@@ -50,6 +50,63 @@ public class HomeTabExtensionTest
     }
 
     [Fact]
+    public void Catalog_WithSharedTargets_InsertsSharedWithMeAfterSpaces()
+    {
+        // #385 — the caller was invited into modules in OTHER partitions; they surface as a
+        // "Shared with me" tab so they're discoverable in nav (not only reachable by URL).
+        var catalog = (TabsControl)UserActivityLayoutAreas.BuildCatalog(
+            NodePath, NodePath, extensionTabs: null, sharedTargets: ["OrgA/Module", "OrgB/Deck"]);
+
+        catalog.Areas.Select(a => a.Id)
+            .Should().Equal("Spaces", "Shared with me", "My Items", "Last Read", "Last Edited");
+    }
+
+    [Fact]
+    public void Catalog_WithoutSharedTargets_OmitsTheSharedWithMeTab()
+    {
+        var catalog = (TabsControl)UserActivityLayoutAreas.BuildCatalog(
+            NodePath, NodePath, extensionTabs: null, sharedTargets: []);
+
+        catalog.Areas.Select(a => a.Id).Should().NotContain("Shared with me");
+    }
+
+    [Fact]
+    public void SharedTargetPaths_KeepsCrossPartitionTargets_ExcludesOwnPartitionAndEmpty()
+    {
+        MeshNode Assignment(string scope) =>
+            MeshNode.FromPath($"{scope}/_Access/{NodePath}_Access") with
+            {
+                NodeType = "AccessAssignment",
+                MainNode = scope,
+            };
+
+        var assignments = new[]
+        {
+            Assignment("OrgA/Module"),              // cross-partition → kept
+            Assignment("OrgB/Deck"),                // cross-partition → kept
+            Assignment($"{NodePath}/Private"),      // own partition → excluded
+            Assignment("OrgA/Module"),              // duplicate → deduped
+        };
+
+        var targets = UserActivityLayoutAreas.SharedTargetPaths(assignments, NodePath);
+
+        targets.Should().Equal("OrgA/Module", "OrgB/Deck");
+    }
+
+    [Fact]
+    public void SharedTargetPaths_FallsBackToScopeFromPath_WhenMainNodeMissing()
+    {
+        // A grant persisted without MainNode still resolves via the node path's scope.
+        var assignment = MeshNode.FromPath($"OrgA/Module/_Access/{NodePath}_Access") with
+        {
+            NodeType = "AccessAssignment",
+        };
+
+        UserActivityLayoutAreas.SharedTargetPaths([assignment], NodePath)
+            .Should().Equal("OrgA/Module");
+    }
+
+    [Fact]
     public void MapHomeTab_MapsSearchQueryPlaceholderAndCreateHref()
     {
         var (label, search) = UserActivityLayoutAreas.MapHomeTab(HomeTabNode("Courses", new

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PerSchemaAccessClauseLeakTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PerSchemaAccessClauseLeakTests.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+using MeshWeaver.Fixture;
+using MeshThread = MeshWeaver.AI.Thread;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// #471/#385 RC3 — the cross-partition public-read feed leak. The unscoped "Last Edited"
+/// (<c>source:activity</c>) fan-out and any unscoped <c>nodeType:Markdown/Thread</c> query
+/// route through <see cref="PostgreSqlSqlGenerator"/>'s <c>BuildPerSchemaAccessClause</c>. That
+/// clause used to emit <c>public_read OR (partition_access AND node)</c> — the lone outlier that
+/// OR'd public_read OUTSIDE the partition gate — so a partition's public-read content (Markdown,
+/// Threads, …) leaked into a user's feed even with NO access to that partition (the "listed but
+/// access-denied on open" symptom). The documented invariant (AccessControl.md, the
+/// <c>search_across_schemas</c> stored proc, the schema-qualified <c>GenerateAccessControlClause</c>)
+/// is <c>partition_access AND (public_read OR node)</c>.
+///
+/// <para>These tests pin BOTH sides: (a) DENY — a partition's public-read Markdown / Thread /
+/// activity feed is NOT visible to a user with no access to it; (b) ALLOW — a genuinely GRANTED
+/// cross-partition node (including a shared thread) STILL appears; and (c) the GUARDRAIL — the
+/// <c>auth</c> global identity directory keeps its public-read visibility (display-name
+/// resolution / subject picker / login) even though no user holds a <c>partition_access</c> row
+/// for it, while a NON-auth partition's public-read User node stays gated.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class PerSchemaAccessClauseLeakTests
+{
+    private readonly PostgreSqlFixture _fixture;
+    private readonly JsonSerializerOptions _options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    private const string User = "leak_testuser";
+
+    public PerSchemaAccessClauseLeakTests(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static ParsedQuery Parse(string q) => new QueryParser().Parse(q);
+
+    private Task Exec(string sql, CancellationToken ct)
+        => _fixture.DataSource.ExecuteNonQuery(sql, ct).Should().Within(30.Seconds()).Emit();
+
+    /// <summary>Runs a fan-out over the given schemas as <paramref name="userId"/> — the exact
+    /// path that engages <c>BuildPerSchemaAccessClause</c>.</summary>
+    private Task<List<MeshNode>> FanOut(
+        ParsedQuery query, string tableName, IReadOnlyList<string> schemas,
+        string? userId, CancellationToken ct)
+        => new PostgreSqlCrossSchemaQueryProvider(_fixture.DataSource)
+            .QueryAcrossSchemasAsync(query, _options, schemas, tableName, userId, activityUserId: null, ct)
+            .Collect(ct).Should().Within(30.Seconds()).Emit();
+
+    /// <summary>
+    /// Three data partitions (acme = user has access, future = user has NONE, beta = user has a
+    /// node-level cross-partition grant) plus the global <c>auth</c> identity directory.
+    /// </summary>
+    private async Task SetupAsync(CancellationToken ct)
+    {
+        await _fixture.CleanDataAsync();
+
+        var partitionDef = new PartitionDefinition
+        {
+            TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+            NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings()
+        };
+
+        async Task<PostgreSqlStorageAdapter> Schema(string schema, string ns)
+        {
+            var (_, adapter) = await _fixture.CreateSchemaAdapterAsync(
+                schema, partitionDef with { Namespace = ns, Schema = schema }, ct);
+            return adapter;
+        }
+
+        var acme = await Schema("acme", "ACME");
+        var future = await Schema("future", "FutuRe");
+        var beta = await Schema("beta", "Beta");
+        var auth = await Schema("auth", "auth");
+
+        // ── acme (user HAS access) ──
+        await acme.WriteAsync(new MeshNode("Report", "ACME")
+        {
+            Name = "ACME Report", NodeType = "Markdown", State = MeshNodeState.Active,
+            LastModified = DateTimeOffset.UtcNow.AddMinutes(-1)
+        }, _options, ct);
+        await acme.WriteAsync(new MeshNode("acme-thread-1", "ACME/_Thread")
+        {
+            Name = "ACME thread", NodeType = "Thread", MainNode = "ACME",
+            State = MeshNodeState.Active, Content = new MeshThread { CreatedBy = "someone" }
+        }, _options, ct);
+        await acme.WriteAsync(new MeshNode("a1", "ACME/Report/_activity")
+        {
+            Name = "edit", NodeType = "Activity", MainNode = "ACME/Report",
+            State = MeshNodeState.Active, Content = new ActivityLog("DataUpdate") { HubPath = "ACME/Report" }
+        }, _options, ct);
+
+        // ── future (user has NO access — must NOT leak) ──
+        await future.WriteAsync(new MeshNode("Report", "FutuRe")
+        {
+            Name = "FutuRe Report", NodeType = "Markdown", State = MeshNodeState.Active,
+            LastModified = DateTimeOffset.UtcNow.AddMinutes(-2)
+        }, _options, ct);
+        await future.WriteAsync(new MeshNode("future-thread-1", "FutuRe/_Thread")
+        {
+            Name = "FutuRe thread", NodeType = "Thread", MainNode = "FutuRe",
+            State = MeshNodeState.Active, Content = new MeshThread { CreatedBy = "someone" }
+        }, _options, ct);
+        await future.WriteAsync(new MeshNode("f1", "FutuRe/Report/_activity")
+        {
+            Name = "edit", NodeType = "Activity", MainNode = "FutuRe/Report",
+            State = MeshNodeState.Active, Content = new ActivityLog("DataUpdate") { HubPath = "FutuRe/Report" }
+        }, _options, ct);
+        // A public-read User node in a DATA partition — must stay gated (deny control).
+        await future.WriteAsync(new MeshNode("futureuser")
+        {
+            Name = "Future User", NodeType = "User", State = MeshNodeState.Active
+        }, _options, ct);
+
+        // ── beta (user was GRANTED a node-level cross-partition Read on beta/Secret) ──
+        await beta.WriteAsync(new MeshNode("Secret", "Beta")
+        {
+            Name = "Beta Secret", NodeType = "Document", State = MeshNodeState.Active
+        }, _options, ct);
+        await beta.WriteAsync(new MeshNode("beta-thread-1", "Beta/_Thread")
+        {
+            Name = "Beta shared thread", NodeType = "Thread", MainNode = "Beta",
+            State = MeshNodeState.Active, Content = new MeshThread { CreatedBy = "someone" }
+        }, _options, ct);
+
+        // ── auth (global identity directory) — a public-read User node ──
+        await auth.WriteAsync(new MeshNode("shareduser")
+        {
+            Name = "Shared Directory User", NodeType = "User", State = MeshNodeState.Active,
+            Content = new MeshWeaver.Mesh.Security.User { Email = "shared@example.com" }
+        }, _options, ct);
+
+        // public_read node types per schema (Markdown/Thread/User; Document is NOT public_read).
+        foreach (var (schema, types) in new[]
+                 {
+                     ("acme", new[] { "Markdown", "Thread" }),
+                     ("future", new[] { "Markdown", "Thread", "User" }),
+                     ("beta", new[] { "Markdown", "Thread" }),
+                     ("auth", new[] { "User", "Group", "Role" }),
+                 })
+        {
+            foreach (var t in types)
+                await Exec(
+                    $"INSERT INTO \"{schema}\".node_type_permissions (node_type, public_read) " +
+                    $"VALUES ('{t}', true) ON CONFLICT (node_type) DO UPDATE SET public_read = true", ct);
+        }
+
+        // Access: user has partition + Read on ACME; a node-level grant on beta/Secret (which also
+        // grants partition_access to beta). NO access to future. NO partition_access to auth.
+        await Exec("DELETE FROM public.partition_access WHERE user_id = '" + User + "'", ct);
+        await Exec(
+            "INSERT INTO public.partition_access (user_id, partition) VALUES " +
+            $"('{User}', 'acme'), ('{User}', 'beta') ON CONFLICT DO NOTHING", ct);
+        await Exec(
+            "INSERT INTO acme.user_effective_permissions (user_id, node_path_prefix, permission, is_allow) " +
+            $"VALUES ('{User}', 'ACME', 'Read', true) ON CONFLICT DO NOTHING", ct);
+        await Exec(
+            "INSERT INTO beta.user_effective_permissions (user_id, node_path_prefix, permission, is_allow) " +
+            $"VALUES ('{User}', 'Beta/Secret', 'Read', true) ON CONFLICT DO NOTHING", ct);
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task PublicReadMarkdownFeed_DoesNotLeakUngrantedPartition()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await SetupAsync(ct);
+
+        var results = await FanOut(
+            Parse("nodeType:Markdown is:main sort:LastModified-desc"),
+            "mesh_nodes", ["acme", "future", "beta"], User, ct);
+
+        var paths = results.Select(n => n.Path).ToList();
+        paths.Should().Contain("ACME/Report", "the user has access to ACME");
+        paths.Should().NotContain("FutuRe/Report",
+            "public_read must NOT bypass the partition gate — the user has no access to future");
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task SourceActivityFeed_DoesNotLeakUngrantedPartition()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await SetupAsync(ct);
+
+        var results = await FanOut(
+            Parse("source:activity scope:subtree is:main sort:LastModified-desc"),
+            "mesh_nodes", ["acme", "future", "beta"], User, ct);
+
+        var paths = results.Select(n => n.Path).ToList();
+        paths.Should().Contain("ACME/Report", "the user has access to ACME's activity feed");
+        paths.Should().NotContain("FutuRe/Report",
+            "the Last-Edited (source:activity) feed must not surface an ungranted partition's public-read node");
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task PublicReadThreadFeed_LeaksNothingUngranted_ButShowsGrantedPartition()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await SetupAsync(ct);
+
+        var results = await FanOut(
+            Parse("nodeType:Thread sort:LastModified-desc"),
+            "threads", ["acme", "future", "beta"], User, ct);
+
+        var paths = results.Select(n => n.Path).ToList();
+        paths.Should().Contain("ACME/_Thread/acme-thread-1", "the user has access to ACME");
+        paths.Should().Contain("Beta/_Thread/beta-thread-1",
+            "a shared thread in a partition the user was granted into stays visible (public_read + partition_access)");
+        paths.Should().NotContain("FutuRe/_Thread/future-thread-1",
+            "an ungranted partition's public-read thread must not leak into the fan-out");
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task GrantedCrossPartitionNode_IsStillVisible()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await SetupAsync(ct);
+
+        // beta/Secret is a Document (NOT public_read) — visible ONLY via the explicit node-level
+        // cross-partition Read grant. Proves the fix keeps genuinely-shared content reachable.
+        var results = await FanOut(
+            Parse("nodeType:Document is:main"),
+            "mesh_nodes", ["acme", "future", "beta"], User, ct);
+
+        results.Select(n => n.Path).Should().Contain("Beta/Secret",
+            "a genuinely-granted cross-partition node must remain visible");
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task AuthDirectory_UserRoute_StaysResolvable_WithoutPartitionAccess()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await SetupAsync(ct);
+
+        // The pinned nodeType:User → auth route. The user holds NO partition_access to auth, yet
+        // display-name resolution / subject picker / login require the public identity directory
+        // to stay resolvable. The auth exemption preserves exactly that.
+        var results = await FanOut(
+            Parse("nodeType:User"), "mesh_nodes", ["auth"], User, ct);
+
+        results.Select(n => n.Path).Should().Contain("shareduser",
+            "the auth identity directory must stay readable to every authenticated user (name resolution)");
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task NonAuthPartition_PublicReadUser_StaysGatedByPartitionAccess()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await SetupAsync(ct);
+
+        // Deny control: the auth exemption is auth-ONLY. A public-read User node living in a
+        // DATA partition the user cannot access must still be gated.
+        var results = await FanOut(
+            Parse("nodeType:User"), "mesh_nodes", ["future"], User, ct);
+
+        results.Select(n => n.Path).Should().NotContain("futureuser",
+            "a non-auth partition's public-read User must not bypass the partition gate");
+    }
+}

--- a/test/MeshWeaver.Security.Test/SharedWithMeDiscoveryTest.cs
+++ b/test/MeshWeaver.Security.Test/SharedWithMeDiscoveryTest.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// #385 RC4 — "Shared with me". A user invited into a module that lives in ANOTHER partition can
+/// reach it by URL but it is invisible in nav. The home's "Shared with me" tab sources the caller's
+/// own <c>AccessAssignment</c> grants (<c>content.accessObject == me</c>) and resolves each to its
+/// governed cross-partition target scope (<see cref="MeshNode.MainNode"/>) — the exact projection
+/// <c>UserActivityLayoutAreas.SharedTargetPaths</c> performs for the tab (unit-tested in
+/// <c>HomeTabExtensionTest</c>). This is purely additive: it READS the caller's own readable grants,
+/// no security surface changes.
+/// </summary>
+public class SharedWithMeDiscoveryTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddSpaceType()
+            .AddMeshNodes(
+                // A space in ANOTHER partition (OrgA) with a module the invitee is granted into.
+                new MeshNode("OrgA")
+                {
+                    Name = "Org A", NodeType = "Space", State = MeshNodeState.Active, Content = new Space()
+                },
+                new MeshNode("Module", "OrgA")
+                {
+                    Name = "Shared Module", NodeType = "Markdown", State = MeshNodeState.Active
+                },
+                // alice is invited into OrgA/Module (Viewer = Read) — a cross-partition grant.
+                AssignmentNodeFactory.UserRole("alice", "Viewer", "OrgA/Module")
+            );
+
+    /// <summary>Security discovery test — no blanket admin grant (that would mask the per-user path).</summary>
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    /// <summary>The same projection the "Shared with me" tab applies (public AccessSubjectQueries helpers).</summary>
+    private static IReadOnlyList<string> CrossPartitionTargets(IEnumerable<MeshNode> assignments, string ownerId)
+        => assignments
+            .Select(a => AccessSubjectQueries.ScopeOfAssignment(
+                string.IsNullOrEmpty(a.MainNode) ? a.Path : a.MainNode)?.Trim('/'))
+            .Where(s => !string.IsNullOrEmpty(s))
+            .Select(s => s!)
+            .Where(s => !string.Equals(AccessSubjectQueries.Partition(s), ownerId, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    [Fact(Timeout = 20000)]
+    public async Task InvitedCrossPartitionModule_AppearsInSharedTargets()
+    {
+        TestUsers.DevLogin(Mesh, new AccessContext { ObjectId = "alice", Name = "Alice" });
+
+        // The exact query ObserveSharedTargets issues for the "Shared with me" tab.
+        var change = await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery(
+                "nodeType:AccessAssignment content.accessObject:alice"))
+            .Should().Match(c => c.ChangeType == QueryChangeType.Initial);
+
+        Output.WriteLine($"alice's readable assignments: {change.Items.Count}");
+        foreach (var a in change.Items)
+            Output.WriteLine($"  - {a.Path} (mainNode={a.MainNode})");
+
+        CrossPartitionTargets(change.Items, "alice").Should().Contain("OrgA/Module",
+            "an invited cross-partition module must be discoverable via the Shared-with-me projection");
+    }
+
+    [Fact(Timeout = 20000)]
+    public async Task OwnPartitionGrant_IsNotListedAsSharedWithMe()
+    {
+        TestUsers.DevLogin(Mesh, new AccessContext { ObjectId = "alice", Name = "Alice" });
+
+        var change = await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery(
+                "nodeType:AccessAssignment content.accessObject:alice"))
+            .Should().Match(c => c.ChangeType == QueryChangeType.Initial);
+
+        // Treat OrgA as the owner's own partition → the grant is NOT "shared with me from elsewhere".
+        CrossPartitionTargets(change.Items, "OrgA").Should().NotContain("OrgA/Module",
+            "a grant inside the owner's own partition is not surfaced as shared-with-me");
+    }
+}


### PR DESCRIPTION
Fixes #385 and the enumeration/feed residual of #471 (RC1 shipped in #521).

## What shipped

### RC3 — cross-partition public-read feed leak (security)
`BuildPerSchemaAccessClause` (`PostgreSqlSqlGenerator.cs`) was the **lone outlier** emitting `public_read OR (partition_access AND node)` — OR'ing `public_read` **outside** the partition gate. The unscoped "Last Edited" (`source:activity`) feed and any unscoped `nodeType:Markdown/Thread` fan-out route through it, so a partition's public-read content (Markdown, Threads, …) leaked into a user's feed **with no access to that partition** — the "listed but access-denied on open" symptom of #385.

Aligned it to the documented invariant `partition_access AND (public_read OR node)` — the exact shape already used by the `search_across_schemas` stored proc and the schema-qualified `GenerateAccessControlClause`. Mirrored in `SnowflakeSqlGenerator` for parity.

**Guardrail preserved — the `auth` identity directory stays public.** `nodeType:User` is pinned to the `auth` mirror, which is excluded from the tenant fan-out and for which **no user holds a `partition_access` row**. `auth` keeps the public-read bypass so display-name resolution / subject picker / invites / login stay intact; non-public directory types (e.g. `ApiToken`) still fall through to the node-level check, and a **non-auth** partition's public-read `User` stays gated.

### RC4 — "Shared with me" nav (additive, #385)
New home tab in `UserActivityLayoutAreas.BuildCatalog`. Sources the caller's own `AccessAssignment` grants (`content.accessObject == me`), fanned out cross-partition + access-filtered, resolved to each governed target scope (`MainNode`, normalised via `ScopeOfAssignment`) and kept only when **outside** the owner's own partition. Surfaces invited modules that were reachable by URL but invisible in nav. **No security surface changes** — it reads only the caller's own readable grants.

### RC2 — user enumeration: DEFERRED (design decision needed)
The `AccessSubjectQueries.Users` surface feeds the add-assignment **subject picker**, which is already gated by manage-access permission on the node and is needed to invite users. Admin-gating / narrowing it would **break invites for non-admin space owners** — which the guardrail explicitly forbids. Email harvest is being addressed by **RC1 (#521, in flight)**. Cleanly separating "name readable by all (for pickers/@mentions/invites)" from "not blanket-enumerable" requires a **name-only public projection** — a design decision, so RC2 is not shipped here. No changes to `UserPublicReadTest`/`AccessSubjectQueries`.

## Test coverage (allow AND deny)

**RC3 — `PerSchemaAccessClauseLeakTests` (PostgreSQL Testcontainers), revert-proven** (the 4 deny tests fail with the outlier restored, pass with the fix):
- DENY: public-read Markdown does NOT leak to an ungranted partition
- DENY: the `source:activity` feed does NOT leak an ungranted partition's node
- DENY: public-read Thread does NOT leak (but a shared thread in a granted partition IS shown)
- ALLOW: a genuinely-granted cross-partition node (a non-public Document) STILL appears
- ALLOW (guardrail): the `auth` directory `nodeType:User` route stays resolvable **without** `partition_access`
- DENY control: a non-auth partition's public-read `User` stays gated

**RC4 — `HomeTabExtensionTest` (Graph.Test) + `SharedWithMeDiscoveryTest` (MonolithMeshTestBase):**
- the "Shared with me" tab is inserted after Spaces when cross-partition grants exist, omitted otherwise
- `SharedTargetPaths` keeps cross-partition targets, excludes own-partition/root, dedupes, and falls back to the path scope when `MainNode` is unset
- integration: an invited cross-partition module (`OrgA/Module` granted to alice) appears in the projection; an own-partition grant does not

## Flows confirmed still working
- **auth `nodeType:User` route** (display-name resolution / subject picker / login): preserved by the `auth` exemption + proven by the guardrail allow-test
- **invites / subject picker**: untouched (RC2 deferred)
- **granted cross-partition visibility**: proven by the RC3 allow-tests
- **global-admin / Space discovery**: unchanged — existing `GlobalAdminSpaceSearchTests` (admin visibility via explicit `partition_access`, and `PublicRead_StillRequiresPartitionAccess`) already encode this invariant; the broad regression across the cross-partition + user fan-out suites is green

## Regression run
100/100 existing cross-partition + user + fan-out + access PG tests pass. One unrelated failure, `GroupMembershipRecomputeTests.CrossPartitionGroup_LicensedOnAnotherPartition` — a **pre-existing** failure in the DDL group-recompute trigger subsystem (verified: fails identically on `origin/main` with my change reverted; its assertion reads `user_effective_permissions` directly and never touches the query-generation path I changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)