### PR TITLE
Fix MCP-reconnect wedge: originate activity tracking from a dedicated activity hub

### DIFF
--- a/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
@@ -190,25 +190,29 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
     };
 
     /// <summary>
-    /// Posts a fire-and-forget <see cref="TrackActivityRequest"/> with
-    /// <see cref="ActivityType.Login"/> for the just-resolved user. Process-
-    /// level deduped (see <see cref="_loginDedup"/>) so a request burst from
-    /// a single user doesn't spam the activity grain. Exits silently on any
-    /// failure — auth must never depend on activity tracking.
+    /// Posts a <see cref="TrackActivityRequest"/> with <see cref="ActivityType.Login"/>
+    /// for the just-resolved user. Process-level deduped (see <see cref="_loginDedup"/>)
+    /// so a request burst from a single user doesn't spam the activity hub. The request
+    /// is handled on the dedicated activity-tracking hub (see
+    /// <c>ActivityTrackingHub</c> / <c>MeshNodeExtensions.HandleTrackActivity</c>), which
+    /// fully observes its own reactive pipeline and surfaces faults at Error — so this is
+    /// a plain message dispatch, not a swallowed fire-and-forget. Any synchronous fault
+    /// posting the request is logged at Warning (never swallowed) but must not break
+    /// authentication, which does not depend on activity tracking.
     /// </summary>
     private void TrackLogin(AccessContext userContext, IMessageHub hub)
     {
+        if (string.IsNullOrEmpty(userContext.ObjectId))
+            return;
+
+        var now = DateTimeOffset.UtcNow;
+        var last = _loginDedup.GetValueOrDefault(userContext.ObjectId, DateTimeOffset.MinValue);
+        if (now - last < LoginDedupWindow)
+            return;
+        _loginDedup[userContext.ObjectId] = now;
+
         try
         {
-            if (string.IsNullOrEmpty(userContext.ObjectId))
-                return;
-
-            var now = DateTimeOffset.UtcNow;
-            var last = _loginDedup.GetValueOrDefault(userContext.ObjectId, DateTimeOffset.MinValue);
-            if (now - last < LoginDedupWindow)
-                return;
-            _loginDedup[userContext.ObjectId] = now;
-
             hub.Post(new TrackActivityRequest(
                 NodePath: userContext.ObjectId,
                 UserId: userContext.ObjectId,
@@ -218,9 +222,13 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
             )
             { ActivityType = ActivityType.Login });
         }
-        catch
+        catch (Exception ex)
         {
-            // Activity tracking is best-effort.
+            // Never swallow silently (feedback_no_bandaids): surface at Warning so a
+            // broken tracking-post is visible in Loki. Auth still proceeds — tracking
+            // is not on the authentication critical path.
+            logger.LogWarning(ex,
+                "TrackLogin: failed to post TrackActivityRequest for {ObjectId}", userContext.ObjectId);
         }
     }
 

--- a/src/MeshWeaver.Graph/Configuration/ActivityTrackingHub.cs
+++ b/src/MeshWeaver.Graph/Configuration/ActivityTrackingHub.cs
@@ -1,4 +1,3 @@
-using System.Reactive.Linq;
 using MeshWeaver.Data;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;

