### PR TITLE
Skills: configurable source list (AiSettings.SkillQueries) + node-type source + package install primitive

### DIFF
--- a/src/MeshWeaver.AI/AgentPickerProjection.cs
+++ b/src/MeshWeaver.AI/AgentPickerProjection.cs
@@ -85,18 +85,24 @@ public static class AgentPickerProjection
     public const string SkillSubNamespace = "Skill";
 
     /// <summary>Array form of <see cref="BuildSkillQuery"/> for the <c>hub.GetQuery</c> surface.</summary>
-    public static string[] BuildSkillQueries(string? userPath = null, string? spacePath = null)
-        => new[] { BuildSkillQuery(userPath, spacePath) };
+    public static string[] BuildSkillQueries(
+        string? userPath = null, string? spacePath = null, string? nodeTypePath = null)
+        => new[] { BuildSkillQuery(userPath, spacePath, nodeTypePath) };
 
     /// <summary>
     /// THE single canonical skill-registry query — IDENTICAL pattern to agents + models. Skills live in a
     /// dedicated <c>/Skill</c> sub-namespace PER PARTITION (platform <c>Skill</c> + <c>{space}/Skill</c> +
-    /// <c>{user}/Skill</c>), listed directly as a <c>namespace:A|B|C</c> exact-membership alternation — one
-    /// registry pattern for every public top-level domain (Agent, Model, Skill, …). Produces e.g.
-    /// <c>namespace:rbuergi/Skill|AgenticPension/Skill|Skill nodeType:Skill</c>.
+    /// <c>{typePartition}/Skill</c> + <c>{user}/Skill</c>), listed directly as a <c>namespace:A|B|C</c>
+    /// exact-membership alternation — one registry pattern for every public top-level domain
+    /// (Agent, Model, Skill, …). <paramref name="nodeTypePath"/> is the current node's TYPE path
+    /// (e.g. <c>Office/Slide</c>); its PARTITION contributes <c>Office/Skill</c>, so skills a plugin
+    /// ships next to its types resolve wherever those types are used. Produces e.g.
+    /// <c>namespace:rbuergi/Skill|AgenticPension/Skill|Office/Skill|Skill nodeType:Skill</c>.
     /// </summary>
-    public static string BuildSkillQuery(string? userPath = null, string? spacePath = null)
-        => BuildRegistryQuery(SkillNodeType.NodeType, SkillSubNamespace, userPath, spacePath, "");
+    public static string BuildSkillQuery(
+        string? userPath = null, string? spacePath = null, string? nodeTypePath = null)
+        => BuildRegistryQuery(SkillNodeType.NodeType, SkillSubNamespace, userPath, spacePath, "",
+            PartitionOf(nodeTypePath));
 
     // Rogue/reserved ROUTE partitions — auto-minted page artifacts (login, welcome, settings, …; mirrors
     // the reserved-schema list in PostgreSqlCrossSchemaQueryProvider). They carry NO read policy and never
@@ -123,7 +129,8 @@ public static class AgentPickerProjection
     /// flat, well-known namespace per partition, so there is no graph search.
     /// </summary>
     private static string BuildRegistryQuery(
-        string nodeType, string sub, string? userPath, string? spacePath, string extra)
+        string nodeType, string sub, string? userPath, string? spacePath, string extra,
+        string? typePartition = null)
     {
         var namespaces = new List<string>();
         void Add(string? partition)
@@ -136,6 +143,7 @@ public static class AgentPickerProjection
         }
         Add(userPath);
         Add(spacePath);
+        Add(typePartition); // the current node type's owning partition (skills shipped with a plugin)
         namespaces.Add(sub); // platform defaults — always present, last
         var nsClause = namespaces.Count > 1
             ? $"namespace:{string.Join("|", namespaces)}"

--- a/src/MeshWeaver.AI/AiSettings.cs
+++ b/src/MeshWeaver.AI/AiSettings.cs
@@ -33,4 +33,17 @@ public record AiSettings
     /// <c>{userPath}</c> tokens. Empty ⇒ <see cref="AgentPickerProjection.BuildModelQueries"/> defaults.
     /// </summary>
     public ImmutableArray<string> ModelQueries { get; init; } = ImmutableArray<string>.Empty;
