### PR TITLE
feat(seo): per-page metadata, robots.txt, sitemap.xml, noscript content

### DIFF
--- a/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
@@ -1,0 +1,143 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Xml.Linq;
+using Memex.Portal.Shared.Seo;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Memex.Portal.Shared.Api;
+
+/// <summary>
+/// The crawler plumbing: a real <c>/robots.txt</c> and <c>/sitemap.xml</c>. Without these the
+/// Blazor catch-all served the SPA HTML shell on both URLs — a crawler asking for robots.txt got
+/// a web page. The sitemap enumerates exactly the ANONYMOUS surface: every top-level node that
+/// passes <see cref="AnonymousGate.AllowAnonymous"/> (public covers, the Store, Space landings)
+/// plus each store plugin's declared public segments (the marketing brochures). Fail-open to an
+/// empty sitemap — a mesh hiccup must never turn into a 500 for a crawler.
+/// </summary>
+public static class SeoEndpoints
+{
+    /// <summary>Node types whose top-level mains are sitemap candidates.</summary>
+    private static readonly string[] CandidateNodeTypes = ["Store/Plugin", "Store/Catalog", "Space"];
+
+    public static IEndpointRouteBuilder MapSeo(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/robots.txt", (HttpContext http) =>
+        {
+            var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}";
+            return Results.Text(
+                $"""
+                 User-agent: *
+                 Disallow: /login
+                 Disallow: /api/
+                 Disallow: /_blazor
+                 Disallow: /dev/
+                 Sitemap: {baseUrl}/sitemap.xml
+                 """, "text/plain");
+        }).AllowAnonymous();
+
+        app.MapGet("/sitemap.xml", (IMessageHub hub, HttpContext http, CancellationToken ct) =>
+        {
+            var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}";
+            return BuildSitemap(hub, baseUrl)
+                .Select(xml => Results.Text(xml, "application/xml"))
+                .FirstAsync()
+                .ToTask(ct);
+        }).AllowAnonymous();
+
+        return app;
+    }
+
+    /// <summary>
+    /// The sitemap XML, built reactively: candidate roots from the (System-read) type queries,
+    /// each gated through the REAL anonymous permission check, public-segment children of store
+    /// plugins verified to exist before listing. Cold; never errors (fail-open to fewer URLs).
+    /// </summary>
+    public static IObservable<string> BuildSitemap(IMessageHub hub, string baseUrl)
+    {
+        var mesh = hub.ServiceProvider.GetService<IMeshService>();
+        var adapter = hub.ServiceProvider.GetService<IStorageAdapter>();
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        if (mesh is null || adapter is null)
+            return Observable.Return(Render(baseUrl, []));
+
+        // Candidate enumeration runs as System (an anonymous HTTP entry has no query identity);
+        // ANONYMOUS readability is then decided per node by the fail-closed gate — the sitemap
+        // can never list more than a logged-out visitor can open.
+        var candidates = CandidateNodeTypes
+            .Select(type => Observable.Using(
+                () => accessService?.ImpersonateAsSystem() ?? System.Reactive.Disposables.Disposable.Empty,
+                _ => mesh.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{type} is:main limit:500"))
+                    .Take(1)
+                    .Select(change => change.Items
+                        .Where(n => !n.Path.Contains('/'))     // top-level roots only
+                        .ToList())))
+            .ToObservable().Concat().ToList()
+            .Select(lists => lists.SelectMany(l => l).DistinctBy(n => n.Path).ToList());
+
+        return candidates
+            .SelectMany(roots => roots.Count == 0
+                ? Observable.Return(new List<(MeshNode Node, string Url)>())
+                : roots
+                    .Select(root => AnonymousGate.AllowAnonymous(hub, root.Path)
+                        .Take(1)
+                        .SelectMany(allowed => allowed
+                            ? PagesOf(adapter, hub, root)
+                            : Observable.Return<IReadOnlyList<(MeshNode, string)>>([])))
+                    .ToObservable().Concat().ToList()
+                    .Select(pages => pages.SelectMany(p => p).ToList()))
+            .Select(pages => Render(baseUrl, pages.DistinctBy(p => p.Item2).ToList()))
+            .Timeout(TimeSpan.FromSeconds(20))
+            .Catch<string, Exception>(_ => Observable.Return(Render(baseUrl, [])));
+    }
+
+    // The sitemap pages of one anonymous-readable root: the root itself plus, for store
+    // plugins, each declared public segment whose node actually exists (the brochures).
+    private static IObservable<IReadOnlyList<(MeshNode, string)>> PagesOf(
+        IStorageAdapter adapter, IMessageHub hub, MeshNode root)
+    {
+        var self = (root, root.Path);
+        var segments = PublicSegments(root);
+        if (segments.Count == 0)
+            return Observable.Return<IReadOnlyList<(MeshNode, string)>>([self]);
+        return segments
+            .Select(segment => adapter
+                .Read($"{root.Path}/{segment}", hub.JsonSerializerOptions)
+                .Take(1)
+                .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null)))
+            .ToObservable().Concat().ToList()
+            .Select(children => (IReadOnlyList<(MeshNode, string)>)
+                new[] { self }
+                    .Concat(children.Where(c => c is not null).Select(c => (c!, c!.Path)))
+                    .ToList());
+    }
+
+    private static IReadOnlyList<string> PublicSegments(MeshNode root) =>
+        root.Content is JsonElement { ValueKind: JsonValueKind.Object } je
+            && je.TryGetProperty("publicSegments", out var segs)
+            && segs.ValueKind == JsonValueKind.Array
+            ? segs.EnumerateArray()
+                .Where(s => s.ValueKind == JsonValueKind.String)
+                .Select(s => s.GetString()!)
+                .ToList()
+            : [];
+
+    private static string Render(string baseUrl, IReadOnlyList<(MeshNode Node, string Url)> pages)
+    {
+        XNamespace ns = "http://www.sitemaps.org/schemas/sitemap/0.9";
+        var urlset = new XElement(ns + "urlset",
+            pages.Select(p => new XElement(ns + "url",
+                new XElement(ns + "loc", $"{baseUrl}/{p.Url}"),
+                p.Node.LastModified == default
+                    ? null
+                    : new XElement(ns + "lastmod", p.Node.LastModified.UtcDateTime.ToString("yyyy-MM-dd")))));
+        return new XDocument(new XDeclaration("1.0", "utf-8", null), urlset).ToString();
+    }
+}