--- a/src/MeshWeaver.Graph/Configuration/ActivityTrackingHub.cs
+++ b/src/MeshWeaver.Graph/Configuration/ActivityTrackingHub.cs
@@ -1,0 +1,99 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The dedicated, stable, registered sub-hub that ALL user-activity tracking
+/// (login, navigation, …) originates from.
+///
+/// <para>🚨 Why this exists (production wedge, memex-cloud 2026-07): the
+/// <see cref="MeshWeaver.Mesh.Activity.TrackActivityRequest"/> handler used to run
+/// on whichever hub happened to post it — the top-level portal hub, or a
+/// transient per-connection / MCP back-connection hub. Its
+/// <c>GetMeshNodeStream(activityPath).Update(...)</c> therefore opened its
+/// <see cref="IMeshNodeStreamCache"/> sync subscription on that hub's cache
+/// (<c>cache/{connectionId}</c>), whose initial-state / <c>PatchDataResponse</c>
+/// had to route back through that hub's <b>transient</b> mesh root
+/// (<c>mesh/{connectionId}</c>). For an MCP back-connection that mesh address is
+/// unregistered with routing, so every response <c>[ROUTE] NotFound</c>'d, the
+/// write stalled 30 s ("no initial state arrived within 30s"), and the wedge
+/// rejected the reconnecting client. See
+/// <c>Doc/Architecture/ActivityControlPlane.md</c> and
+/// <c>Doc/Architecture/MeshNodeStreamCache.md</c>.</para>
+///
+/// <para>The fix: a single hosted hub, keyed to the mesh <b>root</b> id (stable
+/// per process, NOT per connection), created lazily and idempotently via
+/// <see cref="IMessageHub.GetHostedHub(Address, System.Func{MessageHubConfiguration, MessageHubConfiguration}, HostedHubCreation)"/>.
+/// It is:</para>
+/// <list type="bullet">
+///   <item><b>Off the mesh root</b> — its own DI container registers no
+///     persistence, so <see cref="IMeshNodeStreamCache"/> resolves by fallback
+///     to the mesh root's <b>shared</b> singleton (<c>cache/{meshRootId}</c>),
+///     which IS a stream-routed, registered address. The activity write's sync
+///     subscription and <c>PatchDataResponse</c> therefore route back to a
+///     registered hub — never a transient <c>mesh/{connectionId}</c>.</item>
+///   <item><b>Registered with routing</b> in <see cref="MessageHubConfiguration.WithInitialization(System.Action{IMessageHub})"/>
+///     (the same <c>routingService.RegisterStream(hub)</c> contract the cache and
+///     portal hubs use) so any delivery addressed to it resolves.</item>
+///   <item><b>Its own workspace</b> (<see cref="DataExtensions.AddData(MessageHubConfiguration)"/>)
+///     so <c>GetWorkspace().GetMeshNodeStream(...)</c> works, and the Graph type
+///     registry (<see cref="MeshNodeExtensions.WithGraphTypes(MessageHubConfiguration)"/>)
+///     so <see cref="MeshWeaver.Data.ActivityLog"/> / <c>UserActivityRecord</c>
+///     content round-trips typed.</item>
+/// </list>
+/// </summary>
+public static class ActivityTrackingHub
+{
+    /// <summary>
+    /// The stable id segment of the activity-tracking hub's address. Fixed (NOT a
+    /// per-connection guid) so exactly one tracking hub is hosted under a given
+    /// mesh root; <c>GetHostedHub</c> is idempotent, so repeat calls return it.
+    /// </summary>
+    private const string TrackingHubId = "_tracking";
+
+    /// <summary>
+    /// Returns the process-stable activity-tracking hub, creating it once (lazily,
+    /// idempotently) under the caller's mesh <b>root</b>. All activity-tracking
+    /// reads/writes MUST originate from this hub's workspace so they route through
+    /// the shared, registered mesh-root cache — never a transient per-connection
+    /// hub. Never returns null (creation mode is <see cref="HostedHubCreation.Always"/>).
+    /// </summary>
+    public static IMessageHub GetActivityTrackingHub(this IMessageHub hub)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        var meshRoot = hub.GetMeshHub();
+        return meshRoot.GetHostedHub(
+            new Address(AddressExtensions.ActivityType, TrackingHubId),
+            ConfigureTrackingHub,
+            HostedHubCreation.Always)!;
+    }
+
+    private static MessageHubConfiguration ConfigureTrackingHub(MessageHubConfiguration config)
+        => config
+            // Own workspace so GetMeshNodeStream / GetQuery work. Deliberately does NOT
+            // register persistence — IMeshNodeStreamCache then resolves by DI fallback to
+            // the mesh root's shared singleton (cache/{meshRootId}), the stable registered
+            // cache. This is the whole point: the tracking write must not spin up a
+            // per-connection cache whose responses route through a transient mesh root.
+            .AddData()
+            // Graph type registry so ActivityLog / UserActivityRecord Content round-trips
+            // typed across the cross-hub write. (WithGraphTypes also re-registers the
+            // TrackActivityRequest handler here, which is harmless — a request routed to
+            // this hub is handled on this hub, which is exactly where we want it.)
+            .WithGraphTypes()
+            // Register with routing so any delivery addressed to the tracking hub resolves —
+            // same contract the cache and portal hubs use (PortalApplication.DefaultPortalConfig,
+            // MeshNodeStreamCache ctor). Runs post-startup on a hosted hub, so resolving
+            // IRoutingService here does not hit the mesh-construction circular-DI deadlock.
+            .WithInitialization(h =>
+            {
+                var routing = h.ServiceProvider.GetService<IRoutingService>();
+                if (routing is not null)
+                    h.RegisterForDisposal(routing.RegisterStream(h));
+            });
+}

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -237,7 +237,20 @@ public static class MeshNodeExtensions
         // below (FoldOntoLive), so the query's eventual consistency only ever decides
         // create-vs-update — never the AccessCount. The create-vs-update race is coalesced by
         // the CreateNode catch below, which folds the increment in via stream.Update.
