### PR TITLE
Query: slashes in key:value are literal (nodeType:Edu/Exercise) — regression tests + investigation

### DIFF
--- a/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionSearchTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/CrossPartitionSearchTests.cs
@@ -560,6 +560,80 @@ public class CrossPartitionSearchTests
             "the fan-out query must not be pinned to the first query's schema");
     }
 
+    /// <summary>
+    /// Repro for the live memex-cloud defect (2026-07-19): a fan-out query whose nodeType
+    /// VALUE contains a slash (`nodeType:Edu/Exercise`, `nodeType:Store/Plugin`) returned zero
+    /// rows even though the rows exist. Exercises the exact production cross-schema fan-out.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task CrossSchema_SlashedNodeType_FoundAcrossPartitions()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (_, partitions) = await SetupMultiOrgEnvironment(ct);
+
+        foreach (var (org, (_, adapter)) in partitions)
+        {
+            await adapter.WriteAsync(new MeshNode("Ex1", $"{org}/Course")
+            {
+                Name = $"{org} Exercise",
+                NodeType = "Edu/Exercise",
+                State = MeshNodeState.Active,
+            }, _options, ct);
+        }
+
+        var schemas = partitions.Keys.Select(k => k.ToLowerInvariant()).ToList();
+        var xsAdapter = new PostgreSqlStorageAdapter(_fixture.DataSource);
+        var query = new QueryParser().Parse("nodeType:Edu/Exercise");
+
+        var results = await xsAdapter.QueryNodesAcrossSchemasAsync(query, _options, schemas, ct: ct)
+            .Collect(ct).Should().Within(30.Seconds()).Emit();
+
+        results.Should().HaveCount(3, "each of the 3 partitions holds one Edu/Exercise node");
+        results.Select(n => n.NodeType).Distinct()
+            .Should().BeEquivalentTo(new[] { "Edu/Exercise" }, JsonSerializerOptions.Default);
+    }
+
+    /// <summary>
+    /// The full production fan-out orchestrator (PostgreSqlPartitionedMeshQuery) for the same
+    /// slashed-nodeType query — no path, no namespace → genuine cross-schema fan-out.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task PartitionedQuery_SlashedNodeTypeFanOut_ReturnsRows()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (_, partitions) = await SetupMultiOrgEnvironment(ct);
+
+        foreach (var (org, (_, adapter)) in partitions)
+        {
+            await adapter.WriteAsync(new MeshNode("Ex1", $"{org}/Course")
+            {
+                Name = $"{org} Exercise",
+                NodeType = "Edu/Exercise",
+                State = MeshNodeState.Active,
+            }, _options, ct);
+        }
+        await PopulateSearchableSchemas(
+            partitions.Keys.Select(k => k.ToLowerInvariant()), ct);
+
+        using var provider = CreatePartitionProvider();
+        var query = new PostgreSqlPartitionedMeshQuery(
+            new PostgreSqlCrossSchemaQueryProvider(_fixture.DataSource),
+            partitionProvider: provider);
+
+        var request = MeshQueryRequest.FromQuery("nodeType:Edu/Exercise", WellKnownUsers.System);
+
+        var initial = await query.Query<MeshNode>(request, _options)
+            .Where(c => c.ChangeType == QueryChangeType.Initial)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(ct);
+
+        var paths = initial.Items.Select(n => n.Path).ToList();
+        paths.Should().Contain("ACME/Course/Ex1");
+        paths.Should().Contain("FutuRe/Course/Ex1");
+        paths.Should().Contain("Contoso/Course/Ex1");
+    }
+
     private PostgreSqlPartitionStorageProvider CreatePartitionProvider()
         => new(
             _fixture.DataSource,

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/QuerySyntaxTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/QuerySyntaxTests.cs
@@ -601,6 +601,65 @@ public class QuerySyntaxTests
 
     #endregion
 
+    #region Slashed nodeType values (Edu/Exercise, Store/Plugin)
+
+    private async Task SeedSlashedTypes()
+    {
+        await _fixture.CleanData().Should().Within(60.Seconds()).Emit();
+        var adapter = _fixture.StorageAdapter;
+        var ac = _fixture.AccessControl;
+        var ct = TestContext.Current.CancellationToken;
+
+        await adapter.Write(new MeshNode("Ex1", "ACME/Course")
+        {
+            Name = "Exercise One",
+            NodeType = "Edu/Exercise",
+        }, _options).Should().Within(30.Seconds()).Emit();
+
+        await adapter.Write(new MeshNode("Ex2", "ACME/Course")
+        {
+            Name = "Exercise Two",
+            NodeType = "Edu/Exercise",
+        }, _options).Should().Within(30.Seconds()).Emit();
+
+        await adapter.Write(new MeshNode("Plug1", "ACME/Store")
+        {
+            Name = "A Plugin",
+            NodeType = "Store/Plugin",
+        }, _options).Should().Within(30.Seconds()).Emit();
+
+        await ac.Grant("ACME", "Anonymous", "Read", isAllow: true, ct).Should().Within(30.Seconds()).Emit();
+    }
+
+    [Fact]
+    public async Task SlashedNodeType_ScopedFilter_MatchesRows()
+    {
+        await SeedSlashedTypes();
+        var query = new PostgreSqlMeshQuery(_fixture.StorageAdapter);
+        var request = MeshQueryRequest.FromQuery("nodeType:Edu/Exercise path:ACME scope:descendants");
+
+        var results = await CollectResults(query, request);
+
+        results.Should().HaveCount(2);
+        results.Select(n => n.NodeType).Distinct()
+            .Should().BeEquivalentTo(new[] { "Edu/Exercise" }, JsonSerializerOptions.Default);
+    }
+
+    [Fact]
+    public async Task SlashedNodeType_StorePlugin_MatchesRow()
+    {
+        await SeedSlashedTypes();
+        var query = new PostgreSqlMeshQuery(_fixture.StorageAdapter);
+        var request = MeshQueryRequest.FromQuery("nodeType:Store/Plugin");
+
+        var results = await CollectResults(query, request);
+
+        results.Should().HaveCount(1);
+        results[0].Name.Should().Be("A Plugin");
+    }
+
+    #endregion
+
     private async Task<List<MeshNode>> CollectResults(PostgreSqlMeshQuery query, MeshQueryRequest request)
         => (await query.QueryList(request, _options, TestContext.Current.CancellationToken)
             .Should().Within(30.Seconds()).Emit())

--- a/test/MeshWeaver.Query.Test/QueryParserTests.cs
+++ b/test/MeshWeaver.Query.Test/QueryParserTests.cs
@@ -675,6 +675,22 @@ public class QueryParserTests
         comparison.Condition.Value.Should().Be("ACME/Project/Todo");
     }
 
