### PR TITLE
fix(#472): file-browser rows — target table.fluent-data-grid, the element that actually renders

### DIFF
--- a/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor.css
+++ b/src/MeshWeaver.Blazor/FileExplorer/FileBrowser.razor.css
@@ -64,14 +64,18 @@
         text-decoration: underline;
     }
 
-/* Content-height rows at every folder depth (issue #472). The FluentDataGrid's CSS grid gets
-   a definite height from its layout-area container; with the grid default `align-content:
-   stretch` the surplus height is distributed INTO the row tracks, so a folder with few items
-   renders each row several × too tall, with the (top-aligned) single-line cell content
-   floating at the top of the tall row. The effect worsens with depth because deeper folders
-   hold fewer items (fewer rows share the same surplus). Pack the tracks to the top at content
-   height instead of stretching them. `::deep` reaches the FluentUI web-component element. */
-::deep fluent-data-grid {
+/* Content-height rows at every folder depth (issue #472). FluentDataGrid renders a
+   `<table class="fluent-data-grid grid">` with `display: grid` whose rows are `<tr>`s with
+   `display: contents` — the CELLS are the grid items, and the row heights are the grid's
+   IMPLICIT row tracks. The table is `flex: 1` inside `.file-browser`, so it gets a definite
+   height; with the grid default `align-content: stretch` the surplus height is distributed
+   INTO the row tracks (measured: `grid-template-rows: 290px 282px 282px` for a header + two
+   32px rows), so a folder with few items renders each row several × too tall. The effect
+   worsens with depth because deeper folders hold fewer items (fewer rows share the same
+   surplus). Pack the tracks to the top at content height instead of stretching them.
+   🚨 The selector must target `table.fluent-data-grid` — there is NO `<fluent-data-grid>`
+   custom element in the rendered DOM (that was the original, ineffective fix). */
+::deep table.fluent-data-grid {
     align-content: start;      /* don't distribute surplus height into the row tracks */
     grid-auto-rows: min-content; /* each row sizes to its content, not stretched */
 }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-22-file-browser-row-height.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-22-file-browser-row-height.md
@@ -1,0 +1,14 @@
+---
+Name: File browser rows no longer stretch
+Category: What's New
+Description: Folder rows in the content file browser are content-height at every depth — no more huge empty bands between rows.
+Icon: Sparkle
+---
+
+# File browser rows no longer stretch
+
+The content file browser used to render folder rows progressively taller the deeper you
+navigated — a folder with only a couple of entries spread them across the whole page with
+large empty bands between the rows. Rows now always size to their content, at the collection
+root and at every nesting depth, whether you navigate in-app or open a deep folder URL
+directly.


### PR DESCRIPTION
## What

Re-fix of #472 (reported still broken by @sierragolflima after #507). One-selector change in
`FileBrowser.razor.css`: `::deep fluent-data-grid` → `::deep table.fluent-data-grid`, plus a
What's New entry.

## Why #507 didn't work

FluentDataGrid does **not** render a `<fluent-data-grid>` custom element: it renders a
`<table class="fluent-data-grid grid">` with `display: grid`, rows as `display: contents`
`<tr>`s, and the **cells** as grid items — row heights are the grid's implicit tracks. The
table is `flex: 1` inside `.file-browser`, so it gets a definite height and the default
`align-content: stretch` distributes the surplus into the row tracks. The #507 rule matched
nothing and was dead code.

## Verification (disposable e2e mesh, current `memex-portal-ai:main` image)

- Reproduced the tester's exact repro (`/{space}/content/test_A` with 2 subfolders):
  computed `grid-template-rows: 290px 282px 282px` — a header + two single-line rows
  stretched to ~282px each, worsening with depth.
- With this rule injected: `grid-template-rows: 40px 32px 32px` — content-height rows,
  packed to the top, at every depth. Navigation/selection unaffected.

Closes #472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)