### PR TITLE
feat(clients): access-denied → configurable redirect parity for portal-next + RN

### DIFF
--- a/clients/portal-next/app/[[...meshPath]]/AreaSnapshot.tsx
+++ b/clients/portal-next/app/[[...meshPath]]/AreaSnapshot.tsx
@@ -18,6 +18,8 @@ import {
   fetchRenderedArea,
   mintToken,
   resolvePortalOrigin,
+  type AreaTarget,
+  type RenderedAreaResult,
 } from "../../src/server/snapshot";
 import { LiveArea } from "../../src/client/LiveArea";
 
@@ -35,29 +37,37 @@ export async function AreaSnapshot({ path }: { path: string }) {
   // area is the generic overview, not the dashboard). Explicit paths resolve into (node address,
   // area remainder); that resolution and the rendered snapshot fetch in parallel — render-area
   // does its own resolution internally, so neither depends on the other.
-  const [target, rendered] = !mint || !resolvedPath
-    ? [{ address: resolvedPath, area: "", id: "" }, null]
-    : !path
-      ? await Promise.all([
-          Promise.resolve({ address: resolvedPath, area: "Activity", id: "" }),
-          fetchRenderedArea(origin, mint.rawToken, resolvedPath, "Activity"),
-        ])
-      : await Promise.all([
-          fetchAreaTarget(origin, mint.rawToken, resolvedPath),
-          fetchRenderedArea(origin, mint.rawToken, resolvedPath),
-        ]);
+  const none: RenderedAreaResult = { kind: "none" };
+  const [target, rendered]: [AreaTarget, RenderedAreaResult] =
+    !mint || !resolvedPath
+      ? [{ address: resolvedPath, area: "", id: "", redirectOnDenied: null }, none]
+      : !path
+        ? await Promise.all([
+            Promise.resolve<AreaTarget>({ address: resolvedPath, area: "Activity", id: "", redirectOnDenied: null }),
+            fetchRenderedArea(origin, mint.rawToken, resolvedPath, "Activity"),
+          ])
+        : await Promise.all([
+            fetchAreaTarget(origin, mint.rawToken, resolvedPath),
+            fetchRenderedArea(origin, mint.rawToken, resolvedPath),
+          ]);
+
+  const tree = rendered.kind === "ok" ? rendered.tree : null;
   const snapshot =
-    !rendered && mint && resolvedPath ? await fetchNodeSnapshot(origin, mint.rawToken, resolvedPath) : null;
+    !tree && mint && resolvedPath ? await fetchNodeSnapshot(origin, mint.rawToken, resolvedPath) : null;
 
   return (
     <LiveArea
       path={resolvedPath}
       target={target}
-      initialTree={rendered ?? (snapshot ? buildInitialTree(snapshot) : null)}
+      initialTree={tree ?? (snapshot ? buildInitialTree(snapshot) : null)}
       // A rendered frame roots at the requested area (an explicit-area URL roots at its name;
       // the default-area subscribe at ""); the synthesized preview tree always roots at "".
-      initialRootArea={rendered ? target.area : ""}
+      initialRootArea={tree ? target.area : ""}
       unauthenticated={!mint}
+      // Server-detected RLS denial (authenticated visitor lacks Read) → the client redirects to the
+      // node's public cover / paywall when the policy safely configures one — the same "no access ⇒
+      // redirect here" the Blazor NamedAreaView does. The loop-guard + navigation live in LiveArea.
+      initialDenied={rendered.kind === "denied"}
     />
   );
 }

