### PR TITLE
Self-heal grain activation across a transient Postgres outage

### DIFF
--- a/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting.PostgreSql/PostgreSqlStorageAdapter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reactive;
 using MeshWeaver.Hosting.Embeddings;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
@@ -218,9 +219,106 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     private static bool IsUndefinedTable(Exception ex)
         => ex is PostgresException pg && pg.SqlState == "42P01";
 
+    // Transient Postgres connectivity faults (connection dropped / endpoint momentarily
+    // unreachable) get a SHORT bounded retry at the read leaf so a sub-second-to-second blip
+    // (the common case during a host reboot or failover) never surfaces as a hard read fault.
+    // A LONGER outage exhausts these retries and the fault propagates — the upstream
+    // MeshNodeStreamCache classifies it as transient (IsTransientDatabaseFailure) and its ≤60s
+    // breaker self-heals the activation instead of wedging it until a manual recycle (the memex
+    // AgenticEngineering incident, 2026-07-23). Deliberately short (≤3 retries, 200→800ms) so it
+    // never approaches the 60s SubscribeRequest budget. READS only — writes are never
+    // auto-retried (no idempotency key ⇒ replay risk).
+    private const int MaxTransientReadRetries = 3;
+
+    private static readonly HashSet<string> TransientPostgresSqlStates = new(StringComparer.Ordinal)
+    {
+        "57P01", "57P02", "57P03",                     // admin/crash shutdown, cannot_connect_now (startup)
+        "53300", "53400",                              // too_many_connections, configuration_limit_exceeded
+        "08000", "08001", "08003", "08004", "08006",   // connection_exception family
+        "40001", "40P01",                              // serialization_failure, deadlock_detected (retryable)
+    };
+
+    /// <summary>
+    /// True when <paramref name="ex"/> (or an inner exception) is a TRANSIENT Postgres
+    /// connectivity fault worth a bounded retry — a dropped/unreachable connection, a server
+    /// restart/failover, connection/pool exhaustion, or a serialization/deadlock race — as
+    /// opposed to a real query/schema error. A <see cref="PostgresException"/> with a
+    /// non-transient <c>SqlState</c> (e.g. <c>42P01</c> undefined_table, <c>23505</c> unique
+    /// violation, a syntax error) is NOT transient and must propagate. A bare
+    /// <see cref="NpgsqlException"/> that is not a server <see cref="PostgresException"/> is a
+    /// client/connection failure ("Failed to connect", "Timeout during connection attempt") and
+    /// IS transient.
+    /// </summary>
+    internal static bool IsTransientConnectionFault(Exception? ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            switch (e)
+            {
+                case TimeoutException:
+                case System.Net.Sockets.SocketException:
+                    return true;
+                case PostgresException pg when TransientPostgresSqlStates.Contains(pg.SqlState):
+                    return true;
+                case PostgresException:
+                    break; // a real server error (42P01, 23505, syntax, …) — not transient
+                case NpgsqlException:
+                    return true; // connection-layer Npgsql failure (not a server error)
+            }
+        }
+        return false;
+    }
+
+    /// <summary>Bounded exponential backoff for the transient-read retry: 200ms, 400ms, 800ms (capped).</summary>
+    internal static TimeSpan TransientReadBackoff(int attempt)
+        => TimeSpan.FromMilliseconds(Math.Min(200 * Math.Pow(2, attempt), 800));
+
+    /// <summary>
+    /// Wraps a cold read observable with a bounded exponential-backoff retry that fires ONLY on
+    /// <see cref="IsTransientConnectionFault"/>. Any non-transient error (and any transient fault
+    /// past <see cref="MaxTransientReadRetries"/>) propagates unchanged so the caller's existing
+    /// <c>.Catch(IsUndefinedTable …)</c> and the upstream breaker still see the real exception.
+    /// </summary>
+    private IObservable<T> WithTransientRetry<T>(Func<IObservable<T>> read, string op)
+        => RetryTransientReads(read, IsTransientConnectionFault, MaxTransientReadRetries,
+            TransientReadBackoff,
+            (ex, attempt, delay) => _logger?.LogWarning(ex,
+                "PostgreSqlStorageAdapter: transient DB fault on {Op}, attempt {Attempt}/{Max}, retrying in {Delay}ms",
+                op, attempt, MaxTransientReadRetries, delay.TotalMilliseconds),
+            scheduler: null);
+
+    /// <summary>
+    /// Deterministically testable core of <see cref="WithTransientRetry{T}"/>: re-subscribes the
+    /// cold <paramref name="read"/> on a transient fault with <paramref name="backoff"/> delay, up
+    /// to <paramref name="maxRetries"/>, then lets the fault propagate. Split out (with an injectable
+    /// <paramref name="scheduler"/>) so tests can drive the backoff with a <c>TestScheduler</c> —
+    /// mirrors <c>RoutingGrain.DeliverToGrainObservable</c>.
+    /// </summary>
+    internal static IObservable<T> RetryTransientReads<T>(
+        Func<IObservable<T>> read,
+        Func<Exception, bool> isTransient,
+        int maxRetries,
+        Func<int, TimeSpan> backoff,
+        Action<Exception, int, TimeSpan>? onRetry = null,
+        IScheduler? scheduler = null)
+    {
+        var sch = scheduler ?? Scheduler.Default;
+        return Observable.Defer(read)
+            .RetryWhen(errors => errors
+                .Select((ex, i) => (Exception: ex, Attempt: i))
+                .SelectMany(t =>
+                {
+                    if (t.Attempt >= maxRetries || !isTransient(t.Exception))
+                        return Observable.Throw<long>(t.Exception);
+                    var delay = backoff(t.Attempt);
+                    onRetry?.Invoke(t.Exception, t.Attempt + 1, delay);
+                    return Observable.Timer(delay, sch);
+                }));
+    }
+
     /// <inheritdoc />
     public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
