### PR TITLE
Stability batch: console-capture leak, acked-write-loss flush, ApiToken issuance read-back, NU1903 bump

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -135,7 +135,7 @@
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta5.25306.1" />
     <PackageVersion Include="System.Composition.AttributedModel" Version="10.0.7" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.7" />
     <PackageVersion Include="System.Text.Json" Version="10.0.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />

--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs
@@ -155,7 +155,20 @@ internal class ApiTokenService(IMeshService nodeFactory, IMessageHub hub, ILogge
                     logger.LogInformation("Creating API token {Label} for user {UserId} (hash prefix {HashPrefix})",
                         label, userId, hashPrefix);
 
-                    return indexObs.Select(_ => new TokenCreationResult(rawToken, created));
+                    // 🚨 Confirm BOTH nodes are readable before returning the raw token. On a
+                    // multi-silo portal a just-created node is not instantly routable: the /token
+                    // exchange issues the token on one replica and the MCP client reconnects
+                    // (validates) near-instantly, often on ANOTHER replica, where ValidateToken's
+                    // one-shot hub.GetMeshNode hits [ROUTE] NotFound during the create→routable
+                    // window → the token is rejected ("Got new credentials, but memex rejected them
+                    // on reconnect"). Reading each node back through the resilient GetMeshNodeStream
+                    // poll activates its owning per-node hub from Postgres, so by the time /token
+                    // returns the token is validatable on any replica. Keeps the HOT validation path
+                    // on the fast one-shot read (only issuance — a one-time login — pays this).
+                    return indexObs.SelectMany(_ =>
+                        ConfirmReadable(indexNode.Path)
+                            .SelectMany(__ => ConfirmReadable(created.Path))
+                            .Select(___ => new TokenCreationResult(rawToken, created)));
                 });
         });
     }
@@ -255,6 +268,44 @@ internal class ApiTokenService(IMeshService nodeFactory, IMessageHub hub, ILogge
                 () => accessService.ImpersonateAsSystem(),
                 _ => hub.GetMeshNode(path, TimeSpan.FromSeconds(5)))
             : hub.GetMeshNode(path, TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Best-effort confirm that a just-created node is readable, tolerating the
+    /// create→persist→routable lag. Reads via the authoritative
+    /// <c>GetMeshNodeStream(path)</c> — which activates the owning per-node hub from
+    /// Postgres — polling one subscription at a time (Concat, never Merge, so a lagging
+    /// node never accumulates concurrent owner-hub subscriptions). Each attempt swallows
+    /// the transient "No node found" and re-subscribes after 50 ms until the node loads
+    /// with content, bounded by a 10 s timeout. On timeout it logs and returns null rather
+    /// than failing issuance — the token IS created; worst case validation resolves it a
+    /// beat later. System identity: the ApiToken/index nodes are System-owned.
+    /// </summary>
+    private IObservable<MeshNode?> ConfirmReadable(string path)
+    {
+        IObservable<MeshNode?> Attempt() =>
+            hub.GetWorkspace().GetMeshNodeStream(path)
+                .Take(1)
+                .Where(n => n is not null && n.Content is not null)
+                .Select(n => (MeshNode?)n)
+                .Catch<MeshNode?, Exception>(_ => Observable.Empty<MeshNode?>())
+                .Concat(Observable.Defer(Attempt).DelaySubscription(TimeSpan.FromMilliseconds(50)));
+
+        var poll = Observable.Defer(Attempt)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(10))
+            .Catch<MeshNode?, Exception>(ex =>
+            {
+                logger.LogWarning(ex,
+                    "API token node {Path} not confirmed readable within 10s of issuance; returning token anyway",
+                    path);
+                return Observable.Return<MeshNode?>(null);
+            });
+
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        return accessService != null
+            ? Observable.Using(() => accessService.ImpersonateAsSystem(), _ => poll)
+            : poll;
     }
 
     private ApiToken? FinalizeToken(MeshNode? tokenNode, ApiToken? apiToken, string hash, string hashPrefix)

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -457,6 +457,53 @@ public static class MeshDataSourceExtensions
     }
 
     /// <summary>
