### PR TITLE
fix: query-in-render deadlock wedges nodes (SocialMedia Post, PandasExplorer)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AsynchronousCalls.md
@@ -545,7 +545,7 @@ This is also how you **wait for work to finish** — subscribe until a field in 
 
 Even when a query is the right idea (listings, filters, existence checks), **do not `await` the `IAsyncEnumerable<T>`** version — use `IMeshService.Query<T>`. It returns `IObservable<QueryResultChange<T>>` with an initial full set and then incremental deltas, composing with `Select` / `Where` / `Subscribe` like every other mesh observable.
 
-> **Even `Query` is wrong inside a layout area for displaying values.** Declare a binding and let the Blazor view subscribe. See [Data Binding](/Doc/GUI/DataBinding). Backend rendering code should be fully synchronous and side-effect-free.
+> **`IMeshService.Query` inside a layout-area render is now SAFE — the framework subscribes every render off the owning hub's action block.** It was once the canonical query-in-render deadlock (see [Query-in-render is safe](#-query-in-render-is-safe--the-framework-subscribes-every-render-off-the-hub-turn) below and [OrleansTaskScheduler](/Doc/Architecture/OrleansTaskScheduler)); the render pipeline now hops the subscribe onto `TaskPoolScheduler.Default`, so a generator that composes `IMeshService.Query(...).Select(...)` no longer wedges the grain. For *displaying* a single node's values a binding is still cleaner — declare it and let the Blazor view subscribe (see [Data Binding](/Doc/GUI/DataBinding)) — but query-in-render is no longer a trap.
 
 **`QueryAsync` breaks the update flow.** It is a one-shot snapshot — the view freezes. If a row is added, removed, or mutated, the list doesn't change. `Query` emits the initial set plus a delta for every subsequent change, so the downstream chain stays live.
 
@@ -576,6 +576,59 @@ meshService.Query<MeshNode>(MeshQueryRequest.FromQuery("nodeType:Post"))
 - **HTTP endpoints that render once and close** — e.g. a CSV download.
 
 Rule of thumb: **if any downstream code re-renders or re-computes when data changes, you need `Query`.** `QueryAsync` is only safe when the caller serialises the snapshot and walks away.
