### PR TITLE
fix(access): seed the invite-grant reconcile from an authoritative storage read on cold start

### DIFF
--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -264,11 +264,14 @@ public sealed class EventSubscriptionRunner(
     {
         try
         {
-            return System.Text.Json.JsonSerializer.Deserialize<EventSubscription>(
-                je.GetRawText(), hub.JsonSerializerOptions);
+            // Deserialize straight from the JsonElement — no GetRawText() string round-trip / re-parse.
+            return System.Text.Json.JsonSerializer.Deserialize<EventSubscription>(je, hub.JsonSerializerOptions);
         }
-        catch
+        catch (System.Text.Json.JsonException ex)
         {
+            // A malformed subscription node must not abort the whole cold-start seed — skip it, but SURFACE
+            // it (never a silent swallow) so a genuine data problem is visible.
+            logger?.LogWarning(ex, "Skipping malformed EventSubscription content in the cold-start reconcile");
             return null;
         }
     }

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -62,6 +62,8 @@ public sealed class EventSubscriptionRunner(
     private IDisposable? pendingSub;
     private IDisposable? feedSub;
     private IDisposable? legacySub;
+    // One-shot cold-start reconcile seeded from an authoritative storage read (see StartAsync) — disposed on stop.
+    private IDisposable? startupSub;
 
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
@@ -116,6 +118,32 @@ public sealed class EventSubscriptionRunner(
                         if (subs.TryRemove(id, out var d))
                             d.Dispose();
             }, ex => logger?.LogWarning(ex, "Event-subscriptions query failed"));
+
+        // 🚨 Cold-start authoritative reconcile — the fix for the memex 2026-07-20 stranded-invite incident.
+        // The live pendingSub above reads the WORKSPACE cache (GetQuery): on a cold start it is EMPTY until
+        // the Admin partition syncs into the workspace, and it does NOT re-emit when the partition later
+        // warms — only on a subsequent write. So after every deploy restart the runner's pending set stayed
+        // empty and NOTHING reconciled until an unrelated Admin/EventSubscription write happened to nudge
+        // the query; an invited, already-onboarded user's Pending grants were stranded for hours (bari: his
+        // User node existed and his AddToGroup/GrantSpaceAccess subs were Pending, yet none fired after the
+        // roll until a write re-triggered the reconcile). IMeshService.Query is a FRESH storage read that
+        // does NOT wait on the workspace cache, so it returns the outstanding subscriptions even on a cold
+        // start — seed the reconcile once from it. Every already-matchable Created subscription fires now,
+        // and each fire's terminal Fired-write re-emits pendingSub (warm) so the live path takes over.
+        // One-shot + idempotent (the Fired write gates re-entry; continuations are create-or-update).
+        startupSub = AsSystem(() => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(
+                    $"path:{EventSubscriptionNodeType.Namespace} scope:children nodeType:{EventSubscriptionNodeType.NodeType}"))
+                .Where(c => c.ChangeType == QueryChangeType.Initial)
+                .Select(c => c.Items)
+                .Take(1))
+            .Subscribe(items =>
+            {
+                foreach (var node in items ?? [])
+                    if (ReadSubscription(node) is
+                        { Status: EventSubscriptionStatus.Pending,
+                          TriggerType: EventTriggerType.NodeChange, TriggerKind: MeshChangeKind.Created } s)
+                        Reconcile(s);
+            }, ex => logger?.LogWarning(ex, "Startup authoritative reconcile failed"));
 
         // Live: fire on the actual change event.
         feedSub = changeFeed.Subscribe(OnChange);
@@ -218,6 +246,31 @@ public sealed class EventSubscriptionRunner(
                     }
                 },
                 ex => logger?.LogWarning(ex, "Trigger-node watch for {NodeType} failed", nodeType));
