### PR TITLE
Fix NodeType-compilation memory leaks (ALC-per-recompile + LSP workspace)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
@@ -798,14 +798,68 @@ internal class CompilationCacheService(
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        return _loadContexts.GetOrAdd(dllPath, path =>
+        var created = false;
+        var ctx = _loadContexts.GetOrAdd(dllPath, path =>
         {
+            created = true;
             logger.LogDebug("Creating new path-keyed AssemblyLoadContext for {NodeName} at {DllPath}", nodeName, path);
-            var ctx = new NodeAssemblyLoadContext(nodeName, path, logger);
+            var c = new NodeAssemblyLoadContext(nodeName, path, logger);
             if (_probingDirs.TryGetValue(nodeName, out var dirs) && !dirs.IsDefaultOrEmpty)
-                ctx.SetProbingDirectories(dirs);
-            return ctx;
+                c.SetProbingDirectories(dirs);
+            return c;
         });
+
+        // A genuinely NEW path-keyed context means a fresh compile/release just superseded any
+        // prior assembly for this NodeType. Each recompile writes to a unique
+        // {nodeName}_{timestamp}_{guid} directory (see EmitToDiskWithRetry), so the OLD entries —
+        // same NodeName, different key — are never reused. Left in place they pin their collectible
+        // NodeAssemblyLoadContext (and its native metadata/JIT images) for the ENTIRE life of the
+        // (long-lived) NodeType hub, unloaded only on hub teardown (UnloadNodeContexts). That
+        // per-recompile accumulation is the native-memory leak that drove memex to the server-GC
+        // hard limit (~21 GB at the 28 Gi cap) and its GC-thrash crashes. Evict them now — but only
+        // when WE added the current context (created), so a re-request of an already-cached path can
+        // never evict the live assembly. See EvictSupersededContexts for why this is safe mid-recompile.
+        if (created)
+            EvictSupersededContexts(nodeName, keepKey: dllPath);
+
+        return ctx;
+    }
+
+    /// <summary>
+    /// Unloads every load context for <paramref name="nodeName"/> whose dictionary key is not
+    /// <paramref name="keepKey"/> — the assemblies a just-loaded recompile/release superseded —
+    /// bounding <see cref="_loadContexts"/> to the current context per NodeType instead of one per
+    /// recompile.
+    /// </summary>
+    /// <remarks>
+    /// Safe to call mid-recompile, while old instance hubs may still be running on the superseded
+    /// assembly: <see cref="NodeAssemblyLoadContext.Dispose"/> calls the COOPERATIVE
+    /// <see cref="System.Runtime.Loader.AssemblyLoadContext.Unload"/>, which does not rip out loaded
+    /// types — a context still referenced by a live hub stays fully mapped and usable and is
+    /// collected only once that hub recycles onto the new assembly and drops its last reference. The
+    /// context's <c>Unloading</c> handler (<c>ReflectionCacheEviction.EvictFor</c>) purges Autofac's
+    /// shared reflection cache so the freed context is neither rooted nor left as a dangling key.
+    /// Mirrors the match in <see cref="UnloadNodeContexts"/>/<see cref="InvalidateCache"/> (both key
+    /// on <see cref="NodeAssemblyLoadContext.NodeName"/>), just triggered per recompile rather than
+    /// only on hub teardown.
+    /// </remarks>
+    private void EvictSupersededContexts(string nodeName, string keepKey)
+    {
+        if (_disposed)
+            return;
+
+        var stale = _loadContexts
+            .Where(kvp => !string.Equals(kvp.Key, keepKey, StringComparison.Ordinal)
+                       && string.Equals(kvp.Value.NodeName, nodeName, StringComparison.Ordinal))
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (var key in stale)
+            UnloadContext(key);
+
+        if (stale.Count > 0)
+            logger.LogDebug("Evicted {Count} superseded AssemblyLoadContext(s) for recompiled node {NodeName}",
+                stale.Count, nodeName);
     }
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
@@ -92,6 +92,23 @@ internal sealed class MeshNodeLanguageService(
                         : _ioPool.Run(ct =>
                             speculativeCompilation.GetDiagnosticsAsync(inputs, sourcePath, proposedCode, ct))));
 
