### PR TITLE
Anchor a satellite's MainNode to its owning node, not the _Access container

### DIFF
--- a/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
+++ b/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
@@ -57,6 +57,7 @@ public static class MigrationRegistry
         new V46_AddExcludeFromContextColumn(),
         new V47_SerializeUepRebuildAdvisoryLock(),
         new V48_RetypeBuiltinFeedbackToPlugin(),
+        new V49_FixAccessAssignmentMainNode(),
     ];
 
     /// <summary>

--- a/memex/aspire/Memex.Database.Migration/Migrations/V49_FixAccessAssignmentMainNode.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V49_FixAccessAssignmentMainNode.cs
@@ -1,0 +1,116 @@
+namespace Memex.Database.Migration.Migrations;
+
+/// <summary>
+/// Repairs <c>AccessAssignment.main_node</c> values that point at the <c>_Access</c> satellite
+/// CONTAINER instead of the node the grant was made on, then rebuilds the permissions derived from
+/// them.
+///
+/// <para><b>The bug.</b> A grant written without an explicit <c>MainNode</c> (the invite flows, MCP
+/// <c>create</c>, any plain <c>CreateNodeRequest</c>) had it auto-stamped to the node's NAMESPACE —
+/// <c>{scope}/_Access</c> — by the satellite rule in <c>MeshExtensions</c>. That is a path no node
+/// lives at, and <c>main_node</c> is read as a real node in two places that matter:</para>
+/// <list type="number">
+///   <item><b>Permissions</b>: <c>rebuild_user_effective_permissions()</c> projects each grant at
+///     prefix <c>COALESCE(aa.main_node, aa.namespace)</c>, so the grant landed on
+///     <c>{scope}/_Access</c> — one level BELOW the node it was granted on. The invitee got rows
+///     that cover only the access list, not <c>{scope}</c> itself.</item>
+///   <item><b>The invitation</b>: the access-granted mail named and linked <c>main_node</c> —
+///     "You've been given access to CollaborationNotus/_Access".</item>
+/// </list>
+///
+/// <para>The stamp is fixed at the source (<c>SatelliteTableMapping.OwnerOfSatellitePath</c>), so
+/// new grants are written correctly; this migration repairs the rows already stored. Idempotent:
+/// it only touches rows whose <c>main_node</c> still contains an <c>_Access</c> SEGMENT (an
+/// <c>_AccessLog</c>-style path is left alone), and re-running it matches nothing.</para>
+///
+/// <para>Scope is deliberately the <c>access</c> table only — it is the one whose <c>main_node</c>
+/// feeds the permission projection. Other satellites (<c>_Thread</c>, <c>_Activity</c>, …) set
+/// MainNode explicitly at their write sites or are re-stamped on their next write.</para>
+/// </summary>
+public sealed class V49_FixAccessAssignmentMainNode : IMigration
+{
+    public int Version => 49;
+    public string Description =>
+        "Point AccessAssignment.main_node at the granted node instead of the _Access container (grants projected one level too deep) and rebuild permissions";
+
+    public async Task RunAsync(MigrationContext ctx)
+    {
+        var schemas = new List<string>();
+        await using (var discover = ctx.DataSource.CreateCommand("""
+            SELECT t.table_schema
+            FROM information_schema.tables t
+            WHERE t.table_name = 'access'
+              AND t.table_schema NOT IN ('information_schema','pg_catalog','pg_toast')
+              AND t.table_schema NOT LIKE '%\_versions'
+            ORDER BY t.table_schema
+            """))
+        await using (var rdr = await discover.ExecuteReaderAsync())
+        {
+            while (await rdr.ReadAsync())
+                schemas.Add(rdr.GetString(0));
+        }
+
+        var totalFixed = 0;
+        foreach (var schema in schemas)
+        {
+            var quotedSchema = "\"" + schema.Replace("\"", "\"\"") + "\"";
+
+            // Cut main_node at its FIRST _Access segment: 'Space/_Access' -> 'Space',
+            // 'Space/_Access/a1/_Activity' -> 'Space'. The regex anchors on a full SEGMENT, so
+            // 'Space/_AccessLog' — an ordinary node — is untouched.
+            //
+            // A ROOT-LEVEL '_Access' main_node is deliberately NOT repaired here. Its correct value
+            // is '' — and '' is the projection's MESH-WIDE prefix (what GlobalAdminSeed writes on
+            // purpose for platform admins), so rewriting it would turn dormant rows into global
+            // grants during an upgrade. New writes get '' from the fixed stamp; existing ones are
+            // reported below for an operator to review deliberately.
+            int affected;
+            await using (var fix = ctx.DataSource.CreateCommand($"""
+                UPDATE {quotedSchema}.access
+                SET main_node = regexp_replace(main_node, '/_Access(/.*)?$', '')
+                WHERE main_node IS NOT NULL
+                  AND main_node ~ '/_Access(/|$)'
+                """))
+            {
+                affected = await fix.ExecuteNonQueryAsync();
+            }
+
+            await using (var rootScoped = ctx.DataSource.CreateCommand($"""
+                SELECT count(*) FROM {quotedSchema}.access WHERE main_node ~ '^_Access(/|$)'
+                """))
+            {
+                if (await rootScoped.ExecuteScalarAsync() is long count and > 0)
+                    ctx.Logger.LogWarning(
+                        "Repair v49: '{Schema}' — {Count} grant(s) carry the root-level main_node '_Access'. "
+                        + "Left as-is: their correct value ('') is a MESH-WIDE grant, so activating them is an "
+                        + "explicit admin decision, not an upgrade side effect", schema, count);
+            }
+
+            if (affected == 0)
+                continue;
+
+            totalFixed += affected;
+            ctx.Logger.LogInformation(
+                "Repair v49: '{Schema}' — {Count} AccessAssignment main_node(s) re-pointed at the granted node",
+                schema, affected);
+
+            // The permission rows were materialized from the old prefix — re-project them. Guarded:
+            // a schema without the rebuild function (very old / bare) still gets its data repaired.
+            try
+            {
+                await using var rebuild = ctx.DataSource.CreateCommand(
+                    $"SELECT {quotedSchema}.rebuild_user_effective_permissions()");
+                await rebuild.ExecuteNonQueryAsync();
+            }
+            catch (Exception ex)
+            {
+                ctx.Logger.LogWarning(ex,
+                    "Repair v49: '{Schema}' — permission rebuild failed; rows are repaired and the next "
+                    + "access write (or the boot-time self-heal) re-projects them", schema);
+            }
+        }
+
+        ctx.Logger.LogInformation(
+            "Repair v49: done — {Count} main_node(s) fixed across {Schemas} schema(s)", totalFixed, schemas.Count);
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-26-access-mail-opens-the-node.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-26-access-mail-opens-the-node.md
@@ -1,0 +1,18 @@
+---
+Name: Sharing a node grants — and opens — that node
+Category: What's New
+Description: Invitations now name and link the node that was shared, and the access they grant applies to it rather than one level below.
+Icon: Sparkle
+---
+
+# Sharing a node grants — and opens — that node
+
+When someone shared a space or a page with you, the invitation could name the internal access list
+behind it — "You've been given access to CollaborationNotus/_Access" — and its button opened that
+list instead of the space. The same mix-up applied the permission one level too deep, so a freshly
+invited person could be told they had access while the space itself still looked closed to them.
+
+Grants are now anchored to the node they were made on: invitations name and open that node, and the
+access takes effect there and everywhere below it. Existing grants are repaired automatically on
+upgrade. Installation-wide grants, which have no single node to open, no longer send an invitation
+mail.

--- a/src/MeshWeaver.Graph/AccessGrantNotifier.cs
+++ b/src/MeshWeaver.Graph/AccessGrantNotifier.cs
@@ -109,7 +109,8 @@ public sealed class AccessGrantNotifier(
     /// <summary>
     /// Pure decision: should the created <paramref name="assignmentNode"/> raise an access-granted
     /// notification, and to whom / for what? Returns <c>true</c> only for an actual grant (a
-    /// non-denied role) that is NOT a self-grant (creator == subject) and carries a target node.
+    /// non-denied role) that is NOT a self-grant (creator == subject) and governs a real node
+    /// (see <see cref="ResolveGrantedNode"/> — a root-scope grant has none).
     /// Does not resolve whether the subject is a user (that needs a read). Pure + unit-testable.
     /// </summary>
     internal static bool TryResolveGrant(
@@ -133,13 +134,37 @@ public sealed class AccessGrantNotifier(
         if (string.Equals(assignmentNode.CreatedBy, assignment.AccessObject, StringComparison.Ordinal))
             return false;
 
-        if (string.IsNullOrEmpty(assignmentNode.MainNode))
+        var scope = ResolveGrantedNode(assignmentNode);
+        if (string.IsNullOrEmpty(scope))
             return false;
 
         recipient = assignment.AccessObject;
-        grantedNodePath = assignmentNode.MainNode;
+        grantedNodePath = scope;
         roleText = string.Join(", ", grantedRoles);
         return true;
+    }
+
+    /// <summary>
+    /// The node the grant GOVERNS — what the recipient is told they can now open, and what the
+    /// notification links to. An assignment lives at <c>{scope}/_Access/{subject}_Access</c> (legacy
+    /// shape: <c>{scope}/{subject}_Access</c>), so the governed node is
+    /// <see cref="SatelliteTableMapping.OwnerOfSatellitePath"/> of its namespace — the same owner
+    /// the create handler now stamps into <see cref="MeshNode.MainNode"/>.
+    ///
+    /// <para>🚨 Derived from the NAMESPACE, not read from MainNode, because rows written before that
+    /// stamp was fixed still carry the <c>_Access</c> CONTAINER there — which is how the recipient
+    /// got "You've been given access to CollaborationNotus/_Access" with a link to the container
+    /// instead of the space. MainNode is only a fallback for an assignment with no namespace.</para>
+    ///
+    /// <para>A ROOT-scope grant (namespace <c>_Access</c> or empty — e.g. the global-admin seed)
+    /// resolves to <c>""</c>: there is no node to name or link to, so no notification is raised.</para>
+    /// </summary>
+    internal static string ResolveGrantedNode(MeshNode assignmentNode)
+    {
+        var fromNamespace = SatelliteTableMapping.OwnerOfSatellitePath(assignmentNode.Namespace).Trim('/');
+        return fromNamespace.Length > 0
+            ? fromNamespace
+            : SatelliteTableMapping.OwnerOfSatellitePath(assignmentNode.MainNode).Trim('/');
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -372,13 +372,24 @@ public static class MeshExtensions
                     return Observable.Empty<(string mode, MeshNode node)>();
                 }
 
-                // 1b. Auto-set MainNode for satellite types before validation.
+                // 1b. Auto-set MainNode for satellite types before validation: the OWNING MAIN NODE —
+                // the namespace with its satellite tail cut off (`{owner}/_Access` → `{owner}`), which
+                // for the legacy no-segment placement (`{owner}` itself) is the namespace unchanged.
+                // NOT the raw namespace: that is the satellite CONTAINER, a path no node lives at, and
+                // every consumer of MainNode reads it as a real node — SatelliteAccessRule DELEGATES the
+                // satellite's permissions to it, `rebuild_user_effective_permissions` projects an
+                // AccessAssignment's grant at prefix COALESCE(main_node, namespace) (so a container
+                // stamp granted access one level too deep — under `{scope}/_Access` instead of on
+                // `{scope}`), satellite-table scope filters match `main_node` as the attachment point,
+                // and the access-granted notification named "{scope}/_Access" instead of the node that
+                // was shared. A root-level satellite (`_Access/{id}`, the root-scope grant) has no
+                // owner: MainNode = "" is that shape's documented value (see ActivityNodeGuard).
                 if (!string.IsNullOrEmpty(node.NodeType)
                     && !string.IsNullOrEmpty(node.Namespace)
                     && meshConfig.IsSatelliteNodeType(node.NodeType)
                     && node.MainNode == node.Path)
                 {
-                    node = node with { MainNode = node.Namespace };
+                    node = node with { MainNode = SatelliteTableMapping.OwnerOfSatellitePath(node.Namespace) };
                 }
                 // 1b'. Repair a STALE BARE-ID self-default MainNode on a MAIN (non-satellite) node.
                 // MainNode is a STORED property: unlike the computed Path/Segments it does NOT follow

--- a/src/MeshWeaver.Mesh.Contract/SatelliteTableMapping.cs
+++ b/src/MeshWeaver.Mesh.Contract/SatelliteTableMapping.cs
@@ -67,10 +67,44 @@ public sealed record SatelliteTableMapping(string Segment, string Table, params 
     {
         if (string.IsNullOrEmpty(path)) return false;
         foreach (var seg in path.Split('/', StringSplitOptions.RemoveEmptyEntries))
-            if (seg.Length > 1 && seg[0] == '_'
-                && Defaults.Any(m => m.Segment.Length > 0 && m.Segment[0] == '_'
-                                     && string.Equals(m.Segment, seg, StringComparison.Ordinal)))
+            if (IsSatelliteSegment(seg))
                 return true;
         return false;
     }
+
+    /// <summary>
+    /// The owning MAIN node of <paramref name="path"/>: everything BEFORE its first satellite
+    /// segment — <c>Space/_Access/alice_Access</c> → <c>Space</c>, <c>Space/_Access</c> →
+    /// <c>Space</c>, <c>Doc/_Thread/t1/_ThreadMessage/m1</c> → <c>Doc</c>. A path that holds no
+    /// satellite segment IS a main node and is returned unchanged; a root-level satellite
+    /// (<c>_Access/{id}</c> — the root-scope grant) has no owner and yields <c>""</c>.
+    ///
+    /// <para>This is what <see cref="MeshNode.MainNode"/> must hold for a satellite, and why the cut
+    /// is at the FIRST satellite segment rather than the last: a satellite's MainNode is the node its
+    /// permissions DELEGATE to (<c>SatelliteAccessRule</c>) and the prefix its grants project at
+    /// (<c>COALESCE(main_node, namespace)</c> in <c>rebuild_user_effective_permissions</c>), so it has
+    /// to be a real main node. A MainNode left pointing at a satellite CONTAINER
+    /// (<c>{owner}/_Access</c>) names a node that does not exist — it made the access-granted mail
+    /// read "you've been given access to X/_Access" and projected the grant one level too deep, below
+    /// the node it was granted on.</para>
+    /// </summary>
+    public static string OwnerOfSatellitePath(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return "";
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < segments.Length; i++)
+            if (IsSatelliteSegment(segments[i]))
+                return string.Join('/', segments[..i]);
+        return path;
+    }
+
+    /// <summary>
+    /// True if <paramref name="segment"/> is exactly one of the underscore-prefixed
+    /// <see cref="Defaults"/> satellite segments — the shared test behind
+    /// <see cref="IsSatellitePath"/> and <see cref="OwnerOfSatellitePath"/>.
+    /// </summary>
+    private static bool IsSatelliteSegment(string segment)
+        => segment.Length > 1 && segment[0] == '_'
+           && Defaults.Any(m => m.Segment.Length > 0 && m.Segment[0] == '_'
+                                && string.Equals(m.Segment, segment, StringComparison.Ordinal));
 }

--- a/test/MeshWeaver.Graph.Test/AccessGrantNotifierTargetTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessGrantNotifierTargetTest.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins <see cref="AccessGrantNotifier.ResolveGrantedNode"/> — the node an access-granted
+/// notification names and links to. It must ALWAYS be the governed node, never the <c>_Access</c>
+/// satellite container: the reported bug was a mail reading "You've been given access to
+/// CollaborationNotus/_Access" whose button opened <c>/CollaborationNotus/_Access</c> instead of the
+/// space. Cause: the notifier used <see cref="MeshNode.MainNode"/>, which an assignment written
+/// without an explicit MainNode gets auto-stamped to its NAMESPACE — the container.
+/// </summary>
+public class AccessGrantNotifierTargetTest
+{
+    private static readonly JsonSerializerOptions Options = new();
+
+    private static MeshNode Assignment(
+        string subject, string @namespace, string mainNode, string createdBy = "admin", string role = "Admin") =>
+        new($"{subject}_Access", @namespace)
+        {
+            NodeType = "AccessAssignment",
+            MainNode = mainNode,
+            CreatedBy = createdBy,
+            Content = new AccessAssignment
+            {
+                AccessObject = subject,
+                Roles = [new RoleAssignment { Role = role }],
+            },
+        };
+
+    [Fact]
+    public void AutoStampedMainNode_StripsTheAccessContainer()
+    {
+        // The reported shape: no explicit MainNode at write time → auto-stamped to the namespace.
+        var node = Assignment("alice", "CollaborationNotus/_Access", "CollaborationNotus/_Access");
+
+        Assert.True(AccessGrantNotifier.TryResolveGrant(
+            node, Options, out var recipient, out var granted, out var roleText));
+        Assert.Equal("alice", recipient);
+        Assert.Equal("CollaborationNotus", granted);
+        Assert.Equal("Admin", roleText);
+    }
+
+    [Fact]
+    public void NestedNode_ResolvesToTheGrantedNodeNotThePartition()
+    {
+        // A grant on a node deep inside a space must link to THAT node, not the space root.
+        var node = Assignment("alice", "Space/Docs/Report/_Access", "Space/Docs/Report/_Access");
+
+        Assert.True(AccessGrantNotifier.TryResolveGrant(node, Options, out _, out var granted, out _));
+        Assert.Equal("Space/Docs/Report", granted);
+    }
+
+    [Fact]
+    public void ExplicitMainNode_IsAlreadyTheGovernedNode_AndIsLeftAlone()
+    {
+        // The Access Control tab writes MainNode = the granted node path.
+        var node = Assignment("alice", "TeamSpace/_Access", "TeamSpace");
+
+        Assert.True(AccessGrantNotifier.TryResolveGrant(node, Options, out _, out var granted, out _));
+        Assert.Equal("TeamSpace", granted);
+    }
+
+    [Fact]
+    public void LegacyShape_WithoutAnAccessSegment_ResolvesToItsNamespace()
+    {
+        // Pre-_Access-segment placement (production shape repaired by V01): `{scope}/{subject}_Access`.
+        var node = Assignment("alice", "TestOrg", "TestOrg");
+
+        Assert.True(AccessGrantNotifier.TryResolveGrant(node, Options, out _, out var granted, out _));
+        Assert.Equal("TestOrg", granted);
+    }
+
+    [Fact]
+    public void MainNodeFallback_WhenTheAssignmentHasNoNamespace()
+    {
+        var node = Assignment("alice", "", "TeamSpace/_Access");
+
+        Assert.True(AccessGrantNotifier.TryResolveGrant(node, Options, out _, out var granted, out _));
+        Assert.Equal("TeamSpace", granted);
+    }
+
+    [Fact]
+    public void RootScopeGrant_RaisesNoNotification()
+    {
+        // A mesh-wide grant (global-admin seed) governs no node: there is nothing to name or link
+        // to, so it must be skipped rather than mail "access to _Access" / an empty title.
+        var node = Assignment("alice", "_Access", "_Access");
+
+        Assert.False(AccessGrantNotifier.TryResolveGrant(node, Options, out _, out _, out _));
+    }
+
+    [Fact]
+    public void ASegmentThatMerelyStartsWithAccess_IsNotStripped()
+    {
+        // "_AccessLog" is not the "_Access" satellite segment — the path must survive intact.
+        var node = Assignment("alice", "Space/_AccessLog", "Space/_AccessLog");
+
+        Assert.True(AccessGrantNotifier.TryResolveGrant(node, Options, out _, out var granted, out _));
+        Assert.Equal("Space/_AccessLog", granted);
+    }
+}

--- a/test/MeshWeaver.PathResolution.Test/SatelliteOwnerPathTest.cs
+++ b/test/MeshWeaver.PathResolution.Test/SatelliteOwnerPathTest.cs
@@ -1,0 +1,61 @@
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.PathResolution.Test;
+
+/// <summary>
+/// Pins <see cref="SatelliteTableMapping.OwnerOfSatellitePath"/> — the derivation behind a
+/// satellite's <see cref="MeshNode.MainNode"/>. MainNode must be a REAL main node: permissions
+/// delegate to it (<c>SatelliteAccessRule</c>), an AccessAssignment's grant projects at prefix
+/// <c>COALESCE(main_node, namespace)</c>, and the access-granted notification names and links it.
+/// Stamping the satellite CONTAINER (<c>{owner}/_Access</c>) instead broke all three.
+/// </summary>
+public class SatelliteOwnerPathTest
+{
+    [Theory]
+    // The container itself (what the create handler stamps from — the node's namespace).
+    [InlineData("Space/_Access", "Space")]
+    [InlineData("Space/Docs/Report/_Access", "Space/Docs/Report")]
+    [InlineData("Doc/_Thread", "Doc")]
+    // A full satellite instance path.
+    [InlineData("Space/_Access/alice_Access", "Space")]
+    [InlineData("Doc/_Thread/hello-world", "Doc")]
+    // Nested satellites cut at the FIRST segment — the owner is the last real node, and a MainNode
+    // pointing at another satellite is the "Access denied" shape migration V08 had to repair.
+    [InlineData("Doc/_Thread/t1/_ThreadMessage/m1", "Doc")]
+    [InlineData("Space/_Access/a1/_Activity/log1", "Space")]
+    // No satellite segment → the path IS a main node (the legacy `{scope}/{subject}_Access` shape).
+    [InlineData("TestOrg", "TestOrg")]
+    [InlineData("Space/Docs/Report", "Space/Docs/Report")]
+    // Root-level satellite: no owner — the documented MainNode of a root-scope grant.
+    [InlineData("_Access", "")]
+    [InlineData("_Access/rbuergi_Access", "")]
+    // Only the EXACT satellite segments count: `_Policy`/`_AccessLog` are ordinary mesh_nodes rows,
+    // and `Source`/`Test` are primary content that shares the code table.
+    [InlineData("Space/_Policy", "Space/_Policy")]
+    [InlineData("Space/_AccessLog", "Space/_AccessLog")]
+    [InlineData("MyType/Source", "MyType/Source")]
+    // Case-sensitive, like the storage router's segment matching.
+    [InlineData("Space/_access", "Space/_access")]
+    [InlineData("", "")]
+    public void OwnerOfSatellitePath_CutsAtTheFirstSatelliteSegment(string path, string expected)
+        => Assert.Equal(expected, SatelliteTableMapping.OwnerOfSatellitePath(path));
+
+    [Fact]
+    public void OwnerOfSatellitePath_NullIsEmpty()
+        => Assert.Equal("", SatelliteTableMapping.OwnerOfSatellitePath(null));
+
+    [Fact]
+    public void OwnerOfSatellitePath_NeverReturnsASatellitePath()
+    {
+        // The invariant that matters downstream: whatever comes back can be permission-checked and
+        // linked as a node. (An owner that is itself a satellite path is the V08 defect shape.)
+        foreach (var path in new[]
+                 {
+                     "Space/_Access/alice_Access", "Doc/_Thread/t1/_ThreadMessage/m1",
+                     "Space/_Access/a1/_Activity/log1", "Doc/_Comment/c1",
+                 })
+            Assert.False(SatelliteTableMapping.IsSatellitePath(
+                SatelliteTableMapping.OwnerOfSatellitePath(path)));
+    }
+}

--- a/test/MeshWeaver.Query.Test/UserActivityQueryTests.cs
+++ b/test/MeshWeaver.Query.Test/UserActivityQueryTests.cs
@@ -363,11 +363,15 @@ public class ActivityTrackingFilterTests(ITestOutputHelper output) : MonolithMes
     }
 
     /// <summary>
-    /// Verify that the satellite MainNode auto-setting works correctly:
-    /// satellite types created via NodeFactory.CreateNode should have MainNode == Namespace (not Path).
+    /// Verify that the satellite MainNode auto-setting works correctly: a satellite created via
+    /// NodeFactory.CreateNode gets MainNode = the OWNING MAIN NODE — the namespace with its
+    /// satellite segment cut off — never its own Path and never the satellite CONTAINER.
+    /// The container stamp (`{p}/_Access`) is a path no node lives at, and MainNode is read as a
+    /// real node: permissions delegate to it and an AccessAssignment's grant projects at prefix
+    /// COALESCE(main_node, namespace), so a container stamp granted access one level too deep.
     /// </summary>
     [Fact(Timeout = 30000)]
-    public async Task SatelliteTypes_HaveMainNodeSetToNamespace()
+    public async Task SatelliteTypes_HaveMainNodeSetToOwningNode()
     {
         var p = P();
 
@@ -387,16 +391,17 @@ public class ActivityTrackingFilterTests(ITestOutputHelper output) : MonolithMes
         threadNodes.Should().ContainSingle();
         var threadNode = threadNodes[0];
         threadNode.MainNode.Should().NotBe(threadNode.Path,
-            "Thread is a satellite type — MainNode should be set to namespace, not path");
-        threadNode.MainNode.Should().Be($"{p}/_Thread",
-            "Thread's MainNode should point to the parent namespace");
+            "Thread is a satellite type — MainNode is set to its owner, never self-referencing");
+        threadNode.MainNode.Should().Be(p,
+            "Thread's MainNode should point to the node it hangs off, not the _Thread container");
 
         var accessNodes = (await MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{p}/_Access/a1")).Should().Match(c => c.ChangeType == QueryChangeType.Initial)).Items;
         accessNodes.Should().ContainSingle();
         var accessNode = accessNodes[0];
         accessNode.MainNode.Should().NotBe(accessNode.Path,
-            "AccessAssignment is a satellite type — MainNode should be set to namespace, not path");
-        accessNode.MainNode.Should().Be($"{p}/_Access",
-            "AccessAssignment's MainNode should point to the parent namespace");
+            "AccessAssignment is a satellite type — MainNode is set to its owner, never self-referencing");
+        accessNode.MainNode.Should().Be(p,
+            "the grant's MainNode is the node it was granted ON — the _Access container would project "
+            + "the grant below that node and name a non-existent node in the invitation");
     }
 }