--- a/clients/portal-next/next.config.mjs
+++ b/clients/portal-next/next.config.mjs
@@ -62,6 +62,9 @@ const nextConfig = {
       // /wire is the React-FREE wire-folding leaf — the server snapshot module imports it
       // without dragging the renderer (React context/components) into the RSC server graph.
       "@meshweaver/react/wire": path.resolve(here, "../react/src/live/wire.ts"),
+      // React-FREE area-error classifier — the server snapshot module imports it (like /wire)
+      // without dragging the renderer into the RSC server graph.
+      "@meshweaver/react/accessError": path.resolve(here, "../react/src/area/accessError.ts"),
       "@meshweaver/react/styles": path.resolve(here, "../react/src/render/meshStyles.ts"),
       "@meshweaver/react/core": path.resolve(here, "../react/src/core.ts"),
       "@meshweaver/react": path.resolve(here, "../react/src/index.tsx"),

--- a/clients/portal-next/src/client/LiveArea.tsx
+++ b/clients/portal-next/src/client/LiveArea.tsx
@@ -16,12 +16,22 @@
 // connection, exactly like the Vite SPA.
 
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { useRouter } from "next/navigation";
 import { Button, MessageBar, MessageBarActions, MessageBarBody, Spinner } from "@fluentui/react-components";
-import { EmbeddedAreaProvider, MeshAreaView, StaticAreaSource } from "@meshweaver/react";
+import { classifyAreaError, EmbeddedAreaProvider, MeshAreaView, StaticAreaSource } from "@meshweaver/react";
 import type { AreaSource, AreaTree } from "@meshweaver/react";
-import { rootAreaOf, targetKey, type AreaTarget } from "./live";
+import { deniedRedirectTarget, rootAreaOf, targetKey, type AreaTarget } from "./live";
 import { useLiveConnection, usePublishNavigation } from "./LiveConnection";
 import { useHydratedTheme } from "./useHydratedTheme";
+
+/** Redirect an unauthenticated visitor to the portal's unified /login, preserving where they were so
+ *  sign-in returns them here (the Blazor NavigationService appends the same returnUrl). /login is a
+ *  root-origin portal page (not a basePath route), so a full-page window.location navigation is right. */
+function goToLogin(): void {
+  if (typeof window === "undefined") return;
+  const returnUrl = encodeURIComponent(window.location.href);
+  window.location.href = `/login?returnUrl=${returnUrl}`;
+}
 
 export interface LiveAreaProps {
   /** The URL mesh path as routed (or the user's home partition for the default route). */
@@ -35,6 +45,10 @@ export interface LiveAreaProps {
   initialRootArea?: string;
   /** True when the server-side token mint failed (no authenticated session was forwarded). */
   unauthenticated?: boolean;
+  /** True when the server-side render detected an RLS access denial (the authenticated visitor lacks
+   *  Read). Combined with a safely-configured `target.redirectOnDenied`, the client redirects to the
+   *  node's public cover / paywall — the same "no access ⇒ redirect here" the Blazor NamedAreaView does. */
+  initialDenied?: boolean;
 }
 
 /** True once a source has folded its first Full frame (an empty tree is the pre-frame state). */
@@ -45,8 +59,9 @@ function hasContent(source: AreaSource): boolean {
 
 const noSubscription = () => () => {};
 
-export function LiveArea({ path, target, initialTree, initialRootArea = "", unauthenticated }: LiveAreaProps) {
+export function LiveArea({ path, target, initialTree, initialRootArea = "", unauthenticated, initialDenied }: LiveAreaProps) {
   const { theme } = useHydratedTheme();
+  const router = useRouter();
   const live = useLiveConnection();
   const publishNavigation = usePublishNavigation();
 
@@ -77,6 +92,26 @@ export function LiveArea({ path, target, initialTree, initialRootArea = "", unau
   const streamError = live.areaErrors[targetKey(target)];
   const offline = live.state.kind === "offline";
 
+  // Classify a live-subscription fault so the shell makes the SAME decisions the Blazor NamedAreaView
+  // makes: an access denial can redirect to a paywall; a routing NotFound gets a graceful placeholder
+  // (never the raw "No node found at 'u/_Activity/…'" diagnostic); anything else shows verbatim.
+  const errorInfo = streamError ? classifyAreaError(streamError) : null;
+
+  // "No access ⇒ redirect here": a denied visitor — detected on the server render (initialDenied) or
+  // by a live access-denied fault mid-session — is sent to the node's public cover / paywall when its
+  // policy safely configures one (deniedRedirectTarget's loop-guard refuses a target that would bounce
+  // back). Without a safe target it falls through to the honest denied affordance below. The paywall
+  // is an in-app mesh route → navigate via the basePath-aware app router.
+  const redirectTarget = deniedRedirectTarget({
+    initialDenied,
+    streamError,
+    address: target.address,
+    redirectOnDenied: target.redirectOnDenied,
+  });
+  useEffect(() => {
+    if (redirectTarget) router.replace(redirectTarget);
+  }, [redirectTarget, router]);
+
   // ONE hub: the embed factory comes from the session's single MeshAreaRegistry (LiveConnection),
   // the SAME registry getAreaSource uses — a page area and any `@@` embed of it share one stream.
   // (Previously each LiveArea built its own factory over the connection: a second registry, a second
@@ -93,7 +128,7 @@ export function LiveArea({ path, target, initialTree, initialRootArea = "", unau
   // with a sign-in affordance rather than yanked away from an anonymous reader.
   const needsLogin = !!unauthenticated && !active;
   useEffect(() => {
-    if (needsLogin && typeof window !== "undefined") window.location.href = "/login";
+    if (needsLogin) goToLogin();
   }, [needsLogin]);
 
   const view = active ? (
@@ -125,7 +160,7 @@ export function LiveArea({ path, target, initialTree, initialRootArea = "", unau
               </MessageBarBody>
               {authFailed && (
                 <MessageBarActions>
-                  <Button size="small" appearance="primary" onClick={() => (window.location.href = "/login")}>
+                  <Button size="small" appearance="primary" onClick={goToLogin}>
                     Sign in
                   </Button>
                 </MessageBarActions>
@@ -134,10 +169,16 @@ export function LiveArea({ path, target, initialTree, initialRootArea = "", unau
           </div>
         );
       })()}
-      {streamError && (
-        <div data-mw-area-error style={{ marginBottom: 16 }}>
-          <MessageBar intent="error">
-            <MessageBarBody>Live area “{path}” failed: {streamError}</MessageBarBody>
+      {streamError && !redirectTarget && (
+        <div data-mw-area-error data-mw-error-kind={errorInfo?.kind ?? "other"} style={{ marginBottom: 16 }}>
+          <MessageBar intent={errorInfo?.kind === "access-denied" ? "warning" : errorInfo?.kind === "not-found" ? "info" : "error"}>
+            <MessageBarBody>
+              {errorInfo?.kind === "access-denied"
+                ? `You don’t have access to “${path}”.`
+                : errorInfo?.kind === "not-found"
+                  ? `“${path}” is no longer available.`
+                  : `Live area “${path}” failed: ${streamError}`}
+            </MessageBarBody>
           </MessageBar>
         </div>
       )}

--- a/clients/portal-next/src/client/live.ts
+++ b/clients/portal-next/src/client/live.ts
@@ -10,7 +10,7 @@
 // This file is client-only by construction (window.location default); the server-side counterpart
 // (src/server/snapshot.ts) is REST-only and never opens a stream.
 
-import { GrpcAreaSource, type AreaSource } from "@meshweaver/react/core";
+import { classifyAreaError, GrpcAreaSource, isSafeRedirect, type AreaSource } from "@meshweaver/react/core";
 import type {
   ContentListing,
   MarkdownCellSubmission,
@@ -327,6 +327,10 @@ export interface AreaTarget {
   address: string;
   area: string;
   id: string;
+  /** The node's configured "if no access ⇒ redirect here" target (public cover / paywall), or null.
+   *  Carried through from the server resolve (snapshot.ts AreaTarget); LiveArea redirects a denied
+   *  viewer there (gated by isSafeRedirect). Not part of the subscription key. */
+  redirectOnDenied?: string | null;
 }
 
 /**
@@ -356,6 +360,26 @@ export function rootAreaOf(target: AreaTarget): string {
 /** Cache key for one target's live source — one stream per (address, area, id). */
 export function targetKey(target: AreaTarget): string {
   return `${target.address}\u0000${target.area}\u0000${target.id}`;
+}
+
+/**
+ * The public cover / paywall to redirect a DENIED viewer to, or null. "Denied" means the server
+ * render flagged an RLS denial (`initialDenied`) OR the live subscription faulted with an
+ * access-denied error. The target is the node's configured `redirectOnDenied` (from the resolve
+ * response), gated by `isSafeRedirect` so it can never loop (redirecting the target or a node beneath
+ * it back to itself is refused). Returns a leading-'/' in-app mesh route ready for router.replace, or
+ * null to fall through to the honest denied/error affordance. Pure — the TS twin of the Blazor
+ * NamedAreaView redirect decision, unit-tested without a renderer.
+ */
+export function deniedRedirectTarget(args: {
+  initialDenied?: boolean;
+  streamError?: string | null;
+  address: string;
+  redirectOnDenied?: string | null;
+}): string | null {
+  const denied = !!args.initialDenied || classifyAreaError(args.streamError)?.kind === "access-denied";
+  if (!denied || !isSafeRedirect(args.address, args.redirectOnDenied)) return null;
+  return "/" + (args.redirectOnDenied ?? "").replace(/^\/+/, "");
 }
 
 /** Root area key of a default-area subscription (matches the SSR preview tree's root, so live

--- a/clients/portal-next/src/server/snapshot.ts
+++ b/clients/portal-next/src/server/snapshot.ts
@@ -33,6 +33,8 @@ import * as React from "react";
 // client-context modules OUT of this file's RSC server graph (next build rejects createContext
 // in server components).
 import { normalizeEntityStore } from "@meshweaver/react/wire";
+// React-FREE classifier (own subpath, like /wire) — safe in this RSC server module.
+import { isAccessDenied } from "@meshweaver/react/accessError";
 import type { AreaTree, Json, UiControl } from "@meshweaver/react/core";
 
 // React.cache exists in Next's vendored server runtime (per-request memoization). Stable react
@@ -139,6 +141,16 @@ export async function fetchNodeSnapshot(
   }
 }
 
+/** Outcome of a server-side rendered-area fetch:
+ *  - `ok`     — a hydratable {areas,data} tree (seeds StaticAreaSource);
+ *  - `denied` — an RLS access denial (the caller may redirect to the node's public cover / paywall);
+ *  - `none`   — nothing seedable: older portal without the verb, render timeout, not-found, or an
+ *               unparseable body (degrade to the node-snapshot preview). */
+export type RenderedAreaResult =
+  | { kind: "ok"; tree: AreaTree }
+  | { kind: "denied" }
+  | { kind: "none" };
+
 /**
  * Fetch the node's rendered DEFAULT layout area over REST (`POST /api/mesh/render-area`) — the
  * PRIMARY SSR seed. The response is the first fully-materialised Full frame of the same
@@ -146,9 +158,10 @@ export async function fetchNodeSnapshot(
  * ships it; normalizeEntityStore folds the wire keys the same way GrpcAreaSource folds a live
  * Full frame, so the resulting tree seeds StaticAreaSource with wire fidelity.
  *
- * Returns null on ANY miss — a 404 (older portal without the verb), a 504 (portal-side render
- * timeout), the "Error: …"/"Not found: …" sentinel (e.g. an RLS denial), or an unparseable body —
- * so the caller degrades to the node-snapshot preview exactly as before.
+ * An RLS denial arrives as the HTTP-200 sentinel `"Error: Access denied…"`; this distinguishes it
+ * (`denied`) from a plain miss (`none`) so the caller can send a not-yet-enrolled visitor to the
+ * node's public cover — the same "no access ⇒ redirect here" the Blazor NamedAreaView does — instead
+ * of a dead-end shell preview.
  */
 export async function fetchRenderedArea(
   origin: string,
@@ -156,7 +169,7 @@ export async function fetchRenderedArea(
   path: string,
   area?: string,
   id?: string,
-): Promise<AreaTree | null> {
+): Promise<RenderedAreaResult> {
   try {
     const resp = await fetch(`${origin}/api/mesh/render-area`, {
       method: "POST",
@@ -164,22 +177,24 @@ export async function fetchRenderedArea(
       headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
       body: JSON.stringify({ path, ...(area ? { area } : {}), ...(id ? { id } : {}) }),
     });
-    if (!resp.ok) return null; // 404 = older portal, 504 = render timeout — degrade to preview
+    if (!resp.ok) return { kind: "none" }; // 404 = older portal, 504 = render timeout — degrade to preview
     const text = await resp.text();
-    if (text.startsWith("Error:") || text.startsWith("Not found:")) return null;
+    if (text.startsWith("Error:") || text.startsWith("Not found:")) {
+      return isAccessDenied(text) ? { kind: "denied" } : { kind: "none" };
+    }
     let parsed: Json;
     try {
       parsed = JSON.parse(text);
     } catch {
-      return null;
+      return { kind: "none" };
     }
-    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return { kind: "none" };
     const tree = normalizeEntityStore(parsed);
     // A hydratable frame must carry rendered areas; anything else is not seedable.
-    if (tree.areas == null || Object.keys(tree.areas).length === 0) return null;
-    return tree;
+    if (tree.areas == null || Object.keys(tree.areas).length === 0) return { kind: "none" };
+    return { kind: "ok", tree };
   } catch {
-    return null;
+    return { kind: "none" };
   }
 }
 
@@ -190,6 +205,11 @@ export interface AreaTarget {
   address: string;
   area: string;
   id: string;
+  /** The node's configured "if no access ⇒ redirect here" target (public cover / paywall), or null.
+   *  Populated from the resolve response's `redirectOnDenied` (the REST twin of
+   *  hub.GetRedirectOnDenied); the shell redirects a denied viewer there instead of a dead-end error,
+   *  gated by isSafeRedirect. */
+  redirectOnDenied?: string | null;
 }
 
 /** Split a resolution remainder into (area, id) — first segment is the area, the rest the id
@@ -210,7 +230,7 @@ export function splitRemainder(remainder: string | null | undefined): { area: st
  * verb is missing (older portal) or resolution fails, matching the pre-resolution behavior.
  */
 export async function fetchAreaTarget(origin: string, token: string, path: string): Promise<AreaTarget> {
-  const fallback: AreaTarget = { address: path, area: "", id: "" };
+  const fallback: AreaTarget = { address: path, area: "", id: "", redirectOnDenied: null };
   if (!path) return fallback;
   try {
     const resp = await fetch(`${origin}/api/mesh/resolve`, {
@@ -231,7 +251,9 @@ export async function fetchAreaTarget(origin: string, token: string, path: strin
     const prefix = asString(pick(parsed, "prefix"));
     if (!prefix) return fallback;
     const { area, id } = splitRemainder(asString(pick(parsed, "remainder")));
-    return { address: prefix, area, id };
+    // The node's configured paywall/cover redirect (nearest-ancestor policy), or null when none.
+    const redirectOnDenied = asString(pick(parsed, "redirectOnDenied")) ?? null;
+    return { address: prefix, area, id, redirectOnDenied };
   } catch {
     return fallback;
   }

--- a/clients/portal-next/test/redirectDecision.test.ts
+++ b/clients/portal-next/test/redirectDecision.test.ts
@@ -1,0 +1,69 @@
+// The "no access ⇒ redirect here" decision LiveArea makes — the portal-next twin of the Blazor
+// NamedAreaView redirect (combining the shared classifier + isSafeRedirect loop-guard). Pure, so it
+// is unit-tested without rendering the client boundary.
+import { describe, expect, it } from "vitest";
+import { deniedRedirectTarget } from "../src/client/live";
+
+const denialFor = (path: string) => `Access denied: user 'u' lacks Read permission on '${path}'`;
+
+describe("deniedRedirectTarget", () => {
+  it("redirects a server-detected denial to the configured cover", () => {
+    expect(
+      deniedRedirectTarget({
+        initialDenied: true,
+        address: "Course/Lesson1",
+        redirectOnDenied: "Course/Cover",
+      }),
+    ).toBe("/Course/Cover");
+  });
+
+  it("redirects a live access-denied fault to the configured cover", () => {
+    expect(
+      deniedRedirectTarget({
+        streamError: denialFor("Course/Lesson1"),
+        address: "Course/Lesson1",
+        redirectOnDenied: "Course/Cover",
+      }),
+    ).toBe("/Course/Cover");
+  });
+
+  it("normalizes a leading slash on the target to a single in-app route", () => {
+    expect(
+      deniedRedirectTarget({ initialDenied: true, address: "Course/Lesson1", redirectOnDenied: "/Course/Cover" }),
+    ).toBe("/Course/Cover");
+  });
+
+  it("does NOT redirect when denied but no target is configured (⇒ honest error)", () => {
+    expect(deniedRedirectTarget({ initialDenied: true, address: "Course/Lesson1", redirectOnDenied: null })).toBeNull();
+  });
+
+  it("does NOT redirect when the target would loop (target itself / a node under it denied)", () => {
+    expect(
+      deniedRedirectTarget({ initialDenied: true, address: "Course/Cover", redirectOnDenied: "Course/Cover" }),
+    ).toBeNull();
+    expect(
+      deniedRedirectTarget({ initialDenied: true, address: "Course/Cover/Sub", redirectOnDenied: "Course/Cover" }),
+    ).toBeNull();
+  });
+
+  it("does NOT redirect when the error is not an access denial (a plain failure / node gone)", () => {
+    expect(
+      deniedRedirectTarget({
+        streamError: "No node found at 'Course/Lesson1'.",
+        address: "Course/Lesson1",
+        redirectOnDenied: "Course/Cover",
+      }),
+    ).toBeNull();
+    expect(
+      deniedRedirectTarget({
+        streamError: "the area stream closed before delivering a snapshot",
+        address: "Course/Lesson1",
+        redirectOnDenied: "Course/Cover",
+      }),
+    ).toBeNull();
+  });
+
+  it("does NOT redirect when there is no denial at all", () => {
+    expect(deniedRedirectTarget({ address: "Course/Lesson1", redirectOnDenied: "Course/Cover" })).toBeNull();
+  });
+});

--- a/clients/portal-next/test/renderArea.test.ts
+++ b/clients/portal-next/test/renderArea.test.ts
@@ -1,7 +1,8 @@
 // The PRIMARY SSR seed: POST /api/mesh/render-area returns the first Full {areas,data} frame
 // EXACTLY as the gRPC wire delivers it ($type discriminators, JSON-encoded InstanceCollection
 // keys); fetchRenderedArea folds it with the SAME normalize the live GrpcAreaSource applies, and
-// degrades to null on every miss so the caller falls back to the node-snapshot preview.
+// returns a discriminated result: `ok` (hydratable tree), `denied` (RLS access denial ⇒ the shell
+// may redirect to the node's public cover), or `none` (any other miss ⇒ node-snapshot preview).
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchRenderedArea } from "../src/server/snapshot";
 
@@ -45,7 +46,7 @@ describe("fetchRenderedArea", () => {
   it("POSTs /api/mesh/render-area with the Bearer token and folds the wire frame", async () => {
     const spy = mockFetch(() => new Response(JSON.stringify(wireFrame), { status: 200 }));
 
-    const tree = await fetchRenderedArea("https://portal.example", "mw_abc", "ACME/Pricing");
+    const result = await fetchRenderedArea("https://portal.example", "mw_abc", "ACME/Pricing");
 
     const [url, init] = spy.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("https://portal.example/api/mesh/render-area");
@@ -55,7 +56,8 @@ describe("fetchRenderedArea", () => {
 
     // Instance keys decoded to PLAIN names (the shape StaticAreaSource / the renderer consume);
     // the $type collection marker is dropped, control $types stay wire-faithful.
-    expect(tree).not.toBeNull();
+    expect(result.kind).toBe("ok");
+    const tree = result.kind === "ok" ? result.tree : null;
     expect(Object.keys(tree!.areas!)).toEqual(["", "Overview", "Overview/1", "Overview/2"]);
     expect(tree!.areas![""]).toMatchObject({ $type: "NamedAreaControl", area: "Overview" });
     expect(tree!.areas!["Overview/2"]).toMatchObject({ $type: "MarkdownControl" });
@@ -63,39 +65,49 @@ describe("fetchRenderedArea", () => {
     expect(tree).not.toHaveProperty("$type");
   });
 
-  it("returns null on 404 — an older portal without the render-area verb (preview fallback)", async () => {
+  it("is `none` on 404 — an older portal without the render-area verb (preview fallback)", async () => {
     mockFetch(() => new Response("Not Found", { status: 404 }));
-    expect(await fetchRenderedArea("https://p", "t", "A/B")).toBeNull();
+    expect((await fetchRenderedArea("https://p", "t", "A/B")).kind).toBe("none");
   });
 
-  it("returns null on the 504 render-timeout JSON error", async () => {
+  it("is `none` on the 504 render-timeout JSON error", async () => {
     mockFetch(
       () =>
         new Response(JSON.stringify({ error: "Timed out after 30s waiting for the first full frame" }), {
           status: 504,
         }),
     );
-    expect(await fetchRenderedArea("https://p", "t", "A/B")).toBeNull();
+    expect((await fetchRenderedArea("https://p", "t", "A/B")).kind).toBe("none");
   });
 
-  it("returns null on the MeshOperations sentinel strings (RLS denial / unknown path)", async () => {
+  it("is `denied` on the RLS access-denied sentinel (so the shell can redirect to the paywall)", async () => {
     mockFetch(() => new Response("Error: Access denied", { status: 200 }));
-    expect(await fetchRenderedArea("https://p", "t", "Secret/Node")).toBeNull();
+    expect((await fetchRenderedArea("https://p", "t", "Secret/Node")).kind).toBe("denied");
 
+    mockFetch(
+      () => new Response("Error: user 'u' lacks Read permission on 'Course/Lesson'", { status: 200 }),
+    );
+    expect((await fetchRenderedArea("https://p", "t", "Course/Lesson")).kind).toBe("denied");
+  });
+
+  it("is `none` on a non-denial sentinel (unknown path / other error)", async () => {
     mockFetch(() => new Response("Not found: No/Such/Node", { status: 200 }));
-    expect(await fetchRenderedArea("https://p", "t", "No/Such/Node")).toBeNull();
+    expect((await fetchRenderedArea("https://p", "t", "No/Such/Node")).kind).toBe("none");
+
+    mockFetch(() => new Response("Error: something else broke", { status: 200 }));
+    expect((await fetchRenderedArea("https://p", "t", "A/B")).kind).toBe("none");
   });
 
-  it("returns null when the frame carries no areas (not hydratable)", async () => {
+  it("is `none` when the frame carries no areas (not hydratable)", async () => {
     mockFetch(() => new Response(JSON.stringify({ $type: "MeshWeaver.Data.EntityStore", data: {} }), { status: 200 }));
-    expect(await fetchRenderedArea("https://p", "t", "A/B")).toBeNull();
+    expect((await fetchRenderedArea("https://p", "t", "A/B")).kind).toBe("none");
   });
 
-  it("returns null on an unparseable body or network error", async () => {
+  it("is `none` on an unparseable body or network error", async () => {
     mockFetch(() => new Response("<html>proxy error</html>", { status: 200 }));
-    expect(await fetchRenderedArea("https://p", "t", "A/B")).toBeNull();
+    expect((await fetchRenderedArea("https://p", "t", "A/B")).kind).toBe("none");
 
     globalThis.fetch = vi.fn(() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch;
-    expect(await fetchRenderedArea("https://p", "t", "A/B")).toBeNull();
+    expect((await fetchRenderedArea("https://p", "t", "A/B")).kind).toBe("none");
   });
 });

--- a/clients/portal-next/test/resolveTarget.test.ts
+++ b/clients/portal-next/test/resolveTarget.test.ts
@@ -1,0 +1,66 @@
+// POST /api/mesh/resolve turns a URL path into its live-subscription target (node address + area/id)
+// AND carries the node's configured RedirectOnDenied (the REST twin of hub.GetRedirectOnDenied), so a
+// denied viewer can be redirected to the public cover instead of a dead-end error.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchAreaTarget } from "../src/server/snapshot";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+function mockFetch(handler: (url: string, init: RequestInit) => Response | Promise<Response>) {
+  const spy = vi.fn((url: string | URL | Request, init?: RequestInit) => Promise.resolve(handler(String(url), init ?? {})));
+  globalThis.fetch = spy as unknown as typeof fetch;
+  return spy;
+}
+
+describe("fetchAreaTarget", () => {
+  it("parses prefix/remainder and the redirectOnDenied hint", async () => {
+    const spy = mockFetch(
+      () =>
+        new Response(
+          JSON.stringify({ prefix: "Course/Lesson1", remainder: "Overview", redirectOnDenied: "Course/Cover" }),
+          { status: 200 },
+        ),
+    );
+
+    const target = await fetchAreaTarget("https://p", "mw_t", "Course/Lesson1/Overview");
+
+    const [url, init] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://p/api/mesh/resolve");
+    expect((init.headers as Record<string, string>).authorization).toBe("Bearer mw_t");
+    expect(target).toEqual({
+      address: "Course/Lesson1",
+      area: "Overview",
+      id: "",
+      redirectOnDenied: "Course/Cover",
+    });
+  });
+
+  it("defaults redirectOnDenied to null when the resolve response omits it", async () => {
+    mockFetch(() => new Response(JSON.stringify({ prefix: "ACME/Pricing", remainder: "" }), { status: 200 }));
+    const target = await fetchAreaTarget("https://p", "t", "ACME/Pricing");
+    expect(target).toEqual({ address: "ACME/Pricing", area: "", id: "", redirectOnDenied: null });
+  });
+
+  it("falls back to the whole path (redirectOnDenied null) on a sentinel / error / older portal", async () => {
+    mockFetch(() => new Response("Not found: No/Such/Node", { status: 200 }));
+    expect(await fetchAreaTarget("https://p", "t", "No/Such/Node")).toEqual({
+      address: "No/Such/Node",
+      area: "",
+      id: "",
+      redirectOnDenied: null,
+    });
+
+    mockFetch(() => new Response("Not Found", { status: 404 }));
+    expect(await fetchAreaTarget("https://p", "t", "A/B")).toEqual({
+      address: "A/B",
+      area: "",
+      id: "",
+      redirectOnDenied: null,
+    });
+  });
+});

--- a/clients/portal-next/test/ssr.test.tsx
+++ b/clients/portal-next/test/ssr.test.tsx
@@ -64,8 +64,9 @@ describe("server-side rendering", () => {
       Promise.resolve(new Response(JSON.stringify(wireFrame), { status: 200 })),
     ) as unknown as typeof fetch;
     try {
-      const tree = await fetchRenderedArea("https://portal.example", "mw_abc", "ACME/Pricing");
-      expect(tree).not.toBeNull();
+      const rendered = await fetchRenderedArea("https://portal.example", "mw_abc", "ACME/Pricing");
+      expect(rendered.kind).toBe("ok");
+      const tree = rendered.kind === "ok" ? rendered.tree : null;
 
       // Seed StaticAreaSource straight from the fetched frame — NO translation — and SSR it
       // through the real registry, rooted at the same "" key the live subscription uses.

--- a/clients/portal-next/test/stubs/next-navigation.ts
+++ b/clients/portal-next/test/stubs/next-navigation.ts
@@ -1,0 +1,31 @@
+// Vitest stub for `next/navigation`. The app-router hooks (useRouter, …) require Next's
+// AppRouterContext, which a bare renderToString / render in a unit test never provides — the real
+// useRouter THROWS ("expected app router to be mounted") without it. This stub returns a no-op router
+// so components that call useRouter (LiveArea's access-denied redirect) render in tests; the REAL
+// next/navigation is used at runtime (this alias lives only in vitest.config.ts, never next.config).
+export function useRouter() {
+  return {
+    push: () => {},
+    replace: () => {},
+    refresh: () => {},
+    back: () => {},
+    forward: () => {},
+    prefetch: () => {},
+  };
+}
+
+export function usePathname(): string {
+  return "/";
+}
+
+export function useSearchParams(): URLSearchParams {
+  return new URLSearchParams();
+}
+
+export function redirect(): never {
+  throw new Error("NEXT_REDIRECT");
+}
+
+export function notFound(): never {
+  throw new Error("NEXT_NOT_FOUND");
+}

--- a/clients/portal-next/tsconfig.json
+++ b/clients/portal-next/tsconfig.json
@@ -17,6 +17,7 @@
     "baseUrl": ".",
     "paths": {
       "@meshweaver/react/wire": ["../react/src/live/wire.ts"],
+      "@meshweaver/react/accessError": ["../react/src/area/accessError.ts"],
       "@meshweaver/react/styles": ["../react/src/render/meshStyles.ts"],
       "@meshweaver/react/core": ["../react/src/core.ts"],
       "@meshweaver/react": ["../react/src/index.tsx"],

--- a/clients/portal-next/vitest.config.ts
+++ b/clients/portal-next/vitest.config.ts
@@ -14,10 +14,14 @@ export default defineConfig({
     dedupe: ["react", "react-dom", "@fluentui/react-components"],
     alias: {
       "@meshweaver/react/wire": path.resolve(here, "../react/src/live/wire.ts"),
+      "@meshweaver/react/accessError": path.resolve(here, "../react/src/area/accessError.ts"),
       "@meshweaver/react/core": path.resolve(here, "../react/src/core.ts"),
       "@meshweaver/react": path.resolve(here, "../react/src/index.tsx"),
       "@meshweaver/client-web": path.resolve(here, "../grpc-web/src/index.ts"),
       "server-only": path.resolve(here, "test/stubs/server-only.ts"),
+      // The app-router hooks need Next's AppRouterContext (absent in a bare render) — stub so
+      // LiveArea (useRouter for the access-denied redirect) is unit-testable.
+      "next/navigation": path.resolve(here, "test/stubs/next-navigation.ts"),
     },
   },
   test: {

--- a/clients/react-native/src/Shell.tsx
+++ b/clients/react-native/src/Shell.tsx
@@ -16,6 +16,7 @@
 import { useEffect, useState, useSyncExternalStore, type ReactNode } from "react";
 import { View, Text, TextInput, Pressable, ScrollView, StyleSheet, useWindowDimensions } from "react-native";
 import { RenderArea, type AreaSource, type AreaTree } from "@meshweaver/react/core";
+import { areaErrorMessage } from "./areaError";
 import { type NavTarget } from "./nav";
 import { CLIENT_MENUS, ClientScreen, type ClientDestination } from "./screens";
 import { loadInstances, currentInstance, setCurrentInstance, instanceIdentity, type InstanceIdentity } from "./connection";
@@ -45,6 +46,13 @@ interface MenuItem {
 
 function useTree(source: AreaSource): AreaTree {
   return useSyncExternalStore(source.subscribe, source.getState, source.getState);
+}
+
+/** The live source's error string, reactively (set when the area subscription faults / ends before a
+ *  snapshot). Lets the shell surface a denied/gone area instead of a silent blank pane. */
+function useAreaError(source: AreaSource): string | null {
+  const read = () => source.error ?? null;
+  return useSyncExternalStore(source.subscribe, read, read);
 }
 
 function menuItems(tree: AreaTree, key: string): MenuItem[] {
@@ -334,6 +342,11 @@ function NavRow({ label, active, onPress }: { label: string; active: boolean; on
 // ── main content ────────────────────────────────────────────────────────────────
 function ContentPane({ source, nav, onNavigate }: { source: AreaSource; nav: NavTarget; onNavigate: (t: NavTarget) => void }): ReactNode {
   const styles = useSheet();
+  const tree = useTree(source);
+  const error = useAreaError(source);
+  // The requested area faulted (access denied / node gone / transient) AND delivered no content:
+  // show a classified notice instead of the silent blank column RenderArea would otherwise render.
+  const showError = error != null && tree.areas?.[nav.area] == null;
   const onClickCapture = (e: any) => {
     const anchor = e?.target?.closest?.("a");
     if (!anchor) return;
@@ -347,9 +360,24 @@ function ContentPane({ source, nav, onNavigate }: { source: AreaSource; nav: Nav
     <View style={styles.content}>
       <ScrollView style={styles.contentScroll} contentContainerStyle={styles.contentInner}>
         <View style={styles.contentColumn} {...({ onClick: onClickCapture } as any)}>
-          <RenderArea areaKey={nav.area} />
+          {showError ? <AreaErrorNotice message={error!} /> : <RenderArea areaKey={nav.area} />}
         </View>
       </ScrollView>
+    </View>
+  );
+}
+
+/** A friendly, classified notice for an area-subscription fault — the RN twin of the Blazor
+ *  NamedAreaView placeholder: a denial / gone node gets a human message, never the raw
+ *  framework diagnostic (a mobile client has no login/redirect flow, so it just informs). */
+function AreaErrorNotice({ message }: { message: string }): ReactNode {
+  const text = areaErrorMessage(message);
+  return (
+    <View
+      accessibilityRole="alert"
+      style={{ padding: 16, marginVertical: 16, borderRadius: 8, backgroundColor: "rgba(127,127,127,0.12)" }}
+    >
+      <Text style={{ fontSize: 15, lineHeight: 22 }}>{text}</Text>
     </View>
   );
 }

--- a/clients/react-native/src/areaError.test.ts
+++ b/clients/react-native/src/areaError.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { areaErrorMessage } from "./areaError";
+
+// The RN-specific mapping of a faulted area subscription to a friendly notice. The classification
+// itself is covered in @meshweaver/react (accessError.test); this pins the mobile message choice.
+describe("areaErrorMessage", () => {
+  it("is a friendly access message for a denial", () => {
+    expect(areaErrorMessage("Access denied: user 'u' lacks Read permission on 'Course/Lesson'")).toBe(
+      "You don’t have access to this view.",
+    );
+  });
+
+  it("is a graceful message for a gone node (never the raw routing diagnostic)", () => {
+    expect(
+      areaErrorMessage("No node found at 'u/_Activity/markdown-abc'. Closest ancestor is 'u' (remainder='…')."),
+    ).toBe("This view is no longer available.");
+  });
+
+  it("is a generic message for any other fault", () => {
+    expect(areaErrorMessage("the area stream closed before delivering a snapshot")).toBe(
+      "This view could not be loaded.",
+    );
+  });
+});

--- a/clients/react-native/src/areaError.ts
+++ b/clients/react-native/src/areaError.ts
@@ -1,0 +1,16 @@
+import { classifyAreaError } from "@meshweaver/react/core";
+
+/**
+ * The human message for an area-subscription fault, classified via the shared AreaErrorClassifier
+ * twin. A mobile client has no login / paywall-redirect flow, so it just informs — the RN analog of
+ * the Blazor NamedAreaView placeholder: a denial or a gone node gets a friendly message, never the
+ * raw framework diagnostic ("No node found at 'u/_Activity/…'. Closest ancestor is …").
+ */
+export function areaErrorMessage(message: string): string {
+  const info = classifyAreaError(message);
+  return info?.kind === "access-denied"
+    ? "You don’t have access to this view."
+    : info?.kind === "not-found"
+      ? "This view is no longer available."
+      : "This view could not be loaded.";
+}

--- a/clients/react/src/area/accessError.test.ts
+++ b/clients/react/src/area/accessError.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyAreaError,
+  getAccessDeniedPath,
+  isAccessDenied,
+  isNodeGone,
+  isSafeRedirect,
+} from "./accessError.js";
+
+// Mirrors test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs — the TS classifier must make the
+// SAME decisions the server AreaErrorClassifier makes, so the shells' redirect/denied behavior stays
+// 1:1 with the Blazor NamedAreaView.
+
+describe("getAccessDeniedPath", () => {
+  it.each([
+    ["Access denied: user 'roland.buergi' lacks Read permission on 'AgenticEngineering'", "AgenticEngineering"],
+    ["Access denied: user 'u' lacks Read permission on 'AgenticEngineering/Module1'", "AgenticEngineering/Module1"],
+    ["User 'u' lacks Read permission on 'DataModeling'", "DataModeling"],
+  ])("extracts the path from %s", (message, expected) => {
+    expect(getAccessDeniedPath(message)).toBe(expected);
+  });
+
+  it.each([
+    ["No node found at 'x/y'."], // routing NotFound — different banner
+    ["Validation failed for field 'name'"], // no "permission on '"
+    ["boom"],
+  ])("is null when there is no quoted permission path: %s", (message) => {
+    expect(getAccessDeniedPath(message)).toBeNull();
+  });
+
+  it("is null for null/empty", () => {
+    expect(getAccessDeniedPath(null)).toBeNull();
+    expect(getAccessDeniedPath(undefined)).toBeNull();
+    expect(getAccessDeniedPath("")).toBeNull();
+  });
+});
+
+describe("isAccessDenied", () => {
+  it.each([
+    "Access denied: user lacks Read",
+    "User 'u' lacks Read permission on 'X'",
+    "Unauthorized",
+    "Forbidden",
+  ])("is true for a denial: %s", (message) => {
+    expect(isAccessDenied(message)).toBe(true);
+  });
+
+  it.each(["No node found at 'x/y'.", "Validation failed for X", "boom", ""])(
+    "is false for non-denials: %s",
+    (message) => {
+      expect(isAccessDenied(message)).toBe(false);
+    },
+  );
+});
+
+describe("isNodeGone", () => {
+  it.each([
+    "No node found at Foo/Bar",
+    "No node found at 'rbuergi/_Activity/markdown-abc'. Closest ancestor is 'rbuergi' (remainder='_Activity/markdown-abc').",
+  ])("is true for routing NotFound: %s", (message) => {
+    expect(isNodeGone(message)).toBe(true);
+  });
+
+  it.each(["Access denied: user lacks Read", "Validation failed for X", ""])(
+    "is false for other failures: %s",
+    (message) => {
+      expect(isNodeGone(message)).toBe(false);
+    },
+  );
+});
+
+describe("isSafeRedirect (loop-guard)", () => {
+  it.each<[string | null, string | null, boolean]>([
+    // A gated node redirects to a DIFFERENT public page → safe.
+    ["AgenticEngineering/Introduction", "AgenticEngineering/Cover", true],
+    // A leading '/' on the target is ignored.
+    ["AgenticEngineering/Introduction", "/AgenticEngineering/Cover", true],
+    // The redirect TARGET itself being denied → would loop → NOT safe.
+    ["AgenticEngineering/Cover", "AgenticEngineering/Cover", false],
+    // A node UNDER the target being denied → would loop → NOT safe.
+    ["AgenticEngineering/Cover/Sub", "AgenticEngineering/Cover", false],
+    // No target configured → nothing to redirect to.
+    ["AgenticEngineering/Introduction", null, false],
+    ["AgenticEngineering/Introduction", "", false],
+    ["AgenticEngineering/Introduction", "   ", false],
+    // No denied path → nothing to redirect.
+    [null, "AgenticEngineering/Cover", false],
+  ])("isSafeRedirect(%s, %s) === %s", (deniedPath, redirectPath, expected) => {
+    expect(isSafeRedirect(deniedPath, redirectPath)).toBe(expected);
+  });
+});
+
+describe("classifyAreaError", () => {
+  it("classifies an access denial with its path", () => {
+    expect(classifyAreaError("Access denied: user 'u' lacks Read permission on 'Course/Lesson'")).toEqual({
+      message: "Access denied: user 'u' lacks Read permission on 'Course/Lesson'",
+      kind: "access-denied",
+      deniedPath: "Course/Lesson",
+    });
+  });
+
+  it("classifies a routing NotFound as not-found with no denied path", () => {
+    const info = classifyAreaError("No node found at 'x/y'.");
+    expect(info?.kind).toBe("not-found");
+    expect(info?.deniedPath).toBeNull();
+  });
+
+  it("classifies an engineering fault as other", () => {
+    expect(classifyAreaError("boom")?.kind).toBe("other");
+  });
+
+  it("is null for a null/empty message", () => {
+    expect(classifyAreaError(null)).toBeNull();
+    expect(classifyAreaError("")).toBeNull();
+  });
+});

--- a/clients/react/src/area/accessError.ts
+++ b/clients/react/src/area/accessError.ts
@@ -1,0 +1,97 @@
+// Area-subscription error classification — the TypeScript twin of the server-side
+// MeshWeaver.Layout.AreaErrorClassifier (the decisions Blazor's NamedAreaView makes on an area
+// stream fault). A layout-area subscription can fault for user reasons (access denied, node gone)
+// rather than engineering faults; a shell that just prints the raw string leaks framework-internal
+// diagnostics ("No node found at 'u/_Activity/…'. Closest ancestor is …") and — for the course
+// funnel — dead-ends a not-yet-enrolled visitor on an "Access denied" card instead of sending them
+// to the public cover. These pure predicates let every shell (portal-next, react-native) make the
+// SAME denial / redirect decisions the Blazor client makes, unit-tested without a renderer.
+//
+// Kept in sync with src/MeshWeaver.Layout/AreaErrorClassifier.cs — each predicate below has a
+// matching C# method + test (test/MeshWeaver.Layout.Test/AreaErrorClassifierTest.cs).
+
+/** What kind of user-facing failure an area error is. */
+export type AreaErrorKind = "access-denied" | "not-found" | "other";
+
+export interface AreaErrorInfo {
+  /** The raw error message (for logging / verbatim display of genuine errors). */
+  message: string;
+  kind: AreaErrorKind;
+  /** For an access-denied error: the mesh path the denial names (see getAccessDeniedPath), else null. */
+  deniedPath: string | null;
+}
+
+/**
+ * The mesh path an "Access denied" error names — the segment right after `permission on '`. Mirrors
+ * AreaErrorClassifier.TryGetAccessDeniedPath. Both denial banners put the path there:
+ *   - "Access denied: user 'u' lacks Read permission on 'AgenticEngineering'"
+ *   - "User 'u' lacks Read permission on 'AgenticEngineering/Module1'"
+ * Returns null when the message carries no such quoted path (a routing NotFound uses a different
+ * banner and is deliberately NOT matched). The marker match is case-insensitive; the extracted path
+ * keeps its original casing.
+ */
+export function getAccessDeniedPath(message: string | null | undefined): string | null {
+  if (!message) return null;
+  const marker = "permission on '";
+  const open = message.toLowerCase().lastIndexOf(marker); // marker is lowercase ASCII → indices align
+  if (open < 0) return null;
+  const start = open + marker.length;
+  const end = message.indexOf("'", start);
+  return end > start ? message.slice(start, end) : null;
+}
+
+/** True when the error is an access denial (as opposed to a not-found / validation / engineering
+ *  fault). A superset trigger for the "you don't have access" affordance; a non-null
+ *  getAccessDeniedPath implies this. */
+export function isAccessDenied(message: string | null | undefined): boolean {
+  if (!message) return false;
+  const m = message.toLowerCase();
+  return (
+    m.includes("access denied") ||
+    m.includes("unauthorized") ||
+    m.includes("forbidden") ||
+    m.includes("permission on '") ||
+    m.includes("lacks read permission") ||
+    m.includes("not allowed")
+  );
+}
+
+/** True when the failure is a routing NotFound ("No node found at …") — the "the thing you were
+ *  viewing is gone" case. Mirrors AreaErrorClassifier.IsNodeGoneNotFound; the raw diagnostic is
+ *  framework-internal and must be replaced with a graceful placeholder, never shown verbatim. */
+export function isNodeGone(message: string | null | undefined): boolean {
+  return !!message && message.trimStart().toLowerCase().startsWith("no node found");
+}
+
+/**
+ * Whether redirecting a viewer denied `deniedPath` to `redirectPath` ("if no access ⇒ redirect
+ * here") is SAFE — i.e. cannot loop. True only when a target is set AND the denied node is neither
+ * the target itself nor a node under it (redirecting the target or its subtree back to the target
+ * would bounce forever). A leading '/' on the target is ignored. Mirrors
+ * AreaErrorClassifier.IsSafeRedirect. The redirect TARGET itself comes from the node's
+ * PartitionAccessPolicy (the resolve response's `redirectOnDenied`), not from this function.
+ */
+export function isSafeRedirect(
+  deniedPath: string | null | undefined,
+  redirectPath: string | null | undefined,
+): boolean {
+  if (!deniedPath || !redirectPath || redirectPath.trim().length === 0) return false;
+  const target = redirectPath.trim().replace(/^\/+/, "");
+  if (target.length === 0) return false;
+  return deniedPath !== target && !deniedPath.startsWith(target + "/");
+}
+
+/** Classify an area error string into a user-facing kind + the denied path (if any). Returns null
+ *  for a null/empty message. The single entry point shells use to decide redirect vs. denied vs.
+ *  gone vs. generic-error rendering. */
+export function classifyAreaError(message: string | null | undefined): AreaErrorInfo | null {
+  if (!message) return null;
+  const deniedPath = getAccessDeniedPath(message);
+  const kind: AreaErrorKind =
+    deniedPath !== null || isAccessDenied(message)
+      ? "access-denied"
+      : isNodeGone(message)
+        ? "not-found"
+        : "other";
+  return { message, kind, deniedPath };
+}

--- a/clients/react/src/area/types.ts
+++ b/clients/react/src/area/types.ts
@@ -49,4 +49,9 @@ export interface AreaSource {
   getState(): AreaTree;
   subscribe(listener: () => void): () => void;
   emit(event: MeshEvent): void;
+  /** The raw error string when the subscription faulted / ended before a snapshot (access denied,
+   *  node gone, transient miss), or null/undefined while healthy. Set by GrpcAreaSource and notified
+   *  to subscribers; shells classify it via `classifyAreaError` (area/accessError). Optional so the
+   *  in-memory StaticAreaSource — which never faults — need not declare it. */
+  readonly error?: string | null;
 }

--- a/clients/react/src/core.ts
+++ b/clients/react/src/core.ts
@@ -59,6 +59,17 @@ export {
 } from "./render/embeddedArea.js";
 export { getPointer, setPointer, mergePatch, resolve, bindingPointer } from "./area/pointer.js";
 export type { AreaSource, AreaTree, UiControl, Skin, NamedArea, MeshEvent, Json } from "./area/types.js";
+// Area-error classification — the TS twin of the server AreaErrorClassifier. Shells use these to make
+// the SAME access-denied / redirect / node-gone decisions the Blazor NamedAreaView makes.
+export {
+  classifyAreaError,
+  getAccessDeniedPath,
+  isAccessDenied,
+  isNodeGone,
+  isSafeRedirect,
+  type AreaErrorInfo,
+  type AreaErrorKind,
+} from "./area/accessError.js";
 // Field/option binding + string coercion — shared by ALL leaf packs (the RN pack used to
 // re-implement these because they weren't exported from the core).
 export { str, useClick, useField, useOptions, useText, type Field } from "./controls/common.js";

--- a/clients/react/src/index.tsx
+++ b/clients/react/src/index.tsx
@@ -91,6 +91,15 @@ export {
 export { getPointer, setPointer, mergePatch, resolve } from "./area/pointer.js";
 export type { AreaSource, AreaTree, UiControl, Skin, NamedArea, MeshEvent, Json } from "./area/types.js";
 export {
+  classifyAreaError,
+  getAccessDeniedPath,
+  isAccessDenied,
+  isNodeGone,
+  isSafeRedirect,
+  type AreaErrorInfo,
+  type AreaErrorKind,
+} from "./area/accessError.js";
+export {
   useThemeMode,
   readStoredThemeMode,
   writeStoredThemeMode,

--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -1274,13 +1274,25 @@ public class MeshOperations
         return pathResolver.ResolveNavigationPath(resolvedPath)
             .Take(1)
             .Timeout(TimeSpan.FromSeconds(10))
-            .Select(resolution => resolution is null
-                ? $"Not found: {resolvedPath}"
-                : new JsonObject
-                {
-                    ["prefix"] = resolution.Prefix,
-                    ["remainder"] = resolution.Remainder,
-                }.ToJsonString())
+            .SelectMany(resolution => resolution is null
+                ? Observable.Return($"Not found: {resolvedPath}")
+                // Also surface the node's configured "if no access ⇒ redirect here" target
+                // (PartitionAccessPolicy.RedirectOnDenied — nearest ancestor wins) so a remote shell can
+                // do the SAME access-denied redirect the Blazor NamedAreaView does: a not-yet-enrolled
+                // visitor who hits a gated course lands on its public paywall / {course}/Overview instead
+                // of a dead-end "Access denied" card. Best-effort + bounded — on error/timeout the field
+                // is null and the shell falls through to the honest error. The loop-guard (IsSafeRedirect)
+                // and the navigation itself live client-side, exactly as they do in NamedAreaView.
+                : hub.GetRedirectOnDenied(resolution.Prefix)
+                    .Take(1)
+                    .Timeout(TimeSpan.FromSeconds(5))
+                    .Catch((Exception _) => Observable.Return<string?>(null))
+                    .Select(redirect => new JsonObject
+                    {
+                        ["prefix"] = resolution.Prefix,
+                        ["remainder"] = resolution.Remainder,
+                        ["redirectOnDenied"] = redirect,
+                    }.ToJsonString()))
             .Catch((Exception ex) =>
             {
                 logger.LogWarning(ex, "Resolve failed for {Path}", resolvedPath);

--- a/test/MeshWeaver.AI.Test/ResolveRedirectOnDeniedTest.cs
+++ b/test/MeshWeaver.AI.Test/ResolveRedirectOnDeniedTest.cs
@@ -8,7 +8,6 @@ using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
-using MeshWeaver.Messaging;
 using Xunit;
 
 namespace MeshWeaver.AI.Test;

--- a/test/MeshWeaver.AI.Test/ResolveRedirectOnDeniedTest.cs
+++ b/test/MeshWeaver.AI.Test/ResolveRedirectOnDeniedTest.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins that <see cref="MeshOperations.Resolve"/> (the core behind <c>POST /api/mesh/resolve</c>)
+/// surfaces the node's configured <see cref="PartitionAccessPolicy.RedirectOnDenied"/> as a
+/// <c>redirectOnDenied</c> field. This is the REST twin of <c>hub.GetRedirectOnDenied(path)</c>: it
+/// lets a remote shell (portal-next / react-native) do the SAME "no access ⇒ redirect here"
+/// navigation the Blazor <c>NamedAreaView</c> does — a not-yet-enrolled visitor who hits a gated
+/// course lands on its public cover instead of a dead-end "Access denied" card. The loop-guard
+/// (<c>IsSafeRedirect</c>) and the navigation itself live client-side.
+/// </summary>
+public class ResolveRedirectOnDeniedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    // Real RLS (ConfigureMeshBase) with NO PublicAdminAccess grant — the redirect hint must resolve
+    // from the partition policy regardless of the caller's own permissions, exactly as it does for a
+    // denied viewer in the GUI.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            // A resolvable course node…
+            .AddMeshNodes(
+                new MeshNode("RedirectCourse")
+                {
+                    Name = "Redirect Course",
+                    NodeType = "Markdown",
+                    Content = new MarkdownContent { Content = "# course" }
+                },
+                // …whose partition policy configures the public cover to redirect denied visitors to.
+                new MeshNode("_Policy", "RedirectCourse")
+                {
+                    NodeType = SecurityCollections.PartitionAccessPolicyNodeType,
+                    Content = new PartitionAccessPolicy { RedirectOnDenied = "RedirectCourse/Cover" }
+                },
+                // A plain node under no ancestor policy — its redirect hint must be null.
+                new MeshNode("PlainNode")
+                {
+                    Name = "Plain Node",
+                    NodeType = "Markdown",
+                    Content = new MarkdownContent { Content = "# plain" }
+                });
+
+    private static CancellationToken Ct => new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token;
+
+    [Fact(Timeout = 60000)]
+    public async Task Resolve_IncludesConfiguredRedirectOnDenied()
+    {
+        var json = await new MeshOperations(Mesh)
+            .Resolve("@RedirectCourse")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        root.GetProperty("prefix").GetString().Should().Be("RedirectCourse");
+        root.GetProperty("redirectOnDenied").GetString().Should().Be("RedirectCourse/Cover",
+            "the resolve response must carry the node's PartitionAccessPolicy.RedirectOnDenied so a remote "
+            + "shell can redirect a denied viewer to the public cover, exactly like the Blazor NamedAreaView");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Resolve_RedirectOnDenied_IsNull_WhenNoPolicyConfigured()
+    {
+        var json = await new MeshOperations(Mesh)
+            .Resolve("@PlainNode")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(45)).ToTask(Ct);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        root.GetProperty("prefix").GetString().Should().Be("PlainNode");
+        // Present-but-null (not a missing field) so the shell can read it unconditionally and fall
+        // through to the honest access-denied when no redirect is configured.
+        root.GetProperty("redirectOnDenied").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+}


### PR DESCRIPTION
## Why

The JS clients (`portal-next`, `react-native`, shared `@meshweaver/react`) were last synced with Blazor on **2026-07-12** (`c66fa267f`, a "Blazor parity" pass). Every UI-facing feature that landed afterwards was Blazor-only. Most of it auto-inherits because MeshWeaver is server-driven UI (a layout area is a `UiControl` tree the renderer interprets) — e.g. the data-driven home tabs (`TabsControl` + `MeshSearchControl`) and the doc `@@content` embeds. The one thing that **doesn't** inherit is shell-level access-control behavior, which isn't in the control tree.

This PR brings the **access-denied → configurable redirect** ("no access ⇒ redirect here" — the course-funnel paywall / `{course}/Overview` redirect the Blazor `NamedAreaView` performs) to parity.

## What

**Shared `@meshweaver/react`**
- `area/accessError.ts` — the TS twin of `AreaErrorClassifier`: `getAccessDeniedPath`, `isAccessDenied`, `isNodeGone`, `isSafeRedirect`, `classifyAreaError`. Exported from `core` + `index`, unit-tested 1:1 with `AreaErrorClassifierTest.cs`.
- `AreaSource` gains an optional `error` field (already set by `GrpcAreaSource`) so a shell can read/classify a faulted subscription.

**Server (one additive REST field — read-only, still authorized, no auth-posture change)**
- `MeshOperations.Resolve` now also returns `redirectOnDenied` (= `hub.GetRedirectOnDenied(prefix)`) — the REST twin of the in-process lookup `NamedAreaView` reads. New test `ResolveRedirectOnDeniedTest`.

**portal-next**
- A denied visitor — server-detected on first paint (`initialDenied`) **or** a live access-denied fault mid-session — is redirected to the node's public cover / paywall when its policy safely configures one (`isSafeRedirect` loop-guard), via the basePath-aware app router.
- `fetchRenderedArea` returns a discriminated `{ok|denied|none}`; `fetchAreaTarget` carries `redirectOnDenied` through.
- `/login` redirects now preserve `returnUrl`.
- The area-error bar is classified (friendly denied / graceful "no longer available" / verbatim), no longer leaking raw framework diagnostics.

**react-native (light)**
- A faulted area shows a classified notice instead of a blank pane. Mobile has no login/redirect flow, so it just informs.

## Deliberately NOT included (a security decision, not maintenance)

Rendering explicitly **Anonymous**-granted public pages (course covers) for logged-out visitors would require minting anonymous tokens or opening `/api/mesh` to unauthenticated callers — a change to the portal's API **auth posture**. Left out for a separate decision. portal-next still sends every anonymous visitor to `/login` first (login-first, matching Blazor); the paywall applies to the then-authenticated visitor.

## Verification (all green locally)

| Package | Typecheck | Tests | Build |
|---|---|---|---|
| C# (`MeshWeaver.AI` + `.Test`) | — | `ResolveRedirectOnDeniedTest` 2/2 | Release/`-warnaserror` ✓ |
| `@meshweaver/react` | ✓ | 191/191 | — |
| `portal-next` | ✓ | 63/63 | `next build` ✓ |
| `react-native` | ✓ | 58/58 | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