-        => _ioPool.Invoke(ct => ReadAsyncCore(path, options, ct));
+        => WithTransientRetry(() => _ioPool.Invoke(ct => ReadAsyncCore(path, options, ct)), "Read");
 
     private async Task<MeshNode?> ReadAsyncCore(string path, JsonSerializerOptions options, CancellationToken ct)
     {
@@ -497,7 +595,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
 
     /// <inheritdoc />
     public IObservable<bool> Exists(string path)
-        => _ioPool.Invoke(ct => ExistsAsyncCore(path, ct))
+        => WithTransientRetry(() => _ioPool.Invoke(ct => ExistsAsyncCore(path, ct)), "Exists")
             .Catch<bool, Exception>(ex => IsUndefinedTable(ex)
                 ? Observable.Return(false)
                 : Observable.Throw<bool>(ex));
@@ -523,7 +621,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     /// <inheritdoc />
     public IObservable<(MeshNode? Node, int MatchedSegments)> FindBestPrefixMatch(
         string fullPath, JsonSerializerOptions options)
-        => _ioPool.Invoke(ct => FindBestPrefixMatchAsyncCore(fullPath, options, ct))
+        => WithTransientRetry(() => _ioPool.Invoke(ct => FindBestPrefixMatchAsyncCore(fullPath, options, ct)), "FindBestPrefixMatch")
             .Catch<(MeshNode?, int), Exception>(ex => IsUndefinedTable(ex)
                 ? Observable.Return<(MeshNode?, int)>((null, 0))
                 : Observable.Throw<(MeshNode?, int)>(ex));
@@ -566,7 +664,7 @@ public class PostgreSqlStorageAdapter : IScopedQueryStorageAdapter, IAsyncDispos
     /// </summary>
     public IObservable<(MeshNode? Node, int MatchedSegments)> ResolvePath(
         string fullPath, JsonSerializerOptions options)
-        => _ioPool.Invoke(ct => ResolvePathAsyncCore(fullPath, options, ct))
+        => WithTransientRetry(() => _ioPool.Invoke(ct => ResolvePathAsyncCore(fullPath, options, ct)), "ResolvePath")
             .Catch<(MeshNode?, int), Exception>(ex => IsUndefinedTable(ex)
                 ? Observable.Return<(MeshNode?, int)>((null, 0))
                 : Observable.Throw<(MeshNode?, int)>(ex));

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -1122,9 +1122,61 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             // Transient by design — the address may reactivate (recycle), and if the node is
             // genuinely gone the NEXT probe gets the authoritative routing NotFound.
             if (msg.Contains("is shutting down", StringComparison.OrdinalIgnoreCase)) return true;
+            // A silo that momentarily lost its Postgres connection (host reboot, network
+            // blackout, admin restart/failover, pool exhaustion) surfaces the owner READ as
+            // an Npgsql/Postgres fault. This is a node-EXISTS-but-DB-unreachable miss — the
+            // node is fine, the connection is not, so a later read succeeds and the transient
+            // breaker's ≤60s re-probe self-heals it. Without this the fault fell through to
+            // the un-broker'd "faulted forever" bucket and permanently wedged EVERY
+            // re-activation until a manual recycle (memex AgenticEngineering, 2026-07-23:
+            // Azure emergency host repair rebooted the node → PG unreachable ~2 min → course
+            // dead until an admin recycle). See IsTransientDatabaseFailure.
+            if (IsTransientDatabaseFailure(msg)) return true;
         }
         return false;
     }
