### PR TITLE
Plugin registry: gate /api/plugins to registered instances (bearer tokens)

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
@@ -73,7 +73,8 @@ public static class PluginRegistryEndpoints
         config.GetSection(PluginRegistryTokens.SectionName).GetChildren()
             .Select(c => c.Value)
             .Where(v => !string.IsNullOrWhiteSpace(v))
-            .Select(v => v!)
+            // Trim: secrets get copy-pasted with stray whitespace, and Validate compares exact bytes.
+            .Select(v => v!.Trim())
             .ToList();
 
     /// <summary>One configured registry source: the git package source, the ref it serves, and a

--- a/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
@@ -13,28 +13,50 @@ using Microsoft.Extensions.Logging;
 namespace Memex.Portal.Shared.Api;
 
 /// <summary>
-/// The PUBLIC plugin-registry surface — this instance acting as the distribution point for plugin
+/// The plugin-registry surface — this instance acting as the distribution point for plugin
 /// modules. <c>GET /api/plugins</c> lists the catalog; <c>POST /api/plugins/files</c> returns one
 /// package's files. Both are backed by the registry's configured git <see cref="IPackageSource"/>s
 /// (<c>PluginCatalog:Sources:N:*</c> — e.g. the plugins repo AND an education repo — or the legacy
 /// single <c>PluginCatalog:SourceRepoPath</c>, via GitSync), so a consuming instance
 /// browses/installs over HTTP with NO git/GitHub credentials of its own: the registry's GitHub App
