### PR TITLE
Reset MeshNodeStreamCache breaker + negative cache on recycle invalidation

### DIFF
--- a/src/MeshWeaver.Hosting.Orleans/GrainActivationFailureRegistry.cs
+++ b/src/MeshWeaver.Hosting.Orleans/GrainActivationFailureRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using MeshWeaver.Mesh.Services;
 
 namespace MeshWeaver.Hosting.Orleans;
 
@@ -30,12 +31,34 @@ namespace MeshWeaver.Hosting.Orleans;
 /// shared across the silo's grains, with an instance map only — NO static state
 /// (<c>NoStaticState.md</c>). A process restart clears it, which is correct: a redeployed /
 /// recompiled fix re-activates cleanly and the stale error is gone.</para>
+///
+/// <para><b>Invalidation.</b> The registry also subscribes to the
+/// <see cref="IMeshChangeFeed"/> invalidation broadcast (the same signal a recycle —
+/// <c>MeshOperations.RecycleCore</c> — and every post-commit write publish, relayed
+/// cross-silo by <c>PathCacheInvalidatorGrain</c>): a change event for a path clears any
+/// stored activation error for that grain key. A recycled / just-written node must get a
+/// completely fresh activation attempt — without this, <see cref="RoutingGrain"/>'s
+/// NACK fallback served the STALE pre-recycle error text (e.g. a compile failure that was
+/// already fixed) to every sender until the grain happened to activate cleanly once.</para>
 /// </summary>
-public sealed class GrainActivationFailureRegistry
+public sealed class GrainActivationFailureRegistry : IDisposable
 {
     // grainKey (node address path) → last activation error message. Instance, never static.
     private readonly ConcurrentDictionary<string, string> _lastError =
         new(StringComparer.Ordinal);
+
+    private readonly IDisposable? _changeFeedSubscription;
+
+    /// <summary>
+    /// Creates the registry, optionally attached to the mesh change feed so
+    /// invalidation broadcasts (recycle / post-commit writes) clear stale errors.
+    /// </summary>
+    /// <param name="changeFeed">The mesh change feed to observe; when null (minimal
+    /// fixtures) the registry still works, it just never auto-clears on broadcasts.</param>
+    public GrainActivationFailureRegistry(IMeshChangeFeed? changeFeed = null)
+    {
+        _changeFeedSubscription = changeFeed?.Subscribe(evt => Clear(evt.Path));
+    }
 
     /// <summary>Record the real activation error for <paramref name="grainKey"/>.</summary>
     public void Record(string grainKey, string error)
@@ -59,4 +82,7 @@ public sealed class GrainActivationFailureRegistry
         => !string.IsNullOrEmpty(grainKey) && _lastError.TryGetValue(grainKey, out var e)
             ? e
             : null;
+
+    /// <inheritdoc />
+    public void Dispose() => _changeFeedSubscription?.Dispose();
 }

--- a/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
+++ b/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
@@ -120,6 +120,9 @@ public static class OrleansServerRegistryExtensions
         // RoutingGrain falls back to it when a persistent activation-fault loop would otherwise
         // NACK the raw Orleans rejection ("DeactivateOnIdle was called … Rejecting now") instead
         // of the actual cause (a compilation failure). See issue #464, Defect 3.
+        // The registry's ctor takes the IMeshChangeFeed (registered below; DI injects it into
+        // the optional parameter) so a recycle / post-commit invalidation broadcast clears the
+        // stored error — stale pre-recycle error text must never be NACKed after a recycle.
         services.TryAddSingleton<GrainActivationFailureRegistry>();
 
         // Register Orleans-distributed change feed (wraps local feed + Orleans streams).

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -91,6 +91,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         private int subscribers;
         private long lastActiveAt = Environment.TickCount64; // monotonic ms
         private bool evicted;
+        private bool faulted;
 
         public MeshNodeStreamHandle Handle { get; } = handle;
 
@@ -104,6 +105,17 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
 
         /// <summary>True while the entry is usable. Does NOT refresh the idle window.</summary>
         public bool IsLive { get { lock (gate) return !evicted; } }
