### PR TITLE
Stuck enrichment bindings self-heal: overlaid/defaulted instances recycle themselves when their NodeType becomes usable

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -155,8 +155,14 @@ internal static class NodeTypeEnrichmentHelpers
                         logger?.LogWarning(
                             "EnrichWithNodeType: NodeType '{NodeType}' has no static registration and no persisted node at that path — applying error overlay to '{InstancePath}'",
                             nodeType, node.Path);
+                        // Self-heal with a NULL version gate — there is no type
+                        // node at all yet; the first usable state (the type gets
+                        // registered/imported and compiled later) recycles this
+                        // instance off the overlay.
                         return Observable.Return(
-                            WithCompilationErrorOverlay(node, nodeType, msg, meshConfiguration));
+                            WithOverlaySelfHeal(
+                                WithCompilationErrorOverlay(node, nodeType, msg, meshConfiguration),
+                                meshHub, nodeType, typeVersionAtOverlay: null, logger));
                     }
                     return BuildEnrichmentChain(meshHub, meshConfiguration, compilationService, node, nodeType, logger);
                 });
@@ -227,14 +233,27 @@ internal static class NodeTypeEnrichmentHelpers
                 // Build a user-actionable message — TimeoutException's bare
                 // "The operation has timed out." gives the operator nothing
                 // to act on. Tell them which NodeType, which budget, and
-                // where to look.
-                var userMessage = ex is TimeoutException
-                    ? $"NodeType '{nodeType}' compile did not settle within {SlowPathTimeout.TotalSeconds:0}s.\n"
-                      + $"Instance '{node.Path}' is rendering this fallback. Check the NodeType's source code, "
-                      + $"its Code nodes' compilation diagnostics, or trigger a fresh release."
+                // where to look. The timeout is NOT a compile error — the
+                // build simply hasn't settled (mesh restart in progress,
+                // recompile storm-queued, per-NodeType hub unreachable) — so
+                // that page swaps the "correct the code" copy for the
+                // auto-recovery story (see UnsettledBuildIntro/Guidance).
+                var timedOut = ex is TimeoutException;
+                var userMessage = timedOut
+                    ? $"NodeType '{nodeType}' build did not settle within {SlowPathTimeout.TotalSeconds:0}s.\n"
+                      + $"Instance '{node.Path}' is rendering this fallback until the type's build settles."
                     : $"NodeType '{nodeType}' enrichment failed for instance '{node.Path}': {ex.Message}";
+                // Self-heal with a NULL version gate: no type node is in hand
+                // here, and a currently-usable state would have settled instead
+                // of timing out — so the first usable emission is genuine news
+                // and recycles this instance off the overlay.
                 return Observable.Return(
-                    WithCompilationErrorOverlay(node, nodeType, userMessage, meshConfiguration));
+                    WithOverlaySelfHeal(
+                        WithCompilationErrorOverlay(node, nodeType, userMessage, meshConfiguration,
+                            guidance: timedOut ? UnsettledBuildGuidance : null,
+                            intro: timedOut ? UnsettledBuildIntro : null,
+                            callToAction: timedOut ? UnsettledBuildCallToAction : null),
+                        meshHub, nodeType, typeVersionAtOverlay: null, logger));
             });
     }
 
@@ -525,10 +544,16 @@ internal static class NodeTypeEnrichmentHelpers
                         logger?.LogWarning(
                             "EnrichWithNodeType: pinned release {ReleasePath} for {NodeType} could not be resolved",
                             requestedReleasePath, nodeType);
+                        // Version-gated self-heal (typeNode.Version): the type's
+                        // LATEST build may already be usable while the pin is
+                        // broken — without the gate the watcher would fire on
+                        // the replayed current state and hot-loop the recycle.
                         return Observable.Return(
-                            WithCompilationErrorOverlay(node, nodeType,
-                                $"Pinned release '{requestedReleasePath}' for '{nodeType}' could not be resolved.",
-                                meshConfiguration));
+                            WithOverlaySelfHeal(
+                                WithCompilationErrorOverlay(node, nodeType,
+                                    $"Pinned release '{requestedReleasePath}' for '{nodeType}' could not be resolved.",
+                                    meshConfiguration),
+                                meshHub, nodeType, typeNode.Version, logger));
                     }
                     // Use the persisted integer version the IAssemblyStore.Put used,
                     // not a parse of the display Version string.
@@ -555,10 +580,16 @@ internal static class NodeTypeEnrichmentHelpers
                                     logger?.LogWarning(
                                         "EnrichWithNodeType: pinned release {ReleasePath} bytes still not found in store after {Attempts} recompile attempt(s) (collection={Coll}, version={Version})",
                                         requestedReleasePath, recompileAttempts, release.AssemblyCollection, releaseVersion);
