### PR TITLE
fix(embeds): @@ embeds render without any collaboration UI

### DIFF
--- a/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor
+++ b/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor
@@ -134,8 +134,8 @@
         </div>
     }
 
-    @* Bottom page comment section *@
-    @if (!string.IsNullOrEmpty(BoundNodePath))
+    @* Bottom page comment section — suppressed for @@ embeds (HideAnnotations) *@
+    @if (!BoundHideAnnotations && !string.IsNullOrEmpty(BoundNodePath))
     {
         <div class="page-comment-section">
             @if (_showPageCommentInput)

--- a/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
@@ -43,6 +43,7 @@ public partial class CollaborativeMarkdownView
     private string? BoundHubAddress;
     private bool BoundCanComment;
     private bool BoundCanEdit;
+    private bool BoundHideAnnotations;
 
     // The document node's current hub version — stamped onto new comments and used to decide
     // whether a comment's stored offsets are still valid or it must be re-anchored at render time.
@@ -179,8 +180,10 @@ public partial class CollaborativeMarkdownView
 
         BoundNodePath = ViewModel.NodePath;
         BoundHubAddress = ViewModel.HubAddress;
-        BoundCanComment = ViewModel.CanComment;
-        BoundCanEdit = ViewModel.CanEdit;
+        BoundHideAnnotations = ViewModel.HideAnnotations;
+        // Hidden annotations imply no commenting/reviewing — the flags never contradict each other.
+        BoundCanComment = ViewModel.CanComment && !BoundHideAnnotations;
+        BoundCanEdit = ViewModel.CanEdit && !BoundHideAnnotations;
 
         // Resolve current user for comment metadata
         var accessService = Hub.ServiceProvider.GetService<AccessService>();
@@ -227,9 +230,14 @@ public partial class CollaborativeMarkdownView
             DataBind(ViewModel.Value, x => x.RawContent, defaultValue: "");
         }
 
-        // Subscribe to comment nodes to track resolved/active status for filtering
-        SubscribeToCommentStatuses();
-        SubscribeToChanges();
+        // Subscribe to comment nodes to track resolved/active status for filtering.
+        // Skipped entirely when annotations are hidden (@@ embeds): no comment/change data is
+        // loaded, so no highlights, sidebar, or toolbar can ever render.
+        if (!BoundHideAnnotations)
+        {
+            SubscribeToCommentStatuses();
+            SubscribeToChanges();
+        }
 
         ProcessContent();
     }
@@ -357,9 +365,10 @@ public partial class CollaborativeMarkdownView
             await jsModule.InvokeVoidAsync("positionCards");
         }
 
-        // Enable comment-from-selection — always initialize so the floating button appears.
+        // Enable comment-from-selection so the floating button appears — except when annotations
+        // are hidden (@@ embeds): selecting text in an embedded section must not offer commenting.
         // Permissions are checked server-side when actually creating the comment.
