### PR TITLE
Home: flat first-level catalog, last-accessed default + user sort, and a data-driven admin-editable HomeConfig

### DIFF
--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
@@ -73,6 +73,18 @@
                     }
                 </select>
             </label>
+            @if (HasSortOptions)
+            {
+                <label class="mesh-search-viewbar-field">
+                    <span class="mesh-search-viewbar-label">Sort by</span>
+                    <select class="mesh-search-sortby" @bind="SortBySelection">
+                        @foreach (var opt in BoundSortOptions)
+                        {
+                            <option value="@opt.Query">@opt.Label</option>
+                        }
+                    </select>
+                </label>
+            }
             <div class="mesh-search-viewbar-spacer"></div>
             <div class="mesh-search-viewbar-menu-wrap">
                 <button type="button" class="mesh-search-viewbar-menu-btn" title="Display options"

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor
@@ -80,7 +80,7 @@
                     <select class="mesh-search-sortby" @bind="SortBySelection">
                         @foreach (var opt in BoundSortOptions)
                         {
-                            <option value="@opt.Query">@opt.Label</option>
+                            <option value="@opt.Label">@opt.Label</option>
                         }
                     </select>
                 </label>

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
@@ -284,8 +284,8 @@ public partial class MeshSearchView : IDisposable
     }
 
     // ----- Sort-by dropdown (view-options) -----
-    // The selected option's Query (an override of the hidden query). null ⇒ the default (first) option.
-    private string? _viewSortQuery;
+    // The selected option's Label. null ⇒ the default (first) option.
+    private string? _viewSortLabel;
 
     /// <summary>The user-selectable sort choices supplied by the control (empty ⇒ no Sort-by dropdown).</summary>
     private IReadOnlyList<MeshSearchSortOption> BoundSortOptions => ViewModel?.SortOptions ?? [];
@@ -294,21 +294,23 @@ public partial class MeshSearchView : IDisposable
     private bool HasSortOptions => BoundSortOptions.Count > 0;
 
     /// <summary>
