### PR TITLE
MeshQuery + Export/Import: make a stalled-provider hang diagnosable and bounded

### DIFF
--- a/src/MeshWeaver.AI/MeshOperations.cs
+++ b/src/MeshWeaver.AI/MeshOperations.cs
@@ -2580,8 +2580,18 @@ public class MeshOperations
 
         // 1. Snapshot the subtree (root + descendants) — the same query Copy traverses. Ancestor-first
         //    ordering so an inherited collection is attributed to its owning ancestor on dedup.
+        //    Bounded fail-loud: this was the ONE stage of the chain with no bound, so a stalled query
+        //    provider (see MeshQuery's Initial stall probe) hung the whole Export in total silence —
+        //    for an agent tool call that is a forever-hung round. The timeout converts the invisible
+        //    hang into a named error; the ROOT CAUSE of any stall is the provider (fix there), never
+        //    this bound.
         return mesh.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{root} scope:subtree"))
             .Take(1)
+            .Timeout(TimeSpan.FromSeconds(60))
+            .Catch((TimeoutException _) => Observable.Throw<QueryResultChange<MeshNode>>(
+                new TimeoutException(
+                    $"Export: the subtree snapshot query for '{root}' produced no result within 60s — "
+                    + "a query provider stalled (check the 'has not emitted an Initial' warnings in the log).")))
             .Select(change => change.Items
                 .Where(n => !string.IsNullOrEmpty(n.Path))
                 .ToList())
@@ -2837,7 +2847,16 @@ public class MeshOperations
                                 .Where(bytes => bytes is not null)
                                 .Select(bytes => new ExportedFile(
                                     nodePath, collectionName, file.Path.TrimStart('/'), bytes!)))
-                            .Concat());
+                            .Concat())
+                    // Bounded fail-loud: GetCollection / the per-file reads had no bound, so one
+                    // stalled backing store hung the whole Export in silence. Rx's relative Timeout
+                    // bounds the GAP between emissions (subscribe→first, then file→file), so slow
+                    // MANY-file collections are fine as long as individual reads respond. Real
+                    // errors still propagate unchanged — only the silent stall becomes named.
+                    .Timeout(TimeSpan.FromSeconds(120))
+                    .Catch((TimeoutException _) => Observable.Throw<ExportedFile>(new TimeoutException(
+                        $"Export: reading content files for '{nodePath}/{collectionName}' stalled "
+                        + "(no progress for 120s) — the collection's backing store did not respond.")));
             }))
             .ToObservable()
             .Concat()
@@ -2933,6 +2952,11 @@ public class MeshOperations
         };
         return mesh.CreateNode(newNode)
             .Select(_ => 1)
+            // Bounded: a CreateNode that neither emits nor errors would stall the import's
+            // sequential Concat forever in silence. The timeout routes into the existing
+            // tolerant per-node catch below, so one stalled node logs and counts as failed
+            // instead of hanging the whole import.
+            .Timeout(TimeSpan.FromSeconds(30))
             .Catch((Exception ex) =>
             {
                 logger.LogWarning(ex, "Import: create failed for {Path}", newPath);

--- a/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
@@ -450,34 +450,27 @@ public class MeshQuery : IMeshQueryCore
                 return ClipMergedInitial<T>(hits, change, parsed, request);
             });
             // Same stall probe as the multi-provider merge below — a single provider that
