### PR TITLE
ValidateToken: resilient cross-pod read (fix fresh-token 401s on MCP reconnect)

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenAuthenticationHandler.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenAuthenticationHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Security.Claims;
@@ -37,9 +38,21 @@ public class ApiTokenAuthenticationHandler(
         var tokenService = serviceProvider.GetRequiredService<ApiTokenService>();
         // HTTP boundary — bridge IObservable to Task once. The service exposes
         // IObservable<ApiToken?> per the "no async in hub-reachable code" rule.
+        var validationStopwatch = Stopwatch.StartNew();
         var apiToken = await tokenService.ValidateToken(rawToken).FirstAsync().ToTask();
         if (apiToken == null)
+        {
+            // 🚨 Never a silent 401: every rejected Bearer token gets a Warning naming
+            // the hash prefix (never the raw token) and how long validation took —
+            // ApiTokenService has already logged the exact failing stage
+            // (index/token read-timeout, hash mismatch, revoked, expired) under the
+            // same prefix. The silent Fail is what made the 2026-07-24 fresh-token
+            // 401 storm untraceable server-side.
+            Logger.LogWarning(
+                "API token authentication failed for hash prefix {HashPrefix} after {ElapsedMs} ms — see the ApiTokenService warning with the same prefix for the failing stage",
+                ApiTokenService.HashToken(rawToken)[..12], validationStopwatch.ElapsedMilliseconds);
             return AuthenticateResult.Fail("Invalid or expired API token");
+        }
 
         var claims = BuildClaims(apiToken).ToList();
 

--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
@@ -26,8 +27,9 @@ namespace Memex.Portal.Shared.Authentication;
 /// 🚨 No async / Task / FromAsync / await anywhere in this file. Every
 /// reachable method returns <see cref="IObservable{T}"/> and the chain
 /// stays observable end-to-end. Reads of known paths go through
-/// <c>hub.GetMeshNode(path)</c> (one-shot) or
-/// <c>workspace.GetMeshNodeStream(path)</c> (live); listings go through
+/// <c>hub.GetMeshNode(path)</c> (one-shot, issuance-side) or the bounded
+/// resilient <c>workspace.GetMeshNodeStream(path)</c> poll
+/// (validation-side, <see cref="ReadValidationNode"/>); listings go through
 /// <c>workspace.GetQuery(id, queries...)</c> (synced + path-keyed dedup).
 /// QueryAsync / <see cref="IAsyncEnumerable{T}"/> iteration is forbidden
 /// in this file per <c>Doc/Architecture/AsynchronousCalls.md</c> and
@@ -55,6 +57,28 @@ internal class ApiTokenService(IMeshService nodeFactory, IMessageHub hub, ILogge
     private readonly ConcurrentDictionary<string, DateTimeOffset> lastStampDispatchedAt = new();
 
     private int stampDispatchCount;
+
+    /// <summary>
+    /// Upper bound on each of the two validation-side node reads (index at
+    /// <c>ApiToken/{hashPrefix}</c>, then the user-scoped token node). The read is the
+    /// resilient <c>GetMeshNodeStream</c> poll (same shape as
+    /// <c>OAuthCodeStore.ReadCodeNode</c>), so a WARM token resolves on the first
+    /// attempt with no added latency — only a genuine miss (unknown token, or a fresh
+    /// token still inside the create→routable window on THIS replica) keeps polling
+    /// and burns the window. 8 s default: ample margin over the observed cross-replica
+    /// create→routable lag on memex-cloud (a fresh token 401ed for ~2 min under the
+    /// old one-shot read; the poll rides the lag out instead). Init-only so tests can
+    /// shorten it — never a static bound to "tune away" a failure.
+    /// </summary>
+    public TimeSpan ValidationReadTimeout { get; init; } = TimeSpan.FromSeconds(8);
+
+    /// <summary>
+    /// Pause between validation read attempts — matches <c>OAuthCodeStore.ReadCodeNode</c>
+    /// and <see cref="ConfirmReadable"/> (self-paced Concat: the next attempt subscribes
+    /// only after the previous one completed, so exactly one owner-hub subscription is
+    /// live at a time).
+    /// </summary>
+    private static readonly TimeSpan ValidationRetryDelay = TimeSpan.FromMilliseconds(50);
 
     /// <summary>
     /// Number of LastUsedAt stamp writes this instance has DISPATCHED — the
@@ -181,6 +205,13 @@ internal class ApiTokenService(IMeshService nodeFactory, IMessageHub hub, ILogge
     /// identity, then <c>.Select</c>. Emits an empty array on missing
     /// assignment or read failure (the issued token still has identity
     /// but no role grants — correct outcome).
+    /// <para>ISSUANCE-ONLY — called exclusively from <see cref="CreateToken"/>,
+    /// never on the validation path (Bearer-request role enrichment goes
+    /// through <c>UserRoleResolver.LoadDbRolesAsync</c> → the synced query),
+    /// so the one-shot read's timeout cannot 401 anybody; a miss only means
+    /// the new token carries no captured roles. Do not "harden" it with the
+    /// validation-side resilient poll — issuance is a one-time login that
+    /// must not stall on a genuinely absent assignment.</para>
     /// </summary>
     private IObservable<IReadOnlyCollection<string>> ResolveSelfScopeRoles(string assignmentPath)
     {
@@ -218,14 +249,28 @@ internal class ApiTokenService(IMeshService nodeFactory, IMessageHub hub, ILogge
     }
 
     /// <summary>
-    /// Reactive token validation. Reads index node at
-    /// <c>ApiToken/{hashPrefix}</c> via <c>hub.GetMeshNode</c> (one-shot,
-    /// authoritative — never <c>QueryAsync</c> for a known path per
-    /// <c>Doc/Architecture/AsynchronousCalls.md</c>); when the index
-    /// points at a user-scoped token, follows the pointer with a second
-    /// one-shot read. The chain is fully observable — no
-    /// <c>FromAsync</c>, no <c>FirstOrDefaultAsync.AsTask()</c>, no
-    /// <c>await</c>.
+    /// Reactive token validation. Reads the index node at
+    /// <c>ApiToken/{hashPrefix}</c> — and, when it points at a user-scoped token,
+    /// the token node — through the bounded resilient
+    /// <c>GetMeshNodeStream</c> poll (<see cref="ReadValidationNode"/>, same shape
+    /// as <c>OAuthCodeStore.ReadCodeNode</c>), NOT a one-shot <c>hub.GetMeshNode</c>.
+    /// <para>
+    /// Why: on a multi-replica portal a freshly-minted token is not instantly
+    /// routable on the replicas that did NOT mint it. The old one-shot read hit
+    /// [ROUTE] NotFound for the full 5 s and then emitted null SILENTLY → every
+    /// /mcp reconnect on pods B/C returned 401 for ~2 minutes with zero server-side
+    /// trace (memex-cloud 2026-07-24, ingress logs: every rejected request took
+    /// exactly 5.000–5.007 s). The issuance-side warm-up (#624) only helps the
+    /// minting pod. The resilient read activates the owning per-node hub from
+    /// shared Postgres and rides out the lag; a warm token resolves on the first
+    /// attempt, so the hot path pays nothing.
+    /// </para>
+    /// <para>
+    /// Every failure is logged at Warning with the hash prefix (never the raw
+    /// token), the failing stage (index-read-timeout / index-hash-mismatch /
+    /// token-read-timeout / token-hash-mismatch / revoked / expired) and elapsed ms.
+    /// The chain is fully observable — no <c>FromAsync</c>, no <c>await</c>.
+    /// </para>
     /// </summary>
     public IObservable<ApiToken?> ValidateToken(string rawToken)
     {
@@ -236,38 +281,116 @@ internal class ApiTokenService(IMeshService nodeFactory, IMessageHub hub, ILogge
         var hashPrefix = hash[..12];
         var indexPath = $"{ApiTokenNamespace}/{hashPrefix}";
 
-        return ReadAsSystem(indexPath)
-            .SelectMany(indexNode =>
-            {
-                if (indexNode == null)
-                    return Observable.Return<(MeshNode? node, ApiToken? token)>((null, null));
-
-                var index = indexNode.Content as ApiTokenIndex ?? ExtractApiTokenIndex(indexNode);
-                if (index != null)
+        return Observable.Defer(() =>
+        {
+            var elapsed = Stopwatch.StartNew();
+            return ReadValidationNode(indexPath, node => IndexHashVerdict(node, hash), "index", hashPrefix, elapsed)
+                .SelectMany(indexNode =>
                 {
-                    if (!string.Equals(index.TokenHash, hash, StringComparison.OrdinalIgnoreCase))
+                    if (indexNode == null)
                         return Observable.Return<(MeshNode? node, ApiToken? token)>((null, null));
-                    return ReadAsSystem(index.TokenPath)
-                        .Select(tn => (
-                            node: tn,
-                            token: (tn?.Content as ApiToken) ?? ExtractApiToken(tn)));
-                }
-                // Legacy format: full ApiToken at index path.
-                return Observable.Return((
-                    node: (MeshNode?)indexNode,
-                    token: (indexNode.Content as ApiToken) ?? ExtractApiToken(indexNode)));
-            })
-            .Select(t => FinalizeToken(t.node, t.token, hash, hashPrefix));
+
+                    var index = indexNode.Content as ApiTokenIndex ?? ExtractApiTokenIndex(indexNode);
+                    if (index != null)
+                        return ReadValidationNode(
+                                index.TokenPath, node => TokenHashVerdict(node, hash), "token", hashPrefix, elapsed)
+                            .Select(tn => (
+                                node: tn,
+                                token: (tn?.Content as ApiToken) ?? ExtractApiToken(tn)));
+
+                    // Legacy format: full ApiToken at the index path (its hash already
+                    // matched in the verdict — a mismatch would have terminated above).
+                    return Observable.Return((
+                        node: (MeshNode?)indexNode,
+                        token: (indexNode.Content as ApiToken) ?? ExtractApiToken(indexNode)));
+                })
+                .Select(t => FinalizeToken(t.node, t.token, hash, hashPrefix, elapsed));
+        });
     }
 
-    private IObservable<MeshNode?> ReadAsSystem(string path)
+    /// <summary>
+    /// Verdict for one successfully-read candidate node during validation:
+    /// <c>true</c> = expected content present with the MATCHING hash (emit the node);
+    /// <c>false</c> = content present but a DIFFERENT hash — someone else's token
+    /// colliding on the 12-char prefix / tampering — a TERMINAL mismatch that must
+    /// fail fast, never spin the poll; <c>null</c> = content not (yet) extractable —
+    /// transient (mid-create, sync lag), keep polling until the timeout.
+    /// </summary>
+    private bool? IndexHashVerdict(MeshNode node, string hash)
     {
+        var index = node.Content as ApiTokenIndex ?? ExtractApiTokenIndex(node);
+        if (index != null)
+            return string.Equals(index.TokenHash, hash, StringComparison.OrdinalIgnoreCase);
+        var legacy = node.Content as ApiToken ?? ExtractApiToken(node);
+        if (legacy != null)
+            return string.Equals(legacy.TokenHash, hash, StringComparison.OrdinalIgnoreCase);
+        return null;
+    }
+
+    /// <inheritdoc cref="IndexHashVerdict"/>
+    private bool? TokenHashVerdict(MeshNode node, string hash)
+    {
+        var token = node.Content as ApiToken ?? ExtractApiToken(node);
+        if (token != null)
+            return string.Equals(token.TokenHash, hash, StringComparison.OrdinalIgnoreCase);
+        return null;
+    }
+
+    /// <summary>
+    /// Bounded resilient read for the validation path — the exact
+    /// <c>OAuthCodeStore.ReadCodeNode</c> shape (#620), with one correctness nuance:
+    /// a node that reads SUCCESSFULLY but carries a non-matching hash is a terminal
+    /// mismatch (emit null immediately, logged as <c>{stage}-hash-mismatch</c>) —
+    /// only read-error/absence re-polls. Each attempt reads through the authoritative
+    /// <c>GetMeshNodeStream(path)</c> (activates the owning per-node hub from
+    /// Postgres), swallows the transient "No node found", and — ONLY on no-verdict —
+    /// re-subscribes after <see cref="ValidationRetryDelay"/> via <c>Concat</c>
+    /// (never <c>Merge</c>: exactly one owner-hub subscription live at a time).
+    /// Bounded by <see cref="ValidationReadTimeout"/> → Warning
+    /// (<c>{stage}-read-timeout</c>) → null. System identity established at
+    /// subscribe time (<c>Observable.Using</c>): validation is the entry point that
+    /// turns a raw token into an identity, so the caller is by definition
+    /// unauthenticated; the hash compare is the actual authentication step.
+    /// </summary>
+    private IObservable<MeshNode?> ReadValidationNode(
+        string path, Func<MeshNode, bool?> hashVerdict, string stage, string hashPrefix, Stopwatch elapsed)
+    {
+        IObservable<MeshNode?> Attempt() =>
+            hub.GetWorkspace().GetMeshNodeStream(path)
+                .Take(1)
+                .SelectMany(node =>
+                {
+                    var verdict = node is null ? null : hashVerdict(node);
+                    if (verdict == true)
+                        return Observable.Return((MeshNode?)node);
+                    if (verdict == false)
+                        return Observable.Defer(() =>
+                        {
+                            logger.LogWarning(
+                                "API token validation failed at {Stage} for hash prefix {HashPrefix} after {ElapsedMs} ms: node at {Path} exists but carries a different token hash",
+                                stage + "-hash-mismatch", hashPrefix, elapsed.ElapsedMilliseconds, path);
+                            return Observable.Return((MeshNode?)null);
+                        });
+                    return Observable.Empty<MeshNode?>();
+                })
+                .Catch<MeshNode?, Exception>(_ => Observable.Empty<MeshNode?>())
+                .Concat(Observable.Defer(Attempt).DelaySubscription(ValidationRetryDelay));
+
+        var poll = Observable.Defer(Attempt)
+            .Take(1)
+            .Timeout(ValidationReadTimeout)
+            .Catch<MeshNode?, Exception>(ex =>
+            {
+                logger.LogWarning(ex,
+                    "API token validation failed at {Stage} for hash prefix {HashPrefix} after {ElapsedMs} ms: node at {Path} not readable within {Timeout}",
+                    stage + "-read-timeout", hashPrefix, elapsed.ElapsedMilliseconds, path, ValidationReadTimeout);
+                return Observable.Return<MeshNode?>(null);
+            });
+
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         return accessService != null
-            ? Observable.Using(
-                () => accessService.ImpersonateAsSystem(),
-                _ => hub.GetMeshNode(path, TimeSpan.FromSeconds(5)))
-            : hub.GetMeshNode(path, TimeSpan.FromSeconds(5));
+            ? Observable.Using(() => accessService.ImpersonateAsSystem(), _ => poll)
+            : poll;
     }
 
     /// <summary>
@@ -308,20 +431,34 @@ internal class ApiTokenService(IMeshService nodeFactory, IMessageHub hub, ILogge
             : poll;
     }
 
-    private ApiToken? FinalizeToken(MeshNode? tokenNode, ApiToken? apiToken, string hash, string hashPrefix)
+    private ApiToken? FinalizeToken(MeshNode? tokenNode, ApiToken? apiToken, string hash, string hashPrefix, Stopwatch elapsed)
     {
         if (apiToken == null)
-            return null;
+            return null; // read failure/mismatch — already logged by ReadValidationNode with its stage
         if (!string.Equals(apiToken.TokenHash, hash, StringComparison.OrdinalIgnoreCase))
+        {
+            // Defense in depth — the verdict in ReadValidationNode already terminates
+            // mismatches, so this branch should be unreachable; log it if it ever fires.
+            logger.LogWarning(
+                "API token validation failed at {Stage} for hash prefix {HashPrefix} after {ElapsedMs} ms",
+                "token-hash-mismatch", hashPrefix, elapsed.ElapsedMilliseconds);
             return null;
+        }
+        // Warning, not Debug: a rejected token surfaces as a bare 401 to the client —
+        // without a server-side line naming the stage, prod triage is blind (the
+        // 2026-07-24 fresh-token 401s cost hours because every failure was silent).
         if (apiToken.IsRevoked)
         {
-            logger.LogDebug("Token {HashPrefix} is revoked", hashPrefix);
+            logger.LogWarning(
+                "API token validation failed at {Stage} for hash prefix {HashPrefix} after {ElapsedMs} ms",
+                "revoked", hashPrefix, elapsed.ElapsedMilliseconds);
             return null;
         }
         if (apiToken.ExpiresAt.HasValue && apiToken.ExpiresAt.Value < DateTimeOffset.UtcNow)
         {
-            logger.LogDebug("Token {HashPrefix} has expired", hashPrefix);
+            logger.LogWarning(
+                "API token validation failed at {Stage} for hash prefix {HashPrefix} after {ElapsedMs} ms (expired {ExpiresAt})",
+                "expired", hashPrefix, elapsed.ElapsedMilliseconds, apiToken.ExpiresAt.Value);
             return null;
         }
 

--- a/test/MeshWeaver.Auth.Test/ApiTokenServiceStaleReadTest.cs
+++ b/test/MeshWeaver.Auth.Test/ApiTokenServiceStaleReadTest.cs
@@ -39,7 +39,14 @@ public class ApiTokenServiceStaleReadTest(ITestOutputHelper output) : MonolithMe
             Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
             Mesh,
             Mesh.ServiceProvider.GetRequiredService<ILogger<ApiTokenService>>()
-        );
+        )
+        {
+            // Short resilient-read window: the revoked/deleted-token checks below
+            // wait out ValidateToken's read timeout by design (the revoke deletes
+            // the global index entry). Prod default is 8 s — same pattern as
+            // OAuthCodeStoreTest.NewStore's ReadTimeout.
+            ValidationReadTimeout = TimeSpan.FromSeconds(2),
+        };
 
     /// <summary>
     /// SHOULD-FAIL-IF: <c>RevokeToken</c> resolves the token via

--- a/test/MeshWeaver.Auth.Test/ApiTokenServiceTests.cs
+++ b/test/MeshWeaver.Auth.Test/ApiTokenServiceTests.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Security.Cryptography;
 using Memex.Portal.Shared.Authentication;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -20,12 +23,20 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder);
 
-    private ApiTokenService GetService() =>
+    private ApiTokenService GetService(TimeSpan? validationReadTimeout = null, ILogger<ApiTokenService>? logger = null) =>
         new(
             Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
             Mesh,
-            Mesh.ServiceProvider.GetRequiredService<ILogger<ApiTokenService>>()
-        );
+            logger ?? Mesh.ServiceProvider.GetRequiredService<ILogger<ApiTokenService>>()
+        )
+        {
+            // Short read window so the negative-path tests (unknown / revoked-with-
+            // deleted-index / deleted token, which wait out the resilient read's
+            // timeout by design) stay fast on the single in-memory mesh; a valid
+            // token resolves on the first attempt regardless. Prod default is 8 s —
+            // same pattern as OAuthCodeStoreTest.NewStore's ReadTimeout.
+            ValidationReadTimeout = validationReadTimeout ?? TimeSpan.FromSeconds(2),
+        };
 
     [Fact]
     public async Task CreateToken_ReturnsTokenWithCorrectPrefix()
@@ -127,7 +138,8 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
     [Fact]
     public async Task ValidateToken_ExpiredToken_ReturnsNull()
     {
-        var service = GetService();
+        var logs = new CapturingLogger();
+        var service = GetService(logger: logs);
         var result = await service.CreateToken(
             "user1", "Test User", "test@example.com", "Expired",
             expiresAt: DateTimeOffset.UtcNow.AddDays(-1)).Should().Emit();
@@ -135,6 +147,135 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
         var validated = await service.ValidateToken(result.RawToken).Should().Emit();
 
         validated.Should().BeNull();
+        // No silent rejection: the failing stage must be named at Warning with the
+        // hash prefix (never the raw token) — the diagnosability gap behind the
+        // untraceable 401s of 2026-07-24.
+        var hashPrefix = ApiTokenService.HashToken(result.RawToken)[..12];
+        logs.Entries.Should().Contain(e =>
+                e.Level == LogLevel.Warning && e.Message.Contains("expired") && e.Message.Contains(hashPrefix),
+            "an expired-token rejection must log a Warning naming the stage and hash prefix");
+        logs.Entries.Should().NotContain(e => e.Message.Contains(result.RawToken),
+            "the raw token must never appear in any log line");
+    }
+
+    // ── Resilient validation read (the fresh-token multi-replica 401 fix) ──
+    //
+    // Prod bug being pinned (memex-cloud 2026-07-24, 3+ KEDA replicas): /token minted
+    // an mw_ token on pod A; the MCP client's immediate reconnect landed on pods B/C,
+    // where ValidateToken's one-shot 5 s GetMeshNode read hit the create→routable
+    // window, timed out, and emitted null SILENTLY → 401 for ~2 minutes (ingress:
+    // every rejected request took exactly 5.000–5.007 s). The fix mirrors
+    // OAuthCodeStore.ReadCodeNode (#620): a self-paced GetMeshNodeStream poll bounded
+    // by ValidationReadTimeout, with a hash MISMATCH on a successfully-read node as a
+    // terminal fail-fast (never a poll spin).
+
+    /// <summary>
+    /// SHOULD-FAIL-IF: the resilient read adds latency to the hot path — a warm
+    /// token must resolve on the FIRST poll attempt (well under 1 s), never touch
+    /// the retry window. The 2 s test window doubles as the discriminator: a
+    /// retried/timed-out read would blow both the wall-clock and the null check.
+    /// </summary>
+    [Fact]
+    public async Task ValidateToken_WarmToken_ResolvesOnFirstAttempt_NoAddedLatency()
+    {
+        var service = GetService();
+        var result = await service.CreateToken(
+            "user1", "Test User", "test@example.com", "Warm").Should().Emit();
+
+        // First validation absorbs any residual create→readable lag (issuance already
+        // confirmed both nodes readable, so this normally hits first-attempt too).
+        (await service.ValidateToken(result.RawToken).Should().Emit()).Should().NotBeNull();
+
+        var stopwatch = Stopwatch.StartNew();
+        var validated = await service.ValidateToken(result.RawToken).Should().Emit();
+        stopwatch.Stop();
+
+        validated.Should().NotBeNull();
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(1),
+            "a warm token must validate on the first read attempt — the resilient poll may add latency ONLY on a genuine miss");
+    }
+
+    /// <summary>
+    /// SHOULD-FAIL-IF: an unknown token is rejected INSTANTLY — that is exactly the
+    /// behavior that 401ed fresh tokens during the create→routable window on the
+    /// non-minting replicas. The resilient read must keep polling for the full
+    /// <see cref="ApiTokenService.ValidationReadTimeout"/> before concluding null,
+    /// and the timeout must be named at Warning with the hash prefix.
+    /// </summary>
+    [Fact]
+    public async Task ValidateToken_UnknownToken_FailsAtReadTimeout_NotInstantly()
+    {
+        var logs = new CapturingLogger();
+        var window = TimeSpan.FromSeconds(1);
+        var service = GetService(window, logs);
+        const string unknownToken = "mw_thistokenwasneverissued0123456789";
+
+        var stopwatch = Stopwatch.StartNew();
+        var validated = await service.ValidateToken(unknownToken).Should().Emit();
+        stopwatch.Stop();
+
+        validated.Should().BeNull();
+        stopwatch.Elapsed.Should().BeGreaterThanOrEqualTo(window - TimeSpan.FromMilliseconds(100),
+            "an unknown token must poll the full ValidationReadTimeout window — an instant no is indistinguishable from a fresh token that is not yet routable on this replica");
+
+        var hashPrefix = ApiTokenService.HashToken(unknownToken)[..12];
+        logs.Entries.Should().Contain(e =>
+                e.Level == LogLevel.Warning
+                && e.Message.Contains("index-read-timeout")
+                && e.Message.Contains(hashPrefix),
+            "the read timeout must be logged at Warning with the failing stage and hash prefix — never a silent null");
+        logs.Entries.Should().NotContain(e => e.Message.Contains(unknownToken),
+            "the raw token must never appear in any log line");
+    }
+
+    /// <summary>
+    /// SHOULD-FAIL-IF: a node that reads SUCCESSFULLY but carries a different full
+    /// hash (someone else's token colliding on the 12-char prefix, or tampering)
+    /// spins the poll to the timeout. A read that succeeded with non-matching
+    /// content is a TERMINAL mismatch — fail fast, log <c>index-hash-mismatch</c>.
+    /// </summary>
+    [Fact]
+    public async Task ValidateToken_ExistingIndexWithWrongHash_FailsFast_NotAtTimeout()
+    {
+        var logs = new CapturingLogger();
+        // Generous window so the timing assert genuinely discriminates fail-fast
+        // from wait-out-the-window.
+        var service = GetService(TimeSpan.FromSeconds(8), logs);
+
+        var rawToken = "mw_" + Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
+            .Replace("+", "-").Replace("/", "_").TrimEnd('=');
+        var hashPrefix = ApiTokenService.HashToken(rawToken)[..12];
+
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var indexNode = new MeshNode(hashPrefix, "ApiToken")
+        {
+            NodeType = "ApiToken",
+            State = MeshNodeState.Active,
+            Content = new ApiTokenIndex
+            {
+                TokenHash = new string('0', 64), // NOT rawToken's hash — colliding entry
+                TokenPath = $"user1/ApiToken/{hashPrefix}",
+            },
+        };
+        await meshService.CreateNode(indexNode).Should().Emit();
+        // Ensure the node is readable BEFORE measuring, so the wall-clock below
+        // captures the mismatch verdict, not create→readable lag.
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => ReadNode(indexNode.Path))
+            .Should().Match(n => n is not null);
+
+        var stopwatch = Stopwatch.StartNew();
+        var validated = await service.ValidateToken(rawToken).Should().Emit();
+        stopwatch.Stop();
+
+        validated.Should().BeNull("a hash mismatch must reject");
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(4),
+            "a successfully-read node with a non-matching hash is a terminal mismatch — it must NOT spin the poll to the 8 s timeout");
+        logs.Entries.Should().Contain(e =>
+                e.Level == LogLevel.Warning
+                && e.Message.Contains("index-hash-mismatch")
+                && e.Message.Contains(hashPrefix),
+            "the terminal mismatch must be logged at Warning with the failing stage and hash prefix");
     }
 
     [Fact]
