### PR TITLE
ApiToken issuance: confirm node readable before returning (fix MCP reconnect reject)

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs
@@ -155,7 +155,20 @@ internal class ApiTokenService(IMeshService nodeFactory, IMessageHub hub, ILogge
                     logger.LogInformation("Creating API token {Label} for user {UserId} (hash prefix {HashPrefix})",
                         label, userId, hashPrefix);
 
-                    return indexObs.Select(_ => new TokenCreationResult(rawToken, created));
+                    // 🚨 Confirm BOTH nodes are readable before returning the raw token. On a
+                    // multi-silo portal a just-created node is not instantly routable: the /token
+                    // exchange issues the token on one replica and the MCP client reconnects
+                    // (validates) near-instantly, often on ANOTHER replica, where ValidateToken's
+                    // one-shot hub.GetMeshNode hits [ROUTE] NotFound during the create→routable
+                    // window → the token is rejected ("Got new credentials, but memex rejected them
+                    // on reconnect"). Reading each node back through the resilient GetMeshNodeStream
+                    // poll activates its owning per-node hub from Postgres, so by the time /token
+                    // returns the token is validatable on any replica. Keeps the HOT validation path
+                    // on the fast one-shot read (only issuance — a one-time login — pays this).
+                    return indexObs.SelectMany(_ =>
+                        ConfirmReadable(indexNode.Path)
+                            .SelectMany(__ => ConfirmReadable(created.Path))
+                            .Select(___ => new TokenCreationResult(rawToken, created)));
                 });
         });
     }
@@ -255,6 +268,44 @@ internal class ApiTokenService(IMeshService nodeFactory, IMessageHub hub, ILogge
                 () => accessService.ImpersonateAsSystem(),
                 _ => hub.GetMeshNode(path, TimeSpan.FromSeconds(5)))
             : hub.GetMeshNode(path, TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Best-effort confirm that a just-created node is readable, tolerating the
+    /// create→persist→routable lag. Reads via the authoritative
+    /// <c>GetMeshNodeStream(path)</c> — which activates the owning per-node hub from
+    /// Postgres — polling one subscription at a time (Concat, never Merge, so a lagging
+    /// node never accumulates concurrent owner-hub subscriptions). Each attempt swallows
+    /// the transient "No node found" and re-subscribes after 50 ms until the node loads
+    /// with content, bounded by a 10 s timeout. On timeout it logs and returns null rather
+    /// than failing issuance — the token IS created; worst case validation resolves it a
+    /// beat later. System identity: the ApiToken/index nodes are System-owned.
+    /// </summary>
+    private IObservable<MeshNode?> ConfirmReadable(string path)
+    {
+        IObservable<MeshNode?> Attempt() =>
+            hub.GetWorkspace().GetMeshNodeStream(path)
+                .Take(1)
+                .Where(n => n is not null && n.Content is not null)
+                .Select(n => (MeshNode?)n)
+                .Catch<MeshNode?, Exception>(_ => Observable.Empty<MeshNode?>())
+                .Concat(Observable.Defer(Attempt).DelaySubscription(TimeSpan.FromMilliseconds(50)));
+
+        var poll = Observable.Defer(Attempt)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(10))
+            .Catch<MeshNode?, Exception>(ex =>
+            {
+                logger.LogWarning(ex,
+                    "API token node {Path} not confirmed readable within 10s of issuance; returning token anyway",
+                    path);
+                return Observable.Return<MeshNode?>(null);
+            });
+
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        return accessService != null
+            ? Observable.Using(() => accessService.ImpersonateAsSystem(), _ => poll)
+            : poll;
     }
 
     private ApiToken? FinalizeToken(MeshNode? tokenNode, ApiToken? apiToken, string hash, string hashPrefix)


### PR DESCRIPTION
## Problem (the next layer of the MCP-connect failure, observed live)
After #620 fixed the OAuth code exchange, the `/token` flow now succeeds and issues an `mw_` API token (live logs: `Node created at rbuergi/ApiToken/...` + global index). But the MCP client's immediate reconnect was rejected — user report: *"Got new credentials, but memex rejected them on reconnect."*

Same `create→routable` lag, one layer up: `ApiTokenService.ValidateToken` reads the just-created token/index nodes via the one-shot `hub.GetMeshNode(path)`, which hits `[ROUTE] NotFound` during the window before the node is routable on the validating replica (issuance and reconnect often land on different replicas).

## Fix
Confirm-readable at **issuance**, not on the hot validation path. After creating the token node + global index, `CreateToken` reads BOTH back through the resilient `GetMeshNodeStream` poll (self-paced `Concat`, swallows the transient "No node found", 10s bound, best-effort → returns the token anyway on timeout) BEFORE returning the raw token. This activates each node's owning per-node hub from Postgres, so the token is validatable on any replica by the time `/token` returns. `ValidateToken` keeps the fast one-shot read — only the one-time login pays the read-back.

## Verification
- `MeshWeaver.Auth.Test` ApiToken suite: **50/50** (real run, Release). Monolith tests confirm no regression (they can't reproduce the multi-silo lag — in-process routing is authoritative).
- The multi-silo reconnect is verified against the **live portal** after deploy (the decisive proof), same as #620.

No What's New entry — completes the MCP-connect fix chain; user-facing effect covered by #609's entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)