### PR TITLE
Close the two residual acked-write-loss holes behind TwoSiloRecycleConvergenceTest

### DIFF
--- a/src/MeshWeaver.Data.Contract/MeshNodeError.cs
+++ b/src/MeshWeaver.Data.Contract/MeshNodeError.cs
@@ -48,7 +48,18 @@ public enum MeshNodeErrorCode
     /// (e.g. missing required field, value-out-of-range). Diagnostic carries
     /// the validation error.
     /// </summary>
-    Validation = 6
+    Validation = 6,
+    /// <summary>
+    /// The owning activation started disposing (idle-recycle / restart) after the
+    /// patch was delivered but BEFORE its merge turn ran — the patch was provably
+    /// NEVER applied. Unlike <see cref="OwnerUnreachable"/> (routing failed) or a
+    /// silent ack loss (owner busy — the patch still applies when the queue drains),
+    /// this code is the owner's explicit statement that the write is gone, so the
+    /// mirror may safely re-enqueue the SAME update against the fresh activation:
+    /// the re-enqueue re-diffs against the freshest state, making it idempotent and
+    /// ordering-safe. Every other NACK code stays terminal (never auto-retried).
+    /// </summary>
+    OwnerDisposing = 7
 }
 
 /// <summary>

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -762,6 +762,55 @@ public static class DataExtensions
     }
 
     /// <summary>
+    /// 🚨 Owner-side disposal NACK for an in-flight <see cref="PatchDataRequest"/>. The patch
+    /// pipeline registers its ack watcher / merge turn on structures that DIE SILENTLY with the
+    /// hub (postSub / deferSub / flushSub are <c>hub.RegisterForDisposal</c>'d; the merge turn's
+    /// <c>UpdateStreamRequest</c> queued on the sync hub is dropped by the shutting-down gate) —
+    /// so an activation disposed after the request was delivered but before the merge committed
+    /// never posted ANY response: the mirror's optimistic emit stood while the write was gone
+    /// (the residual acked-write-loss behind TwoSiloRecycleConvergenceTest, main run 30159928718 /
+    /// PR-645 run 30160988085). This registers a disposal action that claims the shared AckOnce
+    /// gate and posts an explicit <see cref="MeshNodeErrorCode.OwnerDisposing"/> NACK; a real ack
+    /// that already won the Interlocked gate makes it a no-op.
+    /// <para>Disposal actions run in the ShutDown phase, where this hub's OWN Post is gated
+    /// closed (PostImplGeneric fails every non-shutdown message once RunLevel ≥
+    /// DisposeHostedHubs). The NACK therefore posts through the PARENT hub — the same escape the
+    /// MessageService shutting-down NACK uses; response correlation rides ResponseFor's
+    /// RequestId property, never the posting hub's identity. During a WHOLE-MESH teardown the
+    /// parent is itself past DisposeHostedHubs, the guard skips the post, and nobody is waiting
+    /// anyway (the mirror died with the same mesh).</para>
+    /// </summary>
+    /// <param name="hub">The owning per-node hub handling the patch.</param>
+    /// <param name="request">The in-flight patch request to NACK on disposal.</param>
+    /// <param name="hubPath">The hub's path (error payload).</param>
+    /// <param name="tryClaimAck">Claims the shared once-only ack gate; false ⇒ already acked.</param>
+    private static void RegisterOwnerDisposingNack(
+        IMessageHub hub,
+        IMessageDelivery<PatchDataRequest> request,
+        string hubPath,
+        Func<bool> tryClaimAck)
+    {
+        hub.RegisterForDisposal(_ =>
+        {
+            if (!tryClaimAck())
+                return;
+            var nodeErr = new MeshNodeError(
+                MeshNodeErrorCode.OwnerDisposing,
+                hubPath,
+                "owner activation disposing before the merge turn ran — the patch was NOT applied; "
+                + "safe to retry against the fresh activation");
+            var resp = new PatchDataResponse(false, hub.Version)
+            {
+                Error = nodeErr.Message,
+                NodeError = nodeErr,
+            };
+            var parent = hub.Configuration.ParentHub;
+            if (parent is not null && parent.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
+                parent.Post(resp, o => o.ResponseFor(request));
+        });
+    }
+
+    /// <summary>
     /// Maps owner-side patch exceptions to structured <see cref="MeshNodeError"/>
     /// codes. Unknown exception types fall through as
     /// <see cref="MeshNodeErrorCode.Unknown"/> with the exception type prefixed
@@ -1058,6 +1107,21 @@ public static class DataExtensions
             return;
         }
 
