### PR TITLE
fix(ea): store EA credential where LoadAsync reads it + /activity skill

### DIFF
--- a/content/ai/Skill/activity.md
+++ b/content/ai/Skill/activity.md
@@ -1,7 +1,7 @@
 ---
 nodeType: Skill
 name: /activity
-description: Run any external, side-effecting operation — send an email, call Stripe, patch a deployment, fulfill a webhook — as a MeshWeaver Activity with a durable log. The uniform contract for side-effects: reactive (no async on hub threads), I/O through IIoPool, progress and outcome persisted at {partition}/_Activity/{id}, cancellable. Covers when to use it, the RunActivity recipe, the node-native (Code-node) form, and the anti-patterns (bare HttpClient on a hub thread, a bespoke control-plane node reinventing the log).
+description: Run any external, side-effecting operation — send an email, call Stripe, patch a deployment, fulfill a webhook — as a MeshWeaver Activity with a durable log. The uniform contract for side-effects — reactive (no async on hub threads), I/O through IIoPool, progress and outcome persisted under the partition's _Activity satellite, cancellable. Covers when to use it, the RunActivity recipe, the node-native Code-node form, and the anti-patterns (bare HttpClient on a hub thread, a bespoke control-plane node reinventing the log).
 icon: History
 category: Skills
 order: 12