+
+        /// <summary>Marks the entry's hydration as terminally errored — its replay
+        /// subject holds an OnError terminal, so every future subscriber would
+        /// replay the stale failure. Set by the storm-breaker bookkeeping observer;
+        /// consumed by the change-feed invalidation reset, which evicts ONLY
+        /// faulted entries (a healthy live entry must never be torn down by a
+        /// routine post-commit Updated broadcast).</summary>
+        public void MarkFaulted() { lock (gate) faulted = true; }
+
+        /// <summary>True when the entry's hydration terminated with an error.</summary>
+        public bool IsFaulted { get { lock (gate) return faulted; } }
 
         /// <summary>Refreshes the sliding idle window (read/write activity hit).</summary>
         public void Touch() { lock (gate) lastActiveAt = Environment.TickCount64; }
@@ -217,6 +229,23 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     private readonly TimeSpan readStreamSweepInterval;
     private readonly IDisposable idleSweep;
 
+    // 🚨 Invalidation signal: the SAME IMeshChangeFeed broadcast every write path
+    // already publishes — post-commit storage writes (Created/Updated/Deleted) AND
+    // the recycle operation (MeshOperations.RecycleCore publishes an Updated event
+    // before posting DisposeRequest; in Orleans the PathCacheInvalidatorGrain
+    // relays it cross-silo into each process's local feed). On each event the
+    // cache RESETS its failure state for that exact path: the storm-breaker
+    // negative entry (error, fail count, backoff window) is dropped and a
+    // terminally-FAULTED read entry is evicted, so the next natural read gets a
+    // completely fresh resolution attempt. Without this, a recycle after a
+    // compile-error era could never heal the path: the breaker's grown backoff
+    // window (up to StormMaxCooldown) kept fast-failing every read/write and the
+    // faulted entry replayed the stale error — only a pod restart cleared it
+    // (memex-cloud 2026-07-19, AgenticEngineering/Install). EVICTION/RESET ONLY —
+    // this never re-subscribes anything (2026-06-08 rule); re-probing is always
+    // the next natural read.
+    private readonly IDisposable? changeFeedReset;
+
     // Diagnostic/test seam: one event per released read entry (idle sweep,
     // Invalidate, storm-breaker stale removal). Subject.Synchronize because
     // releases fire from the sweep timer thread and hub threads concurrently.
@@ -250,7 +279,11 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     // after it elapses re-probes the owner exactly once. There is NO timer that
     // re-subscribes on its own (an auto-resubscribe watchdog is exactly what caused the
     // 2026-06-08 prod outage; this only ever evicts, never re-subscribes). A successful
-    // read clears the entry immediately. Consecutive failures grow the window
+    // read clears the entry immediately, and so does a change-feed invalidation for the
+    // path (recycle broadcast / post-commit write — see ResetFailureState: a real write
+    // on the path is authoritative proof the cached failure is stale, so the window
+    // closes and the counters reset instead of a healthy-again node fast-failing for
+    // the remainder of a grown backoff window). Consecutive failures grow the window
     // (StormBaseCooldown · 2^(n-1), capped at StormMaxCooldown); crossing
     // StormFailThreshold logs ONE "[STORM-BREAKER] suppressing" warning so the storm is
     // visible in Grafana/Loki without the per-failure log flood.
@@ -420,6 +453,96 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         // so no pass starts after teardown begins.
         idleSweep = Observable.Interval(readStreamSweepInterval)
             .Subscribe(_ => ReleaseIdleReadStreams());
