### PR TITLE
Harden startup: hub activation awaits its NodeType compile (no fresh-pod wedge) + pre-warm

### DIFF
--- a/memex/Memex.Portal.Monolith/Program.cs
+++ b/memex/Memex.Portal.Monolith/Program.cs
@@ -80,6 +80,10 @@ builder.UseMeshWeaver(
     }
 );
 
+// Front-load dynamic NodeType compiles at startup so a fresh process doesn't make the
+// first visitor of each type wait out a cold Roslyn compile (best-effort, non-blocking).
+builder.Services.AddDynamicTypePreWarming();
+
 var app = builder.Build();
 
 // Map Aspire default endpoints (health checks)

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -5,6 +5,7 @@ using Memex.Portal.Shared;
 using MeshWeaver.Hosting.Embeddings;
 using Microsoft.AspNetCore.DataProtection;
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Orleans;
 using MeshWeaver.Hosting.PostgreSql;
 using MeshWeaver.Messaging;
@@ -226,6 +227,12 @@ builder.Services.AddHostedService<Memex.Portal.Distributed.DbVersionGate>();
 // (e.g. someone manually rolled a partial migration via psql).
 builder.Services.AddHealthChecks()
     .AddCheck<Memex.Portal.Distributed.DbVersionHealthCheck>("db_version");
+
+// Front-load dynamic NodeType compiles at startup so a fresh pod (every image roll /
+// self-update spins one up) doesn't make the first visitor of each type wait out a cold
+// Roslyn compile. Best-effort, non-blocking, does NOT gate readiness — Part 2
+// (enrichment awaits the in-flight compile) handles anything still compiling on arrival.
+builder.Services.AddDynamicTypePreWarming();
 
 var app = builder.Build();
 

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -303,7 +303,7 @@ internal static class NodeTypeEnrichmentHelpers
                     "EnrichWithNodeType: self-heal Pending flip for {NodeType} faulted",
                     nodeType));
 
-        return typeStream
+        var settled = typeStream
             .Do(typeNode => logger?.LogInformation(
                 "[COMPILE-TRACE] Slow-path typeStream emission for {NodeType} (instance={InstancePath}): HubConfig={HasHub} Status={Status} Coll={Coll} Path={Path}",
                 nodeType, node.Path,
@@ -366,11 +366,79 @@ internal static class NodeTypeEnrichmentHelpers
                             && !string.IsNullOrEmpty(def.LatestAssemblyPath))
                         || def.CompilationStatus == CompilationStatus.Error))
                 || typeNode.Content is not NodeTypeDefinition)
-            .Take(1)
-            .Timeout(SlowPathTimeout)
+            .Take(1);
+
+        // 🚨 Fresh-pod wedge fix: DON'T cut short an in-flight compile with a fixed
+        // wall-clock. RunCompile ALWAYS writes a terminal Ok/Error, so once a compile
+        // is genuinely in flight the wait is bounded by the compile FINISHING — which
+        // on a cold pod compiling dozens of dynamic types (each queued on the Compile
+        // IoPool) legitimately runs past SlowPathTimeout. WaitForCompileSettled arms
+        // the wall-clock ONLY while nothing is compiling (the genuine "type is stuck /
+        // misconfigured, no compile coming" case → overlay, the graceful sink) and
+        // DISARMS it the moment a Pending/Compiling state is observed. Never a
+        // timeout-that-caches mid-compile (the wedge that a manual recycle had to heal).
+        return WaitForCompileSettled(
+                typeStream, settled, SlowPathTimeout,
+                () => new TimeoutException(
+                    $"NodeType '{nodeType}' has no compile in flight and did not settle " +
+                    $"within {SlowPathTimeout.TotalSeconds:0}s."))
             .Finally(healSub.Dispose)
             .SelectMany(typeNode => ApplyStreamResult(
                 typeNode, node, nodeType, meshConfiguration, compilationService, meshHub, logger));