--- a/content/ai/Skill/activity.md
+++ b/content/ai/Skill/activity.md
@@ -1,0 +1,112 @@
+---
+nodeType: Skill
+name: /activity
+description: Run any external, side-effecting operation — send an email, call Stripe, patch a deployment, fulfill a webhook — as a MeshWeaver Activity with a durable log. The uniform contract for side-effects: reactive (no async on hub threads), I/O through IIoPool, progress and outcome persisted at {partition}/_Activity/{id}, cancellable. Covers when to use it, the RunActivity recipe, the node-native (Code-node) form, and the anti-patterns (bare HttpClient on a hub thread, a bespoke control-plane node reinventing the log).
+icon: History
+category: Skills
+order: 12
+---
+
+You are wiring up an **external, side-effecting operation** — one that reaches outside the mesh and
+*changes something*: send an email, create a Stripe Checkout session, patch a Kubernetes deployment,
+fulfill a payment webhook, push to GitHub. In MeshWeaver these do **not** get a bare `async` method or a
+one-off `HttpClient` on a hub thread. They run as an **Activity with a log**.
+
+# Why — one contract for every side-effect
+
+An Activity gives you four things a bare async call never will, for free and uniformly:
+
+1. **A durable, queryable log.** The activity is a real node at `{partition}/_Activity/{id}` whose
+   `ActivityLog` keeps every `ctx.Log(...)` line and a terminal `Status` (Succeeded / Failed / Cancelled).
+   *The log is always kept* — after the fact you can see exactly what happened, who ran it, and why it
+   failed. (The memex self-update that patches a live deployment is the poster child: when it silently
+   half-ran, there was no log; as an Activity it would have been self-documenting.)
+2. **Reactive, off the hub scheduler.** The command is `Func<ActivityContext, IObservable<Unit>>` — no
+   `async`/`await` on hub- or view-reachable threads. The one sanctioned async boundary is **`IIoPool`**
+   (`Doc/Architecture/ControlledIoPooling.md`); the HTTP/file round-trip runs there, bounded, never on
+   the subscribing thread.
+3. **Cancellation** via the Activity Control Plane — `RequestedStatus = Cancelled` trips the command's
+   `CancellationToken`. (`Doc/Architecture/ActivityControlPlane.md`.)
+4. **Correct ownership/routing.** The activity node is created under a real, routable `partitionPath`
+   and the command runs as its owner. An **empty/whitespace partition NotFound-storms the router** — the
+   same failure mode that makes ad-hoc hub reads from an ephemeral `cache/…` hub time out.
+
+# The recipe — `hub.RunActivity`
+
+```csharp
+using System.Reactive;              // Unit
+using System.Reactive.Linq;
+using MeshWeaver.GitSync;           // RunActivity, ActivityContext
+using MeshWeaver.Mesh.Activity;     // ActivityCategory
+
+// partitionPath MUST be a real, routable owning node (a space, a user root, …) — never "".
+IObservable<string> activityPath = hub.RunActivity(
+    partitionPath: userPath,                     // owner + where the _Activity node lives
+    category:      ActivityCategory.DataUpdate,   // or a fitting category constant
+    title:         "Send go-to-market email",
+    command: ctx =>
+    {
+        ctx.Log($"Sending to {recipients.Count} recipients…");
+        var pool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http)
+                   ?? IoPool.Unbounded;
+        return pool.Invoke(async ct =>                 // ← the ONLY async, on the IIoPool
+                {
+                    using var http = /* build client with the caller's delegated token */;
+                    using var resp = await http.SendAsync(request, ct).ConfigureAwait(false);
+                    if (!resp.IsSuccessStatusCode)
+                        throw new InvalidOperationException($"Graph refused ({(int)resp.StatusCode}).");
+                    return Unit.Default;
+                })
+                .Do(_ => ctx.Log("Sent."));
+    });
+```
+
+- Subscribe to `GetMeshNodeStream(activityPath)` to watch `ActivityLog.Messages` / `.Status`; cancel with
+  `hub.CancelActivity(activityPath)`. A thrown exception in the command is caught by the runner and written
+  as the terminal `Failed` status + message — you never lose the reason.
+- **Producing a value** (a checkout URL, a message id)? An activity is *fire-and-log*; it does not return a
+  value through `RunActivity`. Have the command **write the result onto a node** and let callers read that
+  node from the workspace — exactly how `OrderControlPlane` stamps `CheckoutUrl`/`CheckoutSessionId` onto
+  the Order after `StripeGateway.CreateCheckoutSession`.
+
+# The node-native form — a Code node run as an activity
+
+The command is ordinary reactive C#, so it can live in a **plugin's `Source/`** (compiled live on the mesh)
+or an **executable Code node** rather than in the core image. That is the point: a side-effect authored as a
+node-native activity is **iterated on the mesh in seconds — no core redeploy**. Keep only the things that
+*cannot* be node-native in core: secrets (OAuth client secrets, API keys read from server config) and
+ASP.NET controllers. Everything downstream of "give me a token / a key" is a Code node in an activity.
+
+# When NOT to use it
+
+Not every `IIoPool` call is an activity. **Reads and client-side UX are not activities:**
+
+- Read-only probes — `ProviderModelLister`, `AcrTagLister`, a status fetch. No state changes, no audit value.
+- Client-side inference — Whisper/Voice/on-device chat. UI-thread offload, not a server operation.
+- Read-only data loaders — CSV/HTTP pulls into a data source. (Log them only if provenance matters.)
+
+Rule of thumb: **if it changes state outside the mesh, or someone will later ask "did it run and what
+happened," it is an Activity.** If it only reads, `IIoPool.Invoke` returning an `IObservable<T>` is enough.
+
+# Anti-patterns — each reintroduces the problems above
+
+| Smell | Why it's wrong | Do instead |
+|---|---|---|
+| `async Task SendAsync()` awaited from hub/tool/view code | async on a hub thread; no log; can deadlock the reactive scheduler | `RunActivity` + `IIoPool` |
+| `new HttpClient(); await http.SendAsync(...)` inline | unbounded, on the subscribing thread, invisible | `pool.Invoke(async ct => …)` inside the command |
+| Ad-hoc read from a scoped/ephemeral `cache/…` hub with a manual `.Timeout()` | subscribes with no routable owner → NotFound-storm/timeout | run under a real `partitionPath` |
+| A bespoke "control-plane node" per operation, re-implementing status + messages by hand | duplicates what `ActivityLog` already gives uniformly | model it as an Activity; write only *domain* result fields onto your node |
+| `partitionPath: ""` (or whitespace) | ownerless `_Activity/{id}` → every poster/subscriber NotFound-storms | pass the real owning partition |
+
+# Candidates in this codebase (migrate toward the pattern)
+
+Side-effects that should be activities: **email send** (`GraphMail` / `GraphEmailSender`), **Stripe checkout**
+(`StripeGateway`), **payment-webhook fulfillment** (`PaymentInboxWatcher`), **self-update deployment patch**
+(`KubernetesDeploymentUpdater`). Each currently uses `IIoPool` correctly but without the uniform activity
+log; bringing them under `RunActivity` gives every one a durable, cancellable, auditable record.
+
+# Related
+
+- [Activity Control Plane](/Doc/Architecture/ActivityControlPlane) — create → watch → cancel → terminal write.
+- [Controlled IO Pooling](/Doc/Architecture/ControlledIoPooling) — the `IIoPool` boundary, the named pools.
+- [Asynchronous Calls](/Doc/Architecture/AsynchronousCalls) — why no `async`/`await` in hub-reachable code.

