### PR TITLE
fix(sync+comments): saved comment text renders without a refresh

### DIFF
--- a/src/MeshWeaver.Data/StandardReducers.cs
+++ b/src/MeshWeaver.Data/StandardReducers.cs
@@ -84,10 +84,26 @@ public static class StandardReducers
                         && (id.Equals(u.Id) || id.ToString() == u.Id?.ToString())).ToArray());
     }
 
+    // 🚨 Version stamp on subscriber-side patches: CARRY the base version the patch was computed
+    // on (stream.Current — the owner's clock as of the last applied frame), NEVER stream.Hub.Version.
+    // These patch functions run on SUBSCRIBER-side projections (a client's layout-area JsonElement
+    // stream, a reduced InstanceCollection), whose hub clock is a DIFFERENT counter than the
+    // owner's — and every monotonicity guard compares owner-clock versions
+    // (ISynchronizationStream.Current docs: "OWNER-ONLY Version … a non-owner stamping its own
+    // Version breaks ordering"). Stamping the local hub clock broke BOTH directions, depending on
+    // which clock happened to be ahead:
+    //   • busy client (Blazor circuit, clock ≫ owner): a local optimistic edit jumped the mirror's
+    //     Version sky-high, so every subsequent owner broadcast was dropped as "stale" — the page
+    //     froze on pre-save state until a refresh re-subscribed (the "comment only appears after
+    //     refreshing" bug on the UWDeepfield treaty tabs).
+    //   • quiet client (clock < owner): the outgoing PatchDataChangeRequest carried a version below
+    //     the owner mirror's Current and the USER'S EDIT was silently dropped on the owner.
+    // (UpdateStream re-stamps INCOMING patches with delivery.Message.Version before SetCurrent, so
+    // applying received frames is unaffected — this stamp matters for locally-originated updates.)
     private static ChangeItem<JsonElement> PatchJsonElement(ISynchronizationStream<JsonElement> stream, JsonElement current, JsonElement updated, JsonPatch? patch, string changedBy)
     {
         var typeRegistry = stream.Hub.TypeRegistry;
-        return new(updated, changedBy, stream.StreamId, ChangeType.Patch, stream.Hub.Version, current.ToEntityUpdates(updated, patch!, stream.Hub.JsonSerializerOptions, typeRegistry));
+        return new(updated, changedBy, stream.StreamId, ChangeType.Patch, stream.Current?.Version ?? stream.Hub.Version, current.ToEntityUpdates(updated, patch!, stream.Hub.JsonSerializerOptions, typeRegistry));
     }
     private static ChangeItem<InstanceCollection> PatchInstanceCollectionJsonElement(ISynchronizationStream<InstanceCollection> stream, InstanceCollection current, JsonElement updated, JsonPatch? patch, string changedBy)
     {
@@ -97,7 +113,7 @@ public static class StandardReducers
             changedBy,
             stream.StreamId,
             ChangeType.Patch,
-            stream.Hub.Version,
+            stream.Current?.Version ?? stream.Hub.Version,
             current.ToEntityUpdates((CollectionReference)stream.Reference, updated, patch!, stream.Hub.JsonSerializerOptions));
     }
 