-            // neither emits nor completes hangs its consumer just as silently.
+            // neither emits nor completes hangs its consumer just as silently. The probe is a
+            // standalone hub-independent object (see InitialStallProbe) so the process-global
+            // TimerQueue timer can never pin the owning hub past disposal (MeshHubDisposalLeakTest).
+            var singleProbe = new InitialStallProbe([observables[0].Provider]);
+            var singleProbeLogger = Logger;
+            var singleProbeQuery = request.Query;
+            var singleProbeUser = request.UserId;
             return Observable.Create<QueryResultChange<T>>(observer =>
             {
-                // Benign race by design: a plain bool flag read by the probe timer. Worst
-                // case is one spurious warning when the Initial lands exactly at the probe
-                // deadline — acceptable for a diagnostic; no gate lock on the hot path.
-                var gotInitial = false;
-                var providerName = observables[0].Provider;
-                var probe = Observable.Timer(InitialStallProbeDelay).Subscribe(_ =>
-                {
-                    if (gotInitial)
-                        return;
-                    Logger?.LogWarning(
-                        "Query provider [{Provider}] has not emitted an Initial after {Delay}s for query "
-                        + "'{Query}' (user '{UserId}') — its consumer hangs with no error. Fix the stalled "
-                        + "provider; never bump the consumer's timeout.",
-                        providerName, InitialStallProbeDelay.TotalSeconds, request.Query, request.UserId);
-                });
+                var probeArm = singleProbe.Arm(
+                    InitialStallProbeDelay, singleProbeLogger, singleProbeQuery, singleProbeUser);
                 var sub = single.Subscribe(
                     change =>
                     {
                         if (change.ChangeType == QueryChangeType.Initial)
-                            gotInitial = true;
+                            singleProbe.MarkSeen(0);
                         observer.OnNext(change);
                     },
                     observer.OnError,
                     observer.OnCompleted);
-                return new System.Reactive.Disposables.CompositeDisposable(probe, sub);
+                return new System.Reactive.Disposables.CompositeDisposable(probeArm, sub);
             });
         }
 
@@ -518,6 +511,11 @@ public class MeshQuery : IMeshQueryCore
             var initialSeen = new bool[observables.Count];
             ParsedQuery? lastQuery = null;
             var gate = new object();
+
+            // Standalone, hub-independent stall probe (see the Arm(...) call after the subscribe
+            // loop). Driven by MarkSeen(idx) in each provider's Initial handler below; keeps the
+            // TimerQueue timer off the merge's closure so it can't root the hub.
+            var stallProbe = new InitialStallProbe(observables.Select(o => o.Provider).ToArray());
 
             // Live-stream dedup: track Path so a Removed for a path
             // we never Added is dropped, and an Added for a path that's already
@@ -586,6 +584,7 @@ public class MeshQuery : IMeshQueryCore
                                     initialSeen[idx] = true;
                                     initialCount++;
                                 }
+                                stallProbe.MarkSeen(idx);
 
                                 EmitMergedInitialIfComplete(change);
                             }
@@ -624,6 +623,9 @@ public class MeshQuery : IMeshQueryCore
                                 providerName, request.Query, request.UserId);
                             initialSeen[idx] = true;
                             initialCount++;
+                            // A provider that COMPLETED (even without an Initial) is not stalled —
+                            // mark it seen so the stall probe doesn't also flag it.
+                            stallProbe.MarkSeen(idx);
                             // Stamp Query even when EVERY provider went silent (lastQuery never
                             // set) — downstream consumers rely on QueryResultChange.Query being
                             // populated on an Initial; fall back to parsing the request.
@@ -648,28 +650,15 @@ public class MeshQuery : IMeshQueryCore
             // nor errors starves the gate FOREVER and the consumer hangs in TOTAL silence
             // (CI 2026-07-21: ExportImportAccessControlTest watchdog-killed at 60s with a
             // flat heap and not one log line — this warning is the line that was missing).
-            // Warning level so default CI/prod log levels carry it; names the exact laggard
+            // Warning level so default CI/prod log levels carry it; names the exact laggards
             // so the NEXT occurrence is attributable. Disposed with the subscriptions, so a
             // normally-answered query never logs.
-            var stallProbe = Observable.Timer(InitialStallProbeDelay).Subscribe(_ =>
-            {
-                string missing;
-                lock (gate)
-                {
-                    if (initialCount == initialTarget)
-                        return;
-                    missing = string.Join(", ", observables
-                        .Where((_, k) => !initialSeen[k])
-                        .Select(o => o.Provider));
-                }
-                Logger?.LogWarning(
-                    "Query providers [{Providers}] have not emitted an Initial after {Delay}s for query "
-                    + "'{Query}' (user '{UserId}') — the merged query is silently stalled on its "
-                    + "all-providers gate and its consumer hangs with no error. Fix the stalled "
-                    + "provider; never bump the consumer's timeout.",
-                    missing, InitialStallProbeDelay.TotalSeconds, request.Query, request.UserId);
-            });
-            subscriptions.Add(stallProbe);
+            // 🚨 The timer lives on the process-global TimerQueue for the probe window; it reads a
+            // standalone InitialStallProbe (provider-name strings + a seen flag), NEVER the merge's
+            // closure — so it cannot root the owning hub past disposal (MeshHubDisposalLeakTest).
+            // The per-provider Initial handler above calls stallProbe.MarkSeen(idx).
+            subscriptions.Add(stallProbe.Arm(
+                InitialStallProbeDelay, Logger, request.Query, request.UserId));
 
             return new System.Reactive.Disposables.CompositeDisposable(subscriptions);
         });