@@ -500,11 +641,11 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
     /// <c>.Should().Match(...)</c>, which blocks (≤ the assertion timeout) for the first
     /// snapshot satisfying the predicate. No polling, no <c>Task.Delay</c>.
     /// <para>
-    /// Required for ApiToken paths because those nodes are <c>IsSatelliteType</c> and have no
-    /// per-node hub — the test base's <c>ReadNodeAsync</c> (and <c>GetMeshNodeStream(path)</c>)
-    /// would hang for 30s waiting for a route. The mesh-level <c>Query</c> reads the
-    /// authoritative persistence state through the same pipeline production <c>ApiTokenService</c>
-    /// uses for its own reads, with live change-notifier deltas instead of a polling loop.
+    /// Used for ApiToken paths as a route-independent read: the mesh-level <c>Query</c> reads
+    /// the authoritative persistence state with live change-notifier deltas instead of a
+    /// polling loop. (ApiToken nodes are regular content nodes — <c>IsSatelliteType = false</c>
+    /// per <c>ApiTokenNodeType.CreateMeshNode</c> — so <c>GetMeshNodeStream(path)</c> also works;
+    /// production <c>ValidateToken</c> reads through it since the resilient-read fix.)
     /// </para>
     /// </summary>
     private IObservable<MeshNode?> ObserveNode(string path)