--- a/src/MeshWeaver.Graph/CommentLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/CommentLayoutAreas.cs
@@ -21,6 +21,44 @@ namespace MeshWeaver.Graph;
 /// </summary>
 public static class CommentLayoutAreas
 {
+    /// <summary>
+    /// Per-layout-area-session view state for the comment Overview. Two jobs:
+    /// <list type="bullet">
+    ///   <item><b>Once-per-session seeds</b> (<see cref="EditSeeded"/> &amp; friends) — a re-render of
+    ///     the Overview (the node stream and the permission stream both emit repeatedly by design)
+    ///     must not reset the user's edit/expand state or stomp the text they are typing.</item>
+    ///   <item><b>Current-value shadows</b> (<see cref="Editing"/>, <see cref="Text"/>, …) — every
+    ///     sub-view stream re-subscribed on a re-render starts with <c>.StartWith(shadow)</c>, because
+    ///     the transient <c>/data</c> seed does NOT reliably replay to a second subscription (see the
+    ///     same defense in <c>EditorExtensions.BuildToggleableProperty</c>). Without the shadow the
+    ///     re-rendered sub-view never emits and the PREVIOUSLY rendered content sticks — the
+    ///     "comment only appears after a page refresh" bug.</item>
+    /// </list>
+    /// Instance state on the host's render pipeline — never static (NoStaticState.md).
+    /// </summary>
+    internal sealed class OverviewSession
+    {
+        public bool EditSeeded;
+        public bool RepliesSeeded;
+        public bool ReplyFormSeeded;
+
+        /// <summary>Shadow of the editState_* data item — is the editor open right now?</summary>
+        public bool Editing;
+        /// <summary>Shadow of the commentText_* buffer — the text currently displayed/edited.</summary>
+        public string Text = "";
+        /// <summary>The node text the buffer was last seeded from — external-change detection.</summary>
+        public string NodeText = "";
+
+        /// <summary>Shadow of the replyPath_* data item — the open reply draft, "" when none.</summary>
+        public string ReplyPath = "";
+        /// <summary>The reply path whose draft buffer was already seeded — seed each draft ONCE.</summary>
+        public string? SeededReplyPath;
+
+        public LayoutAreaControl[] RepliesControls = Array.Empty<LayoutAreaControl>();
+        public bool RepliesExpanded;
+        public int RepliesVisible = InitialReplyCount;
+    }
+
     /// <summary>Area name for the Overview layout area.</summary>
     public const string OverviewArea = "Overview";
     /// <summary>Area name for the Edit layout area.</summary>
@@ -71,7 +109,7 @@ public static class CommentLayoutAreas
         var currentUser = accessService?.Context?.Name ?? "";
 
         var editStateId = $"editState_comment_{hubPath.Replace("/", "_")}";
-        var initialized = new[] { false, false, false }; // [0]=editState, [1]=repliesExpanded, [2]=replyForm
+        var session = new OverviewSession();
 
         var parentPath = hubPath.Contains('/') ? hubPath[..hubPath.LastIndexOf('/')] : hubPath;
         var permissionsStream = host.Hub.GetEffectivePermissions(parentPath);
@@ -95,6 +133,7 @@ public static class CommentLayoutAreas
                     .OrderBy(n => n.ContentAs<Comment>(host.Hub.JsonSerializerOptions)!.CreatedAt)
                     .Select(n => Controls.LayoutArea(n.Path, OverviewArea))
                     .ToArray();
+                session.RepliesControls = replyControls;
                 host.UpdateData(repliesDataId, replyControls);
             });
 
@@ -103,7 +142,7 @@ public static class CommentLayoutAreas
             {
                 var canComment = perms.HasFlag(Permission.Comment) || perms.HasFlag(Permission.Update);
                 var canDelete = perms.HasFlag(Permission.Delete);
-                return (UiControl?)BuildOverview(host, node, hubPath, editStateId, initialized,
+                return (UiControl?)BuildOverview(host, node, hubPath, editStateId, session,
                     currentUser, canComment, canDelete, repliesDataId);
             });
     }
