### PR TITLE
Helm: chart-native PVC mounts for /data — stop reverting to emptyDir on every helm upgrade

### DIFF
--- a/deploy/aks/envs/memex-cloud/portal-patch.json
+++ b/deploy/aks/envs/memex-cloud/portal-patch.json
@@ -1,12 +1,8 @@
 [
   { "op": "add", "path": "/spec/template/spec/nodeSelector", "value": { "workload": "silos" } },
 
-  { "op": "replace", "path": "/spec/template/spec/volumes/0",
-    "value": { "name": "memex-data", "persistentVolumeClaim": { "claimName": "memex-data" } } },
-  { "op": "replace", "path": "/spec/template/spec/volumes/1",
-    "value": { "name": "memex-users", "persistentVolumeClaim": { "claimName": "memex-users" } } },
-  { "op": "add", "path": "/spec/template/spec/volumes/-",
-    "value": { "name": "memex-content", "persistentVolumeClaim": { "claimName": "memex-content" } } },
+  { "_comment": "data/users/content PVC volumes + mounts now render from the CHART (persistence: in values.aks.yaml) — this patch only adds the memex-cloud-specific extras below.",
+    "op": "test", "path": "/spec/template/spec/volumes/0/name", "value": "memex-data" },
   { "op": "add", "path": "/spec/template/spec/volumes/-",
     "value": { "name": "memex-attachments", "persistentVolumeClaim": { "claimName": "memex-attachments" } } },
   { "op": "add", "path": "/spec/template/spec/volumes/-",
@@ -16,8 +12,6 @@
                "csi": { "driver": "secrets-store.csi.k8s.io", "readOnly": true,
                         "volumeAttributes": { "secretProviderClass": "memexcloud-portal-ai-secrets" } } } },
 