-    /// Two-way bound value of the Sort-by dropdown — the selected option's full hidden query. Unlike
-    /// Group-by (a client-side re-bucket), a sort choice can change BOTH the ordering and the result set
-    /// (e.g. "Last accessed" uses <c>source:accessed</c>), so setting it swaps the hidden query and
-    /// re-queries via the same <c>_overriddenHiddenQuery</c> path the search-options editor uses.
+    /// Two-way bound value of the Sort-by dropdown — the selected option's Label. Unlike Group-by (a
+    /// client-side re-bucket), a sort choice can change BOTH the ordering and the result set (e.g. "Last
+    /// accessed" uses <c>source:accessed</c>; an option's query may even be a newline-joined union — see
+    /// <see cref="BuildQueryRequest"/>), so setting it swaps the hidden query and re-queries via the same
+    /// <c>_overriddenHiddenQuery</c> path the search-options editor uses.
     /// </summary>
     private string SortBySelection
     {
-        get => _viewSortQuery ?? BoundSortOptions.FirstOrDefault()?.Query ?? BoundHiddenQuery;
+        get => _viewSortLabel ?? BoundSortOptions.FirstOrDefault()?.Label ?? "";
         set
         {
-            if (string.IsNullOrEmpty(value) || value == SortBySelection)
+            var option = BoundSortOptions.FirstOrDefault(o => o.Label == value);
+            if (option is null || value == SortBySelection)
                 return;
-            _viewSortQuery = value;
-            _overriddenHiddenQuery = value;
-            _lastBoundHiddenQuery = value; // keep OnParametersSet from re-triggering on the same change
+            _viewSortLabel = value;
+            _overriddenHiddenQuery = option.Query;
+            _lastBoundHiddenQuery = option.Query; // keep OnParametersSet from re-triggering on the same change
             if (IsPrecomputedMode)
                 return;
             if (IsNamespaceTreeMode)
@@ -603,8 +605,7 @@ public partial class MeshSearchView : IDisposable
     {
         _reactiveSubscription?.Dispose();
         var accumulator = _resultAccumulator = new SearchResultAccumulator();
-        var query = BuildFullQuery();
-        _reactiveSubscription = MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery(query))
+        _reactiveSubscription = MeshQuery.Query<MeshNode>(BuildQueryRequest())
             .Subscribe(
                 change =>
                 {
@@ -883,6 +884,28 @@ public partial class MeshSearchView : IDisposable
             parts.Add(_currentValue.Trim());
 
         return string.Join(" ", parts);
+    }
+
+    /// <summary>
+    /// Builds the query request for the main result stream. A hidden query may declare a UNION of
+    /// sub-queries, one per LINE (e.g. the home catalog's first-level index — "partition roots the user
+    /// can read" on one line, "the user's home direct children" on another). Each sub-query is combined
+    /// with the current visible search term and the engine yields their path-keyed union as a single
+    /// live snapshot (sort/limit taken from the FIRST sub-query). A single-line hidden query keeps the
+    /// plain single-query path (<see cref="BuildFullQuery"/>).
+    /// </summary>
+    private MeshQueryRequest BuildQueryRequest()
+    {
+        var subQueries = BoundHiddenQuery
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (subQueries.Length <= 1)
+            return MeshQueryRequest.FromQuery(BuildFullQuery());
+
+        var visible = string.IsNullOrWhiteSpace(_currentValue) ? null : _currentValue.Trim();
+        var unioned = subQueries
+            .Select(q => visible is null ? q : $"{q} {visible}")
+            .ToArray();
+        return MeshQueryRequest.FromQueries(unioned);
     }
 
     private const int CompletionLimit = 20;

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.cs
@@ -283,6 +283,43 @@ public partial class MeshSearchView : IDisposable
         }
     }
 
+    // ----- Sort-by dropdown (view-options) -----
+    // The selected option's Query (an override of the hidden query). null ⇒ the default (first) option.
+    private string? _viewSortQuery;
+
+    /// <summary>The user-selectable sort choices supplied by the control (empty ⇒ no Sort-by dropdown).</summary>
+    private IReadOnlyList<MeshSearchSortOption> BoundSortOptions => ViewModel?.SortOptions ?? [];
+
+    /// <summary>Render the Sort-by dropdown only when the control declares options.</summary>
+    private bool HasSortOptions => BoundSortOptions.Count > 0;
+
+    /// <summary>
+    /// Two-way bound value of the Sort-by dropdown — the selected option's full hidden query. Unlike
+    /// Group-by (a client-side re-bucket), a sort choice can change BOTH the ordering and the result set
+    /// (e.g. "Last accessed" uses <c>source:accessed</c>), so setting it swaps the hidden query and
+    /// re-queries via the same <c>_overriddenHiddenQuery</c> path the search-options editor uses.
+    /// </summary>
+    private string SortBySelection
+    {
+        get => _viewSortQuery ?? BoundSortOptions.FirstOrDefault()?.Query ?? BoundHiddenQuery;
+        set
+        {
+            if (string.IsNullOrEmpty(value) || value == SortBySelection)
+                return;
+            _viewSortQuery = value;
+            _overriddenHiddenQuery = value;
+            _lastBoundHiddenQuery = value; // keep OnParametersSet from re-triggering on the same change
+            if (IsPrecomputedMode)
+                return;
+            if (IsNamespaceTreeMode)
+                ResetTree();
+            else if (IsGraphNavigatorMode)
+                ResetGraphNavigator();
+            else
+                LoadResults();
+        }
+    }
+
     /// <summary>Section counts after applying the display-menu override.</summary>
     private bool EffectiveShowCounts =>
         _showCountsOverride ?? (BoundSections?.ShowCounts ?? true);

--- a/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.css
+++ b/src/MeshWeaver.Blazor/Components/MeshSearchView.razor.css
@@ -97,7 +97,8 @@
     color: var(--neutral-foreground-hint, #666);
 }
 
-.mesh-search-groupby {
+.mesh-search-groupby,
+.mesh-search-sortby {
     font-size: 13px;
     padding: 3px 24px 3px 8px;
     height: 28px;
@@ -108,7 +109,8 @@
     cursor: pointer;
 }
 
-.mesh-search-groupby:hover {
+.mesh-search-groupby:hover,
+.mesh-search-sortby:hover {
     border-color: var(--accent-fill-rest, #0078d4);
 }
 

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -62,6 +62,7 @@ public static class GraphConfigurationExtensions
                 .AddActivityType()
                 .AddUserActivityType()
                 .AddHomeTabType()
+                .AddHomeConfigType()
                 .AddKernel()
                 .AddApiTokenType()
                 .AddMeshDataSourceType()

--- a/src/MeshWeaver.Graph/Configuration/HomeConfigNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/HomeConfigNodeType.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The DATA-DRIVEN default home config — a single well-known platform node an admin edits IN-PLATFORM
+/// (no code change, no image roll) to change how every user's home catalog lists content. The node
+/// lives in the <b>Admin</b> partition (<see cref="ConfigPath"/>) where platform admins have standing
+/// write, and is <b>public-read</b> so every user's home can read it. The home reads it REACTIVELY (via
+/// the shared, per-user-RLS, empty-on-absent <c>GetQuery</c> cache — never a point-read that could
+/// NotFound-storm), so an admin's edit updates every open home live. When the node is absent — or any
+/// field is unset — the shipped <see cref="Defaults"/> apply (<b>FirstLevel + Flat + LastAccessed</b>),
+/// so nothing regresses without the node. See <see cref="HomeConfig"/>.
+/// </summary>
+public static class HomeConfigNodeType
+{
+    /// <summary>The NodeType discriminator.</summary>
+    public const string NodeType = "HomeConfig";
+
+    /// <summary>The singleton instance id.</summary>
+    public const string NodeId = "HomeConfig";
+
+    /// <summary>The Admin partition that holds the platform config node.</summary>
+    public const string AdminPartition = "Admin";
+
+    /// <summary>The well-known singleton path: <c>Admin/HomeConfig</c>.</summary>
+    public const string ConfigPath = AdminPartition + "/" + NodeId;
+
+    /// <summary>The shipped defaults, applied whenever the config node is absent or a field is unset.</summary>
+    public static HomeConfig Defaults { get; } = new();
+
+    /// <summary>
+    /// Registers the HomeConfig node type + typed content, makes it public-read (every home reads it),
+    /// wires the safe node-bound Edit form, and seeds the singleton with defaults so an admin has an
+    /// editable node immediately.
+    /// </summary>
+    public static TBuilder AddHomeConfigType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        builder.AddAutocompleteExcludedTypes(NodeType);
+        // Typed content so the home reads HomeConfig (not raw JSON) and the Edit form binds its fields.
+        builder.ConfigureHub(config => config.WithType<HomeConfig>(nameof(HomeConfig)));
+        // Platform config: readable by every user's home; only admins (Admin partition) can WRITE it.
+        builder.ConfigureNodeTypeAccess(a => a.WithPublicRead(NodeType));
+        // Seed the singleton with defaults (the GlobalSettings _Setting pattern) so it's editable at
+        // once. If a backend doesn't materialise this Admin-partition seed, the in-code Defaults keep
+        // the home correct and an admin can create the node in-platform.
+        builder.AddMeshNodes(new MeshNode(NodeId, AdminPartition)
+        {
+            Name = "Home Page",
+            NodeType = NodeType,
+            State = MeshNodeState.Active,
+            Content = new HomeConfig(),
+            ExcludeFromContext = new HashSet<string> { "search", "create" },
+        });
+        return builder;
+    }
+
+    /// <summary>MeshNode definition for <c>nodeType:HomeConfig</c> — typed content + the node-bound Edit form.</summary>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "Home Page",
+        Icon = "/static/NodeTypeIcons/layout.svg",
+        IsSatelliteType = false,
+        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        HubConfiguration = config => config
+            .AddDefaultLayoutAreas()
+            .AddMeshDataSource(source => source.WithContentType<HomeConfig>())
+            // Override the generic Edit with the standard node-bound content editor (data-binds each
+            // field straight to the node and auto-persists — no /data replica, no Save button), gated
+            // to writers only. This is the sanctioned MeshNodeContentEditor, not the property-editor.
+            .AddLayout(layout => layout.WithView(MeshNodeLayoutAreas.EditArea, EditHomeConfig))
+    };
+
+    /// <summary>The admin Edit form for the home config — the node-bound content editor, writers only.</summary>
+    public static IObservable<UiControl?> EditHomeConfig(LayoutAreaHost host, RenderingContext _)
+    {
+        var hubPath = host.Hub.Address.ToString();
+        return host.Hub.GetEffectivePermissions(hubPath)
+            .Select(permissions => permissions.HasFlag(Permission.Update)
+                ? (UiControl?)MeshNodeContentEditorControl.ForType(hubPath, typeof(HomeConfig))
+                : MeshNodeLayoutAreas.BuildAccessDenied(hubPath));
+    }
+
+    /// <summary>
+    /// Live home config: reads the well-known node via the shared, per-user-RLS, empty-on-absent
+    /// <c>GetQuery</c> cache (never a point-read → never NotFound-storms), maps it through
+    /// <see cref="Effective"/>, and emits the <see cref="Defaults"/> immediately for the first paint,
+    /// then the live node content. An admin editing the node re-emits, so every home updates live.
+    /// </summary>
+    public static IObservable<HomeConfig> Observe(IWorkspace workspace, JsonSerializerOptions options) =>
+        Observe(workspace, options, ConfigPath);
+
+    /// <summary>Reads the config at an explicit path (defaults to <see cref="ConfigPath"/>); used by tests.</summary>
+    internal static IObservable<HomeConfig> Observe(IWorkspace workspace, JsonSerializerOptions options, string configPath) =>
+        workspace
+            .GetQuery($"home-config:{configPath}", $"path:{configPath} nodeType:{NodeType}")
+            .Select(nodes => Effective(
+                nodes.FirstOrDefault(n => string.Equals(n.NodeType, NodeType, System.StringComparison.OrdinalIgnoreCase)),
+                options))
+            .StartWith(Defaults)
+            .DistinctUntilChanged();
+
+    /// <summary>
+    /// The effective config for a node: the saved <see cref="HomeConfig"/>, or <see cref="Defaults"/>
+    /// when the node is absent or its content can't be read (a partial/empty node behaves as defaults).
+    /// </summary>
+    public static HomeConfig Effective(MeshNode? node, JsonSerializerOptions options) =>
+        node?.Content switch
+        {
+            HomeConfig c => c,
+            JsonElement je => TryDeserialize(je, options) ?? Defaults,
+            _ => Defaults,
+        };
+
+    private static HomeConfig? TryDeserialize(JsonElement je, JsonSerializerOptions options)
+    {
+        try { return JsonSerializer.Deserialize<HomeConfig>(je.GetRawText(), options); }
+        catch { return null; }
+    }
+}

--- a/src/MeshWeaver.Graph/HomeConfig.cs
+++ b/src/MeshWeaver.Graph/HomeConfig.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>How deep the home catalog lists content.</summary>
+public enum HomeCatalogScope
+{
+    /// <summary>Only the TOP-LEVEL entries — the partition roots (spaces, courses, plugins) the viewer
+    /// can read plus their own top-level home items. A shallow, first-level index (the default).</summary>
+    FirstLevel,
+
+    /// <summary>Everything the viewer can read, at every depth (the full tree).</summary>
+    Subtree,
+}
+
+/// <summary>How the home catalog renders its items.</summary>
+public enum HomeCatalogRender
+{
+    /// <summary>One flat list of items — no per-type sections (the default).</summary>
+    Flat,
+
+    /// <summary>Grouped into collapsible per-type sections with counts.</summary>
+    Grouped,
+}
+
+/// <summary>The default sort order of the home catalog (the user can still switch it).</summary>
+public enum HomeCatalogSort
+{
+    /// <summary>Most-recently-opened first — the user's own access recency (the default).</summary>
+    LastAccessed,
+
+    /// <summary>Most-recently-edited first.</summary>
+    LastModified,
+
+    /// <summary>Alphabetical, by name.</summary>
+    Alphabetical,
+}
+
+/// <summary>
+/// The DATA-DRIVEN display config for the user home's catalog region — the platform node an admin edits
+/// (in-platform, no code change or image roll) to change how EVERY user's home lists content. Read
+/// reactively from the well-known platform node (<see cref="MeshWeaver.Graph.Configuration.HomeConfigNodeType.ConfigPath"/>);
+/// when the node is absent (or a field is unset) the shipped defaults apply — <b>FirstLevel + Flat +
+/// LastAccessed</b> — so the home behaves identically with or without the node. Kept deliberately small:
+/// this is "the home's display settings live in a node an admin can edit", not a templating engine.
+/// </summary>
+public record HomeConfig
+{
+    /// <summary>Depth of the home listing: FirstLevel (top-level entries only) or Subtree (the full tree).</summary>
+    [Description("How deep the home lists content. FirstLevel shows only top-level entries (the spaces, courses and plugins you can see, plus your own top-level home items). Subtree shows everything you can read.")]
+    public HomeCatalogScope Scope { get; init; } = HomeCatalogScope.FirstLevel;
+
+    /// <summary>How items are rendered: Flat (one list) or Grouped (per-type sections).</summary>
+    [Description("How the home renders items. Flat is one list; Grouped shows collapsible per-type sections.")]
+    public HomeCatalogRender Render { get; init; } = HomeCatalogRender.Flat;
+
+    /// <summary>The default ordering (the user can still change it via the Sort-by control).</summary>
+    [Description("The default ordering. Last accessed shows your recently-opened items first; Last modified shows recent edits; Alphabetical sorts by name.")]
+    public HomeCatalogSort DefaultSort { get; init; } = HomeCatalogSort.LastAccessed;
+}

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -594,15 +594,28 @@ public static class UserActivityLayoutAreas
             // there starts a proper thread via StartThread.
             .WithCreateHref($"/{nodeOwnerId}/{ChatArea}");
 
+    // The three user-selectable sort orders for the unified catalog (the view-options "Sort by"
+    // dropdown). LAST ACCESSED is the DEFAULT: source:accessed JOINs the user's UserActivity satellite
+    // and projects its timestamp into last_modified, so the list is the user's accessed working set,
+    // most-recently-opened first — the home dashboard default (it supersedes the old "Last Read" tab).
+    // LAST MODIFIED and ALPHABETICAL drop source:accessed, so they span the FULL readable set (every
+    // partition the viewer can see) ordered by edit-recency / name. Each is a complete hidden query
+    // because the option changes the result SET, not just the ordering; the FIRST is the default and
+    // MUST equal the control's HiddenQuery.
+    private const string CatalogSortLastAccessed = "source:accessed scope:subtree is:main context:search sort:LastModified-desc";
+    private const string CatalogSortLastModified = "is:main context:search sort:LastModified-desc";
+    private const string CatalogSortAlphabetical = "is:main context:search sort:Name-asc";
+
     /// <summary>
-    /// The catalog region — ONE unified, grouped "everything" view. A single reactive
-    /// <see cref="MeshSearchControl"/> over <c>is:main context:search</c> with NO namespace
-    /// restriction, so it spans every partition the viewer can read in one grouped-by-type list:
-    /// their own home items, the spaces they can see, and Store/Plugin courses+plugins all appear as
-    /// labelled, collapsible sections (Space, Store/Plugin, Markdown, Code, …). This REPLACES the
-    /// former Spaces / My Items / Last Read / Last Edited tab row AND the data-driven extension tabs —
-    /// an extension's content already shows up here in its type section, so a plugin no longer needs a
-    /// tab.
+    /// The catalog region — ONE unified, tab-less, grouped "everything" list. A single reactive
+    /// <see cref="MeshSearchControl"/> with NO namespace restriction, so it spans every partition the
+    /// viewer can read in one grouped-by-type list (Space, Store/Plugin, Markdown, Code, …): their own
+    /// home items, the spaces they can see, and Store/Plugin courses+plugins. It DEFAULTS to
+    /// <b>last-accessed</b> order (the user's recently-opened working set) and exposes a view-options
+    /// "Sort by" control so the user controls the order — <b>Last accessed</b> (default),
+    /// <b>Last modified</b>, and <b>Alphabetical</b> (by name); the last two span the full readable set.
+    /// This REPLACES the former Spaces / My Items / Last Read / Last Edited tab row AND the data-driven
+    /// extension tabs — an extension's content already shows up here in its type section.
     /// <para>The one thing a broad query can't reach is a module in ANOTHER partition the caller was
     /// specifically invited into (#385): those are resolved from the caller's own readable
     /// <c>AccessAssignment</c> grants (<paramref name="sharedTargets"/>) and appended as an additive
@@ -612,18 +625,21 @@ public static class UserActivityLayoutAreas
     /// </summary>
     internal static UiControl BuildCatalog(IReadOnlyList<string>? sharedTargets = null)
     {
-        // The unified, cross-partition "everything" search: no namespace clause → every partition the
-        // reader can see; grouped by type with counts + collapsible sections so it reads as sections.
-        // View-options let the user regroup/search across everything. The item limit is bounded (this
-        // query is cross-partition — never unbounded-scan), matching the former Spaces / My Items tabs.
-        // "+" opens the generic create page (a type picker), never a type-specific target.
+        // The unified, cross-partition "everything" search. Default order = last accessed; the "Sort by"
+        // dropdown (WithViewOptions + WithSortOptions) lets the user switch order — the query itself
+        // carries the sort/source, so no client-side WithSortBy (that would override the query order).
+        // Grouped by type with counts + collapsible sections. The item limit is bounded (this query is
+        // cross-partition — never unbounded-scan). "+" opens the generic create page (a type picker).
         var everything = Controls.MeshSearch
-            .WithHiddenQuery("is:main context:search sort:LastModified-desc")
+            .WithHiddenQuery(CatalogSortLastAccessed)
+            .WithSortOptions(
+                new MeshSearchSortOption("Last accessed", CatalogSortLastAccessed),
+                new MeshSearchSortOption("Last modified", CatalogSortLastModified),
+                new MeshSearchSortOption("Alphabetical", CatalogSortAlphabetical))
             .WithShowSearchBox(true)
             .WithViewOptions(true)
             .WithShowEmptyMessage(true)
             .WithRenderMode(MeshSearchRenderMode.Grouped)
-            .WithSortBy("LastModified", ascending: false)
             .WithSectionCounts(true)
             .WithCollapsibleSections(true)
             .WithItemLimit(50)

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -475,11 +475,15 @@ public static class UserActivityLayoutAreas
     internal static IObservable<UiControl?> CatalogAreaView(LayoutAreaHost host, RenderingContext _)
     {
         var ownerId = OwnerIdOf(host.Hub.Address.ToString());
-        // The unified catalog spans every partition the reader can see; the only thing it can't reach
-        // is a cross-partition module the caller was specifically invited into (#385), sourced from
-        // the caller's own readable AccessAssignments. Starts empty so the home paints instantly.
-        return ObserveSharedTargets(host, ownerId)
-            .Select(shared => (UiControl?)BuildCatalog(shared));
+        var options = host.Hub.JsonSerializerOptions;
+        // The home's DISPLAY CONFIG is DATA-DRIVEN: read the admin-editable Admin/HomeConfig platform
+        // node reactively (shipped defaults when absent), so an admin's edit updates every open home
+        // LIVE — no code change, no image roll. Combined with the caller's cross-partition grants
+        // (#385, the one thing a first-level query can't reach). Both start with a value so the home
+        // paints instantly.
+        return HomeConfigNodeType.Observe(host.Workspace, options)
+            .CombineLatest(ObserveSharedTargets(host, ownerId),
+                (config, shared) => (UiControl?)BuildCatalog(ownerId, config, shared));
     }
 
     /// <summary>
@@ -594,61 +598,92 @@ public static class UserActivityLayoutAreas
             // there starts a proper thread via StartThread.
             .WithCreateHref($"/{nodeOwnerId}/{ChatArea}");
 
-    // The three user-selectable sort orders for the unified catalog (the view-options "Sort by"
-    // dropdown). LAST ACCESSED is the DEFAULT: source:accessed JOINs the user's UserActivity satellite
-    // and projects its timestamp into last_modified, so the list is the user's accessed working set,
-    // most-recently-opened first — the home dashboard default (it supersedes the old "Last Read" tab).
-    // LAST MODIFIED and ALPHABETICAL drop source:accessed, so they span the FULL readable set (every
-    // partition the viewer can see) ordered by edit-recency / name. Each is a complete hidden query
-    // because the option changes the result SET, not just the ordering; the FIRST is the default and
-    // MUST equal the control's HiddenQuery.
-    private const string CatalogSortLastAccessed = "source:accessed scope:subtree is:main context:search sort:LastModified-desc";
-    private const string CatalogSortLastModified = "is:main context:search sort:LastModified-desc";
-    private const string CatalogSortAlphabetical = "is:main context:search sort:Name-asc";
+    // ── First-level catalog queries ────────────────────────────────────────────────────────────────
+    // The home is a SHALLOW, first-level index — NOT a full-tree dump. Each sort order is a UNION of two
+    // sub-queries (newline-joined; MeshSearchView issues them as a MeshQueryRequest union, sort/limit
+    // taken from the FIRST):
+    //   1. `namespace:` (empty) → the root-level partition nodes the reader can see — spaces,
+    //      courses/plugins, their own home root (default scope is children-of-root = the roots).
+    //   2. `namespace:{ownerId}` → the user's OWN top-level home items (default scope children = the
+    //      DIRECT children of their home partition root).
+    // Neither spans a subtree, so no deep `…/Introduction/Exercise/…` nodes leak in.
+    /// <summary>Builds the two-query first-level UNION for a given sort/source suffix (newline-joined).</summary>
+    private static string FirstLevelUnion(string ownerId, string sortSuffix) =>
+        $"namespace: is:main context:search {sortSuffix}\n" +
+        $"namespace:{ownerId} is:main context:search {sortSuffix}";
+
+    /// <summary>The catalog query for a scope + sort suffix: the first-level union (partition roots + the
+    /// user's home children), or a cross-partition SUBTREE query (everything the viewer can read at every
+    /// depth) when <see cref="HomeConfig.Scope"/> selects <see cref="HomeCatalogScope.Subtree"/>.</summary>
+    private static string CatalogQuery(HomeCatalogScope scope, string ownerId, string sortSuffix) =>
+        scope == HomeCatalogScope.Subtree
+            ? $"is:main context:search {sortSuffix}"
+            : FirstLevelUnion(ownerId, sortSuffix);
+
+    // The three user-selectable sort orders (the view-options "Sort by" dropdown). LAST ACCESSED:
+    // source:accessed JOINs the user's UserActivity satellite and projects its timestamp into
+    // last_modified, so the list is ordered by the user's own access recency (it supersedes the old
+    // "Last Read" tab). LAST MODIFIED / ALPHABETICAL drop source:accessed, ordering by edit-recency /
+    // name. Immutable constant lookup — enum · label · query suffix.
+    private const string SortSuffixLastAccessed = "source:accessed sort:LastModified-desc";
+    private const string SortSuffixLastModified = "sort:LastModified-desc";
+    private const string SortSuffixAlphabetical = "sort:Name-asc";
+    private static readonly (HomeCatalogSort Sort, string Label, string Suffix)[] CatalogSorts =
+    {
+        (HomeCatalogSort.LastAccessed, "Last accessed", SortSuffixLastAccessed),
+        (HomeCatalogSort.LastModified, "Last modified", SortSuffixLastModified),
+        (HomeCatalogSort.Alphabetical, "Alphabetical", SortSuffixAlphabetical),
+    };
 
     /// <summary>
-    /// The catalog region — ONE unified, tab-less, grouped "everything" list. A single reactive
-    /// <see cref="MeshSearchControl"/> with NO namespace restriction, so it spans every partition the
-    /// viewer can read in one grouped-by-type list (Space, Store/Plugin, Markdown, Code, …): their own
-    /// home items, the spaces they can see, and Store/Plugin courses+plugins. It DEFAULTS to
-    /// <b>last-accessed</b> order (the user's recently-opened working set) and exposes a view-options
-    /// "Sort by" control so the user controls the order — <b>Last accessed</b> (default),
-    /// <b>Last modified</b>, and <b>Alphabetical</b> (by name); the last two span the full readable set.
-    /// This REPLACES the former Spaces / My Items / Last Read / Last Edited tab row AND the data-driven
-    /// extension tabs — an extension's content already shows up here in its type section.
-    /// <para>The one thing a broad query can't reach is a module in ANOTHER partition the caller was
+    /// The catalog region — ONE tab-less list, whose shape is DATA-DRIVEN by <paramref name="config"/>
+    /// (the admin-editable <c>Admin/HomeConfig</c> platform node; <c>null</c> ⇒
+    /// <see cref="HomeConfigNodeType.Defaults"/> = <b>FirstLevel + Flat + LastAccessed</b>). The config
+    /// drives the depth (first-level top-level entries vs the full subtree), the render (flat list vs
+    /// grouped-by-type sections), and the default sort — and a view-options "Sort by" control still lets
+    /// the user pick <b>Last accessed</b> / <b>Last modified</b> / <b>Alphabetical</b> at will. FIRST-LEVEL
+    /// shows only the partition roots (spaces, courses, plugins) the viewer can read plus their own
+    /// top-level home items — NOT the whole tree. This REPLACES the former Spaces / My Items / Last Read /
+    /// Last Edited tab row AND the data-driven extension tabs.
+    /// <para>The one thing a first-level query can't reach is a module in ANOTHER partition the caller was
     /// specifically invited into (#385): those are resolved from the caller's own readable
     /// <c>AccessAssignment</c> grants (<paramref name="sharedTargets"/>) and appended as an additive
-    /// "Shared with me" band, present ONLY when the caller actually has such grants. With none (the
-    /// common case) the catalog is literally a single grouped search.</para>
+    /// "Shared with me" band, present ONLY when the caller actually has such grants.</para>
     /// <para>Pure (no hub) so the catalog shape is unit-testable without standing up a hub.</para>
     /// </summary>
-    internal static UiControl BuildCatalog(IReadOnlyList<string>? sharedTargets = null)
+    internal static UiControl BuildCatalog(
+        string nodeOwnerId, HomeConfig? config = null, IReadOnlyList<string>? sharedTargets = null)
     {
-        // The unified, cross-partition "everything" search. Default order = last accessed; the "Sort by"
-        // dropdown (WithViewOptions + WithSortOptions) lets the user switch order — the query itself
+        var cfg = config ?? HomeConfigNodeType.Defaults;
+
+        // Sort options, DEFAULT first (so the dropdown's default selection == HiddenQuery). Each option
+        // carries its full catalog query (first-level union or subtree, per cfg.Scope); the query itself
         // carries the sort/source, so no client-side WithSortBy (that would override the query order).
-        // Grouped by type with counts + collapsible sections. The item limit is bounded (this query is
-        // cross-partition — never unbounded-scan). "+" opens the generic create page (a type picker).
+        var sortOptions = CatalogSorts
+            .OrderByDescending(s => s.Sort == cfg.DefaultSort)
+            .Select(s => new MeshSearchSortOption(s.Label, CatalogQuery(cfg.Scope, nodeOwnerId, s.Suffix)))
+            .ToArray();
+
         var everything = Controls.MeshSearch
-            .WithHiddenQuery(CatalogSortLastAccessed)
-            .WithSortOptions(
-                new MeshSearchSortOption("Last accessed", CatalogSortLastAccessed),
-                new MeshSearchSortOption("Last modified", CatalogSortLastModified),
-                new MeshSearchSortOption("Alphabetical", CatalogSortAlphabetical))
+            .WithHiddenQuery(sortOptions[0].Query)
+            .WithSortOptions(sortOptions)
             .WithShowSearchBox(true)
             .WithViewOptions(true)
             .WithShowEmptyMessage(true)
-            .WithRenderMode(MeshSearchRenderMode.Grouped)
-            .WithSectionCounts(true)
-            .WithCollapsibleSections(true)
+            .WithRenderMode(cfg.Render == HomeCatalogRender.Grouped
+                ? MeshSearchRenderMode.Grouped
+                : MeshSearchRenderMode.Flat)
             .WithItemLimit(50)
-            .WithMaxRows(3)
+            .WithMaxRows(6)
             .WithMaxColumns(4)
             .WithReactiveMode(true)
             .WithCreateHref("/create");
 
-        // No cross-partition invitations → the catalog IS the single unified search.
+        // Grouped render → collapsible per-type sections with counts (flat is the default, no grouping).
+        if (cfg.Render == HomeCatalogRender.Grouped)
+            everything = everything.WithSectionCounts(true).WithCollapsibleSections(true);
+
+        // No cross-partition invitations → the catalog IS the single list.
         if (sharedTargets is not { Count: > 0 })
             return everything;
 

--- a/src/MeshWeaver.Layout/MeshSearchControl.cs
+++ b/src/MeshWeaver.Layout/MeshSearchControl.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using MeshWeaver.Layout.Catalog;
 
 namespace MeshWeaver.Layout;
@@ -50,6 +51,18 @@ public enum MeshSearchRenderMode
     /// </summary>
     GraphNavigator
 }
+
+/// <summary>
+/// One user-selectable sort choice for the view-options "Sort by" dropdown: a display
+/// <paramref name="Label"/> and the full hidden <paramref name="Query"/> applied when the user picks
+/// it. Each option is a complete query so an option can change BOTH the ordering AND the result set
+/// (e.g. "Last accessed" uses <c>source:accessed</c> — the user's accessed working set, ordered by
+/// access recency — while "Last modified" / "Alphabetical" span the full readable set). The FIRST
+/// option is the default and should match the control's <see cref="MeshSearchControl.HiddenQuery"/>.
+/// </summary>
+/// <param name="Label">The label shown in the "Sort by" dropdown.</param>
+/// <param name="Query">The full hidden query applied when this option is selected.</param>
+public record MeshSearchSortOption(string Label, string Query);
 
 /// <summary>
 /// A control that provides a configurable search with results displayed in a LayoutGrid.
@@ -110,6 +123,14 @@ public record MeshSearchControl()
     /// the Flat and Grouped render modes.
     /// </summary>
     public object? ShowViewOptions { get; init; }
+
+    /// <summary>
+    /// Optional user-selectable sort choices for the view-options "Sort by" dropdown (only rendered
+    /// when <see cref="ShowViewOptions"/> is on). Each entry carries a full hidden query, so picking
+    /// one can change the ordering AND the result set. The FIRST entry is the default and should equal
+    /// <see cref="HiddenQuery"/>. Null/empty ⇒ no sort dropdown (unchanged behaviour).
+    /// </summary>
+    public IReadOnlyList<MeshSearchSortOption>? SortOptions { get; init; }
 
     /// <summary>
     /// Whether to exclude the base path node from results (default true).
@@ -297,6 +318,11 @@ public record MeshSearchControl()
     /// <param name="ascending"><c>true</c> for ascending; <c>false</c> for descending.</param>
     public MeshSearchControl WithThenBy(string property, bool ascending = true) =>
         this with { Sorting = (Sorting ?? new SortConfig()) with { ThenByProperty = property, ThenByAscending = ascending } };
+
+    /// <summary>Returns a copy with the view-options "Sort by" dropdown offering <paramref name="options"/>.</summary>
+    /// <param name="options">The user-selectable sort choices; the first is the default and should match <see cref="HiddenQuery"/>.</param>
+    public MeshSearchControl WithSortOptions(params MeshSearchSortOption[] options) =>
+        this with { SortOptions = options };
 
     // Grid fluent methods
     /// <summary>Returns a copy with responsive grid column widths set per breakpoint (MUI grid units, 1–12).</summary>

--- a/test/MeshWeaver.Graph.Test/HomeCatalogTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeCatalogTest.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
+using System.Text.Json;
 using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
 using Xunit;
@@ -8,36 +10,28 @@ using Xunit;
 namespace MeshWeaver.Graph.Test;
 
 /// <summary>
-/// The user home's catalog is ONE unified, tab-less, grouped "everything" list — a single reactive
-/// <see cref="MeshSearchControl"/> (NOT a tab control) that spans every partition the reader can see
-/// (their own items, spaces, Store/Plugin courses+plugins), grouped by type. It DEFAULTS to
-/// last-accessed order (the user's recently-opened working set) and exposes a view-options "Sort by"
-/// control — Last accessed (default), Last modified, Alphabetical — so the user controls the order. It
-/// replaces the former Spaces / My Items / Last Read / Last Edited tab row PLUS the data-driven
-/// extension tabs. The one gap a broad query can't reach — a module in ANOTHER partition the caller was
-/// invited into (#385) — is resolved from the caller's own <c>AccessAssignment</c> grants
-/// (<see cref="UserActivityLayoutAreas.SharedTargetPaths"/>) and appended as an additive "Shared with
-/// me" band, present only when such grants exist.
+/// The user home's catalog is ONE tab-less, FLAT, FIRST-LEVEL list — a single reactive
+/// <see cref="MeshSearchControl"/> (NOT a tab control, NOT grouped-by-type) showing only the TOP-LEVEL
+/// entries the viewer can see: the partition roots (spaces, courses, plugins) plus the user's own
+/// top-level home items — NOT the whole tree. It DEFAULTS to last-accessed order and exposes a
+/// view-options "Sort by" control — Last accessed (default), Last modified, Alphabetical. The one gap
+/// this can't reach — a module in ANOTHER partition the caller was invited into (#385) — is resolved
+/// from the caller's own <c>AccessAssignment</c> grants (<see cref="UserActivityLayoutAreas.SharedTargetPaths"/>)
+/// and appended as an additive "Shared with me" band, present only when such grants exist.
 /// </summary>
 public class HomeCatalogTest
 {
     private const string NodePath = "rbuergi";
 
     [Fact]
-    public void Catalog_IsASingleTablessGroupedSearch()
+    public void Catalog_IsASingleTablessFlatList()
     {
-        var catalog = UserActivityLayoutAreas.BuildCatalog();
+        var catalog = UserActivityLayoutAreas.BuildCatalog(NodePath);
 
-        // NO tabs — a single MeshSearch, never a TabsControl.
+        // NO tabs — a single MeshSearch, never a TabsControl. FLAT, not grouped-by-type.
         var search = catalog.Should().BeOfType<MeshSearchControl>().Subject;
         catalog.Should().NotBeOfType<TabsControl>();
-        // Spans every readable partition (NO namespace restriction), grouped by type.
-        search.HiddenQuery!.ToString().Should().Contain("is:main");
-        search.HiddenQuery!.ToString().Should().Contain("context:search");
-        search.HiddenQuery!.ToString().Should().NotContain("namespace:");
-        search.RenderMode.Should().Be(MeshSearchRenderMode.Grouped);
-        search.Sections!.ShowCounts.Should().Be(true);
-        search.Sections!.Collapsible.Should().Be(true);
+        search.RenderMode.Should().Be(MeshSearchRenderMode.Flat);
         search.ShowSearchBox.Should().Be(true);
         // View-options on → the user controls the order.
         search.ShowViewOptions.Should().Be(true);
@@ -46,9 +40,23 @@ public class HomeCatalogTest
     }
 
     [Fact]
+    public void Catalog_IsFirstLevelOnly_NotTheWholeTree()
+    {
+        var search = UserActivityLayoutAreas.BuildCatalog(NodePath).Should().BeOfType<MeshSearchControl>().Subject;
+        var query = search.HiddenQuery!.ToString()!;
+
+        // A UNION of two first-level sub-queries (one per line): partition roots + the user's home
+        // direct children — NEITHER spans a subtree, so no deep descendants leak in.
+        query.Should().Contain("namespace: is:main", "partition roots = the empty-namespace top level");
+        query.Should().Contain($"namespace:{NodePath} is:main", "the user's own top-level home items");
+        query.Should().NotContain("scope:subtree");
+        query.Should().NotContain("scope:descendants");
+    }
+
+    [Fact]
     public void Catalog_DefaultsToLastAccessedOrder()
     {
-        var search = UserActivityLayoutAreas.BuildCatalog().Should().BeOfType<MeshSearchControl>().Subject;
+        var search = UserActivityLayoutAreas.BuildCatalog(NodePath).Should().BeOfType<MeshSearchControl>().Subject;
 
         // Default order = last accessed (source:accessed projects the UserActivity access time into the
         // sort slot), most-recently-opened first — supersedes the old "Last Read" tab.
@@ -59,35 +67,41 @@ public class HomeCatalogTest
     [Fact]
     public void Catalog_OffersLastAccessedLastModifiedAndAlphabeticalSorts()
     {
-        var search = UserActivityLayoutAreas.BuildCatalog().Should().BeOfType<MeshSearchControl>().Subject;
+        var search = UserActivityLayoutAreas.BuildCatalog(NodePath).Should().BeOfType<MeshSearchControl>().Subject;
 
         var options = search.SortOptions!;
         options.Select(o => o.Label).Should().Equal("Last accessed", "Last modified", "Alphabetical");
         // The first option is the default and MUST equal the control's HiddenQuery.
         options[0].Query.Should().Be(search.HiddenQuery!.ToString());
-        // Last accessed = the user's accessed working set; the other two span the full readable set.
+        // Last accessed = access-ordered working set; the other two order the first-level set differently.
         options[0].Query.Should().Contain("source:accessed");
         options[1].Query.Should().Contain("sort:LastModified-desc");
         options[1].Query.Should().NotContain("source:accessed");
         options[2].Query.Should().Contain("sort:Name-asc");
         options[2].Query.Should().NotContain("source:accessed");
+        // Every option stays first-level (union of roots + home children, no subtree).
+        foreach (var o in options)
+        {
+            o.Query.Should().Contain("namespace: is:main");
+            o.Query.Should().Contain($"namespace:{NodePath} is:main");
+            o.Query.Should().NotContain("scope:subtree");
+        }
     }
 
     [Fact]
-    public void Catalog_WithoutSharedTargets_IsJustTheUnifiedSearch()
+    public void Catalog_WithoutSharedTargets_IsJustTheFlatList()
     {
-        UserActivityLayoutAreas.BuildCatalog(sharedTargets: [])
-            .Should().BeOfType<MeshSearchControl>("no cross-partition grants → literally one search");
+        UserActivityLayoutAreas.BuildCatalog(NodePath, sharedTargets: [])
+            .Should().BeOfType<MeshSearchControl>("no cross-partition grants → literally one flat list");
     }
 
     [Fact]
     public void Catalog_WithSharedTargets_AppendsASharedWithMeBand()
     {
-        // #385 — the caller was invited into modules in OTHER partitions; a broad is:main query can't
-        // reach them, so they're appended as an additive "Shared with me" band below the unified view.
-        var catalog = UserActivityLayoutAreas.BuildCatalog(sharedTargets: ["OrgA/Module", "OrgB/Deck"]);
+        // #385 — the caller was invited into modules in OTHER partitions; the first-level query can't
+        // reach them, so they're appended as an additive "Shared with me" band below the flat list.
+        var catalog = UserActivityLayoutAreas.BuildCatalog(NodePath, sharedTargets: ["OrgA/Module", "OrgB/Deck"]);
 
-        // A stack of the unified search + the shared band (two areas), never a bare search.
         var stack = catalog.Should().BeOfType<StackControl>().Subject;
         stack.Areas.Should().HaveCount(2);
     }
@@ -126,5 +140,104 @@ public class HomeCatalogTest
 
         UserActivityLayoutAreas.SharedTargetPaths([assignment], NodePath)
             .Should().Equal("OrgA/Module");
+    }
+
+    // ── Data-driven home config (Admin/HomeConfig) ──────────────────────────────────────────────────
+
+    [Fact]
+    public void HomeConfig_ShippedDefaults_AreFirstLevelFlatLastAccessed()
+    {
+        HomeConfigNodeType.Defaults.Scope.Should().Be(HomeCatalogScope.FirstLevel);
+        HomeConfigNodeType.Defaults.Render.Should().Be(HomeCatalogRender.Flat);
+        HomeConfigNodeType.Defaults.DefaultSort.Should().Be(HomeCatalogSort.LastAccessed);
+    }
+
+    [Fact]
+    public void Catalog_NullConfig_EqualsTheShippedDefaults()
+    {
+        // No config == the shipped defaults == exactly what BuildCatalog(ownerId) produces.
+        var byDefault = UserActivityLayoutAreas.BuildCatalog(NodePath).Should().BeOfType<MeshSearchControl>().Subject;
+        var byNull = UserActivityLayoutAreas.BuildCatalog(NodePath, config: null).Should().BeOfType<MeshSearchControl>().Subject;
+
+        byNull.HiddenQuery!.ToString().Should().Be(byDefault.HiddenQuery!.ToString());
+        byNull.RenderMode.Should().Be(MeshSearchRenderMode.Flat);
+    }
+
+    [Fact]
+    public void Catalog_ConfigSubtree_QueriesTheWholeTree_NotJustFirstLevel()
+    {
+        var cfg = new HomeConfig { Scope = HomeCatalogScope.Subtree };
+        var search = UserActivityLayoutAreas.BuildCatalog(NodePath, cfg).Should().BeOfType<MeshSearchControl>().Subject;
+
+        var query = search.HiddenQuery!.ToString()!;
+        query.Should().Contain("is:main context:search");
+        query.Should().NotContain("namespace:");   // no first-level roots/home-children union
+        query.Should().NotContain("\n");           // a single query, not a union
+    }
+
+    [Fact]
+    public void Catalog_ConfigGrouped_RendersPerTypeSections()
+    {
+        var cfg = new HomeConfig { Render = HomeCatalogRender.Grouped };
+        var search = UserActivityLayoutAreas.BuildCatalog(NodePath, cfg).Should().BeOfType<MeshSearchControl>().Subject;
+
+        search.RenderMode.Should().Be(MeshSearchRenderMode.Grouped);
+        search.Sections!.ShowCounts.Should().Be(true);
+        search.Sections!.Collapsible.Should().Be(true);
+    }
+
+    [Fact]
+    public void Catalog_ConfigDefaultSort_MakesTheChosenSortTheDefault()
+    {
+        var cfg = new HomeConfig { DefaultSort = HomeCatalogSort.Alphabetical };
+        var search = UserActivityLayoutAreas.BuildCatalog(NodePath, cfg).Should().BeOfType<MeshSearchControl>().Subject;
+
+        // The chosen default is FIRST and equals HiddenQuery; all three sorts are still offered.
+        search.SortOptions![0].Label.Should().Be("Alphabetical");
+        search.SortOptions![0].Query.Should().Be(search.HiddenQuery!.ToString());
+        search.HiddenQuery!.ToString().Should().Contain("sort:Name-asc");
+        search.SortOptions!.Select(o => o.Label).OrderBy(l => l, StringComparer.Ordinal).Should()
+            .Equal("Alphabetical", "Last accessed", "Last modified");
+    }
+
+    [Fact]
+    public void HomeConfig_Effective_FallsBackToDefaults_WhenNodeAbsent()
+    {
+        HomeConfigNodeType.Effective(null, new JsonSerializerOptions()).Should().Be(HomeConfigNodeType.Defaults);
+    }
+
+    [Fact]
+    public void HomeConfig_Effective_ReadsTypedContent()
+    {
+        var options = new JsonSerializerOptions();
+        var node = MeshNode.FromPath(HomeConfigNodeType.ConfigPath) with
+        {
+            NodeType = HomeConfigNodeType.NodeType,
+            Content = new HomeConfig
+            {
+                Scope = HomeCatalogScope.Subtree,
+                Render = HomeCatalogRender.Grouped,
+                DefaultSort = HomeCatalogSort.LastModified,
+            },
+        };
+
+        var effective = HomeConfigNodeType.Effective(node, options);
+        effective.Scope.Should().Be(HomeCatalogScope.Subtree);
+        effective.Render.Should().Be(HomeCatalogRender.Grouped);
+        effective.DefaultSort.Should().Be(HomeCatalogSort.LastModified);
+    }
+
+    [Fact]
+    public void HomeConfig_Effective_ReadsJsonElementContent()
+    {
+        var options = new JsonSerializerOptions();
+        var je = JsonSerializer.SerializeToElement(new HomeConfig { Render = HomeCatalogRender.Grouped });
+        var node = MeshNode.FromPath(HomeConfigNodeType.ConfigPath) with
+        {
+            NodeType = HomeConfigNodeType.NodeType,
+            Content = je,
+        };
+
+        HomeConfigNodeType.Effective(node, options).Render.Should().Be(HomeCatalogRender.Grouped);
     }
 }

--- a/test/MeshWeaver.Graph.Test/HomeCatalogTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeCatalogTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using MeshWeaver.Graph;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
@@ -7,37 +8,69 @@ using Xunit;
 namespace MeshWeaver.Graph.Test;
 
 /// <summary>
-/// The user home's catalog is ONE unified, grouped "everything" view — a single reactive
-/// <see cref="MeshSearchControl"/> over <c>is:main context:search</c> that spans every partition the
-/// reader can see (their own items, spaces, Store/Plugin courses+plugins), grouped by type. It
+/// The user home's catalog is ONE unified, tab-less, grouped "everything" list — a single reactive
+/// <see cref="MeshSearchControl"/> (NOT a tab control) that spans every partition the reader can see
+/// (their own items, spaces, Store/Plugin courses+plugins), grouped by type. It DEFAULTS to
+/// last-accessed order (the user's recently-opened working set) and exposes a view-options "Sort by"
+/// control — Last accessed (default), Last modified, Alphabetical — so the user controls the order. It
 /// replaces the former Spaces / My Items / Last Read / Last Edited tab row PLUS the data-driven
-/// extension tabs (a tab node's content already surfaces in the unified list). The one gap a broad
-/// query can't reach — a module in ANOTHER partition the caller was invited into (#385) — is resolved
-/// from the caller's own <c>AccessAssignment</c> grants (<see cref="UserActivityLayoutAreas.SharedTargetPaths"/>)
-/// and appended as an additive "Shared with me" band, present only when such grants exist.
+/// extension tabs. The one gap a broad query can't reach — a module in ANOTHER partition the caller was
+/// invited into (#385) — is resolved from the caller's own <c>AccessAssignment</c> grants
+/// (<see cref="UserActivityLayoutAreas.SharedTargetPaths"/>) and appended as an additive "Shared with
+/// me" band, present only when such grants exist.
 /// </summary>
 public class HomeCatalogTest
 {
     private const string NodePath = "rbuergi";
 
     [Fact]
-    public void Catalog_IsASingleUnifiedGroupedSearch()
+    public void Catalog_IsASingleTablessGroupedSearch()
     {
         var catalog = UserActivityLayoutAreas.BuildCatalog();
 
+        // NO tabs — a single MeshSearch, never a TabsControl.
         var search = catalog.Should().BeOfType<MeshSearchControl>().Subject;
-        // The unified query — spans every readable partition (NO namespace restriction), grouped by type.
+        catalog.Should().NotBeOfType<TabsControl>();
+        // Spans every readable partition (NO namespace restriction), grouped by type.
         search.HiddenQuery!.ToString().Should().Contain("is:main");
         search.HiddenQuery!.ToString().Should().Contain("context:search");
-        search.HiddenQuery!.ToString().Should().Contain("sort:LastModified-desc");
         search.HiddenQuery!.ToString().Should().NotContain("namespace:");
         search.RenderMode.Should().Be(MeshSearchRenderMode.Grouped);
         search.Sections!.ShowCounts.Should().Be(true);
         search.Sections!.Collapsible.Should().Be(true);
         search.ShowSearchBox.Should().Be(true);
+        // View-options on → the user controls the order.
         search.ShowViewOptions.Should().Be(true);
         // Generic create (type picker), never a type-specific target.
         search.CreateHref.Should().Be("/create");
+    }
+
+    [Fact]
+    public void Catalog_DefaultsToLastAccessedOrder()
+    {
+        var search = UserActivityLayoutAreas.BuildCatalog().Should().BeOfType<MeshSearchControl>().Subject;
+
+        // Default order = last accessed (source:accessed projects the UserActivity access time into the
+        // sort slot), most-recently-opened first — supersedes the old "Last Read" tab.
+        search.HiddenQuery!.ToString().Should().Contain("source:accessed");
+        search.HiddenQuery!.ToString().Should().Contain("sort:LastModified-desc");
+    }
+
+    [Fact]
+    public void Catalog_OffersLastAccessedLastModifiedAndAlphabeticalSorts()
+    {
+        var search = UserActivityLayoutAreas.BuildCatalog().Should().BeOfType<MeshSearchControl>().Subject;
+
+        var options = search.SortOptions!;
+        options.Select(o => o.Label).Should().Equal("Last accessed", "Last modified", "Alphabetical");
+        // The first option is the default and MUST equal the control's HiddenQuery.
+        options[0].Query.Should().Be(search.HiddenQuery!.ToString());
+        // Last accessed = the user's accessed working set; the other two span the full readable set.
+        options[0].Query.Should().Contain("source:accessed");
+        options[1].Query.Should().Contain("sort:LastModified-desc");
+        options[1].Query.Should().NotContain("source:accessed");
+        options[2].Query.Should().Contain("sort:Name-asc");
+        options[2].Query.Should().NotContain("source:accessed");
     }
 
     [Fact]

--- a/test/MeshWeaver.Graph.Test/HomeConfigReactiveTest.cs
+++ b/test/MeshWeaver.Graph.Test/HomeConfigReactiveTest.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The home's display config is DATA-DRIVEN and read REACTIVELY: <see cref="HomeConfigNodeType.Observe"/>
+/// emits the shipped defaults immediately (so the home paints), then re-emits live whenever the config
+/// node is created/edited — the mechanism that lets an admin change every user's home without a deploy.
+/// Uses a test-controlled path so the reactive composition is exercised deterministically.
+/// </summary>
+public class HomeConfigReactiveTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact(Timeout = 30000)]
+    public async Task Observe_EmitsDefaults_ThenTheConfigNode_LiveOnCreate()
+    {
+        var workspace = Mesh.GetWorkspace();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var options = Mesh.JsonSerializerOptions;
+        // A path the auto-logged-in admin (rbuergi) owns — deterministic, no Admin-seed dependency.
+        const string configPath = "rbuergi/HomeConfig";
+
+        // Absent → the shipped defaults (FirstLevel + Flat + LastAccessed).
+        var first = await HomeConfigNodeType.Observe(workspace, options, configPath)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(10)).ToTask();
+        first.Should().Be(HomeConfigNodeType.Defaults);
+
+        // An admin creates the config node with NON-default settings.
+        await meshService.CreateNode(MeshNode.FromPath(configPath) with
+        {
+            NodeType = HomeConfigNodeType.NodeType,
+            Name = "Home Page",
+            State = MeshNodeState.Active,
+            Content = new HomeConfig
+            {
+                Scope = HomeCatalogScope.Subtree,
+                Render = HomeCatalogRender.Grouped,
+                DefaultSort = HomeCatalogSort.Alphabetical,
+            },
+        }).FirstAsync().Timeout(TimeSpan.FromSeconds(10)).ToTask();
+
+        // Observe re-emits the edited config live — every open home would update without a deploy.
+        var updated = await HomeConfigNodeType.Observe(workspace, options, configPath)
+            .Where(c => c.Render == HomeCatalogRender.Grouped)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(15)).ToTask();
+        updated.Scope.Should().Be(HomeCatalogScope.Subtree);
+        updated.DefaultSort.Should().Be(HomeCatalogSort.Alphabetical);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/UserActivityHomeOverrideTest.cs
+++ b/test/MeshWeaver.Graph.Test/UserActivityHomeOverrideTest.cs
@@ -128,10 +128,12 @@ public class UserActivityHomeOverrideTest
     {
         var catalog = UserActivityLayoutAreas.BuildCatalog();
 
-        // ONE unified, grouped "everything" search — no tab row. It spans every partition the reader
-        // can see (no namespace restriction) and groups by type.
+        // ONE unified, tab-less, grouped list — no tab row. It spans every partition the reader can see
+        // (no namespace restriction), groups by type, and defaults to last-accessed order.
         var search = catalog.Should().BeOfType<MeshSearchControl>().Subject;
+        catalog.Should().NotBeOfType<TabsControl>();
         search.HiddenQuery!.ToString().Should().Contain("is:main context:search");
+        search.HiddenQuery!.ToString().Should().Contain("source:accessed");
         search.HiddenQuery!.ToString().Should().NotContain("namespace:");
         search.RenderMode.Should().Be(MeshSearchRenderMode.Grouped);
     }

--- a/test/MeshWeaver.Graph.Test/UserActivityHomeOverrideTest.cs
+++ b/test/MeshWeaver.Graph.Test/UserActivityHomeOverrideTest.cs
@@ -124,17 +124,15 @@ public class UserActivityHomeOverrideTest
     }
 
     [Fact]
-    public void Catalog_IsAUnifiedGroupedEverythingSearch()
+    public void Catalog_IsATablessFlatFirstLevelList()
     {
-        var catalog = UserActivityLayoutAreas.BuildCatalog();
+        var catalog = UserActivityLayoutAreas.BuildCatalog(NodePath);
 
-        // ONE unified, tab-less, grouped list — no tab row. It spans every partition the reader can see
-        // (no namespace restriction), groups by type, and defaults to last-accessed order.
+        // ONE tab-less, FLAT, FIRST-LEVEL list — no tab row, no grouping, defaults to last-accessed.
         var search = catalog.Should().BeOfType<MeshSearchControl>().Subject;
         catalog.Should().NotBeOfType<TabsControl>();
-        search.HiddenQuery!.ToString().Should().Contain("is:main context:search");
         search.HiddenQuery!.ToString().Should().Contain("source:accessed");
-        search.HiddenQuery!.ToString().Should().NotContain("namespace:");
-        search.RenderMode.Should().Be(MeshSearchRenderMode.Grouped);
+        search.HiddenQuery!.ToString().Should().NotContain("scope:subtree");
+        search.RenderMode.Should().Be(MeshSearchRenderMode.Flat);
     }
 }


