### PR TITLE
feat: mw-plugin-test — the MeshWeaver.Plugins PR-gate image (+ fresh-mesh install fixes)

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -240,6 +240,7 @@ jobs:
           [MeshWeaver.Courses.Test]=20
           [MeshWeaver.Layout.Test]=20
           [MeshWeaver.PluginCatalog.Test]=20
+          [MeshWeaver.PluginTester.Test]=60
           [MeshWeaver.Markdown.Test]=20
           [MeshWeaver.PathResolution.Test]=15
           [MeshWeaver.PensionFund.Test]=15

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -199,6 +199,71 @@ jobs:
           -p:ContainerRepository=memex-migration
           -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"'
 
+  # The MeshWeaver.Plugins PR gate image: `mw-plugin-test` (tools/MeshWeaver.PluginTester)
+  # imports a node-repo checkout into a fresh in-process mesh, asserts every NodeType compiles,
+  # renders, and its `Tests` layout area executes green. The plugins repo's ci.yml `test-repos`
+  # job runs INSIDE this image (repo variable MW_TEST_IMAGE), so every main build must refresh
+  # it — `latest` is the stable tag that variable pins.
+  plugin-test-image:
+    name: "Build + push mw-plugin-test image"
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          dotnet: false
+          android: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+      # Same $(Version) computation as the other legs — GITHUB_RUN_NUMBER is shared across the
+      # run, so the 3.0.0-ci.<n> tag matches the portal/migration images by construction.
+      - name: Compute image tags (version + short SHA)
+        id: vars
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          VERSION=$(dotnet msbuild tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj \
+            -getProperty:Version -p:CIRun=true -nologo | tr -d '[:space:]')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Computed image version: $VERSION (run #$GITHUB_RUN_NUMBER)"
+      - name: Ensure Azure CLI
+        run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: ACR login
+        run: az acr login --name meshweaver
+      # Lean console image on the standard multi-arch base; <RuntimeIdentifiers> lives in the
+      # csproj (project-local — a global -p:RuntimeIdentifiers breaks referenced libs, see above).
+      # `latest` rides along so the plugins repo can pin MW_TEST_IMAGE=…/mw-plugin-test:latest.
+      - name: Build + push mw-plugin-test
+        run: >
+          dotnet publish tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+          -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
+          -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
+          -p:CIRun=true
+          -p:ContainerRegistry=${{ env.ACR }}
+          -p:ContainerRepository=mw-plugin-test
+          -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main;latest"'
+
   # ─────────────────────────────── NO DEPLOY JOB ─────────────────────────────
   # Deployment is PULL-BASED, not push. CI's job ends at "publish the image to ACR" (the image
   # jobs above). Each installation — memex / atioz / memex-cloud AND every external install in the

--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -167,6 +167,7 @@
     <Project Path="test/MeshWeaver.Hosting.Cosmos.Test/MeshWeaver.Hosting.Cosmos.Test.csproj" />
     <Project Path="test/MeshWeaver.Hosting.PostgreSql.Test/MeshWeaver.Hosting.PostgreSql.Test.csproj" />
     <Project Path="test/MeshWeaver.PluginImage.Test/MeshWeaver.PluginImage.Test.csproj" />
+    <Project Path="test/MeshWeaver.PluginTester.Test/MeshWeaver.PluginTester.Test.csproj" />
     <Project Path="test/MeshWeaver.Hosting.Snowflake.Test/MeshWeaver.Hosting.Snowflake.Test.csproj" />
     <Project Path="test/MeshWeaver.Hosting.Sqlite.Test/MeshWeaver.Hosting.Sqlite.Test.csproj" />
     <Project Path="test/MeshWeaver.Connection.SignalR.Test/MeshWeaver.Connection.SignalR.Test.csproj" />
@@ -189,6 +190,7 @@
   <Folder Name="/tools/">
     <File Path="tools/generate-memex-template.cs" />
     <Project Path="tools/MeshWeaver.MemexTemplate.Pack/MeshWeaver.MemexTemplate.Pack.csproj" />
+    <Project Path="tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj" />
     <Project Path="tools/MeshWeaver.ThumbnailGenerator/MeshWeaver.ThumbnailGenerator.csproj" />
   </Folder>
 </Solution>

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -1956,6 +1956,23 @@ public static class MeshExtensions
                     {
                         if (d.Message is CreateNodeResponse cr && cr.Success && cr.Node is not null)
                             PostOk(cr.Node, isCreate: true, $"Created node at '{node.Path}'");
+                        // Upsert semantics must be RACE-FREE: the read-then-branch above is a
+                        // TOCTOU — the node can materialise between the persistence read (null)
+                        // and the inner create's own existence check (e.g. an earlier write of
+                        // the same path flushing through the DEBOUNCED per-node persist, the
+                        // partition bootstrap's root heal, or any concurrent creator). A verb
+                        // named create-OR-update must never fail "already exists" — losing the
+                        // create race simply means the node exists NOW, so fall through to the
+                        // update path (same treat-as-success rule EnsurePartitionBootstrap
+                        // documents for its own root-create race).
+                        else if ((d.Message as CreateNodeResponse)?.RejectionReason
+                                 == NodeCreationRejectionReason.NodeAlreadyExists)
+                        {
+                            logger.LogDebug(
+                                "[CreateOrUpdate] lost the create race for {Path}; applying as update",
+                                node.Path);
+                            ApplyUpdateViaStream(node);
+                        }
                         else
                             PostFail(
                                 (d.Message as CreateNodeResponse)?.Error ?? "Inner CreateNode returned no response",

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -325,17 +325,30 @@ public static class PackageInstaller
         //     needs the type NODE to exist, not its compile.
         // Underscore satellites (_Access, _Policy, …) land LAST — a satellite must anchor under
         // an already-existing owner.
+        //
+        // 🚨 Bucket 0 is EXACTLY the types' compile inputs — the Source/ and Test/ subtrees.
+        // It must NOT swallow every descendant of a type path: a typed INSTANCE nested under
+        // its leaf-shaped type (ClaimsDeepfield/Cedent/NSV under type ClaimsDeepfield/Cedent)
+        // would then write BEFORE the type node and be refused "NodeType … is not registered"
+        // on a fresh mesh. The same bucket previously also matched via the package ROOT when
+        // the root node carries NodeTypeDefinition CONTENT on a Space root (UWDeepfield) —
+        // its path prefixes the whole package, pulling every instance ahead of the types.
+        // The root is therefore classified FIRST (stage-0 territory), and only Source/Test
+        // children order ahead of their type; other descendants (instances, docs, Release
+        // satellites) land in stage 2, after the types' visibility barrier.
         int Order(MeshNode n)
         {
             if (n.Path.Split('/').Any(seg => seg.StartsWith('_')))
                 return 4;                                        // satellites after their owners
+            if (!n.Path.Contains('/', StringComparison.Ordinal))
+                return 2;                                        // the root (written in stage 0/2)
             if (n.Content is NodeTypeDefinition)
                 return 1;                                        // the types (after their Source)
-            if (nodeTypePaths.Any(t => n.Path.StartsWith(t + "/", StringComparison.Ordinal)))
-                return 0;                                        // a type's Source/Test/docs
-            if (!n.Path.Contains('/', StringComparison.Ordinal))
-                return 2;                                        // the root (its type now exists)
-            return 3;                                            // plain content
+            if (nodeTypePaths.Any(t =>
+                    n.Path.StartsWith(t + "/Source/", StringComparison.Ordinal)
+                    || n.Path.StartsWith(t + "/Test/", StringComparison.Ordinal)))
+                return 0;                                        // a type's compile inputs
+            return 3;                                            // plain content + typed instances
         }
 
         // Three stages with VISIBILITY BARRIERS between them, solving two races at once:

--- a/test/MeshWeaver.PluginCatalog.Test/NodeRepoInstanceOrderingTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/NodeRepoInstanceOrderingTest.cs
@@ -1,0 +1,89 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins the FRESH-MESH install ordering for the two node-repo shapes the plugins repo ships
+/// that used to be refused "NodeType … is not registered":
+/// <list type="number">
+///   <item>A typed INSTANCE nested under its leaf-shaped type's path
+///     (<c>ClaimsDeepfield/Cedent.json</c> + <c>ClaimsDeepfield/Cedent/NSV.json</c>) — the old
+///     ordering classified everything under a type path as the type's "Source/Test/docs" and
+///     wrote the instance BEFORE the type node.</item>
+///   <item>A package ROOT whose CONTENT is a <c>NodeTypeDefinition</c> on a Space root
+///     (UWDeepfield) — the root's path then prefixes the whole package, pulling every instance
+///     into the before-the-types bucket.</item>
+/// </list>
+/// On a portal these only surfaced when the type had never been installed before — a fresh
+/// mesh (the CI gate, a new deployment) hits them deterministically.
+/// </summary>
+public class NodeRepoInstanceOrderingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddGraph().AddPluginCatalog();
+
+    // Shape 1 + 2 combined: the root carries NodeTypeDefinition content (UWDeepfield quirk),
+    // the type is leaf-shaped (Type.json + Type/Source), and one instance lives under the type
+    // path while another lives beside it.
+    private static readonly IReadOnlyList<RepoFile> Repo = new List<RepoFile>
+    {
+        new("Pack/index.json",
+            """{"$type":"MeshNode","id":"Pack","namespace":"","path":"Pack","mainNode":"Pack","name":"Pack","nodeType":"Space","state":"Active","content":{"$type":"NodeTypeDefinition","description":"a Space root carrying NodeTypeDefinition content (the UWDeepfield shape)"}}"""),
+        new("Pack/Widget.json",
+            """{"$type":"MeshNode","id":"Widget","namespace":"Pack","path":"Pack/Widget","mainNode":"Pack/Widget","name":"Widget","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"the type"}}"""),
+        new("Pack/Widget/Source/Widget.cs",
+            "public record Widget { public string Name { get; init; } = string.Empty; }"),
+        new("Pack/Widget/Nested.json",
+            """{"$type":"MeshNode","id":"Nested","namespace":"Pack/Widget","path":"Pack/Widget/Nested","mainNode":"Pack/Widget/Nested","name":"Nested","nodeType":"Pack/Widget","state":"Active"}"""),
+        new("Pack/Sibling.json",
+            """{"$type":"MeshNode","id":"Sibling","namespace":"Pack","path":"Pack/Sibling","mainNode":"Pack/Sibling","name":"Sibling","nodeType":"Pack/Widget","state":"Active"}"""),
+    };
+
+    [Fact(Timeout = 120_000)]
+    public async Task TypedInstances_UnderAndBesideTheirInPackageType_InstallOnFreshMesh()
+    {
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch =
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("commit-order", Repo));
+        var source = new NodeRepoPackageSource(fetch, "https://github.com/acme/pack");
+        var manifest = new PackageManifest
+        {
+            Id = "Pack",
+            Name = "Pack",
+            Kind = PackageKind.NodeRepo,
+            TargetPartition = "Pack",
+            SourceFolder = "Pack",
+            Version = "commit-order",
+        };
+        var files = await source.FetchPackageFiles(manifest, "HEAD").FirstAsync().ToTask();
+        files.Count.Should().Be(5);
+
+        var result = await PackageInstaller.Install(Mesh, manifest, files, "commit-order")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(90)).ToTask();
+        result.Written.Should().Be(5,
+            "every node must land — the type before its instances, on a mesh that never saw the type");
+
+        // Both instances landed TYPED — proof the type node was persistence-visible first.
+        (await Read("Pack/Widget/Nested")).NodeType.Should().Be("Pack/Widget");
+        (await Read("Pack/Sibling")).NodeType.Should().Be("Pack/Widget");
+        (await Read("Pack")).NodeType.Should().Be("Space");
+    }
+
+    private async Task<MeshNode> Read(string path) =>
+        await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null).Select(n => n!)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+}