+    /// <inheritdoc />
+    public void Evict(string nodeTypePath)
+    {
+        // Drop + dispose the cached AdhocWorkspace so its CSharpCompilation / SyntaxTrees /
+        // symbol graph are released the moment the NodeType hub disposes, rather than lingering
+        // for the life of this singleton. Dispose() is the same release BuildOrReuseWorkspace does
+        // on a version change; here it is triggered by node deletion / hub teardown instead.
+        if (_cache.TryRemove(nodeTypePath, out var cached))
+        {
+            cached.Workspace.Dispose();
+            logger.LogDebug("Evicted cached AdhocWorkspace for disposed NodeType {NodeTypePath}", nodeTypePath);
+        }
+    }
+
+    /// <summary>Test seam (InternalsVisibleTo): is a workspace currently cached for this NodeType?</summary>
+    internal bool IsWorkspaceCached(string nodeTypePath) => _cache.ContainsKey(nodeTypePath);
+
     /// <summary>
     /// Resolves the NodeType MeshNode, fetches <see cref="CompilationInputs"/>, and builds
     /// (or reuses) an <see cref="AdhocWorkspace"/> whose Documents mirror the input sources.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -12,6 +12,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Services.LanguageServer;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -689,6 +690,16 @@ public static class MeshDataSourceExtensions
                 var sanitizedNodeName = compilationCache.SanitizeNodeName(hub.Address.Path);
                 hub.RegisterForDisposal(_ => compilationCache.UnloadNodeContexts(sanitizedNodeName));
             }
+
+            // 🚨 Memory: same per-node reclaim for the LSP workspace cache. The language service is a
+            // singleton whose _cache holds one AdhocWorkspace — a full Roslyn CSharpCompilation +
+            // SyntaxTrees + symbol graph — per NodeType path, never evicted once queried. Drop this
+            // node's entry on hub teardown so that managed Roslyn heap (the 619 MB memex managed leak)
+            // is released with the node instead of held for the process lifetime. No-op for nodes the
+            // language service never cached.
+            var languageService = hub.ServiceProvider.GetService<IMeshLanguageService>();
+            if (languageService != null)
+                hub.RegisterForDisposal(_ => languageService.Evict(hub.Address.Path));
 
             // Persistence sampler: posts SaveMeshNodeRequest to the per-node
             // hub at most every SaveSampleInterval, with the latest version of

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshLanguageService.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshLanguageService.cs
@@ -64,6 +64,22 @@ public interface IMeshLanguageService
         string nodeTypePath,
         string sourcePath,
         string proposedCode);
+
+    /// <summary>
+    /// Drops and disposes the cached Roslyn workspace for <paramref name="nodeTypePath"/>, if any.
+    /// Called when the NodeType's hub disposes (node deleted / grain deactivated) so its
+    /// <c>AdhocWorkspace</c> — which strongly roots a full <c>CSharpCompilation</c>, every
+    /// <c>SyntaxTree</c> and the whole <c>PENamedTypeSymbol</c>/<c>MetadataReference</c> symbol graph
+    /// — does not linger for the life of this singleton service. Without it the cache is bounded
+    /// only by "distinct NodeTypes ever queried by the language service," each entry an enormous
+    /// managed Roslyn graph held forever (the 619 MB managed Roslyn heap seen on memex).
+    /// <para>
+    /// A synchronous fire-and-forget cleanup, NOT part of the reactive query surface: it neither
+    /// blocks nor awaits, so it is safe to call from a hub-disposal callback. A no-op when nothing
+    /// is cached for the path.
+    /// </para>
+    /// </summary>
+    void Evict(string nodeTypePath);
 }
 
 /// <summary>0-based line/character position. LSP convention (Monaco is 1-based for lines — converted at the boundary).</summary>

--- a/test/MeshWeaver.Graph.Test/AssemblyLoadContextLeakTest.cs
+++ b/test/MeshWeaver.Graph.Test/AssemblyLoadContextLeakTest.cs
@@ -161,4 +161,66 @@ public sealed class AssemblyLoadContextLeakTest : IDisposable
         weak.IsAlive.Should().BeFalse(
             "UnloadContext must release the collectible context so per-node disposal reclaims memory");
     }