### PR DESCRIPTION
## What

Iterative refinement of the home catalog (on top of merged #570), plus a data-driven config so admins can change the default home **without a code change or image roll**.

### 1. Tab-less, FLAT, FIRST-LEVEL list

- **No tabs / no grouping** — the catalog is a single `MeshSearchControl`, `RenderMode.Flat` (one list, no per-type sections).
- **First-level only** (not the whole tree): the hidden query is a **UNION** of two first-level sub-queries — `namespace:` (empty → the partition roots the reader can see: spaces, courses, plugins) and `namespace:{ownerId}` (→ the user's own top-level home items, `scope:children`). Neither spans a subtree, so no deep descendants leak in. `MeshSearchView` issues a newline-joined hidden query as a `MeshQueryRequest` union (sort/limit from the first sub-query), reactively.

### 2. Default = last accessed, user-sortable

- Default order is **last accessed** (`source:accessed` projects the user's `UserActivity` access time into the sort slot), most-recently-opened first.
- A view-options **"Sort by"** dropdown (new, generic `MeshSearchControl.SortOptions` + `MeshSearchView`) lets the user pick **Last accessed** (default) / **Last modified** / **Alphabetical**. Each option carries its full query; picking one swaps the query and re-queries. Purely additive — every other MeshSearch is unchanged (no options ⇒ no dropdown).

### 3. Data-driven, admin-editable HomeConfig

- New typed `HomeConfig` content (`Scope` FirstLevel|Subtree, `Render` Flat|Grouped, `DefaultSort` LastAccessed|LastModified|Alphabetical) + `HomeConfigNodeType`, registered **public-read** at the well-known Admin platform node **`Admin/HomeConfig`**, **seeded** with defaults, with the node-bound `MeshNodeContentEditor` Edit form (the `MeshNodeContentEditorControl.ForType` editor — data-bound, auto-persisting, writers only).
- `CatalogAreaView` reads it **reactively** via the shared, per-user-RLS, empty-on-absent `GetQuery` cache (never a point-read → never NotFound-storms; the `AiSettingsNodeType` pattern), so an admin's edit updates every open home **live, no deploy**.
- `BuildCatalog(ownerId, config)` applies scope/render/default-sort. The built-in `Defaults` (null config) == **flat + first-level + last-accessed**, so nothing regresses without the node.

**How an admin edits it:** open `/Admin/HomeConfig` (the seeded platform node) and Edit — the content editor exposes Scope / Render / Default sort. Saving updates every user's home live.

The additive "Shared with me" band (#385, only-when-grants) is kept.

## Tests

`HomeCatalogTest` + `HomeConfigReactiveTest`: no `TabsControl`; flat; first-level (union of roots + home children, no `scope:subtree`/`descendants`); default last-accessed; the three sort options (first == HiddenQuery); config overrides each field (Subtree → whole-tree query, Grouped → sections, DefaultSort → reordered); `Effective` defaults-on-absent + typed/JsonElement content; and a **reactive-update integration test** (defaults → live config on create). Local `dotnet build -c Release -warnaserror` green for Layout + Blazor + Graph + Graph.Test; **28/28** pass.

## Caveats

- **"Last accessed" surfaces the accessed working set** (`source:accessed` is an INNER JOIN on `user_activities` — access time only exists for opened nodes); **Last modified / Alphabetical** order the full first-level set. Making "everything ordered by last accessed" would need a LEFT-JOIN `source:accessed` across providers — out of scope.
- The interactive **Sort-by dropdown is Blazor-only** for now; JS (react/RN) clients honor the last-accessed default via the query but don't render the dropdown — a parity follow-up.
- The `Admin/HomeConfig` seed follows the `DocumentationExtensions` namespaced built-in-seed pattern; if a backend doesn't materialise it, the in-code `Defaults` keep the home correct and an admin can create the node in-platform.
- Not driven through a running portal here (no UI/model harness); covered by build + unit + one reactive integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)