+    }
+
+    /// <summary>
+    /// Wait for a NodeType's compile to reach a SETTLED terminal state (emitted by
+    /// <paramref name="settled"/>) WITHOUT cutting short a compile that is genuinely
+    /// in flight — the fresh-pod wedge fix.
+    ///
+    /// <para>Two-phase bound:
+    /// <list type="bullet">
+    ///   <item><b>Phase A — nothing compiling yet.</b> Bounded by
+    ///     <paramref name="noProgressBudget"/>: a terminal state ends the wait; if the
+    ///     budget elapses with NO compile ever going in flight the type is genuinely
+    ///     stuck/misconfigured → OnError, and the caller overlays the diagnostic (the
+    ///     graceful sink).</item>
+    ///   <item><b>Phase B — a compile IS in flight (Status Pending/Compiling).</b> The
+    ///     wall-clock is DISARMED; the wait is bounded by the compile FINISHING
+    ///     (<see cref="NodeTypeCompilationHelpers.RunCompile"/> always writes a terminal
+    ///     Ok/Error). A compile-in-progress is a WAIT, not a fault — so a cold pod
+    ///     compiling many dynamic types (each queued on the Compile IoPool far past
+    ///     <paramref name="noProgressBudget"/>) is never faulted-and-cached mid-compile
+    ///     (the wedge that previously required a manual recycle).</item>
+    /// </list></para>
+    ///
+    /// <para>Reactive-only: an <c>Observable.Timer</c> gated by <c>TakeUntil</c> on the
+    /// in-flight signal, merged with <paramref name="settled"/>. The timer never emits
+    /// OnNext, so <c>Merge</c> forwards only the settled node (or the timer's OnError
+    /// when Phase A elapses). <paramref name="scheduler"/> is for deterministic
+    /// virtual-time tests; production uses the default scheduler.</para>
+    /// </summary>
+    internal static IObservable<MeshNode> WaitForCompileSettled(
+        IObservable<MeshNode> typeStream,
+        IObservable<MeshNode> settled,
+        TimeSpan noProgressBudget,
+        Func<Exception> onNoProgress,
+        System.Reactive.Concurrency.IScheduler? scheduler = null)
+    {
+        // A compile is genuinely in flight for this NodeType — its terminal write is
+        // guaranteed by RunCompile, so the wait is bounded by the compile FINISHING,
+        // not a wall clock. Observing it DISARMS the no-progress deadline.
+        var compileInFlight = typeStream
+            .Where(t => t?.Content is NodeTypeDefinition d
+                && d.CompilationStatus is CompilationStatus.Pending
+                                       or CompilationStatus.Compiling)
+            .Take(1);
+
+        var noProgressDeadline = Observable
+            .Timer(noProgressBudget, scheduler ?? System.Reactive.Concurrency.Scheduler.Default)
+            .TakeUntil(compileInFlight)                 // disarm once a compile is running
+            .SelectMany(_ => Observable.Throw<MeshNode>(onNoProgress()));
+
+        // The timer never emits OnNext (only OnError, or it completes empty once
+        // disarmed), so the only value flowing through Merge is the settled node.
+        // Take(1) then unsubscribes the still-armed timer on the happy path.
+        return settled.Merge(noProgressDeadline).Take(1);
     }
 
     /// <summary>
@@ -713,7 +781,11 @@ internal static class NodeTypeEnrichmentHelpers
                     return curr;
                 }))
             .Take(1)
-            .SelectMany(_ => typeStream
+            // Same fresh-pod fix as BuildSlowPath: after the Ok→Pending flip above the
+            // recompile is in flight, so wait for it to FINISH — never fault-and-cache
+            // if the (possibly queue-delayed) compile outlasts the wall-clock. The
+            // wall-clock only bounds the case where no compile ever goes in flight.
+            .SelectMany(_ => WaitForCompileSettled(typeStream, typeStream
                 .Where(typeNode =>
                 {
                     if (typeNode.Content is not NodeTypeDefinition d)
@@ -769,8 +841,11 @@ internal static class NodeTypeEnrichmentHelpers
                             && !string.IsNullOrEmpty(d.LatestAssemblyCollection)
                             && !string.IsNullOrEmpty(d.LatestAssemblyPath));
                 })
-                .Take(1)
-                .Timeout(SlowPathTimeout)
+                .Take(1),
+                SlowPathTimeout,
+                () => new TimeoutException(
+                    $"NodeType '{nodeType}' recompile did not settle and no compile is " +
+                    $"in flight (within {SlowPathTimeout.TotalSeconds:0}s)."))
                 .SelectMany(newTypeNode => ApplyStreamResult(
                     newTypeNode, node, nodeType, meshConfiguration,
                     compilationService, meshHub, logger, recompileAttempts + 1)));

--- a/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
+++ b/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="MeshWeaver.Graph.Test" />
     <InternalsVisibleTo Include="MeshWeaver.Query.Test" />
