### PR TITLE
Measure deploy shutdown/ramp-up in Loki; fix rollout drain + probe regressions

### DIFF
--- a/deploy/aks/dashboards/memex-cluster-pods.json
+++ b/deploy/aks/dashboards/memex-cluster-pods.json
@@ -6,7 +6,11 @@
     "schemaVersion": 39,
     "refresh": "30s",
     "time": { "from": "now-6h", "to": "now" },
-    "templating": { "list": [] },
+    "templating": {
+      "list": [
+        { "type": "query", "name": "namespace", "label": "Namespace", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "query": "label_values(kube_pod_status_phase, namespace)", "refresh": 2, "sort": 1, "includeAll": false, "multi": false, "current": { "text": "memex-cloud", "value": "memex-cloud" }, "options": [] }
+      ]
+    },
     "panels": [
       {
         "type": "timeseries",
@@ -33,7 +37,7 @@
         "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
         "fieldConfig": { "defaults": { "custom": { "align": "auto" } }, "overrides": [] },
         "options": { "showHeader": true },
-        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "kube_pod_status_phase{namespace=\"memex\"} == 1", "format": "table", "instant": true }],
+        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "kube_pod_status_phase{namespace=\"$namespace\"} == 1", "format": "table", "instant": true }],
         "transformations": [
           { "id": "organize", "options": { "excludeByName": { "Time": true, "Value": true, "__name__": true, "container": true, "endpoint": true, "job": true, "instance": true, "service": true, "uid": true, "namespace": true }, "renameByName": { "pod": "Pod", "phase": "Phase" } } }
         ]
@@ -45,7 +49,7 @@
         "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
         "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "short" }, "overrides": [] },
         "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum by (pod) (kube_pod_container_status_restarts_total{namespace=\"memex\"})", "legendFormat": "{{pod}}" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum by (pod) (kube_pod_container_status_restarts_total{namespace=\"$namespace\"})", "legendFormat": "{{pod}}" }]
       },
       {
         "type": "timeseries",
@@ -54,7 +58,7 @@
         "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
         "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 15 }, "unit": "short" }, "overrides": [] },
         "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"memex\",container!=\"\",container!=\"POD\"}[5m]))", "legendFormat": "{{pod}}" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container!=\"\",container!=\"POD\"}[5m]))", "legendFormat": "{{pod}}" }]
       },
       {
         "type": "timeseries",
@@ -63,7 +67,7 @@
         "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
         "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 15 }, "unit": "decmbytes" }, "overrides": [] },
         "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"memex\",container!=\"\",container!=\"POD\"}) / 1024 / 1024", "legendFormat": "{{pod}}" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"$namespace\",container!=\"\",container!=\"POD\"}) / 1024 / 1024", "legendFormat": "{{pod}}" }]
       }
     ]
   },