+
+    /// <summary>
+    /// Skill discovery query TEMPLATES — the user's SKILL SOURCES, one query per row. Tokens:
+    /// <c>{currentPath}</c> (the current SPACE partition), <c>{nodeTypePath}</c> (the current node
+    /// type's partition) and <c>{userPath}</c> (the user's home); a template whose token has no value
+    /// in the current context is dropped (<see cref="AiSettingsNodeType.ResolveQueries"/>). Empty ⇒
+    /// the four defaults (<see cref="AiSettingsNodeType.DefaultSkillQueryTemplates"/>): global
+    /// <c>Skill</c> + <c>{space}/Skill</c> + <c>{typePartition}/Skill</c> + <c>{user}/Skill</c>.
+    /// Installing a SKILL PACKAGE appends its source here (e.g.
+    /// <c>namespace:Office/Skill nodeType:Skill</c>, <see cref="AiSettingsNodeType.MergeSkillSource"/>),
+    /// seeding the defaults first so adding a package never silently drops the standard sources.
+    /// </summary>
+    public ImmutableArray<string> SkillQueries { get; init; } = ImmutableArray<string>.Empty;
 }

--- a/src/MeshWeaver.AI/AiSettingsNodeType.cs
+++ b/src/MeshWeaver.AI/AiSettingsNodeType.cs
@@ -87,8 +87,110 @@ public static class AiSettingsNodeType
             ModelQueries = AgentPickerProjection
                 .BuildModelQueries(CurrentPathToken, NodeTypePathToken, null, UserPathToken)
                 .ToImmutableArray(),
+            SkillQueries = DefaultSkillQueryTemplates,
         };
     }