+        // Once-only ack gate at METHOD scope (not inside the Take(1) callback): the disposal
+        // NACK below must be able to claim it even when the hub dies BEFORE the stream's first
+        // emission released the callback — the deferred path's silent-death window.
+        var ackPosted = 0;
+        void AckOnce(bool success, MeshNodeError? error = null)
+        {
+            if (System.Threading.Interlocked.Exchange(ref ackPosted, 1) != 0) return;
+            var resp = new PatchDataResponse(success, hub.Version);
+            if (error is not null)
+                resp = resp with { Error = error.Message, NodeError = error };
+            hub.Post(resp, o => o.ResponseFor(request));
+        }
+        RegisterOwnerDisposingNack(hub, request, hubPath,
+            () => System.Threading.Interlocked.Exchange(ref ackPosted, 1) == 0);
+
         stream
             .Take(1)
             .Subscribe(change =>
@@ -1123,17 +1187,11 @@ public static class DataExtensions
                     var merged = System.Text.Json.JsonSerializer.Deserialize<T>(mergedJson, jsonOpts);
                     if (merged is null)
                     {
-                        var nodeErr = new MeshNodeError(
+                        AckOnce(false, new MeshNodeError(
                             MeshNodeErrorCode.Deserialization,
                             hubPath,
                             "Merged value deserialised to null",
-                            patchText);
-                        hub.Post(new PatchDataResponse(false, hub.Version)
-                            {
-                                Error = nodeErr.Message,
-                                NodeError = nodeErr,
-                            },
-                            o => o.ResponseFor(request));
+                            patchText));
                         return;
                     }
 
@@ -1147,16 +1205,6 @@ public static class DataExtensions
                     // deadlock under load. The post-commit response timing
                     // is preserved (caller's RegisterCallback fires after the
                     // commit lands, before any subsequent Get).
-                    var ackPosted = 0;
-                    void AckOnce(bool success, MeshNodeError? error = null)
-                    {
-                        if (System.Threading.Interlocked.Exchange(ref ackPosted, 1) != 0) return;
-                        var resp = new PatchDataResponse(success, hub.Version);
-                        if (error is not null)
-                            resp = resp with { Error = error.Message, NodeError = error };
-                        hub.Post(resp, o => o.ResponseFor(request));
-                    }
-
                     var postSub = stream
                         .Skip(1)
                         .Take(1)
@@ -1199,13 +1247,7 @@ public static class DataExtensions
                 }
                 catch (Exception ex)
                 {
-                    var nodeErr = ClassifyPatchException(ex, hubPath);
-                    hub.Post(new PatchDataResponse(false, hub.Version)
-                        {
-                            Error = nodeErr.Message,
-                            NodeError = nodeErr,
-                        },
-                        o => o.ResponseFor(request));
+                    AckOnce(false, ClassifyPatchException(ex, hubPath));
                 }
             });
     }
@@ -1305,6 +1347,10 @@ public static class DataExtensions
                 },
                 ex => AckOnce(false, ClassifyPatchException(ex, hubPath)));
         hub.RegisterForDisposal(postSub);
+        // Registered AFTER postSub so the composite disposes the watcher FIRST, then this NACK
+        // claims the gate — an unacked in-flight patch always gets a terminal, never silence.
+        RegisterOwnerDisposingNack(hub, request, hubPath,
+            () => System.Threading.Interlocked.Exchange(ref ackPosted, 1) == 0);
 
         // Resolve the target id SYNCHRONOUSLY from the reduced stream's Current (Id is immutable)
         // — never a nested Take(1).Subscribe that re-enters the owner.

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -464,6 +464,23 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 // the process-singleton cache from every domain type a tenant
                 // happens to register.
                 .AddData()  // IWorkspace registration so GetEntry can build the stream handle
+                // 🚨 LATE owner-response seam. A PatchDataResponse whose 2s caller window
+                // (UpdateRemote's bounded wait) already closed has no pending Observe callback,
+                // so HandleCallbacks lets it fall through to this typed handler — the ONLY
+                // place a post-optimistic-emit verdict (above all the OwnerDisposing disposal
+                // NACK) can still be observed without holding a >2s responseSubjects entry
+                // (which the Quiescing leak detector would flag at teardown). Dispatch is a
+                // no-op for timely responses: the caller's bounded wait already disarmed the
+                // registry entry synchronously inside the callback dispatch. See
+                // LatePatchResponseRegistry.
+                .WithHandler<PatchDataResponse>((hub, delivery) =>
+                {
+                    if (delivery.Properties.TryGetValue(PostOptions.RequestId, out var rid)
+                        && rid?.ToString() is { Length: > 0 } requestId)
+                        hub.ServiceProvider.GetService<LatePatchResponseRegistry>()
+                            ?.Dispatch(requestId, delivery.Message);
+                    return delivery.Processed();
+                })
                 .WithInitialization(hub =>
                     hub.RegisterForDisposal(routingService.RegisterStream(hub))),
             HostedHubCreation.Always)!;

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
@@ -691,6 +691,11 @@ public static class PersistenceExtensions
         // upstream subscription per path serves every consumer.
         services.TryAddSingleton<MeshNodeStreamCache>();
         services.TryAddSingleton<IMeshNodeStreamCache>(sp => sp.GetRequiredService<MeshNodeStreamCache>());