--- a/deploy/aks/dashboards/memex-deploy-timings.json
+++ b/deploy/aks/dashboards/memex-deploy-timings.json
@@ -1,0 +1,82 @@
+{
+  "dashboard": {
+    "uid": "memex-deploy-timings",
+    "title": "Memex Deploy Timings",
+    "tags": ["memex", "deploy"],
+    "schemaVersion": 39,
+    "refresh": "30s",
+    "time": { "from": "now-3h", "to": "now" },
+    "templating": {
+      "list": [
+        { "type": "query", "name": "namespace", "label": "Namespace", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "query": "label_values(namespace)", "refresh": 2, "sort": 1, "includeAll": false, "multi": false, "current": { "text": "memex-cloud", "value": "memex-cloud" }, "options": [] }
+      ]
+    },
+    "panels": [
+      {
+        "type": "timeseries",
+        "title": "PortalReady (ms) per pod",
+        "description": "Time from process start to PortalReady, per portal pod. Each point is the max PortalReady duration logged in the interval.",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+        "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
+        "fieldConfig": { "defaults": { "custom": { "drawStyle": "points", "pointSize": 8, "fillOpacity": 0 }, "unit": "ms" }, "overrides": [] },
+        "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "max by (pod) (max_over_time({namespace=\"$namespace\", pod=~\"memex-portal-deployment-.*\"} |= \"PortalReady\" | regexp \"in (?P<elapsed_ms>[0-9]+) ms\" | unwrap elapsed_ms [$__auto]))", "legendFormat": "{{pod}}", "queryType": "range" }]
+      },
+      {
+        "type": "timeseries",
+        "title": "PortalShutdown (ms) per pod",
+        "description": "Time for graceful shutdown (PortalShutdown complete), per portal pod.",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+        "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
+        "fieldConfig": { "defaults": { "custom": { "drawStyle": "points", "pointSize": 8, "fillOpacity": 0 }, "unit": "ms" }, "overrides": [] },
+        "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "max by (pod) (max_over_time({namespace=\"$namespace\", pod=~\"memex-portal-deployment-.*\"} |= \"PortalShutdown complete\" | regexp \"in (?P<elapsed_ms>[0-9]+) ms\" | unwrap elapsed_ms [$__auto]))", "legendFormat": "{{pod}}", "queryType": "range" }]
+      },
+      {
+        "type": "timeseries",
+        "title": "Circuit churn",
+        "description": "Blazor circuit connections dropped (DOWN) and opened per minute. A spike of DOWN followed by opened is the user-visible cost of a rollout.",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+        "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
+        "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 70 }, "unit": "short" }, "overrides": [{ "matcher": { "id": "byName", "options": "circuits down" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }, { "matcher": { "id": "byName", "options": "circuits opened" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }] },
+        "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+        "targets": [
+          { "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |= \"Circuit connection DOWN\" [1m]))", "legendFormat": "circuits down", "queryType": "range" },
+          { "refId": "B", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |= \"Circuit opened\" [1m]))", "legendFormat": "circuits opened", "queryType": "range" }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "title": "Errors (fail/crit) rate",
+        "description": "fail/crit log lines per minute across the namespace. Should stay flat through a rollout.",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+        "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
+        "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 70 }, "unit": "short", "color": { "mode": "fixed", "fixedColor": "red" } }, "overrides": [] },
+        "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |~ \"^(fail|crit):\" [1m]))", "legendFormat": "errors/min", "queryType": "range" }]
+      },
+      {
+        "type": "timeseries",
+        "title": "Per-pod log activity (rollout overlap)",
+        "description": "Log lines per 30s for each portal pod. During a rollout the old and new pods' series must OVERLAP — both pods logging at the same time means zero-downtime handover. A gap between the old pod's series ending and the new pod's series starting = downtime.",
+        "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+        "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
+        "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 25 }, "unit": "short" }, "overrides": [] },
+        "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum by (pod) (count_over_time({namespace=\"$namespace\", pod=~\"memex-portal-deployment-.*\"} [30s]))", "legendFormat": "{{pod}}", "queryType": "range" }]
+      },
+      {
+        "type": "logs",
+        "title": "Lifecycle log lines",
+        "description": "Raw startup/shutdown lifecycle events from the portal pods.",
+        "gridPos": { "h": 10, "w": 24, "x": 0, "y": 24 },
+        "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
+        "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending", "enableLogDetails": true, "dedupStrategy": "none", "prettifyLogMessage": false },
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "{namespace=\"$namespace\", pod=~\"memex-portal-deployment-.*\"} |~ \"PortalReady|PortalShutdown|Now listening on|Application started|Application is shutting down|startup complete\"", "queryType": "range" }]
+      }
+    ]
+  },
+  "overwrite": true,
+  "folderId": 0,
+  "message": "Provisioned by Claude Code"
+}

--- a/deploy/aks/dashboards/memex-logs-errors.json
+++ b/deploy/aks/dashboards/memex-logs-errors.json
@@ -8,6 +8,7 @@
     "time": { "from": "now-3h", "to": "now" },
     "templating": {
       "list": [
+        { "type": "query", "name": "namespace", "label": "Namespace", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "query": "label_values(namespace)", "refresh": 2, "sort": 1, "includeAll": false, "multi": false, "current": { "text": "memex-cloud", "value": "memex-cloud" }, "options": [] },
         { "type": "textbox", "name": "filter", "label": "Text filter (regex)", "query": "", "current": { "text": "", "value": "" } }
       ]
     },