@@ -682,6 +671,70 @@ public class MeshQuery : IMeshQueryCore
     /// single-digit seconds), short enough to land well before consumer watchdogs (60s+).
     /// </summary>
     private static readonly TimeSpan InitialStallProbeDelay = TimeSpan.FromSeconds(20);
+
+    /// <summary>
+    /// Standalone, HUB-INDEPENDENT state + timer for the Initial stall diagnostic. It exists as its
+    /// own object (not the merge's closure) for one load-bearing reason: the diagnostic timer lives
+    /// on the PROCESS-GLOBAL TimerQueue for the whole probe window, and a timer whose callback closed
+    /// over the merge's <c>Observable.Create</c> scope would transitively root the observer chain and
+    /// the owning <c>MessageHub</c> until it fires — pinning a disposed mesh's hub past disposal and
+    /// failing <c>MeshHubDisposalLeakTest</c>. This object holds ONLY provider-name strings and a
+    /// seen flag, so the timer that reads it can never reach a hub. It is fed by <see cref="MarkSeen"/>
+    /// from each provider's Initial (or silent-completion) handler; <see cref="Arm"/> starts the timer.
+    /// </summary>
+    private sealed class InitialStallProbe(string[] providerNames)
+    {
+        private readonly bool[] _seen = new bool[providerNames.Length];
+        private readonly object _gate = new();
+        private int _seenCount;
+
+        /// <summary>Records that provider <paramref name="idx"/> has delivered (or terminally
+        /// completed) its Initial, so the probe no longer counts it as stalled. Idempotent.</summary>
+        public void MarkSeen(int idx)
+        {
+            lock (_gate)
+            {
+                if (idx >= 0 && idx < _seen.Length && !_seen[idx])
+                {
+                    _seen[idx] = true;
+                    _seenCount++;
+                }
+            }
+        }
+
+        /// <summary>Comma-joined names of providers that have not yet delivered an Initial, or
+        /// <c>null</c> when every provider has — i.e. nothing is stalled.</summary>
+        private string? MissingOrNull()
+        {
+            lock (_gate)
+            {
+                if (_seenCount >= _seen.Length)
+                    return null;
+                return string.Join(", ", providerNames.Where((_, k) => !_seen[k]));
+            }
+        }
+
+        /// <summary>
+        /// Arms the diagnostic timer. The returned subscription is added to the merge's disposables,
+        /// so a normally-answered (and thus unsubscribed) query cancels the timer well before it
+        /// fires. The callback closes over ONLY <c>this</c> (hub-free) + the passed logger/strings —
+        /// deliberately a separate display class from the merge closure (this method is on this
+        /// nested type, not inside <c>Observable.Create</c>), which is what keeps the hub uncaptured.
+        /// </summary>
+        public IDisposable Arm(TimeSpan delay, ILogger? logger, string? query, string? userId) =>
+            Observable.Timer(delay).Subscribe(_ =>
+            {
+                var missing = MissingOrNull();
+                if (missing is null)
+                    return;
+                logger?.LogWarning(
+                    "Query provider(s) [{Providers}] have not emitted an Initial after {Delay}s for query "
+                    + "'{Query}' (user '{UserId}') — the query is silently stalled on its all-providers "
+                    + "Initial gate and its consumer hangs with no error. Fix the stalled provider; "
+                    + "never bump the consumer's timeout.",
+                    missing, delay.TotalSeconds, query, userId);
+            });
+    }
 
     /// <summary>
     /// Sort + skip + clip the merged initial set. The authoritative ordering

--- a/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
@@ -431,7 +431,7 @@ public class MeshQuery : IMeshQueryCore
             // Single-provider ordering is preserved when OrderBy is absent
             // and all scores are equal, because LINQ's OrderByDescending
             // is stable.
