### PR TITLE
MCP OAuth: replica-safe authorization codes via mesh-backed store

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/OAuthCodeNodeType.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OAuthCodeNodeType.cs
@@ -1,0 +1,53 @@
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+
+namespace Memex.Portal.Shared.Authentication;
+
+/// <summary>
+/// NodeType definition for <see cref="AuthorizationCode"/> nodes — the pending OAuth
+/// authorization codes <see cref="OAuthCodeStore"/> persists at
+/// <c>Admin/OAuthCode/{hashPrefix}</c> so a /token exchange on ANY portal replica can
+/// redeem a code minted by any other (the in-memory predecessor broke under KEDA
+/// scale-out). Short-lived infrastructure rows: single-use (consumed by delete on
+/// exchange), 5-minute lifetime, System-identity managed — excluded from search,
+/// create menus, and autocomplete.
+/// </summary>
+public static class OAuthCodeNodeType
+{
+    /// <summary>The node-type identifier string for OAuth authorization-code nodes.</summary>
+    public const string NodeType = "OAuthCode";
+
+    /// <summary>
+    /// Registers the OAuthCode node type on the mesh builder: adds the MeshNode type
+    /// definition, excludes it from autocomplete, and registers the
+    /// <see cref="AuthorizationCode"/> content type so code nodes (de)serialize across
+    /// silos and persistence round-trips.
+    /// </summary>
+    public static TBuilder AddOAuthCodeType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        builder.AddAutocompleteExcludedTypes(NodeType);
+        builder.WithMeshType<AuthorizationCode>();
+        return builder;
+    }
+
+    /// <summary>Builds the MeshNode type definition for OAuth authorization codes.</summary>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "OAuth Authorization Code",
+        NodeType = "NodeType",
+        Icon = "/static/NodeTypeIcons/key.svg",
+        IsSatelliteType = false,
+        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        Content = new NodeTypeDefinition
+        {
+            Description = "Pending OAuth authorization code (PKCE) awaiting its /token exchange. "
+                          + "Stored under Admin/OAuthCode/{hashPrefix}; single-use and short-lived.",
+        },
+        HubConfiguration = config => config
+            .AddMeshDataSource(source => source
+                .WithContentType<AuthorizationCode>())
+    };
+}

--- a/memex/Memex.Portal.Shared/Authentication/OAuthCodeNodeType.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OAuthCodeNodeType.cs
@@ -40,7 +40,7 @@ public static class OAuthCodeNodeType
         NodeType = "NodeType",
         Icon = "/static/NodeTypeIcons/key.svg",
         IsSatelliteType = false,
