### PR TITLE
GitSync: import only what git changed since the last successful sync

### DIFF
--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -366,16 +366,25 @@ public sealed class GitHubSyncService
                 var token = auth.Token;
                 logger?.LogInformation("Re-importing {Space} at {Ref} (twoWay={TwoWay}, force={Force})",
                     spacePath, commitish, config.TwoWay, force);
+                // Baseline for the git-diff scope: the last SUCCESSFULLY-synced commit. `force` ignores
+                // it (deliberate full overwrite/prune). Because RecordLastSync only advances on a clean
+                // success (below), this base always names a commit the mesh REALLY reached — so the diff
+                // is cumulative and self-heals a previously-failed push (its files are still in the diff
+                // until an import actually lands them).
                 return FetchAndImport(repoUrl, commitish, config.Subdirectory, token, spacePath,
-                        SyncIgnore.For(config), progress, policy)
+                        SyncIgnore.For(config), progress, policy,
+                        baseSha: force ? null : config.LastSyncCommitSha)
                     // 🚨 Only advance the last-sync baseline when the mesh is now IN SYNC with the repo.
                     // A two-way import that PRESERVED server-newer nodes leaves the mesh AHEAD of the repo
                     // (those edits aren't committed back yet); advancing LastSyncedAt would move the
                     // baseline past them, so the NEXT update would no longer see them as "newer on the
                     // server" and would overwrite them — losing the very edits two-way just protected.
-                    // Leave the baseline until a commit carries them back (which advances it). A clean
-                    // import (nothing preserved — always the case git-first) records normally.
+                    // A FAILED import must ALSO not advance the baseline — otherwise the next diff would
+                    // start past the commit whose nodes never landed, permanently skipping them. Leave
+                    // the baseline until an import cleanly reaches the head. A clean import (nothing
+                    // preserved — always the case git-first) records normally.
                     .SelectMany(x => x.Result.Preserved > 0
+                            || string.Equals(x.Result.Outcome, "Failed", StringComparison.OrdinalIgnoreCase)
                         ? Observable.Return(x.Result)
                         : RecordLastSync(spacePath, x.CommitSha, sourceId).Select(_ => x.Result));
             });
@@ -431,17 +440,62 @@ public sealed class GitHubSyncService
 
     private IObservable<(StaticRepoImportResult Result, string CommitSha)> FetchAndImport(
         string repoUrl, string commitish, string? subdirectory, string token, string spaceId,
-        SyncIgnore ignore, Action<string, LogLevel>? progress = null, ImportConflictPolicy? policy = null)
+        SyncIgnore ignore, Action<string, LogLevel>? progress = null, ImportConflictPolicy? policy = null,
+        string? baseSha = null)
     {
         return repoClient.Fetch(repoUrl, commitish, subdirectory, token).SelectMany(snapshot =>
-            ParseSnapshot(snapshot, spaceId, ignore, progress).SelectMany(parsed =>
-            {
-                var source = new InMemoryStaticRepoSource(
-                    spaceId, parsed.Children, parsed.Root, parsed.ContentSyncs);
-                return StaticRepoImporter.ImportSource(hub, source, logger, policy)
-                    .Select(result => (result, snapshot.CommitSha));
-            }));
+        {
+            // Git-diff scope: when we know the last SUCCESSFULLY-synced commit (a routine
+            // webhook/update — not a force, not a first import), ask GitHub what changed between it
+            // and the head and import ONLY those nodes. A null answer (no base, force, force-push,
+            // truncated, or a compare error) falls back to a full import — never a silent
+            // under-import. This is what stops a routine push from re-materialising the whole
+            // partition and storming the live compiler (the memex-cloud outage loop, 2026-07-23).
+            var diff = string.IsNullOrEmpty(baseSha) || policy?.Force == true
+                ? Observable.Return<IReadOnlyList<string>?>(null)
+                : repoClient.GetChangedPaths(repoUrl, baseSha!, snapshot.CommitSha, subdirectory, token);
+            return diff.SelectMany(changedFiles =>
+                ParseSnapshot(snapshot, spaceId, ignore, progress).SelectMany(parsed =>
+                {
+                    var source = new InMemoryStaticRepoSource(
+                        spaceId, parsed.Children, parsed.Root, parsed.ContentSyncs);
+                    var changedNodePaths = ChangedNodePaths(changedFiles, spaceId);
+                    if (changedNodePaths is not null)
+                        logger?.LogInformation(
+                            "[GitSync] {Space}: git-diff {Base}..{Head} → {Count} changed node(s) — "
+                            + "importing only those (full partition left untouched).",
+                            spaceId, Short(baseSha), Short(snapshot.CommitSha), changedNodePaths.Count);
+                    return StaticRepoImporter.ImportSource(hub, source, logger, policy, changedNodePaths)
+                        .Select(result => (result, snapshot.CommitSha));
+                }));
+        });
     }