@@ -130,7 +169,7 @@ public static class CommentLayoutAreas
     }
 
     internal static UiControl BuildOverview(LayoutAreaHost host, MeshNode? node, string hubPath,
-        string editStateId, bool[] initialized, string currentUser,
+        string editStateId, OverviewSession session, string currentUser,
         bool canComment = true, bool canDelete = true, string? repliesDataId = null)
     {
         // ContentAs (deserialize), not `as Comment`: this view is data-bound via CombineLatest on
@@ -192,23 +231,67 @@ public static class CommentLayoutAreas
 
         container = container.WithView(headerRow);
 
-        // Toggleable content: click to edit (author only), Done to return
+        // Toggleable content: click to edit (author only), Done to return.
+        var textDataId = $"commentText_{hubPath.Replace("/", "_")}";
+        // The displayed/edited text lives in ONE session buffer (the commentText_* data item):
+        // the editor binds to it, the Done click persists FROM it, and the read-only view renders
+        // FROM it. That makes the text the user just saved appear IMMEDIATELY on Done — the old
+        // code rendered the comment.Text captured at the LAST node emission, so the fresh text
+        // only showed up once the node stream re-emitted AND the /data replay reached the
+        // re-rendered sub-view; under production timing neither is guaranteed, and the comment
+        // only appeared after a full page refresh (add AND edit — the UWDeepfield report).
         if (canEdit)
         {
             container = container.WithView((h, _) =>
             {
-                // Initialize edit state once — a fresh (empty) comment opens straight in the editor.
-                if (!initialized[0])
+                if (!session.EditSeeded)
                 {
-                    h.UpdateData(editStateId, OpensInEdit(comment.Text));
-                    initialized[0] = true;
+                    // Seed once — a fresh (empty) comment opens straight in the editor.
+                    session.Editing = OpensInEdit(comment.Text);
+                    session.Text = comment.Text ?? "";
+                    session.NodeText = comment.Text ?? "";
+                    h.UpdateData(textDataId, new Dictionary<string, object?> { ["text"] = session.Text });
+                    h.UpdateData(editStateId, session.Editing);
+                    session.EditSeeded = true;
+                }
+                else if (!session.Editing && (comment.Text ?? "") != session.NodeText)
+                {
+                    // The node's text changed under us (another user / another surface) while we
+                    // are NOT editing → refresh the buffer. NEVER while editing — a re-render
+                    // mid-edit must not stomp what the user is typing (the old per-render re-seed
+                    // in BuildCommentEditor did exactly that).
+                    session.NodeText = comment.Text ?? "";
+                    session.Text = session.NodeText;
+                    h.UpdateData(textDataId, new Dictionary<string, object?> { ["text"] = session.Text });
                 }
 
+                // StartWith(shadow): a re-subscribed sub-view gets no reliable /data replay — it
+                // must default to the session's current state and then react (same defense as
+                // EditorExtensions.BuildToggleableProperty), or the re-rendered area never emits
+                // and the previously rendered (stale) content sticks until a refresh.
                 return h.Stream.GetDataStream<bool>(editStateId)
+                    .StartWith(session.Editing)
                     .DistinctUntilChanged()
-                    .Select(isEditing => isEditing
-                        ? BuildCommentEditor(h, hubPath, comment.Text, editStateId)
-                        : BuildCommentReadOnly(comment.Text));
+                    .Select(isEditing =>
+                    {
+                        session.Editing = isEditing;
+                        return isEditing
+                            // While editing the view is static — keystrokes flow into the buffer
+                            // without re-rendering the editor control.
+                            ? Observable.Return(BuildCommentEditor(h, hubPath, editStateId, textDataId, session))
+                            // Read-only renders LIVE from the buffer, so the text saved by Done
+                            // (already in the buffer) shows without any node-stream round-trip.
+                            : h.Stream.GetDataStream<Dictionary<string, object?>>(textDataId)
+                                .Select(d => d?.GetValueOrDefault("text")?.ToString() ?? "")
+                                .StartWith(session.Text)
+                                .DistinctUntilChanged()
+                                .Select(text =>
+                                {
+                                    session.Text = text;
+                                    return BuildCommentReadOnly(text);
+                                });
+                    })
+                    .Switch();
             });
         }
         else
@@ -232,17 +315,24 @@ public static class CommentLayoutAreas
             var replyPathStateId = $"replyPath_{hubPath.Replace("/", "_")}";
             container = container.WithView((h, _) =>
             {
-                if (!initialized[2])
+                if (!session.ReplyFormSeeded)
                 {
                     h.UpdateData(replyPathStateId, "");
-                    initialized[2] = true;
+                    session.ReplyFormSeeded = true;
                 }
 
+                // StartWith(shadow) — same no-replay defense as the edit toggle above, so an open
+                // reply draft survives a re-render instead of the area sticking on stale content.
                 return h.Stream.GetDataStream<string>(replyPathStateId)
+                    .StartWith(session.ReplyPath)
                     .DistinctUntilChanged()
-                    .Select(replyPath => string.IsNullOrEmpty(replyPath)
-                        ? (UiControl?)null
-                        : BuildReplyCreateForm(h, replyPath, replyPathStateId, comment, currentUser));
+                    .Select(replyPath =>
+                    {
+                        session.ReplyPath = replyPath;
+                        return string.IsNullOrEmpty(replyPath)
+                            ? (UiControl?)null
+                            : BuildReplyCreateForm(h, replyPath, replyPathStateId, comment, currentUser, session);
+                    });
             });
         }
 
