### PR TITLE
fix(security): a denied write into the Auth/User mirror must not grant Admin

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/SpaceAdminInvariantValidator.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceAdminInvariantValidator.cs
@@ -66,6 +66,13 @@ public sealed class SpaceAdminInvariantValidator(IMessageHub hub, ILogger<SpaceA
             return Observable.Return(NodeValidationResult.Valid());
         var partition = path[..idx];
 
+        // System-managed mirror partitions (User, Auth) have no user administrator and reject
+        // interactive writes; the "keep at least one admin" invariant does not apply to them. This
+        // also lets an errant `Auth/_Access` admin grant (from a pre-fix partition bootstrap) be
+        // removed instead of being pinned forever as "the last admin of Auth".
+        if (WellKnownPartitions.IsMirror(partition))
+            return Observable.Return(NodeValidationResult.Valid());
+
         // The whole partition is going away: when this delete is part of a cascade rooted at
         // the partition (or an ancestor of it), the space itself is being removed — keeping
         // "at least one admin" is moot, and blocking here would make deleting a Space

--- a/src/MeshWeaver.Graph/Security/PartitionWriteGuardValidator.cs
+++ b/src/MeshWeaver.Graph/Security/PartitionWriteGuardValidator.cs
@@ -79,8 +79,10 @@ public sealed class PartitionWriteGuardValidator : INodeValidator, IOwnerEnforce
     /// constant lookup (never mutated at runtime) — case-insensitive so <c>user</c>,
     /// <c>User</c>, <c>auth</c>, <c>Auth</c> all match.
     /// </summary>
-    private static readonly ImmutableHashSet<string> ReservedMirrorPartitions =
-        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "User", "Auth");
+    // Canonical set lives in Mesh.Contract (WellKnownPartitions.Mirror) so the write guard, the
+    // self-healing partition bootstrap, and the last-admin invariant all enforce the SAME notion of
+    // "system-managed mirror" — they must never drift.
+    private static readonly ImmutableHashSet<string> ReservedMirrorPartitions = WellKnownPartitions.Mirror;
 
     /// <summary>
     /// Initializes a new instance of the partition write-guard validator.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -699,6 +699,16 @@ public static class MeshExtensions
         if (string.IsNullOrEmpty(partition))
             return Observable.Return(System.Reactive.Unit.Default);
 
+        // Never bootstrap a system-managed MIRROR partition (User, Auth). These reject ALL
+        // interactive writes (PartitionWriteGuardValidator Rule 1), so a create attempt into e.g.
+        // `Auth/…` — which this method reaches BEFORE the validators run — would otherwise heal a
+        // bogus Space root + creator-Admin grant on `Auth` (the RLS CheckPermission below passes for
+        // a global admin), and THEN have the child write rejected by the structural guard, leaving
+        // the errant grant (and its "you've been given access to Auth" email) behind. The mirror is
+        // middleware-only; there is nothing to bootstrap.
+        if (WellKnownPartitions.IsMirror(partition))
+            return Observable.Return(System.Reactive.Unit.Default);
+
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
         var meshService = hub.ServiceProvider.GetService<IMeshService>();
         if (persistence is null || meshService is null)

--- a/src/MeshWeaver.Mesh.Contract/Security/WellKnownPartitions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/WellKnownPartitions.cs
@@ -1,0 +1,33 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Mesh.Security;
+
+/// <summary>
+/// Well-known top-level partitions with special, framework-managed semantics — the canonical
+/// source shared by the write guard, the self-healing partition bootstrap, and the admin
+/// invariant so all three enforce the SAME notion of "system-managed".
+/// </summary>
+public static class WellKnownPartitions
+{
+    /// <summary>
+    /// System-managed <b>lookup-mirror</b> partitions (User / Group / Role / VUser / ApiToken /
+    /// EaCredential rows), written ONLY by the platform middleware / DB mirror trigger — never by
+    /// an interactive user, not even a platform admin. Consequences, enforced consistently:
+    /// <list type="bullet">
+    ///   <item><c>PartitionWriteGuardValidator</c> rejects interactive Create/Update here.</item>
+    ///   <item>The self-healing partition bootstrap never provisions a Space root or a
+    ///     creator-Admin grant here — there is no user Space to bootstrap.</item>
+    ///   <item>The "keep at least one admin" invariant does not apply — these have no user admin.</item>
+    /// </list>
+    /// Case-insensitive (<c>auth</c> ≡ <c>Auth</c>).
+    /// </summary>
+    public static readonly ImmutableHashSet<string> Mirror =
+        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "User", "Auth");
+
+    /// <summary>
+    /// True when <paramref name="partition"/> is a system-managed mirror partition
+    /// (<see cref="Mirror"/>). Expects a bare partition segment, e.g. <c>"Auth"</c>.
+    /// </summary>
+    public static bool IsMirror(string? partition) =>
+        !string.IsNullOrEmpty(partition) && Mirror.Contains(partition);
+}

