### PR TITLE
Auto-retry a parked NodeType compile when its sources change

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -144,8 +144,12 @@ internal static class NodeTypeCompilationHelpers
         //     AccessControl rejects without Edit (intended) or accepts and
         //     produces a Release attributed to the user.
         // The IsDirty computed property on NodeTypeDefinition stays as
-        // informational state — UI uses it to enable the Compile button, but
-        // it NEVER auto-fires a recompile. Doc: AccessContextPropagation.md.
+        // informational state — UI uses it to enable the Compile button, and a
+        // healthy (never-parked) type does NOT auto-fire a recompile on a source
+        // edit. The one exception: a PARKED (terminally-failed) type whose source
+        // then changes IS auto-retried — InstallSourcesWatcher un-parks and flips
+        // Pending so a redeploy/edit that fixes the break heals without a manual
+        // Compile ("retry only if the sources changed"). Doc: AccessContextPropagation.md.
         var ownStream = workspace.GetMeshNodeStream();
 
         var hubPath = hub.Address.Path;
@@ -501,6 +505,11 @@ internal static class NodeTypeCompilationHelpers
         // Source-set discovery is read as System (see the GetSources call in the
         // Select below — break-the-cycle fix for the activation self-deadlock).
         var accessService = hub.ServiceProvider.GetService<AccessService>();
+        // 🅿️ Park registry — when a source change lands on a PARKED (terminally-failed) type,
+        // this watcher un-parks and re-drives the compile (the "retry only if the sources
+        // changed" path). Same mesh-scoped singleton the compile watcher's parked short-circuit
+        // uses; null in the rare host that does not register it (no auto-retry, unchanged before).
+        var parkRegistry = hub.ServiceProvider.GetService<NodeTypeCompileParkRegistry>();
 
         // Outer subscription: discover the source path set via the shared
         // synced query (NodeSources.GetSources). When the path set changes
@@ -587,6 +596,45 @@ internal static class NodeTypeCompilationHelpers
             .Subscribe(
                 snapshot =>
                 {
+                    // 🅿️ Auto-retry a PARKED (terminally-failed) type when its SOURCE snapshot has
+                    // CHANGED since the failure — the "retry only if the sources changed" path. The
+                    // compile watcher's parked short-circuit swallows a bare Pending flip, so we
+                    // Unpark FIRST (in-memory + synchronous → happens-before the Pending emission the
+                    // watcher observes), then flip Pending under System (re-driving framework compile
+                    // state is infrastructure, not a user write — same shape as the parked
+                    // re-settle in InstallCompileWatcher) so a fresh compile runs against the fixed
+                    // sources. An UNCHANGED broken type never reaches here (ShouldRetryForSourceChange
+                    // is false), so the failure stays contained — no recompile storm.
+                    if (parkRegistry?.ShouldRetryForSourceChange(hubPath, snapshot) == true)
+                    {
+                        parkRegistry.Unpark(hubPath);
+                        using (accessService?.ImpersonateAsSystem())
+                            workspace.GetMeshNodeStream().Update(curr =>
+                            {
+                                if (curr.Content is not NodeTypeDefinition def) return curr;
+                                // Never clobber an in-flight compile (Pending/Compiling) — only
+                                // refresh the snapshot; a settled state re-drives to Pending.
+                                var status =
+                                    def.CompilationStatus is CompilationStatus.Pending
+                                        or CompilationStatus.Compiling
+                                        ? def.CompilationStatus
+                                        : CompilationStatus.Pending;
+                                return curr with
+                                {
+                                    Content = def with
+                                    {
+                                        CurrentSourceVersions = snapshot,
+                                        CompilationStatus = status
+                                    }
+                                };
+                            }).Subscribe(
+                                _ => { },
+                                ex => logger?.LogWarning(ex,
+                                    "SourcesWatcher: failed to auto-retry parked {HubPath} after source change",
+                                    hubPath));
+                        return;
+                    }
+
                     workspace.GetMeshNodeStream().Update(curr =>
                     {
                         if (curr.Content is not NodeTypeDefinition def) return curr;
@@ -1260,9 +1308,16 @@ internal static class NodeTypeCompilationHelpers
                                 ?? (outcome.Result?.Log?.Errors() is { Count: > 0 } perr
                                     ? string.Join("; ", perr.Select(m => m.Message))
                                     : "Compilation produced no assembly");
-                            var requestedBy = outcome.PendingNode.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions)?.RequestedReleaseBy;
+                            var pendingDef = outcome.PendingNode.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions);
+                            var requestedBy = pendingDef?.RequestedReleaseBy;
+                            // 🅿️ Capture the exact source snapshot this compile consumed (from the
+                            // failed result; fall back to the node's live CurrentSourceVersions) and
+                            // park it WITH the failure. A later edit that changes the snapshot then
+                            // auto-un-parks + recompiles (ShouldRetryForSourceChange in the sources
+                            // watcher) — "retry only if the sources changed".
+                            var failedSources = outcome.Result?.CompiledSources ?? pendingDef?.CurrentSourceVersions;
                             parkRegistry.OnCompileFailed(
-                                hub, hubPath, parkError, deterministic, requestedBy, logger);
+                                hub, hubPath, parkError, deterministic, requestedBy, failedSources, logger);
                         }
                     }
 

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompileParkRegistry.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompileParkRegistry.cs
@@ -33,7 +33,9 @@ namespace MeshWeaver.Graph.Configuration;
 /// <para><b>Un-park.</b> The single un-park trigger is a DELIBERATE retry — the user
 /// requests a fresh release (<c>InstallReleaseRequestWatcher</c> calls
 /// <see cref="Unpark"/> before promoting the request to Pending), or a compile genuinely