+
+    /// <summary>
+    /// The default SKILL SOURCES, one template ROW per source so each resolves (or drops) independently:
+    /// the platform <c>Skill</c> catalog, the current space's <c>{space}/Skill</c>, the current node
+    /// type's <c>{typePartition}/Skill</c> (skills a plugin ships next to its types), and the user's own
+    /// <c>{user}/Skill</c>. A skill package adds a fifth row (<see cref="MergeSkillSource"/>).
+    /// </summary>
+    public static readonly ImmutableArray<string> DefaultSkillQueryTemplates = ImmutableArray.Create(
+        $"namespace:{AgentPickerProjection.SkillSubNamespace} nodeType:{SkillNodeType.NodeType}",
+        $"namespace:{CurrentPathToken}/{AgentPickerProjection.SkillSubNamespace} nodeType:{SkillNodeType.NodeType}",
+        $"namespace:{NodeTypePathToken}/{AgentPickerProjection.SkillSubNamespace} nodeType:{SkillNodeType.NodeType}",
+        $"namespace:{UserPathToken}/{AgentPickerProjection.SkillSubNamespace} nodeType:{SkillNodeType.NodeType}");
+
+    /// <summary>
+    /// Resolves the user's skill sources for a context: takes <see cref="AiSettings.SkillQueries"/>
+    /// (empty ⇒ <see cref="DefaultSkillQueryTemplates"/>), substitutes <c>{currentPath}</c> with the
+    /// context's PARTITION, <c>{nodeTypePath}</c> with the node type's PARTITION and <c>{userPath}</c>
+    /// with the user's home (reserved/rogue partitions nulled so a poisoned context can't break the
+    /// query), drops rows whose token has no value, and dedupes. Falls back to the canonical
+    /// <see cref="SkillNodeType.SkillQueries"/> defaults if everything resolves away.
+    /// </summary>
+    public static string[] ResolveSkillQueries(
+        AiSettings? settings, string? contextPath, string? nodeTypePath, string? userPath)
+    {
+        var templates = settings is { SkillQueries.IsDefaultOrEmpty: false }
+            ? settings.SkillQueries.AsEnumerable()
+            : DefaultSkillQueryTemplates;
+        string? Partition(string? path)
+            => AgentPickerProjection.IsReservedPartition(path) ? null : AgentPickerProjection.PartitionOf(path);
+        var resolved = ResolveQueries(templates, Partition(contextPath), Partition(nodeTypePath), userPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return resolved.Length > 0
+            ? resolved
+            : SkillNodeType.SkillQueries(contextPath, userPath, nodeTypePath);
+    }
+
+    /// <summary>
+    /// Pure merge for "install this skill package": appends the package's source query
+    /// (<c>namespace:{sourceNamespace} nodeType:Skill</c>) to <see cref="AiSettings.SkillQueries"/>.
+    /// When the list is still empty (= "code defaults"), it is seeded with
+    /// <see cref="DefaultSkillQueryTemplates"/> FIRST so adding a package never silently drops the
+    /// standard sources. Idempotent — an already-present source (case-insensitive) is not duplicated.
+    /// </summary>
+    public static AiSettings MergeSkillSource(AiSettings settings, string sourceNamespace)
+    {
+        var rows = settings.SkillQueries.IsDefaultOrEmpty
+            ? DefaultSkillQueryTemplates
+            : settings.SkillQueries;
+        var query = $"namespace:{sourceNamespace} nodeType:{SkillNodeType.NodeType}";
+        return rows.Contains(query, StringComparer.OrdinalIgnoreCase)
+            ? settings with { SkillQueries = rows }
+            : settings with { SkillQueries = rows.Add(query) };
+    }
+
+    /// <summary>
+    /// Installs a SKILL PACKAGE for <paramref name="user"/>: appends the package's skill folder (e.g.
+    /// <c>Office/Skill</c>) to the user's <see cref="AiSettings.SkillQueries"/> sources — idempotent,
+    /// fire-and-forget, same keyed-query read discipline as <see cref="EnsureExists"/> (never a
+    /// point-read of a possibly-absent node).
+    /// </summary>
+    public static void AddSkillSource(
+        IMessageHub hub, IServiceProvider services, string user, string sourceNamespace)
+    {
+        var meshService = services.GetService<IMeshService>();
+        if (meshService is null || string.IsNullOrEmpty(user) || string.IsNullOrEmpty(sourceNamespace))
+            return;
+        var path = PathFor(user);
+        hub.GetWorkspace()
+            .GetQuery($"{NodeType}|{user}", $"path:{path} nodeType:{NodeType}")
+            .Take(1)
+            .SelectMany(nodes =>
+            {
+                var node = nodes.FirstOrDefault(n =>
+                    string.Equals(n.NodeType, NodeType, StringComparison.OrdinalIgnoreCase));
+                var current = Effective(node, BuildDefaults(services), hub.JsonSerializerOptions);
+                var merged = MergeSkillSource(current, sourceNamespace);
+                var target = node ?? MeshNode.FromPath(path) with { NodeType = NodeType, Name = "AI Settings" };
+                return meshService.CreateOrUpdateNode(target with { Content = merged });
+            })
+            .Subscribe(
+                _ => { },
+                ex => services.GetService<ILoggerFactory>()
+                    ?.CreateLogger(typeof(AiSettingsNodeType))
+                    .LogWarning(ex, "AddSkillSource: appending {Source} for {Path} failed",
+                        sourceNamespace, path));
+    }
+
+    /// <summary>
+    /// The LIVE resolved skill queries for a user + context — the reactive form the skill surfaces
+    /// (slash autocomplete, slash execution) consume: observes the user's <see cref="AiSettings"/>
+    /// (defaults when there is no signed-in user) and re-resolves the source templates on change.
+    /// </summary>
+    public static IObservable<string[]> ObserveSkillQueries(
+        IWorkspace workspace, IMessageHub hub, IServiceProvider services,
+        string? user, string? contextPath, string? nodeTypePath)
+        => string.IsNullOrEmpty(user)
+            ? Observable.Return(ResolveSkillQueries(null, contextPath, nodeTypePath, user))
+            : Observe(workspace, hub, services, user!)
+                .Select(settings => ResolveSkillQueries(settings, contextPath, nodeTypePath, user))
+                .DistinctUntilChanged(qs => string.Join("\n", qs));
 
     private const string CurrentPathToken = "{currentPath}";
     private const string NodeTypePathToken = "{nodeTypePath}";

--- a/src/MeshWeaver.AI/Completion/SkillAutocompleteProvider.cs
+++ b/src/MeshWeaver.AI/Completion/SkillAutocompleteProvider.cs
@@ -45,11 +45,23 @@ public class SkillAutocompleteProvider : IAutocompleteProvider
         // subscription isn't shared across identities.
         var accessService = _serviceProvider.GetService<AccessService>();
         var userHome = AgentPickerProjection.ResolveUserHome(accessService);
-        var queries = BuildQueries(accessService, contextPath);
-        return AgentPickerProjection.ObserveSnapshot(
-                workspace, hub, $"skill-autocomplete|{contextPath}|{userHome}", queries)
+        // The user's SKILL SOURCES are configurable (AiSettings.SkillQueries — one query row per
+        // source, defaulting to global/space/type/user; installing a skill package appends its row).
+        // Observe the settings and Switch to the resolved query set; the cache id carries the
+        // query-set key so different source sets never share a snapshot entry.
+        return AiSettingsNodeType
+            .ObserveSkillQueries(workspace, hub, _serviceProvider, userHome, contextPath, nodeTypePath: null)
+            .Select(queries => AgentPickerProjection.ObserveSnapshot(
+                workspace, hub,
+                $"skill-autocomplete|{contextPath}|{userHome}|{QueryKey(queries)}", queries))
+            .Switch()
             .Select(snapshot => BuildItems(snapshot, hub));
     }
