### PR TITLE
fix(gitsync): webhook config lookup runs as System

### DIFF
--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -234,9 +234,7 @@ public sealed class GitHubWebhookProcessor
     private IObservable<IReadOnlyList<PushTarget>> MatchingSyncTargets(string repoUrl, PushEvent push)
     {
         var target = ParseSafe(repoUrl);
-        return meshService
-            .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{GitHubSyncService.ConfigNodeType}"))
-            .Take(1)
+        return QueryConfigNodesAsSystem()
             .Select(c => (IReadOnlyList<PushTarget>)c.Items
                 .Where(n => RepoMatches(n, target))
                 .Where(n => ConfigMatchesPush(
@@ -264,13 +262,28 @@ public sealed class GitHubWebhookProcessor
 
     // ── helpers ──────────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// The full <c>GitHubSyncConfig</c> node set, queried under the SYSTEM identity. The webhook
+    /// HTTP request is anonymous — its authorization is the verified HMAC signature — and
+    /// <c>_GitSync</c> satellites are not anonymous-readable, so an ambient-identity query
+    /// silently matches nothing on an access-gated portal (the DevLogin test fallback masked
+    /// exactly this). Same identity model as the write path below.
+    /// </summary>
+    private IObservable<QueryResultChange<MeshNode>> QueryConfigNodesAsSystem()
+    {
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        return Observable.Using(
+            () => accessService.ImpersonateAsSystem(),
+            _ => meshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{GitHubSyncService.ConfigNodeType}"))
+                .Take(1));
+    }
+
     /// <summary>The distinct Space paths whose GitHub sync config targets <paramref name="repoUrl"/>.</summary>
     private IObservable<IReadOnlyList<string>> MatchingSpaces(string repoUrl)
     {
         var target = ParseSafe(repoUrl);
-        return meshService
-            .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{GitHubSyncService.ConfigNodeType}"))
-            .Take(1)
+        return QueryConfigNodesAsSystem()
             .Select(c => (IReadOnlyList<string>)c.Items
                 .Where(n => RepoMatches(n, target))
                 .Select(n => n.Path.Split('/', 2)[0])

--- a/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs
@@ -1,5 +1,11 @@
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -209,21 +215,37 @@ public class GitHubWebhookProcessorTest(ITestOutputHelper output) : GitHubSyncTe
         await CreateSpace(b, "Push Target Space");
         await Sync.SaveConfig(b, repo, "main", null, true, true).Timeout(30.Seconds()).ToTask();
 
-        // A push on a DIFFERENT branch matches nothing.
-        var otherBranch = JsonDocument.Parse("""
-        { "ref": "refs/heads/develop", "size": 1,
-          "repository": { "full_name": "test/push-auto" },
-          "commits": [ { "added": ["Welcome.md"], "modified": [], "removed": [] } ] }
-        """).RootElement;
-        Assert.Equal(0, await Webhooks.Process("push", otherBranch).Timeout(60.Seconds()).ToTask());
+        // 🚨 The webhook HTTP request is ANONYMOUS (its authorization is the HMAC signature).
+        // Drop every ambient identity — the DevLogin persistent circuit fallback masked the
+        // prod defect where the config-node query ran as anonymous and matched NOTHING on an
+        // access-gated portal. The processor must impersonate System for its own lookups.
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.ClearPersistentCircuitContext();
+        accessService.SetCircuitContext(null);
+        accessService.SetContext(null);
+        int triggered;
+        try
+        {
+            // A push on a DIFFERENT branch matches nothing.
+            var otherBranch = JsonDocument.Parse("""
+            { "ref": "refs/heads/develop", "size": 1,
+              "repository": { "full_name": "test/push-auto" },
+              "commits": [ { "added": ["Welcome.md"], "modified": [], "removed": [] } ] }
+            """).RootElement;
+            Assert.Equal(0, await Webhooks.Process("push", otherBranch).Timeout(60.Seconds()).ToTask());
 
-        // The main-branch push triggers the headless update for BOTH sync sources.
-        var payload = JsonDocument.Parse("""
-        { "ref": "refs/heads/main", "size": 1,
-          "repository": { "full_name": "test/push-auto" },
-          "commits": [ { "added": [], "modified": ["Welcome.md"], "removed": [] } ] }
-        """).RootElement;
-        var triggered = await Webhooks.Process("push", payload).Timeout(60.Seconds()).ToTask();
+            // The main-branch push triggers the headless update for BOTH sync sources.
+            var payload = JsonDocument.Parse("""
+            { "ref": "refs/heads/main", "size": 1,
+              "repository": { "full_name": "test/push-auto" },
+              "commits": [ { "added": [], "modified": ["Welcome.md"], "removed": [] } ] }
+            """).RootElement;
+            triggered = await Webhooks.Process("push", payload).Timeout(60.Seconds()).ToTask();
+        }
+        finally
+        {
+            accessService.SetCircuitContext(new AccessContext { ObjectId = UserId, Name = TestUsers.Admin.Name });
+        }
         Assert.Equal(2, triggered);
 
         // The import runs as a background activity — observe the node landing in Space B.


### PR DESCRIPTION
Live-found rolling out #527 on memex-cloud: the push webhook delivered 200 but triggered no update.

**Root cause:** the webhook HTTP request is anonymous (its authorization is the verified HMAC signature), and `_GitSync` config satellites are not anonymous-readable — the processor's ambient-identity config query matched **nothing** on an access-gated portal. The DevLogin persistent circuit fallback masked this in tests (the same masking the activity-owner-credential tests pinned).

**Fix:** the shared config-node query (push-target matching AND issue-space matching) impersonates System — the identity model the webhook write path already uses. The push E2E test now clears every ambient identity before invoking the processor; revert-proven (fails on the unfixed query, passes fixed). GitSync suite 131/131; Release `-warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)