-        ExcludeFromContext = new HashSet<string> { "search", "create" },
+        ExcludeFromContext = System.Collections.Immutable.ImmutableHashSet.Create("search", "create"),
         Content = new NodeTypeDefinition
         {
             Description = "Pending OAuth authorization code (PKCE) awaiting its /token exchange. "

--- a/memex/Memex.Portal.Shared/Authentication/OAuthCodeStore.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OAuthCodeStore.cs
@@ -289,10 +289,11 @@ internal class OAuthCodeStore(IMeshService meshService, IMessageHub hub, ILogger
         => $"{CodeNamespace}/{HashRawCode(code)[..HashPrefixLength]}";
 
     /// <summary>
-    /// Node content → <see cref="AuthorizationCode"/>. In-process the content stays the
-    /// CLR record; after a PG round-trip it comes back as a JsonElement (the type is
-    /// internal and not in the TypeRegistry) — same fallback shape as
-    /// <c>ApiTokenService.ExtractApiToken</c>.
+    /// Node content → <see cref="AuthorizationCode"/>. In-process the content usually stays
+    /// the typed CLR record (<see cref="OAuthCodeNodeType.AddOAuthCodeType{TBuilder}"/>
+    /// registers the type via <c>WithMeshType</c>); the JsonElement fallback covers reads
+    /// through hubs that have not registered the type and older persisted rows — same
+    /// fallback shape as <c>ApiTokenService.ExtractApiToken</c>.
     /// </summary>
     private static AuthorizationCode? ExtractEntry(MeshNode? node)
     {

--- a/memex/Memex.Portal.Shared/Authentication/OAuthCodeStore.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OAuthCodeStore.cs
@@ -1,23 +1,78 @@
-using System.Collections.Concurrent;
+using System.Reactive.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Memex.Portal.Shared.Authentication;
 
 /// <summary>
-/// In-memory store for OAuth authorization codes with PKCE support.
-/// Codes expire after 5 minutes and are single-use (consumed on exchange).
-/// Uses ConcurrentDictionary for thread-safe mutation (per AGENTS.md exception).
+/// Mesh-backed store for OAuth authorization codes with PKCE support.
+///
+/// <para>
+/// Each pending code is a MeshNode at <c>Admin/OAuthCode/{hashPrefix}</c> (Admin partition,
+/// regular <c>mesh_nodes</c> table — PG-persisted, shared by every portal replica). This is
+/// what makes the store <b>replica-safe</b>: the previous in-memory ConcurrentDictionary
+/// broke the moment KEDA scaled the portal past one replica — <c>/authorize</c> minted the
+/// code on pod A, the MCP client's <c>/token</c> exchange landed on pod B, and the exchange
+/// failed with invalid_grant (prod 2026-07-23, three pods, every MCP connect dead). Pod
+/// restarts likewise wiped all pending codes. Now any replica can exchange a code minted by
+/// any other, and codes survive restarts.
+/// </para>
+///
+/// <para>
+/// The raw code is never persisted — the node id is the first 12 chars of the code's
+/// SHA-256 hash and the content carries the full hash (same scheme as
+/// <see cref="ApiTokenService"/>). Codes expire after <see cref="CodeLifetime"/> and are
+/// single-use: <b>consumption IS the node delete</b>, and only the caller whose
+/// <see cref="IMeshService.DeleteNode"/> actually removed the node may honor the exchange
+/// (a missing node makes DeleteNode error with NodeNotFound). First delete wins — the
+/// owning per-node hub serialises the deletes, so single-use is atomic across replicas
+/// without any distributed lock.
+/// </para>
+///
+/// <para>
+/// All nodes live in the Admin partition, which ordinary users have no rights on — every
+/// mesh operation here runs under the System identity
+/// (<see cref="AccessService.ImpersonateAsSystem"/>), the same pattern
+/// <see cref="ApiTokenService"/> uses for the global token index.
+/// 🚨 No async/await/Task in this file — the surface is <see cref="IObservable{T}"/>
+/// end-to-end; <see cref="OAuthConnectController"/> bridges at the HTTP boundary only.
+/// </para>
 /// </summary>
-internal class OAuthCodeStore
+internal class OAuthCodeStore(IMeshService meshService, IMessageHub hub, ILogger<OAuthCodeStore> logger)
 {
-    private readonly ConcurrentDictionary<string, AuthorizationCode> _codes = new();
-    private static readonly TimeSpan CodeLifetime = TimeSpan.FromMinutes(5);
+    private const string NodeTypeOAuthCode = "OAuthCode";
+    private const string CodeNamespace = "Admin/OAuthCode";
 
     /// <summary>
-    /// Generates a new authorization code and stores it with the given parameters.
+    /// Upper bound on the exchange-side node read. Generous because the code node's
+    /// per-node hub may cold-activate on the replica that received /token (it was
+    /// created on a different replica); the MCP client is blocking on the /token
+    /// HTTP response anyway. Typical case is sub-second.
     /// </summary>
-    public string GenerateCode(
+    private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Codes expire 5 minutes after issuance (RFC 6749 §4.1.2 recommends ≤10).
+    /// Init-settable so tests can pin the expiry branch deterministically
+    /// (a zero lifetime makes every issued code already expired) instead of sleeping.
+    /// </summary>
+    internal TimeSpan CodeLifetime { get; init; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Generates a new authorization code and persists it as a mesh node under the
+    /// System identity. Cold observable — the node write happens on Subscribe and the
+    /// raw code is emitted once the create commits (so a following /token exchange on
+    /// ANY replica can find it). Errors propagate: a code that could not be persisted
+    /// must not be handed to the client.
+    /// </summary>
+    public IObservable<string> GenerateCode(
         string userId,
         string userName,
         string userEmail,
@@ -26,15 +81,19 @@ internal class OAuthCodeStore
         string? codeChallenge,
         string? codeChallengeMethod)
     {
-        // Clean up expired codes opportunistically
+        // Opportunistic, fire-and-forget sweep of expired sibling codes (abandoned
+        // authorize flows would otherwise accumulate forever). No timer/watchdog —
+        // it only ever runs on the reactive generate path.
         CleanupExpired();
 
         var code = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
             .Replace("+", "-").Replace("/", "_").TrimEnd('=');
+        var hash = HashRawCode(code);
+        var hashPrefix = hash[..HashPrefixLength];
 
         var entry = new AuthorizationCode
         {
-            Code = code,
+            CodeHash = hash,
             UserId = userId,
             UserName = userName,
             UserEmail = userEmail,
@@ -45,65 +104,100 @@ internal class OAuthCodeStore
             CreatedAt = DateTimeOffset.UtcNow,
         };
 
-        _codes[code] = entry;
-        return code;
+        var node = new MeshNode(hashPrefix, CodeNamespace)
+        {
+            Name = $"OAuth code {hashPrefix}",
+            NodeType = NodeTypeOAuthCode,
+            State = MeshNodeState.Active,
+            Content = entry,
+        };
+
+        return AsSystem(() => meshService.CreateNode(node)).Select(_ => code);
     }
 
     /// <summary>
     /// Exchanges an authorization code for the stored entry.
-    /// Returns null if the code is invalid, expired, or already consumed — with the exact
-    /// failing check in <paramref name="failureReason"/> so the caller can log a diagnosable
+    /// Emits a <see cref="CodeExchangeResult"/> whose <see cref="CodeExchangeResult.Entry"/>
+    /// is null on failure — with the exact failing check in
+    /// <see cref="CodeExchangeResult.FailureReason"/> so the caller can log a diagnosable
     /// warning (a bare "invalid_grant" made real-world flow failures unattributable).
     /// Validates PKCE code_verifier if a code_challenge was stored.
+    ///
+    /// <para>
     /// Consume-first is intentional: a code is single-use on ANY exchange attempt (standard
-    /// OAuth hardening — prevents retry brute-force), so a duplicate callback surfaces here
-    /// as "unknown or already consumed", not as a second success.
+    /// OAuth hardening — prevents retry brute-force). The consume is the node DELETE, and
+    /// the exchange is only honored when THIS caller's delete removed the node — a lost
+    /// race (duplicate callback, replay against another replica) surfaces as a failure,
+    /// never as a second success.
+    /// </para>
     /// </summary>
-    public AuthorizationCode? ExchangeCode(
-        string code, string clientId, string redirectUri, string? codeVerifier, out string? failureReason)
+    public IObservable<CodeExchangeResult> ExchangeCode(
+        string code, string clientId, string redirectUri, string? codeVerifier)
     {
-        if (!_codes.TryRemove(code, out var entry))
-        {
-            failureReason = "unknown or already consumed code (never issued by this process, "
-                + "expired-and-cleaned, or burnt by an earlier exchange attempt — e.g. a duplicate callback)";
-            return null;
-        }
+        if (string.IsNullOrEmpty(code))
+            return Observable.Return(CodeExchangeResult.Failure(UnknownCodeReason));
 
+        var hash = HashRawCode(code);
+        var path = $"{CodeNamespace}/{hash[..HashPrefixLength]}";
+
+        return AsSystem(() => hub.GetMeshNode(path, ReadTimeout))
+            .SelectMany(node =>
+            {
+                var entry = ExtractEntry(node);
+                if (entry is null
+                    || !string.Equals(entry.CodeHash, hash, StringComparison.OrdinalIgnoreCase))
+                    return Observable.Return(CodeExchangeResult.Failure(UnknownCodeReason));
+
+                // Consume FIRST — the delete is the atomic cross-replica single-use gate.
+                // DeleteNode errors with "Node not found" when another exchange already
+                // consumed the code between our read and this delete; that loser maps to
+                // invalid_grant. Any OTHER delete failure (infrastructure) propagates so
+                // it surfaces as a server error, not a silent invalid_grant.
+                return AsSystem(() => meshService.DeleteNode(path))
+                    .Select(_ => true)
+                    .Catch<bool, Exception>(ex =>
+                        IsNotFound(ex)
+                            ? Observable.Return(false)
+                            : Observable.Throw<bool>(ex))
+                    .Select(consumed => consumed
+                        ? Validate(entry, clientId, redirectUri, codeVerifier)
+                        : CodeExchangeResult.Failure(
+                            "already consumed: lost the single-use consume race (first delete wins) "
+                            + "— e.g. a duplicate callback or the same code replayed against another replica"));
+            });
+    }
+
+    /// <summary>
+    /// Post-consume validation — runs only for the caller whose delete won.
+    /// Same checks and failure-reason strings as always: expiry, client_id,
+    /// redirect_uri, then PKCE. The node is already deleted at this point, so an
+    /// expired code is rejected AND gone (no separate cleanup needed for it).
+    /// </summary>
+    private CodeExchangeResult Validate(
+        AuthorizationCode entry, string clientId, string redirectUri, string? codeVerifier)
+    {
         var age = DateTimeOffset.UtcNow - entry.CreatedAt;
         if (age > CodeLifetime)
-        {
-            failureReason = $"expired: age {(int)age.TotalSeconds}s > lifetime {(int)CodeLifetime.TotalSeconds}s";
-            return null;
-        }
+            return CodeExchangeResult.Failure(
+                $"expired: age {(int)age.TotalSeconds}s > lifetime {(int)CodeLifetime.TotalSeconds}s");
 
         if (!string.Equals(entry.ClientId, clientId, StringComparison.Ordinal))
-        {
-            failureReason = "client_id mismatch between /authorize and /token";
-            return null;
-        }
+            return CodeExchangeResult.Failure("client_id mismatch between /authorize and /token");
         if (!string.Equals(entry.RedirectUri, redirectUri, StringComparison.Ordinal))
-        {
-            failureReason = "redirect_uri mismatch between /authorize and /token";
-            return null;
-        }
+            return CodeExchangeResult.Failure("redirect_uri mismatch between /authorize and /token");
 
         if (!string.IsNullOrEmpty(entry.CodeChallenge))
         {
             if (string.IsNullOrEmpty(codeVerifier))
-            {
-                failureReason = "PKCE code_verifier missing (a code_challenge was supplied at /authorize)";
-                return null;
-            }
+                return CodeExchangeResult.Failure(
+                    "PKCE code_verifier missing (a code_challenge was supplied at /authorize)");
 
             if (!VerifyPkce(codeVerifier, entry.CodeChallenge, entry.CodeChallengeMethod))
-            {
-                failureReason = "PKCE verification failed (code_verifier does not match code_challenge)";
-                return null;
-            }
+                return CodeExchangeResult.Failure(
+                    "PKCE verification failed (code_verifier does not match code_challenge)");
         }
 
-        failureReason = null;
-        return entry;
+        return new CodeExchangeResult(entry, null);
     }
 
     private static bool VerifyPkce(string codeVerifier, string codeChallenge, string? method)
@@ -120,20 +214,121 @@ internal class OAuthCodeStore
         return string.Equals(codeVerifier, codeChallenge, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Fire-and-forget sweep of expired code nodes, run on the generate path. One-shot
+    /// snapshot off the cached synced query (listing children is a sanctioned query use);
+    /// each expired sibling is deleted best-effort — losing a delete race against a
+    /// concurrent sweep or exchange on another replica is the expected outcome for a
+    /// loser and only logged, while an unexpected sweep failure surfaces as a warning.
+    /// </summary>
     private void CleanupExpired()
     {
         var cutoff = DateTimeOffset.UtcNow - CodeLifetime;
-        foreach (var kvp in _codes)
+        AsSystem(() => hub.GetWorkspace()
+                .GetQuery("oauth-codes:cleanup", $"namespace:{CodeNamespace} nodeType:{NodeTypeOAuthCode}"))
+            .Take(1)
+            .SelectMany(snapshot => snapshot
+                .Where(n => n?.Path is not null
+                            && ExtractEntry(n) is { } e
+                            && e.CreatedAt < cutoff)
+                .Select(n => AsSystem(() => meshService.DeleteNode(n.Path))
+                    .Catch<bool, Exception>(ex =>
+                    {
+                        logger.LogDebug(ex,
+                            "Expired OAuth code cleanup skipped {Path} (already gone or delete rejected)",
+                            n.Path);
+                        return Observable.Return(false);
+                    }))
+                .Merge())
+            .Subscribe(
+                _ => { },
+                ex => logger.LogWarning(ex, "Expired OAuth code cleanup sweep failed"));
+    }
+
+    /// <summary>
+    /// Runs <paramref name="inner"/> under the System identity — code nodes live in the
+    /// Admin partition, which the calling end-user has no rights on. Subscribe-time scope
+    /// (Observable.Using), same shape as <see cref="ApiTokenService"/>'s index writes.
+    /// Null <see cref="AccessService"/> (bare unit-test DI) falls through to the caller's
+    /// ambient identity.
+    /// </summary>
+    private IObservable<T> AsSystem<T>(Func<IObservable<T>> inner)
+    {
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        return accessService is null
+            ? Observable.Defer(inner)
+            : Observable.Using(() => accessService.ImpersonateAsSystem(), _ => inner());
+    }
+
+    /// <summary>
+    /// "not found" delete failures mean the code node was already consumed/cleaned —
+    /// <see cref="IMeshService.DeleteNode"/> surfaces NodeNotFound as an
+    /// <see cref="InvalidOperationException"/> with a "not found" message.
+    /// </summary>
+    private static bool IsNotFound(Exception ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
         {
-            if (kvp.Value.CreatedAt < cutoff)
-                _codes.TryRemove(kvp.Key, out _);
+            if (e.Message.Contains("not found", StringComparison.OrdinalIgnoreCase)
+                || e.Message.Contains("no node found", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    private const int HashPrefixLength = 12;
+
+    private static string HashRawCode(string code)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(code))).ToLowerInvariant();
+
+    /// <summary>
+    /// The mesh path a raw code's node lives at — exposed for tests
+    /// (visibility waits, expiry manipulation) via InternalsVisibleTo.
+    /// </summary>
+    internal static string PathForCode(string code)
+        => $"{CodeNamespace}/{HashRawCode(code)[..HashPrefixLength]}";
+
+    /// <summary>
+    /// Node content → <see cref="AuthorizationCode"/>. In-process the content stays the
+    /// CLR record; after a PG round-trip it comes back as a JsonElement (the type is
+    /// internal and not in the TypeRegistry) — same fallback shape as
+    /// <c>ApiTokenService.ExtractApiToken</c>.
+    /// </summary>
+    private static AuthorizationCode? ExtractEntry(MeshNode? node)
+    {
+        switch (node?.Content)
+        {
+            case AuthorizationCode direct:
+                return direct;
+            case System.Text.Json.JsonElement jsonElement:
+                try
+                {
+                    return System.Text.Json.JsonSerializer.Deserialize<AuthorizationCode>(
+                        jsonElement.GetRawText(),
+                        new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                }
+                catch
+                {
+                    return null;
+                }
+            default:
+                return null;
         }
     }
+
+    private const string UnknownCodeReason =
+        "unknown or already consumed code (never issued, expired-and-cleaned, or burnt by an "
+        + "earlier exchange attempt on any replica — e.g. a duplicate callback)";
 }
 
+/// <summary>
+/// Persisted content of an <c>Admin/OAuthCode/{hashPrefix}</c> node. Carries the full
+/// SHA-256 hash of the code (never the raw code) plus everything the /token exchange
+/// validates and the token issuance needs.
+/// </summary>
 internal record AuthorizationCode
 {
-    public required string Code { get; init; }
+    public required string CodeHash { get; init; }
     public required string UserId { get; init; }
     public required string UserName { get; init; }
     public required string UserEmail { get; init; }
@@ -142,4 +337,15 @@ internal record AuthorizationCode
     public string? CodeChallenge { get; init; }
     public string? CodeChallengeMethod { get; init; }
     public DateTimeOffset CreatedAt { get; init; }
+}
+
+/// <summary>
+/// Result of <see cref="OAuthCodeStore.ExchangeCode"/>: exactly one of
+/// <see cref="Entry"/> (success) or <see cref="FailureReason"/> (the exact failing
+/// check, logged by the /token endpoint — the wire response stays a generic
+/// invalid_grant per RFC 6749).
+/// </summary>
+internal record CodeExchangeResult(AuthorizationCode? Entry, string? FailureReason)
+{
+    public static CodeExchangeResult Failure(string reason) => new(null, reason);
 }

--- a/memex/Memex.Portal.Shared/Authentication/OAuthConnectController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OAuthConnectController.cs
@@ -131,16 +131,20 @@ public class OAuthConnectController(
     /// <summary>
     /// OAuth Authorization Endpoint — redirects authenticated users to the client's redirect_uri
     /// with an authorization code. Unauthenticated users are sent to /login first.
+    /// The code is persisted as a mesh node (replica-safe: the /token exchange may land on a
+    /// different pod), so this action bridges the store's IObservable to Task at the HTTP
+    /// boundary — same single-bridge shape as <see cref="ExchangeToken"/>.
     /// </summary>
     [HttpGet("/authorize")]
-    public IActionResult Authorize(
+    public Task<IActionResult> Authorize(
         [FromQuery] string response_type,
         [FromQuery] string client_id,
         [FromQuery] string redirect_uri,
         [FromQuery] string? state,
         [FromQuery] string? scope,
         [FromQuery] string? code_challenge,
-        [FromQuery] string? code_challenge_method)
+        [FromQuery] string? code_challenge_method,
+        CancellationToken ct = default)
     {
         logger.LogInformation(
             "OAuth /authorize: response_type={ResponseType}, client_id={ClientId}, redirect_uri={RedirectUri}, has_state={HasState}, has_pkce={HasPkce}, authenticated={Authenticated}",
@@ -151,13 +155,13 @@ public class OAuthConnectController(
         if (response_type != "code")
         {
             logger.LogWarning("OAuth /authorize rejected: unsupported response_type={ResponseType}", response_type);
-            return BadRequest(new { error = "unsupported_response_type" });
+            return Task.FromResult<IActionResult>(BadRequest(new { error = "unsupported_response_type" }));
         }
 
         if (string.IsNullOrEmpty(client_id) || string.IsNullOrEmpty(redirect_uri))
         {
             logger.LogWarning("OAuth /authorize rejected: missing client_id or redirect_uri");
-            return BadRequest(new { error = "invalid_request", error_description = "client_id and redirect_uri are required" });
+            return Task.FromResult<IActionResult>(BadRequest(new { error = "invalid_request", error_description = "client_id and redirect_uri are required" }));
         }
 
         // If user is not authenticated, redirect to login with return URL
@@ -166,7 +170,7 @@ public class OAuthConnectController(
             var authorizeUrl = $"{Request.Scheme}://{Request.Host}{Request.Path}{Request.QueryString}";
             var loginUrl = $"/login?returnUrl={Uri.EscapeDataString(authorizeUrl)}";
             logger.LogInformation("OAuth /authorize: redirecting unauthenticated caller to {LoginUrl}", loginUrl);
-            return Redirect(loginUrl);
+            return Task.FromResult<IActionResult>(Redirect(loginUrl));
         }
 
         // Extract user identity from cookie claims (email/name are display
@@ -185,7 +189,7 @@ public class OAuthConnectController(
         if (string.IsNullOrEmpty(email))
         {
             logger.LogWarning("OAuth /authorize rejected: authenticated principal has no email/preferred_username claim");
-            return BadRequest(new { error = "invalid_request", error_description = "Unable to determine user identity" });
+            return Task.FromResult<IActionResult>(BadRequest(new { error = "invalid_request", error_description = "Unable to determine user identity" }));
         }
 
         // Refuse to issue a code with an unresolved or email-shaped userId — it
@@ -199,27 +203,43 @@ public class OAuthConnectController(
                 "OAuth /authorize rejected: no resolved mesh identity for {Email} (userId='{UserId}'). "
                 + "Retry after a browser login provisions/loads the User node.",
                 email, userId ?? "(null)");
-            return BadRequest(new { error = "invalid_request", error_description = "Unable to determine user identity" });
+            return Task.FromResult<IActionResult>(BadRequest(new { error = "invalid_request", error_description = "Unable to determine user identity" }));
         }
 
-        // Generate authorization code
-        var code = CodeStore.GenerateCode(
-            userId: userId,
-            userName: name,
-            userEmail: email,
-            clientId: client_id,
-            redirectUri: redirect_uri,
-            codeChallenge: code_challenge,
-            codeChallengeMethod: code_challenge_method);
+        // Generate + persist the authorization code (mesh node — visible to every
+        // replica). The redirect only fires once the node write committed; a code
+        // whose persistence failed must never reach the client (it could not be
+        // exchanged anywhere), so a store error surfaces as 500 server_error.
+        return CodeStore.GenerateCode(
+                userId: userId,
+                userName: name,
+                userEmail: email,
+                clientId: client_id,
+                redirectUri: redirect_uri,
+                codeChallenge: code_challenge,
+                codeChallengeMethod: code_challenge_method)
+            .Select(code =>
+            {
+                logger.LogInformation("Issued OAuth authorization code for user {Email}, client {ClientId}", email, client_id);
 
-        logger.LogInformation("Issued OAuth authorization code for user {Email}, client {ClientId}", email, client_id);
+                // Redirect to client with code (and state if provided)
+                var callbackUrl = string.IsNullOrEmpty(state)
+                    ? $"{redirect_uri}?code={Uri.EscapeDataString(code)}"
+                    : $"{redirect_uri}?code={Uri.EscapeDataString(code)}&state={Uri.EscapeDataString(state)}";
 
-        // Redirect to client with code (and state if provided)
-        var callbackUrl = string.IsNullOrEmpty(state)
-            ? $"{redirect_uri}?code={Uri.EscapeDataString(code)}"
-            : $"{redirect_uri}?code={Uri.EscapeDataString(code)}&state={Uri.EscapeDataString(state)}";
-
-        return Redirect(callbackUrl);
+                return (IActionResult)Redirect(callbackUrl);
+            })
+            .Catch<IActionResult, Exception>(ex =>
+            {
+                logger.LogError(ex,
+                    "OAuth /authorize failed to persist the authorization code for user {Email}, client {ClientId}",
+                    email, client_id);
+                return Observable.Return<IActionResult>(StatusCode(
+                    StatusCodes.Status500InternalServerError,
+                    new { error = "server_error", error_description = "Failed to persist the authorization code" }));
+            })
+            .FirstAsync()
+            .ToTask(ct);
     }
 
     /// <summary>
@@ -247,49 +267,52 @@ public class OAuthConnectController(
             return Task.FromResult<IActionResult>(BadRequest(new { error = "invalid_request" }));
         }
 
-        var entry = CodeStore.ExchangeCode(
-            request.code,
-            request.client_id,
-            request.redirect_uri,
-            request.code_verifier,
-            out var failureReason);
-
-        if (entry == null)
-        {
-            // The reason names the exact failing check (unknown/consumed, expired, client_id,
-            // redirect_uri, PKCE) — the wire response stays a generic invalid_grant per RFC 6749.
-            logger.LogWarning(
-                "OAuth token exchange failed for client {ClientId}: {FailureReason}",
-                request.client_id, failureReason);
-            return Task.FromResult<IActionResult>(BadRequest(new { error = "invalid_grant" }));
-        }
-
-        // Create an mw_ API token via the existing token service. Lifetime
-        // is long-lived because OAuth clients (MCP, CLI tools) typically
-        // can't run interactive re-auth flows — a token that expires in 30
-        // days surprises users who connect once and come back months later.
-        // Refresh-token flow isn't implemented yet; until it is, default to
-        // 1 year. Bump if needed via TokenLifetime below.
-        //
-        // No await: pull IObservable up to the controller's return type.
-        // Single bridge to Task happens at .ToTask(ct) — passing the
-        // request's cancellation token so a client disconnect tears down
-        // the reactive subscription.
-        return TokenService.CreateToken(
-                userId: entry.UserId,
-                userName: entry.UserName,
-                userEmail: entry.UserEmail,
-                label: $"OAuth: {request.client_id}",
-                expiresAt: DateTimeOffset.UtcNow.Add(TokenLifetime))
-            .Select(creation =>
+        // Exchange the code against the mesh-backed store (replica-safe: the code may
+        // have been minted by any pod, and the single-use consume is atomic across
+        // replicas — first delete wins), then mint the mw_ API token. One reactive
+        // chain, single bridge to Task at .ToTask(ct).
+        return CodeStore.ExchangeCode(
+                request.code,
+                request.client_id,
+                request.redirect_uri,
+                request.code_verifier)
+            .SelectMany(exchange =>
             {
-                logger.LogInformation("Issued OAuth access token for user {Email}, client {ClientId}", entry.UserEmail, request.client_id);
-                return (IActionResult)Ok(new
+                if (exchange.Entry is null)
                 {
-                    access_token = creation.RawToken,
-                    token_type = "Bearer",
-                    expires_in = (int)TokenLifetime.TotalSeconds,
-                });
+                    // The reason names the exact failing check (unknown/consumed, lost consume
+                    // race, expired, client_id, redirect_uri, PKCE) — the wire response stays
+                    // a generic invalid_grant per RFC 6749.
+                    logger.LogWarning(
+                        "OAuth token exchange failed for client {ClientId}: {FailureReason}",
+                        request.client_id, exchange.FailureReason);
+                    return Observable.Return<IActionResult>(BadRequest(new { error = "invalid_grant" }));
+                }
+
+                var entry = exchange.Entry;
+
+                // Create an mw_ API token via the existing token service. Lifetime
+                // is long-lived because OAuth clients (MCP, CLI tools) typically
+                // can't run interactive re-auth flows — a token that expires in 30
+                // days surprises users who connect once and come back months later.
+                // Refresh-token flow isn't implemented yet; until it is, default to
+                // 1 year. Bump if needed via TokenLifetime below.
+                return TokenService.CreateToken(
+                        userId: entry.UserId,
+                        userName: entry.UserName,
+                        userEmail: entry.UserEmail,
+                        label: $"OAuth: {request.client_id}",
+                        expiresAt: DateTimeOffset.UtcNow.Add(TokenLifetime))
+                    .Select(creation =>
+                    {
+                        logger.LogInformation("Issued OAuth access token for user {Email}, client {ClientId}", entry.UserEmail, request.client_id);
+                        return (IActionResult)Ok(new
+                        {
+                            access_token = creation.RawToken,
+                            token_type = "Bearer",
+                            expires_in = (int)TokenLifetime.TotalSeconds,
+                        });
+                    });
             })
             .FirstAsync()
             .ToTask(ct);

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -652,6 +652,13 @@ public static class MemexConfiguration
                 // credential nodes. Without this the create throws "NodeType 'ApiCredential' is not
                 // registered" — the OAuth callback's persist step fails and sign-in reports failure.
                 .AddApiCredentialType()
+                // Register the OAuthCode NodeType + AuthorizationCode content type so the
+                // MCP OAuth server (OAuthCodeStore) can persist pending authorization codes
+                // as Admin/OAuthCode/{hashPrefix} mesh nodes — the replica-safe store every
+                // pod shares (the /token exchange may land on a different replica than the
+                // /authorize that minted the code). Without this the create fails with
+                // "NodeType 'OAuthCode' is not registered" and no MCP client can connect.
+                .AddOAuthCodeType()
                 // Seed root-scope Admin AccessAssignments for users listed under
                 // `Auth:GlobalAdmins` so configured admins bypass per-partition
                 // RLS for cross-partition operations (list Spaces, create

--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -335,6 +335,26 @@ public static class JsonSynchronizationStream
                         reduced.StreamId),
                 ex =>
                 {
+                    // 🚨 TRANSIENT shutdown reject (ErrorType.ShuttingDown): our SubscribeRequest
+                    // raced the owner hub's DisposeRequest — a recycle / restart in flight, NOT a
+                    // missing owner. The owner's fresh activation re-announces via the change feed
+                    // and the resubscribe latch below re-sends the SubscribeRequest (~2s later in
+                    // the recycle flow), so the ONLY correct reaction is to keep the stream and
+                    // the keep-alive ALIVE and wait for that rehydration — exactly what happened
+                    // under the pre-NACK silent drop. Faulting here killed the latch with the
+                    // stream and wedged every reader of a mid-recycle NodeType to its timeout
+                    // (CI 30003419841, NodeTypeCompileParkTest.RecycleRetry). This is not a
+                    // retry/watchdog: nothing re-posts on a timer — recovery stays event-driven
+                    // (change-feed announce → latch), the same protocol as an owner restart.
+                    if (ex is DeliveryFailureException { Failure.ErrorType: ErrorType.ShuttingDown })
+                    {
+                        logger.LogDebug(
+                            "SubscribeRequest for stream {StreamId} rejected — owner {Owner} is shutting down "
+                            + "(recycle/restart in flight); keeping the stream alive for the resubscribe latch",
+                            reduced.StreamId, owner);
+                        return;
+                    }
+
                     // DeliveryFailure / NotFound — the owner address does not exist. Terminal: fault
                     // subscribers + tear down the keep-alive so we NEVER heartbeat or resubscribe a
                     // non-existent owner (the storm that wedges the session).

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -973,6 +973,25 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
             ).WithHandler<DeliveryFailure>((_, delivery) =>
                 {
                     var failure = delivery.Message;
+                    // 🚨 A TRANSIENT shutdown reject is NOT terminal for a sync stream. It
+                    // means one delivery (typically our SubscribeRequest) raced the owner
+                    // hub's DisposeRequest during a recycle/restart — the address is about
+                    // to reactivate. This stream's own recovery machinery (keep-alive +
+                    // the change-feed resubscribe latch) re-sends the SubscribeRequest
+                    // once the fresh activation announces itself, so the right reaction is
+                    // to RIDE IT OUT. Calling OnError here tore that machinery down with
+                    // the stream: the latch never fired, nothing rehydrated, and every
+                    // reader of a mid-recycle NodeType waited to its timeout
+                    // (CI 30003419841, NodeTypeCompileParkTest.RecycleRetry — the exact
+                    // regression the ShuttingDown ErrorType exists to prevent). All other
+                    // failure kinds (RLS denial, validation, NotFound, …) stay terminal.
+                    if (failure.ErrorType == ErrorType.ShuttingDown)
+                    {
+                        logger.LogDebug(
+                            "Stream {StreamId} received transient shutdown reject: {Message} — keeping the stream alive for the resubscribe latch",
+                            StreamId, failure.Message);
+                        return delivery.Processed();
+                    }
                     logger.LogWarning("Stream {StreamId} received DeliveryFailure: {Message}", StreamId, failure.Message);
                     OnError(new DeliveryFailureException(failure));
                     return delivery.Processed();

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-23-mcp-connect-reliability.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-23-mcp-connect-reliability.md
@@ -1,0 +1,10 @@
+---
+Name: Reliable MCP sign-in on scaled deployments
+Category: What's New
+Description: Connecting an MCP client (Claude Code, Copilot, IDEs) now works reliably on portals running multiple replicas.
+Icon: Sparkle
+---
+
+# Reliable MCP sign-in on scaled deployments
+
+Connecting an MCP client to the portal could fail with an authorization error when the portal was running more than one replica — the sign-in would only succeed if two consecutive requests happened to reach the same server instance. Authorization codes are now stored in the mesh itself, so any replica can complete a sign-in started on any other. Codes remain single-use and short-lived, and interrupted sign-ins now fail fast with a clear error instead of hanging.

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -1117,6 +1117,11 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             if (msg.Contains("target hub was not found", StringComparison.OrdinalIgnoreCase)) return true;
             if (msg.Contains("No response received in hub", StringComparison.OrdinalIgnoreCase)) return true;
             if (msg.Contains("undeliverable", StringComparison.OrdinalIgnoreCase)) return true;
+            // MessageService.ScheduleNotify's shutdown-drop NACK (ErrorType.ShuttingDown):
+            // a delivery raced the target hub's DisposeRequest (recycle / delete / restart).
+            // Transient by design — the address may reactivate (recycle), and if the node is
+            // genuinely gone the NEXT probe gets the authoritative routing NotFound.
+            if (msg.Contains("is shutting down", StringComparison.OrdinalIgnoreCase)) return true;
         }
         return false;
     }

--- a/src/MeshWeaver.Layout/AreaErrorClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaErrorClassifier.cs
@@ -33,6 +33,11 @@ public static class AreaErrorClassifier
             if (msg.Contains("No response received in hub", StringComparison.OrdinalIgnoreCase)) return true;
             if (msg.Contains("target hub was not found", StringComparison.OrdinalIgnoreCase)) return true;
             if (msg.Contains("undeliverable", StringComparison.OrdinalIgnoreCase)) return true;
+            // MessageService's shutdown-drop NACK ("Hub X is shutting down … Rejecting now."):
+            // the delivery raced the target hub's DisposeRequest (recycle / restart) — retry-
+            // worthy, the address typically reactivates on the next probe. Mirrors
+            // MeshNodeStreamCache.IsTransientOwnerFailure so the layers agree.
+            if (msg.Contains("is shutting down", StringComparison.OrdinalIgnoreCase)) return true;
         }
         return false;
     }

--- a/src/MeshWeaver.Messaging.Contract/Events.cs
+++ b/src/MeshWeaver.Messaging.Contract/Events.cs
@@ -178,7 +178,20 @@ public enum ErrorType
     /// <summary>
     /// The caller is authenticated but lacks permission for this operation.
     /// </summary>
-    Forbidden
+    Forbidden,
+    /// <summary>
+    /// TRANSIENT rejection: the delivery raced the target hub's disposal
+    /// (<c>MessageService.ScheduleNotify</c>'s shutdown-drop NACK — a recycle, restart,
+    /// or delete in flight). The ADDRESS may reactivate on the very next probe, so this
+    /// is retry-worthy, never terminal: request/response callers surface it like any
+    /// failure (their caller retries or maps it to absence), while long-lived consumers
+    /// with their own recovery machinery — chiefly <c>SynchronizationStream</c>'s
+    /// keep-alive + change-feed resubscribe latch — MUST ride it out rather than tear
+    /// down (CI 30003419841: erroring the sync stream on this NACK killed the resubscribe
+    /// latch and wedged every read of a mid-recycle NodeType). Mirrors the Orleans
+    /// mid-DeactivateOnIdle forwarding reject ("invalid activation. Rejecting now.").
+    /// </summary>
+    ShuttingDown
 }
 
 

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -399,6 +399,41 @@ public class MessageService : IMessageService
                 logger.LogDebug("Dropping message {MessageType} (ID: {MessageId}) in {Address} - hub is shutting down (RunLevel={RunLevel})",
                     delivery.Message?.GetType().Name, delivery.Id, Address, hub.RunLevel);
             MessageTrace.Write($"hub={Address} msg={typeName} id={delivery.Id} DROPPED_SHUTTING_DOWN runLevel={hub.RunLevel}");
+
+            // 🚨 NACK, never a silent drop, for messages a SENDER IS AWAITING. Callers of
+            // hostedHub.DeliverMessage (HierarchicalRouting, RoutingServiceBase) return
+            // Forwarded() without inspecting our Failed state, so a request landing here —
+            // e.g. a GetDataRequest racing the per-node hub's post-delete DisposeRequest —
+            // used to vanish and the sender's hub.Observe(...) sat silent until its full
+            // RequestTimeout (the OAuth consumed-code re-exchange stalled 30s on exactly
+            // this). Post the DeliveryFailure through the PARENT hub: our own Post would
+            // re-enter this same gate and be dropped. Cascade-safe by the same exclusions
+            // ReportFailure applies — never NACK a DeliveryFailure (no ping-pong: a NACK
+            // arriving at another disposing hub is excluded here) nor [CanBeIgnored]
+            // lifecycle traffic (no requester is waiting).
+            if (delivery.Message is not DeliveryFailure
+                && delivery.Message is not null
+                && !delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>()
+                && delivery.Sender is not null
+                && !delivery.Sender.Equals(Address)
+                && ParentHub is { } parent
+                && parent.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
+            {
+                try
+                {
+                    parent.Post(new DeliveryFailure(delivery)
+                    {
+                        ErrorType = ErrorType.NotFound,
+                        Message = $"Hub {Address} is shutting down (RunLevel={hub.RunLevel}) — cannot process {typeName}."
+                    }, o => o.ResponseFor(delivery));
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex,
+                        "Failed to NACK {MessageType} (ID: {MessageId}) dropped by shutting-down hub {Address}",
+                        typeName, delivery.Id, Address);
+                }
+            }
             return delivery.Failed("Hub is shutting down");
         }
 

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -411,6 +411,23 @@ public class MessageService : IMessageService
             // ReportFailure applies — never NACK a DeliveryFailure (no ping-pong: a NACK
             // arriving at another disposing hub is excluded here) nor [CanBeIgnored]
             // lifecycle traffic (no requester is waiting).
+            //
+            // 🚨 The NACK is a TRANSIENT rejection — ErrorType.ShuttingDown — never NotFound,
+            // never a generic terminal failure. A disposing hub cannot know whether its
+            // address is gone for good (node deleted) or about to REACTIVATE (recycle /
+            // restart): the very same drop fires for a SubscribeRequest racing a recycle's
+            // DisposeRequest. It mirrors the Orleans mid-DeactivateOnIdle reject ("invalid
+            // activation. Rejecting now.") that the transient classifiers (MeshNodeStream-
+            // Cache.IsTransientOwnerFailure, RoutingGrain.IsTransientFailure, AreaError-
+            // Classifier.IsTransientHubFailure) already treat as retry-worthy: the sender's
+            // next probe gets the authoritative answer — a fresh activation (recycle) or a
+            // routing NotFound (deleted). Consumers with their own recovery machinery ride
+            // it out: SynchronizationStream keeps the stream ALIVE on this ErrorType so its
+            // change-feed resubscribe latch rehydrates after the reactivation. Both wrong
+            // shapes are CI-proven (run 30003419841, NodeTypeCompileParkTest.RecycleRetry):
+            // a NotFound NACK faulted the stream cache's shared Replay(1) with no re-probe
+            // path, and ANY terminal treatment killed the sync stream's resubscribe latch —
+            // each wedged every read of the mid-recycle NodeType.
             if (delivery.Message is not DeliveryFailure
                 && delivery.Message is not null
                 && !delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>()
@@ -423,8 +440,9 @@ public class MessageService : IMessageService
                 {
                     parent.Post(new DeliveryFailure(delivery)
                     {
-                        ErrorType = ErrorType.NotFound,
-                        Message = $"Hub {Address} is shutting down (RunLevel={hub.RunLevel}) — cannot process {typeName}."
+                        ErrorType = ErrorType.ShuttingDown,
+                        Message = $"Hub {Address} is shutting down (RunLevel={hub.RunLevel}) — cannot process "
+                                  + $"{typeName}; the address may reactivate (recycle / restart). Rejecting now."
                     }, o => o.ResponseFor(delivery));
                 }
                 catch (Exception ex)

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -407,10 +407,25 @@ public class MessageService : IMessageService
             // used to vanish and the sender's hub.Observe(...) sat silent until its full
             // RequestTimeout (the OAuth consumed-code re-exchange stalled 30s on exactly
             // this). Post the DeliveryFailure through the PARENT hub: our own Post would
-            // re-enter this same gate and be dropped. Cascade-safe by the same exclusions
-            // ReportFailure applies — never NACK a DeliveryFailure (no ping-pong: a NACK
-            // arriving at another disposing hub is excluded here) nor [CanBeIgnored]
-            // lifecycle traffic (no requester is waiting).
+            // re-enter this same gate and be dropped.
+            //
+            // The NACK is GATED to deliveries a caller can actually be awaiting:
+            //  • typed IRequest messages (hub.Observe request/response);
+            //  • RawJson — cross-hub deliveries reach this gate UNDESERIALIZED (the
+            //    MESHWEAVER_MSG_TRACE captures show the dropped GetDataRequest and
+            //    SubscribeRequest both as msg=RawJson here), so the payload type cannot
+            //    be inspected: fail LOUD rather than reintroduce the silent 30s hang.
+            //    An IRequest-only gate would silently skip exactly the two flows this
+            //    NACK exists for. The one RawJson we skip is a payload that looks like
+            //    a DeliveryFailure itself (cheap content sniff) — NACKing a NACK
+            //    between two concurrently-disposing hubs would ping-pong; a false
+            //    positive on the sniff merely reverts that delivery to the historical
+            //    silent drop.
+            // Typed fire-and-forget events (DataChangedEvent & co) fall back to the
+            // historical silent drop — nobody awaits them, and NACKing them was pure
+            // disposal noise. Cascade-safe by the same exclusions ReportFailure applies —
+            // never NACK a DeliveryFailure nor [CanBeIgnored] lifecycle traffic (no
+            // requester is waiting).
             //
             // 🚨 The NACK is a TRANSIENT rejection — ErrorType.ShuttingDown — never NotFound,
             // never a generic terminal failure. A disposing hub cannot know whether its
@@ -428,8 +443,9 @@ public class MessageService : IMessageService
             // a NotFound NACK faulted the stream cache's shared Replay(1) with no re-probe
             // path, and ANY terminal treatment killed the sync stream's resubscribe latch —
             // each wedged every read of the mid-recycle NodeType.
-            if (delivery.Message is not DeliveryFailure
-                && delivery.Message is not null
+            if ((delivery.Message is IRequest
+                    || (delivery.Message is RawJson rawJson
+                        && !rawJson.Content.Contains(nameof(DeliveryFailure), StringComparison.Ordinal)))
                 && !delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>()
                 && delivery.Sender is not null
                 && !delivery.Sender.Equals(Address)

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -2,5 +2,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\memex\Memex.Portal.Shared\Memex.Portal.Shared.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
+    <!-- OAuthCodeStoreTest runs against a full monolith mesh (the store persists
+         authorization codes as mesh nodes — the multi-replica safety contract). -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Memex.Portal.Shared.Test/OAuthCodeStoreTest.cs
+++ b/test/Memex.Portal.Shared.Test/OAuthCodeStoreTest.cs
@@ -1,25 +1,57 @@
 using System;
+using System.Reactive.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Memex.Portal.Shared.Test;
 
 /// <summary>
-/// OAuthCodeStore exchange semantics: single-use consume-first codes, and the exact
+/// Mesh-backed OAuthCodeStore semantics: single-use consume-first codes, and the exact
 /// failure reason for every rejection branch (unknown/consumed, expired, client_id,
 /// redirect_uri, PKCE). The reason string is what the /token endpoint logs at Warning —
 /// the bare "invalid or expired" line made real-world MCP-login failures unattributable
 /// (2026-07-02: a failed exchange on memex-cloud could not be told apart from a
 /// duplicate-callback burn or a PKCE mismatch).
+///
+/// <para>
+/// The store persists codes as mesh nodes at <c>Admin/OAuthCode/{hashPrefix}</c> — the
+/// replica-safety fix for the 2026-07-23 prod outage where /authorize minted the code in
+/// pod A's in-memory dictionary and the MCP client's /token exchange landed on pod B
+/// ("never issued by this process"). <see cref="TwoStoreInstances_GenerateOnOne_ExchangeOnOther"/>
+/// pins exactly that scenario: two store INSTANCES sharing one mesh (two replicas sharing
+/// one PG) must exchange each other's codes, and the single-use consume (first delete
+/// wins) must hold across instances.
+/// </para>
 /// </summary>
-public class OAuthCodeStoreTest
+public class OAuthCodeStoreTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     private const string ClientId = "client-1";
     private const string RedirectUri = "http://localhost:12345/callback";
 
-    private static OAuthCodeStore NewStore() => new();
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        // Same registration the portal wires in ConfigureMemexMesh — the OAuthCode
+        // NodeType + AuthorizationCode content type the store persists.
+        => base.ConfigureMesh(builder).AddOAuthCodeType();
+
+    /// <summary>
+    /// Each call builds an independent store instance on the SAME mesh — the same
+    /// relationship two KEDA replicas have to the shared PG-backed mesh.
+    /// </summary>
+    private OAuthCodeStore NewStore(TimeSpan? codeLifetime = null) => new(
+        Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
+        Mesh,
+        Mesh.ServiceProvider.GetRequiredService<ILogger<OAuthCodeStore>>())
+    {
+        CodeLifetime = codeLifetime ?? TimeSpan.FromMinutes(5),
+    };
 
     private static string Challenge(string verifier)
     {
@@ -27,105 +59,183 @@ public class OAuthCodeStoreTest
         return Convert.ToBase64String(hash).Replace("+", "-").Replace("/", "_").TrimEnd('=');
     }
 
-    private static string Issue(OAuthCodeStore store, string? challenge = null, string? method = null)
-        => store.GenerateCode("rbuergi", "Roland", "rbuergi@systemorph.com",
-            ClientId, RedirectUri, challenge, method);
+    /// <summary>
+    /// Issues a code and waits until its node is readable — absorbs create→routing
+    /// visibility lag (sanctioned Interval+re-read pattern, WritingTests.md) so the
+    /// exchange under test exercises its own branch, not read-side lag.
+    /// </summary>
+    private async Task<string> Issue(OAuthCodeStore store, string? challenge = null, string? method = null)
+    {
+        var code = await store.GenerateCode("rbuergi", "Roland", "rbuergi@systemorph.com",
+                ClientId, RedirectUri, challenge, method)
+            .Should().Within(30.Seconds()).Emit();
+
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => ReadNode(OAuthCodeStore.PathForCode(code)))
+            .Should().Within(30.Seconds()).Match(n => n is not null);
+
+        return code;
+    }
+
+    private Task<CodeExchangeResult> Exchange(
+        OAuthCodeStore store, string code,
+        string clientId = ClientId, string redirectUri = RedirectUri, string? verifier = null)
+        => store.ExchangeCode(code, clientId, redirectUri, verifier)
+            .Should().Within(30.Seconds()).Emit();
 
     [Fact]
-    public void Exchange_WithMatchingParameters_ReturnsEntry_NoReason()
+    public async Task Exchange_WithMatchingParameters_ReturnsEntry_NoReason()
     {
         var store = NewStore();
-        var code = Issue(store);
+        var code = await Issue(store);
 
-        var entry = store.ExchangeCode(code, ClientId, RedirectUri, null, out var reason);
+        var result = await Exchange(store, code);
 
-        Assert.NotNull(entry);
-        Assert.Null(reason);
-        Assert.Equal("rbuergi", entry!.UserId);
+        result.Entry.Should().NotBeNull();
+        result.FailureReason.Should().BeNull();
+        result.Entry!.UserId.Should().Be("rbuergi");
+        result.Entry.UserEmail.Should().Be("rbuergi@systemorph.com");
     }
 
     [Fact]
-    public void Exchange_UnknownCode_ReportsUnknown()
+    public async Task Exchange_UnknownCode_ReportsUnknown()
     {
         var store = NewStore();
 
-        var entry = store.ExchangeCode("no-such-code", ClientId, RedirectUri, null, out var reason);
+        var result = await Exchange(store, "no-such-code");
 
-        Assert.Null(entry);
-        Assert.Contains("unknown or already consumed", reason);
+        result.Entry.Should().BeNull();
+        result.FailureReason.Should().Contain("unknown or already consumed");
     }
 
     [Fact]
-    public void Exchange_SecondAttempt_IsConsumed()
+    public async Task Exchange_SecondAttempt_IsConsumed()
     {
         var store = NewStore();
-        var code = Issue(store);
-        Assert.NotNull(store.ExchangeCode(code, ClientId, RedirectUri, null, out _));
+        var code = await Issue(store);
+        var first = await Exchange(store, code);
+        first.Entry.Should().NotBeNull();
 
-        var second = store.ExchangeCode(code, ClientId, RedirectUri, null, out var reason);
+        var second = await Exchange(store, code);
 
-        Assert.Null(second);
-        Assert.Contains("unknown or already consumed", reason);
+        second.Entry.Should().BeNull();
+        second.FailureReason.Should().Contain("unknown or already consumed");
     }
 
     [Fact]
-    public void Exchange_ClientIdMismatch_ReportsClientId()
+    public async Task Exchange_ExpiredCode_ReportsExpired()
+    {
+        // Zero lifetime → the code is already expired by the time the exchange
+        // validates it (deterministic — no sleeping). The consume-first delete has
+        // already removed the node, so an expired code is rejected AND gone.
+        var store = NewStore(codeLifetime: TimeSpan.Zero);
+        var code = await Issue(store);
+
+        var result = await Exchange(store, code);
+
+        result.Entry.Should().BeNull();
+        result.FailureReason.Should().Contain("expired");
+
+        // reject + delete: the expired code's node was consumed by the rejection.
+        var after = await ReadNode(OAuthCodeStore.PathForCode(code)).Should().Within(30.Seconds()).Emit();
+        after.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Exchange_ClientIdMismatch_ReportsClientId()
     {
         var store = NewStore();
-        var code = Issue(store);
+        var code = await Issue(store);
 
-        var entry = store.ExchangeCode(code, "other-client", RedirectUri, null, out var reason);
+        var result = await Exchange(store, code, clientId: "other-client");
 
-        Assert.Null(entry);
-        Assert.Contains("client_id mismatch", reason);
+        result.Entry.Should().BeNull();
+        result.FailureReason.Should().Contain("client_id mismatch");
     }
 
     [Fact]
-    public void Exchange_RedirectUriMismatch_ReportsRedirectUri()
+    public async Task Exchange_RedirectUriMismatch_ReportsRedirectUri()
     {
         var store = NewStore();
-        var code = Issue(store);
+        var code = await Issue(store);
 
-        var entry = store.ExchangeCode(code, ClientId, "http://localhost:9/other", null, out var reason);
+        var result = await Exchange(store, code, redirectUri: "http://localhost:9/other");
 
-        Assert.Null(entry);
-        Assert.Contains("redirect_uri mismatch", reason);
+        result.Entry.Should().BeNull();
+        result.FailureReason.Should().Contain("redirect_uri mismatch");
     }
 
     [Fact]
-    public void Exchange_S256Pkce_RoundTrips()
+    public async Task Exchange_S256Pkce_RoundTrips()
     {
         var store = NewStore();
         const string verifier = "the-verifier-string-with-enough-entropy";
-        var code = Issue(store, Challenge(verifier), "S256");
+        var code = await Issue(store, Challenge(verifier), "S256");
 
-        var entry = store.ExchangeCode(code, ClientId, RedirectUri, verifier, out var reason);
+        var result = await Exchange(store, code, verifier: verifier);
 
-        Assert.NotNull(entry);
-        Assert.Null(reason);
+        result.Entry.Should().NotBeNull();
+        result.FailureReason.Should().BeNull();
     }
 
     [Fact]
-    public void Exchange_MissingVerifier_ReportsMissing()
+    public async Task Exchange_PlainPkce_RoundTrips()
     {
+        // plain method: challenge == verifier, compared verbatim.
         var store = NewStore();
-        var code = Issue(store, Challenge("v"), "S256");
+        const string verifier = "plain-verifier-with-enough-entropy-0123456789";
+        var code = await Issue(store, verifier, "plain");
 
-        var entry = store.ExchangeCode(code, ClientId, RedirectUri, null, out var reason);
+        var result = await Exchange(store, code, verifier: verifier);
 
-        Assert.Null(entry);
-        Assert.Contains("code_verifier missing", reason);
+        result.Entry.Should().NotBeNull();
+        result.FailureReason.Should().BeNull();
     }
 
     [Fact]
-    public void Exchange_WrongVerifier_ReportsPkceFailure()
+    public async Task Exchange_MissingVerifier_ReportsMissing()
     {
         var store = NewStore();
-        var code = Issue(store, Challenge("right-verifier"), "S256");
+        var code = await Issue(store, Challenge("v"), "S256");
 
-        var entry = store.ExchangeCode(code, ClientId, RedirectUri, "wrong-verifier", out var reason);
+        var result = await Exchange(store, code);
 
-        Assert.Null(entry);
-        Assert.Contains("PKCE verification failed", reason);
+        result.Entry.Should().BeNull();
+        result.FailureReason.Should().Contain("code_verifier missing");
+    }
+
+    [Fact]
+    public async Task Exchange_WrongVerifier_ReportsPkceFailure()
+    {
+        var store = NewStore();
+        var code = await Issue(store, Challenge("right-verifier"), "S256");
+
+        var result = await Exchange(store, code, verifier: "wrong-verifier");
+
+        result.Entry.Should().BeNull();
+        result.FailureReason.Should().Contain("PKCE verification failed");
+    }
+
+    [Fact]
+    public async Task TwoStoreInstances_GenerateOnOne_ExchangeOnOther()
+    {
+        // The prod 2026-07-23 outage shape: /authorize on replica A, /token on replica B.
+        // Two independent store instances share the mesh the way two pods share PG —
+        // B must be able to exchange A's code, and the single-use consume must then
+        // hold on EVERY replica (a replay against A is a lost first-delete-wins race,
+        // never a second success).
+        var replicaA = NewStore();
+        var replicaB = NewStore();
+
+        var code = await Issue(replicaA);
+
+        var onB = await Exchange(replicaB, code);
+        onB.Entry.Should().NotBeNull();
+        onB.FailureReason.Should().BeNull();
+        onB.Entry!.UserId.Should().Be("rbuergi");
+
+        var replayOnA = await Exchange(replicaA, code);
+        replayOnA.Entry.Should().BeNull();
+        replayOnA.FailureReason.Should().Contain("unknown or already consumed");
     }
 }

--- a/test/MeshWeaver.Auth.Test/OAuthConnectControllerTests.cs
+++ b/test/MeshWeaver.Auth.Test/OAuthConnectControllerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Security.Claims;
 using System.Security.Cryptography;
@@ -29,10 +30,20 @@ namespace MeshWeaver.Auth.Test;
 /// </summary>
 public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
+    protected override MeshWeaver.Mesh.MeshBuilder ConfigureMesh(MeshWeaver.Mesh.MeshBuilder builder)
+        // Same registration the portal wires in ConfigureMemexMesh — the OAuthCode
+        // NodeType + AuthorizationCode content type the mesh-backed code store persists.
+        => base.ConfigureMesh(builder).AddOAuthCodeType();
+
     private OAuthConnectController CreateController(ClaimsPrincipal? user = null, string host = "memex.test", string scheme = "https")
     {
         var services = new ServiceCollection();
-        services.AddSingleton<OAuthCodeStore>();
+        // The code store is mesh-backed (replica-safe) — build it on the test mesh's
+        // services, the same way the ApiTokenService below is.
+        services.AddSingleton(new OAuthCodeStore(
+            Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
+            Mesh,
+            Mesh.ServiceProvider.GetRequiredService<ILogger<OAuthCodeStore>>()));
         services.AddSingleton(new ApiTokenService(
             Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
             Mesh,
@@ -46,6 +57,17 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
         controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
         return controller;
     }
+
+    /// <summary>
+    /// Waits until the authorization-code node minted by /authorize is readable —
+    /// absorbs create→routing visibility lag (sanctioned Interval+re-read pattern)
+    /// so the /token exchange under test exercises its own logic, not read lag.
+    /// </summary>
+    private async Task AwaitCodeVisible(string code) =>
+        await Observable
+            .Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => ReadNode(OAuthCodeStore.PathForCode(code)))
+            .Should().Within(30.Seconds()).Match(n => n is not null);
 
     private static ClaimsPrincipal AuthenticatedUser(string email = "alice@example.com", string name = "Alice")
     {
@@ -238,7 +260,7 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
     // ─── /authorize ──────────────────────────────────────────────────────────
 
     [Fact]
-    public void Authorize_Unauthenticated_RedirectsToLogin()
+    public async Task Authorize_Unauthenticated_RedirectsToLogin()
     {
         // "we should go to our login screen" — this is the step the user was waiting for.
         // Unauthenticated calls to /authorize must 302 to /login?returnUrl=... so the portal
@@ -248,14 +270,15 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
         controller.ControllerContext.HttpContext.Request.QueryString = new QueryString(
             "?response_type=code&client_id=c1&redirect_uri=https%3A%2F%2Fclaude.ai%2Fcb&state=xyz&code_challenge=abc&code_challenge_method=S256");
 
-        var result = controller.Authorize(
+        var result = await controller.Authorize(
             response_type: "code",
             client_id: "c1",
             redirect_uri: "https://claude.ai/cb",
             state: "xyz",
             scope: "mcp",
             code_challenge: "abc",
-            code_challenge_method: "S256") as RedirectResult;
+            code_challenge_method: "S256",
+            ct: TestContext.Current.CancellationToken) as RedirectResult;
 
         result.Should().NotBeNull();
         result!.Url.Should().StartWith("/login?returnUrl=");
@@ -264,18 +287,19 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
     }
 
     [Fact]
-    public void Authorize_Authenticated_IssuesCodeAndRedirectsToClient()
+    public async Task Authorize_Authenticated_IssuesCodeAndRedirectsToClient()
     {
         var controller = CreateController(AuthenticatedUser());
 
-        var result = controller.Authorize(
+        var result = await controller.Authorize(
             response_type: "code",
             client_id: "c1",
             redirect_uri: "https://claude.ai/cb",
             state: "nonce-42",
             scope: "mcp",
             code_challenge: null,
-            code_challenge_method: null) as RedirectResult;
+            code_challenge_method: null,
+            ct: TestContext.Current.CancellationToken) as RedirectResult;
 
         result.Should().NotBeNull();
         result!.Url.Should().StartWith("https://claude.ai/cb?code=");
@@ -283,67 +307,71 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
     }
 
     [Fact]
-    public void Authorize_AuthenticatedNoState_RedirectsWithoutStateParam()
+    public async Task Authorize_AuthenticatedNoState_RedirectsWithoutStateParam()
     {
         // Edge: some minimal clients don't pass state. Must not emit state= with empty value.
         var controller = CreateController(AuthenticatedUser());
 
-        var result = controller.Authorize(
+        var result = await controller.Authorize(
             response_type: "code",
             client_id: "c1",
             redirect_uri: "https://claude.ai/cb",
             state: null,
             scope: null,
             code_challenge: null,
-            code_challenge_method: null) as RedirectResult;
+            code_challenge_method: null,
+            ct: TestContext.Current.CancellationToken) as RedirectResult;
 
         result!.Url.Should().StartWith("https://claude.ai/cb?code=");
         result.Url.Should().NotContain("state=");
     }
 
     [Fact]
-    public void Authorize_UnsupportedResponseType_Returns400()
+    public async Task Authorize_UnsupportedResponseType_Returns400()
     {
         var controller = CreateController(AuthenticatedUser());
 
-        var result = controller.Authorize(
+        var result = await controller.Authorize(
             response_type: "token",
             client_id: "c1",
             redirect_uri: "https://claude.ai/cb",
-            state: null, scope: null, code_challenge: null, code_challenge_method: null) as BadRequestObjectResult;
+            state: null, scope: null, code_challenge: null, code_challenge_method: null,
+            ct: TestContext.Current.CancellationToken) as BadRequestObjectResult;
 
         result.Should().NotBeNull();
         result!.Value!.GetType().GetProperty("error")!.GetValue(result.Value).Should().Be("unsupported_response_type");
     }
 
     [Fact]
-    public void Authorize_MissingClientId_Returns400()
+    public async Task Authorize_MissingClientId_Returns400()
     {
         var controller = CreateController(AuthenticatedUser());
 
-        var result = controller.Authorize(
+        var result = await controller.Authorize(
             response_type: "code",
             client_id: "",
             redirect_uri: "https://claude.ai/cb",
-            state: null, scope: null, code_challenge: null, code_challenge_method: null) as BadRequestObjectResult;
+            state: null, scope: null, code_challenge: null, code_challenge_method: null,
+            ct: TestContext.Current.CancellationToken) as BadRequestObjectResult;
 
         result.Should().NotBeNull();
         result!.Value!.GetType().GetProperty("error")!.GetValue(result.Value).Should().Be("invalid_request");
     }
 
     [Fact]
-    public void Authorize_AuthenticatedWithoutEmail_Returns400()
+    public async Task Authorize_AuthenticatedWithoutEmail_Returns400()
     {
         // Degenerate: a cookie claim set without email/preferred_username — we can't issue
         // an API token for an unknown user.
         var identity = new ClaimsIdentity([new Claim(ClaimTypes.Name, "No Email")], authenticationType: "Test");
         var controller = CreateController(new ClaimsPrincipal(identity));
 
-        var result = controller.Authorize(
+        var result = await controller.Authorize(
             response_type: "code",
             client_id: "c1",
             redirect_uri: "https://claude.ai/cb",
-            state: null, scope: null, code_challenge: null, code_challenge_method: null) as BadRequestObjectResult;
+            state: null, scope: null, code_challenge: null, code_challenge_method: null,
+            ct: TestContext.Current.CancellationToken) as BadRequestObjectResult;
 
         result.Should().NotBeNull();
         var err = result!.Value!.GetType().GetProperty("error")!.GetValue(result.Value);
@@ -375,17 +403,19 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
         var challenge = Convert.ToBase64String(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)))
             .Replace("+", "-").Replace("/", "_").TrimEnd('=');
 
-        var authRedirect = (RedirectResult)controller.Authorize(
+        var authRedirect = (RedirectResult)await controller.Authorize(
             response_type: "code",
             client_id: reg.ClientId,
             redirect_uri: "https://claude.ai/cb",
             state: "s1",
             scope: "mcp",
             code_challenge: challenge,
-            code_challenge_method: "S256")!;
+            code_challenge_method: "S256",
+            ct: TestContext.Current.CancellationToken);
 
         var code = Uri.UnescapeDataString(
             authRedirect.Url["https://claude.ai/cb?code=".Length..authRedirect.Url.IndexOf("&state=")]);
+        await AwaitCodeVisible(code);
 
         // Step 3: exchange code for token. ExchangeToken returns Task<IActionResult>
         // (genuine controller SDK boundary) — bridge it to the reactive assertion via
@@ -416,10 +446,12 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
         var challenge = Convert.ToBase64String(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)))
             .Replace("+", "-").Replace("/", "_").TrimEnd('=');
 
-        var authRedirect = (RedirectResult)controller.Authorize(
-            "code", "c1", "https://claude.ai/cb", "s", "mcp", challenge, "S256")!;
+        var authRedirect = (RedirectResult)await controller.Authorize(
+            "code", "c1", "https://claude.ai/cb", "s", "mcp", challenge, "S256",
+            TestContext.Current.CancellationToken);
         var code = Uri.UnescapeDataString(
             authRedirect.Url["https://claude.ai/cb?code=".Length..authRedirect.Url.IndexOf("&state=")]);
+        await AwaitCodeVisible(code);
 
         var result = await controller.ExchangeToken(new TokenRequest
         {
@@ -440,9 +472,11 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
         // RFC 6749 §4.1.3: token endpoint MUST verify the code was issued to the same client.
         var controller = CreateController(AuthenticatedUser());
 
-        var authRedirect = (RedirectResult)controller.Authorize(
-            "code", "client-A", "https://claude.ai/cb", null, null, null, null)!;
+        var authRedirect = (RedirectResult)await controller.Authorize(
+            "code", "client-A", "https://claude.ai/cb", null, null, null, null,
+            TestContext.Current.CancellationToken);
         var code = authRedirect.Url["https://claude.ai/cb?code=".Length..];
+        await AwaitCodeVisible(Uri.UnescapeDataString(code));
 
         var result = await controller.ExchangeToken(new TokenRequest
         {
@@ -461,9 +495,11 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
     {
         var controller = CreateController(AuthenticatedUser());
 
-        var authRedirect = (RedirectResult)controller.Authorize(
-            "code", "c1", "https://claude.ai/cb", null, null, null, null)!;
+        var authRedirect = (RedirectResult)await controller.Authorize(
+            "code", "c1", "https://claude.ai/cb", null, null, null, null,
+            TestContext.Current.CancellationToken);
         var code = authRedirect.Url["https://claude.ai/cb?code=".Length..];
+        await AwaitCodeVisible(Uri.UnescapeDataString(code));
 
         var result = await controller.ExchangeToken(new TokenRequest
         {
@@ -483,9 +519,11 @@ public class OAuthConnectControllerTests(ITestOutputHelper output) : MonolithMes
         // Codes are single-use. Second exchange of the same code must fail.
         var controller = CreateController(AuthenticatedUser());
 
-        var authRedirect = (RedirectResult)controller.Authorize(
-            "code", "c1", "https://claude.ai/cb", null, null, null, null)!;
+        var authRedirect = (RedirectResult)await controller.Authorize(
+            "code", "c1", "https://claude.ai/cb", null, null, null, null,
+            TestContext.Current.CancellationToken);
         var code = Uri.UnescapeDataString(authRedirect.Url["https://claude.ai/cb?code=".Length..]);
+        await AwaitCodeVisible(code);
 
         var first = await controller.ExchangeToken(new TokenRequest
         {


### PR DESCRIPTION
## Problem
MCP clients could not connect to memex-cloud: the OAuth authorization-code store was an in-memory per-process dictionary, so with 2–8 KEDA replicas behind one ingress, `/authorize` minted the code on pod A and the client's `/token` exchange landed on pod B → `unknown or already consumed code (never issued by this process)` (observed on 3 pods in prod Loki, 2026-07-23 09:58–10:01). Pod restarts also wiped pending codes.

## Fix
- Codes are mesh nodes at `Admin/OAuthCode/{sha256-prefix}` (PG-persisted, shared across replicas), mirroring the ApiToken scheme: hash-keyed, raw code never stored, System identity writes, new `OAuthCodeNodeType` registration.
- **Atomic cross-replica single-use**: consumption IS the `DeleteNode` — the exchange is honored only when this caller's delete removed the node; a lost race → `invalid_grant`, never a second success.
- 5-min expiry checked post-consume; opportunistic cleanup of expired siblings on generate; PKCE unchanged; reactive surface with one `ToTask` bridge at the HTTP boundary; diagnosable `FailureReason` strings kept.
- Framework fix the tests exposed: requests delivered to a per-node hub disposing after its delete were silently dropped, hanging the sender 30s. `MessageService` now NACKs the sender with `DeliveryFailure(NotFound)` via the parent hub (cascade-safe, same exclusions as `ReportFailure`).

## Verification
- `Memex.Portal.Shared.Test` OAuthCodeStore: 11/11 (incl. `TwoStoreInstances_GenerateOnOne_ExchangeOnOther` — two store instances on one mesh = two replicas on one PG)
- `MeshWeaver.Auth.Test` OAuthConnectController: 26/26
- `MeshWeaver.Messaging.Hub.Test` full regression: 102/102
- Release `-warnaserror` clean for all touched projects + dependents
- What's New entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)