+
+    /// <summary>Stable in-process key for a resolved query set — distinct source sets must not share a
+    /// synced-query cache entry (the cache is keyed by id + user).</summary>
+    private static string QueryKey(string[] queries)
+        => string.Join("|", queries).GetHashCode().ToString("x8");
 
     /// <summary>
     /// The skill-autocomplete query union: the platform <c>Skill</c> catalog plus the current space's

--- a/src/MeshWeaver.AI/SkillNodeType.cs
+++ b/src/MeshWeaver.AI/SkillNodeType.cs
@@ -73,14 +73,20 @@ public static class SkillNodeType
     };
 
     /// <summary>
-    /// The query that discovers the skills available in a context — the SAME unified registry pattern as
-    /// agents and models: platform <c>Skill</c> + the current space's <c>{space}/Skill</c> + the user's
-    /// <c>{user}/Skill</c>, as one <c>namespace:A|B|C</c> exact-membership query
-    /// (<see cref="AgentPickerProjection.BuildSkillQueries"/>). <paramref name="contextPath"/> names the
-    /// space (its partition); <paramref name="userPath"/> the user's home.
+    /// The DEFAULT query that discovers the skills available in a context — the SAME unified registry
+    /// pattern as agents and models: platform <c>Skill</c> + the current space's <c>{space}/Skill</c> +
+    /// the current node type's <c>{typePartition}/Skill</c> + the user's <c>{user}/Skill</c>, as one
+    /// <c>namespace:A|B|C</c> exact-membership query (<see cref="AgentPickerProjection.BuildSkillQueries"/>).
+    /// <paramref name="contextPath"/> names the space (its partition); <paramref name="nodeTypePath"/> the
+    /// current node's TYPE path (its partition contributes the plugin-shipped skills, e.g. a node of type
+    /// <c>Office/Slide</c> surfaces <c>Office/Skill/*</c>); <paramref name="userPath"/> the user's home.
+    /// A user overrides/extends this default set via <see cref="AiSettings.SkillQueries"/> — resolved by
+    /// <see cref="AiSettingsNodeType.ResolveSkillQueries"/>, which falls back to exactly this builder.
     /// </summary>
-    public static string[] SkillQueries(string? contextPath, string? userPath)
-        => AgentPickerProjection.BuildSkillQueries(userPath, AgentPickerProjection.PartitionOf(contextPath));
+    public static string[] SkillQueries(
+        string? contextPath, string? userPath, string? nodeTypePath = null)
+        => AgentPickerProjection.BuildSkillQueries(
+            userPath, AgentPickerProjection.PartitionOf(contextPath), nodeTypePath);
 
     /// <summary>
     /// Projects a mesh-node snapshot into the available skills, deduped by id (the slash word). Reads

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -1829,12 +1829,22 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             return;
         }
 