+    [Theory]
+    [InlineData("nodeType:Edu/Exercise", "Edu/Exercise")]
+    [InlineData("nodeType:Store/Plugin", "Store/Plugin")]
+    [InlineData("nodeType:Store/Catalog", "Store/Catalog")]
+    public void Parse_SlashedNodeTypeValue_KeepsFullValue(string query, string expected)
+    {
+        var result = _parser.Parse(query);
+
+        result.Filter.Should().BeOfType<QueryComparison>();
+        var comparison = (QueryComparison)result.Filter!;
+        comparison.Condition.Selector.Should().Be("nodeType");
+        comparison.Condition.Operator.Should().Be(QueryOperator.Equal);
+        comparison.Condition.Value.Should().Be(expected);
+        result.TextSearch.Should().BeNull("the slashed value is a literal, not a free-text token");
+    }
+
     #endregion
 
     #region Namespace Parameter


### PR DESCRIPTION
## Summary

Follow-up on the memex-cloud report (2026-07-19) that a structured query whose **value contains a slash** matched nothing:

- `nodeType:Edu/Exercise` → 0 results, though the nodes exist
- `nodeType:Store/Plugin` → 0, though the node exists

The stated hypothesis was that the **query tokenizer drops/mis-splits the value at the slash**.

## What the investigation found

The tokenizer and the full Postgres query pipeline **already treat a slash inside a `key:value` value as a literal** that runs to the next whitespace. I could not reproduce a slash-drop anywhere in current `main`:

- **Parser** (`QueryParser.Tokenize` → `ParseSingleValue`): a value reads to the next whitespace; `/` is an ordinary value char (and a valid field char). Pre-existing tests already cover this (`Parse_PathValueWithSlash_ParsesCorrectly` for `nodeType:ACME/Project/Todo`, `Parse_ActivityQueryPattern` for `type/Story`). This behaviour has been in place since #407 (2026-07-10), i.e. **before** the 2026-07-19 observation.
- **SQL generation** (`PostgreSqlSqlGenerator`): `nodeType:Edu/Exercise` → `LOWER(n.node_type) = @p0`, param `edu/exercise` — parameterized, slash intact.
- **Table routing** (`ResolveTableByNodeType`, `ResolvePinnedPartition`, routing hints): a slashed value is not a known satellite type and has no namespace, so it resolves to `mesh_nodes` and fans out across every searchable partition — no mis-pin.
- **Live check**: `nodeType:Store/Plugin` and `nodeType:Edu/Exercise` both return rows on the live **memex** mesh right now.

So the parser test the report expected to go **RED** actually goes **GREEN** — there is no tokenizer defect to fix. Fabricating a code change to a working parser would be a fake fix, so this PR ships **regression coverage only** and documents the finding.

The memex-cloud symptom was therefore almost certainly **not** a tokenizer bug — most likely environmental (an older deployed image, or the partition holding those nodes not yet present in `searchable_schemas` at query time). That is a separate, non-slash-specific issue (a non-slashed nodeType in the same partition would fail the same way) and is out of scope here.

## Tests added (all green; Release + `-warnaserror` clean)

- `QueryParserTests.Parse_SlashedNodeTypeValue` — `Edu/Exercise`, `Store/Plugin`, `Store/Catalog` keep the whole value; no stray free-text token.
- `QuerySyntaxTests` — scoped (`path:… scope:descendants`) and unscoped single-partition `nodeType:Edu/Exercise` / `nodeType:Store/Plugin` return the seeded rows.
- `CrossPartitionSearchTests` — the **production cross-schema fan-out** (`PostgreSqlStorageAdapter.QueryNodesAcrossSchemasAsync` and the full `PostgreSqlPartitionedMeshQuery` orchestrator) returns slashed-type nodes across every partition.

No production code changed — the PR is orthogonal to #562 (per-subject permission fold); it merged cleanly with current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)