### PR TITLE
DataGrid: default 50 rows per page (was 10)

### DIFF
--- a/src/MeshWeaver.Blazor/Components/DataGridView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/DataGridView.razor.cs
@@ -80,7 +80,7 @@ public partial class DataGridView
 
         // Store previous value to detect programmatic changes
         var previousItemsPerPage = itemsPerPage;
-        DataBind(ViewModel.ItemsPerPage, x => x.itemsPerPage, defaultValue: 10);
+        DataBind(ViewModel.ItemsPerPage, x => x.itemsPerPage, defaultValue: 50);
 
         // If ItemsPerPage changed programmatically (not by user), reset the flag
         if (previousItemsPerPage != itemsPerPage && userChangedPageSize)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-19-datagrid-rows-default-50.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-19-datagrid-rows-default-50.md
@@ -1,0 +1,10 @@
+---
+Name: Data grids show more rows before paging
+Category: What's New
+Description: Tables now display up to 50 rows per page by default, instead of 10.
+Icon: Sparkle
+---
+
+# Data grids show more rows before paging
+
+Data grids used to page after just 10 rows, so most tables — statements, movement reports, self-check batteries — hid the majority of their content behind pagination. The default page size is now **50**, so a typical table shows in full at a glance. Grids that set an explicit page size are unaffected, and very large datasets still page (and virtualize) as before.


### PR DESCRIPTION
## What

Raises the `DataGridView` `ItemsPerPage` default from **10 → 50**.

## Why

Most tables page after only 10 rows, hiding the bulk of their content behind pagination — statements, movement reports, the self-check batteries in the interactive courses, etc. A default of 50 shows a typical table in full at a glance.

Grids that set an explicit page size (via `WithItemsPerPage(...)`) are unaffected; very large datasets still page and virtualize as before.

One-line change in `DataGridView.razor.cs`, plus a What's-New entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)