### PR TITLE
GitSync: bulk transfer over the git protocol — stop paying REST per file

### DIFF
--- a/src/MeshWeaver.GitSync/GitCredentials.cs
+++ b/src/MeshWeaver.GitSync/GitCredentials.cs
@@ -1,0 +1,24 @@
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// The ONE way a GitHub token reaches the <c>git</c> CLI: an inline credential helper that reads
+/// it from the <c>GW_TOKEN</c> environment variable — the secret never appears in argv (visible
+/// to <c>ps</c>) and never persists in <c>.git/config</c>. Shared by every git-protocol caller
+/// (<see cref="GitWorkingTreeService"/>, <see cref="GitProtocolRepoClient"/>).
+/// </summary>
+internal static class GitCredentials
+{
+    /// <summary>The credential-helper config args that read the token from <c>$GW_TOKEN</c>.
+    /// Empty when there is no token (anonymous access to a public remote).</summary>
+    public static IReadOnlyList<string> AuthArgs(string? token) => string.IsNullOrEmpty(token)
+        ? []
+        : [
+            // Clear any inherited helper (system credential store), then install ours.
+            "-c", "credential.helper=",
+            "-c", "credential.helper=!f() { test \"$1\" = get && printf 'username=x-access-token\\npassword=%s\\n' \"$GW_TOKEN\"; }; f",
+          ];
+
+    /// <summary>The environment carrying the token for <see cref="AuthArgs"/>'s helper.</summary>
+    public static IReadOnlyDictionary<string, string>? AuthEnv(string? token) =>
+        string.IsNullOrEmpty(token) ? null : new Dictionary<string, string> { ["GW_TOKEN"] = token };
+}

--- a/src/MeshWeaver.GitSync/GitCredentials.cs
+++ b/src/MeshWeaver.GitSync/GitCredentials.cs
@@ -20,5 +20,8 @@ internal static class GitCredentials
 
     /// <summary>The environment carrying the token for <see cref="AuthArgs"/>'s helper.</summary>
     public static IReadOnlyDictionary<string, string>? AuthEnv(string? token) =>
-        string.IsNullOrEmpty(token) ? null : new Dictionary<string, string> { ["GW_TOKEN"] = token };
+        string.IsNullOrEmpty(token)
+            ? null
+            : System.Collections.Immutable.ImmutableDictionary<string, string>.Empty
+                .Add("GW_TOKEN", token);
 }

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -40,7 +40,15 @@ public static class GitHubSyncConfiguration
             sp.GetRequiredService<IoPoolRegistry>(),
             sp.GetRequiredService<IOptions<GitHubAppOptions>>(),
             sp.GetService<ILogger<GitHubAppTokenService>>()));
-        services.AddSingleton<IGitHubRepoClient, OctokitGitHubRepoClient>();
+        // The production repo client: BULK transfer (push/fetch) over the git protocol — REST
+        // paid one request PER FILE, so one big-repo sync exhausted the GitHub App installation's
+        // hourly budget — with refs/PRs/issues remaining on the Octokit REST client it wraps.
+        services.AddSingleton<OctokitGitHubRepoClient>();
+        services.AddSingleton<IGitHubRepoClient>(sp => new GitProtocolRepoClient(
+            sp.GetRequiredService<OctokitGitHubRepoClient>(),
+            sp.GetRequiredService<GitCli>(),
+            sp.GetRequiredService<IoPoolRegistry>(),
+            sp.GetService<ILogger<GitProtocolRepoClient>>()));
         services.AddSingleton<GitHubCredentialService>();
         services.AddSingleton<GitHubSyncService>();
         services.AddSingleton<PullRequestService>();

