### PR TITLE
fix(mcp): replica-safe stateful MCP sessions across silos (ISessionMigrationHandler)

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/McpSessionMigrationHandler.cs
+++ b/memex/Memex.Portal.Shared/Authentication/McpSessionMigrationHandler.cs
@@ -1,0 +1,104 @@
+using System.Reactive.Threading.Tasks;
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.AspNetCore;
+using ModelContextProtocol.Protocol;
+
+namespace Memex.Portal.Shared.Authentication;
+
+/// <summary>
+/// Makes stateful MCP sessions pod-independent across horizontally-scaled portal replicas, the
+/// same way <see cref="OAuthCodeStore"/> made the OAuth code exchange replica-safe.
+///
+/// <para>
+/// The MCP Streamable-HTTP transport keeps per-session state in the process that served the
+/// <c>initialize</c> request. With more than one silo the MCP client — which carries no affinity
+/// cookie (unlike the Blazor browser) — can send a follow-up request for an established
+/// <c>Mcp-Session-Id</c> to a replica that never saw the session, and the SDK rejects it 404
+/// ("Session not found"). This is the "works on one silo, breaks on two" bug.
+/// </para>
+///
+/// <para>
+/// The framework's <c>AddMeshMcp</c> calls <c>WithHttpTransport()</c> with a null configure
+/// callback, so the SDK resolves an <see cref="ISessionMigrationHandler"/> from DI. On
+/// <c>initialize</c> this one persists the session's <see cref="InitializeRequestParams"/> to a
+/// mesh node via <see cref="McpSessionStore"/> (keyed by the id the client caches and echoes on
+/// every request); when a request arrives on a replica that doesn't know the id, the SDK calls
+/// <see cref="AllowSessionMigrationAsync"/>, which re-hydrates it here — owner-checked, so only
+/// the original authenticated caller may re-bind the session. Registered as a singleton in
+/// <c>ConfigureMemexServices</c> next to <see cref="OAuthCodeStore"/>.
+/// </para>
+/// </summary>
+internal sealed class McpSessionMigrationHandler(
+    McpSessionStore store,
+    ILogger<McpSessionMigrationHandler> logger) : ISessionMigrationHandler
+{
+    public async ValueTask OnSessionInitializedAsync(
+        HttpContext context,
+        string sessionId,
+        InitializeRequestParams initializeParams,
+        CancellationToken cancellationToken)
+    {
+        var owner = ResolveOwner(context);
+        try
+        {
+            var json = JsonSerializer.Serialize(initializeParams, McpJsonUtilities.DefaultOptions);
+            await store.StoreSession(sessionId, owner, json).ToTask(cancellationToken);
+            logger.LogInformation(
+                "Persisted MCP session {SessionId} for cross-replica migration (owner {Owner})",
+                sessionId, owner);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a failed persist must not fail the initialize handshake. The only
+            // consequence is that this session can't migrate — a follow-up on another replica
+            // would 404 and the client re-initializes, i.e. the pre-fix behaviour.
+            logger.LogWarning(ex,
+                "Failed to persist MCP session {SessionId} for migration (owner {Owner})",
+                sessionId, owner);
+        }
+    }
+
+    public async ValueTask<InitializeRequestParams?> AllowSessionMigrationAsync(
+        HttpContext context,
+        string sessionId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entry = await store.ReadSession(sessionId).ToTask(cancellationToken);
+            if (entry is null)
+                return null; // unknown / expired → the SDK returns 404, which is correct
+
+            var caller = ResolveOwner(context);
+            if (!string.Equals(entry.Owner, caller, StringComparison.Ordinal))
+            {
+                logger.LogWarning(
+                    "Refused MCP session migration {SessionId}: caller {Caller} is not owner {Owner}",
+                    sessionId, caller, entry.Owner);
+                return null;
+            }
+
+            logger.LogInformation("Migrated MCP session {SessionId} to this replica for {Owner}", sessionId, caller);
+            return JsonSerializer.Deserialize<InitializeRequestParams>(
+                entry.InitializeParamsJson, McpJsonUtilities.DefaultOptions);
+        }
+        catch (Exception ex)
+        {
+            // A read/deserialize failure rejects the migration (→ 404, client re-initializes)
+            // rather than throwing into the transport.
+            logger.LogWarning(ex, "MCP session migration {SessionId} failed; rejecting", sessionId);
+            return null;
+        }
+    }
+
+    private static string ResolveOwner(HttpContext context) =>
+        context.User.FindFirst("oid")?.Value
+        ?? context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+        ?? context.User.FindFirst(ClaimTypes.Email)?.Value
+        ?? context.User.Identity?.Name
+        ?? string.Empty;
+}