+    /// 🚨 Pending-save tracker for the own-node persistence sampler — the state the
+    /// dispose-time final flush reads so a write that was APPLIED AND ACKED inside the
+    /// 200 ms <c>Sample</c> window is never dropped on hub teardown.
+    ///
+    /// <para><b>The defect this closes (CI run 30068597014,
+    /// <c>TwoSiloRecycleConvergenceTest</c>):</b> a <c>PatchDataRequest</c> that lands in the
+    /// owner hub's Quiescing window (after <c>Dispose()</c> posted the
+    /// <c>DisposeRequest</c>, before <c>RunLevel</c> reaches <c>DisposeHostedHubs</c> — the
+    /// ShuttingDown NACK gate) is processed normally: the patch commits in-RAM and the
+    /// owner posts <c>PatchDataResponse</c> Success. The persistence sampler then holds the
+    /// new state in its 200 ms <c>Sample</c> buffer — and the ShutDown phase's
+    /// <c>DisposeImpl</c> disposed that subscription with the save still pending. The
+    /// acknowledged write was durably LOST: the next activation loaded the stale persisted
+    /// version. Creates/deletes were already covered (<c>MeshNodeTypeSource</c>'s
+    /// <c>FlushPendingWrites</c> reactive dispose action); updates were not — this tracker
+    /// plus <see cref="FlushPendingOwnSave"/> gives the update sampler the same guarantee.</para>
+    ///
+    /// <para>Holds only <see cref="MeshNode"/> references (never the hub), so stamping it
+    /// from inside the sampler's timer chain cannot recreate the TimerQueue-roots-the-hub
+    /// leak the sampler's static-local-function shape exists to prevent.</para>
+    /// </summary>
+    internal sealed class PendingOwnSave
+    {
+        private volatile MeshNode? latest;
+        private volatile MeshNode? requested;
+
+        /// <summary>Latest own-node state that passed the sampler's gates (candidate for save).</summary>
+        public void Track(MeshNode node) => latest = node;
+
+        /// <summary>Marks <paramref name="node"/>'s save as dispatched — its
+        /// <c>SaveMeshNodeRequest</c> was ACCEPTED by the hub (not rejected by the
+        /// teardown guard), so the inbox will process it before the FIFO-ordered
+        /// phase-advance <c>ShutdownRequest</c>s and the storage write runs on the
+        /// mesh IO pool, which outlives the hub.</summary>
+        public void MarkRequested(MeshNode node) => requested = node;
+
+        /// <summary>The latest gated state whose save was never dispatched — or null when
+        /// everything the sampler saw has a dispatched save. Reference identity is exact
+        /// here: <c>Sample</c> forwards the same instance the gate chain stamped.</summary>
+        public MeshNode? TakeUnsaved()
+        {
+            var l = latest;
+            return l is null || ReferenceEquals(l, requested) ? null : l;
+        }
+    }
+
+    /// <summary>
     /// Best-effort: write a <c>Release</c> MeshNode at
     /// <c>{nodeTypePath}/Release/{version}</c> capturing the compiled assembly
     /// path + the markdown release notes from the NodeType's
@@ -729,11 +776,14 @@ public static class MeshDataSourceExtensions
             // RegisterForDisposal / compile-watcher uses below), transitively pinning the hub. A
             // `static` local function cannot capture the enclosing scope, so the hub is referenced
             // solely by the WeakReference and an abandoned hub stays collectable; a live hub is kept
