### PR TITLE
Serialize user_effective_permissions rebuild with an advisory lock (40P01)

### DIFF
--- a/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
+++ b/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
@@ -55,6 +55,7 @@ public static class MigrationRegistry
         new V44_FixMeshNodeHistoryTriggerPerSchema(),
         new V45_AddNodeAuthorshipColumns(),
         new V46_AddExcludeFromContextColumn(),
+        new V47_SerializeUepRebuildAdvisoryLock(),
     ];
 
     /// <summary>

--- a/memex/aspire/Memex.Database.Migration/Migrations/V47_SerializeUepRebuildAdvisoryLock.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V47_SerializeUepRebuildAdvisoryLock.cs
@@ -1,0 +1,87 @@
+using MeshWeaver.Hosting.PostgreSql;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Database.Migration.Migrations;
+
+/// <summary>
+/// Re-applies <c>rebuild_user_effective_permissions()</c> on every schema that has it so the
+/// function takes the global transaction-scoped advisory lock
+/// (<c>pg_advisory_xact_lock(hashtext('meshweaver_uep_rebuild'))</c>) as its FIRST statement.
+///
+/// <para><b>The bug (memex-cloud 2026-07-19, twice).</b> Concurrent <c>_Access</c> writes from
+/// DIFFERENT partitions deadlocked with <c>40P01 deadlock detected</c>: two plugin hubs warming
+/// concurrently each ran their access-seeding pass; each grant write fired that schema's
+/// <c>access_changed</c> trigger, which runs the FULL <c>rebuild_user_effective_permissions()</c>
+/// inside the originating write's transaction. Each rebuild takes ACCESS EXCLUSIVE on its OWN
+/// schema's <c>user_effective_permissions</c> (the atomic-swap <c>ALTER TABLE … RENAME</c>) AND
+/// writes the SHARED <c>public.partition_access</c> rows — two transactions touching different
+/// schema <c>access</c> tables but the same shared rows interleave those locks in opposite orders
+/// → lock cycle → PG kills one → the whole seeding pass of that hub aborts
+/// (<c>MeshNode Unknown at 'AgenticEngineering/Start/_Access/Public_Access': 40P01</c>).</para>
+///
+/// <para><b>The fix.</b> <c>PostgreSqlSchemaInitializer.GetUepRebuildFunctionScript</c> (the
+/// single-sourced body all installers now embed) opens with the advisory lock, so rebuild
+/// transactions QUEUE instead of interleaving into a cycle; the xact-scoped lock releases
+/// automatically at commit/rollback. No retries, no app-side locking.</para>
+///
+/// <para><b>Why a migration?</b> The schema script only runs for the boot schema
+/// (<c>InitializeAsync</c> → <c>GetSchemaScript</c>) and for partitions that go through
+/// <c>public.ensure_partition_schema</c> again (new provisioning) — EXISTING partition schemas
+/// keep their deployed function body until something re-CREATEs it. This migration is that
+/// something: one <c>CREATE OR REPLACE</c> per schema that already has the function (probed via
+/// <c>pg_proc</c> — unversioned schemas never had it and are skipped). Fresh DBs skip this repair
+/// and get the locked body straight from the initializer templates. Idempotent; the function's
+/// projection semantics are unchanged, so no data backfill / re-rebuild is needed.</para>
+/// </summary>
+public sealed class V47_SerializeUepRebuildAdvisoryLock : IMigration
+{
+    public int Version => 47;
+    public string Description =>
+        "Serialize rebuild_user_effective_permissions() with a global advisory xact lock (40P01 cross-partition deadlock)";
+
+    public async Task RunAsync(MigrationContext ctx)
+    {
+        // Every schema that carries the function — public + versioned partitions. Probing
+        // pg_proc (not table existence) keeps this surgical: schemas without the function
+        // (unversioned admin/portal/kernel shapes) are untouched.
+        var schemas = new List<string>();
+        await using (var discover = ctx.DataSource.CreateCommand("""
+            SELECT n.nspname
+            FROM pg_proc p
+            JOIN pg_namespace n ON n.oid = p.pronamespace
+            WHERE p.proname = 'rebuild_user_effective_permissions'
+            ORDER BY n.nspname
+            """))
+        await using (var rdr = await discover.ExecuteReaderAsync())
+        {
+            while (await rdr.ReadAsync())
+                schemas.Add(rdr.GetString(0));
+        }
+
+        foreach (var schema in schemas)
+        {
+            // Per-schema data source (search_path = "{schema},public") so the unqualified
+            // CREATE OR REPLACE FUNCTION lands in that schema — same OID, so the existing
+            // access_changed trigger picks the locked body up immediately.
+            await using var schemaDs = SchemaHelpers.BuildSchemaDataSource(
+                ctx.ConnectionString, schema, useVector: false);
+            var schemaRef = "'" + schema.Replace("'", "''") + "'";
+            try
+            {
+                await using var cmd = schemaDs.CreateCommand(
+                    PostgreSqlSchemaInitializer.GetUepRebuildFunctionScript(schemaRef));
+                await cmd.ExecuteNonQueryAsync();
+                ctx.Logger.LogInformation(
+                    "Repair v47: \"{Schema}\".rebuild_user_effective_permissions now serializes via the global advisory lock",
+                    schema);
+            }
+            catch (Exception ex)
+            {
+                ctx.Logger.LogWarning(ex,
+                    "Repair v47: \"{Schema}\" — CREATE OR REPLACE rebuild_user_effective_permissions failed", schema);
+            }
+        }
+
+        ctx.Logger.LogInformation("Repair v47: done — {Count} schema(s) updated", schemas.Count);
+    }
+}

