### PR TITLE
fix(flakes): cure the load-shaped CI flake cluster — lost own-write echo + lost immediate response

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -873,11 +873,16 @@ public class MeshOperations
 
             try
             {
-                var delivery = hub.Post(
-                    DataChangeRequest.Update([node]),
-                    o => o.WithTarget(new Address(node.Path)))!;
-
-                innerSubscription = hub.Observe(delivery)
+                // 🚨 Pre-registering Observe(request, options) — registers the response
+                // subject BEFORE posting. The old Post-then-Observe(delivery) shape had a
+                // window in which an immediate response/DeliveryFailure (deleted target →
+                // instant NotFound) was pumped before the subject existed and silently
+                // lost; the caller then sat until the hub's 60s RequestTimeout — the
+                // McpNegativeOperationsTest.DeletedNode_EveryVerb_FailsCleanly 45.5s CI
+                // flake (PR #500, run 29571004819 shard 0).
+                innerSubscription = hub.Observe(
+                        DataChangeRequest.Update([node]),
+                        o => o.WithTarget(new Address(node.Path)))
                     .Subscribe(
                         d =>
                         {
@@ -991,11 +996,12 @@ public class MeshOperations
             IDisposable? innerSubscription = null;
             try
             {
-                var delivery = hub.Post(
-                    new GetDataRequest(reference),
-                    o => o.WithTarget(address))!;
-
-                innerSubscription = hub.Observe(delivery)
+                // 🚨 Pre-registering Observe(request, options) — subject registered
+                // BEFORE the post, so an immediate response/DeliveryFailure can never
+                // race past the registration and be lost (see UpdateViaDataChange).
+                innerSubscription = hub.Observe(
+                        new GetDataRequest(reference),
+                        o => o.WithTarget(address))
                     .Subscribe(
                         d =>
                         {
@@ -1762,11 +1768,12 @@ public class MeshOperations
 
             try
             {
-                var delivery = hub.Post(
-                    new PatchDataRequest(new MeshNodeReference(), new RawJson(rawPatch)),
-                    o => o.WithTarget(new Address(resolvedPath)))!;
-
-                innerSubscription = hub.Observe(delivery)
+                // 🚨 Pre-registering Observe(request, options) — subject registered
+                // BEFORE the post, so an immediate response/DeliveryFailure can never
+                // race past the registration and be lost (see UpdateViaDataChange).
+                innerSubscription = hub.Observe(
+                        new PatchDataRequest(new MeshNodeReference(), new RawJson(rawPatch)),
+                        o => o.WithTarget(new Address(resolvedPath)))
                     .Subscribe(
                         d =>
                         {
@@ -2444,11 +2451,17 @@ public class MeshOperations
             IDisposable? innerSubscription = null;
             try
             {
-                var delivery = hub.Post(
-                    new MoveNodeRequest(resolvedSource, resolvedTarget),
-                    o => o.WithTarget(new Address(resolvedSource)))!;
-
-                innerSubscription = hub.Observe(delivery)
+                // 🚨 Pre-registering Observe(request, options) — subject registered
+                // BEFORE the post. The old Post-then-Observe(delivery) shape lost the
+                // DELETED-source case's immediate DeliveryFailure whenever it was pumped
+                // before Observe registered the subject: the caller then waited out the
+                // hub's 60s RequestTimeout while the test's 45s bound fired first — the
+                // McpNegativeOperationsTest.DeletedNode_EveryVerb_FailsCleanly (line 105,
+                // the MOVE verb) CI flake on PR #500 (run 29571004819 shard 0; locally
+                // the round-trip never beat the registration, hence 646ms green).
+                innerSubscription = hub.Observe(
+                        new MoveNodeRequest(resolvedSource, resolvedTarget),
+                        o => o.WithTarget(new Address(resolvedSource)))
                     .Subscribe(
                         d =>
                         {

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1284,34 +1284,82 @@ public static class MeshDataSourceExtensions
         if (initial || current.ChangeType != ChangeType.Patch)
             return new(node, current.StreamId, current.Version);
 
-        // Patch path: take the EntityUpdate whose Value is the targeted MeshNode.
-        // If reference.Path is set, prefer the update whose payload matches that
-        // path so a same-frame multi-entity update doesn't emit a sibling's value
-        // here. Falls back to FirstOrDefault for the no-path case.
-        var change = !string.IsNullOrEmpty(reference.Path)
-            ? current.Updates.FirstOrDefault(u =>
-                u.Value is MeshNode m
-                && string.Equals(m.Path, reference.Path, StringComparison.OrdinalIgnoreCase))
-                ?? current.Updates.FirstOrDefault()
-            : current.Updates.FirstOrDefault();
+        // Patch path with a targeted reference: emit ONLY when an EntityUpdate
+        // actually concerns the referenced node. 🚨 NO sibling fallback — the old
+        // `?? current.Updates.FirstOrDefault()` surfaced a SIBLING node (a
+        // Source/Release/_Activity satellite patched in the same collection) as
+        // this stream's value with a bumped Version. Every own-node subscriber
+        // then saw a foreign node masquerading as the own node; UpdateOwn's echo
+        // detection accepted it as "my write landed" and completed with a
+        // pre-write state — the lost-compile-dispatch wedge behind the
+        // FrameworkStaleInstanceRenderTest CI flake (run 29749071939). A patch
+        // whose updates all target siblings does not change the referenced node:
+        // emit a null-Value item so the reduced pipeline's not-null filter drops
+        // it (pinned by MeshNodeReducePatchTest).
+        if (!string.IsNullOrEmpty(reference.Path))
+        {
+            foreach (var u in current.Updates)
+            {
+                // u.Value is a JsonElement when the update was derived from a JSON
+                // patch (cross-hub / mirror path) — `is MeshNode` alone would miss
+                // it and previously fell into the sibling fallback by luck.
+                // Deserialize to probe the target path; a delete-shaped update
+                // (Value null) is matched via OldValue.
+                var valueNode = AsMeshNode(u.Value, options);
+                var candidate = valueNode ?? AsMeshNode(u.OldValue, options);
+                if (candidate is null
+                    || !string.Equals(candidate.Path, reference.Path, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                return new(valueNode, current.ChangedBy, current.StreamId,
+                    ChangeType.Patch, current.Version, [u]);
+            }
+            if (current.Updates.Count == 0)
+                // Patch with no Updates at all — fall back to full value instead of
+                // returning null (which silently drops the emission and blocks live updates).
+                return new(node, current.StreamId, current.Version);
+            // Updates exist but none targets the referenced node — sibling-only churn.
+            return new(null, current.ChangedBy, current.StreamId,
+                ChangeType.Patch, current.Version, []);
+        }
+
+        // No-path reference (legacy single-instance shape): keep the historical
+        // first-update behaviour.
+        var change = current.Updates.FirstOrDefault();
         if (change == null)
         {
             // Patch with no matching Updates — fall back to full value instead of
             // returning null (which silently drops the emission and blocks live updates).
             return new(node, current.StreamId, current.Version);
         }
-        // change.Value is a JsonElement when the update was derived from a JSON
-        // patch (cross-hub / mirror path) — `as MeshNode` would silently null it
-        // out, dropping a null-content ChangeItem into the mirror. Deserialize it
-        // the same way the sibling PatchMeshNode does.
-        var changedNode = change.Value switch
-        {
-            MeshNode m => m,
-            JsonElement je => je.Deserialize<MeshNode>(options),
-            _ => null
-        };
+        var changedNode = AsMeshNode(change.Value, options);
         return new(changedNode, current.ChangedBy, current.StreamId,
             ChangeType.Patch, current.Version, [change]);
+    }
+
+    /// <summary>
+    /// Converts an <see cref="EntityUpdate"/> payload to a <see cref="MeshNode"/>:
+    /// typed instances pass through; JsonElement payloads (cross-hub / mirror
+    /// patches) are deserialized; anything else — including undeserializable
+    /// JSON — yields null.
+    /// </summary>
+    private static MeshNode? AsMeshNode(object? value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case MeshNode m:
+                return m;
+            case JsonElement je:
+                try
+                {
+                    return je.Deserialize<MeshNode>(options);
+                }
+                catch (JsonException)
+                {
+                    return null;
+                }
+            default:
+                return null;
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -526,21 +526,6 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                 observer.OnCompleted();
             }
 
-            // Subscribe before applying the partition write so the post-update emission
-            // is never missed. Baseline = pre-write version; first emission past it wins.
-            long? baseline = null;
-            var sub = refStream.Subscribe(change =>
-            {
-                if (baseline is null)
-                {
-                    baseline = change.Version;
-                    return;
-                }
-                if (change.Version <= baseline.Value) return;
-                if (change.Value is { } node)
-                    EmitOnce(node);
-            }, observer.OnError);
-
             // Resolve the target Path: an explicit _path wins, otherwise default to the
             // workspace's own hub path. The InstanceCollection holds the OWN MeshNode
             // alongside any satellite nodes the data source has loaded (e.g. NodeType
@@ -550,6 +535,54 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
             // resolved correctly. When neither path is available, fall back to
             // FirstOrDefault â€” only legacy single-instance shapes hit this branch.
             var targetPath = _path ?? _workspace.Hub.Address.Path;
+
+            // 🚨 Echo detection is WRITE-IDENTITY-based, never emission-count-based.
+            // The update lambda stamps the strictly-increasing Version it writes
+            // (MeshNode.NextVersion — always > current.Version) into stampedVersion
+            // BEFORE the commit; the subscription emits only a state of the TARGET
+            // node at-or-past that stamp — a state that provably CONTAINS this
+            // caller's write.
+            //
+            // The previous shape ("baseline = first observed stream version; emit on
+            // any emission with a higher version") accepted FOREIGN emissions as the
+            // echo. Two real failure modes (the FrameworkStaleInstanceRenderTest CI
+            // flake, 2026-07-20 run 29749071939):
+            //   1. A concurrent write to ANOTHER instance in the same collection (a
+            //      Source/Release/_Activity satellite — which ReduceToMeshNode's
+            //      patch path even surfaced as the emission's Value) or a concurrent
+            //      writer on the SAME node bumped the stream version in the window
+            //      between Subscribe and this caller's update lambda running — the
+            //      observable completed with a PRE-WRITE (or sibling) node while the
+            //      lambda hadn't run. HandleDispatchCompile then read
+            //      weTransitioned == false, skipped the compile dispatch, and the
+            //      Pending→Compiling flip landed with NO compile driver → NodeType
+            //      wedged at Compiling forever (the 60s GetCompilationPathRequest
+            //      timeout in the CI trace was downstream of that wedge).
+            //   2. Under load, the subscription's initial replay could be delivered
+            //      AFTER the write applied — the post-write state became the
+            //      baseline and the true echo never came → the observable hung.
+            // Version-gating on the caller's own stamp eliminates both: pre-stamp
+            // emissions are ignored, and the post-commit echo (guaranteed — the
+            // subscription attaches before the write, and a replay delivered after
+            // the commit already carries Version >= stamp) always satisfies the
+            // gate. The happens-before chain (stamp write → commit under the
+            // stream's synchronization → emission/replay reads the committed state)
+            // makes the stamp visible on the emission thread whenever a post-write
+            // state is; Volatile is belt-and-suspenders.
+            long stampedVersion = -1;
+            var sub = refStream.Subscribe(change =>
+            {
+                var stamped = System.Threading.Volatile.Read(ref stampedVersion);
+                if (stamped < 0) return; // our write hasn't been applied yet
+                if (change.Value is not { } node) return;
+                // Only the referenced node can satisfy the echo — a sibling emission
+                // (same collection, different Path) must never complete this write.
+                if (!string.IsNullOrEmpty(targetPath)
+                    && !string.Equals(node.Path, targetPath, StringComparison.OrdinalIgnoreCase))
+                    return;
+                if (node.Version < stamped) return; // pre-write state
+                EmitOnce(node);
+            }, observer.OnError);
 
             try
             {
@@ -597,6 +630,9 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     {
                         Version = MeshNode.NextVersion(_workspace.Hub.Version, current.Version)
                     };
+                    // Stamp BEFORE the commit — the echo subscription above only emits
+                    // once it can see this write's Version on the target node.
+                    System.Threading.Volatile.Write(ref stampedVersion, updated.Version);
                     var newStore = store.Update(nameof(MeshNode), c => c.Update(updated.Id, updated));
                     return dsStream.ApplyChanges(new EntityStoreAndUpdates(newStore,
                         [new EntityUpdate(nameof(MeshNode), updated.Id, updated) { OldValue = current }],

--- a/src/MeshWeaver.Reactive.Assertions/ObservableAssertions.cs
+++ b/src/MeshWeaver.Reactive.Assertions/ObservableAssertions.cs
@@ -112,10 +112,15 @@ public class ObservableAssertions<T>
     {
         try
         {
+            // Same sentinel discipline as WaitForFirst: only the WAIT's own timeout maps
+            // to "did not"; a source-thrown TimeoutException surfaces via "errored:".
             await _subject.SubscribeOn(TaskPoolScheduler.Default)
-                .IgnoreElements().Timeout(_timeout).ToTask();
+                .IgnoreElements()
+                .Timeout(_timeout, Observable.Defer(() =>
+                    Observable.Throw<T>(new AssertionWaitTimeoutException())))
+                .ToTask();
         }
-        catch (TimeoutException)
+        catch (AssertionWaitTimeoutException)
         {
             throw new ObservableAssertionException(
                 $"Expected the observable to complete within {Describe(_timeout)}{Reason(because)}, but it did not.");
@@ -162,10 +167,20 @@ public class ObservableAssertions<T>
         var source = predicate is null ? _subject : _subject.Where(predicate);
         try
         {
+            // 🚨 The assertion's OWN timeout throws the private sentinel below, so it is
+            // distinguishable from a TimeoutException raised by the SOURCE (e.g. the hub's
+            // RequestTimeout: "No response received in hub X within 30s for request Y →
+            // target Z"). The old plain .Timeout(_timeout) folded both into the same catch
+            // and reported "did not emit within 90s" for a source that ERRORED at 60s —
+            // masking the diagnostic that names the timed-out request and target hub
+            // (FrameworkStaleInstanceRenderTest CI triage, run 29749071939).
             return await source.SubscribeOn(TaskPoolScheduler.Default)
-                .Take(1).Timeout(_timeout).ToTask();
+                .Take(1)
+                .Timeout(_timeout, Observable.Defer(() =>
+                    Observable.Throw<T>(new AssertionWaitTimeoutException())))
+                .ToTask();
         }
-        catch (TimeoutException)
+        catch (AssertionWaitTimeoutException)
         {
             throw new ObservableAssertionException(
                 $"Expected the observable to {expectation} within {Describe(_timeout)}{Reason(because)}, but it did not.");
@@ -175,7 +190,7 @@ public class ObservableAssertions<T>
             // Source completed without producing a (matching) value — Take(1).ToTask() throws
             // InvalidOperationException("Sequence contains no elements"). Same "did not" outcome.
             throw new ObservableAssertionException(
-                $"Expected the observable to {expectation} within {Describe(_timeout)}{Reason(because)}, but it did not.");
+                $"Expected the observable to {expectation} within {Describe(_timeout)}{Reason(because)}, but it completed without one.");
         }
         catch (Exception ex)
         {
@@ -183,6 +198,14 @@ public class ObservableAssertions<T>
                 $"Expected the observable to {expectation} within {Describe(_timeout)}{Reason(because)}, but it errored: {ex.Message}.");
         }
     }
+
+    /// <summary>
+    /// Private sentinel thrown by the assertion's own <c>Timeout</c> operator so a
+    /// timeout of the WAIT is distinguishable from a <see cref="TimeoutException"/>
+    /// raised by the observed source itself (which carries the real diagnostic and
+    /// must surface via the "errored:" message).
+    /// </summary>
+    private sealed class AssertionWaitTimeoutException : Exception;
 
     private static string Describe(TimeSpan t)
         => t.TotalSeconds >= 1 ? $"{t.TotalSeconds:0.##}s" : $"{t.TotalMilliseconds:0}ms";

--- a/test/MeshWeaver.AI.Test/McpImmediateFailureObservationTest.cs
+++ b/test/MeshWeaver.AI.Test/McpImmediateFailureObservationTest.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.AI.Plugins;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Pins the response-observation contract behind the fix for the
+/// <c>McpNegativeOperationsTest.DeletedNode_EveryVerb_FailsCleanly</c> CI flake
+/// (PR #500, run 29571004819 shard 0: the MOVE verb produced NO emission for 45.5s
+/// under CI load while passing locally in 646ms).
+///
+/// <para><b>The race:</b> <c>MeshOperations</c>' mutation verbs used the
+/// Post-then-<c>Observe(delivery)</c> shape: the response subject was registered
+/// only AFTER the request was posted. A target that fails immediately (a DELETED
+/// node → instant NotFound/DeliveryFailure) can have its failure pumped through
+/// the caller hub's action block inside that window; the failure finds no
+/// registered callback and is dropped, and the later-registered subject never
+/// fires — the caller then sits until the hub's 60s <c>RequestTimeout</c>, past
+/// the test's 45s bound. Under CI load the posting thread is routinely preempted
+/// between the two calls, which is why the flake was load-shaped.</para>
+///
+/// <para><b>The fix:</b> the verbs now use the pre-registering
+/// <c>hub.Observe(request, options)</c> overload — the subject is registered
+/// BEFORE the post and (being an AsyncSubject) buffers the terminal event for
+/// any subscriber, however late. The test below proves that property in the
+/// worst case: the terminal event is FORCED to be fully pumped (fenced by two
+/// complete unrelated request/response round-trips) before the caller ever
+/// subscribes — the exact interleaving that lost the response pre-fix.</para>
+/// </summary>
+public class McpImmediateFailureObservationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private MeshOperations Ops => new(Mesh);
+
+    [Fact(Timeout = 60000)]
+    public async Task PreRegisteredObserve_DeliversTerminalEvent_ToArbitrarilyLateSubscriber()
+    {
+        // A live node to fence round-trips against, and a node we create then delete
+        // so its address fails fast — the exact shape of the flaky MOVE verb.
+        var fenceId = $"fence-{Guid.NewGuid():N}";
+        var doomedId = $"doomed-{Guid.NewGuid():N}";
+        await NodeFactory.CreateNode(new MeshNode(fenceId, TestPartition)
+        {
+            Name = fenceId, NodeType = "Markdown",
+            Content = new MarkdownContent { Content = "# fence" }
+        }).Should().Emit();
+        await NodeFactory.CreateNode(new MeshNode(doomedId, TestPartition)
+        {
+            Name = doomedId, NodeType = "Markdown",
+            Content = new MarkdownContent { Content = "# doomed" }
+        }).Should().Emit();
+        await NodeFactory.DeleteNode($"{TestPartition}/{doomedId}").Should().Emit();
+
+        // Observe(request, options) posts EAGERLY and registers the response subject
+        // BEFORE the post. Hold the returned observable WITHOUT subscribing.
+        var deletedAddress = new Address($"{TestPartition}/{doomedId}");
+        var pending = Mesh.Observe(
+            new MoveNodeRequest($"{TestPartition}/{doomedId}", $"{TestPartition}/dest-{Guid.NewGuid():N}"),
+            o => o.WithTarget(deletedAddress));
+
+        // FENCE: two complete request/response round-trips through the same hub.
+        // By the time both responses have arrived, the deleted-target request's
+        // terminal event (response or DeliveryFailure) has been pumped long since —
+        // this is the interleaving in which the old Post-then-Observe(delivery)
+        // shape had already dropped it.
+        var fenceAddress = new Address($"{TestPartition}/{fenceId}");
+        await Mesh.Observe(new PingRequest(), o => o.WithTarget(fenceAddress)).Should().Emit();
+        await Mesh.Observe(new PingRequest(), o => o.WithTarget(fenceAddress)).Should().Emit();
+
+        // LATE subscribe: the buffered terminal event must still be delivered —
+        // as a response (Move handler answering Success=false) or as an error
+        // (DeliveryFailure). Either way it must arrive promptly; only a LOST
+        // event would leave the stream silent (the pre-fix 45s hang).
+        var notification = await pending.Materialize()
+            .Should().Within(TimeSpan.FromSeconds(15)).Emit(
+                "the pre-registered response subject buffers the terminal event for late subscribers");
+        if (notification.Kind == System.Reactive.NotificationKind.OnNext)
+        {
+            (notification.Value.Message is MoveNodeResponse { Success: false })
+                .Should().BeTrue("a move of a deleted node must not succeed");
+        }
+        else
+        {
+            notification.Kind.Should().Be(System.Reactive.NotificationKind.OnError,
+                "the only acceptable non-response terminal event is the delivery failure");
+        }
+
+        // And the user-facing surface: MOVE of a deleted node must produce its
+        // error envelope promptly — never a silent stall.
+        var moveResult = await Ops.Move($"{TestPartition}/{doomedId}", $"{TestPartition}/dest2-{Guid.NewGuid():N}")
+            .Should().Within(TimeSpan.FromSeconds(15)).Emit();
+        moveResult.Should().Contain("Error",
+            "moving a deleted node must surface an error envelope");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/MeshNodeReducePatchTest.cs
+++ b/test/MeshWeaver.Graph.Test/MeshNodeReducePatchTest.cs
@@ -1,0 +1,143 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Deterministic pin for <see cref="MeshDataSourceExtensions.ReduceToMeshNode"/>'s Patch path —
+/// the reducer behind every own-node <c>MeshNodeReference</c> stream on a per-node hub.
+///
+/// <para><b>The defect this pins (FrameworkStaleInstanceRenderTest CI flake, run
+/// 29749071939):</b> the per-NodeType hub's InstanceCollection holds the own node
+/// side-by-side with its satellites (Source / Release / _Activity). When a Patch
+/// change carried updates ONLY for a satellite, the old
+/// <c>?? current.Updates.FirstOrDefault()</c> fallback emitted the SIBLING MeshNode as
+/// the own-node stream's value with a bumped stream version. UpdateOwn's echo
+/// detection accepted that foreign emission as "my write landed" and completed
+/// BEFORE the caller's update lambda ran — HandleDispatchCompile then read
+/// <c>weTransitioned == false</c>, skipped the compile dispatch, and the NodeType
+/// wedged at Compiling forever (the observed CI trace: <c>Status=Compiling fv=''
+/// asm=none</c> at +350ms, then silence until the 60s request timeout).</para>
+///
+/// <para>Correct semantics, asserted here: a patch whose updates all target siblings
+/// does not change the referenced node — the reducer must emit a null-Value item
+/// (dropped by the reduced pipeline's not-null filter), never a sibling's node.</para>
+/// </summary>
+public class MeshNodeReducePatchTest
+{
+    private const string OwnPath = "type/StaleArea";
+    private static readonly JsonSerializerOptions Options = new();
+
+    private static readonly MeshNode OwnNode = new("StaleArea", "type")
+    {
+        Name = "Own",
+        NodeType = MeshNode.NodeTypePath,
+        Version = 5
+    };
+
+    private static readonly MeshNode SiblingSource = new("Source", OwnPath)
+    {
+        Name = "code",
+        NodeType = "Code",
+        Version = 3
+    };
+
+    private static InstanceCollection Collection(params MeshNode[] nodes)
+        => new()
+        {
+            Instances = nodes.ToImmutableDictionary(n => (object)n.Id, n => (object)n)
+        };
+
+    private static ChangeItem<InstanceCollection> Patch(
+        InstanceCollection collection, params EntityUpdate[] updates)
+        => new(collection, ChangedBy: null, StreamId: "test",
+            ChangeType.Patch, Version: 42, updates);
+
+    [Fact]
+    public void SiblingOnlyPatch_DoesNotEmitTheSiblingAsTheOwnNode()
+    {
+        var change = Patch(
+            Collection(OwnNode, SiblingSource),
+            new EntityUpdate(nameof(MeshNode), SiblingSource.Id, SiblingSource));
+
+        var reduced = MeshDataSourceExtensions.ReduceToMeshNode(
+            change, new MeshNodeReference(OwnPath), initial: false, Options);
+
+        // The patch does not concern the referenced node: the reducer must not
+        // surface the sibling (the old fallback returned SiblingSource here) and
+        // must not re-assert the own node with a bumped version either — it emits
+        // a null Value the reduced pipeline's not-null filter drops.
+        reduced.Value.Should().BeNull(
+            "a patch whose updates all target siblings does not change the referenced node");
+    }
+
+    [Fact]
+    public void OwnNodePatch_EmitsTheOwnNode()
+    {
+        var updatedOwn = OwnNode with { Name = "Renamed", Version = 6 };
+        var change = Patch(
+            Collection(updatedOwn, SiblingSource),
+            new EntityUpdate(nameof(MeshNode), updatedOwn.Id, updatedOwn) { OldValue = OwnNode });
+
+        var reduced = MeshDataSourceExtensions.ReduceToMeshNode(
+            change, new MeshNodeReference(OwnPath), initial: false, Options);
+
+        reduced.Value.Should().NotBeNull();
+        reduced.Value!.Path.Should().Be(OwnPath);
+        reduced.Value.Name.Should().Be("Renamed");
+    }
+
+    [Fact]
+    public void OwnNodePatch_AsJsonElement_StillResolvesTheOwnNode()
+    {
+        // Cross-hub / mirror patches carry the update payload as JsonElement. The
+        // old code's typed-only match missed it and only resolved the own node BY
+        // LUCK through the sibling fallback; the fix must resolve it by identity.
+        var updatedOwn = OwnNode with { Name = "FromMirror", Version = 7 };
+        var json = JsonSerializer.SerializeToElement(updatedOwn, Options);
+        var change = Patch(
+            Collection(updatedOwn, SiblingSource),
+            new EntityUpdate(nameof(MeshNode), updatedOwn.Id, json));
+
+        var reduced = MeshDataSourceExtensions.ReduceToMeshNode(
+            change, new MeshNodeReference(OwnPath), initial: false, Options);
+
+        reduced.Value.Should().NotBeNull();
+        reduced.Value!.Path.Should().Be(OwnPath);
+        reduced.Value.Name.Should().Be("FromMirror");
+    }
+
+    [Fact]
+    public void MixedPatch_PicksTheOwnNodeUpdate_NotTheSibling()
+    {
+        var updatedOwn = OwnNode with { Name = "Mixed", Version = 8 };
+        var change = Patch(
+            Collection(updatedOwn, SiblingSource),
+            new EntityUpdate(nameof(MeshNode), SiblingSource.Id, SiblingSource),
+            new EntityUpdate(nameof(MeshNode), updatedOwn.Id, updatedOwn));
+
+        var reduced = MeshDataSourceExtensions.ReduceToMeshNode(
+            change, new MeshNodeReference(OwnPath), initial: false, Options);
+
+        reduced.Value.Should().NotBeNull();
+        reduced.Value!.Path.Should().Be(OwnPath);
+        reduced.Value.Name.Should().Be("Mixed");
+    }
+
+    [Fact]
+    public void PatchWithNoUpdates_FallsBackToFullValue()
+    {
+        // Legacy live-update guard: a Patch carrying no updates must still emit the
+        // full reduced value rather than silently dropping the emission.
+        var change = Patch(Collection(OwnNode, SiblingSource));
+
+        var reduced = MeshDataSourceExtensions.ReduceToMeshNode(
+            change, new MeshNodeReference(OwnPath), initial: false, Options);
+
+        reduced.Value.Should().NotBeNull();
+        reduced.Value!.Path.Should().Be(OwnPath);
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/OwnUpdateEchoIntegrityTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/OwnUpdateEchoIntegrityTest.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the write-echo contract of <c>MeshNodeStreamHandle.UpdateOwn</c> — the
+/// primitive behind every own-hub <c>workspace.GetMeshNodeStream().Update(...)</c>.
+///
+/// <para><b>The defect this pins (FrameworkStaleInstanceRenderTest CI flake, run
+/// 29749071939):</b> UpdateOwn used to complete on the FIRST own-stream emission
+/// whose stream version exceeded a baseline captured at subscribe time — without
+/// verifying the emission reflected the caller's own write. Any concurrent write
+/// (another writer on the same node, or a satellite create in the same collection)
+/// landing in the window between Subscribe and the caller's update lambda made the
+/// observable complete with a PRE-WRITE state, before the lambda even ran. In
+/// production that misfired <c>HandleDispatchCompile</c>'s <c>weTransitioned</c>
+/// read → the compile dispatch was skipped → the NodeType wedged at
+/// <c>Compiling</c> forever. Under CI load the window was hit routinely; locally
+/// almost never — the definition of the flake.</para>
+///
+/// <para>The assertion here is VALUE-based, not timing-based: an Update's emission
+/// must always contain that Update's own write. Post-fix this holds by
+/// construction (the echo is gated on the writer's own stamped Version); pre-fix
+/// the interleaving loop below violates it within a few iterations.</para>
+/// </summary>
+public class OwnUpdateEchoIntegrityTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override bool ShareMeshAcrossTests => true;
+
+    [Fact(Timeout = 120_000)]
+    public async Task ConcurrentOwnUpdates_EachEmissionContainsItsOwnWrite()
+    {
+        var nodeId = $"echo-race-{Guid.NewGuid():N}";
+        var nodePath = $"{TestPartition}/{nodeId}";
+
+        await NodeFactory.CreateNode(
+                new MeshNode(nodeId, TestPartition) { Name = "seed", NodeType = "Markdown" })
+            .Should().Emit();
+
+        // Activate the per-node hub and grab it — UpdateOwn only runs on the
+        // owning hub's workspace (a pathed handle from another hub routes remote).
+        var client = GetClient();
+        var nodeAddress = new Address(nodePath);
+        await client.Observe(new PingRequest(), o => o.WithTarget(nodeAddress)).Should().Emit();
+        var nodeHub = Mesh.GetHostedHub(nodeAddress, HostedHubCreation.Never);
+        nodeHub.Should().NotBeNull("node hub must exist after ping");
+
+        var workspace = nodeHub!.GetWorkspace();
+
+        // Two concurrent writers per iteration, each touching a DIFFERENT field.
+        // Whatever interleaving the scheduler produces, writer A's emission must
+        // carry A's Name value and writer B's emission must carry B's Description
+        // value — any state at-or-past a writer's own commit contains that
+        // writer's field, because only that writer touches it. The old
+        // baseline-version echo detection returned the OTHER writer's (or the
+        // pre-write) state here within a few iterations.
+        const int iterations = 200;
+        for (var i = 0; i < iterations; i++)
+        {
+            var expectedName = $"name-{i}";
+            var expectedDescription = $"desc-{i}";
+
+            var writerA = workspace.GetMeshNodeStream()
+                .Update(curr => curr with { Name = expectedName })
+                .Should().Within(TimeSpan.FromSeconds(30)).Emit(
+                    $"writer A's update (iteration {i}) must land and echo");
+            var writerB = workspace.GetMeshNodeStream()
+                .Update(curr => curr with { Description = expectedDescription })
+                .Should().Within(TimeSpan.FromSeconds(30)).Emit(
+                    $"writer B's update (iteration {i}) must land and echo");
+
+            var emittedA = await writerA;
+            var emittedB = await writerB;
+
+            emittedA.Path.Should().Be(nodePath,
+                $"iteration {i}: writer A's echo must be the target node, never a sibling");
+            emittedB.Path.Should().Be(nodePath,
+                $"iteration {i}: writer B's echo must be the target node, never a sibling");
+            emittedA.Name.Should().Be(expectedName,
+                $"iteration {i}: writer A's emission must contain writer A's own write "
+                + "(a pre-write or foreign echo means the Update completed before its lambda ran)");
+            emittedB.Description.Should().Be(expectedDescription,
+                $"iteration {i}: writer B's emission must contain writer B's own write");
+        }
+    }
+}


### PR DESCRIPTION
Cures the chronic load-shaped CI flake cluster by fixing the two real races underneath — no timeout widening, no retries, no sleeps.

## 1. FrameworkStaleInstanceRenderTest (shard 1, run 29749071939) — lost compile dispatch

**Observed failure:** `Status=Compiling fv='' asm=none` at +350ms, then silence; "did not emit within 90s" at ~60s (actually the hub's 60s `RequestTimeout`, mislabelled by the assertion — also fixed, see below).

**Root cause — two compounding defects in the own-node write path:**

1. **`MeshDataSourceExtensions.ReduceToMeshNode` (patch path):** when a Patch carried updates ONLY for a *sibling* instance in the per-node hub's collection (a `Source`/`Release`/`_Activity` satellite), the `?? current.Updates.FirstOrDefault()` fallback emitted the **sibling's node** as the own-node stream's value, with a bumped stream version.
2. **`MeshNodeStreamHandle.UpdateOwn`:** the write-echo detection accepted **any** emission with a stream version past a subscribe-time baseline — including those foreign emissions — so `Update(...)` could complete **before the caller's update lambda ever ran** (or, with a delayed initial replay, hang forever).

**How that kills the test:** `HandleDispatchCompile` flips Pending→Compiling via `Update(...)` and dispatches `RunCompile` from the emission callback, guarded by `weTransitioned`. When the test's `Source` satellite create landed in the subscribe→lambda window (routine on a loaded 2-core CI runner, ~never locally), the callback fired early with `weTransitioned == false` → *"status already past Pending — skipping dispatch"* → the flip landed milliseconds later with **no compile driver** → NodeType wedged at `Compiling` forever. Everything downstream (the 60s `GetCompilationPathRequest` timeout, the 90s assert) is a symptom of that wedge.

**Fix (removes the race, doesn't hide it):**
- `ReduceToMeshNode`: an update must actually target the referenced path (typed or JsonElement payload; `OldValue` for deletes) to emit; sibling-only patches emit a null-Value item the reduce pipeline's not-null filter drops (`NullReturn` is never enabled in src, so no subscriber can see the null).
- `UpdateOwn`: echo detection is now **write-identity-based** — the update lambda stamps the strictly-increasing `Version` it writes (`MeshNode.NextVersion` ⇒ always > current), and the subscription emits only a state of the **target node at-or-past that stamp**, i.e. a state that provably contains the caller's write. Both failure modes (early-complete and baseline-after-write hang) are structurally impossible.

**Deterministic repro (red pre-fix, green post-fix):**
- `MeshNodeReducePatchTest` (pure unit, `MeshWeaver.Graph.Test`): sibling-only patch must not emit the sibling — **red pre-fix**; also pins own-node-as-JsonElement resolution (previously worked only by luck via the sibling fallback), mixed patches, and the no-updates full-value fallback.
- `OwnUpdateEchoIntegrityTest` (`MeshWeaver.Hosting.Monolith.Test`): value-asserted two-concurrent-writer loop — each `Update`'s emission must contain that update's own write. **Red pre-fix on iteration 0 even on an idle dev machine** (`Expected "name-0" but found "seed"` — the observable completed before its own lambda's write). No timing assertions, so no flake potential post-fix.

**Diagnosability fix:** `ObservableAssertions.WaitForFirst`/`Complete` folded a *source-thrown* `TimeoutException` (the hub's `RequestTimeout` with its "No response received … → target …" diagnostic) into the misleading "did not emit within &lt;outer timeout&gt;". The assertion's own timeout now throws a private sentinel; a source `TimeoutException` surfaces via "errored: &lt;real message&gt;".

## 2. McpNegativeOperationsTest.DeletedNode_EveryVerb_FailsCleanly (PR #500, run 29571004819 shard 0) — lost immediate response

**Observed failure:** the MOVE verb (line 105) produced NO emission for 45.5s under CI load; locally green in 646ms.

**Root cause:** `MeshOperations`' `Update`/`Get`-data/`Patch`/`Move` verbs used the **Post-then-`Observe(delivery)`** shape. The response subject registers only in the `Observe` call — a target that fails immediately (deleted node → instant NotFound/DeliveryFailure) can have its terminal event pumped through the caller hub in the window between the two calls; it finds no callback and is dropped; the later-registered subject never fires; the caller sits until the hub's **60s** `RequestTimeout`, past the test's 45s bound. CI load widens the window via preemption of the posting thread — the exact load-shape of the flake.

**Fix:** all four sites now use the pre-registering `hub.Observe(request, options)` overload — the framework primitive whose doc says verbatim it exists to close this race (subject registered *before* the post; AsyncSubject buffers the terminal event for any subscriber).

**Pin:** `McpImmediateFailureObservationTest` forces the worst interleaving deterministically — the deleted-target request's terminal event is fully pumped (fenced by two complete unrelated request/response round-trips) **before** the caller subscribes, and must still be delivered; plus the user-facing `Ops.Move(deleted, …)` must emit its error envelope promptly.

## 3. ApiToken LastUsedAt — already cured; verified, no change needed

The known flake (2026-07-03, "Expected 9 … found 14") was the throttle re-stamping under lagged reads. The dispatch-time single-flight memo (`937c6ab42` + `ec69997b9`, landed 2026-07-04 — one day after the last recorded failure) fixed the race at dispatch time, pinned by `ValidateToken_RapidBackToBackValidations_StampOnlyOnce` (`StampDispatchCount == 1`). Scanned all failed CI runs since 2026-07-04: **zero ApiToken failures**. Ran `ApiTokenServiceTests` locally: 30/30 green. The memory note calling it "unfixed" is stale.

## Verification

- `dotnet build -c Release -warnaserror` green for all touched projects.
- Pre-fix red / post-fix green for both new pins of fix 1 (see above).
- Full runs (Release, one pass each): `MeshWeaver.Graph.Test`, `MeshWeaver.Hosting.Monolith.Test`, `MeshWeaver.AI.Test`, `MeshWeaver.Auth.Test` (ApiToken class).
- `FrameworkStaleInstanceRenderTest` and the full `McpNegativeOperationsTest` class green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