+
+        // Failure-state reset on the EXISTING invalidation broadcast (see the
+        // changeFeedReset field doc). Optional service: minimal test fixtures
+        // without AddMeshCatalog's feed registration simply have no reset seam.
+        changeFeedReset = meshHub.ServiceProvider.GetService<IMeshChangeFeed>()
+            ?.Subscribe(OnMeshChange);
+    }
+
+    /// <summary>
+    /// Change-feed handler: a published change event for a path is authoritative
+    /// proof of a real write / recycle on that path, so any cached FAILURE state
+    /// for it is stale by definition — reset it (see <see cref="ResetFailureState"/>).
+    /// Runs synchronously on the publisher's thread; pure dictionary ops plus
+    /// disposing an already-terminated Rx subscription — no I/O, no hub post.
+    /// </summary>
+    private void OnMeshChange(MeshChangeEvent change)
+    {
+        if (System.Threading.Volatile.Read(ref _disposed) != 0)
+            return;
+        if (string.IsNullOrEmpty(change.Path))
+            return;
+        try
+        {
+            ResetFailureState(change.Path);
+        }
+        catch (Exception ex)
+        {
+            // The feed's Subject.OnNext runs handlers synchronously on the
+            // PUBLISHER's thread (a post-commit storage write / the recycle
+            // operation) and an unhandled throw here would fault that pipeline
+            // and starve the feed's remaining subscribers. The reset is state
+            // hygiene — surface the fault loudly, never break the writer.
+            logger.LogError(ex,
+                "MeshNodeStreamCache: failure-state reset faulted for {Path}", change.Path);
+        }
+    }
+
+    /// <summary>
+    /// Gives <paramref name="path"/> a completely fresh resolution attempt:
+    /// <list type="number">
+    ///   <item>Drops the storm-breaker negative entry — cached error, fail count
+    ///     AND backoff window (closed; counters back to zero).</item>
+    ///   <item>Evicts the read entry IFF its hydration terminated with an error
+    ///     (<see cref="Entry.IsFaulted"/>) — its Replay(1) would otherwise keep
+    ///     replaying the stale terminal error to every future subscriber even
+    ///     with the breaker cleared. A healthy live entry is left untouched: the
+    ///     owner's sync stream already delivers routine updates, and tearing the
+    ///     shared handle down on every post-commit broadcast would sever live
+    ///     GUI subscribers.</item>
+    /// </list>
+    /// Same discipline as the storm-breaker's own re-probe eviction (guard #2 in
+    /// <see cref="GetStreamRaw"/>): dispose ONLY the Rx hydration — a terminally
+    /// errored upstream has already torn down its own keep-alive, and posting
+    /// UnsubscribeRequest at a mid-recycle owner would race its re-activation.
+    /// </summary>
+    internal void ResetFailureState(string path)
+    {
+        if (_negative.TryRemove(path, out var cleared))
+        {
+            // One line when a genuinely-suppressed storm is lifted (mirrors the
+            // single "[STORM-BREAKER] suppressing" warning); routine clears stay at Debug.
+            if (cleared.FailCount >= StormFailThreshold)
+                logger.LogInformation(
+                    "[STORM-BREAKER] Cleared '{Path}' on change-feed invalidation after {FailCount} recorded failures "
+                    + "(window was open until {OpenUntil:O}) — next read re-probes fresh.",
+                    path, cleared.FailCount, cleared.OpenUntil);
+            else
+                logger.LogDebug(
+                    "MeshNodeStreamCache: cleared negative entry for {Path} on change-feed invalidation (failCount={FailCount})",
+                    path, cleared.FailCount);
+        }
+
+        if (_streams.TryGetValue(path, out var lazy) && lazy.IsValueCreated && lazy.Value.IsFaulted
+            && _streams.TryRemove(new KeyValuePair<string, Lazy<Entry>>(path, lazy)))
+        {
+            try
+            {
+                var stale = lazy.Value;
+                stale.MarkEvicted();
+                stale.HydrationSub.Dispose();
+                readStreamEvictions.OnNext(new ReadStreamEviction(path, false, "invalidate"));
+                logger.LogDebug(
+                    "MeshNodeStreamCache: evicted faulted read entry for {Path} on change-feed invalidation", path);
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex,
+                    "MeshNodeStreamCache: error disposing faulted entry for {Path}", path);
+            }
+        }
     }
 
     /// <summary>
@@ -439,6 +562,11 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         catch (Exception ex)
         {
             logger.LogDebug(ex, "MeshNodeStreamCache: error disposing idle sweep");
+        }
+        try { changeFeedReset?.Dispose(); }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "MeshNodeStreamCache: error disposing change-feed reset subscription");
         }
         try { readStreamEvictions.OnCompleted(); }
         catch (Exception ex)
@@ -629,17 +757,29 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             // transient classifier retries) but leave the cache clean so the very next read
             // re-probes the fresh activation. Symmetric with the write path (see the
             // [UpdateQueue] FAILED branch), which already guards RecordNegative the same way.