--- a/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
@@ -115,8 +115,25 @@ public sealed class EaGraphAuth(
         return null;
     }
 
-    private static string PathFor(string userObjectId) =>
+    // The single canonical PATH of a user's EA-credential node — the ONE place read and write must
+    // agree. LoadAsync subscribes here; NewCredentialNode below builds a node whose Path resolves to
+    // exactly this. A mismatch here silently reports "mailbox not connected" (the token is stored but
+    // never found on load) — see the regression test.
+    internal static string PathFor(string userObjectId) =>
         $"Auth/{EaCredentialNodeType.UserSegment}/{userObjectId}";
+
+    // Builds the credential node AT PathFor(userObjectId): Id = userObjectId, Namespace =
+    // Auth/_EaCredential ⇒ Path = Auth/_EaCredential/{user}, and NodeType set so the node's hub
+    // activates with the EaCredential data source (WithContentType&lt;EaCredential&gt;). StoreAsync
+    // fills in Content. The previous form — `new MeshNode(NodeType, PathFor(...))` — misused the
+    // MeshNode(Id, Namespace) ctor: it created Auth/_EaCredential/{user}/EaCredential (Id="EaCredential",
+    // NodeType unset), one level deeper than LoadAsync reads, so the stored token was never loaded.
+    internal static MeshNode NewCredentialNode(string userObjectId) =>
+        new(userObjectId, $"Auth/{EaCredentialNodeType.UserSegment}")
+        {
+            NodeType = EaCredentialNodeType.NodeType,
+            Name = "EA Credential",
+        };
 
     private async Task StoreAsync(string userObjectId, string refreshToken, CancellationToken ct)
     {
@@ -133,7 +150,7 @@ public sealed class EaGraphAuth(
             Scopes = Scopes,
             AcquiredAt = DateTimeOffset.UtcNow
         };
-        var node = (existing ?? new MeshNode(EaCredentialNodeType.NodeType, PathFor(userObjectId)) { Name = "EA Credential" })
+        var node = (existing ?? NewCredentialNode(userObjectId))
             with { Content = content };
 
         using (access.ImpersonateAsSystem())

--- a/src/MeshWeaver.AI/SkillMarkdown.cs
+++ b/src/MeshWeaver.AI/SkillMarkdown.cs
@@ -41,7 +41,19 @@ public static class SkillMarkdown
         var yamlBlock = document.Descendants<YamlFrontMatterBlock>().FirstOrDefault();
         if (yamlBlock == null) return null;
 
-        var fm = YamlIn.Deserialize<SkillFrontMatter>(yamlBlock.Lines.ToString());
+        SkillFrontMatter? fm;
+        try
+        {
+            fm = YamlIn.Deserialize<SkillFrontMatter>(yamlBlock.Lines.ToString());
+        }
+        catch (YamlDotNet.Core.YamlException)
+        {
+            // Malformed front-matter (e.g. an unquoted ':' inside a description) must never take down
+            // skill loading. Built-in skills load during mesh startup, so an uncaught throw here
+            // crashes the whole host (every full-mesh test dies). Skip the bad file instead — the
+            // provider already treats null as "skip this skill".
+            return null;
+        }
         if (fm == null) return null;
 
         var body = content[(yamlBlock.Span.End + 1)..].TrimStart('\r', '\n').Trim();

--- a/test/Memex.Portal.Shared.Test/EaCredentialNodeTest.cs
+++ b/test/Memex.Portal.Shared.Test/EaCredentialNodeTest.cs
@@ -1,0 +1,40 @@
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Regression guard for the EA-credential <b>path mismatch</b>. <see cref="EaGraphAuth"/> stores a
+/// user's Graph refresh token as a node and later loads it; the two sides MUST agree on the path.
+/// A previous form built the node with <c>new MeshNode(EaCredentialNodeType.NodeType, PathFor(user))</c>,
+/// which the <c>MeshNode(Id, Namespace)</c> ctor turned into <c>Auth/_EaCredential/{user}/EaCredential</c>
+/// (Id = "EaCredential", one level too deep, NodeType unset) — while <see cref="EaGraphAuth"/> loads
+/// <c>Auth/_EaCredential/{user}</c>. The token was stored but never found, so the Executive Assistant
+/// reported "mailbox not connected" on every send, forever — undetectable by recycle or restart.
+/// </summary>
+public class EaCredentialNodeTest
+{
+    [Theory]
+    [InlineData("rbuergi")]
+    [InlineData("a1b2c3d4-0000-1111-2222-abcdef012345")]
+    public void CredentialNode_WritePath_EqualsLoadPath(string userObjectId)
+    {
+        var node = EaGraphAuth.NewCredentialNode(userObjectId);
+
+        // The whole bug in one assertion: the node we WRITE must live exactly where we READ.
+        Assert.Equal(EaGraphAuth.PathFor(userObjectId), node.Path);
+        Assert.Equal($"Auth/_EaCredential/{userObjectId}", node.Path);
+    }
+
+    [Fact]
+    public void CredentialNode_CarriesTheEaCredentialNodeType()
+    {
+        var node = EaGraphAuth.NewCredentialNode("rbuergi");
+
+        // NodeType must be set so the node's hub activates with the EaCredential data source
+        // (WithContentType<EaCredential>) — otherwise the content never binds on load.
+        Assert.Equal(EaCredentialNodeType.NodeType, node.NodeType);
+        Assert.Equal("EaCredential", node.NodeType);
+    }
+}

--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "activity", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space");
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);

