### PR TITLE
helm(portal): permanent probe fix + crash dumps + /mcp affinity ingress

### DIFF
--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -43,9 +43,22 @@ spec:
                 name: "memex-portal-config"
             - secretRef:
                 name: "memex-portal-secrets"
+          env:
+            # 🩺 Crash diagnostics. We hit a native SIGSEGV (exit 139) in the Npgsql → SslStream TLS
+            # read path: the process dies with NO managed exception, so the logs show nothing useful.
+            # Write a dump to the persistent /data volume (a hostPath that survives the restart on the
+            # same node) so the next crash — and the heap, to confirm/refute the suspected leak — is
+            # analyzable. Type 2 = heap (WithPrivateReadWriteMemory). Dumps only appear on crash.
+            - name: "DOTNET_DbgEnableMiniDump"
+              value: "1"
+            - name: "DOTNET_DbgMiniDumpType"
+              value: "2"
+            - name: "DOTNET_DbgMiniDumpName"
+              value: "/data/dumps/coredump.%p.%t"
+            - name: "DOTNET_CreateDumpDiagnostics"
+              value: "1"
           {{- with .Values.selfUpdate }}
           {{- if .azureClientId }}
-          env:
             # Explicit AZURE_CLIENT_ID for the self-updater's ACR credential (the workload-identity
             # webhook also injects this; set here so it's correct even without the webhook).
             - name: "AZURE_CLIENT_ID"
@@ -81,7 +94,14 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 60
           readinessProbe:
-            httpGet: { path: /health, port: 8080 }
+            # ⚠️ /alive (light: process-up), NOT /health (heavy: DB + mesh checks). /health as the
+            # readiness probe is the "probe death-spiral": under load a heavy /health times out (5s) →
+            # 3 fails → the pod is yanked from the Service endpoints → 503 flapping, and the connection
+            # churn that follows aggravates the SslStream SIGSEGV. The rollout gate stays correct
+            # because the STARTUP probe below already holds readiness on /health until the mesh is up
+            # (so no 502 to a booting pod); once up, /alive keeps a serving pod in rotation and never
+            # flaps it out. (Fixed live 2026-07-21; it regressed because the fix wasn't in this chart.)
+            httpGet: { path: /alive, port: 8080 }
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3

--- a/deploy/helm/templates/memex-portal/ingress.yaml
+++ b/deploy/helm/templates/memex-portal/ingress.yaml
@@ -91,4 +91,64 @@ spec:
                 port:
                   number: {{ .Values.grpc.port }}
 {{- end }}
+# ---- MCP + its OAuth flow pinned to ONE pod (stateful per-pod sessions) ------
+# /mcp (Streamable HTTP) and its OAuth endpoints (/register /authorize /token) keep session +
+# dynamic-client-registration + issued-token state IN-MEMORY PER POD. With >1 replica, the site's
+# cookie affinity does NOT help (the MCP HTTP client doesn't carry the cookie), so requests bounce
+# between pods → "authenticated user does not match the session" / "rejected on reconnect". A
+# dedicated Ingress routes the whole flow to a SINGLE pod via a constant hash ($host) so
+# registration, token and session all land together. Low traffic; if that pod dies the consistent
+# hash remaps to a live one (reconnect once). Real fix: shared/distributed MCP session state.
+---
+apiVersion: "networking.k8s.io/v1"
+kind: "Ingress"
+metadata:
+  name: "memex-portal-mcp-ingress"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "memex-portal"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+  annotations:
+    nginx.ingress.kubernetes.io/upstream-hash-by: "$host"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+spec:
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tlsSecret | quote }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: "/mcp"
+            pathType: "Prefix"
+            backend:
+              service:
+                name: "memex-portal-service"
+                port:
+                  number: {{ .Values.config.memex_portal.ASPNETCORE_HTTP_PORTS | default 8080 }}
+          - path: "/register"
+            pathType: "Prefix"
+            backend:
+              service:
+                name: "memex-portal-service"
+                port:
+                  number: {{ .Values.config.memex_portal.ASPNETCORE_HTTP_PORTS | default 8080 }}
+          - path: "/authorize"
+            pathType: "Prefix"
+            backend:
+              service:
+                name: "memex-portal-service"
+                port:
+                  number: {{ .Values.config.memex_portal.ASPNETCORE_HTTP_PORTS | default 8080 }}
+          - path: "/token"
+            pathType: "Prefix"
+            backend:
+              service:
+                name: "memex-portal-service"
+                port:
+                  number: {{ .Values.config.memex_portal.ASPNETCORE_HTTP_PORTS | default 8080 }}
 {{- end }}


### PR DESCRIPTION
Three memex-portal fixes that kept **regressing because they were live `kubectl` patches, never in the chart** — so every `helm upgrade`/deploy reverted them (the exact thing that broke prod again today).

1. **readinessProbe `/health` → `/alive`.** Heavy `/health` as readiness is the *probe death-spiral*: it times out under load → the pod is pulled from the Service endpoints → **503 flapping**, and the connection churn aggravates the SslStream crash (#2). The rollout gate is unaffected — the **startup** probe still holds readiness on `/health` until the mesh is up (no 502 to a booting pod); once up, `/alive` keeps a serving pod in rotation without flapping.
2. **Crash dumps.** The pods `exit=139` on a **native SIGSEGV in the Npgsql → SslStream TLS read path** — no managed exception, so logs are empty. `DOTNET_DbgEnableMiniDump` writes a heap dump (type 2) to the persistent `/data` hostPath so the next crash *and the heap* (to confirm/refute the suspected leak) are analyzable.
3. **`/mcp` + OAuth affinity ingress.** MCP session/registration/token state is in-memory **per pod**; with 2+ replicas the MCP client can't carry the cookie affinity → "rejected on reconnect". A dedicated ingress pins `/mcp /register /authorize /token` to one pod via `upstream-hash-by: $host`.

Renders clean (`helm template`). Prod currently runs these as live patches; merging + `helm upgrade` makes them the source of truth so they stop regressing. The SslStream SIGSEGV itself still needs the dump to root-cause (or a runtime bump) — this PR makes it *diagnosable* and stops the flap that triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)