+    <InternalsVisibleTo Include="MeshWeaver.Hosting" />
     <InternalsVisibleTo Include="MeshWeaver.Hosting.Monolith.Test" />
   </ItemGroup>
 

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -1,0 +1,177 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>Terminal outcome of pre-warming one dynamic NodeType's hub.</summary>
+public enum PreWarmStatus
+{
+    /// <summary>The NodeType reached a usable compiled build.</summary>
+    Compiled,
+    /// <summary>The NodeType's compile settled at Error (its diagnostics are already logged by the compile watcher).</summary>
+    CompileError,
+    /// <summary>The per-type warm budget elapsed before the compile settled — Part 2 handles the late arrival.</summary>
+    TimedOut,
+    /// <summary>The warm subscription faulted (best-effort — the lazy path still works).</summary>
+    Faulted
+}
+
+/// <summary>One dynamic NodeType's pre-warm result.</summary>
+public record PreWarmOutcome(string TypePath, PreWarmStatus Status, string? Detail = null);
+
+/// <summary>
+/// Best-effort, background PRE-WARM of dynamic NodeType hubs at startup (Part 1 of the
+/// fresh-pod compile-race hardening).
+///
+/// <para><b>The window it shrinks.</b> On a fresh pod — every image roll / self-update
+/// spins one up — the platform's <see cref="NodeTypeCompilationHelpers.FrameworkVersion"/>
+/// (Graph's MVID) changes, so every dynamic NodeType's cached assembly is ABI-stale and
+/// must recompile. Nothing drives that until the FIRST user request activates a per-node
+/// hub — so the unlucky first visitor of each type waits out the cold Roslyn compile.
+/// This warmer front-loads those compiles: it activates each dynamic NodeType's own hub
+/// (which fires the framework-stale / first-build kickoff → Roslyn), so the compiles run
+/// proactively rather than on a user's critical path.</para>
+///
+/// <para><b>Best-effort — never blocks, never wedges.</b> It runs on a background
+/// subscription after the silo is up (<c>ApplicationStarted</c>), bounds concurrency with
+/// a reactive <c>Merge(maxConcurrency)</c> (Roslyn itself is already serialized on the
+/// Compile IoPool, so this only caps how many activations are in flight), and gives each
+/// type a generous per-type budget. A type that fails to compile, times out, or faults is
+/// LOGGED and skipped — it does not block the others and it is NOT gated on. If any type
+/// is still compiling when a user arrives, Part 2
+/// (<see cref="NodeTypeEnrichmentHelpers.WaitForCompileSettled"/>) makes that activation
+/// WAIT for the compile instead of faulting — so the warmer is a latency optimisation, not
+/// a correctness dependency. It deliberately does NOT gate the readiness probe: a slow or
+/// broken compile must never keep a pod out of rotation (Part 2 already covers late
+/// arrivals), and a readiness gate would risk the exact "slow pod startup" it is meant to
+/// avoid.</para>
+/// </summary>
+public static class DynamicTypePreWarmer
+{
+    /// <summary>How many dynamic NodeType hubs to activate concurrently. The compiles
+    /// themselves serialize on the Compile IoPool; this just caps in-flight activations.</summary>
+    public const int DefaultMaxConcurrency = 4;
+
+    /// <summary>Per-type warm budget — generous, because a cold Roslyn compile queued behind
+    /// others on the Compile IoPool can legitimately take a while. On elapse we log
+    /// <see cref="PreWarmStatus.TimedOut"/> and move on (Part 2 handles the eventual arrival).</summary>
+    public static readonly TimeSpan DefaultPerTypeBudget = TimeSpan.FromMinutes(5);
+
+    /// <summary>Budget for the one-shot enumeration query of dynamic NodeTypes.</summary>
+    private static readonly TimeSpan EnumerationBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Enumerate the dynamic NodeTypes on the mesh and activate each one's hub, waiting
+    /// (best-effort, bounded) for its compile to settle. Emits one
+    /// <see cref="PreWarmOutcome"/> per type and completes when all have settled or timed
+    /// out. Never throws — enumeration/activation failures fold into an outcome or an empty
+    /// completion so a subscriber can simply log the summary.
+    /// </summary>
+    public static IObservable<PreWarmOutcome> WarmDynamicTypes(
+        IMessageHub mesh,
+        ILogger? logger = null,
+        int maxConcurrency = DefaultMaxConcurrency,
+        TimeSpan? perTypeBudget = null)
+    {
+        var budget = perTypeBudget ?? DefaultPerTypeBudget;
+        var meshService = mesh.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null)
+        {
+            logger?.LogDebug("DynamicTypePreWarmer: no IMeshService registered — nothing to warm");
+            return Observable.Empty<PreWarmOutcome>();
+        }
+        var accessService = mesh.ServiceProvider.GetService<AccessService>();
+        var workspace = mesh.GetWorkspace();
+
+        // 🚨 System-scoped: enumerating + activating dynamic NodeType defs across EVERY
+        // partition is infrastructure, not a user-attributable read (mirrors the enrichment
+        // probe + activation reads). Observable.Using holds the scope across the live
+        // subscription, not just the synchronous build.
+        return Observable.Using(
+            () => AccessContextScope.AsSystem(accessService),
+            _ => meshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
+                .Take(1)
+                .Timeout(EnumerationBudget)
+                .SelectMany(change =>
+                {
+                    var typePaths = change.Items
+                        .Where(n => !string.IsNullOrEmpty(n.Path)
+                            && n.State == MeshNodeState.Active
+                            && n.Content is NodeTypeDefinition d
+                            // Only DYNAMIC types have source to compile. Static/framework
+                            // NodeTypes ship their assembly with the process — nothing to warm.
+                            && HasCompilableSource(d))
+                        .Select(n => n.Path!)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+
+                    logger?.LogInformation(
+                        "DynamicTypePreWarmer: warming {Count} dynamic NodeType hub(s) (maxConcurrency={Max}, perTypeBudget={Budget})",
+                        typePaths.Length, maxConcurrency, budget);
+
+                    return typePaths.Length == 0
+                        ? Observable.Empty<PreWarmOutcome>()
+                        : typePaths
+                            .Select(p => WarmOne(workspace, accessService, p, budget, logger))
+                            .Merge(Math.Max(1, maxConcurrency));
+                })
+                .Catch<PreWarmOutcome, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "DynamicTypePreWarmer: enumeration of dynamic NodeTypes failed — pre-warm skipped (Part 2 still compiles lazily on first access)");
+                    return Observable.Empty<PreWarmOutcome>();
+                }));
+    }
+
+    /// <summary>A NodeType has something for Roslyn to compile (so it is a dynamic type worth warming).</summary>
+    private static bool HasCompilableSource(NodeTypeDefinition d) =>
+        !string.IsNullOrWhiteSpace(d.Configuration)
+        || !string.IsNullOrWhiteSpace(d.HubConfiguration)
+        || (d.Sources is { Count: > 0 });
+
+    /// <summary>
+    /// Activate one dynamic NodeType's hub by subscribing to its own MeshNode stream —
+    /// which routes a SubscribeRequest to the owning hub, activating it and firing the
+    /// compile watcher's framework-stale / first-build kickoff. Holds the subscription
+    /// (keeping the grain alive) until the compile reaches a usable build or Error, bounded
+    /// by <paramref name="budget"/>. Best-effort: every non-success folds into an outcome,
+    /// never an exception.
+    /// </summary>
+    private static IObservable<PreWarmOutcome> WarmOne(
+        IWorkspace workspace,
+        AccessService? accessService,
+        string typePath,
+        TimeSpan budget,
+        ILogger? logger)
+        => Observable.Using(
+                () => AccessContextScope.AsSystem(accessService),
+                _ => workspace.GetMeshNodeStream(typePath)
+                    .Where(n => n?.Content is NodeTypeDefinition d
+                        && (NodeTypeCompilationHelpers.HasUsableBuild(n, d)
+                            || d.CompilationStatus == CompilationStatus.Error))
+                    .Take(1)
+                    .Timeout(budget)
+                    .Select(n =>
+                    {
+                        var d = (NodeTypeDefinition)n!.Content!;
+                        return d.CompilationStatus == CompilationStatus.Error
+                            ? new PreWarmOutcome(typePath, PreWarmStatus.CompileError, d.CompilationError)
+                            : new PreWarmOutcome(typePath, PreWarmStatus.Compiled);
+                    }))
+            .Catch<PreWarmOutcome, Exception>(ex => Observable.Return(
+                ex is TimeoutException
+                    ? new PreWarmOutcome(typePath, PreWarmStatus.TimedOut)
+                    : new PreWarmOutcome(typePath, PreWarmStatus.Faulted, ex.Message)))
+            .Do(o => logger?.LogInformation(
+                "DynamicTypePreWarmer: {TypePath} → {Status}{Detail}",
+                o.TypePath, o.Status,
+                string.IsNullOrEmpty(o.Detail) ? "" : $" ({o.Detail})"));
+}

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -1,0 +1,107 @@
+using System.Reactive.Linq;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>
+/// Kicks <see cref="DynamicTypePreWarmer.WarmDynamicTypes"/> once, in the background, after
+/// the host has fully started (so the Orleans silo is up and grains can activate).
+///
+/// <para>Registered via <see cref="PreWarmServiceCollectionExtensions.AddDynamicTypePreWarming"/>
+/// — opt-in, portal-only. It is NOT wired into the shared <see cref="MeshHostApplicationBuilder"/>
+/// so tests and non-portal hosts never pay for a startup warm-up they don't want.</para>
+///
+/// <para><b>Never blocks host startup or readiness.</b> <see cref="StartAsync"/> returns
+/// immediately; the warm-up is launched from the <c>ApplicationStarted</c> callback and runs
+/// on a background Rx subscription. The subscription is torn down on shutdown.</para>
+/// </summary>
+public sealed class DynamicTypePreWarmerHostedService(
+    IServiceProvider services,
+    IHostApplicationLifetime lifetime,
+    ILogger<DynamicTypePreWarmerHostedService> logger) : IHostedService, IDisposable
+{
+    private IDisposable? _warmSubscription;
+    private IDisposable? _startedRegistration;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // ApplicationStarted fires only after EVERY hosted service (incl. the Orleans silo)
+        // has started — so grains can activate. Registering the kick here, rather than doing
+        // work in StartAsync, guarantees the silo is up without any ordering assumptions.
+        _startedRegistration = lifetime.ApplicationStarted.Register(KickWarmup);
+        return Task.CompletedTask;
+    }
+
+    private void KickWarmup()
+    {
+        var mesh = services.GetService<IMessageHub>();
+        if (mesh is null)
+        {
+            logger.LogDebug("DynamicTypePreWarmer: no mesh hub resolved — skipping startup warm-up");
+            return;
+        }
+
+        var startedAt = DateTimeOffset.UtcNow;
+        var compiled = 0;
+        var errored = 0;
+        var timedOut = 0;
+        var faulted = 0;
+
+        logger.LogInformation("DynamicTypePreWarmer: starting background warm-up of dynamic NodeType hubs");
+        _warmSubscription = DynamicTypePreWarmer
+            .WarmDynamicTypes(mesh, logger)
+            .Subscribe(
+                outcome =>
+                {
+                    switch (outcome.Status)
+                    {
+                        case PreWarmStatus.Compiled: Interlocked.Increment(ref compiled); break;
+                        case PreWarmStatus.CompileError: Interlocked.Increment(ref errored); break;
+                        case PreWarmStatus.TimedOut: Interlocked.Increment(ref timedOut); break;
+                        default: Interlocked.Increment(ref faulted); break;
+                    }
+                },
+                ex => logger.LogWarning(ex, "DynamicTypePreWarmer: warm-up stream faulted (best-effort — lazy compile still works)"),
+                () => logger.LogInformation(
+                    "DynamicTypePreWarmer: warm-up complete in {Elapsed} — compiled={Compiled} compileErrors={Errored} timedOut={TimedOut} faulted={Faulted}",
+                    DateTimeOffset.UtcNow - startedAt,
+                    Volatile.Read(ref compiled), Volatile.Read(ref errored),
+                    Volatile.Read(ref timedOut), Volatile.Read(ref faulted)));
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _startedRegistration?.Dispose();
+        _startedRegistration = null;
+        _warmSubscription?.Dispose();
+        _warmSubscription = null;
+    }
+}
+
+/// <summary>Opt-in registration for the dynamic-NodeType startup pre-warm (portal hosts).</summary>
+public static class PreWarmServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="DynamicTypePreWarmerHostedService"/> so the pod front-loads its
+    /// dynamic NodeType compiles at startup (Part 1 of the fresh-pod compile-race hardening).
+    /// Best-effort and non-blocking — safe to call from any portal host; a no-op if no mesh
+    /// hub / mesh service is present.
+    /// </summary>
+    public static IServiceCollection AddDynamicTypePreWarming(this IServiceCollection services)
+    {
+        services.AddHostedService<DynamicTypePreWarmerHostedService>();
+        return services;
+    }
+}

