### PR TITLE
fix(#325): de-risk + prove the cross-silo change-feed relay transport (DI cycle + allowed-types gate) [HELD — do not merge]

### DIFF
--- a/src/MeshWeaver.Hosting.Orleans/OrleansMeshChangeFeed.cs
+++ b/src/MeshWeaver.Hosting.Orleans/OrleansMeshChangeFeed.cs
@@ -23,7 +23,7 @@ namespace MeshWeaver.Hosting.Orleans;
 public class OrleansMeshChangeFeed : IMeshChangeFeed, IDisposable
 {
     private readonly InProcessMeshChangeFeed _local;
-    private readonly IMessageHub _hub;
+    private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<OrleansMeshChangeFeed>? _logger;
     private readonly Subject<MeshChangeEvent> _broadcastQueue = new();
     private readonly IDisposable _broadcastSubscription;
@@ -34,18 +34,26 @@ public class OrleansMeshChangeFeed : IMeshChangeFeed, IDisposable
     /// Orleans memory stream in arrival order.
     /// </summary>
     /// <param name="localFeed">The in-process change feed serving local subscribers and providing local publish/subscribe.</param>
-    /// <param name="hub">The mesh hub used to resolve the I/O pool and the Orleans cluster client.</param>
+    /// <param name="serviceProvider">
+    /// The mesh service provider used to LAZILY resolve the I/O pool (at construction) and the
+    /// Orleans cluster client (at broadcast time). 🚨 Captured as <see cref="IServiceProvider"/>,
+    /// NOT <see cref="IMessageHub"/>: this feed is constructed from
+    /// <c>Workspace..ctor → TrySubscribeToChangeFeed(hub.ServiceProvider)</c> mid-hub-build, so a
+    /// factory that resolved <c>IMessageHub</c> here re-entered <c>BuildHub → new Workspace →
+    /// IMeshChangeFeed → …</c> and stack-overflowed. Holding the provider and resolving the pieces
+    /// on demand breaks that cycle (the cluster client is only touched once the host is fully up).
+    /// </param>
     /// <param name="logger">Optional logger for broadcast diagnostics and failures.</param>
     public OrleansMeshChangeFeed(
         InProcessMeshChangeFeed localFeed,
-        IMessageHub hub,
+        IServiceProvider serviceProvider,
         ILogger<OrleansMeshChangeFeed>? logger = null)
     {
         _local = localFeed;
-        _hub = hub;
+        _serviceProvider = serviceProvider;
         _logger = logger;
 
-        var ioPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get("orleans-broadcast")
+        var ioPool = serviceProvider.GetService<IoPoolRegistry>()?.Get("orleans-broadcast")
                      ?? IoPool.Unbounded;
         // Per-event Catch: one failed broadcast is logged and skipped — it must not
         // tear down the queue (matches the old per-event try/catch). A fault of the
@@ -84,7 +92,7 @@ public class OrleansMeshChangeFeed : IMeshChangeFeed, IDisposable
 
     private async Task<Unit> BroadcastAsync(MeshChangeEvent change, CancellationToken ct)
     {
-        var client = _hub.ServiceProvider.GetService<IClusterClient>();
+        var client = _serviceProvider.GetService<IClusterClient>();
         if (client == null)
         {
             _logger?.LogDebug("OrleansMeshChangeFeed: no IClusterClient — broadcast skipped for {Path} {Kind}",

--- a/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
+++ b/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
@@ -122,12 +122,16 @@ public static class OrleansServerRegistryExtensions
         // of the actual cause (a compilation failure). See issue #464, Defect 3.
         services.TryAddSingleton<GrainActivationFailureRegistry>();
 
-        // Register Orleans-distributed change feed (wraps local feed + Orleans streams)
+        // Register Orleans-distributed change feed (wraps local feed + Orleans streams).
+        // 🚨 The factory captures the ROOT IServiceProvider (sp), never IMessageHub — the feed is
+        // constructed from Workspace..ctor mid-hub-build, and resolving IMessageHub there re-enters
+        // BuildHub → new Workspace → IMeshChangeFeed → factory → … and stack-overflows. See
+        // OrleansMeshChangeFeed's ctor doc. The cluster client / IoPool are resolved lazily from sp.
         services.TryAddSingleton<InProcessMeshChangeFeed>();
         services.TryAddSingleton<IMeshChangeFeed>(sp =>
             new OrleansMeshChangeFeed(
                 sp.GetRequiredService<InProcessMeshChangeFeed>(),
-                sp.GetRequiredService<IMessageHub>(),
+                sp,
                 sp.GetService<ILoggerFactory>()?.CreateLogger<OrleansMeshChangeFeed>()));
 
         services.AddMeshCatalog();

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -31,6 +31,13 @@ public static class MeshExtensions
         config.TypeRegistry.WithType(typeof(PingResponse), nameof(PingResponse));
         config.TypeRegistry.WithType(typeof(MeshNode), nameof(MeshNode));
         config.TypeRegistry.WithType(typeof(MeshNodeState), nameof(MeshNodeState));
+        // MeshChangeEvent rides over the Orleans memory stream for the cross-silo change-feed
+        // relay (OrleansMeshChangeFeed). The Orleans allowed-types gate (MeshTypeNameFilter) only
+        // permits IMessageDelivery + types the hub's ITypeRegistry knows; unregistered, a
+        // MeshChangeEvent published to the stream is rejected at the manifest gate and never
+        // reaches a cross-silo subscriber. Register it (short name) so it can cross that boundary.
+        config.TypeRegistry.WithType(typeof(MeshWeaver.Mesh.Services.MeshChangeEvent), nameof(MeshWeaver.Mesh.Services.MeshChangeEvent));
+        config.TypeRegistry.WithType(typeof(MeshWeaver.Mesh.Services.MeshChangeKind), nameof(MeshWeaver.Mesh.Services.MeshChangeKind));
         // AccessContext rides as a TYPED field on every IMessageDelivery. Unregistered, the
         // polymorphic resolver stamps it a full-name $type ("MeshWeaver.Messaging.AccessContext") —
         // harmless for the typed field (it round-trips) but it's ongoing log noise (the

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansCrossSiloStreamProbeTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansCrossSiloStreamProbeTest.cs
@@ -1,0 +1,91 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Orleans.TestingHost;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// PROBE (issue #325, cross-silo change-feed relay defect 3): does an EXPLICIT per-silo
+/// subscriber receive a MeshChangeEvent published from another silo over the shared Orleans
+/// memory stream? This is the transport primitive the relay needs — and the question the prior
+/// investigation left open (the <c>[ImplicitStreamSubscription]</c> grain never activated).
+///
+/// <para>Publishes directly through the keyed <see cref="IStreamProvider"/> on silo A, and
+/// subscribes directly on silo B (bypassing OrleansMeshChangeFeed / the grain), so a green
+/// result isolates "the memory-stream transport CAN carry MeshChangeEvent cross-silo to a
+/// non-grain subscriber" from any wiring defect in the feed itself. Bounded everywhere — no
+/// Task.Delay, no unbounded await.</para>
+/// </summary>
+public class OrleansCrossSiloStreamProbeTest : IClassFixture<TwoSiloCacheUpdateFixture>
+{
+    private readonly TwoSiloCacheUpdateFixture _fixture;
+
+    public OrleansCrossSiloStreamProbeTest(TwoSiloCacheUpdateFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static IServiceProvider SiloServices(TestCluster cluster, int index)
+        => ((InProcessSiloHandle)cluster.Silos[index]).SiloHost.Services;
+
+    [Fact(Timeout = 90000)]
+    public async Task ExplicitSubscriber_ReceivesCrossSiloPublish()
+    {
+        var ct = new CancellationTokenSource(TimeSpan.FromSeconds(70)).Token;
+        var cluster = _fixture.Cluster;
+        Assert.True(cluster.Silos.Count >= 2, "probe needs two silos");
+
+        var siloA = SiloServices(cluster, 0);
+        var siloB = SiloServices(cluster, 1);
+
+        const string streamNs = "mesh-updated";
+        var streamId = StreamId.Create(streamNs, Guid.Empty);
+        var received = new TaskCompletionSource<MeshChangeEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Subscribe on silo B (the NON-publishing silo) via the keyed provider — the exact
+        // mechanism OrleansRoutingService uses for cross-silo message delivery.
+        var providerB = siloB.GetRequiredKeyedService<IStreamProvider>(StreamProviders.Memory);
+        var handle = await providerB.GetStream<MeshChangeEvent>(streamId)
+            .SubscribeAsync((evt, _) =>
+            {
+                received.TrySetResult(evt);
+                return Task.CompletedTask;
+            })
+            .WaitAsync(TimeSpan.FromSeconds(30), ct);
+
+        try
+        {
+            // Publish from silo A.
+            var providerA = siloA.GetRequiredKeyedService<IStreamProvider>(StreamProviders.Memory);
+            var evt = new MeshChangeEvent(
+                Namespace: "probe",
+                Id: "n1",
+                Path: "probe/n1",
+                Kind: MeshChangeKind.Updated,
+                NodeType: "Markdown",
+                Version: 1,
+                Timestamp: DateTimeOffset.UtcNow);
+            await providerA.GetStream<MeshChangeEvent>(streamId).OnNextAsync(evt).WaitAsync(TimeSpan.FromSeconds(30), ct);
+
+            // Assert silo B's subscriber received it (bounded).
+            var got = await received.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
+            Assert.Equal("probe/n1", got.Path);
+            Assert.Equal(MeshChangeKind.Updated, got.Kind);
+        }
+        finally
+        {
+            try { await handle.UnsubscribeAsync().WaitAsync(TimeSpan.FromSeconds(10), CancellationToken.None); }
+            catch { /* best-effort teardown */ }
+        }
+    }
+}


### PR DESCRIPTION
Fixes the multi-replica residual of #325: repairs the cross-silo change-feed relay (shadowed feed + DI cycle + implicit-subscription delivery) so an orphaned mirror resubscribes — **partially**. This PR ships the **proven, storm-safe subset** and, after deterministic investigation, **deliberately defers** the per-write relay activation, which turned out to be architecturally storm-prone and to have a second, previously-unidentified blocker (double-firing every stateful business consumer). 🚨 **PROD-CRITICAL — HELD FOR HUMAN REVIEW. Do NOT merge without a human decision on the transport/architecture direction below.**

## What ships (all proven safe + green)

**1. Defect 2 — `OrleansMeshChangeFeed` DI cycle → StackOverflow (fixed).**
The factory resolved `IMessageHub`, but the feed is constructed from `Workspace..ctor → TrySubscribeToChangeFeed(hub.ServiceProvider)` mid-hub-build, so resolving `IMessageHub` re-entered `BuildHub → new Workspace → IMeshChangeFeed → factory → …` and stack-overflowed. Fix: capture the root `IServiceProvider`, lazily resolve the `IoPool` (ctor) and `IClusterClient` (broadcast time). This is the fix that makes the Orleans feed *constructible at all* — a prerequisite for any future relay.

**2. Allowed-types gate — `MeshChangeEvent` was never registered (fixed).**
The Orleans `MeshTypeNameFilter` only permits `IMessageDelivery` + types in the hub `TypeRegistry`. `MeshChangeEvent` was **not** registered, so a `MeshChangeEvent` published to the memory stream is rejected at the manifest gate and can never reach a cross-silo subscriber. Registered `MeshChangeEvent` + `MeshChangeKind` in `AddMeshTypes`.

**3. `OrleansCrossSiloStreamProbeTest` — proves the transport works (green, 2-silo).**
An **explicit per-silo subscriber** *does* receive a `MeshChangeEvent` published from another silo over the shared memory stream. This resolves the prior open question ("the `[ImplicitStreamSubscription]` relay never delivers"): **the transport is viable**; the implicit-`Guid.Empty` grain was the wrong tool.

Runtime behavior of the framework is **unchanged** (the Orleans feed stays shadowed by `InProcessMeshChangeFeed`; the type registration is additive; the `EventLog` serializes via plain `System.Text.Json`, unaffected). `OrleansMeshChangeFeedTest` stays green (2/2).

## The 3 stated defects — verified

| Defect | Status |
|---|---|
| 1. `OrleansMeshChangeFeed` shadowed by `InProcessMeshChangeFeed` (`TryAdd` ordering: `AddPartitionedInMemoryPersistence`→`AddMeshCatalog` claims the slot first) | **Confirmed, NOT flipped** — see below |
| 2. DI cycle → StackOverflow (factory resolves `IMessageHub`) | **Fixed** |
| 3. `[ImplicitStreamSubscription]` grain never activates / delivers | **Root-caused** — (a) implicit-`Guid.Empty` grain = single cluster-wide instance, cannot fan out to every silo's local feed; (b) `MeshChangeEvent` blocked by the allowed-types gate (now fixed). The transport itself works with an explicit subscriber (probe proves it). |

## Why the relay is NOT activated (two blockers found during this investigation)

**Blocker A — double-firing stateful business consumers.** The distributed portal **co-hosts silo + web** (`Memex.Portal.Distributed/Program.cs:141`), so 2 replicas = 2 copies of every business `IHostedService` that subscribes to `IMeshChangeFeed`: `AccessGrantNotifier`, `EventSubscriptionRunner`, `EventLogWriter`, `ApprovalToPublishHandler`, `SyncedQueryMeshNodes` (`MemexConfiguration.cs:184-200`). Today a write publishes only on the owning silo's feed → these fire **exactly once**. Relaying cross-silo into the shared `IMeshChangeFeed` (via `PublishLocal`, as `PathCacheInvalidatorGrain` does) makes every replica's feed see every write → **double notifications / double approvals / double event-subscription firings**. The relay must therefore drive *only* cache invalidation, never the shared feed.

**Blocker B — a per-write invalidation relay is storm-prone by construction.** The relay event and the mirror's normal cross-hub sync frame race across two independent channels. In the healthy case, whenever the relay wins that race, a version gate still sees `mirrorVersion < eventVersion` and invalidates → the live mirror drops + resubscribes → **on every write to a hot mirrored path**. Closing that race needs a "has been stale for a while" temporal check — i.e. a timer/watchdog, which is banned. So the version gate **cannot** make a per-write relay storm-safe.

Per the strict gate ("never ship an unproven cross-silo invalidation change; a per-write cross-silo broadcast can wedge prod if it storms"), neither Blocker-A nor Blocker-B is acceptable, so **nothing that activates the relay is shipped**.

## Recommended direction (for the human reviewer)

The storm-safe fix is **not** a new per-write broadcast. It is to make the **existing** sync-stream resubscribe heal cross-silo after an owner recycle — i.e. the **frame-version floor (Option 2)**: `SynchronizationStream.OwnerVersion()` returns `Hub.Version` (resets per activation), so post-recycle frames are stamped with a fresh low version and the receiver's `< Current.Version` guard drops them. Floor the owner frame version at the **per-activation content baseline** (loaded `node.Version`, `MeshNodeTypeSource.cs:520-543`; **0 for layout/ephemeral** so the layout-Full path is untouched — the naive floor was reverted once because partial cross-hub patches carry `version=0` and flapped, breaking `ExportDocumentScriptRelayTest`). This introduces no per-write broadcast, so Blockers A and B don't apply. It still needs a **deterministic 2-silo repro of symptom-2** (owner idle-recycle + post-recycle UPDATE; mirror on the non-owner silo stays orphaned on main → converges with the floor) — that repro remains the hard unwritten piece — plus the layout-Full and export-relay regression guards.

If a cross-silo cache-invalidation relay is still wanted (e.g. for created/deleted path-resolution invalidation), it must (i) target `MeshNodeStreamCache.Invalidate` / path-resolution directly, **never** `IMeshChangeFeed.PublishLocal` (Blocker A), and (ii) be limited to low-frequency lifecycle events, not per-write UPDATE (Blocker B).

## Validation run
- `OrleansCrossSiloStreamProbeTest` — **green** (proves cross-silo transport).
- `OrleansMeshChangeFeedTest` — **green** 2/2 (regression: type registration + defect-2 change don't alter existing behavior).
- Release `-warnaserror -p:CIRun=true` build of the touched projects + Orleans test project — **0 warnings, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
