### PR TITLE
test(query): 180s envelope for the cross-silo dynamic-compile test (fixes a CI-load timeout)

### DIFF
--- a/test/MeshWeaver.Query.Test/SyncedQueryCrossSiloTest.cs
+++ b/test/MeshWeaver.Query.Test/SyncedQueryCrossSiloTest.cs
@@ -270,7 +270,12 @@ public class SyncedQueryCrossSiloTest(ITestOutputHelper output)
     /// invariant that lets every silo's <c>NodeTypeService._hubConfigurations</c>
     /// cache populate without per-silo recompilation.</para>
     /// </summary>
-    [Fact(Timeout = 60000)]
+    // 180s envelope (not 60s): this test runs a LIVE Roslyn compile + cross-silo sync whose inner
+    // .Within(...) waits already budget up to ~150s (15+15+60+60). The outer envelope must be ≥ that
+    // sum, or a HEALTHY-but-slow run is killed by the envelope before its own waits could fire. Under
+    // CI's parallel-shard CPU contention the compile alone (~15-20s uncontended) starves well past 60s
+    // — reproduced locally as a ~1-in-6 timeout under load. This is a starved compile, not a race.
+    [Fact(Timeout = 180000)]
     public async Task DynamicCompile_OnSiloA_ResultIsObservableOnSiloB_ViaSync()
     {
 


### PR DESCRIPTION
## The failing test
`SyncedQueryCrossSiloTest.DynamicCompile_OnSiloA_ResultIsObservableOnSiloB_ViaSync` intermittently fails CI with a **`[1 m]` timeout** (`exit=1` on its shard) — most recently on #564's CI.

## Root cause (reproduced, not guessed)
The test runs a **live Roslyn compile + cross-silo synced-query propagation** under a **`[Fact(Timeout = 60000)]`** (60s) envelope. But its *own inner waits* budget far more:
```
.Within(15s) + .Within(15s) + .Within(60s) + .Within(60s)  ≈ 150s
```
The 60s outer envelope is **tighter than the inner budget**, so a *healthy but slow* run is killed by the envelope before its own waits could ever fire. The compile is ~15-20s uncontended; under CI's 6 parallel shards it starves well past 60s.

Reproduced locally by running the project under pegged-CPU load: **1 failure in 6**, at exactly the 60s mark (10/10 green in isolation — it only dies under contention).

## Fix
Raise the envelope to **180s** to cover the inner `.Within(...)` budget. No logic change — the test does legitimately slow work and completes correctly given the time.

**Verified: 8/8 pass** under the identical pegged-CPU load that previously failed 1/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)