### PR TITLE
fix(upsert): CreateOrUpdate merge carries Description/Order/ExcludeFromContext

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -2068,6 +2068,14 @@ public static class MeshExtensions
             NodeType = sourceNode.NodeType ?? state.NodeType,
             Icon = sourceNode.Icon ?? state.Icon,
             Category = sourceNode.Category ?? state.Category,
+            // Description / Order / ExcludeFromContext were MISSING here: an upsert of an
+            // EXISTING node silently dropped them — a GitSync re-import could never land a
+            // frontmatter change to these fields (the chrome-less brochures kept their headers
+            // while freshly-created nodes worked). Same null-keeps-state convention as the
+            // rest: clearing a field is an explicit stream.Update, not an absent source value.
+            Description = sourceNode.Description ?? state.Description,
+            Order = sourceNode.Order ?? state.Order,
+            ExcludeFromContext = sourceNode.ExcludeFromContext ?? state.ExcludeFromContext,
             Content = sourceNode.Content ?? state.Content,
             State = sourceNode.State == default ? state.State : sourceNode.State,
             PreRenderedHtml = sourceNode.PreRenderedHtml ?? state.PreRenderedHtml,

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/ExcludeFromContextPersistenceTest.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/ExcludeFromContextPersistenceTest.cs
@@ -116,4 +116,58 @@ public class ExcludeFromContextPersistenceTest(PostgreSqlFixture fixture, ITestO
             .Should().Within(30.Seconds()).Emit();
         cleared!.IsExcludedFromContext(MeshNodeVisibility.HeaderContext).Should().BeFalse();
     }
+
+    /// <summary>
+    /// 🚨 The GitSync re-import shape: CreateOrUpdateNode of an EXISTING node. The upsert's
+    /// UPDATE path merges field-by-field (UpdateAccordingToSourceNode) and silently DROPPED
+    /// Description / Order / ExcludeFromContext — a re-imported brochure could never gain its
+    /// <c>ExcludeFromContext: [header]</c> frontmatter (freshly-created nodes worked; live
+    /// memex-cloud nodes never did). Pins that the upsert-update path carries all three.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task CreateOrUpdate_OfExistingNode_CarriesExcludeFromContextDescriptionOrder()
+    {
+        var spaceId = $"pgupd_{Guid.NewGuid():N}".ToLowerInvariant()[..16];
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var workspace = Mesh.GetWorkspace();
+
+        await meshService.CreateNode(new MeshNode(spaceId)
+        {
+            NodeType = SpaceNodeType.NodeType,
+            Name = spaceId,
+            State = MeshNodeState.Active,
+            Content = new Space(),
+        }).Should().Within(45.Seconds()).Emit();
+
+        // First import: the node exists WITHOUT the opt-out (pre-parser-fix state).
+        var childPath = $"{spaceId}/Overview";
+        await meshService.CreateNode(new MeshNode("Overview", spaceId)
+        {
+            NodeType = "Markdown",
+            Name = "Brochure v1",
+            State = MeshNodeState.Active,
+        }).Should().Within(30.Seconds()).Emit();
+
+        // Re-import: same path, now carrying the frontmatter-derived fields.
+        await meshService.CreateOrUpdateNode(new MeshNode("Overview", spaceId)
+        {
+            NodeType = "Markdown",
+            Name = "Brochure v2",
+            Description = "The glossy one-pager.",
+            Order = 7,
+            State = MeshNodeState.Active,
+            ExcludeFromContext = [MeshNodeVisibility.HeaderContext],
+        }).Should().Within(30.Seconds()).Emit();
+
+        var updated = await workspace.GetMeshNodeStream(childPath)
+            .Where(n => n is not null && n.Name == "Brochure v2").Take(1)
+            .Should().Within(30.Seconds()).Emit();
+        updated!.ExcludeFromContext.Should().NotBeNull(
+            "the upsert-update merge must carry the source node's ExcludeFromContext");
+        updated.IsExcludedFromContext(MeshNodeVisibility.HeaderContext).Should().BeTrue();
+        updated.Description.Should().Be("The glossy one-pager.",
+            "the upsert-update merge must carry the source node's Description");
+        updated.Order.Should().Be(7,
+            "the upsert-update merge must carry the source node's Order");
+    }
 }


### PR DESCRIPTION
Third and final link in the chrome-less chain: parser (#545/#546) parsed the frontmatter, PG (#548) persisted the field — but `UpdateAccordingToSourceNode` (the `CreateOrUpdateNodeRequest` UPDATE-path merge) never copied **Description, Order, ExcludeFromContext** from the source node, so a GitSync re-import of an existing node dropped them every time. Create path worked; update path lost them — which is why every test passed while the live brochures kept their headers.

Fix follows the merge's existing null-keeps-state convention (clearing stays an explicit `stream.Update`). New Testcontainers test pins the exact re-import shape (create without → upsert with → read back all three fields).

Local gate: Release `-warnaserror` on Mesh.Contract green; PG test suite 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)