### PR TITLE
CD: isolate per-RID container-publish outputs; alert on main CD failure

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -264,6 +264,51 @@ jobs:
           -p:ContainerRepository=mw-plugin-test
           -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main;latest"'
 
+  # ───────────────────────────── FAILURE ALERTING ────────────────────────────
+  # A red CD after a green merge is otherwise INVISIBLE (nobody watches the Actions tab), and the
+  # consequence is severe: the merged commit never gets a deployable image, so every pull-based
+  # self-updating install silently stays on the previous image (2026-07-22: prod ran a leaky build
+  # for 20h because run 29929207634 failed unnoticed). This job makes a failed main CD loud: it
+  # files (or comments on) a GitHub issue labeled `ci-failure`.
+  # - `if: failure()` with `needs`: fires only when at least one image job actually FAILED —
+  #   not when they were skipped (PR-triggered workflow_run) and not on cancellation.
+  # - Idempotent: one open `ci-failure` issue collects repeat failures as comments; a new issue is
+  #   only created when none is open (close the issue once CD is green again).
+  alert-on-failure:
+    name: "Alert: CD failed on main"
+    needs: [portal-image, migration-image, plugin-test-image]
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Job-level permissions REPLACE the workflow-level map for this job: the default GITHUB_TOKEN
+    # here only needs to read/write issues (no checkout, no OIDC).
+    permissions:
+      issues: write
+    steps:
+      - name: Create or comment on ci-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          # Ensure the label exists (--force = update-or-create, idempotent).
+          gh label create ci-failure --repo "$GITHUB_REPOSITORY" \
+            --description "A main-branch CD run failed - no deployable image was published" \
+            --color B60205 --force
+          body="CD failed on main: [run ${GITHUB_RUN_ID}](${RUN_URL}) for commit \`${HEAD_SHA}\`.
+
+          No deployable image was published for this merge - every self-updating install stays on the PREVIOUS image until a CD run goes green. Triage the failed job in the linked run, fix (or re-run if infrastructure), and close this issue once CD is green."
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label ci-failure --state open \
+            --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "CD failed on main: run ${GITHUB_RUN_ID}" \
+              --label ci-failure --body "$body"
+          fi
+
   # ─────────────────────────────── NO DEPLOY JOB ─────────────────────────────
   # Deployment is PULL-BASED, not push. CI's job ends at "publish the image to ACR" (the image
   # jobs above). Each installation — memex / atioz / memex-cloud AND every external install in the

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,18 +53,42 @@
     <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0</PlatformVersion>
   </PropertyGroup>
   <!-- Multi-arch container publish race fix (main-cd / release-images / edge-images pass
-       -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"). The SDK builds the two RID legs of the
-       publish CONCURRENTLY. A reference assembly is RID-INVARIANT, so its intermediate path has NO rid
-       segment (obj/<cfg>/<tfm>/ref/<Asm>.dll) — both legs' CopyRefAssembly target write that SAME file
-       and intermittently collide → "error MSB3883: … MeshWeaver.Graph.dll … being used by another
-       process" (the intermittent portal-ai image-build failure). Ref assemblies exist only to skip
-       downstream recompilation on INCREMENTAL rebuilds; a from-clean CI container publish gains
-       nothing from them, so turning them off for the multi-arch publish removes the one shared,
-       contended output — killing the race at its source while keeping both RID legs parallel (no
-       serialization, no retry). ContainerRuntimeIdentifiers is a global property, so this condition is
-       seen by every project in the publish graph — including the referenced libraries that actually
-       race. It is empty in normal dev / the Build-and-Test CI, so ref assemblies (and fast incremental
-       builds) are UNAFFECTED there. -->
+       -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"). The SDK's _PublishMultiArchContainers
+       target invokes THIS SAME project once per RID with AdditionalProperties
+       "ContainerRuntimeIdentifier=<rid>;RuntimeIdentifier=<rid>;…" and BuildInParallel=true — two full
+       publish legs run CONCURRENTLY in one MSBuild session. The entry project is safe (RuntimeIdentifier
+       is set, so its bin/obj get the RID appended). The LIBRARIES are not: the ProjectReference protocol
+       undefines RuntimeIdentifier/SelfContained for RID-agnostic references, but ContainerRuntimeIdentifier
+       (singular) is NOT undefined — it flows to every library in the graph, so the two legs' library
+       builds are DISTINCT MSBuild configurations (no build-once dedupe) that both compile and copy into
+       the SAME RID-agnostic bin/obj paths. That shared-path double build is the whole race class:
+       obj/<cfg>/<tfm>/ref/<Asm>.dll (MSB3883, PR #552) and bin/<cfg>/<tfm>/<Asm>.dll — one leg's
+       _CopyFilesToOutputDirectory rewriting MeshWeaver.Graph.dll while the other leg's CSC reads it as a
+       reference (CS0009 "Metadata file … being used by another process", CD run 29929207634).
+
+       ROOT FIX: use the same per-leg discriminator (ContainerRuntimeIdentifier — global, per-leg unique,
+       visible to every project at evaluation time) to give each leg FULLY ISOLATED bin/obj trees. Both
+       legs stay parallel (no serialization, no retry); they just stop sharing any output path.
+       MSBuildProjectExtensionsPath is pinned to the standard obj/ so NuGet's restore outputs
+       (project.assets.json, nuget.g.props/targets) — written ONCE by the outer `dotnet publish` restore
+       before the legs fork, and only READ during the legs — stay where restore put them.
+       Scoped to RID-agnostic projects ('$(RuntimeIdentifier)' == ''): the entry project already gets
+       RID-qualified paths from AppendRuntimeIdentifierToOutputPath. Inert in normal dev / Build-and-Test
+       CI (ContainerRuntimeIdentifier is only a global property inside multi-arch publish legs). -->
+  <PropertyGroup Condition="'$(ContainerRuntimeIdentifiers)' != '' and '$(ContainerRuntimeIdentifier)' != '' and '$(RuntimeIdentifier)' == ''">
+    <MSBuildProjectExtensionsPath>$(MSBuildProjectDirectory)/obj/</MSBuildProjectExtensionsPath>
+    <BaseIntermediateOutputPath>obj/container/$(ContainerRuntimeIdentifier)/</BaseIntermediateOutputPath>
+    <BaseOutputPath>bin/container/$(ContainerRuntimeIdentifier)/</BaseOutputPath>
+    <!-- The SDK derives DefaultItemExcludes from Base(Intermediate)OutputPath — with those moved,
+         the STANDARD obj/ and bin/ (holding the outer restore + the outer build's generated
+         AssemblyInfo.cs) would fall back into the default **/*.cs compile glob → CS0579 duplicate
+         assembly attributes. Keep them excluded explicitly (also covers obj/container/, nested). -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**</DefaultItemExcludes>
+  </PropertyGroup>
+  <!-- Ref assemblies stay OFF for the whole multi-arch publish (PR #552): with per-leg isolation they
+       no longer collide, but a from-clean CI container publish gains nothing from producing them
+       (they only skip downstream recompiles on INCREMENTAL rebuilds), so this is pure saved work.
+       Empty in normal dev / Build-and-Test CI — ref assemblies and incremental builds unaffected there. -->
   <PropertyGroup Condition="'$(ContainerRuntimeIdentifiers)' != ''">
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>


### PR DESCRIPTION
## Problem
Recurring multi-arch publish race: `_PublishMultiArchContainers` runs one publish graph per RID with `BuildInParallel`, and `ContainerRuntimeIdentifier` flows as a global property into every referenced library — two distinct global-property sets defeat build-once dedup, so **every library compiles twice, concurrently, into the same RID-invariant `bin`/`obj`**. Manifestations: MSB3883 on `obj/**/ref/*.dll` (PR #552) and now `CS0009` on `bin/Release/net10.0/MeshWeaver.Graph.dll` (run 29929207634) — which cost ci.1306 its deployable image and left prod on a leaky, OOM-crashing build for 20 hours.

## Fix
`Directory.Build.props`: inside container legs (`ContainerRuntimeIdentifiers` set, per-leg `ContainerRuntimeIdentifier` set, `RuntimeIdentifier` empty) each leg gets fully disjoint trees — `obj/container/{rid}/` + `bin/container/{rid}/` — while restore outputs stay shared read-only (pinned `MSBuildProjectExtensionsPath`); standard `obj/`/`bin/` re-excluded from item globs (else CS0579 on generated AssemblyInfo). Legs stay fully parallel; entry project untouched (already RID-qualified); #552's `ProduceReferenceAssembly` gate kept. Covers main-cd, release-images and edge-images (same mechanism).

`main-cd.yml`: new `alert-on-failure` job (`if: failure()`, `issues: write`) that idempotently creates or comments on an open `ci-failure` issue with the run link, SHA, and the "no image published" consequence — a red main CD can no longer go unnoticed.

## Verification
- `dotnet msbuild -getProperty` per leg: disjoint `obj/container/linux-x64|arm64` and `bin/container/...`; control + entry project paths unchanged.
- The **actual CD command** (full multi-RID `PublishContainer` of Memex.Portal.Distributed, Release, `CIRun=true`, local OCI archive): exit 0, zero errors, multi-arch index assembled from two per-RID manifests.
- Workflow validated with actionlint + YAML parse + `bash -n`.

No What's New entry — pure CI/infrastructure change, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)