### PR TITLE
fix(ci): kill the multi-arch publish CopyRefAssembly race (MSB3883)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,6 +52,22 @@
          a deployed binary syncs from. -->
     <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0</PlatformVersion>
   </PropertyGroup>
+  <!-- Multi-arch container publish race fix (main-cd / release-images / edge-images pass
+       -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"). The SDK builds the two RID legs of the
+       publish CONCURRENTLY. A reference assembly is RID-INVARIANT, so its intermediate path has NO rid
+       segment (obj/<cfg>/<tfm>/ref/<Asm>.dll) — both legs' CopyRefAssembly target write that SAME file
+       and intermittently collide → "error MSB3883: … MeshWeaver.Graph.dll … being used by another
+       process" (the intermittent portal-ai image-build failure). Ref assemblies exist only to skip
+       downstream recompilation on INCREMENTAL rebuilds; a from-clean CI container publish gains
+       nothing from them, so turning them off for the multi-arch publish removes the one shared,
+       contended output — killing the race at its source while keeping both RID legs parallel (no
+       serialization, no retry). ContainerRuntimeIdentifiers is a global property, so this condition is
+       seen by every project in the publish graph — including the referenced libraries that actually
+       race. It is empty in normal dev / the Build-and-Test CI, so ref assemblies (and fast incremental
+       builds) are UNAFFECTED there. -->
+  <PropertyGroup Condition="'$(ContainerRuntimeIdentifiers)' != ''">
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
   <!-- Two version channels — CONTINUOUS (CI) vs RELEASED (CD):
        • RELEASED  (-p:PublicRelease=true, the CD/release pipeline): clean $(PlatformVersion).
          This is what NuGet packages AND the Docker image carry, e.g. 3.0.0-rc1. Tag the repo


### PR DESCRIPTION
## The flake

The portal-ai image build intermittently fails the continuous deploy with:

```
error MSB3883: Unexpected exception:  [.../MeshWeaver.Graph/MeshWeaver.Graph.csproj]
IOException: The process cannot access the file
'.../MeshWeaver.Graph/obj/Release/net10.0/ref/MeshWeaver.Graph.dll'
because it is being used by another process.  (CopyRefAssembly)
```

(e.g. CD run 29687305177). This is a **build-time** race, not a runtime one — no hub / observable / cached-instance involved.

## Root cause

The CD/release/edge image builds publish **per-RID** via `-p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"`, and the SDK builds the two RID legs **concurrently**. A **reference assembly is RID-invariant**, so its intermediate path has *no* rid segment — `obj/<cfg>/<tfm>/ref/<Asm>.dll`. Both RID legs' `CopyRefAssembly` target therefore write the **same** file and intermittently collide. It's non-deterministic because it only fails when the two legs happen to hit `CopyRefAssembly` for the same referenced library at the same instant.

## The fix

Turn off reference-assembly production **for the multi-arch publish only**, in `Directory.Build.props`, gated on the global `ContainerRuntimeIdentifiers` being set (a global property, so it is seen by every project in the publish graph — including the referenced libraries that actually race).

Reference assemblies only accelerate **incremental** rebuilds; a from-clean CI container publish gains nothing from them — so this removes the one shared, contended output while keeping **both RID legs parallel** (no serialization, no retry, no slowdown). Normal dev builds and the `Build and Test` CI leave `ContainerRuntimeIdentifiers` empty, so ref assemblies and fast incremental builds are **unaffected** there. Covers `main-cd`, `release-images`, and `edge-images` from one place — no per-command drift.

## Verification

Deterministically checked on `MeshWeaver.Graph` (the project that raced), via `dotnet msbuild -getProperty:ProduceReferenceAssembly`:

| Context | `ProduceReferenceAssembly` |
|---|---|
| normal build (no multi-arch prop) | `true` (default — unchanged) |
| `-p:ContainerRuntimeIdentifiers=linux-x64%3Blinux-arm64` (publish) | `false` (racy artifact not produced) |

No user-facing change → no What's New entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)