### PR TITLE
fix(access): deferred invite grants fire on sign-up independent of the change feed

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-20-invite-lands-access-on-signup.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-20-invite-lands-access-on-signup.md
@@ -1,0 +1,12 @@
+---
+Name: Invited people reliably get their access the moment they sign up
+Category: What's New
+Description: A pending group or space invite now grants membership and access as soon as the invitee onboards — even on the multi-node portal where the sign-up event used to be missed
+Icon: Sparkle
+---
+
+# Invites now land access on sign-up, every time
+
+When you invite someone who doesn't have an account yet, the platform schedules their group membership and space access to apply the moment they onboard. On the distributed portal that hand-off could be missed: the invitee signed up, but their pending grants stayed stuck until the next restart — so they'd log in and find they had access to nothing.
+
+The onboarding hand-off no longer depends on an in-memory event that can be dropped between nodes. It now watches for the new user through the database directly, so a pending invite fires reliably the instant the account is created — no restart, no manual fix-up. Existing pending invitations heal automatically.

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -52,6 +52,13 @@ public sealed class EventSubscriptionRunner(
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, IDisposable> timerSubs = new();
     // Live NodeStatus watches, same lifecycle contract as timerSubs.
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, IDisposable> statusSubs = new();
+    // Live trigger-node watches — one per DISTINCT TriggerNodeType among pending NodeChange/Created
+    // subscriptions (keyed by node type, NOT subscription id, so a handful of entries, never a per-
+    // subscription registry leak). The change-feed-INDEPENDENT firing path: a synced query re-emits via
+    // the storage layer (PG LISTEN/NOTIFY — silo-independent) when a matching node is created, so a
+    // deferred invite fires even when the in-process/Orleans change feed's best-effort cross-silo relay
+    // never delivers the User/Created event to this runner. Same lifecycle contract as timerSubs/statusSubs.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, IDisposable> nodeChangeSubs = new();
     private IDisposable? pendingSub;
     private IDisposable? feedSub;
     private IDisposable? legacySub;
@@ -87,6 +94,22 @@ public sealed class EventSubscriptionRunner(
                     ScheduleTimer(s);
                 foreach (var s in list.Where(s => s is { TriggerType: EventTriggerType.NodeStatus, WatchPath.Length: > 0 }))
                     WatchNodeStatus(s);
+
+                // Change-feed-INDEPENDENT reconcile: keep a live trigger-node query per distinct node type
+                // among the pending Created subscriptions. It re-emits (via PG LISTEN/NOTIFY, silo-agnostic)
+                // when a matching node is created even if the change-feed event never reaches this runner —
+                // the memex 2026-07-20 stranded-invite root cause (cross-silo relay dropped the create).
+                var neededNodeTypes = list
+                    .Where(s => s is { TriggerType: EventTriggerType.NodeChange, TriggerKind: MeshChangeKind.Created,
+                        TriggerNodeType.Length: > 0 })
+                    .Select(s => s.TriggerNodeType!)
+                    .ToHashSet(StringComparer.Ordinal);
+                foreach (var nodeType in neededNodeTypes)
+                    WatchTriggerNodeType(nodeType);
+                foreach (var nodeType in nodeChangeSubs.Keys.Where(nt => !neededNodeTypes.Contains(nt)).ToList())
+                    if (nodeChangeSubs.TryRemove(nodeType, out var d))
+                        d.Dispose();
+
                 var pendingIds = list.Select(s => s.Id).ToHashSet();
                 foreach (var (subs, _) in new[] { (timerSubs, 0), (statusSubs, 0) })
                     foreach (var id in subs.Keys.Where(id => !pendingIds.Contains(id)).ToList())
@@ -141,6 +164,52 @@ public sealed class EventSubscriptionRunner(
                 if (node is not null)
                     Execute(subscription, node);
             }, ex => logger?.LogWarning(ex, "Reconcile query for subscription {Id} failed", subscription.Id));
+    }
+
+    /// <summary>
+    /// Establishes a LIVE query over every node of <paramref name="nodeType"/> and reconciles the pending
+    /// <see cref="EventTriggerType.NodeChange"/>/<see cref="MeshChangeKind.Created"/> subscriptions of that
+    /// type against each emission — the reliable, change-feed-INDEPENDENT firing path.
+    ///
+    /// <para><see cref="OnChange"/> fires the instant a node is written, but the change feed's cross-silo
+    /// relay is best-effort: on a distributed portal a <c>User</c> created in its own partition hub (another
+    /// silo) may never reach this runner, so the deferred invite strands until the next restart's reconcile
+    /// (the memex 2026-07-20 "bari onboarded but got no access" incident — all six of his pending
+    /// subscriptions stayed Pending). A synced query re-emits through the storage layer (PG LISTEN/NOTIFY),
+    /// which is silo-independent, so this watch fires the subscription regardless of change-feed delivery.
+    /// It supplements — does not replace — the feed + startup reconcile; all three are idempotent (the
+    /// terminal <c>Fired</c> write gates re-entry and every continuation is a create-or-update), so they
+    /// cannot double-apply. One watch per node type (a small bounded set; the dictionary key is the node
+    /// type, not the subscription id, so no per-subscription registry leak), disposed when no pending
+    /// Created subscription needs it and on runner stop.</para>
+    /// </summary>
+    private void WatchTriggerNodeType(string nodeType)
+    {
+        if (nodeChangeSubs.ContainsKey(nodeType))
+            return;
+        var slot = new System.Reactive.Disposables.SingleAssignmentDisposable();
+        if (!nodeChangeSubs.TryAdd(nodeType, slot))
+            return;   // lost the race — another emission just established this node type
+        slot.Disposable = AsSystem(() => meshService.Query<MeshNode>(
+                MeshQueryRequest.FromQuery($"nodeType:{nodeType}")))
+            .Select(c => c.Items)
+            .Subscribe(
+                items =>
+                {
+                    List<EventSubscription> candidates;
+                    lock (gate)
+                        candidates = pending
+                            .Where(s => s is { TriggerType: EventTriggerType.NodeChange, TriggerKind: MeshChangeKind.Created }
+                                        && string.Equals(s.TriggerNodeType, nodeType, StringComparison.Ordinal))
+                            .ToList();
+                    foreach (var s in candidates)
+                    {
+                        var node = (items ?? []).FirstOrDefault(n => Matches(s, n));
+                        if (node is not null)
+                            Execute(s, node);
+                    }
+                },
+                ex => logger?.LogWarning(ex, "Trigger-node watch for {NodeType} failed", nodeType));
     }
 
     private bool Matches(EventSubscription subscription, MeshNode node)
