### PR TITLE
fix(pg): persist MeshNode.ExcludeFromContext

### DIFF
--- a/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
+++ b/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
@@ -54,6 +54,7 @@ public static class MigrationRegistry
         new V43_FixAccessTriggerSchemaResolutionAndBackfill(),
         new V44_FixMeshNodeHistoryTriggerPerSchema(),
         new V45_AddNodeAuthorshipColumns(),
+        new V46_AddExcludeFromContextColumn(),
     ];
 
     /// <summary>

--- a/memex/aspire/Memex.Database.Migration/Migrations/V46_AddExcludeFromContextColumn.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V46_AddExcludeFromContextColumn.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Database.Migration.Migrations;
+
+/// <summary>
+/// Adds the <c>exclude_from_context</c> column to every partition's <c>mesh_nodes</c>.
+///
+/// <para><b>Background.</b> <c>MeshNode.ExcludeFromContext</c> carries the instance-level
+/// context opt-outs (<c>"header"</c> for chrome-less marketing pages, <c>"search"</c>,
+/// <c>"create"</c> — see <c>MeshNodeVisibility</c>), but the Postgres <c>mesh_nodes</c> table
+/// never had a column for it and the adapter never wrote/read it — so on every PG-backed mesh
+/// the field silently round-tripped as NULL: imported brochures kept rendering the node header
+/// and instance-level search/create exclusions never applied. Same defect class as the V45
+/// authorship columns; the adapter (same change set) now persists and hydrates the column.</para>
+///
+/// <para><b>Steps per partition schema (idempotent):</b> <c>ALTER TABLE … ADD COLUMN IF NOT
+/// EXISTS exclude_from_context TEXT[]</c>. History tables are untouched — the opt-out is
+/// current-state metadata, not versioned content. No backfill: the field was never captured;
+/// values populate on the first write (e.g. a forced GitSync re-import) after the fix.</para>
+/// </summary>
+public sealed class V46_AddExcludeFromContextColumn : IMigration
+{
+    public int Version => 46;
+    public string Description => "Add exclude_from_context TEXT[] to mesh_nodes on every partition schema (PG dropped MeshNode.ExcludeFromContext on write)";
+
+    public async Task RunAsync(MigrationContext ctx)
+    {
+        var schemas = new List<string>();
+        await using (var discover = ctx.DataSource.CreateCommand("""
+            SELECT table_schema
+            FROM information_schema.tables
+            WHERE table_name = 'mesh_nodes'
+              AND table_schema NOT IN ('information_schema','pg_catalog','pg_toast')
+              AND table_schema NOT LIKE '%\_versions'
+            ORDER BY table_schema
+            """))
+        await using (var rdr = await discover.ExecuteReaderAsync())
+        {
+            while (await rdr.ReadAsync())
+                schemas.Add(rdr.GetString(0));
+        }
+
+        foreach (var schema in schemas)
+        {
+            var quotedSchema = "\"" + schema.Replace("\"", "\"\"") + "\"";
+            await using var alter = ctx.DataSource.CreateCommand($"""
+                ALTER TABLE {quotedSchema}.mesh_nodes
+                    ADD COLUMN IF NOT EXISTS exclude_from_context TEXT[]
+                """);
+            await alter.ExecuteNonQueryAsync();
+        }
+
+        ctx.Logger.LogInformation(
+            "Repair v46: done — {Count} partition schema(s) now persist MeshNode.ExcludeFromContext", schemas.Count);
+    }
+}

--- a/src/MeshWeaver.Hosting.PostgreSql/PgMeshNodeReader.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PgMeshNodeReader.cs
@@ -46,6 +46,25 @@ internal static class PgMeshNodeReader
     }
 
     /// <summary>
