### PR TITLE
Distributed portal: register the "storage" source collection (every mapped per-node collection was dead on memex)

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -5,6 +5,7 @@ using Memex.Portal.Shared;
 using MeshWeaver.Hosting.Embeddings;
 using Microsoft.AspNetCore.DataProtection;
 using MeshWeaver.Graph.Configuration;
+using MeshWeaver.ContentCollections;
 using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Orleans;
 using MeshWeaver.Hosting.PostgreSql;
@@ -228,7 +229,27 @@ builder.UseOrleansMeshServer(address, silo =>
                 }
                 : null))
     .ConfigureMemexMesh(builder.Configuration, builder.Environment.IsDevelopment())
-    .ConfigureMemexPortal();
+    .ConfigureMemexPortal()
+    // 🚨 Register the "storage" SOURCE collection at mesh level — the backing store that every
+    // per-node MapContentCollection("x", "storage", …) mapping resolves against
+    // (ContentService.ResolveMappedConfig looks the source up on the parent content service and
+    // returns NULL when it is absent, so the mapped collection silently reports
+    // "collection 'x' not found"). The Monolith has always registered this from the same
+    // `Storage` config section (Memex.Portal.Monolith/Program.cs); the Distributed portal never
+    // did — so on memex EVERY mapped per-node collection was dead: ReinsuranceDemo/Setup's
+    // packs zip (the demo could not be imported at all), Reinsurance/Cedent + Underwriting/
+    // Submission `content`, and Claims/Claim `files`. The AKS values already supply
+    // Storage__SourceType=FileSystem + Storage__BasePath=/mnt/content, so this reads config that
+    // is deployed today. Same shape as the Monolith: a read-only static backing store, hidden
+    // from children (IsEditable / ExposeInChildren stay false — the per-node MAPPING is the
+    // writable view).
+    .ConfigureHub(hub =>
+    {
+        var storageConfig = builder.Configuration.GetSection("Storage").Get<ContentCollectionConfig>();
+        return storageConfig is null
+            ? hub
+            : hub.AddContentCollection(_ => storageConfig with { IsStatic = true });
+    });
 
 // Hard gate: refuse to start if the DB isn't migrated. Aspire's
 // WaitForCompletion(dbMigration) is a soft hint at deploy time — Container


### PR DESCRIPTION
## The bug

`ContentService.ResolveMappedConfig` resolves a mapped collection by looking its **source** collection up on the parent content service — and returns `null` when the source is absent, so the mapped collection silently reports **"collection 'x' not found"**.

The **Monolith** has always registered the `storage` source from the `Storage` config section (`Memex.Portal.Monolith/Program.cs:48-60`). The **Distributed** portal — which memex runs — never did. `deploy/aks/values.aks.yaml` even documents the gap in prose: *"the 'storage' SOURCE collection is not separately registered — only the Monolith registers it."*

## Impact on memex (all of it silent)

Every per-node `MapContentCollection(…, "storage", …)` was dead:
- **`ReinsuranceDemo/Setup`** — couldn't hold *or* read its packs zip, so the demo was **un-importable**: clicking Import produced an empty page.
- **`Reinsurance/Cedent`**, **`Underwriting/Submission`** — `content` collections unreachable.
- **`Claims/Claim`** — per-claim `files` unreachable.

## How it was isolated

A full memex pod restart reproduced the error on **fresh pods with the NodeType compiled `Ok`** — ruling out the pod-local stale-assembly wedge that was masking it. Uploads to a *partition-root* collection (`@ReinsuranceDemo/content/…`) succeed, which is what made the contrast conclusive: root collections work, mapped ones don't.

## The fix

Register the source collection in the Distributed portal, mirroring the Monolith — read-only static backing store, hidden from children (the per-node *mapping* is the writable view). The AKS values already ship `Storage__SourceType=FileSystem` + `Storage__BasePath=/mnt/content`, so this reads configuration that is **already deployed** — no manifest change required.

Build: `Memex.Portal.Distributed` — 0 warnings / 0 errors.

⚠️ CI blocked on the org billing outage; built locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)