### PR TITLE
fix(space): plugin-package roots render their authored body, not the welcome placeholder

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
@@ -43,6 +43,17 @@ public record NodeTypeDefinition
     public string? Description { get; init; }
 
     /// <summary>
+    /// Optional authored markdown home page for a PARTITION-ROOT node whose content is this
+    /// NodeTypeDefinition (a plugin-package Space root — e.g. UWDeepfield, whose root's content
+    /// IS the partition-level compile config and therefore cannot be a <see cref="Space"/>).
+    /// The Space Overview renders it exactly like <c>Space.Body</c> (recovered in
+    /// <c>SpaceLayoutAreas.ResolveSpace</c>'s foreign-typed probe). Declared as a first-class
+    /// member so typed round-trips and compile write-backs (<c>with</c>-expressions on this
+    /// record) PRESERVE the authored page instead of silently dropping an unknown JSON member.
+    /// </summary>
+    public string? Body { get; init; }
+
+    /// <summary>
     /// Default values for initializing new instances of this type.
     /// Keys are property names, values are default values.
     /// </summary>

--- a/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceLayoutAreas.cs
@@ -193,10 +193,13 @@ public static class SpaceLayoutAreas
     /// <summary>
     /// Resolves the <see cref="Space"/> off a node's <see cref="MeshNode.Content"/>, robust to
     /// every form Content can take: an already-typed <see cref="Space"/>, a degraded
-    /// <see cref="JsonElement"/>, or — when the content lost its typing entirely — a raw string.
-    /// A JSON-object string is deserialised back into the Space; any other non-empty string is
-    /// taken as the body so the page still shows the author's text instead of the welcome
-    /// placeholder. Returns null only when there is genuinely nothing to render.
+    /// <see cref="JsonElement"/>, a FOREIGN-typed content that carries an authored
+    /// <c>body</c> (a plugin-package Space root whose content is the partition's
+    /// <see cref="Configuration.NodeTypeDefinition"/> — the UWDeepfield shape), or — when the content lost
+    /// its typing entirely — a raw string. A JSON-object string is deserialised back into the
+    /// Space; any other non-empty string is taken as the body so the page still shows the
+    /// author's text instead of the welcome placeholder. Returns null only when there is
+    /// genuinely nothing to render.
     /// </summary>
     internal static Space? ResolveSpace(MeshNode? node, JsonSerializerOptions options)
     {
@@ -206,6 +209,28 @@ public static class SpaceLayoutAreas
         var space = node.ContentAs<Space>(options);
         if (space != null)
             return space;
+
+        // Foreign-typed content (a differently-named CLR type — ContentAs correctly returns
+        // null so call sites can probe-dispatch). The node still IS a Space to the viewer, and
+        // such content may carry an authored `body` (NodeTypeDefinition.Body on a plugin-package
+        // root). Recover it via a JSON round-trip so the Overview renders the authored home page
+        // instead of the welcome placeholder. Serialized AS the concrete runtime type — the
+        // object-declared path would adopt the foreign type into this hub's registry as a read
+        // side effect (same rationale as ContentAs's own cross-assembly recovery).
+        if (node.Content is not null and not string and not JsonElement)
+        {
+            try
+            {
+                var el = JsonSerializer.SerializeToElement(node.Content, node.Content.GetType(), options);
+                if (el.ValueKind == JsonValueKind.Object
+                    && el.TryGetProperty("body", out var b)
+                    && b.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(b.GetString()))
+                    return new Space { Body = b.GetString() };
+            }
+            catch (Exception e) when (e is JsonException or NotSupportedException or InvalidOperationException)
+            { /* not recoverable — fall through to the placeholder */ }
+        }
 
         // Content degraded to a bare string (or a JSON-string JsonElement) — recover it
         // rather than falling back to the welcome placeholder.

--- a/test/MeshWeaver.Graph.Test/SpaceResolveSpaceTest.cs
+++ b/test/MeshWeaver.Graph.Test/SpaceResolveSpaceTest.cs
@@ -2,6 +2,7 @@
 
 using System.Text.Json;
 using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
 using Xunit;
@@ -98,5 +99,39 @@ public class SpaceResolveSpaceTest
         var md = Assert.IsType<MarkdownControl>(control);
         md.NodePath.Should().Be("Acme");
         md.Markdown.ToString()!.Should().Contain("Hi");
+    }
+
+    // ---------- Foreign-typed content carrying an authored body ----------
+    // A plugin-package Space root's content IS the partition's NodeTypeDefinition (the
+    // UWDeepfield shape) — the node is still a Space to the viewer, and its authored home
+    // page lives in NodeTypeDefinition.Body. ResolveSpace must recover it; without this,
+    // no content edit can ever replace the welcome placeholder on such a root (verified
+    // live on memex.systemorph.com 2026-07-23: a stored body was rendered-inert).
+
+    [Fact]
+    public void ForeignTypedContent_WithBody_RecoveredAsSpaceBody()
+    {
+        var def = new NodeTypeDefinition { Description = "package node", Body = "# UW Deepfield\n\n@@(\"area/Search\")" };
+        var space = SpaceLayoutAreas.ResolveSpace(Node(def), Options);
+        space.Should().NotBeNull("an authored body on foreign-typed content must render, not the placeholder");
+        space!.Body.Should().Contain("UW Deepfield");
+    }
+
+    [Fact]
+    public void ForeignTypedContent_WithoutBody_Null()
+    {
+        // No authored body ⇒ genuinely nothing to render — the welcome placeholder path stays.
+        var def = new NodeTypeDefinition { Description = "package node" };
+        SpaceLayoutAreas.ResolveSpace(Node(def), Options).Should().BeNull();
+    }
+
+    [Fact]
+    public void JsonElementForeignContent_WithBody_Recovered()
+    {
+        // The same shape after a query-boundary degrade to JsonElement: Deserialize<Space> maps
+        // the camel-cased `body` member onto Space.Body directly.
+        var je = JsonSerializer.SerializeToElement(
+            new NodeTypeDefinition { Body = "BODY" }, Options);
+        SpaceLayoutAreas.ResolveSpace(Node(je), Options)!.Body.Should().Be("BODY");
     }
 }


### PR DESCRIPTION
A Space root whose content is the partition's `NodeTypeDefinition` (the plugin-package shape — e.g. **UWDeepfield**, whose root content IS the partition-level compile config and cannot be retyped to `Space`) could never author its home page: `ResolveSpace`'s `ContentAs<Space>` correctly returns null for the foreign-typed content, so `BuildBodyContent` always fell through to the welcome placeholder. **Verified live** on memex.systemorph.com (2026-07-23): a stored `content.body` was render-inert — and the Space's own ⋯→Edit page writes to exactly that inert field.

Two-part fix:
- **`ResolveSpace` foreign-typed probe**: content that isn't a Space / string / JsonElement is round-tripped (serialized AS its concrete runtime type — same registry-safety rationale as `ContentAs`' cross-assembly recovery) and an authored non-empty `body` member is recovered as `Space.Body`. No body → null, so the placeholder path is unchanged for genuinely empty roots.
- **`NodeTypeDefinition.Body`** becomes a first-class property, so typed round-trips and compile write-backs (`with`-expressions on the record) **preserve** the authored page instead of silently dropping an unknown JSON member on the next recompile.

Tests: 3 new cases in `SpaceResolveSpaceTest` (foreign-typed with body / without body / the JsonElement-degraded shape) — suite 11/11 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)