### PR TITLE
No-op upsert guard: identical CreateOrUpdate skips the owner write

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -3,6 +3,7 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Text.Json;
 using MeshWeaver.Data;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
@@ -1940,6 +1941,11 @@ public static class MeshExtensions
                     DispatchInnerCreate();
                     return;
                 }
+                if (IsNoOpUpsert(existing, node, hub.JsonSerializerOptions))
+                {
+                    SkipNoOpIfAuthorized(existing);
+                    return;
+                }
                 ApplyUpdateViaStream(existing);
             },
             ex =>
@@ -1994,6 +2000,50 @@ public static class MeshExtensions
                             "[CreateOrUpdate] inner CreateNode faulted for {Path}", node.Path);
                         PostFail($"Inner CreateNode faulted: {ex.Message}",
                             NodeUpsertRejectionReason.Unknown);
+                    });
+        }
+
+        // 🚨 THE NO-OP UPSERT GUARD — the owner-side churn breaker. An upsert whose applied fields
+        // are IDENTICAL to the persisted state must not reach the owner: the stream write
+        // unconditionally re-stamps LastModified and mints a fresh Version, which re-broadcasts the
+        // node to every subscriber (the deploy screen-flicker), appends a version-history row, and
+        // for NodeType/Code nodes can flip IsDirty into a pointless recompile + hub recycle. A full
+        // re-sync of unchanged content (a GitSync re-import whose _Activity manifest was lost, a
+        // plugin re-install without a manifest) hits this for EVERY node. Acknowledge with the
+        // persisted state instead — but only for a caller who could have written anyway
+        // (SkipNoOpIfAuthorized): success-without-write must never become a permission bypass or a
+        // content-confirmation oracle for callers the owner would have refused.
+        void SkipNoOpIfAuthorized(MeshNode existing)
+        {
+            (string.IsNullOrEmpty(requestedBy)
+                    ? Observable.Return(false)
+                    : hub.GetEffectivePermissions(node.Path, requestedBy!)
+                        .Take(1)
+                        .Timeout(NodeOpForwardTimeout)
+                        .Select(p => p.HasFlag(Permission.Update) || p.HasFlag(Permission.Sync))
+                        .Catch((Exception _) => Observable.Return(false)))
+                .Subscribe(
+                    authorized =>
+                    {
+                        if (authorized)
+                        {
+                            logger.LogDebug(
+                                "[CreateOrUpdate] no-op upsert for {Path}: identical to persisted state; skipped",
+                                node.Path);
+                            PostOk(existing, isCreate: false,
+                                $"Node at '{node.Path}' unchanged — no-op upsert skipped");
+                        }
+                        else
+                            // Not (provably) authorized → the normal owner path stays the single
+                            // authority on allow/deny; it will refuse exactly as before.
+                            ApplyUpdateViaStream(existing);
+                    },
+                    ex =>
+                    {
+                        logger.LogDebug(ex,
+                            "[CreateOrUpdate] no-op permission probe failed for {Path}; taking the write path",
+                            node.Path);
+                        ApplyUpdateViaStream(existing);
                     });
         }
 
@@ -2074,6 +2124,50 @@ public static class MeshExtensions
             NodeCreationRejectionReason.ValidationFailed => NodeUpsertRejectionReason.ValidationFailed,
             _ => NodeUpsertRejectionReason.Unknown,
         };