@@ -20,9 +21,9 @@
         "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 70, "stacking": { "mode": "normal" } }, "unit": "short" }, "overrides": [{ "matcher": { "id": "byName", "options": "errors" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }, { "matcher": { "id": "byName", "options": "warnings" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "yellow" } }] }, { "matcher": { "id": "byName", "options": "info" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }] },
         "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
         "targets": [
-          { "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"memex\"} |~ `^info:` [$__auto]))", "legendFormat": "info", "queryType": "range" },
-          { "refId": "B", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"memex\"} |~ `^warn:` [$__auto]))", "legendFormat": "warnings", "queryType": "range" },
-          { "refId": "C", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"memex\"} |~ `^(fail|crit):` [$__auto]))", "legendFormat": "errors", "queryType": "range" }
+          { "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |~ `^info:` [$__auto]))", "legendFormat": "info", "queryType": "range" },
+          { "refId": "B", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |~ `^warn:` [$__auto]))", "legendFormat": "warnings", "queryType": "range" },
+          { "refId": "C", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |~ `^(fail|crit):` [$__auto]))", "legendFormat": "errors", "queryType": "range" }
         ]
       },
       {
@@ -32,7 +33,7 @@
         "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
         "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
         "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" },
-        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"memex\"} |~ `^(info|warn|fail|crit|dbug|trce):` [$__range]))", "queryType": "instant" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |~ `^(info|warn|fail|crit|dbug|trce):` [$__range]))", "queryType": "instant" }]
       },
       {
         "type": "stat",
@@ -41,7 +42,7 @@
         "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
         "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "short" }, "overrides": [] },
         "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "background", "graphMode": "area", "textMode": "auto" },
-        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"memex\"} |~ `^(fail|crit):` [$__range]))", "queryType": "instant" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |~ `^(fail|crit):` [$__range]))", "queryType": "instant" }]
       },
       {
         "type": "table",
@@ -50,7 +51,7 @@
         "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
         "fieldConfig": { "defaults": { "custom": { "align": "auto" } }, "overrides": [] },
         "options": { "showHeader": true, "sortBy": [{ "displayName": "Count", "desc": true }] },
-        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "topk(20, sum by (category) (count_over_time({namespace=\"memex\"} |~ `^(warn|fail|crit):` | regexp `^\\w{4}: (?P<category>[A-Za-z0-9_.]+)` [$__range])))", "queryType": "instant" }],
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "topk(20, sum by (category) (count_over_time({namespace=\"$namespace\"} |~ `^(warn|fail|crit):` | regexp `^\\w{4}: (?P<category>[A-Za-z0-9_.]+)` [$__range])))", "queryType": "instant" }],
         "transformations": [
           { "id": "labelsToFields", "options": {} },
           { "id": "organize", "options": { "excludeByName": { "Time": true }, "renameByName": { "category": "Category", "Value": "Count" } } }
@@ -62,7 +63,7 @@
         "gridPos": { "h": 11, "w": 24, "x": 0, "y": 17 },
         "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
         "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending", "enableLogDetails": true, "dedupStrategy": "none", "prettifyLogMessage": false },
-        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "{namespace=\"memex\"} |~ `(?i)${filter:raw}`", "queryType": "range" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "{namespace=\"$namespace\"} |~ `(?i)${filter:raw}`", "queryType": "range" }]
       }
     ]
   },

--- a/deploy/aks/dashboards/memex-overview.json
+++ b/deploy/aks/dashboards/memex-overview.json
@@ -6,7 +6,11 @@
     "schemaVersion": 39,
     "refresh": "30s",
     "time": { "from": "now-6h", "to": "now" },
