### PR TITLE
fix(funnel): denied visitors land on the marketing page (RedirectOnDenied), not a dead wall

### DIFF
--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -207,13 +207,28 @@ public static class MeshNodeLayoutAreas
         var hubPath = host.Hub.Address.ToString();
         // CombineLatest with permission stream — pure observable composition, no await.
         return host.Workspace.GetMeshNodeStream().CombineLatest(
-            host.Hub.GetEffectivePermissions(hubPath),
-            (node, permissions) =>
+                host.Hub.GetEffectivePermissions(hubPath),
+                (node, permissions) => (Node: node, Permissions: permissions))
+            .SelectMany(t =>
             {
-                if (!permissions.HasFlag(Permission.Read))
-                    return (UiControl?)BuildAccessDenied(hubPath);
-                var canEdit = permissions.HasFlag(Permission.Update);
-                return (UiControl?)host.BuildDetailsContent(node, null, canEdit);
+                if (t.Permissions.HasFlag(Permission.Read))
+                    return Observable.Return((UiControl?)host.BuildDetailsContent(
+                        t.Node, null, t.Permissions.HasFlag(Permission.Update)));
+                // Read denied: the partition's declared funnel page (RedirectOnDenied — e.g.
+                // a product's glossy marketing brochure) takes the viewer there instead of a
+                // dead-end Request-Access wall. Rendering the denial INSIDE the area used to
+                // pre-empt the area-level redirect entirely, so the policy never applied on
+                // full-page Overviews. Fail-safe: no/looping/erroring policy → the denial page.
+                return host.Hub.GetRedirectOnDenied(hubPath)
+                    .Take(1)
+                    .Catch<string?, Exception>(_ => Observable.Return<string?>(null))
+                    .Select(redirect => redirect is { Length: > 0 }
+                        && !string.Equals(redirect, hubPath, StringComparison.OrdinalIgnoreCase)
+                        ? (UiControl?)Controls.Stack
+                            .WithView(Controls.Redirect("/" + redirect.TrimStart('/')), "Redirect")
+                            .WithView(Controls.Markdown(
+                                $"[Continue here →](/{redirect.TrimStart('/')})"))
+                        : BuildAccessDenied(hubPath));
             });
     }
 

--- a/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
+++ b/src/MeshWeaver.Hosting.Blazor/NavigationService.cs
@@ -91,6 +91,7 @@ internal class NavigationService : INavigationService
     // production; injectable via the internal ctor so the wiring tests drive both outcomes
     // (allow / login) without mocking the permission stack.
     private readonly Func<string, IObservable<bool>> _anonymousGate;