-/// credential stays here and is never handed out (npm/NuGet-style encapsulation). Only curated
-/// packages — each addressed by its plugin id in the configured source (node-native
-/// <c>&lt;Plugin&gt;.json</c> Space roots by default, or <c>package.json</c> folders) — are exposed,
-/// so anonymous read is safe by design.
+/// credential stays here and is never handed out (npm/NuGet-style encapsulation).
+///
+/// <para>🚨 The surface is NOT public: it serves only <b>registered MeshWeaver instances</b>, each
+/// holding a token issued at registration and listed in the registry's
+/// <c>PluginCatalog:RegistryTokens</c> (see <see cref="PluginRegistryTokens"/>). Requests without a
+/// valid <c>Authorization: Bearer</c> token are 401. Only when NO tokens are configured — the
+/// local-dev / e2e-stub mode — does the registry answer anonymously; a production registry always
+/// configures tokens.</para>
 ///
 /// <para>Consumed by <see cref="RegistryPackageSource"/>; the wire shapes are produced by
 /// <see cref="PluginRegistryPayloads"/> so producer and consumer cannot drift.</para>
 /// </summary>
 public static class PluginRegistryEndpoints
 {
-    /// <summary>Maps the anonymous <c>/api/plugins</c> registry group. Call alongside <c>MapMeshApi</c>.</summary>
+    /// <summary>Maps the token-gated <c>/api/plugins</c> registry group. Call alongside <c>MapMeshApi</c>.</summary>
     public static IEndpointRouteBuilder MapPluginRegistry(this IEndpointRouteBuilder endpoints)
     {
-        // PUBLIC — no auth: a plugin registry is meant to be pulled by any installation. The registry
-        // serves only curated packages from its configured source; its own credentials never leave.
+        // AllowAnonymous at the ASP.NET auth layer: callers are INSTANCES, not signed-in users, so
+        // the user auth schemes don't apply. The real gate is the instance-token filter below —
+        // only registered instances (their issued token in PluginCatalog:RegistryTokens) get through.
         var group = endpoints.MapGroup(RegistryPackageSource.RoutePrefix).AllowAnonymous();
+
+        group.AddEndpointFilter(async (ctx, next) =>
+        {
+            var config = ctx.HttpContext.RequestServices.GetRequiredService<IConfiguration>();
+            var issued = IssuedTokens(config);
+            if (issued.Count == 0)
+                return await next(ctx); // no tokens issued → the open local-dev / e2e-stub registry
+            if (PluginRegistryTokens.Validate(ctx.HttpContext.Request.Headers.Authorization, issued))
+                return await next(ctx);
+            ctx.HttpContext.RequestServices.GetService<ILoggerFactory>()
+                ?.CreateLogger(typeof(PluginRegistryEndpoints))
+                .LogWarning("Plugin registry: rejected request to {Path} without a valid instance token",
+                    ctx.HttpContext.Request.Path);
+            return Results.Json(
+                new { error = "A registered instance token is required (Authorization: Bearer …)." },
+                statusCode: StatusCodes.Status401Unauthorized);
+        });
 
         group.MapGet("", (IMessageHub rootHub, IConfiguration config, CancellationToken ct) =>
             List(rootHub, config, ct));
@@ -44,6 +66,15 @@ public static class PluginRegistryEndpoints
 
         return endpoints;
     }
+
+    /// <summary>The instance tokens this registry has issued — <c>PluginCatalog:RegistryTokens:N</c>
+    /// (registering an instance = issuing it a token and provisioning it into this list).</summary>
+    private static IReadOnlyList<string> IssuedTokens(IConfiguration config) =>
+        config.GetSection(PluginRegistryTokens.SectionName).GetChildren()
+            .Select(c => c.Value)
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Select(v => v!)
+            .ToList();
 
     /// <summary>One configured registry source: the git package source, the ref it serves, and a
     /// display name (for logs). The registry is authoritative on each source's ref (its configured

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginAuthoring.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginAuthoring.md
@@ -81,11 +81,13 @@ and check the type's page.
 A platform admin installs from the GUI: **Settings ▸ Administration ▸ Plugin Catalog**. The tab
 lists the registry's modules with Install / Update / Installed status and installs on click — the
 consumer pulls the package over HTTP and compiles it locally; no GitHub credential is involved. The
-tab reads `PluginCatalog:RegistryUrl` (the registry base URL) and the registry's public endpoints:
+tab reads `PluginCatalog:RegistryUrl` (the registry base URL) plus the instance token the registry
+issued this installation (`PluginCatalog:RegistryToken`, sent as `Authorization: Bearer`) and calls
+the registry's token-gated endpoints:
 
 ```text
-GET  {registry}/api/plugins             → the catalog { packages:[…] }    (anonymous)
-POST {registry}/api/plugins/files {id}  → a package's files { files:[…] } (anonymous)
+GET  {registry}/api/plugins             → the catalog { packages:[…] }    (Bearer instance token)
+POST {registry}/api/plugins/files {id}  → a package's files { files:[…] } (Bearer instance token)
 ```
 
 The types compile on first import; re-running is an upsert. See [Plugin
@@ -134,8 +136,10 @@ Any MeshWeaver instance can be the distribution point for its own plugins. One-t
 
 5. **Point the instance's catalog source at your plugins repo** — set
    `PluginCatalog:SourceRepoPath` to the repo URL (the App credential above lets it read a private
-   repo). The instance now serves the catalog anonymously at `GET /api/plugins`; consumers set their
-   `PluginCatalog:RegistryUrl` to this instance and install from the **Plugin Catalog** admin tab.
+   repo). The instance now serves the catalog at `GET /api/plugins` — gated to registered
+   consumers once you issue tokens into `PluginCatalog:RegistryTokens` (open only while that list is
+   empty, the dev mode); consumers set their `PluginCatalog:RegistryUrl` to this instance, put their
+   issued token in `PluginCatalog:RegistryToken`, and install from the **Plugin Catalog** admin tab.
 
 The App credential lives on this ONE instance; every consumer pulls over HTTP — that's the whole
 point ([Plugin Registry](/Doc/Architecture/PluginRegistry) → credential encapsulation).

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -1,7 +1,7 @@
 ---
 Name: Plugin Registry
 Category: Architecture
-Description: One MeshWeaver instance acts as the plugin registry — it holds the source credential, syncs plugins from git, and re-serves them over a public REST surface so any installation's platform admin can browse and install plugins without its own GitHub access. The credential is encapsulated in the registry, npm/NuGet-style.
+Description: One MeshWeaver instance acts as the plugin registry — it holds the source credential, syncs plugins from git, and re-serves them over a token-gated REST surface so any registered installation's platform admin can browse and install plugins without its own GitHub access. The credential is encapsulated in the registry, npm/NuGet-style.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v4H3z"/><path d="M5 7v14h14V7"/><path d="M10 12h4"/></svg>
 ---
 
@@ -33,11 +33,17 @@ the registry has source access and clients just speak HTTP.
                                                             └────────────────────────┘
 ```
 
-## The surface — public, curated
+## The surface — registered instances only, curated
 
-Two endpoints, mapped by `PluginRegistryEndpoints` (`memex/Memex.Portal.Shared/Api`). Unlike the
-authenticated `/api/mesh/*` surface, these are **anonymous** — a plugin registry is meant to be
-pulled by any installation. That is safe because the registry only exposes **curated plugins**:
+Two endpoints, mapped by `PluginRegistryEndpoints` (`memex/Memex.Portal.Shared/Api`). The surface is
+**not public**: it serves only **registered MeshWeaver instances**. Registering an instance means
+issuing it a token and adding that token to the registry's `PluginCatalog:RegistryTokens` list
+(config/secret on the registry); the consumer sends its token as `Authorization: Bearer` (its
+`PluginCatalog:RegistryToken`, or per-registry `Registries:N:Token`), and a request without a valid
+token is 401 (validated fixed-time by `PluginRegistryTokens`, the shared producer/consumer contract).
+Only when **no** tokens are configured — the local-dev / e2e-stub mode — does the registry answer
+anonymously; a production registry always configures tokens. What a registered instance can then
+read is **curated plugins** only:
 by default the node-native repos the [`MeshWeaver.Plugins`](/Doc/Architecture/Plugins) repo ships —
 `<Plugin>/index.json` **Space** roots carrying a `PluginManifest`, node-per-file — via a
 `NodeRepoPackageSource` (`PluginCatalog:SourceFormat=node-repo`, the default). A `package.json`-manifest
@@ -116,8 +122,9 @@ in a shared partition.
   installation is "point `PluginCatalog:RegistryUrl` at the registry," not "provision it a GitHub App."
 - **Not a Space.** The catalog is an admin tab reading a remote registry; there is no partition for a
   non-admin to navigate into and be denied.
-- **Curated + public.** Only `package.json` folders are exposed, so anonymous read is safe and the
-  catalog lists real modules (Slides, Edu, …), not every partition that happens to define a type.
+- **Registered + curated.** Only registered instances (their issued token in
+  `PluginCatalog:RegistryTokens`) can read, and only `package.json` folders are exposed — the
+  catalog lists real modules (Publish, Edu, …), not every partition that happens to define a type.
 - **Capability, not data.** A package ships its `NodeType`/`Code`/content folder — never a partition's
   user data — so installing a plugin gives you the types and their code, not anyone's records.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-21-registry-instance-tokens.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-21-registry-instance-tokens.md
@@ -1,0 +1,17 @@
+---
+Name: Plugin registry is now gated to registered instances
+Category: What's New
+Description: The /api/plugins registry surface requires an issued instance token — anonymous access is reserved for local-dev registries with no tokens configured.
+Icon: ShieldKeyhole
+---
+
+# Plugin registry is now gated to registered instances
+
+The plugin registry no longer serves its catalog publicly. An installation registers with the
+registry and receives an **instance token**; the Plugin Catalog sends it on every request, and the
+registry answers only requests carrying a valid token.
+
+For operators: on the registry, list the issued tokens under `PluginCatalog:RegistryTokens`; on each
+consuming installation, set `PluginCatalog:RegistryToken` (or `Registries:N:Token` per registry) to
+the token it was issued. A registry with **no** tokens configured keeps answering anonymously — the
+local-dev and test-stub mode — so nothing changes for development setups.

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogOptions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogOptions.cs
@@ -30,6 +30,12 @@ public sealed class PluginCatalogOptions
     /// so the registry could honor a pinned rollout later without a consumer change.</summary>
     public string RegistryRef { get; set; } = "HEAD";
 
+    /// <summary>The instance token this installation was issued when it registered with the
+    /// registry, sent as <c>Authorization: Bearer</c> (see <see cref="PluginRegistryTokens"/>).
+    /// Empty → requests go out unauthenticated (only an open dev/e2e registry answers them).
+    /// Legacy single-registry key — prefer <see cref="PluginRegistryReference.Token"/>.</summary>
+    public string RegistryToken { get; set; } = "";
+
     /// <summary>
     /// The registries this installation consumes, in display order
     /// (<c>PluginCatalog:Registries:0:{Name,Url,Ref}</c>, …). Empty → falls back to the legacy
@@ -47,7 +53,7 @@ public sealed class PluginCatalogOptions
             ? configured
             : string.IsNullOrWhiteSpace(RegistryUrl)
                 ? []
-                : [new PluginRegistryReference { Url = RegistryUrl, Ref = RegistryRef }];
+                : [new PluginRegistryReference { Url = RegistryUrl, Ref = RegistryRef, Token = RegistryToken }];
 }
 
 /// <summary>One registry a consumer reads its plugin catalog from (an entry of
@@ -63,4 +69,8 @@ public sealed class PluginRegistryReference
 
     /// <summary>Advisory git ref (see <see cref="PluginCatalogOptions.RegistryRef"/>).</summary>
     public string Ref { get; set; } = "HEAD";
+
+    /// <summary>The instance token issued for THIS registry when the installation registered with it
+    /// (see <see cref="PluginCatalogOptions.RegistryToken"/> and <see cref="PluginRegistryTokens"/>).</summary>
+    public string Token { get; set; } = "";
 }

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogSettingsTab.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogSettingsTab.cs
@@ -96,7 +96,7 @@ public static class PluginCatalogSettingsTab
             var label = string.IsNullOrWhiteSpace(registry.Name) ? registry.Url : registry.Name;
             if (registries.Count > 1)
                 stack = stack.WithView(Controls.Title(label, 2));
-            var source = new RegistryPackageSource(host.Hub, registry.Url);
+            var source = new RegistryPackageSource(host.Hub, registry.Url, registry.Token);
             stack = stack.WithView((h, _) => CatalogLayoutAreas.RenderFromSource(
                 h, source, registry.Ref, description: null, sourceLabel: registry.Url));
         }

--- a/src/MeshWeaver.PluginCatalog/PluginRegistryTokens.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginRegistryTokens.cs
@@ -1,0 +1,52 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The instance-token contract of the plugin-registry surface — one place for BOTH sides, so the
+/// producer (the registry's <c>/api/plugins</c> endpoints) and the consumer
+/// (<see cref="RegistryPackageSource"/>) cannot drift, mirroring <see cref="PluginRegistryPayloads"/>.
+///
+/// <para>The registry is NOT public: it serves only <b>registered MeshWeaver instances</b>. Registering
+/// an instance means issuing it a token and adding that token to the registry's
+/// <c>PluginCatalog:RegistryTokens</c> list (provisioned as config/secret on the registry — the
+/// managed-instance control plane writes it there when it provisions an instance). The consumer sends
+/// its token as <c>Authorization: Bearer &lt;token&gt;</c>
+/// (<see cref="PluginRegistryReference.Token"/>). With no tokens configured the registry is open —
+/// the local-dev / e2e-stub mode; a production registry always configures tokens.</para>
+/// </summary>
+public static class PluginRegistryTokens
+{
+    /// <summary>Config key holding the registry's issued instance tokens
+    /// (<c>PluginCatalog:RegistryTokens:0</c>, <c>:1</c>, …).</summary>
+    public const string SectionName = "PluginCatalog:RegistryTokens";
+
+    /// <summary>The HTTP auth scheme the token travels under.</summary>
+    public const string Scheme = "Bearer";
+
+    /// <summary>Formats the <c>Authorization</c> header value the consumer sends.</summary>
+    public static string AuthorizationHeader(string token) => $"{Scheme} {token}";
+
+    /// <summary>
+    /// Validates a request's <c>Authorization</c> header against the registry's issued tokens.
+    /// The header must be <c>Bearer &lt;token&gt;</c> (scheme case-insensitive) and the token must
+    /// match one of <paramref name="issuedTokens"/>. Every comparison is fixed-time
+    /// (<see cref="CryptographicOperations.FixedTimeEquals(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>)
+    /// so a mismatch reveals nothing about how much of a token matched.
+    /// </summary>
+    public static bool Validate(string? authorizationHeader, IReadOnlyCollection<string> issuedTokens)
+    {
+        if (issuedTokens.Count == 0 || string.IsNullOrWhiteSpace(authorizationHeader))
+            return false;
+        var trimmed = authorizationHeader.Trim();
+        if (!trimmed.StartsWith(Scheme + " ", StringComparison.OrdinalIgnoreCase))
+            return false;
+        var presented = Encoding.UTF8.GetBytes(trimmed[(Scheme.Length + 1)..].Trim());
+        // Check EVERY issued token (no early exit) so timing does not leak which token was closest.
+        var valid = false;
+        foreach (var issued in issuedTokens)
+            valid |= CryptographicOperations.FixedTimeEquals(presented, Encoding.UTF8.GetBytes(issued));
+        return valid;
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
@@ -34,12 +34,17 @@ public sealed class RegistryPackageSource : IPackageSource
     private readonly string _registryUrl;
     private readonly IIoPool _httpPool;
     private readonly HttpClient _http;
+    private readonly string _token;
 
     /// <summary>Creates the source. <paramref name="registryUrl"/> is the registry instance base URL
-    /// (e.g. <c>https://memex.meshweaver.cloud</c>); trailing slash is trimmed.</summary>
-    public RegistryPackageSource(IMessageHub hub, string registryUrl)
+    /// (e.g. <c>https://memex.meshweaver.cloud</c>); trailing slash is trimmed.
+    /// <paramref name="token"/> is the instance token issued when this installation registered with
+    /// the registry (see <see cref="PluginRegistryTokens"/>), sent as <c>Authorization: Bearer</c>;
+    /// empty → unauthenticated (only an open dev/e2e registry answers).</summary>
+    public RegistryPackageSource(IMessageHub hub, string registryUrl, string? token = null)
     {
         _registryUrl = (registryUrl ?? "").TrimEnd('/');
+        _token = (token ?? "").Trim();
         _httpPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
         _http = hub.ServiceProvider.GetService<IHttpClientFactory>()?.CreateClient("plugin-registry") ?? SharedHttp;
     }
@@ -47,12 +52,27 @@ public sealed class RegistryPackageSource : IPackageSource
     private sealed record ListResponse(IReadOnlyList<PackageManifest>? Packages);
     private sealed record FilesResponse(IReadOnlyList<PackageFile>? Files);
 
+    // Per-REQUEST auth header — never on the client: _http can be the process-wide SharedHttp, and
+    // mutating its DefaultRequestHeaders would leak this registry's token to every other registry.
+    private HttpRequestMessage Request(HttpMethod method, string url, HttpContent? content = null)
+    {
+        var request = new HttpRequestMessage(method, url) { Content = content };
+        if (_token.Length > 0)
+            request.Headers.TryAddWithoutValidation("Authorization", PluginRegistryTokens.AuthorizationHeader(_token));
+        return request;
+    }
+
     /// <inheritdoc />
     public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
         _httpPool.Invoke(async ct =>
         {
             var url = $"{_registryUrl}{RoutePrefix}?ref={Uri.EscapeDataString(gitRef ?? "")}";
-            var json = await _http.GetStringAsync(url, ct).ConfigureAwait(false);
+            using var request = Request(HttpMethod.Get, url);
+            using var resp = await _http.SendAsync(request, ct).ConfigureAwait(false);
+            var json = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+                throw new InvalidOperationException(
+                    $"Registry catalog list failed ({(int)resp.StatusCode}): {json}");
             var parsed = JsonSerializer.Deserialize<ListResponse>(json, Json);
             return (IReadOnlyList<PackageManifest>)(parsed?.Packages ?? []);
         });
@@ -65,8 +85,8 @@ public sealed class RegistryPackageSource : IPackageSource
             // curated catalog (see PluginRegistryEndpoints), so a consumer can't reach arbitrary paths.
             var body = JsonSerializer.Serialize(new { id = package.Id, @ref = gitRef }, Json);
             using var content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
-            using var resp = await _http.PostAsync($"{_registryUrl}{RoutePrefix}/files", content, ct)
-                .ConfigureAwait(false);
+            using var request = Request(HttpMethod.Post, $"{_registryUrl}{RoutePrefix}/files", content);
+            using var resp = await _http.SendAsync(request, ct).ConfigureAwait(false);
             var json = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
                 throw new InvalidOperationException(

--- a/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
@@ -58,7 +58,10 @@ public sealed class RegistryPackageSource : IPackageSource
     {
         var request = new HttpRequestMessage(method, url) { Content = content };
         if (_token.Length > 0)
-            request.Headers.TryAddWithoutValidation("Authorization", PluginRegistryTokens.AuthorizationHeader(_token));
+            // Typed header, not TryAddWithoutValidation: a malformed configured token (e.g. with a
+            // CRLF) must throw here rather than travel as an invalid header.
+            request.Headers.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue(PluginRegistryTokens.Scheme, _token);
         return request;
     }
 

--- a/test/MeshWeaver.PluginCatalog.Test/PluginCatalogOptionsTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PluginCatalogOptionsTest.cs
@@ -24,11 +24,13 @@ public class PluginCatalogOptionsTest
         {
             RegistryUrl = "https://memex.meshweaver.cloud",
             RegistryRef = "main",
+            RegistryToken = "tok-instance-1",
         };
 
         var registry = Assert.Single(options.EffectiveRegistries);
         Assert.Equal("https://memex.meshweaver.cloud", registry.Url);
         Assert.Equal("main", registry.Ref);
+        Assert.Equal("tok-instance-1", registry.Token);
     }
 
     [Fact]

--- a/test/MeshWeaver.PluginCatalog.Test/PluginRegistryTokensTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/PluginRegistryTokensTest.cs
@@ -1,0 +1,53 @@
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Pins <see cref="PluginRegistryTokens.Validate"/> — the instance-token gate of the plugin-registry
+/// surface: only a <c>Bearer</c> header carrying one of the registry's issued tokens passes; a
+/// missing header, a wrong scheme, an unknown token, or an empty issued list all fail closed.
+/// </summary>
+public class PluginRegistryTokensTest
+{
+    private static readonly string[] Issued = ["tok-instance-1", "tok-instance-2"];
+
+    [Theory]
+    [InlineData("Bearer tok-instance-1")]
+    [InlineData("Bearer tok-instance-2")]
+    [InlineData("bearer tok-instance-1")] // scheme is case-insensitive
+    [InlineData("  Bearer tok-instance-1  ")] // surrounding whitespace is tolerated
+    public void IssuedToken_Passes(string header)
+    {
+        Assert.True(PluginRegistryTokens.Validate(header, Issued));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Bearer")] // scheme without a token
+    [InlineData("Bearer tok-unknown")]
+    [InlineData("Bearer tok-instance")] // prefix of an issued token
+    [InlineData("Bearer tok-instance-11")] // issued token plus a suffix
+    [InlineData("Basic tok-instance-1")] // wrong scheme
+    [InlineData("tok-instance-1")] // bare token without a scheme
+    public void AnythingElse_FailsClosed(string? header)
+    {
+        Assert.False(PluginRegistryTokens.Validate(header, Issued));
+    }
+
+    [Fact]
+    public void NoIssuedTokens_NeverValidates()
+    {
+        // The endpoints only consult Validate when tokens ARE configured (no tokens → the open
+        // dev/e2e registry); Validate itself still fails closed on an empty list.
+        Assert.False(PluginRegistryTokens.Validate("Bearer tok-instance-1", []));
+    }
+
+    [Fact]
+    public void AuthorizationHeader_RoundTripsThroughValidate()
+    {
+        Assert.True(PluginRegistryTokens.Validate(
+            PluginRegistryTokens.AuthorizationHeader("tok-instance-1"), Issued));
+    }
+}


### PR DESCRIPTION
## What

The plugin-registry surface (`GET /api/plugins`, `POST /api/plugins/files`) is no longer public: it serves only **registered MeshWeaver instances**, each holding a token issued at registration.

- **`PluginRegistryTokens`** (new, `MeshWeaver.PluginCatalog`) — the shared producer/consumer contract: the `Authorization: Bearer` header shape plus fixed-time validation (`CryptographicOperations.FixedTimeEquals`, every issued token checked with no early exit, so timing leaks nothing).
- **`PluginRegistryEndpoints`** — an endpoint filter rejects requests without a valid token (401 + a warning log) whenever `PluginCatalog:RegistryTokens` is non-empty. With **no** tokens configured the registry answers anonymously — the local-dev / e2e-stub mode, so dev setups and the education-repo disposable mesh keep working unchanged.
- **Consumer** — `PluginCatalogOptions.RegistryToken` (legacy single) and `Registries:N:Token` per registry; `RegistryPackageSource` sends the token **per request** (deliberately not on the `HttpClient`, which can be the process-wide shared client — default headers there would leak one registry's token to every other registry). The settings tab passes it through.
- **Docs** — `PluginRegistry.md` and `PluginAuthoring.md` rewritten from "anonymous by design" to the registered-instances model; What's New entry included (operator-facing behavior change).

## Why

The registry must not hand its catalog and package files to anyone on the internet — only instances we registered. Registering an instance = issuing it a token and provisioning that token into the registry's `PluginCatalog:RegistryTokens` (config/secret). The managed-instance control plane is the future automation point for issuance.

## Rollout note

Order matters: issue tokens to consumers **before** configuring them on the registry, or installs 401 in the window.

## Testing

- `dotnet build -c Release -p:CIRun=true -warnaserror` green on `MeshWeaver.PluginCatalog` and `Memex.Portal.Shared`.
- `test/MeshWeaver.PluginCatalog.Test`: 36/36 green, including a new token-gate matrix (unknown token, prefix/suffix of an issued token, wrong scheme, bare token, missing header, empty issued list — all fail closed) and the options folding of the new token fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDhZdYyZSZBHn3uDuZRj54