-        var pipeline = workspace
+        // 🚨 Build (and subscribe) the whole read+write pipeline UNDER the caller's identity.
+        // WrapWithPerUserRls (SyncedQueryDataSourceExtensions) captures AccessService.Context
+        // EAGERLY at the GetQuery(...) call — on the workspace's hub (the tracking hub) — so the
+        // per-user RLS filter must see the caller's identity AT THAT CALL, not only at the write's
+        // subscribe. Observable.Using acquires Impersonate() BEFORE invoking the factory, so
+        // GetQuery is called with the caller's context established on the tracking hub's
+        // AccessService (fail-closed when callerCtx is null: no context ⇒ empty userId ⇒ the RLS
+        // wrap yields no rows for the exact-path existence probe, and the subsequent write posts
+        // context-null and is rejected by PostPipeline). The inner per-write Observable.Using
+        // (Impersonate) still re-establish the identity on each write's own emission thread —
+        // AsyncLocal does not flow across Rx scheduler hops, so the outer scope alone is not enough.
+        var pipeline = Observable.Using(
+            Impersonate,
+            _ => workspace
             .GetQuery($"UserActivity|{activityPath}", $"path:{activityPath} nodeType:UserActivity")
             .Take(1)
             .Select(nodes => nodes.FirstOrDefault(n =>
@@ -345,7 +358,7 @@ public static class MeshNodeExtensions
                         ? Observable.Using(Impersonate, _ => storage.Write(saveNode, jsonOptions))
                         : Observable.Empty<MeshNode>();
                 });
-            });
+            }));
 
         // No fire-and-forget: the pipeline is fully observed and faults surface at Error.
         pipeline.Subscribe(

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -160,7 +160,45 @@ public static class MeshNodeExtensions
             return delivery.Processed();
         }
 
-        var workspace = hub.GetWorkspace();
+        // 🚨 ORIGINATE FROM THE DEDICATED ACTIVITY HUB — never the calling
+        // (portal / per-connection / MCP back-connection) hub. Running the write
+        // from the caller opened its IMeshNodeStreamCache sync subscription on
+        // that hub's cache (cache/{connectionId}), whose initial-state /
+        // PatchDataResponse routed back through a TRANSIENT, UNREGISTERED mesh
+        // root (mesh/{connectionId}) → [ROUTE] NotFound → 30s "no initial state
+        // arrived within 30s" stall → the reconnecting MCP client was rejected.
+        // The tracking hub is hosted off the mesh ROOT and resolves the shared,
+        // registered mesh-root cache (cache/{meshRootId}). See ActivityTrackingHub.
+        var activityHub = hub.GetActivityTrackingHub();
+        var workspace = activityHub.GetWorkspace();
+        // The tracking hub's own JSON options (WithGraphTypes) know UserActivityRecord —
+        // the caller's hub may not, so use the tracking hub's for typed round-trip.
+        var jsonOptions = activityHub.JsonSerializerOptions;
+
+        // Each hub has its OWN AccessService; the caller's per-delivery AccessContext
+        // lives on the CALLING hub's. Capture it here (handler thread, where it is set)
+        // and re-establish it on the write hubs' AccessServices across each cold write's
+        // Subscribe via Observable.Using — so the activity write is attributed to the
+        // acting user and owner-side RLS lets it land. Mirrors GitSync ActivityRunner's
+        // per-write owner re-stamp; AsyncLocal does not survive the Rx scheduler hops.
+        var callerAccess = hub.ServiceProvider.GetService<AccessService>();
+        var callerCtx = callerAccess?.Context ?? callerAccess?.CircuitContext;
+        var meshRoot = activityHub.GetMeshHub();
+        var trackingAccess = activityHub.ServiceProvider.GetService<AccessService>();
+        var rootAccess = meshRoot.ServiceProvider.GetService<AccessService>();
+
+        IDisposable Impersonate()
+        {
+            if (callerCtx is null)
+                return System.Reactive.Disposables.Disposable.Empty;
+            var d = new System.Reactive.Disposables.CompositeDisposable();
+            if (trackingAccess is not null)
+                d.Add(trackingAccess.SwitchAccessContext(callerCtx));
+            if (rootAccess is not null && !ReferenceEquals(rootAccess, trackingAccess))
+                d.Add(rootAccess.SwitchAccessContext(callerCtx));
+            return d;
+        }
+
         var encodedPath = req.NodePath.Replace("/", "_");
         // Activity records live under {userId}/_UserActivity/{id} — every user
         // owns a top-level partition named after their userId, and the