+    /// Reads a nullable <c>text[]</c> column by name, or null when the column is absent from
+    /// the result set or NULL/empty. Defensive like <see cref="ReadNullableString"/> — used for
+    /// <c>exclude_from_context</c> so SELECTs predating the column keep working.
+    /// </summary>
+    internal static string[]? ReadStringArray(NpgsqlDataReader reader, string column)
+    {
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            if (!string.Equals(reader.GetName(i), column, StringComparison.Ordinal))
+                continue;
+            if (reader.IsDBNull(i))
+                return null;
+            var value = reader.GetFieldValue<string[]>(i);
+            return value.Length > 0 ? value : null;
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Reads a nullable timestamptz column by name as a UTC <see cref="DateTimeOffset"/>, or
     /// null when absent/NULL. Used for <c>created_date</c>; mirrors how the adapter reads
     /// <c>last_modified</c> (<c>new DateTimeOffset(GetDateTime(), TimeSpan.Zero)</c>).

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlCrossSchemaQueryProvider.cs
@@ -431,6 +431,7 @@ public class PostgreSqlCrossSchemaQueryProvider : ICrossSchemaQueryProvider
             Version = reader.GetInt64(reader.GetOrdinal("version")),
             State = (MeshNodeState)reader.GetInt16(reader.GetOrdinal("state")),
             SyncBehavior = PgMeshNodeReader.ReadSyncBehavior(reader),
+            ExcludeFromContext = PgMeshNodeReader.ReadStringArray(reader, "exclude_from_context"),
             Content = content,
             DesiredId = reader.IsDBNull(reader.GetOrdinal("desired_id")) ? null : reader.GetString(reader.GetOrdinal("desired_id")),
             MainNode = reader.IsDBNull(reader.GetOrdinal("main_node"))

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
@@ -1004,6 +1004,9 @@ public static class PostgreSqlSchemaInitializer
                 -- 2=ExcludeThisAndChildren). Persists the "Not synced" decouple so an
                 -- admin-claimed node/partition survives restart + the next import.
                 sync_behavior   SMALLINT    NOT NULL DEFAULT 0,
+                -- instance-level context opt-outs ("header", "search", "create") --
+                -- MeshNode.ExcludeFromContext; NULL = visible everywhere.
+                exclude_from_context TEXT[],
                 content         JSONB,
                 desired_id      TEXT,
                 main_node       TEXT,
@@ -1336,6 +1339,9 @@ public static class PostgreSqlSchemaInitializer
                 -- 2=ExcludeThisAndChildren). Persists the "Not synced" decouple so an
                 -- admin-claimed node/partition survives restart + the next import.
                 sync_behavior   SMALLINT    NOT NULL DEFAULT 0,
+                -- instance-level context opt-outs ("header", "search", "create") --
+                -- MeshNode.ExcludeFromContext; NULL = visible everywhere.
+                exclude_from_context TEXT[],
                 content         JSONB,
                 desired_id      TEXT,
                 main_node       TEXT,
@@ -1721,6 +1727,9 @@ public static class PostgreSqlSchemaInitializer
                 -- 2=ExcludeThisAndChildren). Persists the "Not synced" decouple so an
                 -- admin-claimed node/partition survives restart + the next import.
                 sync_behavior   SMALLINT    NOT NULL DEFAULT 0,
+                -- instance-level context opt-outs ("header", "search", "create") --
+                -- MeshNode.ExcludeFromContext; NULL = visible everywhere.
+                exclude_from_context TEXT[],
                 content         JSONB,
                 desired_id      TEXT,
                 main_node       TEXT,
@@ -2059,6 +2068,9 @@ public static class PostgreSqlSchemaInitializer
                 -- 2=ExcludeThisAndChildren). Persists the "Not synced" decouple so an
                 -- admin-claimed node/partition survives restart + the next import.
                 sync_behavior   SMALLINT    NOT NULL DEFAULT 0,
+                -- instance-level context opt-outs ("header", "search", "create") --
+                -- MeshNode.ExcludeFromContext; NULL = visible everywhere.
+                exclude_from_context TEXT[],
                 content         JSONB,
                 desired_id      TEXT,
                 main_node       TEXT,
@@ -2441,6 +2453,9 @@ public static class PostgreSqlSchemaInitializer
                 -- 2=ExcludeThisAndChildren). Persists the "Not synced" decouple so an
                 -- admin-claimed node/partition survives restart + the next import.
                 sync_behavior   SMALLINT    NOT NULL DEFAULT 0,
+                -- instance-level context opt-outs ("header", "search", "create") --
+                -- MeshNode.ExcludeFromContext; NULL = visible everywhere.
+                exclude_from_context TEXT[],
                 content         JSONB,
                 desired_id      TEXT,
                 main_node       TEXT,

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSqlGenerator.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSqlGenerator.cs
@@ -220,6 +220,15 @@ public class PostgreSqlSqlGenerator
             ? "n.sync_behavior"
             : "0::smallint AS sync_behavior";
 
+    // exclude_from_context lives only on mesh_nodes (like sync_behavior). Omitting it here
+    // strips the instance-level context opt-outs ("header"/"search"/"create") from every
+    // QUERY-served node — and the MeshNodeStreamCache hydrates cold nodes through this path,
+    // so the header gate saw null even though the adapter's direct Read mapped the column.
+    private static string ExcludeFromContextColumn(string tableName) =>
+        tableName.Contains("mesh_nodes", StringComparison.OrdinalIgnoreCase)
+            ? "n.exclude_from_context"
+            : "NULL::text[] AS exclude_from_context";
+
     /// <summary>
     /// Builds a complete <c>SELECT</c> statement (columns, optional activity/user-activity joins,
     /// scope, order, and limit) for a parsed query, with bound parameters.