### PR DESCRIPTION
## The bug

An invitation mail arrived reading **"You've been given access to CollaborationNotus/_Access"**, with
a button opening `/CollaborationNotus/_Access` — the access list, not the space.

Root cause: a satellite node written without an explicit `MainNode` gets it auto-stamped to its
**namespace** (`MeshExtensions`, step 1b) — for a grant that is `{scope}/_Access`, the satellite
**container**, a path no node lives at. The invite flows, MCP `create` and any plain
`CreateNodeRequest` take that path (the Access Control tab sets `MainNode = nodePath` explicitly,
which is why this only showed on some grants).

`MainNode` is read as a REAL node in three places, so the container stamp broke all three:

1. **Permissions** — `rebuild_user_effective_permissions()` projects every grant at prefix
   `COALESCE(aa.main_node, aa.namespace)`. A container stamp put the grant at `{scope}/_Access`,
   i.e. **one level below the node it was granted on**: the invitee's rows covered the access list,
   not `{scope}`.
2. **Access delegation** — `SatelliteAccessRule` delegates a satellite's permission check to its
   MainNode (migration V08 repaired the same shape for ThreadMessages: a MainNode pointing at a
   satellite path denies access).
3. **The invitation** — `AccessGrantNotifier` named and linked MainNode, hence the mail above.

