### PR TITLE
Source tree: group shared code per package, link the folder header to the package

### DIFF
--- a/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
@@ -713,8 +713,8 @@ public static class NodeTypeLayoutAreas
     /// each containing the file tree its queries resolved to. Files under the group's
     /// namespace root are displayed at their relative path (folders by namespace
     /// segment); files outside it — shared code pulled in via <c>@path</c> or
-    /// cross-NodeType <c>namespace:</c> queries — go under a "(shared)" folder at their
-    /// absolute path so their origin remains obvious.
+    /// cross-NodeType <c>namespace:</c> queries — group under one folder PER PACKAGE
+    /// (the owning partition root), whose header links to the package's page.
     /// </summary>
     internal static NavGroupControl BuildCodeNavGroup(
         string groupLabel,
@@ -766,14 +766,18 @@ public static class NodeTypeLayoutAreas
 
     /// <summary>
     /// Groups resolved code nodes into a tree: local files (paths starting with
-    /// <c>{rootPath}/</c>) are relativised; foreign files go under a single
-    /// "(shared)" folder with their absolute path preserved.
+    /// <c>{rootPath}/</c>) are relativised; foreign files are grouped under one
+    /// folder PER PACKAGE — the partition root (first path segment) that owns
+    /// them — with their package-relative path preserved. The old single
+    /// "(shared)" umbrella buried the origin under full absolute paths
+    /// ("shared → (shared) → Underwriting → SampleData → Source → …"); naming
+    /// the package directly lets the renderer give the folder the package icon
+    /// and link its header to the package's page.
     /// </summary>
     internal static CodeTreeFolder BuildCodeTreeForNavigation(string rootPath, IReadOnlyCollection<MeshNode> nodes)
     {
         var rootPrefix = rootPath + "/";
         var tree = new CodeTreeFolder("");
-        CodeTreeFolder? sharedFolder = null;
 
         foreach (var node in nodes.OrderBy(n => n.Path, StringComparer.Ordinal))
         {
@@ -784,14 +788,16 @@ public static class NodeTypeLayoutAreas
             }
             else
             {
-                if (sharedFolder == null)
-                {
-                    sharedFolder = new CodeTreeFolder("(shared)");
-                    tree.AddFolder(sharedFolder);
-                }
-                // Preserve full absolute path so operators can tell which NodeType
-                // owns this shared file. Split on '/' gives a nested folder tree.
-                sharedFolder.Insert(node.Path.Split('/'), 0, node);
+                // One folder per package. GetOrAddFolder (not a fresh folder +
+                // AddFolder) so a package whose name collides with a local
+                // relative folder MERGES instead of silently replacing it —
+                // no file may ever drop out of the tree.
+                var segments = node.Path.Split('/');
+                var packageFolder = tree.GetOrAddFolder(segments[0]);
+                packageFolder.MarkAsPackage(segments[0]);
+                // Package-relative insert; a degenerate single-segment path
+                // (a top-level Code node) becomes a leaf named like the package.
+                packageFolder.Insert(segments, segments.Length == 1 ? 0 : 1, node);
             }
         }
         return tree;
@@ -841,12 +847,44 @@ public static class NodeTypeLayoutAreas
         }
 
         var folder = (CodeTreeFolder)node;
-        var group = new NavGroupControl(folder.Name)
-            .WithIcon(FluentIcons.Folder())
+        var (label, current) = CompressChain(folder);
+
+        var group = new NavGroupControl(label)
+            .WithIcon(folder.PackagePath is not null ? FluentIcons.Box() : FluentIcons.Folder())
             .WithSkin(s => s.WithExpanded(true));
-        foreach (var child in folder.OrderedChildren())
+        // A package folder's header navigates to the package's own page — the
+        // user asked for "which package is this from, and take me there".
+        if (folder.PackagePath is not null)
+            group = group.WithUrl($"/{folder.PackagePath}");
+        foreach (var child in current.OrderedChildren())
             group = AppendCodeTreeNode(group, child, hubAddress);
         return parent.WithGroup(group);
+    }
+
+    /// <summary>
+    /// Path-compresses a pure pass-through chain: a folder with no files and a
+    /// single sub-folder renders as one "A/B" group instead of two nesting
+    /// levels ("SampleData → Source → file" becomes "SampleData/Source" — the
+    /// children rendered are the chain end's). Package folders never compress —
+    /// in neither direction — because their header IS the package identity
+    /// (icon + link to the package page). Pure helper so <c>CodeTreeTest</c>
+    /// can pin the contract without walking the UI control tree.
+    /// </summary>
+    internal static (string Label, CodeTreeFolder Effective) CompressChain(CodeTreeFolder folder)
+    {
+        var label = folder.Name;
+        var current = folder;
+        while (current.PackagePath is null
+               && current.Leaves.Count == 0
+               && current.Folders.Count == 1)
+        {
+            var only = current.Folders.Values.First();
+            if (only.PackagePath is not null)
+                break;
+            label = label.Length == 0 ? only.Name : $"{label}/{only.Name}";
+            current = only;
+        }
+        return (label, current);
     }
 
     /// <summary>