--- a/memex/Memex.Portal.Shared/Authentication/McpSessionNodeType.cs
+++ b/memex/Memex.Portal.Shared/Authentication/McpSessionNodeType.cs
@@ -1,0 +1,54 @@
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+
+namespace Memex.Portal.Shared.Authentication;
+
+/// <summary>
+/// NodeType definition for <see cref="McpSessionEntry"/> nodes — the stateful MCP session
+/// records <see cref="McpSessionStore"/> persists at <c>Admin/McpSession/{hashPrefix}</c> so a
+/// session established on one portal replica can be re-hydrated on any other (the MCP client
+/// carries no affinity cookie, so a follow-up request can land on a replica that never served
+/// the session's <c>initialize</c>). Infrastructure rows: System-identity managed, owner-scoped,
+/// excluded from search, create menus, and autocomplete — the same treatment as
+/// <see cref="OAuthCodeNodeType"/>.
+/// </summary>
+public static class McpSessionNodeType
+{
+    /// <summary>The node-type identifier string for MCP session nodes.</summary>
+    public const string NodeType = "McpSession";
+
+    /// <summary>
+    /// Registers the McpSession node type on the mesh builder: adds the MeshNode type
+    /// definition, excludes it from autocomplete, and registers the
+    /// <see cref="McpSessionEntry"/> content type so session nodes (de)serialize across silos
+    /// and persistence round-trips. Wired in the portal's <c>ConfigureMemexMesh</c> next to
+    /// <c>AddOAuthCodeType()</c>.
+    /// </summary>
+    public static TBuilder AddMcpSessionType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        builder.AddAutocompleteExcludedTypes(NodeType);
+        builder.WithMeshType<McpSessionEntry>();
+        return builder;
+    }
+
+    /// <summary>Builds the MeshNode type definition for MCP session nodes.</summary>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "MCP Session",
+        NodeType = "NodeType",
+        Icon = "/static/NodeTypeIcons/key.svg",
+        IsSatelliteType = false,
+        ExcludeFromContext = System.Collections.Immutable.ImmutableHashSet.Create("search", "create"),
+        Content = new NodeTypeDefinition
+        {
+            Description = "A stateful MCP Streamable-HTTP session's initialize params, persisted so any "
+                          + "portal replica can re-hydrate the session. Stored under Admin/McpSession/{hashPrefix}.",
+        },
+        HubConfiguration = config => config
+            .AddMeshDataSource(source => source
+                .WithContentType<McpSessionEntry>())
+    };
+}