@@ -169,15 +207,22 @@ public static class MeshNodeExtensions
         var now = DateTimeOffset.UtcNow;
 
         logger?.LogDebug(
-            "TrackActivity ENTER: userId={UserId} activityPath={Path} type={ActivityType}",
-            req.UserId, activityPath, req.ActivityType);
+            "TrackActivity ENTER: userId={UserId} activityPath={Path} type={ActivityType} via activityHub={ActivityHub}",
+            req.UserId, activityPath, req.ActivityType, activityHub.Address);
 
-        // workspace.GetMeshNodeStream is itself backed by the process-wide
-        // IMeshNodeStreamCache (MeshNodeStreamCache.cs) — repeat tracks for the
-        // same activity path reuse the warm handle without a second cache layer.
-        // Used ONLY to WRITE (stream.Update) the node when it already exists — never
-        // to probe an absent path (see the GetQuery read below).
+        // workspace.GetMeshNodeStream is backed by the mesh ROOT's shared
+        // IMeshNodeStreamCache (resolved by DI fallback from the tracking hub) —
+        // repeat tracks for the same activity path reuse the warm handle. Used ONLY
+        // to WRITE (stream.Update) the node when it already exists — never to probe an
+        // absent path (see the GetQuery read below).
         var stream = workspace.GetMeshNodeStream(activityPath);
+
+        // First-time creation resolves IMeshService / IStorageAdapter from the mesh ROOT —
+        // IMeshService is AddScoped, so resolving from a leaf scope would target a hub with
+        // no CreateNodeRequest handler. The ONBOARD-FIRST gate below probes the user's
+        // partition root (a read never creates a schema) and skips the write when it's absent.
+        var storage = meshRoot.ServiceProvider.GetService<IStorageAdapter>();
+        var meshService = meshRoot.ServiceProvider.GetService<IMeshService>();
 
         // 🚨 Read existence via GetQuery (empty-on-absent), NEVER a point
         // GetMeshNodeStream(path).Take(1) probe. On a FIRST-time track the activity node
@@ -186,23 +231,20 @@ public static class MeshNodeExtensions
         // (every cold page load through UserContextMiddleware.TrackLogin), that failing
         // subscribe re-storms the router. A GetQuery over the exact path returns an EMPTY set
         // when the node is absent (the documented empty-on-absent behaviour) — no NotFound, no
-        // resubscribe, nothing to storm — and returns typed Content (deserialised through this
-        // hub's options) when present. Mirrors AiSettingsNodeType.EnsureExists / AgentChatClient's
-        // _Selection read.
+        // resubscribe, nothing to storm — and returns typed Content when present.
         //
         // The increment is still folded onto the LIVE node inside the owner-serialised Update
         // below (FoldOntoLive), so the query's eventual consistency only ever decides
