### PR TITLE
Boot must not initialize the whole mesh: lazy pre-warm/seed, read-only import skip, membership tolerance

### DIFF
--- a/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
+++ b/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
@@ -38,6 +38,12 @@ namespace Memex.Portal.Shared;
 /// the cache and the <c>Release</c> node is created even on a read-only partition. Idempotent: a
 /// NodeType that already has a usable build is skipped, so re-boots are cheap. Fire-and-forget off
 /// the thread pool — never blocks host startup.</para>
+///
+/// <para><b>Opt-in per deployment</b> (<c>ShippedRelease:PreseedEnabled</c>, default off): even the
+/// "skip already-built" pass stream-reads every code NodeType in every shipped partition — a boot
+/// subscribe storm on a loaded mesh. By default only the partitions a deployment names in
+/// <c>ShippedRelease:ExtraPreseedPartitions</c> are seeded; everything else compiles lazily on
+/// first access.</para>
 /// </summary>
 public static class ShippedReleaseSeed
 {
@@ -348,25 +354,28 @@ public sealed class ShippedReleaseSeedHostedService(
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        // Boot pre-seed = the shipped sample/framework partitions PLUS any extra partitions a deployment
-        // opts into via config (ShippedRelease:ExtraPreseedPartitions). User/Space partitions are NOT
-        // shipped (they're user-Released), but a deployment can pre-build a heavily-used runtime Space at
-        // boot so its NodeType/dashboard views don't render empty during the cold compile-on-first-access
-        // window after a pod restart. Set PER-DEPLOYMENT (e.g. atioz: AgenticPension) — never hardcode a
-        // customer's space name into framework source. Pre-build is async (never blocks host startup).
+        // Boot pre-seed is OPT-IN (ShippedRelease:PreseedEnabled, default false): enumerating +
+        // stream-reading every code NodeType in every shipped partition is a boot-time subscribe
+        // storm on a loaded mesh, and the lazy compile-on-first-access path already covers
+        // correctness. When disabled, only the explicitly configured extra partitions
+        // (ShippedRelease:ExtraPreseedPartitions) are seeded — a deployment naming a partition
+        // there has asked for exactly that pre-build (e.g. atioz: AgenticPension; set
+        // PER-DEPLOYMENT, never hardcode a customer's space name into framework source). The
+        // platform-version anchor + boot activity below run regardless — they touch one Admin
+        // node, not the mesh. Pre-build is async (never blocks host startup).
         var extra = configuration.GetSection("ShippedRelease:ExtraPreseedPartitions").Get<string[]>()
             ?? [];
-        var partitions = ShippedReleaseSeed.ShippedPartitions
-            .Concat(extra)
+        var preseedShipped = configuration.GetValue("ShippedRelease:PreseedEnabled", false);
+        var partitions = (preseedShipped ? ShippedReleaseSeed.ShippedPartitions.Concat(extra) : extra)
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
         logger?.LogInformation(
-            "[PlatformStartup] version={Version}; pre-building shipped code-NodeType releases as System for "
-            + "{Partitions}{Extra} and recording the boot activity under {VersionNode}.",
+            "[PlatformStartup] version={Version}; pre-seed {Mode}; pre-building shipped code-NodeType releases as System for "
+            + "[{Partitions}] and recording the boot activity under {VersionNode}.",
             ShippedReleaseSeed.InstalledPlatformVersion,
+            preseedShipped ? "ENABLED (ShippedRelease:PreseedEnabled)" : "disabled (config extras only)",
             string.Join(", ", partitions),
-            extra.Length > 0 ? $" (incl. config extras: {string.Join(", ", extra)})" : "",
             ShippedReleaseSeed.PlatformVersionNodePath);
         _subscription = ShippedReleaseSeed
             .RunPlatformStartup(hub, partitions, logger)

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -158,6 +158,21 @@ builder.UseOrleansMeshServer(address, silo =>
             opts.ClusterId = MemexDistributedConstants.ClusterId;
             opts.ServiceId = MemexDistributedConstants.ServiceId;
         });
+        // Membership-probe tolerance. EVERY portal crash on memex-cloud over 2026-07-15..22 was the
+        // same self-inflicted death: a silo starved by load (boot import/compile storm, GC pauses
+        // from the content-render leak) missed probes, got voted dead by its peers, and
+        // Environment.FailFast'd ("I have been told I am dead") — on 2026-07-20 BOTH silos voted
+        // each other dead within a second (full outage). Defaults (10s probe, 3 misses) declare a
+        // busy-but-alive silo dead after ~30s of unresponsiveness. Widen to ~75s and probe
+        // indirectly before condemning: a transiently starved silo recovers instead of dying; a
+        // TRULY wedged pod is still restarted by the k8s liveness probe (/alive, 6×15s), so real
+        // failures don't linger — we only stop killing pods that were about to recover.
+        silo.Configure<ClusterMembershipOptions>(opts =>
+        {
+            opts.ProbeTimeout = TimeSpan.FromSeconds(15);
+            opts.NumMissedProbesLimit = 5;
+            opts.EnableIndirectProbes = true;
+        });
         if (string.Equals(orleansClustering, "Localhost", StringComparison.OrdinalIgnoreCase))
         {
             silo.UseLocalhostClustering();

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -513,12 +513,18 @@ public static class StaticRepoImporter
                 var existing = change.Items.FirstOrDefault();
 
                 // The content-skip path: the content fingerprint matches a prior Succeeded import, so
-                // re-ensure ONLY the CRITICAL governance (partition ROOT + its read-only _Policy —
+                // verify ONLY the CRITICAL governance (partition ROOT + its read-only _Policy —
                 // Harness/Agent/Skill/Provider PublicRead). These MUST exist on every boot: if dropped
                 // after a prior import (a cross-partition prune, a manual delete, a botched migration)
                 // the content-skip would otherwise leave the partition UNREADABLE FOREVER (the "user
-                // 'rbuergi' lacks Read permission on 'harness'" composer denial). EnsureRoot + the
-                // _Policy upsert are idempotent; best-effort so a self-heal hiccup never fails the import.
+                // 'rbuergi' lacks Read permission on 'harness'" composer denial). 🚨 READ-FIRST: check
+                // existence via the query and write ONLY what is missing — the old unconditional
+                // re-upsert made every boot a per-partition write fan-out (root + every governance node
+                // activating its per-node hub), which on a loaded mesh queued behind the boot storm and
+                // timed out at 30s apiece (memex 2026-07-22). A steady-state boot is now pure reads.
+                // The query is eventually consistent: a stale miss upserts idempotently (harmless); a
+                // stale hit merely defers the heal to the next boot — the same lag the Succeeded-marker
+                // short-circuit already accepts. Best-effort so a self-heal hiccup never fails the import.
                 IObservable<StaticRepoImportResult> SkipWithGovernanceHeal()
                 {
                     var governance = nodes
@@ -526,13 +532,19 @@ public static class StaticRepoImporter
                                     || n.Segments.Skip(1).Any(seg => seg.StartsWith('_')))
                         .ToArray();
                     logger?.LogInformation(
-                        "[StaticRepoImport] {Partition} already at {Fingerprint} — content skipped; re-ensuring root + {Count} governance node(s).",
+                        "[StaticRepoImport] {Partition} already at {Fingerprint} — content skipped; verifying root + {Count} governance node(s).",
                         source.Partition, fingerprint, governance.Length);
-                    return EnsureRoot(hub, source, root, activityPath, logger)
+                    return EnsureRoot(hub, source, root, activityPath, logger, refreshExisting: false)
                         .SelectMany(_ => governance.Length == 0
                             ? Observable.Return(0)
                             : governance
-                                .Select(g => Upsert(hub, Materialize(g))
+                                .Select(g => meshService
+                                    .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{g.Path}"))
+                                    .Take(1)
+                                    .SelectMany(c => c.Items.Any(n =>
+                                            string.Equals(n.Path, g.Path, StringComparison.OrdinalIgnoreCase))
+                                        ? Observable.Return(0)
+                                        : Upsert(hub, Materialize(g)))
                                     .Catch<int, Exception>(_ => Observable.Return(0)))
                                 .ToObservable().Merge(BatchSize).Sum())
                         .Select(_ => new StaticRepoImportResult(source.Partition, fingerprint, "Skipped"))
@@ -975,11 +987,15 @@ public static class StaticRepoImporter
     /// create triggers eager schema provisioning + the partition-definition/routing prime + the
     /// admin grant); present → overwrite to refresh the welcome, preserving owner identity. The
     /// create degrades to an overwrite on a concurrent-replica "already exists" so the import never
-    /// faults on the lock race.
+    /// faults on the lock race. With <paramref name="refreshExisting"/> <c>false</c> (the
+    /// unchanged-fingerprint boot skip path) an existing root is left entirely untouched — the
+    /// fingerprint covers the root, so a matching fingerprint means its content is current and the
+    /// refresh write (which activates the root hub and can queue 30s behind a boot storm) is pure
+    /// waste; only an ABSENT root is then (re)created.
     /// </summary>
     private static IObservable<int> EnsureRoot(
         IMessageHub hub, IStaticRepoSource source, MeshNode root,
-        string activityPath, ILogger? logger)
+        string activityPath, ILogger? logger, bool refreshExisting = true)
     {
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
         // 🚨 Honour an admin's "stop sync" claim on the partition ROOT. If the EXISTING root carries a
@@ -1004,6 +1020,8 @@ public static class StaticRepoImporter
                     // schema provisioning + the partition-definition/routing prime + the admin grant.
                     return Upsert(hub, Materialize(root));
                 }
+                if (!refreshExisting)
+                    return Observable.Return(0); // present + skip path: verified, nothing to write.
                 // EXISTING root: check the claim AUTHORITATIVELY (GetMeshNodeStream), never only the
                 // query snapshot — a JUST-SET "sync: none" lags the eventually-consistent query (the
                 // same race ReadClaimedRoots guards; here the stakes are higher because the upsert

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Linq;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -17,12 +18,23 @@ namespace MeshWeaver.Hosting;
 /// <para><b>Never blocks host startup or readiness.</b> <see cref="StartAsync"/> returns
 /// immediately; the warm-up is launched from the <c>ApplicationStarted</c> callback and runs
 /// on a background Rx subscription. The subscription is torn down on shutdown.</para>
+///
+/// <para><b>OFF by default</b> (<c>PreWarm:DynamicTypes</c> config, default <c>false</c>): the
+/// warm-up enumerates EVERY NodeType across EVERY partition and activates + compiles each dynamic
+/// one — on a mesh with many partitions that is a boot-time subscribe/compile storm that starves
+/// the hubs (and, multi-silo, the Orleans membership probes — the "I have been told I am dead"
+/// restart loop on memex, 2026-07-22). Correctness never needs it: first access compiles lazily
+/// via <c>NodeTypeEnrichmentHelpers.WaitForCompileSettled</c>. Opt in only where the
+/// first-visitor compile latency actually hurts and the mesh is small enough to warm quietly.</para>
 /// </summary>
 public sealed class DynamicTypePreWarmerHostedService(
     IServiceProvider services,
     IHostApplicationLifetime lifetime,
     ILogger<DynamicTypePreWarmerHostedService> logger) : IHostedService, IDisposable
 {
+    /// <summary>Config key that opts a deployment into the startup warm-up (default: off).</summary>
+    public const string EnabledConfigKey = "PreWarm:DynamicTypes";
+
     private IDisposable? _warmSubscription;
     private IDisposable? _startedRegistration;
 
@@ -38,6 +50,17 @@ public sealed class DynamicTypePreWarmerHostedService(
 
     private void KickWarmup()
     {
+        // Config-gated, DEFAULT OFF — see the class doc. Read as a raw string (no Binder
+        // dependency); anything but an explicit true stays lazy.
+        var enabled = services.GetService<IConfiguration>()?[EnabledConfigKey];
+        if (!bool.TryParse(enabled, out var isEnabled) || !isEnabled)
+        {
+            logger.LogInformation(
+                "DynamicTypePreWarmer: disabled ({Key} != true) — dynamic NodeTypes compile lazily on first access",
+                EnabledConfigKey);
+            return;
+        }
+
         var mesh = services.GetService<IMessageHub>();
         if (mesh is null)
         {
@@ -94,10 +117,12 @@ public sealed class DynamicTypePreWarmerHostedService(
 public static class PreWarmServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers <see cref="DynamicTypePreWarmerHostedService"/> so the pod front-loads its
+    /// Registers <see cref="DynamicTypePreWarmerHostedService"/> so the pod CAN front-load its
     /// dynamic NodeType compiles at startup (Part 1 of the fresh-pod compile-race hardening).
-    /// Best-effort and non-blocking — safe to call from any portal host; a no-op if no mesh
-    /// hub / mesh service is present.
+    /// The warm-up only actually runs when the deployment opts in via
+    /// <see cref="DynamicTypePreWarmerHostedService.EnabledConfigKey"/> (default: off — startup
+    /// does no mesh-wide enumeration; types compile lazily on first access). Best-effort and
+    /// non-blocking — safe to call from any portal host; a no-op if no mesh hub is present.
     /// </summary>
     public static IServiceCollection AddDynamicTypePreWarming(this IServiceCollection services)
     {

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/StaticRepoImporterTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/StaticRepoImporterTests.cs
@@ -321,6 +321,41 @@ public class StaticRepoImporterTests(PostgreSqlFixture fixture, ITestOutputHelpe
     }
 
     /// <summary>
+    /// A boot re-import at an UNCHANGED fingerprint must be a PURE READ — no writes at all. The old
+    /// skip path "re-ensured" the partition root (an unconditional overwrite) plus every governance
+    /// node on every boot; on a loaded mesh those writes fan out per-node hub activations that queue
+    /// behind the boot storm and time out at 30s apiece (the memex 2026-07-22 startup storm). The
+    /// observable contract: after a Skipped re-run, the root's Version is UNCHANGED (the overwrite
+    /// would have bumped it — see Reimport_ChangedContent_Updates_AndIncrementsVersion).
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task SkippedReimport_IsReadOnly_DoesNotRewriteRoot()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var first = (await Import()).Single(r => r.Partition == _partition);
+        first.Outcome.Should().Be("Imported");
+
+        // Wait for the Succeeded marker to be visible to the importer's own query (same guard as
+        // Import_CreatesSpaceRoot…), so the re-run below deterministically takes the skip path.
+        var markerPath = $"{_partition}/_Activity/import-{first.Fingerprint}";
+        await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+            .SelectMany(_ => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{markerPath}")).Take(1))
+            .Where(c => c.Items.Any(n => n.Content is ActivityLog { Status: ActivityStatus.Succeeded }))
+            .Take(1).Should().Within(30.Seconds()).Emit();
+
+        var rootBefore = await Mesh.GetMeshNodeStream(_partition)
+            .Where(n => n is { NodeType: "Space" }).Should().Within(30.Seconds()).Emit();
+
+        (await Import()).Single(r => r.Partition == _partition).Outcome.Should().Be("Skipped");
+
+        var rootAfter = await Mesh.GetMeshNodeStream(_partition)
+            .Where(n => n is { NodeType: "Space" }).Should().Within(30.Seconds()).Emit();
+        rootAfter!.Version.Should().Be(rootBefore!.Version,
+            "an unchanged-fingerprint boot skip must not rewrite the partition root — every boot "
+            + "bumping the root Version is the write fan-out that starved the memex boot");
+    }
+
+    /// <summary>
     /// SELF-HEALING content sync: a prior Succeeded import marks the partition "done" — but if the
     /// CONTENT nodes are later dropped (a cross-partition prune, a manual delete, a botched migration)
     /// while the <c>_Activity/import-*</c> marker survives, the old marker short-circuit skipped the


### PR DESCRIPTION
## Why

Every memex-cloud portal crash over 2026-07-15..22 (8 events, verified in Loki) is the same self-inflicted death — **not OOM**: the boot-time mesh-wide initialization storm starves the silo until its peers vote it dead and Orleans `FailFast`s ("I have been told I am dead, so this silo will stop!"). On 2026-07-20 **both** silos voted each other dead within a second — a full outage. The storm at every pod start:

- `DynamicTypePreWarmer` enumerates **every NodeType across every partition** and activates + Roslyn-compiles each dynamic one (~25 UWDeepfield types alone, plus BusinessRules, Reinsurance, DataModeling, ClaimsDeepfield, Chess, …).
- `ShippedReleaseSeed` stream-reads every code NodeType in 6 shipped partitions.
- `StaticRepoImporter`'s unchanged-fingerprint skip path still **re-upserted** the partition root + every governance node for Doc/Agent/Provider/Harness/Skill — each write activating a per-node hub that queued behind the storm and timed out at 30s (`[UpdateQueue] FAILED path=Skill … no initial state arrived within 30s`).

## What

Startup now does **no mesh-wide work by default** — the checkpoint/manifest machinery that already exists (partition fingerprint + per-node token manifest at `_Activity/import-manifest`) is honored all the way down:

- **DynamicTypePreWarmer**: config-gated (`PreWarm:DynamicTypes`), **default off**. First access already compiles lazily via `WaitForCompileSettled`; the warm-up was purely a latency optimization.
- **ShippedReleaseSeed**: shipped-partition pre-build opt-in (`ShippedRelease:PreseedEnabled`, default off). `ShippedRelease:ExtraPreseedPartitions` still seeds exactly what a deployment names (e.g. atioz `AgenticPension`). The one-node Admin platform-version anchor + boot activity stay.
- **StaticRepoImporter skip path**: **read-first** governance heal. An unchanged-fingerprint boot verifies root + governance via query and writes only what is actually missing, instead of unconditionally rewriting the root (Version bump every boot) + every governance node. Self-heal semantics preserved: an absent root/governance node is still recreated, and a missing content sentinel still forces the full re-import.
- **Orleans membership tolerance** (distributed portal): `ProbeTimeout` 15s × `NumMissedProbesLimit` 5 + indirect probes — a transiently starved-but-alive silo recovers instead of being voted dead; a truly wedged pod is still restarted by the k8s `/alive` liveness probe (6×15s), so real failures don't linger.

Result: a steady-state boot is a handful of DB queries (one fingerprint-marker check + a few existence checks per static partition), zero mesh writes, zero compiles — and even a genuinely heavy boot (changed content, full re-import) no longer gets the silo executed for being busy.

## Tests

- `MeshWeaver.Graph.Test` importer suite: 13/13
- `MeshWeaver.Hosting.PostgreSql.Test` StaticRepoImporterTests: 8/8, incl. new `SkippedReimport_IsReadOnly_DoesNotRewriteRoot` pinning the write-free skip
- `MeshWeaver.Hosting.Orleans.Test` StaticRepoImport: green
- `MeshWeaver.Hosting.Monolith.Test` DynamicTypePreWarmerTest: 1/1 (tests `WarmDynamicTypes` directly; the gate is on the hosted service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)