-/// succeeds (<see cref="OnCompileSucceeded"/>). The registry is mesh-scoped and held in
+/// succeeds (<see cref="OnCompileSucceeded"/>), or automatically when a parked type's SOURCE
+/// snapshot changes after the failure (<see cref="ShouldRetryForSourceChange"/> — the "retry
+/// only if the sources changed" path). The registry is mesh-scoped and held in
 /// memory, so a process restart also clears it — a redeployed fix recompiles fresh.</para>
 ///
 /// <para>Mesh-scoped singleton (registered in <c>AddGraph</c>): one instance shared by
@@ -79,6 +81,35 @@ public sealed class NodeTypeCompileParkRegistry
     public string? GetParkedError(string nodeTypePath) =>
         _parked.TryGetValue(nodeTypePath, out var p) ? p.Error : null;
 
+    /// <summary>
+    /// <c>true</c> when the NodeType is parked AND <paramref name="currentSources"/> differs from
+    /// the source snapshot captured when it parked — i.e. a source edit/add/remove landed SINCE
+    /// the terminal failure, so the (presumed) fix warrants an automatic recompile. A parked type
+    /// whose sources are UNCHANGED returns <c>false</c>: the failure would reproduce identically,
+    /// so there is nothing to retry (and no storm). This is the "retry only if the sources
+    /// changed" gate — <c>NodeTypeCompilationHelpers.InstallSourcesWatcher</c> consults it on
+    /// every source change and, when it is <c>true</c>, calls <see cref="Unpark"/> and re-drives
+    /// the compile (a fresh <c>CompilationStatus = Pending</c>) with no deliberate Compile/recycle.
+    /// </summary>
+    public bool ShouldRetryForSourceChange(
+        string nodeTypePath, IReadOnlyDictionary<string, long> currentSources) =>
+        _parked.TryGetValue(nodeTypePath, out var p)
+        && !SnapshotEquals(p.Sources, currentSources);
+
+    /// <summary>Source-snapshot equality treating <c>null</c> and an empty map as equal.</summary>
+    private static bool SnapshotEquals(
+        IReadOnlyDictionary<string, long>? a, IReadOnlyDictionary<string, long>? b)
+    {
+        var ca = a?.Count ?? 0;
+        var cb = b?.Count ?? 0;
+        if (ca != cb) return false;
+        if (ca == 0) return true;
+        foreach (var kv in a!)
+            if (!b!.TryGetValue(kv.Key, out var v) || v != kv.Value)
+                return false;
+        return true;
+    }
+
     /// <summary>A compile succeeded — clear any parked failure / retry budget for the type.</summary>
     public void OnCompileSucceeded(string nodeTypePath)
     {
@@ -114,17 +145,21 @@ public sealed class NodeTypeCompileParkRegistry
     /// for a System-driven first-build / seed compile, in which case the notification is a
     /// satellite of the failing type (visible to whoever can read the type).</param>
     /// <param name="logger">Optional logger.</param>
+    /// <param name="sources">The source-version snapshot (<c>{path → LastModified.Ticks}</c>)
+    /// that this failing compile consumed — stored with the park so a later source edit can be
+    /// detected (<see cref="ShouldRetryForSourceChange"/>) and auto-retried.</param>
     public void OnCompileFailed(
         IMessageHub hub,
         string nodeTypePath,
         string error,
         bool deterministic,
         string? recipientUserId,
+        IReadOnlyDictionary<string, long>? sources,
         ILogger? logger)
     {
         var failures = _failureCounts.AddOrUpdate(nodeTypePath, 1, (_, n) => n + 1);
         if (deterministic || failures >= MaxCompileAttempts)
-            ParkAndNotify(hub, nodeTypePath, error, recipientUserId, logger);
+            ParkAndNotify(hub, nodeTypePath, error, sources, recipientUserId, logger);
     }
 
     /// <summary>
@@ -133,9 +168,10 @@ public sealed class NodeTypeCompileParkRegistry
     /// exactly one notification — never a storm).
     /// </summary>
     private void ParkAndNotify(
-        IMessageHub hub, string nodeTypePath, string error, string? recipientUserId, ILogger? logger)
+        IMessageHub hub, string nodeTypePath, string error,
+        IReadOnlyDictionary<string, long>? sources, string? recipientUserId, ILogger? logger)
     {
-        if (!_parked.TryAdd(nodeTypePath, new ParkedCompileFailure(error, DateTimeOffset.UtcNow)))
+        if (!_parked.TryAdd(nodeTypePath, new ParkedCompileFailure(error, DateTimeOffset.UtcNow, sources)))
             return; // already parked — do not re-notify
 
         logger?.LogError(
@@ -217,6 +253,8 @@ public sealed class NodeTypeCompileParkRegistry
         return trimmed.Length <= max ? trimmed : string.Concat(trimmed.AsSpan(0, max), " …");
     }
 
-    /// <summary>Record of a parked terminal compile failure: the error text and when it parked.</summary>
-    private sealed record ParkedCompileFailure(string Error, DateTimeOffset ParkedAt);
+    /// <summary>Record of a parked terminal compile failure: the error text, when it parked, and
+    /// the source-version snapshot that failed (used to detect a later source change).</summary>
+    private sealed record ParkedCompileFailure(
+        string Error, DateTimeOffset ParkedAt, IReadOnlyDictionary<string, long>? Sources);
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CodeEditRecompileTest.cs
@@ -604,15 +604,22 @@ public class CodeEditRecompileTest(ITestOutputHelper output) : MonolithMeshTestB
         parkRegistry.IsParked(typePath).Should().BeTrue(
             "a deterministic compile error must park the type");
 
-        // Fix the source; the sources watcher flips IsDirty — parked state intact.
+        // Fix the SOURCE. A source change on a parked type now auto-un-parks and recompiles —
+        // the "retry only if the sources changed" heal path (pinned in NodeTypeCompileParkTest
+        // .ParkedNodeType_SourceFix_AutoRecompilesAndUnparks). Wait for that automatic heal to
+        // settle Ok + un-parked before exercising the deliberate tool retry below.
         await workspace.GetMeshNodeStream(sourcePath).Update(curr =>
             curr with { Content = new CodeConfiguration { Code = CodeV1, Language = "csharp" } })
             .Should().Within(30.Seconds()).Emit();
-        await WaitForIsDirty(typePath, expected: true);
-        parkRegistry.IsParked(typePath).Should().BeTrue(
-            "editing the source alone must not un-park — only a deliberate retry does");
+        await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok);
+        parkRegistry.IsParked(typePath).Should().BeFalse(
+            "a source fix auto-un-parks the type (retry only if the sources changed)");
 