@@ -521,5 +662,25 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
                 QueryChangeType.Removed => null,
                 _ => current,
             });
+    }
+
+    private sealed record LogEntry(LogLevel Level, string Message);
+
+    /// <summary>
+    /// Minimal in-memory <see cref="ILogger{T}"/> capture so the tests can assert the
+    /// no-silent-401 contract (every validation failure logs a Warning naming the
+    /// failing stage + hash prefix, never the raw token). Instance state on the test —
+    /// dies with it; not a mock of any core mesh interface.
+    /// </summary>
+    private sealed class CapturingLogger : ILogger<ApiTokenService>
+    {
+        public ConcurrentQueue<LogEntry> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+            => Entries.Enqueue(new LogEntry(logLevel, formatter(state, exception)));
     }
 }


### PR DESCRIPTION
## Problem (pinned with ingress evidence)
Fresh mw_ tokens 401 for ~2 minutes on every pod except the minting one. Every rejected `POST /mcp` took EXACTLY 5.000–5.007s (ingress request-time): `ValidateToken`'s one-shot `hub.GetMeshNode(ApiToken/{hash}, 5s)` times out on non-minting pods (the just-created node's hub isn't warm there), silently emits null → 401 with zero server-side trace. #624's issuance ConfirmReadable warms only the minting pod. Same defect class #620 fixed for the OAuth code read; validation still had the one-shot.