+
+---
+
+## 🚨 Query-in-render is SAFE — the framework subscribes every render OFF the hub turn
+
+> **This is the fix for the deadlock that took down multiple production meshes.** A layout area may
+> now do `IMeshService.Query(...)` (or any mesh round-trip — `hub.Observe`, `GetRemoteStream`, a
+> workspace query) *directly in its render*, and it will render instead of wedging the hub. The
+> safety is in the **portal/framework binary**, not in node source — so **already-deployed nodes
+> whose cached assemblies won't recompile become safe automatically.**
+
+### The trap it closes
+
+A layout area's view generator returns an `IObservable<UiControl?>`. The framework's render pipeline
+(`LayoutAreaHost.BuildInitialization`) **subscribes** to it. Before the fix that subscribe ran on the
+layout-area's own synchronisation-stream hub **action block** — a single-threaded actor
+(`MaxDegreeOfParallelism = 1`), and for a node hosted as an Orleans grain, grain-affined (the ROOT
+GRAIN HUB runs on the grain scheduler; see [OrleansTaskScheduler](/Doc/Architecture/OrleansTaskScheduler)).
+So the generator body — and the subscribe to whatever observable it returned — ran **on the hub
+turn**. A generator that did `IMeshService.Query(...)` opened that subscription while the turn was
+held; the query must route through Orleans and come back to **this** hub, but the turn could not
+advance to process the response → **the hub DEADLOCKED**. On startup prerender many grains blocked at
+once → thread-pool starvation → the whole silo wedged (even `/healthz`). Confirmed offenders:
+`Doc/DataMesh/SocialMedia/Post` (List area) and `Doc/DataMesh/PythonPandasNode/PandasExplorer` — each
+queried in-render.
+
+### The fix — one reactive seam, `SubscribeOn(TaskPoolScheduler.Default)`
+
+`LayoutAreaHost` now hops the render subscription (top-level AND every nested container / dialog /
+editor sub-area) onto the thread pool with `.SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default)`
+— the framework's **own designated reactive off-hub move**, the same one `MeshQuery.Query` and
+`IMeshNodeStreamCache.GetQuery` already make (see
+[OrleansTaskScheduler → "SubscribeOn inside a grain-hosted service"](/Doc/Architecture/OrleansTaskScheduler)).
+The generator, and every observable it subscribes in-render, now runs **OFF the hub turn** — which is
+immediately free to route and answer the round-trip. **100% reactive: a pure Rx scheduler operator,
+no `async` / `await` / `Task`.**
+
+**Why it can't reintroduce ordering bugs.** The render *output* never touches the hub directly —
+`PushRenderResult` / `UpdateArea` call `Stream.Update(...)`, which posts an `UpdateStreamRequest` to
+the hub's action block (`hub.Post` is the actor inbox: safe from any thread, re-serialised in order).
+So an emission arriving on a pool thread is re-marshalled onto the owning hub's single-threaded turn
+exactly as before — the offload moves only the **subscribe-time** work off the hub, never the state
+writes. Data-before-control ordering (the queued `UpdateData` → control sequence) is preserved.
+
+### What this does NOT license
+
+Rendering code should still be **reactive and side-effect-free**: compose with `.Select` / `.Where` /
+`.SelectMany`, return the `IObservable<UiControl?>`, never bridge a hub round-trip back to a blocking
+`Task` (`.Result` / `.Wait()` / `.ToTask()` + wait). The framework subscribes you off the hub turn;
+it does not make a **blocking** subscribe safe — a generator that *blocks its subscribing thread* on a
+round-trip still burns a pool thread (and under enough concurrency, the pool). Stay reactive. The rule
+that changed is narrow and important: **a normal reactive `IMeshService.Query` composed into the
+render no longer deadlocks the hub.**
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/OrleansTaskScheduler.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OrleansTaskScheduler.md
@@ -182,6 +182,68 @@ The `SubscribeOn` at the cache layer does not widen this risk — upstream chang
 
 > This `SubscribeOn` offload is the **query-construction** half of keeping the grain free. Its leaf-execution counterpart is the [Controlled I/O Pooling](/Doc/Architecture/ControlledIoPooling) primitive (`IIoPool`), which applies the same `SubscribeOn(TaskPoolScheduler.Default)` move plus a concurrency bound so actual file / blob / HTTP leaf work both runs off the grain *and* cannot fan out unboundedly.
 