+
+    /// <summary>Emit a tiny assembly to a UNIQUE on-disk path — one recompile's output.</summary>
+    private string EmitTinyAssemblyToDisk(string asmName, string typeName)
+    {
+        var bytes = EmitTinyAssembly(asmName, typeName);
+        // Mirror EmitToDiskWithRetry: each release writes to its own {name}_{guid} subdir, so
+        // successive loads of the same node land on DIFFERENT keys in _loadContexts.
+        var dir = Path.Combine(_cacheDir, $"{asmName}_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var dll = Path.Combine(dir, $"{asmName}.dll");
+        File.WriteAllBytes(dll, bytes);
+        return dll;
+    }
+
+    /// <summary>
+    /// Load an emitted assembly through the path-keyed context (the live recompile path,
+    /// <c>CompileResultFromAssembly</c> → <c>GetOrCreateLoadContextForPath</c>), USE its type, and
+    /// return ONLY a weak ref to the context. Locals die with this <see cref="MethodImplOptions.NoInlining"/>
+    /// frame so no strong ref survives on the caller's stack.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private WeakReference LoadPathAndWeakRef(string nodeName, string dllPath)
+    {
+        var context = _service.GetOrCreateLoadContextForPath(nodeName, dllPath);
+        var assembly = context.LoadNodeAssembly();
+        assembly.Should().NotBeNull("the emitted assembly must load from its path-keyed context");
+        var type = assembly!.GetTypes().FirstOrDefault(t => t.IsClass);
+        type.Should().NotBeNull();
+        Activator.CreateInstance(type!).Should().NotBeNull();
+        return new WeakReference(context);
+    }
+
+    /// <summary>
+    /// 🚨 The per-recompile reclaim (the memex native-memory leak). A long-lived NodeType hub is
+    /// recompiled repeatedly WITHOUT tearing down; each recompile writes a new unique path and loads
+    /// it via <see cref="CompilationCacheService.GetOrCreateLoadContextForPath"/>. Loading the NEW
+    /// path must evict + collect the SUPERSEDED context for the same NodeType then and there — not
+    /// only on hub teardown (<c>UnloadNodeContexts</c>). If RED, every recompile pins another
+    /// collectible ALC + its native metadata/JIT for the hub's whole life → unbounded growth to the
+    /// GC hard limit → the GC-thrash crash. The current context must survive (not over-evicted).
+    /// </summary>
+    [Fact]
+    public void RecompileToNewPath_EvictsAndCollects_SupersededContext_WithoutTeardown()
+    {
+        const string node = "recompile_evict_node";
+
+        var v1Dll = EmitTinyAssemblyToDisk($"GenAsm_{node}_v1", "Widget");
+        var weakV1 = LoadPathAndWeakRef(node, v1Dll);
+        weakV1.IsAlive.Should().BeTrue("V1's context is held by the cache after the first load");
+
+        // A recompile: a NEW unique path for the SAME node. Loading it evicts V1's superseded context.
+        var v2Dll = EmitTinyAssemblyToDisk($"GenAsm_{node}_v2", "Widget");
+        var weakV2 = LoadPathAndWeakRef(node, v2Dll);
+
+        ForceCollect(weakV1);
+
+        weakV1.IsAlive.Should().BeFalse(
+            "loading a new path for the same NodeType must evict + collect the SUPERSEDED " +
+            "AssemblyLoadContext without waiting for hub teardown — otherwise every recompile leaks an ALC");
+        weakV2.IsAlive.Should().BeTrue(
+            "the CURRENT context (just-loaded V2) must NOT be evicted — it is the live assembly the hub runs on");
+    }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs
@@ -266,6 +266,42 @@ public record DiagDemo
     }
 
     [Fact]