-        if (jsModule != null && !commentSelectionInitialized)
+        if (jsModule != null && !commentSelectionInitialized && !BoundHideAnnotations)
         {
             commentSelectionInitialized = true;
             dotNetRef = DotNetObjectReference.Create(this);

--- a/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/CollaborativeMarkdownView.razor.cs
@@ -232,8 +232,21 @@ public partial class CollaborativeMarkdownView
 
         // Subscribe to comment nodes to track resolved/active status for filtering.
         // Skipped entirely when annotations are hidden (@@ embeds): no comment/change data is
-        // loaded, so no highlights, sidebar, or toolbar can ever render.
-        if (!BoundHideAnnotations)
+        // loaded, so no highlights, sidebar, or toolbar can ever render. A REBIND may flip the
+        // flag on a live instance, so also drop any caches a previous annotated bind populated —
+        // ProcessContent decorates from these, and stale entries would resurrect the comment UI.
+        if (BoundHideAnnotations)
+        {
+            commentNodes = new();
+            commentPaths = new();
+            changeNodes = new();
+            _resolvedComments = Array.Empty<Comment>();
+            _resolvedChanges = Array.Empty<TrackedChange>();
+            activeAnnotationId = null;
+            _showCommentInput = false;
+            _showPageCommentInput = false;
+        }
+        else
         {
             SubscribeToCommentStatuses();
             SubscribeToChanges();

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-19-embeds-without-comments.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-19-embeds-without-comments.md
@@ -1,0 +1,18 @@
+---
+Name: Embedded sections no longer show comment controls
+Category: What's New
+Description: "@@ embeds render clean content — comment highlights, the selection Comment button, and the Add Comment footer now appear only on a node's own page."
+Icon: Sparkle
+---
+
+# Embedded sections no longer show comment controls
+
+Pages composed of `@@` embeds used to repeat the commenting surface for every embedded
+section: each one showed its own "Add Comment" footer, offered a Comment button on any
+text selection, and displayed comment highlights from the embedded node. On a proposal
+or course page built from several sections, that read as comments everywhere.
+
+Embeds now render the content only. Commenting still works exactly as before on each
+node's own page — open the embedded section directly to read or add comments. Authors
+who want an embed to keep its full page chrome, including comments, can opt back in
+with `@@node?showHeader=true`.

--- a/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
@@ -99,8 +99,9 @@ public static class MarkdownOverviewLayoutArea
 
         // Read-only markdown content — the CollaborativeMarkdownControl is added as
         // a DIRECT child of `container` so agents and tests can locate it without
-        // walking through an intermediate Stack wrapper.
-        container = container.WithView(BuildMarkdownReadView(host, nodePath, rawContent, canComment, canEdit));
+        // walking through an intermediate Stack wrapper. An @@ embed (hideHeader) renders the
+        // body WITHOUT collaboration UI — commenting happens on the embedded node's own page.
+        container = container.WithView(BuildMarkdownReadView(host, nodePath, rawContent, canComment, canEdit, hideAnnotations: hideHeader));
 
         // No hardcoded children section: a node page is a markdown space — children (or any other
         // content) are injected INLINE with the @@(query) operator, never auto-listed (that doubled
@@ -127,7 +128,7 @@ public static class MarkdownOverviewLayoutArea
     /// without skipping a wrapper layer.
     /// </summary>
     private static UiControl BuildMarkdownReadView(
-        LayoutAreaHost host, string nodePath, string rawContent, bool canComment, bool canEdit)
+        LayoutAreaHost host, string nodePath, string rawContent, bool canComment, bool canEdit, bool hideAnnotations)
     {
         if (!string.IsNullOrWhiteSpace(rawContent))
         {
@@ -136,7 +137,8 @@ public static class MarkdownOverviewLayoutArea
                 .WithNodePath(nodePath)
                 .WithHubAddress(host.Hub.Address.ToString())
                 .WithCanComment(canComment)
-                .WithCanEdit(canEdit);
+                .WithCanEdit(canEdit)
+                .WithHideAnnotations(hideAnnotations);
         }
         return Controls.Html("<p style=\"color: var(--neutral-foreground-hint); font-style: italic;\">No content yet. Use the menu to start editing.</p>");
     }

--- a/src/MeshWeaver.Layout/CollaborativeMarkdownControl.cs
+++ b/src/MeshWeaver.Layout/CollaborativeMarkdownControl.cs
@@ -33,6 +33,14 @@ public record CollaborativeMarkdownControl()
     /// </summary>
     public bool CanEdit { get; init; }
 
+    /// <summary>
+    /// Suppresses ALL collaboration UI: comment highlights/sidebar, tracked-change review,
+    /// the selection-comment affordance, and the page-comment footer. Set for @@ embeds, whose
+    /// collaboration surface belongs to the embedded node's own page, not the embedding one.
+    /// Default-false so only the non-default (true) value ever needs to serialize.
+    /// </summary>
+    public bool HideAnnotations { get; init; }
+
     /// <summary>Returns a copy with <paramref name="value"/> as the annotated markdown content.</summary>
     /// <param name="value">The markdown string (with annotation markers) to render.</param>
     /// <returns>A new <see cref="CollaborativeMarkdownControl"/> with the updated value.</returns>
@@ -53,4 +61,8 @@ public record CollaborativeMarkdownControl()
     /// <param name="canEdit">True to enable accept/reject tracked-change controls.</param>
     /// <returns>A new <see cref="CollaborativeMarkdownControl"/> with the updated can-edit flag.</returns>
     public CollaborativeMarkdownControl WithCanEdit(bool canEdit) => this with { CanEdit = canEdit };
+    /// <summary>Returns a copy with <paramref name="hideAnnotations"/> controlling whether collaboration UI is suppressed.</summary>
+    /// <param name="hideAnnotations">True to render the markdown without any comment/tracked-change UI (used for @@ embeds).</param>
+    /// <returns>A new <see cref="CollaborativeMarkdownControl"/> with the updated hide-annotations flag.</returns>
+    public CollaborativeMarkdownControl WithHideAnnotations(bool hideAnnotations) => this with { HideAnnotations = hideAnnotations };
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/MarkdownEmbedAnnotationsTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MarkdownEmbedAnnotationsTest.cs
@@ -1,0 +1,84 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the "@@ embeds render without comments" contract. An @@ embed reaches the Markdown
+/// Overview area with the <c>?showHeader=false</c> reference parameter; the rendered
+/// <see cref="CollaborativeMarkdownControl"/> must then carry <c>HideAnnotations=true</c>
+/// (no comment highlights, sidebar, selection-comment button, or page-comment footer), while
+/// the node's own full page keeps the collaboration surface. Regression for the
+/// "comments everywhere" report on pages composed of several @@ embeds.
+/// </summary>
+public class MarkdownEmbedAnnotationsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact(Timeout = 60000)]
+    public async Task EmbedOverview_HidesAnnotations_FullPageKeepsThem()
+    {
+        var nodeId = $"EmbedMd{Guid.NewGuid():N}"[..16];
+        var path = $"{TestPartition}/{nodeId}";
+        var node = new MeshNode(nodeId, TestPartition)
+        {
+            Name = "Embed Markdown",
+            NodeType = MarkdownNodeType.NodeType,
+            Content = new MarkdownContent { Content = "# Title\n\nBody text." }
+        };
+        await NodeFactory.CreateNode(node).Should().Emit();
+
+        var workspace = GetClient(c => c.AddData()).GetWorkspace();
+
+        var embedded = await RenderMarkdownBody(workspace, path, "?showHeader=false");
+        Assert.True(embedded.HideAnnotations,
+            "an @@ embed (showHeader=false) must render its markdown body without any collaboration UI");
+
+        var fullPage = await RenderMarkdownBody(workspace, path, null);
+        Assert.False(fullPage.HideAnnotations,
+            "the node's own page must keep the collaboration surface");
+
+        await NodeFactory.DeleteNode(path).Should().Emit();
+    }
+
+    /// <summary>
+    /// Renders the node's Overview area with the given area id (query parameters ride on the id)
+    /// and returns the CollaborativeMarkdownControl composing the markdown body — a direct child
+    /// of the Overview container stack (see MarkdownOverviewLayoutArea.BuildOverview).
+    /// </summary>
+    private static async Task<CollaborativeMarkdownControl> RenderMarkdownBody(
+        IWorkspace workspace, string path, string? id)
+    {
+        var reference = new LayoutAreaReference("Overview") { Id = id };
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address(path), reference);
+
+        var root = await stream.GetControlStream(reference.Area!)
+            .Should().Within(30.Seconds()).Match(c => c is StackControl);
+        var stack = (StackControl)root!;
+
+        foreach (var area in stack.Areas)
+        {
+            var name = area.Area?.ToString();
+            if (string.IsNullOrEmpty(name))
+                continue;
+            var child = await stream.GetControlStream(name).Should().Within(10.Seconds()).Match(c => c != null);
+            if (child is CollaborativeMarkdownControl markdown)
+                return markdown;
+        }
+
+        throw new InvalidOperationException(
+            $"No CollaborativeMarkdownControl found among the Overview children: {string.Join(", ", stack.Areas.Select(a => a.Area))}");
+    }
+}