-            var bookkeeping = inner.AsObservable().Subscribe(
-                node => { if (node is not null) _negative.TryRemove(p, out _); },
-                ex => { if (IsMissingNodeFailure(ex)) RecordNegative(p, ex); });
-            var disposal = new System.Reactive.Disposables.CompositeDisposable(hydrationSub, bookkeeping);
             // Store the disposal on the Entry so the mesh hub's pre-Quiescing
             // disposal hook (registered in the ctor) can cancel it — and so the
             // idle sweep can close it when the path goes quiet. Without this,
             // every cache.GetStream(path) leaks a long-lived SubscribeRequest
             // into the mesh hub's responseSubjects and the test base's leak
-            // detection flags it at dispose.
-            return new Entry(handle, inner.AsObservable(), disposal);
+            // detection flags it at dispose. The bookkeeping observer is attached
+            // AFTER the Entry exists so a terminal error can flag the entry as
+            // FAULTED (its ReplaySubject then holds an OnError terminal that
+            // every later subscriber would replay) — the change-feed invalidation
+            // reset (ResetFailureState) evicts exactly those entries. ReplaySubject
+            // replays a terminal to late subscribers, so an error landing between
+            // the hydration subscribe above and this attach is still observed.
+            var disposal = new System.Reactive.Disposables.CompositeDisposable(hydrationSub);
+            var entry = new Entry(handle, inner.AsObservable(), disposal);
+            var bookkeeping = inner.AsObservable().Subscribe(
+                node => { if (node is not null) _negative.TryRemove(p, out _); },
+                ex =>
+                {
+                    entry.MarkFaulted();
+                    if (IsMissingNodeFailure(ex)) RecordNegative(p, ex);
+                });
+            disposal.Add(bookkeeping);
+            return entry;
         }
     }
 
@@ -796,8 +936,11 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// <see cref="StormMaxCooldown"/>). Crossing <see cref="StormFailThreshold"/>
     /// consecutive failures logs ONE warning. Never re-subscribes — purely records
     /// state that <see cref="GetStreamRaw"/> consults to fast-fail.
+    /// Internal as a test seam: the recycle-reset tests seed the grown failure
+    /// history (a compile-error era's worth of consecutive activation failures)
+    /// deterministically instead of waiting out real backoff windows.
     /// </summary>