+        // Late owner-response watch for cross-hub writes: UpdateRemote arms an entry per
+        // posted patch; the cache hub's PatchDataResponse handler dispatches responses whose
+        // 2s caller window already closed (see LatePatchResponseRegistry). Mesh-scoped
+        // instance singleton — dies with the mesh.
+        services.TryAddSingleton<LatePatchResponseRegistry>();
         // Post-commit durable-flush hook for the PatchDataRequest handler: chains the
         // owner's ack off the storage write so a cross-hub stream.Update completion
         // guarantees read-after-write (see IPostCommitFlush / StoragePostCommitFlush).

--- a/src/MeshWeaver.Mesh.Contract/LatePatchWriteWatch.cs
+++ b/src/MeshWeaver.Mesh.Contract/LatePatchWriteWatch.cs
@@ -1,0 +1,108 @@
+using System.Collections.Concurrent;
+using MeshWeaver.Data;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// 🚨 Late owner-response watch for cross-hub MeshNode writes — the mirror-side half of the
+/// acked-write-loss fix behind <c>TwoSiloRecycleConvergenceTest</c> (main run 30159928718 /
+/// PR-645 run 30160988085).
+///
+/// <para><b>Why this exists.</b> <c>MeshNodeStreamHandle.UpdateRemote</c> bounds the caller's
+/// wait for the owner's <c>PatchDataResponse</c> at <c>UpdateResponseWaitBound</c> (~2 s) and
+/// falls back to an optimistic emit — deliberately, so a busy owner never stalls the GUI. But
+/// the owner's TERMINAL verdict can legitimately arrive later: the disposal NACK
+/// (<see cref="MeshNodeErrorCode.OwnerDisposing"/>) lands only after the owner's phased
+/// teardown, and the cold-store-defer NotFound can fire up to ~10 s after a reactivation. With
+/// the response subscription killed at 2 s, a late NACK was observed by NOBODY — the caller saw
+/// success, the write was gone.</para>
+///
+/// <para><b>Why a registry + hub handler, not a detached 30 s <c>hub.Observe</c>
+/// subscription.</b> A pending <c>Observe</c> callback holds a <c>responseSubjects</c> entry,
+/// and the hub's Quiescing phase counts every such entry as a leaked callback
+/// (<c>QuiescingTimedOut</c> — a hard test-teardown failure). A response whose 2 s caller
+/// window already closed has NO pending callback, so <c>HandleCallbacks</c> lets it fall
+/// through to the regular typed-handler chain — the cache hub's <c>PatchDataResponse</c>
+/// handler consults this registry there. Plain dictionary state: nothing pends on the hub, the
+/// quiesce budget is untouched, and the registry dies with the mesh's DI scope (instance
+/// singleton — never static).</para>
+///
+/// <para><b>Exactly-once hand-off.</b> The entry is registered BEFORE the patch is posted and
+/// removed when the caller's bounded wait delivers a real terminal. A response racing the 2 s
+/// timeout is therefore handled exactly once: either the pending callback consumes it (entry
+/// already completed → <see cref="Dispatch"/> misses) or the callback is gone (entry still
+/// armed → <see cref="Dispatch"/> fires). Expired entries (past
+/// <see cref="LateResponseWatchBound"/>) are treated as silence — silence is NEVER retried: a
+/// merely-busy owner still applies the original patch when its queue drains.</para>
+/// </summary>
+public sealed class LatePatchResponseRegistry
+{
+    /// <summary>
+    /// 🚨 How long after the patch post a late owner response is still acted upon. This is
+    /// PROTOCOL, not tuning: it must dominate every owner-side terminal path — the disposal
+    /// NACK after the owner's phased teardown (hosted-hub drain capped at 5 s), the
+    /// cold-store-defer NotFound (up to ~10 s after reactivation), and the owner ack watcher's
+    /// own 20 s bound. A response beyond this window is indistinguishable from a re-delivered
+    /// stale verdict and is ignored.
+    /// </summary>
+    public static readonly TimeSpan LateResponseWatchBound = TimeSpan.FromSeconds(30);
+
+    private sealed record Entry(
+        string Path,
+        DateTimeOffset ExpiresAt,
+        Action<PatchDataResponse> OnLateResponse);
+
+    // Instance state on a mesh-scoped singleton (registered next to IMeshNodeStreamCache) —
+    // dies with the mesh. Keyed by the PatchDataRequest delivery id (= the response's
+    // RequestId property).
+    private readonly ConcurrentDictionary<string, Entry> entries = new();
+
+    /// <summary>
+    /// Arms the late watch for the patch posted as <paramref name="requestId"/>. Registered
+    /// BEFORE the post so no response can slip between the caller's bounded wait dying and the
+    /// watch arming. Opportunistically prunes expired entries so a burst of never-answered
+    /// writes cannot accumulate (writes are low-rate; the scan is proportional to in-flight
+    /// writes only).
+    /// </summary>
+    /// <param name="requestId">The patch request's delivery id.</param>
+    /// <param name="path">The target node path (diagnostics).</param>
+    /// <param name="onLateResponse">Invoked with the owner's late response, at most once.</param>
+    public void Register(string requestId, string path, Action<PatchDataResponse> onLateResponse)
+    {
+        var now = DateTimeOffset.UtcNow;
+        foreach (var kv in entries)
+        {
+            if (kv.Value.ExpiresAt < now)
+                entries.TryRemove(kv.Key, out _);
+        }
+        entries[requestId] = new Entry(path, now + LateResponseWatchBound, onLateResponse);
+    }
+
+    /// <summary>
+    /// Disarms the watch: the caller's bounded response wait delivered a real terminal (ack,
+    /// rejection, or delivery failure), so there is nothing late to act on.
+    /// </summary>
+    /// <param name="requestId">The patch request's delivery id.</param>
+    public void Complete(string requestId) => entries.TryRemove(requestId, out _);
+
+    /// <summary>
+    /// Delivers a LATE owner response to its armed watch. No-op (false) when the watch was
+    /// already disarmed by the caller's bounded wait, was never armed, or has expired past
+    /// <see cref="LateResponseWatchBound"/>.
+    /// </summary>
+    /// <param name="requestId">The response's <c>RequestId</c> correlation property.</param>
+    /// <param name="response">The owner's response.</param>
+    /// <returns>True when an armed, unexpired watch consumed the response.</returns>
+    public bool Dispatch(string requestId, PatchDataResponse response)
+    {
+        if (!entries.TryRemove(requestId, out var entry))
+            return false;
+        if (entry.ExpiresAt < DateTimeOffset.UtcNow)
+            return false;
+        entry.OnLateResponse(response);
+        return true;
+    }
+
+    /// <summary>Number of armed watches — test seam.</summary>
+    public int ArmedCount => entries.Count;
+}

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -93,7 +93,22 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     // queue) — this is exactly what kills the 30s GUI "Response did not arrive in time"
     // stall during thread execution. Callers needing the reconciled state follow the
     // shared GetMeshNodeStream(path) handle.
