### PR TITLE
Fix FutuRe teardown SIGSEGV (#613): drain in-flight layout renders before ALC unload

### DIFF
--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -257,12 +257,13 @@ public record LayoutAreaHost : IDisposable
             // confirmed offenders — Doc/DataMesh/SocialMedia/Post List,
             // Doc/DataMesh/PythonPandasNode/PandasExplorer — all query in-render).
             //
-            // .SubscribeOn(TaskPoolScheduler.Default) hops the SUBSCRIBE onto the thread
-            // pool, so the generator runs and its query subscribes OFF the grain turn,
-            // which is immediately free to route + return the query. This is the SAME
-            // designated reactive move the framework already makes at MeshQuery.Query and
-            // IMeshNodeStreamCache.GetQuery (OrleansTaskScheduler → "SubscribeOn inside a
-            // grain-hosted service") — a pure Rx scheduler hop, no async/await/Task.
+            // ScheduleRenderSubscribe hops the SUBSCRIBE onto a thread-pool thread, so the
+            // generator runs and its query subscribes OFF the grain turn, which is immediately
+            // free to route + return the query. This is the SAME designated reactive move the
+            // framework already makes at MeshQuery.Query and IMeshNodeStreamCache.GetQuery
+            // (OrleansTaskScheduler → "SubscribeOn inside a grain-hosted service") — a pure Rx
+            // scheduler hop, no async/await/Task — and, like MeshQuery, it runs that subscribe as a
+            // TRACKED leaf on the mesh's DRAINABLE Layout pool so teardown can join it.
             //
             // Ordering is preserved: the render output (PushRenderResult) never touches
             // the hub directly — it calls Stream.Update, which posts an UpdateStreamRequest
@@ -272,8 +273,20 @@ public record LayoutAreaHost : IDisposable
             // the offload moves only the SUBSCRIBE-time work off the grain, never the state
             // writes. This makes EVERY layout area query-in-render-safe at one seam, with
             // no change to (and no recompile of) any deployed node's source.
-            var renderSubscription = BuildRenderObservable(context, baseStore)
-                .SubscribeOn(TaskPoolScheduler.Default)
+            // ScheduleRenderSubscribe hops the subscribe onto the mesh's DRAINABLE Layout pool (was a
+            // bare .SubscribeOn(TaskPoolScheduler.Default)): teardown's DrainAll() cancel+joins this
+            // synchronous render (menu renderers resolve services + touch collectible NodeType ALC
+            // types) BEFORE the Autofac scope disposes / the ALC unloads — killing the endemic
+            // teardown ObjectDisposedException-then-SIGSEGV straggler. See ScheduleRenderSubscribe.
+            //
+            // 🚨 Observable.Defer is LOAD-BEARING: LayoutDefinition.Render is EAGER — for a single
+            // applicable renderer it invokes the view generator (and thus GetService / collectible-ALC
+            // type access) the moment BuildRenderObservable is *evaluated*. Without Defer that eager
+            // render would run on the init-observer thread as the argument is built, OUTSIDE the pool
+            // leaf — untracked, exactly the straggler. Defer moves the whole BuildRenderObservable
+            // construction to SUBSCRIBE time, so it runs inside the gated, drain-joined pool leaf.
+            var renderSubscription = ScheduleRenderSubscribe(
+                    Observable.Defer(() => BuildRenderObservable(context, baseStore)))
                 .Subscribe(PushRenderResult, FailRendering);
 
             // Tear down: dispose the render + milestone subscriptions and clear the
@@ -770,6 +783,41 @@ public record LayoutAreaHost : IDisposable
 
     private readonly ConcurrentDictionary<string, List<IDisposable>> disposablesByArea = new();
 
+    // Resolved once: the drainable-subscribe scheduler that runs render subscribes as TRACKED leaves
+    // on the mesh's teardown-drainable Layout I/O pool. Null on hubs without I/O pools registered
+    // (bare messaging-only hubs / HubTestBase) — those compile no collectible ALCs, so the historical
+    // bare SubscribeOn(TaskPoolScheduler.Default) fallback has nothing for the drain to join.
+    private IPooledSubscribeScheduler? renderSubscribeScheduler;
+    private bool renderSubscribeSchedulerResolved;
+
+    /// <summary>
+    /// Hops a render pipeline's SUBSCRIBE off the owning hub's action block (so a view generator that
+    /// queries in-render never wedges the hub turn — see the render-subscribe sites below) AND makes
+    /// that subscribe a TRACKED, cancellable leaf on the mesh's drainable <c>Layout</c> I/O pool.
+    ///
+    /// <para>🚨 This is the fix for the endemic teardown SIGSEGV (FutuRe.Test exit=139). A bare
+    /// <c>SubscribeOn(TaskPoolScheduler.Default)</c> hop is invisible to mesh teardown: during
+    /// disposal the render subscribe keeps executing on a ThreadPool thread AFTER the hub's Autofac
+    /// <c>LifetimeScope</c> is disposed (→ <c>ObjectDisposedException</c> from a menu renderer's
+    /// <c>GetService</c>) and, for a node whose render touches types compiled into a collectible
+    /// <c>AssemblyLoadContext</c>, AFTER that ALC is unloaded (→ native use-after-unload crash).
+    /// Routing through the pool makes <c>IoPoolRegistry.DrainAll()</c> cancel+join the in-flight
+    /// subscribe BEFORE the scope disposes / the ALC unloads — the same contract MeshQuery already
+    /// relies on. Emissions flow through unchanged and re-marshal onto the hub via
+    /// <c>Stream.Update → hub.Post</c>, so ordering is preserved exactly as before.</para>
+    /// </summary>
+    private IObservable<T> ScheduleRenderSubscribe<T>(IObservable<T> source)
+    {
+        if (!renderSubscribeSchedulerResolved)
+        {
+            renderSubscribeScheduler = Hub.ServiceProvider.GetService<IPooledSubscribeScheduler>();
+            renderSubscribeSchedulerResolved = true;
+        }
+        return renderSubscribeScheduler is { } scheduler
+            ? scheduler.SubscribeThroughPool(source)
+            : source.SubscribeOn(TaskPoolScheduler.Default);
+    }
+
 
     /// <summary>
     /// Registers <paramref name="disposable"/> to be disposed when the area identified by
@@ -976,17 +1024,16 @@ public record LayoutAreaHost : IDisposable
         // observable emits, lets the data Patch land before the control Patch.
         var ret = DisposeExistingAreas(store, context);
         RegisterForDisposal(context.Parent?.Area ?? context.Area,
-            generator.Invoke(this, context, ret.Store)
+            ScheduleRenderSubscribe(generator.Invoke(this, context, ret.Store))
                 // 🚨 NEVER ON THE MAIN HUB. This nested-area subscribe is reached both from the
                 // (already off-hub) top-level render AND from UpdateArea, which runs on the owning
                 // hub's ACTION BLOCK (Stream.Update → UpdateStreamRequest). Subscribing the nested
                 // generator there would run its body — and any IMeshService.Query / hub round-trip it
                 // does in-render — on the hub turn → the same query-in-render deadlock as the
-                // top-level path. Hop the subscribe onto the thread pool (see the class-level fix in
-                // BuildInitialization + Doc/Architecture/OrleansTaskScheduler). The UpdateArea
-                // callback re-enters via Stream.Update → hub.Post (the actor inbox, safe from any
-                // thread, re-serialised in order), so ordering is preserved.
-                .SubscribeOn(TaskPoolScheduler.Default)
+                // top-level path. ScheduleRenderSubscribe hops the subscribe onto the mesh's drainable
+                // Layout pool (see BuildInitialization + Doc/Architecture/OrleansTaskScheduler) so it
+                // is joined at teardown. The UpdateArea callback re-enters via Stream.Update → hub.Post
+                // (the actor inbox, safe from any thread, re-serialised in order), so ordering holds.
                 .Subscribe(c => UpdateArea(context, c), ex => FailRendering(ex, context.Area))
         );
         return ret;
@@ -999,12 +1046,13 @@ public record LayoutAreaHost : IDisposable
         // Observable.FromAsync (no await in hub-reachable code), flatten to the inner
         // control stream, and feed UpdateArea on each emission.
         RegisterForDisposal(context.Parent?.Area ?? context.Area,
-            FromViewBuilder(ct => asyncGenerator.Invoke(this, context, store, ct))
-                .Switch()
+            ScheduleRenderSubscribe(
+                    FromViewBuilder(ct => asyncGenerator.Invoke(this, context, store, ct))
+                        .Switch())
                 // 🚨 NEVER ON THE MAIN HUB — see the ViewStream<T> overload above. Subscribe the
                 // nested generator off the owning hub's action block so its in-render mesh work never
-                // wedges the hub turn (UpdateArea re-marshals emissions back via hub.Post).
-                .SubscribeOn(TaskPoolScheduler.Default)
+                // wedges the hub turn (UpdateArea re-marshals emissions back via hub.Post), on the
+                // drainable Layout pool so teardown joins it.
                 .Subscribe(c => UpdateArea(context, c), ex => FailRendering(ex, context.Area)));
         return ret;
     }
