### PR TITLE
Kernel: script assemblies unload with their session (collectible AssemblyLoadContext)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-22-kernel-memory-unload.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-22-kernel-memory-unload.md
@@ -1,0 +1,17 @@
+---
+Name: Interactive kernels now release their memory
+Category: What's New
+Description: Script assemblies from executed code cells unload when their session ends — long interactive sessions and bulk course runs no longer degrade the portal.
+Icon: Memory
+---
+
+# Interactive kernels now release their memory
+
+Every executed code cell compiles to an in-memory assembly. Until now those assemblies could
+never be unloaded — a portal running many interactive pages (a workshop, a course walkthrough,
+a long authoring session) accumulated them for its whole lifetime, slowing down progressively
+until navigations timed out.
+
+Kernel sessions now load their script assemblies into a collectible context that is released
+when the session ends, and dynamically compiled node types were hardened the same way. Memory
+returns to baseline after your notebook pages close; long and busy sessions stay fast.

--- a/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
@@ -213,7 +213,13 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
     private readonly ILogger? _logger;
     private readonly string? _dllPath;
     private readonly object _loadLock = new();
-    private Assembly? _loadedAssembly;
+    // 🚨 Weak, never a strong Assembly field: a collectible context that strongly references
+    // its own assembly forms a cycle THROUGH the runtime's LoaderAllocator GC handle
+    // (LoaderAllocator → handle → context → Assembly → LoaderAllocator) that the GC can never
+    // break — a context dropped WITHOUT Dispose would be immortal garbage. Weak is lossless
+    // here: a live context roots its own assemblies natively, so the target only dies when the
+    // whole context does.
+    private WeakReference<Assembly>? _loadedAssembly;
     private volatile bool _disposed;
     private ImmutableArray<string> _probingDirs = ImmutableArray<string>.Empty;
 
@@ -238,7 +244,8 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
     /// <summary>
     /// Gets the loaded assembly, or null if not yet loaded.
     /// </summary>
-    public Assembly? LoadedAssembly => _loadedAssembly;
+    public Assembly? LoadedAssembly =>
+        _loadedAssembly is { } weak && weak.TryGetTarget(out var assembly) ? assembly : null;
 
     /// <summary>
     /// Gets whether this context has been disposed/unloaded.
@@ -271,9 +278,8 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
             throw new ObjectDisposedException(Name, "Cannot load assembly from disposed context");
 
         // Fast path: already loaded
-        var loaded = _loadedAssembly;
-        if (loaded != null)
-            return loaded;
+        if (LoadedAssembly is { } fast)
+            return fast;
 
         lock (_loadLock)
         {
@@ -281,8 +287,7 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
             if (_disposed)
                 throw new ObjectDisposedException(Name, "Cannot load assembly from disposed context");
 
-            loaded = _loadedAssembly;
-            if (loaded != null)
+            if (LoadedAssembly is { } loaded)
                 return loaded;
 
             if (string.IsNullOrEmpty(_dllPath) || !File.Exists(_dllPath))
@@ -318,11 +323,12 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
             // Load the assembly into this isolated context
             try
             {
-                _loadedAssembly = LoadFromAssemblyPath(_dllPath);
+                var assembly = LoadFromAssemblyPath(_dllPath);
+                _loadedAssembly = new WeakReference<Assembly>(assembly);
                 _logger?.LogDebug("Loaded assembly {AssemblyName} into context {ContextName}",
-                    _loadedAssembly.GetName().Name, Name);
+                    assembly.GetName().Name, Name);
 
-                return _loadedAssembly;
+                return assembly;
             }
             catch (BadImageFormatException ex)
             {
@@ -353,9 +359,8 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
             throw new ObjectDisposedException(Name, "Cannot load assembly from disposed context");
 
         // Fast path: already loaded
-        var loaded = _loadedAssembly;
-        if (loaded != null)
-            return loaded;
+        if (LoadedAssembly is { } fast)
+            return fast;
 
         lock (_loadLock)
         {
@@ -363,18 +368,18 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
             if (_disposed)
                 throw new ObjectDisposedException(Name, "Cannot load assembly from disposed context");
 
-            loaded = _loadedAssembly;
-            if (loaded != null)
+            if (LoadedAssembly is { } loaded)
                 return loaded;
 
             using var assemblyStream = new MemoryStream(assemblyBytes);
             using var pdbStream = pdbBytes != null ? new MemoryStream(pdbBytes) : null;
 
-            _loadedAssembly = LoadFromStream(assemblyStream, pdbStream);
+            var assembly = LoadFromStream(assemblyStream, pdbStream);
+            _loadedAssembly = new WeakReference<Assembly>(assembly);
             _logger?.LogDebug("Loaded assembly {AssemblyName} from bytes into context {ContextName}",
-                _loadedAssembly.GetName().Name, Name);
+                assembly.GetName().Name, Name);
 
-            return _loadedAssembly;
+            return assembly;
         }
     }
 