-        var queries = MeshWeaver.AI.SkillNodeType.SkillQueries(initialContext, _userHome);
+        // The user's SKILL SOURCES are configurable (AiSettings.SkillQueries — one query row per
+        // source, defaulting to global/space/type/user; installing a skill package appends its row).
+        // The node-type source comes from the resolved picker context, same as the model picker; the
+        // cache id carries the query-set key so different source sets never share a snapshot entry.
+        var picker = AgentPickerProjection.DerivePickerContext(_currentNavContext, initialContext);
+        var skillSnapshots = MeshWeaver.AI.AiSettingsNodeType
+            .ObserveSkillQueries(workspace, Hub, Hub.ServiceProvider, _userHome, initialContext, picker.NodeTypePath)
+            .Select(queries => AgentPickerProjection.ObserveSnapshot(
+                workspace, Hub,
+                $"skills|{initialContext}|{_userHome}|{string.Join("|", queries).GetHashCode():x8}", queries))
+            .Switch();
         // Run the skill-resolve read under the durable circuit user — this method is reached from
         // SubmitMessageCore via InvokeAsync and the query fans out on the synced-query scheduler where
         // the AsyncLocal context is gone; context-null here makes the /command either resolve nothing
         // ("Unknown command") or surface skills the user can't read. RunUnderCircuitUser mirrors RunPicker.
-        RunUnderCircuitUser(AgentPickerProjection.ObserveSnapshot(workspace, Hub, $"skills|{initialContext}|{_userHome}", queries))
+        RunUnderCircuitUser(skillSnapshots)
             .Take(1)
             .Timeout(TimeSpan.FromSeconds(5))
             .Subscribe(

--- a/test/MeshWeaver.AI.Test/AgentPickerQueriesTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentPickerQueriesTest.cs
@@ -349,4 +349,82 @@ public class AgentPickerQueriesTest
             .Should().ContainSingle().Which.Should()
             .Be("namespace:AgenticPension/Skill|Skill nodeType:Skill");
     }
+
+    // ─── Skill sources: node-type partition + user-configurable query rows (AiSettings.SkillQueries) ───
+
+    [Fact]
+    public void BuildSkillQuery_NodeTypePath_AddsTypePartition()
+    {
+        // A node of type Office/Slide surfaces the skills its plugin ships next to its types —
+        // the TYPE path's PARTITION contributes {typePartition}/Skill to the default union.
+        AgentPickerProjection.BuildSkillQuery("rbuergi", "AgenticPension", "Office/Slide")
+            .Should().Be("namespace:rbuergi/Skill|AgenticPension/Skill|Office/Skill|Skill nodeType:Skill");
+    }
+
+    [Fact]
+    public void BuildSkillQuery_ReservedTypePartition_IsSkipped()
+    {
+        AgentPickerProjection.BuildSkillQuery("rbuergi", nodeTypePath: "settings/Whatever")
+            .Should().Be("namespace:rbuergi/Skill|Skill nodeType:Skill");
+    }
+
+    [Fact]
+    public void ResolveSkillQueries_Defaults_OneRowPerAvailableSource()
+    {
+        // Empty settings ⇒ the four default template rows; each resolves (or drops) independently.
+        AiSettingsNodeType.ResolveSkillQueries(
+                new AiSettings(), "AgenticPension/Foo/_Thread/x", "Office/Slide", "rbuergi")
+            .Should().Equal(
+                "namespace:Skill nodeType:Skill",
+                "namespace:AgenticPension/Skill nodeType:Skill",
+                "namespace:Office/Skill nodeType:Skill",
+                "namespace:rbuergi/Skill nodeType:Skill");
+    }
+
+    [Fact]
+    public void ResolveSkillQueries_MissingContext_DropsOnlyThatRow()
+    {
+        // No node type, no space ⇒ those rows drop; global + user remain. Null settings = defaults.
+        AiSettingsNodeType.ResolveSkillQueries(null, contextPath: null, nodeTypePath: null, userPath: "rbuergi")
+            .Should().Equal(
+                "namespace:Skill nodeType:Skill",
+                "namespace:rbuergi/Skill nodeType:Skill");
+    }
+
+    [Fact]
+    public void ResolveSkillQueries_CustomRows_ReplaceDefaults()
+    {
+        // A user-authored source list REPLACES the defaults (empty ⇒ defaults semantics), exactly
+        // like AgentQueries/ModelQueries. Package sources are plain literal rows.
+        var settings = new AiSettings
+        {
+            SkillQueries = System.Collections.Immutable.ImmutableArray.Create(
+                "namespace:Skill nodeType:Skill",
+                "namespace:Office/Skill nodeType:Skill"),
+        };
+        AiSettingsNodeType.ResolveSkillQueries(settings, "AgenticPension", "Chess/Game", "rbuergi")
+            .Should().Equal(
+                "namespace:Skill nodeType:Skill",
+                "namespace:Office/Skill nodeType:Skill");
+    }
+
+    [Fact]
+    public void MergeSkillSource_EmptyList_SeedsDefaultsThenAppends()
+    {
+        // Installing a package on pristine settings must not silently drop the standard sources:
+        // the defaults are seeded first, then the package row appended.
+        var merged = AiSettingsNodeType.MergeSkillSource(new AiSettings(), "Office/Skill");
+        merged.SkillQueries.Should().HaveCount(AiSettingsNodeType.DefaultSkillQueryTemplates.Length + 1);
+        merged.SkillQueries.Take(AiSettingsNodeType.DefaultSkillQueryTemplates.Length)
+            .Should().Equal(AiSettingsNodeType.DefaultSkillQueryTemplates);
+        merged.SkillQueries[^1].Should().Be("namespace:Office/Skill nodeType:Skill");
+    }
+
+    [Fact]
+    public void MergeSkillSource_IsIdempotent()
+    {
+        var once = AiSettingsNodeType.MergeSkillSource(new AiSettings(), "Office/Skill");
+        var twice = AiSettingsNodeType.MergeSkillSource(once, "Office/Skill");
+        twice.SkillQueries.Should().Equal(once.SkillQueries);
+    }
 }