--- a/test/MeshWeaver.Graph.Test/CompileWaitDoesNotTimeoutTest.cs
+++ b/test/MeshWeaver.Graph.Test/CompileWaitDoesNotTimeoutTest.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Deterministic (virtual-time) pin for the fresh-pod wedge fix
+/// (<see cref="NodeTypeEnrichmentHelpers.WaitForCompileSettled"/>).
+///
+/// <para>The wedge: on a fresh pod every dynamic NodeType recompiles from source
+/// at once. A user request that activates a per-instance hub while that NodeType is
+/// still mid-compile used to hit a flat <c>SlowPathTimeout</c> wall-clock — it
+/// expired mid-compile, cached the compilation-error overlay onto the instance hub
+/// for its whole lifetime, and only a manual recycle could heal it.</para>
+///
+/// <para>The fix: a compile-in-progress is a WAIT, not a fault. Once a
+/// <c>Pending</c>/<c>Compiling</c> state is observed the wall-clock is DISARMED and
+/// the wait is bounded by the compile FINISHING (RunCompile always writes a terminal
+/// Ok/Error). The wall-clock still bounds the genuine "no compile is coming" case so
+/// a truly stuck/misconfigured type surfaces the diagnostic (the graceful sink).</para>
+///
+/// <para>Virtual time via <see cref="TestScheduler"/> — no <c>Task.Delay</c>, no real
+/// Roslyn compile; the scheduler lets a compile "take" far longer than the budget in
+/// zero wall-clock so the assertion is a pure state race, not a timing race.</para>
+/// </summary>
+public class CompileWaitDoesNotTimeoutTest
+{
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(60);
+
+    private static MeshNode Node(CompilationStatus? status, bool withAssembly = false,
+        string? configuration = null)
+        => new("DynamicType", "Test")
+        {
+            Content = new NodeTypeDefinition
+            {
+                CompilationStatus = status,
+                Configuration = configuration,
+                LatestAssemblyCollection = withAssembly ? "coll" : null,
+                LatestAssemblyPath = withAssembly ? "path" : null,
+            }
+        };
+
+    /// <summary>The BuildSlowPath terminal predicate, in miniature: Ok-with-assembly or Error.</summary>
+    private static bool IsSettled(MeshNode n)
+        => n.Content is NodeTypeDefinition d
+            && ((d.CompilationStatus == CompilationStatus.Ok
+                    && !string.IsNullOrEmpty(d.LatestAssemblyCollection)
+                    && !string.IsNullOrEmpty(d.LatestAssemblyPath))
+                || d.CompilationStatus == CompilationStatus.Error);
+
+    private static IObservable<MeshNode> Settled(IObservable<MeshNode> typeStream)
+        => typeStream.Where(IsSettled).Take(1);
+
+    /// <summary>
+    /// THE Part-2 contract: while a compile is in flight the wall-clock is disarmed —
+    /// the wait outlasts many multiples of the no-progress budget and only resolves
+    /// when the compile finally settles Ok. Before the fix the flat 60 s timeout fired
+    /// and cached the overlay; here we advance 5× the budget with the type still
+    /// Compiling and NOTHING resolves until the Ok write lands.
+    /// </summary>
+    [Fact]
+    public void InFlightCompile_WaitsPastWallClock_ThenEmitsOnTerminalOk()
+    {
+        var scheduler = new TestScheduler();
+        var typeStream = new Subject<MeshNode>();
+
+        MeshNode? emitted = null;
+        Exception? error = null;
+        NodeTypeEnrichmentHelpers
+            .WaitForCompileSettled(typeStream, Settled(typeStream), Budget,
+                () => new TimeoutException("no compile in flight"), scheduler)
+            .Subscribe(n => emitted = n, ex => error = ex);
+
+        // A compile is genuinely in flight — this DISARMS the wall-clock.
+        typeStream.OnNext(Node(CompilationStatus.Compiling));
+
+        // Advance FIVE budgets of virtual time. A flat wall-clock would have fired at
+        // one budget and cached the overlay; the disarmed timer must stay silent.
+        scheduler.AdvanceBy(Budget.Ticks * 5);
+        Assert.Null(error);
+        Assert.Null(emitted);
+
+        // The compile finally settles Ok — NOW the wait resolves.
+        var ok = Node(CompilationStatus.Ok, withAssembly: true);
+        typeStream.OnNext(ok);
+
+        Assert.Null(error);
+        Assert.Same(ok, emitted);
+    }
+
+    /// <summary>
+    /// An in-flight compile that fails LATE still surfaces the Error deterministically
+    /// (never a hang) so the caller can overlay the diagnostics — the
+    /// GrainActivationFailureRegistry/error path stays intact.
+    /// </summary>
+    [Fact]
+    public void InFlightCompile_ThatFailsLate_SurfacesError_NotHang()
+    {
+        var scheduler = new TestScheduler();
+        var typeStream = new Subject<MeshNode>();
+
+        MeshNode? emitted = null;
+        Exception? error = null;
+        NodeTypeEnrichmentHelpers
+            .WaitForCompileSettled(typeStream, Settled(typeStream), Budget,
+                () => new TimeoutException("no compile in flight"), scheduler)
+            .Subscribe(n => emitted = n, ex => error = ex);
+
+        typeStream.OnNext(Node(CompilationStatus.Pending));     // disarm
+        scheduler.AdvanceBy(Budget.Ticks * 3);
+        Assert.Null(error);
+        Assert.Null(emitted);
+
+        var failed = Node(CompilationStatus.Error);
+        typeStream.OnNext(failed);
+
+        Assert.Null(error);                     // the Error node is a VALUE, not a fault
+        Assert.Same(failed, emitted);           // caller applies the compilation-error overlay
+    }
+
+    /// <summary>
+    /// The graceful sink for the genuine "no compile is coming" case: a type stuck at
+    /// a non-settled, non-in-flight state (source present but no compile ever kicked)
+    /// still faults after the budget so the caller overlays a diagnostic — never an
+    /// infinite silent hang.
+    /// </summary>
+    [Fact]
+    public void NoCompileEverStarts_TimesOut_ForGracefulSink()
+    {
+        var scheduler = new TestScheduler();
+        var typeStream = new Subject<MeshNode>();
+
+        MeshNode? emitted = null;
+        Exception? error = null;
+        NodeTypeEnrichmentHelpers
+            .WaitForCompileSettled(typeStream, Settled(typeStream), Budget,
+                () => new TimeoutException("no compile in flight"), scheduler)
+            .Subscribe(n => emitted = n, ex => error = ex);
+
+        // Neither settled nor in-flight: sits waiting for a compile that never starts.
+        typeStream.OnNext(Node(status: null, configuration: "config => config"));
+
+        scheduler.AdvanceBy(Budget.Ticks + 1);
+
+        Assert.Null(emitted);
+        Assert.IsType<TimeoutException>(error);
+    }
+
+    /// <summary>
+    /// A NodeType that is already settled Ok at first observation resolves immediately
+    /// — the wall-clock never even starts to matter.
+    /// </summary>
+    [Fact]
+    public void AlreadySettled_EmitsImmediately_NoTimeout()
+    {
+        var scheduler = new TestScheduler();
+        var typeStream = new Subject<MeshNode>();
+
+        MeshNode? emitted = null;
+        Exception? error = null;
+        NodeTypeEnrichmentHelpers
+            .WaitForCompileSettled(typeStream, Settled(typeStream), Budget,
+                () => new TimeoutException("no compile in flight"), scheduler)
+            .Subscribe(n => emitted = n, ex => error = ex);
+
+        var ok = Node(CompilationStatus.Ok, withAssembly: true);
+        typeStream.OnNext(ok);
+
+        Assert.Same(ok, emitted);
+        Assert.Null(error);
+
+        // Even long past the budget nothing else fires (the timer was unsubscribed).
+        scheduler.AdvanceBy(Budget.Ticks * 5);
+        Assert.Null(error);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/MeshWeaver.Graph.Test.csproj
+++ b/test/MeshWeaver.Graph.Test/MeshWeaver.Graph.Test.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" />
+    <PackageReference Include="Microsoft.Reactive.Testing" />
     <PackageReference Include="Namotion.Reflection" />
     <PackageReference Include="NSubstitute" />
   </ItemGroup>

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Part 1 of the fresh-pod compile-race hardening: the startup pre-warm
+/// (<see cref="DynamicTypePreWarmer"/>) activates every dynamic NodeType's hub so its
+/// Roslyn compile is front-loaded rather than firing on a user's first request.
+///
+/// <para>The contract this pins: the warm-up ENUMERATES and drives ALL dynamic types,
+/// a type that fails to compile does NOT block a good one (both are reported, the good
+/// one reaches a usable build), and the whole thing COMPLETES within budget — it never
+/// hangs, so it could never wedge a readiness gate.</para>
+/// </summary>
+public class DynamicTypePreWarmerTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Partition = "PreWarmTest";
+    private const string GoodPath = $"{Partition}/GoodType";
+    private const string BrokenPath = $"{Partition}/BrokenType";
+
+    [Fact(Timeout = 120_000)]
+    public async Task WarmDynamicTypes_DrivesGoodType_AndBrokenTypeDoesNotBlockIt()
+    {
+        // A good dynamic type — a trivial identity Configuration compiles to a usable
+        // assembly (HasUsableBuild → true).
+        await NodeFactory.CreateNode(new MeshNode("GoodType", Partition)
+        {
+            Name = "Good Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Compiles cleanly.",
+                Configuration = "config => config"
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        // A broken dynamic type — invalid C#; its compile settles at Error.
+        await NodeFactory.CreateNode(new MeshNode("BrokenType", Partition)
+        {
+            Name = "Broken Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Never compiles.",
+                Configuration = "config => this is not valid C# at all (("
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        var logger = Mesh.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("PreWarmTest");
+
+        // Wait only for OUR two types among the outcomes (Take(2) + Timeout on the
+        // ASSERT). The broken type must not stop the good one from being reported — if
+        // a failure blocked the Merge, we'd never receive both and would time out.
+        var outcomes = await DynamicTypePreWarmer
+            .WarmDynamicTypes(Mesh, logger, maxConcurrency: 4, perTypeBudget: TimeSpan.FromSeconds(90))
+            .Where(o => o.TypePath == GoodPath || o.TypePath == BrokenPath)
+            .Take(2)
+            .ToList()
+            .Timeout(TimeSpan.FromSeconds(100))
+            .ToTask();
+
+        var good = outcomes.Single(o => o.TypePath == GoodPath);
+        var broken = outcomes.Single(o => o.TypePath == BrokenPath);
+
+        Output.WriteLine($"Good  → {good.Status} {good.Detail}");
+        Output.WriteLine($"Broken → {broken.Status} {broken.Detail}");
+
+        good.Status.Should().Be(PreWarmStatus.Compiled,
+            "the pre-warmer must drive a healthy dynamic type to a usable compiled build");
+        broken.Status.Should().Be(PreWarmStatus.CompileError,
+            "a non-compiling type surfaces a bounded CompileError — never a hang, never blocking the good type");
+    }
+}


### PR DESCRIPTION
## The defect class

Dynamic-typed nodes (`Store/Plugin`, `Edu/CourseInvite`, course roots, …) compile their NodeType from source **at runtime**. On a **fresh pod** (every image roll / self-update spins one up) the platform framework version (Graph's MVID) changes, so **every** dynamic type is ABI-stale and must recompile. When a user request activated a per-node hub while that node's TYPE was still mid-compile, enrichment hit a **flat 60s wall-clock** (`SlowPathTimeout`), the timeout expired mid-compile, and the compilation-error overlay was **cached onto the instance hub for its whole lifetime** — only a manual recycle could heal it (`AgenticEngineering/Install`, `Courses/Catalog`, course roots wedged this way repeatedly). PR #560 (breaker reset on recycle) made a recycle heal it, but the wedge **window** still hit whatever node a user opened first.

## Part 2 — the root cause: enrichment awaits the compile instead of timing out

`NodeTypeEnrichmentHelpers` no longer cuts short an in-flight compile with a fixed wall-clock. New `WaitForCompileSettled` splits the wait into two phases:

- **Phase A — nothing compiling yet:** bounded by `SlowPathTimeout`. A settled terminal state ends the wait; if the budget elapses with **no compile ever going in flight**, the type is genuinely stuck/misconfigured → surfaces the compilation-error overlay (the graceful sink).
- **Phase B — a compile IS in flight (`Pending`/`Compiling`):** the wall-clock is **DISARMED** the moment a compile is observed, and the wait is bounded by the compile **FINISHING** — `RunCompile` always writes a terminal `Ok`/`Error`, so this is a genuine bound, not an infinite hang. A compile-in-progress is a **WAIT, not a fault**, so a cold pod compiling dozens of dynamic types (each queued on the Compile IoPool far past 60s) is never faulted-and-cached mid-compile.

Reactive-only: `Observable.Timer(...).TakeUntil(compileInFlight)` merged with the settled view — the timer never emits `OnNext`, so `Merge` forwards only the settled node (or the timer's `OnError` in Phase A). Applied at **both** slow-path waits: `BuildSlowPath` and `TriggerRecompileAndRetry`. A genuine compile **Error** still faults deterministically with its diagnostics (the `GrainActivationFailureRegistry`/overlay-NACK path is unchanged).

## Part 1 — reduce the window: startup pre-warm

`DynamicTypePreWarmer` — a best-effort, **non-blocking** hosted service that, after the silo is up (`ApplicationStarted`), enumerates every dynamic NodeType and activates its hub so the Roslyn compile is front-loaded instead of firing on a user's first request. Bounded concurrency (reactive `Merge(maxConcurrency)`; the compiles themselves already serialize on the Compile IoPool), a generous per-type budget, System-scoped, fully logged. A type that fails/times out is logged and skipped — it never blocks the others.

It deliberately does **NOT gate the readiness probe**: a slow/broken compile must never keep a pod out of rotation, and Part 2 already makes any late arrival WAIT rather than fault. Wired opt-in (`AddDynamicTypePreWarming()`) into the Monolith + Distributed portals only — tests and other hosts are unaffected.

## Tests

- `CompileWaitDoesNotTimeoutTest` (Graph.Test, deterministic `TestScheduler` virtual time): in-flight compile disarms the wall-clock and waits past 5× the budget, then emits on terminal `Ok`; a late `Error` surfaces (not a hang); the genuine no-compile case still times out (graceful sink); an already-settled type emits immediately.
- `DynamicTypePreWarmerTest` (Monolith.Test integration): a broken dynamic type does **not** block a good one — both are reported, the good one reaches a usable build, the warm-up completes (no hang).
- Regressions green: `BrokenNodeTypeAccessTest`, `CodeEditRecompileTest`, `FrameworkStaleInstanceRenderTest`, `NodeTypeEnrichmentDoubleCallTest`.

All touched projects build clean under CI flags (`-c Release -p:CIRun=true -warnaserror`): Graph, Hosting, Hosting.Orleans, both portals, Graph.Test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)