### PR TITLE
ci: fail main-cd if a portal/migration image isn't a complete multi-arch manifest

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -139,6 +139,23 @@ jobs:
           -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"'
           -p:ContainerBaseImage=${{ env.ACR }}/memex-portal-ai-base:latest
 
+      # Guard: a partial multi-arch push (e.g. the arm64 leg silently failing when its base layer is
+      # missing) publishes a single-arch image WITHOUT the multi-arch manifest tag that the pull-based
+      # self-updater references — the plain tag then 404s (ImagePullBackOff) and the deployment never
+      # rolls. Fail the build rather than ship a version whose referenced tag isn't a complete manifest
+      # list. (2026-07 memex-cloud outage: migration ci.1184 pushed only -linux-x64, so V46
+      # exclude_from_context never applied and path resolution 42703'd mesh-wide.)
+      - name: Verify multi-arch manifest (portal-ai)
+        run: |
+          set -euo pipefail
+          ref="${{ env.ACR }}/memex-portal-ai:${{ steps.vars.outputs.version }}"
+          raw=$(docker buildx imagetools inspect "$ref" --raw)
+          for arch in amd64 arm64; do
+            echo "$raw" | grep -qE "\"architecture\"[[:space:]]*:[[:space:]]*\"$arch\"" \
+              || { echo "::error::$ref is not a complete multi-arch manifest — missing linux/$arch. Refusing to publish a partial version."; echo "$raw"; exit 1; }
+          done
+          echo "OK: $ref is a multi-arch manifest (amd64 + arm64)."
+
   migration-image:
     name: "Build + push migration image"
     if: >-
@@ -198,6 +215,23 @@ jobs:
           -p:ContainerRegistry=${{ env.ACR }}
           -p:ContainerRepository=memex-migration
           -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"'
+
+      # Guard: a partial multi-arch push (e.g. the arm64 leg silently failing when its base layer is
+      # missing) publishes a single-arch image WITHOUT the multi-arch manifest tag that the pull-based
+      # self-updater references — the plain tag then 404s (ImagePullBackOff) and the deployment never
+      # rolls. Fail the build rather than ship a version whose referenced tag isn't a complete manifest
+      # list. (2026-07 memex-cloud outage: migration ci.1184 pushed only -linux-x64, so V46
+      # exclude_from_context never applied and path resolution 42703'd mesh-wide.)
+      - name: Verify multi-arch manifest (migration)
+        run: |
+          set -euo pipefail
+          ref="${{ env.ACR }}/memex-migration:${{ steps.vars.outputs.version }}"
+          raw=$(docker buildx imagetools inspect "$ref" --raw)
+          for arch in amd64 arm64; do
+            echo "$raw" | grep -qE "\"architecture\"[[:space:]]*:[[:space:]]*\"$arch\"" \
+              || { echo "::error::$ref is not a complete multi-arch manifest — missing linux/$arch. Refusing to publish a partial version."; echo "$raw"; exit 1; }
+          done
+          echo "OK: $ref is a multi-arch manifest (amd64 + arm64)."
 
   # ─────────────────────────────── NO DEPLOY JOB ─────────────────────────────
   # Deployment is PULL-BASED, not push. CI's job ends at "publish the image to ACR" (the image


### PR DESCRIPTION
## Why
The `main-cd.yml` image legs use the .NET SDK multi-arch publish (`ContainerRuntimeIdentifiers="linux-x64;linux-arm64"`). If an arch leg fails (typically its base layer isn't multi-arch — the workflow already flags `memex-portal-ai-base:latest` as a prerequisite), the publish **degrades to a single-arch push**: only `<repo>:<version>-linux-x64` lands, and the **plain `<repo>:<version>` multi-arch manifest tag — the one the pull-based self-updater patches Deployments to — is never created**. K8s then 404s that tag (`ImagePullBackOff`) and the rollout stalls, silently.

That is the **2026-07-19 memex.meshweaver.cloud outage**: the *migration* image for `ci.1184` published only `-linux-x64`, so **V46 (`exclude_from_context`) never applied** while the portal upgraded to code that selects the column → `42703: column n.exclude_from_context does not exist` mesh-wide. (The *portal* leg happened to have a multi-arch base, so it shipped fine — which is exactly how the mismatch arose.)

## What
After each `Build + push`, inspect the pushed `<version>` tag (`docker buildx imagetools inspect --raw`) and **fail the job unless it's a manifest list carrying both `linux/amd64` and `linux/arm64`** — for both `memex-portal-ai` and `memex-migration`. A partial version can no longer be published, so a deploy can never reference a tag that doesn't exist.

+34 lines, no build-logic change (a pure post-condition guard). YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)