The query layer already assumed the correct value: satellite-table scope filters match `main_node`
as the *attachment point* ("a thread at `Org/doc/_Thread` with `main_node=Org/doc`"), and the
framework's own seed/test factories (`GlobalAdminSeed`, `AssignmentNodeFactory`, `TestUsers`) all set
MainNode to the scope explicitly. Only the auto-stamp disagreed.

## The fix

- **`SatelliteTableMapping.OwnerOfSatellitePath`** — one derivation of a satellite's owning main
  node: everything before the FIRST satellite segment (`Space/_Access/alice_Access` → `Space`,
  `Doc/_Thread/t1/_ThreadMessage/m1` → `Doc`), a path without a satellite segment unchanged, `""` for
  a root-level satellite. Cutting at the first segment (not the last) is what guarantees the result
  is a real main node — the V08 invariant. Shares its segment test with `IsSatellitePath`.
- **`MeshExtensions` step 1b** stamps that owner instead of the raw namespace.
- **`AccessGrantNotifier`** resolves the granted node from the assignment's namespace (same helper)
  rather than reading MainNode, so rows written before this fix also name and link the right node. A
  root-scope grant governs no node → no notification instead of "access to `_Access`".
- **`V49_FixAccessAssignmentMainNode`** repairs stored rows: cuts `access.main_node` at its `_Access`
  segment per partition schema and re-runs `rebuild_user_effective_permissions()`, so existing
  invitees actually get the access they were granted. Root-level `_Access` main_nodes are
  deliberately **left alone and logged** — their correct value (`""`) is the projection's mesh-wide
  prefix, and activating dormant global grants must be an explicit admin decision, not an upgrade
  side effect.

## Tests

- `SatelliteOwnerPathTest` (new, 20 cases) — the derivation: containers, instances, nested
  satellites, legacy no-segment placement, root level, `_AccessLog`/`_Policy`/`Source` non-matches,
  case sensitivity, plus the invariant that the owner is never itself a satellite path.
- `AccessGrantNotifierTargetTest` (new, 7 cases) — the reported shape, nested nodes, explicit
  MainNode, legacy shape, MainNode fallback, root-scope suppression.
- `UserActivityQueryTests.SatelliteTypes_HaveMainNodeSetToNamespace` **pinned the defect**
  (`MainNode == "{p}/_Access"`); renamed to `…SetToOwningNode` and asserts the owner — it is the
  end-to-end proof, creating through `NodeFactory.CreateNode`.
- Green locally (Release, `-warnaserror`): Query 357, Threading 128, Security 344, AccessControl 10,
  NodeOperations, Persistence, Graph 633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
