### PR TITLE
fix(compile): terminal-settle hung source snapshots + land forward release triggers over stale bases

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -834,7 +834,7 @@ public static class DataExtensions
     /// Without base values (legacy / one-off senders) it falls back to the
     /// <see cref="DropStaleMonotonicTriggers"/> guard + plain <see cref="MergePatchRecursive"/>.
     /// </summary>
-    private static void ApplyMeshNodeMerge(
+    internal static void ApplyMeshNodeMerge(
         System.Text.Json.Nodes.JsonObject currentNode,
         System.Text.Json.Nodes.JsonObject patchNode,
         bool isMeshNode,
@@ -850,6 +850,14 @@ public static class DataExtensions
                 && System.Text.Json.Nodes.JsonNode.Parse(baseText)
                     is System.Text.Json.Nodes.JsonObject baseValues)
             {
+                // 🚨 Monotonic-trigger resolution BEFORE the three-way merge. The generic merge
+                // REFUSES every conflicting scalar (base ≠ live) — correct for non-monotonic
+                // fields, but for the strictly-increasing RequestedReleaseAt control trigger the
+                // conflict IS mergeable (newest instant wins). Without this, a FORWARD trigger
+                // written off a stale mirror base was silently refused and the user's compile
+                // request LOST (memex-cloud 2026-07-20 GitSync burst: every explicit Store/Plugin
+                // compile trigger was dropped while mirrors lagged the owner).
+                RebaseMonotonicTriggers(currentNode, patchNode, baseValues, jsonOpts, logger, hubPath);
                 Serialization.MeshNodePatchMerge.Apply(currentNode, patchNode, baseValues,
                     onRefuse: key => logger?.LogWarning(
                         "[MergeGuard] {HubPath}: refused stale/reordered cross-hub write to '{Key}' "
@@ -909,6 +917,71 @@ public static class DataExtensions
     /// intentional write — so dropping it is the correct merge, not a band-aid. Scoped to MeshNode by
     /// the caller; the field key is resolved through the same naming policy used elsewhere here.</para>
     /// </summary>
+    /// <summary>
+    /// 🚨 Monotonic-trigger resolution for the THREE-WAY merge path (base values carried).
+    /// <see cref="Serialization.MeshNodePatchMerge.Apply"/> refuses EVERY conflicting scalar
+    /// (live changed since the writer's base) — the right default for non-monotonic fields
+    /// (Status, IsDirty, …) where two concurrent writes are not mergeable. But for the ONE
+    /// strictly-increasing control trigger — <c>NodeTypeDefinition.RequestedReleaseAt</c>, which
+    /// every writer sets to <c>DateTimeOffset.UtcNow</c> and which contractually never moves
+    /// backward — the scalar conflict IS mergeable: the newest instant wins, regardless of what
+    /// base the writer diffed against. Refusing the FORWARD case silently swallows a legitimate
+    /// compile trigger whenever the writer's mirror lags the owner (guaranteed during a GitSync
+    /// burst) — the memex-cloud 2026-07-20 incident where every explicit Store/Plugin compile
+    /// trigger was dropped. Resolution, applied to the parsed patch/base before the merge:
+    /// <list type="bullet">
+    ///   <item>Patch BEHIND live → drop the key from the patch (the flap guard — identical
+    ///     outcome to the refusal, but with the precise monotonic log line).</item>
+    ///   <item>Patch AHEAD of live with a stale base → REBASE the writer's base value to the
+    ///     live value so the three-way merge sees "unchanged since base" and lands the newer
+    ///     trigger. This is the "make the flip a legal write — rebased on current state" fix,
+    ///     not a bypass: only this one contractually-monotonic field gets it.</item>
+    /// </list>
+    /// </summary>
+    internal static void RebaseMonotonicTriggers(
+        System.Text.Json.Nodes.JsonObject currentNode,
+        System.Text.Json.Nodes.JsonObject patchNode,
+        System.Text.Json.Nodes.JsonObject baseValues,
+        System.Text.Json.JsonSerializerOptions jsonOpts,
+        ILogger? logger,
+        string hubPath)
+    {
+        var contentKey = jsonOpts.PropertyNamingPolicy?.ConvertName("Content") ?? "Content";
+        if (patchNode[contentKey] is not System.Text.Json.Nodes.JsonObject patchContent
+            || currentNode[contentKey] is not System.Text.Json.Nodes.JsonObject liveContent)
+            return;
+
+        var triggerKey = jsonOpts.PropertyNamingPolicy?.ConvertName("RequestedReleaseAt")
+            ?? "RequestedReleaseAt";
+        if (!TryReadDateTimeOffset(patchContent, triggerKey, out var patchAt)
+            || !TryReadDateTimeOffset(liveContent, triggerKey, out var liveAt))
+            return;
+
+        if (patchAt < liveAt)
+        {
+            logger?.LogWarning(
+                "[MergeGuard] {HubPath}: dropping stale/reordered {Key} patch ({PatchAt:o} < live {LiveAt:o}) — "
+                + "a strictly-increasing release trigger must not move backward; keeping the live value.",
+                hubPath, triggerKey, patchAt, liveAt);
+            patchContent.Remove(triggerKey);
+            return;
+        }
+
+        if (patchAt > liveAt
+            && baseValues[contentKey] is System.Text.Json.Nodes.JsonObject baseContent
+            && baseContent.TryGetPropertyValue(triggerKey, out var baseVal)
+            && baseVal is not null
+            && !System.Text.Json.Nodes.JsonNode.DeepEquals(baseVal, liveContent[triggerKey]))
+        {
+            logger?.LogInformation(
+                "[MergeGuard] {HubPath}: rebasing monotonic trigger {Key} — patch ({PatchAt:o}) is AHEAD of "
+                + "live ({LiveAt:o}) but the writer's base is stale; a strictly-increasing trigger merges "
+                + "monotonically (newest wins) instead of being refused as a scalar conflict.",
+                hubPath, triggerKey, patchAt, liveAt);
+            baseContent[triggerKey] = liveContent[triggerKey]!.DeepClone();
+        }
+    }
+
     internal static void DropStaleMonotonicTriggers(
         System.Text.Json.Nodes.JsonObject currentNode,
         System.Text.Json.Nodes.JsonObject patchNode,

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -21,6 +21,11 @@ using Microsoft.Extensions.Logging;
 // (ReferenceEquals on Workspace._remoteStreamCache) legitimately open the raw
 // single-node reduce — they test the mechanism itself, not mesh-node access.
 [assembly: InternalsVisibleTo("MeshWeaver.Query.Test")]
+// Owner-side merge internals (ApplyMeshNodeMerge / RebaseMonotonicTriggers): the
+// monotonic-trigger merge semantics are pinned by deterministic unit tests
+// (MonotonicTriggerMergeTest) against the exact internal seam the
+// PatchDataRequest handler runs — not a re-implementation of the call sequence.
+[assembly: InternalsVisibleTo("MeshWeaver.Data.Test")]
 
 namespace MeshWeaver.Data;
 

--- a/src/MeshWeaver.Graph/Configuration/CompilationCacheOptions.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompilationCacheOptions.cs
@@ -52,4 +52,23 @@ public class CompilationCacheOptions
     /// Default: 2000ms
     /// </summary>
     public int LockMaxRetryDelayMs { get; set; } = 2000;
+
+    /// <summary>
+    /// 🚨 Bound on the compile pipeline's ONE-SHOT source-snapshot reads
+    /// (<c>ResolveSources(...).Take(1)</c> over the shared
+    /// <c>NodeSources.GetSources</c> synced query). In every healthy state the
+    /// snapshot arrives instantly (the query is <c>Replay(1)</c>-cached) or after a
+    /// single cold storage read — so this bound only trips when the query's Initial
+    /// is genuinely lost (a synced-query subscription that raced a source-update
+    /// burst and never received its Initial: memex-cloud 2026-07-20, Store/Plugin).
+    /// Without the bound that lost Initial parked the compile FOREVER at
+    /// <c>CompilationStatus=Compiling</c> with no error and no recovery path — the
+    /// absorbing wedge (the compile watcher needs a Pending transition, the release
+    /// watcher gates on a settled status, the recovery kickoff is activation-one-shot).
+    /// On timeout the compile FAILS terminally (Status=Error with a loud message
+    /// naming the dead source query) so the state machine settles and a fresh
+    /// trigger / the Compile button can retry.
+    /// Default: 30 seconds.
+    /// </summary>
+    public TimeSpan SourceSnapshotTimeout { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -385,8 +385,7 @@ internal class MeshNodeCompilationService(
     private IObservable<DateTimeOffset> DiscoverSourceMaxLastModified(
         NodeTypeDefinition? ntDef, string selfPath,
         IReadOnlyList<MeshNode>? sourcesOverride = null) =>
-        ResolveSources(ntDef, selfPath, sourcesOverride)
-            .Take(1)
+        SnapshotSources(ntDef, selfPath, sourcesOverride)
             .Select(nodes => nodes.Aggregate(
                 DateTimeOffset.MinValue,
                 (acc, n) => n.LastModified > acc ? n.LastModified : acc));
@@ -410,8 +409,7 @@ internal class MeshNodeCompilationService(
     public IObservable<ImmutableDictionary<string, long>> DiscoverSourceVersionSnapshot(
         NodeTypeDefinition? ntDef, string selfPath,
         IReadOnlyList<MeshNode>? sourcesOverride = null) =>
-        ResolveSources(ntDef, selfPath, sourcesOverride)
-            .Take(1)
+        SnapshotSources(ntDef, selfPath, sourcesOverride)
             .Select(nodes => nodes
                 .Where(n => !string.IsNullOrEmpty(n.Path))
                 .Aggregate(
@@ -431,6 +429,40 @@ internal class MeshNodeCompilationService(
         if (sourcesOverride is not null)
             return Observable.Return<IEnumerable<MeshNode>>(sourcesOverride);
         return GetSourceCollection(ntDef, selfPath);
+    }
+
+    /// <summary>
+    /// 🚨 The ONE-SHOT source snapshot every compile stage reads — <see cref="ResolveSources"/>
+    /// bounded to exactly one emission with a hard completion guarantee. The underlying
+    /// <c>NodeSources.GetSources</c> synced query is a LIVE, never-completing collection; a bare
+    /// <c>.Take(1)</c> on it means "wait for the first emission, potentially forever". When the
+    /// query's Initial is genuinely lost (a subscription that raced a source-update burst — the
+    /// memex-cloud 2026-07-20 Store/Plugin GitSync burst), that unbounded wait parked the compile
+    /// at <c>CompilationStatus=Compiling</c> with NO error, NO terminal write and NO recovery
+    /// path: the compile watcher needs a Pending TRANSITION, the release watcher gates on a
+    /// SETTLED status, and the recovery kickoff is activation-one-shot — one hung snapshot wedged
+    /// the NodeType absorbing-forever (every later trigger no-oped; only a recycle re-rolled the
+    /// dice). Bounding the snapshot turns the lost Initial into a LOUD terminal failure: the
+    /// timeout propagates through <c>RunCompile</c>'s Catch to a
+    /// <c>CompilationStatus=Error</c> write naming the dead query, the park registry counts a
+    /// bounded (non-deterministic) failure, and a fresh <c>RequestedReleaseAt</c> trigger — or
+    /// the Compile button — retries cleanly. In every healthy state the snapshot is instant
+    /// (Replay(1) cache) or one cold storage read, far below the bound.
+    /// </summary>
+    private IObservable<IEnumerable<MeshNode>> SnapshotSources(
+        NodeTypeDefinition? ntDef, string selfPath, IReadOnlyList<MeshNode>? sourcesOverride)
+    {
+        var bound = _cacheOptions.SourceSnapshotTimeout;
+        return ResolveSources(ntDef, selfPath, sourcesOverride)
+            .Take(1)
+            .Timeout(bound)
+            .Catch<IEnumerable<MeshNode>, TimeoutException>(ex =>
+                Observable.Throw<IEnumerable<MeshNode>>(new TimeoutException(
+                    $"Source snapshot for '{selfPath}' did not emit within {bound.TotalSeconds:0}s — "
+                    + $"the shared synced source query ('{NodeSources.CacheId(selfPath)}') never produced "
+                    + "its Initial (a lost/raced synced-query subscription, not a source-code error). "
+                    + "The compile fails terminally instead of parking at Compiling forever; retry via "
+                    + "the Compile button / a fresh RequestedReleaseAt.", ex)));
     }
 
     /// <summary>
@@ -460,8 +492,7 @@ internal class MeshNodeCompilationService(
         // could pick up the pre-update Initial emission and the V2 compile would
         // silently consume V1 source — that was the V1↔V2 mismatch root cause in
         // CodeEditRecompileTest.
-        var discoverCodeFiles = ResolveSources(ntDef, selfPath, sourcesOverride)
-            .Take(1)
+        var discoverCodeFiles = SnapshotSources(ntDef, selfPath, sourcesOverride)
             .Select(matches =>
             {
                 var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -922,8 +953,7 @@ internal class MeshNodeCompilationService(
         string selfPath = selfDef != null ? node.Path : node.NodeType;
 
         return resolveDef.SelectMany(ntDef =>
-            ResolveSources(ntDef, selfPath, sourcesOverride)
-                .Take(1)
+            SnapshotSources(ntDef, selfPath, sourcesOverride)
                 .SelectMany(matches =>
                 {
                     var pairs = CollectSourcePairs(matches);

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -1207,7 +1207,25 @@ internal static class NodeTypeCompilationHelpers
                         .Take(1)
                         .Select(result => new CompileOutcome(result, null, pendingNode, resolvedActivityPath))
                         .Catch<CompileOutcome, Exception>(ex =>
-                            Observable.Return(new CompileOutcome(null, ex, pendingNode, resolvedActivityPath))))
+                            Observable.Return(new CompileOutcome(null, ex, pendingNode, resolvedActivityPath)))
+                        // 🚨 TOTALITY guard — this subscription is the ONLY component that can
+                        // settle the Compiling status it just flipped, so its termination MUST
+                        // produce exactly one outcome. An EMPTY completion (an upstream stage
+                        // completed without emitting — the silent twin of the hung-snapshot
+                        // wedge) previously fell through Subscribe(onNext, onError) with NO
+                        // terminal write: the NodeType stayed Compiling forever and every later
+                        // trigger no-oped (memex-cloud 2026-07-20, Store/Plugin). Synthesize a
+                        // terminal error outcome so the state machine ALWAYS settles — the same
+                        // completion-guard contract MeshQuery.MergeProviderObservables enforces
+                        // for provider Initials ("every Query observable must emit exactly one
+                        // Initial" ⇒ "every dispatched compile reaches exactly one terminal
+                        // status").
+                        .DefaultIfEmpty(new CompileOutcome(null, new InvalidOperationException(
+                            $"Compile pipeline for '{hubPath}' completed without producing an outcome — "
+                            + "an upstream stage (source snapshot / include resolution / Roslyn bridge) "
+                            + "terminated empty. This is a framework defect surfaced as a terminal "
+                            + "compile failure so the NodeType cannot wedge at Compiling; retry via the "
+                            + "Compile button / a fresh RequestedReleaseAt."), pendingNode, resolvedActivityPath)))
                     .SubscribeOn(System.Reactive.Concurrency.TaskPoolScheduler.Default))
             .Subscribe(
                 outcome =>
@@ -1267,6 +1285,13 @@ internal static class NodeTypeCompilationHelpers
 
                     releasePathObservable
                         .Take(1)
+                        // 🚨 Same totality guard as the compile pipeline above: the terminal
+                        // Status write below runs in THIS OnNext — a release-create observable
+                        // that completed empty would silently skip it and wedge the NodeType at
+                        // Compiling. TryCreateReleaseNode is bounded (null on timeout/fault) by
+                        // contract; DefaultIfEmpty makes the write unconditional even if that
+                        // contract is ever violated.
+                        .DefaultIfEmpty()
                         .Subscribe(newReleasePath =>
                     {
                     // Terminal writes run under System — same rule as every other

--- a/test/MeshWeaver.Data.Test/MonotonicTriggerMergeTest.cs
+++ b/test/MeshWeaver.Data.Test/MonotonicTriggerMergeTest.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Deterministic repro + spec for the owner-side MONOTONIC-TRIGGER merge
+/// (<see cref="DataExtensions.RebaseMonotonicTriggers"/> composed into
+/// <see cref="DataExtensions.ApplyMeshNodeMerge"/> — the exact seam the
+/// <c>PatchDataRequest</c> handler runs for a cross-hub MeshNode write).
+///
+/// <para>Incident pinned (memex-cloud 2026-07-20, Store/Plugin): during a GitSync burst every
+/// mirror's cached base lags the owner, so an EXPLICIT compile trigger — a cross-hub
+/// <c>stream.Update</c> stamping a NEW (strictly larger) <c>RequestedReleaseAt</c> — arrived
+/// with <c>base ≠ live</c>. The generic three-way merge treats every conflicting scalar as
+/// non-mergeable and REFUSES it, keeping the live value: the user's compile request was
+/// silently LOST ("[MergeGuard] refused stale/reordered cross-hub write"), and the stuck
+/// NodeType could never be re-triggered remotely. For the contractually strictly-increasing
+/// trigger the conflict IS mergeable — the newest instant wins — so the merge must land a
+/// FORWARD trigger (rebasing the writer's stale base) while still dropping a BACKWARD (flapped)
+/// one and still refusing every other conflicting scalar.</para>
+/// </summary>
+public class MonotonicTriggerMergeTest
+{
+    private static readonly JsonSerializerOptions Options = new();
+
+    private const string HubPath = "Store/Plugin";
+
+    private static readonly DateTimeOffset T0 = DateTimeOffset.Parse("2026-07-20T21:40:00Z");
+    private static readonly DateTimeOffset T1 = DateTimeOffset.Parse("2026-07-20T21:41:00Z");
+    private static readonly DateTimeOffset T2 = DateTimeOffset.Parse("2026-07-20T21:43:00Z");
+    private static readonly DateTimeOffset T3 = DateTimeOffset.Parse("2026-07-20T21:45:00Z");
+
+    private static JsonObject Node(params (string Key, JsonNode? Value)[] contentFields)
+    {
+        var content = new JsonObject();
+        foreach (var (k, v) in contentFields)
+            content[k] = v;
+        return new JsonObject { ["Content"] = content };
+    }
+
+    private static JsonNode Instant(DateTimeOffset at) => JsonValue.Create(at.ToString("o"));
+
+    private static JsonObject Merge(JsonObject live, JsonObject patch, JsonObject baseValues)
+    {
+        var message = new PatchDataRequest(new MeshNodeReference(), new RawJson(patch.ToJsonString(Options)))
+        {
+            BaseValues = new RawJson(baseValues.ToJsonString(Options))
+        };
+        DataExtensions.ApplyMeshNodeMerge(
+            live, patch, isMeshNode: true, message, Options, logger: null, HubPath);
+        return live;
+    }
+
+    private static DateTimeOffset ReadTrigger(JsonObject live) =>
+        DateTimeOffset.Parse(live["Content"]!["RequestedReleaseAt"]!.GetValue<string>());
+
+    /// <summary>
+    /// THE incident case: the writer's mirror lagged the owner (base=T1 while live already
+    /// advanced to T2), and the writer stamps a genuinely NEWER trigger T3. The generic
+    /// scalar-conflict refusal silently swallowed T3 → the explicit compile trigger produced no
+    /// compile, ever. The monotonic merge must land T3: a strictly-increasing trigger merges by
+    /// "newest instant wins" regardless of the writer's base.
+    /// </summary>
+    [Fact]
+    public void ForwardTrigger_OverStaleBase_LandsNewerTrigger()
+    {
+        var live = Node(("RequestedReleaseAt", Instant(T2)));
+        var @base = Node(("RequestedReleaseAt", Instant(T1)));
+        var patch = Node(("RequestedReleaseAt", Instant(T3)));
+
+        Merge(live, patch, @base);
+
+        Assert.Equal(T3, ReadTrigger(live));
+    }
+
+    /// <summary>
+    /// The original flap guard stays intact: a reordered/stale patch carrying an OLDER trigger
+    /// (T0 &lt; live T2) must never move the trigger backward — the live value is kept.
+    /// </summary>
+    [Fact]
+    public void BackwardTrigger_OverStaleBase_KeepsLive()
+    {
+        var live = Node(("RequestedReleaseAt", Instant(T2)));
+        var @base = Node(("RequestedReleaseAt", Instant(T1)));
+        var patch = Node(("RequestedReleaseAt", Instant(T0)));
+
+        Merge(live, patch, @base);
+
+        Assert.Equal(T2, ReadTrigger(live));
+    }
+
+    /// <summary>
+    /// Unchanged-since-base fast path is untouched: base == live ⇒ the writer's forward value
+    /// applies exactly as before (no conflict, no rebase needed).
+    /// </summary>
+    [Fact]
+    public void ForwardTrigger_CleanBase_AppliesUnchanged()
+    {
+        var live = Node(("RequestedReleaseAt", Instant(T2)));
+        var @base = Node(("RequestedReleaseAt", Instant(T2)));
+        var patch = Node(("RequestedReleaseAt", Instant(T3)));
+
+        Merge(live, patch, @base);
+
+        Assert.Equal(T3, ReadTrigger(live));
+    }
+
+    /// <summary>
+    /// The monotonic exception is scoped to the ONE contractually strictly-increasing trigger.
+    /// Every other conflicting scalar (here CompilationStatus — the compile single-flight
+    /// state) keeps the REFUSE semantics: a stale-based cross-hub status write must never
+    /// clobber the owner's live state (that protection is what keeps a stale mirror from
+    /// flipping Compiling back to Pending mid-compile).
+    /// </summary>
+    [Fact]
+    public void NonMonotonicScalarConflict_StillRefused()
+    {
+        var live = Node(("CompilationStatus", JsonValue.Create("Compiling")),
+            ("RequestedReleaseAt", Instant(T2)));
+        var @base = Node(("CompilationStatus", JsonValue.Create("Ok")),
+            ("RequestedReleaseAt", Instant(T1)));
+        var patch = Node(("CompilationStatus", JsonValue.Create("Pending")),
+            ("RequestedReleaseAt", Instant(T3)));
+
+        Merge(live, patch, @base);
+
+        Assert.Equal("Compiling", live["Content"]!["CompilationStatus"]!.GetValue<string>());
+        // …while the monotonic trigger in the SAME patch still lands.
+        Assert.Equal(T3, ReadTrigger(live));
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/CompileSourceSnapshotWedgeTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CompileSourceSnapshotWedgeTest.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Deterministic repro of the memex-cloud 2026-07-20 <c>Store/Plugin</c> compile wedge.
+///
+/// <para><b>Incident shape:</b> a GitSync burst updated many NodeType sources at once. A compile
+/// was dispatched (Pending → Compiling, activity created: "Compile started" / "Invoking
+/// compiler…"), but its ONE-SHOT source-snapshot read — <c>ResolveSources(...).Take(1)</c> over
+/// the shared <c>NodeSources.GetSources</c> synced query — never received the query's Initial
+/// (a subscription that raced the burst). With no bound and no error path, the compile parked
+/// FOREVER at <c>CompilationStatus=Compiling</c>. The wedge is ABSORBING: the compile watcher
+/// needs a Pending TRANSITION, <c>InstallReleaseRequestWatcher</c> gates on a SETTLED status,
+/// and the recovery kickoff is activation-one-shot — so no later trigger could ever start a
+/// compile again ("no compile ever executed after the flip"; the explicit trigger no-oped).</para>
+///
+/// <para><b>This test</b> pins the wedge with a query provider that withholds the Initial for
+/// exactly the NodeType's source query (the deterministic stand-in for the raced/lost
+/// synced-query Initial — <c>MeshQuery.MergeProviderObservables</c> gates its merged Initial on
+/// EVERY provider by design). Before the fix the NodeType wedges at Compiling forever and the
+/// first assertion times out. After the fix (<c>MeshNodeCompilationService.SnapshotSources</c>
+/// bounds the one-shot read; <c>RunCompile</c> guarantees a terminal outcome), the compile FAILS
+/// TERMINALLY with a loud error naming the dead source query — and a fresh explicit trigger,
+/// once the query is healthy again, runs a REAL compile that settles Ok. Wedges-to-zero: every
+/// dispatched compile reaches exactly one terminal status.</para>
+/// </summary>
+public class CompileSourceSnapshotWedgeTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output), IDisposable
+{
+    private readonly string _cacheDir = Path.Combine(
+        Path.GetTempPath(), $"MeshWeaverSnapshotWedgeTest-{Guid.NewGuid():N}");
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        Directory.CreateDirectory(_cacheDir);
+        return base.ConfigureMesh(builder)
+            .ConfigureServices(services => services
+                // The stalling provider is a MESH-scoped singleton (no static state); the test
+                // resolves the same instance from the mesh to release the stall.
+                .AddSingleton<StallingSourceQueryProvider>()
+                .AddSingleton<IMeshQueryProvider>(sp =>
+                    sp.GetRequiredService<StallingSourceQueryProvider>())
+                .Configure<CompilationCacheOptions>(o =>
+                {
+                    o.CacheDirectory = _cacheDir;
+                    o.EnableCompilationCache = true;
+                    o.EnableDiskCache = true;
+                    // Short snapshot bound so the terminal Error lands quickly; the healthy-path
+                    // snapshot is instant (Replay(1) cache), so this never trips a good compile.
+                    o.SourceSnapshotTimeout = TimeSpan.FromSeconds(5);
+                }));
+    }
+
+    public new void Dispose()
+    {
+        base.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        if (Directory.Exists(_cacheDir))
+            try { Directory.Delete(_cacheDir, recursive: true); } catch { }
+    }
+
+    private const string TypeName = "SnapshotWedgeType";
+    private static readonly string TypePath = $"{TestPartition}/{TypeName}";
+
+    private const string SourceCode = """
+        using MeshWeaver.Layout.Composition;
+        public static class WedgeLayoutAreas
+        {
+            public static UiControl Overview(LayoutAreaHost host, RenderingContext _)
+                => Controls.Html("<div id='marker'>WEDGE_OK</div>");
+        }
+        """;
+
+    [Fact(Timeout = 120000)]
+    public async Task HungSourceSnapshot_SettlesTerminalError_ThenFreshTriggerRecovers()
+    {
+        var provider = Mesh.ServiceProvider.GetRequiredService<StallingSourceQueryProvider>();
+
+        // 1. Create the NodeType + its source. The per-NodeType hub activates, the first-build
+        //    kickoff flips CompilationStatus null → Pending, the compile watcher dispatches, the
+        //    Pending → Compiling transition lands — and the compile's source snapshot parks on
+        //    the withheld synced-query Initial (the raced-burst stand-in).
+        await NodeFactory.CreateNode(new MeshNode(TypeName, TestPartition)
+        {
+            Name = "Snapshot Wedge Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Repro for the 2026-07-20 hung-source-snapshot compile wedge.",
+                Configuration = "config => config.AddDefaultLayoutAreas().AddLayout(layout => layout.WithView(\"Overview\", WedgeLayoutAreas.Overview))",
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        await NodeFactory.CreateNode(new MeshNode("code", $"{TypePath}/Source")
+        {
+            Name = "Code",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = SourceCode, Language = "csharp" }
+        }).Should().Within(30.Seconds()).Emit();
+
+        // 2. 🚨 THE WEDGE ASSERTION. The dispatched compile's snapshot never receives an
+        //    Initial. BEFORE the fix: the NodeType sticks at Compiling forever — no terminal
+        //    write, no error, and no later trigger can recover it (the absorbing wedge) — this
+        //    wait times out and the test is RED. AFTER the fix: the bounded snapshot errors
+        //    loudly and the compile settles TERMINALLY at Error, naming the dead source query.
+        var failed = await Mesh.GetWorkspace().GetMeshNodeStream(TypePath)
+            .Should().Within(TimeSpan.FromSeconds(40))
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Error);
+        var failedDef = (NodeTypeDefinition)failed.Content!;
+        Output.WriteLine($"=== Terminal error landed: {failedDef.CompilationError} ===");
+        failedDef.CompilationError.Should().Contain("Source snapshot",
+            "the terminal error must name the true defect — the source query that never emitted — "
+            + "not a generic compile failure");
+        failedDef.LatestReleasePath.Should().BeNullOrEmpty(
+            "a compile that never saw its sources must not mint a release");
+
+        // 3. The source query heals (the burst subsides): release the withheld Initial on the
+        //    LIVE upstream subscription the cached synced query already holds.
+        provider.Release();
+
+        // 4. A fresh EXPLICIT trigger (the Compile button / MCP compile seam —
+        //    RequestedReleaseAt) must now run a REAL compile that settles Ok. This is exactly
+        //    what the absorbing wedge made impossible: with the status stuck at Compiling the
+        //    release watcher's settled-gate swallowed every trigger. Terminal Error is settled,
+        //    so the trigger dispatches and Roslyn runs against the now-emitting source set.
+        await Mesh.GetWorkspace().GetMeshNodeStream(TypePath).Update(curr =>
+        {
+            if (curr?.Content is not NodeTypeDefinition def) return curr!;
+            return curr with
+            {
+                Content = def with
+                {
+                    RequestedReleaseAt = DateTimeOffset.UtcNow,
+                    RequestedReleaseForce = true,
+                }
+            };
+        }).Should().Within(30.Seconds()).Emit();
+
+        await Mesh.GetWorkspace().GetMeshNodeStream(TypePath)
+            .Should().Within(TimeSpan.FromSeconds(60))
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LatestReleasePath));
+        Output.WriteLine("=== Recovery compile settled Ok ===");
+    }
+}
+
+/// <summary>
+/// Test-only <see cref="IMeshQueryProvider"/> that WITHHOLDS the Initial for any query that
+/// targets the wedge NodeType's source namespace — the deterministic stand-in for a synced-query
+/// subscription whose Initial was lost racing a source-update burst.
+/// <c>MeshQuery.MergeProviderObservables</c> gates its merged Initial on EVERY registered
+/// provider (by design), so one withheld Initial keeps the whole
+/// <c>NodeSources.GetSources</c> synced query from ever emitting. Every other query gets an
+/// immediate empty Initial (well-behaved: exactly one Initial, never completes).
+/// <see cref="Release"/> flushes the withheld Initials on the live subscriptions, modelling the
+/// upstream healing after the burst.
+/// </summary>
+public sealed class StallingSourceQueryProvider : IMeshQueryProvider
+{
+    private readonly object _gate = new();
+    private ImmutableList<Action> _pendingInitials = ImmutableList<Action>.Empty;
+    private bool _released;
+
+    private const string StallMarker = "SnapshotWedgeType/";
+
+    /// <inheritdoc />
+    public string Name => nameof(StallingSourceQueryProvider);
+
+    /// <inheritdoc />
+    public bool Matches(IReadOnlyList<string> queryNamespaces) => true;
+
+    /// <summary>Flushes every withheld Initial and stops stalling new subscriptions.</summary>
+    public void Release()
+    {
+        ImmutableList<Action> toFlush;
+        lock (_gate)
+        {
+            _released = true;
+            toFlush = _pendingInitials;
+            _pendingInitials = ImmutableList<Action>.Empty;
+        }
+        foreach (var emit in toFlush)
+            emit();
+    }
+
+    /// <inheritdoc />
+    public IObservable<QueryResultChange<T>> Query<T>(MeshQueryRequest request, JsonSerializerOptions options)
+        => Observable.Create<QueryResultChange<T>>(observer =>
+        {
+            void EmitInitial() => observer.OnNext(new QueryResultChange<T>
+            {
+                ChangeType = QueryChangeType.Initial,
+                Items = Array.Empty<T>(),
+                Timestamp = DateTimeOffset.UtcNow,
+            });
+
+            var stall = request.EffectiveQueries
+                .Any(q => q?.Contains(StallMarker, StringComparison.Ordinal) == true);
+            if (stall)
+            {
+                lock (_gate)
+                {
+                    if (!_released)
+                    {
+                        // Withhold the Initial: the observer stays subscribed (never completes,
+                        // never errors) until Release() flushes it — the lost-Initial shape.
+                        _pendingInitials = _pendingInitials.Add(EmitInitial);
+                        return Disposable.Empty;
+                    }
+                }
+            }
+            EmitInitial();
+            return Disposable.Empty;
+        });
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyCollection<QueryResult>> Autocomplete(
+        string basePath, string prefix, JsonSerializerOptions options,
+        AutocompleteMode mode = AutocompleteMode.RelevanceFirst,
+        int limit = 10,
+        string? contextPath = null,
+        string? context = null)
+        => Observable.Return((IReadOnlyCollection<QueryResult>)Array.Empty<QueryResult>());
+
+    /// <inheritdoc />
+    public IObservable<T?> Select<T>(string path, string property, JsonSerializerOptions options)
+        => Observable.Return(default(T?));
+}


### PR DESCRIPTION
# Compile pipeline wedge on GitSync source-update burst (memex-cloud 2026-07-20, Store/Plugin)

## Incident

A GitSync burst (MeshWeaver.Plugins PR #109) updated the sources of many dynamic NodeTypes at once. `Store/Plugin` got stuck at `compilationStatus: "Compiling"`: its compile activity stopped after exactly two messages ("Compile started" / "Invoking compiler…"), no Roslyn run and no error, ever. The CompileWatcher recovery (`Compiling→Pending` flip) fired and a second compile start was stamped — but that compile hung the same way. An explicit compile trigger during the stuck period produced no compile and no node write. A recycle during the burst didn't help; a recycle with the system quiet made the next compile succeed in 300ms.

## Root cause

**1. The hung source snapshot → absorbing `Compiling` wedge** (the primary defect).

`RunCompile` creates the activity ("Invoking compiler…") and *then* subscribes the compile pipeline, whose first stage is a ONE-SHOT source-snapshot read: `ResolveSources(...).Take(1)` over the shared `NodeSources.GetSources` synced query (`MeshNodeCompilationService.DiscoverSourceMaxLastModified` / `CompileCore`). The synced query is a LIVE, never-completing collection gated on its Initial — when that Initial is lost racing a source-update burst, the bare `.Take(1)` waits **forever**: no timeout, no error path, no terminal write. And the wedge is **absorbing**:

- the compile watcher needs a Pending **transition** (`DistinctUntilChanged` + `Where(Pending)`);
- `InstallReleaseRequestWatcher` gates on a **settled** status (`not Pending and not Compiling`), so every explicit trigger sits unprocessed forever;
- the recovery kickoff is `Take(1)`-activation-one-shot — a recycle just re-rolls the dice (mid-burst it re-wedged; quiet it succeeded in 300ms).

That is exactly "no compile ever executed after the flip". Why `Store/Order` compiled (~45s) while `Store/Plugin` wedged: the wedge needs a specific per-subscription race — the compile's snapshot subscription missing the query's Initial mid-burst — not bad source *content* (Order compiled the same new shared sources fine).

**2. The MergeGuard refused legitimate FORWARD compile triggers** (the incident's dead explicit trigger).

The three-way `MeshNodePatchMerge` refuses **every** conflicting scalar (live changed since the writer's base). Correct for non-monotonic fields — but during a burst every mirror's base lags the owner, so a cross-hub `RequestedReleaseAt` patch carrying a genuinely **newer** trigger arrives with `base ≠ live` and is refused: the user's compile request is silently lost (the observed `[MergeGuard] … refused stale/reordered cross-hub write` lines are this mechanism firing on burst writes). Note the recovery flip itself is **not** MergeGuard-refused — it is a local `UpdateOwn` on the owner; the refusal killed the *explicit remote* trigger path.

## Fix (no watchdogs, no retries)

**The compile pipeline is now total — every dispatched compile reaches exactly one terminal status:**

- `MeshNodeCompilationService.SnapshotSources` — all four one-shot snapshot reads (`DiscoverSourceMaxLastModified`, `DiscoverSourceVersionSnapshot`, `CompileCore`, `GetCompilationInputsAsync`) are bounded (`CompilationCacheOptions.SourceSnapshotTimeout`, default 30s; the healthy path is instant off the `Replay(1)` cache) and error **loudly**, naming the dead source query. The error propagates through `RunCompile`'s existing `Catch` to a terminal `Status=Error` write + bounded park accounting (non-deterministic failure ⇒ retry-bounded, then parked with a user notification). A fresh `RequestedReleaseAt` / Compile button retries cleanly.
- `NodeTypeCompilationHelpers.RunCompile` — `DefaultIfEmpty` totality guards on the compile-outcome and release-create subscriptions: an empty completion settles the state machine with a terminal Error instead of silence. Same completion-guard contract `MeshQuery.MergeProviderObservables` already enforces for provider Initials.

**The explicit trigger is a legal write again (rebased on current state):**

- `DataExtensions.RebaseMonotonicTriggers` — for the ONE contractually strictly-increasing control trigger (`RequestedReleaseAt`), the scalar conflict IS mergeable: a **forward** value is rebased onto the live state and lands; a **backward** (flapped) value is still dropped; every other scalar conflict (`CompilationStatus`, `IsDirty`, …) keeps the refusal that protects the compile single-flight.

## Repro tests (red before the fix, green after)

- `CompileSourceSnapshotWedgeTest.HungSourceSnapshot_SettlesTerminalError_ThenFreshTriggerRecovers` (MeshWeaver.Hosting.Monolith.Test) — a query provider withholds the Initial for exactly the NodeType's source query (the deterministic stand-in for the raced/lost synced-query Initial; `MeshQuery.MergeProviderObservables` gates its merged Initial on every provider by design). **Pre-fix: the NodeType sticks at Compiling forever (assertion times out — the incident wedge). Post-fix:** terminal Error naming the snapshot within the bound, then — after the query heals — a fresh explicit trigger runs a real compile that settles Ok with a release.
- `MonotonicTriggerMergeTest` (MeshWeaver.Data.Test) — pins the monotonic merge on the exact internal seam the `PatchDataRequest` handler runs: forward-over-stale-base **lands** (pre-fix: refused/lost), backward drops, clean-base applies, non-monotonic scalar conflicts still refused.

## Verification

- Red run: reverted the src fix → wedge test fails with "did not emit within 40s" (stuck Compiling); `ForwardTrigger_OverStaleBase_LandsNewerTrigger` fails (trigger refused, live value kept).
- Green run: both repro tests pass with the fix (wedge test 8s end-to-end).
- `dotnet build MeshWeaver.slnx -c Release -warnaserror`: 0 warnings, 0 errors.
- Surrounding suites (Release, single run): MeshWeaver.Data.Test, MeshWeaver.Query.Test, MeshWeaver.Graph.Test, and the Monolith compile-pipeline subset (CodeEditRecompile / ReleaseRequestWatcher / CompileLeaf / NodeTypeRelease / MeshHubRemoteStream / BrokenNodeTypeAccess).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