+## 🚨 The layout-area render pipeline subscribes OFF the hub turn — query-in-render is safe
+
+**This is the third — and highest-leverage — place the framework makes the same `SubscribeOn` move**,
+and it closes the deadlock class that took down multiple production meshes.
+
+A layout area's view generator returns an `IObservable<UiControl?>`. The framework's render pipeline
+(`LayoutAreaHost.BuildInitialization`, and every nested container / dialog / editor sub-area render)
+**subscribes** to it to drive content to the client. That subscribe runs on the layout-area's own
+synchronisation-stream hub **action block** — a single-threaded actor. When the layout area belongs to
+a node hosted as an Orleans grain, its owning workspace hub is the **root grain hub on the grain
+scheduler** (the table above). So, before the fix, the generator body — and the subscribe to whatever
+observable it returned — ran **on the grain turn**.
+
+That is the query-in-render trap:
+
+1. A view generator does, in-render, `IMeshService.Query(...)` (or `hub.Observe`, `GetRemoteStream`, a
+   workspace query — any mesh round-trip).
+2. The render pipeline subscribes it **on the grain turn**.
+3. The query must route through Orleans and come back to **this grain** to resolve. But the grain turn
+   is held inside the subscribe → the response can never be processed → **the hub deadlocks.**
+4. On startup prerender, many such grains block at once → thread-pool starvation → the whole silo
+   wedges (even `/healthz`). Confirmed offenders: `Doc/DataMesh/SocialMedia/Post` (List area) and
+   `Doc/DataMesh/PythonPandasNode/PandasExplorer`.
+
+**The fix — one reactive seam.** `LayoutAreaHost` wraps the render subscription with
+`.SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default)` — the identical move made at
+`MeshQuery.Query` and `IMeshNodeStreamCache.GetQuery` (the section just above). The generator, and
+every observable it subscribes in-render, now runs **off the grain turn**, which is immediately free
+to route + answer the round-trip. A pure Rx scheduler operator — **no `async` / `await` / `Task`.**
+
+```csharp
+// LayoutAreaHost.BuildInitialization — the top-level render subscription:
+var renderSubscription = BuildRenderObservable(context, baseStore)
+    .SubscribeOn(TaskPoolScheduler.Default)   // ← subscribe OFF the owning (grain) hub's turn
+    .Subscribe(PushRenderResult, FailRendering);
+
+// The same hop guards every nested container/dialog/editor sub-area render in LayoutAreaHost.RenderArea,
+// because those subscribes are reached from UpdateArea, which runs ON the hub turn (Stream.Update →
+// UpdateStreamRequest). A nested area that queries in-render must be off-hub too.
+```
+
+**Why it can't reintroduce ordering bugs.** The render *output* (`PushRenderResult` / `UpdateArea`)
+never touches the hub directly — it calls `Stream.Update(...)`, which posts an `UpdateStreamRequest`
+to the hub's action block (`hub.Post` is the actor inbox: safe from any thread, re-serialised in
+order). So emissions arriving on a pool thread are re-marshalled onto the owning hub's single-threaded
+turn exactly as before — the offload moves only the **subscribe-time** work off the hub, never the
+state writes. Data-before-control ordering is preserved (regression-guarded by the full
+`MeshWeaver.Layout.Test` suite, incl. `EditorTest` / `ContainerControlAreaNestingTest`).
+
+**Why this is the robust fix and not "author around it."** The safety lives in the portal/framework
+binary, so **existing deployed nodes — whose cached assemblies never recompile — become safe with no
+code change.** The prior guidance ("move mesh queries into virtual data sources, never
+`IMeshService.Query` in a view") was a per-node *workaround*; this is the framework making the whole
+class safe at one seam. Regression-pinned by `QueryInRenderDeadlockTest` (a layout area doing an
+in-render mesh round-trip on a hub-turn-blocking subscribe: **hangs without the offload, renders with
+it**).
+
+> **Reactive, not blocking, still required.** The offload subscribes you off the hub turn; it does not
+> make a *blocking* subscribe free. A generator that bridges a round-trip back to a blocking `Task`
+> (`.Result` / `.Wait()` / `.ToTask()` + wait) still burns a pool thread. Compose reactively and
+> return the `IObservable<UiControl?>` — see [Asynchronous Calls](/Doc/Architecture/AsynchronousCalls).
+
 ## Offloading a CPU leaf off the action block — `Task.Run`, identity, and why the gated pool can wedge
 
 A long *synchronous* leaf (Roslyn `Emit`, a big reflection/type-load) that runs

--- a/src/MeshWeaver.Documentation/Data/DataMesh/SocialMedia/Post.json
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SocialMedia/Post.json
@@ -13,6 +13,6 @@
     "namespace": "Doc/DataMesh/SocialMedia",
     "displayName": "Social Media Post",
     "description": "A social media post (scheduled, published, with engagement stats)",
-    "configuration": "config => config.WithContentType<SocialMediaPost>().AddData(data => data.AddSource(source => source.WithType<Platform>(t => t.WithInitialData(Platform.All)))).AddDefaultLayoutAreas().AddLayout(layout => layout.AddSocialMediaPostLayoutAreas().WithDefaultArea(\"List\"))"
+    "configuration": "config => config.WithContentType<SocialMediaPost>().AddData(data => data.AddSource(source => source.WithType<Platform>(t => t.WithInitialData(Platform.All))).WithVirtualDataSource(\"SocialMediaPosts\", vs => vs.WithVirtualType<PostNode>(workspace => SocialMediaPostLayoutAreas.LoadPosts(workspace)))).AddDefaultLayoutAreas().AddLayout(layout => layout.AddSocialMediaPostLayoutAreas().WithDefaultArea(\"List\"))"
   }
 }

--- a/src/MeshWeaver.Documentation/Data/DataMesh/SocialMedia/Post/Source/SocialMediaPostLayoutAreas.cs
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SocialMedia/Post/Source/SocialMediaPostLayoutAreas.cs
@@ -4,10 +4,25 @@
 // </meshweaver>
 
 using System.Collections.Immutable;
+using System.Reactive.Linq;
 using System.Text.Json;
 using System.Web;