--- a/test/MeshWeaver.Security.Test/ReservedPartitionMirrorTest.cs
+++ b/test/MeshWeaver.Security.Test/ReservedPartitionMirrorTest.cs
@@ -1,0 +1,58 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// Guards the fix for the errant-Admin-on-Auth bug. Attempting to create a node inside a
+/// system-managed MIRROR partition (User / Auth) tripped the self-healing partition bootstrap, which
+/// granted the caller Admin on the mirror partition (and emailed them) BEFORE the structural
+/// write-guard rejected the actual write — leaving the grant behind, pinned as "the last admin of
+/// Auth" and impossible to remove. The shared <see cref="WellKnownPartitions"/> predicate now gates
+/// the bootstrap, the write guard, and the last-admin invariant so none of them treats a mirror
+/// partition as a user Space.
+/// </summary>
+public class ReservedPartitionMirrorTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Theory]
+    [InlineData("Auth", true)]
+    [InlineData("auth", true)]        // case-insensitive
+    [InlineData("User", true)]
+    [InlineData("MySpace", false)]
+    [InlineData("rbuergi", false)]
+    [InlineData("", false)]
+    public void IsMirror_IdentifiesTheSystemManagedMirrorPartitions(string partition, bool expected)
+        => Assert.Equal(expected, WellKnownPartitions.IsMirror(partition));
+
+    [Fact]
+    public async Task LastAdminInvariant_ExemptsMirrorPartitions_SoAnErrantAuthGrantIsRemovable()
+    {
+        var validator = new SpaceAdminInvariantValidator(Mesh);
+
+        // The exact errant grant shape: an Admin AccessAssignment under Auth/_Access. Deleting it must
+        // be ALLOWED — the mirror has no user admin to protect — so the cleanup can proceed. Without
+        // the mirror exemption the invariant would block it as "the last administrator of Auth".
+        var node = new MeshNode("rbuergi_Access", "Auth/_Access")
+        {
+            NodeType = "AccessAssignment",
+            Name = "rbuergi Access",
+            Content = new AccessAssignment
+            {
+                AccessObject = "rbuergi",
+                Roles = [new RoleAssignment { Role = "Admin" }],
+            },
+        };
+        var ctx = new NodeValidationContext { Operation = NodeOperation.Delete, Node = node };
+
+        var result = await validator.Validate(ctx).FirstAsync().ToTask();
+
+        Assert.True(result.IsValid, "removing an errant admin grant on the Auth mirror must be allowed");
+    }
+}


### PR DESCRIPTION
## The bug — an errant "you've been given Admin access to Auth"

Trying to write a node into the system-managed **`Auth`** mirror partition granted the caller **Admin on `Auth`** (with a notification email) — even though the write itself was rejected.

**Why:** `EnsurePartitionBootstrap` self-heals a Space root + a creator-Admin grant for a not-yet-provisioned partition, and it deliberately runs **before** the validators (so RLS sees the root/grant on a legit new Space). For a mirror partition that ordering backfires:

1. Create into `Auth/…` → bootstrap's RLS `CheckPermission` passes for a global admin → it heals a bogus `Auth` root + `Auth/_Access/{user}_Access` **Admin** grant (and fires the access-granted email).
2. Then `PartitionWriteGuardValidator` (Rule 1) rejects the actual write — the mirror is middleware-only.
3. The grant is left behind, and `SpaceAdminInvariantValidator` then **refuses to remove it** ("last administrator of Auth").

## The fix
A single canonical **`WellKnownPartitions.Mirror`** = `{User, Auth}` in `Mesh.Contract`, used by all three so they never drift:
- **`EnsurePartitionBootstrap`** — skip mirror partitions (nothing to bootstrap; the write will be rejected anyway).
- **`PartitionWriteGuardValidator`** — reuse the canonical set (dedup).
- **`SpaceAdminInvariantValidator`** — exempt mirror partitions, so a partition with no user admin never triggers the invariant, and an errant grant is removable.

## Test
`ReservedPartitionMirrorTest`: `WellKnownPartitions.IsMirror` (case-insensitive) + the invariant allows deleting an `Auth/_Access` admin grant. **7/7 green.**

Once merged + deployed, the errant `Auth/_Access/rbuergi_Access` grant on memex can finally be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)