-        // create-vs-update — never the AccessCount. The create-vs-update race (two concurrent
-        // tracks, or a query that lags a just-created node) is coalesced by the CreateNode catch
-        // below, which folds the increment in via stream.Update instead of throwing — no lost count.
-        workspace
+        // create-vs-update — never the AccessCount. The create-vs-update race is coalesced by
+        // the CreateNode catch below, which folds the increment in via stream.Update.
+        var pipeline = workspace
             .GetQuery($"UserActivity|{activityPath}", $"path:{activityPath} nodeType:UserActivity")
             .Take(1)
             .Select(nodes => nodes.FirstOrDefault(n =>
                 string.Equals(n.NodeType, "UserActivity", StringComparison.OrdinalIgnoreCase)))
             .SelectMany(existing =>
             {
-                var existingRecord = existing.ContentAs<UserActivityRecord>(hub.JsonSerializerOptions);
+                var existingRecord = existing.ContentAs<UserActivityRecord>(jsonOptions);
                 var record = new UserActivityRecord
                 {
                     Id = encodedPath,
@@ -230,12 +272,10 @@ public static class MeshNodeExtensions
 
                 // 🚨 Fold the increment onto the LIVE node INSIDE the Update lambda, not a
                 // separately-read snapshot. The owner serializes Updates, so each lambda sees
-                // the freshest AccessCount and two concurrent tracks can't lose an increment —
-                // the old discard-lambda `_ => saveNode` slammed a count computed from the
-                // pre-Update probe read. Carry the live version; the owner mints the fresh one.
+                // the freshest AccessCount and two concurrent tracks can't lose an increment.
                 MeshNode FoldOntoLive(MeshNode live)
                 {
-                    var liveRec = live.ContentAs<UserActivityRecord>(hub.JsonSerializerOptions);
+                    var liveRec = live.ContentAs<UserActivityRecord>(jsonOptions);
                     return live with
                     {
                         NodeType = "UserActivity",
@@ -251,39 +291,19 @@ public static class MeshNodeExtensions
                     };
                 }
 
+                // Each write runs under the acting user via Observable.Using(Impersonate):
+                // the impersonation is acquired at the inner Subscribe (where the write
+                // primitive captures AccessContext) and held until the write terminates,
+                // so cross-hub RLS lets it land. See ActivityRunner for the canonical shape.
                 if (existing != null)
                 {
                     logger?.LogDebug(
-                        "TrackActivity UPDATE: {Path} count={Count}",
-                        activityPath, record.AccessCount);
-                    return stream.Update(FoldOntoLive);
+                        "TrackActivity UPDATE: {Path} count={Count}", activityPath, record.AccessCount);
+                    return Observable.Using(Impersonate, _ => stream.Update(FoldOntoLive));
                 }
 
-                // First-time creation: per-node hub isn't activated yet, RemoteStream
-                // can't write. Fall through to IMeshService.CreateNode which routes via
-                // CreateNodeRequest and activates the hub. Subsequent tracks land in the
-                // Update branch above and reuse the now-warm cached stream.
-                //
-                // Resolve IMeshService from the MESH ROOT — IMeshService is registered
-                // AddScoped, so resolving from this hub's scope (e.g. portal/anonymous)
-                // would build a MeshService whose injected IMessageHub is the LOCAL hub,
-                // and CreateNode would target the local hub's address. That hub doesn't
-                // have a CreateNodeRequest handler → "No handler found for ... in
-                // portal/anonymous". Resolving from the mesh root makes MeshService
-                // capture the mesh hub as its target.
-                // ONBOARD-FIRST GATE: activity tracking must NEVER be the thing that
-                // creates a user's partition — partition creation is onboarding's job
-                // (UserOnboardingService.CreateUser). Writing this activity node first
-                // would lazily create the {userId} schema via the path-routing
-                // PendingCreate branch, so a login/navigation BEFORE onboarding would
-                // materialise the partition ahead of the User node (the "partition
-                // created before onboarding" bug). Probe the user's partition ROOT with
-                // a read-only storage read (a read never creates a schema) and skip the
-                // write when it's absent — the identity isn't onboarded yet.
-                var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
-                var meshService = hub.GetMeshHub().ServiceProvider.GetService<IMeshService>();
-                var rootProbe = (storage != null
-                        ? storage.Read(req.UserId, hub.JsonSerializerOptions).Take(1)
+                var rootProbe = Observable.Using(Impersonate, _ => storage != null
+                        ? storage.Read(req.UserId, jsonOptions).Take(1)
                         : Observable.Return<MeshNode?>(null))
                     .Catch<MeshNode?, Exception>(probeEx =>
                     {
@@ -304,17 +324,10 @@ public static class MeshNodeExtensions
                         return Observable.Empty<MeshNode>();
                     }
 
-                    // First-time creation: per-node hub isn't activated yet, RemoteStream
-                    // can't write. Fall through to IMeshService.CreateNode which routes via
-                    // CreateNodeRequest and activates the hub. Subsequent tracks land in the
-                    // Update branch above and reuse the now-warm cached stream. Resolve
-                    // IMeshService from the MESH ROOT so MeshService captures the mesh hub as
-                    // its target (a local-scope resolve would target portal/anonymous which
-                    // has no CreateNodeRequest handler).
                     if (meshService != null)
                     {
                         logger?.LogDebug("TrackActivity CREATE: {Path}", activityPath);
-                        return meshService.CreateNode(saveNode)
+                        return Observable.Using(Impersonate, _ => meshService.CreateNode(saveNode))
                             // Race coalesce: a concurrent track for the same path beat us to
                             // CreateNode — fold our increment in via Update instead of throwing.
                             .Catch<MeshNode, InvalidOperationException>(ex =>
@@ -324,20 +337,22 @@ public static class MeshNodeExtensions
                                 logger?.LogDebug(
                                     "TrackActivity CREATE to UPDATE race for {Path}: another concurrent track won; folding via Update.",
                                     activityPath);
-                                return stream.Update(FoldOntoLive);
+                                return Observable.Using(Impersonate, _ => stream.Update(FoldOntoLive));
                             });
                     }
 
-                    return storage?.Write(saveNode, hub.JsonSerializerOptions)
-                           ?? Observable.Empty<MeshNode>();
+                    return storage != null
+                        ? Observable.Using(Impersonate, _ => storage.Write(saveNode, jsonOptions))
+                        : Observable.Empty<MeshNode>();
                 });
-            })
-            .Subscribe(
-                _ => logger?.LogDebug(
-                    "TrackActivity DONE: {Path}", activityPath),
-                ex => logger?.LogError(ex,
-                    "Failed to track activity for user={UserId} path={Path}",
-                    req.UserId, req.NodePath));
+            });
+
+        // No fire-and-forget: the pipeline is fully observed and faults surface at Error.
+        pipeline.Subscribe(
+            _ => logger?.LogDebug("TrackActivity DONE: {Path}", activityPath),
+            ex => logger?.LogError(ex,
+                "Failed to track activity for user={UserId} path={Path}",
+                req.UserId, req.NodePath));
         return delivery.Processed();
     }
 