--- a/memex/Memex.Portal.Shared/App.razor
+++ b/memex/Memex.Portal.Shared/App.razor
@@ -1,5 +1,6 @@
 @using Microsoft.Extensions.Configuration
 @using MeshWeaver.Blazor.Components
+@using Memex.Portal.Shared.Seo
 
 @inject IConfiguration Configuration
 
@@ -65,7 +66,10 @@
     </script>
 
     <HeadOutlet @rendermode="RenderMode.InteractiveServer" />
-    <PageTitle>Memex Portal</PageTitle>
+    @* Static, per-request SEO head: crawler-facing <title>/description/canonical/OG/JSON-LD for
+       anonymous-readable node pages, the generic instance title otherwise. The interactive
+       circuit's PageTitle (ApplicationPage) takes over the tab title once hydrated. *@
+    <SeoHead />
     @if (hasInstance)
     {
         @* Force the tab title to the instance name, overriding per-node titles set
@@ -88,6 +92,10 @@
         <ThemeSync @bind-Mode="@Mode" @rendermode="RenderMode.InteractiveServer" />
         <Routes @rendermode="RenderMode.InteractiveServer" />
     </CascadingValue>
+
+    @* The page's real content for non-JS crawlers — only what SeoHead resolved as
+       anonymous-readable; invisible to browsers. *@
+    <SeoNoScriptBody />
 
     @*
         Custom Blazor Server reconnect UI. Blazor adds one of these classes to

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1092,6 +1092,11 @@ public static class MemexConfiguration
         // (only curated packages, addressed by plugin id, are exposed; the registry's credential stays here).
         app.MapPluginRegistry();
 
+        // Crawler plumbing — a real /robots.txt + /sitemap.xml (the Blazor catch-all otherwise
+        // serves the SPA shell on both). The sitemap lists exactly the anonymous surface: every
+        // top-level node passing the AnonymousGate plus store plugins' public segments.
+        app.MapSeo();
+
         // Generic webhook inbox — POST /api/hooks/{target} stores the raw delivery as a
         // WebhookEvent node at {target}/_Inbox/{id} for allowlisted targets (WebhookInbox:Targets).
         // The consuming plugin verifies signatures itself; no integration-specific code here.

--- a/memex/Memex.Portal.Shared/Seo/SeoHead.razor
+++ b/memex/Memex.Portal.Shared/Seo/SeoHead.razor
@@ -1,0 +1,120 @@
+@using System.Text.Json
+@using MeshWeaver.Messaging
+@using Microsoft.AspNetCore.Http
+@using Microsoft.Extensions.Configuration
+@namespace Memex.Portal.Shared.Seo
+@inject IMessageHub Hub
+@inject IConfiguration Configuration
+
+@*
+    Crawler-facing head for the INITIAL server response. The interactive circuit overwrites the
+    tab title later (ApplicationPage's PageTitle); what matters here is what a crawler — which
+    rarely holds a Blazor Server websocket long enough to hydrate — reads: a per-page title,
+    description, canonical URL, Open Graph card, and (for store plugins) Course/Product JSON-LD.
+    Only ANONYMOUS-readable nodes get rich metadata (SeoResolver gates through AnonymousGate),
+    so nothing about private content leaks into logged-out markup. Authenticated requests skip
+    the mesh round-trip entirely — their head is app chrome, not SEO surface.
+*@
+
+<title>@_title</title>
+@if (_data is not null)
+{
+    <meta name="description" content="@_description" />
+    <link rel="canonical" href="@_canonical" />
+    <meta property="og:site_name" content="@SiteName" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="@_data.Node.Name" />
+    @if (_description is not null)
+    {
+        <meta property="og:description" content="@_description" />
+    }
+    <meta property="og:url" content="@_canonical" />
+    @if (_image is not null)
+    {
+        <meta property="og:image" content="@_image" />
+        <meta name="twitter:card" content="summary_large_image" />
+    }
+    @if (_jsonLd is not null)
+    {
+        <script type="application/ld+json">@((MarkupString)_jsonLd)</script>
+    }
+}
+
+@code {
+    [CascadingParameter] public HttpContext? HttpContext { get; set; }
+
+    private SeoPageData? _data;
+    private string _title = "";
+    private string? _description;
+    private string? _canonical;
+    private string? _image;
+    private string? _jsonLd;
+
+    private string SiteName =>
+        Configuration["Portal:SiteName"] ?? Configuration["Portal:InstanceName"] ?? "Memex";
+
+    protected override async Task OnInitializedAsync()
+    {
+        _title = Configuration["Portal:InstanceName"] ?? "Memex Portal";
+        var path = HttpContext?.Request.Path.Value;
+        if (HttpContext is null
+            || HttpContext.User.Identity?.IsAuthenticated == true
+            || !SeoResolver.IsCandidatePath(path))
+            return;
+
+        _data = await SeoResolver.ResolveAsync(Hub, path!);
+        if (_data is null)
+            return;
+        // Stash for SeoNoScriptBody (rendered later in <body>) — resolve ONCE per request.
+        HttpContext.Items[SeoResolver.HttpContextItem] = _data;
+
+        var node = _data.Node;
+        _title = $"{node.Name ?? node.Id} · {SiteName}";
+        _description = Truncate(_data.Description, 300);
+        var baseUrl = $"{HttpContext.Request.Scheme}://{HttpContext.Request.Host}";
+        _canonical = $"{baseUrl}/{node.Path}";
+        _image = _data.Image is { } img && img.StartsWith('/') ? baseUrl + img : _data.Image;
+        _jsonLd = BuildJsonLd(node, _description, _image, _canonical);
+    }
+
+    private static string? Truncate(string? text, int max) =>
+        text is null ? null : text.Length <= max ? text : text[..max].TrimEnd() + "…";
+
+    // Course JSON-LD for education store plugins with a real price, Product for other priced
+    // plugins; nothing for free/coupon-only or non-store pages. Serialized with STJ so every
+    // value is properly escaped before landing in the script tag.
+    private static string? BuildJsonLd(
+        MeshWeaver.Mesh.MeshNode node, string? description, string? image, string? url)
+    {
+        if (node.NodeType != "Store/Plugin")
+            return null;
+        var price = SeoResolver.ContentDecimal(node, "price");
+        var isCourse = string.Equals(node.Category, "Education", StringComparison.OrdinalIgnoreCase);
+        var payload = new Dictionary<string, object?>
+        {
+            ["@context"] = "https://schema.org",
+            ["@type"] = isCourse ? "Course" : "Product",
+            ["name"] = node.Name ?? node.Id,
+            ["description"] = description,
+            ["url"] = url,
+        };
+        if (image is not null)
+            payload["image"] = image;
+        if (isCourse)
+            payload["provider"] = new Dictionary<string, object?>
+            {
+                ["@type"] = "Organization",
+                ["name"] = "Systemorph",
+            };
+        if (price is > 0m)
+            payload["offers"] = new Dictionary<string, object?>
+            {
+                ["@type"] = "Offer",
+                ["price"] = price.Value.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture),
+                ["priceCurrency"] = SeoResolver.ContentString(node, "currency") ?? "CHF",
+                ["url"] = url,
+            };
+        return JsonSerializer.Serialize(
+            payload.Where(kv => kv.Value is not null).ToDictionary(kv => kv.Key, kv => kv.Value));
+    }
+}

--- a/memex/Memex.Portal.Shared/Seo/SeoNoScriptBody.razor
+++ b/memex/Memex.Portal.Shared/Seo/SeoNoScriptBody.razor
@@ -1,0 +1,28 @@
+@namespace Memex.Portal.Shared.Seo
+@using Microsoft.AspNetCore.Http
+
+@*
+    The page's actual content for crawlers that do not run JavaScript (Blazor Server pages carry
+    no body content in the initial response — everything hydrates over the circuit). Only what an
+    ANONYMOUS visitor may read is ever emitted: SeoHead resolves through the AnonymousGate and
+    stashes the result; no stash → nothing rendered. <noscript> keeps it invisible to browsers.
+*@
+
+@if (Body is not null)
+{
+    <noscript>
+        <article>
+            @((MarkupString)Body)
+        </article>
+    </noscript>
+}
+
+@code {
+    [CascadingParameter] public HttpContext? HttpContext { get; set; }
+
+    private string? Body =>
+        HttpContext?.Items.TryGetValue(SeoResolver.HttpContextItem, out var stashed) == true
+            && stashed is SeoPageData data
+            ? data.PreRenderedHtml
+            : null;
+}