+                                    // Version-gated self-heal — same rationale as
+                                    // the unresolved-pin overlay above: the latest
+                                    // build may satisfy HasUsableBuild right now,
+                                    // so only a Version ADVANCE may recycle.
                                     return Observable.Return(
-                                        WithCompilationErrorOverlay(node, nodeType,
-                                            $"Pinned release '{requestedReleasePath}' assembly not found in store.",
-                                            meshConfiguration));
+                                        WithOverlaySelfHeal(
+                                            WithCompilationErrorOverlay(node, nodeType,
+                                                $"Pinned release '{requestedReleasePath}' assembly not found in store.",
+                                                meshConfiguration),
+                                            meshHub, nodeType, typeNode.Version, logger));
                                 }
                                 return TriggerRecompileAndRetry(
                                     node, nodeType, meshConfiguration, compilationService, meshHub,
@@ -629,9 +660,39 @@ internal static class NodeTypeEnrichmentHelpers
                             logger?.LogWarning(
                                 "EnrichWithNodeType: latest assembly for {NodeType} still not found in store after {Attempts} recompile attempt(s) (collection={Coll}, version={Version}) — falling back to default config",
                                 nodeType, recompileAttempts, def.LatestAssemblyCollection, compileVersion);
-                            return Observable.Return(ApplyEntry(
+                            // 🚨 The SECOND sticky class (memex two-pod evidence,
+                            // 2026-07-26): this silent default-config fallback is
+                            // cached for the grain's lifetime exactly like the
+                            // error overlay — an instance on a pod whose local
+                            // store lacks the type's bytes serves only generic
+                            // areas until a manual recycle (and each recycle
+                            // re-rolls placement). Attach the same self-heal
+                            // watcher. The version gate is MANDATORY here, not
+                            // optional: HasUsableBuild is already TRUE in this
+                            // state (only the byte resolution missed), so an
+                            // ungated watcher would fire on the replayed current
+                            // state and hot-loop the recycle. Gated, the instance
+                            // self-recycles once per NodeType write — when the
+                            // compile eventually lands on this pod, re-enrichment
+                            // resolves the bytes and heals.
+                            //
+                            // Only wrap when a hub configuration will actually be
+                            // composed (the node's own, or the mesh default the
+                            // factory adds underneath). With NEITHER, the null
+                            // HubConfiguration must survive: routing/grain key
+                            // the fail-fast NACK-fallback hub on it, and that
+                            // hub's DeactivateOnIdle already retries on next
+                            // access — wrapping would swap fail-fast for a bare
+                            // hub that Ignores typed requests (the park class).
+                            var fallback = ApplyEntry(
                                 node, localAssemblyPath: null, hubConfig: null,
-                                nodeType, meshConfiguration));
+                                nodeType, meshConfiguration);
+                            return Observable.Return(
+                                fallback.HubConfiguration is null
+                                && meshConfiguration.DefaultNodeHubConfiguration is null
+                                    ? fallback
+                                    : WithOverlaySelfHeal(
+                                        fallback, meshHub, nodeType, typeNode.Version, logger));
                         }
                         return TriggerRecompileAndRetry(
                             node, nodeType, meshConfiguration, compilationService, meshHub,
@@ -705,11 +766,16 @@ internal static class NodeTypeEnrichmentHelpers
                     "EnrichWithNodeType: {NodeType} assembly is compiled against framework {Compiled} but the live framework is {Live}; still ABI-stale after {Attempts} recompile attempt(s) — overlaying recompile prompt",
                     nodeType, def.CompiledFrameworkVersion ?? "(null)",
                     NodeTypeCompilationHelpers.FrameworkVersion, recompileAttempts);
+                // Version-gated self-heal: when the operator's recompile lands
+                // (a Version-advancing write with a framework-matching build),
+                // every instance stuck on this prompt recycles itself.
                 return Observable.Return(
-                    WithCompilationErrorOverlay(node, nodeType,
-                        "Built against a previous framework version",
-                        meshConfiguration,
-                        guidance: "This type's compiled assembly targets an older MeshWeaver build, so the current process can't load it. Click **Recompile** (or call `compile` via MCP) to rebuild it against the current framework — no source changes are needed."));
+                    WithOverlaySelfHeal(
+                        WithCompilationErrorOverlay(node, nodeType,
+                            "Built against a previous framework version",
+                            meshConfiguration,
+                            guidance: "This type's compiled assembly targets an older MeshWeaver build, so the current process can't load it. Click **Recompile** (or call `compile` via MCP) to rebuild it against the current framework — no source changes are needed."),
+                        meshHub, nodeType, typeNode.Version, logger));
             }
             return TriggerRecompileAndRetry(
                 node, nodeType, meshConfiguration, compilationService, meshHub,
@@ -719,8 +785,15 @@ internal static class NodeTypeEnrichmentHelpers
         }
 
         var error = def.CompilationError ?? "Compilation failed";
+        // Genuine compile failure — the page wording stays as-is ("correct the
+        // code"), but the instance still self-heals: once the author fixes the
+        // source and a SUCCESSFUL compile writes back (Version advances +
+        // HasUsableBuild turns true), every instance stuck on this overlay
+        // recycles itself instead of waiting for a manual Recycle.
         return Observable.Return(
-            WithCompilationErrorOverlay(node, nodeType, error, meshConfiguration));
+            WithOverlaySelfHeal(
+                WithCompilationErrorOverlay(node, nodeType, error, meshConfiguration),
+                meshHub, nodeType, typeNode.Version, logger));
     }
 
     /// <summary>
@@ -927,12 +1000,128 @@ internal static class NodeTypeEnrichmentHelpers
         return node with { HubConfiguration = node.HubConfiguration ?? hubConfig };
     }
 