--- a/test/MeshWeaver.Query.Test/ActivityTrackingHubTest.cs
+++ b/test/MeshWeaver.Query.Test/ActivityTrackingHubTest.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Activity;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Query.Test;
+
+/// <summary>
+/// Regression tests for the activity-tracking WEDGE (memex-cloud 2026-07, MCP reconnect
+/// rejected) and its fix in <see cref="ActivityTrackingHub"/> +
+/// <see cref="MeshNodeExtensions"/> (HandleTrackActivity).
+///
+/// <para><b>Root cause.</b> <see cref="TrackActivityRequest"/> used to be handled on
+/// whichever hub posted it — the portal hub, or a transient per-connection / MCP
+/// back-connection hub. Its <c>GetMeshNodeStream(activityPath).Update(...)</c> therefore
+/// opened its <see cref="IMeshNodeStreamCache"/> sync subscription on THAT hub's cache
+/// (<c>cache/{connectionId}</c>), whose initial-state / <c>PatchDataResponse</c> had to
+/// route back through the hub's transient, UNREGISTERED mesh root
+/// (<c>mesh/{connectionId}</c>) → <c>[ROUTE] NotFound</c> → the write stalled 30 s ("no
+/// initial state arrived within 30s") → the reconnecting client was rejected.</para>
+///
+/// <para><b>Fix.</b> All activity tracking now originates from the dedicated, stable,
+/// registered <see cref="ActivityTrackingHub"/> — hosted off the mesh ROOT, resolving the
+/// mesh root's SHARED, registered <see cref="IMeshNodeStreamCache"/>
+/// (<c>cache/{meshRootId}</c>) instead of a per-connection cache. Its sync subscription's
+/// responses therefore route to a registered hub, never a transient one.</para>
+///
+/// <para>🚨 The exact 30 s stall is a DISTRIBUTED phenomenon — it needs an unregistered
+/// per-connection mesh root, which a single-process monolith cannot express (in-process
+/// routing resolves every hosted hub via <c>GetHostedHub</c> regardless of stream
+/// registration). These tests therefore PIN THE FIX'S CONTRACT — the invariant the old
+/// code violated: (1) the tracking hub is stable, hosted off the mesh root, and shares the
+/// mesh-root cache (NOT a per-caller cache); (2) a track initiated from a distinct
+/// connection-style hub still lands the node, because the write originates from the shared
+/// tracking hub. A regression to "the write uses the calling hub's cache" fails test (1).</para>
+/// </summary>
+public class ActivityTrackingHubTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// The tracking hub is a single, stable, registered hub hosted off the mesh ROOT and
+    /// resolving the mesh root's SHARED cache. This is the whole point of the fix: the
+    /// activity write must go through <c>cache/{meshRootId}</c> (registered, stream-routed),
+    /// never a transient per-connection cache whose responses route through an unregistered
+    /// <c>mesh/{connectionId}</c>.
+    /// </summary>
+    [Fact(Timeout = 20_000)]
+    public void ActivityTrackingHub_IsStable_OffMeshRoot_AndSharesRootCache()
+    {
+        var trackingHub = Mesh.GetActivityTrackingHub();
+        trackingHub.Should().NotBeNull();
+
+        // Stable + idempotent — exactly one tracking hub per mesh root.
+        Mesh.GetActivityTrackingHub().Should().BeSameAs(trackingHub,
+            "GetActivityTrackingHub must be idempotent (a single stable hub, not per-call)");
+
+        // Hosted off the mesh ROOT (its mesh hub is the root), at the dedicated activity address.
+        trackingHub.GetMeshHub().Should().BeSameAs(Mesh,
+            "the tracking hub must be hosted off the mesh root");
+        trackingHub.Address.Type.Should().Be(AddressExtensions.ActivityType);
+
+        // 🚨 Shares the mesh-root cache — resolves the SAME singleton, not its own. If a
+        // future change gives the tracking hub its own cache, its writes' responses would
+        // again route through its own (potentially transient) mesh root — the exact wedge.
+        var rootCache = Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+        var trackingCache = trackingHub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+        trackingCache.Should().BeSameAs(rootCache,
+            "the tracking hub must resolve the mesh root's shared, registered cache (cache/{meshRootId}), " +
+            "never a per-hub cache — that shared cache is what makes the sync-subscription response routable");
+    }
+
+    /// <summary>
+    /// A track INITIATED FROM A CONNECTION-STYLE HUB (the prod shape — the portal / MCP
+    /// back-connection posts it) must still land the UserActivity node, because the handler
+    /// originates the write from the dedicated tracking hub (shared root cache) rather than
+    /// the calling hub. Pre-fix the write ran on the caller's context; post-fix it is
+    /// decoupled onto the stable tracking hub.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task TrackActivity_InitiatedFromConnectionHub_LandsNode()
+    {
+        const string user = "dave";
+        const string nodePath = "dave/MyDoc";
+
+        // ONBOARD-FIRST gate: activity tracking never creates a partition ahead of onboarding.
+        await OnboardPartitionRoot(user);
+
+        // A distinct connection-style hosted hub — the shape that used to handle the request
+        // and wedge. It carries the TrackActivityRequest handler (WithGraphTypes) so a
+        // self-post is handled HERE; the fix must still land the node via the tracking hub.
+        var connHub = Mesh.GetHostedHub(
+            new Address("client", Guid.NewGuid().ToString("N")[..12]),
+            c => c.AddData().WithGraphTypes());
+        connHub.ServiceProvider.GetRequiredService<AccessService>()
+            .SetCircuitContext(new AccessContext { ObjectId = user, Name = user });
+
+        // Sanity: the calling hub is NOT the tracking hub, yet both resolve the same shared
+        // cache — so wherever the request is handled, the write goes through cache/{meshRootId}.
+        connHub.Address.Should().NotBe(connHub.GetActivityTrackingHub().Address);
+
+        connHub.Post(new TrackActivityRequest(
+            NodePath: nodePath,
+            UserId: user,
+            NodeName: "My Doc",
+            NodeType: "Markdown",
+            Namespace: user));
+
+        var node = await PollForFirst($"namespace:{user}/_UserActivity nodeType:UserActivity");
+
+        node.Should().NotBeNull(
+            "a track posted to a connection-style hub must still land a UserActivity node — " +
+            "the handler originates the write from the dedicated tracking hub, not the caller");
+        node!.Path.Should().Be($"{user}/_UserActivity/{nodePath.Replace("/", "_")}");
+        node.NodeType.Should().Be("UserActivity");
+    }
+
+    private async Task OnboardPartitionRoot(string user)
+    {
+        Mesh.ServiceProvider.GetRequiredService<AccessService>()
+            .SetCircuitContext(new AccessContext { ObjectId = user, Name = user });
+
+        await NodeFactory.CreateNode(new MeshNode(user)
+        {
+            NodeType = "User",
+            Name = user,
+            State = MeshNodeState.Active,
+        }).Should().Emit();
+
+        await ReadNode(user).Should().Match(n => n is { State: MeshNodeState.Active });
+    }
+
+    private async Task<MeshNode?> PollForFirst(string query)
+        => await MeshQuery
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(query))
+            .Scan(ImmutableList<MeshNode>.Empty, (acc, c) =>
+                c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset
+                    ? c.Items.ToImmutableList()
+                    : acc.AddRange(c.Items))
+            .Where(list => list.Count > 0)
+            .Select(list => list[0])
+            .Should().Within(TimeSpan.FromSeconds(15)).Emit();
+}

