### PR TITLE
fix(parser): namespaced Slide node types round-trip Notes/Background

### DIFF
--- a/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
@@ -189,7 +189,7 @@ public partial class MarkdownFileParser : IFileFormatParser
         // + stage background) so a git reimport no longer downgrades Slide →
         // MarkdownContent — the slide views read SlideContent, and a MarkdownContent
         // payload would render an empty stage.
-        object nodeContent = nodeType == SlideNodeType.NodeType
+        object nodeContent = IsSlideNodeType(nodeType)
             ? new SlideContent
             {
                 Content = markdownContent,
@@ -222,6 +222,17 @@ public partial class MarkdownFileParser : IFileFormatParser
         return node;
     }
 
+    /// <summary>
+    /// A slide file may carry the built-in <c>Slide</c> node type or a plugin-namespaced
+    /// variant (e.g. <c>Slides/Slide</c> from the Slides store plugin). Both must build
+    /// SlideContent and round-trip Notes/Background: matching only the bare constant let
+    /// a namespaced slide degrade to MarkdownContent on import, and the next mesh→repo
+    /// export then dropped its Notes/Background frontmatter entirely.
+    /// </summary>
+    private static bool IsSlideNodeType(string? nodeType) =>
+        nodeType == SlideNodeType.NodeType
+        || nodeType?.EndsWith("/" + SlideNodeType.NodeType, StringComparison.Ordinal) == true;
+
     /// <inheritdoc />
     public string Serialize(MeshNode node)
     {
@@ -237,7 +248,7 @@ public partial class MarkdownFileParser : IFileFormatParser
         var (slideNotes, slideBackground) = node.Content switch
         {
             SlideContent slide => (NullIfEmpty(slide.Notes), NullIfEmpty(slide.Background)),
-            System.Text.Json.JsonElement je when node.NodeType == SlideNodeType.NodeType =>
+            System.Text.Json.JsonElement je when IsSlideNodeType(node.NodeType) =>
                 (ExtractStringProperty(je, "notes"), ExtractStringProperty(je, "background")),
             _ => (null, null)
         };

--- a/test/MeshWeaver.Content.Test/MarkdownFileParserTest.cs
+++ b/test/MeshWeaver.Content.Test/MarkdownFileParserTest.cs
@@ -527,6 +527,65 @@ public class MarkdownFileParserTest
     }
 
     [Fact(Timeout = 20000)]
+    public void Parse_NamespacedSlideNode_BuildsSlideContent_AndRoundTrips()
+    {
+        // Arrange - a plugin-namespaced slide file exactly as the education repo ships
+        // it (NodeType Slides/Slide). Matching only the bare "Slide" constant degraded
+        // these to MarkdownContent, and the next mesh→repo export dropped their
+        // Notes/Background frontmatter from git.
+        var raw = """
+            ---
+            NodeType: Slides/Slide
+            Name: After a while
+            Order: 4
+            Notes: Pause here. This is the payoff of the daily pages.
+            Background: linear-gradient(135deg,#0b1d3a,#0655bf)
+            ---
+
+            # After a while
+            """;
+
+        // Act
+        var parsed = _parser.Parse("/root/deck/S04.md", raw, "deck/S04.md");
+        var serialized = _parser.Serialize(parsed!);
+
+        // Assert - the namespaced type keeps its typed SlideContent ...
+        parsed!.NodeType.Should().Be("Slides/Slide");
+        var slide = parsed.Content.Should().BeOfType<SlideContent>().Subject;
+        slide.Notes.Should().Be("Pause here. This is the payoff of the daily pages.");
+        slide.Background.Should().Be("linear-gradient(135deg,#0b1d3a,#0655bf)");
+
+        // ... and the export re-emits the frontmatter instead of destroying it
+        serialized.Should().Contain("NodeType: Slides/Slide");
+        serialized.Should().Contain("Notes: Pause here. This is the payoff of the daily pages.");
+        serialized.Should().Contain("Background: linear-gradient(135deg,#0b1d3a,#0655bf)");
+    }
+
+    [Fact(Timeout = 20000)]
+    public void Serialize_NamespacedSlideNode_WithJsonElementContent_EmitsNotesAndBackground()
+    {
+        // Arrange - untyped wire form of a namespaced slide (hub without typed registry)
+        var json = """
+            {"$type":"SlideContent","content":"# Body","notes":"A note.","background":"#0b1d3a"}
+            """;
+        var node = new MeshNode("S05", "deck")
+        {
+            NodeType = "Slides/Slide",
+            Name = "S05",
+            Content = System.Text.Json.JsonDocument.Parse(json).RootElement
+        };
+
+        // Act
+        var serialized = _parser.Serialize(node);
+
+        // Assert
+        serialized.Should().Contain("NodeType: Slides/Slide");
+        serialized.Should().Contain("Notes: A note.");
+        serialized.Should().Contain("Background:").And.Contain("#0b1d3a");
+        serialized.Should().Contain("# Body");
+    }
+
+    [Fact(Timeout = 20000)]
     public void RoundTrip_OrderedMarkdownNode_PreservesOrder()
     {
         // Arrange - Order applies to ANY node type (lesson/module ordering)


### PR DESCRIPTION
`MarkdownFileParser` compared node types against the bare `SlideNodeType.NodeType` (`"Slide"`) only. The Slides store plugin ships slides as `Slides/Slide`, so those files:

1. degraded to `MarkdownContent` on git import (Notes/Background discarded — the live memex-cloud Training slides show `MarkdownContent` today), and
2. on the next mesh→repo export, `Serialize` fell through its SlideContent/JsonElement cases and **destroyed the `Notes:`/`Background:` frontmatter in git** — the 2026-07-18 education bot commit (`07c4d90`) stripped 86 lines (64 presenter notes, all 22 stage backgrounds) exactly this way.

Fix: `IsSlideNodeType()` accepts the bare constant and any `{ns}/Slide` variant, used at both sites (Parse content construction + Serialize JsonElement extraction). New tests pin the namespaced `.md` round-trip and the untyped JsonElement wire form.

Content restoration (the stripped lines, from `07c4d90^`) is education PR Systemorph/education#18 — this parser fix must deploy before the next mesh→repo export of that course, or the export strips them again.

Local gate: `dotnet build -c Release -warnaserror` on MeshWeaver.Hosting + Content.Test green; `MarkdownFileParserTest` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)