### PR TITLE
feat(portal): chrome-less marketing pages + anonymous minimal top bar

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
+++ b/src/MeshWeaver.Blazor.Portal/Layout/PortalLayoutBase.razor
@@ -17,6 +17,26 @@
 
     @if (ViewportInformation.IsDesktop)
     {
+        @* Anonymous mode is a MARKETING surface: no menu bar chrome — just the logo, the
+           public Store entry, and Login. Everything else (search, node/mesh/AI menus, theme,
+           notifications, side panel) is authenticated-only. *@
+        <AuthorizeView>
+        <NotAuthorized>
+        <FluentHeader>
+            <FluentAnchor Appearance="Appearance.Stealth" Href="/" Class="logo">
+                MESHWEAVER
+            </FluentAnchor>
+            <div class="links">
+                <FluentAnchor Appearance="Appearance.Stealth" Href="/Store" Class="store-link"
+                              title="Store — browse plugins and courses" aria-label="Store — browse plugins and courses">
+                    <FluentIcon Value="@(new Icons.Regular.Size20.BuildingShop())" Slot="start" />
+                    Store
+                </FluentAnchor>
+            </div>
+            <UserProfile />
+        </FluentHeader>
+        </NotAuthorized>
+        <Authorized Context="authState">
         <FluentHeader>
             <FluentAnchor Appearance="Appearance.Stealth" Href="/" Class="logo">
                 MESHWEAVER
@@ -224,6 +244,8 @@
         </FluentHeader>
 
         @DesktopNavMenu
+        </Authorized>
+        </AuthorizeView>
     }
     else
     {
@@ -231,13 +253,21 @@
             <FluentSpacer />
 
             <UserProfile />
-            <FluentButton
-                IconEnd="@(IsNavMenuOpen ? new Icons.Regular.Size24.Dismiss() : new Icons.Regular.Size24.Navigation())"
-                Title="Menu" Appearance="Appearance.Stealth" BackgroundColor="transparent"
-                OnClick="@ToggleNavMenu" Class="navigation-button" />
+            <AuthorizeView>
+                <Authorized>
+                    <FluentButton
+                        IconEnd="@(IsNavMenuOpen ? new Icons.Regular.Size24.Dismiss() : new Icons.Regular.Size24.Navigation())"
+                        Title="Menu" Appearance="Appearance.Stealth" BackgroundColor="transparent"
+                        OnClick="@ToggleNavMenu" Class="navigation-button" />
+                </Authorized>
+            </AuthorizeView>
         </FluentHeader>
 
-        @MobileNavMenu
+        <AuthorizeView>
+            <Authorized>
+                @MobileNavMenu
+            </Authorized>
+        </AuthorizeView>
     }
 
     @* Chrome-level breadcrumb trail — rendered on EVERY page, desktop AND mobile (present mode

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -328,6 +328,11 @@ public static class MeshNodeLayoutAreas
     /// </summary>
     internal static UiControl BuildHeader(LayoutAreaHost host, MeshNode? node, bool canEdit = true)
     {
+        // Chrome-less pages: a node excluded from the "header" context ships without the
+        // icon/title/meta block — the content (a marketing hero, a landing page) starts
+        // immediately. One mechanism, reused from MeshNodeVisibility — no parallel flag.
+        if (node?.IsExcludedFromContext(MeshNodeVisibility.HeaderContext) == true)
+            return Controls.Stack;
         var hubPath = host.Hub.Address.ToString();
         var nodePath = node?.Path ?? hubPath;
         var title = node?.Name ?? node?.Id ?? hubPath;

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
@@ -211,6 +211,9 @@ public partial class MarkdownFileParser : IFileFormatParser
             Icon = ResolveIcon(frontMatter?.Icon ?? frontMatter?.Thumbnail, ns),
             State = ParseState(frontMatter?.State),
             Order = frontMatter?.Order,
+            ExcludeFromContext = frontMatter?.ExcludeFromContext is { Count: > 0 } excluded
+                ? excluded
+                : null,
             LastModified = lastModified,
             Content = nodeContent,
             PreRenderedHtml = markdownDocument.PrerenderedHtml
@@ -255,7 +258,10 @@ public partial class MarkdownFileParser : IFileFormatParser
             Abstract = mdContent?.Abstract ?? node.Description,
             Order = node.Order,
             Notes = slideNotes,
-            Background = slideBackground
+            Background = slideBackground,
+            ExcludeFromContext = node.ExcludeFromContext is { Count: > 0 } excluded
+                ? excluded.ToList()
+                : null
         };
 
         // Only write YAML block if there's meaningful content
@@ -270,7 +276,8 @@ public partial class MarkdownFileParser : IFileFormatParser
                             frontMatter.Abstract != null ||
                             frontMatter.Order != null ||
                             frontMatter.Notes != null ||
-                            frontMatter.Background != null;
+                            frontMatter.Background != null ||
+                            frontMatter.ExcludeFromContext?.Count > 0;
 
         if (hasYamlContent)
         {
@@ -513,6 +520,12 @@ public partial class MarkdownFileParser : IFileFormatParser
         public int? Order { get; set; }
         public string? Notes { get; set; }
         public string? Background { get; set; }
+
+        // Context opt-outs, 1:1 with MeshNode.ExcludeFromContext — e.g.
+        // `ExcludeFromContext: [header]` ships a chrome-less marketing page (no
+        // icon/title/meta header). Declared after the earlier keys for byte-stable
+        // serialization of files that don't carry it.
+        public List<string>? ExcludeFromContext { get; set; }
 
         // Legacy aliases. YamlDotNet doesn't follow C# property hierarchy, so we
         // expose them as plain settable properties and fold them in below

--- a/src/MeshWeaver.Mesh.Contract/MeshNode.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNode.cs
@@ -464,6 +464,13 @@ public static class MeshNodeVisibility
     public const string SearchContext = "search";
 
     /// <summary>
+    /// The page-header context: a node excluded from it renders WITHOUT the standard
+    /// icon/title/meta header block — its content starts immediately (marketing covers,
+    /// landing pages). Shipped via markdown frontmatter <c>ExcludeFromContext: [header]</c>.
+    /// </summary>
+    public const string HeaderContext = "header";
+
+    /// <summary>
     /// True when <paramref name="path"/> has any segment starting with <c>'_'</c> — a
     /// hidden/system ("dotfile") path. Empty/null is not hidden.
     /// </summary>

--- a/test/MeshWeaver.Content.Test/MarkdownFileParserTest.cs
+++ b/test/MeshWeaver.Content.Test/MarkdownFileParserTest.cs
@@ -68,6 +68,38 @@ public class MarkdownFileParserTest
     }
 
     [Fact(Timeout = 20000)]
+    public void Parse_ExcludeFromContext_RoundTrips()
+    {
+        // A marketing/landing page ships chrome-less: `ExcludeFromContext: [header]`
+        // maps 1:1 onto MeshNode.ExcludeFromContext (the ONE visibility mechanism —
+        // no parallel HideHeader flag) and must survive the serialize round-trip.
+        var content = """
+            ---
+            Name: Landing
+            ExcludeFromContext:
+              - header
+            ---
+
+            Full-bleed hero starts here.
+            """;
+
+        var node = _parser.Parse("/test/landing.md", content, "test/landing.md");
+
+        node.Should().NotBeNull();
+        node!.ExcludeFromContext.Should().BeEquivalentTo(new[] { "header" }, System.Text.Json.JsonSerializerOptions.Default);
+        node.IsExcludedFromContext(MeshNodeVisibility.HeaderContext).Should().BeTrue();
+
+        var serialized = _parser.Serialize(node);
+        serialized.Should().Contain("ExcludeFromContext:");
+        serialized.Should().Contain("header");
+
+        // And a node without the opt-out never emits the key.
+        var plain = _parser.Parse("/test/plain.md", "Just text.", "test/plain.md");
+        plain!.ExcludeFromContext.Should().BeNull();
+        _parser.Serialize(plain).Should().NotContain("ExcludeFromContext");
+    }
+
+    [Fact(Timeout = 20000)]
     public void Parse_WithMinimalYaml_UsesDefaults()
     {
         // Arrange

--- a/test/MeshWeaver.Hosting.Monolith.Test/OverviewHeaderRenderTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/OverviewHeaderRenderTest.cs
@@ -52,6 +52,43 @@ public class OverviewHeaderRenderTest(ITestOutputHelper output) : MonolithMeshTe
     }
 
     /// <summary>
+    /// A node excluded from the "header" context renders its Overview WITHOUT the
+    /// icon/title/meta header block — the chrome-less marketing-page contract
+    /// (shipped via frontmatter <c>ExcludeFromContext: [header]</c>). The rendered
+    /// store must not carry the title H1 or the "Type:" meta row, while the page
+    /// itself still renders.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Overview_OmitsHeader_ForHeaderExcludedNode()
+    {
+        var nodePath = $"{TestPartition}/chromeless-smoke";
+        await NodeFactory.CreateNode(
+            new MeshNode("chromeless-smoke", TestPartition)
+            {
+                Name = "ChromelessSmokeTitle",
+                NodeType = "Markdown",
+                ExcludeFromContext = [MeshNodeVisibility.HeaderContext],
+            }).Should().Emit();
+
+        var client = GetClient(c => c.AddData(data => data));
+        var address = new Address(nodePath);
+        await client.Observe(new PingRequest(), o => o.WithTarget(address)).Should().Emit();
+
+        var workspace = client.GetWorkspace();
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            address, new LayoutAreaReference(MeshNodeLayoutAreas.OverviewArea));
+
+        var value = await stream.Should().Within(20.Seconds()).Emit();
+        value.Value.ValueKind.Should().NotBe(JsonValueKind.Undefined,
+            "the chrome-less Overview must still render its content");
+        var rendered = value.Value.GetRawText();
+        rendered.Should().NotContain("ChromelessSmokeTitle",
+            "the header title must not render for a header-excluded node");
+        rendered.Should().NotContain("Type:",
+            "the header meta row must not render for a header-excluded node");
+    }
+
+    /// <summary>
     /// The Delete area renders a confirmation page with the progress banner wired to a
     /// local data stream. Before this test existed, a missing <c>using</c> directive on
     /// <c>Address</c> / <c>IMessageDelivery</c> could silently break the page.