--- a/test/MeshWeaver.Query.Test/ActivityTrackingHubTest.cs
+++ b/test/MeshWeaver.Query.Test/ActivityTrackingHubTest.cs
@@ -123,6 +123,16 @@ public class ActivityTrackingHubTest(ITestOutputHelper output) : MonolithMeshTes
             "the handler originates the write from the dedicated tracking hub, not the caller");
         node!.Path.Should().Be($"{user}/_UserActivity/{nodePath.Replace("/", "_")}");
         node.NodeType.Should().Be("UserActivity");
+
+        // 🚨 The write ran under the CALLER's identity, not system/empty. The handler builds
+        // the read (GetQuery, whose per-user RLS captures AccessService.Context eagerly at the
+        // call) AND every write under Observable.Using(Impersonate), which re-establishes the
+        // caller's context on the tracking + root AccessServices. CreateNode stamps CreatedBy
+        // from that context — so a null/system context (the pre-fix RLS-capture bug) would show
+        // up here as an empty/"system-security" CreatedBy.
+        node.CreatedBy.Should().Be(user,
+            "the tracking read+write must run under the caller's identity (Impersonate is in effect " +
+            "when GetQuery's RLS captures context and when the create stamps CreatedBy) — never system/empty");
     }
 
     private async Task OnboardPartitionRoot(string user)