@@ -263,7 +272,7 @@ public class PostgreSqlSqlGenerator
 
         var sql = new StringBuilder("SELECT n.id, n.namespace, n.name, n.node_type, n.description, " +
             $"n.category, n.icon, n.display_order, n.last_modified, n.version, n.state, {contentColumn}, " +
-            $"n.desired_id, n.main_node, {syncBehaviorColumn} FROM {tableName} n");
+            $"n.desired_id, n.main_node, {syncBehaviorColumn}, {ExcludeFromContextColumn(tableName)} FROM {tableName} n");
 
         if (isAccessedQuery)
         {

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -180,6 +180,14 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
             ? "created_by, last_modified_by, created_date"
             : "NULL::text AS created_by, NULL::text AS last_modified_by, NULL::timestamptz AS created_date";
 
+    // ExcludeFromContext lives only on mesh_nodes (like authorship): the instance-level
+    // context opt-outs ("header", "search", "create") are a main-node concern; satellite
+    // selects emit a typed NULL so ReadMeshNode finds the column by name either way.
+    private static string ExcludeCol(string qualifiedTable) =>
+        qualifiedTable.Contains("mesh_nodes", StringComparison.OrdinalIgnoreCase)
+            ? "exclude_from_context"
+            : "NULL::text[] AS exclude_from_context";
+
     private static string NormalizePath(string? path) =>
         path?.Trim('/') ?? "";
 
@@ -227,7 +235,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         {
             await using var cmd = _dataSource.CreateCommand(
                 $"SELECT id, namespace, name, description, node_type, category, icon, display_order, " +
-                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)}, {AuthorCols(table)} " +
+                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)}, {AuthorCols(table)}, {ExcludeCol(table)} " +
                 $"FROM {table} WHERE namespace = $1 AND id = $2");
             cmd.Parameters.AddWithValue(ns);
             cmd.Parameters.AddWithValue(id);
@@ -306,7 +314,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                 Enumerable.Range(2, ids.Length).Select(i => $"${i}"));
             await using var cmd = _dataSource.CreateCommand(
                 $"SELECT id, namespace, name, description, node_type, category, icon, display_order, " +
-                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)}, {AuthorCols(table)} " +
+                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)}, {AuthorCols(table)}, {ExcludeCol(table)} " +
                 $"FROM {table} WHERE namespace = $1 AND id IN ({placeholders})");
             cmd.Parameters.AddWithValue(ns);
             foreach (var id in ids)
@@ -366,11 +374,15 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         var authorInsertCol = writeSync ? ", created_by, last_modified_by, created_date" : "";
         var authorInsertVal = writeSync ? ", $17, $18, $19" : "";
         var authorUpdate = writeSync ? ",\n                last_modified_by = EXCLUDED.last_modified_by" : "";
+        // exclude_from_context lives only on mesh_nodes (like sync_behavior/authorship).
+        var excludeInsertCol = writeSync ? ", exclude_from_context" : "";
+        var excludeInsertVal = writeSync ? ", $20" : "";
+        var excludeUpdate = writeSync ? ",\n                exclude_from_context = EXCLUDED.exclude_from_context" : "";
         await using var cmd = _dataSource.CreateCommand(
             $"""
             INSERT INTO {table} (namespace, id, name, description, node_type, category, icon, display_order,
-                                    last_modified, version, state, content, desired_id, embedding, main_node{syncInsertCol}{authorInsertCol})
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15{syncInsertVal}{authorInsertVal})
+                                    last_modified, version, state, content, desired_id, embedding, main_node{syncInsertCol}{authorInsertCol}{excludeInsertCol})
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15{syncInsertVal}{authorInsertVal}{excludeInsertVal})
             ON CONFLICT (namespace, id) DO UPDATE SET
                 name = EXCLUDED.name,
                 description = EXCLUDED.description,
@@ -384,7 +396,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                 content = EXCLUDED.content,
                 desired_id = EXCLUDED.desired_id,
                 embedding = EXCLUDED.embedding,
-                main_node = EXCLUDED.main_node{syncUpdate}{authorUpdate}
+                main_node = EXCLUDED.main_node{syncUpdate}{authorUpdate}{excludeUpdate}
             """);
 
         cmd.Parameters.AddWithValue(ns);