--- a/test/MeshWeaver.PluginTester.Test/MeshWeaver.PluginTester.Test.csproj
+++ b/test/MeshWeaver.PluginTester.Test/MeshWeaver.PluginTester.Test.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\MeshWeaver.PluginTester\MeshWeaver.PluginTester.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/MeshWeaver.PluginTester.Test/PluginGateRunnerTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/PluginGateRunnerTest.cs
@@ -1,0 +1,228 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Threading.Tasks;
+using MeshWeaver.PluginTester;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// Runs the <c>mw-plugin-test</c> gate IN-PROCESS against minimal fixture node repos — the
+/// exact pipeline the plugins repo's CI container invokes. The good package must come out all
+/// green (compile Ok, default area renders, the <c>Tests</c> layout area EXECUTES green); a
+/// package with a deliberate compile error must fail the run with the Roslyn diagnostics in
+/// the output while the good package stays green (per-package isolation).
+/// </summary>
+public class PluginGateRunnerTest(ITestOutputHelper output)
+{
+    // ── the good package: one Space root, one NodeType with Source + an executable Tests area ──
+
+    private const string WidgetIndexJson =
+        """{"$type":"MeshNode","id":"Widget","namespace":"","path":"Widget","mainNode":"Widget","name":"Widget Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"A widget plugin."}}""";
+
+    private const string ThingNodeTypeJson =
+        """{"$type":"MeshNode","id":"Thing","namespace":"Widget","path":"Widget/Thing","mainNode":"Widget/Thing","name":"Thing","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A thing.","configuration":"config => config.WithContentType<Thing>().AddDefaultLayoutAreas().AddLayout(layout => layout.WithView(\"Tests\", ThingTestsArea.Tests))","includeGlobalTypes":true}}""";
+
+    private const string ThingSource =
+        """
+        public record Thing
+        {
+            public string Name { get; init; } = string.Empty;
+
+            public int Answer() => 42;
+        }
+        """;
+
+    private const string ThingTests =
+        """
+        public static class ThingTests
+        {
+            public static void Answer_Is42()
+            {
+                if (new Thing().Answer() != 42)
+                    throw new System.Exception("expected the answer to be 42");
+            }
+        }
+        """;
+
+    private const string ThingTestsArea =
+        """
+        using System;
+        using System.Reactive.Linq;
+        using MeshWeaver.Layout;
+        using MeshWeaver.Layout.Composition;
+
+        public static class ThingTestsArea
+        {
+            public static IObservable<UiControl?> Tests(LayoutAreaHost host, RenderingContext _)
+            {
+                var cases = new (string Name, Action Body)[]
+                {
+                    ("Answer is 42", ThingTests.Answer_Is42),
+                };
+                var sb = new System.Text.StringBuilder("### Thing tests\n\n| Test | Result |\n|---|---|\n");
+                var passed = 0;
+                foreach (var (name, body) in cases)
+                {
+                    try { body(); sb.Append($"| {name} | ✅ pass |\n"); passed++; }
+                    catch (Exception ex) { sb.Append($"| {name} | ❌ {ex.Message} |\n"); }
+                }
+                sb.Append($"\n**{passed}/{cases.Length} passed.**");
+                return Observable.Return<UiControl?>(Controls.Markdown(sb.ToString()));
+            }
+        }
+        """;
+
+    // ── the broken package: its Source calls a symbol that does not exist (the UWDeepfield
+    //    class of failure — merged source that no longer compiles against the framework) ──
+
+    private const string BrokenIndexJson =
+        """{"$type":"MeshNode","id":"Broken","namespace":"","path":"Broken","mainNode":"Broken","name":"Broken Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"Ships a compile error."}}""";
+
+    private const string GadgetNodeTypeJson =
+        """{"$type":"MeshNode","id":"Gadget","namespace":"Broken","path":"Broken/Gadget","mainNode":"Broken/Gadget","name":"Gadget","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"Does not compile.","configuration":"config => config.WithContentType<Gadget>()","includeGlobalTypes":true}}""";
+
+    private const string GadgetBrokenSource =
+        """
+        public record Gadget
+        {
+            // Deliberate compile error: MissingHelper does not exist anywhere.
+            public string Name => MissingHelper.Frobnicate();
+        }
+        """;
+
+    [Fact(Timeout = 300_000)]
+    public async Task GoodPackage_CompilesRendersAndExecutesTestsGreen_ExitsZero()
+    {
+        var repo = CreateRepo(root =>
+        {
+            WriteFile(root, "Widget/index.json", WidgetIndexJson);
+            WriteFile(root, "Widget/Thing.json", ThingNodeTypeJson);
+            WriteFile(root, "Widget/Thing/Source/Thing.cs", ThingSource);
+            WriteFile(root, "Widget/Thing/Test/ThingTests.cs", ThingTests);
+            WriteFile(root, "Widget/Thing/Test/ThingTestsArea.cs", ThingTestsArea);
+            WriteFile(root, "README.md", "# Fixture repo");
+        });
+        try
+        {
+            var (report, log) = await RunGate(repo);
+
+            report.FatalError.Should().BeNull();
+            report.Packages.Count.Should().Be(1);
+            var widget = report.Packages[0];
+            widget.Id.Should().Be("Widget");
+            widget.InstallError.Should().BeNull();
+
+            var thing = widget.NodeTypes.Single(t => t.Path == "Widget/Thing");
+            thing.Compile.Should().Be(CheckOutcome.Passed,
+                $"the fixture type must compile; detail: {thing.CompileDetail}");
+            thing.Render.Should().Be(CheckOutcome.Passed,
+                $"the type's default area must render; detail: {thing.RenderDetail}");
+            thing.Tests.Should().Be(CheckOutcome.Passed,
+                $"the Tests area must execute green; detail: {thing.TestsDetail}");
+            thing.TestsDetail.Should().Contain("1/1 passed");
+
+            report.ExitCode.Should().Be(0, $"all green must exit 0; log:\n{log}");
+        }
+        finally
+        {
+            TryDelete(repo);
+        }
+    }
+
+    [Fact(Timeout = 300_000)]
+    public async Task CompileError_FailsRunWithRoslynDiagnostics_GoodPackageStaysGreen()
+    {
+        var repo = CreateRepo(root =>
+        {
+            WriteFile(root, "Widget/index.json", WidgetIndexJson);
+            WriteFile(root, "Widget/Thing.json", ThingNodeTypeJson);
+            WriteFile(root, "Widget/Thing/Source/Thing.cs", ThingSource);
+            WriteFile(root, "Widget/Thing/Test/ThingTests.cs", ThingTests);
+            WriteFile(root, "Widget/Thing/Test/ThingTestsArea.cs", ThingTestsArea);
+            WriteFile(root, "Broken/index.json", BrokenIndexJson);
+            WriteFile(root, "Broken/Gadget.json", GadgetNodeTypeJson);
+            WriteFile(root, "Broken/Gadget/Source/Gadget.cs", GadgetBrokenSource);
+        });
+        try
+        {
+            var (report, log) = await RunGate(repo);
+
+            report.ExitCode.Should().NotBe(0, "a compile error must fail the gate");
+
+            var broken = report.Packages.Single(p => p.Id == "Broken");
+            var gadget = broken.NodeTypes.Single(t => t.Path == "Broken/Gadget");
+            gadget.Compile.Should().Be(CheckOutcome.Failed);
+            gadget.CompileDetail.Should().NotBeNull();
+            // The Roslyn diagnostics must surface in the output (CS0103: name does not exist).
+            gadget.CompileDetail.Should().Contain("MissingHelper");
+            log.Should().Contain("MissingHelper");
+
+            // Per-package isolation: the good package still comes out green.
+            var widget = report.Packages.Single(p => p.Id == "Widget");
+            widget.Success.Should().BeTrue(
+                $"the good package must stay green; log:\n{log}");
+        }
+        finally
+        {
+            TryDelete(repo);
+        }
+    }
+
+    private async Task<(GateReport Report, string Log)> RunGate(string repo)
+    {
+        var log = new StringWriter();
+        var options = new GateOptions
+        {
+            RepoRoot = repo,
+            Output = log,
+            CompileTimeout = TimeSpan.FromMinutes(4),
+            RenderTimeout = TimeSpan.FromSeconds(90),
+        };
+        try
+        {
+            var report = await PluginGateRunner.Run(options)
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+            report.WriteSummary(log);
+            return (report, log.ToString());
+        }
+        finally
+        {
+            output.WriteLine(log.ToString());
+        }
+    }
+
+    private static string CreateRepo(Action<string> populate)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-gate-fixture-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        populate(root);
+        return root;
+    }
+
+    private static void WriteFile(string root, string relative, string content)
+    {
+        var full = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static void TryDelete(string dir)
+    {
+        try
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+        catch
+        {
+            // best effort — the OS reclaims temp at reboot
+        }
+    }
+}