### PR DESCRIPTION
Implements the **skill-sources mechanism**: skill discovery becomes a per-user **list of query rows** — by default global / current space / current node type / user — extensible with more paths, so **skill packages** (e.g. the new `Office/Skill/*`) can be installed per user.

## Design (as specified)
> "a list of query strings, where, by default, we will put the ones for global, current space, current node type and user (`/Skill`, `/MySpace/Skill`, `/rbuergi/Skill`, …) — and in there we should be able to add more paths; skill packages can be added there."

It rides the **existing** `AiSettings` template surface (`AgentQueries`/`ModelQueries` precedent — same record, same `{currentPath}/{nodeTypePath}/{userPath}` tokens, same per-user node, same auto-bound settings page):

- **`AiSettings.SkillQueries`** — one query per row; empty ⇒ the four `DefaultSkillQueryTemplates`. Rows resolve independently: a token with no value in context drops just that row.
- **New default source `{typePartition}/Skill`** — a node of type `Office/Slide` surfaces `Office/Skill/*`: skills a plugin ships next to its types resolve wherever those types are used.
- **`MergeSkillSource` / `AddSkillSource`** — the package-install primitive: appends `namespace:{pkg}/Skill nodeType:Skill`, seeding the defaults first (a package install never silently drops the standard sources). Idempotent; keyed-query read discipline (no point-read of a possibly-absent node — the AiSettings NotFound-storm lesson).
- **Both consumers rewired** (slash autocomplete + slash execution): observe the resolved source set, `Switch` to the snapshot, query-set key in the synced-query cache id (distinct source sets never share a cache entry). The slash-run site feeds the node-type partition from `DerivePickerContext`, same as the model picker.

## Tests
7 new in `AgentPickerQueriesTest` — **36/36 green**: type-partition union + reserved filtering, per-row default resolution incl. drop-empty, custom rows replace defaults, merge seeds-then-appends, idempotency.

## Companion (already merged in MeshWeaver.Plugins)
- The global `Skill/` folder is now GitSynced into the plugins repo (`Skill/` subdirectory).
- Plugins PR #96: `Slides` → **Office** package shipping `Office/Skill/{multipart-doc, pdf-package, presentation, slide}` — the first skill package this mechanism installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)