@@ -1132,10 +1180,10 @@ public record LayoutAreaHost : IDisposable
         // Reactive: bridge the Task-producing ViewDefinition via Observable.FromAsync
         // (no await in hub-reachable code) and feed UpdateArea once it resolves.
         RegisterForDisposal(context.Parent?.Area ?? context.Area,
-            FromViewBuilder(ct => generator.Invoke(this, context, ct))
+            ScheduleRenderSubscribe(FromViewBuilder(ct => generator.Invoke(this, context, ct)))
                 // 🚨 NEVER ON THE MAIN HUB — subscribe off the owning hub's action block (this path is
-                // reachable via UpdateArea on the hub turn). See the ViewStream<T> overload above.
-                .SubscribeOn(TaskPoolScheduler.Default)
+                // reachable via UpdateArea on the hub turn), on the drainable Layout pool so teardown
+                // joins it. See the ViewStream<T> overload above.
                 .Subscribe(view => UpdateArea(context, view!), ex => FailRendering(ex, context.Area)));
         return ret;
     }
@@ -1148,11 +1196,12 @@ public record LayoutAreaHost : IDisposable
         // Observable.FromAsync (no await in hub-reachable code) and feed UpdateArea.
         // Switch() keeps only the latest definition's resolution in flight.
         RegisterForDisposal(context.Area,
-            generator
-                .Select(vd => FromViewBuilder(ct => vd.Invoke(this, context, ct)))
-                .Switch()
-                // 🚨 NEVER ON THE MAIN HUB — subscribe off the owning hub's action block. See above.
-                .SubscribeOn(TaskPoolScheduler.Default)
+            ScheduleRenderSubscribe(
+                    generator
+                        .Select(vd => FromViewBuilder(ct => vd.Invoke(this, context, ct)))
+                        .Switch())
+                // 🚨 NEVER ON THE MAIN HUB — subscribe off the owning hub's action block, on the
+                // drainable Layout pool so teardown joins it. See above.
                 .Subscribe(view => UpdateArea(context, view!), ex => FailRendering(ex, context.Area)));
 
         return DisposeExistingAreas(store, context);