--- a/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
+++ b/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
@@ -1,0 +1,116 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Memex.Portal.Shared.Seo;
+
+/// <summary>
+/// What the crawler-facing head needs to know about the requested page: the resolved node and
+/// the pieces of its content the meta tags are built from. Only ever produced for pages an
+/// ANONYMOUS visitor may read (the <see cref="AnonymousGate"/> decision) — a private node's
+/// name/description must never leak into markup served to a logged-out crawler.
+/// </summary>
+public sealed record SeoPageData(MeshNode Node, string? Description, string? Image)
+{
+    /// <summary>The node's pre-rendered markdown body, when it carries one — served inside
+    /// <c>&lt;noscript&gt;</c> so non-JS crawlers index the actual page content.</summary>
+    public string? PreRenderedHtml => Node.PreRenderedHtml;
+}
+
+/// <summary>
+/// Server-side SEO resolution for the initial HTTP response. Reactive end to end; the ONE
+/// <c>Task</c> bridge sits at the Razor static-SSR boundary (<see cref="ResolveAsync"/>), the
+/// same adapter shape the MCP/REST surfaces use. Fail-open to null: a slow or faulted mesh
+/// never delays page delivery — the page just ships the generic head.
+/// </summary>
+public static class SeoResolver
+{
+    /// <summary>Per-request stash key so the head and body components resolve ONCE.</summary>
+    public const string HttpContextItem = "Memex.Seo.PageData";
+
+    /// <summary>Route prefixes that are never mesh nodes — skipped without touching the mesh.</summary>
+    private static readonly string[] NonNodePrefixes =
+        ["login", "api", "_blazor", "_framework", "_content", "dev", "mcp", "static", "webhooks"];
+
+    /// <summary>Whether the request path can be a node page worth resolving.</summary>
+    public static bool IsCandidatePath(string? path)
+    {
+        var trimmed = (path ?? "").Trim('/');
+        if (trimmed.Length == 0)
+            return false;
+        var first = trimmed.Split('/')[0];
+        return !NonNodePrefixes.Any(p => string.Equals(p, first, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Resolves the request path to its node and gates it through
+    /// <see cref="AnonymousGate.AllowAnonymous"/>. Emits null when the path is no node, the node
+    /// is not anonymous-readable, or anything errors/times out. Cold.
+    /// </summary>
+    public static IObservable<SeoPageData?> Resolve(IMessageHub hub, string path)
+    {
+        var resolver = hub.ServiceProvider.GetService<IPathResolver>();
+        if (resolver is null)
+            return Observable.Return<SeoPageData?>(null);
+        return resolver.ResolvePath(path.Trim('/'))
+            .Take(1)
+            .SelectMany(resolution => resolution?.Node is not { } node
+                ? Observable.Return<SeoPageData?>(null)
+                : AnonymousGate.AllowAnonymous(hub, resolution.Prefix)
+                    .Take(1)
+                    .Select(allowed => allowed
+                        ? new SeoPageData(node, ExtractDescription(node), ExtractImage(node))
+                        : null))
+            .Timeout(TimeSpan.FromSeconds(3))
+            .Catch<SeoPageData?, Exception>(_ => Observable.Return<SeoPageData?>(null));
+    }
+
+    /// <summary>The static-SSR boundary bridge — the only <c>Task</c> on this surface.</summary>
+    public static Task<SeoPageData?> ResolveAsync(IMessageHub hub, string path) =>
+        System.Reactive.Threading.Tasks.TaskObservableExtensions.ToTask(
+            Resolve(hub, path).FirstAsync());
+
+    /// <summary>
+    /// The page description for meta tags: the node's Description, else the content's
+    /// <c>abstract</c>/<c>description</c> member (untyped — content arrives as JSON here).
+    /// </summary>
+    public static string? ExtractDescription(MeshNode node) =>
+        FirstNonEmpty(
+            node.Description,
+            ContentString(node, "abstract"),
+            ContentString(node, "description"));
+
+    /// <summary>The share image for og:image: the content's <c>poster</c> (store plugins) or
+    /// <c>thumbnail</c> (markdown pages). Root-relative or absolute URLs only.</summary>
+    public static string? ExtractImage(MeshNode node)
+    {
+        var candidate = FirstNonEmpty(ContentString(node, "poster"), ContentString(node, "thumbnail"));
+        return candidate is not null
+            && (candidate.StartsWith('/') || candidate.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            ? candidate
+            : null;
+    }
+
+    /// <summary>A string member of the node's content, read untyped.</summary>
+    public static string? ContentString(MeshNode node, string property) =>
+        node.Content is JsonElement { ValueKind: JsonValueKind.Object } je
+            && je.TryGetProperty(property, out var value)
+            && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    /// <summary>A decimal member of the node's content, read untyped.</summary>
+    public static decimal? ContentDecimal(MeshNode node, string property) =>
+        node.Content is JsonElement { ValueKind: JsonValueKind.Object } je
+            && je.TryGetProperty(property, out var value)
+            && value.ValueKind == JsonValueKind.Number
+            ? value.GetDecimal()
+            : null;
+
+    private static string? FirstNonEmpty(params string?[] values) =>
+        values.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+}


### PR DESCRIPTION
Crawler audit of the public marketing surface found: static `<title>Memex Portal</title>` everywhere, no description/OG/canonical, `/robots.txt` + `/sitemap.xml` served the **SPA HTML shell** (Blazor catch-all), and zero page content in the initial response (~1.1KB visible text on a brochure page).

- **`SeoHead`** (static SSR, per request): title `{Node.Name} · {SiteName}`, meta description (node Description → content abstract), canonical, Open Graph card (+ `og:image` from poster/thumbnail), and `Course`/`Product` JSON-LD with the CHF offer for priced store plugins. **Leak-safe**: rich metadata only for nodes the fail-closed `AnonymousGate` allows — a crawler is an anonymous visitor; private nodes keep the generic head. Authenticated requests skip resolution entirely; 3s timeout fails open.\n- **`SeoNoScriptBody`**: the node's `PreRenderedHtml` inside `<noscript>` — non-JS crawlers index the actual brochure text (Blazor Server ships none otherwise).\n- **`MapSeo`**: real `/robots.txt` (disallow /login, /api/, /_blazor, /dev + sitemap pointer) and `/sitemap.xml` — top-level nodes passing the AnonymousGate + store plugins' `publicSegments` brochure pages, with `lastmod`. System-read enumeration, per-node anonymous gating — the sitemap can never list more than a logged-out visitor can open.\n\nLocal gate: Release `-warnaserror` green on Portal.Shared + both hosts.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)