+    public async Task Evict_DropsCachedWorkspace_ForDisposedNodeType()
+    {
+        // A query builds + caches the NodeType's AdhocWorkspace (a full CSharpCompilation + symbol
+        // graph). Without eviction that entry lives for the singleton's whole life — the managed
+        // Roslyn leak. Evict (the hub-disposal reclaim) must drop + dispose it.
+        await SeedNodeType(
+            "EvictDemo",
+            new NodeTypeDefinition { Configuration = "config => config.WithContentType<EvictDemo>()" },
+            ("EvictDemo.cs", @"
+public record EvictDemo
+{
+    public string Id { get; init; } = string.Empty;
+}")).Should().Within(60.Seconds()).Emit();
+
+        const string nodeTypePath = "type/EvictDemo";
+
+        await LanguageService.GetDiagnostics(nodeTypePath).Should().Within(60.Seconds()).Emit();
+
+        var concrete = (MeshNodeLanguageService)LanguageService;
+        concrete.IsWorkspaceCached(nodeTypePath).Should().BeTrue(
+            "querying the language service must cache a Roslyn workspace for the NodeType");
+
+        LanguageService.Evict(nodeTypePath);
+
+        concrete.IsWorkspaceCached(nodeTypePath).Should().BeFalse(
+            "Evict must drop the cache entry — otherwise the cache grows one full Roslyn graph per " +
+            "NodeType ever queried, held for the process lifetime (the memex managed Roslyn leak)");
+
+        // Idempotent + safe on an already-evicted / never-queried path (the disposal hook fires for
+        // EVERY node hub, most of which the language service never cached).
+        LanguageService.Evict(nodeTypePath);
+        LanguageService.Evict("type/NeverQueried");
+        concrete.IsWorkspaceCached("type/NeverQueried").Should().BeFalse();
+    }
+
+    [Fact]
     public async Task GetHover_OnPropertyInsideRecord_ReturnsMarkdown()
     {
         // Position the cursor over the `string` keyword in a property declaration, expect


### PR DESCRIPTION
## The leak (memex-cloud, 2026-07-22)

The portal heap climbed to the server-GC hard limit (**~21 GB** at the 28 Gi cap), producing back-to-back 5–6 s Gen2 GC pauses → **liveness/readiness-probe timeouts and restarts**. A live heap dump (`dotnet-gcdump`) showed the *rooted, post-GC* managed heap dominated by `Microsoft.CodeAnalysis.*` Roslyn objects (**619 MB**) with a **~5.4 GB native gap** of accumulated assembly metadata/JIT. Two caches, each keyed per-NodeType, were never evicted during the (long-lived) NodeType hubs' lifetimes:

### 1. `CompilationCacheService` — per-recompile ALC accumulation (the native bulk)
Every recompile emits to a unique `{node}_{timestamp}_{guid}` directory, so `GetOrCreateLoadContextForPath` added a **new** collectible `NodeAssemblyLoadContext` per recompile (the live path from `CompileResultFromAssembly`). The old contexts — same `NodeName`, different key — were only unloaded on **hub teardown** (`UnloadNodeContexts`), so a NodeType hub recompiled *N* times pinned *N* assemblies + their native images for its whole life.

**Fix:** on loading a genuinely new path, `EvictSupersededContexts` `Unload()`s the prior contexts for that NodeType. Safe mid-recompile — `AssemblyLoadContext.Unload()` is **cooperative**: a context still referenced by a running instance hub stays fully mapped and is collected only once that hub recycles onto the new assembly. The existing `ReflectionCacheEviction.EvictFor` (already on the `Unloading` event) purges Autofac's shared reflection cache so nothing is rooted or left dangling.

### 2. `MeshNodeLanguageService` — LSP `AdhocWorkspace` never evicted (the 619 MB managed)
The singleton's `_cache` held one `AdhocWorkspace` — a full `CSharpCompilation` + syntax trees + symbol graph — **per NodeType ever queried**, released only when the *same* NodeType's sources changed, never on deletion.

**Fix:** `IMeshLanguageService.Evict(nodeTypePath)` drops + disposes the workspace, wired into the NodeType hub's disposal hook in `MeshDataSource` (next to the existing ALC unload).

## Tests (all green)
- `AssemblyLoadContextLeakTest.RecompileToNewPath_EvictsAndCollects_SupersededContext_WithoutTeardown` — WeakReference proof that recompiling to a new path GC-collects the **superseded** ALC (delta → 0) while keeping the **current** one live.
- `MeshNodeLanguageServiceTest.Evict_DropsCachedWorkspace_ForDisposedNodeType` — the cache entry is dropped + disposed; idempotent/safe on absent paths.
- Full `MeshWeaver.Graph.Test` (39) + Monolith LSP/recompile/assembly-leak suites (16), incl. `CodeEditRecompileTest`, pass — recompile-then-serve is unaffected.

## Not in scope (flagged)
- The **exit=139 SIGSEGV** is a *separate*, CI-only issue — the ClrMD DAC pthread destructor, already fixed in `fc0843cba`. Production uses no ClrMD, so its crashes are this leak's GC thrash, not that bug.
- The **release-serving path** (`LoadAndExtractConfigurationsFromReleaseAsync` → `GetOrCreateLoadContextForRelease`, keyed by `release.Path`) is secondary and its eviction/teardown-matching should be verified separately — left untouched to avoid an unverified change to the ALC lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)