+    /// <summary>
+    /// Self-healing wrap for a STUCK per-instance binding — the fix for the
+    /// memex 2026-07-25/26 incident: an instance enriched while its NodeType
+    /// was unsettled (pod restart wiped pod-local assemblies, recompile
+    /// storm-delayed, per-NodeType hub unreachable) binds the compilation-error
+    /// overlay — or the silent default-config fallback — ONCE, and the
+    /// <see cref="EnrichWithNodeType"/> re-enrichment short-circuit keeps that
+    /// binding for the grain's whole lifetime, even after the type compiles
+    /// green seconds later. Operators had to post manual DisposeRequests per
+    /// instance (the Underwriting root sat on "This page can't be displayed"
+    /// for ~14h).
+    ///
+    /// <para>The wrap adds a <c>WithInitialization</c> to the enriched node's
+    /// HubConfiguration that arms a BACKGROUND watcher on the instance hub:
+    /// it observes the NodeType's MeshNode stream — the SAME
+    /// <c>meshHub.GetWorkspace().GetMeshNodeStream(nodeType)</c> source the
+    /// slow path reads — and on the first GENUINELY USABLE state
+    /// (<see cref="NodeTypeCompilationHelpers.HasUsableBuild"/>) past
+    /// <paramref name="typeVersionAtOverlay"/> posts a <see cref="DisposeRequest"/>
+    /// to the instance's OWN address — the exact recycle idiom of
+    /// <see cref="RecycleLayoutArea"/>. The hub tears down, the grain
+    /// deactivates, and the NEXT access re-enriches from scratch against the
+    /// now-usable NodeType. The watcher never blocks initialization and is
+    /// disposed with the hub (<c>RegisterForDisposal</c>).</para>
+    ///
+    /// <para>🚨 <paramref name="typeVersionAtOverlay"/> is the anti-loop gate.
+    /// At the call sites that hold a type node (pinned-release, ABI-stale,
+    /// genuine Error, bytes-missing default fallback) the CURRENT replayed
+    /// state can ALREADY satisfy HasUsableBuild — e.g. a pinned release is
+    /// missing while the latest build is fine, or the bytes are absent only on
+    /// THIS pod — so an ungated watcher would fire on the replay and
+    /// recycle → re-overlay → recycle in a hot loop. Requiring the type's
+    /// Version to ADVANCE bounds it to at most one self-recycle per NodeType
+    /// write. Pass null ONLY where no type node was in hand (slow-path
+    /// timeout / probe-missing): a currently-usable state would have settled
+    /// instead of timing out, so the first usable emission is genuine news
+    /// there.</para>
+    ///
+    /// <para>Works on a null HubConfiguration too (the silent default-config
+    /// fallback): the wrap then starts from the bare configuration and
+    /// <c>MeshNodeHubFactory</c> still composes
+    /// <c>DefaultNodeHubConfiguration</c> underneath, so the instance keeps
+    /// serving the generic areas until it heals.</para>
+    /// </summary>
+    internal static MeshNode WithOverlaySelfHeal(
+        MeshNode overlaid,
+        IMessageHub meshHub,
+        string nodeType,
+        long? typeVersionAtOverlay,
+        ILogger? logger)
+    {
+        var baseConfig = overlaid.HubConfiguration;
+        Func<MessageHubConfiguration, MessageHubConfiguration> withWatcher = config =>
+            (baseConfig is null ? config : baseConfig(config))
+                .WithInitialization(instanceHub =>
+                {
+                    // Fire-and-forget: a watcher that cannot be armed must never
+                    // fault hub initialization — worst case is the pre-fix world
+                    // ("manual Recycle heals it"), never a dead instance hub.
+                    try
+                    {
+                        instanceHub.RegisterForDisposal(ArmOverlaySelfHeal(
+                            meshHub.GetWorkspace().GetMeshNodeStream(nodeType),
+                            instanceHub, nodeType, typeVersionAtOverlay, logger));
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.LogWarning(ex,
+                            "Overlay self-heal: could not arm the NodeType watcher for '{NodeType}' on instance '{InstancePath}'",
+                            nodeType, instanceHub.Address);
+                    }
+                });
+        return overlaid with { HubConfiguration = withWatcher };
+    }
+
+    /// <summary>
+    /// Watcher core of <see cref="WithOverlaySelfHeal"/>, split out so the
+    /// firing contract is unit-testable without building a hub
+    /// (<c>OverlaySelfHealWatcherTest</c>): the FIRST emission whose content is
+    /// a <see cref="NodeTypeDefinition"/> with a genuinely usable build
+    /// (<see cref="NodeTypeCompilationHelpers.HasUsableBuild"/>) AND — when
+    /// <paramref name="typeVersionAtOverlay"/> is set — a Version strictly past
+    /// it posts exactly ONE self-<see cref="DisposeRequest"/> (Take(1));
+    /// everything else (unsettled states, the replayed at-overlay state,
+    /// non-advancing versions, non-NodeTypeDefinition content) is ignored.
+    /// Errors are logged, never rethrown — the watcher is best-effort by
+    /// design.
+    /// </summary>
+    internal static IDisposable ArmOverlaySelfHeal(
+        IObservable<MeshNode> typeStream,
+        IMessageHub instanceHub,
+        string nodeType,
+        long? typeVersionAtOverlay,
+        ILogger? logger)
+        => typeStream
+            .Where(t => t?.Content is NodeTypeDefinition d
+                && NodeTypeCompilationHelpers.HasUsableBuild(t, d)
+                && (typeVersionAtOverlay is null || t.Version > typeVersionAtOverlay.Value))
+            .Take(1)
+            .Subscribe(
+                t =>
+                {
+                    logger?.LogInformation(
+                        "Overlay self-heal: NodeType '{NodeType}' reached a usable build (version {Version}, at-overlay {VersionAtOverlay}) — recycling stuck instance '{InstancePath}'",
+                        nodeType, t.Version, typeVersionAtOverlay, instanceHub.Address);
+                    // The RecycleLayoutArea idiom: the hub disposes itself, the
+                    // grain deactivates, and the next access re-enriches from
+                    // scratch against the now-usable NodeType.
+                    instanceHub.Post(new DisposeRequest(), o => o.WithTarget(instanceHub.Address));
+                },
+                ex => logger?.LogWarning(ex,
+                    "Overlay self-heal watcher for NodeType '{NodeType}' (instance '{InstancePath}') faulted — falling back to manual Recycle",
+                    nodeType, instanceHub.Address));
+
     public static MeshNode WithCompilationErrorOverlay(
         MeshNode node,
         string nodeType,
         string? error,
         MeshConfiguration meshConfiguration,
-        string? guidance = null)
+        string? guidance = null,
+        string? intro = null,
+        string? callToAction = null)
     {
         var baseConfig = string.IsNullOrEmpty(error)
             ? (node.HubConfiguration ?? meshConfiguration.DefaultNodeHubConfiguration)
@@ -941,7 +1130,7 @@ internal static class NodeTypeEnrichmentHelpers
         if (string.IsNullOrEmpty(error))
             return node with { HubConfiguration = baseConfig };
 
-        var overlay = CreateCompilationErrorConfiguration(error, guidance);
+        var overlay = CreateCompilationErrorConfiguration(error, guidance, intro, callToAction);
         // Fallback-hub contract: the overlay hub serves what its default config CAN
         // (the error Overview layout, node data binding, Ping) — but everything else,
         // notably typed requests the broken assembly would have registered (which
@@ -964,15 +1153,36 @@ internal static class NodeTypeEnrichmentHelpers
     private const string DefaultCompilationErrorGuidance =
         "Fix the source code or the NodeType's `sources` list, then use the **Recycle** menu to flush the cached grain (or call `GetDiagnostics` via MCP to re-check).";
 
+    // Overlay copy for the UNSETTLED-build case (the slow-path timeout in
+    // BuildEnrichmentChain). The genuine-error page's "There was a compilation
+    // error… Please correct the code" is WRONG there — nothing is broken, the
+    // build just hasn't settled yet (mesh restart in progress, recompile
+    // storm-queued, per-NodeType hub unreachable). Keeps the ⚠ headline and a
+    // "compilation" token — the overlay contract CompileErrorOverviewTest
+    // asserts — while telling the operator the page self-recovers (the
+    // WithOverlaySelfHeal watcher) with manual Recycle only as fallback.
+    private const string UnsettledBuildIntro =
+        "This item's type has not finished **compilation** yet, so its page couldn't be built.";
+    private const string UnsettledBuildCallToAction =
+        "**No code change is needed for this.** ";
+    private const string UnsettledBuildGuidance =
+        "This usually happens while a mesh restart or a bulk recompile is still in progress. "
+        + "The page recovers automatically: once the type's build settles, this instance recycles "
+        + "itself and shows the real page on the next load. If it stays stuck, use the **Recycle** "
+        + "menu to refresh it manually.";
+
     private static Func<MessageHubConfiguration, MessageHubConfiguration>
-        CreateCompilationErrorConfiguration(string errorMessage, string? guidance)
+        CreateCompilationErrorConfiguration(
+            string errorMessage, string? guidance, string? intro = null, string? callToAction = null)
     {
         return config => config.AddLayout(layout =>
             layout.WithView(MeshNodeLayoutAreas.OverviewArea, (host, ctx) =>
-                Observable.Return<UiControl?>(BuildCompilationErrorMarkdown(errorMessage, guidance))));
+                Observable.Return<UiControl?>(
+                    BuildCompilationErrorMarkdown(errorMessage, guidance, intro, callToAction))));
     }
 