+    //
+    // The optimistic emit does NOT abandon the owner's verdict: the write stays armed in
+    // LatePatchResponseRegistry (LateResponseWatchBound, 30s) so a LATE terminal — above
+    // all the OwnerDisposing disposal NACK, which only lands after the owner's phased
+    // teardown — is still observed and a provably-unapplied write is re-enqueued. See
+    // LatePatchResponseRegistry for why the late watch is a registry + hub handler and
+    // not a detached hub.Observe subscription.
     private static readonly TimeSpan UpdateResponseWaitBound = TimeSpan.FromSeconds(2);
+
+    // 🚨 Retry budget for the ONE provably-safe late-NACK case (OwnerDisposing — the owner
+    // stated the patch NEVER applied). Each re-enqueue re-runs the ORIGINAL update lambda
+    // against the freshest state and re-diffs, so a superseding write makes it a no-op;
+    // two re-enqueues cover a re-enqueue that itself lands on a disposing fresh activation
+    // (recycle churn). NEVER retried: silence (a busy owner still applies the original
+    // patch) and every other NACK code (validation/RLS/NotFound are terminal verdicts).
+    private const int MaxOwnerDisposingReenqueues = 2;
 
     internal MeshNodeStreamHandle(IWorkspace workspace, string? path = null,
         IMeshNodeStreamCache? cache = null, bool bypassCache = false)
@@ -805,15 +820,19 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// <para>The returned observable emits the post-merge MeshNode once the
     /// owner's response arrives, then completes.</para>
     /// </summary>
-    private IObservable<MeshNode> UpdateRemote(Func<MeshNode, MeshNode> update)
+    /// <param name="update">The update lambda (already typed-content/context-wrapped).</param>
+    /// <param name="attempt">Re-enqueue depth: 0 for a caller write, incremented by the
+    /// late OwnerDisposing-NACK re-enqueue, capped at <see cref="MaxOwnerDisposingReenqueues"/>.
+    /// Carried as a parameter — never static state.</param>
+    private IObservable<MeshNode> UpdateRemote(Func<MeshNode, MeshNode> update, int attempt = 0)
         => Observable.Create<MeshNode>(observer =>
         {
             var diagLogger = _workspace.Hub.ServiceProvider
                 .GetService<Microsoft.Extensions.Logging.ILoggerFactory>()
                 ?.CreateLogger("MeshWeaver.Mesh.MeshNodeStreamHandle");
             diagLogger?.LogDebug(
-                "[UpdateRemote] BEGIN hub={Hub} target={Path}",
-                _workspace.Hub.Address, _path);
+                "[UpdateRemote] BEGIN hub={Hub} target={Path} attempt={Attempt}",
+                _workspace.Hub.Address, _path, attempt);
 
             // 🚨 Capture AccessContext SYNCHRONOUSLY here, NOT inside the
             // deferred initialSub.Subscribe callback below. The outer
@@ -990,6 +1009,62 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                 }
                             }
 