-            return observables[0].Stream.Select(change =>
+            var single = observables[0].Stream.Select(change =>
             {
                 if (change.ChangeType != QueryChangeType.Initial)
                     return change;
@@ -442,7 +442,42 @@ public class MeshQuery : IMeshQueryCore
                     var score = scores is not null && j < scores.Count ? scores[j] : 0.0;
                     hits.Add((change.Items[j], score));
                 }
-                return ClipMergedInitial<T>(hits, change, change.Query!, request);
+                // Same null-Query defense as the multi-provider merge: a provider that emits an
+                // Initial without stamping Query (contract slip) NRE'd ClipMergedInitial here —
+                // fall back to parsing the request instead of trusting the provider.
+                var parsed = change.Query
+                    ?? new QueryParser().Parse(request.EffectiveQueries.FirstOrDefault() ?? "");
+                return ClipMergedInitial<T>(hits, change, parsed, request);
+            });
+            // Same stall probe as the multi-provider merge below — a single provider that
+            // neither emits nor completes hangs its consumer just as silently.
+            return Observable.Create<QueryResultChange<T>>(observer =>
+            {
+                // Benign race by design: a plain bool flag read by the probe timer. Worst
+                // case is one spurious warning when the Initial lands exactly at the probe
+                // deadline — acceptable for a diagnostic; no gate lock on the hot path.
+                var gotInitial = false;
+                var providerName = observables[0].Provider;
+                var probe = Observable.Timer(InitialStallProbeDelay).Subscribe(_ =>
+                {
+                    if (gotInitial)
+                        return;
+                    Logger?.LogWarning(
+                        "Query provider [{Provider}] has not emitted an Initial after {Delay}s for query "
+                        + "'{Query}' (user '{UserId}') — its consumer hangs with no error. Fix the stalled "
+                        + "provider; never bump the consumer's timeout.",
+                        providerName, InitialStallProbeDelay.TotalSeconds, request.Query, request.UserId);
+                });
+                var sub = single.Subscribe(
+                    change =>
+                    {
+                        if (change.ChangeType == QueryChangeType.Initial)
+                            gotInitial = true;
+                        observer.OnNext(change);
+                    },
+                    observer.OnError,
+                    observer.OnCompleted);
+                return new System.Reactive.Disposables.CompositeDisposable(probe, sub);
             });
         }
 
@@ -607,9 +642,46 @@ public class MeshQuery : IMeshQueryCore
                 subscriptions.Add(sub);
             }
 
+            // 🔦 Stall probe — pure diagnosability, no behavior change. The merged Initial
+            // gates on EVERY provider; the completion guard above covers a provider that
+            // COMPLETES without an Initial, but a provider that neither emits nor completes
+            // nor errors starves the gate FOREVER and the consumer hangs in TOTAL silence
+            // (CI 2026-07-21: ExportImportAccessControlTest watchdog-killed at 60s with a
+            // flat heap and not one log line — this warning is the line that was missing).
+            // Warning level so default CI/prod log levels carry it; names the exact laggard
+            // so the NEXT occurrence is attributable. Disposed with the subscriptions, so a
+            // normally-answered query never logs.
+            var stallProbe = Observable.Timer(InitialStallProbeDelay).Subscribe(_ =>
+            {
+                string missing;
+                lock (gate)
+                {
+                    if (initialCount == initialTarget)
+                        return;
+                    missing = string.Join(", ", observables
+                        .Where((_, k) => !initialSeen[k])
+                        .Select(o => o.Provider));
+                }
+                Logger?.LogWarning(
+                    "Query providers [{Providers}] have not emitted an Initial after {Delay}s for query "
+                    + "'{Query}' (user '{UserId}') — the merged query is silently stalled on its "
+                    + "all-providers gate and its consumer hangs with no error. Fix the stalled "
+                    + "provider; never bump the consumer's timeout.",
+                    missing, InitialStallProbeDelay.TotalSeconds, request.Query, request.UserId);
+            });
+            subscriptions.Add(stallProbe);
+
             return new System.Reactive.Disposables.CompositeDisposable(subscriptions);
         });
     }
+
+    /// <summary>
+    /// How long a query provider may take to deliver its Initial before the merge's stall probe
+    /// names it in a warning. Diagnostic only — nothing is cancelled; generous enough that a slow
+    /// cold provider under suite load doesn't produce noise (the observed healthy worst case is
+    /// single-digit seconds), short enough to land well before consumer watchdogs (60s+).
+    /// </summary>
+    private static readonly TimeSpan InitialStallProbeDelay = TimeSpan.FromSeconds(20);
 
     /// <summary>
     /// Sort + skip + clip the merged initial set. The authoritative ordering

