### PR TITLE
Distributed portal: register the mapped-collection source as "storage" (fixes #652's naming)

### DIFF
--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -248,7 +248,15 @@ builder.UseOrleansMeshServer(address, silo =>
         var storageConfig = builder.Configuration.GetSection("Storage").Get<ContentCollectionConfig>();
         return storageConfig is null
             ? hub
-            : hub.AddContentCollection(_ => storageConfig with { IsStatic = true });
+            // Force the well-known SOURCE name "storage" — NOT storageConfig.Name. The `Storage`
+            // section's Name is already spoken for: ConfigureMemexMesh uses this same section as
+            // the per-node content-collection root, and on AKS it is set to "content"
+            // (values.aks.yaml Storage__Name), which is what makes @{node}/content/… work. The
+            // mapped-collection SOURCE that every plugin references is a different, mesh-level
+            // thing and is always called "storage" (the Monolith's appsettings names it so).
+            // Registering it under the configured name would both shadow the per-node collection
+            // and still leave MapContentCollection(…, "storage", …) unresolved.
+            : hub.AddContentCollection(_ => storageConfig with { Name = "storage", IsStatic = true });
     });
 
 // Hard gate: refuse to start if the DB isn't migrated. Aspire's


### PR DESCRIPTION
Follow-up to #652 — that fix registered the source under its **configured** name, which on AKS is `content` (`values.aks.yaml` → `Storage__Name`), because `ConfigureMemexMesh` uses the *same* `Storage` section as the **per-node content-collection root** (that's what makes `@{node}/content/…` work).

So #652 as merged both risked **shadowing the working per-node collection** and still left every `MapContentCollection(…, "storage", …)` unresolved — the mapped-collection **source** is a separate, mesh-level thing that all plugins reference by the well-known name **`storage`** (as the Monolith's appsettings names it).

**Fix:** force `Name = "storage"` on the registered source. Nothing else uses that name, so it adds the missing source without disturbing per-node collections.

Unblocks on memex: `ReinsuranceDemo/Setup`'s packs zip (demo was un-importable), `Reinsurance/Cedent` + `Underwriting/Submission` `content`, `Claims/Claim` `files`.

Build: `Memex.Portal.Distributed` — 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)