-    private static UiControl BuildCompilationErrorMarkdown(string errorMessage, string? guidance)
+    private static UiControl BuildCompilationErrorMarkdown(
+        string errorMessage, string? guidance, string? intro = null, string? callToAction = null)
         => Controls.Stack
             // Card-style emergency page: an error accent, a comfortable reading
             // width and generous padding so a broken instance gets a real
@@ -982,7 +1192,8 @@ internal static class NodeTypeEnrichmentHelpers
                 "max-width: 820px; margin: 1.5rem auto; padding: 24px 28px; " +
                 "border: 1px solid var(--error, #d13438); border-left: 4px solid var(--error, #d13438); " +
                 "border-radius: 8px; background: var(--neutral-layer-2);")
-            .WithView(Controls.Markdown(BuildCompilationErrorMarkdownText(errorMessage, guidance)));
+            .WithView(Controls.Markdown(
+                BuildCompilationErrorMarkdownText(errorMessage, guidance, intro, callToAction)));
 
     /// <summary>
     /// Builds the markdown body of the emergency compile-error page: a friendly
@@ -991,8 +1202,13 @@ internal static class NodeTypeEnrichmentHelpers
     /// can be unit-tested directly (<c>CompileErrorPageTest</c>). The <c>⚠</c> and
     /// <c>compilation</c> tokens are part of the overlay contract
     /// <c>CompileErrorOverviewTest</c> asserts — keep them.
+    /// <para><paramref name="intro"/> / <paramref name="callToAction"/> override the
+    /// genuine-error reason line and the "Please correct the code." lead-in for
+    /// call sites where a code fix is NOT the remedy (the unsettled-build timeout
+    /// overlay). Null keeps the genuine-Error wording byte-for-byte.</para>
     /// </summary>
-    internal static string BuildCompilationErrorMarkdownText(string errorMessage, string? guidance)
+    internal static string BuildCompilationErrorMarkdownText(
+        string errorMessage, string? guidance, string? intro = null, string? callToAction = null)
     {
         var newlineIdx = errorMessage.IndexOf('\n');
         var header = newlineIdx >= 0 ? errorMessage[..newlineIdx].TrimEnd(':') : errorMessage;
@@ -1000,7 +1216,8 @@ internal static class NodeTypeEnrichmentHelpers
 
         var sb = new System.Text.StringBuilder();
         sb.Append("# ⚠ This page can't be displayed\n\n");
-        sb.Append("There was a **compilation error** in this item's code, so its page couldn't be built.\n\n");
+        sb.Append(intro ?? "There was a **compilation error** in this item's code, so its page couldn't be built.")
+            .Append("\n\n");
         sb.Append("**").Append(header).Append("**\n");
         // Only emit the diagnostics code fence when there's actually a body to show.
         // A single-line message (the generic "Compilation failed" fallback or the
@@ -1009,7 +1226,8 @@ internal static class NodeTypeEnrichmentHelpers
         if (!string.IsNullOrEmpty(body))
             sb.Append("\n```text\n").Append(body).Append("\n```\n");
         sb.Append("\n---\n\n");
-        sb.Append("**Please correct the code.** ").Append(guidance ?? DefaultCompilationErrorGuidance).Append('\n');
+        sb.Append(callToAction ?? "**Please correct the code.** ")
+            .Append(guidance ?? DefaultCompilationErrorGuidance).Append('\n');
         return sb.ToString();
     }
 }