+
+    /// <summary>
+    /// Maps the <c>git diff</c>'s subdirectory-relative changed FILE paths to the set of changed
+    /// NODE paths (the importer's <c>changedNodePaths</c> scope), via <see cref="NodeFileMapper"/> —
+    /// the canonical inverse of the export path mapping. <see langword="null"/> in → null out (diff
+    /// unknown → full import). Content-collection assets (<c>{node}/content/**</c>) are excluded:
+    /// they sync through a separate, unscoped path, so they never need to gate a node upsert.
+    /// </summary>
+    private static IReadOnlySet<string>? ChangedNodePaths(IReadOnlyList<string>? changedFiles, string spaceId)
+    {
+        if (changedFiles is null) return null;
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var rel in changedFiles)
+        {
+            if (string.IsNullOrWhiteSpace(rel) || ContentAssetMapper.IsContentPath(rel))
+                continue;
+            var (id, ns) = NodeFileMapper.FromRelativePath(rel);
+            if (string.IsNullOrEmpty(id))
+                continue;
+            set.Add(ns.Length == 0 ? $"{spaceId}/{id}" : $"{spaceId}/{ns}/{id}");
+        }
+        return set;
+    }
+
+    private static string Short(string? sha) =>
+        string.IsNullOrEmpty(sha) ? "(none)" : sha.Length <= 8 ? sha : sha[..8];
 
     private IObservable<(MeshNode? Root, IReadOnlyList<MeshNode> Children, IReadOnlyList<StaticContentSync> ContentSyncs)> ParseSnapshot(
         RepoSnapshot snapshot, string spaceId, SyncIgnore ignore, Action<string, LogLevel>? progress = null)

--- a/src/MeshWeaver.GitSync/IGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/IGitHubRepoClient.cs
@@ -65,6 +65,25 @@ public interface IGitHubRepoClient
         => Fetch(repositoryUrl, commitish, null, accessToken).Select(snapshot => snapshot.CommitSha);
 
     /// <summary>
+    /// The <paramref name="subdirectory"/>-relative file paths that changed between
+    /// <paramref name="baseSha"/> and <paramref name="headSha"/> (added + modified + removed +
+    /// renamed) — the <c>git diff</c> that lets an import touch ONLY what actually changed since the
+    /// last successful sync instead of re-materialising the whole partition. Paths are made relative
+    /// to <paramref name="subdirectory"/> exactly like <see cref="Fetch(string,string,string?,string)"/>'s
+    /// files; changes OUTSIDE the subdirectory are excluded.
+    ///
+    /// <para>🚨 Returns <see langword="null"/> when the diff cannot be computed RELIABLY — the base is
+    /// not an ancestor of the head (a force-push / history rewrite), or the compare call errored. A
+    /// null answer means "diff unknown → the caller MUST full-import"; it must NEVER be read as
+    /// "nothing changed". The default implementation returns null (no diff support → always
+    /// full-import — the safe fallback); <see cref="OctokitGitHubRepoClient"/> overrides it with the
+    /// GitHub compare API.</para>
+    /// </summary>
+    IObservable<IReadOnlyList<string>?> GetChangedPaths(
+        string repositoryUrl, string baseSha, string headSha, string? subdirectory, string accessToken)
+        => Observable.Return<IReadOnlyList<string>?>(null);
+
+    /// <summary>
     /// Creates <see cref="GitHubCreateBranchRequest.NewBranch"/> from
     /// <see cref="GitHubCreateBranchRequest.BaseRef"/> (resolving the base ref to its
     /// commit SHA first), and emits the new branch + the SHA it points at. Surfaces a

