### PR TITLE
Fix: custom-typed content renders empty after a GitSync re-import

### DIFF
--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1514,6 +1514,16 @@ public record MeshDataSource : GenericUnpartitionedDataSource<MeshDataSource>
         // Register the content type in TypeRegistry for JSON serialization
         Workspace.Hub.TypeRegistry.WithType(dataType, dataType.Name);
 
+        // Also record it in the MESH-WIDE content-type registry. This is the single reliable
+        // choke point where a dynamically-compiled NodeType's CLR content type is in hand (this
+        // call is made by the compiled HubConfiguration when a node's hub cold-activates). Unlike
+        // the per-hub TypeRegistry above — which lives in THIS hub's frozen JsonSerializerOptions —
+        // the mesh singleton is process-wide and survives a re-import, so the degrade seams can
+        // re-type content that the domain-agnostic cache hub deserialised to a bare JsonElement
+        // (the GitSync-reimport-renders-empty bug). See IMeshContentTypeRegistry.
+        Workspace.Hub.ServiceProvider.GetService<Mesh.Services.IMeshContentTypeRegistry>()
+            ?.Register(dataType);
+
         // Store ContentType for UI integration (editor generation, etc.)
         // Content is accessed via MeshNode.Content - there's no separate TypeSource
         return this with { ContentType = dataType };

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -659,27 +659,6 @@ public static class StaticRepoImporter
         NodeTypeCompilationActivity.AppendLog(
             hub, activityPath, $"Importing {nodes.Count} node(s) into {source.Partition}…", logger!);
 
-        // 🔁 Auto-recycle-on-reimport (the fix for "custom-typed content renders empty after a
-        // re-import into a running process"). The importer re-materialises content nodes but never
-        // recycled the per-node hubs, so a node whose custom NodeType hub was already activated keeps
-        // serving content the domain-agnostic cache re-read as an untyped JsonElement. Collect the
-        // set of CUSTOM NodeType keys this partition defines (a NodeType-definition node's own path
-        // plus its short id) so we can, after the upsert, recycle exactly the content INSTANCES of
-        // those types that changed THIS run — not framework/markdown nodes (never darkened), not
-        // incremental-skips. Reuses the RecycleCore mechanism (MeshChangeFeed Updated + DisposeRequest).
-        var customTypeKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var n in nodes)
-        {
-            if (!string.Equals(n.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal))
-                continue;
-            customTypeKeys.Add(n.Path);
-            var segs = n.Path.Split('/');
-            if (segs.Length > 0 && !string.IsNullOrEmpty(segs[^1]))
-                customTypeKeys.Add(segs[^1]);
-        }
-        // Thread-safe: the per-node upsert runs under .Merge(BatchSize) (concurrent).
-        var recyclePaths = new System.Collections.Concurrent.ConcurrentQueue<string>();
-
         // Read the existing target subtree(s) ONCE. A source's nodes may span MULTIPLE partitions
         // (e.g. the model catalog: the read-only _Policy under "Model", the provider/model content
         // under "_Provider"), so read each touched partition's subtree. The snapshot yields each
@@ -848,15 +827,7 @@ public static class StaticRepoImporter
                         // Failed and continue. The Failed tally drives the terminal Warning status
                         // below — the activity never reports a green Succeeded while hiding failures.
                         return Upsert(hub, materialized)
