### PR TITLE
Portal probes: /alive+/health with 5s timeouts, memex-cloud to 2 replicas

### DIFF
--- a/deploy/aks/envs/memex-cloud/portal-patch.json
+++ b/deploy/aks/envs/memex-cloud/portal-patch.json
@@ -1,6 +1,9 @@
 [
-  { "op": "replace", "path": "/spec/replicas", "value": 1 },
+  { "op": "replace", "path": "/spec/replicas", "value": 2 },
   { "op": "add", "path": "/spec/template/spec/nodeSelector", "value": { "workload": "silos" } },
+  { "op": "add", "path": "/spec/template/spec/topologySpreadConstraints",
+    "value": [ { "maxSkew": 1, "topologyKey": "kubernetes.io/hostname", "whenUnsatisfiable": "DoNotSchedule",
+                 "labelSelector": { "matchLabels": { "app.kubernetes.io/component": "memex-portal" } } } ] },
 
   { "op": "replace", "path": "/spec/template/spec/volumes/0",
     "value": { "name": "memex-data", "persistentVolumeClaim": { "claimName": "memex-data" } } },
@@ -32,7 +35,7 @@
   { "op": "add", "path": "/spec/template/spec/containers/0/resources",
     "value": { "requests": { "cpu": "4", "memory": "8Gi" }, "limits": { "cpu": "6", "memory": "16Gi" } } },
   { "op": "add", "path": "/spec/template/spec/containers/0/readinessProbe",
-    "value": { "httpGet": { "path": "/", "port": 8080 }, "initialDelaySeconds": 20, "periodSeconds": 10, "failureThreshold": 6 } },
+    "value": { "httpGet": { "path": "/health", "port": 8080 }, "initialDelaySeconds": 20, "periodSeconds": 10, "timeoutSeconds": 5, "failureThreshold": 6 } },
   { "op": "add", "path": "/spec/template/spec/containers/0/livenessProbe",
-    "value": { "httpGet": { "path": "/", "port": 8080 }, "initialDelaySeconds": 90, "periodSeconds": 20, "failureThreshold": 6 } }
+    "value": { "httpGet": { "path": "/alive", "port": 8080 }, "initialDelaySeconds": 90, "periodSeconds": 20, "timeoutSeconds": 5, "failureThreshold": 6 } }
 ]

--- a/deploy/aks/manifests/portal-ha-patch.yaml
+++ b/deploy/aks/manifests/portal-ha-patch.yaml
@@ -51,19 +51,29 @@ spec:
               app.kubernetes.io/component: memex-portal
       containers:
         - name: memex-portal
+          # Readiness = /health (pulls a wedged pod out of rotation so peers serve);
+          # liveness = /alive (a constant hub-pool-INDEPENDENT check, so a wedged
+          # hub pool can't false-kill the pod on the full /  route). Probing / (the
+          # Blazor route served THROUGH the hub pool) caused the 2-min outage: one
+          # pool wedge failed both probes and k8s waited 6x20s before restarting.
+          # timeoutSeconds 5 (NOT the default 1): a CPU-saturated-but-alive pod
+          # must not be liveness-killed — each kill cold-starts caches/compiles
+          # and drives the next saturation (the probe death spiral of 2026-07-21).
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: 8080
             initialDelaySeconds: 20
             periodSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 6
           livenessProbe:
             httpGet:
-              path: /
+              path: /alive
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 20
+            timeoutSeconds: 5
             failureThreshold: 6
           # Sizable AI image with GENEROUS limits per replica (kept in sync with
           # resources.portal in values.aks.yaml). The AI image is memory-hungry


### PR DESCRIPTION
## The outage (2026-07-21, memex.meshweaver.cloud)

Repeated ~2-minute full outages during a live demo. Root cause was a **probe death spiral**, not a crash:

1. Both k8s probes hit `/` — the full Blazor route served **through the message-hub pool** — with the default **1s timeout**.
2. Any CPU-saturation episode (hub wedge, compile storm, hot render) made `/` miss the 1s window; after 6×20s k8s **killed an alive-but-busy pod**.
3. The restart cold-started caches and live recompiles → more CPU → next kill.
4. memex-cloud's `portal-patch.json` pinned **`replicas: 1`** (overriding the chart's HA default) and the KEDA scaler was paused at 1 — so every kill was a full outage with nothing to fail over to. (An unready sole pod also blinds the HPA's metrics, so autoscaling can't rescue it either.)

## The fix

- **`deploy/aks/envs/memex-cloud/portal-patch.json`**: replicas 1 → 2; hostname `topologySpreadConstraint` (replicas on different silos nodes); readiness → `/health`, liveness → `/alive` (matching the Helm chart's `deployment.yaml`, which was already correct — only the AKS patches had diverged); `timeoutSeconds: 5`.
- **`deploy/aks/manifests/portal-ha-patch.yaml`**: same probe endpoints + timeouts, rationale inline.

`/alive` is the constant hub-pool-independent health check (`ServiceDefaults.cs`) — a wedged hub pool can no longer false-kill the pod; `/health` readiness pulls a struggling pod out of rotation while its peer serves.

## Already live

Applied to memex-cloud via kubectl: 2 pods across 2 nodes, KEDA unpaused min=2/max=4, silos nodepool min=2/max=4. This PR makes the next deploy stop reverting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGgWKSgL8pgrbg86xqfa6o