--- a/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
+++ b/src/MeshWeaver.GitSync/OctokitGitHubRepoClient.cs
@@ -209,6 +209,66 @@ public sealed class OctokitGitHubRepoClient(IoPoolRegistry ioPools, ILogger<Octo
         return ResolveRefSha(client, owner, repo, commitRef);
     }
 
+    // The GitHub compare endpoint returns at most this many files in one response; beyond it the
+    // file list is TRUNCATED, so we cannot trust it as the complete change set → full-import instead.
+    private const int CompareFileCap = 300;
+
+    /// <inheritdoc />
+    public IObservable<IReadOnlyList<string>?> GetChangedPaths(
+        string repositoryUrl, string baseSha, string headSha, string? subdirectory, string accessToken)
+    {
+        if (string.IsNullOrWhiteSpace(baseSha) || string.IsNullOrWhiteSpace(headSha))
+            return Observable.Return<IReadOnlyList<string>?>(null);
+        if (string.Equals(baseSha, headSha, StringComparison.Ordinal))
+            return Observable.Return<IReadOnlyList<string>?>(Array.Empty<string>());
+
+        var (owner, repo) = ParseRepoUrl(repositoryUrl);
+        var client = Client(accessToken);
+        var prefix = NormalizePrefix(subdirectory);
+
+        return Http.InvokeObservable(ct => client.Repository.Commit.Compare(owner, repo, baseSha, headSha))
+            .Select(cmp =>
+            {
+                // Only trust the diff when the head DESCENDS from the base (or equals it). "behind" /
+                // "diverged" means the base is NOT an ancestor — a force-push or history rewrite — so
+                // the file list is not the cumulative change set; and a truncated list (> the cap)
+                // is incomplete. Either way return null → the caller full-imports (never a silent miss).
+                var status = cmp.Status.ToString();
+                if (!string.Equals(status, "ahead", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(status, "identical", StringComparison.OrdinalIgnoreCase))
+                    return null;
+                var files = cmp.Files ?? (IReadOnlyList<GitHubCommitFile>)Array.Empty<GitHubCommitFile>();
+                if (files.Count >= CompareFileCap)
+                    return null;
+                var changed = new List<string>();
+                foreach (var f in files)
+                {
+                    AddIfUnderPrefix(changed, f.Filename, prefix);
+                    // A rename reports the NEW filename; its OLD path must also count as changed so the
+                    // stale node is pruned/re-created (prune handles the delete of the absent old file).
+                    AddIfUnderPrefix(changed, f.PreviousFileName, prefix);
+                }
+                return (IReadOnlyList<string>)changed;
+            })
+            // A compare failure (network, an unknown SHA after a rebase, rate limit) is NOT "nothing
+            // changed" — fall back to a full import so an update is never silently dropped.
+            .Catch<IReadOnlyList<string>?, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "GitHub compare {Base}...{Head} on {Repo} failed — falling back to a full import.",
+                    baseSha, headSha, repositoryUrl);
+                return Observable.Return<IReadOnlyList<string>?>(null);
+            });
+    }
+
+    private static void AddIfUnderPrefix(List<string> into, string? repoPath, string prefix)
+    {
+        if (string.IsNullOrEmpty(repoPath)) return;
+        if (prefix.Length == 0) { into.Add(repoPath); return; }
+        if (repoPath.StartsWith(prefix, StringComparison.Ordinal))
+            into.Add(repoPath[prefix.Length..]);
+    }
+
     /// <summary>Creates a branch from an existing ref (branch name or SHA) resolved to its commit.</summary>
     /// <param name="request">The create-branch request (repo, new branch, base ref, token).</param>
     /// <returns>An observable emitting the new branch name and the commit SHA it points at.</returns>

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -405,14 +405,21 @@ public static class StaticRepoImporter
     /// wrapper), so callers pre-create any user-owned partition root under the user first, then call
     /// this for the content. Reactive — Subscribe to run.
     /// </summary>