--- a/tools/MeshWeaver.PluginTester/AreaProbe.cs
+++ b/tools/MeshWeaver.PluginTester/AreaProbe.cs
@@ -1,0 +1,207 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using MeshWeaver.Data;
+using MeshWeaver.Layout;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>The outcome of rendering one layout area, with a human-readable detail line.</summary>
+/// <param name="Outcome">Pass / fail / skip.</param>
+/// <param name="Detail">The verdict text (the pass summary, or the failing rows / error).</param>
+public sealed record AreaVerdict(CheckOutcome Outcome, string? Detail);
+
+/// <summary>
+/// Headless layout-area probes over the standard client sync stream
+/// (<c>GetRemoteStream&lt;JsonElement, LayoutAreaReference&gt;</c> — the same wire the portal
+/// binds). Rendering a plugin type's <c>Tests</c> area EXECUTES its in-node test suite (the
+/// area function runs the assertions and renders a ✅/❌ table with an <c>N/M passed</c>
+/// summary — the convention the plugins repo's AGENTS.md mandates); the probe waits for a
+/// terminal verdict frame and classifies it.
+/// </summary>
+public static class AreaProbe
+{
+    // The framework's visible failure shapes (LayoutAreaHost.FailRendering / RenderEmergency /
+    // LayoutDefinition.NotFound) — a rendered control carrying one of these IS the red signal.
+    private const string AreaNotFoundMarker = "Area not found";
+    private const string RenderFailedMarker = "This area failed to render";
+    private const string RenderEmergencyMarker = "cannot be rendered";
+
+    private static readonly Regex PassSummary = new(
+        @"(\d+)\s*/\s*(\d+)\s+passed", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Renders the node's DEFAULT area and classifies the first materialised frame: green when
+    /// the resolved area's control landed without a framework error control, red on an error
+    /// control or when nothing materialises within <paramref name="timeout"/>.
+    /// </summary>
+    public static IObservable<AreaVerdict> RenderDefaultArea(
+        IMessageHub client, string nodePath, TimeSpan timeout) =>
+        Frames(client, nodePath, area: null)
+            .Where(frame => IsAreaMaterialized(frame, requestedArea: null))
+            .Take(1)
+            .Select(frame =>
+            {
+                var strings = CollectStrings(frame);
+                var error = strings.FirstOrDefault(s =>
+                    s.Contains(RenderFailedMarker, StringComparison.Ordinal)
+                    || s.Contains(RenderEmergencyMarker, StringComparison.Ordinal)
+                    || s.Contains(AreaNotFoundMarker, StringComparison.Ordinal));
+                return error is null
+                    ? new AreaVerdict(CheckOutcome.Passed, null)
+                    : new AreaVerdict(CheckOutcome.Failed, FirstLines(error));
+            })
+            .Timeout(timeout)
+            .Catch((TimeoutException _) => Observable.Return(new AreaVerdict(
+                CheckOutcome.Failed,
+                $"default area did not materialise within {timeout.TotalSeconds:F0}s")));
+
+    /// <summary>
+    /// Renders (= EXECUTES) the <c>Tests</c> layout area on <paramref name="nodePath"/> and
+    /// waits for a terminal verdict frame: any ❌ row or framework error control is red; an
+    /// all-green <c>N/N passed</c> summary (or ✅ rows without ❌) is green. No verdict within
+    /// <paramref name="timeout"/> is red — a Tests area that reports nothing is a broken gate,
+    /// never a silent pass.
+    /// </summary>
+    public static IObservable<AreaVerdict> ExecuteTestsArea(
+        IMessageHub client, string nodePath, TimeSpan timeout) =>
+        Frames(client, nodePath, area: "Tests")
+            .Select(ClassifyTestsFrame)
+            .Where(verdict => verdict is not null)
+            .Select(verdict => verdict!)
+            .Take(1)
+            .Timeout(timeout)
+            .Catch((TimeoutException _) => Observable.Return(new AreaVerdict(
+                CheckOutcome.Failed,
+                $"Tests area reported no verdict within {timeout.TotalSeconds:F0}s " +
+                "(expected a ✅/❌ table with an 'N/M passed' summary)")));
+
+    // One cold frame stream per probe; the sync stream is disposed on unsubscribe/terminal.
+    private static IObservable<JsonElement> Frames(IMessageHub client, string nodePath, string? area) =>
+        Observable.Defer(() =>
+        {
+            var stream = client.GetWorkspace()
+                .GetRemoteStream<JsonElement, LayoutAreaReference>(
+                    new Address(nodePath), new LayoutAreaReference(area) { Id = "" });
+            return stream.Select(ci => ci.Value).Finally(stream.Dispose);
+        });
+
+    // Terminal classification of a Tests frame; null = keep waiting (still rendering).
+    private static AreaVerdict? ClassifyTestsFrame(JsonElement frame)
+    {
+        var strings = CollectStrings(frame);
+
+        var notFound = strings.FirstOrDefault(s => s.Contains(AreaNotFoundMarker, StringComparison.Ordinal));
+        if (notFound is not null)
+            return new AreaVerdict(CheckOutcome.Failed, FirstLines(notFound));
+
+        var renderError = strings.FirstOrDefault(s =>
+            s.Contains(RenderFailedMarker, StringComparison.Ordinal)
+            || s.Contains(RenderEmergencyMarker, StringComparison.Ordinal));
+        if (renderError is not null)
+            return new AreaVerdict(CheckOutcome.Failed, FirstLines(renderError));
+
+        var red = strings.FirstOrDefault(s => s.Contains('❌'));
+        if (red is not null)
+            return new AreaVerdict(CheckOutcome.Failed, FailingRows(red));
+
+        foreach (var candidate in strings)
+        {
+            var summary = PassSummary.Match(candidate);
+            if (summary.Success)
+            {
+                var passed = int.Parse(summary.Groups[1].Value);
+                var total = int.Parse(summary.Groups[2].Value);
+                return passed == total
+                    ? new AreaVerdict(CheckOutcome.Passed, $"{passed}/{total} passed")
+                    : new AreaVerdict(CheckOutcome.Failed, $"only {passed}/{total} passed");
+            }
+        }
+
+        // A green table without the summary line still counts (❌ was excluded above).
+        return strings.Any(s => s.Contains('✅'))
+            ? new AreaVerdict(CheckOutcome.Passed, "all rendered cases green")
+            : null;
+    }
+
+    /// <summary>
+    /// True when the frame carries the requested area's rendered control — and, for a
+    /// default-area subscription, the resolved area the <c>areas[""]</c> indirection points at.
+    /// Mirrors the AI mesh-operations render probe (<c>MeshOperations.IsAreaMaterialized</c>).
+    /// </summary>
+    private static bool IsAreaMaterialized(JsonElement store, string? requestedArea)
+    {
+        if (store.ValueKind != JsonValueKind.Object
+            || !store.TryGetProperty(LayoutAreaReference.Areas, out var areas)
+            || areas.ValueKind != JsonValueKind.Object)
+            return false;
+
+        var rootKey = requestedArea ?? string.Empty;
+        if (!TryGetWireInstance(areas, rootKey, out var control))
+            return false;
+
+        if (rootKey.Length == 0
+            && control.ValueKind == JsonValueKind.Object
+            && (control.TryGetProperty("area", out var resolved)
+                || control.TryGetProperty("Area", out resolved))
+            && resolved.ValueKind == JsonValueKind.String
+            && resolved.GetString() is { Length: > 0 } resolvedArea)
+            return TryGetWireInstance(areas, resolvedArea, out _);
+
+        return true;
+    }
+
+    // InstanceCollection keys ride JSON-encoded on the wire ("Tests" → property "\"Tests\"").
+    private static bool TryGetWireInstance(JsonElement collection, string key, out JsonElement value)
+    {
+        if (collection.TryGetProperty(JsonSerializer.Serialize(key), out value)
+            && value.ValueKind is not (JsonValueKind.Null or JsonValueKind.Undefined))
+            return true;
+        value = default;
+        return false;
+    }
+
+    // Every string VALUE in the frame, unescaped — the classification scans real text, not
+    // wire-escaped JSON.
+    private static IReadOnlyList<string> CollectStrings(JsonElement element)
+    {
+        var strings = new List<string>();
+        Walk(element, strings);
+        return strings;
+
+        static void Walk(JsonElement node, List<string> into)
+        {
+            switch (node.ValueKind)
+            {
+                case JsonValueKind.String:
+                    if (node.GetString() is { Length: > 0 } s)
+                        into.Add(s);
+                    break;
+                case JsonValueKind.Object:
+                    foreach (var property in node.EnumerateObject())
+                        Walk(property.Value, into);
+                    break;
+                case JsonValueKind.Array:
+                    foreach (var item in node.EnumerateArray())
+                        Walk(item, into);
+                    break;
+            }
+        }
+    }
+
+    // The ❌ rows (plus the summary) of a red table — the actionable lines, not the whole page.
+    private static string FailingRows(string markdown)
+    {
+        var lines = markdown.ReplaceLineEndings("\n").Split('\n')
+            .Where(l => l.Contains('❌') || PassSummary.IsMatch(l))
+            .ToList();
+        return lines.Count > 0 ? string.Join("\n", lines) : FirstLines(markdown);
+    }
+
+    private static string FirstLines(string text, int count = 6)
+    {
+        var lines = text.ReplaceLineEndings("\n").Split('\n');
+        return string.Join("\n", lines.Take(count));
+    }
+}

--- a/tools/MeshWeaver.PluginTester/GateReport.cs
+++ b/tools/MeshWeaver.PluginTester/GateReport.cs
@@ -1,0 +1,121 @@
+using MeshWeaver.Mesh.Services;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>Outcome of one gate check (compile / render / Tests area) on one NodeType.</summary>
+public enum CheckOutcome
+{
+    /// <summary>The check passed.</summary>
+    Passed,
+
+    /// <summary>The check failed — the gate exits non-zero.</summary>
+    Failed,
+
+    /// <summary>The check does not apply (e.g. the type declares no Tests area).</summary>
+    Skipped,
+}
+
+/// <summary>The gate results for one NodeType node of a package.</summary>
+/// <param name="Path">The NodeType node's mesh path (e.g. <c>Edu/CourseInvite</c>).</param>
+/// <param name="Package">The package (top-level folder) the type ships in.</param>
+public sealed record NodeTypeResult(string Path, string Package)
+{
+    /// <summary>Terminal compile state, or null when the type has nothing to compile.</summary>
+    public CompilationStatus? CompilationStatus { get; init; }
+
+    /// <summary>Whether the compile gate passed.</summary>
+    public CheckOutcome Compile { get; init; } = CheckOutcome.Skipped;
+
+    /// <summary>Roslyn diagnostics / error detail when <see cref="Compile"/> failed.</summary>
+    public string? CompileDetail { get; init; }
+
+    /// <summary>Whether the type node's default area rendered without an error control.</summary>
+    public CheckOutcome Render { get; init; } = CheckOutcome.Skipped;
+
+    /// <summary>Failure detail when <see cref="Render"/> failed.</summary>
+    public string? RenderDetail { get; init; }
+
+    /// <summary>Whether the type's <c>Tests</c> layout area executed green.</summary>
+    public CheckOutcome Tests { get; init; } = CheckOutcome.Skipped;
+
+    /// <summary>The Tests verdict detail (the pass/fail summary, or the red rows).</summary>
+    public string? TestsDetail { get; init; }
+
+    /// <summary>True when no gate check failed.</summary>
+    public bool Success =>
+        Compile != CheckOutcome.Failed
+        && Render != CheckOutcome.Failed
+        && Tests != CheckOutcome.Failed;
+}
+
+/// <summary>The gate results for one installed package.</summary>
+/// <param name="Id">The package id (its top-level folder).</param>
+public sealed record PackageResult(string Id)
+{
+    /// <summary>Total nodes the package carried.</summary>
+    public int NodeCount { get; init; }
+
+    /// <summary>Install failure detail; null when the install succeeded.</summary>
+    public string? InstallError { get; init; }
+
+    /// <summary>Per-NodeType gate results.</summary>
+    public IReadOnlyList<NodeTypeResult> NodeTypes { get; init; } = [];
+
+    /// <summary>True when the install and every NodeType gate passed.</summary>
+    public bool Success => InstallError is null && NodeTypes.All(t => t.Success);
+}
+
+/// <summary>The whole run's outcome: per-package results and the process exit code.</summary>
+/// <param name="Packages">Per-package results in install order.</param>
+public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
+{
+    /// <summary>A fatal error outside any single package (discovery, mesh boot).</summary>
+    public string? FatalError { get; init; }
+
+    /// <summary>True when every package passed and no fatal error occurred.</summary>
+    public bool Success => FatalError is null && Packages.All(p => p.Success);
+
+    /// <summary>Process exit code: 0 = all green.</summary>
+    public int ExitCode => Success ? 0 : 1;
+
+    /// <summary>Writes the human-readable per-package summary table.</summary>
+    public void WriteSummary(TextWriter output)
+    {
+        output.WriteLine();
+        output.WriteLine("=== mw-plugin-test summary ===");
+        if (FatalError is not null)
+            output.WriteLine($"FATAL: {FatalError}");
+        foreach (var package in Packages)
+        {
+            output.WriteLine($"[{(package.Success ? "PASS" : "FAIL")}] {package.Id} " +
+                             $"({package.NodeCount} node(s), {package.NodeTypes.Count} type(s))");
+            if (package.InstallError is not null)
+                output.WriteLine($"    install: {package.InstallError}");
+            foreach (var type in package.NodeTypes)
+            {
+                output.WriteLine(
+                    $"    {(type.Success ? "ok " : "RED")} {type.Path}: " +
+                    $"compile={Describe(type.Compile, type.CompilationStatus?.ToString())} " +
+                    $"render={Describe(type.Render)} tests={Describe(type.Tests)}");
+                if (type.CompileDetail is not null)
+                    output.WriteLine(Indent(type.CompileDetail));
+                if (type.RenderDetail is not null)
+                    output.WriteLine(Indent(type.RenderDetail));
+                if (type.TestsDetail is not null)
+                    output.WriteLine(Indent(type.TestsDetail));
+            }
+        }
+        output.WriteLine(Success ? "ALL GREEN." : "GATE FAILED.");
+    }
+
+    private static string Describe(CheckOutcome outcome, string? detail = null) =>
+        outcome switch
+        {
+            CheckOutcome.Passed => detail is null ? "ok" : detail,
+            CheckOutcome.Failed => detail is null ? "FAILED" : $"FAILED({detail})",
+            _ => "skipped",
+        };
+
+    private static string Indent(string text) =>
+        "        " + text.ReplaceLineEndings("\n").Replace("\n", "\n        ");
+}

--- a/tools/MeshWeaver.PluginTester/LocalNodeRepo.cs
+++ b/tools/MeshWeaver.PluginTester/LocalNodeRepo.cs
@@ -1,0 +1,312 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Text;
+using System.Text.Json;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.PluginCatalog;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// Reads a node-repo checkout (the <c>MeshWeaver.Plugins</c> working tree) from the local
+/// filesystem into GitSync's <see cref="RepoSnapshot"/> shape, discovers the installable
+/// packages (top-level folders whose <c>index.json</c> declares a root node), and orders them
+/// by their cross-package source dependencies (a package whose NodeTypes pull shared sources
+/// from a sibling package — e.g. Edu sharing Store sources — installs AFTER that sibling, so
+/// every referenced Code node has landed before the dependent type compiles).
+/// </summary>
+public static class LocalNodeRepo
+{
+    /// <summary>Directories that never carry mesh nodes (VCS/CI/build internals).</summary>
+    private static readonly ImmutableHashSet<string> ExcludedDirectories =
+        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase,
+            ".git", ".github", ".claude", "node_modules", "bin", "obj");
+
+    /// <summary>
+    /// Sweeps <paramref name="repoRoot"/> into a <see cref="RepoSnapshot"/> on the file I/O
+    /// pool (the filesystem walk is a sync-blocking leaf — never run it on a hub scheduler).
+    /// Valid-UTF-8 files ride as text, everything else as binary bytes — the same
+    /// classification GitSync's GitHub fetch applies.
+    /// </summary>
+    public static IObservable<RepoSnapshot> Load(string repoRoot, IIoPool pool) =>
+        pool.InvokeBlocking(_ =>
+        {
+            var root = Path.GetFullPath(repoRoot);
+            if (!Directory.Exists(root))
+                throw new DirectoryNotFoundException($"Repo root '{root}' does not exist.");
+
+            var files = new List<RepoFile>();
+            Sweep(root, root, files);
+            return new RepoSnapshot("local", files
+                .OrderBy(f => f.Path, StringComparer.Ordinal)
+                .ToImmutableList());
+        });
+
+    private static void Sweep(string root, string directory, List<RepoFile> files)
+    {
+        foreach (var file in Directory.EnumerateFiles(directory))
+        {
+            var relative = Path.GetRelativePath(root, file).Replace(Path.DirectorySeparatorChar, '/');
+            var bytes = File.ReadAllBytes(file);
+            files.Add(TryDecodeUtf8(bytes, out var text)
+                ? new RepoFile(relative, text)
+                : new RepoFile(relative, string.Empty, bytes));
+        }
+        foreach (var sub in Directory.EnumerateDirectories(directory))
+        {
+            var name = Path.GetFileName(sub);
+            if (ExcludedDirectories.Contains(name))
+                continue;
+            Sweep(root, sub, files);
+        }
+    }
+
+    // Strict UTF-8 probe (throw-on-invalid decoder) so an arbitrary byte stream — a video, a
+    // font — is classified binary rather than lossily decoded. Mirrors OctokitGitHubRepoClient.
+    private static bool TryDecodeUtf8(byte[] bytes, out string text)
+    {
+        try
+        {
+            text = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true)
+                .GetString(bytes);
+            return true;
+        }
+        catch (DecoderFallbackException)
+        {
+            text = string.Empty;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Discovers every installable package in the snapshot: the roots
+    /// <see cref="NodeRepoPackageSource"/> lists (Space / Store-typed <c>&lt;Pkg&gt;/index.json</c>)
+    /// PLUS any remaining top-level folder whose <c>index.json</c> declares a node type the
+    /// listing does not recognise (e.g. a self-typed root whose type ships in the same package)
+    /// — the gate must exercise every node-repo folder, not only the storefront-listed ones.
+    /// </summary>
+    public static IObservable<IReadOnlyList<PackageManifest>> DiscoverPackages(RepoSnapshot snapshot)
+    {
+        var source = new NodeRepoPackageSource(
+            (_, _, _, _) => Observable.Return(snapshot), repoUrl: "local");
+        return source.ListPackages("HEAD").Select(listed =>
+        {
+            var known = listed.Select(m => m.Id).ToImmutableHashSet(StringComparer.Ordinal);
+            var extra = snapshot.Files
+                .Where(f =>
+                {
+                    var slash = f.Path.IndexOf('/');
+                    return slash > 0
+                        && f.Path.IndexOf('/', slash + 1) < 0
+                        && f.Path.AsSpan(slash + 1).Equals("index.json", StringComparison.OrdinalIgnoreCase)
+                        && !known.Contains(f.Path[..slash])
+                        && DeclaresNodeType(f.Content);
+                })
+                .Select(f =>
+                {
+                    var id = f.Path[..f.Path.IndexOf('/')];
+                    return new PackageManifest
+                    {
+                        Id = id,
+                        Name = id,
+                        Kind = PackageKind.NodeRepo,
+                        TargetPartition = id,
+                        SourceFolder = id,
+                        Version = snapshot.CommitSha,
+                    };
+                });
+            return (IReadOnlyList<PackageManifest>)listed.Concat(extra)
+                .OrderBy(m => m.Id, StringComparer.Ordinal)
+                .ToImmutableList();
+        });
+    }
+
+    private static bool DeclaresNodeType(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("nodeType", out var nt)
+                && nt.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(nt.GetString());
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Orders the packages so that every package installs AFTER the packages it references.
+    /// Dependencies come from three places: each NodeType node's
+    /// <c>content.sources</c>/<c>content.tests</c> query entries (an <c>@Other/…</c> shorthand
+    /// or a multi-segment <c>namespace:Other/…</c> whose first segment is another package id),
+    /// every node's <c>nodeType</c> when it is a path into another package (the plugin roots are
+    /// typed <c>Store/Plugin</c> — the Store package must land first so the type exists), and
+    /// the advisory <see cref="PackageManifest.Requires"/> list. Cycles fall back to
+    /// alphabetical order among the remaining packages.
+    /// </summary>
+    public static IReadOnlyList<PackageManifest> OrderByDependencies(
+        IReadOnlyList<PackageManifest> packages, RepoSnapshot snapshot)
+    {
+        var ids = packages.Select(p => p.Id).ToImmutableHashSet(StringComparer.Ordinal);
+        var dependencies = packages.ToDictionary(
+            p => p.Id,
+            p => CollectDependencies(p, snapshot, ids),
+            StringComparer.Ordinal);
+
+        // Kahn topological sort, alphabetical among the ready set for determinism.
+        var result = new List<PackageManifest>();
+        var remaining = packages.OrderBy(p => p.Id, StringComparer.Ordinal).ToList();
+        while (remaining.Count > 0)
+        {
+            var placed = result.Select(r => r.Id).ToImmutableHashSet(StringComparer.Ordinal);
+            var next = remaining.FirstOrDefault(p => dependencies[p.Id].All(placed.Contains));
+            if (next is null)
+            {
+                // Dependency cycle — install the rest alphabetically; compiles that need a
+                // later sibling settle once its sources land (the sources watcher re-marks
+                // the type dirty), and the gate reports the terminal status either way.
+                result.AddRange(remaining);
+                break;
+            }
+            result.Add(next);
+            remaining.Remove(next);
+        }
+        return result;
+    }
+
+    private static ImmutableHashSet<string> CollectDependencies(
+        PackageManifest package, RepoSnapshot snapshot, ImmutableHashSet<string> packageIds)
+    {
+        var deps = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+        foreach (var required in package.Requires)
+            if (packageIds.Contains(required) && required != package.Id)
+                deps.Add(required);
+
+        var prefix = (package.SourceFolder ?? package.Id) + "/";
+        foreach (var file in snapshot.Files)
+        {
+            if (!file.Path.StartsWith(prefix, StringComparison.Ordinal)
+                || !file.Path.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                continue;
+            foreach (var entry in ReadSourceQueries(file.Content))
+            {
+                var referenced = FirstSegmentOf(entry);
+                if (referenced is not null
+                    && referenced != package.Id
+                    && packageIds.Contains(referenced))
+                    deps.Add(referenced);
+            }
+            // A node typed by a PATH into another package (e.g. every plugin root's
+            // nodeType Store/Plugin) needs that package's type node to exist first.
+            var nodeType = ReadNodeType(file.Content);
+            if (nodeType is not null && nodeType.Contains('/', StringComparison.Ordinal))
+            {
+                var typePackage = nodeType[..nodeType.IndexOf('/')];
+                if (typePackage != package.Id && packageIds.Contains(typePackage))
+                    deps.Add(typePackage);
+            }
+        }
+        return deps.ToImmutable();
+    }
+
+    private static string? ReadNodeType(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("nodeType", out var nt)
+                && nt.ValueKind == JsonValueKind.String
+                    ? nt.GetString()
+                    : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    // The sources/tests query entries of a NodeType node's content; empty for any other file.
+    private static IEnumerable<string> ReadSourceQueries(string json)
+    {
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            yield break;
+        }
+        using (doc)
+        {
+            if (doc.RootElement.ValueKind != JsonValueKind.Object
+                || !doc.RootElement.TryGetProperty("content", out var content)
+                || content.ValueKind != JsonValueKind.Object
+                || !content.TryGetProperty("$type", out var type)
+                || type.GetString() != nameof(NodeTypeDefinition))
+                yield break;
+            foreach (var property in new[] { "sources", "tests" })
+            {
+                if (!content.TryGetProperty(property, out var list)
+                    || list.ValueKind != JsonValueKind.Array)
+                    continue;
+                foreach (var element in list.EnumerateArray())
+                    if (element.ValueKind == JsonValueKind.String
+                        && element.GetString() is { Length: > 0 } entry)
+                        yield return entry;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The top-level segment a sources/tests query entry points at, or null when the entry is
+    /// package-local (a bare <c>namespace:Source</c> is rebased onto the owning type). Handles
+    /// the <c>name=</c> display prefix, the <c>@path</c>/<c>@@path</c> shorthand, and
+    /// <c>namespace:</c>/<c>path:</c> query tokens.
+    /// </summary>
+    private static string? FirstSegmentOf(string entry)
+    {
+        // Strip the optional `name=` display prefix (e.g. "shared=@Edu/InstallManifest/Source"):
+        // present when an '=' occurs before any whitespace or query-token colon.
+        var value = entry;
+        var eq = value.IndexOf('=');
+        if (eq > 0)
+        {
+            var head = value[..eq];
+            if (!head.Contains(' ', StringComparison.Ordinal)
+                && !head.Contains(':', StringComparison.Ordinal))
+                value = value[(eq + 1)..];
+        }
+
+        if (value.StartsWith("@@", StringComparison.Ordinal))
+            return TopSegment(value[2..]);
+        if (value.StartsWith('@'))
+            return TopSegment(value[1..]);
+
+        foreach (var token in value.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (token.StartsWith("namespace:", StringComparison.Ordinal))
+                return MultiSegmentTop(token["namespace:".Length..]);
+            if (token.StartsWith("path:", StringComparison.Ordinal))
+                return MultiSegmentTop(token["path:".Length..]);
+        }
+        return null;
+
+        // A single-segment namespace (no '/') is rebased onto the owning NodeType — local.
+        static string? MultiSegmentTop(string path) =>
+            path.Contains('/', StringComparison.Ordinal) ? TopSegment(path) : null;
+
+        static string? TopSegment(string path)
+        {
+            var slash = path.IndexOf('/');
+            var segment = slash < 0 ? path : path[..slash];
+            return segment.Length == 0 || segment.StartsWith('$') ? null : segment;
+        }
+    }
+}

--- a/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+++ b/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- The CLI the plugins-repo CI invokes: `mw-plugin-test <checkout-root>`. -->
+    <AssemblyName>mw-plugin-test</AssemblyName>
+    <RootNamespace>MeshWeaver.PluginTester</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <!-- Multi-arch container publish (same pair as memex-portal-ai / memex-migration);
+         Directory.Build.props' ProduceReferenceAssembly gate handles the RID-leg race. -->
+    <RuntimeIdentifiers>linux-x64;linux-arm64</RuntimeIdentifiers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- GitHub Actions `container:` jobs run steps through `sh -c`, ignoring the image
+         ENTRYPOINT — `run: mw-plugin-test .` therefore needs the apphost on PATH. -->
+    <ContainerEnvironmentVariable Include="PATH"
+      Value="/app:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.AI\MeshWeaver.AI.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.PluginCatalog\MeshWeaver.PluginCatalog.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.ServiceProvider\MeshWeaver.ServiceProvider.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -1,0 +1,484 @@
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.AI;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using MeshWeaver.ServiceProvider;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>Configuration for one gate run.</summary>
+public sealed record GateOptions
+{
+    /// <summary>The node-repo checkout root (the plugins repo working tree).</summary>
+    public required string RepoRoot { get; init; }
+
+    /// <summary>Progress + summary sink (default: <see cref="Console.Out"/>).</summary>
+    public TextWriter Output { get; init; } = Console.Out;
+
+    /// <summary>Budget for one NodeType to reach a terminal compile status.</summary>
+    public TimeSpan CompileTimeout { get; init; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>Budget for one layout-area render / Tests execution.</summary>
+    public TimeSpan RenderTimeout { get; init; } = TimeSpan.FromMinutes(2);
+}
+
+/// <summary>
+/// The <c>mw-plugin-test</c> pipeline: boots a fresh IN-PROCESS monolith mesh (in-memory
+/// persistence — throwaway, no external services), imports every node-repo package of a
+/// checkout dependency-first through the standard <see cref="PackageInstaller"/>, waits for
+/// every NodeType to reach a terminal <see cref="CompilationStatus"/> (a compile error prints
+/// the Roslyn diagnostics and fails the run), renders each type's default area, and EXECUTES
+/// each type's <c>Tests</c> layout area — a red test fails the run. Reactive end-to-end; the
+/// console <c>Main</c> bridges once at the boundary.
+/// </summary>
+public static class PluginGateRunner
+{
+    /// <summary>The gate's admin identity (the in-process analogue of DevLogin).</summary>
+    private static readonly AccessContext GateAdmin = new()
+    {
+        ObjectId = "mw-plugin-test",
+        Name = "Plugin Gate",
+        Email = "mw-plugin-test@meshweaver.io",
+        Roles = ["Admin"],
+    };
+
+    /// <summary>
+    /// Runs the gate over <paramref name="options"/>' repo root. Cold: the mesh boots on
+    /// subscribe and is torn down when the report emits (or the pipeline faults).
+    /// </summary>
+    public static IObservable<GateReport> Run(GateOptions options) =>
+        Observable.Defer(() =>
+        {
+            var harness = GateMesh.Create(options.Output);
+            var pool = harness.ServiceProvider.GetRequiredService<IoPoolRegistry>()
+                .Get("plugin-test:files");
+            return LocalNodeRepo.Load(options.RepoRoot, pool)
+                .SelectMany(snapshot => LocalNodeRepo.DiscoverPackages(snapshot)
+                    .SelectMany(packages => RunPackages(harness, options, snapshot, packages)))
+                .Catch((Exception ex) => Observable.Return(
+                    new GateReport([]) { FatalError = $"{ex.GetType().Name}: {ex.Message}" }))
+                .Finally(harness.Dispose);
+        });
+
+    private static IObservable<GateReport> RunPackages(
+        GateMesh harness, GateOptions options, RepoSnapshot snapshot,
+        IReadOnlyList<PackageManifest> packages)
+    {
+        if (packages.Count == 0)
+            return Observable.Return(new GateReport([])
+            {
+                FatalError = $"No node-repo packages (top-level folders with an index.json root) " +
+                             $"found under '{options.RepoRoot}'.",
+            });
+
+        var ordered = LocalNodeRepo.OrderByDependencies(packages, snapshot);
+        options.Output.WriteLine(
+            $"Discovered {ordered.Count} package(s), install order: " +
+            string.Join(" → ", ordered.Select(p => p.Id)));
+
+        // Sequential (Concat): installs respect the dependency order; compiles keep running in
+        // the background while later packages install.
+        return ordered
+            .Select(package => TestPackage(harness, options, snapshot, package))
+            .ToObservable().Concat().ToList()
+            .Select(results => new GateReport(results.ToImmutableList()));
+    }
+
+    private static IObservable<PackageResult> TestPackage(
+        GateMesh harness, GateOptions options, RepoSnapshot snapshot, PackageManifest package)
+    {
+        var source = new NodeRepoPackageSource(
+            (_, _, _, _) => Observable.Return(snapshot), repoUrl: "local");
+        return source.FetchPackageFiles(package, "HEAD")
+            .SelectMany(files =>
+            {
+                options.Output.WriteLine($"── {package.Id}: installing {files.Count} file(s)…");
+                var types = DiscoverNodeTypes(package, files);
+                return PackageInstaller.Install(harness.Mesh, package, files, snapshot.CommitSha)
+                    .SelectMany(install =>
+                    {
+                        options.Output.WriteLine(
+                            $"── {package.Id}: installed ({install.Written} written, " +
+                            $"{install.Unchanged} unchanged); checking {types.Count} NodeType(s)…");
+                        return types
+                            .Select(type => TestNodeType(harness, options, type))
+                            .ToObservable().Concat().ToList()
+                            .Select(typeResults => new PackageResult(package.Id)
+                            {
+                                NodeCount = install.Total,
+                                NodeTypes = typeResults.ToImmutableList(),
+                            });
+                    });
+            })
+            .Catch((Exception ex) => Observable.Return(new PackageResult(package.Id)
+            {
+                InstallError = $"{ex.GetType().Name}: {ex.Message}",
+            }));
+    }
+
+    /// <summary>One NodeType of one package, as parsed from its file (pre-install).</summary>
+    private sealed record NodeTypeUnderTest(
+        string Path, string Package, string? Configuration, bool HasSources)
+    {
+        /// <summary>The type compiles when it carries a configuration lambda or source files.</summary>
+        public bool Compiles => !string.IsNullOrWhiteSpace(Configuration) || HasSources;
+
+        /// <summary>The type declares an executable <c>Tests</c> layout area in its configuration.</summary>
+        public bool DeclaresTestsArea =>
+            Configuration?.Contains("WithView(\"Tests\"", StringComparison.Ordinal) == true;
+    }
+
+    // The package's NodeType nodes (content.$type == NodeTypeDefinition), from the raw files —
+    // the same canonical path mapping the installer applies (NodeFileMapper).
+    private static IReadOnlyList<NodeTypeUnderTest> DiscoverNodeTypes(
+        PackageManifest package, IReadOnlyList<PackageFile> files)
+    {
+        var sourceFolders = files
+            .Where(f => f.RelativePath.Contains("/Source/", StringComparison.Ordinal))
+            .Select(f => f.RelativePath[..f.RelativePath.IndexOf("/Source/", StringComparison.Ordinal)])
+            .ToImmutableHashSet(StringComparer.Ordinal);
+
+        var types = new List<NodeTypeUnderTest>();
+        foreach (var file in files)
+        {
+            if (!file.RelativePath.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                continue;
+            string? configuration;
+            try
+            {
+                using var doc = JsonDocument.Parse(file.Content);
+                if (doc.RootElement.ValueKind != JsonValueKind.Object
+                    || !doc.RootElement.TryGetProperty("content", out var content)
+                    || content.ValueKind != JsonValueKind.Object
+                    || !content.TryGetProperty("$type", out var type)
+                    || type.GetString() != nameof(NodeTypeDefinition))
+                    continue;
+                configuration = content.TryGetProperty("configuration", out var config)
+                    && config.ValueKind == JsonValueKind.String
+                        ? config.GetString()
+                        : null;
+            }
+            catch (JsonException)
+            {
+                continue; // malformed json is surfaced by the install itself
+            }
+            var (id, ns) = NodeFileMapper.FromRelativePath(file.RelativePath);
+            var path = string.IsNullOrEmpty(ns) ? id : $"{ns}/{id}";
+            types.Add(new NodeTypeUnderTest(path, package.Id, configuration,
+                HasSources: sourceFolders.Contains(path)));
+        }
+        return types.OrderBy(t => t.Path, StringComparer.Ordinal).ToImmutableList();
+    }
+
+    private static IObservable<NodeTypeResult> TestNodeType(
+        GateMesh harness, GateOptions options, NodeTypeUnderTest type)
+    {
+        var result = new NodeTypeResult(type.Path, type.Package);
+        return AwaitCompile(harness, options, type, result)
+            .SelectMany(afterCompile => afterCompile.Compile == CheckOutcome.Failed
+                // A broken compile already fails the gate — rendering it would only add noise.
+                ? Observable.Return(afterCompile with
+                {
+                    Render = CheckOutcome.Skipped,
+                    Tests = type.DeclaresTestsArea ? CheckOutcome.Skipped : afterCompile.Tests,
+                })
+                : RenderGate(harness, options, type, afterCompile))
+            .Do(r => options.Output.WriteLine(
+                $"   {(r.Success ? "ok " : "RED")} {r.Path} " +
+                $"[compile:{r.Compile} render:{r.Render} tests:{r.Tests}]"));
+    }
+
+    private static IObservable<NodeTypeResult> AwaitCompile(
+        GateMesh harness, GateOptions options, NodeTypeUnderTest type, NodeTypeResult result)
+    {
+        if (!type.Compiles)
+            return Observable.Return(result with { Compile = CheckOutcome.Skipped });
+
+        return harness.Mesh.GetWorkspace().GetMeshNodeStream(type.Path)
+            .Where(node => node?.Content is NodeTypeDefinition def
+                && def.CompilationStatus is CompilationStatus.Ok or CompilationStatus.Error)
+            .Take(1)
+            .Timeout(options.CompileTimeout)
+            .Select(node =>
+            {
+                var def = (NodeTypeDefinition)node!.Content!;
+                if (def.CompilationStatus == CompilationStatus.Ok)
+                    return result with
+                    {
+                        CompilationStatus = def.CompilationStatus,
+                        Compile = CheckOutcome.Passed,
+                    };
+                return result with
+                {
+                    CompilationStatus = def.CompilationStatus,
+                    Compile = CheckOutcome.Failed,
+                    CompileDetail = string.IsNullOrWhiteSpace(def.CompilationError)
+                        ? "compilation failed without diagnostics"
+                        : def.CompilationError,
+                };
+            })
+            .Catch((TimeoutException _) => Observable.Return(result with
+            {
+                Compile = CheckOutcome.Failed,
+                CompileDetail = $"no terminal compile status within " +
+                                $"{options.CompileTimeout.TotalSeconds:F0}s",
+            }));
+    }
+
+    private static IObservable<NodeTypeResult> RenderGate(
+        GateMesh harness, GateOptions options, NodeTypeUnderTest type, NodeTypeResult result)
+        => AreaProbe.RenderDefaultArea(harness.Client, type.Path, options.RenderTimeout)
+            .SelectMany(render =>
+            {
+                var afterRender = result with
+                {
+                    Render = render.Outcome,
+                    RenderDetail = render.Detail,
+                };
+                if (!type.DeclaresTestsArea)
+                    return Observable.Return(afterRender with { Tests = CheckOutcome.Skipped });
+                return ResolveTestsHost(harness, type.Path)
+                    .SelectMany(hostPath => AreaProbe.ExecuteTestsArea(
+                        harness.Client, hostPath, options.RenderTimeout))
+                    .Catch((Exception ex) => Observable.Return(new AreaVerdict(
+                        CheckOutcome.Failed,
+                        $"could not execute Tests area: {ex.GetType().Name}: {ex.Message}")))
+                    .Select(tests => afterRender with
+                    {
+                        Tests = tests.Outcome,
+                        TestsDetail = tests.Detail,
+                    });
+            });
+
+    /// <summary>
+    /// The node whose hub serves the type's <c>Tests</c> area: the area is registered by the
+    /// type's compiled configuration, which runs on INSTANCE hubs (the type node itself is
+    /// served by the NodeType editor). Prefers an instance the package ships; otherwise creates
+    /// a throwaway probe instance under the type path (system-impersonated — the same footing
+    /// as the install).
+    /// </summary>
+    private static IObservable<string> ResolveTestsHost(GateMesh harness, string typePath)
+    {
+        var meshService = harness.ServiceProvider.GetRequiredService<IMeshService>();
+        return meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{typePath}"))
+            .Take(1)
+            .SelectMany(change =>
+            {
+                var shipped = change.Items
+                    .Where(n => n.Path != typePath && n.State == MeshNodeState.Active)
+                    .OrderBy(n => n.Path, StringComparer.Ordinal)
+                    .FirstOrDefault();
+                if (shipped is not null)
+                    return Observable.Return(shipped.Path);
+
+                var probePath = $"{typePath}/GateProbe";
+                var probe = new MeshNode("GateProbe", typePath)
+                {
+                    Name = "Gate Probe",
+                    NodeType = typePath,
+                    MainNode = probePath,
+                    State = MeshNodeState.Active,
+                };
+                var access = harness.ServiceProvider.GetRequiredService<AccessService>();
+                return Observable.Using(
+                        () => access.ImpersonateAsSystem(),
+                        _ => meshService.CreateNode(probe))
+                    .Select(created => created.Path);
+            });
+    }
+
+    /// <summary>
+    /// The in-process mesh + render client for one gate run — the console analogue of the
+    /// monolith test base's mesh: monolith hosting, in-memory persistence, row-level security,
+    /// Graph + Space types, the plugin catalog, an isolated assembly store / compilation cache,
+    /// and an admin circuit identity.
+    /// </summary>
+    private sealed class GateMesh : IDisposable
+    {
+        /// <summary>The mesh hub.</summary>
+        public required IMessageHub Mesh { get; init; }
+
+        /// <summary>The client hub used for layout-area sync streams.</summary>
+        public required IMessageHub Client { get; init; }
+
+        /// <summary>The mesh's root service provider.</summary>
+        public required IServiceProvider ServiceProvider { get; init; }
+
+        private readonly List<IHostedService> startedHostedServices = [];
+        private readonly TextWriter output;
+
+        private GateMesh(TextWriter output) => this.output = output;
+
+        /// <summary>Boots the gate mesh (blocking — runs once at the console boundary).</summary>
+        public static GateMesh Create(TextWriter output)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+            services.AddLogging(logging => logging.SetMinimumLevel(LogLevel.Warning));
+            services.AddOptions();
+
+            var runRoot = Path.Combine(Path.GetTempPath(),
+                $"mw-plugin-test-{Environment.ProcessId}-{Guid.NewGuid():N}");
+            var builder = new MeshBuilder(c => c.Invoke(services), AddressExtensions.CreateMeshAddress())
+                .UseMonolithMesh()
+                .AddInMemoryPersistence()
+                .AddRowLevelSecurity()
+                .AddGraph()
+                .AddSpaceType()
+                // The AI node types (Agent / Skill / Model / …) — plugin packages ship Agent
+                // and Skill nodes (LinkedIn, Feedback, ExplainerVideo), and a portal always
+                // registers these; without them those installs are refused "not registered".
+                .AddAI()
+                .AddPluginCatalog()
+                .AddMeshNodes(RootAdminAccess())
+                // Per-run isolated assembly store + compilation cache (AddInMemoryPersistence
+                // TryAdds a process-pid-scoped store — REPLACE it, mirroring the test base).
+                .ConfigureServices(s =>
+                {
+                    s.RemoveAll<IAssemblyStore>();
+                    return s.AddFileSystemAssemblyStore(Path.Combine(runRoot, "assembly-store"));
+                })
+                .ConfigureServices(s => s.Configure<CompilationCacheOptions>(o =>
+                    o.CacheDirectory = Path.Combine(runRoot, "compilation-cache")))
+                .ConfigureHub(c => c.WithRequestTimeout(TimeSpan.FromSeconds(120)));
+            services.AddSingleton(builder.BuildHub);
+
+            var provider = services.CreateMeshWeaverServiceProvider();
+            var mesh = provider.GetRequiredService<IMessageHub>();
+            var harness = new GateMesh(output)
+            {
+                Mesh = mesh,
+                Client = CreateClient(mesh),
+                ServiceProvider = provider,
+            };
+
+            // Pre-warm the NodeType hubs a runtime CreateNode would otherwise recurse on
+            // (the same chicken-and-egg the monolith test base pre-warms).
+            foreach (var nodeTypePath in new[] { "AccessAssignment", "PartitionAccessPolicy" })
+            {
+                var typeNode = provider.FindStaticNode(nodeTypePath);
+                if (typeNode?.HubConfiguration is { } config)
+                    _ = mesh.GetHostedHub(new Address(nodeTypePath), config);
+            }
+
+            // The gate's admin circuit identity (DevLogin analogue).
+            provider.GetRequiredService<AccessService>().SetCircuitContext(GateAdmin);
+
+            // Activate hosted services DI registered but nothing started (no generic host here).
+            foreach (var hosted in provider.GetServices<IHostedService>())
+            {
+                hosted.StartAsync(CancellationToken.None).GetAwaiter().GetResult();
+                harness.startedHostedServices.Add(hosted);
+            }
+            return harness;
+        }
+
+        // Root-scope Admin for everyone: the gate is a throwaway single-user mesh; the install
+        // itself runs system-impersonated, this grant is what lets the render client READ.
+        private static MeshNode[] RootAdminAccess() =>
+        [
+            new(WellKnownUsers.Public + "_Access", "_Access")
+            {
+                NodeType = "AccessAssignment",
+                Name = "Public Access",
+                MainNode = "",
+                Content = new AccessAssignment
+                {
+                    AccessObject = WellKnownUsers.Public,
+                    DisplayName = "Public",
+                    Roles = [new RoleAssignment { Role = "Admin" }],
+                },
+            },
+        ];
+
+        private static IMessageHub CreateClient(IMessageHub mesh)
+        {
+            var routing = mesh.ServiceProvider.GetRequiredService<IRoutingService>();
+            return mesh.ServiceProvider.CreateMessageHub(
+                new Address("client", Guid.NewGuid().ToString("N")[..12]),
+                configuration =>
+                {
+                    configuration.TypeRegistry.WithType(
+                        typeof(MeshNodeReference), nameof(MeshNodeReference));
+                    return configuration
+                        .AddMeshTypes()
+                        .AddData()
+                        .WithRequestTimeout(TimeSpan.FromSeconds(120))
+                        .WithInitialization(h => h.RegisterForDisposal(routing.RegisterStream(h)));
+                })!;
+        }
+
+        /// <summary>
+        /// Synchronous teardown at the run boundary: stop hosted services, dispose the hubs and
+        /// JOIN their disposal, cancel+join the I/O pools, then tear down the container.
+        /// </summary>
+        public void Dispose()
+        {
+            foreach (var hosted in Enumerable.Reverse(startedHostedServices))
+            {
+                try
+                {
+                    hosted.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    output.WriteLine($"[teardown] hosted service stop failed: {ex.Message}");
+                }
+            }
+            try
+            {
+                Client.Dispose();
+            }
+            catch (Exception ex)
+            {
+                output.WriteLine($"[teardown] client dispose failed: {ex.Message}");
+            }
+            try
+            {
+                Mesh.Dispose();
+                // Block-join at the run boundary: teardown = synchronous dispose that joins.
+                Mesh.DisposalCompleted
+                    .FirstOrDefaultAsync()
+                    .Timeout(TimeSpan.FromSeconds(30))
+                    .Catch((TimeoutException _) =>
+                    {
+                        output.WriteLine("[teardown] mesh disposal did not complete within 30s");
+                        return Observable.Return(Unit.Default);
+                    })
+                    .Wait();
+            }
+            catch (Exception ex)
+            {
+                output.WriteLine($"[teardown] mesh dispose failed: {ex.Message}");
+            }
+            try
+            {
+                ServiceProvider.GetRequiredService<IoPoolRegistry>().DrainAll();
+            }
+            catch (Exception ex)
+            {
+                output.WriteLine($"[teardown] pool drain failed: {ex.Message}");
+            }
+            (ServiceProvider as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.PluginTester;
+
+// mw-plugin-test <repo-root> [--compile-timeout <seconds>] [--render-timeout <seconds>]
+//
+// The MeshWeaver.Plugins PR gate: imports each node-repo package of the checkout into a fresh
+// in-process mesh, waits for every NodeType to compile (Roslyn diagnostics on error), renders
+// each type's default area, and EXECUTES each type's `Tests` layout area. Exit 0 = all green.
+//
+// The one Task bridge lives HERE, at the console boundary — everything below Run() is reactive.
+
+string? root = null;
+var compileTimeout = TimeSpan.FromMinutes(5);
+var renderTimeout = TimeSpan.FromMinutes(2);
+
+for (var i = 0; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "--compile-timeout" when i + 1 < args.Length:
+            compileTimeout = TimeSpan.FromSeconds(
+                double.Parse(args[++i], CultureInfo.InvariantCulture));
+            break;
+        case "--render-timeout" when i + 1 < args.Length:
+            renderTimeout = TimeSpan.FromSeconds(
+                double.Parse(args[++i], CultureInfo.InvariantCulture));
+            break;
+        case "--help" or "-h":
+            Console.WriteLine(
+                "usage: mw-plugin-test <repo-root> [--compile-timeout <s>] [--render-timeout <s>]");
+            return 0;
+        default:
+            if (args[i].StartsWith('-') || root is not null)
+            {
+                Console.Error.WriteLine($"Unknown argument '{args[i]}'. Try --help.");
+                return 2;
+            }
+            root = args[i];
+            break;
+    }
+}
+
+var options = new GateOptions
+{
+    RepoRoot = root ?? ".",
+    CompileTimeout = compileTimeout,
+    RenderTimeout = renderTimeout,
+};
+
+Console.WriteLine($"mw-plugin-test: gating node repos under '{Path.GetFullPath(options.RepoRoot)}'");
+var report = await PluginGateRunner.Run(options).FirstAsync().ToTask();
+report.WriteSummary(Console.Out);
+return report.ExitCode;


### PR DESCRIPTION
## What

Turns on the dormant PR gate of the **MeshWeaver.Plugins** repo. Its `ci.yml` `test-repos` job (gated on `vars.MW_TEST_IMAGE`) runs `mw-plugin-test .` inside a MeshWeaver image — this PR ships that image and the CLI in it, plus two framework fixes the gate itself uncovered by running against the real plugins repo.

**Why now:** a broken plugin source (UWDeepfield calling a removed framework overload) merged and only exploded on the live portal. This gate catches that class on the PR — and, run against today's `MeshWeaver.Plugins` main, it already does (see below).

### 1. `tools/MeshWeaver.PluginTester` — the `mw-plugin-test` CLI

Invoked at a node-repo checkout root, it:
1. **Boots a fresh in-process monolith mesh** — `UseMonolithMesh` + in-memory persistence (throwaway, zero external services, per-run temp assembly store/compile cache), `AddGraph` + `AddSpaceType` + `AddAI` + `AddPluginCatalog`, row-level security with a root admin grant, an admin circuit identity (DevLogin analogue). Runs on a 2-core `ubuntu-latest` runner, no Docker-in-Docker needed.
2. **Discovers packages**: every top-level folder whose `index.json` declares a root node — the storefront-listed roots via the standard `NodeRepoPackageSource`, plus synthesized manifests for self-typed roots the listing doesn't recognise.
3. **Imports dependency-first** through the standard `PackageInstaller` (no parallel installer): topological order over three edge sources — `sources`/`tests` query entries pointing into a sibling package (Edu ↔ shared sources), any node's `nodeType` that is a path into another package (all plugin roots are `Store/Plugin` ⇒ Store installs first), and the advisory `requires` list.
4. **Waits for every NodeType to reach a terminal `CompilationStatus`** reactively on `GetMeshNodeStream(path)` — `Error` prints the full Roslyn diagnostics (incl. the source-discovery trace) and fails the run.
5. **Renders each type's default area** over the standard client sync stream (`GetRemoteStream<JsonElement, LayoutAreaReference>`), failing on the framework's visible error controls.
6. **EXECUTES each type's `Tests` layout area** — verified against a live portal: the area runs on an *instance* of the type (the type node itself is served by the NodeType editor), so the gate uses a shipped instance or creates a throwaway probe instance, renders `Tests` (rendering runs the in-node assertions), and requires a green verdict (the `✅/❌` table with `N/M passed` that the plugins repo's AGENTS.md mandates). Red row, error control, or no verdict ⇒ fail.
7. Prints a per-package summary; **exit 0 = all green**.

Reactive end-to-end; the single `Task` bridge is in `Main`; the filesystem sweep runs on the `IIoPool`; teardown synchronously joins hub disposal and drains the pools.

### 2. Framework fixes the gate uncovered (fresh-mesh installs)

Running the gate over the real `MeshWeaver.Plugins` checkout exposed defects that never fire on a portal that already carries the types, but fire deterministically on a fresh mesh:

- **`PackageInstaller.InstallNodeRepo` ordering**: bucket 0 ("a type's Source/Test/docs") swallowed *every* descendant of a type path — a typed instance nested under its leaf-shaped type (`ClaimsDeepfield/Cedent/NSV`) wrote before the type node and was refused `NodeType … is not registered`; and when a package ROOT carries `NodeTypeDefinition` *content* on a Space root (UWDeepfield), the root's path prefixed the whole package, pulling every instance ahead of the types. Bucket 0 is now exactly the `Source/`+`Test/` compile inputs; instances land after the types' visibility barrier. Pinned by `NodeRepoInstanceOrderingTest`.
- **`CreateOrUpdateNodeRequest` TOCTOU**: the verb's read-then-branch raced a concurrent appearance of the node (debounced per-node persist flush / bootstrap heal) and failed the upsert with `Node already exists` (observed nondeterministically on the Feedback package's root retype). Losing the create race now falls through to the update path — the same treat-as-success rule `EnsurePartitionBootstrap` documents for its own root-create race.

### 3. CD: `mw-plugin-test` image on every main build

Third parallel leg in `main-cd.yml` (modeled on `migration-image`): `dotnet publish -t:PublishContainer`, multi-arch `linux-x64;linux-arm64`, tags `3.0.0-ci.<n>` + short-SHA + `main` + **`latest`** (the stable tag the plugins repo variable pins). The image carries `PATH=/app:…` so `run: mw-plugin-test .` works in a GitHub Actions `container:` job.

### 4. Tests

`test/MeshWeaver.PluginTester.Test` runs the gate **in-process** against fixture repos:
- good package → compile Ok, default area renders, `Tests` area executes `1/1 passed`, exit 0;
- repo with a deliberate compile error (`MissingHelper.Frobnicate()` — the UWDeepfield class) → non-zero exit, `CS0103` + the symbol name in the output, and the good package still green (per-package isolation).

## Verification

- `dotnet build MeshWeaver.slnx -c Release -warnaserror` — green (incl. after merging current main).
- `MeshWeaver.PluginTester.Test` 2/2, `MeshWeaver.PluginCatalog.Test` 21/21 (incl. the new ordering regression test).
- **Full run against the real `Systemorph/MeshWeaver.Plugins` checkout**: 14 packages discovered, install order `Store → BusinessRules → Chess → ClaimsDeepfield → Edu → ExplainerVideo → Feedback → LinkedIn → Reinsurance → RolePlay → Slides → UWDeepfield → X → YouTube`; **12/14 fully green** — ~75 NodeTypes compile Ok + render, and the `Tests` areas execute green (`Edu/CourseInvite` 14/14, `X/Dashboard` 11/11, `YouTube/Dashboard` 11/11). The two remaining reds are **genuine plugin-source rot the gate exists to catch**, with exact diagnostics:
  - `UWDeepfield/ReinsuranceClient(-Index)`: `CS1061 'ContentCollection' does not contain a definition for 'DeleteFileAsync'/'GetContentAsync'`, `IContentService.GetCollectionAsync` — removed framework overloads (the very incident that motivated this gate);
  - `Feedback/Feedback`: `CS0103 'WellKnownUsers' does not exist in the current context`.
  These need fixes in the plugins repo, not here — the gate correctly exits non-zero on them.

## Wiring after this merges (once the first main build has pushed the image)

```bash
gh variable set MW_TEST_IMAGE -R Systemorph/MeshWeaver.Plugins --body "meshweaver.azurecr.io/mw-plugin-test:latest"
# ACR admin credentials (az acr credential show -n meshweaver):
gh secret set ACR_USERNAME -R Systemorph/MeshWeaver.Plugins --body "<acr admin user>"
gh secret set ACR_PASSWORD -R Systemorph/MeshWeaver.Plugins --body "<acr admin password>"
```

Note: the plugins repo's `test-repos` job will be RED until `UWDeepfield/ReinsuranceClient(-Index)` and `Feedback/Feedback` sources are fixed there — set the variable when ready to enforce (or fix those two first).

## Caveats

- `Tests` areas are only executed for types whose configuration registers `WithView("Tests", …)`; types without one are reported `skipped` (the plugins repo's AGENTS.md says every type should have one — enforcement can be tightened later).
- The gate uses in-memory persistence (the same harness the PluginCatalog install tests pin) rather than SQLite — fully in-process and throwaway; the plugins ci.yml comment says "SQLite/filesystem", the intent (no external services) is met.
- `actions/checkout` inside the container falls back to the REST tarball download when `git` is absent in the image (the .NET base images don't ship git); the tool reads the working tree and never needs git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
