### PR TITLE
Recursive/partition-root delete must cascade completely (no orphaned schema)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/PartitionDropPostDeletionHandler.cs
+++ b/src/MeshWeaver.Graph/Configuration/PartitionDropPostDeletionHandler.cs
@@ -11,13 +11,29 @@ namespace MeshWeaver.Graph.Configuration;
 /// <summary>
 /// Tears down a partition's entire backing store when its partition-owning root node is
 /// deleted — the deletion-side mirror of <c>OwnsPartitionProvisioningValidator</c>. Deleting
-/// a <c>Space</c> removes the space's nodes (the recursive delete), and this handler then
+/// a partition root (a <c>Space</c> OR a <c>User</c> home — every <c>OwnsPartition</c> type)
+/// removes that partition's nodes (the recursive delete), and this handler then
 /// (1) drops the partition's backing store on every <see cref="IPartitionStorageProvider"/>
 /// (the Postgres provider drops the schema with all satellite tables — threads, access,
-/// activities — in one <c>DROP SCHEMA … CASCADE</c>), and (2) deletes the
-/// <c>Admin/Partition/{id}</c> <see cref="PartitionDefinition"/> node that
-/// <c>SpacePostCreationHandler</c> emitted, so the partition disappears from the routing
-/// prime and partition listings mesh-wide.
+/// activities, notifications, user_activities — in one <c>DROP SCHEMA … CASCADE</c>), and
+/// (2) deletes the <c>Admin/Partition/{id}</c> <see cref="PartitionDefinition"/> node that
+/// <c>SpacePostCreationHandler</c> emitted (absent for User homes — the definition delete is
+/// best-effort), so the partition disappears from the routing prime and partition listings
+/// mesh-wide.
+///
+/// <para><b>Why the DROP is essential (not merely tidy).</b> The recursive fan-out only
+/// enumerates <c>mesh_nodes</c> descendants; satellite-table rows (threads, notifications,
+/// user_activities, access) live in dedicated tables the fan-out never visits, and RLS can
+/// hide gated children from the enumeration. The unconditional <c>DROP SCHEMA … CASCADE</c>
+/// is what makes a partition-root delete COMPLETE regardless — no orphaned schema, no leaked
+/// satellite rows. A <c>User</c> home that lacked this handler was left entirely behind
+/// (2026-07-19 memex-cloud incident); registering it for every <c>OwnsPartition</c> type is
+/// the fix.</para>
+///
+/// <para>The matched <see cref="NodeType"/> is supplied by the registration site
+/// (<c>AddSpaceType</c> → <c>Space</c>, <c>AddUserType</c> → <c>User</c>) so the same generic
+/// teardown serves every partition-owning type — the <see cref="Handle"/> body is NodeType
+/// agnostic (it keys off the root's <c>Id</c>).</para>
 ///
 /// <para>Sequenced store-drop → definition-delete: when the store drop fails, the
 /// definition node stays so the partition remains visible for a retry instead of turning
@@ -29,10 +45,11 @@ namespace MeshWeaver.Graph.Configuration;
 /// </summary>
 public sealed class PartitionDropPostDeletionHandler(
     IMessageHub hub,
+    string nodeType,
     ILogger<PartitionDropPostDeletionHandler>? logger = null) : INodePostDeletionHandler
 {
     /// <inheritdoc />
-    public string NodeType => SpaceNodeType.NodeType;
+    public string NodeType => nodeType;
 
     /// <inheritdoc />
     public IObservable<Unit> Handle(MeshNode deletedNode, string? deletedBy)

--- a/src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs
@@ -201,6 +201,7 @@ public static class SpaceNodeType
             services.AddSingleton<INodePostDeletionHandler>(sp =>
                 new PartitionDropPostDeletionHandler(
                     sp.GetRequiredService<IMessageHub>(),
+                    NodeType,
                     sp.GetService<ILoggerFactory>()?.CreateLogger<PartitionDropPostDeletionHandler>()));
             return services;
         });