+using MeshWeaver.Data;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Workspace projection of a sibling Post node: the display order plus the raw
+/// <see cref="MeshNode"/> the List view formats. Keyed by <see cref="Path"/> so
+/// the virtual collection stays deduplicated as the query result set evolves.
+/// </summary>
+public record PostNode
+{
+    [Key]
+    public string Path { get; init; } = string.Empty;
+    public MeshNode Node { get; init; } = null!;
+}
 
 public static class SocialMediaPostLayoutAreas
 {
@@ -62,14 +77,34 @@ public static class SocialMediaPostLayoutAreas
         return p.ValueKind == JsonValueKind.String && DateTimeOffset.TryParse(p.GetString(), out var dt) ? dt : null;
     }
 
+    /// <summary>
+    /// Virtual-source loader: the <c>namespace:Doc/DataMesh/SocialMedia/Post</c>
+    /// mesh query, folded to a path-keyed snapshot and projected to
+    /// <see cref="PostNode"/>. Registered in <c>Post.json</c>'s configuration
+    /// via <c>WithVirtualDataSource</c> so the framework subscribes it ONCE at
+    /// hub initialization on a managed scheduler — never from inside a view
+    /// render (a query subscription in a layout-area render runs on the grain's
+    /// activation thread and deadlocks the hub — see AsynchronousCalls). The
+    /// List view then composes only the hub's OWN workspace stream.
+    /// </summary>
+    public static IObservable<IEnumerable<PostNode>> LoadPosts(IWorkspace workspace)
+        => workspace.Hub.ServiceProvider.GetRequiredService<IMeshService>()
+            .Query<MeshNode>(MeshQueryRequest.FromQuery("namespace:Doc/DataMesh/SocialMedia/Post"))
+            .Scan(ImmutableDictionary<string, MeshNode>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase), ApplyChanges)
+            .Select(dict => dict.Values
+                .Select(n => new PostNode { Path = n.Path, Node = n })
+                .ToImmutableList()
+                .AsEnumerable());
+
     public static IObservable<UiControl?> List(LayoutAreaHost host, RenderingContext _)
     {
-        var meshService = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
-        var postsStream = meshService
-            .Query<MeshNode>(MeshQueryRequest.FromQuery("namespace:Doc/DataMesh/SocialMedia/Post"))
-            .Scan(ImmutableDictionary<string, MeshNode>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase), ApplyChanges);
+        var postsStream = host.Workspace.GetStream<PostNode>()
+            ?? Observable.Return<PostNode[]?>(null);
 
-        return postsStream.Select(dict => (UiControl?)BuildList(dict.Values.ToImmutableList()));
+        return postsStream.Select(posts => (UiControl?)BuildList(
+            (posts ?? Enumerable.Empty<PostNode>())
+                .Select(p => p.Node)
+                .ToImmutableList()));
     }
 
     private static UiControl BuildList(ImmutableList<MeshNode> posts)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-19-query-in-render-deadlock-fix.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-19-query-in-render-deadlock-fix.md
@@ -1,0 +1,12 @@
+---
+Name: Layout areas that query while rendering no longer wedge the portal
+Category: What's New
+Description: A layout area that fetches mesh data during its render is now safe — the render subscribes off the hub turn, so it can't deadlock the node
+Icon: Sparkle
+---
+
+# Query-while-rendering is now safe
+
+A layout area whose view fetches mesh data during its render — a `Query`, a workspace read, any hub round-trip — used to be able to deadlock the node that hosts it: the render subscribed on the hub's own turn, and the round-trip needed that same turn to come back. On startup, many such areas rendering at once could starve the thread pool and wedge a whole portal.
+
+The render pipeline now subscribes off the hub turn, so the round-trip is free to route and return. Query-while-rendering is safe, existing pages need no change, and deployed nodes become safe without a recompile. The SocialMedia Post example was also moved to the recommended pattern (loading its data through a virtual data source).

--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
@@ -239,7 +240,40 @@ public record LayoutAreaHost : IDisposable
             // renderers (the typed-content readers) run only on a SUCCESS status;
             // error/cancelled status and missing configuration short-circuit to a
             // visible emergency frame (see BuildRenderObservable).