+    }
+
+    /// <summary>
+    /// Deserializes a node's content to <see cref="EventSubscription"/>, tolerating both a typed instance
+    /// (the workspace <c>GetQuery</c> path) and a raw <see cref="System.Text.Json.JsonElement"/> (the
+    /// storage <c>IMeshService.Query</c> path the cold-start seed reads from). Returns null otherwise.
+    /// </summary>
+    private EventSubscription? ReadSubscription(MeshNode node) => node.Content switch
+    {
+        EventSubscription es => es,
+        System.Text.Json.JsonElement je => TryDeserializeSubscription(je),
+        _ => null,
+    };
+
+    private EventSubscription? TryDeserializeSubscription(System.Text.Json.JsonElement je)
+    {
+        try
+        {
+            return System.Text.Json.JsonSerializer.Deserialize<EventSubscription>(
+                je.GetRawText(), hub.JsonSerializerOptions);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private bool Matches(EventSubscription subscription, MeshNode node)
@@ -436,6 +489,7 @@ public sealed class EventSubscriptionRunner(
         pendingSub?.Dispose();
         feedSub?.Dispose();
         legacySub?.Dispose();
+        startupSub?.Dispose();
         foreach (var subs in new[] { timerSubs, statusSubs, nodeChangeSubs })
             foreach (var id in subs.Keys.ToList())
                 if (subs.TryRemove(id, out var d))

--- a/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
+++ b/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
@@ -255,6 +255,76 @@ public class EventSubscriptionRunnerTest(ITestOutputHelper output) : MonolithMes
         Assert.NotNull(membership);
     }
 
+    /// <summary>
+    /// The restart case behind the memex 2026-07-20 incident: the invitee's subscription AND their User
+    /// node BOTH already exist when the runner (re)starts, and the change feed is silent (a deploy restart
+    /// on a distributed portal — the User/Created event is long gone). The subscription must fire on
+    /// startup and land the membership. This exercises the startup reconcile: the runner cannot rely on the
+    /// live change feed (silent here) nor on a fresh User/Created event (the user pre-exists), only on
+    /// re-evaluating outstanding subscriptions against current state at boot. On prod the workspace-cached
+    /// GetQuery is empty during the Admin-partition cold-start and never re-emits on warmup, which is why
+    /// the startup reconcile now reads the pending set from an authoritative <c>IMeshService.Query</c>.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task PreExistingUserAndSubscription_FireOnRunnerStartup_WithoutTheChangeFeed()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var runnerLogger = Mesh.ServiceProvider
+            .GetService<Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>>();
+
+        var groupPath = $"{Space}/Team3";
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode("Team3", Space)
+            {
+                NodeType = "Group",
+                Name = "Team3",
+                Content = new AccessObject { Description = "Test group" },
+            }).Should().Emit();
+
+        // BOTH the subscription AND the matching User already exist BEFORE the runner starts.
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.NodeChange,
+            TriggerNodeType = "User",
+            TriggerKind = MeshChangeKind.Created,
+            MatchField = "email",
+            MatchValue = InviteeEmail,
+            ContinuationType = EventContinuationType.AddToGroup,
+            TargetPath = groupPath,
+        };
+        await EventSubscriptionOps.CreateSubscription(meshService, subscription).Should().Emit();
+        using (accessService.ImpersonateAsSystem())
+        {
+            await meshService.CreateNode(new MeshNode(InviteeId)
+            {
+                NodeType = "User",
+                Name = "Newcomer",
+                Content = new User { Email = InviteeEmail, FullName = "Newcomer" },
+            }).Should().Emit();
+        }
+
+        // Start the runner AFTER both exist, wired to a SILENT change feed — it can only fire via the
+        // startup reconcile (no live OnChange, no fresh User/Created event).
+        using var runner = new EventSubscriptionRunner(Mesh, new SilentChangeFeed(), meshService, accessService, runnerLogger);
+        await runner.StartAsync(default);
+
+        var final = await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Select(n => n?.Content as EventSubscription)
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.True(final!.Status == EventSubscriptionStatus.Fired,
+            $"subscription ended {final.Status}: {final.LastError}");
+
+        var membershipPath = $"{groupPath}/{InviteeId}_Membership";
+        var membership = await Mesh.GetWorkspace().GetMeshNodeStream(membershipPath)
+            .Where(n => n?.Content is GroupMembership gm
+                        && gm.Member == InviteeId
+                        && gm.Groups.Any(e => e.Group == groupPath))
+            .FirstAsync().Timeout(10.Seconds());
+        Assert.NotNull(membership);
+    }
+
     [Fact(Timeout = 60000)]
     public async Task LegacyScheduledAction_IsMigratedAndFires()
     {


### PR DESCRIPTION
## Problem (the memex 2026-07-20 follow-up)

After #574 shipped the change-feed-independent watch and was deployed to memex (`ci.1253`), invited user **bari** *still* got no access: his User node existed and his 6 `EventSubscription`s were `Pending`, yet **none fired** even after the portal fully warmed.

## Root cause (confirmed on prod)

`EventSubscriptionRunner` reconciles outstanding subscriptions off its live `pendingSub` — a **workspace-cache `GetQuery`** over `Admin/EventSubscription`. On a cold start that GetQuery is **empty until the Admin partition syncs into the workspace**, and it does **not re-emit** when the partition later warms — only on a subsequent write. So after every deploy restart the runner's pending set stayed empty and nothing reconciled until an unrelated `Admin/EventSubscription` write nudged the query.

**Verified live:** patching one of bari's subscriptions (a write → `pendingSub` re-emit) made the runner reconcile against the now-warm index and fire **all six** subs to `Fired` instantly — proving the reconcile is correct; only its cold-start *trigger* was broken. (I also disproved an earlier hypothesis that `Query<MeshNode>` returns content-less rows on PG — a no-`select` query *does* include content, so matching was never the issue.)

## Fix

`IMeshService.Query` is a **fresh storage read** that does not wait on the workspace cache, so it returns the outstanding subscriptions even on a cold start. Seed the reconcile **once** from it at startup (`startupSub`): every already-matchable `Created` subscription fires immediately, and each fire's terminal `Fired`-write re-emits `pendingSub` (now warm) so the live path takes over. One-shot + idempotent (the `Fired` write gates re-entry; continuations are create-or-update). `ReadSubscription` tolerates both content shapes (typed from GetQuery, raw `JsonElement` from `IMeshService.Query`).

## Tests

- New `PreExistingUserAndSubscription_FireOnRunnerStartup_WithoutTheChangeFeed`: subscription + user **both pre-exist**, silent change feed, runner starts → fires on startup (the restart scenario).
- Full `EventSubscriptionRunnerTest`: **7/7 pass**. `MeshWeaver.Graph` Release `-warnaserror`: clean.

Completes #574's fix (which addressed the live path); the cold-start reconcile was the remaining gap that kept it from firing on the distributed portal. bari has been healed on prod (his subs are now all `Fired`).

**What's New:** skipped — the user-facing entry shipped with #574 ("invited people get access on sign-up"); this is the internal completion of that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)