--- a/src/MeshWeaver.Graph/Configuration/UserNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/UserNodeType.cs
@@ -9,6 +9,7 @@ using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using MeshWeaver.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Graph.Configuration;
 
@@ -44,6 +45,19 @@ public static class UserNodeType
                 new UserAccessRule(sp.GetRequiredService<IMessageHub>()));
             services.AddSingleton<INodePostCreationHandler>(sp =>
                 new UserScopeGrantHandler(sp.GetRequiredService<IMeshService>()));
+            // Deleting a User home removes the ENTIRE per-user partition — the deletion-side
+            // mirror of the eager User-partition provisioning (OwnsPartitionProvisioningValidator,
+            // OwnsPartition=true below). After the recursive node delete, drop the backing store
+            // (Postgres schema incl. every satellite table) on every partition storage provider,
+            // so no schema/satellite rows are orphaned. Mirrors AddSpaceType's Space teardown;
+            // without it a System off-boarding delete left the whole partition behind
+            // (2026-07-19 memex-cloud incident). Interactive callers are blocked upstream by
+            // PartitionRootDeletionGuard — only System reaches this teardown.
+            services.AddSingleton<INodePostDeletionHandler>(sp =>
+                new PartitionDropPostDeletionHandler(
+                    sp.GetRequiredService<IMessageHub>(),
+                    NodeType,
+                    sp.GetService<ILoggerFactory>()?.CreateLogger<PartitionDropPostDeletionHandler>()));
             return services;
         });
         builder.ConfigureNodeTypeAccess(a => a.WithPublicRead(NodeType));

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/UserPartitionDeletionCascadeTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/UserPartitionDeletionCascadeTests.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Deleting a USER partition root must remove the ENTIRE partition — every mesh_nodes
+/// descendant AND every satellite-table row (threads, notifications, user_activities,
+/// access, …) AND the backing schema itself. This is the deletion-side mirror of the
+/// eager <c>User</c>-partition provisioning (<c>OwnsPartitionProvisioningValidator</c>).
+///
+/// <para>Regression guard for the 2026-07-19 memex-cloud incident: a System-impersonated
+/// recursive delete of a user partition root reported success but left ~30 descendant
+/// nodes and satellite rows behind in the partition schema. Root cause: <c>User</c>
+/// (unlike <c>Space</c>) had NO <c>PartitionDropPostDeletionHandler</c>, so the schema
+/// was never dropped and the recursive fan-out (which only enumerates <c>mesh_nodes</c>)
+/// never reached the satellite tables — an orphaned partition (storage- and data-leak).</para>
+///
+/// <para>Space-parity mesh shape (RLS + Graph, which registers the User type + its
+/// teardown), same as <see cref="SpaceDeletionPartitionDropTests"/>.</para>
+/// </summary>
+[Collection("PostgreSql")]
+public class UserPartitionDeletionCascadeTests(PostgreSqlFixture fixture, ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private readonly PostgreSqlFixture _fixture = fixture;
+    private readonly JsonSerializerOptions _options = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var csb = new Npgsql.NpgsqlConnectionStringBuilder(_fixture.ConnectionString)
+        {
+            MaxPoolSize = 16,
+            ConnectionIdleLifetime = 10
+        };
+        return builder
+            .UseMonolithMesh()
+            .ConfigureServices(services =>
+                services.AddPartitionedPostgreSqlPersistence(csb.ConnectionString))
+            .AddRowLevelSecurity()
+            .AddGraph()
+            .AddSpaceType();
+    }
+
+    private IObservable<long> SchemaCount(string schema) =>
+        _fixture.DataSource.ScalarLong(
+            "SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = @s",
+            new[] { ("s", (object)schema) });
+
+    /// <summary>
+    /// AUTHORITATIVE total-row count across EVERY table in the partition schema — direct PG,
+    /// past every per-node-hub cache / catalog-stream layer. Returns 0 when the schema (or a
+    /// table) no longer exists, so it works whether the partition teardown DROPs the schema or
+    /// merely empties it. This is the ground truth for "is the partition actually gone".
+    /// </summary>
+    private async Task<long> PartitionRowCountAsync(string schema, CancellationToken ct)
+    {
+        var tables = new List<string>();
+        await using (var listCmd = _fixture.DataSource.CreateCommand(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = @s"))
+        {
+            listCmd.Parameters.AddWithValue("s", schema);
+            await using var rdr = await listCmd.ExecuteReaderAsync(ct);
+            while (await rdr.ReadAsync(ct))
+                tables.Add(rdr.GetString(0));
+        }
+
+        if (tables.Count == 0)
+            return 0L;
+
+        var sb = new StringBuilder("SELECT ");
+        for (var i = 0; i < tables.Count; i++)
+        {
+            if (i > 0) sb.Append(" + ");
+            sb.Append("(SELECT COUNT(*) FROM \"")
+              .Append(schema.Replace("\"", "\"\""))
+              .Append("\".\"")
+              .Append(tables[i].Replace("\"", "\"\""))
+              .Append("\")");
+        }
+
+        await using var sumCmd = _fixture.DataSource.CreateCommand(sb.ToString());
+        return (long)(await sumCmd.ExecuteScalarAsync(ct))!;
+    }
+
+    /// <summary>Direct-PG row count for one satellite table (0 if the table/schema is gone).</summary>
+    private async Task<long> TableRowCountAsync(string schema, string table, CancellationToken ct)
+    {
+        await using var probe = _fixture.DataSource.CreateCommand(
+            "SELECT to_regclass(@q) IS NOT NULL");
+        probe.Parameters.AddWithValue("q", $"\"{schema}\".\"{table}\"");
+        var exists = (bool)(await probe.ExecuteScalarAsync(ct))!;
+        if (!exists) return 0L;
+
+        await using var cmd = _fixture.DataSource.CreateCommand(
+            $"SELECT COUNT(*) FROM \"{schema.Replace("\"", "\"\"")}\".\"{table.Replace("\"", "\"\"")}\"");
+        return (long)(await cmd.ExecuteScalarAsync(ct))!;
+    }
+
+    private IObservable<MeshNode> CreateAsSystem(MeshNode node)
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        return Observable.Using(
+            () => access.ImpersonateAsSystem(),
+            _ => meshService.CreateNode(node));
+    }
+
+    private IObservable<bool> DeleteAsSystem(string path)
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        return Observable.Using(
+            () => access.ImpersonateAsSystem(),
+            _ => meshService.DeleteNode(path));
+    }
+
+    /// <summary>
+    /// The incident reproduction: a User partition root with mesh_nodes descendants AND
+    /// satellite-table rows is deleted under System — the whole partition (schema + every
+    /// table) must be gone afterwards, not just the root row.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task DeletingUserPartitionRoot_UnderSystem_DropsWholePartition()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // Lowercase id ⇒ schema name == id (the router lowercases the first path segment).
+        var userId = $"usrdel{Guid.NewGuid():N}".ToLowerInvariant()[..16];
+
+        // 1. Create the user partition root (System = the legitimate partition provisioner).
+        //    This eagerly provisions the "{userId}" schema + its satellite tables.
+        await SeedTopLevel(new MeshNode(userId)
+        {
+            NodeType = "User",
+            Name = "Delete Me",
+            State = MeshNodeState.Active,
+        });
+        await SchemaCount(userId).Should().Within(30.Seconds()).Be(1L);
+
+        // 2. mesh_nodes descendants — a normal child and a nested "installed course copy"
+        //    child (exactly the shape the incident left behind).
+        await CreateAsSystem(new MeshNode("token1", $"{userId}/ApiToken")
+        {
+            NodeType = "Markdown",
+            Name = "API token",
+            State = MeshNodeState.Active,
+        }).Should().Within(30.Seconds()).Emit();
+        await CreateAsSystem(new MeshNode("ex1", $"{userId}/AgenticEngineering/Module1/Exercise")
+        {
+            NodeType = "Markdown",
+            Name = "Exercise",
+            State = MeshNodeState.Active,
+        }).Should().Within(30.Seconds()).Emit();
+
+        // 3. Satellite-table rows — threads / notifications / user_activities / access. These
+        //    live in dedicated tables the recursive-delete enumeration (mesh_nodes only) never
+        //    reaches; seeded straight into the partition schema so they exist before the delete.
+        var userPartition = new PartitionDefinition
+        {
+            Namespace = userId,
+            DataSource = "default",
+            Schema = userId,
+            TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+            NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings(),
+        };
+        var (_, satelliteAdapter) = await _fixture.CreateSchemaAdapterAsync(userId, userPartition, ct);
+        await satelliteAdapter.Write(new MeshNode("t1", $"{userId}/_Thread")
+        {
+            NodeType = "Thread", Name = "A thread", MainNode = $"{userId}/_Thread",
+        }, _options).Should().Within(30.Seconds()).Emit();
+        await satelliteAdapter.Write(new MeshNode("n1", $"{userId}/_Notification")
+        {
+            NodeType = "Notification", Name = "A notification",
+        }, _options).Should().Within(30.Seconds()).Emit();
+        await satelliteAdapter.Write(new MeshNode("act1", $"{userId}/_UserActivity")
+        {
+            NodeType = "UserActivity", Name = "An activity",
+        }, _options).Should().Within(30.Seconds()).Emit();
+        await satelliteAdapter.Write(new MeshNode("deny1", $"{userId}/_Access")
+        {
+            NodeType = "AccessAssignment", Name = "A deny",
+        }, _options).Should().Within(30.Seconds()).Emit();
+
+        // Sanity: the partition genuinely has both mesh_nodes AND satellite content now.
+        (await PartitionRowCountAsync(userId, ct))
+            .Should().BeGreaterThan(0L, "the partition must have content before the delete");
+        (await TableRowCountAsync(userId, "threads", ct))
+            .Should().BeGreaterThan(0L, "seeded a thread satellite");
+        (await TableRowCountAsync(userId, "notifications", ct))
+            .Should().BeGreaterThan(0L, "seeded a notification satellite");
+        (await TableRowCountAsync(userId, "user_activities", ct))
+            .Should().BeGreaterThan(0L, "seeded a user-activity satellite");
+
+        // 4. Delete the user partition root under System (the incident path).
+        var deleted = await DeleteAsSystem(userId).Should().Within(90.Seconds()).Emit();
+        deleted.Should().BeTrue();
+
+        // 5. The WHOLE partition is gone — schema dropped, EVERY table empty. A delete that
+        //    leaves the schema or any satellite row is the orphaned-partition bug.
+        await SchemaCount(userId).Should().Within(30.Seconds()).Be(0L,
+            "deleting a user partition root must drop the whole partition schema");
+
+        // Sustained-zero window: authoritative direct-PG count across every partition table
+        // stays 0 — a per-node hub reactivating after the delete must not resurrect any row
+        // (mesh_nodes OR satellite). Negative-assertion window — the sanctioned Task.Delay use.
+        for (var i = 0; i < 10; i++)
+        {
+            (await PartitionRowCountAsync(userId, ct))
+                .Should().Be(0L,
+                    "no mesh_nodes row and no satellite row may survive the partition delete");
+            await Task.Delay(100, ct);
+        }
+    }
+}


