### PR TITLE
SEO: og:image for markdown pages — read content members from typed content too

### DIFF
--- a/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
+++ b/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
@@ -95,21 +95,39 @@ public static class SeoResolver
             : null;
     }
 
-    /// <summary>A string member of the node's content, read untyped.</summary>
+    /// <summary>
+    /// A string member of the node's content, by camelCase JSON name. Content arrives here in two
+    /// shapes and both must resolve the same way: untyped <see cref="JsonElement"/> (node-native
+    /// types the portal hub hasn't registered), or a TYPED record when the hub knows the CLR type —
+    /// a markdown page resolves as <c>MarkdownContent</c>, so reading only the JsonElement shape
+    /// silently dropped <c>og:image</c> for every markdown node's <c>thumbnail</c>.
+    /// </summary>
     public static string? ContentString(MeshNode node, string property) =>
-        node.Content is JsonElement { ValueKind: JsonValueKind.Object } je
-            && je.TryGetProperty(property, out var value)
-            && value.ValueKind == JsonValueKind.String
-            ? value.GetString()
-            : null;
+        node.Content switch
+        {
+            JsonElement { ValueKind: JsonValueKind.Object } je
+                when je.TryGetProperty(property, out var value)
+                    && value.ValueKind == JsonValueKind.String => value.GetString(),
+            JsonElement or null => null,
+            var typed => TypedMember(typed, property) as string,
+        };
 
-    /// <summary>A decimal member of the node's content, read untyped.</summary>
+    /// <summary>A decimal member of the node's content, by camelCase JSON name (both shapes).</summary>
     public static decimal? ContentDecimal(MeshNode node, string property) =>
-        node.Content is JsonElement { ValueKind: JsonValueKind.Object } je
-            && je.TryGetProperty(property, out var value)
-            && value.ValueKind == JsonValueKind.Number
-            ? value.GetDecimal()
-            : null;
+        node.Content switch
+        {
+            JsonElement { ValueKind: JsonValueKind.Object } je
+                when je.TryGetProperty(property, out var value)
+                    && value.ValueKind == JsonValueKind.Number => value.GetDecimal(),
+            JsonElement or null => null,
+            var typed => TypedMember(typed, property) is decimal d ? d : null,
+        };
+
+    /// <summary>The PascalCase CLR property matching a camelCase JSON member name.</summary>
+    private static object? TypedMember(object content, string jsonName) =>
+        content.GetType()
+            .GetProperty(char.ToUpperInvariant(jsonName[0]) + jsonName[1..])?
+            .GetValue(content);
 
     private static string? FirstNonEmpty(params string?[] values) =>
         values.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));