+    }
+
+    /// <summary>
+    /// True when applying <paramref name="sourceNode"/> onto <paramref name="existing"/> via
+    /// <see cref="UpdateAccordingToSourceNode"/> would change nothing but the churn stamps
+    /// (LastModified/Version) — the write can then be skipped entirely. MUST mirror that merge
+    /// field-for-field (same null-keeps-state convention); a field added there without a compare
+    /// here would silently stop landing on unchanged-otherwise nodes. Content compares
+    /// structurally through the hub's serializer (bridging typed content against the persisted
+    /// <see cref="JsonElement"/> representation); any doubt — a serialization failure, a mixed
+    /// shape — reports "changed", which merely takes today's write path. Conservative by
+    /// construction: it can only ever under-skip, never over-skip.
+    /// </summary>
+    private static bool IsNoOpUpsert(MeshNode existing, MeshNode sourceNode, JsonSerializerOptions options)
+    {
+        if ((sourceNode.Name ?? existing.Name) != existing.Name
+            || (sourceNode.NodeType ?? existing.NodeType) != existing.NodeType
+            || (sourceNode.Icon ?? existing.Icon) != existing.Icon
+            || (sourceNode.Category ?? existing.Category) != existing.Category
+            || (sourceNode.Description ?? existing.Description) != existing.Description
+            || (sourceNode.Order ?? existing.Order) != existing.Order
+            || (sourceNode.State == default ? existing.State : sourceNode.State) != existing.State
+            || (sourceNode.PreRenderedHtml ?? existing.PreRenderedHtml) != existing.PreRenderedHtml)
+            return false;
+        var excludeApplied = sourceNode.ExcludeFromContext ?? existing.ExcludeFromContext;
+        if (!ReferenceEquals(excludeApplied, existing.ExcludeFromContext)
+            && (excludeApplied is null || existing.ExcludeFromContext is null
+                || !excludeApplied.SequenceEqual(existing.ExcludeFromContext)))
+            return false;
+        var contentApplied = sourceNode.Content ?? existing.Content;
+        if (ReferenceEquals(contentApplied, existing.Content))
+            return true;
+        if (existing.Content is null)
+            return false;
+        try
+        {
+            return JsonElement.DeepEquals(
+                JsonSerializer.SerializeToElement(contentApplied, options),
+                JsonSerializer.SerializeToElement(existing.Content, options));
+        }
+        catch (Exception)
+        {
+            return false; // unserializable content → the write path decides, exactly as before
+        }
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/CreateOrUpdateNodeRequestTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CreateOrUpdateNodeRequestTest.cs
@@ -8,7 +8,9 @@ using MeshWeaver.Data;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.Hosting.Monolith.Test;
@@ -167,5 +169,105 @@ public class CreateOrUpdateNodeRequestTest(ITestOutputHelper output)
             "CreatedBy is identity — UpdateAccordingToSourceNode preserves it");
         after.Path.Should().Be(path, "Path is identity");
         after.Name.Should().Be("Renamed", "Name is writable — should overwrite");
