### PR TITLE
Fix unload-during-scan race in dynamic NodeType compilation (Orleans flake + memex recompile risk)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
@@ -221,6 +221,13 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
     // whole context does.
     private WeakReference<Assembly>? _loadedAssembly;
     private volatile bool _disposed;
+    // In-flight SCANS of this context's loaded assembly (the GetTypes / MeshNodeProviderAttribute
+    // reflection / Activator block in MeshNodeCompilationService). Dispose() drains these before
+    // Unload() so a concurrent recompile / eviction / teardown cannot tear down the collectible
+    // LoaderAllocator mid-metadata-resolution — the "TypeLoadException: could not load type
+    // '…MeshNodeProviderAttribute' … because the format is invalid" race under parallel activation.
+    // See Pin().
+    private int _pins;
     private ImmutableArray<string> _probingDirs = ImmutableArray<string>.Empty;
 
     // Opt-in diagnostic (env MESHWEAVER_ALC_UNLOAD_GC_PROBE=1) — OFF by default, so zero cost in
@@ -251,6 +258,43 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
     /// Gets whether this context has been disposed/unloaded.
     /// </summary>
     public bool IsDisposed => _disposed;
+
+    /// <summary>
+    /// Pins the context for the duration of a SCAN of its loaded assembly (GetTypes + attribute
+    /// reflection + Activator). While any pin is held, <see cref="Dispose"/> waits before
+    /// <see cref="System.Runtime.Loader.AssemblyLoadContext.Unload"/> so it cannot tear down the
+    /// collectible LoaderAllocator mid-metadata-resolution — otherwise a concurrent recompile /
+    /// eviction / teardown surfaces as <c>TypeLoadException: could not load type
+    /// '…MeshNodeProviderAttribute' … because the format is invalid</c>. ALWAYS use the returned
+    /// handle in a <c>using</c>. Throws <see cref="ObjectDisposedException"/> if the context is
+    /// already unloading — the caller must then re-resolve against the current context rather than
+    /// scan a doomed assembly.
+    /// </summary>
+    public IDisposable Pin()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(Name, "Cannot scan an assembly whose context is unloading");
+        Interlocked.Increment(ref _pins);
+        // Re-check after the increment: Dispose sets _disposed then drains _pins, so a pin taken
+        // concurrently with Dispose must not slip past the drain. If Dispose already started, back
+        // out and throw — Dispose's drain will observe the decrement and proceed.
+        if (_disposed)
+        {
+            Interlocked.Decrement(ref _pins);
+            throw new ObjectDisposedException(Name, "Cannot scan an assembly whose context is unloading");
+        }
+        return new PinScope(this);
+    }
+
+    private sealed class PinScope(NodeAssemblyLoadContext ctx) : IDisposable
+    {
+        private int _released;
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+                Interlocked.Decrement(ref ctx._pins);
+        }
+    }
 
     public NodeAssemblyLoadContext(string nodeName, string? dllPath, ILogger? logger = null)
         : base(name: $"DynamicNode_{nodeName}", isCollectible: true)
@@ -421,6 +465,18 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
 
             _logger?.LogDebug("Unloading AssemblyLoadContext {ContextName}", Name);
         }