--- a/memex/Memex.Portal.Shared/Authentication/McpSessionStore.cs
+++ b/memex/Memex.Portal.Shared/Authentication/McpSessionStore.cs
@@ -1,0 +1,215 @@
+using System.Reactive.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Memex.Portal.Shared.Authentication;
+
+/// <summary>
+/// Mesh-backed store for stateful MCP Streamable-HTTP session state, so a session established
+/// on one portal replica can be migrated to any other.
+///
+/// <para>
+/// Each session's <c>InitializeRequestParams</c> (serialised) is a MeshNode at
+/// <c>Admin/McpSession/{hashPrefix}</c> — Admin partition, regular <c>mesh_nodes</c> table
+/// (PG-persisted, shared by every replica), exactly like <see cref="OAuthCodeStore"/>. This
+/// is what makes MCP sessions <b>replica-safe</b>: the MCP client carries no affinity cookie
+/// (unlike the Blazor browser), so with more than one silo a follow-up request for an
+/// established <c>Mcp-Session-Id</c> can land on a replica that never served the
+/// <c>initialize</c> and be rejected 404 ("Session not found"). With this store,
+/// <see cref="McpSessionMigrationHandler"/> re-hydrates the session on whichever replica
+/// receives the request.
+/// </para>
+///
+/// <para>
+/// The raw session id is never persisted — the node id is the first 12 chars of the id's
+/// SHA-256 hash and the content carries the full hash (same scheme as
+/// <see cref="OAuthCodeStore"/> / <see cref="ApiTokenService"/>). All nodes live in the Admin
+/// partition, so every mesh operation runs under the System identity
+/// (<see cref="AccessService.ImpersonateAsSystem"/>).
+/// 🚨 No async/await/Task in this file — the surface is <see cref="IObservable{T}"/>
+/// end-to-end; <see cref="McpSessionMigrationHandler"/> bridges at the transport boundary only.
+/// </para>
+/// </summary>
+internal class McpSessionStore(IMeshService meshService, IMessageHub hub)
+{
+    private const string NodeTypeMcpSession = "McpSession";
+    private const string SessionNamespace = "Admin/McpSession";
+    private const int HashPrefixLength = 12;
+
+    /// <summary>
+    /// Bounded read-your-writes wait for the session node to become readable on the replica
+    /// that receives the migrating request. A stored session resolves in ~1–2 s (Take(1) on
+    /// the first matching emission); an unknown id never matches and falls through to this
+    /// timeout → null → the SDK returns 404 and the client re-initializes. Generous because
+    /// the owning per-node hub may cold-activate from Postgres on a different silo. Init-only
+    /// so tests can shorten it.
+    /// </summary>
+    public TimeSpan ReadTimeout { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// A stored session may be migrated up to this long after its last write. A healthy session
+    /// caches in-memory on each replica after one migration, so this only bounds resuming a
+    /// session that idled out of memory. Init-settable so tests can pin the expiry branch
+    /// (a zero lifetime makes every stored session already expired) instead of sleeping.
+    /// </summary>
+    internal TimeSpan SessionLifetime { get; init; } = TimeSpan.FromDays(1);
+
+    /// <summary>
+    /// Persists a session's initialize params as a mesh node under the System identity. Cold
+    /// observable — the write happens on Subscribe and emits once the create commits, so a
+    /// later request on ANY replica can re-hydrate it. Idempotent: a repeat of the same session
+    /// id (a rare re-initialize) is treated as success rather than a create conflict.
+    /// </summary>
+    public IObservable<bool> StoreSession(string sessionId, string owner, string initializeParamsJson)
+    {
+        var hash = HashSessionId(sessionId);
+        var entry = new McpSessionEntry
+        {
+            SessionIdHash = hash,
+            Owner = owner,
+            InitializeParamsJson = initializeParamsJson,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        var node = new MeshNode(hash[..HashPrefixLength], SessionNamespace)
+        {
+            Name = $"MCP session {hash[..HashPrefixLength]}",
+            NodeType = NodeTypeMcpSession,
+            State = MeshNodeState.Active,
+            Content = entry,
+        };
+
+        return AsSystem(() => meshService.CreateNode(node))
+            .Select(_ => true)
+            // A duplicate id (re-initialize of the same session) is fine — the stored entry is
+            // equivalent; only a genuine infrastructure failure should surface.
+            .Catch<bool, Exception>(ex => IsAlreadyExists(ex)
+                ? Observable.Return(true)
+                : Observable.Throw<bool>(ex));
+    }
+
+    /// <summary>
+    /// Reads the stored session by id (System identity). Emits the entry, or null when no live,
+    /// unexpired session node exists for the id (unknown / expired). Tolerates the
+    /// create→persist→routable lag via the same resilient <c>GetMeshNodeStream</c> poll
+    /// <see cref="OAuthCodeStore"/> uses at /token.
+    /// </summary>
+    public IObservable<McpSessionEntry?> ReadSession(string sessionId)
+    {
+        var hash = HashSessionId(sessionId);
+        var path = PathForSession(sessionId);
+
+        return AsSystem(() => ReadSessionNode(path, hash))
+            .Select(node =>
+            {
+                var entry = ExtractEntry(node);
+                if (entry is null)
+                    return null;
+                if (DateTimeOffset.UtcNow - entry.CreatedAt > SessionLifetime)
+                    return null;
+                return entry;
+            });
+    }
+
+    /// <summary>
+    /// Reads the session node by exact path, tolerating the create→persist→routable lag: a
+    /// freshly-created node is not instantly readable across a multi-silo boundary. Each attempt
+    /// swallows the transient "no node found" and, only on no-match, re-subscribes after 50 ms —
+    /// <c>Concat</c>, never <c>Merge</c>, so exactly ONE owner-hub subscription is live at a time.
+    /// A missing id keeps re-probing until <see cref="ReadTimeout"/> → null; a stored session
+    /// emits on the first matching attempt and the outer <c>Take(1)</c> tears the chain down.
+    /// (Same shape as <c>OAuthCodeStore.ReadCodeNode</c>.)
+    /// </summary>
+    private IObservable<MeshNode?> ReadSessionNode(string path, string hash)
+    {
+        IObservable<MeshNode?> Attempt() =>
+            hub.GetWorkspace().GetMeshNodeStream(path)
+                .Take(1)
+                .Where(n => ExtractEntry(n) is { } e
+                            && string.Equals(e.SessionIdHash, hash, StringComparison.Ordinal))
+                .Select(n => (MeshNode?)n)
+                .Catch<MeshNode?, Exception>(_ => Observable.Empty<MeshNode?>())
+                .Concat(Observable.Defer(Attempt).DelaySubscription(TimeSpan.FromMilliseconds(50)));
+
+        return Observable.Defer(Attempt)
+            .Take(1)
+            .Timeout(ReadTimeout)
+            .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null));
+    }
+
+    /// <summary>
+    /// Runs <paramref name="inner"/> under the System identity — session nodes live in the Admin
+    /// partition, which the calling end-user has no rights on. Subscribe-time scope, same shape
+    /// as <see cref="OAuthCodeStore"/>. Null <see cref="AccessService"/> (bare unit-test DI)
+    /// falls through to the caller's ambient identity.
+    /// </summary>
+    private IObservable<T> AsSystem<T>(Func<IObservable<T>> inner)
+    {
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        return accessService is null
+            ? Observable.Defer(inner)
+            : Observable.Using(() => accessService.ImpersonateAsSystem(), _ => inner());
+    }
+
+    private static bool IsAlreadyExists(Exception ex)
+    {
+        for (Exception? e = ex; e != null; e = e.InnerException)
+        {
+            if (e.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase)
+                || e.Message.Contains("duplicate", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    private static string HashSessionId(string sessionId)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(sessionId))).ToLowerInvariant();
+
+    /// <summary>The mesh path a session's node lives at — exposed for tests.</summary>
+    internal static string PathForSession(string sessionId)
+        => $"{SessionNamespace}/{HashSessionId(sessionId)[..HashPrefixLength]}";
+
+    /// <summary>Node content → <see cref="McpSessionEntry"/>, with a JsonElement fallback for
+    /// hubs that have not registered the type / older persisted rows (same as OAuthCodeStore).</summary>
+    private static McpSessionEntry? ExtractEntry(MeshNode? node)
+    {
+        switch (node?.Content)
+        {
+            case McpSessionEntry direct:
+                return direct;
+            case System.Text.Json.JsonElement jsonElement:
+                try
+                {
+                    return System.Text.Json.JsonSerializer.Deserialize<McpSessionEntry>(
+                        jsonElement.GetRawText(),
+                        new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                }
+                catch
+                {
+                    return null;
+                }
+            default:
+                return null;
+        }
+    }
+}
+
+/// <summary>
+/// Persisted content of an <c>Admin/McpSession/{hashPrefix}</c> node. Carries the full SHA-256
+/// hash of the <c>Mcp-Session-Id</c> (never the raw id), the authenticated owner (so only the
+/// original caller may re-bind the session on another replica), and the session's
+/// <c>InitializeRequestParams</c> serialised as JSON (the MCP SDK owns that type; the store
+/// keeps it opaque).
+/// </summary>
+internal record McpSessionEntry
+{
+    public required string SessionIdHash { get; init; }
+    public required string Owner { get; init; }
+    public required string InitializeParamsJson { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+}

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -65,6 +65,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.UI;
+using ModelContextProtocol.AspNetCore;
 using PortalAuthOptions = MeshWeaver.Blazor.Portal.Authentication.AuthenticationOptions;
 
 namespace Memex.Portal.Shared;
@@ -273,6 +274,13 @@ public static class MemexConfiguration
         // Register API token service for MCP bearer auth and OAuth code store
         services.AddSingleton<ApiTokenService>();
         services.AddSingleton<OAuthCodeStore>();
+        // Replica-safe stateful MCP sessions: the store persists each session's initialize
+        // params as an Admin/McpSession/{hashPrefix} mesh node, and the migration handler
+        // re-hydrates a session on whichever replica a follow-up request lands on (the MCP
+        // client carries no affinity cookie). The MCP SDK's WithHttpTransport() resolves the
+        // ISessionMigrationHandler from DI — registering it here is the entire wiring.
+        services.AddSingleton<McpSessionStore>();
+        services.AddSingleton<ISessionMigrationHandler, McpSessionMigrationHandler>();
         // Automatic, token-based MCP back-connection for the co-hosted Claude Code / Copilot CLIs.
         // The chat clients resolve this at spawn to mint/reuse the per-user MCP ApiToken + URL.
         services.AddSingleton<MeshWeaver.AI.Connect.IMcpBackConnection, McpBackConnectionService>();
@@ -659,6 +667,11 @@ public static class MemexConfiguration
                 // /authorize that minted the code). Without this the create fails with
                 // "NodeType 'OAuthCode' is not registered" and no MCP client can connect.
                 .AddOAuthCodeType()
+                // Register the McpSession NodeType + McpSessionEntry content type so
+                // McpSessionStore can persist stateful MCP sessions as Admin/McpSession/{hashPrefix}
+                // mesh nodes — the replica-safe store that lets any silo re-hydrate a session an
+                // MCP client established on another (the client sends no affinity cookie).
+                .AddMcpSessionType()
                 // Seed root-scope Admin AccessAssignments for users listed under
                 // `Auth:GlobalAdmins` so configured admins bypass per-partition
                 // RLS for cross-partition operations (list Spaces, create

--- a/test/Memex.Portal.Shared.Test/McpSessionStoreTest.cs
+++ b/test/Memex.Portal.Shared.Test/McpSessionStoreTest.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Mesh-backed McpSessionStore semantics — the replica-safety fix that lets a stateful MCP
+/// session established on one silo be re-hydrated on another (the MCP client sends no affinity
+/// cookie, so a follow-up request for an established Mcp-Session-Id can land on a replica that
+/// never served the initialize → 404 "Session not found").
+///
+/// <para>
+/// <see cref="TwoStoreInstances_StoreOnOne_ReadOnOther"/> and
+/// <see cref="Handler_StoreOnOne_MigrateOnOther_RoundTrips"/> pin exactly the multi-silo shape:
+/// two independent store / handler instances share one mesh the way two replicas share one PG,
+/// and B must serve a session A created — mirroring <c>OAuthCodeStoreTest</c>'s
+/// <c>TwoStoreInstances_GenerateOnOne_ExchangeOnOther</c>.
+/// </para>
+/// </summary>
+public class McpSessionStoreTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string InitJson =
+        """{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"claude","version":"1.0"}}""";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        // Same registration the portal wires in ConfigureMemexMesh.
+        => base.ConfigureMesh(builder).AddMcpSessionType();
+
+    /// <summary>Each call builds an independent store on the SAME mesh — two KEDA replicas
+    /// against the shared PG-backed mesh.</summary>
+    private McpSessionStore NewStore(TimeSpan? sessionLifetime = null) => new(
+        Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
+        Mesh)
+    {
+        SessionLifetime = sessionLifetime ?? TimeSpan.FromDays(1),
+        // Short read window so the unknown-session negative path (waits out the timeout by
+        // design) stays fast; a stored session resolves near-instantly via Take(1). Prod = 10 s.
+        ReadTimeout = TimeSpan.FromSeconds(2),
+    };
+
+    private static string NewSessionId() => "sess-" + Guid.NewGuid().ToString("N");
+
+    private McpSessionMigrationHandler NewHandler(McpSessionStore store)
+        => new(store, NullLogger<McpSessionMigrationHandler>.Instance);
+
+    private static HttpContext ContextFor(string oid) => new DefaultHttpContext
+    {
+        User = new ClaimsPrincipal(new ClaimsIdentity([new Claim("oid", oid)], "Test")),
+    };
+
+    [Fact]
+    public async Task StoreThenRead_RoundTrips()
+    {
+        var store = NewStore();
+        var sessionId = NewSessionId();
+
+        (await store.StoreSession(sessionId, "user-1", InitJson).Should().Within(30.Seconds()).Emit())
+            .Should().BeTrue();
+
+        var entry = await store.ReadSession(sessionId).Should().Within(30.Seconds()).Emit();
+        entry.Should().NotBeNull();
+        entry!.Owner.Should().Be("user-1");
+        entry.InitializeParamsJson.Should().Be(InitJson);
+    }
+
+    [Fact]
+    public async Task ReadSession_UnknownId_ReturnsNull()
+    {
+        var store = NewStore();
+
+        var entry = await store.ReadSession(NewSessionId()).Should().Within(30.Seconds()).Emit();
+
+        entry.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReadSession_Expired_ReturnsNull()
+    {
+        // Zero lifetime → the stored session is already expired when read (deterministic).
+        var store = NewStore(sessionLifetime: TimeSpan.Zero);
+        var sessionId = NewSessionId();
+        await store.StoreSession(sessionId, "user-1", InitJson).Should().Within(30.Seconds()).Emit();
+
+        var entry = await store.ReadSession(sessionId).Should().Within(30.Seconds()).Emit();
+
+        entry.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TwoStoreInstances_StoreOnOne_ReadOnOther()
+    {
+        // The multi-silo shape: initialize on replica A, follow-up request on replica B.
+        // Two independent stores share the mesh the way two silos share PG — B must read
+        // a session A stored.
+        var replicaA = NewStore();
+        var replicaB = NewStore();
+        var sessionId = NewSessionId();
+
+        await replicaA.StoreSession(sessionId, "user-1", InitJson).Should().Within(30.Seconds()).Emit();
+
+        var onB = await replicaB.ReadSession(sessionId).Should().Within(30.Seconds()).Emit();
+        onB.Should().NotBeNull();
+        onB!.Owner.Should().Be("user-1");
+        onB.InitializeParamsJson.Should().Be(InitJson);
+    }
+
+    [Fact]
+    public async Task Handler_StoreOnOne_MigrateOnOther_RoundTrips()
+    {
+        // End-to-end through the ISessionMigrationHandler the MCP SDK resolves from DI:
+        // OnSessionInitialized on replica A, AllowSessionMigration on replica B.
+        var handlerA = NewHandler(NewStore());
+        var handlerB = NewHandler(NewStore());
+        var sessionId = NewSessionId();
+        var init = JsonSerializer.Deserialize<InitializeRequestParams>(InitJson, McpJsonUtilities.DefaultOptions)!;
+
+        await handlerA.OnSessionInitializedAsync(ContextFor("user-1"), sessionId, init, CancellationToken.None);
+
+        var migrated = await handlerB.AllowSessionMigrationAsync(ContextFor("user-1"), sessionId, CancellationToken.None);
+        migrated.Should().NotBeNull();
+        migrated!.ProtocolVersion.Should().Be("2024-11-05");
+        migrated.ClientInfo!.Name.Should().Be("claude");
+    }
+
+    [Fact]
+    public async Task Handler_RejectsMigration_ForDifferentOwner()
+    {
+        var handlerA = NewHandler(NewStore());
+        var handlerB = NewHandler(NewStore());
+        var sessionId = NewSessionId();
+        var init = JsonSerializer.Deserialize<InitializeRequestParams>(InitJson, McpJsonUtilities.DefaultOptions)!;
+
+        await handlerA.OnSessionInitializedAsync(ContextFor("user-1"), sessionId, init, CancellationToken.None);
+
+        // A different authenticated caller must not be able to re-bind someone else's session.
+        var stolen = await handlerB.AllowSessionMigrationAsync(ContextFor("attacker"), sessionId, CancellationToken.None);
+        stolen.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handler_UnknownSession_ReturnsNull()
+    {
+        var handler = NewHandler(NewStore());
+
+        var migrated = await handler.AllowSessionMigrationAsync(ContextFor("user-1"), NewSessionId(), CancellationToken.None);
+
+        migrated.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Problem
Stateful MCP Streamable-HTTP sessions are pinned to the silo that served `initialize`. With >1 silo, a follow-up request for an established `Mcp-Session-Id` can land on a silo that never saw the session → the SDK rejects it **404 "Session not found"** (the "works on one silo, breaks on two" bug). The MCP client carries **no affinity cookie** (unlike the Blazor browser), so ACA/nginx sticky sessions can't pin it. Same class of multi-replica bug `OAuthCodeStore` fixed for the OAuth code exchange (2026-07-23 outage).

## Fix — mirrors `OAuthCodeStore` exactly
- **`McpSessionStore`** persists each session's `InitializeRequestParams` as an `Admin/McpSession/{hashPrefix}` mesh node (System identity, PG-persisted, shared by every replica), read back with the **same resilient `GetMeshNodeStream` poll** `OAuthCodeStore` uses at `/token` to ride out the create→routable lag across silos. Raw session id never stored (SHA-256, same scheme as ApiToken/OAuthCode).
- **`McpSessionMigrationHandler : ISessionMigrationHandler`** re-hydrates the session on whichever replica receives the request — **owner-checked** (only the original authenticated caller may re-bind it).
- **Injection:** `AddMeshMcp` calls `WithHttpTransport((Action<HttpServerTransportOptions>)null)` (decompiled to confirm), so the SDK resolves `ISessionMigrationHandler` from DI. Registering it in `ConfigureMemexServices` next to `OAuthCodeStore` is the entire wiring. Ships with the platform (`memex-portal-ai`) image — not a plugin, no package bump; Memex (deployments) just runs the new image.

## Verified — multiple replicas/silos
`test/Memex.Portal.Shared.Test/McpSessionStoreTest.cs` (7/7 green):
- `TwoStoreInstances_StoreOnOne_ReadOnOther` — initialize on replica A, follow-up on replica B, sharing one mesh (the exact multi-replica shape, mirroring `OAuthCodeStoreTest.TwoStoreInstances_GenerateOnOne_ExchangeOnOther`).
- `Handler_StoreOnOne_MigrateOnOther_RoundTrips` — end-to-end through the SDK handler interface; `Handler_RejectsMigration_ForDifferentOwner`; unknown/expired/round-trip.

(Also validated end-to-end earlier against the real `ModelContextProtocol` 1.2.0 SDK with 3 in-process instances: a session created on one served by another, the no-handler control 404'd.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)