### PR TITLE
MeshNodeStreamCache: transient-fault breaker — bound the poisoned-activation re-probe loop

### DIFF
--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -300,6 +300,33 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     private static readonly TimeSpan StormMaxCooldown = TimeSpan.FromMinutes(5);
     private const int StormFailThreshold = 5;
 
+    // 🚨 TRANSIENT-FAULT BREAKER. IsTransientOwnerFailure faults (reactivation reject /
+    // hub-request timeout) are deliberately NEVER negative-cached — the just-idle-collected
+    // grain reactivates and the very next probe lands on the fresh activation, so suppression
+    // would break the "navigate to an idle page" case. But that clean-cache policy assumed the
+    // fault is a ONE-OFF. A PERSISTENTLY faulting activation (2026-07-21: a poisoned
+    // AgenticEngineering init replayed the same cached SubscribeRequest timeout into every
+    // fresh activation) turns the policy into an unbounded instant-re-probe loop: every read
+    // re-opens an upstream SubscribeRequest ~3/sec, each cycle allocates, and the silo leaked
+    // 4→22 GiB in ~12 minutes while its action blocks starved — one broken hub degrading the
+    // whole portal. This breaker keeps BOTH properties: the first TransientGraceFailures
+    // consecutive transient faults stay exactly as before (clean cache, instant re-probe — the
+    // idle-page case never sees it), but a streak beyond the grace is empirical proof the
+    // "transient" claim is false, so re-probes back off exponentially
+    // (TransientBaseCooldown · 2^(n-grace-1), capped at TransientMaxCooldown — a short cap,
+    // because a recycle CAN heal these). Cleared instantly by a real resolution, a change-feed
+    // invalidation (recycle / post-commit write), or a quiet period (a streak with no fault for
+    // TransientStreakExpiry is stale — occasional blips over a long session never accumulate).
+    // Reads only: writes already bound their owner wait (QueueAdvanceBound) and a write is
+    // often the recycle that heals the path.
+    private sealed record TransientStreak(Exception Error, int FailCount, DateTimeOffset OpenUntil,
+        DateTimeOffset LastFailAt, bool Reprobing = false);
+    private readonly ConcurrentDictionary<string, TransientStreak> _transientStreaks = new();
+    private static readonly TimeSpan TransientBaseCooldown = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan TransientMaxCooldown = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan TransientStreakExpiry = TimeSpan.FromMinutes(5);
+    private const int TransientGraceFailures = 3;
+
     // In-flight cross-hub write subscriptions that have OUTLIVED their queue slot. The
     // per-path Update queue advances on a bounded signal (QueueAdvanceBound) so a lost
     // owner response can't starve retries, but each write's subscription to the owner's
@@ -525,6 +552,19 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                     path, cleared.FailCount);
         }
 
+        if (_transientStreaks.TryRemove(path, out var clearedStreak))
+        {
+            if (clearedStreak.FailCount > TransientGraceFailures)
+                logger.LogInformation(
+                    "[TRANSIENT-BREAKER] Cleared '{Path}' on change-feed invalidation after {FailCount} consecutive "
+                    + "transient owner faults — next read re-probes fresh.",
+                    path, clearedStreak.FailCount);
+            else
+                logger.LogDebug(
+                    "MeshNodeStreamCache: cleared transient-fault streak for {Path} on change-feed invalidation (failCount={FailCount})",
+                    path, clearedStreak.FailCount);
+        }
+
         if (_streams.TryGetValue(path, out var lazy) && lazy.IsValueCreated && lazy.Value.IsFaulted
             && _streams.TryRemove(new KeyValuePair<string, Lazy<Entry>>(path, lazy)))
         {
@@ -634,6 +674,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         // 5. Storm-breaker negative cache — drop the cached failure windows so
         //    nothing roots the disposed mesh's exceptions/identities.
         _negative.Clear();
+        _transientStreaks.Clear();
     }
 
     /// <summary>