-        // Retry via the REAL tool surface.
+        // The deliberate compile-tool retry still FORCES a fresh run (RequestedReleaseForce) —
+        // the anti-replay contract: it must report THIS run, never the previous run's snapshot.
         var resultJson = await new MeshOperations(Mesh).Compile(typePath)
             .FirstAsync().Timeout(150.Seconds()).ToTask(ct);
         Output.WriteLine($"Compile tool returned: {resultJson}");

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeCompileParkTest.cs
@@ -281,6 +281,89 @@ public class NodeTypeCompileParkTest(ITestOutputHelper output) : MonolithMeshTes
     }
 
     /// <summary>
+    /// 🅿️ "Retry only if the sources changed." A parked type whose SOURCE Code node is FIXED
+    /// auto-recompiles to Ok and un-parks with NO deliberate Compile/recycle — the redeploy/edit
+    /// heal path. Regression for the 2026-07 UWDeepfield case: a GitSync-imported source fix left
+    /// the type stuck at Error because the in-memory park only cleared on a deliberate retry, so
+    /// the fixed source never recompiled in the running process. The negative half is pinned in
+    /// the same test: while the broken source is UNCHANGED, repeated activations never re-run
+    /// Roslyn (the park still contains the failure — no storm).
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ParkedNodeType_SourceFix_AutoRecompilesAndUnparks_WithoutDeliberateRetry()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var workspace = Mesh.GetWorkspace();
+        var parkRegistry = Mesh.ServiceProvider.GetRequiredService<NodeTypeCompileParkRegistry>();
+        const string typePath = $"{Partition}/SourceAutoRetry";
+        const string sourcePath = $"{Partition}/SourceAutoRetry/Source/code";
+
+        // Plant the deliberately-uncompilable SOURCE Code node FIRST so the type's first-build
+        // compile sees it and fails on the SOURCE (not just a broken inline Configuration).
+        await NodeFactory.CreateNode(new MeshNode("code", $"{Partition}/SourceAutoRetry/Source")
+        {
+            Name = "Code",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = "this is not valid C#;", Language = "csharp" }
+        }).Should().Emit();
+
+        // A NodeType with a VALID Configuration but the broken source above under it.
+        await NodeFactory.CreateNode(new MeshNode("SourceAutoRetry", Partition)
+        {
+            Name = "Source Auto Retry",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Valid config, broken SOURCE node (source-change auto-retry test).",
+                Configuration = ValidConfiguration
+            }
+        }).Should().Emit();
+
+        // Settle at Error + parked (deterministic source error parks on the first failure).
+        await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Error);
+        parkRegistry.IsParked(typePath).Should().BeTrue(
+            "a deterministic SOURCE compile error must park the type");
+        var attemptsAtPark = parkRegistry.GetCompileAttemptCount(typePath);
+        Output.WriteLine($"{typePath} parked at Error after {attemptsAtPark} compile(s).");
+
+        // NEGATIVE — source UNCHANGED: hammer activation/enrichment; Roslyn must NOT re-run.
+        var instance = new MeshNode("src-instance", Partition)
+        {
+            Name = "Src Instance",
+            NodeType = typePath,
+            State = MeshNodeState.Active
+        };
+        await NodeFactory.CreateNode(instance).Should().Emit();
+        var resolver = Mesh.ServiceProvider.GetRequiredService<INodeConfigurationResolver>();
+        for (var i = 0; i < 10; i++)
+            (await resolver.ResolveConfiguration(instance).FirstAsync().Timeout(30.Seconds()).ToTask(ct))
+                .Should().NotBeNull();
+        parkRegistry.GetCompileAttemptCount(typePath).Should().Be(attemptsAtPark,
+            "an UNCHANGED broken source must not re-run Roslyn — retry only if the sources changed");
+        parkRegistry.IsParked(typePath).Should().BeTrue(
+            "the type must stay parked while its source is unchanged");
+        Output.WriteLine("10 enrichments, unchanged source — still parked, no recompile.");
+
+        // FIX the SOURCE — and DO NOTHING ELSE. No Compile tool, no recycle, no release request.
+        // The source-change alone must auto-un-park and drive a fresh compile to Ok.
+        await workspace.GetMeshNodeStream(sourcePath).Update(curr =>
+                curr with { Content = new CodeConfiguration
+                    { Code = "public record AutoRetryOk;", Language = "csharp" } })
+            .Should().Within(30.Seconds()).Emit();
+
+        await workspace.GetMeshNodeStream(typePath)
+            .Should().Within(120.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok);
+        parkRegistry.IsParked(typePath).Should().BeFalse(
+            "fixing the SOURCE must auto-un-park the type WITHOUT a deliberate retry");
+        Output.WriteLine("Source fixed → auto-recompiled to Ok and un-parked (no deliberate retry).");
+    }
+
+    /// <summary>
     /// Creates a NodeType with a deliberately non-compiling Configuration at
     /// <c>{Partition}/{id}</c>, waits for the first-build compile to settle at Error and
     /// asserts the type is parked (deterministic source errors park on the FIRST failure).