@@ -1182,13 +1231,12 @@ public record LayoutAreaHost : IDisposable
         var ret = DisposeExistingAreas(store, context);
         RegisterForDisposal(
             context.Area,
-            generator
-                .DistinctUntilChanged()
-                // 🚨 NEVER ON THE MAIN HUB — subscribe off the owning hub's action block. This
-                // container/dialog sub-area path is reached from UpdateArea on the hub turn, so a
-                // nested generator that queries in-render would otherwise wedge it. See the
-                // ViewStream<T> overload above and Doc/Architecture/OrleansTaskScheduler.
-                .SubscribeOn(TaskPoolScheduler.Default)
+            ScheduleRenderSubscribe(generator.DistinctUntilChanged())
+                // 🚨 NEVER ON THE MAIN HUB — subscribe off the owning hub's action block, on the
+                // drainable Layout pool so teardown joins it. This container/dialog sub-area path is
+                // reached from UpdateArea on the hub turn, so a nested generator that queries in-render
+                // would otherwise wedge it. See the ViewStream<T> overload above and
+                // Doc/Architecture/OrleansTaskScheduler.
                 .Subscribe(
                     view => UpdateArea(context, view),
                     ex => FailRendering(ex, context.Area))

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolOptions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolOptions.cs
@@ -34,6 +34,18 @@ public static class IoPoolNames
     /// </summary>
     public const string Query = "Query";
 
+    /// <summary>
+    /// Layout-area render subscribes (<see cref="IIoPool.SubscribeThroughPool{T}"/>, via
+    /// <c>IPooledSubscribeScheduler</c>). Exists so the render SUBSCRIBE — which hops off the owning
+    /// hub's action block to stay query-in-render-safe, and runs the synchronous render body
+    /// (including menu renderers that resolve services and touch collectible NodeType ALC types) — is
+    /// TRACKED and DRAINABLE at teardown. Without it the render straggler executes on a bare
+    /// ThreadPool thread after the Autofac scope is disposed and the NodeType ALC unloaded → the
+    /// endemic teardown SIGSEGV (FutuRe.Test exit=139). Generous cap: it's a drain hook, not a
+    /// throttle (the slot is held only for the bounded subscribe window).
+    /// </summary>
+    public const string Layout = "Layout";
+
     /// <summary>CPU-bound compilation (Roslyn compile/script). Wave 3.</summary>
     public const string Compile = "Compile";
 
@@ -118,6 +130,13 @@ public sealed record IoPoolOptions
     /// </summary>
     public int Query { get; init; } = 256;
 
+    /// <summary>
+    /// Concurrent layout-area render subscribes (the <c>Layout</c> pool). A drain hook, not a
+    /// throttle — the slot is held only for the bounded subscribe window — so the cap is generous
+    /// (256) to never bottleneck concurrent area renders (a page renders many nested areas at once).
+    /// </summary>
+    public int Layout { get; init; } = 256;
+
     /// <summary>Concurrent compilations. CPU-bound; defaults to the processor count.</summary>
     public int Compile { get; init; } = Environment.ProcessorCount;
 
@@ -165,6 +184,7 @@ public sealed record IoPoolOptions
             IoPoolNames.Http => Http,
             IoPoolNames.Ai => Ai,
             IoPoolNames.Query => Query,
+            IoPoolNames.Layout => Layout,
             IoPoolNames.Compile => Compile,
             IoPoolNames.Process => Process,
             _ => Default,

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolServiceCollectionExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -26,6 +27,12 @@ public static class IoPoolServiceCollectionExtensions
         services.TryAddSingleton(_ =>
             configure is null ? new IoPoolOptions() : configure(new IoPoolOptions()));
         services.TryAddSingleton<IoPoolRegistry>();
+        // The drainable-subscribe scheduler for layout-area renders. Lets LayoutAreaHost (which sits
+        // BELOW this assembly and cannot reference IoPoolRegistry) route its render subscribes through
+        // the drainable Layout pool via the IPooledSubscribeScheduler abstraction, so teardown's
+        // DrainAll() cancel+joins them before the scope disposes / NodeType ALCs unload (the endemic
+        // teardown SIGSEGV).
+        services.TryAddSingleton<IPooledSubscribeScheduler, IoPoolSubscribeScheduler>();
         // The async half of mesh teardown — resources enqueue async cleanup here from
         // their sync Dispose(); the mesh's DisposeAsync drains it before the scope dies.
         services.TryAddSingleton<AsyncDisposeQueue>();

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolSubscribeScheduler.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolSubscribeScheduler.cs
@@ -1,0 +1,19 @@
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Mesh.Threading;
+
+/// <summary>
+/// The <see cref="IPooledSubscribeScheduler"/> implementation: routes a subscribe through the
+/// mesh-scoped, teardown-drainable <see cref="IoPoolNames.Layout"/> pool so
+/// <see cref="IoPoolRegistry.DrainAll"/> cancel+joins it before the service scope disposes and any
+/// collectible NodeType <c>AssemblyLoadContext</c> unloads. Registered as a mesh singleton in
+/// <c>AddIoPools</c>; resolved by <c>LayoutAreaHost</c> (which lives BELOW <c>MeshWeaver.Mesh.Contract</c>
+/// in the dependency graph and therefore cannot reference <see cref="IoPoolRegistry"/> directly — it
+/// sees only the <see cref="IPooledSubscribeScheduler"/> abstraction in <c>MeshWeaver.Messaging.Contract</c>).
+/// </summary>
+public sealed class IoPoolSubscribeScheduler(IoPoolRegistry registry) : IPooledSubscribeScheduler
+{
+    /// <inheritdoc />
+    public IObservable<T> SubscribeThroughPool<T>(IObservable<T> source) =>
+        registry.Get(IoPoolNames.Layout).SubscribeThroughPool(source);
+}

--- a/src/MeshWeaver.Messaging.Contract/IPooledSubscribeScheduler.cs
+++ b/src/MeshWeaver.Messaging.Contract/IPooledSubscribeScheduler.cs
@@ -1,0 +1,35 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// Runs an observable's <b>subscribe</b> through the mesh's teardown-drainable I/O pool instead of a
+/// bare <c>SubscribeOn(TaskPoolScheduler.Default)</c>.
+///
+/// <para>Layout-area render pipelines hop their subscribe off the owning hub's action block so a
+/// view generator that queries in-render cannot wedge the hub turn. Historically that hop used
+/// <c>SubscribeOn(TaskPoolScheduler.Default)</c> — a bare ThreadPool schedule that mesh teardown
+/// cannot see. During teardown that render subscribe keeps executing on a ThreadPool thread AFTER
+/// the hub's Autofac <c>LifetimeScope</c> is disposed (→ <see cref="System.ObjectDisposedException"/>
+/// from <c>GetService</c>) and, for a node whose render touches types compiled into a collectible
+/// <c>AssemblyLoadContext</c>, AFTER that ALC is unloaded (→ native use-after-unload SIGSEGV — the
+/// endemic teardown crash <c>MeshWeaver.FutuRe.Test</c> reproduced as exit=139).</para>
+///
+/// <para>Routing the subscribe through this scheduler makes it a <b>tracked, gated, cancellable</b>
+/// leaf on a drainable pool: mesh teardown's <c>IoPoolRegistry.DrainAll()</c> cancels + <b>joins</b>
+/// the in-flight subscribe before the service scope disposes and the ALCs unload, so no render ever
+/// observes a disposed scope or a freed ALC. This is the exact contract <c>MeshQuery</c> already
+/// relies on for its change-feed subscribes.</para>
+///
+/// <para>Resolved from the hub's <c>ServiceProvider</c>; when a mesh has no I/O pools registered
+/// (bare messaging-only hubs) the caller falls back to the historical
+/// <c>SubscribeOn(TaskPoolScheduler.Default)</c> — those hubs compile no collectible ALCs, so the
+/// drain has nothing to join.</para>
+/// </summary>
+public interface IPooledSubscribeScheduler
+{
+    /// <summary>
+    /// Returns an observable that, when subscribed, runs <paramref name="source"/>'s subscribe on the
+    /// drainable pool (off the calling hub/grain scheduler) as a tracked leaf that mesh teardown
+    /// cancel+joins. Emissions flow through unchanged; ordering is preserved.
+    /// </summary>
+    IObservable<T> SubscribeThroughPool<T>(IObservable<T> source);
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/LayoutRenderTeardownDrainTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/LayoutRenderTeardownDrainTest.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the root cause of the endemic teardown SIGSEGV (<c>MeshWeaver.FutuRe.Test</c> exit=139,
+/// issue #613): a layout-area render subscribe hopped off the owning hub's action block via a BARE
+/// <c>SubscribeOn(TaskPoolScheduler.Default)</c> — a ThreadPool schedule mesh teardown cannot see.
+/// During teardown that render kept executing on a ThreadPool thread AFTER the hub's Autofac
+/// <c>LifetimeScope</c> was disposed (→ <c>ObjectDisposedException</c> from a menu renderer's
+/// <c>GetService</c> — captured verbatim by <c>TeardownStragglerCapturer</c>) and, for a node whose
+/// render touched types compiled into a collectible <c>AssemblyLoadContext</c>, AFTER that ALC was
+/// unloaded (→ native use-after-unload crash).
+///
+/// <para>The fix routes every layout render subscribe through <c>IPooledSubscribeScheduler</c> — the
+/// mesh's teardown-drainable <see cref="IoPoolNames.Layout"/> pool — so
+/// <see cref="IoPoolRegistry.DrainAll"/> cancel+<b>joins</b> the in-flight subscribe BEFORE the
+/// service scope disposes / the ALC unloads. This test forces a render to block mid-subscribe and
+/// asserts BOTH halves of that contract deterministically:</para>
+/// <list type="number">
+///   <item>the render runs as a TRACKED leaf on the Layout pool
+///     (<see cref="IIoPool.CurrentInFlight"/> ≥ 1 while it executes) — pre-fix it ran on a bare
+///     ThreadPool thread, so the Layout pool reported ZERO in-flight; and</item>
+///   <item><see cref="IoPoolRegistry.DrainAll"/> BLOCKS (joins) until the in-flight render releases —
+///     pre-fix it returned immediately because nothing tracked the render, which is precisely how
+///     the scope could dispose / the ALC unload underneath a still-running render.</item>
+/// </list>
+/// Both assertions FAIL on the pre-fix code and PASS after. (We assert the drainable-pool contract
+/// rather than actually unloading an ALC mid-render, because faithfully reproducing the crash would
+/// SIGSEGV the test host — the tracking+join IS the property that prevents it.)
+/// </summary>
+public class LayoutRenderTeardownDrainTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string BlockingArea = nameof(BlockingArea);
+    private static readonly Address HostAddress = new("layout-render-drain-host");
+
+    // Signalled by the render body once it is executing on the pool thread (holding a Layout-pool
+    // permit); the test proceeds only after the render is genuinely in-flight — no sleeps, no polling.
+    private readonly ManualResetEventSlim renderInFlight = new(false);
+    // Held by the render body until the test releases it, keeping the render subscribe in-flight for
+    // the duration of the assertions.
+    private readonly ManualResetEventSlim releaseRender = new(false);
+
+    /// <summary>
+    /// A view generator that mirrors the production render body shape (a synchronous render that
+    /// resolves a service from the hub scope, exactly like <c>NodeMenuItemsExtensions.RenderMenus</c>):
+    /// it signals that it is in-flight, blocks until released, then resolves a service and returns a
+    /// control. Its func body runs synchronously during the top-level render subscribe, so while it
+    /// blocks the Layout pool holds one in-flight permit for it.
+    /// </summary>
+    private IObservable<UiControl?> BlockingView(LayoutAreaHost host, RenderingContext ctx)
+    {
+        renderInFlight.Set();
+        // Bounded so a wiring regression can never hang the suite; the test releases well within this.
+        releaseRender.Wait(TimeSpan.FromSeconds(30));
+        // Same service-resolution shape as the real menu renderer whose GetService threw the disposed
+        // -scope ODE at teardown. With the drain joining this render first, the scope is still alive.
+        _ = host.Hub.ServiceProvider.GetService<ILoggerFactory>();
+        return Observable.Return<UiControl?>(Controls.Html("rendered"));
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task LayoutRenderSubscribe_RunsAsTrackedDrainableLeaf_AndDrainJoinsIt()
+    {
+        // A hosted hub that serves our blocking layout area — same DI-scope inheritance prod uses.
+        _ = Mesh.GetHostedHub(
+            HostAddress,
+            c => c.AddData().AddLayout(layout => layout.WithView<UiControl>(BlockingArea, BlockingView)));
+
+        var ioPools = Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>();
+        var layoutPool = ioPools.Get(IoPoolNames.Layout);
+
+        // Subscribe the area from a client, exactly as the portal does — this drives the server-side
+        // render pipeline. Fire-and-forget: the render blocks, so we must NOT await it here.
+        var client = GetClient(c => c.AddData());
+        var reference = new LayoutAreaReference(BlockingArea);
+        var areaStream = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(HostAddress, reference);
+        using var areaSubscription = areaStream.GetControlStream(BlockingArea).Subscribe(_ => { });
+
+        // Wait until the render body is genuinely executing on the pool (deterministic — no sleep).
+        renderInFlight.Wait(TimeSpan.FromSeconds(30))
+            .Should().BeTrue("the layout render must actually start executing");
+
+        // (1) TRACKED: the in-flight render holds a Layout-pool permit. Pre-fix it ran on a bare
+        //     TaskPoolScheduler thread the pool never saw → CurrentInFlight == 0.
+        layoutPool.CurrentInFlight.Should().BeGreaterThanOrEqualTo(1,
+            "the render subscribe must run as a TRACKED leaf on the drainable Layout pool — a bare " +
+            "SubscribeOn(TaskPoolScheduler.Default) is invisible to the teardown drain (the SIGSEGV root cause)");
+
+        // (2) JOINED: DrainAll must BLOCK until the in-flight render releases. Run it on a background
+        //     thread; it must still be blocked while the render is held. Pre-fix DrainAll returned
+        //     immediately (nothing tracked) — that is exactly how the scope disposed / the ALC
+        //     unloaded underneath a still-running render.
+        var drainReturned = Task.Run(() => ioPools.DrainAll());
+        var returnedWhileBlocked = await Task.WhenAny(drainReturned, Task.Delay(TimeSpan.FromSeconds(1)));
+        returnedWhileBlocked.Should().NotBeSameAs(drainReturned,
+            "DrainAll must JOIN (block on) the in-flight render — returning while a render is still " +
+            "executing is the teardown use-after-dispose/unload window this fix closes");
+
+        // Release the render; DrainAll can now acquire the freed permit and return.
+        releaseRender.Set();
+        await drainReturned.WaitAsync(TimeSpan.FromSeconds(30));
+        layoutPool.CurrentInFlight.Should().Be(0, "the render released its permit once it completed");
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        // Guarantee the render is never left blocked if an assertion aborts early (the [Fact] timeout
+        // would otherwise wait on the 30s render bound before teardown).
+        releaseRender.Set();
+        await base.DisposeAsync();
+        renderInFlight.Dispose();
+        releaseRender.Dispose();
+    }
+}


### PR DESCRIPTION
## Problem (issue #613)
`MeshWeaver.FutuRe.Test` intermittently SIGSEGVs at teardown (`exit=139`, no trx), reddening CI shards.

## Native root cause (confirmed from the CI Linux core dump)
Analyzed the 1.2 GB dump in an amd64 container. The faulting thread:
```
[DynamicHelperFrame] (JIT type-handle helper)  → ConcurrentDictionary.GrowTable
TypeRegistry.IndexFullNameAlias → WithType → CommentNodeType.AddCommentType
MeshBuilder.BuildHub → MonolithMeshTestBase.PreWarmNodeTypeHubs
```
A JIT dynamic-helper deref during NodeType-hub construction — a **use-after-unload of a collectible ALC**. `teardown-stragglers.log` named the precursor: an `ObjectDisposedException` from `NodeMenuItemsExtensions.RenderMenus` (`GetService<ILoggerFactory>`) via `LayoutDefinition.Render`, running on a **`.NET TP Worker` scheduled by `TaskPoolScheduler`** — a layout render still executing after the Autofac scope was disposed. FutuRe compiles NodeTypes into collectible ALCs; when a post-disposal GC unloads one under the still-running render thread → SIGSEGV.

## Fix (root cause, no band-aid)
`LayoutAreaHost` hopped every render subscribe off the hub via a bare `SubscribeOn(TaskPoolScheduler.Default)` — invisible to mesh teardown, so `IoPoolRegistry.DrainAll()` (run before scope disposal / ALC unload) couldn't cancel+join it. `MeshQuery` already solved this exact class via a drainable IO pool; the render path never adopted it.
- New `IPooledSubscribeScheduler` (in `Mesh.Contract`, since Layout sits below it) over a new drainable **`Layout`** `IIoPool`.
- `LayoutAreaHost.ScheduleRenderSubscribe` routes all six render-subscribe sites through it; `DrainAll()` now cancel+joins in-flight renders before teardown. Bare `SubscribeOn` fallback only where a mesh has no IO pools (those compile no collectible ALCs).
- Top-level init render wrapped in `Observable.Defer` (`LayoutDefinition.Render` is eager for a single renderer).

## Verification
- Deterministic repro `LayoutRenderTeardownDrainTest`: holds a render in-flight; asserts it runs as a tracked `Layout`-pool leaf and `DrainAll` joins it — FAILS pre-fix (untracked, drain returns immediately), PASSES after.
- Release `-warnaserror` clean. `Layout.Test` 337/337; `Hosting.Monolith.Test` 369 pass / 2 skip / 0 fail (incl. the repro). `FutuRe.Test` run repeatedly — clean exit + trx every time, no SIGSEGV, no straggler file.
- Note: a pre-existing unrelated warm-cache flake (`EuropeRe_AnnualProfitabilityWaterfall_ShouldRender`) reproduces on `origin/main` too (proven by reverting only `LayoutAreaHost.cs`) — out of scope, worth a separate follow-up.

Closes #613. No What's New entry — internal stability fix, no user-facing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)