@@ -359,7 +428,7 @@ public sealed class EventSubscriptionRunner(
         pendingSub?.Dispose();
         feedSub?.Dispose();
         legacySub?.Dispose();
-        foreach (var subs in new[] { timerSubs, statusSubs })
+        foreach (var subs in new[] { timerSubs, statusSubs, nodeChangeSubs })
             foreach (var id in subs.Keys.ToList())
                 if (subs.TryRemove(id, out var d))
                     d.Dispose();

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -192,6 +192,14 @@ public sealed class EventSubscriptionRunner(
             return;   // lost the race — another emission just established this node type
         slot.Disposable = AsSystem(() => meshService.Query<MeshNode>(
                 MeshQueryRequest.FromQuery($"nodeType:{nodeType}")))
+            // Every ChangeType EXCEPT Removed means "a matching node exists now" and is a valid
+            // existence-based reconcile trigger: Initial/Reset carry the full snapshot, Added a just-
+            // created invitee (the deferred-grant case), Updated an existing one re-emitted. EXCLUDE
+            // Removed — its Items carries the DELETED node (Items is a delta for Added/Updated/Removed,
+            // the full set only for Initial/Reset), and a Created subscription must never fire for a node
+            // being deleted. Repeated fires across emissions are harmless: the terminal Fired write drops
+            // the subscription from `pending` and every continuation is a create-or-update.
+            .Where(c => c.ChangeType != QueryChangeType.Removed)
             .Select(c => c.Items)
             .Subscribe(
                 items =>

--- a/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
+++ b/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
@@ -32,6 +32,19 @@ public class EventSubscriptionRunnerTest(ITestOutputHelper output) : MonolithMes
         public string Status { get; init; } = "";
     }
 
+    /// <summary>
+    /// A change feed that delivers NOTHING. Models the distributed portal's best-effort cross-silo relay
+    /// dropping a <c>User</c>/<c>Created</c> event (the invitee onboarded on another silo, so the event
+    /// created in their own partition hub never reached the portal-hosted runner). The runner must still
+    /// fire the subscription — via the live trigger-node reconcile — rather than depend on the feed.
+    /// </summary>
+    private sealed class SilentChangeFeed : IMeshChangeFeed
+    {
+        public void Publish(MeshChangeEvent change) { }
+        public IDisposable Subscribe(Action<MeshChangeEvent> handler, MeshChangeKind? filter = null)
+            => System.Reactive.Disposables.Disposable.Empty;
+    }
+
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => ConfigureMeshBase(builder)
             .AddMeshNodes(new MeshNode(Space) { Name = "Invite Space", NodeType = "Space" })
@@ -162,6 +175,77 @@ public class EventSubscriptionRunnerTest(ITestOutputHelper output) : MonolithMes
             $"subscription ended {final.Status}: {final.LastError}");
 
         // The membership landed: {groupPath}/{user}_Membership carries Member == userId and the group entry.
+        var membershipPath = $"{groupPath}/{InviteeId}_Membership";
+        var membership = await Mesh.GetWorkspace().GetMeshNodeStream(membershipPath)
+            .Where(n => n?.Content is GroupMembership gm
+                        && gm.Member == InviteeId
+                        && gm.Groups.Any(e => e.Group == groupPath))
+            .FirstAsync().Timeout(10.Seconds());
+        Assert.NotNull(membership);
+    }
+
+    /// <summary>
+    /// The prod regression (memex 2026-07-20, invitee "bari"): a pending AddToGroup subscription must fire
+    /// when the invitee onboards EVEN IF the change feed never delivers the User/Created event to the runner
+    /// — the cross-silo relay on a distributed portal is best-effort. Here the runner is wired to a
+    /// <see cref="SilentChangeFeed"/> (the live path is dead), and the user is created AFTER the subscription
+    /// is already pending (so the startup/set-change reconcile saw no matching user). The subscription must
+    /// still fire, driven by the change-feed-INDEPENDENT live trigger-node query. Fails before the fix
+    /// (nothing re-triggers the reconcile → stranded until restart), passes after.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task PendingAddToGroup_FiresOnUserCreation_EvenWhenChangeFeedDropsTheEvent()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var runnerLogger = Mesh.ServiceProvider
+            .GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>();
+
+        var groupPath = $"{Space}/Team2";
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode("Team2", Space)
+            {
+                NodeType = "Group",
+                Name = "Team2",
+                Content = new AccessObject { Description = "Test group" },
+            }).Should().Emit();
+
+        // The runner's ONLY live trigger is a SilentChangeFeed — it will never learn of the user create
+        // from the feed. If the subscription fires, it can ONLY be via the live trigger-node reconcile.
+        using var runner = new EventSubscriptionRunner(Mesh, new SilentChangeFeed(), meshService, accessService, runnerLogger);
+        await runner.StartAsync(default);
+
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.NodeChange,
+            TriggerNodeType = "User",
+            TriggerKind = MeshChangeKind.Created,
+            MatchField = "email",
+            MatchValue = InviteeEmail,
+            ContinuationType = EventContinuationType.AddToGroup,
+            TargetPath = groupPath,
+        };
+        await EventSubscriptionOps.CreateSubscription(meshService, subscription).Should().Emit();
+
+        // The invitee onboards AFTER the subscription is pending — the runner already reconciled (no user
+        // then) and the feed stays silent. Only the live trigger-node query can catch this.
+        using (accessService.ImpersonateAsSystem())
+        {
+            await meshService.CreateNode(new MeshNode(InviteeId)
+            {
+                NodeType = "User",
+                Name = "Newcomer",
+                Content = new User { Email = InviteeEmail, FullName = "Newcomer" },
+            }).Should().Emit();
+        }
+
+        var final = await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Select(n => n?.Content as EventSubscription)
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.True(final!.Status == EventSubscriptionStatus.Fired,
+            $"subscription ended {final.Status}: {final.LastError}");
+
         var membershipPath = $"{groupPath}/{InviteeId}_Membership";
         var membership = await Mesh.GetWorkspace().GetMeshNodeStream(membershipPath)
             .Where(n => n?.Content is GroupMembership gm


### PR DESCRIPTION
## Problem

Invited someone (memex prod, **bari** → group `SocialMedia/notus`). bari onboarded (User node + Invitation → Accepted at 07:59), but got **no access** — all **six** of his pending `EventSubscription`s (2 `AddToGroup` + 4 `GrantSpaceAccess`) stayed `Pending / version 1`. He had to be added to the group by hand.

## Root cause

`EventSubscriptionRunner` fires a pending `NodeChange`/`Created` subscription (the deferred "add invitee to group / grant space on sign-up") through only:
1. **Live** — `IMeshChangeFeed.OnChange`, whose cross-silo relay is **best-effort**. On the distributed portal, bari's `User`/`Created` event (created in his own partition hub/silo) wasn't delivered to the portal-hosted runner.
2. **Reconcile backstop** — but it re-runs only on **portal startup** or a **subscription-set change**, never tied to user creation.

bari onboarded, no restart followed → nothing re-evaluated → every deferred grant stranded. The existing monolith test passes because the in-process feed always delivers — it never exercises the cross-silo miss. (`CreateOrUpdateNode` for a new node does publish a proper `Created` event, so that path was fine.)

## Fix

`WatchTriggerNodeType`: one **live `nodeType:{type}` query** per distinct trigger node type among pending `Created` subscriptions (keyed by node type → no per-subscription registry leak; established/pruned with the pending set, disposed on stop). It reconciles matching pending subs on every emission. A synced query re-emits via Postgres `LISTEN/NOTIFY` — **silo-independent** — so the grant fires regardless of change-feed delivery. Additive and idempotent with the live feed + startup reconcile (terminal `Fired` write gates re-entry; continuations are create-or-update). One runner, so this covers **group invites and space invites**.

## Tests

- New repro `PendingAddToGroup_FiresOnUserCreation_EvenWhenChangeFeedDropsTheEvent` injects a `SilentChangeFeed` → **fails pre-fix (40 s timeout), passes post-fix (724 ms)**.
- Full `EventSubscriptionRunnerTest`: **6/6 pass**.
- `MeshWeaver.Graph` Release `-warnaserror` build: green.

Once merged + deployed, the startup reconcile + new watch land bari's still-stranded grants (YouTube, AgenticEngineering, DataModeling, LinkedIn, YouTube/Team) automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)