--- a/src/MeshWeaver.Messaging.Contract/MeshWeaver.Messaging.Contract.csproj
+++ b/src/MeshWeaver.Messaging.Contract/MeshWeaver.Messaging.Contract.csproj
@@ -4,6 +4,13 @@
     <RootNamespace>MeshWeaver.Messaging</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Allow NSubstitute's DynamicProxy to access internal members for testing
+         (same grant as MeshWeaver.Messaging.Hub / MeshWeaver.Mesh.Contract) —
+         without it, auto-substituting IMessageDelivery (internal ChangeState)
+         throws TypeLoadException at proxy generation. -->
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
   <ItemGroup>

--- a/test/MeshWeaver.Graph.Test/OverlaySelfHealWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/OverlaySelfHealWatcherTest.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Reactive.Subjects;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using NSubstitute;
+using NSubstitute.Extensions;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Unit contract for the overlay self-heal watcher
+/// (<see cref="NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal"/>) — the fix for
+/// the memex 2026-07-25/26 incident where an instance hub enriched while its
+/// NodeType's compile was unsettled bound the compilation-error overlay (or
+/// the silent default-config fallback) PERMANENTLY, even after the type
+/// compiled green seconds later, until an operator posted a manual
+/// DisposeRequest per instance.
+///
+/// <para>The contract pinned here:</para>
+/// <list type="bullet">
+///   <item>The watcher posts a self-<see cref="DisposeRequest"/> (targeting
+///     the instance hub's OWN address — the RecycleLayoutArea idiom)
+///     <b>exactly once</b>, on the first emission that is a genuinely usable
+///     build (<see cref="NodeTypeCompilationHelpers.HasUsableBuild"/>) past
+///     the version-at-overlay gate.</item>
+///   <item>The replayed at-overlay state — including the usable-but-
+///     bytes-missing shape where HasUsableBuild is ALREADY true — must NOT
+///     fire instantly; only a Version ADVANCE may recycle (the anti-hot-loop
+///     gate).</item>
+///   <item>A null gate (slow-path timeout / probe-missing: no type node in
+///     hand) fires on the FIRST usable emission, ignoring unsettled states
+///     and non-NodeTypeDefinition content.</item>
+///   <item>Disposing the watcher (the hub's RegisterForDisposal hook) stops
+///     it — no post after teardown.</item>
+/// </list>
+/// </summary>
+public class OverlaySelfHealWatcherTest
+{
+    private const string NodeTypePath = "TestData/SelfHealType";
+    private const string InstancePath = "TestData/SelfHealType/instance1";
+
+    private static IMessageHub BuildInstanceHub(out Func<Func<PostOptions, PostOptions>?> capturedOptions)
+    {
+        var hub = Substitute.For<IMessageHub>();
+        hub.Address.Returns(new Address(InstancePath));
+        Func<PostOptions, PostOptions>? captured = null;
+        // Configure() records the Post spec WITHOUT running NSubstitute's
+        // auto-value provider — IMessageDelivery carries an INTERNAL member
+        // (ChangeState), so auto-substituting Post's return type throws
+        // TypeLoadException at proxy generation. Pinning the result to null
+        // covers the fire-time call too (the watcher ignores the delivery).
+        hub.Configure()
+            .Post(Arg.Any<DisposeRequest>(),
+                Arg.Do<Func<PostOptions, PostOptions>>(f => captured = f))
+            .Returns((IMessageDelivery<DisposeRequest>?)null);
+        capturedOptions = () => captured;
+        return hub;
+    }
+
+    /// <summary>
+    /// A NodeType MeshNode emission at <paramref name="version"/>.
+    /// <paramref name="usable"/> == the HasUsableBuild shape: assembly fields
+    /// populated AND CompiledFrameworkVersion matching the CURRENT framework
+    /// (the only state a successful compile write-back produces).
+    /// </summary>
+    private static MeshNode TypeNode(long version, bool usable) =>
+        new MeshNode("SelfHealType", "TestData")
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Version = version,
+            Content = new NodeTypeDefinition
+            {
+                CompilationStatus = usable ? CompilationStatus.Ok : CompilationStatus.Compiling,
+                LatestAssemblyCollection = usable ? "assemblies" : null,
+                LatestAssemblyPath = usable ? $"{NodeTypePath}/Release/v{version}.dll" : null,
+                CompiledFrameworkVersion = usable
+                    ? NodeTypeCompilationHelpers.FrameworkVersion
+                    : null,
+            }
+        };
+
+    private static void AssertNoDispose(IMessageHub hub) =>
+        hub.DidNotReceive().Post(
+            Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+
+    private static void AssertDisposedExactlyOnce(IMessageHub hub) =>
+        hub.Received(1).Post(
+            Arg.Any<DisposeRequest>(), Arg.Any<Func<PostOptions, PostOptions>>());
+
+    [Fact]
+    public void VersionGated_FiresExactlyOnce_OnVersionAdvancingUsableEmission()
+    {
+        var hub = BuildInstanceHub(out var capturedOptions);
+        var typeStream = new Subject<MeshNode>();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, hub, NodeTypePath, typeVersionAtOverlay: 5, logger: null);
+
+        // The replayed at-overlay state: usable but NOT past the gate. This is
+        // the pinned-release-missing / bytes-missing shape where HasUsableBuild
+        // is already true at overlay time — firing here would be the hot
+        // recycle → re-overlay → recycle loop the gate exists to prevent.
+        typeStream.OnNext(TypeNode(version: 5, usable: true));
+        AssertNoDispose(hub);
+
+        // Version advanced but the state is not usable (a compile in flight) —
+        // must not recycle onto a build that isn't there yet.
+        typeStream.OnNext(TypeNode(version: 6, usable: false));
+        AssertNoDispose(hub);
+
+        // Version-advancing usable emission — THE heal signal: exactly one
+        // self-DisposeRequest.
+        typeStream.OnNext(TypeNode(version: 7, usable: true));
+        AssertDisposedExactlyOnce(hub);
+
+        // The post targets the instance's OWN address (the RecycleLayoutArea
+        // idiom). Derive expected from the SAME base options so the
+        // auto-generated MessageId doesn't perturb record equality.
+        var options = capturedOptions();
+        options.Should().NotBeNull("the DisposeRequest must be posted with explicit options");
+        var baseOptions = new PostOptions(new Address("TestData/sender"));
+        options!(baseOptions).Should().Be(baseOptions.WithTarget(new Address(InstancePath)),
+            "the self-heal recycle must target the instance hub's own address");
+
+        // Take(1): a later usable emission must never fire a second recycle.
+        typeStream.OnNext(TypeNode(version: 8, usable: true));
+        AssertDisposedExactlyOnce(hub);
+    }
+
+    /// <summary>
+    /// The SECOND sticky class (two-pod memex evidence, 2026-07-26): the
+    /// bytes-missing default-config fallback arms the watcher while
+    /// HasUsableBuild is ALREADY TRUE (only the byte resolution missed on this
+    /// pod). The at-overlay state must NOT fire instantly — the version gate is
+    /// mandatory there, not optional — and a version-advancing usable emission
+    /// (any later compile write) fires exactly once.
+    /// </summary>
+    [Fact]
+    public void UsableButBytesMissingAtOverlay_DoesNotFireInstantly_VersionAdvanceFiresOnce()
+    {
+        var hub = BuildInstanceHub(out _);
+        var typeStream = new Subject<MeshNode>();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, hub, NodeTypePath, typeVersionAtOverlay: 41, logger: null);
+
+        // Replay of the exact at-overlay state: usable metadata, same version.
+        typeStream.OnNext(TypeNode(version: 41, usable: true));
+        typeStream.OnNext(TypeNode(version: 41, usable: true));
+        AssertNoDispose(hub);
+
+        // Any later write to the NodeType node bumps Version; with a usable
+        // build that is the heal signal — at most ONE self-recycle per write.
+        typeStream.OnNext(TypeNode(version: 42, usable: true));
+        AssertDisposedExactlyOnce(hub);
+
+        typeStream.OnNext(TypeNode(version: 43, usable: true));
+        AssertDisposedExactlyOnce(hub);
+    }
+
+    [Fact]
+    public void NullGate_FiresOnFirstUsableEmission_IgnoringUnsettledAndForeignContent()
+    {
+        var hub = BuildInstanceHub(out _);
+        var typeStream = new Subject<MeshNode>();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null);
+
+        // Non-NodeTypeDefinition content never fires, whatever the version.
+        typeStream.OnNext(new MeshNode("SelfHealType", "TestData") { Version = 100 });
+        AssertNoDispose(hub);
+
+        // Unsettled compile state never fires.
+        typeStream.OnNext(TypeNode(version: 101, usable: false));
+        AssertNoDispose(hub);
+
+        // First usable emission fires — with a null gate there is no version
+        // floor (the timeout/probe-missing sites hold no type node, and a
+        // currently-usable state would have settled instead of timing out).
+        typeStream.OnNext(TypeNode(version: 102, usable: true));
+        AssertDisposedExactlyOnce(hub);
+    }
+
+    [Fact]
+    public void DisposedWatcher_NeverFires()
+    {
+        var hub = BuildInstanceHub(out _);
+        var typeStream = new Subject<MeshNode>();
+        var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, hub, NodeTypePath, typeVersionAtOverlay: null, logger: null);
+
+        // The hub's RegisterForDisposal hook: tearing the hub down disposes the
+        // watcher — a late heal emission must not post to a dead address.
+        watcher.Dispose();
+        typeStream.OnNext(TypeNode(version: 7, usable: true));
+        AssertNoDispose(hub);
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/OverlaySelfHealInstanceRecycleTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/OverlaySelfHealInstanceRecycleTest.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// End-to-end pin for the overlay SELF-HEAL
+/// (<c>NodeTypeEnrichmentHelpers.WithOverlaySelfHeal</c>) — the memex
+/// 2026-07-25/26 incident: an instance hub that activates while its NodeType
+/// cannot produce a usable build binds the compilation-error overlay ONCE and
+/// keeps it for its whole grain lifetime — the re-enrichment short-circuit
+/// (<c>node.HubConfiguration != null</c>) means the type compiling green
+/// seconds later changes NOTHING for the already-activated instance. On memex
+/// the Underwriting root served "This page can't be displayed" for ~14h until
+/// an operator posted a manual DisposeRequest.
+///
+/// <para>The loop pinned here: instance binds the overlay (broken type,
+/// settled Error) → the source is fixed and the type recompiles to Ok with a
+/// usable build → the instance's background watcher posts the
+/// self-<see cref="DisposeRequest"/> (the RecycleLayoutArea idiom) → the next
+/// access re-activates and renders the COMPILED area. The test never posts a
+/// manual recycle — before the fix, every probe kept hitting the still-alive
+/// overlay hub and the final wait timed out (the exact prod symptom).</para>
+/// </summary>
+public class OverlaySelfHealInstanceRecycleTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    // Two real Roslyn compiles (the failing baseline, then the healing
+    // rebuild) plus an activation round-trip per probe — past the 30s/60s
+    // defaults, same rationale as FrameworkStaleInstanceRenderTest.
+    protected override TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(120);
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(240);
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    [Fact(Timeout = 240_000)]
+    public async Task OverlaidInstance_SelfRecycles_WhenTypeCompilesGreen()
+    {
+        var typeId = $"SelfHeal{Guid.NewGuid():N}";
+        var nodeTypePath = $"{TestPartition}/{typeId}";
+        var sourcePath = $"{nodeTypePath}/Source/code";
+        var instancePath = $"{nodeTypePath}/Inst";
+        var marker = $"SELF_HEALED_MARKER_{typeId}";
+        var workspace = Mesh.GetWorkspace();
+
+        // The FIXED source: a distinctive compiled Overview (HtmlControl with a
+        // unique marker) so the healed page is unambiguously distinguishable
+        // from the overlay (a StackControl with markdown).
+        var goodSource = $$"""
+            using MeshWeaver.Layout.Composition;
+            public static class {{typeId}}Areas
+            {
+                public static UiControl Overview(LayoutAreaHost host, RenderingContext _)
+                    => Controls.Html("<div id='marker'>{{marker}}</div>");
+            }
+            """;
+
+        // 1. NodeType + a deliberately BROKEN source — the compile settles at
+        //    Error (genuine failure, no usable build; the type also parks).
+        await NodeFactory.CreateNode(new MeshNode(typeId, TestPartition)
+        {
+            Name = typeId,
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Overlay self-heal end-to-end regression.",
+                Configuration = $"config => config.AddDefaultLayoutAreas().AddLayout(layout => layout.WithView(\"Overview\", {typeId}Areas.Overview))",
+            }
+        }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("code", $"{nodeTypePath}/Source")
+        {
+            Name = "Code",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = "this is not valid C#;", Language = "csharp" }
+        }).Should().Within(30.Seconds()).Emit();
+
+        await TriggerRecompile(nodeTypePath, DateTimeOffset.UtcNow);
+
+        // Error must be visible on the MESH HUB's workspace view — the same
+        // stream activation reads — BEFORE the instance is created, so
+        // enrichment deterministically hits the genuine-Error overlay branch
+        // (not the wait-for-in-flight-compile path).
+        await workspace.GetMeshNodeStream(nodeTypePath)
+            .Should().Within(60.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Error);
+        Output.WriteLine("NodeType settled at Error on the mesh hub view.");
+
+        // 2. An instance of the broken type — activation binds the overlay
+        //    (StackControl; the compiled area would be an HtmlControl). This is
+        //    the stuck state the fix targets.
+        await NodeFactory.CreateNode(new MeshNode("Inst", nodeTypePath)
+        {
+            Name = "Inst",
+            NodeType = nodeTypePath,
+            State = MeshNodeState.Active,
+        }).Should().Within(30.Seconds()).Emit();
+
+        var reference = new LayoutAreaReference("Overview");
+        var overlayClient = GetClient(c => c.AddData());
+        await overlayClient.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(instancePath), reference)
+            .GetControlStream(reference.Area!)
+            .Should().Within(60.Seconds()).Match(c => c is StackControl);
+        Output.WriteLine("Instance is bound to the compilation-error overlay.");
+
+        // 3. Fix the source. A source fix on a parked Error type auto-un-parks
+        //    and recompiles (pinned in NodeTypeCompileParkTest.
+        //    ParkedNodeType_SourceFix_AutoRecompilesAndUnparks) — wait for the
+        //    healed terminal state: Ok WITH a usable build, on the SAME
+        //    mesh-hub stream the instance's self-heal watcher subscribes.
+        await workspace.GetMeshNodeStream(sourcePath).Update(curr =>
+            curr with { Content = new CodeConfiguration { Code = goodSource, Language = "csharp" } })
+            .Should().Within(30.Seconds()).Emit();
+        await workspace.GetMeshNodeStream(nodeTypePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LatestAssemblyCollection)
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath));
+        Output.WriteLine("NodeType healed to Ok with a usable build.");
+
+        // 4. THE CONTRACT — no manual DisposeRequest anywhere in this test:
+        //    the stuck instance must SELF-recycle (the overlay's watcher posts
+        //    the self-DisposeRequest on the healed emission) and the next
+        //    access must re-activate onto the COMPILED configuration. Probe
+        //    with fresh clients — each probe is a new subscription, i.e. a new
+        //    activation once the stuck hub disposed; a probe that lands before
+        //    the recycle sees the overlay and times out its bounded window, so
+        //    retry. Before the fix EVERY probe hit the still-alive overlay hub
+        //    and this wait exhausted all attempts (the prod 14h symptom).
+        string? healedHtml = null;
+        for (var attempt = 0; attempt < 6 && healedHtml is null; attempt++)
+        {
+            var probeClient = GetClient(c => c.AddData());
+            try
+            {
+                var control = await probeClient.GetWorkspace()
+                    .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(instancePath), reference)
+                    .GetControlStream(reference.Area!)
+                    .Where(c => c is HtmlControl h && (h.Data?.ToString() ?? string.Empty).Contains(marker))
+                    .Take(1)
+                    .Timeout(15.Seconds())
+                    .ToTask(TestContext.Current.CancellationToken);
+                healedHtml = (control as HtmlControl)?.Data?.ToString();
+            }
+            catch (TimeoutException)
+            {
+                Output.WriteLine($"Probe {attempt}: still the overlay — self-recycle not landed yet, retrying.");
+            }
+        }
+
+        healedHtml.Should().NotBeNull(
+            "the overlaid instance must self-recycle once its NodeType compiles green — "
+            + "no manual Recycle — and re-activate onto the compiled configuration");
+        healedHtml!.Should().Contain(marker,
+            "the re-activated instance must render the compiled Overview area, not the overlay");
+    }
+
+    /// <summary>
+    /// Canonical explicit compile trigger — the RequestedReleaseAt + Force flip
+    /// on the NodeType MeshNode (same shape as CodeEditRecompileTest's helper;
+    /// the UI Compile button executes this exact write).
+    /// </summary>
+    private async Task TriggerRecompile(string nodeTypePath, DateTimeOffset triggerAt)
+    {
+        await Mesh.GetWorkspace().GetMeshNodeStream(nodeTypePath).Update(curr =>
+        {
+            if (curr?.Content is not NodeTypeDefinition def) return curr!;
+            return curr with
+            {
+                Content = def with
+                {
+                    RequestedReleaseAt = triggerAt,
+                    RequestedReleaseForce = true,
+                }
+            };
+        }).Should().Within(30.Seconds()).Emit();
+    }
+}