### PR DESCRIPTION
## The defect

A recursive delete of a **User partition root** run under System impersonation (2026-07-19, memex-cloud) reported success but **left the entire partition behind**: every `mesh_nodes` descendant (installed course copies, `ApiToken/*`, `_Billing`, `_Install`, `_Memex`, `_Orders`, …) **and** satellite-table rows (`_Thread/*`, `_Notification/*`, `_UserActivity/*`) **and** the backing schema `"roland.buergi"` all survived. The schema had to be `DROP SCHEMA CASCADE`'d by hand. A delete that silently orphans a partition is a correctness bug and a data/storage-leak risk.

## Confirmed root-cause mechanism

`PartitionDropPostDeletionHandler` — the handler that, after the recursive node delete, drops a partition's whole backing store (`DROP SCHEMA … CASCADE`, satellite tables included) — was registered **only for `Space` roots** (in `AddSpaceType`). But `User` is equally an **`OwnsPartition`** type: its schema is eagerly provisioned on create by `OwnsPartitionProvisioningValidator`, exactly like `Space`. `AddUserType` wired **no teardown**, so:

1. The post-deletion dispatch (`RunPostDeletionHandlersObs`) matches handlers strictly by `NodeType` → a `User`-root delete matched **zero** partition-drop handlers → the schema was never dropped.
2. The recursive fan-out (`CollectPathsForDelete` → `FanOutDeleteSubtree`) only enumerates **`mesh_nodes`** descendants; satellite-table rows live in dedicated tables the fan-out never visits (and RLS can hide gated children from the enumeration).