@@ -772,11 +813,22 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             var disposal = new System.Reactive.Disposables.CompositeDisposable(hydrationSub);
             var entry = new Entry(handle, inner.AsObservable(), disposal);
             var bookkeeping = inner.AsObservable().Subscribe(
-                node => { if (node is not null) _negative.TryRemove(p, out _); },
+                node =>
+                {
+                    if (node is not null)
+                    {
+                        _negative.TryRemove(p, out _);
+                        _transientStreaks.TryRemove(p, out _);
+                    }
+                },
                 ex =>
                 {
                     entry.MarkFaulted();
                     if (IsMissingNodeFailure(ex)) RecordNegative(p, ex);
+                    // A transient owner failure stays out of the negative cache (the node
+                    // exists — see IsTransientOwnerFailure), but a STREAK of them is the
+                    // poisoned-activation loop; record it so re-probes back off past the grace.
+                    else if (IsTransientOwnerFailure(ex)) RecordTransient(p, ex);
                 });
             disposal.Add(bookkeeping);
             return entry;
@@ -960,6 +1012,49 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     }
 
     /// <summary>
+    /// Records a TRANSIENT owner fault (<see cref="IsTransientOwnerFailure"/>) for
+    /// <paramref name="path"/> in the transient-fault breaker. The first
+    /// <see cref="TransientGraceFailures"/> consecutive faults open NO window (the ordinary
+    /// just-idle reactivation miss keeps its instant re-probe); past the grace, each further
+    /// fault opens an exponential-backoff window (<see cref="TransientBaseCooldown"/> ·
+    /// 2^(n-grace-1), capped at <see cref="TransientMaxCooldown"/>) that
+    /// <see cref="GetStreamRaw"/> fast-fails inside — breaking the poisoned-activation
+    /// re-probe loop. A streak whose last fault is older than
+    /// <see cref="TransientStreakExpiry"/> restarts from 1 (a blip an hour ago is not
+    /// evidence about now). Crossing the grace logs ONE warning. Never re-subscribes —
+    /// purely records state, mirroring <see cref="RecordNegative"/>.
+    /// Internal as a test seam.
+    /// </summary>
+    internal void RecordTransient(string path, Exception error) =>
+        RecordTransient(path, error, DateTimeOffset.UtcNow);
+
+    /// <summary>Clock-injectable seam so the streak-expiry rule is testable without real waits.</summary>
+    internal void RecordTransient(string path, Exception error, DateTimeOffset now)
+    {
+        var priorFails =
+            _transientStreaks.TryGetValue(path, out var existing) && now - existing.LastFailAt < TransientStreakExpiry
+                ? existing.FailCount
+                : 0;
+        var failCount = priorFails + 1;
+        var openUntil = now;
+        if (failCount > TransientGraceFailures)
+        {
+            var backoffTicks = Math.Min(
+                TransientBaseCooldown.Ticks * (1L << Math.Min(failCount - TransientGraceFailures - 1, 20)),
+                TransientMaxCooldown.Ticks);
+            openUntil = now + TimeSpan.FromTicks(backoffTicks);
+        }
+        _transientStreaks[path] = new TransientStreak(error, failCount, openUntil, now);
+        if (failCount == TransientGraceFailures + 1)
+            logger.LogWarning(
+                "[TRANSIENT-BREAKER] '{Path}' has faulted {FailCount} consecutive times with a transient-classified "
+                + "owner failure: {Error}. The fault is empirically NOT transient (a poisoned activation / wedged owner) — "
+                + "re-probes now back off exponentially (cap {Cap}s) instead of hammering the owner. A recycle or a "
+                + "successful resolution clears the streak immediately.",
+                path, failCount, error.Message, TransientMaxCooldown.TotalSeconds);
+    }
+
+    /// <summary>
     /// True when an owner failure means the node/hub does not exist (NotFound / activation
     /// failed) — the only failure class the storm-breaker suppresses. RLS denials and
     /// <see cref="IsTransientOwnerFailure">transient routing errors</see> are excluded so an
@@ -1089,6 +1184,30 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                     stale.MarkEvicted();
                     stale.HydrationSub.Dispose();
                     readStreamEvictions.OnNext(new ReadStreamEviction(path, false, "storm-breaker"));