+    private readonly Func<string, IObservable<string?>> _redirectOnDenied;
 
     public NavigationService(
         NavigationManager navigationManager,
@@ -113,9 +114,11 @@ internal class NavigationService : INavigationService
         ICircuitContextAccessor circuitContextAccessor,
         int[] retryDelays,
         PageRouteRegistry? pageRoutes = null,
-        Func<string, IObservable<bool>>? anonymousGate = null)
+        Func<string, IObservable<bool>>? anonymousGate = null,
+        Func<string, IObservable<string?>>? redirectOnDenied = null)
     {
         _anonymousGate = anonymousGate ?? (path => AnonymousGate.AllowAnonymous(hub, path));
+        _redirectOnDenied = redirectOnDenied ?? (path => hub.GetRedirectOnDenied(path));
         _pageRoutes = pageRoutes;
         _navigationManager = navigationManager;
         _pathResolver = pathResolver;
@@ -537,11 +540,15 @@ internal class NavigationService : INavigationService
 
         // Anonymous gate: a logged-OUT visitor sees application content ONLY when the resolved
         // node carries an explicit positive Anonymous grant (a public course cover / catalog /
-        // landing). EVERYTHING else goes to /login first — sign-in is always the first step; the
-        // paywall (PartitionAccessPolicy.RedirectOnDenied) applies to the then-AUTHENTICATED
-        // visitor via the area-level access-denied redirect in NamedAreaView. PathResolutionService
-        // resolves under a System bypass, so EVERY existing mesh page (public or private) reaches
-        // here — the gate is the anonymous enforcement point.
+        // landing). Everything else lands on the partition's declared MARKETING page when one
+        // exists — PartitionAccessPolicy.RedirectOnDenied, honored for anonymous visitors ONLY
+        // when that target is itself anonymous-readable (a denied /UWDeepfield goes to the
+        // glossy /UWDeepfield/Overview brochure, not a dead login wall) — and /login otherwise:
+        // sign-in stays the first step wherever no public funnel page is declared. The
+        // authenticated-visitor paywall keeps using the area-level access-denied redirect in
+        // NamedAreaView. PathResolutionService resolves under a System bypass, so EVERY existing
+        // mesh page (public or private) reaches here — the gate is the anonymous enforcement
+        // point.
         //
         // The decision itself lives in AnonymousGate.AllowAnonymous (Mesh.Contract) so it is
         // integration-tested against the REAL PermissionEvaluator; it is FAIL-CLOSED: no
@@ -566,12 +573,30 @@ internal class NavigationService : INavigationService
         {
             _anonymousGate(resolution.Prefix)
                 .Take(1)
+                // Denied → the partition's declared redirect, but ONLY when that target is
+                // ITSELF anonymous-readable (fail-closed: a policy pointing at gated content
+                // must not leak it) and is a DIFFERENT path (a self-pointing policy would
+                // loop the resolver forever). Any error/timeout settles on (false, null) → /login.
+                .SelectMany(allowed => allowed
+                    ? Observable.Return((Allowed: true, Redirect: (string?)null))
+                    : _redirectOnDenied(resolution.Prefix)
+                        .Take(1)
+                        .SelectMany(target =>
+                            string.IsNullOrWhiteSpace(target)
+                            || string.Equals(target, resolution.Prefix, StringComparison.OrdinalIgnoreCase)
+                                ? Observable.Return((Allowed: false, Redirect: (string?)null))
+                                : _anonymousGate(target!)
+                                    .Take(1)
+                                    .Select(ok => (Allowed: false, Redirect: ok ? target : null))))
                 .Timeout(TimeSpan.FromSeconds(10))
-                .Catch<bool, Exception>(_ => Observable.Return(false))
-                .Subscribe(allowed =>
+                .Catch<(bool Allowed, string? Redirect), Exception>(
+                    _ => Observable.Return((false, (string?)null)))
+                .Subscribe(result =>
                 {
-                    if (allowed)
+                    if (result.Allowed)
                         LoadResolved();
+                    else if (result.Redirect is { } marketing)
+                        RedirectToMarketing(marketing);
                     else
                         RedirectToLogin();
                 });
@@ -580,6 +605,18 @@ internal class NavigationService : INavigationService
 
         LoadResolved();
         return;
+
+        void RedirectToMarketing(string marketing)
+        {
+            // The denied path has a PUBLIC funnel page (verified anonymous-readable above):
+            // in-circuit navigation — the target is a normal mesh page and re-enters this
+            // resolver, where its own positive Anonymous grant lets it load.
+            _logger?.LogInformation(
+                "Anonymous-gate: '{Prefix}' denied → marketing page '{Marketing}' (RedirectOnDenied).",
+                resolution.Prefix, marketing);
+            IsResolving = false;
+            _navigationManager.NavigateTo("/" + marketing.TrimStart('/'));
+        }
 
         void RedirectToLogin()
         {

--- a/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/NavigationServiceTest.cs
@@ -228,6 +228,77 @@ public class NavigationServiceTest
         new(_navigationManager, _pathResolver, _hub, _circuitContextAccessor,
             [10, 20], null, gate);
 
+    /// <summary>Same as <see cref="CreateServiceWithGate"/> plus an injected RedirectOnDenied
+    /// lookup — drives the anonymous marketing-funnel wiring explicitly.</summary>
+    private NavigationService CreateServiceWithGateAndRedirect(
+        Func<string, IObservable<bool>> gate,
+        Func<string, IObservable<string?>> redirect) =>
+        new(_navigationManager, _pathResolver, _hub, _circuitContextAccessor,
+            [10, 20], null, gate, redirect);
+
+    [Fact]
+    public async Task AnonymousVisitor_GateDenies_WithPublicFunnel_RedirectsToMarketingPage()
+    {
+        // A denied page whose partition declares RedirectOnDenied pointing at an
+        // ANONYMOUS-READABLE page (the product's glossy marketing brochure): the logged-out
+        // visitor lands THERE, not on a dead login wall.
+        MakeVisitorAnonymous();
+        var service = CreateServiceWithGateAndRedirect(
+            path => System.Reactive.Linq.Observable.Return(
+                path == "UWDeepfield/Overview"),          // root denied, brochure public
+            _ => System.Reactive.Linq.Observable.Return<string?>("UWDeepfield/Overview"));
+        _pathResolver.ResolveNavigationPath(Arg.Any<string>())
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("UWDeepfield", null)));
+
+        service.Initialize();
+        _navigationManager.SimulateLocationChanged("http://localhost/UWDeepfield");
+
+        await WaitForRedirect("/UWDeepfield/Overview");
+        _navigationManager.Uri.Should().Contain("/UWDeepfield/Overview");
+        _navigationManager.Uri.Should().NotContain("/login");
+    }
+
+    [Fact]
+    public async Task AnonymousVisitor_GateDenies_FunnelTargetAlsoDenied_FailsClosedToLogin()
+    {
+        // FAIL-CLOSED: a RedirectOnDenied pointing at a page that is itself NOT
+        // anonymous-readable must never be followed — /login as before.
+        MakeVisitorAnonymous();
+        var service = CreateServiceWithGateAndRedirect(
+            _ => System.Reactive.Linq.Observable.Return(false),   // everything denied
+            _ => System.Reactive.Linq.Observable.Return<string?>("Private/Paywall"));
+        _pathResolver.ResolveNavigationPath(Arg.Any<string>())
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("Private/Space", "Overview")));
+
+        service.Initialize();
+        _navigationManager.SimulateLocationChanged("http://localhost/Private/Space/Overview");
+
+        await WaitForRedirect("/login?returnUrl=");
+        _navigationManager.Uri.Should().Contain("/login?returnUrl=");
+    }
+
+    [Fact]
+    public async Task AnonymousVisitor_GateDenies_SelfPointingFunnel_FailsClosedToLogin()
+    {
+        // FAIL-CLOSED: a policy pointing at the denied path itself must not loop the
+        // resolver — /login.
+        MakeVisitorAnonymous();
+        var service = CreateServiceWithGateAndRedirect(
+            _ => System.Reactive.Linq.Observable.Return(false),
+            _ => System.Reactive.Linq.Observable.Return<string?>("Private/Space"));
+        _pathResolver.ResolveNavigationPath(Arg.Any<string>())
+            .Returns(System.Reactive.Linq.Observable.Return<AddressResolution?>(
+                new AddressResolution("Private/Space", "Overview")));
+
+        service.Initialize();
+        _navigationManager.SimulateLocationChanged("http://localhost/Private/Space/Overview");
+
+        await WaitForRedirect("/login?returnUrl=");
+        _navigationManager.Uri.Should().Contain("/login?returnUrl=");
+    }
+
     [Fact]
     public async Task AnonymousVisitor_GateAllows_LoadsThePage()
     {
@@ -252,9 +323,9 @@ public class NavigationServiceTest
     [Fact]
     public async Task AnonymousVisitor_GateDenies_RedirectsToLogin()
     {
-        // A denied page — regardless of any configured paywall — sends the logged-out visitor to
-        // /login first (returnUrl bounces them back after sign-in; the paywall then applies to
-        // the AUTHENTICATED visitor via the area-level access-denied redirect).
+        // A denied page with NO public funnel declared (the mocked hub yields no
+        // RedirectOnDenied) sends the logged-out visitor to /login (returnUrl bounces them
+        // back after sign-in).
         MakeVisitorAnonymous();
         var service = CreateServiceWithGate(_ =>
             System.Reactive.Linq.Observable.Return(false));


### PR DESCRIPTION
Anonymous `/UWDeepfield` served the empty-Space *Welcome* boilerplate; after locking the root it became `/login` / the in-area **Request Access** page — never the glossy `/UWDeepfield/Overview` the partition's `RedirectOnDenied` declares. Two gaps, both fixed:

1. **NavigationService** — the anonymous gate always bounced to `/login`. It now follows `RedirectOnDenied` for logged-out visitors **only when the target itself passes the fail-closed anonymous gate** and differs from the denied path (no leak, no loop); errors/timeouts keep settling on `/login`. Injectable seam + 3 new wiring tests (funnel redirect / target-denied fail-closed / self-pointing fail-closed), suite 9/9.
2. **MeshNodeLayoutAreas.Overview** — Read-denial rendered `BuildAccessDenied` *inside* the area, pre-empting the area-level redirect entirely. Read-denied now consults `GetRedirectOnDenied` and renders a `Controls.Redirect` to the funnel page (with a fallback link); no/self-pointing/erroring policy keeps the denial page. `EditNode`'s Update-denial intentionally keeps Request-Access.

Live data already staged on memex-cloud: `UWDeepfield/_Policy.redirectOnDenied → UWDeepfield/Overview`, brochure carries its own Anonymous+Public grants, root grants removed. After deploy: `/UWDeepfield` → glossy brochure for every un-entitled visitor.

Local gate: Release `-warnaserror` green on Hosting.Blazor + Graph; Blazor.Test AnonymousVisitor suite 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)