-            // reachable via the mesh/cache so sampling persists normally, and the sampler self-disposes
-            // once the hub is collected or past Started.
+            // reachable via the mesh/cache so sampling persists normally; the sampler self-disposes
+            // once the hub is collected, and on a DISPOSING hub (past Started) it stops posting but
+            // keeps tracking so the dispose-time FlushPendingOwnSave persists the latest state —
+            // teardown's DisposeImpl bounds the chain's lifetime via RegisterForDisposal(saveSub).
             static IDisposable InstallPersistenceSampler(
                 IObservable<MeshNode> own, OwnNodeCache nodeCache,
-                WeakReference<IMessageHub> weakHub, TimeSpan interval)
+                WeakReference<IMessageHub> weakHub, TimeSpan interval,
+                PendingOwnSave pending)
             {
                 var sub = new System.Reactive.Disposables.SingleAssignmentDisposable();
                 sub.Disposable = own
@@ -751,22 +801,48 @@ public static class MeshDataSourceExtensions
                     .Where(n => n != null && !nodeCache.IsDeleted
                         && !ReferenceEquals(n, nodeCache.PersistedSnapshot))
                     .DistinctUntilChanged()
+                    // 🚨 Track every save-worthy state BEFORE the Sample buffer: the
+                    // dispose-time FlushPendingOwnSave persists the latest tracked state
+                    // whose save was never dispatched, so a write acked inside the Sample
+                    // window survives hub teardown (see PendingOwnSave). Holds only the
+                    // MeshNode — no hub reference enters the timer chain.
+                    .Do(pending.Track)
                     .Sample(interval)
                     .Subscribe(node =>
                     {
                         if (nodeCache.IsDeleted) return;
-                        if (!weakHub.TryGetTarget(out var saveHub)
-                            || saveHub.RunLevel > MessageHubRunLevel.Started)
+                        if (!weakHub.TryGetTarget(out var saveHub))
                         {
-                            // Hub collected or past Started — stop sampling so the TimerQueue releases it.
+                            // Hub collected (abandoned at RunLevel=1, never disposed) — stop
+                            // sampling so the TimerQueue releases the chain.
                             sub.Dispose();
+                            return;
+                        }
+                        if (saveHub.RunLevel > MessageHubRunLevel.Started)
+                        {
+                            // Hub is tearing down (Quiescing or later). Do NOT post — the inbox
+                            // may already reject it — and do NOT self-dispose: the chain must
+                            // keep tracking quiesce-window writes (a PatchDataRequest is still
+                            // processed and ACKED during Quiescing) so the dispose-time
+                            // FlushPendingOwnSave persists the true latest state. Teardown
+                            // bounds the chain's lifetime: DisposeImpl disposes it via the
+                            // RegisterForDisposal(saveSub) registration. The old `sub.Dispose()`
+                            // here silently DISCARDED the pending save — half of the
+                            // acked-write-lost-on-recycle defect (CI run 30068597014).
                             return;
                         }
                         // Per-node hub auto-persists its OWN MeshNode on every change. SaveMeshNodeRequest
                         // is [SystemMessage] (PostPipeline accepts a null AccessContext — per-node hub
                         // self-write); no ImpersonateAsHub stamping (the hub address polluted CreatedBy via
                         // the AsyncLocal leak, fixed 2026-05-22). See AccessContextPropagation.md.
-                        saveHub.Post(new SaveMeshNodeRequest(node));
+                        var posted = saveHub.Post(new SaveMeshNodeRequest(node));
+                        // Only a delivery the hub ACCEPTED counts as dispatched — Post returns
+                        // Failed("Hub is shutting down") from the hoisted teardown guard when the
+                        // RunLevel flipped between our check above and the post. An accepted
+                        // delivery is FIFO-ordered ahead of the phase-advance ShutdownRequests,
+                        // so its handler runs and the storage write lands on the IO pool.
+                        if (posted is not null && posted.State != MessageDeliveryState.Failed)
+                            pending.MarkRequested(node);
                     });
                 return sub;
             }