+                }
+                catch (Exception ex) { logger.LogDebug(ex, "MeshNodeStreamCache: error disposing stale entry for {Path}", path); }
+            }
+        }
+
+        // TRANSIENT-FAULT BREAKER: same fast-fail + single-flight re-probe discipline as the
+        // negative cache above, but for a persistent STREAK of "transient" owner faults (see
+        // _transientStreaks). Within the grace no entry has an open window, so this block is a
+        // no-op for the ordinary just-idle reactivation miss.
+        if (_transientStreaks.TryGetValue(path, out var streak))
+        {
+            if (streak.OpenUntil > DateTimeOffset.UtcNow)
+                return Observable.Throw<MeshNode>(streak.Error);
+            if (streak.FailCount > TransientGraceFailures
+                && !streak.Reprobing
+                && _transientStreaks.TryUpdate(path, streak with { Reprobing = true }, streak)
+                && _streams.TryRemove(path, out var staleTransientLazy) && staleTransientLazy.IsValueCreated)
+            {
+                try
+                {
+                    var stale = staleTransientLazy.Value;
+                    stale.MarkEvicted();
+                    stale.HydrationSub.Dispose();
+                    readStreamEvictions.OnNext(new ReadStreamEviction(path, false, "transient-breaker"));
                 }
                 catch (Exception ex) { logger.LogDebug(ex, "MeshNodeStreamCache: error disposing stale entry for {Path}", path); }
             }

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheTransientBreakerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheTransientBreakerTest.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the TRANSIENT-FAULT BREAKER — the fix for the 2026-07-21 memex-cloud poisoned-activation
+/// loop that one broken plugin hub turned into a whole-portal outage.
+///
+/// <para><b>The live defect.</b> The <c>AgenticEngineering</c> root hub's activation faulted
+/// persistently (a poisoned init replayed the same cached <c>SubscribeRequest</c> timeout into
+/// every fresh activation). That failure class is <see cref="MeshNodeStreamCache.IsTransientOwnerFailure"/>
+/// — deliberately NEVER negative-cached, so the just-idle-collected grain keeps its instant
+/// re-probe. But with the fault PERSISTENT, the clean-cache policy meant every read re-opened an
+/// upstream <c>SubscribeRequest</c> ~3/second, forever: the silo leaked 4→22&#160;GiB in ~12
+/// minutes, its action blocks starved, probes failed, and the pod died — taking every other
+/// plugin's compiled assembly with it.</para>
+///
+/// <para><b>The contract under test.</b> The first <c>TransientGraceFailures</c> (3) consecutive
+/// transient faults change NOTHING (the ordinary idle-page reactivation miss keeps its instant
+/// re-probe). A streak beyond the grace opens an exponential-backoff window that fast-fails
+/// reads (base 1&#160;s, cap 60&#160;s). The streak clears instantly on a successful resolution,
+/// on a change-feed invalidation (recycle broadcast / post-commit write), and a streak whose
+/// last fault is older than <c>TransientStreakExpiry</c> (5&#160;min) restarts from one. The
+/// breaker only ever records state and evicts — it never re-subscribes on its own
+/// (the 2026-06-08 rule).</para>
+/// </summary>
+public class MeshNodeStreamCacheTransientBreakerTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private MeshNodeStreamCache Cache =>
+        (MeshNodeStreamCache)Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+
+    private async Task<string> CreateNodeAsync(string prefix)
+    {
+        var path = $"{TestPartition}/{prefix}-{Guid.NewGuid():N}";
+        var node = MeshNode.FromPath(path) with
+        {
+            Name = "Original",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        };
+        await NodeFactory.CreateNode(node).Should().Within(60.Seconds()).Emit();
+        return path;
+    }
+
+    /// <summary>The exact broadcast <c>MeshOperations.RecycleCore</c> publishes for a
+    /// recycled path (Updated kind, NodeType-path marker, version 0).</summary>
+    private void PublishRecycleBroadcast(string path)
+    {
+        var segments = path.Split('/');
+        Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>().Publish(new MeshChangeEvent(
+            Namespace: segments.Length > 1 ? string.Join("/", segments[..^1]) : "",
+            Id: segments.Length > 0 ? segments[^1] : path,
+            Path: path,
+            Kind: MeshChangeKind.Updated,
+            NodeType: MeshNode.NodeTypePath,
+            Version: 0,
+            Timestamp: DateTimeOffset.UtcNow));
+    }
+
+    /// <summary>The poisoned-activation failure shape as it reached the cache on memex-cloud:
+    /// the hub-request timeout, classified transient (and therefore never negative-cached) —
+    /// precondition-checked so a classifier change can't silently hollow out these tests.</summary>
+    private static TimeoutException TransientFault(string path) => new(
+        $"No response received in hub cache/mesh-node-cache within 00:01:00 for request " +
+        $"SubscribeRequest (id=16Rmeava) → target {path}. The request may have been " +
+        "undeliverable or the target hub was not found.");
+
+    /// <summary>
+    /// Within the grace, the breaker must be invisible: no window opens, reads resolve
+    /// immediately. This IS the "navigating to a just-idle page" guarantee that made
+    /// transient faults exempt from the storm-breaker in the first place.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task GraceFaults_DoNotSuppressReads()
+    {
+        var cache = Cache;
+        var path = await CreateNodeAsync("grace");
+        var fault = TransientFault(path);
+        MeshNodeStreamCache.IsTransientOwnerFailure(fault).Should().BeTrue(
+            "precondition: the seeded error must be the transient class");
+        MeshNodeStreamCache.IsMissingNodeFailure(fault).Should().BeFalse(
+            "precondition: a transient fault must never look like a missing node");
+
+        for (var i = 0; i < 3; i++)
+            cache.RecordTransient(path, fault);
+
+        var node = await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Where(n => n is not null)
+            .Should().Within(30.Seconds()).Emit(
+                "up to the grace, transient faults must not delay the re-probe at all");
+        node!.Path.Should().Be(path);
+    }
+
+    /// <summary>
+    /// The poisoned-activation loop: a streak past the grace must fast-fail reads by
+    /// replaying the recorded error WITHOUT opening an upstream SubscribeRequest. Ten
+    /// recordings put the window at 1s·2^6 = 64s ⇒ capped at 60s — impossible to outwait
+    /// within the test budget, exactly like the production loop's unbounded lifetime.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task StreakPastGrace_FastFailsReads()
+    {
+        var cache = Cache;
+        var path = await CreateNodeAsync("streak");
+        var fault = TransientFault(path);
+
+        for (var i = 0; i < 10; i++)
+            cache.RecordTransient(path, fault);
+
+        var readFail = await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Materialize()
+            .Should().Within(5.Seconds()).Match(
+                n => n.Kind == NotificationKind.OnError,
+                "an open transient-breaker window must fast-fail reads with the recorded error");
+        readFail.Exception!.Message.Should().Contain("No response received",
+            "the fast-fail must replay the recorded owner fault");
+    }
+
+    /// <summary>
+    /// A recycle broadcast — the operator's remedy for a poisoned activation — must clear
+    /// the streak so the very next read re-probes fresh, without waiting out the window.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task RecycleBroadcast_ClearsStreak_SoNextReadResolves()
+    {
+        var cache = Cache;
+        var path = await CreateNodeAsync("recycle-streak");
+        var fault = TransientFault(path);
+
+        for (var i = 0; i < 10; i++)
+            cache.RecordTransient(path, fault);
+
+        await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Materialize()
+            .Should().Within(5.Seconds()).Match(
+                n => n.Kind == NotificationKind.OnError,
+                "precondition: the window must be open before the recycle");
+
+        PublishRecycleBroadcast(path);
+
+        var node = await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Where(n => n is not null)
+            .Should().Within(30.Seconds()).Emit(
+                "a recycle broadcast must clear the transient streak immediately — " +
+                "the operator's recycle is the sanctioned way out of a poisoned activation");
+        node!.Path.Should().Be(path);
+    }
+
+    /// <summary>
+    /// A successful resolution is authoritative proof the fault healed: it must zero the
+    /// streak, so a later blip starts a fresh grace instead of inheriting the old count.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task SuccessfulResolution_ClearsStreak()
+    {
+        var cache = Cache;
+        var path = await CreateNodeAsync("heal");
+        var fault = TransientFault(path);
+
+        // Grace-level streak (no window) …
+        for (var i = 0; i < 3; i++)
+            cache.RecordTransient(path, fault);
+
+        // … a successful read clears it (bookkeeping observer on the shared subject) …
+        await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Where(n => n is not null)
+            .Should().Within(30.Seconds()).Emit();
+
+        // … so one MORE fault is fault #1 of a NEW streak (≤ grace ⇒ no window), not #4 of
+        // the old one (which would have opened a window and fast-failed this read).
+        cache.RecordTransient(path, fault);
+        var node = await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Where(n => n is not null)
+            .Should().Within(30.Seconds()).Emit(
+                "after a successful resolution the streak must restart from zero");
+        node!.Path.Should().Be(path);
+    }
+
+    /// <summary>
+    /// A streak whose last fault is older than the expiry is stale evidence: the next fault
+    /// restarts counting from one. Uses the clock-injectable seam — no real waits.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task StaleStreak_RestartsCounting()
+    {
+        var cache = Cache;
+        var path = await CreateNodeAsync("stale");
+        var fault = TransientFault(path);
+
+        // Five faults, all ten minutes ago — well past TransientStreakExpiry (5 min).
+        var longAgo = DateTimeOffset.UtcNow - TimeSpan.FromMinutes(10);
+        for (var i = 0; i < 5; i++)
+            cache.RecordTransient(path, fault, longAgo);
+
+        // Today's fault is #1 of a fresh streak (≤ grace ⇒ no window) — reads stay instant.
+        cache.RecordTransient(path, fault, DateTimeOffset.UtcNow);
+        var node = await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Where(n => n is not null)
+            .Should().Within(30.Seconds()).Emit(
+                "a blip ten minutes ago is not evidence about now — the streak must restart");
+        node!.Path.Should().Be(path);
+    }
+}