-  { "op": "add", "path": "/spec/template/spec/containers/0/volumeMounts/-",
-    "value": { "name": "memex-content", "mountPath": "/mnt/content" } },
   { "op": "add", "path": "/spec/template/spec/containers/0/volumeMounts/-",
     "value": { "name": "memex-attachments", "mountPath": "/mnt/attachments" } },
   { "op": "add", "path": "/spec/template/spec/containers/0/volumeMounts/-",

--- a/deploy/aks/scripts/deploy.sh
+++ b/deploy/aks/scripts/deploy.sh
@@ -24,8 +24,11 @@ kubectl -n "$NS" scale statefulset memex-postgres-statefulset --replicas=0 || tr
 # The chart hardcodes the ghcr image path -> repoint to the shared ACR.
 kubectl -n "$NS" set image deployment/memex-portal-deployment    memex-portal="$ACR/memex-portal-ai:latest"
 kubectl -n "$NS" set image deployment/memex-migration-deployment memex-migration="$ACR/memex-migration:latest" || true
-# 1-replica baseline + mount the Azure Files PVCs (/data already mounted by the chart; add /mnt/content).
-kubectl -n "$NS" patch deployment memex-portal-deployment --type=json -p '[{"op":"replace","path":"/spec/replicas","value":1},{"op":"replace","path":"/spec/template/spec/volumes/0","value":{"name":"memex-data","persistentVolumeClaim":{"claimName":"memex-data"}}},{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"memex-content","persistentVolumeClaim":{"claimName":"memex-content"}}},{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"memex-content","mountPath":"/mnt/content"}}]'
+# 1-replica baseline. The PVC volumes/mounts (data, users, content) render from the CHART itself
+# (persistence: in values.aks.yaml) — no volume patching here any more: the old bolt-on patch meant
+# any plain `helm upgrade` reverted /data to emptyDir until the patch re-ran, wiping the
+# assembly/nuget/DataProtection caches on every restart in the gap.
+kubectl -n "$NS" patch deployment memex-portal-deployment --type=json -p '[{"op":"replace","path":"/spec/replicas","value":1}]'
 # Chart-gen gap: the secret template hardcodes the in-cluster pg connection string -> repoint
 # both portal + migration at the external Flexible Server (private IP + password + SSL).
 for s in memex-portal-secrets memex-migration-secrets; do

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -275,21 +275,28 @@ keda:
 # MUST be ReadWriteMany. They use the custom `azurefile-memex` StorageClass
 # (manifests/storageclass-azurefile.yaml) which pins uid/gid=1654 so the non-root
 # portal user can write. The Postgres data volume is single-writer and uses
-# managed-csi (Premium SSD) for IOPS. The chart ships these as emptyDir today;
-# ./manifests/portal-pvcs.yaml creates the real PVCs.
+# managed-csi (Premium SSD) for IOPS. ./manifests/portal-pvcs.yaml (or
+# aks-extras.yaml on the memex ns) creates the PVCs; the CHART mounts every
+# entry with a claimName — a plain `helm upgrade` renders the PVC volumes
+# directly, no post-apply kubectl patch needed (the old bolt-on patches meant
+# any unpatched apply silently reverted /data to emptyDir and every restart
+# wiped the assembly/nuget/DataProtection caches).
 #
 # One Azure Files "drive" per concern, mounted at an explicit path:
 #   data        -> /data            framework caches only (DP keys, asm + nuget cache)
 #   content     -> /mnt/content     the content collection (Storage__BasePath)
-#   attachments -> /mnt/attachments dedicated attachments drive (forward-looking)
+#   attachments -> /mnt/attachments dedicated attachments drive (memex-cloud only —
+#                                   claimName stays empty here; its env patch adds it)
 #   users       -> /mnt/users       co-hosted CLI configs
 persistence:
   data:
+    claimName: "memex-data"           # chart-mounted at /data
     storageClass: "azurefile-memex"   # RWX, uid/gid 1654
     accessMode: "ReadWriteMany"
     mountPath: "/data"
     size: "16Gi"                      # shrunk: content moved off /data
   content:
+    claimName: "memex-content"        # chart-mounted at mountPath
     storageClass: "azurefile-memex"   # RWX, uid/gid 1654
     accessMode: "ReadWriteMany"
     mountPath: "/mnt/content"
@@ -300,6 +307,7 @@ persistence:
     mountPath: "/mnt/attachments"
     size: "64Gi"
   users:
+    claimName: "memex-users"          # chart-mounted at /mnt/users
     storageClass: "azurefile-memex"   # RWX, uid/gid 1654
     accessMode: "ReadWriteMany"
     mountPath: "/mnt/users"

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -96,6 +96,15 @@ spec:
               mountPath: "/data"
             - name: "memex-users"
               mountPath: "/mnt/users"
+{{- /* Extra persistent mounts (content, attachments, workspace, …) declared under
+       .Values.persistence. data + users are mounted above at fixed paths — their
+       persistence entries only supply the claim for the volumes below. */}}
+{{- range $name, $spec := .Values.persistence }}
+{{- if and $spec $spec.claimName $spec.mountPath (ne $name "data") (ne $name "users") }}
+            - name: "memex-{{ $name }}"
+              mountPath: "{{ $spec.mountPath }}"
+{{- end }}
+{{- end }}
             - name: "memex-dumps"
               mountPath: "/data/dumps"
           imagePullPolicy: "IfNotPresent"
@@ -156,13 +165,22 @@ spec:
 {{- end }}
 {{- end }}
       volumes:
+        # 💾 /data holds the framework caches that MUST survive restarts and be SHARED across
+        # replicas (DataProtection keys, the NodeType assembly cache, the NuGet package cache).
+        # Priority: persistence.data.claimName (a pre-created RWX PVC — the production path,
+        # rendered by the CHART so a plain `helm upgrade` never reverts /data to ephemeral;
+        # previously this was bolted on by per-env kubectl JSON patches, and any unpatched
+        # apply silently ran emptyDir — every restart wiped the caches) → persistDataVolume
+        # (single-node k3s hostPath) → emptyDir (dev/tests only).
         - name: "memex-data"
-{{- if .Values.persistDataVolume }}
+{{- if ((.Values.persistence).data).claimName }}
+          persistentVolumeClaim:
+            claimName: "{{ .Values.persistence.data.claimName }}"
+{{- else if .Values.persistDataVolume }}
           # Local dev only: keep /data (the DataProtection keys under /data/dataprotection-keys, plus the
           # nuget/compile caches) on a node hostPath so a pod restart does NOT wipe the keys and invalidate
           # every session (the "have to refresh / Anonymous resubscribe loop" churn). Single-node k3s;
-          # multiple pods during a rollout share the same node dir. Prod (AKS) leaves this false and
-          # persists keys to Azure Blob instead, so /data can stay ephemeral there.
+          # multiple pods during a rollout share the same node dir.
           hostPath:
             path: /var/lib/memex-portal-data
             type: DirectoryOrCreate
@@ -170,7 +188,22 @@ spec:
           emptyDir: {}
 {{- end }}
         - name: "memex-users"
+{{- if ((.Values.persistence).users).claimName }}
+          persistentVolumeClaim:
+            claimName: "{{ .Values.persistence.users.claimName }}"
+{{- else }}
           emptyDir: {}
+{{- end }}
+{{- /* Extra persistent volumes declared under .Values.persistence (content, attachments,
+       workspace, …). Rendered between users and dumps so the historical volume order
+       (data=0, users=1) stays stable for any remaining per-env index patches. */}}
+{{- range $name, $spec := .Values.persistence }}
+{{- if and $spec $spec.claimName $spec.mountPath (ne $name "data") (ne $name "users") }}
+        - name: "memex-{{ $name }}"
+          persistentVolumeClaim:
+            claimName: "{{ $spec.claimName }}"
+{{- end }}
+{{- end }}
         # 🩺 Crash-dump target (DOTNET_DbgMiniDumpName=/data/dumps/…). createdump does NOT create
         # directories — without this mount every crash failed with "Could not create output file …:
         # No such file or directory", destroying its own evidence (and burning ~6s + a ~350k-line

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -2,8 +2,25 @@ parameters: {}
 # Local dev only (memex-local sets this true via --set): persist /data — the DataProtection keys under
 # /data/dataprotection-keys plus the nuget/compile caches — on a node hostPath, so a pod restart does NOT
 # wipe the keys and invalidate every session (the "have to refresh / Anonymous resubscribe loop" churn).
-# Prod (AKS) leaves this false (default) and persists DataProtection keys to Azure Blob instead.
+# Prod (AKS) leaves this false and mounts PVCs via `persistence:` below instead.
 persistDataVolume: false
+# ---- Persistent volumes (production) ----------------------------------------
+# Pre-created PVC claim names the CHART mounts directly — the single source of truth for durable
+# storage. When a claimName is set the deployment renders a persistentVolumeClaim volume for it;
+# empty claimNames fall back to persistDataVolume (data) / emptyDir. `data` and `users` mount at
+# fixed paths (/data, /mnt/users); any other entry needs BOTH claimName and mountPath and is
+# rendered as an extra volume + mount (content, attachments, workspace, …). With multiple portal
+# replicas every claim MUST be ReadWriteMany — all replicas share /data (DataProtection keys, the
+# NodeType assembly cache, the NuGet cache); a per-pod /data forces a full recompile storm per pod.
+# PVC creation stays out of the chart (deploy/aks/manifests/portal-pvcs.yaml or aks-extras.yaml) so
+# a `helm uninstall` can never take the data with it. Previously these mounts were bolted on by
+# per-env kubectl JSON patches AFTER helm — any unpatched `helm upgrade` silently reverted /data to
+# emptyDir, wiping the caches on every restart.
+persistence:
+  data:
+    claimName: ""
+  users:
+    claimName: ""
 # ---- Self-update (in-pod patch of the portal's own deployment) -------------
 # The portal polls the registry and, on Kubernetes, patches its own deployment to a newer image per
 # the Admin/UpdatePolicy node (see Doc/Architecture/ReleaseStrategy). The chart always creates the


### PR DESCRIPTION
## Why

Investigating the 2026-07-25/26 "NodeType compile did not settle" overlays: the portal's assembly cache (`/data/assembly-cache`), NuGet cache and DataProtection keys are supposed to live on the shared RWX Azure Files PVC — and on both live namespaces they currently do — but **only because per-env kubectl JSON patches bolt the PVCs on after helm**. The chart itself renders `emptyDir`, so:

- a plain `helm upgrade` reverts `/data` to ephemeral until someone re-runs the patch;
- a new environment that forgets the patch silently runs ephemeral — every restart wipes the caches and every deploy becomes a full recompile-on-activation storm racing the 60s enrichment settle window.

## What

`persistence:` in values becomes the single source of truth **rendered by the chart**:

- `data`/`users`: `claimName` set → `persistentVolumeClaim` at the fixed mounts (`/data`, `/mnt/users`); else the existing fallbacks (k3s `persistDataVolume` hostPath, else emptyDir) — order preserved (data=0, users=1) for any remaining index patches.
- Any other entry with `claimName` + `mountPath` → extra PVC volume + mount (content, attachments, workspace, …).
- `values.aks.yaml` sets the claim names (data/users/content). The memex-cloud env patch keeps only its true extras (attachments, workspace, KV CSI, nodeSelector, resources) and gains a `test` op guarding the chart-rendered volume order; `deploy.sh` drops its volume patching.
- PVC **creation** deliberately stays outside the chart (`portal-pvcs.yaml` / `aks-extras.yaml`) so `helm uninstall` can never take data with it.

## Verified

`helm lint` clean; `helm template` renders correct volumes for: default values (emptyDir), `--set persistDataVolume=true` (hostPath), and AKS values (PVC claims memex-data/users/content + `/mnt/content` mount), volume order stable.

Note: the rollout-day recompile storm itself is the (by-design) FrameworkTag cache invalidation + the pending boot-storm fixes (#602 family) — this PR removes the *ephemeral-/data* failure mode and makes new environments correct by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)