@@ -258,19 +348,28 @@ public static class CommentLayoutAreas
 
             container = container.WithView((h, _) =>
             {
-                if (!initialized[1])
+                if (!session.RepliesSeeded)
                 {
                     h.UpdateData(expandedStateId, false);
                     h.UpdateData(visibleCountStateId, InitialReplyCount);
-                    initialized[1] = true;
+                    session.RepliesSeeded = true;
                 }
 
+                // StartWith(shadow) on all three inputs — CombineLatest only fires once EVERY
+                // source has emitted, so a single missing /data replay after a re-render would
+                // freeze the whole replies section on its previous render.
                 return h.Stream.GetDataStream<LayoutAreaControl[]>(repliesDataId)
+                    .StartWith(session.RepliesControls)
+                    .DistinctUntilChanged()
                     .CombineLatest(
-                        h.Stream.GetDataStream<bool>(expandedStateId),
-                        h.Stream.GetDataStream<int>(visibleCountStateId),
+                        h.Stream.GetDataStream<bool>(expandedStateId)
+                            .StartWith(session.RepliesExpanded).DistinctUntilChanged(),
+                        h.Stream.GetDataStream<int>(visibleCountStateId)
+                            .StartWith(session.RepliesVisible).DistinctUntilChanged(),
                         (replyControls, expanded, visibleCount) =>
                         {
+                            session.RepliesExpanded = expanded;
+                            session.RepliesVisible = visibleCount;
                             var totalCount = replyControls?.Length ?? 0;
                             if (totalCount == 0)
                                 return (UiControl)Controls.Stack;
@@ -341,13 +440,17 @@ public static class CommentLayoutAreas
         return view;
     }
 
-    private static UiControl BuildCommentEditor(LayoutAreaHost host, string hubPath, string text, string editStateId)
+    private static UiControl BuildCommentEditor(LayoutAreaHost host, string hubPath, string editStateId,
+        string textDataId, OverviewSession session)
     {
         var stack = Controls.Stack.WithWidth("100%");
-        var textDataId = $"commentText_{hubPath.Replace("/", "_")}";
 
-        // Initialize text data area with current comment text
-        host.UpdateData(textDataId, new Dictionary<string, object?> { ["text"] = text ?? "" });
+        // 🚨 NO buffer seeding here. The session buffer (textDataId) is seeded ONCE by the edit
+        // toggle in BuildOverview and refreshed only on an external node-text change while NOT
+        // editing. This method runs on every re-render of the Overview while the editor is open
+        // (the node and permission streams emit repeatedly by design) — the unconditional re-seed
+        // that used to live here overwrote the text the user was typing with the stale captured
+        // node text on every such re-render.
 
         // Editor bound to data area — no WithAutoSave() to avoid overwriting
         // the Comment node with a Markdown node (which saves as .md instead of .json)
@@ -388,8 +491,25 @@ public static class CommentLayoutAreas
                                 existing ??= new Comment();
                                 return n with { Content = existing with { Text = newText } };
                             }, host.Hub.JsonSerializerOptions).Subscribe(
-                                _ => ctx.Host.UpdateData(editStateId, false),
-                                _ => ctx.Host.UpdateData(editStateId, false));
+                                _ =>
+                                {
+                                    // Update the session shadows BEFORE flipping to read-only: the
+                                    // read-only view starts from session.Text, so the text the user
+                                    // just saved renders immediately — no dependency on the node
+                                    // stream echoing the write back in time (it does not under
+                                    // production timing; that was the "only after refresh" bug).
+                                    session.Text = newText;
+                                    session.NodeText = newText;
+                                    ctx.Host.UpdateData(editStateId, false);
+                                },
+                                ex =>
+                                {
+                                    // Keep the editor OPEN on a failed save — flipping to read-only
+                                    // would silently discard the user's text. Same contract as the
+                                    // reply create-form.
+                                    host.Hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>()
+                                        ?.LogWarning(ex, "Failed to save comment at {Path}", ownPath);
+                                });
                         });
                     return Task.CompletedTask;
                 })));