+    }
+
+    /// <summary>
+    /// The no-op guard: an upsert IDENTICAL to the persisted state must be acknowledged without
+    /// reaching the owner — no Version mint, no LastModified re-stamp, no history row, no stream
+    /// re-broadcast (the deploy-flicker source when a full re-sync rewrites unchanged nodes).
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Upsert_WithIdenticalState_IsSkipped_NoVersionOrTimestampChurn()
+    {
+        var path = $"{TestPartition}/upsert-noop-{Guid.NewGuid():N}";
+        MeshNode Node() => new(path.Split('/').Last(), TestPartition)
+        {
+            Name = "Same",
+            NodeType = "Markdown",
+            Content = new MarkdownContent { Content = "# identical" },
+            State = MeshNodeState.Active,
+        };
+
+        await NodeFactory.CreateNode(Node()).Should().Emit();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var before = await ReadStable(storage, path);
+
+        var resp = await Mesh
+            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(Node()))
+            .Select(d => d.Message)
+            .Should().Emit();
+
+        resp.Success.Should().BeTrue(resp.Error ?? "");
+        resp.WasCreated.Should().BeFalse();
+        resp.Node.Should().NotBeNull();
+        resp.Log!.Messages.Any(m => m.Message.Contains("no-op", StringComparison.OrdinalIgnoreCase))
+            .Should().BeTrue("the skip must be visible in the activity log, not a silent success");
+
+        // The persisted stamps prove no write reached the owner: any write re-stamps LastModified
+        // and mints a fresh Version unconditionally. ReadStable's quiet window (>1.2s, well past
+        // the 200ms persist debounce) would catch a stray write.
+        var after = await ReadStable(storage, path);
+        after.Version.Should().Be(before.Version, "an identical upsert must not mint a Version");
+        after.LastModified.Should().Be(before.LastModified, "an identical upsert must not re-stamp LastModified");
+    }
+
+    /// <summary>
+    /// The guard must not over-skip: a single changed writable field (here Name; content identical)
+    /// still takes the write path.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Upsert_WithOneChangedField_StillWrites()
+    {
+        var path = $"{TestPartition}/upsert-nearnoop-{Guid.NewGuid():N}";
+        await NodeFactory.CreateNode(new MeshNode(path.Split('/').Last(), TestPartition)
+        {
+            Name = "Before",
+            NodeType = "Markdown",
+            Content = new MarkdownContent { Content = "# same content" },
+            State = MeshNodeState.Active,
+        }).Should().Emit();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var before = await ReadStable(storage, path);
+
+        var resp = await Mesh
+            .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(
+                new MeshNode(path.Split('/').Last(), TestPartition)
+                {
+                    Name = "After",
+                    NodeType = "Markdown",
+                    Content = new MarkdownContent { Content = "# same content" },
+                    State = MeshNodeState.Active,
+                }))
+            .Select(d => d.Message)
+            .Should().Emit();
+        resp.Success.Should().BeTrue(resp.Error ?? "");
+
+        var after = await ReadStable(storage, path, n => n.Name == "After");
+        after.Name.Should().Be("After");
+        after.LastModified.Should().BeAfter(before.LastModified,
+            "a real change takes the write path and re-stamps");
+    }
+
+    // Reads until the persisted node satisfies the predicate AND its Version is unchanged across
+    // 4 consecutive samples (~1.2s quiet — past the 200ms persist debounce), so enrichment/debounce
+    // trails can't masquerade as churn.
+    private async Task<MeshNode> ReadStable(
+        IStorageAdapter storage, string path, Func<MeshNode, bool>? predicate = null)
+    {
+        MeshNode? last = null;
+        var stable = 0;
+        for (var i = 0; i < 100 && stable < 4; i++)
+        {
+            var current = await storage.Read(path, Mesh.JsonSerializerOptions).FirstAsync().ToTask();
+            stable = current is not null && last is not null
+                     && current.Version == last.Version
+                     && (predicate is null || predicate(current))
+                ? stable + 1
+                : 0;
+            last = current ?? last;
+            await Task.Delay(300);
+        }
+        last.Should().NotBeNull($"node {path} must be persisted");
+        return last!;
     }
 }


### PR DESCRIPTION
## Why

Every upsert reaching the owner re-stamps `LastModified` + mints a fresh `Version` unconditionally (`UpdateAccordingToSourceNode`), even when nothing changed. So a full re-sync of unchanged content — a GitSync re-import whose `_Activity` import-manifest was lost, a plugin re-install without a manifest — re-broadcasts **every** node to every subscriber (the deploy screen-flicker), appends a version-history row per node, and can flip a NodeType's `IsDirty` into a pointless recompile + hub recycle. This is the owner-side defense-in-depth companion to #629 (which skips upstream via CI manifests).

## What

`HandleCreateOrUpdateNodeRequest` gains a no-op guard: when applying the source node would change nothing but the churn stamps (field-for-field mirror of `UpdateAccordingToSourceNode`, same null-keeps-state convention; content compared structurally through the hub serializer so typed content bridges against the persisted `JsonElement`), the handler acknowledges with the persisted state **without dispatching the stream write** — no Version mint, no history row, no re-broadcast, no `IsDirty` flip.

**Security**: the skip is taken only when the caller provably holds `Update` or `Sync` on the path (`GetEffectivePermissions` probe) — success-without-write must not become a permission bypass or a content-confirmation oracle. Anyone else (and any probe failure/timeout) falls through to the owner path, which allows/refuses exactly as before. Conservative by construction: mixed or unserializable content, any doubt → today's write path. The guard can only under-skip, never over-skip.

## Tests

- New: identical upsert → success, the activity log names the skip, and the persisted `Version`/`LastModified` are byte-identical across a >1.2s quiet window (past the 200ms persist debounce — a stray write would land inside it).
- New: one changed field (same content) → still writes and re-stamps.
- Full `MeshWeaver.Hosting.Monolith.Test` suite: **390 passed, 0 failed** locally with the guard in place.

Independent of #629; revertable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzRRVuSy3rcsWfnPtDqftG