-    private void RecordNegative(string path, Exception error)
+    internal void RecordNegative(string path, Exception error)
     {
         var priorFails = _negative.TryGetValue(path, out var existing) ? existing.FailCount : 0;
         var failCount = priorFails + 1;
@@ -1627,10 +1770,14 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// <c>HandleDeleteNodeRequest</c> after the persistence delete commits —
     /// the Replay(1) cache otherwise holds the pre-delete MeshNode forever
     /// (the upstream observable doesn't emit "deleted" — the per-node hub is
-    /// gone). Idempotent.
+    /// gone). Also drops the storm-breaker negative entry for the path — an
+    /// invalidation means "give this path a completely fresh resolution attempt",
+    /// so a stale failure window (error, fail count, backoff) must not outlive
+    /// it; if the path is genuinely absent, the next read re-records. Idempotent.
     /// </summary>
     public void Invalidate(string path)
     {
+        _negative.TryRemove(path, out _);
         if (_streams.TryRemove(path, out var lazyEntry))
         {
             // Dispose the upstream SubscribeRequest so it doesn't dangle in

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheRecycleResetTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheRecycleResetTest.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the fix for the 2026-07-19 memex-cloud wedge: a recycled node must get a
+/// COMPLETELY FRESH resolution attempt — cleared storm-breaker window, cleared
+/// negative cache, cleared failure counters, and no replay of a stale terminal
+/// error from a faulted read entry.
+///
+/// <para><b>The live defect.</b> The per-node hub <c>AgenticEngineering/Install</c>
+/// (NodeType <c>Edu/CourseInvite</c>) went through a ~6-minute compile-error era in
+/// which every grain activation faulted. Each failure grew the
+/// <see cref="MeshNodeStreamCache"/> storm-breaker's exponential backoff
+/// (2s&#160;·&#160;2^(n-1), capped at 5&#160;min), and the shared read entry's
+/// Replay(1) terminated with the activation error. After the NodeType compiled
+/// green again, <c>recycle</c> (DisposeRequest + the "cache invalidation broadcast
+/// via MeshChangeFeed", see <c>MeshOperations.RecycleCore</c>) was issued
+/// repeatedly — but the cache never consumed that broadcast: the negative entry
+/// kept fast-failing every read AND write for the full grown window, and the
+/// faulted entry kept replaying the stale error. The hub stayed unreachable for
+/// 20+ minutes until a full pod restart cleared the in-process state.</para>
+///
+/// <para><b>The contract under test.</b> A change-feed event for a path (recycle
+/// broadcast, post-commit Created/Updated/Deleted) resets the cache's failure
+/// state for exactly that path: the negative entry is dropped (window closed,
+/// counters zeroed) and a FAULTED read entry is evicted so the next natural read
+/// re-probes the owner — without waiting out the old backoff window. Healthy live
+/// entries are untouched (a routine post-commit broadcast must never sever live
+/// subscribers). The reset only ever clears state / evicts — it never
+/// re-subscribes anything (the 2026-06-08 rule).</para>
+/// </summary>
+public class MeshNodeStreamCacheRecycleResetTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private MeshNodeStreamCache Cache =>
+        (MeshNodeStreamCache)Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+
+    private async Task<string> CreateNodeAsync(string prefix)
+    {
+        var path = $"{TestPartition}/{prefix}-{Guid.NewGuid():N}";
+        var node = MeshNode.FromPath(path) with
+        {
+            Name = "Original",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        };
+        await NodeFactory.CreateNode(node).Should().Within(60.Seconds()).Emit();
+        return path;
+    }
+
+    /// <summary>The exact broadcast <c>MeshOperations.RecycleCore</c> publishes for a
+    /// recycled path (Updated kind, NodeType-path marker, version 0).</summary>
+    private void PublishRecycleBroadcast(string path)
+    {
+        var segments = path.Split('/');
+        Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>().Publish(new MeshChangeEvent(
+            Namespace: segments.Length > 1 ? string.Join("/", segments[..^1]) : "",
+            Id: segments.Length > 0 ? segments[^1] : path,
+            Path: path,
+            Kind: MeshChangeKind.Updated,
+            NodeType: MeshNode.NodeTypePath,
+            Version: 0,
+            Timestamp: DateTimeOffset.UtcNow));
+    }
+
+    /// <summary>
+    /// The deterministic pin of the live repro. The node EXISTS (as
+    /// <c>AgenticEngineering/Install</c> did); the compile-era failure history is
+    /// seeded through the breaker's own recording seam so the backoff window sits
+    /// at the 5-minute cap — impossible to outwait within the test budget, exactly
+    /// like the production wedge. Reads AND writes must fast-fail while the window
+    /// is open; after the recycle broadcast the very next read must deliver the
+    /// node. Without the reset this test can only go green by waiting out the
+    /// 5-minute window — i.e. it deterministically fails.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task RecycleBroadcast_ResetsBreaker_SoHealthyNodeResolvesWithoutWaitingOutBackoff()
+    {
+        var cache = Cache;
+        var path = await CreateNodeAsync("recycle");
+
+        // The compile-era failure shape: activation faulted because the NodeType
+        // couldn't compile. Classified as a missing-node failure (recorded by the
+        // breaker), NOT transient — precondition-checked so a classifier change
+        // can't silently hollow out this test.
+        var activationError = new InvalidOperationException(
+            $"Delivery to '{path}' failed: activation failed: Compilation failed for " +
+            "'Edu/CourseInvite': CS0246: The type or namespace name 'Foo' could not be found");
+        MeshNodeStreamCache.IsMissingNodeFailure(activationError).Should().BeTrue(
+            "precondition: the seeded error must be the class the storm-breaker records");
+
+        // ~6 minutes of consecutive activation failures: 9 recordings put the
+        // window at 2s·2^8 = 512s ⇒ capped at StormMaxCooldown (5 min).
+        for (var i = 0; i < 9; i++)
+            cache.RecordNegative(path, activationError);
+
+        // Breaker OPEN ⇒ reads fast-fail by replaying the cached error…
+        var readFail = await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Materialize()
+            .Should().Within(5.Seconds()).Match(
+                n => n.Kind == NotificationKind.OnError,
+                "an open breaker window must fast-fail reads with the cached error");
+        readFail.Exception!.Message.Should().Contain("activation failed",
+            "the fast-fail must replay the recorded owner error");
+
+        // …and writes fast-fail too (the write-side breaker on the same negative cache).
+        var writeFail = await cache.Update(path, n => n with { Name = "MustNotLand" }, Mesh.JsonSerializerOptions)
+            .Materialize()
+            .Should().Within(5.Seconds()).Match(
+                n => n.Kind == NotificationKind.OnError,
+                "an open breaker window must fast-fail writes as well");
+        writeFail.Exception!.Message.Should().Contain("activation failed");
+
+        // The recycle: the SAME broadcast RecycleCore publishes.
+        PublishRecycleBroadcast(path);
+
+        // Fresh resolution attempt IMMEDIATELY — no waiting out the 5-minute
+        // window. This is the exact step that never healed on memex-cloud.
+        var node = await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Where(n => n is not null)
+            .Should().Within(30.Seconds()).Emit(
+                "a recycled path must get a completely fresh resolution attempt — " +
+                "cleared breaker window, cleared negative cache, cleared failure counters");
+        node!.Path.Should().Be(path);
+
+        // And writes work again through the same reset state.
+        await Mesh.GetMeshNodeStream(path)
+            .Update(n => n with { Name = "AfterRecycle" })
+            .Should().Within(15.Seconds()).Emit(
+                "the write-side breaker must be reset by the same broadcast");
+    }
+
+    /// <summary>
+    /// The organic end-to-end variant: a REAL missing-node read opens the breaker
+    /// and leaves a FAULTED read entry whose Replay(1) holds the terminal error.
+    /// The failure history is then grown to the cap (so the window cannot elapse
+    /// naturally within the test), and the node is brought into being by a real
+    /// <c>CreateNode</c> — whose post-commit <see cref="MeshChangeKind.Created"/>
+    /// publish IS the invalidation signal. The immediate next read must emit the
+    /// node: this pins BOTH halves of the reset — the negative-cache clear AND the
+    /// faulted-entry eviction (with the entry left in place, the read would replay
+    /// the stale pre-create error even with the breaker cleared).
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task CreateAfterFailureEra_ClearsBreakerAndFaultedEntry_ViaChangeFeed()
+    {
+        var cache = Cache;
+        var path = $"{TestPartition}/breaker-organic-{Guid.NewGuid():N}";
+
+        // 1) Organic failure: the read reaches the owner, resolution fails with a
+        //    genuine missing-node error; the breaker records it and the shared
+        //    entry's replay terminates with the error.
+        var firstFail = await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Where(n => n?.Content is not null)
+            .Materialize()
+            .Should().Within(15.Seconds()).Match(
+                n => n.Kind == NotificationKind.OnError,
+                "reading a nonexistent path must surface the owner's NotFound as OnError");
+        MeshNodeStreamCache.IsMissingNodeFailure(firstFail.Exception!).Should().BeTrue(
+            "precondition: the organic failure must be the class the breaker records");
+
+        // 2) Grow the failure history to the cap — the window can no longer elapse
+        //    within the test budget, so a green run can only come from the reset.
+        for (var i = 0; i < 8; i++)
+            cache.RecordNegative(path, firstFail.Exception!);
+
+        // 3) While the window is open, a re-read fast-fails by replaying the cached
+        //    error without re-probing the owner.
+        await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Materialize()
+            .Should().Within(5.Seconds()).Match(
+                n => n.Kind == NotificationKind.OnError,
+                "the open window must fast-fail the re-read");
+
+        // 4) Bring the node into being through the REAL pipeline. The post-commit
+        //    Created publish on IMeshChangeFeed is the invalidation broadcast.
+        var node = MeshNode.FromPath(path) with
+        {
+            Name = "NowExists",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        };
+        await NodeFactory.CreateNode(node).Should().Within(60.Seconds()).Emit();
+
+        // 5) Immediate read — no waiting out the old backoff window, no replay of
+        //    the stale pre-create error from the faulted entry.
+        var fresh = await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Where(n => n is not null)
+            .Should().Within(30.Seconds()).Emit(
+                "after the Created broadcast the path must resolve fresh — the faulted " +
+                "entry must have been evicted and the negative entry dropped");
+        fresh!.Path.Should().Be(path);
+        fresh.Name.Should().Be("NowExists");
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/GrainActivationFailureRegistryTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/GrainActivationFailureRegistryTest.cs
@@ -1,0 +1,65 @@
+using System;
+using MeshWeaver.Hosting;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Pins the invalidation half of <see cref="GrainActivationFailureRegistry"/>:
+/// a change-feed broadcast for a path (the recycle broadcast
+/// <c>MeshOperations.RecycleCore</c> publishes, or any post-commit write) must
+/// clear the stored activation error for that grain key — otherwise
+/// <c>RoutingGrain</c>'s NACK fallback keeps serving the STALE pre-recycle error
+/// text (e.g. a compile failure that was already fixed) after the node was
+/// recycled (the 2026-07-19 memex-cloud <c>AgenticEngineering/Install</c> wedge).
+/// Deterministic unit test over the real feed + registry — no cluster, no mocks.
+/// </summary>
+public class GrainActivationFailureRegistryTest
+{
+    private const string RecycledPath = "AgenticEngineering/Install";
+    private const string OtherPath = "AgenticEngineering/Other";
+
+    private static MeshChangeEvent RecycleBroadcast(string path)
+    {
+        var segments = path.Split('/');
+        return new MeshChangeEvent(
+            Namespace: segments.Length > 1 ? string.Join("/", segments[..^1]) : "",
+            Id: segments[^1],
+            Path: path,
+            Kind: MeshChangeKind.Updated,
+            NodeType: MeshNode.NodeTypePath,
+            Version: 0,
+            Timestamp: DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void ChangeFeedBroadcast_ClearsStoredActivationError_ForExactlyThatPath()
+    {
+        using var feed = new InProcessMeshChangeFeed();
+        using var registry = new GrainActivationFailureRegistry(feed);
+
+        registry.Record(RecycledPath, "Compilation failed for 'Edu/CourseInvite': CS0246 …");
+        registry.Record(OtherPath, "Compilation failed for 'Edu/Other': CS1501 …");
+        registry.TryGet(RecycledPath).Should().NotBeNull("precondition: the error is stored");
+
+        feed.Publish(RecycleBroadcast(RecycledPath));
+
+        registry.TryGet(RecycledPath).Should().BeNull(
+            "the recycle broadcast must clear the stale activation error so it is never " +
+            "NACKed to a sender after the node was recycled");
+        registry.TryGet(OtherPath).Should().NotBeNull(
+            "the reset is scoped to the broadcast path — other grains' errors stay");
+    }
+
+    [Fact]
+    public void WithoutChangeFeed_RegistryStillRecordsAndClearsManually()
+    {
+        using var registry = new GrainActivationFailureRegistry();
+        registry.Record(RecycledPath, "boom");
+        registry.TryGet(RecycledPath).Should().Be("boom");
+        registry.Clear(RecycledPath);
+        registry.TryGet(RecycledPath).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## The live wedge (memex-cloud, 2026-07-19 ~19:40–20:05 UTC)

The per-node hub `AgenticEngineering/Install` (NodeType `Edu/CourseInvite`) became **permanently unreachable**: every `SubscribeRequest` timed out ("No response received in hub cache/… within 00:01:00") and the Orleans grain churned through activations that immediately hit `DeactivateOnIdle`. Sequence:

1. The node's NodeType had a ~6-minute compile-error era during which every grain activation legitimately faulted (node resolution / enrichment failed).
2. Each failure grew the `MeshNodeStreamCache` storm-breaker's exponential backoff (`StormBaseCooldown · 2^(n-1)`, capped at 5 min). While the window is open, `GetStreamRaw` fast-fails reads (and `UpdateRaw` fast-fails writes) by replaying the cached error — and the shared read entry's Replay(1) terminated with the stale activation error.
3. After the NodeType compiled green again, `recycle` (DisposeRequest + the "cache invalidation broadcast via MeshChangeFeed", `MeshOperations.RecycleCore`) was issued repeatedly — **but the cache never consumed that broadcast**. The negative cache, the breaker window, the failure counters and the faulted entry all survived every recycle. The hub stayed unreachable for 20+ minutes until a full pod restart cleared the in-process state.

**Root cause: the recycle / MeshChangeFeed cache-invalidation path never reset the `MeshNodeStreamCache`'s negative cache and storm-breaker/backoff state for the invalidated path.**

## The fix

A recycled (or written) path now gets a **completely fresh resolution attempt** — the reset rides the EXISTING invalidation signal (the `IMeshChangeFeed` broadcast recycle already publishes and every post-commit storage write already publishes; cross-silo relayed by `PathCacheInvalidatorGrain`). No new watcher, no timer, no polling; the reset only ever clears state / evicts — it never re-subscribes anything (the 2026-06-08 rule).

`MeshNodeStreamCache` (src/MeshWeaver.Hosting/MeshNodeStreamCache.cs):
- Subscribes to `IMeshChangeFeed` at construction (`changeFeedReset`, disposed with the cache). On each event for a path, `ResetFailureState(path)`:
  - **drops the storm-breaker negative entry** — cached error, fail count AND backoff window (window closed, counters zeroed, stuck `Reprobing` latch gone);
  - **evicts the read entry iff it is FAULTED** (its hydration terminated with an error — the Replay(1) would otherwise keep replaying the stale terminal error to every future subscriber even with the breaker cleared). Healthy live entries are untouched, so routine post-commit broadcasts never sever live subscribers. The eviction follows the storm-breaker's own re-probe discipline: dispose only the Rx hydration, never post `UnsubscribeRequest` at a mid-recycle owner.
- `Entry` gains a `faulted` flag set by the existing storm-breaker bookkeeping observer on terminal error.
- `Invalidate(path)` (the delete path) now also drops the negative entry — "invalidate" means a completely fresh resolution attempt.
- Scope matches the existing invalidation semantics: exact path (the same scoping `Invalidate` and `Workspace.EvictForPath` use; the broadcast carries one path per event, and delete fan-out publishes per-leaf events).

`GrainActivationFailureRegistry` (src/MeshWeaver.Hosting.Orleans/GrainActivationFailureRegistry.cs):
- Now subscribes to the same `IMeshChangeFeed` (injected via DI into the optional ctor parameter): a broadcast for a path clears the stored activation error for that grain key, so `RoutingGrain`'s NACK fallback can never serve **stale pre-recycle error text** (e.g. a compile failure that was already fixed) after a recycle.

## Tests

`test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheRecycleResetTest.cs` (MonolithMeshTestBase, real mesh, no mocks):
- **`RecycleBroadcast_ResetsBreaker_SoHealthyNodeResolvesWithoutWaitingOutBackoff`** — the deterministic pin of the live repro: node exists; the compile-era failure history is seeded through the breaker's own recording seam so the window sits at the 5-minute cap (impossible to outwait in the test budget, exactly like prod); reads AND writes fast-fail; then the *exact* broadcast `RecycleCore` publishes is published — and the very next read must deliver the node, and a write must land.
- **`CreateAfterFailureEra_ClearsBreakerAndFaultedEntry_ViaChangeFeed`** — organic end-to-end: a REAL missing-node read opens the breaker and leaves a faulted entry; the history is grown to the cap; a real `CreateNode`'s post-commit `Created` publish is the invalidation signal; the immediate next read must emit the node. Pins BOTH halves (negative-cache clear + faulted-entry eviction — with the entry left in place the read would replay the stale pre-create error even with the breaker cleared).

`test/MeshWeaver.Hosting.Orleans.Test/GrainActivationFailureRegistryTest.cs` — deterministic unit tests over the real feed + registry: a broadcast clears the stored error for exactly the broadcast path (and the registry still works standalone without a feed).

All four tests pass; `MeshNodeStreamCacheIdleReleaseTest` + `MeshNodeStreamCacheNegativeClassifierTest` + `MissingSatelliteTest` (the adjacent breaker/idle contracts) re-verified green. `dotnet build -c Release -warnaserror` clean for the touched projects and their test dependents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
