### PR TITLE
Add PluginCatalog__RegistryUrl to the portal chart

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -162,6 +162,15 @@ data:
   WebSearch__Provider: "{{ .Values.config.memex_portal.WebSearch__Provider | default "" }}"
   WebSearch__Google__ApiKey: "{{ .Values.config.memex_portal.WebSearch__Google__ApiKey | default "" }}"
   WebSearch__Google__Cx: "{{ .Values.config.memex_portal.WebSearch__Google__Cx | default "" }}"
+  # ---- Plugin catalog (Settings ▸ Administration ▸ Plugin Catalog) — optional -
+  # The registry this installation installs plugins FROM. Left empty the admin tab
+  # renders "No plugin registry is configured" and no plugin can be installed — the
+  # catalog is opt-in, since an instance that should not pull third-party modules
+  # simply never sets it. The public registry is https://memex.meshweaver.cloud,
+  # which serves the curated MeshWeaver.Plugins node repos; a consumer needs NO
+  # GitHub credential of its own (the registry holds it). Several registries can be
+  # consumed via PluginCatalog:Registries instead — see /Doc/Architecture/PluginRegistry.
+  PluginCatalog__RegistryUrl: "{{ .Values.config.memex_portal.PluginCatalog__RegistryUrl | default "" }}"
   # ---- Observability (OTLP collector) — optional ----------------------------
   OTEL_EXPORTER_OTLP_ENDPOINT: "{{ .Values.config.memex_portal.OTEL_EXPORTER_OTLP_ENDPOINT | default "" }}"
   OTEL_EXPORTER_OTLP_PROTOCOL: "{{ .Values.config.memex_portal.OTEL_EXPORTER_OTLP_PROTOCOL | default "" }}"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -200,6 +200,11 @@ config:
     ModelTier__Light: ""
     ModelTier__Utility: ""
     ClaudeCode__ConfigDirRoot: ""
+    # Plugin catalog — the registry this installation installs plugins FROM.
+    # Empty = the admin tab reports no registry configured and nothing can be
+    # installed (opt-in by design). An overlay sets it per environment, e.g.
+    # "https://memex.meshweaver.cloud" for the public curated registry.
+    PluginCatalog__RegistryUrl: ""
     # ---- System email (Microsoft Graph) — BIDIRECTIONAL. Off by default; an
     # overlay turns it on per environment by setting Email__Enabled + the env's
     # own MailboxAddress / TenantId / ClientId (+ WebhookBaseUrl for inbound).


### PR DESCRIPTION
The Plugin Catalog admin tab (Settings ▸ Administration) reads `PluginCatalog:RegistryUrl` to know which registry an installation installs plugins from. **The chart never templated the key**, so a Helm-deployed portal had no way to set it — the tab always rendered *"No plugin registry is configured"* and no plugin could be installed.

The only workaround was patching the live ConfigMap by hand, which the next `helm upgrade` silently discards.

## The change

One templated key in `deploy/helm/templates/memex-portal/config.yaml`, following the existing optional-key style (`| default ""`), plus its declaration in `values.yaml`.

**Defaults to empty**, so the catalog stays opt-in and existing deployments are unchanged: an instance that should not pull third-party modules simply never sets it. An overlay sets it per environment, e.g. `https://memex.meshweaver.cloud` for the public curated registry.

## Verified

```
$ helm template memex deploy/helm | grep PluginCatalog__RegistryUrl
  PluginCatalog__RegistryUrl: ""

$ helm template memex deploy/helm \
    --set config.memex_portal.PluginCatalog__RegistryUrl=https://memex.meshweaver.cloud | grep PluginCatalog
  PluginCatalog__RegistryUrl: "https://memex.meshweaver.cloud"
```

Chart renders both ways — inert by default, populated when an overlay sets it.

Found while installing the newly published `Manufacturing` plugin onto a local Helm-deployed portal: the registry serves it correctly, but the consumer had no supported way to point at a registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)