+            //
+            // 🚨 SUBSCRIBE OFF THE OWNING HUB'S ACTION BLOCK. This init pipeline runs
+            // on the hub that owns this layout area's stream. For a node hosted as an
+            // Orleans grain that hub IS the ROOT GRAIN HUB — its action block runs on
+            // the GRAIN SCHEDULER (a single-threaded, grain-affined TaskScheduler; see
+            // Doc/Architecture/OrleansTaskScheduler). Subscribing the render pipeline on
+            // that thread means the view generator body — and every observable it
+            // returns — is SUBSCRIBED on the grain turn. A generator that does
+            // `IMeshService.Query(...)` (or any hub round-trip: `hub.Observe`,
+            // `GetRemoteStream`, a workspace query) then opens that subscription while
+            // the grain turn is held; the query must route through Orleans and come back
+            // to THIS grain, but the turn can't advance to process the response → the hub
+            // DEADLOCKS. On startup prerender many such grains block at once → thread-pool
+            // starvation → the silo wedges (took down multiple production meshes; the
+            // confirmed offenders — Doc/DataMesh/SocialMedia/Post List,
+            // Doc/DataMesh/PythonPandasNode/PandasExplorer — all query in-render).
+            //
+            // .SubscribeOn(TaskPoolScheduler.Default) hops the SUBSCRIBE onto the thread
+            // pool, so the generator runs and its query subscribes OFF the grain turn,
+            // which is immediately free to route + return the query. This is the SAME
+            // designated reactive move the framework already makes at MeshQuery.Query and
+            // IMeshNodeStreamCache.GetQuery (OrleansTaskScheduler → "SubscribeOn inside a
+            // grain-hosted service") — a pure Rx scheduler hop, no async/await/Task.
+            //
+            // Ordering is preserved: the render output (PushRenderResult) never touches
+            // the hub directly — it calls Stream.Update, which posts an UpdateStreamRequest
+            // to the hub's ACTION BLOCK (hub.Post is the actor inbox, safe from any thread
+            // and re-serialised in order). So emissions arriving on a pool thread are
+            // re-marshalled onto the owning hub's single-threaded turn exactly as before —
+            // the offload moves only the SUBSCRIBE-time work off the grain, never the state
+            // writes. This makes EVERY layout area query-in-render-safe at one seam, with
+            // no change to (and no recompile of) any deployed node's source.
             var renderSubscription = BuildRenderObservable(context, baseStore)
+                .SubscribeOn(TaskPoolScheduler.Default)
                 .Subscribe(PushRenderResult, FailRendering);
 
             // Tear down: dispose the render + milestone subscriptions and clear the
@@ -943,6 +977,16 @@ public record LayoutAreaHost : IDisposable
         var ret = DisposeExistingAreas(store, context);
         RegisterForDisposal(context.Parent?.Area ?? context.Area,
             generator.Invoke(this, context, ret.Store)
+                // 🚨 NEVER ON THE MAIN HUB. This nested-area subscribe is reached both from the
+                // (already off-hub) top-level render AND from UpdateArea, which runs on the owning
+                // hub's ACTION BLOCK (Stream.Update → UpdateStreamRequest). Subscribing the nested
+                // generator there would run its body — and any IMeshService.Query / hub round-trip it
+                // does in-render — on the hub turn → the same query-in-render deadlock as the
+                // top-level path. Hop the subscribe onto the thread pool (see the class-level fix in
+                // BuildInitialization + Doc/Architecture/OrleansTaskScheduler). The UpdateArea
+                // callback re-enters via Stream.Update → hub.Post (the actor inbox, safe from any
+                // thread, re-serialised in order), so ordering is preserved.
+                .SubscribeOn(TaskPoolScheduler.Default)
                 .Subscribe(c => UpdateArea(context, c), ex => FailRendering(ex, context.Area))
         );
         return ret;
@@ -957,6 +1001,10 @@ public record LayoutAreaHost : IDisposable
         RegisterForDisposal(context.Parent?.Area ?? context.Area,
             FromViewBuilder(ct => asyncGenerator.Invoke(this, context, store, ct))
                 .Switch()
+                // 🚨 NEVER ON THE MAIN HUB — see the ViewStream<T> overload above. Subscribe the
+                // nested generator off the owning hub's action block so its in-render mesh work never
+                // wedges the hub turn (UpdateArea re-marshals emissions back via hub.Post).
+                .SubscribeOn(TaskPoolScheduler.Default)
                 .Subscribe(c => UpdateArea(context, c), ex => FailRendering(ex, context.Area)));
         return ret;
     }