@@ -891,10 +929,27 @@ public static class NodeTypeLayoutAreas
         public IReadOnlyList<CodeTreeLeaf> Leaves => _leaves;
 
         /// <summary>
-        /// Splices an externally-built folder into this tree under its own name.
-        /// Used to attach the synthetic "(shared)" folder for foreign code files.
+        /// Set when this folder represents a PACKAGE — the partition root (first
+        /// path segment) owning shared files pulled in from outside the NodeType's
+        /// subtree. The renderer gives such folders the package icon and links
+        /// their header to the package's page; they sort after local folders and
+        /// never path-compress.
         /// </summary>
-        public void AddFolder(CodeTreeFolder folder) => _folders[folder.Name] = folder;
+        public string? PackagePath { get; private set; }
+
+        public void MarkAsPackage(string packagePath) => PackagePath = packagePath;
+
+        /// <summary>
+        /// Returns the sub-folder of that name, creating it when absent — the
+        /// merge-safe way to attach package folders (a name collision with a
+        /// local relative folder must merge, never replace).
+        /// </summary>
+        public CodeTreeFolder GetOrAddFolder(string name)
+        {
+            if (!_folders.TryGetValue(name, out var folder))
+                _folders[name] = folder = new CodeTreeFolder(name);
+            return folder;
+        }
 
         public void Insert(string[] segments, int index, MeshNode node)
         {
@@ -910,7 +965,8 @@ public static class NodeTypeLayoutAreas
         }
 
         public IEnumerable<CodeTreeNode> OrderedChildren()
-            => _folders.Values.OrderBy(f => f.Name, StringComparer.Ordinal)
+            => _folders.Values.Where(f => f.PackagePath is null).OrderBy(f => f.Name, StringComparer.Ordinal)
+                .Concat(_folders.Values.Where(f => f.PackagePath is not null).OrderBy(f => f.Name, StringComparer.Ordinal))
                 .Cast<CodeTreeNode>()
                 .Concat(_leaves.OrderBy(l => l.Name, StringComparer.Ordinal));
     }

--- a/test/MeshWeaver.Graph.Test/CodeTreeTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeTreeTest.cs
@@ -159,7 +159,9 @@ public class CodeTreeTest
 
     // -----------------------------------------------------------------------
     // BuildCodeTreeForNavigation — the side-menu variant: takes a resolved list
-    // (Sources or Tests query output) and renders foreign files under "(shared)".
+    // (Sources or Tests query output); foreign files group per PACKAGE (their
+    // partition root), marked with PackagePath so the renderer can link the
+    // folder header to the package page.
     // -----------------------------------------------------------------------
 
     [Fact]
@@ -176,15 +178,16 @@ public class CodeTreeTest
         tree.Folders.Keys.Should().Contain("Source");
         tree.Folders["Source"].Leaves.Should().ContainSingle(l => l.Name == "Program.cs");
         tree.Folders["Source"].Folders["Models"].Leaves.Should().ContainSingle(l => l.Name == "Person.cs");
-        tree.Folders.Keys.Should().NotContain("(shared)");
+        tree.Folders["Source"].PackagePath.Should().BeNull("local folders are not packages");
     }
 
     [Fact]