@@ -787,9 +863,28 @@ public static class MeshDataSourceExtensions
             // WithMeshNodes (FindServedStaticNode) so serving and persisting stay in lockstep.
             if (FindServedStaticNode(hub.ServiceProvider, hub.Address.Path) is null)
             {
+                var pending = new PendingOwnSave();
                 var saveSub = InstallPersistenceSampler(
-                    ownStream, cache, new WeakReference<IMessageHub>(hub), SaveSampleInterval);
+                    ownStream, cache, new WeakReference<IMessageHub>(hub), SaveSampleInterval, pending);
                 hub.RegisterForDisposal(saveSub);
+                // 🚨 Final flush — the update-path twin of MeshNodeTypeSource's
+                // FlushPendingWrites dispose action (which covers creates/deletes). A write
+                // that commits and ACKS during the Quiescing window sits in the 200 ms Sample
+                // buffer above; without this flush, DisposeImpl disposed the sampler with the
+                // save still pending and the ACKED write was durably lost — the reactivated
+                // hub loaded the stale persisted version (TwoSiloRecycleConvergenceTest flake,
+                // CI run 30068597014: post-recycle patch acked, store never advanced).
+                // Registered as a REACTIVE dispose action: the returned observable's write
+                // leaf runs on the mesh IO pool (outlives this hub); a fault surfaces through
+                // DisposeImpl's [DISPOSE-ACTION] logging, never silently.
+                // Block-bodied lambda: binds the Func<IMessageHub, IObservable<Unit>>
+                // (reactive dispose action) overload unambiguously — an expression lambda
+                // is also convertible to Action<IMessageHub>, which would never subscribe
+                // the (cold) flush observable.
+                hub.RegisterForDisposal(h =>
+                {
+                    return FlushPendingOwnSave(h, cache, pending);
+                });
             }
 
             // Per-NodeType compile auto-watcher: fires RunCompile whenever the own
@@ -923,6 +1018,48 @@ public static class MeshDataSourceExtensions
             }
         });
         hub.RegisterForDisposal(delSub);
