### PR TITLE
fix(#458): composer auto-grow — dodge BlazorMonaco's colliding container class; keep the fill out of compact-mode

### DIFF
--- a/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/Chat/ThreadChatView.razor.css
@@ -44,8 +44,13 @@
    scoped to `.no-messages`, keeping the inline `max-height` cap + Monaco's internal scroll.
    `::deep` reaches the child component's root; `!important` beats the inline height (and the
    JS grow-writes, which we don't want in the fill state anyway). The with-messages composer
-   has no `.no-messages` class, so its #178 auto-grow is completely untouched. */
-.thread-chat-container.no-messages .input-container ::deep .monaco-editor-container {
+   has no `.no-messages` class, so its #178 auto-grow is completely untouched.
+   🚨 Scoped to :not(.compact-mode): in compact-mode (the dashboard/user-activity composer)
+   the container is `position: static` and the whole chain sizes to CONTENT — there is no
+   definite height to fill, so `height: 100%` resolves against an auto-height parent,
+   collapses to the 80px min, AND its `!important` blocks the auto-grow height writes.
+   In compact-mode the composer must rely on #178 auto-grow instead of the fill. */
+.thread-chat-container.no-messages:not(.compact-mode) .input-container ::deep .monaco-editor-container {
     height: 100% !important;
 }
 

--- a/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
+++ b/src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor.js
@@ -325,7 +325,13 @@ export function initEditor(editorId, placeholder, dotNetRef, codeEditMode = fals
                 if (st.resizeTimeout) clearTimeout(st.resizeTimeout);
                 st.resizeTimeout = setTimeout(() => {
                     const inner = document.getElementById(editorId);
-                    const outer = inner?.closest('.monaco-editor-container');
+                    // 🚨 #editorId is BlazorMonaco's OWN root div, which carries BlazorMonaco's
+                    // default class `monaco-editor-container` — the SAME name as our wrapper.
+                    // A plain `inner.closest(...)` therefore self-matches the inner element,
+                    // and the height write lands on the `!important`-pinned .monaco-editor-view
+                    // (silently ignored) instead of the wrapper — auto-grow dead on every
+                    // surface (issue #458). Start the search at the PARENT to reach the wrapper.
+                    const outer = inner?.parentElement?.closest('.monaco-editor-container');
                     // Guard against a dispose race: the editor can be torn down during the 50ms
                     // debounce window, after which layout() throws "Couldn't find the editor…".
                     // getDomNode() returns null once the instance is disposed — bail if so.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-22-composer-auto-grow.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-22-composer-auto-grow.md
@@ -1,0 +1,14 @@
+---
+Name: Chat composer grows with your message again
+Category: What's New
+Description: Typing or pasting a long message expands the chat composer up to its cap instead of scrolling invisibly inside a small box.
+Icon: Sparkle
+---
+
+# Chat composer grows with your message again
+
+The chat message box stopped expanding as you typed — long or pasted messages scrolled
+invisibly inside a fixed ~80&nbsp;px box, in the side panel and in the dashboard composer
+alike. The auto-grow behaviour is restored everywhere: the composer follows your content up
+to its viewport cap, then scrolls, and shrinks back when you delete. The tall new-chat
+composer in the side panel keeps filling its slot as before.


### PR DESCRIPTION
## What

Re-fix of #458 (reported still broken by @sierragolflima after #506 — his screenshot shows the
**with-messages** side-panel composer refusing to grow on paste). Two small changes + a What's
New entry:

1. **`MonacoEditorView.razor.js`** — the #178 auto-grow handler resolved its write target with
   `inner.closest('.monaco-editor-container')`, but `#editorId` (BlazorMonaco's own root div)
   carries BlazorMonaco's *default* class `monaco-editor-container` — the same name as our
   wrapper — so `closest()` self-matched the inner element, whose height is pinned
   `100% !important` by `MonacoEditorView.razor.css`. The write was silently ignored → auto-grow
   dead on **every** surface (main pane, side panel, dashboard). Start the search at
   `parentElement` to reach the actual wrapper.

2. **`ThreadChatView.razor.css`** — scope the #506 `.no-messages` fill (`height:100% !important`)
   to `:not(.compact-mode)`. In compact-mode (the dashboard/user-activity composer) the container
   is `position: static` and the chain sizes to content, so there is no height to fill: the rule
   collapsed the composer to its 80px min *and* its `!important` blocked the grow writes. The
   side-panel new-chat fill (non-compact) is untouched.

## Verification (disposable e2e mesh, current `memex-portal-ai:main` image)

- Reproduced: 25 lines pasted into the composer → stays 80px, content scrolls invisibly
  (contentHeight 516px), no JS errors — the handler fired but wrote to the pinned inner element.
- With both changes emulated in-page: composer grows 80 → **400px** (the `max-height` cap) on
  20 pasted lines and shrinks back to **80px** (min) on delete; the side-panel new-chat
  composer still fills its slot (400px cap).

Closes #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)