### PR TITLE
MessageService: hot-path Debug logs summarize, never serialize the payload

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -148,6 +148,21 @@ public class MessageService : IMessageService
     }
 
     /// <summary>
+    /// Cheap per-delivery log line — type, id, sender → target, state. The hot Debug logs
+    /// (start-processing, deserializing) run for EVERY delivery, so they must never serialize
+    /// the payload: even through <see cref="LoggingSerializerOptions"/>, only properties
+    /// explicitly marked <c>[PreventLogging]</c> are stripped, and a burst of cross-hub patches
+    /// carrying fat unmarked payloads turned the discarded log JSON into a GB-scale allocation
+    /// storm that starved every action block in the process (the CrossHubPatchAtomicityTest
+    /// watchdog kills: +3.9 GiB / 14k gen-0 GCs in one test, 2.7 GB of live log strings in the
+    /// mid-storm heap dump, 2026-07-22). Payload rendering (<see cref="LogText"/>) is reserved
+    /// for the rare error path, where it is worth its cost.
+    /// </summary>
+    private static string LogSummary(IMessageDelivery delivery) =>
+        $"{delivery.Message?.GetType().Name ?? "(null)"} (ID: {delivery.Id}, "
+        + $"{delivery.Sender} -> {delivery.Target}, {delivery.State})";
+
+    /// <summary>
     /// Creates the message service for a hub: captures the address and parent hub, picks the per-hub
     /// turn scheduler (the configured <c>TaskScheduler</c> or <c>TaskScheduler.Default</c>), composes the
     /// post and delivery pipelines from configuration, wires hierarchical routing and the storm breaker,
@@ -863,7 +878,7 @@ public class MessageService : IMessageService
             logger.LogTrace("MESSAGE_FLOW: EXECUTION_START | {MessageType} | Hub: {Address} | MessageId: {MessageId}",
                 messageTypeName, Address, delivery.Id);
         if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("Start processing {Delivery} in {Address}", LogText(delivery), Address);
+            logger.LogDebug("Start processing {Delivery} in {Address}", LogSummary(delivery), Address);
 
         var executionStopwatch = Stopwatch.StartNew();
         var isDisposing = hub.RunLevel >= MessageHubRunLevel.ShutDown;
@@ -1009,7 +1024,7 @@ public class MessageService : IMessageService
         if (delivery.Message is not RawJson rawJson)
             return delivery;
         if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("Deserializing {Delivery} in {Address}", LogText(delivery), Address);
+            logger.LogDebug("Deserializing {Delivery} in {Address}", LogSummary(delivery), Address);
         var deserializedMessage = JsonSerializer.Deserialize(rawJson.Content, typeof(object), hub.JsonSerializerOptions);
         if (deserializedMessage == null)
             return delivery.Failed("Deserialization returned null");


### PR DESCRIPTION
## The flake (CI shard 0, 2026-07-21: `ExportImportAccessControlTest` watchdog-killed at 60s; locally: `CrossHubPatchAtomicityTest` killed at 104–113s in **5 out of 5** bulk runs)

Debugged per the `/debug` skill — bulk repro, phase-trace timeline, then a mid-storm `dotnet-stack` + 10 GB `dotnet-dump` of the xUnit v3 test process:

- The per-delivery **Debug** logs (`Start processing …`, `Deserializing …`) rendered the delivery via `LogText` — a **full JSON serialization of the message payload**. `LoggingSerializerOptions` only strips properties explicitly marked `[PreventLogging]`; everything else serializes whole.
- `CrossHubPatchAtomicityTest`'s 1,152-write cross-hub burst carries a node whose dict grows to 288 entries — the discarded log JSON grows quadratically. Measured inside the one test: **+3.9 GiB managed, ~14k gen-0 GCs**; the mid-storm heap dump shows **2.7 GB of live `System.String` (69% of the heap)** and 40 action-block threads inside `LogText`'s serializer.
- The GC storm starves every action block in the process, so **whichever test shares the process gets watchdog-killed** — the 'different victim each run' shard flake.

## Fix

Hot-path Debug lines now log a cheap `LogSummary` (type, id, sender → target, state). The full `LogText` payload render stays on the rare error path, where it's worth its cost.

## Verification (same bulk run + Debug logging that reproduced 5/5)

| | before | after |
|---|---|---|
| `CrossHubPatchAtomicityTest` | 104–113s, watchdog-killed | **16s, green** |
| Full `MeshWeaver.AI.Test` suite | ~5m45s, 1 failed | **3m22s–3m27s, 889/889 green ×2** |
| Memory-pressure watchdog events | `MEM_CRITICAL` 6.5 GiB | **0** |

Note: a rarer, distinct silent-stall flake at Warning level (the CI `ExportImportAccessControlTest` instance — flat memory, zero activity, matches the `SubscribeRequest`-race the `MeshNodeStreamCache` comments document) is **not** addressed here; this PR removes the dominant, proven storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGgWKSgL8pgrbg86xqfa6o