-    "templating": { "list": [] },
+    "templating": {
+      "list": [
+        { "type": "query", "name": "namespace", "label": "Namespace", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "query": "label_values(namespace)", "refresh": 2, "sort": 1, "includeAll": false, "multi": false, "current": { "text": "memex-cloud", "value": "memex-cloud" }, "options": [] }
+      ]
+    },
     "panels": [
       {
         "type": "stat",
@@ -15,7 +19,7 @@
         "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
         "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }, "unit": "short" }, "overrides": [] },
         "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "background", "graphMode": "none", "textMode": "auto" },
-        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum(kube_deployment_status_replicas_available{namespace=\"memex\",deployment=~\"memex-portal.*\"})" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum(kube_deployment_status_replicas_available{namespace=\"$namespace\",deployment=~\"memex-portal.*\"})" }]
       },
       {
         "type": "stat",
@@ -24,7 +28,7 @@
         "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
         "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }] }, "unit": "short" }, "overrides": [] },
         "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "none", "textMode": "auto" },
-        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "count(kube_pod_status_phase{namespace=\"memex\",phase=\"Running\"} == 1)" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "count(kube_pod_status_phase{namespace=\"$namespace\",phase=\"Running\"} == 1)" }]
       },
       {
         "type": "stat",
@@ -33,7 +37,7 @@
         "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
         "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "short" }, "overrides": [] },
         "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "background", "graphMode": "area", "textMode": "auto" },
-        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"memex\"} |~ `^(fail|crit):` [$__range]))", "queryType": "instant" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |~ `^(fail|crit):` [$__range]))", "queryType": "instant" }]
       },
       {
         "type": "stat",
@@ -42,7 +46,7 @@
         "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
         "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }] }, "unit": "short" }, "overrides": [] },
         "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "background", "graphMode": "area", "textMode": "auto" },
-        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"memex\"} |~ `^warn:` [$__range]))", "queryType": "instant" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |~ `^warn:` [$__range]))", "queryType": "instant" }]
       },
       {
         "type": "timeseries",
@@ -52,9 +56,9 @@
         "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 60, "stacking": { "mode": "normal" } }, "unit": "short" }, "overrides": [{ "matcher": { "id": "byName", "options": "errors" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }, { "matcher": { "id": "byName", "options": "warnings" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "yellow" } }] }, { "matcher": { "id": "byName", "options": "info" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }] },
         "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
         "targets": [
-          { "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"memex\"} |~ `^info:` [$__auto]))", "legendFormat": "info", "queryType": "range" },
-          { "refId": "B", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"memex\"} |~ `^warn:` [$__auto]))", "legendFormat": "warnings", "queryType": "range" },
-          { "refId": "C", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"memex\"} |~ `^(fail|crit):` [$__auto]))", "legendFormat": "errors", "queryType": "range" }
+          { "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |~ `^info:` [$__auto]))", "legendFormat": "info", "queryType": "range" },
+          { "refId": "B", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |~ `^warn:` [$__auto]))", "legendFormat": "warnings", "queryType": "range" },
+          { "refId": "C", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "sum(count_over_time({namespace=\"$namespace\"} |~ `^(fail|crit):` [$__auto]))", "legendFormat": "errors", "queryType": "range" }
         ]
       },
       {
@@ -64,7 +68,7 @@
         "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
         "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 15 }, "unit": "short" }, "overrides": [] },
         "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
-        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"memex\",pod=~\"memex-portal.*\",container!=\"\",container!=\"POD\"}[5m]))", "legendFormat": "cpu cores" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",pod=~\"memex-portal.*\",container!=\"\",container!=\"POD\"}[5m]))", "legendFormat": "cpu cores" }]
       },
       {
         "type": "timeseries",
@@ -73,7 +77,7 @@
         "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
         "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 15 }, "unit": "decmbytes" }, "overrides": [] },
         "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
-        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum(container_memory_working_set_bytes{namespace=\"memex\",pod=~\"memex-portal.*\",container!=\"\",container!=\"POD\"}) / 1024 / 1024", "legendFormat": "working set" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }, "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"memex-portal.*\",container!=\"\",container!=\"POD\"}) / 1024 / 1024", "legendFormat": "working set" }]
       },
       {
         "type": "logs",
@@ -81,7 +85,7 @@
         "gridPos": { "h": 10, "w": 24, "x": 0, "y": 12 },
         "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" },
         "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending", "enableLogDetails": true, "dedupStrategy": "none", "prettifyLogMessage": false },