-    public void BuildCodeTreeForNavigation_ForeignFiles_GoUnderSharedFolder()
+    public void BuildCodeTreeForNavigation_ForeignFiles_GroupPerPackage()
     {
         // Shared code pulled in via "@Shared/Utils" or "namespace:Other/Lib…" must
-        // still be visible — the user asked for "show all files as queried by
-        // Source resolution" — but labelled as shared so its origin is obvious.
+        // still be visible, and its owning PACKAGE named directly — one folder per
+        // partition root, files at their package-relative path, so the renderer
+        // can put the package icon on the folder and link its header to /{package}.
         var nodes = new List<MeshNode>
         {
             Code($"{RootPath}/Source/Local.cs"),
@@ -195,14 +198,15 @@ public class CodeTreeTest
         var tree = NodeTypeLayoutAreas.BuildCodeTreeForNavigation(RootPath, nodes);
 
         tree.Folders.Keys.Should().Contain("Source", "local file is relativised");
-        tree.Folders.Keys.Should().Contain("(shared)", "foreign files collect under a shared folder");
+        tree.Folders.Keys.Should().NotContain("(shared)", "the umbrella folder is replaced by per-package folders");
 
-        var shared = tree.Folders["(shared)"];
-        // Foreign files keep their full path so operators see where they came from.
-        shared.Folders.Keys.Should().Contain("Shared");
-        shared.Folders["Shared"].Folders["Utils"].Leaves.Should().ContainSingle(l => l.Name == "Helper.cs");
-        shared.Folders.Keys.Should().Contain("Other");
-        shared.Folders["Other"].Folders["Lib"].Leaves.Should().ContainSingle(l => l.Name == "CommonTypes.cs");
+        tree.Folders.Keys.Should().Contain("Shared");
+        tree.Folders["Shared"].PackagePath.Should().Be("Shared");
+        tree.Folders["Shared"].Folders["Utils"].Leaves.Should().ContainSingle(l => l.Name == "Helper.cs");
+
+        tree.Folders.Keys.Should().Contain("Other");
+        tree.Folders["Other"].PackagePath.Should().Be("Other");
+        tree.Folders["Other"].Folders["Lib"].Leaves.Should().ContainSingle(l => l.Name == "CommonTypes.cs");
     }
 
     [Fact]
@@ -224,7 +228,127 @@ public class CodeTreeTest
 
         var tree = NodeTypeLayoutAreas.BuildCodeTreeForNavigation(RootPath, nodes);
 
-        tree.Folders.Keys.Should().Contain("(shared)");
-        tree.Folders.Keys.Should().NotContain("Source", "no local files means no local root folder");
+        tree.Folders.Keys.Should().BeEquivalentTo(new[] { "Shared" }, System.Text.Json.JsonSerializerOptions.Default);
+        tree.Folders["Shared"].PackagePath.Should().Be("Shared");
+        tree.Folders["Shared"].Folders["Utils"].Leaves.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void BuildCodeTreeForNavigation_SameParentPackage_GroupsSharedPoolsTogether()
+    {
+        // The real-world shape that motivated per-package grouping: a NodeType
+        // (Underwriting/Guideline) pulling the partition-shared pools
+        // shared=@Underwriting/Source + shared=@Underwriting/SampleData/Source.
+        // Both belong to the SAME package (the partition root "Underwriting"),
+        // so they must land inside ONE package folder, package-relative.
+        var nodes = new List<MeshNode>
+        {
+            Code("Underwriting/Source/IScope.cs"),
+            Code("Underwriting/Source/RulesEngine.cs"),
+            Code("Underwriting/SampleData/Source/SampleData.cs"),
+        };
+
+        var tree = NodeTypeLayoutAreas.BuildCodeTreeForNavigation("Underwriting/Guideline", nodes);
+
+        tree.Folders.Keys.Should().BeEquivalentTo(new[] { "Underwriting" }, System.Text.Json.JsonSerializerOptions.Default);
+        var package = tree.Folders["Underwriting"];
+        package.PackagePath.Should().Be("Underwriting");
+        package.Folders["Source"].Leaves.Should().HaveCount(2);
+        package.Folders["SampleData"].Folders["Source"].Leaves.Should().ContainSingle(l => l.Name == "SampleData.cs");
+    }
+
+    [Fact]
+    public void BuildCodeTreeForNavigation_PackageCollidingWithLocalFolder_MergesWithoutLosingFiles()
+    {
+        // A package named like a local relative folder must MERGE into it —
+        // the old AddFolder-style dictionary overwrite would silently drop the
+        // local files. No file may ever fall out of the tree.
+        var nodes = new List<MeshNode>
+        {
+            Code($"{RootPath}/Shared/Local.cs"),
+            Code("Shared/Utils/Foreign.cs"),
+        };
+
+        var tree = NodeTypeLayoutAreas.BuildCodeTreeForNavigation(RootPath, nodes);
+
+        var merged = tree.Folders["Shared"];
+        merged.PackagePath.Should().Be("Shared");
+        merged.Leaves.Should().ContainSingle(l => l.Name == "Local.cs");
+        merged.Folders["Utils"].Leaves.Should().ContainSingle(l => l.Name == "Foreign.cs");
+    }
+
+    [Fact]
+    public void BuildCodeTreeForNavigation_OrderedChildren_LocalFoldersBeforePackages()
+    {
+        // Packages sort AFTER local folders (and before leaves): the type's own
+        // code stays up top, pulled-in packages read as an appendix.
+        var nodes = new List<MeshNode>
+        {
+            Code($"{RootPath}/Source/Local.cs"),
+            Code("Alpha/Source/A.cs"),
+        };
+
+        var tree = NodeTypeLayoutAreas.BuildCodeTreeForNavigation(RootPath, nodes);
+
+        var ordered = tree.OrderedChildren().Select(n => n.Name).ToArray();
+        ordered.Should().Equal("Source", "Alpha");
+    }
+
+    // -----------------------------------------------------------------------
+    // CompressChain — the render-time path compression of pure pass-through
+    // folder chains ("SampleData → Source" with no files at either level
+    // renders as one "SampleData/Source" group).
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void CompressChain_PassThroughChain_MergesLabels()
+    {
+        var nodes = new List<MeshNode>
+        {
+            Code("Underwriting/SampleData/Source/SampleData.cs"),
+        };
+        var tree = NodeTypeLayoutAreas.BuildCodeTreeForNavigation("Underwriting/Guideline", nodes);
+        var package = tree.Folders["Underwriting"];
+
+        var (label, effective) = NodeTypeLayoutAreas.CompressChain(package.Folders["SampleData"]);
+
+        label.Should().Be("SampleData/Source");
+        effective.Leaves.Should().ContainSingle(l => l.Name == "SampleData.cs");
+    }
+
+    [Fact]
+    public void CompressChain_StopsAtFilesAndBranches()
+    {
+        // A folder with its own files, or more than one sub-folder, is a real
+        // level — no compression.
+        var nodes = new List<MeshNode>
+        {
+            Code($"{RootPath}/Source/A.cs"),
+            Code($"{RootPath}/Source/Models/B.cs"),
+        };
+        var tree = NodeTypeLayoutAreas.BuildCodeTreeForNavigation(RootPath, nodes);
+
+        var (label, effective) = NodeTypeLayoutAreas.CompressChain(tree.Folders["Source"]);
+
+        label.Should().Be("Source");
+        effective.Should().BeSameAs(tree.Folders["Source"]);
+    }
+
+    [Fact]
+    public void CompressChain_PackageFolder_NeverCompresses()
+    {
+        // The package folder's header carries the package identity (icon + link
+        // to the package page) — compressing "Underwriting" with its single
+        // "Source" child into "Underwriting/Source" would destroy it.
+        var nodes = new List<MeshNode>
+        {
+            Code("Underwriting/Source/IScope.cs"),
+        };
+        var tree = NodeTypeLayoutAreas.BuildCodeTreeForNavigation("Acme/Type", nodes);
+
+        var (label, effective) = NodeTypeLayoutAreas.CompressChain(tree.Folders["Underwriting"]);
+
+        label.Should().Be("Underwriting");
+        effective.Should().BeSameAs(tree.Folders["Underwriting"]);
     }
 }