--- a/src/MeshWeaver.Graph/Configuration/ScriptCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/ScriptCompilationService.cs
@@ -1,8 +1,11 @@
 using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.Loader;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -17,7 +20,18 @@ namespace MeshWeaver.Graph.Configuration;
 /// <summary>
 /// Service that compiles MeshNode configurations using CSharpScript.
 /// Unlike MeshNodeCompilationService which generates assemblies, this service
-/// evaluates scripts directly and caches the compiled Script objects.
+/// evaluates scripts directly and caches the compiled executors.
+///
+/// <para>🚨 Each cached entry's assembly is emitted by US into a <b>collectible</b>
+/// <see cref="AssemblyLoadContext"/>, never run through <c>Script.RunAsync</c> — Roslyn's own
+/// script loader is permanently non-collectible (verified against Roslyn 5.3), and the cache
+/// key includes <c>node.LastModified</c>, so with RunAsync every node UPDATE stranded the
+/// previous entry's assembly for the process lifetime (a co-driver of the portal's
+/// memory-fatigue wall alongside the kernel's per-cell leak — see <c>ScriptSession</c> in
+/// MeshWeaver.Kernel.Hub for the same cure on the REPL path). Invalidation now unloads the
+/// entry's context; a <c>HubConfiguration</c> delegate still referenced by a running hub keeps
+/// its context alive until the hub dies (unloading is cooperative), then everything is
+/// reclaimed.</para>
 /// </summary>
 internal class ScriptCompilationService : IDisposable
 {
@@ -27,8 +41,17 @@ internal class ScriptCompilationService : IDisposable
     private readonly ScriptOptions _scriptOptions;
     private readonly INuGetAssemblyResolver _nugetResolver;
 
-    // In-memory cache of compiled scripts by cache key
-    private readonly ConcurrentDictionary<string, Script<MeshNode>> _compiledScripts = new();
+    // In-memory cache of compiled config executors by cache key. The entry owns its
+    // collectible load context; the Factory delegate (→ its target method → assembly) is what
+    // keeps the context alive while cached — Unload() on eviction lets it die.
+    private sealed record CompiledConfig(Func<object?[], Task<MeshNode>> Factory, AssemblyLoadContext LoadContext)
+    {
+        /// <summary>The generated submission entry point: slot 0 = globals (none here), slot 1
+        /// is written by the submission itself — a fresh 2-slot array per execution.</summary>
+        public Task<MeshNode> ExecuteAsync() => Factory(new object?[2]);
+    }
+
+    private readonly ConcurrentDictionary<string, CompiledConfig> _compiledScripts = new();
 
     // Track script source files on disk for debugging
     private readonly ConcurrentDictionary<string, string> _sourceFiles = new();
@@ -65,8 +88,8 @@ internal class ScriptCompilationService : IDisposable
 
         _logger.LogDebug("Compiling script for {NodePath} with cache key {CacheKey}", node.Path, cacheKey);
 
-        // Try to get cached compiled script
-        if (!_compiledScripts.TryGetValue(cacheKey, out var script))
+        // Try to get cached compiled executor
+        if (!_compiledScripts.TryGetValue(cacheKey, out var compiled))
         {
             // Generate script source
             var rawSource = _generator.GenerateScriptSource(node, codeFile, hubConfiguration, contentCollections);
@@ -87,21 +110,12 @@ internal class ScriptCompilationService : IDisposable
                 await SaveSourceToDiskAsync(node.Path, cacheKey, source, ct);
             }
 
-            // Compile the script
-            script = CSharpScript.Create<MeshNode>(source, scriptOptions);
-
-            // Validate compilation
-            var diagnostics = script.Compile(ct);
-            var errors = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
-            if (errors.Any())
-            {
-                var errorMessage = string.Join("\n", errors.Select(e => e.ToString()));
-                _logger.LogError("Script compilation failed for {NodePath}:\n{Errors}", node.Path, errorMessage);
-                throw new CompilationException(node.Path, errorMessage);
-            }
-
-            // Cache the compiled script
-            _compiledScripts[cacheKey] = script;
+            var fresh = CompileToCollectibleContext(node.Path, source, scriptOptions, ct);
+            // On a lost publication race the winner stays cached; shed the duplicate's context
+            // (unloading is cooperative — this call can still execute from it safely).
+            compiled = _compiledScripts.GetOrAdd(cacheKey, fresh);
+            if (!ReferenceEquals(compiled, fresh))
+                fresh.LoadContext.Unload();
             _logger.LogDebug("Script compiled and cached for {NodePath}", node.Path);
         }
         else