-        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "{namespace=\"memex\"} |~ `(?i)(error|exception|fail|warn|crit)`", "queryType": "range" }]
+        "targets": [{ "refId": "A", "datasource": { "type": "loki", "uid": "P8E80F9AEF21F6940" }, "expr": "{namespace=\"$namespace\"} |~ `(?i)(error|exception|fail|warn|crit)`", "queryType": "range" }]
       }
     ]
   },

--- a/deploy/aks/envs/memex-cloud/portal-ingress.yaml
+++ b/deploy/aks/envs/memex-cloud/portal-ingress.yaml
@@ -11,6 +11,12 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-name: "MEMEXCLOUD_AFFINITY"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
     nginx.ingress.kubernetes.io/session-cookie-samesite: "Lax"
+    # Rollout resilience: re-pin the affinity cookie when the pinned pod goes away (without this,
+    # persistent affinity keeps routing to the draining/terminated pod), and retry the surviving
+    # upstream on the cutover instant instead of surfacing a 502 to the browser.
+    nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"
+    nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout http_502"
+    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "3"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"

--- a/deploy/aks/envs/memex-cloud/portal-patch.json
+++ b/deploy/aks/envs/memex-cloud/portal-patch.json
@@ -1,5 +1,4 @@
 [
-  { "op": "replace", "path": "/spec/replicas", "value": 1 },
   { "op": "add", "path": "/spec/template/spec/nodeSelector", "value": { "workload": "silos" } },
 
   { "op": "replace", "path": "/spec/template/spec/volumes/0",
@@ -30,9 +29,5 @@
     "value": { "secretRef": { "name": "memexcloud-portal-ai-secrets" } } },
 
   { "op": "add", "path": "/spec/template/spec/containers/0/resources",
-    "value": { "requests": { "cpu": "4", "memory": "8Gi" }, "limits": { "cpu": "6", "memory": "16Gi" } } },
-  { "op": "add", "path": "/spec/template/spec/containers/0/readinessProbe",
-    "value": { "httpGet": { "path": "/", "port": 8080 }, "initialDelaySeconds": 20, "periodSeconds": 10, "failureThreshold": 6 } },
-  { "op": "add", "path": "/spec/template/spec/containers/0/livenessProbe",
-    "value": { "httpGet": { "path": "/", "port": 8080 }, "initialDelaySeconds": 90, "periodSeconds": 20, "failureThreshold": 6 } }
+    "value": { "requests": { "cpu": "4", "memory": "8Gi" }, "limits": { "cpu": "6", "memory": "16Gi" } } }
 ]

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -25,6 +25,11 @@ spec:
       # The in-pod self-updater patches this deployment via the Kubernetes API using this SA's
       # projected token (RBAC in rbac.yaml). See Doc/Architecture/ReleaseStrategy.
       serviceAccountName: "memex-portal-sa"
+      # Graceful drain budget: the host's ShutdownTimeout is 90s (Memex.Portal.Distributed
+      # Program.cs) and the preStop below sleeps 15s — the k8s default of 30s SIGKILLed the
+      # portal mid-drain on every rollout (circuits and the Orleans silo torn down abruptly).
+      # 120 is a ceiling, not a delay: a fast shutdown still exits fast.
+      terminationGracePeriodSeconds: 120
       initContainers:
         # Postgres and the portal start concurrently on a fresh install; the portal's hub
         # init FAILS (and the host aborts) if Postgres isn't yet accepting connections.
@@ -38,6 +43,15 @@ spec:
       containers:
         - image: "ghcr.io/systemorph/memex-portal-ai:latest"
           name: "memex-portal"