--- a/src/MeshWeaver.GitSync/GitProtocolRepoClient.cs
+++ b/src/MeshWeaver.GitSync/GitProtocolRepoClient.cs
@@ -1,0 +1,367 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// The production <see cref="IGitHubRepoClient"/>: BULK transfer (<see cref="Push"/> /
+/// <see cref="Fetch(string,string,string?,string)"/>) over the native <b>git protocol</b> via
+/// <see cref="GitCli"/>; every other operation (refs, PRs, issues — cheap single calls) delegated
+/// to <see cref="OctokitGitHubRepoClient"/>.
+///
+/// <para><b>Why:</b> the REST Git Data API pays ONE request PER FILE — a blob read per file on
+/// fetch, a blob create per file on push — so a single sync of a large content repo (a course with
+/// thousands of files) burned most of a GitHub App installation's 5,000 req/h budget and rate-limited
+/// every other sync for the hour. Git smart-HTTP transfer (clone / fetch / push with the
+/// installation token) does not count against the REST rate limit at all; what remains on REST is
+/// repo creation, ref lookups and the PR/issue surface — a handful of calls per operation.</para>
+///
+/// <para>Semantics are byte-identical to the Octokit implementation and pinned by the shared
+/// contract tests: mirror-within-subdirectory (files outside the prefix untouched, removed files
+/// deleted), a missing branch on a non-empty repo based on the default-branch head (never an
+/// orphan), an empty repo initialized by the first pushed commit (the Contents-API
+/// <c>.gitkeep</c> dance is obsolete — the git protocol can create the first commit directly),
+/// and strict UTF-8 text/binary classification (<see cref="RepoFileCodec"/>). Additionally the
+/// git protocol writes <see cref="RepoFile.Bytes"/>, so BINARY files push losslessly — the REST
+/// path could only create UTF-8 blobs.</para>
+///
+/// <para>Reactive end-to-end: every git invocation is a blocking Process leaf bridged through
+/// <see cref="IIoPool"/> by <see cref="GitCli"/>; worktree reads/writes run on the
+/// <see cref="IoPoolNames.FileSystem"/> pool. All methods return COLD observables. Each operation
+/// works in its own unique temp clone, removed on termination.</para>
+/// </summary>
+public sealed class GitProtocolRepoClient(
+    OctokitGitHubRepoClient octokit,
+    GitCli git,
+    IoPoolRegistry ioPools,
+    ILogger<GitProtocolRepoClient>? logger = null) : IGitHubRepoClient
+{
+    private IIoPool FileSystem => ioPools.Get(IoPoolNames.FileSystem);
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Bulk transfer — the git protocol
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Mirrors the request's files into the repo as a single commit over the git protocol:
+    /// shallow-clone, materialize the mirror in the worktree, commit as the requested author,
+    /// push. Repo auto-create (a GitHub REST call — the one thing git cannot do) stays on the
+    /// Octokit client.
+    /// </summary>
+    public IObservable<GitHubPushResult> Push(GitHubPushRequest request)
+    {
+        var branch = string.IsNullOrWhiteSpace(request.Branch) ? "main" : request.Branch.Trim();
+        var prefix = NormalizePrefix(request.Subdirectory);
+        return EnsureRepo(request)
+            .SelectMany(repoCreated => WithTempDir(tmp =>
+                Clone(request.RepositoryUrl, request.AccessToken, tmp)
+                    .SelectMany(_ => CheckoutTargetBranch(tmp, branch, request))
+                    .SelectMany(refExists => TrackedFilesUnder(tmp, prefix)
+                        .SelectMany(existing =>
+                        {
+                            var exportPaths = request.Files
+                                .Select(f => prefix + f.Path)
+                                .ToHashSet(StringComparer.Ordinal);
+                            var deleted = existing.Count(p => !exportPaths.Contains(p));
+                            return MirrorWorktree(tmp, prefix, request.Files)
+                                .SelectMany(_ => Commit(tmp, request))
+                                .SelectMany(_ => Expect(git.Run(tmp,
+                                    [.. GitCredentials.AuthArgs(request.AccessToken),
+                                        "push", "-q", "origin", $"HEAD:refs/heads/{branch}"],
+                                    GitCredentials.AuthEnv(request.AccessToken))))
+                                .SelectMany(_ => Expect(git.Run(tmp, ["rev-parse", "HEAD"])))
+                                .Select(sha => new GitHubPushResult(
+                                    sha.StdOut.Trim(), request.RepositoryUrl,
+                                    request.Files.Count, deleted, repoCreated));
+                        }))));
+    }
+
+    /// <summary>
+    /// Snapshot at a commitish over the git protocol: <c>init + fetch --depth 1 + checkout</c>
+    /// (one negotiated pack transfer instead of a REST call per file), then read the worktree.
+    /// A SHORT commit SHA cannot travel over the wire protocol (only refs and full SHAs can) —
+    /// that one case delegates to the REST client.
+    /// </summary>
+    public IObservable<RepoSnapshot> Fetch(
+        string repositoryUrl, string commitish, string? subdirectory, string accessToken)
+        => Fetch(repositoryUrl, commitish, subdirectory, accessToken, _ => true);
+
+    /// <summary>
+    /// Filtered fetch. The git protocol transfers the (shallow) pack in one exchange, so the
+    /// filter is applied while reading the worktree — same REST cost (zero) either way. The
+    /// interface's contract (only matching files in the snapshot) is unchanged.
+    /// </summary>
+    public IObservable<RepoSnapshot> Fetch(
+        string repositoryUrl, string commitish, string? subdirectory, string accessToken,
+        Func<string, bool> pathFilter)
+    {
+        ArgumentNullException.ThrowIfNull(pathFilter);
+        var commitRef = string.IsNullOrWhiteSpace(commitish) ? "main" : commitish.Trim();
+        if (IsShortSha(commitRef))
+            // Wire fetch needs a ref or a FULL SHA; a short SHA resolves only through REST.
+            return octokit.Fetch(repositoryUrl, commitRef, subdirectory, accessToken, pathFilter);
+        var prefix = NormalizePrefix(subdirectory);
+        return WithTempDir(tmp =>
+            Expect(git.Run(tmp, ["init", "-q"]))
+                .SelectMany(_ => Expect(git.Run(tmp, ["remote", "add", "origin", repositoryUrl])))
+                .SelectMany(_ => Expect(git.Run(tmp,
+                    [.. GitCredentials.AuthArgs(accessToken), "fetch", "-q", "--depth", "1", "origin", commitRef],
+                    GitCredentials.AuthEnv(accessToken))))
+                .SelectMany(_ => Expect(git.Run(tmp, ["checkout", "-q", "--detach", "FETCH_HEAD"])))
+                .SelectMany(_ => Expect(git.Run(tmp, ["rev-parse", "FETCH_HEAD"])))
+                .SelectMany(sha => ReadWorktree(tmp, prefix, pathFilter)
+                    .Select(files => new RepoSnapshot(sha.StdOut.Trim(), files))));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Everything else — cheap single REST calls, delegated to Octokit
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <inheritdoc />
+    public IObservable<string> GetHeadSha(string repositoryUrl, string commitish, string accessToken)
+        => octokit.GetHeadSha(repositoryUrl, commitish, accessToken);
+
+    /// <inheritdoc />
+    public IObservable<GitHubBranchResult> CreateBranch(GitHubCreateBranchRequest request)
+        => octokit.CreateBranch(request);
+
+    /// <inheritdoc />
+    public IObservable<GitHubPullRequestInfo> OpenPullRequest(GitHubOpenPullRequestRequest request)
+        => octokit.OpenPullRequest(request);
+
+    /// <inheritdoc />
+    public IObservable<GitHubPullRequestInfo> GetPullRequestStatus(
+        string repositoryUrl, int number, string accessToken)
+        => octokit.GetPullRequestStatus(repositoryUrl, number, accessToken);
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<GitHubIssue>> ListIssues(
+        string repositoryUrl, GitHubIssueState? state, string accessToken)
+        => octokit.ListIssues(repositoryUrl, state, accessToken);
+
+    /// <inheritdoc />
+    public IObservable<GitHubIssue> GetIssue(string repositoryUrl, int number, string accessToken)
+        => octokit.GetIssue(repositoryUrl, number, accessToken);
+
+    /// <inheritdoc />
+    public IObservable<GitHubIssue> CreateIssue(GitHubCreateIssueRequest request)
+        => octokit.CreateIssue(request);
+
+    /// <inheritdoc />
+    public IObservable<GitHubIssueComment> CommentIssue(
+        string repositoryUrl, int number, string body, string accessToken)
+        => octokit.CommentIssue(repositoryUrl, number, body, accessToken);
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<GitHubPullRequestSummary>> ListPullRequests(
+        string repositoryUrl, PullRequestStatus? state, string accessToken)
+        => octokit.ListPullRequests(repositoryUrl, state, accessToken);
+
+    /// <inheritdoc />
+    public IObservable<GitHubPullRequestDetail> GetPullRequestDetail(
+        string repositoryUrl, int number, string accessToken)
+        => octokit.GetPullRequestDetail(repositoryUrl, number, accessToken);
+
+    /// <inheritdoc />
+    public IObservable<GitHubIssueComment> CommentPullRequest(
+        string repositoryUrl, int number, string body, string accessToken)
+        => octokit.CommentPullRequest(repositoryUrl, number, body, accessToken);
+
+    /// <inheritdoc />
+    public IObservable<GitHubMergeResult> MergePullRequest(GitHubMergePullRequestRequest request)
+        => octokit.MergePullRequest(request);
+
+    // ── push internals ───────────────────────────────────────────────────────
+
+    /// <summary>Repo existence/creation is REST-only (git cannot create a GitHub repo) — and only
+    /// meaningful for a GitHub remote; a local/file remote (tests) is taken as existing.</summary>
+    private IObservable<bool> EnsureRepo(GitHubPushRequest request)
+        => IsGitHubUrl(request.RepositoryUrl)
+            ? octokit.EnsureRepoExists(
+                request.RepositoryUrl, request.AccessToken, request.CreatePrivateIfMissing)
+            : Observable.Return(false);
+
+    /// <summary>
+    /// Shallow clone of the remote's DEFAULT branch. Tolerates an EMPTY repo (git exits 0 with an
+    /// unborn HEAD — the first commit then initializes it; no Contents-API seeding needed).
+    /// </summary>
+    private IObservable<GitCommandResult> Clone(string url, string token, string tmp)
+        => Expect(git.Run(tmp,
+            [.. GitCredentials.AuthArgs(token), "clone", "-q", "--depth", "1", url, "."],
+            GitCredentials.AuthEnv(token)));
+
+    /// <summary>
+    /// Puts the worktree on the TARGET branch and reports whether it existed on the remote:
+    /// <list type="bullet">
+    ///   <item>exists → fetch it (depth 1) and check it out at the remote head;</item>
+    ///   <item>missing + auto-create + a non-empty clone → a new branch BASED ON THE DEFAULT
+    ///     HEAD (never an orphan — the same policy the REST path pinned in NewBranchBaseTest);</item>
+    ///   <item>missing + auto-create + an EMPTY repo (unborn HEAD) → rename the unborn branch,
+    ///     so the first commit creates it;</item>
+    ///   <item>missing + auto-create disabled → error.</item>
+    /// </list>
+    /// </summary>
+    private IObservable<bool> CheckoutTargetBranch(string tmp, string branch, GitHubPushRequest request)
+        => Expect(git.Run(tmp,
+                [.. GitCredentials.AuthArgs(request.AccessToken), "ls-remote", "--heads", "origin", branch],
+                GitCredentials.AuthEnv(request.AccessToken)))
+            .SelectMany(remote =>
+            {
+                var refExists = remote.StdOut.Trim().Length > 0;
+                if (refExists)
+                    return Expect(git.Run(tmp,
+                            [.. GitCredentials.AuthArgs(request.AccessToken),
+                                "fetch", "-q", "--depth", "1", "origin", branch],
+                            GitCredentials.AuthEnv(request.AccessToken)))
+                        .SelectMany(_ => Expect(git.Run(tmp, ["checkout", "-q", "-B", branch, "FETCH_HEAD"])))
+                        .Select(_ => true);
+                if (!request.CreateBranchIfMissing)
+                    return Observable.Throw<bool>(new InvalidOperationException(
+                        $"Branch '{branch}' does not exist and branch auto-create is disabled."));
+                // Unborn HEAD (empty repo) cannot `checkout -B`; renaming the unborn ref suffices.
+                return git.Run(tmp, ["rev-parse", "--verify", "--quiet", "HEAD"])
+                    .SelectMany(head => head.Ok
+                        ? Expect(git.Run(tmp, ["checkout", "-q", "-B", branch])).Select(_ => false)
+                        : Expect(git.Run(tmp, ["symbolic-ref", "HEAD", $"refs/heads/{branch}"]))
+                            .Select(_ => false));
+            });
+
+    /// <summary>The tracked repo-relative paths under <paramref name="prefix"/> — the deletion
+    /// candidates of the mirror. Empty on an unborn HEAD (nothing tracked yet).</summary>
+    private IObservable<IReadOnlyList<string>> TrackedFilesUnder(string tmp, string prefix)
+        => Expect(git.Run(tmp, prefix.Length == 0
+                ? ["ls-files"]
+                : ["ls-files", "--", prefix]))
+            .Select(r => (IReadOnlyList<string>)r.StdOut
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+    /// <summary>
+    /// Materializes the mirror in the worktree: everything under <paramref name="prefix"/> is
+    /// removed (whole worktree minus <c>.git</c> when the prefix is empty — the export fully
+    /// defines the tree), then every file is written from its BYTES (binary-safe — the REST path
+    /// could only create UTF-8 blobs). <c>git add -A</c> turns the difference into the commit.
+    /// </summary>
+    private IObservable<System.Reactive.Unit> MirrorWorktree(
+        string tmp, string prefix, IReadOnlyList<RepoFile> files)
+        => FileSystem.InvokeBlocking<System.Reactive.Unit>(_ =>
+        {
+            var root = Path.GetFullPath(tmp);
+            var target = prefix.Length == 0 ? root : Path.Combine(root, prefix.TrimEnd('/'));
+            if (Directory.Exists(target))
+            {
+                if (prefix.Length == 0)
+                {
+                    foreach (var entry in Directory.EnumerateFileSystemEntries(root))
+                    {
+                        if (string.Equals(Path.GetFileName(entry), ".git", StringComparison.Ordinal))
+                            continue;
+                        if (Directory.Exists(entry)) Directory.Delete(entry, recursive: true);
+                        else File.Delete(entry);
+                    }
+                }
+                else
+                {
+                    Directory.Delete(target, recursive: true);
+                }
+            }
+            foreach (var file in files)
+            {
+                var full = Path.GetFullPath(Path.Combine(root, prefix + file.Path));
+                if (!full.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+                    throw new InvalidOperationException($"Path '{file.Path}' escapes the repository.");
+                Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+                File.WriteAllBytes(full, file.Bytes);
+            }
+            return System.Reactive.Unit.Default;
+        });
+
+    /// <summary>Stages the mirror and commits as the requested author. <c>--allow-empty</c> keeps
+    /// parity with the REST path, which records a sync commit even when nothing changed.</summary>
+    private IObservable<GitCommandResult> Commit(string tmp, GitHubPushRequest request)
+        => Expect(git.Run(tmp, ["add", "-A"]))
+            .SelectMany(_ => Expect(git.Run(tmp,
+            [
+                "-c", $"user.name={request.AuthorName}",
+                "-c", $"user.email={request.AuthorEmail}",
+                "-c", "commit.gpgsign=false",
+                "commit", "-q", "--allow-empty", "-m", request.CommitMessage,
+            ])));
+
+    // ── fetch internals ──────────────────────────────────────────────────────
+
+    /// <summary>Reads the checked-out worktree into subdirectory-relative <see cref="RepoFile"/>s,
+    /// classifying text vs binary exactly like the blob decode (<see cref="RepoFileCodec"/>).</summary>
+    private IObservable<IReadOnlyList<RepoFile>> ReadWorktree(
+        string tmp, string prefix, Func<string, bool> pathFilter)
+        => FileSystem.InvokeBlocking(_ =>
+        {
+            var root = Path.GetFullPath(tmp);
+            var files = new List<RepoFile>();
+            foreach (var full in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+            {
+                var rel = Path.GetRelativePath(root, full).Replace('\\', '/');
+                if (rel.StartsWith(".git/", StringComparison.Ordinal))
+                    continue;
+                if (prefix.Length > 0 && !rel.StartsWith(prefix, StringComparison.Ordinal))
+                    continue;
+                var subRel = prefix.Length == 0 ? rel : rel[prefix.Length..];
+                if (!pathFilter(subRel))
+                    continue;
+                files.Add(RepoFileCodec.FromBytes(subRel, File.ReadAllBytes(full)));
+            }
+            return (IReadOnlyList<RepoFile>)files;
+        });
+
+    // ── shared plumbing ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A unique temp directory around a cold pipeline: created (on the FileSystem pool) before
+    /// the work subscribes, removed (best effort, on the pool) when it terminates — success,
+    /// error, or unsubscribe alike. Each operation owns its own directory, so concurrent syncs
+    /// never collide.
+    /// </summary>
+    private IObservable<T> WithTempDir<T>(Func<string, IObservable<T>> work)
+        => Observable.Defer(() =>
+        {
+            var tmp = Path.Combine(Path.GetTempPath(), "mw-gitsync-" + Guid.NewGuid().ToString("N"));
+            return FileSystem.InvokeBlocking(_ =>
+                {
+                    Directory.CreateDirectory(tmp);
+                    return tmp;
+                })
+                .SelectMany(work)
+                .Finally(() => FileSystem.InvokeBlocking<System.Reactive.Unit>(_ =>
+                    {
+                        if (Directory.Exists(tmp))
+                            Directory.Delete(tmp, recursive: true);
+                        return System.Reactive.Unit.Default;
+                    })
+                    .Subscribe(
+                        _ => { },
+                        ex => logger?.LogWarning(ex, "Temp clone cleanup failed for {Dir}.", tmp)));
+        });
+
+    /// <summary>Passes Ok results through; converts a non-zero git exit into a typed error.</summary>
+    private static IObservable<GitCommandResult> Expect(IObservable<GitCommandResult> op)
+        => op.SelectMany(r => r.Ok
+            ? Observable.Return(r)
+            : Observable.Throw<GitCommandResult>(new InvalidOperationException(
+                $"git failed (exit {r.ExitCode}): {r.Message}")));
+
+    /// <summary>True for a GitHub http(s) remote — where the REST surface (repo create) applies.</summary>
+    private static bool IsGitHubUrl(string url)
+        => url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+           || url.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>An abbreviated commit SHA (7–39 hex chars) — resolvable via REST only; the wire
+    /// protocol fetches refs and FULL 40-char SHAs.</summary>
+    private static bool IsShortSha(string s)
+        => s.Length is >= 7 and < 40 && s.All(Uri.IsHexDigit);
+
+    private static string NormalizePrefix(string? subdirectory)
+    {
+        var s = subdirectory?.Trim().Trim('/');
+        return string.IsNullOrEmpty(s) ? "" : s + "/";
+    }
+}

--- a/src/MeshWeaver.GitSync/GitProtocolRepoClient.cs
+++ b/src/MeshWeaver.GitSync/GitProtocolRepoClient.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.Logging;
@@ -98,11 +99,8 @@ public sealed class GitProtocolRepoClient(
     {
         ArgumentNullException.ThrowIfNull(pathFilter);
         var commitRef = string.IsNullOrWhiteSpace(commitish) ? "main" : commitish.Trim();
-        if (IsShortSha(commitRef))
-            // Wire fetch needs a ref or a FULL SHA; a short SHA resolves only through REST.
-            return octokit.Fetch(repositoryUrl, commitRef, subdirectory, accessToken, pathFilter);
         var prefix = NormalizePrefix(subdirectory);
-        return WithTempDir(tmp =>
+        var wire = WithTempDir(tmp =>
             Expect(git.Run(tmp, ["init", "-q"]))
                 .SelectMany(_ => Expect(git.Run(tmp, ["remote", "add", "origin", repositoryUrl])))
                 .SelectMany(_ => Expect(git.Run(tmp,
@@ -112,6 +110,19 @@ public sealed class GitProtocolRepoClient(
                 .SelectMany(_ => Expect(git.Run(tmp, ["rev-parse", "FETCH_HEAD"])))
                 .SelectMany(sha => ReadWorktree(tmp, prefix, pathFilter)
                     .Select(files => new RepoSnapshot(sha.StdOut.Trim(), files))));
+        // A hex-looking name is tried over the wire FIRST — "deadbee" may be a legitimate
+        // branch/tag, and the whole point of this client is to avoid per-file REST. Only when
+        // the wire fetch fails AND the commitish is an ABBREVIATED SHA (the one commitish the
+        // protocol cannot serve — upload-pack wants refs or full SHAs) does REST resolve it.
+        return IsShortSha(commitRef)
+            ? wire.Catch((Exception ex) =>
+            {
+                logger?.LogInformation(
+                    "Wire fetch of '{Commitish}' failed ({Error}); resolving the abbreviated SHA via REST.",
+                    commitRef, ex.Message);
+                return octokit.Fetch(repositoryUrl, commitRef, subdirectory, accessToken, pathFilter);
+            })
+            : wire;
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -310,7 +321,7 @@ public sealed class GitProtocolRepoClient(
                     continue;
                 files.Add(RepoFileCodec.FromBytes(subRel, File.ReadAllBytes(full)));
             }
-            return (IReadOnlyList<RepoFile>)files;
+            return (IReadOnlyList<RepoFile>)files.ToImmutableList();
         });
 
     // ── shared plumbing ──────────────────────────────────────────────────────
@@ -359,9 +370,20 @@ public sealed class GitProtocolRepoClient(
     private static bool IsShortSha(string s)
         => s.Length is >= 7 and < 40 && s.All(Uri.IsHexDigit);
 
+    /// <summary>
+    /// Normalizes the mirror subdirectory to a <c>segment/…/</c> prefix and REJECTS any shape
+    /// that could escape the clone: rooted paths, <c>.</c>/<c>..</c> segments, backslashes. The
+    /// prefix names the deletion target of the mirror — defense here must not depend on
+    /// upstream request validation.
+    /// </summary>
     private static string NormalizePrefix(string? subdirectory)
     {
         var s = subdirectory?.Trim().Trim('/');
-        return string.IsNullOrEmpty(s) ? "" : s + "/";
+        if (string.IsNullOrEmpty(s))
+            return "";
+        if (s.Contains('\\') || Path.IsPathRooted(s)
+            || s.Split('/').Any(seg => seg.Length == 0 || seg is "." or ".."))
+            throw new ArgumentException($"Invalid repo subdirectory '{subdirectory}'.");
+        return s + "/";
     }
 }

--- a/src/MeshWeaver.GitSync/GitWorkingTreeService.cs
+++ b/src/MeshWeaver.GitSync/GitWorkingTreeService.cs
@@ -288,17 +288,11 @@ public sealed class GitWorkingTreeService(
         return changes;
     }
 
-    /// <summary>The credential-helper config that reads the token from <c>$GW_TOKEN</c> (token never in argv).</summary>
-    private static IReadOnlyList<string> AuthArgs(string? token) => string.IsNullOrEmpty(token)
-        ? []
-        : [
-            // Clear any inherited helper (system credential store), then install ours.
-            "-c", "credential.helper=",
-            "-c", "credential.helper=!f() { test \"$1\" = get && printf 'username=x-access-token\\npassword=%s\\n' \"$GW_TOKEN\"; }; f",
-          ];
+    /// <summary>The shared <c>$GW_TOKEN</c> credential-helper config (token never in argv).</summary>
+    private static IReadOnlyList<string> AuthArgs(string? token) => GitCredentials.AuthArgs(token);
 
     private static IReadOnlyDictionary<string, string>? AuthEnv(string? token) =>
-        string.IsNullOrEmpty(token) ? null : new Dictionary<string, string> { ["GW_TOKEN"] = token };
+        GitCredentials.AuthEnv(token);
 
     /// <summary>Resolves a repo-relative path and guarantees it stays inside the user's working tree.</summary>
     private string ResolveInTree(string userId, string repoSlug, string relativePath)

--- a/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using System.Reactive.Linq;
-using System.Text;
 using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.Logging;
 using Octokit;
@@ -513,6 +512,14 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
     /// </summary>
     internal static HeadInfo AsNewBranchBase(HeadInfo defaultHead) => defaultHead with { RefExists = false };
 
+    /// <summary>The repo-existence/creation REST step exposed for <see cref="GitProtocolRepoClient"/> —
+    /// the one push ingredient git itself cannot do. Emits true when the repo was created.</summary>
+    internal IObservable<bool> EnsureRepoExists(string repositoryUrl, string accessToken, bool createIfMissing)
+    {
+        var (owner, repo) = ParseRepoUrl(repositoryUrl);
+        return EnsureRepo(Client(accessToken), owner, repo, createIfMissing);
+    }
+
     /// <summary>Ensures the repo exists; creates it private (under the user or the org) when missing.</summary>
     private IObservable<bool> EnsureRepo(IObservableGitHubClient client, string owner, string repo, bool createIfMissing)
         => Http.InvokeObservable(ct => client.Repository.Get(owner, repo))
@@ -665,33 +672,9 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
     {
         if (!string.Equals(blob.Encoding.StringValue, "base64", StringComparison.OrdinalIgnoreCase))
             return new RepoFile(path, blob.Content);
-        var bytes = Convert.FromBase64String(blob.Content);
-        return TryDecodeUtf8(bytes, out var text)
-            ? new RepoFile(path, text)
-            : new RepoFile(path, string.Empty, bytes);
+        // Shared strict-UTF-8 text/binary classification (RepoFileCodec) — one rule per transport.
+        return RepoFileCodec.FromBytes(path, Convert.FromBase64String(blob.Content));
     }
-
-    /// <summary>
-    /// True + the decoded text when <paramref name="bytes"/> is valid UTF-8; false for binary content.
-    /// Uses a strict (throw-on-invalid) UTF-8 decoder so an arbitrary byte stream (a video, a font) is
-    /// classified binary rather than silently lossily decoded.
-    /// </summary>
-    private static bool TryDecodeUtf8(byte[] bytes, out string text)
-    {
-        try
-        {
-            text = StrictUtf8.GetString(bytes);
-            return true;
-        }
-        catch (DecoderFallbackException)
-        {
-            text = string.Empty;
-            return false;
-        }
-    }
-
-    private static readonly Encoding StrictUtf8 =
-        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
     private static string NormalizePrefix(string? subdirectory)
     {

--- a/src/MeshWeaver.GitSync/RepoFileCodec.cs
+++ b/src/MeshWeaver.GitSync/RepoFileCodec.cs
@@ -1,0 +1,42 @@
+using System.Text;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// The ONE text-vs-binary classification for repo file bytes, shared by every transport
+/// (<see cref="OctokitGitHubRepoClient"/>'s blob decode, <see cref="GitProtocolRepoClient"/>'s
+/// worktree read). Valid UTF-8 becomes a text <see cref="RepoFile"/> (so node/markdown parsing is
+/// unchanged); anything else carries its raw bytes in <see cref="RepoFile.Binary"/> — round-tripping
+/// arbitrary bytes through a UTF-8 string corrupts them (the bug that repeatedly nuked the course
+/// videos).
+/// </summary>
+internal static class RepoFileCodec
+{
+    private static readonly Encoding StrictUtf8 =
+        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    /// <summary>A <see cref="RepoFile"/> from raw bytes: text when valid UTF-8, binary otherwise.</summary>
+    public static RepoFile FromBytes(string path, byte[] bytes) =>
+        TryDecodeUtf8(bytes, out var text)
+            ? new RepoFile(path, text)
+            : new RepoFile(path, string.Empty, bytes);
+
+    /// <summary>
+    /// True + the decoded text when <paramref name="bytes"/> is valid UTF-8; false for binary
+    /// content. Uses a strict (throw-on-invalid) decoder so an arbitrary byte stream (a video,
+    /// a font) is classified binary rather than silently lossily decoded.
+    /// </summary>
+    public static bool TryDecodeUtf8(byte[] bytes, out string text)
+    {
+        try
+        {
+            text = StrictUtf8.GetString(bytes);
+            return true;
+        }
+        catch (DecoderFallbackException)
+        {
+            text = string.Empty;
+            return false;
+        }
+    }
+}

--- a/test/MeshWeaver.GitSync.Test/GitProtocolRepoClientTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitProtocolRepoClientTest.cs
@@ -214,6 +214,43 @@ public class GitProtocolRepoClientTest(ITestOutputHelper output) : GitHubSyncTes
         Assert.All(snapshot.Files, f => Assert.EndsWith("index.json", f.Path));
     }
 
+    [Fact(Timeout = 120000)]
+    public async Task Fetch_HexLookingBranchName_TravelsOverTheWire()
+    {
+        var temp = NewTempDir();
+        var bare = await SeedBareRemote(temp, ("Docs/a.md", "on main"));
+        // A legitimate branch whose name LOOKS like an abbreviated SHA must still fetch over
+        // the wire (REST would fail here outright — the remote is a local file URL).
+        var seed = Path.Combine(temp, "seed");
+        await RunGit(seed, "checkout", "-b", "deadbee");
+        await File.WriteAllTextAsync(Path.Combine(seed, "Docs/a.md"), "on deadbee");
+        await RunGit(seed, "add", "-A");
+        await RunGit(seed, "-c", "user.email=t@t.dev", "-c", "user.name=T", "commit", "-m", "branch");
+        await RunGit(seed, "push", "-q", "origin", "deadbee");
+
+        var snapshot = await Client.Fetch(FileUrl(bare), "deadbee", "Docs", "").Timeout(60.Seconds()).ToTask();
+        Assert.Equal("on deadbee", Assert.Single(snapshot.Files).Content);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Push_TraversalSubdirectory_IsRejected()
+    {
+        var temp = NewTempDir();
+        var bare = await SeedBareRemote(temp, ("README.md", "# base\n"));
+        foreach (var evil in new[] { "../outside", "a/../../b", ".", "a/./b" })
+            await Assert.ThrowsAsync<ArgumentException>(() => Client.Push(new GitHubPushRequest
+            {
+                RepositoryUrl = FileUrl(bare),
+                Branch = "main",
+                Subdirectory = evil,
+                Files = [new RepoFile("x.txt", "x")],
+                CommitMessage = "x",
+                AuthorName = "T",
+                AuthorEmail = "t@t.dev",
+                AccessToken = "",
+            }).Timeout(60.Seconds()).ToTask());
+    }
+
     // ── local-remote plumbing ────────────────────────────────────────────────
 
     /// <summary>A bare remote seeded with one commit on <c>main</c> carrying the given files.</summary>

--- a/test/MeshWeaver.GitSync.Test/GitProtocolRepoClientTest.cs
+++ b/test/MeshWeaver.GitSync.Test/GitProtocolRepoClientTest.cs
@@ -1,0 +1,275 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// Contract tests for <see cref="GitProtocolRepoClient"/>'s bulk transfer against a LOCAL bare
+/// remote (no network, no GitHub, no REST): the push/fetch semantics the Octokit implementation
+/// pinned — subdirectory mirror (outside untouched, removed deleted), new-branch-on-default-head,
+/// empty-repo first commit, strict text/binary classification — must hold identically over the
+/// git protocol. The REST-only ingredients (repo auto-create, short-SHA resolution) are exercised
+/// through GitHub URLs only, so a local remote never touches them.
+/// </summary>
+public class GitProtocolRepoClientTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    private GitCli Git => Mesh.ServiceProvider.GetRequiredService<GitCli>();
+
+    private GitProtocolRepoClient Client => new(
+        Mesh.ServiceProvider.GetRequiredService<OctokitGitHubRepoClient>(),
+        Git,
+        Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>());
+
+    [Fact(Timeout = 120000)]
+    public async Task Push_MirrorsSubdirectory_PreservesOutside_DeletesRemoved()
+    {
+        var temp = NewTempDir();
+        var bare = await SeedBareRemote(temp,
+            ("README.md", "# keep me\n"),
+            ("Edu/old.json", "{\"old\":true}"),
+            ("Edu/stale.json", "{\"stale\":true}"));
+
+        var result = await Client.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = FileUrl(bare),
+            Branch = "main",
+            Subdirectory = "Edu",
+            Files =
+            [
+                new RepoFile("old.json", "{\"old\":false}"),
+                new RepoFile("fresh.md", "# fresh\n"),
+            ],
+            CommitMessage = "mirror Edu",
+            AuthorName = "Mesh Weaver",
+            AuthorEmail = "mesh@weaver.test",
+            AccessToken = "",
+        }).Timeout(60.Seconds()).ToTask();
+
+        Assert.Equal(2, result.FilesWritten);
+        Assert.Equal(1, result.FilesDeleted); // stale.json vanished
+        Assert.False(result.RepoCreated);
+
+        var check = await CloneForInspection(temp, bare);
+        Assert.Equal("# keep me\n", await File.ReadAllTextAsync(Path.Combine(check, "README.md")));
+        Assert.Equal("{\"old\":false}", await File.ReadAllTextAsync(Path.Combine(check, "Edu/old.json")));
+        Assert.Equal("# fresh\n", await File.ReadAllTextAsync(Path.Combine(check, "Edu/fresh.md")));
+        Assert.False(File.Exists(Path.Combine(check, "Edu/stale.json")));
+        // The reported SHA is the remote head.
+        var head = await Git.Run(check, ["rev-parse", "HEAD"]).Timeout(30.Seconds()).ToTask();
+        Assert.Equal(head.StdOut.Trim(), result.CommitSha);
+        // The commit records the requested author.
+        var author = await Git.Run(check, ["log", "-1", "--pretty=%an <%ae>"]).Timeout(30.Seconds()).ToTask();
+        Assert.Equal("Mesh Weaver <mesh@weaver.test>", author.StdOut.Trim());
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Push_BinaryFile_RoundTripsLosslessly()
+    {
+        var temp = NewTempDir();
+        var bare = await SeedBareRemote(temp, ("README.md", "# seed\n"));
+        // Deliberately invalid UTF-8 (a fake video header) — the REST path could not push this.
+        var bytes = new byte[] { 0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0xFF, 0xFE, 0x80, 0x01 };
+
+        await Client.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = FileUrl(bare),
+            Branch = "main",
+            Subdirectory = "Space",
+            Files = [new RepoFile("content/clip.mp4", "", bytes)],
+            CommitMessage = "binary",
+            AuthorName = "T",
+            AuthorEmail = "t@t.dev",
+            AccessToken = "",
+        }).Timeout(60.Seconds()).ToTask();
+
+        var check = await CloneForInspection(temp, bare);
+        Assert.Equal(bytes, await File.ReadAllBytesAsync(Path.Combine(check, "Space/content/clip.mp4")));
+
+        // And the fetch classifies it binary again — full loop, bytes intact.
+        var snapshot = await Client.Fetch(FileUrl(bare), "main", "Space", "").Timeout(60.Seconds()).ToTask();
+        var clip = Assert.Single(snapshot.Files, f => f.Path == "content/clip.mp4");
+        Assert.True(clip.IsBinary);
+        Assert.Equal(bytes, clip.Bytes);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Push_MissingBranch_BasesOnDefaultHead_NeverOrphan()
+    {
+        var temp = NewTempDir();
+        var bare = await SeedBareRemote(temp, ("README.md", "# base\n"));
+
+        await Client.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = FileUrl(bare),
+            Branch = "sync/export",
+            Subdirectory = "Data",
+            Files = [new RepoFile("a.json", "{}")],
+            CommitMessage = "first export",
+            AuthorName = "T",
+            AuthorEmail = "t@t.dev",
+            AccessToken = "",
+        }).Timeout(60.Seconds()).ToTask();
+
+        // The new branch carries the default branch's history (mergeable, not an orphan).
+        var check = await CloneForInspection(temp, bare, "sync/export");
+        Assert.True(File.Exists(Path.Combine(check, "README.md")), "default-branch content preserved");
+        var mergeBase = await Git.Run(check, ["merge-base", "origin/main", "HEAD"]).Timeout(30.Seconds()).ToTask();
+        Assert.True(mergeBase.Ok, "the sync branch shares an ancestor with main");
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Push_EmptyRepo_CreatesFirstCommit()
+    {
+        var temp = NewTempDir();
+        var bare = Path.Combine(temp, "empty.git");
+        await RunGit(temp, "init", "--bare", "-b", "main", bare);
+        await RunGit(temp, "-C", bare, "config", "uploadpack.allowAnySHA1InWant", "true");
+
+        var result = await Client.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = FileUrl(bare),
+            Branch = "main",
+            Subdirectory = null,
+            Files = [new RepoFile("index.json", "{\"id\":\"X\"}")],
+            CommitMessage = "initial mirror",
+            AuthorName = "T",
+            AuthorEmail = "t@t.dev",
+            AccessToken = "",
+        }).Timeout(60.Seconds()).ToTask();
+
+        Assert.Equal(1, result.FilesWritten);
+        var check = await CloneForInspection(temp, bare);
+        Assert.Equal("{\"id\":\"X\"}", await File.ReadAllTextAsync(Path.Combine(check, "index.json")));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Push_MissingBranch_AutoCreateDisabled_Fails()
+    {
+        var temp = NewTempDir();
+        var bare = await SeedBareRemote(temp, ("README.md", "# base\n"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Client.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = FileUrl(bare),
+            Branch = "does/not-exist",
+            Files = [new RepoFile("a.txt", "a")],
+            CommitMessage = "x",
+            AuthorName = "T",
+            AuthorEmail = "t@t.dev",
+            AccessToken = "",
+            CreateBranchIfMissing = false,
+        }).Timeout(60.Seconds()).ToTask());
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Fetch_SubdirectorySnapshot_AtBranchAndAtSha()
+    {
+        var temp = NewTempDir();
+        var bare = await SeedBareRemote(temp,
+            ("README.md", "# outside\n"),
+            ("Docs/a.md", "version 1"));
+        var shaV1 = await RemoteHead(temp, bare);
+
+        // Second commit changes the file — the branch fetch sees v2, the SHA fetch v1.
+        await Client.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = FileUrl(bare),
+            Branch = "main",
+            Subdirectory = "Docs",
+            Files = [new RepoFile("a.md", "version 2")],
+            CommitMessage = "v2",
+            AuthorName = "T",
+            AuthorEmail = "t@t.dev",
+            AccessToken = "",
+        }).Timeout(60.Seconds()).ToTask();
+
+        var atBranch = await Client.Fetch(FileUrl(bare), "main", "Docs", "").Timeout(60.Seconds()).ToTask();
+        Assert.Equal("version 2", Assert.Single(atBranch.Files, f => f.Path == "a.md").Content);
+        Assert.NotEqual(shaV1, atBranch.CommitSha);
+
+        var atSha = await Client.Fetch(FileUrl(bare), shaV1, "Docs", "").Timeout(60.Seconds()).ToTask();
+        Assert.Equal(shaV1, atSha.CommitSha);
+        Assert.Equal("version 1", Assert.Single(atSha.Files, f => f.Path == "a.md").Content);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Fetch_PathFilter_LimitsTheSnapshot()
+    {
+        var temp = NewTempDir();
+        var bare = await SeedBareRemote(temp,
+            ("Plugins/A/index.json", "{\"a\":1}"),
+            ("Plugins/A/Source/code.cs", "// a"),
+            ("Plugins/B/index.json", "{\"b\":1}"));
+
+        var snapshot = await Client
+            .Fetch(FileUrl(bare), "main", "Plugins", "", p => p.EndsWith("/index.json", StringComparison.Ordinal))
+            .Timeout(60.Seconds()).ToTask();
+
+        Assert.Equal(2, snapshot.Files.Count);
+        Assert.All(snapshot.Files, f => Assert.EndsWith("index.json", f.Path));
+    }
+
+    // ── local-remote plumbing ────────────────────────────────────────────────
+
+    /// <summary>A bare remote seeded with one commit on <c>main</c> carrying the given files.</summary>
+    private async Task<string> SeedBareRemote(string temp, params (string Path, string Content)[] files)
+    {
+        var bare = Path.Combine(temp, "remote.git");
+        var seed = Path.Combine(temp, "seed");
+        await RunGit(temp, "init", "--bare", "-b", "main", bare);
+        await RunGit(temp, "-c", "init.defaultBranch=main", "init", seed);
+        foreach (var (path, content) in files)
+        {
+            var full = Path.Combine(seed, path);
+            Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+            await File.WriteAllTextAsync(full, content);
+        }
+        await RunGit(seed, "add", "-A");
+        await RunGit(seed, "-c", "user.email=t@t.dev", "-c", "user.name=Seed", "commit", "-m", "seed");
+        await RunGit(seed, "remote", "add", "origin", bare);
+        await RunGit(seed, "push", "-q", "origin", "main");
+        // GitHub's upload-pack allows fetching reachable commits by SHA; mirror that on the
+        // local remote so the fetch-at-SHA contract is testable offline.
+        await RunGit(temp, "-C", bare, "config", "uploadpack.allowAnySHA1InWant", "true");
+        return bare;
+    }
+
+    /// <summary>The remote as the client sees it — a <c>file://</c> URL, so shallow (depth-1)
+    /// transfers use the real wire protocol instead of the local hardlink shortcut.</summary>
+    private static string FileUrl(string bare) => new Uri(bare).AbsoluteUri;
+
+    private async Task<string> CloneForInspection(string temp, string bare, string? branch = null)
+    {
+        var check = Path.Combine(temp, "check-" + Guid.NewGuid().ToString("N"));
+        if (branch is null)
+            await RunGit(temp, "clone", "-q", bare, check);
+        else
+            await RunGit(temp, "clone", "-q", "--branch", branch, bare, check);
+        return check;
+    }
+
+    private async Task<string> RemoteHead(string temp, string bare)
+    {
+        var r = await Git.Run(temp, ["-C", bare, "rev-parse", "refs/heads/main"]).Timeout(30.Seconds()).ToTask();
+        Assert.True(r.Ok, r.Message);
+        return r.StdOut.Trim();
+    }
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mw-gitproto-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private async Task RunGit(string dir, params string[] args)
+    {
+        var r = await Git.Run(dir, args).Timeout(30.Seconds()).ToTask();
+        Assert.True(r.Ok, $"git {string.Join(' ', args)} failed (exit {r.ExitCode}): {r.Message}");
+    }
+}


### PR DESCRIPTION
## Why

A single GitSync of a large content repo (a course with ~2k files) burned most of the GitHub App installation's **5,000 req/h REST budget**: the Git Data API pays **one request per file** (`Git.Blob.Get` per blob on fetch, `Git.Blob.Create` per file on push). Result: every other space's sync rate-limited for the rest of the hour — the Store/Publish/Edu deploys on memex were blocked by this two days running (installation 144517285).

## What

`GitProtocolRepoClient` becomes the production `IGitHubRepoClient`:

- **`Push` / `Fetch` run over git smart-HTTP** (shallow `clone` / `fetch --depth 1` / `push` via the existing `GitCli`) — one negotiated pack transfer, **zero REST requests**. Git-protocol transfers don't count against the REST rate limit at all.
- **Refs, PRs, issues, `GetHeadSha`, repo auto-create** — a handful of cheap single calls — stay on the wrapped `OctokitGitHubRepoClient` (repo creation is the one push ingredient git itself cannot do; exposed as internal `EnsureRepoExists`).
- The installation token reaches git through the shared **`GW_TOKEN` credential helper** (`GitCredentials`, extracted from `GitWorkingTreeService` — never in argv, never persisted in `.git/config`).
- Each operation works in its own unique temp clone (FileSystem pool), removed on termination; all git invocations run through `GitCli`/`IIoPool` — reactive end-to-end, no async/await on any surface.

## Semantics pinned

Offline contract tests against a **local bare remote** (`GitProtocolRepoClientTest`, 7 cases) pin the behaviors the REST path established: subdirectory mirror (outside untouched, removed files deleted, `FilesDeleted` counted), missing branch **based on the default head** (never an orphan — the `NewBranchBaseTest` policy), **empty repo initialized by the first pushed commit** (the Contents-API `.gitkeep` dance is obsolete on this path), fetch at branch and at full SHA (`uploadpack.allowAnySHA1InWant`, as GitHub configures), path-filtered fetch, and strict UTF-8 text/binary classification (`RepoFileCodec`, extracted and now shared with the Octokit blob decode).

Two improvements fall out:
- **Binary files push losslessly** (`RepoFile.Bytes` written to the worktree) — the REST path could only create UTF-8 blobs, which is why content assets (course videos) kept vanishing from sync commits.
- A **short abbreviated SHA** — the one commitish the wire protocol cannot fetch — delegates to the REST client explicitly.

## Tests

`MeshWeaver.GitSync.Test`: **139/139 green** (Release, `-warnaserror`); `Memex.Portal.Shared` (heaviest dependent) builds clean with CI's flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpQeRyimCLKg3og3hoxw2k