### PR TITLE
Chat popup: palette-width cap + fit-to-space open direction

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.cs
@@ -2071,11 +2071,12 @@ public partial class ThreadChatView : BlazorView<ThreadChatControl, ThreadChatVi
             }
         }
 
-        // Anchor the FIXED chat popup (login dialog / agent-model picker) just above the composer. The
-        // widget is position:fixed (so it escapes the chat's overflow clip and paints over the sticky
-        // header); JS sets its left/width/bottom to hover over .thread-chat-input-content and keeps it
-        // there on resize. Runs on every render while a popup is open (cheap; no-op when none).
-        if ((LoginDialogOpen || pendingPicker is not null) && !_isDisposed)
+        // Anchor the FIXED chat popup (login dialog / agent-model picker / delete confirm) to the
+        // composer. The widget is position:fixed (so it escapes the chat's overflow clip and paints
+        // over the sticky header); JS sets its left/width, open direction and fitted max-height from
+        // .thread-chat-input-content and keeps it there on resize. Runs on every render while a popup
+        // is open (cheap; no-op when none).
+        if ((LoginDialogOpen || pendingPicker is not null || _deleteConfirmId is not null) && !_isDisposed)
         {
             try
             {

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
@@ -625,20 +625,23 @@ button.thread-chat-status-item {
        scroll area, so an absolute popup could never sit over the header no matter its z-index. Fixed +
        z-index 10000 puts it in the root/top stacking layer, above every sticky heading (≤1100). No
        ancestor has transform/filter (verified), so fixed is NOT trapped. JS (anchorChatPopup) sets
-       left/width/bottom each frame to hover just above the composer; the fallback keeps it on-screen. */
+       left/width, the open direction (above/below the composer) and a max-height fitted to the free
+       space on that side, each frame; the values here are only the first-frame fallback. */
     position: fixed;
     left: 0;
     right: 0;
     bottom: 96px;
     z-index: 10000;
+    /* Command-palette width, not a sheet: cap it so the full-width home-page composer doesn't
+       produce a viewport-wide menu (anchorChatPopup applies the same cap when it takes over). */
+    max-width: 560px;
     border: 1px solid var(--neutral-stroke-rest);
     border-radius: 8px;
     background: var(--neutral-layer-1);
     overflow: hidden;
-    /* Responsive cap: never taller than the space between the side-panel header and the input,
-       so the popup (agent/model picker AND the CLI-login dialog) can't overrun the "New Thread"
-       header at the top of a short side panel. calc(100vh - 180px) ≈ viewport minus header+input+gap;
-       capped at 440px so it stays compact on a tall window. The inner list scrolls past that. */
+    /* First-frame fallback only — anchorChatPopup replaces this with the measured free space
+       above/below the composer, so a composer near the top of a short window (the home page) can't
+       overrun the viewport top and cover the portal header. The inner list scrolls past the cap. */
     max-height: min(440px, calc(100vh - 180px));
     display: flex;
     flex-direction: column;

--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.js
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.js
@@ -51,10 +51,19 @@ export function attach(container) {
     };
 }
 
-// Anchor the FIXED chat popup (login dialog / agent·model picker) just above the composer.
+// Anchor the FIXED chat popup (login dialog / agent·model picker) to the composer.
 // The widget is position:fixed to escape the chat's overflow clip and paint OVER the sticky header;
-// here we set its left/width/bottom to hover over .thread-chat-input-content. Registered once, a resize
-// listener keeps it aligned. Idempotent + cheap; a no-op when no popup is present.
+// here we set its left/width and vertical placement relative to .thread-chat-input-content.
+// Registered once, a resize listener keeps it aligned. Idempotent + cheap; a no-op when no popup
+// is present. Two layout constraints the CSS alone can't express:
+// - WIDTH: the popup is a command palette, not a sheet — follow the composer's left edge (where
+//   the chips/commands that opened it live) but cap the width, so the full-page home composer
+//   doesn't produce a viewport-wide menu for a four-item list.
+// - HEIGHT/DIRECTION: size the popup to the space actually available on the chosen side of the
+//   composer. The side panel has the composer at the screen bottom (open upward, lots of room);
+//   the home page has it near the top of a possibly short window, where a fixed 440px cap would
+//   overrun the viewport top, cover the portal header and clip the list. Prefer upward, but flip
+//   downward when there is more room below.
 let _popupResizeBound = false;
 export function anchorChatPopup() {
     const reposition = () => {
@@ -64,11 +73,24 @@ export function anchorChatPopup() {
         if (!w || !anchor) return;
         const r = anchor.getBoundingClientRect();
         if (r.width === 0) return;
+        const gap = 6;      // breathing room between popup and composer
+        const margin = 8;   // minimum clearance to the viewport edge
+        const cap = 440;    // tallest the popup ever gets; the inner list scrolls past it
         w.style.left = Math.round(r.left) + 'px';
-        w.style.width = Math.round(r.width) + 'px';
+        w.style.width = Math.round(Math.min(r.width, 560)) + 'px';
         w.style.right = 'auto';
-        // Sit its bottom edge 6px above the composer's top edge.
-        w.style.bottom = Math.round(window.innerHeight - r.top + 6) + 'px';
+        const above = r.top - gap - margin;
+        const below = window.innerHeight - r.bottom - gap - margin;
+        if (above >= 220 || above >= below) {
+            // Open upward, bottom edge 6px above the composer's top edge.
+            w.style.top = 'auto';
+            w.style.bottom = Math.round(window.innerHeight - r.top + gap) + 'px';
+            w.style.maxHeight = Math.round(Math.min(cap, Math.max(above, 120))) + 'px';
+        } else {
+            w.style.bottom = 'auto';
+            w.style.top = Math.round(r.bottom + gap) + 'px';
+            w.style.maxHeight = Math.round(Math.min(cap, Math.max(below, 120))) + 'px';
+        }
     };
     reposition();
     if (!_popupResizeBound) {


### PR DESCRIPTION
## Problem

Opening the agent picker (`/agent`, or clicking the Assistant chip) from the **home-page composer** produced this:

- The popup takes the **full composer width** (`anchorChatPopup` sets `width = anchor.width`) — on the home page that's the whole viewport, a giant menu for a four-item list.
- It **always opens upward** with `max-height: min(440px, calc(100vh - 180px))`, which assumes the composer sits at the screen bottom (side panel). On the home page the composer is near the **top** of a possibly short window, so the popup overran the viewport top, covered the portal header, and clipped the list mid-item.

## Fix (`ThreadChatView.razor.js` / `.css` / `.cs`)

`anchorChatPopup` now:
- caps the popup at **command-palette width (560px)**, anchored to the composer's left edge (where the chips that opened it live);
- measures the free space **above and below** the composer, opens on the roomier side (upward preferred when it has ≥220px), and sets `max-height` to what actually fits — the inner list scrolls past it;
- the CSS `left:0; right:0; bottom:96px; max-height` block is now a first-frame fallback only, with a matching `max-width: 560px`;
- the **delete-confirm** widget is included in the anchor condition — it renders `.thread-chat-widget` too but was never anchored, so it lived on the fallback (full-width strip) forever.

Side-panel behavior is unchanged: composer at the screen bottom → plenty of space above → opens upward as before, same 440px cap.

`MeshWeaver.Blazor.Portal` builds clean (0 warnings / 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGgWKSgL8pgrbg86xqfa6o