+          # On rollout, endpoint removal propagates to the ingress-nginx upstreams asynchronously —
+          # without this grace window the pod stops accepting the instant it is SIGTERMed and
+          # in-flight/new requests briefly hit a dead socket (the deploy 502 blip). Sleep first so
+          # the endpoint drains from the upstream set BEFORE the host begins shutting down.
+          # (Base image is Debian aspnet — sh exists.)
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 15"]
           envFrom:
             - configMapRef:
                 name: "memex-portal-config"

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1166,9 +1166,45 @@ public static class MemexConfiguration
             .AddMeshViews()
             .AddInteractiveServerRenderMode();
 
+        // Deploy-timing lifecycle markers, measurable in Loki (grep "PortalReady" /
+        // "PortalShutdown"). A dedicated Information-level category (the same surfaced-channel
+        // pattern as MeshWeaver.Blazor.Circuit) — the general Memex.* namespace stays at Warning
+        // in prod, so these lines must NOT ride on the class logger or they never reach stdout.
+        var lifecycleLogger = app.Services.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Memex.Portal.Lifecycle");
+        var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
+        var shutdownWatch = new System.Diagnostics.Stopwatch();
+        lifetime.ApplicationStarted.Register(() =>
+        {
+            // PID 1 in the container ⇒ process start ≈ container start; TickCount64 would be
+            // time-since-OS-boot, which is wrong here.
+#pragma warning disable CA1416
+            var elapsed = DateTime.UtcNow
+                          - System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime();
+            lifecycleLogger.LogInformation(
+                "PortalReady in {ElapsedMs} ms (PID {PID})",
+                (long)elapsed.TotalMilliseconds, Environment.ProcessId);
+#pragma warning restore CA1416
+        });
+#pragma warning disable CA1416
+        lifetime.ApplicationStopping.Register(() =>
+        {
+            shutdownWatch.Restart();
+            // This line IS the SIGTERM timestamp in Loki — the shutdown window opens here.
+            lifecycleLogger.LogInformation("PortalShutdown starting (PID {PID})", Environment.ProcessId);
+        });
+        lifetime.ApplicationStopped.Register(() =>
+            // Registered callback, not code after Run(): the console logger still flushes here.
+            // Its ABSENCE in Loki for a pod means the kubelet SIGKILLed mid-drain (grace too low).
+            lifecycleLogger.LogInformation(
+                "PortalShutdown complete in {ElapsedMs} ms (PID {PID})",
+                shutdownWatch.ElapsedMilliseconds, Environment.ProcessId));
+#pragma warning restore CA1416
+
         app.Run();
 #pragma warning disable CA1416
-        logger.LogInformation("Started Memex portal on PID: {PID}", Environment.ProcessId);
+        // After Run() returns the host has already stopped — this is an EXIT marker, not a start.
+        logger.LogInformation("Memex portal exited (PID {PID})", Environment.ProcessId);
 #pragma warning restore CA1416
     }
 

--- a/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
+++ b/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
@@ -383,7 +383,15 @@ public sealed class ShippedReleaseSeedHostedService(
             .Subscribe(
                 _ => { },
                 ex => logger?.LogWarning(ex, "[PlatformStartup] startup failed."),
-                () => logger?.LogInformation("[PlatformStartup] startup complete."));
+                // The "fully warm" deploy-timing marker (seeding completes after
+                // ApplicationStarted/PortalReady): elapsed since process start, greppable in Loki.
+#pragma warning disable CA1416
+                () => logger?.LogInformation(
+                    "[PlatformStartup] startup complete in {ElapsedMs} ms since process start.",
+                    (long)(DateTime.UtcNow
+                           - System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime())
+                        .TotalMilliseconds));
+#pragma warning restore CA1416
         return Task.CompletedTask;
     }
 

--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -26,6 +26,17 @@
       // is the "one object = one log line" channel — orders of magnitude below the
       // per-message MESSAGE_FLOW trace that only appears when MeshWeaver is forced to Trace.
       "MeshWeaver.Mesh.CreateNode": "Information",
