### PR TITLE
Fix teardown SIGSEGV (#613): cascade hosted-hub creation freeze through the subtree

### DIFF
--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -919,7 +919,24 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
 
         logger.LogDebug("Creating Synchronization Stream {StreamId} for Host {Host} and {StreamIdentity} and {Reference}", StreamId, Host.Address, StreamIdentity, Reference);
 
-        Hub = Host.GetHostedHub(SynchronizationAddress.Create(ClientId), ConfigureSynchronizationHub);
+        var syncHub = Host.GetHostedHub(
+            SynchronizationAddress.Create(ClientId), ConfigureSynchronizationHub, HostedHubCreation.Always);
+        if (syncHub is null)
+        {
+            // Creation was refused: an ANCESTOR hub began disposing and the
+            // creation-freeze cascade closed this collection before the Host's
+            // own RunLevel moved (the gap the RunLevel check above cannot see).
+            // Same dead-stream semantics as that check — without this, Hub
+            // would be a null on a LIVE stream and every downstream touch NREs.
+            logger.LogDebug(
+                "[SYNC_STREAM] Hosted-hub creation refused for {Reference} on {Host} (teardown creation freeze); creating dead stream",
+                Reference, Host.Address);
+            isDisposed = true;
+            Hub = null!;
+            Store.OnCompleted();
+            return;
+        }
+        Hub = syncHub;
 
         // 🚨 Capture the creating user's identity ONCE, here on the thread that constructs
         // the stream — in production that is the circuit thread (cache.GetMeshNodeStream)

--- a/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
+++ b/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
@@ -161,8 +161,26 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
     /// whose timers later detonate on the disposed container (the post-teardown
     /// ObjectDisposedException straggler class). Existing hubs remain resolvable for the
     /// drain; only CREATION is refused (logged, observable).
+    ///
+    /// <para>🚨 The freeze CASCADES through the entire hosted-hub SUBTREE immediately.
+    /// The per-hub flip alone left every DESCENDANT collection open until the dispose
+    /// cascade reached it — potentially seconds into teardown — so a straggler emission
+    /// (a workspace Reduce, a routed enrichment) could still enter hub CONSTRUCTION on a
+    /// mid-tree hub while the root container and the compiled-NodeType collectible ALCs
+    /// were already being torn down. Constructing a hub there walks the type registry
+    /// (TypeRegistry ctor → XmlDocs.Summary) over types whose ALC is unloading — the
+    /// FutuRe.Test teardown SIGSEGV (exit=139, issue #613; dump: String.Ctor over a
+    /// span into the unloaded assembly's metadata). Freezing the whole subtree at
+    /// root-dispose start closes that window at the single choke point every hub
+    /// creation goes through. The tree is acyclic (each hub has one parent), so the
+    /// recursion terminates.</para>
     /// </summary>
-    public void CloseCreation() => creationClosed = true;
+    public void CloseCreation()
+    {
+        creationClosed = true;
+        foreach (var hub in messageHubs.Values)
+            (hub as MessageHub)?.CloseHostedHubCreation();
+    }
 
     // Reactive completion source of truth — completed exactly once (CAS-guarded) when every
     // hosted hub has finished disposing (or the 10 s cap elapses). ReplaySubject(1) so a late

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1352,6 +1352,15 @@ public sealed class MessageHub : IMessageHub
     /// machine, and arms a watchdog that force-completes disposal if that path ever wedges. Returns
     /// immediately; observe <see cref="DisposalCompleted"/> for completion.
     /// </summary>
+    /// <summary>
+    /// Freezes creation of NEW hosted hubs beneath this hub, cascading through the
+    /// whole subtree. Invoked by the parent's <see cref="HostedHubsCollection.CloseCreation"/>
+    /// the moment an ANCESTOR begins disposing, so no straggler emission anywhere in
+    /// the tree can enter hub construction during teardown (issue #613). Does NOT
+    /// dispose anything — existing hubs keep draining until their own dispose phase.
+    /// </summary>
+    internal void CloseHostedHubCreation() => hostedHubs.CloseCreation();
+
     public void Dispose()
     {
         var totalStopwatch = Stopwatch.StartNew();
@@ -1374,7 +1383,9 @@ public sealed class MessageHub : IMessageHub
         // phase disposes the collection. A hub created in the Quiescing window races
         // DisposeHubsReactive's snapshot and leaks as a zombie whose timers later
         // detonate on the disposed container (post-dispose ObjectDisposedException
-        // stragglers). Existing hubs still resolve for the drain.
+        // stragglers). CloseCreation cascades the freeze through the ENTIRE subtree
+        // (see HostedHubsCollection.CloseCreation — the FutuRe.Test teardown SIGSEGV,
+        // issue #613). Existing hubs still resolve for the drain.
         hostedHubs.CloseCreation();
 
         // Log all hosted hubs that will be disposed

--- a/test/MeshWeaver.Messaging.Hub.Test/TeardownHubCreationFreezeTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/TeardownHubCreationFreezeTest.cs
@@ -1,0 +1,91 @@
+using System.Threading;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Pins the teardown hub-creation freeze CASCADE (issue #613, the FutuRe.Test
+/// exit=139 teardown SIGSEGV).
+///
+/// <para>The defect: <c>MessageHub.Dispose</c> froze creation only on the disposing
+/// hub's OWN <c>HostedHubsCollection</c>; every descendant collection stayed open
+/// until the async dispose cascade reached it. A straggler emission (a workspace
+/// Reduce, a routed enrichment) landing on a mid-tree hub in that window entered
+/// full hub CONSTRUCTION — <c>MessageHubConfiguration</c> → <c>TypeRegistry</c> ctor
+/// → <c>XmlDocs.Summary</c> — walking type metadata of compiled-NodeType assemblies
+/// whose collectible ALCs were already unloading. Best case: an
+/// ObjectDisposedException storm off the disposed Autofac scope (the
+/// teardown-straggler log). Worst case: SIGSEGV in <c>String.Ctor</c> over a span
+/// into the unloaded assembly image (the CI dump, thread 22, "address not mapped").</para>
+///
+/// <para>The freeze must therefore be visible on EVERY level of the subtree
+/// SYNCHRONOUSLY when <c>root.Dispose()</c> returns — before the async shutdown
+/// pipeline has run at all. To pin exactly that (and not accidentally pass because
+/// the async cascade already reached the children), the root's single-threaded
+/// action block is deliberately stalled by a gated handler for the duration of the
+/// assertions: the posted ShutdownRequest cannot be processed, so the ONLY thing
+/// that can freeze the descendants is the synchronous cascade inside Dispose().</para>
+/// </summary>
+public class TeardownHubCreationFreezeTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record Blocker;
+
+    [Fact]
+    public void DisposingRoot_FreezesHubCreation_AcrossTheWholeSubtree_BeforeAsyncShutdownRuns()
+    {
+        using var handlerEntered = new ManualResetEventSlim(false);
+        using var releaseHandler = new ManualResetEventSlim(false);
+
+        var client = GetClient();
+        // Independent root so disposing it cannot interfere with the fixture's own hubs.
+        var root = client.ServiceProvider.CreateMessageHub(
+            new Address("freeze-root", "1"),
+            c => c
+                .WithPostingIdentity(PostingIdentity.System)
+                .WithTypes(typeof(Blocker))
+                .WithHandler<Blocker>((_, request) =>
+                {
+                    handlerEntered.Set();
+                    // Deliberately ignores cancellation: keeps the root's action
+                    // block busy so the ShutdownRequest posted by Dispose() cannot
+                    // be processed until the test releases the gate.
+                    releaseHandler.Wait(TimeSpan.FromSeconds(30));
+                    return request.Processed();
+                }));
+
+        var child = root.GetHostedHub(new Address("freeze-child", "1"));
+        var grandchild = child.GetHostedHub(new Address("freeze-grandchild", "1"));
+        child.Should().NotBeNull();
+        grandchild.Should().NotBeNull();
+
+        try
+        {
+            // Stall the root's message loop, then dispose. The async shutdown
+            // pipeline is provably NOT running during the assertions below —
+            // any freeze observed on the descendants came from the synchronous
+            // cascade inside Dispose().
+            root.Post(new Blocker(), o => o.WithTarget(root.Address));
+            handlerEntered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the blocker handler must be running");
+
+            root.Dispose();
+
+            root.GetHostedHub(new Address("freeze-child", "2"), HostedHubCreation.Always)
+                .Should().BeNull("the disposing root must refuse new hosted hubs");
+            child.GetHostedHub(new Address("freeze-grandchild", "2"), HostedHubCreation.Always)
+                .Should().BeNull("root disposal must freeze creation on child collections synchronously");
+            grandchild.GetHostedHub(new Address("freeze-greatgrandchild", "1"), HostedHubCreation.Always)
+                .Should().BeNull("root disposal must freeze creation arbitrarily deep in the subtree");
+
+            // Only CREATION is refused — the drain still needs to resolve live hubs.
+            root.GetHostedHub(new Address("freeze-child", "1"), HostedHubCreation.Never)
+                .Should().BeSameAs(child);
+            child.GetHostedHub(new Address("freeze-grandchild", "1"), HostedHubCreation.Never)
+                .Should().BeSameAs(grandchild);
+        }
+        finally
+        {
+            releaseHandler.Set();
+        }
+    }
+}


### PR DESCRIPTION
## The flake, solved — not re-run

`MeshWeaver.FutuRe.Test` intermittently exited 139 at process exit on Linux CI with every test passing (issue #613; hit PR #609 once, PR #644 twice; never reproduces locally). Root-caused from the CI createdump (run 30158616890 shard 3, `dotnet-2737.dmp`, faulting thread 22 — "address not mapped to object"):

```
SynchronizationStream.Reduce → ReduceManager.ReduceStream → new SynchronizationStream
  → HostedHubsCollection.GetHub (Lazy) → new MessageHubConfiguration → new TypeRegistry
    → XmlDocs.Summary(Type) → String.Ctor(ReadOnlySpan<char>)   ← SIGSEGV
```

A straggler workspace-reduce emission entered **full hub construction during teardown**; the new `TypeRegistry` walked type metadata of compiled-NodeType assemblies whose **collectible ALCs were already unloading** — the string ctor copied from a span into the unloaded assembly image. The post-dispose `ObjectDisposedException` storm in the teardown-stragglers log is the same race's benign twin (same stack, landing on the disposed Autofac scope instead).

## Root cause

`MessageHub.Dispose` froze creation only on the disposing hub's **own** `HostedHubsCollection`. Every descendant collection stayed open until the async dispose cascade reached it — and the mid-tree Host's `RunLevel` was still `Started`, so `SynchronizationStream`'s dead-stream check couldn't see the teardown either. That window is where both the ODE storm and the segv live.

## Fix

- `HostedHubsCollection.CloseCreation()` **cascades the freeze through the whole subtree synchronously** (tree is acyclic; existing hubs remain resolvable for the drain — only creation is refused).
- `SynchronizationStream` ctor treats a refused (null) hosted-hub creation as its existing dead-stream path, so refusal degrades exactly like the `RunLevel` case instead of leaving `Hub` null on a live stream.

## Deterministic pin

`TeardownHubCreationFreezeTest` stalls the root's action block with a gated handler so the async shutdown pipeline **provably has not run**, then asserts `Dispose()` froze every subtree level synchronously (and that existing hubs still resolve with `HostedHubCreation.Never`). Verified **red without the cascade, green with** — no timing, no sleeps.

## Follow-ups (tracked, out of scope here)

- Quiesce the straggler sources themselves (`Reduce` / `MeshQuery.MergeProviderObservables` still emit post-dispose — they now get refused instead of crashing).
- Type-registry retention of collectible-ALC types after unload (same class as the earlier Autofac reflection-cache ALC fix).
- `TwoSiloRecycleConvergenceTest.PostRecycleUpdate_NonOwnerSiloMirror_ConvergesInsteadOfOrphaning` recurred on main after #635 (run 30159928718) — separate RCA.

Tests: `TeardownHubCreationFreezeTest` red/green verified; full `MeshWeaver.Messaging.Hub.Test`, `MeshWeaver.FutuRe.Test`, `MeshWeaver.Data.Test` suites running clean locally (Release); solution `-warnaserror` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)