--- a/test/Memex.Portal.Shared.Test/SeoResolverContentTest.cs
+++ b/test/Memex.Portal.Shared.Test/SeoResolverContentTest.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using Memex.Portal.Shared.Seo;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins <see cref="SeoResolver"/>'s content-member reads across BOTH content shapes. A node's
+/// Content reaches the SEO surface either as an untyped <see cref="JsonElement"/> (node-native
+/// types the portal hub hasn't registered) or as a TYPED record when the hub knows the CLR type —
+/// a markdown page resolves as <see cref="MarkdownContent"/>. Reading only the JsonElement shape
+/// silently dropped <c>og:image</c> for every markdown node's <c>thumbnail</c> (UWDeepfield /
+/// ClaimsDeepfield Overview share cards, 2026-07).
+/// </summary>
+public class SeoResolverContentTest
+{
+    private sealed record FakePluginContent(string? Poster, decimal? Price);
+
+    private static MeshNode Node(object? content, string? description = null) =>
+        new("Overview", "Space") { NodeType = "Markdown", Description = description, Content = content };
+
+    private static JsonElement Json(object value) => JsonSerializer.SerializeToElement(value);
+
+    [Fact]
+    public void ExtractImage_UntypedJson_ReadsPosterThenThumbnail()
+    {
+        Assert.Equal("/static/S/p.png", SeoResolver.ExtractImage(Node(Json(new { poster = "/static/S/p.png" }))));
+        Assert.Equal("/static/S/t.png", SeoResolver.ExtractImage(Node(Json(new { thumbnail = "/static/S/t.png" }))));
+    }
+
+    [Fact]
+    public void ExtractImage_TypedMarkdownContent_ReadsThumbnail()
+    {
+        var content = new MarkdownContent { Content = "# page", Thumbnail = "/static/S/videos/x.poster.png" };
+
+        Assert.Equal("/static/S/videos/x.poster.png", SeoResolver.ExtractImage(Node(content)));
+    }
+
+    [Fact]
+    public void ExtractImage_TypedContent_ReadsPoster()
+    {
+        Assert.Equal("/static/S/og.png", SeoResolver.ExtractImage(Node(new FakePluginContent("/static/S/og.png", 900m))));
+    }
+
+    [Fact]
+    public void ExtractImage_RejectsNonRootedCandidates_BothShapes()
+    {
+        Assert.Null(SeoResolver.ExtractImage(Node(Json(new { thumbnail = "relative.png" }))));
+        Assert.Null(SeoResolver.ExtractImage(Node(new MarkdownContent { Content = "x", Thumbnail = "relative.png" })));
+    }
+
+    [Fact]
+    public void ExtractImage_NullAndMemberlessContent_ReturnNull()
+    {
+        Assert.Null(SeoResolver.ExtractImage(Node(null)));
+        Assert.Null(SeoResolver.ExtractImage(Node(Json(new { other = 1 }))));
+        Assert.Null(SeoResolver.ExtractImage(Node(new MarkdownContent { Content = "x" })));
+    }
+
+    [Fact]
+    public void ExtractDescription_TypedMarkdownContent_FallsBackToAbstract()
+    {
+        var content = new MarkdownContent { Content = "# page", Abstract = "The one-line summary." };
+
+        Assert.Equal("The one-line summary.", SeoResolver.ExtractDescription(Node(content)));
+        // The node's own Description column still wins over the content member.
+        Assert.Equal("Node desc", SeoResolver.ExtractDescription(Node(content, description: "Node desc")));
+    }
+
+    [Fact]
+    public void ContentDecimal_BothShapes_ReadPrice()
+    {
+        Assert.Equal(900m, SeoResolver.ContentDecimal(Node(Json(new { price = 900 })), "price"));
+        Assert.Equal(900m, SeoResolver.ContentDecimal(Node(new FakePluginContent(null, 900m)), "price"));
+        Assert.Null(SeoResolver.ContentDecimal(Node(new FakePluginContent(null, null)), "price"));
+    }
+}


### PR DESCRIPTION
## Problem

`SeoResolver.ContentString`/`ContentDecimal` read content members only from **untyped `JsonElement`** content. But a markdown node resolves **typed** (`MarkdownContent`) on the portal hub — so its `thumbnail` never reached `og:image`, and every markdown page shipped a share card without a picture (found on the UWDeepfield / ClaimsDeepfield Overview pages: the node carries `content.thumbnail`, the crawler-facing head omits `og:image`). The same latent break applies to `price`/`poster` on any content type the hub has registered.

## Fix

When content is a typed record, fall back to the PascalCase CLR property matching the camelCase JSON member name — both shapes now resolve identically. `JsonElement`/null behavior unchanged.

## Tests

`SeoResolverContentTest` (new, in `Memex.Portal.Shared.Test`) — 7 cases, all green:
- image from untyped JSON (`poster` then `thumbnail`) — pins existing behavior
- image from typed `MarkdownContent.Thumbnail` and a typed poster record — the fix
- URL-shape gate (non-rooted candidates rejected) in both shapes
- null/memberless content → null
- description fallback to typed `Abstract`; node `Description` still wins
- `ContentDecimal` price in both shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)