@@ -1085,6 +1133,9 @@ public record LayoutAreaHost : IDisposable
         // (no await in hub-reachable code) and feed UpdateArea once it resolves.
         RegisterForDisposal(context.Parent?.Area ?? context.Area,
             FromViewBuilder(ct => generator.Invoke(this, context, ct))
+                // 🚨 NEVER ON THE MAIN HUB — subscribe off the owning hub's action block (this path is
+                // reachable via UpdateArea on the hub turn). See the ViewStream<T> overload above.
+                .SubscribeOn(TaskPoolScheduler.Default)
                 .Subscribe(view => UpdateArea(context, view!), ex => FailRendering(ex, context.Area)));
         return ret;
     }
@@ -1100,6 +1151,8 @@ public record LayoutAreaHost : IDisposable
             generator
                 .Select(vd => FromViewBuilder(ct => vd.Invoke(this, context, ct)))
                 .Switch()
+                // 🚨 NEVER ON THE MAIN HUB — subscribe off the owning hub's action block. See above.
+                .SubscribeOn(TaskPoolScheduler.Default)
                 .Subscribe(view => UpdateArea(context, view!), ex => FailRendering(ex, context.Area)));
 
         return DisposeExistingAreas(store, context);
@@ -1131,6 +1184,11 @@ public record LayoutAreaHost : IDisposable
             context.Area,
             generator
                 .DistinctUntilChanged()
+                // 🚨 NEVER ON THE MAIN HUB — subscribe off the owning hub's action block. This
+                // container/dialog sub-area path is reached from UpdateArea on the hub turn, so a
+                // nested generator that queries in-render would otherwise wedge it. See the
+                // ViewStream<T> overload above and Doc/Architecture/OrleansTaskScheduler.
+                .SubscribeOn(TaskPoolScheduler.Default)
                 .Subscribe(
                     view => UpdateArea(context, view),
                     ex => FailRendering(ex, context.Area))

--- a/test/MeshWeaver.Layout.Test/QueryInRenderDeadlockTest.cs
+++ b/test/MeshWeaver.Layout.Test/QueryInRenderDeadlockTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Text.Json;
 using System.Threading;