--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlSchemaInitializer.cs
@@ -973,6 +973,10 @@ public static class PostgreSqlSchemaInitializer
     {
         var dim = options.VectorDimensions;
         var schemaName = options.Schema ?? "public";
+        // Quoted SQL literal for the schema self-reference — feeds the single-sourced
+        // rebuild_user_effective_permissions() body (same contract as
+        // GetVersionedPartitionDdl's schemaRef parameter).
+        var schemaRef = $"'{schemaName}'";
         return $$"""
             CREATE EXTENSION IF NOT EXISTS vector;
 
@@ -1103,213 +1107,7 @@ public static class PostgreSqlSchemaInitializer
             -- Shadow table for atomic rebuild
             CREATE TABLE IF NOT EXISTS user_effective_permissions_shadow (LIKE user_effective_permissions INCLUDING ALL);
 
-            -- Rebuild function: reads AccessAssignment from access satellite table, GroupMembership from mesh_nodes
-            -- AccessAssignment content: {"accessObject":"...","roles":[{"role":"...","denied":true},...]}
-            CREATE OR REPLACE FUNCTION rebuild_user_effective_permissions() RETURNS void AS $$
-            BEGIN
-                -- Set search_path so unqualified table names resolve to this schema
-                EXECUTE format('SET LOCAL search_path TO %I, public', '{{schemaName}}');
-                TRUNCATE user_effective_permissions_shadow;
-
-                -- Direct entries from AccessAssignment nodes (access satellite table)
-                INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                SELECT
-                    aa.content->>'accessObject' AS user_id,
-                    COALESCE(aa.main_node, aa.namespace) AS node_path_prefix,
-                    perm.permission,
-                    NOT COALESCE((role_entry->>'denied')::boolean, false) AS is_allow
-                FROM access aa
-                CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
-                CROSS JOIN LATERAL (
-                    SELECT COALESCE(
-                        (SELECT (role_node.content->>'permissions')::int
-                         FROM mesh_nodes role_node
-                         WHERE role_node.node_type = 'Role'
-                           AND role_node.id = role_entry->>'role'
-                         LIMIT 1),
-                        CASE role_entry->>'role'
-                            WHEN 'Admin' THEN 1535
-                            WHEN 'PlatformAdmin' THEN 1535
-                            WHEN 'Editor' THEN 1527
-                            WHEN 'Viewer' THEN 161
-                            WHEN 'Commenter' THEN 145
-                            ELSE 0
-                        END
-                    ) AS permissions
-                ) r
-                CROSS JOIN LATERAL (
-                    SELECT unnest(
-                        CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
-                    ) AS permission
-                ) perm
-                WHERE aa.content->>'accessObject' IS NOT NULL
-                  AND aa.content->'roles' IS NOT NULL
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
-
-                -- Group expansion: read GroupMembership MeshNodes
-                INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                WITH RECURSIVE all_members AS (
-                    SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
-                    FROM "auth".mesh_nodes gm
-                    CROSS JOIN LATERAL jsonb_array_elements(gm.content->'groups') AS group_entry
-                    WHERE gm.node_type = 'GroupMembership'
-                    UNION
-                    SELECT am.group_path, gm.content->>'member'
-                    FROM all_members am
-                    JOIN "auth".mesh_nodes gm ON gm.node_type = 'GroupMembership'
-                    WHERE EXISTS (
-                        SELECT 1 FROM jsonb_array_elements(gm.content->'groups') g
-                        WHERE g->>'group' = am.member_id
-                    )
-                ),
-                leaf_members AS (
-                    SELECT group_path, member_id FROM all_members
-                    WHERE NOT EXISTS (
-                        SELECT 1 FROM "auth".mesh_nodes gm2
-                        CROSS JOIN LATERAL jsonb_array_elements(gm2.content->'groups') AS g2
-                        WHERE gm2.node_type = 'GroupMembership'
-                          AND g2->>'group' = all_members.member_id
-                    )
-                )
-                SELECT lm.member_id, COALESCE(aa.main_node, aa.namespace), perm.permission,
-                       NOT COALESCE((role_entry->>'denied')::boolean, false) AS is_allow
-                FROM access aa
-                JOIN leaf_members lm ON aa.content->>'accessObject' = lm.group_path
-                CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
-                CROSS JOIN LATERAL (
-                    SELECT COALESCE(
-                        (SELECT (role_node.content->>'permissions')::int
-                         FROM mesh_nodes role_node
-                         WHERE role_node.node_type = 'Role'
-                           AND role_node.id = role_entry->>'role'
-                         LIMIT 1),
-                        CASE role_entry->>'role'
-                            WHEN 'Admin' THEN 1535
-                            WHEN 'PlatformAdmin' THEN 1535
-                            WHEN 'Editor' THEN 1527
-                            WHEN 'Viewer' THEN 161
-                            WHEN 'Commenter' THEN 145
-                            ELSE 0
-                        END
-                    ) AS permissions
-                ) r
-                CROSS JOIN LATERAL (
-                    SELECT unnest(
-                        CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
-                    ) AS permission
-                ) perm
-                WHERE aa.content->'roles' IS NOT NULL
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
-
-                -- Direct entries from access_control table (convenience methods)
-                INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                SELECT subject, node_path, permission, is_allow
-                FROM access_control
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
-
-                -- Group expansion from group_members + access_control
-                INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                WITH RECURSIVE all_members AS (
-                    SELECT group_name, member_id FROM group_members
-                    UNION
-                    SELECT am.group_name, gm.member_id
-                    FROM all_members am
-                    JOIN group_members gm ON gm.group_name = am.member_id
-                ),
-                leaf_members AS (
-                    SELECT group_name, member_id FROM all_members
-                    WHERE member_id NOT IN (SELECT DISTINCT group_name FROM group_members)
-                )
-                SELECT lm.member_id, ac.node_path, ac.permission, ac.is_allow
-                FROM access_control ac
-                JOIN leaf_members lm ON lm.group_name = ac.subject
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
-
-                -- Apply PartitionAccessPolicy caps
-                INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
-                SELECT DISTINCT
-                    uep.user_id,
-                    policy.namespace AS node_path_prefix,
-                    perm.permission,
-                    false
-                FROM mesh_nodes policy
-                CROSS JOIN (SELECT DISTINCT user_id FROM user_effective_permissions_shadow) uep
-                CROSS JOIN (
-                    SELECT unnest(ARRAY['Read','Create','Update','Delete','Comment']) AS permission,
-                           unnest(ARRAY['read','create','update','delete','comment']) AS field
-                ) perm
-                WHERE policy.node_type = 'PartitionAccessPolicy'
-                  AND policy.id = '_Policy'
-                  AND (policy.content->>perm.field)::boolean = false
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE SET is_allow = false;
-
-                -- Atomic swap
-                ALTER TABLE user_effective_permissions RENAME TO user_effective_permissions_old;
-                ALTER TABLE user_effective_permissions_shadow RENAME TO user_effective_permissions;
-                ALTER TABLE user_effective_permissions_old RENAME TO user_effective_permissions_shadow;
-
-                -- Sync partition_access: upsert users with Read permission, remove revoked
-                BEGIN
-                    INSERT INTO public.partition_access (user_id, partition)
-                    SELECT DISTINCT user_id, '{{schemaName}}'
-                    FROM user_effective_permissions
-                    WHERE permission = 'Read' AND is_allow = true
-                    ON CONFLICT (user_id, partition) DO NOTHING;
-
-                    DELETE FROM public.partition_access
-                    WHERE partition = '{{schemaName}}'
-                      AND user_id NOT IN (
-                        SELECT user_id FROM user_effective_permissions
-                        WHERE permission = 'Read' AND is_allow = true
-                      );
-                EXCEPTION WHEN undefined_table THEN
-                    -- partition_access table may not exist yet (first migration)
-                    NULL;
-                END;
-            END;
-            -- jit off: the dedup aggregate's cost estimate (inflated by jsonb SRF default row
-            -- estimates) exceeds jit_above_cost, and LLVM then spends ~450ms compiling the
-            -- unnest expressions PER STATEMENT — in a trigger path that runs on every
-            -- _Access write and once per schema in the boot self-heal sweep.
-            $$ LANGUAGE plpgsql SET jit = off;
+            {{GetUepRebuildFunctionScript(schemaRef)}}
 
             -- Access satellite table (must exist before trigger creation)
             CREATE TABLE IF NOT EXISTS access (
@@ -1676,6 +1474,258 @@ public static class PostgreSqlSchemaInitializer
     internal const string PartitionNameSentinel = "__mw_partition__";
 
     /// <summary>
+    /// DDL for the schema-scoped <c>rebuild_user_effective_permissions()</c> function —
+    /// single-sourced because THREE installers ship it: <see cref="GetMeshSchemaScript"/>,
+    /// <see cref="GetVersionedPartitionDdl"/> (and through it the
+    /// <c>public.ensure_partition_schema</c> proc), and the V47 migration that re-applies
+    /// the current body to every EXISTING partition schema (the schema script only runs
+    /// for the boot schema + newly provisioned partitions, so a body change needs the
+    /// migration to reach already-provisioned schemas).
+    ///
+    /// <para><paramref name="schemaRef"/> is the SQL literal/expression for the owning
+    /// schema — same contract as <see cref="GetVersionedPartitionDdl"/> (a quoted literal
+    /// like <c>'rbuergi'</c>, or the quoted <see cref="PartitionNameSentinel"/> that the
+    /// provisioning proc <c>replace()</c>s at runtime).</para>
+    ///
+    /// <para>🚨 <b>The first body statement takes a GLOBAL transaction-scoped advisory
+    /// lock.</b> Every rebuild takes ACCESS EXCLUSIVE on its OWN schema's
+    /// <c>user_effective_permissions</c> (the atomic-swap <c>ALTER TABLE … RENAME</c>)
+    /// AND writes the SHARED <c>public.partition_access</c> rows. Two rebuilds running
+    /// concurrently from DIFFERENT partitions (e.g. two plugin hubs seeding their
+    /// <c>_Access</c> grants at warm-up — the trigger runs the rebuild inside the
+    /// originating write's transaction) interleave those locks in opposite orders →
+    /// <c>40P01 deadlock detected</c>; PG kills one transaction and the whole seeding
+    /// pass of that hub aborts (memex-cloud 2026-07-19,
+    /// <c>AgenticEngineering/Start/_Access/Public_Access</c>). The xact-scoped advisory
+    /// lock queues rebuilds one-at-a-time instead; it releases automatically at
+    /// commit/rollback, so an erroring rebuild can never leak it.</para>
+    /// </summary>
+    public static string GetUepRebuildFunctionScript(string schemaRef) => $$"""
+        -- Rebuild function: reads AccessAssignment from access satellite table, GroupMembership from mesh_nodes
+        -- AccessAssignment content: {"accessObject":"...","roles":[{"role":"...","denied":true},...]}
+        CREATE OR REPLACE FUNCTION rebuild_user_effective_permissions() RETURNS void AS $$
+        BEGIN
+            -- Serialize rebuilds GLOBALLY (one lock for ALL partition schemas): each rebuild
+            -- takes ACCESS EXCLUSIVE on its own schema's user_effective_permissions (the
+            -- atomic-swap RENAMEs below) AND writes the SHARED public.partition_access rows.
+            -- Concurrent rebuilds from different partitions interleave those locks in
+            -- opposite orders -> 40P01 deadlock detected, aborting the originating _Access
+            -- write (memex-cloud 2026-07-19). The xact-scoped advisory lock queues rebuilds
+            -- instead and releases automatically at commit/rollback.
+            PERFORM pg_advisory_xact_lock(hashtext('meshweaver_uep_rebuild'));
+
+            -- Set search_path so unqualified table names resolve to this schema
+            EXECUTE format('SET LOCAL search_path TO %I, public', {{schemaRef}});
+            TRUNCATE user_effective_permissions_shadow;
+
+            -- Direct entries from AccessAssignment nodes (access satellite table)
+            -- Unnest the roles[] array to get each role assignment
+            INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+            SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+            FROM (
+            SELECT
+                aa.content->>'accessObject' AS user_id,
+                COALESCE(aa.main_node, aa.namespace) AS node_path_prefix,
+                perm.permission,
+                NOT COALESCE((role_entry->>'denied')::boolean, false) AS is_allow
+            FROM access aa
+            CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
+            CROSS JOIN LATERAL (
+                SELECT COALESCE(
+                    (SELECT (role_node.content->>'permissions')::int
+                     FROM mesh_nodes role_node
+                     WHERE role_node.node_type = 'Role'
+                       AND role_node.id = role_entry->>'role'
+                     LIMIT 1),
+                    -- Fallback: built-in role lookup
+                    CASE role_entry->>'role'
+                        WHEN 'Admin' THEN 1535
+                        WHEN 'PlatformAdmin' THEN 1535
+                        WHEN 'Editor' THEN 1527
+                        WHEN 'Viewer' THEN 161
+                        WHEN 'Commenter' THEN 145
+                        ELSE 0
+                    END
+                ) AS permissions
+            ) r
+            CROSS JOIN LATERAL (
+                SELECT unnest(
+                    CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
+                ) AS permission
+            ) perm
+            WHERE aa.content->>'accessObject' IS NOT NULL
+              AND aa.content->'roles' IS NOT NULL
+            ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+            GROUP BY user_id, node_path_prefix, permission
+            ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
+                SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
+
+            -- Group expansion: read GroupMembership MeshNodes
+            -- New model: content has "member" + "groups" array of {"group":"..."}
+            INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+            SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+            FROM (
+            WITH RECURSIVE all_members AS (
+                SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
+                FROM "auth".mesh_nodes gm
+                CROSS JOIN LATERAL jsonb_array_elements(gm.content->'groups') AS group_entry
+                WHERE gm.node_type = 'GroupMembership'
+                UNION
+                SELECT am.group_path, gm.content->>'member'
+                FROM all_members am
+                JOIN "auth".mesh_nodes gm ON gm.node_type = 'GroupMembership'
+                WHERE EXISTS (
+                    SELECT 1 FROM jsonb_array_elements(gm.content->'groups') g
+                    WHERE g->>'group' = am.member_id
+                )
+            ),
+            leaf_members AS (
+                SELECT group_path, member_id FROM all_members
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM "auth".mesh_nodes gm2
+                    CROSS JOIN LATERAL jsonb_array_elements(gm2.content->'groups') AS g2
+                    WHERE gm2.node_type = 'GroupMembership'
+                      AND g2->>'group' = all_members.member_id
+                )
+            )
+            SELECT lm.member_id, COALESCE(aa.main_node, aa.namespace), perm.permission,
+                   NOT COALESCE((role_entry->>'denied')::boolean, false) AS is_allow
+            FROM access aa
+            JOIN leaf_members lm ON aa.content->>'accessObject' = lm.group_path
+            CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
+            CROSS JOIN LATERAL (
+                SELECT COALESCE(
+                    (SELECT (role_node.content->>'permissions')::int
+                     FROM mesh_nodes role_node
+                     WHERE role_node.node_type = 'Role'
+                       AND role_node.id = role_entry->>'role'
+                     LIMIT 1),
+                    CASE role_entry->>'role'
+                        WHEN 'Admin' THEN 1535
+                        WHEN 'PlatformAdmin' THEN 1535
+                        WHEN 'Editor' THEN 1527
+                        WHEN 'Viewer' THEN 161
+                        WHEN 'Commenter' THEN 145
+                        ELSE 0
+                    END
+                ) AS permissions
+            ) r
+            CROSS JOIN LATERAL (
+                SELECT unnest(
+                    CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
+                    || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
+                ) AS permission
+            ) perm
+            WHERE aa.content->'roles' IS NOT NULL
+            ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+            GROUP BY user_id, node_path_prefix, permission
+            ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
+                SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
+
+            -- Direct entries from access_control table (convenience methods)
+            INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+            SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+            FROM (
+            SELECT subject, node_path, permission, is_allow
+            FROM access_control
+            ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+            GROUP BY user_id, node_path_prefix, permission
+            ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
+                SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
+
+            -- Group expansion from group_members + access_control
+            INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+            SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
+            FROM (
+            WITH RECURSIVE all_members AS (
+                SELECT group_name, member_id FROM group_members
+                UNION
+                SELECT am.group_name, gm.member_id
+                FROM all_members am
+                JOIN group_members gm ON gm.group_name = am.member_id
+            ),
+            leaf_members AS (
+                SELECT group_name, member_id FROM all_members
+                WHERE member_id NOT IN (SELECT DISTINCT group_name FROM group_members)
+            )
+            SELECT lm.member_id, ac.node_path, ac.permission, ac.is_allow
+            FROM access_control ac
+            JOIN leaf_members lm ON lm.group_name = ac.subject
+            ) AS dedup(user_id, node_path_prefix, permission, is_allow)
+            GROUP BY user_id, node_path_prefix, permission
+            ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
+                SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
+
+            -- Apply PartitionAccessPolicy caps: deny permissions set to false
+            -- For each policy, insert deny rows at the policy namespace for ALL users
+            -- for permissions that the policy explicitly denies (field value = false).
+            -- The most-specific-prefix-wins query logic then correctly denies those permissions.
+            INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
+            SELECT DISTINCT
+                uep.user_id,
+                policy.namespace AS node_path_prefix,
+                perm.permission,
+                false
+            FROM mesh_nodes policy
+            CROSS JOIN (SELECT DISTINCT user_id FROM user_effective_permissions_shadow) uep
+            CROSS JOIN (
+                SELECT unnest(ARRAY['Read','Create','Update','Delete','Comment']) AS permission,
+                       unnest(ARRAY['read','create','update','delete','comment']) AS field
+            ) perm
+            WHERE policy.node_type = 'PartitionAccessPolicy'
+              AND policy.id = '_Policy'
+              AND (policy.content->>perm.field)::boolean = false
+            ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE SET is_allow = false;
+
+            -- Atomic swap
+            ALTER TABLE user_effective_permissions RENAME TO user_effective_permissions_old;
+            ALTER TABLE user_effective_permissions_shadow RENAME TO user_effective_permissions;
+            ALTER TABLE user_effective_permissions_old RENAME TO user_effective_permissions_shadow;
+
+            -- Sync partition_access: upsert users with Read permission, remove revoked
+            BEGIN
+                INSERT INTO public.partition_access (user_id, partition)
+                SELECT DISTINCT user_id, {{schemaRef}}
+                FROM user_effective_permissions
+                WHERE permission = 'Read' AND is_allow = true
+                ON CONFLICT (user_id, partition) DO NOTHING;
+
+                DELETE FROM public.partition_access
+                WHERE partition = {{schemaRef}}
+                  AND user_id NOT IN (
+                    SELECT user_id FROM user_effective_permissions
+                    WHERE permission = 'Read' AND is_allow = true
+                  );
+            EXCEPTION WHEN undefined_table THEN
+                -- partition_access table may not exist yet (first migration)
+                NULL;
+            END;
+        END;
+        -- jit off: the dedup aggregate's cost estimate (inflated by jsonb SRF default row
+        -- estimates) exceeds jit_above_cost, and LLVM then spends ~450ms compiling the
+        -- unnest expressions PER STATEMENT — in a trigger path that runs on every
+        -- _Access write and once per schema in the boot self-heal sweep.
+        $$ LANGUAGE plpgsql SET jit = off;
+        """;
+
+    /// <summary>
     /// The full versioned-partition DDL (mesh_nodes + support tables + the access
     /// satellite + permission-rebuild functions + notify/mirror/history triggers).
     /// Unqualified — resolves against the connection's <c>search_path</c>.
@@ -1826,219 +1876,7 @@ public static class PostgreSqlSchemaInitializer
             -- Shadow table for atomic rebuild
             CREATE TABLE IF NOT EXISTS user_effective_permissions_shadow (LIKE user_effective_permissions INCLUDING ALL);
 
-            -- Rebuild function: reads AccessAssignment from access satellite table, GroupMembership from mesh_nodes
-            -- AccessAssignment content: {"accessObject":"...","roles":[{"role":"...","denied":true},...]}
-            CREATE OR REPLACE FUNCTION rebuild_user_effective_permissions() RETURNS void AS $$
-            BEGIN
-                -- Set search_path so unqualified table names resolve to this schema
-                EXECUTE format('SET LOCAL search_path TO %I, public', {{schemaRef}});
-                TRUNCATE user_effective_permissions_shadow;
-
-                -- Direct entries from AccessAssignment nodes (access satellite table)
-                -- Unnest the roles[] array to get each role assignment
-                INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                SELECT
-                    aa.content->>'accessObject' AS user_id,
-                    COALESCE(aa.main_node, aa.namespace) AS node_path_prefix,
-                    perm.permission,
-                    NOT COALESCE((role_entry->>'denied')::boolean, false) AS is_allow
-                FROM access aa
-                CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
-                CROSS JOIN LATERAL (
-                    SELECT COALESCE(
-                        (SELECT (role_node.content->>'permissions')::int
-                         FROM mesh_nodes role_node
-                         WHERE role_node.node_type = 'Role'
-                           AND role_node.id = role_entry->>'role'
-                         LIMIT 1),
-                        -- Fallback: built-in role lookup
-                        CASE role_entry->>'role'
-                            WHEN 'Admin' THEN 1535
-                            WHEN 'PlatformAdmin' THEN 1535
-                            WHEN 'Editor' THEN 1527
-                            WHEN 'Viewer' THEN 161
-                            WHEN 'Commenter' THEN 145
-                            ELSE 0
-                        END
-                    ) AS permissions
-                ) r
-                CROSS JOIN LATERAL (
-                    SELECT unnest(
-                        CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
-                    ) AS permission
-                ) perm
-                WHERE aa.content->>'accessObject' IS NOT NULL
-                  AND aa.content->'roles' IS NOT NULL
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
-
-                -- Group expansion: read GroupMembership MeshNodes
-                -- New model: content has "member" + "groups" array of {"group":"..."}
-                INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                WITH RECURSIVE all_members AS (
-                    SELECT group_entry->>'group' AS group_path, gm.content->>'member' AS member_id
-                    FROM "auth".mesh_nodes gm
-                    CROSS JOIN LATERAL jsonb_array_elements(gm.content->'groups') AS group_entry
-                    WHERE gm.node_type = 'GroupMembership'
-                    UNION
-                    SELECT am.group_path, gm.content->>'member'
-                    FROM all_members am
-                    JOIN "auth".mesh_nodes gm ON gm.node_type = 'GroupMembership'
-                    WHERE EXISTS (
-                        SELECT 1 FROM jsonb_array_elements(gm.content->'groups') g
-                        WHERE g->>'group' = am.member_id
-                    )
-                ),
-                leaf_members AS (
-                    SELECT group_path, member_id FROM all_members
-                    WHERE NOT EXISTS (
-                        SELECT 1 FROM "auth".mesh_nodes gm2
-                        CROSS JOIN LATERAL jsonb_array_elements(gm2.content->'groups') AS g2
-                        WHERE gm2.node_type = 'GroupMembership'
-                          AND g2->>'group' = all_members.member_id
-                    )
-                )
-                SELECT lm.member_id, COALESCE(aa.main_node, aa.namespace), perm.permission,
-                       NOT COALESCE((role_entry->>'denied')::boolean, false) AS is_allow
-                FROM access aa
-                JOIN leaf_members lm ON aa.content->>'accessObject' = lm.group_path
-                CROSS JOIN LATERAL jsonb_array_elements(aa.content->'roles') AS role_entry
-                CROSS JOIN LATERAL (
-                    SELECT COALESCE(
-                        (SELECT (role_node.content->>'permissions')::int
-                         FROM mesh_nodes role_node
-                         WHERE role_node.node_type = 'Role'
-                           AND role_node.id = role_entry->>'role'
-                         LIMIT 1),
-                        CASE role_entry->>'role'
-                            WHEN 'Admin' THEN 1535
-                            WHEN 'PlatformAdmin' THEN 1535
-                            WHEN 'Editor' THEN 1527
-                            WHEN 'Viewer' THEN 161
-                            WHEN 'Commenter' THEN 145
-                            ELSE 0
-                        END
-                    ) AS permissions
-                ) r
-                CROSS JOIN LATERAL (
-                    SELECT unnest(
-                        CASE WHEN (r.permissions & 1) > 0 THEN ARRAY['Read'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 2) > 0 THEN ARRAY['Create'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 4) > 0 THEN ARRAY['Update'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 8) > 0 THEN ARRAY['Delete'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 16) > 0 THEN ARRAY['Comment'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 32) > 0 THEN ARRAY['Execute'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 64) > 0 THEN ARRAY['Thread'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 128) > 0 THEN ARRAY['Api'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 256) > 0 THEN ARRAY['Export'] ELSE ARRAY[]::text[] END
-                        || CASE WHEN (r.permissions & 1024) > 0 THEN ARRAY['Compile'] ELSE ARRAY[]::text[] END
-                    ) AS permission
-                ) perm
-                WHERE aa.content->'roles' IS NOT NULL
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
-
-                -- Direct entries from access_control table (convenience methods)
-                INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                SELECT subject, node_path, permission, is_allow
-                FROM access_control
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
-
-                -- Group expansion from group_members + access_control
-                INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
-                SELECT user_id, node_path_prefix, permission, bool_and(is_allow) AS is_allow
-                FROM (
-                WITH RECURSIVE all_members AS (
-                    SELECT group_name, member_id FROM group_members
-                    UNION
-                    SELECT am.group_name, gm.member_id
-                    FROM all_members am
-                    JOIN group_members gm ON gm.group_name = am.member_id
-                ),
-                leaf_members AS (
-                    SELECT group_name, member_id FROM all_members
-                    WHERE member_id NOT IN (SELECT DISTINCT group_name FROM group_members)
-                )
-                SELECT lm.member_id, ac.node_path, ac.permission, ac.is_allow
-                FROM access_control ac
-                JOIN leaf_members lm ON lm.group_name = ac.subject
-                ) AS dedup(user_id, node_path_prefix, permission, is_allow)
-                GROUP BY user_id, node_path_prefix, permission
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE
-                    SET is_allow = CASE WHEN EXCLUDED.is_allow = false THEN false ELSE user_effective_permissions_shadow.is_allow END;
-
-                -- Apply PartitionAccessPolicy caps: deny permissions set to false
-                -- For each policy, insert deny rows at the policy namespace for ALL users
-                -- for permissions that the policy explicitly denies (field value = false).
-                -- The most-specific-prefix-wins query logic then correctly denies those permissions.
-                INSERT INTO user_effective_permissions_shadow (user_id, node_path_prefix, permission, is_allow)
-                SELECT DISTINCT
-                    uep.user_id,
-                    policy.namespace AS node_path_prefix,
-                    perm.permission,
-                    false
-                FROM mesh_nodes policy
-                CROSS JOIN (SELECT DISTINCT user_id FROM user_effective_permissions_shadow) uep
-                CROSS JOIN (
-                    SELECT unnest(ARRAY['Read','Create','Update','Delete','Comment']) AS permission,
-                           unnest(ARRAY['read','create','update','delete','comment']) AS field
-                ) perm
-                WHERE policy.node_type = 'PartitionAccessPolicy'
-                  AND policy.id = '_Policy'
-                  AND (policy.content->>perm.field)::boolean = false
-                ON CONFLICT (user_id, node_path_prefix, permission) DO UPDATE SET is_allow = false;
-
-                -- Atomic swap
-                ALTER TABLE user_effective_permissions RENAME TO user_effective_permissions_old;
-                ALTER TABLE user_effective_permissions_shadow RENAME TO user_effective_permissions;
-                ALTER TABLE user_effective_permissions_old RENAME TO user_effective_permissions_shadow;
-
-                -- Sync partition_access: upsert users with Read permission, remove revoked
-                BEGIN
-                    INSERT INTO public.partition_access (user_id, partition)
-                    SELECT DISTINCT user_id, {{schemaRef}}
-                    FROM user_effective_permissions
-                    WHERE permission = 'Read' AND is_allow = true
-                    ON CONFLICT (user_id, partition) DO NOTHING;
-
-                    DELETE FROM public.partition_access
-                    WHERE partition = {{schemaRef}}
-                      AND user_id NOT IN (
-                        SELECT user_id FROM user_effective_permissions
-                        WHERE permission = 'Read' AND is_allow = true
-                      );
-                EXCEPTION WHEN undefined_table THEN
-                    -- partition_access table may not exist yet (first migration)
-                    NULL;
-                END;
-            END;
-            -- jit off: the dedup aggregate's cost estimate (inflated by jsonb SRF default row
-            -- estimates) exceeds jit_above_cost, and LLVM then spends ~450ms compiling the
-            -- unnest expressions PER STATEMENT — in a trigger path that runs on every
-            -- _Access write and once per schema in the boot self-heal sweep.
-            $$ LANGUAGE plpgsql SET jit = off;
+            {{GetUepRebuildFunctionScript(schemaRef)}}
 
             -- Access satellite table (must exist before trigger creation)
             CREATE TABLE IF NOT EXISTS access (

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/ConcurrentUepRebuildTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/ConcurrentUepRebuildTests.cs
@@ -1,0 +1,150 @@
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Pins the FULL <c>rebuild_user_effective_permissions()</c> against CONCURRENT execution from
+/// DIFFERENT partition schemas — the memex-cloud 2026-07-19 production deadlock.
+///
+/// <para><b>Production failure being guarded.</b> Two plugin hubs warming concurrently each ran
+/// their access-seeding pass; each pass wrote <c>_Access</c> grants into its OWN partition
+/// schema's <c>access</c> table, and each write's <c>access_changed</c> trigger ran the full
+/// rebuild inside the originating write's transaction. Each rebuild takes ACCESS EXCLUSIVE on
+/// its own schema's <c>user_effective_permissions</c> (the atomic-swap
+/// <c>ALTER TABLE … RENAME</c>) AND writes the SHARED <c>public.partition_access</c> rows — two
+/// transactions touching different schemas' tables but the same shared rows interleave those
+/// locks in opposite orders → <c>40P01 deadlock detected</c> → PG kills one and the whole
+/// seeding pass of that hub aborts
+/// (<c>MeshNode Unknown at 'AgenticEngineering/Start/_Access/Public_Access'</c>).</para>
+///
+/// <para><b>The fix being pinned.</b> The function's FIRST statement is now
+/// <c>PERFORM pg_advisory_xact_lock(hashtext('meshweaver_uep_rebuild'))</c> — one GLOBAL
+/// transaction-scoped advisory lock shared by every schema's rebuild, so concurrent rebuilds
+/// QUEUE instead of interleaving into a lock cycle (released automatically at
+/// commit/rollback). The test asserts the deployed body carries the lock (deterministic-red if
+/// it is ever removed) and then hammers interleaved rebuilds across two partitions — with the
+/// lock this is deterministic-green; without it the storm may (and in prod did) die with
+/// 40P01.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class ConcurrentUepRebuildTests
+{
+    private readonly PostgreSqlFixture _fixture;
+
+    // Storage serialization MUST be camelCase — the rebuild reads camelCase JSON keys
+    // (content->>'accessObject'), same as the mesh hub's naming policy.
+    private readonly JsonSerializerOptions _options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    public ConcurrentUepRebuildTests(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private async Task<PostgreSqlStorageAdapter> ProvisionProdShapeAdapterAsync(
+        string space, string schema, CancellationToken ct)
+    {
+        await _fixture.DataSource.ExecuteNonQuery(
+            $"SELECT public.ensure_partition_schema('{schema}')", ct)
+            .Should().Within(60.Seconds()).Emit();
+
+        var def = new PartitionDefinition
+        {
+            Namespace = space,
+            Schema = schema,
+            TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+            NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings()
+        };
+        return new PostgreSqlStorageAdapter(_fixture.DataSource, partitionDefinition: def);
+    }
+
+    private async Task SeedPartitionAsync(
+        PostgreSqlStorageAdapter adapter, string space, string user, CancellationToken ct)
+    {
+        await adapter.WriteAsync(new MeshNode(space)
+        {
+            Name = $"{space} Inc.",
+            NodeType = SpaceNodeType.NodeType,
+            State = MeshNodeState.Active,
+            MainNode = space,
+            Content = new Space()
+        }, _options, ct);
+
+        // Grant through the standard path: {space}/_Access/{user}_Access → access satellite
+        // table → access_changed trigger → rebuild. Gives the full rebuild real rows to
+        // project and a public.partition_access row to sync — the shared state the deadlock
+        // cycled on.
+        await adapter.WriteAsync(AssignmentNodeFactory.UserRole(user, "Admin", space), _options, ct);
+    }
+
+    private async Task RunFullRebuildAsync(string schema, CancellationToken ct)
+    {
+        // One statement = one transaction = one advisory-lock scope — exactly the lock
+        // footprint the access_changed trigger's full-rebuild path holds inside the
+        // originating grant write's transaction.
+        await using var cmd = _fixture.DataSource.CreateCommand(
+            $"SELECT \"{schema}\".rebuild_user_effective_permissions()");
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task ConcurrentRebuilds_AcrossTwoPartitions_SerializeInsteadOf40P01()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanDataAsync();
+
+        const string schemaA = "cueprebuilda";
+        const string spaceA = "ConcurrentUepA";
+        const string alice = "cuep_alice";
+        const string schemaB = "cueprebuildb";
+        const string spaceB = "ConcurrentUepB";
+        const string bob = "cuep_bob";
+
+        var adapterA = await ProvisionProdShapeAdapterAsync(spaceA, schemaA, ct);
+        var adapterB = await ProvisionProdShapeAdapterAsync(spaceB, schemaB, ct);
+        await SeedPartitionAsync(adapterA, spaceA, alice, ct);
+        await SeedPartitionAsync(adapterB, spaceB, bob, ct);
+
+        // Deterministic pin: BOTH provisioned schemas ship the advisory-lock body. Without
+        // this the concurrency storm below could go silently green on a lucky interleave
+        // even after a regression removed the lock.
+        foreach (var schema in new[] { schemaA, schemaB })
+        {
+            var locked = await _fixture.DataSource.ScalarLong(
+                "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace " +
+                $"WHERE p.proname = 'rebuild_user_effective_permissions' AND n.nspname = '{schema}' " +
+                "AND p.prosrc LIKE '%meshweaver_uep_rebuild%'", ct)
+                .Should().Within(30.Seconds()).Emit();
+            locked.Should().Be(1,
+                $"\"{schema}\".rebuild_user_effective_permissions must serialize via the global advisory xact lock");
+        }
+
+        // The repro shape: interleaved full rebuilds from BOTH partitions racing on the
+        // shared public.partition_access rows + their own schemas' atomic swaps. 8 parallel
+        // transactions (4 per schema) — with the advisory lock they queue and ALL succeed;
+        // unfixed, this interleave is the 40P01 cycle that killed the prod seeding passes.
+        var storm = Enumerable.Range(0, 8)
+            .Select(i => RunFullRebuildAsync(i % 2 == 0 ? schemaA : schemaB, ct))
+            .ToArray();
+        await Task.WhenAll(storm);
+
+        // The serialized rebuilds must land on the correct converged state — no lost sync
+        // from the concurrent swap storm.
+        var aliceAccess = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM public.partition_access WHERE user_id = '{alice}' AND partition = '{schemaA}'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        aliceAccess.Should().Be(1, "the rebuild storm must preserve alice's partition_access row");
+
+        var bobAccess = await _fixture.DataSource.ScalarLong(
+            $"SELECT count(*) FROM public.partition_access WHERE user_id = '{bob}' AND partition = '{schemaB}'", ct)
+            .Should().Within(30.Seconds()).Emit();
+        bobAccess.Should().Be(1, "the rebuild storm must preserve bob's partition_access row");
+    }
+}


### PR DESCRIPTION
## The defect (confirmed live on memex-cloud 2026-07-19, twice)

Concurrent mesh-node ACCESS writes from **different partitions** deadlock in Postgres with `40P01: deadlock detected`. Two plugin hubs warming concurrently each ran their access-seeding pass; each pass writes `_Access` grants into its own partition schema's `access` table, and each write's `access_changed` trigger runs the FULL `rebuild_user_effective_permissions()` **inside the originating write's transaction**. Each rebuild:

- takes ACCESS EXCLUSIVE on its **own schema's** `user_effective_permissions` (the atomic-swap `ALTER TABLE … RENAME` trio), and
- writes the **shared** `public.partition_access` rows (upsert + revoke-delete sync).

Two such transactions touch (a) different schemas' tables and (b) the same shared rows in different lock orders → lock cycle → PG kills one → the whole seeding pass of that hub aborts:

```
MeshNode Unknown at 'AgenticEngineering/Start/_Access/Public_Access': PostgresException: 40P01: deadlock detected
```

## The fix

The function's **first body statement** is now

```sql
PERFORM pg_advisory_xact_lock(hashtext('meshweaver_uep_rebuild'));
```

one **global** transaction-scoped advisory lock shared by every schema's rebuild. Concurrent rebuilds queue instead of interleaving into a cycle; the lock releases automatically at commit/rollback (an erroring rebuild can never leak it). No retry loops, no timeouts, no app-side locking.

While landing this, the rebuild-function DDL — which had drifted into two near-identical copies (`GetMeshSchemaScript` and `GetVersionedPartitionDdl`) — is single-sourced in the new `PostgreSqlSchemaInitializer.GetUepRebuildFunctionScript(schemaRef)`. Both schema scripts and (through `GetVersionedPartitionDdl`) the `public.ensure_partition_schema` proc embed it, so every installer ships one identical body.

## How EXISTING databases get the updated function

The schema script only `CREATE OR REPLACE`s the function for the **boot schema** (`InitializeAsync` → `GetSchemaScript`) and for partitions that go through `public.ensure_partition_schema` again (new provisioning). Already-provisioned partition schemas keep their deployed body — so the mechanism for live DBs is the new **`V47_SerializeUepRebuildAdvisoryLock` migration**: it probes `pg_proc` for every schema that has `rebuild_user_effective_permissions` and re-`CREATE OR REPLACE`s it there (same OID — the existing `access_changed` trigger picks the locked body up immediately). The memex-family deployments (memex / memex-cloud / atioz) run `Memex.Database.Migration` on every deploy, so V47 lands on the next roll-out. Fresh DBs skip repairs (`MigrationRunner` fast-forwards) and get the locked body straight from the initializer templates. Snowflake is untouched — it has no SQL rebuild function (C#-side projection).

## Tests

- `test/MeshWeaver.Hosting.PostgreSql.Test` (Testcontainers, full project): **553 passed, 0 failed, 1 skipped** (pre-existing skip).
- New `ConcurrentUepRebuildTests.ConcurrentRebuilds_AcrossTwoPartitions_SerializeInsteadOf40P01`: provisions two prod-shape partitions via `ensure_partition_schema`, seeds a Space + grant in each through the real trigger path, **pins that both provisioned function bodies carry the advisory lock** (deterministic-red if it is ever removed), then fires 8 interleaved full rebuilds across the two schemas and asserts all succeed and `public.partition_access` converges. With the lock this is deterministic-green; without it, the interleave is exactly the prod 40P01 cycle.

`dotnet build -c Release -warnaserror` is clean for `MeshWeaver.Hosting.PostgreSql`, `Memex.Database.Migration`, `Memex.Portal.Distributed`, and the PG/Orleans/indexing test projects. (Note: `tools/MeshWeaver.Tools.PostgreSqlImport` does not compile, but that is pre-existing — it references `StorageImporter`/`ImportHelper` which no longer exist anywhere, and it is in neither the solution nor CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)