### PR DESCRIPTION
## Incident

memex, 2026-07-25 → 26: after the evening pod restarts, the **Underwriting** root (nodeType `Store/Plugin`) served the cached *"NodeType 'Store/Plugin' compile did not settle within 60s"* fallback for **~14 hours** — while `Store/Plugin` was `CompilationStatus.Ok` the whole time, with `compiledSources` exactly matching `currentSourceVersions`. Manual per-instance Recycle was the only heal, and with two pods + pod-local assemblies each recycle re-rolls grain placement, so recycling sometimes *broke* previously-working instances ("pod roulette", observed live while healing).

## Root cause

`EnrichWithNodeType` binds `HubConfiguration` once per grain lifetime and short-circuits re-enrichment once it is set. Two bindings are sticky:

1. **The compilation-error overlay** — bound when the slow path times out (60s) because the per-NodeType hub is unreachable / the recompile is storm-queued. The 07-20 fresh-pod wedge fix (`WaitForCompileSettled`) only disarms the wall-clock on an *observed* Pending/Compiling emission; a silent stream (unreachable type hub) still times out and caches.
2. **The silent default-config fallback** — the bytes-missing branch (`ResolveAssembly` misses after `MaxRecompileAttempts`) binds `hubConfig: null`; the instance serves only generic areas with no error shown, equally permanent.