+
+        // Drain in-flight assembly SCANS before tearing down the LoaderAllocator. _disposed is set
+        // above, so Pin() now rejects NEW scans; wait (time-bounded) for the ones already running to
+        // release. Unloading mid-GetTypes/attribute-resolution corrupts the assembly the scanner is
+        // holding (TypeLoadException '…format is invalid'), the race that flakes the concurrent
+        // Orleans dynamic-compilation tests and risks the same under a live-mesh recompile. A scan
+        // is milliseconds; the 5 s ceiling can never deadlock teardown — after it we unload anyway
+        // (last-resort, matching the prior always-unload behaviour).
+        var drainDeadline = Environment.TickCount64 + 5_000;
+        var spin = new SpinWait();
+        while (Volatile.Read(ref _pins) > 0 && Environment.TickCount64 < drainDeadline)
+            spin.SpinOnce();
 
         // Initiate unload outside the lock - the context will be collected when all references are released
         Unload();

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -1098,9 +1098,18 @@ internal class MeshNodeCompilationService(
                 // so V1 and V2 ALCs are separate; loading from the canonical shared path
                 // would always return V1's assembly after V2 compiles. In-memory
                 // assemblies keep the old keyed-by-nodeName path.
-                var assembly = assemblyLocation.StartsWith("memory://", StringComparison.Ordinal)
-                    ? cacheService.LoadAssembly(nodeName)
-                    : cacheService.GetOrCreateLoadContextForPath(nodeName, assemblyLocation).LoadNodeAssembly();
+                // PIN the context across BOTH the load AND the GetTypes / MeshNodeProviderAttribute
+                // scan below. A concurrent recompile/eviction/teardown must not Unload this context
+                // while we reflect over its assembly, or the scan faults with
+                // "TypeLoadException: could not load type '…MeshNodeProviderAttribute' … because the
+                // format is invalid" (the flaky Orleans dynamic-compilation race). The pin releases
+                // when this method returns; Dispose() drains pins before Unload(). Pin throws if the
+                // context is already unloading → the catch below records it as a load miss (retryable).
+                var context = assemblyLocation.StartsWith("memory://", StringComparison.Ordinal)
+                    ? cacheService.GetOrCreateLoadContext(nodeName)
+                    : cacheService.GetOrCreateLoadContextForPath(nodeName, assemblyLocation);
+                using var scanPin = context.Pin();
+                var assembly = context.LoadNodeAssembly();
                 if (assembly == null)
                 {
                     // Promoted from Warning → Error: this is the root cause that
@@ -1704,7 +1713,12 @@ internal class MeshNodeCompilationService(
 
         try
         {
-            var assembly = cacheService.LoadAssemblyFromRelease(release, releaseFolder);
+            // PIN across load + the GetTypes/MeshNodeProviderAttribute scan below — same
+            // unload-during-scan race as CompileResultFromAssembly (TypeLoadException 'format is
+            // invalid'). Released when the method returns; Dispose() drains pins before Unload().
+            var context = cacheService.GetOrCreateLoadContextForRelease(release, releaseFolder);
+            using var scanPin = context.Pin();
+            var assembly = context.LoadNodeAssembly();
             if (assembly == null)
             {
                 logger.LogWarning("Failed to load assembly from {DllPath}", dllPath);

--- a/test/MeshWeaver.Graph.Test/AssemblyLoadContextLeakTest.cs
+++ b/test/MeshWeaver.Graph.Test/AssemblyLoadContextLeakTest.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using MeshWeaver.Graph.Configuration;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -222,5 +223,43 @@ public sealed class AssemblyLoadContextLeakTest : IDisposable
             "AssemblyLoadContext without waiting for hub teardown — otherwise every recompile leaks an ALC");
         weakV2.IsAlive.Should().BeTrue(
             "the CURRENT context (just-loaded V2) must NOT be evicted — it is the live assembly the hub runs on");
+    }
+
+    /// <summary>
+    /// 🚨 The unload-during-scan guard. A context PINNED by an in-flight assembly scan must not be
+    /// torn down: <see cref="System.Runtime.Loader.AssemblyLoadContext.Unload"/> mid-scan corrupts
+    /// the assembly the scanner holds (TypeLoadException '…format is invalid' — the flaky Orleans
+    /// dynamic-compilation race). So <c>Dispose()</c> must DRAIN pins before unloading: it blocks
+    /// while a pin is held and completes once released.
+    /// </summary>
+    [Fact]
+    public void Pin_MakesDispose_DrainBeforeUnload()
+    {
+        var ctx = _service.GetOrCreateLoadContext("pin_drain_node");
+        var pin = ctx.Pin();
+
+        var disposeReturned = new ManualResetEventSlim(false);
+        var disposer = new Thread(() => { ctx.Dispose(); disposeReturned.Set(); }) { IsBackground = true };
+        disposer.Start();
+
+        // While the pin is held, Dispose() must still be draining — it must NOT have returned.
+        disposeReturned.Wait(300).Should().BeFalse(
+            "Dispose() must block (drain) while a scan pin is held, or it unloads the LoaderAllocator mid-scan");
+
+        // Release the pin → the drain completes and Dispose() returns.
+        pin.Dispose();
+        disposeReturned.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue(
+            "releasing the pin must let Dispose() finish the unload");
+        disposer.Join();
+    }
+
+    /// <summary>Once a context starts unloading, a NEW scan must not be able to pin it — the caller
+    /// must re-resolve against the current context rather than scan a doomed assembly.</summary>
+    [Fact]
+    public void Pin_Throws_OnceContextIsUnloading()
+    {
+        var ctx = _service.GetOrCreateLoadContext("pin_disposed_node");
+        ctx.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => ctx.Pin());
     }
 }


### PR DESCRIPTION
## The race

Dynamic NodeType assemblies are held by a `WeakReference<Assembly>` — deliberately, so collectible ALCs stay collectible (`#596`): *"a live context roots its own assemblies natively, so the target only dies when the whole context does."*

So `TypeLoadException: could not load type '…MeshNodeProviderAttribute' … because the format is invalid` means a context was **`Unload()`ed while a concurrent activation was still scanning its assembly** — `assembly.GetTypes()` + `MeshNodeProviderAttribute` reflection + `Activator.CreateInstance` in `CompileResultFromAssembly`. Parallel Orleans fixtures sharing one dynamic type hit this intermittently at fixture `InitializeAsync` (`OrleansDynamicCompilationTest`, `TwoSiloRecycleConvergenceTest`, `OrleansPortalFlowTest`, …). A live-mesh recompile could hit it too.

**It became more likely after the memex leak fix (#605):** before, contexts unloaded only on hub *teardown* (nothing scanning); the per-recompile eviction unloads a *superseded* context on every recompile, widening the unload-during-scan window.

## The fix — a per-context scan pin

- `NodeAssemblyLoadContext.Pin()` marks an in-flight scan. `Dispose()` sets `_disposed` (so `Pin()` rejects **new** scans) and then **drains** existing pins — time-bounded (5 s ceiling, so it can never deadlock teardown; a scan is milliseconds) — before `Unload()` tears down the LoaderAllocator.
- `CompileResultFromAssembly` and `LoadAndExtractConfigurationsFromReleaseAsync` hold the pin **across load + the whole GetTypes/attribute scan**.
- This makes **every** unload path safe — the per-recompile eviction (#605), teardown, and invalidate — not just the one I introduced.

## Tests
- `Pin_MakesDispose_DrainBeforeUnload` — `Dispose()` blocks while a pin is held, completes on release (deterministic).
- `Pin_Throws_OnceContextIsUnloading` — a new scan can't pin an unloading context.
- Graph.Test ALC suite **5/5**, Monolith compile+recompile integration **10/10**, build clean.

> ⚠️ The Orleans race is **intermittent and needs the parallel suite** to reproduce, so it can't be unit-tested — please let CI run a few times to confirm the flake is gone. The pin/drain *invariant* is covered deterministically by the two tests above.

Pairs with `#605`/`#596` (the memex leak fix + the collectible-ALC weak-ref design). Touches the LoaderAllocator-lifetime area — review welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)