### PR TITLE
fix(layout): total string->Icon conversion ends NavLink icon-binding error storm

### DIFF
--- a/src/MeshWeaver.Application.Styles/FluentIcons.cs
+++ b/src/MeshWeaver.Application.Styles/FluentIcons.cs
@@ -9,7 +9,7 @@ namespace MeshWeaver.Application.Styles;
 public static class FluentIcons
 {
     /// <summary>The icon-provider key for the Fluent UI System Icons set.</summary>
-    public const string Provider = "fluent-ui";
+    public const string Provider = Icon.FluentProvider;
     /// <summary>The "Accessibility" Fluent UI icon.</summary>
     public static Icon Accessibility(IconSize size = IconSize.Size24, IconVariant variant = IconVariant.Regular) => new Icon(Provider, "Accessibility") { Size = size, Variant = variant };
 

--- a/src/MeshWeaver.Blazor/Components/NavLink.razor
+++ b/src/MeshWeaver.Blazor/Components/NavLink.razor
@@ -1,18 +1,47 @@
+@using MeshWeaver.Graph
 @inherits NavItemView<NavLinkControl, NavLink>
 
 @if (IsInMenuContext)
 {
     <a href="@Href" class="menu-item-link@(IsActive ? " active" : "")" @onclick="OnClick">
-        @if (Icon != null)
+        @if (ResolvedFluentIcon is not null)
         {
-            <FluentIcon Value="@Icon.ToFluentIcon()" Width="20px" Style="fill: var(--accent-fill-rest); flex-shrink: 0;" />
+            <FluentIcon Value="@ResolvedFluentIcon" Width="20px" Style="fill: var(--accent-fill-rest); flex-shrink: 0;" />
+        }
+        else
+        {
+            @RawIcon
         }
         <span>@Title</span>
     </a>
 }
 else
 {
-    <FluentNavLink Href="@Href" Icon="@Icon?.ToFluentIcon()" OnClick="@OnClick"
-                   Class="@(IsActive ? "active" : null)">@Title</FluentNavLink>
+    <FluentNavLink Href="@Href" Icon="@ResolvedFluentIcon" OnClick="@OnClick"
+                   Class="@(IsActive ? "active" : null)">@RawIcon@Title</FluentNavLink>
 }
 
+@code {
+    private Microsoft.FluentUI.AspNetCore.Components.Icon? ResolvedFluentIcon => Icon?.ToFluentIcon();
+
+    // A MeshNode.Icon travels as a raw string and Icon.Parse classifies it (see Domain.Icon):
+    // Fluent names render through the FluentIcon slot above; the other forms render here with the
+    // SAME mechanism the node cards/thumbnails use — an image URL / data URI as <img>, inline
+    // <svg> markup verbatim (sized via MeshNodeImageHelper.SizeInlineSvg), and a text glyph
+    // (emoji) as text. Anything else renders nothing — never a throw, never a per-render log.
+    private RenderFragment RawIcon => __builder =>
+    {
+        if (Icon is { Provider: MeshWeaver.Domain.Icon.UrlProvider } urlIcon)
+        {
+            <img src="@urlIcon.Id" alt="" style="width: 20px; height: 20px; flex-shrink: 0; vertical-align: middle;" />
+        }
+        else if (Icon is { Provider: MeshWeaver.Domain.Icon.InlineSvgProvider } svgIcon)
+        {
+            <span style="display: inline-flex; flex-shrink: 0; vertical-align: middle;">@((MarkupString)MeshNodeImageHelper.SizeInlineSvg(svgIcon.Id, 20))</span>
+        }
+        else if (Icon is { Provider: MeshWeaver.Domain.Icon.TextProvider } textIcon)
+        {
+            <span style="font-size: 16px; flex-shrink: 0; vertical-align: middle;">@textIcon.Id</span>
+        }
+    };
+}

--- a/src/MeshWeaver.Blazor/ViewModelExtensions.cs
+++ b/src/MeshWeaver.Blazor/ViewModelExtensions.cs
@@ -17,11 +17,26 @@ public static class ViewModelExtensions
     public static Microsoft.FluentUI.AspNetCore.Components.Icon? ToFluentIcon(this Icon icon) =>
         icon.Provider switch
         {
-            FluentIcons.Provider =>
-                new IconInfo { Name = icon.Id, Size = (IconSize)icon.Size, Variant = (IconVariant)icon.Variant }.GetInstance(),
+            FluentIcons.Provider => CreateFluentIcon(icon),
             CustomIcons.Provider => CreateCustomIcon(icon),
             _ => null
         };
+
+    private static Microsoft.FluentUI.AspNetCore.Components.Icon? CreateFluentIcon(Icon icon)
+    {
+        try
+        {
+            return new IconInfo { Name = icon.Id, Size = (IconSize)icon.Size, Variant = (IconVariant)icon.Variant }
+                .GetInstance();
+        }
+        catch (ArgumentException)
+        {
+            // A PascalCase word that is not an actual Fluent icon name (Icon.Parse classifies any
+            // such free-text node icon as FluentProvider) must degrade to "no icon" — GetInstance's
+            // only signal for an unknown name is this throw, and a per-render throw storms the log.
+            return null;
+        }
+    }
 
     private static Microsoft.FluentUI.AspNetCore.Components.Icon? CreateCustomIcon(Icon icon)
     {

--- a/src/MeshWeaver.Domain/Icon.cs
+++ b/src/MeshWeaver.Domain/Icon.cs
@@ -9,6 +9,18 @@
 /// <param name="Id"></param>
 public record Icon(string Provider, string Id)
 {
+    /// <summary>The provider key for Fluent UI icons referenced by name (e.g. "Document").</summary>
+    public const string FluentProvider = "fluent-ui";
+
+    /// <summary>The provider key for icons referenced by an image URL or data URI held in <see cref="Id"/>.</summary>
+    public const string UrlProvider = "url";
+
+    /// <summary>The provider key for icons carried as raw inline <c>&lt;svg&gt;</c> markup in <see cref="Id"/>.</summary>
+    public const string InlineSvgProvider = "inline-svg";
+
+    /// <summary>The provider key for icons carried as a literal text glyph (e.g. an emoji) in <see cref="Id"/>.</summary>
+    public const string TextProvider = "text";
+
     /// <summary>
     /// The rendered size of the icon; defaults to <see cref="IconSize.Size24"/>.
     /// </summary>
@@ -19,6 +31,27 @@ public record Icon(string Provider, string Id)
     /// </summary>
     public IconVariant Variant { get; init; } = IconVariant.Regular;
 
+    /// <summary>
+    /// TOTAL conversion of the raw string forms an icon field (e.g. <c>MeshNode.Icon</c>) legitimately
+    /// holds: inline <c>&lt;svg&gt;</c> markup (<see cref="InlineSvgProvider"/>), an image URL or data
+    /// URI (<see cref="UrlProvider"/>), or a Fluent UI icon name such as "Document"
+    /// (<see cref="FluentProvider"/>). Any other non-empty value — an emoji or arbitrary text — degrades
+    /// to <see cref="TextProvider"/> so binding NEVER throws; null/whitespace parses to null.
+    /// </summary>
+    /// <param name="value">The raw icon string to classify.</param>
+    /// <returns>The parsed icon, or null for null/whitespace input.</returns>
+    public static Icon? Parse(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        if (value.TrimStart().StartsWith("<svg", StringComparison.OrdinalIgnoreCase))
+            return new Icon(InlineSvgProvider, value) { Size = IconSize.Custom };
+        if (value.Contains('/') || value.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            return new Icon(UrlProvider, value);
+        if (char.IsAsciiLetterUpper(value[0]) && value.All(char.IsAsciiLetter))
+            return new Icon(FluentProvider, value);
+        return new Icon(TextProvider, value);
+    }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
+++ b/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
@@ -9,6 +9,7 @@ using MeshWeaver.Data.Serialization;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Icon = MeshWeaver.Domain.Icon;
 
 namespace MeshWeaver.Layout.Client;
 
@@ -253,6 +254,13 @@ public static class LayoutClientExtensions
         conversion ??= null;
         if (conversion != null)
             return conversion.Invoke(value, defaultValue);
+        // A node's icon field legitimately holds a RAW STRING — a Fluent icon name ("Document"),
+        // an image URL ("/static/NodeTypeIcons/document.svg"), or inline <svg> markup. Binding
+        // such a string into an Icon-typed slot goes through the TOTAL Icon.Parse; the generic
+        // paths (Deserialize / ConvertString) both throw on the string form, which logged a
+        // `fail` line on EVERY NavLink render (prod error storm) while the icon rendered as nothing.
+        if (typeof(T) == typeof(Icon) && TryGetStringValue(value, out var iconString))
+            return (T?)(object?)Icon.Parse(iconString);
         return value switch
         {
             null => defaultValue,
@@ -396,6 +404,23 @@ public static class LayoutClientExtensions
                 : (T)(object)(ulong)Math.Truncate(value),
             _ => throw new InvalidOperationException($"Unsupported integer type: {targetType.Name}")
         };
+    }
+
+    /// <summary>
+    /// Extracts a plain string from the raw binding value regardless of how it arrived —
+    /// as a CLR string, a <see cref="JsonElement"/> string token, or a <see cref="JsonValue"/>
+    /// string node — so type-specific string parsing (e.g. <see cref="Icon.Parse"/>) sees ONE shape.
+    /// </summary>
+    private static bool TryGetStringValue(object? value, out string? s)
+    {
+        s = value switch
+        {
+            string str => str,
+            JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
+            JsonValue jv when jv.TryGetValue<string>(out var nodeString) => nodeString,
+            _ => null
+        };
+        return s != null;
     }
 
     private static T ConvertString<T>(string s)

--- a/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
+++ b/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
@@ -4,6 +4,7 @@ using MeshWeaver.Fixture;
 using MeshWeaver.Layout.Client;
 using MeshWeaver.Messaging;
 using Xunit;
+using Icon = MeshWeaver.Domain.Icon;
 
 namespace MeshWeaver.Layout.Test;
 
@@ -431,5 +432,114 @@ public class LayoutClientExtensionsTest(ITestOutputHelper output) : HubTestBase(
         var result = hub.ConvertSingle<double>(element, null);
 
         result.Should().Be(322.844);
+    }
+
+    // ---- NavLink icon binding: MeshNode.Icon is a raw STRING (Fluent name / URL / inline SVG) ------
+    // A layout area (e.g. MarkdownOverviewLayoutArea's sub-node nav) feeds MeshNodeImageHelper
+    // .ResolveNodeIcon(child) — a string — into NavLinkControl.Icon, which the Blazor NavItemView
+    // binds into a MeshWeaver.Domain.Icon-typed slot. Before the fix, ConvertString<Icon> threw
+    // InvalidOperationException ("Cannot convert /static/NodeTypeIcons/document.svg to
+    // MeshWeaver.Domain.Icon") on EVERY render — the memex-cloud prod error storm. The conversion
+    // must be TOTAL: all legitimate forms parse, garbage degrades, nothing throws.
+
+    private const string InlineSvg =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"M0 0h24v24H0z\"/></svg>";
+
+    [Fact]
+    public void ConvertSingle_IconUrlString_ParsesToUrlIcon()
+    {
+        var hub = GetHost();
+
+        var result = hub.ConvertSingle<Icon>("/static/NodeTypeIcons/document.svg", null);
+
+        result.Should().NotBeNull("a URL-form node icon must bind, not throw (prod error storm)");
+        result!.Provider.Should().Be(Icon.UrlProvider);
+        result.Id.Should().Be("/static/NodeTypeIcons/document.svg");
+    }
+
+    [Fact]
+    public void ConvertSingle_InlineSvgString_ParsesToInlineSvgIcon()
+    {
+        var hub = GetHost();
+
+        var result = hub.ConvertSingle<Icon>(InlineSvg, null);
+
+        result.Should().NotBeNull();
+        result!.Provider.Should().Be(Icon.InlineSvgProvider);
+        result.Id.Should().Be(InlineSvg, "the markup renders verbatim client-side");
+        result.Size.Should().Be(MeshWeaver.Domain.IconSize.Custom);
+    }
+
+    [Fact]
+    public void ConvertSingle_FluentIconNameString_ParsesToFluentIcon()
+    {
+        var hub = GetHost();
+
+        var result = hub.ConvertSingle<Icon>("Document", null);
+
+        result.Should().NotBeNull();
+        result!.Provider.Should().Be(Icon.FluentProvider);
+        result.Id.Should().Be("Document");
+    }
+
+    [Fact]
+    public void ConvertSingle_EmojiIconString_DegradesToTextGlyph()
+    {
+        var hub = GetHost();
+
+        var result = hub.ConvertSingle<Icon>("\U0001F680", null);
+
+        result.Should().NotBeNull();
+        result!.Provider.Should().Be(Icon.TextProvider);
+        result.Id.Should().Be("\U0001F680");
+    }
+
+    [Fact]
+    public void ConvertSingle_GarbageIconString_NeverThrows()
+    {
+        var hub = GetHost();
+
+        var result = hub.ConvertSingle<Icon>("??!! not-an-icon", null);
+
+        result.Should().NotBeNull("an unknown form must degrade gracefully, never throw");
+        result!.Provider.Should().Be(Icon.TextProvider);
+    }
+
+    [Fact]
+    public void ConvertSingle_WhitespaceIconString_ReturnsNull()
+    {
+        var hub = GetHost();
+
+        var result = hub.ConvertSingle<Icon>("  ", null);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ConvertSingle_IconStringJsonElement_ParsesSameAsString()
+    {
+        // The same raw string arriving as a JSON string token (the data-bound pointer path) went
+        // through Deserialize<Icon>, threw JsonException, and logged an error per render — the
+        // JsonElement shape must route through the same total parse.
+        var hub = GetHost();
+        var element = JsonSerializer.SerializeToElement("/static/NodeTypeIcons/document.svg");
+
+        var result = hub.ConvertSingle<Icon>(element, null);
+
+        result.Should().NotBeNull();
+        result!.Provider.Should().Be(Icon.UrlProvider);
+        result.Id.Should().Be("/static/NodeTypeIcons/document.svg");
+    }
+
+    [Fact]
+    public void ConvertSingle_IconInstance_PassesThroughUnchanged()
+    {
+        // Regression: a properly-typed Icon (the existing wire/object form) must be untouched.
+        var hub = GetHost();
+        var icon = new Icon(Icon.FluentProvider, "Home");
+
+        var result = hub.ConvertSingle<Icon>(icon, null);
+
+        result.Should().BeSameAs(icon);
     }
 }


### PR DESCRIPTION
## Prod defect (memex-cloud, storming)

```
fail: MeshWeaver.Blazor.Components.NavLink[0]
      Error binding value '/static/NodeTypeIcons/document.svg' in Area Overview/1/1/2
      System.InvalidOperationException: Cannot convert /static/NodeTypeIcons/document.svg to MeshWeaver.Domain.Icon
         at MeshWeaver.Layout.Client.LayoutClientExtensions.ConvertString[T](String s)
```

The same failure fires for inline-SVG icon strings in `Overview/1/1/1..6` — one `fail` log line per NavLink per render, and the icon renders as nothing.

## Root cause

A `MeshNode.Icon` legitimately holds a raw string in one of three forms: a Fluent UI icon name (`Document`), an image URL (`/static/NodeTypeIcons/document.svg`), or inline `<svg>` markup. `MarkdownOverviewLayoutArea.BuildWithSubNodeNav` (`src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs:72-75`) feeds `MeshNodeImageHelper.ResolveNodeIcon(child)` — which *always* returns a URL/SVG/emoji string for a non-null node — into `NavLinkControl.Icon` (the Education areas do the same with `page.Icon`). The Blazor `NavItemView` binds that value into a `MeshWeaver.Domain.Icon`-typed slot, and the generic conversion (`ConvertString<Icon>` for CLR strings, `Deserialize<Icon>` for JSON string tokens) has no string→Icon case — it throws, `DataBind` catches + logs at Error, on **every** render.

## Fix — one total conversion path, no new rendering mechanism

- **`Icon.Parse` (MeshWeaver.Domain)** — total classifier of the raw string forms into provider-tagged Icons: `inline-svg` / `url` / `fluent-ui` / `text` (emoji or arbitrary text — graceful degradation, never a throw). Null/whitespace → null. The wire format of existing serialized Icons (`{Provider, Id, Size, Variant}`) is untouched; `FluentIcons.Provider` now aliases `Icon.FluentProvider` (same value, one source of truth).
- **`ConvertSingle` (Layout client)** — the single binding choke point routes any string-shaped value (CLR string, `JsonElement`/`JsonValue` string token) into `Icon.Parse` when the target slot is `Icon`-typed. This also kills the sibling per-render `ConvertJson<Icon>` error-log path for data-bound pointers.
- **`NavLink.razor`** — renders the non-Fluent forms with the SAME mechanism the node cards/thumbnails already use: URL/data-URI as `<img>`, inline SVG verbatim (sized via the existing `MeshNodeImageHelper.SizeInlineSvg`), text glyph as text. No hand-built HTML strings, no parallel mechanism.
- **`ToFluentIcon`** — an unknown Fluent icon name (free-text PascalCase word on a node) degrades to null instead of a per-render `ArgumentException` from `IconInfo.GetInstance`.

Other `Icon`-typed views (NavGroup, MenuItem, Button, …) automatically degrade gracefully: unknown providers → `ToFluentIcon` → null → no icon, no log.

## Tests (`MeshWeaver.Layout.Test/LayoutClientExtensionsTest`)

- `ConvertSingle_IconUrlString_ParsesToUrlIcon` — the exact prod repro (threw `InvalidOperationException` pre-fix)
- `ConvertSingle_InlineSvgString_ParsesToInlineSvgIcon`
- `ConvertSingle_FluentIconNameString_ParsesToFluentIcon`
- `ConvertSingle_EmojiIconString_DegradesToTextGlyph`
- `ConvertSingle_GarbageIconString_NeverThrows`
- `ConvertSingle_WhitespaceIconString_ReturnsNull`
- `ConvertSingle_IconStringJsonElement_ParsesSameAsString`
- `ConvertSingle_IconInstance_PassesThroughUnchanged` (wire/object-form regression)

## Gate

- Full solution `dotnet build -c Release -p:CIRun=true -warnaserror`: **0 warnings, 0 errors**
- `MeshWeaver.Layout.Test` full project: **337/337 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)