Both turn a *transient* storm into *permanent* broken pages.

## Fix

`WithOverlaySelfHeal` wraps every stuck binding with a `WithInitialization` that arms a background watcher on the instance hub: it observes the NodeType's MeshNode stream (`meshHub.GetWorkspace().GetMeshNodeStream(nodeType)` — the slow path's exact source) and, on the first genuinely usable state (`HasUsableBuild`) past the type version at overlay time, posts a `DisposeRequest` to the instance's **own** address (the `RecycleLayoutArea` idiom). The grain deactivates; the next access re-enriches from scratch against the now-usable type.

- **Version gate (anti-loop):** mandatory at call sites where the replayed current state can already be usable (pinned-release, ABI-stale, genuine Error, bytes-missing default) — ungated it would recycle → re-overlay → recycle hot. Gated: at most one self-recycle per NodeType write. Null gate only where no type node was in hand (slow-path timeout / probe-missing), where a usable state would have settled instead of timing out.
- **Honest timeout copy:** the timeout page no longer claims *"There was a compilation error in this item's code"* — new copy says the build hasn't settled (mesh restart / bulk recompile) and the page recovers automatically; manual Recycle only as fallback. The ⚠ headline + "compilation" token contract (`CompileErrorOverviewTest`) is kept; genuine-Error wording unchanged byte-for-byte.
- Watcher arming is try/caught and disposed with the hub — a watcher that can't arm degrades to the pre-fix "manual Recycle" world, never a dead hub.