--- a/test/MeshWeaver.Layout.Test/QueryInRenderDeadlockTest.cs
+++ b/test/MeshWeaver.Layout.Test/QueryInRenderDeadlockTest.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// 🚨 REGRESSION GUARD FOR THE QUERY-IN-RENDER DEADLOCK THAT TOOK DOWN PRODUCTION MESHES.
+///
+/// <para><b>The trap.</b> A layout area's view generator subscribes, IN-RENDER, to an observable
+/// that performs a MESH round-trip — most importantly <c>IMeshService.Query(...)</c>, but equally
+/// <c>hub.Observe(...)</c>, <c>GetRemoteStream</c>, or any workspace query. The framework's render
+/// pipeline (<see cref="LayoutAreaHost"/>'s init subscription) SUBSCRIBES to whatever the generator
+/// returns — and, before the fix, it did so ON the layout-area's own synchronization-stream hub
+/// action block: a single-threaded actor (<c>MaxDegreeOfParallelism = 1</c>). For a node hosted as
+/// an Orleans grain that hub is grain-affined. If the SUBSCRIBE occupies the hub turn until a mesh
+/// round-trip completes — and that round-trip must be routed / answered BY THAT SAME HUB — the turn
+/// is held inside the subscribe and the round-trip can never make progress → the hub DEADLOCKS. On
+/// startup prerender many area hubs block at once → thread-pool starvation → the whole silo wedges
+/// (even /healthz). Confirmed offenders: <c>Doc/DataMesh/SocialMedia/Post</c> (List area) and
+/// <c>Doc/DataMesh/PythonPandasNode/PandasExplorer</c> — each queries in-render.</para>
+///
+/// <para><b>The framework-level fix</b> (not a per-node authoring workaround): the render
+/// subscription in <see cref="LayoutAreaHost"/>.<c>BuildInitialization</c> is offloaded OFF the
+/// owning hub's action block with <c>.SubscribeOn(TaskPoolScheduler.Default)</c> — the framework's
+/// own designated reactive off-hub move (the same one <c>MeshQuery.Query</c> and
+/// <c>IMeshNodeStreamCache.GetQuery</c> already make). The generator, and every observable it
+/// subscribes in-render, now runs OFF the hub turn, which is immediately free to route and answer the
+/// round-trip. This makes EVERY layout area query-in-render-safe at ONE seam, with no recompile of
+/// any deployed node's source. See <c>Doc/Architecture/OrleansTaskScheduler</c> and
+/// <c>Doc/Architecture/AsynchronousCalls</c>.</para>
+///
+/// <para><b>How this test reproduces the deadlock without a DB.</b> A layout area's generator returns
+/// an observable that, ON SUBSCRIBE, does a mesh round-trip that the layout-area's OWN
+/// synchronization-stream hub must answer, and does not return control from the subscribe until that
+/// round-trip resolves — the shape a naive query-in-render takes when the layout-seam offload is
+/// absent (the round-trip's completion is gated behind the very turn that is subscribing). If the
+/// render pipeline subscribes this on the hub turn, the round-trip's response can never be dequeued
+/// and the subscribe never returns → the area never renders. The layout-seam offload is the ONLY
+/// thing that moves this subscribe off the hub turn; the observable itself carries no scheduler hop.
+/// Before the fix the render subscribe wedges the stream-hub turn and the control never lands (the
+/// <c>.Should().Within(20.Seconds())</c> deadline FAILS the test — a DEBUG <c>HubFact</c> applies no
+/// timeout, so the deadline is the real guard). After the fix the subscribe is off the hub turn, the
+/// round-trip is answered on the free turn, and the control lands within the deadline.</para>
+/// </summary>
+public class QueryInRenderDeadlockTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string QueryInRenderArea = nameof(QueryInRenderArea);
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithRoutes(r => r.RouteAddress(ClientType, (_, d) => d.Package()))
+            .AddLayout(layout => layout.WithView(QueryInRenderArea, QueryInRender));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    /// <summary>
+    /// The offending pattern, distilled: a view generator whose observable, ON SUBSCRIBE, performs a
+    /// mesh round-trip the layout area's OWN (single-threaded) synchronization-stream hub must answer,
+    /// and blocks the subscribing thread until it resolves. This is the deadlock topology of
+    /// <c>meshService.Query(...)</c> reached in-render when the layout-seam offload is missing: the
+    /// query routes to a hub that is, at that instant, the very hub blocked inside this subscribe. A
+    /// self-directed <c>PingRequest</c> stands in for the query so the test needs no DB. The
+    /// bounded-wait is the diagnostic knob: if the subscribe runs on the stream-hub turn, the ping's
+    /// response can never be dequeued and the wait times out to a null control (the area never
+    /// renders); if it runs OFF the turn (the fix), the ping is answered and the control emits.
+    /// </summary>
+    private static IObservable<UiControl?> QueryInRender(LayoutAreaHost host, RenderingContext _)
+        => Observable.Create<UiControl?>(observer =>
+        {
+            // A round-trip the layout area's OWN stream hub must answer (every hub answers PingRequest
+            // on its own action block). If THIS subscribe is running on that hub's turn, the ping sits
+            // in the inbox behind us and cannot be dequeued until we return — but we are (below)
+            // waiting for it: the deadlock. Off the turn (the fix), the hub is free to answer it.
+            var pong = new ManualResetEventSlim(false);
+            using var sub = host.Stream.Hub
+                .Observe(new PingRequest(), o => o.WithTarget(host.Stream.Hub.Address))
+                .Take(1)
+                .Subscribe(_ => pong.Set());
+
+            // Blocks the SUBSCRIBING thread until the round-trip resolves — the sync-over-mesh shape a
+            // query-in-render collapses to when it is on the wrong scheduler. Bounded so a genuinely
+            // wedged hub surfaces as "area never rendered" (null control → the .Within deadline fails
+            // the test) instead of hanging the whole run.
+            var answered = pong.Wait(TimeSpan.FromSeconds(15));
+
+            observer.OnNext(answered
+                ? (UiControl?)Controls.Markdown("QUERY_IN_RENDER_RESOLVED")
+                : (UiControl?)Controls.Markdown("QUERY_IN_RENDER_WEDGED"));
+            observer.OnCompleted();
+            return System.Reactive.Disposables.Disposable.Empty;
+        });
+
+    /// <summary>
+    /// Before the layout-seam fix, the render subscribe holds the layout-area stream hub's
+    /// single-threaded action block while the generator waits on a round-trip that same hub must
+    /// answer — the ping never resolves, the generator emits the WEDGED marker (or the whole render
+    /// stalls), and the <c>QUERY_IN_RENDER_RESOLVED</c> control never lands → the
+    /// <c>.Should().Within(20.Seconds())</c> deadline fails the test. After the fix the render
+    /// pipeline subscribes OFF the hub turn, the hub answers the ping on its free turn, and the
+    /// RESOLVED control lands within the deadline.
+    /// </summary>
+    [HubFact]
+    public async Task QueryInRender_DoesNotDeadlockTheHub_AndRenders()
+    {
+        var reference = new LayoutAreaReference(QueryInRenderArea);
+        var stream = GetClient().GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(CreateHostAddress(), reference);
+
+        var control = await stream.GetControlStream(reference.Area!)
+            .Where(c => c is MarkdownControl m
+                        && (m.Markdown?.ToString() ?? string.Empty).Contains("QUERY_IN_RENDER_RESOLVED"))
+            .Should().Within(20.Seconds())
+            .Match(c => c is MarkdownControl);
+
+        control.Should().NotBeNull(
+            "a layout area that does an in-render mesh round-trip must render — the render " +
+            "subscription must be OFF the owning hub's action block, never blocking it");
+    }
+}