+
+    /// <summary>
+    /// Canonical markers of a TRANSIENT database-connectivity fault — the connection
+    /// dropped or the endpoint was momentarily unreachable, not a query/schema error
+    /// (a real error such as <c>42P01</c> undefined_table must NOT match — it is a
+    /// legitimate "no such relation", handled elsewhere as an empty read).
+    /// <para>Matched by MESSAGE, not exception type, on purpose: across the Orleans grain
+    /// boundary the typed <c>NpgsqlException</c>/<c>PostgresException</c> is flattened to
+    /// its message string (the inner <see cref="TimeoutException"/> object does not survive
+    /// serialization), so the same string is what reaches the cache whether the read faulted
+    /// in-process (monolith) or cross-silo (Orleans portal). Kept in sync with the mirrored
+    /// classifiers <c>AreaErrorClassifier.IsTransientHubFailure</c>,
+    /// <c>RoutingGrain.IsTransientFailure</c> and
+    /// <c>SynchronizationStream.IsTransientHubTimeout</c>.</para>
+    /// </summary>
+    internal static readonly string[] TransientDatabaseFailureMarkers =
+    [
+        "Failed to connect",                                    // Npgsql: endpoint unreachable
+        "Timeout during connection attempt",                    // Npgsql: connect timed out
+        "error connecting",                                     // Npgsql connect wrapper
+        "connection reset",                                     // socket reset by peer
+        "existing connection was forcibly closed",              // Windows socket reset
+        "server closed the connection unexpectedly",            // backend gone mid-query
+        "connection pool has been exhausted",                   // pool starvation during a blackout
+        "terminating connection due to administrator command",  // 57P01 admin_shutdown / failover
+        "the database system is starting up",                   // 57P03 — post-restart warmup
+        "the database system is shutting down",                 // 57P03
+        "the database system is in recovery mode",              // crash recovery
+        "no connection could be made",                          // socket refused
+        "connection refused",                                   // socket refused
+    ];
+
+    /// <summary>
+    /// True when <paramref name="message"/> is a transient database-connectivity fault
+    /// (see <see cref="TransientDatabaseFailureMarkers"/>) rather than a real query/schema
+    /// error — so the storm/transient breaker treats it as a retryable miss that self-heals
+    /// instead of caching it as a permanent owner failure.
+    /// </summary>
+    internal static bool IsTransientDatabaseFailure(string? message) =>
+        !string.IsNullOrEmpty(message)
+        && Array.Exists(TransientDatabaseFailureMarkers,
+            m => message.Contains(m, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Returns a per-user access-gated view of the cached shared stream. The

--- a/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheNegativeClassifierTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/MeshNodeStreamCacheNegativeClassifierTest.cs
@@ -130,4 +130,66 @@ public class MeshNodeStreamCacheNegativeClassifierTest
     {
         MeshNodeStreamCache.IsTransientOwnerFailure(null).Should().BeFalse();
     }
+
+    // ---- TRANSIENT DATABASE-CONNECTIVITY: the 2026-07-23 memex outage ----
+    //
+    // An Azure emergency host repair rebooted the silo's node; for ~2 min the silo could not reach
+    // Postgres. The owner READ for the AgenticEngineering NodeType node faulted with an Npgsql
+    // "Failed to connect …", which crossed the Orleans grain boundary FLATTENED to its message
+    // string (the inner TimeoutException object lost in serialization) and reached the cache as a
+    // DeliveryFailureException. Before the fix it matched NEITHER predicate → the entry was marked
+    // faulted with NO breaker window → every re-activation replayed the stale error FOREVER, until
+    // a manual recycle. It MUST classify transient so the ≤60s breaker self-heals it.
+
+    // The verbatim shape the silo routing grain posts when the owner read hits a dead PG endpoint.
+    private const string PgConnectFailureMessage =
+        "Delivery to 'AgenticEngineering' failed: Failed to connect to 10.42.18.4:5432";
+
+    [Fact]
+    public void PostgresConnectFailure_AsNack_IsTransient_NotMissingNode()
+    {
+        var nack = Nack(PgConnectFailureMessage, ErrorType.Failed);
+        MeshNodeStreamCache.IsTransientOwnerFailure(nack).Should().BeTrue(
+            "a lost Postgres connection is a node-EXISTS-but-DB-unreachable miss that self-heals — " +
+            "the exact 2026-07-23 memex wedge");
+        MeshNodeStreamCache.IsMissingNodeFailure(nack).Should().BeFalse(
+            "a transient DB fault must NEVER be recorded as a missing-node negative (it would suppress a live node)");
+    }
+
+    [Theory]
+    [InlineData("Failed to connect to 10.42.18.4:5432")]
+    [InlineData("Timeout during connection attempt")]
+    [InlineData("Exception while connecting: connection reset by peer")]
+    [InlineData("server closed the connection unexpectedly")]
+    [InlineData("The connection pool has been exhausted, either raise MaxPoolSize or Timeout")]
+    [InlineData("57P01: terminating connection due to administrator command")]
+    [InlineData("the database system is starting up")]
+    [InlineData("the database system is in recovery mode")]
+    [InlineData("No connection could be made because the target machine actively refused it")]
+    public void TransientDatabaseFaultMessages_AreTransient(string message)
+    {
+        MeshNodeStreamCache.IsTransientDatabaseFailure(message).Should().BeTrue();
+        MeshNodeStreamCache.IsTransientOwnerFailure(Nack(message, ErrorType.Failed)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TransientDatabaseFault_WrappedAsInner_IsStillTransient()
+    {
+        var wrapped = new InvalidOperationException("owner read failed",
+            new Exception("Failed to connect to 10.42.18.4:5432"));
+        MeshNodeStreamCache.IsTransientOwnerFailure(wrapped).Should().BeTrue(
+            "the classifier walks the inner-exception chain");
+    }
+
+    [Theory]
+    [InlineData("relation \"mesh_nodes\" does not exist")]            // 42P01 — a real missing table, NOT transient
+    [InlineData("duplicate key value violates unique constraint")]    // 23505 — a real write conflict
+    [InlineData("syntax error at or near \"SELCT\"")]                 // a real SQL bug
+    [InlineData("Access denied: user lacks Read permission")]         // an RLS denial
+    [InlineData("")]
+    public void NonTransientMessages_AreNotTransientDatabaseFaults(string message)
+    {
+        MeshNodeStreamCache.IsTransientDatabaseFailure(message).Should().BeFalse(
+            "only connectivity faults are transient — a real query/schema/permission error must propagate");
+    }
 }

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/PostgreSqlTransientRetryTest.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/PostgreSqlTransientRetryTest.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Net.Sockets;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using Npgsql;
+using Xunit;
+
+namespace MeshWeaver.Hosting.PostgreSql.Test;
+
+/// <summary>
+/// Deterministic unit tests for the <see cref="PostgreSqlStorageAdapter"/> transient-read
+/// resilience added after the 2026-07-23 memex outage (an Azure emergency host repair rebooted
+/// the silo's node; for ~2 min the silo could not reach Postgres, and the un-retried read fault
+/// wedged grain re-activation until a manual recycle).
+///
+/// <para>Two things are pinned: (1) the connectivity-vs-real-error classifier
+/// <see cref="PostgreSqlStorageAdapter.IsTransientConnectionFault"/> — a dropped/unreachable
+/// connection is transient, a real query/schema error (42P01, 23505, syntax) is NOT; and (2) the
+/// bounded backoff retry <see cref="PostgreSqlStorageAdapter.RetryTransientReads{T}"/> — it
+/// re-subscribes the cold read on a transient fault up to the limit, then lets the fault
+/// propagate to the caller's <c>.Catch(IsUndefinedTable …)</c> and the upstream breaker.</para>
+/// </summary>
+public class PostgreSqlTransientRetryTest
+{
+    // A server PostgresException with a specific SqlState (the 4-arg public ctor).
+    private static PostgresException Pg(string sqlState) =>
+        new("some message", "ERROR", "ERROR", sqlState);
+
+    // ---- Classifier: transient connectivity faults ----
+
+    [Fact]
+    public void NpgsqlConnectFailure_IsTransient() =>
+        Assert.True(PostgreSqlStorageAdapter.IsTransientConnectionFault(
+            new NpgsqlException("Failed to connect to 10.42.18.4:5432")));
+
+    [Fact]
+    public void TimeoutException_IsTransient() =>
+        Assert.True(PostgreSqlStorageAdapter.IsTransientConnectionFault(new TimeoutException()));
+
+    [Fact]
+    public void SocketException_IsTransient() =>
+        Assert.True(PostgreSqlStorageAdapter.IsTransientConnectionFault(new SocketException(10061)));
+
+    [Theory]
+    [InlineData("57P01")] // admin_shutdown / failover
+    [InlineData("57P03")] // cannot_connect_now (starting up)
+    [InlineData("53300")] // too_many_connections
+    [InlineData("08006")] // connection_failure
+    [InlineData("08001")] // unable_to_establish
+    [InlineData("40001")] // serialization_failure (retryable)
+    [InlineData("40P01")] // deadlock_detected (retryable)
+    public void TransientSqlStates_AreTransient(string sqlState) =>
+        Assert.True(PostgreSqlStorageAdapter.IsTransientConnectionFault(Pg(sqlState)));
+
+    [Fact]
+    public void TransientFault_NestedAsInner_IsTransient() =>
+        Assert.True(PostgreSqlStorageAdapter.IsTransientConnectionFault(
+            new InvalidOperationException("read failed", new NpgsqlException("Timeout during connection attempt"))));
+
+    // ---- Classifier: real errors are NOT transient (must propagate) ----
+
+    [Theory]
+    [InlineData("42P01")] // undefined_table — a legit "no such relation", handled as an empty read
+    [InlineData("23505")] // unique_violation — a real write conflict
+    [InlineData("42601")] // syntax_error
+    [InlineData("42501")] // insufficient_privilege (RLS)
+    public void RealServerErrors_AreNotTransient(string sqlState) =>
+        Assert.False(PostgreSqlStorageAdapter.IsTransientConnectionFault(Pg(sqlState)));
+
+    [Fact]
+    public void UnrelatedException_IsNotTransient() =>
+        Assert.False(PostgreSqlStorageAdapter.IsTransientConnectionFault(new InvalidOperationException("boom")));
+
+    [Fact]
+    public void Null_IsNotTransient() =>
+        Assert.False(PostgreSqlStorageAdapter.IsTransientConnectionFault(null));
+
+    // ---- Backoff shape ----
+
+    [Theory]
+    [InlineData(0, 200)]
+    [InlineData(1, 400)]
+    [InlineData(2, 800)]
+    [InlineData(3, 800)] // capped
+    [InlineData(5, 800)] // capped
+    public void Backoff_IsBoundedExponential(int attempt, int expectedMs) =>
+        Assert.Equal(expectedMs, (int)PostgreSqlStorageAdapter.TransientReadBackoff(attempt).TotalMilliseconds);
+
+    // ---- Retry policy behaviour (deterministic: immediate scheduler + zero backoff) ----
+
+    private static readonly Func<int, TimeSpan> NoDelay = _ => TimeSpan.Zero;
+
+    [Fact]
+    public void Retry_RecoversAfterTransientFaults()
+    {
+        var subscribes = 0;
+        Func<IObservable<int>> read = () =>
+        {
+            var n = ++subscribes;
+            return n <= 2 ? Observable.Throw<int>(new NpgsqlException("Failed to connect")) : Observable.Return(42);
+        };
+
+        var result = PostgreSqlStorageAdapter
+            .RetryTransientReads(read, PostgreSqlStorageAdapter.IsTransientConnectionFault, maxRetries: 3, NoDelay, scheduler: Scheduler.Immediate)
+            .Wait();
+
+        Assert.Equal(42, result);
+        Assert.Equal(3, subscribes); // 2 transient failures + 1 success
+    }
+
+    [Fact]
+    public void Retry_GivesUpAfterMaxRetries_ThenPropagates()
+    {
+        var subscribes = 0;
+        Func<IObservable<int>> read = () =>
+        {
+            subscribes++;
+            return Observable.Throw<int>(new NpgsqlException("Failed to connect"));
+        };
+
+        Assert.Throws<NpgsqlException>(() => PostgreSqlStorageAdapter
+            .RetryTransientReads(read, PostgreSqlStorageAdapter.IsTransientConnectionFault, maxRetries: 3, NoDelay, scheduler: Scheduler.Immediate)
+            .Wait());
+
+        Assert.Equal(4, subscribes); // initial + 3 retries
+    }
+
+    [Fact]
+    public void Retry_DoesNotRetryRealErrors()
+    {
+        var subscribes = 0;
+        Func<IObservable<int>> read = () =>
+        {
+            subscribes++;
+            return Observable.Throw<int>(Pg("42P01")); // undefined_table — not transient
+        };
+
+        Assert.Throws<PostgresException>(() => PostgreSqlStorageAdapter
+            .RetryTransientReads(read, PostgreSqlStorageAdapter.IsTransientConnectionFault, maxRetries: 3, NoDelay, scheduler: Scheduler.Immediate)
+            .Wait());
+
+        Assert.Equal(1, subscribes); // no retry on a real error
+    }
+
+    [Fact]
+    public void Retry_PassesThroughSuccess_NoRetry()
+    {
+        var subscribes = 0;
+        Func<IObservable<int>> read = () => { subscribes++; return Observable.Return(7); };
+
+        var result = PostgreSqlStorageAdapter
+            .RetryTransientReads(read, PostgreSqlStorageAdapter.IsTransientConnectionFault, maxRetries: 3, NoDelay, scheduler: Scheduler.Immediate)
+            .Wait();
+
+        Assert.Equal(7, result);
+        Assert.Equal(1, subscribes);
+    }
+}


### PR DESCRIPTION
## The incident (memex, 2026-07-23)

An **Azure emergency host repair** rebooted a portal silo's node overnight (`VMEventScheduled: "Host server is undergoing an emergency repair"`, EventId F7B70A7A). For ~2 minutes the silo could not reach Postgres (`Npgsql: Failed to connect to <pg>:5432`, cascading `[ROUTE] Path resolution failed … TimeoutException` and `[STALE-CALLBACK] … pending > 41s`). When the silo restarted, per-instance node hubs (e.g. the `AgenticEngineering` Space root) tried to activate, needed to read their NodeType node from PG, that read timed out — and the grain came back **un-addressable and never self-healed**. The course stayed dead until a **manual recycle**. This has recurred: every prior fix cured that day's *trigger*, never the underlying fragility — *a transient DB outage during activation permanently wedges a grain*.

## Root cause

A PG connection fault crosses the Orleans grain boundary **flattened to its message string** (the inner `TimeoutException` object is lost in serialization). `MeshNodeStreamCache`'s transient classifier (`IsTransientOwnerFailure`) recognized `TimeoutException`/Orleans rejects but **not** Npgsql/Postgres connection faults → the cache entry was `MarkFaulted()` with **no breaker window recorded** → it replayed the stale error into every future read and every grain re-activation **forever**, until a change-feed reset (what a recycle triggers). The grain's own retry-on-next-access was defeated by the poisoned cache entry.

## Fix

**A — self-heal (load-bearing), `MeshNodeStreamCache`:** classify transient DB-connectivity faults (`Failed to connect`, `Timeout during connection attempt`, 57P01 admin_shutdown, startup/recovery, pool exhaustion, …) as transient. The fault now routes into the **existing** transient breaker, whose ≤60s re-probe recovers the activation **with no human recycle**.

**B — source, defense-in-depth, `PostgreSqlStorageAdapter`:** bounded exponential-backoff retry (≤3, 200→800ms) on the read leaf (`Read`/`Exists`/`FindBestPrefixMatch`/`ResolvePath`), firing only on a new `IsTransientConnectionFault` classifier (connection SqlStates + bare `NpgsqlException` + `Timeout`/`Socket`), so a sub-second-to-second blip never escapes the adapter. Real errors (42P01, 23505, syntax) are **never** retried; **writes are never auto-retried** (no idempotency key → replay risk).

## What this does and doesn't fix

- ✅ A node reboot / transient PG outage no longer leaves a grain wedged — it recovers on its own within ≤60s.
- ⚠️ It does **not** stop Azure from repairing hosts (unavoidable). And a *long* outage still shows the client "Area unavailable" banner until a reload — but the **server self-heals**, so no admin recycle is ever needed again.

## Tests

- `MeshNodeStreamCacheNegativeClassifierTest` — added DB-fault cases incl. the **verbatim incident message**; transient vs. real-error truth table. (Full cache suite **38/38**.)
- `PostgreSqlTransientRetryTest` (new) — classifier truth-table + deterministic retry policy (recovers after N transient faults, gives up + propagates past the limit, never retries real errors, passes success through) via `Scheduler.Immediate`. (**26/26**.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)