+      // Deploy-timing lifecycle markers — ≤4 lines per pod lifetime ("PortalReady in X ms",
+      // "PortalShutdown starting/complete in X ms"; StartMemexApplication). The Grafana
+      // "Memex Deploy Timings" dashboard unwraps these; without this level they never
+      // reach stdout/Loki (Memex.* is Warning).
+      "Memex.Portal.Lifecycle": "Information",
+      // The "[PlatformStartup] …" boot-seed lines incl. "startup complete in X ms" — the
+      // fully-warm marker the deploy-timing measurement cross-checks. A bounded burst per boot.
+      "Memex.Portal.Shared.ShippedReleaseSeedHostedService": "Information",
+      // ~5 lines per boot/shutdown: "Now listening on", "Application started", "Application
+      // is shutting down" — the Kestrel-bind and SIGTERM markers.
+      "Microsoft.Hosting.Lifetime": "Information",
       "Microsoft": "Warning",
       "Microsoft.AspNetCore": "Warning",
       "Orleans": "Warning",


### PR DESCRIPTION
## Baseline (measured in Loki, memex-cloud rollout 2026-07-24 ~03:58Z)

- The old pods were **SIGTERMed ~3s after the new pods' first log line** — traffic cut over to still-booting pods.
- The old pods' **last log lines are mid-drain Orleans `SiloUnavailableException` errors with no shutdown-complete marker** — the k8s default 30s grace SIGKILLs the host mid-drain (its `ShutdownTimeout` is 90s).
- The startup lifecycle log lines never reach Loki at all (`Memex`/`Microsoft` filtered to Warning), so ramp-up wasn't measurable.

## Measure

- `Memex.Portal.Lifecycle` markers (Information-surfaced channel, ≤4 lines per pod lifetime): `PortalReady in {ms}` on ApplicationStarted (elapsed from process start = container start at PID 1), `PortalShutdown starting` (= the SIGTERM timestamp), `PortalShutdown complete in {ms}` on ApplicationStopped — its **absence** for a pod = SIGKILL truncation. `[PlatformStartup] startup complete` now carries elapsed ms (fully-warm marker). The misleading post-`app.Run()` "Started Memex portal" line renamed to "Memex portal exited".
- `Microsoft.Hosting.Lifetime` raised to Information ("Now listening on"/"Application started"/"Application is shutting down").
- New Grafana dashboard **memex-deploy-timings** (PortalReady/PortalShutdown unwrap panels, circuit churn, fail/crit rate, per-pod log-activity overlap — a gap = downtime, lifecycle logs panel) + a `namespace` template variable on **all** dashboards (prod runs in `memex-cloud`; the hardcoded `memex` made every dashboard blind to it).

## Minimize

- Chart: `terminationGracePeriodSeconds: 120` + `preStop: sleep 15` on the portal container (drain the nginx upstream before shutdown begins; let the 90s host drain finish).
- `portal-patch.json`: **drop the stale `replicas:1` and `path:"/"` probe overrides.** The live cluster already runs 2 replicas (KEDA min2, AdoNet clustering verified) with the chart's `/health` startup + `/alive` probes — re-running `deploy.sh` today would regress probes to the probe-to-`/` leak pattern (the 2026-06-12 outage shape) and fight the HPA.
- Ingress: `session-cookie-change-on-failure` (re-pin affinity when the pinned pod dies) + `proxy-next-upstream error timeout http_502` (retry the surviving upstream at the cutover instant).

## Rollout

Repo-only; cluster-side apply is a deliberate separate step: re-stage + run `deploy.sh` (helm chart + patched patch + ingress), re-run `import-dashboards.sh`, ship the instrumented image via main-cd/self-update — then re-measure a rollout on the new dashboard. Success criteria: no per-pod log-overlap gap, `PortalShutdown complete` present < 90s, circuit DOWN burst confined to the draining pod with matching re-opens, zero ingress 5xx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzRRVuSy3rcsWfnPtDqftG