+                            // 🚨 Arm the LATE-response watch BEFORE opening the bounded wait —
+                            // exactly-once hand-off: a response racing the 2s timeout is either
+                            // consumed by the still-pending Observe callback (which Completes the
+                            // watch synchronously, below) or falls through to the cache hub's
+                            // PatchDataResponse handler, which finds the watch still armed. A
+                            // LATE NACK whose code is OwnerDisposing (the owner's explicit "the
+                            // patch NEVER applied") re-enqueues the ORIGINAL update lambda —
+                            // recursion through UpdateRemote re-reads the freshest state and
+                            // re-diffs, so it is idempotent and ordering-safe (a superseding
+                            // write makes the re-diff a no-op). Silence and every other late
+                            // code are never retried. See LatePatchResponseRegistry.
+                            var lateRegistry = _workspace.Hub.ServiceProvider
+                                .GetService<LatePatchResponseRegistry>();
+                            var requestId = delivery.Id;
+                            lateRegistry?.Register(requestId, _path!, resp =>
+                            {
+                                if (resp.Success && resp.NodeError is null)
+                                {
+                                    diagLogger?.LogDebug(
+                                        "[UpdateRemote] LATE_ACK hub={Hub} target={Path} — write applied after the optimistic emit",
+                                        _workspace.Hub.Address, _path);
+                                    return;
+                                }
+                                var lateErr = resp.NodeError ?? new MeshNodeError(
+                                    MeshNodeErrorCode.Unknown, _path!,
+                                    resp.Error ?? "Update rejected by owner");
+                                if (lateErr.Code == MeshNodeErrorCode.OwnerDisposing
+                                    && attempt < MaxOwnerDisposingReenqueues)
+                                {
+                                    diagLogger?.LogWarning(
+                                        "[UpdateRemote] LATE_NACK_REENQUEUE hub={Hub} target={Path} attempt={Attempt} — owner disposed before the merge turn; re-enqueueing the original update against the fresh activation",
+                                        _workspace.Hub.Address, _path, attempt + 1);
+                                    // Restore the writer's identity: this callback runs on the
+                                    // cache hub's action block where the AsyncLocal context is
+                                    // the hub's own, and the re-posted patch must carry the
+                                    // ORIGINAL caller's AccessContext (UpdateRemote's eager
+                                    // capture runs synchronously inside Subscribe).
+                                    using (accessServiceAtEntry is not null && capturedContextAtEntry is not null
+                                        ? accessServiceAtEntry.SwitchAccessContext(capturedContextAtEntry)
+                                        : null)
+                                    {
+                                        UpdateRemote(update, attempt + 1).Subscribe(
+                                            _ => { },
+                                            ex2 => diagLogger?.LogWarning(ex2,
+                                                "[UpdateRemote] LATE_NACK_REENQUEUE failed hub={Hub} target={Path} attempt={Attempt}",
+                                                _workspace.Hub.Address, _path, attempt + 1));
+                                    }
+                                }
+                                else
+                                {
+                                    diagLogger?.LogWarning(
+                                        "[UpdateRemote] LATE_NACK_TERMINAL hub={Hub} target={Path} code={Code} attempt={Attempt} msg={Msg} — the optimistically-acked write did NOT apply and is not auto-retryable",
+                                        _workspace.Hub.Address, _path, lateErr.Code, attempt, lateErr.Message);
+                                }
+                            });
+
                             // 🚨 BOUNDED response wait — emit as soon as the activity is
                             // STARTED (the patch is accepted), fail-fast on errors, and NEVER
                             // wait for the round to finish. We still observe the owner's
@@ -1006,12 +1081,18 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             // optimistic snapshot — the RFC 7396 patch is deterministic, so
                             // `updated` matches the owner's reconciled state. Callers needing the
                             // reconciled state follow the shared GetMeshNodeStream(path) handle.