## Fix
- Both validation reads (global index, then token node) now use the sanctioned resilient read (`ReadValidationNode`, mirroring `OAuthCodeStore.ReadCodeNode`): self-paced 50ms Concat poll over `GetMeshNodeStream(path)`, one owner-hub subscription at a time, bounded by init-only `ValidationReadTimeout` (default 8s). Warm tokens resolve on the FIRST attempt (no added latency); only genuine misses burn the window.
- Correctness nuance: a successfully-read node with a NON-matching hash is a terminal fast fail (tri-state verdict) — no poll spin on hash mismatch; only absence/read-error retries.
- Silent-401 killed: every failure stage logs Warning with hashPrefix + elapsed (`index-read-timeout`/`index-hash-mismatch`/`token-read-timeout`/`token-hash-mismatch`/`revoked`/`expired`); the auth handler logs Warning on Fail. Raw token never logged.
- `ResolveSelfScopeRoles` one-shot verified issuance-only (documented); validation-path role enrichment is the synced query — untouched.

## Verification
- 4 new pinning tests with discriminating timings (warm <1s first-attempt; unknown polls full window; wrong-hash fails in 0.16s vs 8s window with the Warning asserted; expired logs prefix, never raw token).
- MeshWeaver.Auth.Test ApiToken+OAuthConnectController: 79/79. Memex.Portal.Shared.Test OAuthCodeStore: 11/11. Full-solution CI-exact build: 0 warnings 0 errors.
- Post-deploy: live cross-pod probe (mint token, validate against every pod) before declaring fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)