### PR TITLE
GitSync: prerender relative markdown links against the full mesh path (#582)

### DIFF
--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -495,13 +495,24 @@ public sealed class GitHubSyncService
         // Error (ActivityRunner.Finish rolls the terminal status up to Failed) in addition to
         // the server log. Files with no registered parser (.yml, .py, …) stay silent — repos
         // legitimately carry non-node files.
-        var parsed = parsers.TryParse(ext, file.Path, file.Content, file.Path, (path, ex) =>
+        // The relative path handed to the parser must carry the SPACE prefix for CHILD nodes:
+        // the parser derives the node path from it and bakes it into the content's
+        // PrerenderedHtml as the base for RELATIVE markdown links (LinkUrlCleanupExtension).
+        // Parsing with the bare in-repo path prerendered "../.." on
+        // {space}/TDD/Exercise/X against "TDD/Exercise/X" — every relative link in the
+        // stored prerender lost the partition segment (core #582). The id/namespace the
+        // parser derives from the prefixed path are overridden by the rebase below either
+        // way, so only the prerender base changes. The root index keeps the bare path (its
+        // namespace is the space itself; prefixing would double it).
+        var isRoot = NodeFileMapper.IsRootIndex(file.Path);
+        var parseRelativePath = isRoot ? file.Path : $"{spaceId}/{file.Path}";
+        var parsed = parsers.TryParse(ext, file.Path, file.Content, parseRelativePath, (path, ex) =>
         {
             logger?.LogWarning(ex, "Failed to parse {Path} — file skipped on import.", path);
             progress?.Invoke($"Failed to parse '{path}': {ex.Message} — file skipped.", LogLevel.Error);
         });
         if (parsed is null) return Observable.Return(((MeshNode?)null, false));
-        if (NodeFileMapper.IsRootIndex(file.Path))
+        if (isRoot)
         {
             var root = parsed with
             {

--- a/test/MeshWeaver.Content.Test/MarkdownFileParserTest.cs
+++ b/test/MeshWeaver.Content.Test/MarkdownFileParserTest.cs
@@ -821,4 +821,37 @@ public class MarkdownFileParserTest
     }
 
     #endregion
+
+    #region Relative-link prerender base (core #582)
+
+    /// <summary>
+    /// Pins core #582: the prerender resolves RELATIVE markdown links against the relativePath the
+    /// caller hands in — so an importer must pass the FULL mesh path ({space}/{in-repo path}), not
+    /// the bare in-repo path. With the space-prefixed path, "../../Solution/X" on
+    /// {space}/TDD/Exercise/X prerenders as href="/{space}/TDD/Solution/X"; with the bare path the
+    /// partition segment is lost (href="/TDD/…" — the broken hrefs the courses shipped).
+    /// GitHubSyncService.ParseFile passes the prefixed path since the fix.
+    /// </summary>
+    [Fact(Timeout = 20000)]
+    public void Parse_RelativeLinks_PrerenderAgainstTheGivenNodePath()
+    {
+        var content = "See **[the solution](../../Solution/OrdinalSuffix)** and [the module](../../).";
+
+        var prefixed = _parser.Parse(
+            "/repo/TDD/Exercise/OrdinalSuffix.md", content,
+            "AgenticEngineering/TDD/Exercise/OrdinalSuffix.md");
+        var md = Assert.IsType<MarkdownContent>(prefixed!.Content);
+        Assert.Contains("href=\"/AgenticEngineering/TDD/Solution/OrdinalSuffix\"", md.PrerenderedHtml);
+        Assert.Contains("href=\"/AgenticEngineering/TDD\"", md.PrerenderedHtml);
+
+        // The bug shape the fix guards against: a bare in-repo path loses the partition segment.
+        var bare = _parser.Parse(
+            "/repo/TDD/Exercise/OrdinalSuffix.md", content,
+            "TDD/Exercise/OrdinalSuffix.md");
+        var bareMd = Assert.IsType<MarkdownContent>(bare!.Content);
+        Assert.Contains("href=\"/TDD/Solution/OrdinalSuffix\"", bareMd.PrerenderedHtml);
+        Assert.DoesNotContain("/AgenticEngineering/", bareMd.PrerenderedHtml);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
ParseFile prerendered with the bare in-repo path, so relative markdown links lost the partition segment in stored `PrerenderedHtml` (`href="/TDD/…"` instead of `/AgenticEngineering/TDD/…`). Child files now parse with `{spaceId}/{file.Path}`; the rebase still overrides id/namespace, so only the prerender base changes. Root index unchanged. Parser-contract regression test included (both shapes). Closes #582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)