### PR DESCRIPTION
Marketing pages (e.g. `/UWDeepfield/Overview`) must open straight with their hero — no icon/title/`Type: … Updated: …` header — and anonymous visitors should get a marketing surface, not app chrome.

## One mechanism, no competing concepts
- `MeshNode.ExcludeFromContext` (the existing visibility set) gains the well-known **`header`** context (`MeshNodeVisibility.HeaderContext`). `MeshNodeLayoutAreas.BuildHeader` returns an empty control for excluded nodes — all ~10 layout areas that compose the header inherit it with zero call-site changes. No new node field, no schema change, no parallel HideHeader flag.
- Shippable from the repo: `ExcludeFromContext: [header]` in markdown frontmatter, mapped **symmetrically** in `MarkdownFileParser` (parse + serialize + emit-gate) — appended after existing keys so untouched files keep byte-identical frontmatter.
- `node.icon` remains the single icon source (catalog/search cards unaffected by the hidden header).

## Anonymous minimal top bar
- Desktop: anonymous renders **logo + Store + Login** only — search, node/mesh/AI menus, theme toggle, notifications and the side panel are authenticated-only. (The storefront must stay reachable anonymously; dropping the slim bar entirely would orphan it.)
- Mobile: hamburger + nav menu authenticated-only; anonymous gets Login.

## Verification
- `Parse_ExcludeFromContext_RoundTrips` (frontmatter → node → frontmatter; absent-key stability).
- `Overview_OmitsHeader_ForHeaderExcludedNode` — renders, but without the title or `Type:` meta (fails without the BuildHeader gate).
- `OverviewHeaderRenderTest` 5/5; `dotnet build -c Release -warnaserror` clean on touched projects.

Content follow-up after deploy: the marketing pages in the plugin repos get `ExcludeFromContext: [header]` + proper inline-SVG icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)