### PR TITLE
Fix self-typed-root install race: compile+register the in-package NodeType before creating the node it types

### DIFF
--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -399,6 +399,30 @@ public static class PackageInstaller
                 : batch.Select(n => UpsertIfChanged(hub, persistence, n, options))
                     .ToObservable().Concat().ToList(); // sequential to respect the ordering
 
+        // 🚨 CONFIRM THE SELF-TYPED ROOT'S RETYPE RECONCILED before the install reports success.
+        // Stage 2 retypes the Space placeholder to the in-package type via
+        // GetMeshNodeStream(root).Update. That write is UpdateRemote: it returns the OPTIMISTIC
+        // snapshot the instant the patch is ACCEPTED and does NOT wait for the owner's reconciled
+        // state to echo back onto the shared IMeshNodeStreamCache handle (its own contract —
+        // "callers needing the reconciled state follow the shared GetMeshNodeStream(path) handle").
+        // So without this the install completed while that shared handle still replayed the Space
+        // PLACEHOLDER: a reader immediately after install (the GUI, the SelfTypedRootInstallTest pin)
+        // read NodeType "Space" instead of the in-package type — the intermittent flake under CI
+        // load, where the owner's async fan-out lags the install's optimistic completion. FOLLOW the
+        // shared handle until it carries the real type, so the install's completion is a happens-
+        // before for every reader of that SAME handle. Reactive and bounded by the retype LANDING
+        // (it is in flight and always settles); the Timeout is the graceful sink for a wedged owner,
+        // never a fixed sleep that would cache the fallback.
+        IObservable<System.Reactive.Unit> RootRetypeReconciled() =>
+            placeholderRoot is null || root is null || string.IsNullOrEmpty(root.NodeType)
+                ? Observable.Return(System.Reactive.Unit.Default)
+                : hub.GetMeshNodeStream(root.Path)
+                    .Where(n => n is not null
+                        && string.Equals(n.NodeType, root.NodeType, StringComparison.Ordinal))
+                    .Take(1)
+                    .Timeout(TimeSpan.FromSeconds(30))
+                    .Select(_ => System.Reactive.Unit.Default);
+
         // Eager provisioning must also cover the package's OWN partition: with a dynamic root
         // type the placeholder covers it, but belt-and-braces keeps the fresh-mesh pin honest.
         return EnsurePartitionsProvisioned(hub, manifest.TargetPartition ?? manifest.Id, InstalledPartition)
@@ -407,6 +431,9 @@ public static class PackageInstaller
                 .SelectMany(_ => WriteAll(stage1))
                 .SelectMany(typeWrites => Visible(nodeTypePaths)
                     .SelectMany(_ => WriteAll(stage2))
+                    // The retype's optimistic emit is not the reconciled state — wait for the
+                    // shared root handle to actually carry the in-package type before reporting.
+                    .SelectMany(rest => RootRetypeReconciled().Select(_ => rest))
                     // A placeholder's write is bookkeeping, not content — its FINAL retype in
                     // stage 2 is the root's one counted write (keeps Written ≤ node count).
                     .Select(rest => (IList<bool>)(placeholderRoot is null ? rootWrites : [])


### PR DESCRIPTION
## The flake

`MeshWeaver.PluginCatalog.Test.SelfTypedRootInstallTest.RootTypedByAnInPackageNodeType_Installs` fails intermittently under CI load:

```
AssertionException : Expected value to be "Shop/Front", but found "Space".
```

The scenario: install a node-repo package whose **ROOT** is typed by a NodeType shipped **in the same package** (root `Shop` = nodeType `Shop/Front`, defined by a child node). Intermittently the root reads back as `"Space"` (the placeholder) instead of `"Shop/Front"`.

## Root cause — the confirmed ordering

`InstallNodeRepo` installs a self-typed root in stages: it writes a **`Space` placeholder** root first (stage 0, to reserve the root and pre-empt the partition-bootstrap heal that would otherwise race a generic `Space` root through the debounced per-node persist), writes the in-package NodeType + Source (stage 1), then **retypes** the root to `Shop/Front` (stage 2).

The stage-2 retype is `GetMeshNodeStream(root).Update(...)`, which routes through the process-wide `IMeshNodeStreamCache` as `UpdateRemote`. `UpdateRemote` **returns the OPTIMISTIC snapshot the instant the patch is accepted** and, by its own documented contract, does *not* wait for the owner's reconciled state to echo back onto the shared cache handle:

> "callers needing the reconciled state follow the shared `GetMeshNodeStream(path)` handle."

The installer skipped that follow-up. So the install reported success (`Written == 4`) while the shared cache handle still replayed the stage-0 **`Space` placeholder** — the owner's async fan-out that reconciles the handle to `Shop/Front` lands on a *separate* path from the success ack. A reader immediately after install (the GUI, and `SelfTypedRootInstallTest`, both reading the same shared handle via `GetMeshNodeStream`) then observed `NodeType = "Space"`. Under CI load the fan-out lags the optimistic completion, so the stale read wins — the flake.

(The *persisted* NodeType is always correct: the retype is an UPDATE that preserves the set `NodeType`, dynamic types are exempt from the content-discriminator validator, and the owner's forward-only version guard keeps `Shop/Front@v>=2` from ever regressing to the placeholder `Space@v1`. The defect is purely that the install's completion was **not a happens-before** for the shared-handle read.)

## The fix

After stage 2, the install now **follows the shared `GetMeshNodeStream(root)` handle until it carries the real in-package type** before reporting success:

```csharp
hub.GetMeshNodeStream(root.Path)
    .Where(n => n is not null && string.Equals(n.NodeType, root.NodeType, StringComparison.Ordinal))
    .Take(1)
    .Timeout(TimeSpan.FromSeconds(30))
```

This makes the install's completion a happens-before for every reader of that same handle. It's reactive and bounded by the retype **landing** (it is in flight and always settles); the `Timeout` is the graceful sink for a genuinely wedged owner — never a fixed sleep, retry loop, or widened assertion. Only self-typed roots (those that got a placeholder) wait; static-typed roots short-circuit.

## Verification

- `SelfTypedRootInstallTest` unchanged (assertion kept exactly) — green.
- Full `MeshWeaver.PluginCatalog.Test` (21 tests) — green.
- Release + `-warnaserror -p:CIRun=true` build of `MeshWeaver.PluginCatalog` and its test project — clean.
- The exact CI-load interleaving (async fan-out lagging the optimistic completion) did not reproduce on an idle/CPU-loaded dev machine — the race window is the fan-out lag, which only widens under full-suite CI load. The fix removes the race by construction (the happens-before), rather than by chasing the timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)