@@ -408,13 +420,16 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
 
         cmd.Parameters.AddWithValue(node.MainNode);
 
-        // $16–$19 — only bound when the target is mesh_nodes (see writeSync above).
+        // $16–$20 — only bound when the target is mesh_nodes (see writeSync above).
         if (writeSync)
         {
             cmd.Parameters.AddWithValue((short)node.SyncBehavior);
             cmd.Parameters.AddWithValue((object?)node.CreatedBy ?? DBNull.Value);
             cmd.Parameters.AddWithValue((object?)node.LastModifiedBy ?? DBNull.Value);
             cmd.Parameters.AddWithValue(node.CreatedDate == default ? DBNull.Value : node.CreatedDate);
+            cmd.Parameters.AddWithValue(node.ExcludeFromContext is { Count: > 0 } efc
+                ? efc.ToArray()
+                : (object)DBNull.Value);
         }
 
         await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
@@ -526,7 +541,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
         var table = ResolveTable(normalizedPath);
         await using var cmd = _dataSource.CreateCommand(
             $"SELECT id, namespace, name, description, node_type, category, icon, display_order, " +
-            $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)}, {AuthorCols(table)} " +
+            $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(table)}, {AuthorCols(table)}, {ExcludeCol(table)} " +
             $"FROM {table} WHERE $1 = path OR $1 LIKE path || '/%' " +
             $"ORDER BY LENGTH(path) DESC LIMIT 1");
         cmd.Parameters.AddWithValue(normalizedPath);
@@ -586,7 +601,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
                 : $"\"{_schemaName}\".\"{t}\"";
             unionBranches.Add(
                 $"SELECT id, namespace, name, description, node_type, category, icon, display_order, " +
-                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(qualified)}, {AuthorCols(qualified)} " +
+                $"last_modified, version, state, content, desired_id, main_node, {SyncBehaviorCol(qualified)}, {AuthorCols(qualified)}, {ExcludeCol(qualified)} " +
                 $"FROM {qualified} " +
                 $"WHERE $1 = path OR $1 LIKE path || '/%'");
         }
@@ -1354,6 +1369,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
             Version = reader.GetInt64(reader.GetOrdinal("version")),
             State = (MeshNodeState)reader.GetInt16(reader.GetOrdinal("state")),
             SyncBehavior = PgMeshNodeReader.ReadSyncBehavior(reader),