+                            //
+                            // Every REAL terminal below disarms the late watch (Complete); ONLY
+                            // the TimeoutException branch leaves it armed — that is the one case
+                            // where the owner's verdict is still outstanding after the caller's
+                            // optimistic emit.
                             var responseSub = _workspace.Hub.Observe(delivery)
                                 .Timeout(UpdateResponseWaitBound)
                                 .Take(1)
                                 .Subscribe(
                                     d =>
                                     {
+                                        lateRegistry?.Complete(requestId);
                                         // Owner posted a structured rejection (deserialization /
                                         // validation gate) as PatchDataResponse.NodeError, or a
                                         // non-success ack → surface as a typed exception (fail-fast).
@@ -1043,6 +1124,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                         if (ex is DeliveryFailureException dfx
                                             && dfx.Failure?.ErrorType == ErrorType.Unauthorized)
                                         {
+                                            lateRegistry?.Complete(requestId);
                                             diagLogger?.LogWarning(
                                                 "[UpdateRemote] OWNER_DENIED hub={Hub} target={Path} msg={Msg}",
                                                 _workspace.Hub.Address, _path, dfx.Failure.Message);
@@ -1055,6 +1137,9 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                             // is running). Emit the optimistic snapshot now rather
                                             // than wait for the activity to finish; the patch is
                                             // posted and applies when the owner drains its queue.
+                                            // The late watch STAYS armed — a late OwnerDisposing
+                                            // NACK proves the patch will never apply and triggers
+                                            // the re-enqueue above.
                                             diagLogger?.LogDebug(
                                                 "[UpdateRemote] RESPONSE_TIMEOUT hub={Hub} target={Path} — optimistic emit (owner busy)",
                                                 _workspace.Hub.Address, _path);
@@ -1062,6 +1147,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                         }
                                         else
                                         {
+                                            lateRegistry?.Complete(requestId);
                                             // Other owner-side / delivery error → surface it (fail-fast).
                                             diagLogger?.LogWarning(ex,
                                                 "[UpdateRemote] response wait errored hub={Hub} target={Path}",

--- a/test/MeshWeaver.Hosting.Monolith.Test/LateNackReenqueueTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/LateNackReenqueueTest.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins hole 2 of the residual acked-write-loss behind <c>TwoSiloRecycleConvergenceTest</c>
+/// (main run 30159928718 / PR-645 run 30160988085): the mirror's <c>UpdateRemote</c> bounds
+/// its owner-response wait at ~2s and emits the optimistic snapshot on timeout — but the OLD
+/// shape also KILLED the response subscription there, so an owner verdict arriving later
+/// (above all the <see cref="MeshNodeErrorCode.OwnerDisposing"/> disposal NACK, which only
+/// lands after the owner's phased teardown) was observed by NOBODY. The caller saw success;
+/// the write was gone.
+///
+/// <para>The fix: the write stays armed in <c>LatePatchResponseRegistry</c> for
+/// <c>LateResponseWatchBound</c> (30s); the cache hub's <c>PatchDataResponse</c> handler
+/// dispatches the late verdict, and an OwnerDisposing NACK — the owner's explicit
+/// "the patch NEVER applied" — re-enqueues the ORIGINAL update lambda against the fresh
+/// activation (bounded re-enqueue budget, re-diffed against the freshest state).</para>
+///
+/// <para>The scripted interleaving: park the owner's merge turn behind a gated no-op turn
+/// (so no response can arrive inside the 2s window), let the caller take its optimistic
+/// terminal, THEN dispose the owner — the disposal NACK is necessarily LATE. The write must
+/// still reach durable storage via the re-enqueue. Without Part 2 the late NACK is dropped
+/// and the storage poll times out at the pre-write state.</para>
+/// </summary>
+public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact(Timeout = 90_000)]
+    public async Task LateOwnerDisposingNack_AfterOptimisticEmit_ReenqueuesAndLands()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var path = $"{TestPartition}/late-nack-node";
+        await NodeFactory.CreateNode(
+                new MeshNode("late-nack-node", TestPartition) { Name = "initial", NodeType = "Markdown" })
+            .Should().Emit();
+
+        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+            .Should().Emit();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(10.Seconds()).ToTask(ct);
+
+        var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
+        nodeHub.Should().NotBeNull();
+
+        // Park the owner's merge executor (same gating pattern as OwnerDisposalNackTest):
+        // the cross-hub write below is accepted by the owner's handler but its merge turn
+        // provably cannot run — no ack can arrive inside the caller's 2s window.
+        var primary = nodeHub!.GetWorkspace().DataContext
+            .GetDataSourceForType(typeof(MeshNode))!
+            .GetStreamForPartition(null)!;
+        using var gateEntered = new ManualResetEventSlim(false);
+        using var releaseGate = new ManualResetEventSlim(false);
+        primary.Update((Func<EntityStore?, ChangeItem<EntityStore>?>)(_ =>
+        {
+            gateEntered.Set();
+            releaseGate.Wait(TimeSpan.FromSeconds(60));
+            return null;
+        }), _ => { });
+        gateEntered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue(
+            "the gated turn must be running on the primary stream's executor before the write");
+
+        try
+        {
+            // Cross-hub cache write — the production mirror path (UpdateRemote via the
+            // per-path queue). With the owner's merge parked, the caller's terminal is the
+            // OPTIMISTIC emit at ~2s carrying the locally-computed snapshot.
+            var marker = $"post-nack-{Guid.NewGuid():N}"[..24];
+            var workspace = Mesh.GetWorkspace();
+            var optimistic = await workspace.GetMeshNodeStream(path)
+                .Update(n => n with { Name = marker })
+                .FirstAsync().Timeout(10.Seconds()).ToTask(ct);
+            optimistic.Name.Should().Be(marker, "the caller's terminal is the optimistic snapshot");
+            Output.WriteLine($"[write] optimistic terminal received with marker {marker}");
+
+            // Fence: the patch handler has provably run on the owner (registered the
+            // disposal NACK) before the dispose below.
+            await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+                .Should().Within(10.Seconds()).Emit();
+
+            // Dispose the owner AFTER the optimistic emit — its OwnerDisposing NACK
+            // (posted from the ShutDown-phase disposal action) is necessarily LATE. The
+            // armed late watch must consume it and re-enqueue the ORIGINAL update against
+            // the fresh activation the re-posted patch brings up.
+            nodeHub!.Dispose();
+            Output.WriteLine($"[dispose] owner per-node hub disposal invoked for {path}");
+
+            // Ground truth: the write eventually lands in durable storage. Without the
+            // late-NACK re-enqueue the store stays frozen at 'initial' (the parked merge
+            // turn died with the sync hub; nobody re-applies) and this poll times out —
+            // the WaitForPersistedBeyond signature of the TwoSilo failure.
+            var persisted = await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+                .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+                .Where(n => n is not null && n.Name == marker)
+                .FirstAsync().Timeout(45.Seconds()).ToTask(ct);
+            persisted!.Name.Should().Be(marker,
+                "an optimistically-acked write whose owner NACKed OwnerDisposing must be "
+                + "re-enqueued and applied on the fresh activation — never silently lost");
+        }
+        finally
+        {
+            releaseGate.Set();
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/OwnerDisposalNackTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/OwnerDisposalNackTest.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins hole 1 of the residual acked-write-loss behind <c>TwoSiloRecycleConvergenceTest</c>
+/// (main run 30159928718 / PR-645 run 30160988085): an owner per-node hub disposed AFTER a
+/// <c>PatchDataRequest</c> was delivered (handler ran, ack watcher + merge turn queued) but
+/// BEFORE the merge turn committed used to die SILENTLY — the ack watcher (<c>postSub</c>)
+/// was <c>hub.RegisterForDisposal</c>'d so disposal killed it before its own timeout could
+/// fire, and the parked merge turn's <c>UpdateStreamRequest</c> was dropped by the sync hub's
+/// shutting-down gate. No response was EVER posted; the sender waited to its full request
+/// timeout while the write was gone.
+///
+/// <para>The fix (<c>DataExtensions.RegisterOwnerDisposingNack</c>): the patch handler
+/// registers a disposal action that claims the once-only ack gate and posts an explicit
+/// <c>PatchDataResponse</c> NACK with <see cref="MeshNodeErrorCode.OwnerDisposing"/> —
+/// routed through the PARENT hub, because the disposing hub's own Post is gated closed in
+/// the ShutDown phase where disposal actions run. This test parks the merge turn behind a
+/// gated no-op turn on the primary data-source stream's executor (the
+/// <c>TeardownHubCreationFreezeTest</c> gating pattern), disposes the owner, and requires
+/// the NACK as the sender's terminal. Without the fix it fails with a silent timeout.</para>
+/// </summary>
+public class OwnerDisposalNackTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact(Timeout = 60_000)]
+    public async Task DisposingOwner_BeforeMergeTurnRuns_NacksOwnerDisposing()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var path = $"{TestPartition}/disposal-nack-node";
+        await NodeFactory.CreateNode(
+                new MeshNode("disposal-nack-node", TestPartition) { Name = "initial", NodeType = "Markdown" })
+            .Should().Emit();
+
+        // Warm the per-node hub and wait until the CREATE is durable, so the owner's
+        // data-source streams are fully initialized before the gate goes in.
+        await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+            .Should().Emit();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(10.Seconds()).ToTask(ct);
+
+        var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
+        nodeHub.Should().NotBeNull();
+
+        // Park the PRIMARY data-source stream's turn executor with a gated no-op turn:
+        // the patch's merge turn queues BEHIND it on the same serialized executor, so it
+        // provably cannot run before the hub is disposed. Test-side gating only — the
+        // same ManualResetEventSlim pattern as TeardownHubCreationFreezeTest.
+        var primary = nodeHub!.GetWorkspace().DataContext
+            .GetDataSourceForType(typeof(MeshNode))!
+            .GetStreamForPartition(null)!;
+        using var gateEntered = new ManualResetEventSlim(false);
+        using var releaseGate = new ManualResetEventSlim(false);
+        primary.Update((Func<EntityStore?, ChangeItem<EntityStore>?>)(_ =>
+        {
+            gateEntered.Set();
+            releaseGate.Wait(TimeSpan.FromSeconds(60));
+            return null;
+        }), _ => { });
+        gateEntered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue(
+            "the gated turn must be running on the primary stream's executor before the patch is posted");
+
+        try
+        {
+            // Post the patch with a pre-registered response observable, then FENCE on a
+            // GetDataRequest response from the same single-threaded action block — when the
+            // fence answers, the patch handler has run: ack watcher + disposal NACK are
+            // registered and the merge turn is parked behind the gate.
+            var nameKey = Mesh.JsonSerializerOptions.PropertyNamingPolicy?.ConvertName(nameof(MeshNode.Name))
+                ?? nameof(MeshNode.Name);
+            var patchJson = new System.Text.Json.Nodes.JsonObject { [nameKey] = "never-applied" }
+                .ToJsonString(Mesh.JsonSerializerOptions);
+            var respTask = Mesh.Observe(
+                    new PatchDataRequest(new MeshNodeReference(), new RawJson(patchJson)),
+                    o => o.WithTarget(new Address(path)))
+                .FirstAsync().Timeout(10.Seconds()).ToTask(ct);
+            await Mesh.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+                .Should().Within(10.Seconds()).Emit();
+
+            nodeHub!.Dispose();
+            Output.WriteLine($"[dispose] owner per-node hub disposal invoked for {path}");
+
+            // WITHOUT the disposal NACK this wait dies silently (postSub disposed with the
+            // hub, merge turn dropped) and times out at 10s — the acked-write-loss
+            // signature. WITH the fix, the ShutDown-phase disposal action posts the
+            // OwnerDisposing NACK through the parent hub within the phased-teardown bound
+            // (hosted-hub drain is capped at 5s even with the sync hub parked).
+            var response = await respTask;
+            var patchResponse = response.Message.Should().BeOfType<PatchDataResponse>().Subject;
+            patchResponse.Success.Should().BeFalse(
+                "the merge turn never ran — a disposing owner must never claim success");
+            patchResponse.NodeError.Should().NotBeNull(
+                "the disposal NACK carries a structured error so the mirror can classify it");
+            patchResponse.NodeError!.Code.Should().Be(MeshNodeErrorCode.OwnerDisposing,
+                "OwnerDisposing is the owner's explicit 'the patch was NOT applied — safe to retry' "
+                + "verdict; any other code (or silence) loses the acked-at-mirror write");
+        }
+        finally
+        {
+            releaseGate.Set();
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #635 (cbaa4fab0), which fixed the OWNER-side false ack. The test recurred twice today (main run 30159928718, PR #645 run 30160988085) — same signature: resilient write "succeeds", store frozen at the pre-recycle version. Two residual holes, both closed here:

## Hole 1 — silent death on a disposing owner
A `PatchDataRequest` delivered to an owner hub that disposes before the merge turn runs left the sender in silence forever (the pending-ack subscription was disposed with the hub; no NACK path fired).
**Fix:** a disposal action claims the shared `AckOnce` gate and posts `PatchDataResponse{Success=false, NodeError.Code=OwnerDisposing}` (new wire-compatible enum member) — via the parent hub, because the dying hub's own `Post` is gated closed at `RunLevel ≥ DisposeHostedHubs`. Applied to both the in-turn MeshNode path and the deferred path (whose `AckOnce` was unreachable when the hub died first — hoisted).

## Hole 2 — mirror abandons the response after its optimistic emit
`UpdateRemote` bounds the owner-response wait at 2 s and emits the locally-computed optimistic snapshot on timeout — and then nobody observed the owner's LATE response. A late `OwnerDisposing` NACK (provably-never-applied) meant the caller saw success while the write was gone.
**Fix:** every write arms a `LatePatchResponseRegistry` entry before posting; late responses (whose 2 s caller window closed) dispatch to it via a typed `PatchDataResponse` handler on the cache hub. Late success → no-op; late `OwnerDisposing` → the ORIGINAL update lambda is re-enqueued (max 2 attempts, under the captured AccessContext) — ordering-safe because it re-diffs against the freshest state and self-neutralizes if superseded; any other late NACK is terminal and logged loud. Exactly-once hand-off between the 2 s timeout branch and the registry.

## Verification
- `OwnerDisposalNackTest`: **red without Part 1** (silent timeout), green with.
- `LateNackReenqueueTest`: **red without Part 2** (optimistic success, durable-storage poll times out = the acked-write-loss), green with.
- `TwoSiloRecycleConvergenceTest` ×3 sequential: green.
- Suites: Data 287/287, Messaging.Hub 103/103, Monolith 393/0 fail, Orleans 133/134*.
- Full `Release -warnaserror`: clean.

*The one Orleans-suite failure is a **third, pre-existing mechanism** with hard evidence on pre-fix main (run 30159928718 attempt 1): the post-recycle patch landed on a **stale second per-node activation**; the three-way MergeGuard refused every content key yet committed + flushed the stale state **with a success ack** — a loss no NACK-based machinery can catch. That is the #325 split-brain family and needs the single-writer activation invariant; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)