@@ -403,14 +523,20 @@ public static class CommentLayoutAreas
     /// Create writes the reply Active with its text in a single <c>CreateNode</c>.
     /// </summary>
     private static UiControl BuildReplyCreateForm(LayoutAreaHost host, string replyPath, string replyPathStateId,
-        Comment comment, string currentUser)
+        Comment comment, string currentUser, OverviewSession session)
     {
         var nodeFactory = host.Hub.ServiceProvider.GetRequiredService<IMeshService>();
         var replyTextDataId = $"replyText_{replyPath.Replace("/", "_")}";
         var replyErrorDataId = $"replyError_{replyPath.Replace("/", "_")}";
 
-        host.UpdateData(replyTextDataId, new Dictionary<string, object?> { ["text"] = "" });
-        host.UpdateData(replyErrorDataId, "");
+        // Seed each reply draft ONCE. This form is rebuilt on every Overview re-render while the
+        // draft is open — an unconditional re-seed would wipe the reply the user is typing.
+        if (!string.Equals(session.SeededReplyPath, replyPath, StringComparison.Ordinal))
+        {
+            session.SeededReplyPath = replyPath;
+            host.UpdateData(replyTextDataId, new Dictionary<string, object?> { ["text"] = "" });
+            host.UpdateData(replyErrorDataId, "");
+        }
 
         var stack = Controls.Stack
             .WithStyle("margin-top: 4px; padding: 4px; padding-left: 6px; border-left: 2px solid var(--accent-fill-rest);");

--- a/test/MeshWeaver.Content.Test/CommentDoneReactivityTest.cs
+++ b/test/MeshWeaver.Content.Test/CommentDoneReactivityTest.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Documentation;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.ShortGuid;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Content.Test;
+
+/// <summary>
+/// Deterministic repro for the "comment only appears after a page refresh" bug (UWDeepfield treaty
+/// tabs, but the defect is the generic comment Overview): pressing <b>Done</b> in the comment editor
+/// persists the text, yet the read-only view keeps rendering the text CAPTURED when the Overview was
+/// last built — the freshly typed text only shows up after re-subscribing (a browser refresh).
+///
+/// <para>The flow is the EXACT client flow: render the comment's Overview area over a remote
+/// layout-area stream, click ✎ (for the edit case; a fresh empty comment opens straight in the
+/// editor), write the text through <see cref="LayoutClientExtensions.UpdatePointer"/> — the same
+/// call the Blazor markdown editor makes — then click Done and require the read-only
+/// <see cref="MarkdownControl"/> to show the NEW text on the SAME stream, no re-subscribe.</para>
+/// </summary>
+[Collection("SamplesGraphData")]
+public class CommentDoneReactivityTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    protected override bool ShareMeshAcrossTests => true;
+
+    private const string DocPath = "Doc/DataMesh/CollaborativeEditing";
+
+    private static readonly string SharedCacheDirectory = Path.Combine(
+        Path.GetTempPath(), "MeshWeaverCommentDoneReactivityTests", ".mesh-cache");
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var graphPath = TestPaths.SamplesGraph;
+        var dataDirectory = TestPaths.SamplesGraphData;
+        Directory.CreateDirectory(SharedCacheDirectory);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Graph:Storage:SourceType"] = "FileSystem",
+                ["Graph:Storage:BasePath"] = graphPath
+            })
+            .Build();
+
+        return builder
+            .UseMonolithMesh()
+            .AddPartitionedFileSystemPersistence(dataDirectory)
+            .AddMeshWeaverDocs()
+            .AddDoc()
+            .AddDocumentation()
+            .ConfigureServices(services =>
+            {
+                services.Configure<CompilationCacheOptions>(o =>
+                {
+                    o.CacheDirectory = SharedCacheDirectory;
+                    o.EnableDiskCache = true;
+                });
+                services.AddSingleton<IConfiguration>(configuration);
+                return services;
+            })
+            .AddGraph()
+            .ConfigureDefaultNodeHub(config => config.AddDefaultLayoutAreas());
+    }
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    /// <summary>
+    /// EDIT flow: ✎ → editor → type → Done. The read-only view on the SAME stream must render the
+    /// edited text — the user must not need a refresh to see their own edit.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task EditingComment_DoneShowsEditedText_WithoutRefresh()
+    {
+        var (stream, commentAddress, commentPath, reference) =
+            await RenderCommentOverview("Original comment");
+
+        var editArea = await FindArea(stream, reference.Area!,
+            c => c is HtmlControl h && (h.Data?.ToString() ?? "").Contains("✎"));
+        editArea.Should().NotBeNull("the comment Overview must render a ✎ Edit button for the author");
+        stream.Hub.Post(new ClickedEvent(editArea!, stream.StreamId), o => o.WithTarget(commentAddress));
+
+        await WaitForStoreToContain(stream, "Write your comment",
+            "clicking ✎ Edit must open the comment editor");
+        Output.WriteLine("Editor open — typing new text…");
+
+        await TypeCommentText(stream, commentPath, "Edited comment text");
+        await ClickDone(stream, commentAddress, reference);
+        await WaitForPersistedText(commentPath, "Edited comment text");
+
+        await WaitForReadOnlyMarkdown(stream, reference, "Edited comment text",
+            "after Done the read-only view must show the text just saved — not the stale text captured at the last node emission (the 'only after refresh' bug)");
+        Output.WriteLine("✅ Edited text rendered read-only without a refresh.");
+    }
+
+    /// <summary>
+    /// ADD flow (the treaty-tab "+ Comment" path): a fresh EMPTY comment opens straight in the
+    /// editor; after typing and Done the comment text must render — pre-fix the view falls back to
+    /// the "No comment text" placeholder because it renders the empty text captured at creation.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task NewComment_DoneShowsTypedText_WithoutRefresh()
+    {
+        var (stream, commentAddress, commentPath, reference) =
+            await RenderCommentOverview("");
+
+        // A fresh (empty) comment opens straight in the editor — no ✎ click needed.
+        await WaitForStoreToContain(stream, "Write your comment",
+            "a fresh empty comment must open straight in the editor");
+        Output.WriteLine("Editor open on the fresh comment — typing…");
+
+        await TypeCommentText(stream, commentPath, "My brand-new comment");
+        await ClickDone(stream, commentAddress, reference);
+        await WaitForPersistedText(commentPath, "My brand-new comment");
+
+        await WaitForReadOnlyMarkdown(stream, reference, "My brand-new comment",
+            "after Done the freshly written comment must render — not the 'No comment text' placeholder (the 'only after refresh' bug)");
+        Output.WriteLine("✅ New comment rendered read-only without a refresh.");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>Creates a Comment authored by the test user and renders its live Overview area.</summary>
+    private async Task<(ISynchronizationStream<JsonElement> stream, Address commentAddress, string commentPath, LayoutAreaReference reference)>
+        RenderCommentOverview(string initialText)
+    {
+        var commentId = Guid.NewGuid().AsString();
+        var commentNode = new MeshNode(commentId, DocPath)
+        {
+            Name = "Comment by Roland",
+            NodeType = CommentNodeType.NodeType,
+            Content = new Comment
+            {
+                Id = commentId,
+                PrimaryNodePath = DocPath,
+                Author = TestUsers.Admin.Name,   // "Roland" — the auto-logged-in test user
+                Text = initialText,
+                Status = CommentStatus.Active
+            }
+        };
+
+        var created = await NodeFactory.CreateNode(commentNode).Should().Emit();
+        var commentAddress = new Address(created.Path!);
+        Output.WriteLine($"Created comment at {created.Path}");
+
+        var workspace = GetClient().GetWorkspace();
+        var reference = new LayoutAreaReference(CommentLayoutAreas.OverviewArea);
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(commentAddress, reference);
+
+        await stream.GetControlStream(reference.Area!)
+            .Should().Within(45.Seconds()).Match(c => c is StackControl);
+
+        return (stream, commentAddress, created.Path!, reference);
+    }
+
+    /// <summary>
+    /// Writes <paramref name="text"/> into the comment editor's bound data item the way the Blazor
+    /// markdown editor does — a client-side pointer update on the layout-area stream — and waits for
+    /// it to land in the synchronized store so the Done click's read sees it.
+    /// </summary>
+    private async Task TypeCommentText(ISynchronizationStream<JsonElement> stream, string commentPath, string text)
+    {
+        // Let the render/seed frames finish syncing before "typing": a pointer patch computed on a
+        // client state that lags the host is dropped by the sync stream's version guard (a real
+        // user's keystrokes span seconds, so their client has long caught up).
+        await Task.Delay(1500);
+        var textDataId = $"commentText_{commentPath.Replace("/", "_")}";
+        stream.UpdatePointer(text, LayoutAreaReference.GetDataPointer(textDataId), new JsonPointerReference("text"));
+        await WaitForStoreToContain(stream, text,
+            "the typed text must synchronize into the layout-area store before Done reads it");
+        // The store-contains check observes the client-side application of the patch; give the
+        // round-trip to the host a beat so the Done click's host-side read sees the typed text.
+        // (WaitForPersistedText after Done distinguishes a lost patch from the render-staleness bug.)
+        await Task.Delay(750);
+    }
+
+    /// <summary>
+    /// Verifies the Done write itself landed (the persistence half the user DOES see after a
+    /// refresh) — separating "the patch/typed text never reached the host" from the actual bug,
+    /// "persisted fine but the read-only view still shows the stale text".
+    /// </summary>
+    private async Task WaitForPersistedText(string commentPath, string expectedText)
+        => (await Mesh.GetWorkspace().GetMeshNodeStream(commentPath)
+                .Where(n => n?.ContentAs<Comment>(Mesh.JsonSerializerOptions)?.Text == expectedText)
+                .Should().Within(20.Seconds()).Emit())
+            .Should().NotBeNull($"the Done click must persist '{expectedText}'");
+
+    /// <summary>Finds and clicks the editor's Done button.</summary>
+    private async Task ClickDone(ISynchronizationStream<JsonElement> stream, Address commentAddress, LayoutAreaReference reference)
+    {
+        var doneArea = await FindArea(stream, reference.Area!,
+            c => c is ButtonControl b && (b.Data?.ToString() ?? "") == "Done");
+        doneArea.Should().NotBeNull("the comment editor must render a Done button");
+        Output.WriteLine($"Clicking Done at area '{doneArea}'…");
+        stream.Hub.Post(new ClickedEvent(doneArea!, stream.StreamId), o => o.WithTarget(commentAddress));
+    }
+
+    /// <summary>
+    /// Reactively waits until the rendered control tree contains a read-only
+    /// <see cref="MarkdownControl"/> showing <paramref name="expectedText"/> — the post-Done
+    /// read-only rendering. Watching the CONTROL TREE (not the raw store text) matters: the typed
+    /// text already sits in the editor's /data item, so a raw-store contains-check would pass even
+    /// while the visible read-only view still shows the stale text.
+    /// </summary>
+    private async Task WaitForReadOnlyMarkdown(ISynchronizationStream<JsonElement> stream,
+        LayoutAreaReference reference, string expectedText, string because)
+    {
+        string? found = null;
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (found is null && DateTime.UtcNow < deadline)
+        {
+            found = await FindArea(stream, reference.Area!,
+                c => c is MarkdownControl m && (m.Markdown?.ToString() ?? "").Contains(expectedText));
+            if (found is null)
+                await Task.Delay(1000);
+        }
+        found.Should().NotBeNull(because);
+    }
+
+    /// <summary>Reactively waits until the area's serialized store contains <paramref name="needle"/>.</summary>
+    private async Task WaitForStoreToContain(ISynchronizationStream<JsonElement> stream, string needle, string because)
+        => (await stream
+                .Where(item => item.Value.ValueKind != JsonValueKind.Undefined
+                               && item.Value.GetRawText().Contains(needle))
+                .Should().Within(30.Seconds()).Emit())
+            .Should().NotBeNull(because);
+
+    /// <summary>
+    /// Depth-first searches the control tree under <paramref name="rootArea"/> for the first control
+    /// matching <paramref name="predicate"/>, returning its area key. Descends StackControls.
+    /// </summary>
+    private async Task<string?> FindArea(ISynchronizationStream<JsonElement> stream, string rootArea,
+        Func<UiControl?, bool> predicate)
+    {
+        var control = await TryGetControl(stream, rootArea);
+        if (predicate(control))
+            return rootArea;
+        if (control is StackControl { Areas: { } areas })
+        {
+            foreach (var named in areas)
+            {
+                var childArea = named.Area?.ToString();
+                if (string.IsNullOrEmpty(childArea))
+                    continue;
+                var found = await FindArea(stream, childArea, predicate);
+                if (found != null)
+                    return found;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>Reads the control at <paramref name="area"/>, or null if none materializes quickly.</summary>
+    private static async Task<UiControl?> TryGetControl(ISynchronizationStream<JsonElement> stream, string area)
+    {
+        try
+        {
+            return await stream.GetControlStream(area).Should().Within(5.Seconds()).Match(c => c != null);
+        }
+        catch (AssertionException)
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## The report

On memex.systemorph.com, in the UWDeepfield treaty tabs: **adding a comment** (the editor opens, you type, press Done) — the comment only appears after refreshing the page. **Editing an existing comment** — the edited text likewise only appears after a refresh. The save itself always works; only the screen stays stale.

## Root causes (two independent defects, both fixed here)

### 1. Subscriber-side patches stamp the wrong clock (`StandardReducers`)

`PatchJsonElement` / `PatchInstanceCollectionJsonElement` stamped `stream.Hub.Version` — the **subscriber** hub's message counter — onto locally-originated ChangeItems, while every monotonicity guard (`SynchronizationStream.UpdateStream`) compares **owner-clock** versions. The `ISynchronizationStream.Current` docs state the contract explicitly: *"OWNER-ONLY Version … a non-owner stamping its own Version breaks ordering."* Which direction broke depended on which clock happened to be ahead:

- **Busy client** (a Blazor circuit hub, clock ≫ a quiet per-node owner hub — i.e. production): the user's optimistic edit jumps the client mirror's `Current.Version` to the circuit clock, so **every subsequent owner broadcast is dropped as "stale"** — the page freezes on pre-save state until a refresh re-subscribes. This is the reported bug, and it's deterministic in production.
- **Quiet client** (clock < owner — a fresh client, first edits after page load): the outgoing `PatchDataChangeRequest` carries a version below the owner mirror's `Current` and the **user's edit is silently dropped on the owner**. Reproduced deterministically by the new test (typed text lost, save no-ops).

Fix: carry the **base version** the patch was computed on — `stream.Current?.Version ?? stream.Hub.Version` — carry, never bump. `UpdateStream` already re-stamps *incoming* patches with `delivery.Message.Version` before `SetCurrent`, so applying received frames is unchanged; this only corrects locally-originated updates.

### 2. The comment Overview renders state captured at build time (`CommentLayoutAreas`)

- The read-only view rendered the `comment.Text` **captured at the last node emission** — stale immediately after Done unless the node stream echoed the write back in time *and* the `/data` replay reached the re-rendered sub-view.
- `BuildCommentEditor` **re-seeded the text buffer on every re-render** (the node + permission streams re-emit by design), stomping in-flight typing — proven by the diagnostic trace: a re-seed with stale text landed *between* the Done click's read and the save.
- The toggle / reply-form / replies sub-views subscribed `GetDataStream` **without `StartWith`** — the documented no-replay stall (`EditorExtensions.BuildToggleableProperty` defends against exactly this): a re-subscribed sub-view never emits and the previously rendered content sticks forever.

Fix: one `OverviewSession` per layout-area session — once-per-session seeds, current-value shadows feeding `StartWith(...)` on every sub-view stream, and the `commentText_*` buffer as the **single display/edit source**: the editor binds to it, Done persists from it and updates the session shadows *before* flipping to read-only, and the read-only view renders live from it — so the text the user just saved appears with **no dependency on the node-stream echo**. External node edits refresh the buffer only while not editing; a failed save now keeps the editor open (matching the reply form's contract) instead of silently discarding the draft.

## Regression tests

`CommentDoneReactivityTest` drives the **full client flow** over a remote layout-area stream: render the Overview, open the editor (✎ for the edit flow; a fresh empty comment opens straight in the editor), type through `LayoutClientExtensions.UpdatePointer` exactly like the Blazor markdown editor, click Done — then assert the text **persists** and the read-only `MarkdownControl` shows it **on the same stream, without re-subscribing**. Pre-fix: the edit flow silently lost the typed text (defect 1, quiet-client direction) and the add flow stuck on stale content under production timing (defect 2).

## Verification

| Suite | Result |
|---|---|
| MeshWeaver.Data.Test | 281/281 |
| MeshWeaver.Layout.Test | 337/337 |
| MeshWeaver.Content.Test | 249/249 (incl. both new tests) |
| MeshWeaver.Graph.Test | 609/609 |
| MeshWeaver.Persistence.Test | 407/407 |
| MeshWeaver.Markdown.Collaboration.Test | 355/356 — the one failure is `FormatTimeAgo_OldDate_ShowsFormattedDate` expecting `"Mar 15, 2024"` vs `"März 15, 2024"`: pre-existing locale-dependent assertion on de-DE machines, unrelated |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