+            ExcludeFromContext = PgMeshNodeReader.ReadStringArray(reader, "exclude_from_context"),
             Content = content,
             // Mirror the prerendered HTML onto the top-level field, like the FileSystem/Caching
             // adapters do (CachingStorageAdapter.MergeIndexMarkdownAsync). Consumers that render

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/ExcludeFromContextPersistenceTest.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/ExcludeFromContextPersistenceTest.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// 🚨 Repro for the 2026-07-19 memex-cloud chrome-less regression:
+/// <see cref="MeshNode.ExcludeFromContext"/> had NO column on the Postgres
+/// <c>mesh_nodes</c> table, so the adapter dropped it on every write — a brochure
+/// imported with <c>ExcludeFromContext: [header]</c> frontmatter kept rendering the
+/// node header on every PG-backed portal (and instance-level search/create opt-outs
+/// silently never applied), while the same flow passed on in-memory storage. Pins
+/// the full PG round-trip: write a node with the opt-out → read it back → the
+/// opt-outs survive; clearing them must persist too (NULL round-trip).
+/// </summary>
+[Collection("PostgreSql")]
+public class ExcludeFromContextPersistenceTest(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private readonly PostgreSqlFixture _fixture = fixture;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new Npgsql.NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
+        {
+            MaxPoolSize = 16,
+            ConnectionIdleLifetime = 10
+        };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services =>
+                services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString))
+            .AddRowLevelSecurity()
+            .AddGraph()
+            .AddSpaceType();
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task ExcludeFromContext_RoundTripsThroughPostgres()
+    {
+        var spaceId = $"pgefc_{Guid.NewGuid():N}".ToLowerInvariant()[..16];
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var workspace = Mesh.GetWorkspace();
+
+        await meshService.CreateNode(new MeshNode(spaceId)
+        {
+            NodeType = SpaceNodeType.NodeType,
+            Name = spaceId,
+            State = MeshNodeState.Active,
+            Content = new Space(),
+        }).Should().Within(45.Seconds()).Emit();
+
+        // The chrome-less brochure shape: a Markdown child opting out of the header.
+        var childPath = $"{spaceId}/Overview";
+        await meshService.CreateNode(new MeshNode("Overview", spaceId)
+        {
+            NodeType = "Markdown",
+            Name = "Brochure",
+            State = MeshNodeState.Active,
+            ExcludeFromContext = [MeshNodeVisibility.HeaderContext, MeshNodeVisibility.SearchContext],
+        }).Should().Within(30.Seconds()).Emit();
+
+        // The physical row must carry the column value (write side) …
+        await using (var cmd = _fixture.DataSource.CreateCommand(
+            $"""SELECT exclude_from_context FROM "{spaceId}".mesh_nodes WHERE id = 'Overview'"""))
+        {
+            var raw = await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+            raw.Should().BeOfType<string[]>("the adapter must write the opt-outs to the column, not drop them");
+        }
+
+        // … the adapter hydration must map it (read side, storage layer) …
+        var storageAdapter = Mesh.ServiceProvider.GetRequiredService<MeshWeaver.Mesh.Services.IStorageAdapter>();
+        var adapterRead = await storageAdapter.Read(childPath, Mesh.JsonSerializerOptions)
+            .Should().Within(30.Seconds()).Emit();
+        adapterRead!.ExcludeFromContext.Should().NotBeNull(
+            "the adapter SELECT must include exclude_from_context and ReadMeshNode must map it");
+
+        // … the hub wire serialization must round-trip it …
+        var wireJson = System.Text.Json.JsonSerializer.Serialize(adapterRead, Mesh.JsonSerializerOptions);
+        wireJson.Should().Contain("xcludeFromContext",
+            "the hub serializer must emit the field on the sync frame");
+        var wireBack = System.Text.Json.JsonSerializer.Deserialize<MeshNode>(wireJson, Mesh.JsonSerializerOptions);
+        wireBack!.ExcludeFromContext.Should().NotBeNull(
+            "the hub serializer must rehydrate the field from the sync frame");
+
+        // … and the hydrated node must carry it too (read side, hub stream).
+        var readBack = await workspace.GetMeshNodeStream(childPath)
+            .Where(n => n is not null).Take(1)
+            .Should().Within(30.Seconds()).Emit();
+        readBack!.ExcludeFromContext.Should().NotBeNull(
+            "the opt-outs must survive the PG write/read round-trip — the header gate reads them off the hydrated node");
+        readBack.ExcludeFromContext!.Count.Should().Be(2);
+        readBack.ExcludeFromContext.Should().Contain(MeshNodeVisibility.HeaderContext);
+        readBack.ExcludeFromContext.Should().Contain(MeshNodeVisibility.SearchContext);
+        readBack.IsExcludedFromContext(MeshNodeVisibility.HeaderContext).Should().BeTrue();
+
+        // Clearing the opt-out must persist as well (NULL round-trip, not sticky state).
+        await workspace.GetMeshNodeStream(childPath)
+            .Update(n => n with { ExcludeFromContext = null })
+            .Should().Within(30.Seconds()).Emit();
+        var cleared = await workspace.GetMeshNodeStream(childPath)
+            .Where(n => n is not null && n.ExcludeFromContext is null).Take(1)
+            .Should().Within(30.Seconds()).Emit();
+        cleared!.IsExcludedFromContext(MeshNodeVisibility.HeaderContext).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
**The chrome-less header gate (#545) was inert on every PG-backed portal**: `MeshNode.ExcludeFromContext` had no `mesh_nodes` column, so the adapter dropped it on write and hydrated `null` on read — the re-imported UWDeepfield/ClaimsDeepfield brochures kept their headers, and instance-level `search`/`create` opt-outs silently never applied (`PostgreSqlMeshQuery` checks them in memory on nodes that could never carry them). Same defect class as the V45 authorship columns; #545's render test passed because in-memory storage round-trips the field.

Two independent hydration paths both needed the column (bisected with the new test):
1. the adapter's Read/ReadMany/query SELECTs (+ upsert $20 + `ReadMeshNode`),
2. **`PostgreSqlSqlGenerator`'s query select list** — `MeshNodeStreamCache` hydrates cold nodes through the query path, exactly the trap the `sync_behavior` comment there documents.

Migration **V46** adds `exclude_from_context TEXT[]` idempotently across every partition schema (mirrors V45). No backfill — values land on the first write; the brochures need one forced GitSync re-import after deploy.

`ExcludeFromContextPersistenceTest` (Testcontainers) pins every hop: physical row → adapter read → wire serialization → hub stream, plus clear-to-null. Local gate: Release `-warnaserror` green on adapter + migration + test; test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)