### PR DESCRIPTION
## The outage this fixes

2026-07-21, memex-cloud: the `AgenticEngineering` root hub's activation faulted persistently (a poisoned init replayed the same cached `SubscribeRequest` timeout into every fresh activation). That failure class is `IsTransientOwnerFailure` — deliberately **never** negative-cached so a just-idle-collected grain keeps its instant re-probe. With the fault *persistent*, the clean-cache policy became an unbounded instant-re-probe loop: ~3 `SubscribeRequest`s/sec, the silo leaked **4→22 GiB in ~12 minutes**, action blocks starved, probes failed, the pod died — and took every plugin's live-compiled assembly with it. One broken hub degraded the whole portal.

## The fix

A **transient-fault breaker** alongside the storm-breaker, keeping both properties:

- The first `TransientGraceFailures` (3) consecutive transient faults change **nothing** — the "navigate to a just-idle page" case keeps its instant re-probe (the reason these faults were exempted in the first place).
- A streak past the grace is empirical proof the "transient" claim is false: re-probes back off exponentially (1s · 2^(n-4), capped at **60s** — short, because a recycle CAN heal these), fast-failing reads with the recorded error instead of hammering the owner.

The streak clears instantly on a successful resolution, on a change-feed invalidation (recycle broadcast / post-commit write — same discipline as the storm-breaker), and a streak idle past 5 minutes restarts from one. Records state and evicts only — never re-subscribes (the 2026-06-08 rule).

## Tests

5 new deterministic tests (`MeshNodeStreamCacheTransientBreakerTest`) pin the contract via the `RecordTransient` seam with an injectable clock: grace invisible · streak fast-fails · recycle clears · success clears · stale streak restarts. Full `MeshWeaver.Hosting.Monolith.Test` suite: **363 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)