--- a/test/MeshWeaver.Hosting.Test/MeshQueryMergeContractTest.cs
+++ b/test/MeshWeaver.Hosting.Test/MeshQueryMergeContractTest.cs
@@ -127,4 +127,49 @@ public class MeshQueryMergeContractTest
         paths.Should().Contain("p/one");
         paths.Should().Contain("q/two");
     }
+
+    /// <summary>
+    /// The single-provider fast path is wrapped by the Initial stall probe (a diagnostic timer
+    /// that names a provider which never delivers its Initial). The wrapper must be TRANSPARENT:
+    /// the Limit clip still applies and the emission flows unchanged.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task SingleProvider_ClipStillApplies_ThroughStallProbeWrapper()
+    {
+        var a = new FakeProvider("a",
+            () => Observable.Return(Initial(Node("p/one"), Node("p/two"), Node("p/three"))));
+
+        var query = new MeshQuery([a], hub: null!);
+
+        var change = await ((IMeshQueryCore)query)
+            .Query<MeshNode>(new MeshQueryRequest { Query = "nodeType:Markdown", Limit = 2 }, Options)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(10))
+            .ToTask();
+
+        change.ChangeType.Should().Be(QueryChangeType.Initial);
+        change.Items.Should().HaveCount(2, "the Limit clip must still apply through the probe wrapper");
+    }
+
+    /// <summary>
+    /// A single provider's error must surface on the consumer's OnError unchanged — the stall
+    /// probe wrapper may only observe, never swallow.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task SingleProvider_ErrorPropagates_ThroughStallProbeWrapper()
+    {
+        var boom = new FakeProvider("boom",
+            () => Observable.Throw<QueryResultChange<MeshNode>>(
+                new InvalidOperationException("backing store down")));
+
+        var query = new MeshQuery([boom], hub: null!);
+
+        var act = () => ((IMeshQueryCore)query)
+            .Query<MeshNode>(new MeshQueryRequest { Query = "nodeType:Markdown", Limit = 10 }, Options)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(10))
+            .ToTask();
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
 }


### PR DESCRIPTION
## The second CI shard flake

Distinct from the LogText storm (#608, merged). CI 2026-07-21: `ExportImportAccessControlTest.Export_EditorFullAccess` hung 60s with a **flat heap, zero activity, and not one log line**, then the watchdog killed it. That signature is a query provider that neither emits its Initial nor completes nor errors: `MeshQuery`'s merge gates its Initial on **every** provider, so one silent provider starves the gate forever and the consumer hangs in **total silence** — undiagnosable, and for an agent tool call a forever-hung round.

I could not reproduce the provider stall itself (10 back-to-back Warning-level bulk runs of `MeshWeaver.AI.Test` on latest main stayed green and probe-silent). So rather than guess at a fix for an unproven edge, this PR makes the **next occurrence self-identifying** and converts every silent infinite hang on this path into a **named, bounded error**.

## Changes

- **`MeshQuery` — Initial stall probe (diagnosability).** A 20s timer on both the multi-provider merge and the single-provider fast path logs a **Warning naming the exact provider(s), query, and user** that never delivered an Initial. Diagnostic only — nothing is cancelled; the probe is disposed when the query answers, so a healthy query never logs. *This is the log line whose absence cost the entire investigation.*
- **`Export` — fail-loud bounds.** The subtree-snapshot query (the one unbounded stage) now fails after 60s with an error pointing at the provider warnings; the content-file gather leg gets a 120s inter-emission bound. Real errors propagate unchanged — only silence becomes a named `TimeoutException`.
- **`Import` — bounded per-node create.** A `CreateNode` that neither emits nor errors now times out (30s) into the existing tolerant per-node catch instead of stalling the sequential import forever.
- **Null-Query hardening** surfaced by the new single-provider wrapper: mirror the merge's existing null-`Query` defense on the fast path (a provider emitting an Initial without stamping `Query` used to NRE `ClipMergedInitial`).

## Tests

Two new `MeshQueryMergeContractTest` cases pin the single-provider wrapper's **transparency**: the `Limit` clip still applies through the probe wrapper, and a provider error still propagates to the consumer's `OnError` (the probe may observe, never swallow).

- `MeshWeaver.Hosting.Test` — 80/80 green
- `MeshWeaver.AI.Test` — 889/889 green; also green + probe-silent across 10 back-to-back Warning-level bulk runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGgWKSgL8pgrbg86xqfa6o