+    }
+
+    /// <summary>
+    /// Dispose-time final flush for the own-node persistence sampler: persists the latest
+    /// save-worthy own-node state whose <see cref="SaveMeshNodeRequest"/> was never
+    /// dispatched (see <see cref="PendingOwnSave"/>). Runs as a REACTIVE dispose action in
+    /// <c>DisposeImpl</c> — the storage adapter is mesh-scoped and runs its async leaf on
+    /// the mesh IO pool, which outlives this hub, so the write completes in the background;
+    /// the hub never awaits. Applies the same guards as <c>HandleSaveMeshNode</c>
+    /// (recently-deleted tombstone, Version >= 1) plus the sampler's own gates re-checked
+    /// at flush time (IsDeleted, PersistedSnapshot identity). A fault propagates to
+    /// DisposeImpl's Catch wrapper and is logged as <c>[DISPOSE-ACTION] … faulted</c>.
+    /// </summary>
+    private static IObservable<System.Reactive.Unit> FlushPendingOwnSave(
+        IMessageHub hub, OwnNodeCache cache, PendingOwnSave pending)
+    {
+        var node = pending.TakeUnsaved();
+        if (node is null || cache.IsDeleted || ReferenceEquals(node, cache.PersistedSnapshot))
+            return Observable.Return(System.Reactive.Unit.Default);
+
+        var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
+        if (persistence is null)
+            return Observable.Return(System.Reactive.Unit.Default);
+
+        // "Delete wins" — same tombstone guard as HandleSaveMeshNode: never let the flush
+        // resurrect a just-deleted path.
+        var recentlyDeleted = hub.ServiceProvider.GetService<RecentlyDeletedRegistry>();
+        if (recentlyDeleted?.IsRecentlyDeleted(node.Path) == true)
+            return Observable.Return(System.Reactive.Unit.Default);
+
+        if (node.Version == 0)
+            node = node with { Version = 1 };
+
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Graph.SaveMeshNodeHandler");
+        logger?.LogDebug("[SaveMeshNode] dispose-flush start path={Path} version={Version}",
+            node.Path, node.Version);
+        return persistence.Write(node, hub.JsonSerializerOptions)
+            .Do(saved => logger?.LogDebug(
+                "[SaveMeshNode] dispose-flush persisted path={Path} version={Version}",
+                saved?.Path, saved?.Version))
+            .Select(_ => System.Reactive.Unit.Default);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Kernel.Hub/CapturingTextWriter.cs
+++ b/src/MeshWeaver.Kernel.Hub/CapturingTextWriter.cs
@@ -20,19 +20,41 @@ namespace MeshWeaver.Kernel.Hub;
 /// capture's stdout target, <c>Console.Error.WriteLine</c> on its stderr target —
 /// so a script's error prints reach the ActivityLog (as error-level messages)
 /// instead of vanishing into the host process's stderr.</para>
+///
+/// <para>🚨 The AsyncLocal holds a mutable <see cref="CaptureCell"/>, NEVER the
+/// writer itself. Anything that snapshots the ExecutionContext while a capture is
+/// active — a lazily-created long-lived <c>TimerQueueTimer</c>, a pending Rx delay,
+/// a pooled work item — freezes the AsyncLocal map into that snapshot, and the
+/// scope's Restorer can never reach it. When the map held the
+/// <c>LoggerTextWriter</c> directly, one such timer pinned the writer →
+/// <c>ActivityLogLogger</c> → the DISPOSED kernel activity hub → the whole mesh for
+/// the timer's lifetime (the <c>MeshHubDisposalLeakTest</c> CI retention path, run
+/// 30068597014). With the cell indirection, scope disposal nulls
+/// <see cref="CaptureCell.Target"/> and SEVERS the graph even inside frozen
+/// snapshots — a stray context keeps only the empty cell.</para>
 /// </summary>
-internal sealed class CapturingTextWriter(AsyncLocal<TextWriter?> channel, TextWriter fallback) : TextWriter
+internal sealed class CapturingTextWriter(AsyncLocal<CapturingTextWriter.CaptureCell?> channel, TextWriter fallback) : TextWriter
 {
+    /// <summary>
+    /// Indirection between the AsyncLocal map and the capture target. Captured
+    /// ExecutionContexts reference this cell; disposing the capture scope nulls
+    /// <see cref="Target"/>, releasing the writer graph from every snapshot.
+    /// </summary>
+    internal sealed class CaptureCell
+    {
+        public volatile TextWriter? Target;
+    }
+
     // AsyncLocal flow-state (NOT a cache/collection): scopes each capture to its own
     // logical execution context. One channel per standard stream.
-    private static readonly AsyncLocal<TextWriter?> CurrentOutTarget = new();
-    private static readonly AsyncLocal<TextWriter?> CurrentErrorTarget = new();
+    private static readonly AsyncLocal<CaptureCell?> CurrentOutTarget = new();
+    private static readonly AsyncLocal<CaptureCell?> CurrentErrorTarget = new();
     private static int installedOut;
     private static int installedError;
 
     public override Encoding Encoding => fallback.Encoding;
 
-    private TextWriter Active => channel.Value ?? fallback;
+    private TextWriter Active => channel.Value?.Target ?? fallback;
 
     public override void Write(char value) => Active.Write(value);
     public override void Write(string? value) => Active.Write(value);
@@ -44,7 +66,9 @@ internal sealed class CapturingTextWriter(AsyncLocal<TextWriter?> channel, TextW
     /// <summary>
     /// Begin capturing <c>Console.Out</c> writes to <paramref name="outTarget"/> and
     /// <c>Console.Error</c> writes to <paramref name="errorTarget"/> on the current
-    /// async-flow. Dispose the returned scope to restore the previous targets.
+    /// async-flow. Dispose the returned scope to restore the previous targets AND
+    /// sever the targets from any ExecutionContext snapshotted during the scope
+    /// (see the class remarks — this is what keeps disposed meshes collectible).
     /// Idempotently installs the global console hooks on first use.
     /// </summary>
     public static IDisposable Capture(TextWriter outTarget, TextWriter errorTarget)
@@ -56,10 +80,18 @@ internal sealed class CapturingTextWriter(AsyncLocal<TextWriter?> channel, TextW
 
         var prevOut = CurrentOutTarget.Value;
         var prevError = CurrentErrorTarget.Value;
-        CurrentOutTarget.Value = outTarget;
-        CurrentErrorTarget.Value = errorTarget;
+        var outCell = new CaptureCell { Target = outTarget };
+        var errorCell = new CaptureCell { Target = errorTarget };
+        CurrentOutTarget.Value = outCell;
+        CurrentErrorTarget.Value = errorCell;
         return new Restorer(() =>
         {
+            // Sever FIRST: contexts already captured by timers / pool items during
+            // the scope hold these cells — nulling Target releases the writer graph
+            // inside those frozen snapshots (their late writes fall back to the real
+            // console instead of a disposed pipe). Then restore the current flow.
+            outCell.Target = null;
+            errorCell.Target = null;
             CurrentOutTarget.Value = prevOut;
             CurrentErrorTarget.Value = prevError;
         });

--- a/test/MeshWeaver.Hosting.Monolith.Test/ConsoleCaptureExecutionContextLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ConsoleCaptureExecutionContextLeakTest.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using MeshWeaver.Kernel.Hub;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Deterministic repro for the <see cref="MeshHubDisposalLeakTest"/> CI flake
+/// (run 30068597014, shard 1): the ClrMD retention path was
+/// <c>TimerQueueTimer → ExecutionContext → AsyncLocalValueMap →
+/// MeshWeaver.Kernel.Hub.LoggerTextWriter → ActivityLogLogger → MessageHub
+/// (kernelExec/…/_Activity/…, RunLevel=6)</c> — a DISPOSED kernel activity hub,
+/// and through it the whole mesh, pinned forever.
+///
+/// <para>Mechanism: <see cref="CapturingTextWriter.Capture"/> stores the script's
+/// stdout/stderr pipe in an <see cref="AsyncLocal{T}"/>. Any long-lived timer (or
+/// pooled work item) whose creation falls INSIDE the capture window snapshots the
+/// ExecutionContext — including that AsyncLocal map. Restoring the AsyncLocal on
+/// scope disposal only affects the current flow; it can never reach the frozen
+/// snapshots, so the writer → activity-hub → mesh graph stays rooted for the
+/// timer's lifetime. Intermittent on CI because it needs an infrastructure
+/// timer's first creation to land inside a script run.</para>
+///
+/// <para>The fix stores the target behind a mutable indirection cell; disposing
+/// the capture scope nulls the cell's target, severing the graph even inside
+/// already-captured ExecutionContexts. This test creates a timer inside a capture
+/// scope, keeps the timer alive, and asserts the capture target is collectible
+/// after the scope is disposed.</para>
+/// </summary>
+public class ConsoleCaptureExecutionContextLeakTest
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference Target, Timer Timer) CreateTimerInsideCaptureScope()
+    {
+        var target = new StringWriter(); // stands in for LoggerTextWriter → ActivityLogLogger → hub
+        Timer timer;
+        using (CapturingTextWriter.Capture(target, target))
+        {
+            // A long-lived timer created inside the capture scope snapshots the
+            // ExecutionContext — exactly what a lazily-initialized infrastructure
+            // timer does when its first creation falls inside a kernel script run.
+            timer = new Timer(static _ => { }, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+        return (new WeakReference(target), timer);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ForceCollect(WeakReference weak)
+    {
+        for (var i = 0; i < 12 && weak.IsAlive; i++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+        }
+    }
+
+    [Fact]
+    public void CaptureScopeDisposal_SeversTargetFromCapturedExecutionContexts()
+    {
+        var (weak, timer) = CreateTimerInsideCaptureScope();
+        using (timer) // the timer stays alive across the collect — the CI TimerQueue pin
+        {
+            ForceCollect(weak);
+            weak.IsAlive.Should().BeFalse(
+                "disposing the console-capture scope must sever the capture target from " +
+                "ExecutionContexts snapshotted by timers created inside the scope — otherwise " +
+                "the LoggerTextWriter → ActivityLogLogger → kernel activity hub → mesh graph " +
+                "stays pinned for the timer's lifetime (MeshHubDisposalLeakTest CI retention path)");
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/DisposalPendingSaveFlushTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DisposalPendingSaveFlushTest.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 Deterministic repro of the acked-write-lost-on-teardown defect behind the
+/// <c>TwoSiloRecycleConvergenceTest</c> flake (main run 30068597014, shard 2): the
+/// post-recycle patch raced the owner hub's <c>Dispose()</c> into the Quiescing window
+/// (the ShuttingDown NACK gate only starts at <c>RunLevel &gt;= DisposeHostedHubs</c>),
+/// was applied and ACKED (<c>PatchDataResponse</c> Success) — and then durably LOST:
+/// the per-node hub's persistence sampler (<c>MeshDataSource.SubscribeToOwnDeletion</c>)
+/// debounces updates with <c>Sample(200 ms)</c>, and <c>DisposeImpl</c> disposed that
+/// subscription with the save still pending. The store never advanced past the
+/// pre-recycle version, so the test's <c>WaitForPersistedBeyond</c> timed out.
+///
+/// <para>This test forces the exact interleaving without Orleans: write through the
+/// canonical own-node <c>stream.Update</c>, observe the own stream carry the write
+/// (the sampler — an earlier subscriber of the same stream — has necessarily seen it),
+/// then dispose the per-node hub INSIDE the 200 ms sample window. On main the pending
+/// save is dropped both ways the race can land (sampler disposed before the window
+/// elapses, or its <c>RunLevel &gt; Started</c> branch discarding the sampled value), so
+/// the marker never reaches storage — RED. With the final-flush dispose action
+/// (<c>FlushPendingOwnSave</c>, the update-path twin of <c>MeshNodeTypeSource</c>'s
+/// create/delete <c>FlushPendingWrites</c>) the write becomes durable — GREEN.</para>
+/// </summary>
+public class DisposalPendingSaveFlushTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact(Timeout = 60_000)]
+    public async Task WriteAckedInsideSampleWindow_SurvivesHubDisposal()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var path = $"{TestPartition}/flush-node";
+        await NodeFactory.CreateNode(
+                new MeshNode("flush-node", TestPartition) { Name = "initial", NodeType = "Markdown" })
+            .Should().Emit();
+
+        // Activate the per-node hub (lazy) and grab its workspace — same shape as
+        // WorkspaceUpdateMeshNodePropagationTest.
+        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+            .Should().Emit();
+        var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
+        nodeHub.Should().NotBeNull("the per-node hub must be activated by the GetDataRequest above");
+        var workspace = nodeHub!.GetWorkspace();
+
+        // Baseline: the CREATE is durable before we race the UPDATE against disposal,
+        // so the final read can only be satisfied by the update itself.
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(10.Seconds()).ToTask(ct);
+
+        // The update — canonical own-node stream.Update, the same primitive a cross-hub
+        // PatchDataRequest commits through. Await the ack emission (the write is applied).
+        var marker = $"updated-{Guid.NewGuid():N}"[..16];
+        await workspace.GetMeshNodeStream()
+            .Update(n => n with { Name = marker })
+            .FirstAsync().Timeout(10.Seconds()).ToTask(ct);
+
+        // Confirm the own stream carries the write. The persistence sampler subscribed to
+        // this same stream at hub init — emissions fan out to subscribers in subscription
+        // order on the emission walk, so once WE see the marker the sampler has tracked it
+        // and is now holding the save in its 200 ms Sample buffer.
+        await workspace.GetMeshNodeStream()
+            .Where(n => n is not null && n.Name == marker)
+            .FirstAsync().Timeout(10.Seconds()).ToTask(ct);
+
+        // Dispose the per-node hub IMMEDIATELY — inside the sample window. This is the
+        // idle-recycle / owner-teardown path: the pending debounced save must not be
+        // dropped on the floor.
+        nodeHub!.Dispose();
+        Output.WriteLine($"[repro] disposed {path} with save for '{marker}' pending in the Sample window");
+
+        // The acked write MUST become durable. storage.Read does not activate hubs, so
+        // nothing can resurrect the value except the persistence pipeline itself.
+        var persisted = await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+            .Where(n => n is not null && n.Name == marker)
+            .FirstAsync().Timeout(15.Seconds()).ToTask(ct);
+
+        persisted!.Name.Should().Be(marker,
+            "a write that was applied and acknowledged before hub disposal must survive the "
+            + "teardown — the dispose-time flush persists the pending sampled state instead of "
+            + "dropping it (the TwoSiloRecycleConvergenceTest post-recycle orphan, run 30068597014)");
+    }
+}


### PR DESCRIPTION
## One PR, four fixes — combined per repo-owner request to land in a single CI cycle (fewer flake windows)

1. **Kernel console-capture ExecutionContext leak** (supersedes #626): `CapturingTextWriter`'s AsyncLocal froze the script-stdout pipe (writer → ActivityLogLogger → activity hub → mesh) into timer ExecutionContext snapshots, pinning DISPOSED meshes — the real cause of the `MeshHubDisposalLeakTest` "flake" (retention path identical in both CI failures). Fix: mutable `CaptureCell` indirection severed at scope disposal. Deterministic repro `ConsoleCaptureExecutionContextLeakTest` (red pre-fix in 12ms, green post).
2. **Acked-write loss on per-node hub teardown** (supersedes #627): a patch ACKed during the recycle Quiescing window could be durably LOST — the `Sample(200ms)` persistence debounce was disposed with the save pending (updates lacked the final-flush creates/deletes have). Real prod data loss; also the true cause of the `TwoSiloRecycleConvergenceTest` flake. Fix: `PendingOwnSave` tracker + `FlushPendingOwnSave` dispose action on the mesh IO pool. Deterministic repro `DisposalPendingSaveFlushTest` (red pre-fix with the CI failure's exact signature, green post).
3. **ApiToken issuance read-back** (supersedes #624): `/token` now confirms the just-created token + index nodes are readable (resilient GetMeshNodeStream poll) before returning the raw token, so an immediate reconnect validates on any replica; hot validation path unchanged.
4. **NU1903 advisory bump**: `System.Security.Cryptography.Xml` 10.0.7 → 10.0.10 (GHSA-g8r8-53c2-pm3f, GHSA-mmjf-rqrv-855v). Restore is now audit-clean — 0 warnings (was warning repo-wide).

## Verification (combined branch, real runs)
- CI-exact `dotnet restore` (0 audit warnings) + `dotnet build --no-restore -c Release -p:CIRun=true -warnaserror`: **0 warnings, 0 errors**.
- `ConsoleCaptureExecutionContextLeakTest` + `DisposalPendingSaveFlushTest` + `MeshHubDisposalLeakTest` + `LayoutRenderTeardownDrainTest`: **4/4**.
- ApiToken + OAuthConnectController suites: **76/76**.

Closes #626, closes #627, closes #624 (their commits are contained here).
No What's New entry — internal stability/security-hygiene batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)