+    /// <param name="changedNodePaths">Optional git-diff scope: when non-null, an EXISTING node whose
+    /// path is NOT in this set is treated as unchanged and its upsert is skipped — even when the
+    /// per-node manifest is missing/stale. Sourced from <c>git diff</c> between the last
+    /// SUCCESSFULLY-synced commit and the new head (see <c>GitHubSyncService.FetchAndImport</c>), so
+    /// a routine webhook push touches only the handful of nodes it actually changed instead of
+    /// re-materialising the whole partition (the memex-cloud recompile storm, 2026-07-23). Null =
+    /// full import (every node evaluated) — the safe fallback whenever the diff can't be computed.</param>
     public static IObservable<StaticRepoImportResult> ImportSource(
         IMessageHub meshHub, IStaticRepoSource source, ILogger? logger = null,
-        ImportConflictPolicy? policy = null)
+        ImportConflictPolicy? policy = null, IReadOnlySet<string>? changedNodePaths = null)
     {
         logger ??= meshHub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.Graph.StaticRepoImporter");
         var importHub = CreateImportHub(meshHub, logger);
-        return Import(importHub, source, logger, policy: policy);
+        return Import(importHub, source, logger, policy: policy, changedNodePaths: changedNodePaths);
     }
 
     /// <summary>
@@ -477,7 +484,8 @@ public static class StaticRepoImporter
     /// <returns>An observable that emits the import outcome for the partition.</returns>
     public static IObservable<StaticRepoImportResult> Import(
         IMessageHub hub, IStaticRepoSource source, ILogger? logger = null,
-        PartitionSyncMode? syncModeOverride = null, ImportConflictPolicy? policy = null)
+        PartitionSyncMode? syncModeOverride = null, ImportConflictPolicy? policy = null,
+        IReadOnlySet<string>? changedNodePaths = null)
     {
         logger ??= hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.Graph.StaticRepoImporter");
@@ -579,7 +587,7 @@ public static class StaticRepoImporter
                         }
                     };
                     return Upsert(hub, activityNode)