### PR DESCRIPTION
## Why

A layout area whose view generator does a mesh round-trip **during render** — `IMeshService.Query`, `hub.Observe`, `GetRemoteStream`, a workspace query — could **deadlock the node that hosts it**. The render pipeline subscribed on the owning hub's action block; for an Orleans-grain-hosted node that's the **root grain hub on the grain scheduler**. Opening a query subscription there holds the grain turn while the query needs that same turn to return → deadlock. On startup prerender, many grains block at once → thread-pool starvation → the silo wedges (even `/healthz`). **This took down multiple production meshes.** Because `Doc/DataMesh/SocialMedia/Post` is a Doc-partition node synced to every mesh, it was the recurring trigger; `Doc/DataMesh/PythonPandasNode/PandasExplorer` is a second confirmed offender.

This is why **atioz was pinned off the continuous channel** (to a manual `socialmedia-fix` image) — main still had this deadlock. This PR fixes it in main so atioz (and every mesh) can run current images safely.

## The fix

Two commits (both authored earlier, brought onto current main):

1. **Framework root-cause fix** (`LayoutAreaHost`) — the render subscription (top-level and every nested container/dialog/editor sub-area) now hops onto `TaskPoolScheduler.Default` via `.SubscribeOn(...)`, the framework's own designated off-hub move (identical to `MeshQuery.Query` / `IMeshNodeStreamCache.GetQuery`). The generator and every observable it subscribes in-render now run **off** the grain turn, which is immediately free to route + answer the round-trip. Pure Rx — no `async`/`await`/`Task`. Ordering is preserved: render output flows through `Stream.Update → hub.Post` (the actor inbox), so only subscribe-time work moves off the turn, never the state writes. The safety lives in the framework binary, so already-deployed nodes become safe **without a recompile**. Carries the deterministic `QueryInRenderDeadlockTest` (hangs the 20s reactive deadline without the offload; ~350 ms with it).

2. **SocialMedia Post → correct pattern** — moves the `Doc/DataMesh/SocialMedia/Post` query out of the List render into a **virtual data source** (`WithVirtualDataSource`/`LoadPosts`); List composes `host.Workspace.GetStream<PostNode>()`. Defense-in-depth + makes the shipped example demonstrate the recommended pattern.

## Testing

- `QueryInRenderDeadlockTest` passes (the proving repro).
- Full **`MeshWeaver.Layout.Test` — 329/329 green** (the `LayoutAreaHost` change regresses nothing).
- `DocumentationLinkIntegrityTest` green (touches `AsynchronousCalls.md`, `OrleansTaskScheduler.md`, + a What's New entry).
- Build green with CI flags (`-c Release -p:CIRun=true -warnaserror`).

## Follow-up

Once this is green on main and a new `ci.<n>` image is built, **atioz can be rolled back onto the continuous channel** (it is currently on the now-untagged `socialmedia-fix` image, which carries this fix out-of-band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)