Together these orphan the whole partition. (Interactive callers can't even reach this — `PartitionRootDeletionGuard` blocks a non-System User-root delete; only a deliberate System off-boarding does, which is the incident path.)

## The fix — one asymmetry, closed

Register `PartitionDropPostDeletionHandler` for `User` too, mirroring `AddSpaceType`. The handler body was already NodeType-agnostic (it keys off the deleted root's `Id`); the matched NodeType is now a constructor parameter supplied by each registration site (`AddSpaceType` → `Space`, `AddUserType` → `User`).

**What the cascade now covers for a partition-root delete:** the unconditional `DROP SCHEMA … CASCADE` removes **`mesh_nodes` + every satellite table** (`threads`, `notifications`, `user_activities`, `access`, `activities`, `annotations`, `code`) in one atomic DDL — so completeness no longer depends on the fan-out enumeration reaching every row. Non-PG providers use the `IPartitionStorageProvider.DeletePartition` interface **no-op default** (whose doc already names "Space/User root" as the trigger), so in-memory/embedded meshes are unaffected.

## Relationship to #562 (per-subject read fold) — no overlap/conflict

Deliberately **did NOT** touch the descendant-enumeration's subject filtering. Deletion completeness for a partition root is achieved by the **schema-prefix `DROP … CASCADE`**, which **bypasses read-visibility entirely** — orthogonal to #562's per-subject read fold. Deletion authorization (gated at the root) ≠ read visibility, so this change neither reintroduces nor fights #562's semantics. Merged current `origin/main` (incl. #562) before finalizing; all tests pass on top of the merged fold.

## Repro test + result

`test/MeshWeaver.Hosting.PostgreSql.Test/UserPartitionDeletionCascadeTests.cs` (Testcontainers): creates a User partition root under System (schema provisioned), seeds `mesh_nodes` descendants + satellite rows (thread/notification/user_activity/access), deletes the root under System, then asserts the partition schema is **dropped** and an authoritative direct-PG count across **every** table in the schema is **0**.

- **RED** on the pre-fix tree: `Expected … 0 … but found 1` — the schema (and its content) survived.
- **GREEN** after the fix.

Adjacent tests re-verified green: `SpaceDeletionPartitionDropTests` + `PartitionLifecycleTests` (7/7), `PartitionRootDeletionGuardTest` (13/13). Release `-warnaserror` build clean.

## Caveats

- Fixing new future `OwnsPartition` types still requires the same one-line teardown registration in their `Add*Type` (consistent with how the codebase already registers per-type handlers). The `DeletePartition` no-op default keeps non-storage providers safe.
- A separate agent is fixing the query parser (slashes in `nodeType:Edu/Exercise` values) in `PostgreSqlMeshQuery`; this PR does not touch that layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)