-                        .SelectMany(_ => Run(hub, source, nodes, root, activityPath, fingerprint, syncMode, logger, policy))
+                        .SelectMany(_ => Run(hub, source, nodes, root, activityPath, fingerprint, syncMode, logger, policy, changedNodePaths))
                         .Catch<StaticRepoImportResult, Exception>(ex =>
                         {
                             logger?.LogWarning(ex,
@@ -645,7 +653,7 @@ public static class StaticRepoImporter
     private static IObservable<StaticRepoImportResult> Run(
         IMessageHub hub, IStaticRepoSource source, IReadOnlyList<MeshNode> nodes,
         MeshNode root, string activityPath, string fingerprint, PartitionSyncMode syncMode, ILogger? logger,
-        ImportConflictPolicy? policy = null)
+        ImportConflictPolicy? policy = null, IReadOnlySet<string>? changedNodePaths = null)
     {
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
         NodeTypeCompilationActivity.AppendLog(
@@ -753,6 +761,24 @@ public static class StaticRepoImporter
                         {
                             logger?.LogDebug(
                                 "[StaticRepoImport] {Partition}: skip claimed {Path}", source.Partition, path);
+                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 0));
+                        }
+
+                        // 🅶 Git-diff scope: when the caller supplied the changed-path set (a webhook /
+                        // reimport that diffed the last-synced commit against the new head), an EXISTING
+                        // node NOT in that set was not touched by any commit since the last sync — skip it
+                        // WITHOUT computing its token or re-upserting. This survives a missing/stale
+                        // manifest (the failure that made every webhook re-materialise the whole partition
+                        // → mass recompile storm, memex-cloud 2026-07-23): git, not a mesh write that can
+                        // fail under load, is the authority on "what changed". A node ABSENT from the DB is
+                        // NOT skipped even if outside the diff (first materialisation / self-heal safety),
+                        // and prune still runs over the full source set, so deletes are unaffected.
+                        if (changedNodePaths is not null && target is not null
+                            && !changedNodePaths.Contains(path))
+                        {
+                            logger?.LogDebug(
+                                "[StaticRepoImport] {Partition}: outside git-diff scope, skipping {Path}",
+                                source.Partition, path);
                             return Observable.Return((Imported: 0, Failed: 0, Preserved: 0));
                         }
 

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/StaticRepoImporterTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/StaticRepoImporterTests.cs
@@ -265,6 +265,71 @@ public class StaticRepoImporterTests(PostgreSqlFixture fixture, ITestOutputHelpe
     }
 
     /// <summary>
+    /// Git-diff scope (<c>changedNodePaths</c>): a webhook/reimport that supplies the set of nodes
+    /// that changed since the last successful sync must re-upsert ONLY those — leaving every other
+    /// EXISTING node untouched (Version unchanged), EVEN WHEN the per-node manifest is gone. This is
+    /// the fix for the memex-cloud outage loop: a failed manifest write used to make every webhook
+    /// re-materialise the WHOLE partition (every source node re-versioned → the mass recompile storm
+    /// that starved the mesh). With git as the change oracle, an out-of-scope node is skipped
+    /// regardless of manifest state — and a node ABSENT from the mesh is still imported
+    /// (first-materialisation safety), so the scope can never silently under-import.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task ScopedImport_UpsertsOnlyChangedNodes_EvenWithoutManifest()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        _source.Nodes =
+        [
+            new MeshNode("Page1", _partition) { NodeType = "Markdown", Name = "Page 1", State = MeshNodeState.Active,
+                Content = new MarkdownContent { Content = "one" } },
+            new MeshNode("Page2", _partition) { NodeType = "Markdown", Name = "Page 2", State = MeshNodeState.Active,
+                Content = new MarkdownContent { Content = "two" } },
+        ];
+        (await Import()).Single(r => r.Partition == _partition).Outcome.Should().Be("Imported");
+        var page2VersionBefore = (await Read($"{_partition}/Page2"))!.Version;
+
+        // Simulate the production failure that started the loop: the manifest write never landed, so
+        // the per-node token skip is BLIND — without the git-diff scope the next import re-upserts
+        // every node (the storm). Deleting the manifest reproduces exactly that state.
+        await meshService.DeleteNode($"{_partition}/_Activity/import-manifest")
+            .Should().Within(30.Seconds()).Emit();
+
+        // The push changed ONLY Page1 and ADDED Page3; Page2's repo content is unchanged. Model that:
+        // edit Page1, add Page3, leave Page2 — and scope the import to exactly what git reported.
+        _source.Nodes =
+        [
+            new MeshNode("Page1", _partition) { NodeType = "Markdown", Name = "Page 1", State = MeshNodeState.Active,
+                Content = new MarkdownContent { Content = "one-EDITED" } },
+            new MeshNode("Page2", _partition) { NodeType = "Markdown", Name = "Page 2", State = MeshNodeState.Active,
+                Content = new MarkdownContent { Content = "two" } },
+            new MeshNode("Page3", _partition) { NodeType = "Markdown", Name = "Page 3", State = MeshNodeState.Active,
+                Content = new MarkdownContent { Content = "three-NEW" } },
+        ];
+        IReadOnlySet<string> changed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            { $"{_partition}/Page1", $"{_partition}/Page3" };
+
+        (await StaticRepoImporter.ImportSource(Mesh, _source, null, null, changed)
+                .ToList().Should().Within(120.Seconds()).Emit())
+            .Single(r => r.Partition == _partition).Outcome.Should().Be("Imported");
+
+        // Page1 (in scope) re-imported with its new content.
+        var page1 = await Mesh.GetMeshNodeStream($"{_partition}/Page1")
+            .Where(n => n?.Content is MarkdownContent mc && mc.Content.Contains("EDITED"))
+            .Should().Within(30.Seconds()).Emit();
+        (page1!.Content as MarkdownContent)!.Content.Should().Contain("one-EDITED");
+
+        // Page3 (in scope, ABSENT from the mesh) created — the scope never blocks a first import.
+        (await Read($"{_partition}/Page3")).Should().NotBeNull(
+            "a node absent from the mesh must be imported even when in scope — first-materialisation safety");
+
+        // Page2 (OUT of scope, already present) NOT re-upserted despite the missing manifest — its
+        // Version is unchanged. That avoided re-write is exactly the recompile storm the scope prevents.
+        (await Read($"{_partition}/Page2"))!.Version.Should().Be(page2VersionBefore,
+            "an out-of-scope existing node must not be re-upserted (Version unchanged) even with no "
+            + "manifest — the needless re-write is what stormed the live compiler on memex-cloud");
+    }
+
+    /// <summary>
     /// "sync: none" on a partition ROOT. Setting the partition root's <see cref="SyncBehavior"/> to
     /// <see cref="SyncBehavior.ExcludeThisAndChildren"/> must DURABLY decouple the whole partition: a
     /// later source change (new fingerprint → full re-import) must leave the root's claim intact AND


### PR DESCRIPTION
## The outage loop this fixes

memex.meshweaver.cloud kept going "arbitrarily unstable" (2026-07-22..23). Root cause, traced end to end:

1. Every push to `MeshWeaver.Plugins` fires the GitHub webhook → memex-cloud re-imports the **whole** `UWDeepfield` subtree.
2. The importer skips unchanged nodes via a **mesh-stored per-node manifest** (`{partition}/_Activity/import-manifest`). Under load that manifest write **times out and never lands** (`content manifest write failed` in the logs).
3. With no manifest, the next webhook re-materialises **every** node → each source rewrite bumps its version → dirties its NodeType → kicks a Roslyn recompile. For UWDeepfield (~35 live-compiled types sharing ~60 `Source/` files) that is a **mass simultaneous recompile** that starves the mesh.
4. Starved, the import's own `_Activity/import-*` marker write times out → **no Succeeded marker** → the next webhook re-imports in full → **self-sustaining loop**. Symptoms: `[UpdateQueue] FAILED path=…import-…`, `EnrichWithNodeType … faulted (TimeoutException) → compilation-error overlay`, STALE-CALLBACK pile-ups, pages timing out.

Confirmed the source is fine: **every UWDeepfield NodeType compiles clean** (`compile-check.py`: 29/29 OK). This was never a broken-source problem — it was the *full* re-import doing needless work.

## The fix — git is the change oracle, not a mesh write that can fail

Derive "what changed" from `git diff` between the last **successfully-synced** commit and the new head, and import only those nodes.

- **`IGitHubRepoClient.GetChangedPaths(base, head)`** — GitHub compare API → subdirectory-relative changed files. Returns **null** (→ full import) whenever the diff can't be trusted: base not an ancestor (force-push/history rewrite), `> 300` files (compare truncation), or any API error. Default interface impl returns null.
- **`GitHubSyncService.FetchAndImport`** takes `config.LastSyncCommitSha` as the base (`ReimportAtCommit`; `force` and first-import pass null), maps changed files → node paths via the canonical `NodeFileMapper` inverse, and hands the importer a `changedNodePaths` scope. `LastSyncCommitSha` now advances **only on a clean (non-Failed) import**, so the base always names a commit the mesh really reached — the diff is cumulative and **self-heals** a previously-failed push (its files stay in the diff until an import actually lands them).
- **`StaticRepoImporter.Run`**: when `changedNodePaths` is supplied, an **existing** node outside it is not re-upserted (no version bump → no recompile). A node **absent** from the mesh is still imported (first-materialisation safety). Prune, the fingerprint marker, and the manifest all still operate over the **full** source set — so deletes, idempotency, and any later full import stay correct.

Null scope everywhere == today's full import. This can only ever do **less** needless work, never miss an update. Boot imports (`ImportAll`) have no git diff and stay full-import.

### Effect
A routine 1–3 file push now upserts 1–3 nodes and recompiles the handful of affected types instead of re-versioning the whole partition — the storm can't form, the import's writes land, the marker advances, and the loop is broken. Pairs with #602 (lazy boot / read-first skip) and #605 (ALC leak); those removed the boot-time and per-recompile storms, this removes the webhook-triggered one.

## Tests
- **New** `ScopedImport_UpsertsOnlyChangedNodes_EvenWithoutManifest` (Hosting.PostgreSql) — deletes the manifest to reproduce the production condition, then proves an out-of-scope existing node is **not** re-versioned while an in-scope edit and a brand-new node still import.
- `MeshWeaver.Hosting.PostgreSql` importer suite **9/9**, `MeshWeaver.GitSync` **141/141** (all on the null-fallback path → confirms zero behavior change to existing flows), `MeshWeaver.Graph` importer **13/13**.

## Deploy note
On merge, CD rolls this to memex-cloud. If a mesh's `LastSyncCommitSha` is very stale (a large cumulative diff `> 300` files), the first import is still full (and now, with #602/#605 in, should complete and advance the baseline); every push after that is incrementally scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)