### PR TITLE
Comment Overview: a fresh (empty) comment opens straight in the editor

### DIFF
--- a/src/MeshWeaver.Graph/CommentLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CommentLayoutAreas.cs
@@ -54,6 +54,11 @@ public static class CommentLayoutAreas
         return $"{(int)(elapsed.TotalDays / 365)}y";
     }
 
+    /// <summary>A comment with nothing written yet opens straight in EDIT mode — "+ Comment" exists to
+    /// write, so a freshly created (empty) comment must not demand an extra ✎ click before typing.
+    /// Anything already written renders read-only until the author toggles the editor.</summary>
+    internal static bool OpensInEdit(string? text) => string.IsNullOrWhiteSpace(text);
+
     /// <summary>
     /// Renders the Overview area for a Comment node.
     /// Shows author, comment text (as rendered markdown), click-to-edit toggle,
@@ -192,10 +197,10 @@ public static class CommentLayoutAreas
         {
             container = container.WithView((h, _) =>
             {
-                // Initialize edit state once
+                // Initialize edit state once — a fresh (empty) comment opens straight in the editor.
                 if (!initialized[0])
                 {
-                    h.UpdateData(editStateId, false);
+                    h.UpdateData(editStateId, OpensInEdit(comment.Text));
                     initialized[0] = true;
                 }
 

--- a/test/MeshWeaver.Graph.Test/CommentEditStateTest.cs
+++ b/test/MeshWeaver.Graph.Test/CommentEditStateTest.cs
@@ -1,0 +1,22 @@
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Tests for <see cref="CommentLayoutAreas.OpensInEdit"/> — the initial edit-state seed of a comment's
+/// Overview area. A freshly created comment is empty and must open straight in the editor (no extra ✎
+/// click before typing); anything already written renders read-only until the author toggles.
+/// </summary>
+public class CommentEditStateTest
+{
+    [Theory(Timeout = 5000)]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FreshEmptyComment_OpensInEdit(string? text)
+        => Assert.True(CommentLayoutAreas.OpensInEdit(text));
+
+    [Fact(Timeout = 5000)]
+    public void WrittenComment_OpensReadOnly()
+        => Assert.False(CommentLayoutAreas.OpensInEdit("looks good — but check the aggregate limit"));
+}


### PR DESCRIPTION
"+ Comment" creates an empty comment node, but the Overview area seeded its edit flag to `false` unconditionally — the author stared at an empty read-only card and had to click ✎ before typing. This seeds the flag from the text (`OpensInEdit`: empty/whitespace → editor; written → read-only), so a freshly created comment is immediately writable while existing comments keep opening in display mode. Regression tests in `CommentEditStateTest`; `MeshWeaver.Graph.Test` comment suites 12/12 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)