### PR DESCRIPTION
## Problem (MCP client "rejected on reconnect", root cause confirmed from live Loki)
After #620/#624, the OAuth exchange succeeds and a token is issued — but the client's reconnect wedges. Token validation is **not** the cause. The failure is activity tracking:

`TrackActivityRequest` was registered via `WithGraphTypes → WithHandler<TrackActivityRequest>` on **every hub**, so `HandleTrackActivity` ran on whichever hub posted it — the top-level portal hub or a transient per-connection / MCP back-connection hub. Its `GetMeshNodeStream({userId}/_UserActivity/{userId}).Update(...)` therefore resolved **that hub's** `cache/{connectionId}`, and the cross-hub write's sync initial-state response had to route back through that hub's **transient, unregistered** mesh root `mesh/{connectionId}`:
```
[ROUTE] NotFound: No node found at 'mesh/{connectionId}'
[UpdateRemote] ERROR hub=cache/{connectionId} target=…/_UserActivity/… type=TimeoutException
[UpdateQueue] FAILED … no initial state arrived within 30s
[STALE-CALLBACK] … SubscribeRequest@…/_UserActivity … (34s→59s)
```
→ the round wedges → the reconnecting client is rejected. Fire-and-forget (`TrackLogin`'s swallowing `catch`) buried it.

## Fix
- New **`ActivityTrackingHub`** (`activity/_tracking`), hosted off the mesh **root**, created lazily + idempotently. It registers no persistence of its own, so `IMeshNodeStreamCache` resolves to the mesh root's **shared, registered** singleton cache — the write's sync responses route to a registered address, never `mesh/{connectionId}`.
- `HandleTrackActivity` relocated onto the tracking hub's workspace; services resolved from the mesh root; caller `AccessContext` re-established across each cold write via `Observable.Using(Impersonate)` (AsyncLocal doesn't survive Rx scheduler hops). Fully reactive, fully observed, faults surfaced at Error — nothing fire-and-forget.
- `UserContextMiddleware.TrackLogin`: removed the swallowing `catch{}`; post faults log at Warning; auth still never depends on tracking.

## Verification
- New `ActivityTrackingHubTest` pins the contract the old code violated (tracking hub stable/idempotent, hosted off the mesh root, resolves the SAME shared cache as the root; a track initiated from a distinct connection-style hub still lands). The exact 30s stall is a distributed phenomenon a monolith can't express (in-process routing ignores stream registration), so the monolith test pins the fix's contract; **the stall's disappearance is verified against the live portal after deploy.**
- `dotnet build -c Release -warnaserror` clean; ActivityTrackingHubTest + UserActivity + ApiToken + OAuthConnect suites green (real runs).

## Note (separate decision)
This does NOT convert the deduped `_UserActivity` access *counter* into append-only `_Activity`/`ActivityLog` nodes — that's a semantic/data redesign (RecentlyViewed/dashboard/`source:accessed` depend on the counter) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)