### PR TITLE
deploy(aks): fix portal probe timeout (1s→15s) + raise memory limit (16→28Gi)

### DIFF
--- a/deploy/aks/manifests/portal-ha-patch.yaml
+++ b/deploy/aks/manifests/portal-ha-patch.yaml
@@ -51,20 +51,28 @@ spec:
               app.kubernetes.io/component: memex-portal
       containers:
         - name: memex-portal
+          # timeoutSeconds is CRITICAL: the portal's `/` renders the full Blazor home and
+          # legitimately takes ~1s (more under GC pressure or partition load). Omitting it lets
+          # k8s apply the DEFAULT timeoutSeconds: 1 — so a normal-but-slow response failed the
+          # probe, 6 failures killed the pod (exit 139), and it crash-looped (memex-cloud,
+          # 2026-07-21: "TDD won't load, then crash"). 15s tolerates a busy moment; the liveness
+          # failureThreshold of 10 × 30s = 300s before a kill.
           readinessProbe:
             httpGet:
               path: /
               port: 8080
             initialDelaySeconds: 20
-            periodSeconds: 10
-            failureThreshold: 6
+            periodSeconds: 15
+            timeoutSeconds: 15
+            failureThreshold: 8
           livenessProbe:
             httpGet:
               path: /
               port: 8080
             initialDelaySeconds: 60
-            periodSeconds: 20
-            failureThreshold: 6
+            periodSeconds: 30
+            timeoutSeconds: 15
+            failureThreshold: 10
           # Sizable AI image with GENEROUS limits per replica (kept in sync with
           # resources.portal in values.aks.yaml). The AI image is memory-hungry
           # (NodeType compile cache, agent runtimes); on the 32 GiB Standard_D8s_v5
@@ -75,7 +83,11 @@ spec:
               memory: "8Gi"
             limits:
               cpu: "6"
-              memory: "16Gi"
+              # 28Gi (was 16Gi): .NET server-GC targets ~75% of the container limit, so a 16Gi cap
+              # put the GC ceiling at ~12GB — exactly where the three big courses' live set sits, so
+              # every burst thrashed the GC and stalled Orleans (the memex-cloud spiral, 2026-07-21).
+              # The 32 GiB nodes have room for 28Gi + system pods.
+              memory: "28Gi"
           # volumeMounts merge by `mountPath`. The first two mirror the chart's
           # existing mounts (no-op); the last two are the NEW /mnt drives.
           volumeMounts:

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -242,7 +242,9 @@ resources:
       memory: "8Gi"    # a bit of RAM
     limits:
       cpu: "6"         # generous CPU ceiling
-      memory: "16Gi"   # generous memory ceiling (half a 32 GiB node)
+      memory: "28Gi"   # .NET server-GC targets ~75% of the limit; 16Gi put the GC ceiling at ~12GB
+                       # (where the courses' live set sits) → GC thrash + Orleans stalls. Kept in
+                       # sync with portal-ha-patch.yaml. The 32 GiB nodes fit 28Gi + system pods.
 
 # --- HA / replicas ----------------------------------------------------------
 # Launch 2 portal replicas by default (still needs cookie session affinity +


### PR DESCRIPTION
Two memex-cloud production-stability fixes, root-caused live on 2026-07-21 (repeated crash-loops — "TDD page won't load, then crashes").

**1. Probe timeout — the crash-loop cause.** `deploy/aks/manifests/portal-ha-patch.yaml` re-declared readiness/liveness probes on `/` but **omitted `timeoutSeconds`**, so k8s applied the default **1s**. The portal's `/` renders the full Blazor home (~1s normally, more under GC/partition load) → a normal-but-slow response failed the probe → 6 failures killed the pod (exit 139) → crash-loop. It also silently overrode the chart's sensible `/health`+`/alive` probes. Now `timeoutSeconds: 15`, liveness `failureThreshold: 10` (≈300s before a kill).

**2. Memory 16Gi → 28Gi.** .NET server-GC targets ~75% of the container limit → 16Gi put the GC ceiling at ~12GB, exactly the live-set of the three big courses → GC thrash + Orleans health stalls. 32 GiB nodes fit 28Gi + system pods. Updated in both the HA patch and `values.aks.yaml resources.portal` (kept in sync).

Both **already applied live** via `kubectl` and verified (fresh pod stable; `/`=0.4s, TDD=1.1s — the 1.1s that used to trip the 1s probe). This PR lands them durably so the next deploy doesn't revert them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)