### PR TITLE
ApiToken validation: absent row rejects instantly (fail-fast 401s)

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs
@@ -362,25 +362,35 @@ internal class ApiTokenService(
     private IObservable<MeshNode?> ReadValidationNode(
         string path, Func<MeshNode, bool?> hashVerdict, string stage, string hashPrefix, Stopwatch elapsed)
     {
+        // 🚨 An ABSENT row is a TERMINAL negative, never a reason to poll.
+        // CreateToken confirms both rows are committed to the shared store BEFORE
+        // the raw token leaves the server (ConfirmReadable), so by the time any
+        // client can PRESENT a token, its rows exist — absence at validation means
+        // unknown/deleted, full stop. The previous shape re-polled absence until
+        // ValidationReadTimeout, making every bad-token 401 cost the full 8 s
+        // (measured 8.2 s per unauthenticated /mcp probe on memex-cloud after the
+        // storage-direct cutover) — a leftover from the cross-silo mesh read whose
+        // lag no longer exists. Only a THROWN storage error (connection blip)
+        // re-polls, bounded by ValidationReadTimeout.
         IObservable<MeshNode?> Attempt() =>
             storage.Read(path, hub.JsonSerializerOptions)
-                .SelectMany(node =>
+                .Select(node =>
                 {
                     var verdict = node is null ? null : hashVerdict(node);
                     if (verdict == true)
-                        return Observable.Return((MeshNode?)node);
+                        return (MeshNode?)node;
                     if (verdict == false)
-                        return Observable.Defer(() =>
-                        {
-                            logger.LogWarning(
-                                "API token validation failed at {Stage} for hash prefix {HashPrefix} after {ElapsedMs} ms: node at {Path} exists but carries a different token hash",
-                                stage + "-hash-mismatch", hashPrefix, elapsed.ElapsedMilliseconds, path);
-                            return Observable.Return((MeshNode?)null);
-                        });
-                    return Observable.Empty<MeshNode?>();
+                        logger.LogWarning(
+                            "API token validation failed at {Stage} for hash prefix {HashPrefix} after {ElapsedMs} ms: node at {Path} exists but carries a different token hash",
+                            stage + "-hash-mismatch", hashPrefix, elapsed.ElapsedMilliseconds, path);
+                    else
+                        logger.LogWarning(
+                            "API token validation failed at {Stage} for hash prefix {HashPrefix} after {ElapsedMs} ms: no row at {Path} (unknown or deleted token)",
+                            stage + "-not-found", hashPrefix, elapsed.ElapsedMilliseconds, path);
+                    return (MeshNode?)null;
                 })
-                // A transient storage error (connection blip) re-polls like an
-                // absent row — the outer Timeout bounds the whole chain.
+                // A transient storage ERROR (not absence) re-polls — the outer
+                // Timeout bounds the whole chain.
                 .Catch<MeshNode?, Exception>(_ => Observable.Empty<MeshNode?>())
                 .Concat(Observable.Defer(Attempt).DelaySubscription(ValidationRetryDelay));
 

--- a/test/MeshWeaver.Auth.Test/ApiTokenServiceTests.cs
+++ b/test/MeshWeaver.Auth.Test/ApiTokenServiceTests.cs
@@ -196,17 +196,22 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
     }
 
     /// <summary>
-    /// SHOULD-FAIL-IF: an unknown token is rejected INSTANTLY — that is exactly the
-    /// behavior that 401ed fresh tokens during the create→routable window on the
-    /// non-minting replicas. The resilient read must keep polling for the full
-    /// <see cref="ApiTokenService.ValidationReadTimeout"/> before concluding null,
-    /// and the timeout must be named at Warning with the hash prefix.
+    /// SHOULD-FAIL-IF: an unknown token polls the read window before rejecting.
+    /// That poll-on-absence was the resilient-read shape for the CROSS-SILO mesh
+    /// read, whose lag no longer exists: validation reads the shared store
+    /// directly, and <see cref="ApiTokenService.CreateToken"/> confirms both rows
+    /// are committed BEFORE the raw token leaves the server — so absence at
+    /// validation is a terminal negative. Polling it anyway made every bad-token
+    /// 401 cost the full 8 s window (measured on memex-cloud 2026-07-25). The
+    /// rejection must be fast and named at Warning with the hash prefix.
     /// </summary>
     [Fact]
-    public async Task ValidateToken_UnknownToken_FailsAtReadTimeout_NotInstantly()
+    public async Task ValidateToken_UnknownToken_FailsFast_NotAtTimeout()
     {
         var logs = new CapturingLogger();
-        var window = TimeSpan.FromSeconds(1);
+        // Generous window so the timing assert genuinely discriminates fail-fast
+        // from wait-out-the-window.
+        var window = TimeSpan.FromSeconds(8);
         var service = GetService(window, logs);
         const string unknownToken = "mw_thistokenwasneverissued0123456789";
 
@@ -215,15 +220,15 @@ public class ApiTokenServiceTests(ITestOutputHelper output) : MonolithMeshTestBa
         stopwatch.Stop();
 
         validated.Should().BeNull();
-        stopwatch.Elapsed.Should().BeGreaterThanOrEqualTo(window - TimeSpan.FromMilliseconds(100),
-            "an unknown token must poll the full ValidationReadTimeout window — an instant no is indistinguishable from a fresh token that is not yet routable on this replica");
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(4),
+            "an absent row in the authoritative store is a terminal negative — rejection must not wait out the read window");
 
         var hashPrefix = ApiTokenService.HashToken(unknownToken)[..12];
         logs.Entries.Should().Contain(e =>
                 e.Level == LogLevel.Warning
-                && e.Message.Contains("index-read-timeout")
+                && e.Message.Contains("index-not-found")
                 && e.Message.Contains(hashPrefix),
-            "the read timeout must be logged at Warning with the failing stage and hash prefix — never a silent null");
+            "the rejection must be logged at Warning with the failing stage and hash prefix — never a silent null");
         logs.Entries.Should().NotContain(e => e.Message.Contains(unknownToken),
             "the raw token must never appear in any log line");
     }


### PR DESCRIPTION
Follow-up to #644. Unknown/invalid Bearer tokens still burned the full 8 s `ValidationReadTimeout` before their 401 (measured 8.2 s per unauthenticated `/mcp` probe on the rolled memex-cloud): `ReadValidationNode` kept the poll-on-absence shape inherited from the cross-silo mesh read, whose lag no longer exists.

**Why instant rejection is correct now:** `CreateToken` confirms both rows are committed to the shared store (`ConfirmReadable`) *before* the raw token leaves the server — so by the time any client can present a token, its rows exist. Absence at validation = unknown/deleted, terminally. Only a *thrown* storage error (connection blip) re-polls, still bounded by the window.

- 401 latency for bad tokens: ~8.2 s → milliseconds; logged as `index-not-found` Warning with the hash prefix (never the raw token).
- Test updated: `ValidateToken_UnknownToken_FailsFast_NotAtTimeout` (red under the old poll shape).
- `MeshWeaver.Auth.Test`: 114/114 (suite runtime 37 s → 25 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)