### PR TITLE
AI: populate "# Current User" from the thread owner (agent no longer asks who you are)

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -600,9 +600,14 @@ public class AgentChatClient : IAgentChat
         if (!string.IsNullOrEmpty(cachedSystemPrompt))
             messageText.Append(cachedSystemPrompt);
 
-        // User identity
+        // User identity. Prefer the DURABLE thread-user identity captured at submission
+        // (ExecutionContext.UserAccessContext) — by the time this prompt is built the agent runs
+        // async on the agent hub, where the ambient AccessContext has often been reset to null or an
+        // impersonated System principal, leaving the block empty so the agent has to ASK who the user
+        // is. The thread owner is the correct identity (ThreadExecution re-asserts it the same way).
         var accessService = hub.ServiceProvider.GetService<AccessService>();
-        var userContext = accessService?.Context ?? accessService?.CircuitContext;
+        var userContext = ExecutionContext?.UserAccessContext
+            ?? accessService?.Context ?? accessService?.CircuitContext;
         if (userContext != null)
         {
             messageText.AppendLine("# Current User");


### PR DESCRIPTION
An agent running a skill that files under `{User ID}/…` (e.g. `/feedback`) had to **ask the user for their own username**. `AgentChatClient.BuildMessageWithContextAsync` built the `# Current User` block only from `accessService.Context ?? CircuitContext` — but by the time the prompt is assembled (async, on the agent hub, typically after an `ImpersonateAsSystem`) that ambient context is null or a System principal, so the block was empty.

**Fix:** prefer the durable thread-user identity captured at submission — `ExecutionContext.UserAccessContext` (the thread owner, which `ThreadExecution` already re-asserts as the correct identity at lines ~1052/1264) — falling back to the ambient context. One line; fixes it for **every** skill/agent, not just feedback.

`MeshWeaver.AI` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)