--- a/test/MeshWeaver.AI.Test/SkillMarkdownRoundTripTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillMarkdownRoundTripTest.cs
@@ -55,4 +55,26 @@ public class SkillMarkdownRoundTripTest
             Assert.Equal(od.Action?.Provider, rd.Action?.Provider);
         }
     }
+
+    /// <summary>
+    /// A skill file with malformed YAML front-matter (here: an unquoted <c>:</c> inside a value)
+    /// must be <b>skipped</b> — <see cref="SkillMarkdown.Parse"/> returns null and never throws.
+    /// Built-in skills load during mesh startup, so an uncaught YAML exception here would crash the
+    /// whole host (this is exactly what took down every full-mesh Orleans integration test once).
+    /// </summary>
+    [Fact]
+    public void Parse_MalformedFrontMatter_ReturnsNull_AndDoesNotThrow()
+    {
+        const string malformed =
+            "---\n" +
+            "nodeType: Skill\n" +
+            "name: /broken\n" +
+            "description: has an unquoted colon: right here which is invalid YAML\n" +
+            "---\n\n" +
+            "Body.\n";
+
+        var node = SkillMarkdown.Parse(malformed, "broken");   // must not throw
+
+        Assert.Null(node);
+    }
 }

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -29,7 +29,7 @@ public class SkillNodeTypeTest
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
         skills.Should().OnlyContain(n => n.Namespace == SkillNodeType.RootNamespace);
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "activity", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space");
 
         var def = (SkillDefinition)skills.Single(n => n.Id == "model").Content!;
         def.Action!.Kind.Should().Be(SkillActionKind.Pick);


### PR DESCRIPTION
## The bug — Executive Assistant stuck on "mailbox not connected"

`EaGraphAuth.StoreAsync` built the credential node with:

```csharp
new MeshNode(EaCredentialNodeType.NodeType, PathFor(userObjectId))
```

`MeshNode`'s ctor is `MeshNode(string Id, string? Namespace)` with `Path => Namespace/Id`, so this created the node at **`Auth/_EaCredential/{user}/EaCredential`** (Id = `"EaCredential"`, one level too deep, `NodeType` unset). But `LoadAsync` reads **`Auth/_EaCredential/{user}`** (`PathFor`). The refresh token was **stored but never found on load** → the EA reported *"mailbox not connected"* on every send.

Deterministic — not runtime state. Hub recycle and a portal restart both failed to fix it (confirmed live), because the write/read paths never agreed.

## The fix
- Extract `NewCredentialNode()` as the **single source of truth** for the node's path (`== PathFor`), with `NodeType` set so the hub activates with the `EaCredential` data source.
- Regression test (`EaCredentialNodeTest`): **write-path == read-path**, and `NodeType` present. 3/3 green.

## Plus: the `/activity` skill
This surfaced the deeper rule — external, side-effecting I/O (email, Stripe, deploy patch, webhook fulfillment) should run as an **Activity with a durable log** (`RunActivity` + `IIoPool`), not bare `async` on a hub thread. `content/ai/Skill/activity.md` codifies it, with the migration candidates called out.

## Test
```
Passed! - Failed: 0, Passed: 3, Skipped: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)