@@ -112,14 +126,54 @@ internal class ScriptCompilationService : IDisposable
         // Execute the script
         try
         {
-            var result = await script.RunAsync(cancellationToken: ct);
-            return result.ReturnValue;
+            return await compiled.ExecuteAsync();
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Script execution failed for {NodePath}", node.Path);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Compiles the config script through Roslyn's script API but emits + loads it into a
+    /// fresh collectible context and binds the generated <c>&lt;Factory&gt;</c> entry point —
+    /// the submission protocol of the scripting host, minus its permanent loader.
+    /// </summary>
+    private CompiledConfig CompileToCollectibleContext(
+        string nodePath, string source, ScriptOptions scriptOptions, CancellationToken ct)
+    {
+        var script = CSharpScript.Create<MeshNode>(source, scriptOptions);
+        var compilation = script.GetCompilation();
+
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+        var emitted = compilation.Emit(
+            peStream,
+            pdbStream,
+            options: new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb),
+            cancellationToken: ct);
+        if (!emitted.Success)
+        {
+            var errorMessage = string.Join("\n", emitted.Diagnostics
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .Select(e => e.ToString()));
+            _logger.LogError("Script compilation failed for {NodePath}:\n{Errors}", nodePath, errorMessage);
+            throw new CompilationException(nodePath, errorMessage);
+        }
+
+        // One context per entry; a single submission never needs sibling resolution, so every
+        // bind falls through to the default context. 🚨 Never store the Assembly on the
+        // context itself — a strong self-reference is a GC-handle cycle that can never unload.
+        var loadContext = new AssemblyLoadContext($"node-config-script:{nodePath}", isCollectible: true);
+        peStream.Position = 0;
+        pdbStream.Position = 0;
+        var assembly = loadContext.LoadFromStream(peStream, pdbStream);
+        var scriptClass = compilation.ScriptClass!.MetadataName;
+        var factory = assembly.GetType(scriptClass, throwOnError: true)!
+                          .GetMethod("<Factory>", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                      ?? throw new InvalidOperationException($"Submission type '{scriptClass}' has no <Factory> entry point.");
+        return new CompiledConfig(factory.CreateDelegate<Func<object?[], Task<MeshNode>>>(), loadContext);
     }
 
     /// <summary>
@@ -141,7 +195,8 @@ internal class ScriptCompilationService : IDisposable
     /// </summary>
     public void InvalidateCache(string cacheKey)
     {
-        _compiledScripts.TryRemove(cacheKey, out _);
+        if (_compiledScripts.TryRemove(cacheKey, out var evicted))
+            evicted.LoadContext.Unload();
 
         if (_sourceFiles.TryRemove(cacheKey, out var sourcePath) && File.Exists(sourcePath))
         {
@@ -179,7 +234,9 @@ internal class ScriptCompilationService : IDisposable
     /// </summary>
     public void ClearCache()
     {
-        _compiledScripts.Clear();
+        foreach (var key in _compiledScripts.Keys.ToList())
+            if (_compiledScripts.TryRemove(key, out var evicted))
+                evicted.LoadContext.Unload();
         _sourceFiles.Clear();
     }
 
@@ -318,7 +375,6 @@ internal class ScriptCompilationService : IDisposable
 
     public void Dispose()
     {
-        _compiledScripts.Clear();
-        _sourceFiles.Clear();
+        ClearCache();
     }
 }

--- a/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
@@ -36,7 +36,10 @@ namespace MeshWeaver.Kernel.Hub;
 /// </summary>
 internal sealed class KernelExecutor(IMessageHub publicHub)
 {
-    private ScriptState<object>? scriptState;
+    // The REPL chain + its collectible AssemblyLoadContext — see ScriptSession. Owning the
+    // emit/load path (instead of ScriptState.RunAsync) is what lets the per-cell assemblies
+    // unload with the session; Roslyn's own script loader is permanently non-collectible.
+    private ScriptSession? session;
     private ScriptOptions scriptOptions = ScriptOptions.Default;
     private MeshScriptGlobals? scriptGlobals;
     private ScriptLogger? scriptLogger;
@@ -98,10 +101,23 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
         config.TypeRegistry.WithType(typeof(SubmitCodeResponse), nameof(SubmitCodeResponse));
         config.TypeRegistry.WithType(typeof(CancelScriptRequest), nameof(CancelScriptRequest));
         // Start the serial REPL processor ONCE. Concat runs queued submissions strictly in
-        // arrival order — each Execute fully completes (scriptState assigned) before the next
-        // subscribes — so cross-submission state sharing is deterministic without any lock.
+        // arrival order — each Execute fully completes (the session's chain advanced) before
+        // the next subscribes — so cross-submission state sharing is deterministic without any
+        // lock.
         submissionPump = submissions.Select(RunSubmission).Concat().Subscribe();
         return config
+            .WithInitialization(hub =>
+                // Executor hub disposal (idle disconnect / session close) eagerly unloads the
+                // session's collectible AssemblyLoadContext — the per-cell script assemblies
+                // die with the session instead of accumulating for the process lifetime — and
+                // stops the pump. Disposing the session while a script is still running is
+                // safe: unloading is cooperative and completes when the last reference dies.
+                hub.RegisterForDisposal(System.Reactive.Disposables.Disposable.Create(() =>
+                {
+                    submissionPump?.Dispose();
+                    session?.Dispose();
+                    session = null;
+                })))
             .WithHandler<SubmitCodeRequest>(HandleSubmitCodeRequest)
             .WithHandler<CancelScriptRequest>(HandleCancelRequest);
     }
@@ -348,20 +364,21 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
             // Roslyn compile+execute on the bounded Compile IoPool (see `compilePool`) —
             // NOT a bare Observable.FromAsync on the shared ThreadPool. `t` is the pool's
             // cancellation (cancelled on unsubscribe), identical to the prior FromAsync CT,
-            // so REPL state + CancelScriptRequest semantics are preserved.
-            scope => compilePool.Invoke(t => scriptState is null
-                    ? CSharpScript.RunAsync(cleaned, scriptOptions, scriptGlobals, typeof(MeshScriptGlobals), t)
-                    : scriptState.ContinueWithAsync(cleaned, scriptOptions, t))
-                .Select(state =>
+            // so REPL state + CancelScriptRequest semantics are preserved. The session owns
+            // chain advancement (only on success — a throwing submission's variables are
+            // discarded, the historical ScriptState behavior).
+            scope => compilePool.Invoke(t =>
+                    (session ??= new ScriptSession(scriptGlobals!))
+                        .RunAsync(cleaned, scriptOptions, typeof(MeshScriptGlobals), t))
+                .Select(returnValue =>
                 {
-                    scriptState = state;
                     scope.Flush();
-                    if (state.ReturnValue is not null)
+                    if (returnValue is not null)
                     {
-                        UpdateView(viewId, state.ReturnValue);
-                        scriptOutputLogger.LogInformation("{Value}", state.ReturnValue.ToString() ?? "");
+                        UpdateView(viewId, returnValue);
+                        scriptOutputLogger.LogInformation("{Value}", returnValue.ToString() ?? "");
                     }
-                    return state.ReturnValue;
+                    return returnValue;
                 }));
     }
 

--- a/src/MeshWeaver.Kernel.Hub/MeshWeaver.Kernel.Hub.csproj
+++ b/src/MeshWeaver.Kernel.Hub/MeshWeaver.Kernel.Hub.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="MeshWeaver.AI.Test" />
+    <InternalsVisibleTo Include="MeshWeaver.Hosting.Monolith.Test" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MeshWeaver.Kernel.Hub/ScriptSession.cs
+++ b/src/MeshWeaver.Kernel.Hub/ScriptSession.cs
@@ -1,0 +1,164 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace MeshWeaver.Kernel.Hub;
+
+/// <summary>
+/// One REPL session's Roslyn script chain, with every submission assembly loaded into a
+/// single <b>collectible</b> <see cref="AssemblyLoadContext"/> owned by the session — so the
+/// per-cell assemblies actually unload when the session dies, instead of accumulating for the
+/// process lifetime.
+///
+/// <para>🚨 Why not <c>CSharpScript.RunAsync</c>/<c>ScriptState.ContinueWithAsync</c>: Roslyn's
+/// scripting host loads every submission through an <c>InteractiveAssemblyLoader</c> whose
+/// internal <c>LoadContext</c> is created NON-collectible (verified against Roslyn 5.3) — the
+/// emitted assembly per <c>--render</c> cell is permanent even after the loader is disposed.
+/// That is the portal's memory-fatigue wall: a long compile/execute run climbs monotonically
+/// until GC/thread-pool stalls kill it. So this class keeps Roslyn for what it is good at —
+/// building the submission <em>compilation chain</em> via <c>CSharpScript.Create</c> /
+/// <see cref="Script.ContinueWith(string, ScriptOptions)"/> — and owns emit + load + invoke
+/// itself, replicating the scripting host's submission protocol: slot 0 of the state array is
+/// the globals instance, slot N+1 is submission #N's instance, and each submission's generated
+/// <c>&lt;Factory&gt;(object[])</c> reads its predecessors from and writes itself into that
+/// array. REPL semantics (block #2 sees block #1's variables, functions, and types) are
+/// preserved — pinned by <c>KernelReplChainingTest</c>.</para>
+///
+/// <para>🚨 The load context's submission map holds <see cref="WeakReference{T}"/>s, never
+/// strong <see cref="Assembly"/> references: a collectible context that strongly references its
+/// own assemblies creates an uncollectable cycle THROUGH A GC HANDLE (LoaderAllocator →
+/// strong handle → context object → Assembly → LoaderAllocator) and never unloads — the exact
+/// pin this class exists to remove. Weak is sufficient: a live context roots its own
+/// assemblies natively, so the target can only be collected once the whole context is.</para>
+///
+/// <para>Not thread-safe by design — all calls are serialized by the executor's Concat pump.
+/// <see cref="Dispose"/> initiates an eager unload; unloading is cooperative, so a script
+/// still executing (or a script-created object still referenced by a live layout area) keeps
+/// the context alive until those references die, then everything is reclaimed. Even without
+/// Dispose, an abandoned session's context island is garbage-collected once unreferenced —
+/// the weak map is what makes that possible.</para>
+/// </summary>
+internal sealed class ScriptSession(object globals) : IDisposable
+{
+    /// <summary>The session context's <see cref="AssemblyLoadContext.Name"/> — asserted gone
+    /// after mesh disposal by <c>KernelScriptMemoryLeakTest</c>.</summary>
+    public const string LoadContextName = "kernel-script-session";
+
+    private readonly SessionLoadContext loadContext = new();
+    private readonly List<object?> submissionStates = [globals];
+    private Script<object>? previousScript;
+    private bool disposed;
+
+    /// <summary>
+    /// Compiles <paramref name="code"/> as the next submission of this session's chain, loads
+    /// it into the session's collectible context, and executes it. Returns the submission's
+    /// return value (the last expression, or null). Compilation errors throw
+    /// <see cref="CompilationErrorException"/> — the same contract as
+    /// <c>CSharpScript.RunAsync</c>. A submission that throws at RUNTIME does not advance the
+    /// chain (its variables are discarded), matching <c>ScriptState</c> semantics.
+    /// </summary>
+    public async Task<object?> RunAsync(string code, ScriptOptions options, Type globalsType, CancellationToken ct)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        var script = previousScript is null
+            ? CSharpScript.Create(code, options, globalsType)
+            : previousScript.ContinueWith(code, options);
+        var compilation = script.GetCompilation();
+
+        using var peStream = new MemoryStream();
+        using var pdbStream = new MemoryStream();
+        var emitted = compilation.Emit(
+            peStream,
+            pdbStream,
+            options: new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb),
+            cancellationToken: ct);
+        if (!emitted.Success)
+        {
+            var errors = emitted.Diagnostics
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .ToImmutableArray();
+            throw new CompilationErrorException(
+                string.Join(Environment.NewLine, errors.Select(d => d.ToString())),
+                errors.IsEmpty ? emitted.Diagnostics : errors);
+        }
+
+        var assembly = loadContext.LoadSubmission(compilation.AssemblyName!, peStream, pdbStream);
+
+        // The scripting host's submission protocol: the generated static
+        // Task<object> <Factory>(object[] submissionStates) reads predecessors from the array
+        // (slot 0 = globals, slot i+1 = submission #i) and writes its own instance into its slot.
+        var scriptClass = compilation.ScriptClass!.MetadataName;
+        var factory = assembly.GetType(scriptClass, throwOnError: true)!
+                          .GetMethod("<Factory>", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                      ?? throw new InvalidOperationException($"Submission type '{scriptClass}' has no <Factory> entry point.");
+        var submissionIndex = SubmissionIndex(scriptClass);
+        while (submissionStates.Count < submissionIndex + 2)
+            submissionStates.Add(null);
+        var states = submissionStates.ToArray();
+
+        // Await the factory directly — no WaitAsync(ct): a running submission is never
+        // abandoned mid-flight (parity with ScriptState.RunAsync); cancellation reaches the
+        // script through its own globals.Ct at its await points, exactly as before.
+        var returnValue = await factory.CreateDelegate<Func<object[], Task<object>>>()(states!)
+            .ConfigureAwait(false);
+
+        // Advance the chain only on success — a throwing submission's variables are discarded,
+        // exactly like ScriptState (its orphaned assembly stays in the context until unload).
+        for (var i = 0; i < states.Length; i++)
+            submissionStates[i] = states[i];
+        previousScript = script;
+        return returnValue;
+    }
+
+    // "Submission#0" → 0. The generated script-class name is the submission protocol's
+    // load-bearing index; failing loudly beats guessing a slot.
+    private static int SubmissionIndex(string scriptClassMetadataName)
+    {
+        var hash = scriptClassMetadataName.LastIndexOf('#');
+        if (hash < 0 || !int.TryParse(scriptClassMetadataName[(hash + 1)..], out var index))
+            throw new InvalidOperationException(
+                $"Unexpected submission type name '{scriptClassMetadataName}' — cannot derive the submission slot.");
+        return index;
+    }
+
+    /// <summary>Eagerly initiates the context unload and drops the chain so the session's
+    /// assemblies can be reclaimed. Safe while a script is still running (cooperative).</summary>
+    public void Dispose()
+    {
+        if (disposed) return;
+        disposed = true;
+        previousScript = null;
+        submissionStates.Clear();
+        loadContext.Unload();
+    }
+
+    private sealed class SessionLoadContext() : AssemblyLoadContext(LoadContextName, isCollectible: true)
+    {
+        // 🚨 WeakReference values — see the class doc; a strong Assembly ref here recreates the
+        // GC-handle cycle that makes the context permanent.
+        private readonly Dictionary<string, WeakReference<Assembly>> submissions = [];
+
+        public Assembly LoadSubmission(string assemblyName, MemoryStream pe, MemoryStream pdb)
+        {
+            pe.Position = 0;
+            pdb.Position = 0;
+            var assembly = LoadFromStream(pe, pdb);
+            submissions[assemblyName] = new WeakReference<Assembly>(assembly);
+            return assembly;
+        }
+
+        // Later submissions reference earlier ones by assembly identity; everything else falls
+        // through (null) to the default context — host assemblies, NuGet-restored packages, …
+        protected override Assembly? Load(AssemblyName assemblyName)
+            => assemblyName.Name is not null
+               && submissions.TryGetValue(assemblyName.Name, out var weak)
+               && weak.TryGetTarget(out var assembly)
+                ? assembly
+                : null;
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/KernelReplChainingTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/KernelReplChainingTest.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Kernel;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the kernel's REPL contract across submissions now that the executor owns emit + load
+/// through <c>ScriptSession</c>'s collectible AssemblyLoadContext (instead of
+/// <c>ScriptState.ContinueWithAsync</c>): block #2 must see block #1's <b>variables</b>,
+/// <b>functions</b>, and — the riskiest binding path — <b>types</b> defined in an earlier
+/// submission's assembly, resolved across submission assemblies inside the session's load
+/// context. A regression here means the manual submission-state protocol (slot 0 = globals,
+/// slot N+1 = submission #N) or the context's by-name assembly resolution broke.
+/// </summary>
+public class KernelReplChainingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    [Fact(Timeout = 120_000)]
+    public async Task SecondSubmission_SeesFirstSubmissionsVariablesFunctionsAndTypes()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var kernelId = Guid.NewGuid().ToString("N");
+        const string ownerPath = "rbuergi";
+        var activityNamespace = $"{ownerPath}/_Activity";
+        var activityNode = new MeshNode($"replchain-{kernelId}", activityNamespace)
+        {
+            Name = "REPL chaining probe",
+            NodeType = "Activity",
+            MainNode = ownerPath,
+            State = MeshNodeState.Active,
+            Content = new ActivityLog("KernelExecution") { Status = ActivityStatus.Running }
+        };
+        await meshService.CreateNode(activityNode).Should().Within(60.Seconds()).Emit();
+        var kernelAddress = new Address($"{activityNamespace}/replchain-{kernelId}");
+
+        var client = GetClient();
+
+        IObservable<ActivityLog> LogWith(string marker) => client.GetWorkspace()
+            .GetMeshNodeStream(kernelAddress.Path)
+            .Select(change => change?.Content as ActivityLog)
+            .Where(log => log is not null && log!.Messages.Any(m => m.Message.Contains(marker)))!;
+
+        // Block #1: a variable, a function, and a TYPE — each lives in submission #0's assembly.
+        client.Post(
+            new SubmitCodeRequest(
+                """
+                var theAnswer = 40;
+                int Bump(int v) => v + 1;
+                class Chained { public int One => 1; }
+                Console.WriteLine("repl-block1-done");
+                """),
+            o => o.WithTarget(kernelAddress));
+        await LogWith("repl-block1-done").Should().Within(60.Seconds()).Emit();
+
+        // Block #2 (submission #1) reads all three across the assembly boundary.
+        client.Post(
+            new SubmitCodeRequest(
+                """Console.WriteLine($"repl-chain-{Bump(theAnswer) + new Chained().One}");"""),
+            o => o.WithTarget(kernelAddress));
+        await LogWith("repl-chain-42").Should().Within(60.Seconds()).Emit();
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/KernelScriptMemoryLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/KernelScriptMemoryLeakTest.cs
@@ -114,14 +114,30 @@ public class KernelScriptMemoryLeakTest(ITestOutputHelper output) : MonolithMesh
 
         ForceCollect();
 
-        // CI trace shows alc count +1 per kernel-script test, never reclaimed —
-        // name every surviving context (Roslyn's script LoadContext is the suspect).
         foreach (var alc in System.Runtime.Loader.AssemblyLoadContext.All)
         {
             Output.WriteLine(
                 $"[alc] {alc.GetType().FullName} name={alc.Name} collectible={alc.IsCollectible} " +
                 $"assemblies=[{string.Join(", ", alc.Assemblies.Select(a => a.GetName().Name).Take(5))}{(alc.Assemblies.Count() > 5 ? ", …" : "")}]");
         }
+
+        // The kernel's per-cell script assemblies load into ScriptSession's COLLECTIBLE
+        // "kernel-script-session" context (Roslyn's own script loader is permanently
+        // non-collectible — the historical +1-ALC-per-session leak this suite used to only
+        // LOG). After hub + SP disposal the session was disposed (context unloaded);
+        // unloading completes asynchronously, so retry collect-and-check. A context that
+        // survives this loop is pinned — the classic cause is a STRONG Assembly reference
+        // held by the context itself (the map must stay WeakReference-valued; see
+        // ScriptSession.SessionLoadContext).
+        static bool SessionContextAlive() =>
+            System.Runtime.Loader.AssemblyLoadContext.All
+                .Any(alc => alc.Name == Kernel.Hub.ScriptSession.LoadContextName);
+        for (var round = 0; round < 10 && SessionContextAlive(); round++)
+            ForceCollect();
+        SessionContextAlive().Should().BeFalse(
+            "every kernel ScriptSession load context must unload after the mesh and its " +
+            "ServiceProvider are disposed — a surviving context means the per-cell script " +
+            "assemblies leak for the process lifetime (the memory-fatigue wall)");
 
         var (pinned, report) = AnalyzeScriptRoots();
         Output.WriteLine(report);


### PR DESCRIPTION
## The leak (the portal's memory-fatigue wall)

Every executed code cell emits a Roslyn assembly that **never unloads**. `CSharpScript.RunAsync` loads submissions through Roslyn's `InteractiveAssemblyLoader`, whose internal `LoadContext` is created **non-collectible** — verified empirically against Roslyn 5.3: even an explicitly disposed loader's context survives GC. A long compile/execute run (the education e2e: ~180 workbench+solution executions) climbs monotonically to ~2 GB and dies in a GC/thread-pool death spiral (the portal's own self-monitoring logged 52 s thread-pool delays; `docker compose restart` doesn't help because restart *reloads* persisted assemblies).

## The fix

`ScriptSession` (new): keep Roslyn for the submission **compilation chain** (`CSharpScript.Create` / `ContinueWith`) but own **emit + load + invoke** — each submission is emitted (portable PDB preserved) into **one collectible `AssemblyLoadContext` per kernel session**, invoked through the scripting host's own submission protocol (slot 0 = globals, slot N+1 = submission #N, the generated `<Factory>(object[])` entry point), and the context is **unloaded on executor-hub disposal** (the 15-min idle disconnect). REPL semantics are unchanged: variables, functions, and **types** defined in block #1 resolve in block #2 across submission assemblies; a runtime-throwing submission discards its variables (exact `ScriptState` parity, including cancellation reaching scripts via `globals.Ct` only).

**The load-bearing detail** (found by ClrMD bisection on Linux): the session context's submission map holds `WeakReference<Assembly>`. A collectible context that *strongly* references its own assemblies forms a cycle through the runtime's LoaderAllocator GC handle (LoaderAllocator → strong handle → context → Assembly → LoaderAllocator) that the GC can never break — it never unloads, even after `Unload()`. Weak is lossless: a live context roots its own assemblies natively.

Two more instances of the same trap, hardened the same way:
- `NodeAssemblyLoadContext._loadedAssembly` (node-type compiles) — strong self-reference; a context dropped **without** `Dispose` was immortal garbage. Now a `WeakReference`.
- `ScriptCompilationService` (config scripts; currently unwired, kept per the iOS-split plan) — converted from cached `Script<MeshNode>.RunAsync` (permanent loader per entry; its cache key includes `LastModified`, so every node update stranded the previous entry) to the same emit-into-collectible-context shape, with **unload on eviction**.

## Verification

- **`KernelReplChainingTest`** (new): block #2 reads a variable, calls a function, and instantiates a **class** defined in block #1, across submission assemblies, on a real mesh → `repl-chain-42`.
- **`KernelScriptMemoryLeakTest`** (extended): now **fails** if a `kernel-script-session` context survives mesh + ServiceProvider disposal (previously the +1-ALC-per-session leak was only logged as a suspect). Green.
- Suites: Monolith kernel/compile (40), Markdown (120), Graph (596), AI kernel (21) — all green; full solution `restore` + `build --no-restore -c Release -p:CIRun=true -warnaserror` clean. (The 608 `NU1903` restore advisories on `System.Security.Cryptography.Xml` are pre-existing and don't gate CI's restore/build split.)
- Standalone probes (scratch, Linux + macOS): Roslyn 5.3 non-collectibility; the full chain through a collectible context executing correctly; strong-map pinned vs weak-map unloaded (`alive=False`).

The end-to-end validation is the education repo's `e2e-mesh` suite once this image rolls — expected to clear the late-run timeout tail that killed it at ~2 GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDhZdYyZSZBHn3uDuZRj54