## Tests (executed green)

- **`OverlaySelfHealWatcherTest`** (Graph.Test, 4): fires exactly once on a version-advancing usable emission with the self-address pinned; does **not** fire on the usable-but-bytes-missing replay at overlay time; null-gate fires on first usable, ignores unsettled/non-NodeTypeDefinition; disposed watcher never fires.
- **`OverlaySelfHealInstanceRecycleTest`** (Monolith.Test, end-to-end): broken type → instance binds overlay → source fixed → recompile Ok → instance self-recycles → real page renders, **no manual DisposeRequest**. Counterfactual verified: fails (probes exhausted, 91s) with the watcher neutered.
- Guards re-run green: `NodeTypeEnrichmentDoubleCallTest`, `CompileErrorPageTest`, `CompileErrorOverviewTest` (2), `CompileWaitDoesNotTimeoutTest` suite (28), `CodeEditRecompileTest` (7), `FrameworkStaleInstanceRenderTest`, `FrameworkStaleProactiveRebuildTest` (one load-flake in a 4-class parallel run, standalone green twice — pre-existing Compile-IoPool contention, path untouched).
- `dotnet build MeshWeaver.slnx`: 0 warnings / 0 errors.

`InternalsVisibleTo("DynamicProxyGenAssembly2")` added to Messaging.Contract (NSubstitute proxy over `IMessageDelivery` — same grant Messaging.Hub / Mesh.Contract already carry).

## Notes for the operator

⚠️ GitHub Actions is currently not running org-wide (billing: "recent account payments have failed") — CI on this PR will not start until billing is fixed. All gates above were executed locally.

Follow-up (separate PR): the structural fix for the class — shared (blob) assembly store instead of pod-local `latestAssemblyCollection: "local"`, so a pod restart never creates asymmetric pods racing the settle window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)