### PR DESCRIPTION
## Problem

A NodeType whose source does not compile is **parked** (bounded + terminal) so a broken type can't drive a recompile storm — good. But the only un-park triggers were a **deliberate** retry (Compile button / recycle) or a **process restart**. So a source **fix** that lands in a running process — a GitSync import, an in-place Code-node edit — did **not** recompile: the in-memory park swallowed it and the type stayed at `Error` even though its source was now valid.

Observed live on systemorph.com: the `UWDeepfield` partition's `Source/*` Code nodes were fixed via GitSync, `TreatyDecision`/the Markdown pages recompiled Ok, but `TreatySubmission` stayed stuck at `Error` — its fixed source parked in the running process with no retry path short of a pod restart. (Also the likely shape of the recompile-heavy retained-assembly pressure on long-lived meshes.)

## Fix — "retry only if the sources changed"

- `NodeTypeCompileParkRegistry` stores the **source-version snapshot** that failed alongside the park, and exposes `ShouldRetryForSourceChange(path, current)` — true only when parked **and** the current snapshot differs from the failed one (`null` == empty).
- The compile failure site parks the failed compile's `CompiledSources` snapshot.
- `InstallSourcesWatcher` (already recomputes the snapshot on every source edit) **un-parks + flips `CompilationStatus = Pending`** under System when the snapshot changed, so the compile watcher drives a fresh compile against the fixed source. Un-park happens-before the `Pending` emission, so the parked short-circuit doesn't swallow it. An **unchanged** broken type never retries (no storm).

**Scope:** the snapshot is Source/Test Code nodes only (`NodeSources.GetSources`), **not** the NodeType's own `Configuration` string — so a `Configuration` edit still requires a deliberate retry (unchanged contract), while an external source edit heals automatically.

## Tests

- New `NodeTypeCompileParkTest.ParkedNodeType_SourceFix_AutoRecompilesAndUnparks_WithoutDeliberateRetry`: parks on a broken **Source Code node**, proves no recompile while unchanged, then a source fix **alone** auto-heals to `Ok` + un-parks.
- Updated `CodeEditRecompileTest.FailedCompile_DirectCompileToolRetry` to the new contract (source fix auto-heals; the tool retry still **forces** a fresh run — anti-replay coverage retained here and in `CompileTool_UnchangedSources_ForcesFreshRun`).
- Full `NodeTypeCompileParkTest` + `CodeEditRecompileTest` suites green (13/13), incl. the `Configuration`-edit "must not un-park" invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)