### PR TITLE
deploy: Kimi-K2.6 in the AzureFoundry model list

### DIFF
--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -129,6 +129,10 @@ config:
     AzureFoundry__Models__0: "DeepSeek-V4-Pro"
     AzureFoundry__Models__1: "DeepSeek-V3-0324"
     AzureFoundry__Models__2: "DeepSeek-V4-Flash"
+    # MoonshotAI Kimi — newest general Kimi on the s-meshweaver Foundry account
+    # (no K3 in the catalog as of 2026-07; K2.7-Code exists for code-heavy use).
+    # Deployment cap 20K TPM = the account's full Kimi-K2.6 quota.
+    AzureFoundry__Models__3: "Kimi-K2.6"
     # Tier → model (h/m/l + utility). Open-weight DeepSeek ladder, all deployed on
     # s-meshweaver. Claude works very well but costs more — it's NOT wired via Helm
     # here; add it node-based later and pin per-agent via PreferredModel when worth it.


### PR DESCRIPTION
Mirrors the live memex-cloud configmap patch (`AzureFoundry__Models__3: Kimi-K2.6` + rollout restart, 2026-07-19) into `values.aks.yaml` so the next `helm upgrade` keeps it.

Context: no **Kimi K3** exists in the Azure Foundry catalog — newest MoonshotAI entries are K2.5, K2.6 (2026-04-20) and K2.7-Code (2026-06-12). `Kimi-K2.6` was already deployed on `s-meshweaver` (GlobalStandard, cap 20 = the subscription's entire 20K-TPM quota for that model; a raise goes through the Azure quota blade). Smoke-tested: chat completion HTTP 200 (reasoning model — emits `reasoning_content`).

Note while here: `AzureFoundry__Models__1: DeepSeek-V3-0324` is a known deprecated 410 ghost — left untouched, separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)