### PR DESCRIPTION
## What

The NodeType side menu's Sources/Tests tree buried pulled-in shared code under a **"(shared)"** umbrella at full absolute paths — e.g. `shared → (shared) → Underwriting → SampleData → Source → file`. The owning package was implicit, deep, and not clickable.

Now:

- **One folder per package.** Foreign files group under the partition root that owns them, at their package-relative path. `shared=@Underwriting/Source` + `shared=@Underwriting/SampleData/Source` render as one 📦 **Underwriting** folder containing `Source/…` and `SampleData/Source/…`.
- **The folder header navigates to the package.** Package folders get the package icon (Box) and `NavGroup.WithUrl("/{package}")` — click the header, land on the package's page.
- **Pass-through chains compress.** A folder with no files and a single sub-folder renders as one `A/B` group (`SampleData/Source`), cutting a nesting level. Package folders never compress — their header is the package identity.
- **Ordering + merge safety.** Package folders sort after the type's own folders (own code up top, packages as appendix) and *merge* into a same-named local folder instead of dictionary-overwriting it (the old `AddFolder` could silently drop files on a name collision).

## Known limit (deliberate)

Attribution is by **physical location**. Files *vendored* from another package — e.g. the BusinessRules scopes vendored into `Underwriting/Source` — attribute to the vendoring package. True provenance for vendored files needs vendoring metadata on the Code node (or `shared=` consumption from the origin package once cross-partition `shared=` resolves). Follow-up material.

## Tests

`CodeTreeTest` 11 → 17, all executed green: per-package grouping, same-package shared pools under one folder, collision-merge without file loss, package-after-local ordering, and the three `CompressChain` contracts (merge labels, stop at files/branches, package barrier). Full solution build: 0 warnings / 0 errors. The one red elsewhere in `Graph.Test` (`EventSubscriptionRunnerTest` teardown leak when the class runs together) reproduces identically on clean `main` — pre-existing, unrelated.

⚠️ GitHub Actions is currently not running org-wide (billing) — checks on this PR will not start until that's fixed; all gates above ran locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)