-                            .Select(_ =>
-                            {
-                                // Only content INSTANCES of a custom NodeType this partition defines are
-                                // recycled (so their hubs re-activate → re-run WithContentType → re-type).
-                                // Framework/markdown nodes fall through (their NodeType is not a custom key).
-                                if (materialized.NodeType is { Length: > 0 } nt && customTypeKeys.Contains(nt))
-                                    recyclePaths.Enqueue(path);
-                                return (Imported: 1, Failed: 0, Preserved: 0);
-                            })
+                            .Select(_ => (Imported: 1, Failed: 0, Preserved: 0))
                             .Catch<(int Imported, int Failed, int Preserved), Exception>(ex =>
                             {
                                 logger?.LogWarning(ex,
@@ -922,10 +893,6 @@ public static class StaticRepoImporter
                         // diff sees exactly what's now in the partition. One write; survives prune (_Activity).
                         return WriteManifest(hub, source.Partition, nodes, hub.JsonSerializerOptions, logger).Select(_ =>
                         {
-                            // 🔁 Recycle the custom-typed instances upserted THIS run so their per-node
-                            // hubs re-activate cold and re-register their content type — the same heal a
-                            // manual recycle performed after the outage, now automatic on every import.
-                            RecycleReimportedNodes(hub, recyclePaths, activityPath, logger);
                             // 🚨 Terminal status reflects per-file outcomes: ANY failed upsert →
                             // Warning (the ⚠ lines above pinpoint which files), all-clear →
                             // Succeeded. Written via Complete so the status + summary land in ONE
@@ -1238,52 +1205,6 @@ public static class StaticRepoImporter
     /// </summary>
     private static bool IsGovernance(MeshNode node) =>
         node.Segments.Skip(1).Any(seg => seg.StartsWith('_'));
-
-    /// <summary>
-    /// Recycles the per-node hubs of the custom-typed content instances upserted this run: publishes a
-    /// <see cref="MeshChangeKind.Updated"/> event (invalidates the shared node-stream cache) and posts a
-    /// <see cref="DisposeRequest"/> (tears the hub down so the next read activates it COLD and re-runs
-    /// its compiled <c>WithContentType</c>). Same mechanism as <c>MeshOperations.RecycleCore</c>, but it
-    /// deliberately does NOT stamp a release request — these are content instances, not NodeType nodes,
-    /// so there is nothing to recompile. Fire-and-forget + per-node guarded: a recycle hiccup must never
-    /// fail the import that already succeeded.
-    /// </summary>
-    private static void RecycleReimportedNodes(
-        IMessageHub hub, System.Collections.Concurrent.ConcurrentQueue<string> paths,
-        string activityPath, ILogger? logger)
-    {
-        if (paths.IsEmpty)
-            return;
-        var changeFeed = hub.ServiceProvider.GetService<IMeshChangeFeed>();
-        var recycled = 0;
-        foreach (var path in paths.Distinct(StringComparer.OrdinalIgnoreCase))
-        {
-            try
-            {
-                var segments = path.Split('/');
-                var id = segments.Length > 0 ? segments[^1] : path;
-                var ns = segments.Length > 1 ? string.Join("/", segments[..^1]) : "";
-                changeFeed?.Publish(new MeshChangeEvent(
-                    Namespace: ns, Id: id, Path: path, Kind: MeshChangeKind.Updated,
-                    NodeType: null, Version: 0, Timestamp: DateTimeOffset.UtcNow));
-                hub.Post(new DisposeRequest(), o => o.WithTarget(new Address(path)));
-                recycled++;
-            }
-            catch (Exception ex)
-            {
-                logger?.LogWarning(ex,
-                    "[StaticRepoImport] recycle of re-imported node {Path} failed (continuing).", path);
-            }
-        }
-        if (recycled > 0)
-        {
-            logger?.LogInformation(
-                "[StaticRepoImport] recycled {Count} re-imported custom-typed node hub(s) so content re-types on next read.",
-                recycled);
-            NodeTypeCompilationActivity.AppendLog(hub, activityPath,
-                $"🔁 Recycled {recycled} re-imported custom-typed node(s) so their content re-types.", logger!);
-        }
-    }
 
     /// <summary>
     /// Computes prerendered HTML for markdown nodes via the shared <see cref="MarkdownContent.Parse"/>

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -659,6 +659,27 @@ public static class StaticRepoImporter
         NodeTypeCompilationActivity.AppendLog(
             hub, activityPath, $"Importing {nodes.Count} node(s) into {source.Partition}…", logger!);
 
+        // 🔁 Auto-recycle-on-reimport (the fix for "custom-typed content renders empty after a
+        // re-import into a running process"). The importer re-materialises content nodes but never
+        // recycled the per-node hubs, so a node whose custom NodeType hub was already activated keeps
+        // serving content the domain-agnostic cache re-read as an untyped JsonElement. Collect the
+        // set of CUSTOM NodeType keys this partition defines (a NodeType-definition node's own path
+        // plus its short id) so we can, after the upsert, recycle exactly the content INSTANCES of
+        // those types that changed THIS run — not framework/markdown nodes (never darkened), not
+        // incremental-skips. Reuses the RecycleCore mechanism (MeshChangeFeed Updated + DisposeRequest).
+        var customTypeKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var n in nodes)
+        {
+            if (!string.Equals(n.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal))
+                continue;
+            customTypeKeys.Add(n.Path);
+            var segs = n.Path.Split('/');
+            if (segs.Length > 0 && !string.IsNullOrEmpty(segs[^1]))
+                customTypeKeys.Add(segs[^1]);
+        }
+        // Thread-safe: the per-node upsert runs under .Merge(BatchSize) (concurrent).
+        var recyclePaths = new System.Collections.Concurrent.ConcurrentQueue<string>();
+
         // Read the existing target subtree(s) ONCE. A source's nodes may span MULTIPLE partitions
         // (e.g. the model catalog: the read-only _Policy under "Model", the provider/model content
         // under "_Provider"), so read each touched partition's subtree. The snapshot yields each
@@ -827,7 +848,15 @@ public static class StaticRepoImporter
                         // Failed and continue. The Failed tally drives the terminal Warning status
                         // below — the activity never reports a green Succeeded while hiding failures.
                         return Upsert(hub, materialized)
-                            .Select(_ => (Imported: 1, Failed: 0, Preserved: 0))
+                            .Select(_ =>
+                            {
+                                // Only content INSTANCES of a custom NodeType this partition defines are
+                                // recycled (so their hubs re-activate → re-run WithContentType → re-type).
+                                // Framework/markdown nodes fall through (their NodeType is not a custom key).
+                                if (materialized.NodeType is { Length: > 0 } nt && customTypeKeys.Contains(nt))
+                                    recyclePaths.Enqueue(path);
+                                return (Imported: 1, Failed: 0, Preserved: 0);
+                            })
                             .Catch<(int Imported, int Failed, int Preserved), Exception>(ex =>
                             {
                                 logger?.LogWarning(ex,
@@ -893,6 +922,10 @@ public static class StaticRepoImporter
                         // diff sees exactly what's now in the partition. One write; survives prune (_Activity).
                         return WriteManifest(hub, source.Partition, nodes, hub.JsonSerializerOptions, logger).Select(_ =>
                         {
+                            // 🔁 Recycle the custom-typed instances upserted THIS run so their per-node
+                            // hubs re-activate cold and re-register their content type — the same heal a
+                            // manual recycle performed after the outage, now automatic on every import.
+                            RecycleReimportedNodes(hub, recyclePaths, activityPath, logger);
                             // 🚨 Terminal status reflects per-file outcomes: ANY failed upsert →
                             // Warning (the ⚠ lines above pinpoint which files), all-clear →
                             // Succeeded. Written via Complete so the status + summary land in ONE
@@ -1205,6 +1238,52 @@ public static class StaticRepoImporter
     /// </summary>
     private static bool IsGovernance(MeshNode node) =>
         node.Segments.Skip(1).Any(seg => seg.StartsWith('_'));
+
+    /// <summary>
+    /// Recycles the per-node hubs of the custom-typed content instances upserted this run: publishes a
+    /// <see cref="MeshChangeKind.Updated"/> event (invalidates the shared node-stream cache) and posts a
+    /// <see cref="DisposeRequest"/> (tears the hub down so the next read activates it COLD and re-runs
+    /// its compiled <c>WithContentType</c>). Same mechanism as <c>MeshOperations.RecycleCore</c>, but it
+    /// deliberately does NOT stamp a release request — these are content instances, not NodeType nodes,
+    /// so there is nothing to recompile. Fire-and-forget + per-node guarded: a recycle hiccup must never
+    /// fail the import that already succeeded.
+    /// </summary>
+    private static void RecycleReimportedNodes(
+        IMessageHub hub, System.Collections.Concurrent.ConcurrentQueue<string> paths,
+        string activityPath, ILogger? logger)
+    {
+        if (paths.IsEmpty)
+            return;
+        var changeFeed = hub.ServiceProvider.GetService<IMeshChangeFeed>();
+        var recycled = 0;
+        foreach (var path in paths.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            try
+            {
+                var segments = path.Split('/');
+                var id = segments.Length > 0 ? segments[^1] : path;
+                var ns = segments.Length > 1 ? string.Join("/", segments[..^1]) : "";
+                changeFeed?.Publish(new MeshChangeEvent(
+                    Namespace: ns, Id: id, Path: path, Kind: MeshChangeKind.Updated,
+                    NodeType: null, Version: 0, Timestamp: DateTimeOffset.UtcNow));
+                hub.Post(new DisposeRequest(), o => o.WithTarget(new Address(path)));
+                recycled++;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex,
+                    "[StaticRepoImport] recycle of re-imported node {Path} failed (continuing).", path);
+            }
+        }
+        if (recycled > 0)
+        {
+            logger?.LogInformation(
+                "[StaticRepoImport] recycled {Count} re-imported custom-typed node hub(s) so content re-types on next read.",
+                recycled);
+            NodeTypeCompilationActivity.AppendLog(hub, activityPath,
+                $"🔁 Recycled {recycled} re-imported custom-typed node(s) so their content re-types.", logger!);
+        }
+    }
 
     /// <summary>
     /// Computes prerendered HTML for markdown nodes via the shared <see cref="MarkdownContent.Parse"/>

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -209,6 +209,12 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     private readonly IMessageHub cacheHub;
     private readonly ILogger<MeshNodeStreamCache> logger;
 
+    // Mesh-wide $type→CLR-Type resolver (see IMeshContentTypeRegistry). The cache hub is
+    // domain-type-agnostic, so a dynamic-node content type deserialises here to a bare
+    // JsonElement; this registry lets the two degrade seams below re-type it on the
+    // already-degraded path. Resolved once from the process-shared root provider.
+    private readonly MeshWeaver.Mesh.Services.IMeshContentTypeRegistry? contentTypeRegistry;
+
     // 🚨 Lazy<Entry> wraps the factory because ConcurrentDictionary.GetOrAdd
     // is NOT threadsafe for compound operations: under contention the factory
     // delegate runs more than once, the losing values are discarded, but any
@@ -406,6 +412,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     {
         this.meshHub = meshHub;
         this.logger = logger;
+        contentTypeRegistry = meshHub.ServiceProvider.GetService<MeshWeaver.Mesh.Services.IMeshContentTypeRegistry>();
         var opts = options ?? new MeshNodeStreamCacheOptions();
         readStreamIdleExpiration = opts.ReadStreamIdleExpiration;
         readStreamSweepInterval = opts.ReadStreamSweepInterval;
@@ -1614,7 +1621,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// <see cref="IMeshNodeStreamCache.GetStream(string, JsonSerializerOptions)"/>.
     /// </summary>
     public IObservable<MeshNode> GetStream(string path, JsonSerializerOptions options) =>
-        GetStreamRaw(path).Select(node => ConvertContentJsonElementToTyped(node, options, logger));
+        GetStreamRaw(path).Select(node => ConvertContentJsonElementToTyped(node, options, logger, contentTypeRegistry));
 
     /// <summary>
     /// Caller-typed write: deserialises the current MeshNode's <c>Content</c>
@@ -1631,7 +1638,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     {
         Func<MeshNode, MeshNode> wrapped = node =>
         {
-            var typed = ConvertContentJsonElementToTyped(node, options, logger);
+            var typed = ConvertContentJsonElementToTyped(node, options, logger, contentTypeRegistry);
             var updated = update(typed);
             return ConvertContentTypedToJsonElement(updated, options);
         };
@@ -1680,7 +1687,9 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         return result;
     }
 
-    private static MeshNode ConvertContentJsonElementToTyped(MeshNode node, JsonSerializerOptions options, ILogger logger)
+    private static MeshNode ConvertContentJsonElementToTyped(
+        MeshNode node, JsonSerializerOptions options, ILogger logger,
+        MeshWeaver.Mesh.Services.IMeshContentTypeRegistry? contentTypeRegistry)
     {
         // Only convert when the cache emitted a raw JsonElement (the cache hub
         // doesn't know domain types, so Content lands here as JsonElement). If
@@ -1693,10 +1702,19 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             // when the caller's TypeRegistry can't resolve the $type discriminator. The
             // node then crosses the GetStream/GetMeshNodeStream boundary STILL untyped,
             // so every downstream `Content is X` / `as X` silently fails (renders empty,
-            // reactive waits time out with no visible cause). Surface it LOUDLY here —
-            // the degrade was previously invisible at this seam.
-            if (deserialized is JsonElement)
+            // reactive waits time out with no visible cause).
+            if (deserialized is JsonElement degraded)
             {
+                // Self-heal: the mesh-wide content-type registry is the ONE $type→CLR-Type map for
+                // dynamically-compiled NodeTypes, independent of this (frozen, domain-agnostic) cache
+                // hub's options. When it names the discriminator, re-type on the already-degraded path
+                // (no hot-path cost) — this is what cures the GitSync-reimport-renders-empty bug
+                // WITHOUT waiting for a manual recycle. Only genuinely-unresolvable content falls
+                // through to the loud warning below.
+                var recovered = contentTypeRegistry?.TryRecover(degraded, options);
+                if (recovered is not null)
+                    return node with { Content = recovered };
+
                 logger.LogWarning(
                     "MeshNodeStreamCache.GetStream: Content for {Path} stayed an untyped JsonElement after "
                     + "deserialization (TypeRegistry lacks the $type discriminator) — downstream "
@@ -1897,11 +1915,13 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         // inert (no Subscribe), so there's no upstream leak.
         return _optionsWrappedQueries.GetOrAdd((id, options), static (_, state) =>
             System.Reactive.Linq.Observable.Select(state.raw, items =>
-                (IEnumerable<MeshNode>)items.Select(node => DeserializeContent(node, state.options, state.logger)).ToArray()),
-            (raw, options, logger));
+                (IEnumerable<MeshNode>)items.Select(node => DeserializeContent(node, state.options, state.logger, state.registry)).ToArray()),
+            (raw, options, logger, registry: contentTypeRegistry));
     }
 
-    private static MeshNode DeserializeContent(MeshNode node, JsonSerializerOptions options, ILogger logger)
+    private static MeshNode DeserializeContent(
+        MeshNode node, JsonSerializerOptions options, ILogger logger,
+        MeshWeaver.Mesh.Services.IMeshContentTypeRegistry? contentTypeRegistry)
     {
         if (node.Content is not JsonElement je || je.ValueKind != JsonValueKind.Object)
             return node;
@@ -1913,10 +1933,16 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             // 🚨 Bad-data tolerance: Deserialize<object> degrades BACK to a JsonElement when
             // the caller's TypeRegistry can't resolve the $type — the GetQuery resolution
             // boundary then hands consumers an untyped JsonElement and every `Content is X`
-            // soft-cast silently fails. Surface it (don't fault the query) so the corrupt row
-            // is visible rather than rendering empty / timing out a reactive wait.
-            if (deserialized is JsonElement)
+            // soft-cast silently fails.
+            if (deserialized is JsonElement degraded)
             {
+                // Self-heal via the mesh-wide content-type registry before warning — same cure as
+                // the GetStream seam above: re-type a dynamically-compiled NodeType's content that
+                // this domain-agnostic hub's frozen options can't resolve (reimport-renders-empty).
+                var recovered = contentTypeRegistry?.TryRecover(degraded, options);
+                if (recovered is not null)
+                    return node with { Content = recovered };
+
                 logger.LogWarning(
                     "MeshNodeStreamCache.GetQuery: Content for {Path} stayed an untyped JsonElement after "
                     + "deserialization (TypeRegistry lacks the $type discriminator) — downstream "

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
@@ -674,6 +674,12 @@ public static class PersistenceExtensions
     public static IServiceCollection AddMeshCatalog(this IServiceCollection services)
     {
         services.TryAddSingleton<IMeshChangeFeed, InProcessMeshChangeFeed>();
+        // Mesh-wide content-type resolver: the ONE $type→CLR-Type map for dynamically-compiled
+        // NodeTypes, reachable from every hub (incl. the domain-agnostic cache hub) and retained
+        // for the process lifetime. Populated at MeshDataSource.WithContentType; consulted by the
+        // degrade seams (MeshNodeStreamCache, EnsureTypedContent) to re-type content that froze as
+        // a bare JsonElement after a re-import — see IMeshContentTypeRegistry.
+        services.TryAddSingleton<IMeshContentTypeRegistry, MeshContentTypeRegistry>();
         // PathResolutionService owns the positive-only per-path promise cache
         // (Replay(1).AutoConnect(0); null resolutions never cached) and
         // subscribes to IMeshChangeFeed internally for invalidation.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -76,6 +76,11 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     private readonly bool _bypassCache;
     private readonly JsonSerializerOptions _jsonOptions;
 
+    // Mesh-wide $type→CLR-Type resolver (see IMeshContentTypeRegistry). When Content arrives as a
+    // bare JsonElement whose $type this workspace's options can't resolve (a dynamically-compiled
+    // NodeType after a re-import), EnsureTypedContent re-types it from here instead of degrading.
+    private readonly MeshWeaver.Mesh.Services.IMeshContentTypeRegistry? _contentTypeRegistry;
+
     // 🚨 How long a cross-hub Update waits for the OWNER's PatchDataResponse before
     // falling back to the optimistic snapshot. Deliberately SHORT (not the old 30s):
     // a content write must EMIT AS SOON AS THE ACTIVITY IS STARTED (the message is
@@ -104,6 +109,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
         // second divergent stream.
         _bypassCache = bypassCache;
         _jsonOptions = workspace.Hub.JsonSerializerOptions;
+        _contentTypeRegistry = workspace.Hub.ServiceProvider.GetService<MeshWeaver.Mesh.Services.IMeshContentTypeRegistry>();
     }
 
     private bool IsOwn => _path is null
@@ -191,7 +197,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     {
         try
         {
-            var typedObserver = new TypedContentObserver(observer, _jsonOptions);
+            var typedObserver = new TypedContentObserver(observer, _jsonOptions, _contentTypeRegistry);
             // 🚨 Cross-hub reads route through IMeshNodeStreamCache (when one is
             // registered): one shared process-wide upstream subscription per
             // path. The cache holds the upstream alive; ad-hoc GetRemoteStream
@@ -230,14 +236,16 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// up the producer stack where it would tear down unrelated streams.
     /// </para>
     /// </summary>
-    private sealed class TypedContentObserver(IObserver<MeshNode> inner, JsonSerializerOptions jsonOptions) : IObserver<MeshNode>
+    private sealed class TypedContentObserver(
+        IObserver<MeshNode> inner, JsonSerializerOptions jsonOptions,
+        MeshWeaver.Mesh.Services.IMeshContentTypeRegistry? contentTypeRegistry = null) : IObserver<MeshNode>
     {
         public void OnNext(MeshNode value)
         {
             MeshNode typed;
             try
             {
-                typed = EnsureTypedContent(value, jsonOptions);
+                typed = EnsureTypedContent(value, jsonOptions, contentTypeRegistry);
             }
             catch (System.Exception ex)
             {
@@ -271,13 +279,27 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// typed error card; tests can assert on <c>Error.Code</c>.
     /// </para>
     /// </summary>
-    internal static MeshNode EnsureTypedContent(MeshNode node, JsonSerializerOptions jsonOptions)
+    internal static MeshNode EnsureTypedContent(
+        MeshNode node, JsonSerializerOptions jsonOptions,
+        MeshWeaver.Mesh.Services.IMeshContentTypeRegistry? contentTypeRegistry = null)
     {
         if (node.Content is JsonElement je)
         {
             try
             {
-                return node with { Content = je.Deserialize<object>(jsonOptions) };
+                var deserialized = je.Deserialize<object>(jsonOptions);
+                // Deserialize<object> degrades BACK to a JsonElement when these options' (frozen)
+                // TypeRegistry can't resolve the $type — a dynamically-compiled NodeType whose
+                // registration lives only in another hub's options. Re-type it from the mesh-wide
+                // content-type registry (the reimport-renders-empty cure) before handing subscribers
+                // an untyped value they would silently `as MyType ?? new MyType()`.
+                if (deserialized is JsonElement degraded && contentTypeRegistry is not null)
+                {
+                    var recovered = contentTypeRegistry.TryRecover(degraded, jsonOptions);
+                    if (recovered is not null)
+                        return node with { Content = recovered };
+                }
+                return node with { Content = deserialized };
             }
             catch (System.Text.Json.JsonException ex)
             {
@@ -289,9 +311,13 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                 // polymorphic discriminator names a type that isn't
                 // registered in the consumer hub's options — the recurring
                 // "type 'X' is not registered in this hub's TypeRegistry"
-                // footgun. Same translation: surface loudly with the raw
-                // JSON snippet so the caller can see which discriminator
-                // value is missing.
+                // footgun. Try the mesh-wide registry first (it may own the
+                // dynamically-compiled type this hub's options lack); only if
+                // it can't resolve do we surface loudly with the raw JSON
+                // snippet so the caller sees which discriminator is missing.
+                var recovered = contentTypeRegistry?.TryRecover(je, jsonOptions);
+                if (recovered is not null)
+                    return node with { Content = recovered };
                 throw new MeshNodeStreamException(BuildDeserializationError(node, je, ex), ex);
             }
         }
@@ -409,7 +435,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                 ? null
                 : accessService.SwitchAccessContext(capturedForLambda))
             {
-                return update(EnsureTypedContent(node, _jsonOptions));
+                return update(EnsureTypedContent(node, _jsonOptions, _contentTypeRegistry));
             }
         };
 
@@ -463,7 +489,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                 // converter — callers chaining `.Select(node => node.Content as MyType)`
                 // off the Update's returned observable get the same typed
                 // shape as Subscribe.
-                .Select(node => EnsureTypedContent(node, _jsonOptions)),
+                .Select(node => EnsureTypedContent(node, _jsonOptions, _contentTypeRegistry)),
             $"MeshNodeStreamHandle.Update(path='{_path ?? "<own>"}')",
             _workspace.Hub.ServiceProvider);
     }
@@ -497,7 +523,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             + $"on hub '{_workspace.Hub.Address}', but none is registered."))
                 // Same clamp as Update — see the comment there.
                 .CarryAccessContext(_workspace.Hub.ServiceProvider, restoreNullCapture: true)
-                .Select(n => EnsureTypedContent(n, _jsonOptions)),
+                .Select(n => EnsureTypedContent(n, _jsonOptions, _contentTypeRegistry)),
             $"MeshNodeStreamHandle.Overwrite(path='{_path ?? "<own>"}')",
             _workspace.Hub.ServiceProvider);
     }

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshContentTypeRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshContentTypeRegistry.cs
@@ -1,0 +1,127 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// Process-wide (mesh singleton) map from a dynamically-compiled NodeType's content
+/// <c>$type</c> discriminator (its CLR short/full name) — and, where known, its NodeType
+/// path — to the concrete CLR <see cref="Type"/>.
+///
+/// <para><b>Why this exists.</b> The <c>$type</c> → CLR-<see cref="Type"/> mapping for a
+/// dynamically-compiled NodeType was registered ONLY as a per-hub side effect of
+/// <c>MeshDataSource.WithContentType</c> (which runs at the per-node hub's cold
+/// activation, into that hub's <c>JsonSerializerOptions</c>). System.Text.Json freezes each
+/// hub's options on first use, and <c>PolymorphicTypeInfoResolver</c> deliberately refuses to
+/// auto-adopt collectible-assembly (dynamic-node) types — so any hub whose options were frozen
+/// without the registration (notably the domain-agnostic mesh-node cache hub) deserialises that
+/// content to a bare <see cref="JsonElement"/>. After a GitSync re-import into a RUNNING process
+/// the content re-materialises as <see cref="JsonElement"/> and every <c>Content is T</c> /
+/// <c>as T</c> silently fails (pages render empty) until a manual recycle re-activates the hub.</para>
+///
+/// <para>This registry is the ONE mesh-wide source of truth for that mapping, independent of any
+/// hub's frozen options: populated once (at <c>WithContentType</c>) and retained for the process
+/// lifetime, it lets the degrade seams (<c>MeshNodeStreamCache</c>, <c>EnsureTypedContent</c>)
+/// recover the concrete type on the ALREADY-degraded path — no hot-path cost, no dependency on
+/// per-hub option ordering. Registered in DI exactly like <c>IAssemblyStore</c> so it is reachable
+/// from every hub's <see cref="System.IServiceProvider"/>, including the cache hub.</para>
+/// </summary>
+public interface IMeshContentTypeRegistry
+{
+    /// <summary>
+    /// Records <paramref name="contentType"/> under its short name and full name (both are valid
+    /// <c>$type</c> discriminators), and — when supplied — under its <paramref name="nodeTypePath"/>.
+    /// Idempotent; last-writer-wins on a short-name collision (the same accepted risk the rest of the
+    /// framework's short-name <c>$type</c> resolution already carries).
+    /// </summary>
+    void Register(Type contentType, string? nodeTypePath = null);
+
+    /// <summary>Resolves a <c>$type</c> discriminator (short or full name) to its CLR type.</summary>
+    bool TryResolveByDiscriminator(string discriminator, out Type contentType);
+
+    /// <summary>Resolves a NodeType path to its content CLR type, when one was registered.</summary>
+    bool TryResolveByNodeType(string nodeTypePath, out Type contentType);
+
+    /// <summary>
+    /// Best-effort recovery of a degraded <see cref="JsonElement"/> whose <c>$type</c> names a
+    /// registered content type: reads the discriminator, resolves the concrete CLR type and
+    /// deserialises <paramref name="content"/> to it using <paramref name="options"/> (the concrete
+    /// target is passed explicitly, so the caller hub's registry need not know the type). Returns
+    /// <c>null</c> when the element carries no resolvable <c>$type</c> or deserialisation fails —
+    /// leaving the caller to keep the existing untyped-JsonElement warning for the genuinely
+    /// unresolvable case.
+    /// </summary>
+    object? TryRecover(JsonElement content, JsonSerializerOptions options);
+}
+
+/// <summary>
+/// Default <see cref="IMeshContentTypeRegistry"/>: two lock-free concurrent maps
+/// (discriminator → type, NodeType path → type). No mutable static state; one instance per mesh,
+/// held as a DI singleton for the process lifetime.
+/// </summary>
+public sealed class MeshContentTypeRegistry : IMeshContentTypeRegistry
+{
+    private readonly ConcurrentDictionary<string, Type> _byDiscriminator = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Type> _byNodeType = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public void Register(Type contentType, string? nodeTypePath = null)
+    {
+        if (contentType is null)
+            return;
+        _byDiscriminator[contentType.Name] = contentType;
+        if (contentType.FullName is { } fullName)
+            _byDiscriminator[fullName] = contentType;
+        if (!string.IsNullOrEmpty(nodeTypePath))
+            _byNodeType[nodeTypePath] = contentType;
+    }
+
+    /// <inheritdoc />
+    public bool TryResolveByDiscriminator(string discriminator, out Type contentType)
+    {
+        if (!string.IsNullOrEmpty(discriminator) && _byDiscriminator.TryGetValue(discriminator, out var t))
+        {
+            contentType = t;
+            return true;
+        }
+        contentType = null!;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryResolveByNodeType(string nodeTypePath, out Type contentType)
+    {
+        if (!string.IsNullOrEmpty(nodeTypePath) && _byNodeType.TryGetValue(nodeTypePath, out var t))
+        {
+            contentType = t;
+            return true;
+        }
+        contentType = null!;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public object? TryRecover(JsonElement content, JsonSerializerOptions options)
+    {
+        if (content.ValueKind != JsonValueKind.Object
+            || !content.TryGetProperty("$type", out var typeProp)
+            || typeProp.ValueKind != JsonValueKind.String)
+            return null;
+
+        var discriminator = typeProp.GetString();
+        if (discriminator is null || !TryResolveByDiscriminator(discriminator, out var contentType))
+            return null;
+
+        try
+        {
+            // Deserialise to the CONCRETE type explicitly: STJ maps the JSON to its properties and
+            // ignores the stale $type member, so recovery works regardless of whether `options`'
+            // (frozen) registry knows the type — exactly the ContentAs<T> JsonElement contract.
+            return content.Deserialize(contentType, options);
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/ReimportTypedContentRecoveryTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ReimportTypedContentRecoveryTest.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text.Json;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 Root-cause pin for "a GitSync re-import of a partition with custom NodeTypes renders empty
+/// until a manual recycle." A dynamically-compiled NodeType's <c>$type</c> → CLR-Type mapping was
+/// registered ONLY as a per-hub side effect of <c>MeshDataSource.WithContentType</c>, into that
+/// hub's frozen <see cref="JsonSerializerOptions"/>. Any hub whose options don't carry it — notably
+/// the domain-agnostic mesh-node cache hub — deserialises that content to a bare
+/// <see cref="JsonElement"/>, so every <c>Content is T</c> / <c>as T</c> downstream silently fails.
+///
+/// <para>These tests pin the cure — the mesh-wide <see cref="IMeshContentTypeRegistry"/> — at the
+/// real degrade seam (<c>MeshNodeStreamExtensions.EnsureTypedContent</c>, internal, visible here):
+/// WITHOUT the registry the content stays an untyped JsonElement (the bug is reproduced); WITH it,
+/// the concrete type is recovered on the already-degraded path (the fix). A dynamic-node content
+/// type is modelled by a COLLECTIBLE Reflection.Emit type — same CLR shape the compiler produces
+/// (per-compile identity, <c>PolymorphicTypeInfoResolver</c> refuses to auto-adopt it) — without
+/// dragging Roslyn into a unit test.</para>
+/// </summary>
+public class ReimportTypedContentRecoveryTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>
+    /// The seam-level regression, at the recovery boundary the degrade seams
+    /// (<c>MeshNodeStreamCache</c>, <c>EnsureTypedContent</c>) all funnel through. First it REPRODUCES
+    /// the bug — a real hub's polymorphic options deserialise a dynamic-node <c>$type</c> they don't
+    /// know to a bare <see cref="JsonElement"/> — then it pins the fix: the mesh-wide registry re-types
+    /// that same element. Two states of the same input, exactly what fails without / passes with the fix.
+    /// </summary>
+    [Fact]
+    public void DegradedContent_StaysUntypedWithoutRegistry_RecoversThroughRegistry()
+    {
+        var client = GetClient();
+        var options = client.JsonSerializerOptions;
+
+        var contentType = EmitCollectibleType("ReimportSlideContent", "Title");
+        contentType.Assembly.IsCollectible.Should().BeTrue(
+            "the emitted assembly must model a dynamic NodeType compilation (loaded collectible)");
+
+        // A stored content row carrying the short-name $type — the shape a re-import re-materialises.
+        // Serialise the instance THROUGH the hub options (as the owning hub would), so the $type
+        // discriminator and property casing match exactly what the mesh persists.
+        var instance = Activator.CreateInstance(contentType)!;
+        contentType.GetProperty("Title")!.SetValue(instance, "Slide One");
+        var json = JsonSerializer.Serialize(instance, contentType, options);
+        json.Should().Contain(contentType.Name, "the owning hub stamps the short-name $type discriminator");
+        var stored = JsonSerializer.Deserialize<JsonElement>(json);
+
+        // BUG REPRODUCED: a real hub's options can't resolve the collectible $type, so the polymorphic
+        // reader degrades it to a bare JsonElement — the untyped value that makes `content as T` null
+        // and renders the page empty. (This assertion holds WITH or WITHOUT the fix — it documents the
+        // defect the fix recovers from.)
+        var degraded = JsonSerializer.Deserialize<object>(stored.GetRawText(), options);
+        degraded.Should().BeOfType<JsonElement>(
+            "a real hub's frozen options can't resolve a dynamic-node $type — it degrades to JsonElement");
+
+        // FIX: the mesh-wide content-type registry (populated exactly as WithContentType populates it)
+        // recovers the concrete CLR type on that already-degraded element — no per-hub registration,
+        // no recycle.
+        var registry = new MeshContentTypeRegistry();
+        registry.Register(contentType);
+        var recovered = registry.TryRecover((JsonElement)degraded!, options);
+
+        recovered.Should().NotBeNull(
+            "the mesh-wide content-type registry must re-type content that degraded to JsonElement");
+        recovered!.GetType().Should().Be(contentType, "recovery must land on the exact registered CLR type");
+        contentType.GetProperty("Title")!.GetValue(recovered).Should().Be("Slide One",
+            "recovery must round-trip the payload, not just the type tag");
+    }
+
+    /// <summary>
+    /// The resolver only heals what it can resolve: a discriminator NOT in the registry returns null
+    /// (so the caller's genuine-corruption warning still fires) rather than being force-fit.
+    /// </summary>
+    [Fact]
+    public void UnregisteredDiscriminator_IsNotRecovered()
+    {
+        var options = GetClient().JsonSerializerOptions;
+
+        var registry = new MeshContentTypeRegistry();
+        registry.Register(EmitCollectibleType("KnownContent", "Value"));
+
+        var stored = JsonSerializer.Deserialize<JsonElement>(
+            """{"$type":"SomeOtherContentTheMeshNeverCompiled","Value":"x"}""");
+
+        registry.TryRecover(stored, options).Should().BeNull(
+            "an unresolvable discriminator must NOT be recovered — the caller keeps its corruption warning");
+    }
+
+    /// <summary>The registry indexes a type by both its short and full name (both valid $type
+    /// discriminators) and resolves the concrete type back.</summary>
+    [Fact]
+    public void MeshContentTypeRegistry_ResolvesByShortAndFullName()
+    {
+        var contentType = EmitCollectibleType("FactRecord", "Amount");
+        var registry = new MeshContentTypeRegistry();
+        registry.Register(contentType, nodeTypePath: "space/Fact");
+
+        registry.TryResolveByDiscriminator(contentType.Name, out var byShort).Should().BeTrue();
+        byShort.Should().Be(contentType);
+        registry.TryResolveByDiscriminator(contentType.FullName!, out var byFull).Should().BeTrue();
+        byFull.Should().Be(contentType);
+        registry.TryResolveByNodeType("space/Fact", out var byNodeType).Should().BeTrue();
+        byNodeType.Should().Be(contentType);
+
+        registry.TryResolveByDiscriminator("Nope", out _).Should().BeFalse();
+        registry.TryResolveByNodeType("space/Absent", out _).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Emits a minimal public class with one string property into a COLLECTIBLE dynamic assembly —
+    /// the CLR shape of a compiled dynamic-node content type without dragging Roslyn into the test.
+    /// (Mirrors <c>TypeRegistryTest.EmitCollectibleType</c>.)
+    /// </summary>
+    private static Type EmitCollectibleType(string typeName, string propertyName)
+    {
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName($"DynamicNode_{typeName}"), AssemblyBuilderAccess.RunAndCollect);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("main");
+        var typeBuilder = moduleBuilder.DefineType(
+            typeName, TypeAttributes.Public | TypeAttributes.Class);
+        var field = typeBuilder.DefineField($"_{propertyName}", typeof(string), FieldAttributes.Private);
+        var property = typeBuilder.DefineProperty(propertyName, PropertyAttributes.None, typeof(string), null);
+        const MethodAttributes accessorAttributes =
+            MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
+        var getter = typeBuilder.DefineMethod($"get_{propertyName}", accessorAttributes, typeof(string), Type.EmptyTypes);
+        var getterIl = getter.GetILGenerator();
+        getterIl.Emit(OpCodes.Ldarg_0);
+        getterIl.Emit(OpCodes.Ldfld, field);
+        getterIl.Emit(OpCodes.Ret);
+        var setter = typeBuilder.DefineMethod($"set_{propertyName}", accessorAttributes, null, new[] { typeof(string) });
+        var setterIl = setter.GetILGenerator();
+        setterIl.Emit(OpCodes.Ldarg_0);
+        setterIl.Emit(OpCodes.Ldarg_1);
+        setterIl.Emit(OpCodes.Stfld, field);
+        setterIl.Emit(OpCodes.Ret);
+        property.SetGetMethod(getter);
+        property.SetSetMethod(setter);
+        return typeBuilder.CreateType()!;
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/ReimportTypedContentRecoveryTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ReimportTypedContentRecoveryTest.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Text.Json;
 using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using Xunit;
 
@@ -111,6 +112,43 @@ public class ReimportTypedContentRecoveryTest(ITestOutputHelper output) : HubTes
 
         registry.TryResolveByDiscriminator("Nope", out _).Should().BeFalse();
         registry.TryResolveByNodeType("space/Absent", out _).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The SEAM wiring, end to end: drives the real degrade seam
+    /// <c>MeshNodeStreamHandle.EnsureTypedContent</c> (the boundary every cross-hub read passes
+    /// through). WITHOUT the mesh-wide registry the seam hands consumers a bare
+    /// <see cref="JsonElement"/> (the bug); WITH it the seam re-types the content. This pins the
+    /// wiring itself — deleting the registry call from the seam turns this test red — where
+    /// <see cref="DegradedContent_StaysUntypedWithoutRegistry_RecoversThroughRegistry"/> pins only
+    /// the recovery primitive.
+    /// </summary>
+    [Fact]
+    public void EnsureTypedContent_Seam_RecoversViaRegistry_DegradesWithout()
+    {
+        var options = GetClient().JsonSerializerOptions;
+
+        var contentType = EmitCollectibleType("SeamSlideContent", "Heading");
+        var instance = Activator.CreateInstance(contentType)!;
+        contentType.GetProperty("Heading")!.SetValue(instance, "Seam One");
+        var stored = JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(instance, contentType, options));
+        var node = new MeshNode("n") { Content = stored };
+
+        // Seam WITHOUT the registry → content stays a degraded JsonElement (the defect at the seam).
+        MeshNodeStreamHandle.EnsureTypedContent(node, options, contentTypeRegistry: null)
+            .Content.Should().BeOfType<JsonElement>(
+                "without the registry the degrade seam hands consumers an untyped JsonElement");
+
+        // Seam WITH the registry → EnsureTypedContent re-types via the registry (the wired fix).
+        var registry = new MeshContentTypeRegistry();
+        registry.Register(contentType);
+        var typed = MeshNodeStreamHandle.EnsureTypedContent(node, options, registry);
+
+        typed.Content!.GetType().Should().Be(contentType,
+            "the seam must consult the mesh-wide registry on the degraded path, not just warn");
+        contentType.GetProperty("Heading")!.GetValue(typed.Content).Should().Be("Seam One",
+            "the seam must round-trip the payload, not merely the type tag");
     }
 
     /// <summary>


### PR DESCRIPTION
## The bug
After a GitSync **re-import** of a partition that defines custom NodeTypes, that partition's custom-typed content deserialises as a bare `JsonElement`, so every `Content is T` / `as T` silently fails and pages render empty **until a manual recycle**. It took UWDeepfield down on systemorph. Assemblies compile `Ok` and load fine — the miss is purely the per-hub serializer registration (registered only as a side effect of `MeshDataSource.WithContentType` into that hub's frozen `JsonSerializerOptions`; the domain-agnostic cache hub never gets it; a re-import re-materialises content those frozen options can't type).

## The cure — self-heal, no import-time writes
1. **`IMeshContentTypeRegistry`** — a process-wide (mesh singleton) `$type→CLR-Type` map, DI-registered like `IAssemblyStore`, reachable from every hub incl. the cache hub, populated at `WithContentType`, independent of any hub's frozen options.
2. **Self-healing deserialization** — the degrade seams (`MeshNodeStreamCache` ×2; `MeshNodeStreamExtensions.EnsureTypedContent`, degrade + exception paths) recover the concrete type from the registry **on the already-degraded path only** (no hot-path cost); the loud warning still fires for genuinely unresolvable content.

> An earlier revision also auto-recycled re-imported nodes, but that reintroduced the import-time write fan-out `StaticRepoImporterTests.SkippedReimport_IsReadOnly_DoesNotRewriteRoot` guards against (the memex boot-starvation pattern) — dropped. The self-heal fixes the bug with **zero** import-time writes, so the importer stays read-only on an unchanged re-import.

## Tests (`ReimportTypedContentRecoveryTest`, 4/4 green)
Reproduces the degrade against a **collectible** Reflection.Emit type (the CLR shape of a compiled dynamic-node type), proves the registry recovers type + payload, pins the **seam wiring** end to end (`EnsureTypedContent` re-types with the registry, degrades without — deleting the call turns it red), and checks an unresolvable discriminator is not force-fit. Fast, in-memory; build 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)