### PR DESCRIPTION
## Problem

Pages composed of `@@` embeds (e.g. `/PartnerRe/EslProposal`, six embedded sections) showed the commenting surface once **per embedded section**:

- an unconditional **"+ Add Comment" footer** on every embed (gated only on `NodePath`),
- the **selection→Comment floating button** (`enableCommentSelection` was always initialized),
- **comment highlights + sidebar cards** from each embedded node's `_Comment` satellites.

The documented embed contract (LayoutAreaMarkdownRenderer: an `@@` embed hides "the embedded node's own header, comments + side menu") was only half-implemented — `MarkdownOverviewLayoutArea` suppressed just the header and the inline comments *section*.

## Fix

- `CollaborativeMarkdownControl.HideAnnotations` (default `false`, so only the non-default value ever needs to serialize) + `WithHideAnnotations`.
- `MarkdownOverviewLayoutArea.BuildMarkdownReadView` sets it from the existing embed signal (`?showHeader=false` reference parameter — no new syntax; `@@node?showHeader=true` opts the full chrome incl. comments back in).
- `CollaborativeMarkdownView`: when hidden, skips the comment/tracked-change satellite subscriptions (no highlights/sidebar/toolbar can ever render), skips `enableCommentSelection`, forces `BoundCanComment`/`BoundCanEdit` false, and the razor gates the page-comment footer.

React client already strips annotations for this control — no parity change needed.

## Test

`MarkdownEmbedAnnotationsTest` (Monolith.Test): renders the Markdown Overview area with and without `?showHeader=false` and asserts `HideAnnotations` on the rendered `CollaborativeMarkdownControl`. Green locally on Release `-warnaserror` after merging current main.

What's New entry included (user-facing change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQRKtviGXZRA3kBnVNWvsE