### PR TITLE
Fix all 64 npm Dependabot alerts; port Video/SlideShow/MenuItem to React; add portal-next CI

### DIFF
--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -96,7 +96,7 @@ jobs:
         run: npm install --no-audit --no-fund && npm run gen
       # Targeted install: RN types for typecheck; react-test-renderer for the render test
       # (react-native mocked — vitest.config.ts); expo-av types the speech recorder.
-      - run: npm install --no-save --no-audit --no-fund react-native@0.76.5 react@18.3.1 react-test-renderer@18.3.1 @types/react@18.3.12 @types/react-test-renderer@18.3.0 expo-av@15.0.2 vitest@2.1.9 typescript@5.6.3
+      - run: npm install --no-save --no-audit --no-fund react-native@0.76.5 react@18.3.1 react-test-renderer@18.3.1 @types/react@18.3.12 @types/react-test-renderer@18.3.0 expo-av@15.0.2 vitest@4.1.9 typescript@5.6.3
       - run: npx tsc --noEmit
       # Headless render of the sample area + the speech pipeline (transcription client, push-to-talk→submit).
       - run: npx vitest run
@@ -124,6 +124,36 @@ jobs:
       - run: npm install --no-audit --no-fund
       - run: npx tsc --noEmit # vite build transpiles without type-checking — check types explicitly
       - run: npm run build
+
+  portal-next:
+    name: "Portal-next (typecheck + test + build)"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: clients/portal-next
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          # Matches the Dockerfile's node:22-alpine — build the app on the runtime it ships on.
+          node-version: 22
+      # vitest.config.ts source-aliases the renderer (../react/src); its own deps must resolve.
+      - name: Install renderer deps
+        working-directory: clients/react
+        run: npm install --no-audit --no-fund
+      # next.config.mjs + vitest.config.ts alias @meshweaver/client-web to ../grpc-web/src, whose
+      # src/gen is GENERATED (gitignored) from the canonical mesh.proto — without it the build fails
+      # with "Can't resolve './gen/mesh_pb'".
+      - name: Install + generate grpc-web client
+        working-directory: clients/grpc-web
+        run: npm install --no-audit --no-fund && npm run gen
+      # `npm ci` (not install) — this is the only client with a committed lockfile, and it is what
+      # the Dockerfile runs; drift between package.json and the lock fails here rather than in the
+      # image build.
+      - run: npm ci --no-audit --no-fund
+      - run: npm run typecheck # next build skips type-checking by design (see next.config.mjs)
+      - run: npm test # vitest: server snapshot, SSR shell, token mint, redirect decision, mesh paths
+      - run: npm run build # the standalone production bundle the Docker image ships
 
   rn-web-e2e:
     name: "RN web (Playwright)"

--- a/clients/grpc-web/package.json
+++ b/clients/grpc-web/package.json
@@ -28,6 +28,6 @@
     "@bufbuild/buf": "^1.47.0",
     "@bufbuild/protoc-gen-es": "^2.2.0",
     "typescript": "^5.6.0",
-    "vitest": "^2.1.0"
+    "vitest": "^4.1.9"
   }
 }

--- a/clients/portal-next/app/[[...meshPath]]/AreaSnapshot.tsx
+++ b/clients/portal-next/app/[[...meshPath]]/AreaSnapshot.tsx
@@ -24,8 +24,9 @@ import {
 import { LiveArea } from "../../src/client/LiveArea";
 
 export async function AreaSnapshot({ path }: { path: string }) {
-  const origin = resolvePortalOrigin(headers());
-  const cookieHeader = cookies()
+  // Next 15: `headers()` / `cookies()` are async.
+  const origin = resolvePortalOrigin(await headers());
+  const cookieHeader = (await cookies())
     .getAll()
     .map((c) => `${c.name}=${c.value}`)
     .join("; ");

--- a/clients/portal-next/app/[[...meshPath]]/page.tsx
+++ b/clients/portal-next/app/[[...meshPath]]/page.tsx
@@ -13,8 +13,10 @@ import { AreaSnapshot } from "./AreaSnapshot";
 // Every request depends on the caller's cookies (per-request token mint) — never prerender.
 export const dynamic = "force-dynamic";
 
-export default function MeshPage({ params }: { params: { meshPath?: string[] } }) {
-  const path = meshPathFromSegments(params.meshPath);
+// Next 15: dynamic route `params` is a Promise — awaited here, before the Suspense boundary, so the
+// skeleton still flushes first (the await resolves from the already-parsed URL, it does no I/O).
+export default async function MeshPage({ params }: { params: Promise<{ meshPath?: string[] }> }) {
+  const path = meshPathFromSegments((await params).meshPath);
   return (
     <Suspense fallback={<AreaSkeleton path={path} />}>
       <AreaSnapshot path={path} />

--- a/clients/portal-next/app/search/page.tsx
+++ b/clients/portal-next/app/search/page.tsx
@@ -23,13 +23,15 @@ function all(v: string | string[] | undefined): string[] {
   return Array.isArray(v) ? v : v ? [v] : [];
 }
 
-export default function SearchPage({ searchParams }: { searchParams: SearchParams }) {
-  const limitRaw = Number.parseInt(first(searchParams.limit), 10);
+// Next 15: `searchParams` is a Promise — awaited here (resolves from the already-parsed URL).
+export default async function SearchPage({ searchParams }: { searchParams: Promise<SearchParams> }) {
+  const params = await searchParams;
+  const limitRaw = Number.parseInt(first(params.limit), 10);
   return (
     <SearchResults
-      query={first(searchParams.q)}
-      hiddenQuery={all(searchParams.hq).filter(Boolean).join(" ")}
-      namespace={first(searchParams.ns)}
+      query={first(params.q)}
+      hiddenQuery={all(params.hq).filter(Boolean).join(" ")}
+      namespace={first(params.ns)}
       limit={Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 50}
     />
   );

--- a/clients/portal-next/next.config.mjs
+++ b/clients/portal-next/next.config.mjs
@@ -48,12 +48,13 @@ const nextConfig = {
   // it's declining to re-type-check vendored source through the wrong tsconfig.
   typescript: { ignoreBuildErrors: true },
   eslint: { ignoreDuringBuilds: true },
+  // Monorepo root for standalone output tracing (clients/) — server.js lands under
+  // .next/standalone/portal-next/server.js (see Dockerfile). Top-level since Next 15
+  // (was `experimental.outputFileTracingRoot` in 14).
+  outputFileTracingRoot: path.join(here, ".."),
   experimental: {
     // Compile the ../react and ../grpc-web sources (outside this app dir).
     externalDir: true,
-    // Monorepo root for standalone output tracing (clients/) — server.js lands under
-    // .next/standalone/portal-next/server.js (see Dockerfile).
-    outputFileTracingRoot: path.join(here, ".."),
   },
   webpack: (config) => {
     config.resolve.alias = {

--- a/clients/portal-next/package-lock.json
+++ b/clients/portal-next/package-lock.json
@@ -15,8 +15,8 @@
         "@fluentui/react-icons": "^2.0.260",
         "@monaco-editor/react": "^4.7.0",
         "chart.js": "^4.4.1",
-        "mermaid": "^11.4.1",
-        "next": "^14.2.5",
+        "mermaid": "^11.16.0",
+        "next": "^15.5.22",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^9.0.1",
@@ -44,15 +44,6 @@
         "package-manager-detector": "^1.3.0",
         "tinyexec": "^1.0.1"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@antfu/utils": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-8.1.1.tgz",
-      "integrity": "sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -424,55 +415,10 @@
       "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/cst-dts-gen/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/gast/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
-    },
-    "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@chevrotain/types": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
     },
     "node_modules/@connectrpc/connect": {
@@ -641,6 +587,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/hash": {
@@ -2732,19 +2688,563 @@
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.3.0.tgz",
-      "integrity": "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
       "license": "MIT",
       "dependencies": {
-        "@antfu/install-pkg": "^1.0.0",
-        "@antfu/utils": "^8.1.0",
+        "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
-        "debug": "^4.4.0",
-        "globals": "^15.14.0",
-        "kolorist": "^1.8.0",
-        "local-pkg": "^1.0.0",
-        "mlly": "^1.7.4"
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2804,12 +3304,12 @@
       "license": "MIT"
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.3.0.tgz",
-      "integrity": "sha512-HsvL6zgE5sUPGgkIDlmAWR1HTNHz2Iy11BAWPTa4Jjabkpguy4Ze2gzfLrg6pdRuBvFwgUYyxiaNqZwrEEXepA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "license": "MIT",
       "dependencies": {
-        "langium": "3.0.0"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@monaco-editor/loader": {
@@ -2836,15 +3336,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.35",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
-      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.22.tgz",
+      "integrity": "sha512-O5BlKb3KtsHkvO0gjjV66PuJnAgCtIEIzwkt50HRAHsQkU1t77eksIXSZV84/WMtZJjWrnDUPKHVRi0D62nSAA==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
-      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.22.tgz",
+      "integrity": "sha512-/VISwtffSg8+fVvBbXdglsvruCsdbBC4dG25iU6xascKVqfQKsj/OtjGnOEkIS7pX5GB9e9/r5QprpicsGL3gw==",
       "cpu": [
         "arm64"
       ],
@@ -2858,9 +3358,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
-      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.22.tgz",
+      "integrity": "sha512-NiA9ve8hbiuhG/Q17a2mZDRVxMTtg3rTOgjLnDaLlE+AEPAQlkkuKrfePEbeOrgYmX0U2KGX4EVEn09hXU5GlQ==",
       "cpu": [
         "x64"
       ],
@@ -2874,9 +3374,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
-      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.22.tgz",
+      "integrity": "sha512-vAPa9vltW+UW/KWtjXeSUFgV3wb1x9d/BeyC6WFI6eBpL0D2f70oGwtOp6193mNW3qusrpgBzMQferPf+Zh8Dw==",
       "cpu": [
         "arm64"
       ],
@@ -2893,9 +3393,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
-      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.22.tgz",
+      "integrity": "sha512-iknK80pWlNDnkdSr13bd8mMuG3Z2oTxODwsZHvuMY7caMk77+rBLdHVWsy8v2EVa3ZojJ/+wJX5fnq8va6Gv8A==",
       "cpu": [
         "arm64"
       ],
@@ -2912,9 +3412,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
-      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.22.tgz",
+      "integrity": "sha512-penuEdkwU2OOAiS+n4LE8T/VIoCfAI01QcLZTJ2xc3+l4Q22L/DzURocmI2LU1b+8BMQoLAP1Sze3uYAZT05Bg==",
       "cpu": [
         "x64"
       ],
@@ -2931,9 +3431,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
-      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.22.tgz",
+      "integrity": "sha512-ZM0BKJm3FZ+guG6WT6PcyOLtp6paZ5tngcJC/uUKvLW4Y0TQnnVi1+UGdo8Q6Yxp5gaS82pmC1rD/oFlhkWB3g==",
       "cpu": [
         "x64"
       ],
@@ -2950,9 +3450,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
-      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.22.tgz",
+      "integrity": "sha512-rY/YaumrZaS0//94BnHLF5VSRp0GFUO4GvXNuoCBb0cGSci96yO+p1JaNL2aq9YZAYv9cuZRziV02x5IQH/wjg==",
       "cpu": [
         "arm64"
       ],
@@ -2965,26 +3465,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
-      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
-      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.22.tgz",
+      "integrity": "sha512-s5IA4cyrbR2XK/5NWcu5dp8CfPBiKME+UhvNperia7uQybEgg5+LIhGMiY37WQE4rcI4owsDcU4IVUjLoTuDkA==",
       "cpu": [
         "x64"
       ],
@@ -3399,12 +3883,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
@@ -3894,6 +4372,16 @@
       "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
       "license": "ISC"
     },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -4028,18 +4516,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -4150,17 +4626,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001800",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
@@ -4253,38 +4718,6 @@
         "pnpm": ">=8"
       }
     },
-    "node_modules/chevrotain": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.0.3",
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/regexp-to-ast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "@chevrotain/utils": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/chevrotain-allstar": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "chevrotain": "^11.0.0"
-      }
-    },
-    "node_modules/chevrotain/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
-    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -4309,12 +4742,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/confbox": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
-      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4842,9 +5269,9 @@
       }
     },
     "node_modules/dagre-d3-es": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.11.tgz",
-      "integrity": "sha512-tvlJLyQf834SylNKax8Wkzco/1ias1OPw8DcUMDE7oUIoSEW25riQVuiu/0OWEFqT0cxHT3Pa9/D82Jr47IONw==",
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",
@@ -4926,6 +5353,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -4947,9 +5384,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5005,6 +5442,17 @@
       "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -5100,12 +5548,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/exsolve": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
-      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
-      "license": "MIT"
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5154,24 +5596,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
     },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
@@ -5252,6 +5676,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/inline-style-parser": {
@@ -5451,50 +5885,11 @@
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
-    "node_modules/kolorist": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
-      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
-      "license": "MIT"
-    },
-    "node_modules/langium": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-3.0.0.tgz",
-      "integrity": "sha512-+Ez9EoiByeoTu/2BXmEaZ06iPNXM6thWJp02KfBO/raSMyCJ4jw7AkWWa+zBCTm0+Tw1Fj9FOxdqSskyN5nAwg==",
-      "license": "MIT",
-      "dependencies": {
-        "chevrotain": "~11.0.3",
-        "chevrotain-allstar": "~0.3.0",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.11",
-        "vscode-uri": "~3.0.8"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/layout-base": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "license": "MIT"
-    },
-    "node_modules/local-pkg": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
-      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "mlly": "^1.7.4",
-        "pkg-types": "^2.3.0",
-        "quansync": "^0.2.11"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -5855,43 +6250,44 @@
       "license": "CC0-1.0"
     },
     "node_modules/mermaid": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.4.1.tgz",
-      "integrity": "sha512-Mb01JT/x6CKDWaxigwfZYuYmDZ6xtrNwNlidKZwkSrDaY9n90tdrJTV5Umk+wP1fZscGptmKFXHsXMDEVZ+Q6A==",
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.0.1",
-        "@iconify/utils": "^2.1.32",
-        "@mermaid-js/parser": "^0.3.0",
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
-        "cytoscape": "^3.29.2",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
-        "dagre-d3-es": "7.0.11",
-        "dayjs": "^1.11.10",
-        "dompurify": "^3.2.1",
-        "katex": "^0.16.9",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
-        "lodash-es": "^4.17.21",
-        "marked": "^13.0.2",
+        "marked": "^16.3.0",
         "roughjs": "^4.6.6",
-        "stylis": "^4.3.1",
+        "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
-        "uuid": "^9.0.1"
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/mermaid/node_modules/marked": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
-      "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/micromark": {
@@ -6457,35 +6853,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/mlly": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
-      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "ufo": "^1.6.3"
-      }
-    },
-    "node_modules/mlly/node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "license": "MIT"
-    },
-    "node_modules/mlly/node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
@@ -6504,9 +6871,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -6522,41 +6889,40 @@
       }
     },
     "node_modules/next": {
-      "version": "14.2.35",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
-      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.22.tgz",
+      "integrity": "sha512-mrtal1sRxO4YrlDS98sDuIvGZivKbFix8w7oAL9ZynfOgc3cADQOQgvwtMooc18Qr8bKzvQAcHwHZ0mbJ7zcfQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.35",
-        "@swc/helpers": "0.5.5",
-        "busboy": "1.6.0",
+        "@next/env": "15.5.22",
+        "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
-        "graceful-fs": "^4.2.11",
         "postcss": "8.4.31",
-        "styled-jsx": "5.1.1"
+        "styled-jsx": "5.1.6"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.33",
-        "@next/swc-darwin-x64": "14.2.33",
-        "@next/swc-linux-arm64-gnu": "14.2.33",
-        "@next/swc-linux-arm64-musl": "14.2.33",
-        "@next/swc-linux-x64-gnu": "14.2.33",
-        "@next/swc-linux-x64-musl": "14.2.33",
-        "@next/swc-win32-arm64-msvc": "14.2.33",
-        "@next/swc-win32-ia32-msvc": "14.2.33",
-        "@next/swc-win32-x64-msvc": "14.2.33"
+        "@next/swc-darwin-arm64": "15.5.22",
+        "@next/swc-darwin-x64": "15.5.22",
+        "@next/swc-linux-arm64-gnu": "15.5.22",
+        "@next/swc-linux-arm64-musl": "15.5.22",
+        "@next/swc-linux-x64-gnu": "15.5.22",
+        "@next/swc-linux-x64-musl": "15.5.22",
+        "@next/swc-win32-arm64-msvc": "15.5.22",
+        "@next/swc-win32-x64-msvc": "15.5.22",
+        "sharp": "^0.34.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -6566,19 +6932,21 @@
         "@playwright/test": {
           "optional": true
         },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
         "sass": {
           "optional": true
         }
       }
     },
     "node_modules/next/node_modules/@swc/helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
-      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/node-releases": {
@@ -6606,9 +6974,9 @@
       }
     },
     "node_modules/package-manager-detector": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
-      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
       "license": "MIT"
     },
     "node_modules/parse-entities": {
@@ -6659,6 +7027,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -6680,17 +7049,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pkg-types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
-      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.2.4",
-        "exsolve": "^1.0.8",
-        "pathe": "^2.0.3"
-      }
-    },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
@@ -6708,9 +7066,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6727,9 +7085,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -6769,22 +7127,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/quansync": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
-      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/antfu"
-        },
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/sxzz"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -7060,6 +7402,69 @@
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
       "license": "MIT"
     },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -7106,14 +7511,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -7147,9 +7544,9 @@
       }
     },
     "node_modules/styled-jsx": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
-      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
       "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
@@ -7158,7 +7555,7 @@
         "node": ">= 12.0.0"
       },
       "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -7330,12 +7727,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ufo": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
-      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
-      "license": "MIT"
-    },
     "node_modules/undici": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
@@ -7481,17 +7872,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vfile": {
@@ -7597,35 +7987,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/vitest": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
@@ -7715,55 +8076,6 @@
           "optional": false
         }
       }
-    },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
-      }
-    },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-uri": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/clients/portal-next/package.json
+++ b/clients/portal-next/package.json
@@ -18,8 +18,8 @@
     "@fluentui/react-icons": "^2.0.260",
     "@monaco-editor/react": "^4.7.0",
     "chart.js": "^4.4.1",
-    "mermaid": "^11.4.1",
-    "next": "^14.2.5",
+    "mermaid": "^11.16.0",
+    "next": "^15.5.22",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1",
@@ -36,5 +36,16 @@
     "jsdom": "^29.1.1",
     "typescript": "^5.6.0",
     "vitest": "^4.1.9"
+  },
+  "_overrides_note": [
+    "Transitive pins our direct deps hold below their patched versions (Dependabot alerts).",
+    "postcss: next pins 8.4.31 exactly (both 15.x and 16.x) — forced to the 8.5.x patch line.",
+    "dompurify: monaco-editor pins 3.2.7 exactly (0.56.0 still pins 3.4.8) — forced to 3.4.12.",
+    "sharp: next declares ^0.34.3 (optional, image optimization — unused here) — forced past the libvips CVEs."
+  ],
+  "overrides": {
+    "postcss": "^8.5.23",
+    "dompurify": "^3.4.12",
+    "sharp": "^0.35.3"
   }
 }

--- a/clients/portal/package.json
+++ b/clients/portal/package.json
@@ -22,6 +22,6 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
     "typescript": "^5.6.0",
-    "vite": "^5.4.0"
+    "vite": "^7.3.6"
   }
 }

--- a/clients/react-native/package.json
+++ b/clients/react-native/package.json
@@ -39,6 +39,21 @@
     "@types/react-test-renderer": "~18.3.0",
     "react-test-renderer": "18.3.1",
     "typescript": "^5.6.0",
-    "vitest": "^2.1.0"
+    "vitest": "^4.1.9"
+  },
+  "_overrides_note": [
+    "postcss: expo 52 → @expo/metro-config pins 8.4.49, below the 8.5.x patch line. This is the one",
+    "advisory in the Expo tree that is BOTH reachable from what we build (the web export bundles CSS",
+    "through metro-config) and safe to force — same major, no API change.",
+    "The rest of the Expo-toolchain advisories (tar, @xmldom/xmldom, uuid, brace-expansion) are NOT",
+    "overridden on purpose: each patched version is a breaking major for its CJS consumer inside",
+    "@expo/cli / native prebuild (brace-expansion@5 is ESM-only and minimatch requires() it; uuid@11",
+    "likewise breaks xcode's require; tar 6→7 and xmldom 0.7→0.9 are breaking API changes). They are",
+    "reachable only from `expo prebuild` / `expo run:*`, not from the web export or the test run.",
+    "Forcing them would break the build to quiet a scanner — the real fix is the Expo SDK upgrade",
+    "(expo@57 + react-native@0.86), which is its own migration."
+  ],
+  "overrides": {
+    "postcss": "^8.5.23"
   }
 }

--- a/clients/react/package.json
+++ b/clients/react/package.json
@@ -57,11 +57,20 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
     "jsdom": "^29.1.1",
-    "mermaid": "11.4.1",
+    "mermaid": "11.16.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "typescript": "^5.6.0",
-    "vite": "^5.4.0",
+    "vite": "^7.3.6",
     "vitest": "^4.1.9"
+  },
+  "_overrides_note": [
+    "dompurify: monaco-editor (via @monaco-editor/react) pins 3.2.7 exactly, and even its latest",
+    "0.56.0 pins 3.4.8 — both below the patched 3.4.12. Forced here so this repo's installs are",
+    "clean; consumers of the published package resolve their own tree (npm ignores a dependency's",
+    "overrides), which is why @monaco-editor/react stays a plain dependency."
+  ],
+  "overrides": {
+    "dompurify": "^3.4.12"
   }
 }

--- a/clients/react/package.json
+++ b/clients/react/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
+    "@types/node": "^22.10.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",

--- a/clients/react/src/controls/display.tsx
+++ b/clients/react/src/controls/display.tsx
@@ -5,7 +5,7 @@ import { Badge, Button, Text, Tooltip, MessageBar, MessageBarBody, MessageBarTit
 import { Play16Regular } from "@fluentui/react-icons";
 import type { UiControl } from "../area/types.js";
 import { ScopeProvider, useAreaState, useResolve } from "../area/context.js";
-import { useHtmlLinkInterceptor } from "../area/navigation.js";
+import { isExternalTarget, normalizeTarget, useHtmlLinkInterceptor, useNavigation } from "../area/navigation.js";
 import { RenderArea } from "../render/ControlRenderer.js";
 import { useAreaSourceFactory, type EmbeddedAreaHandle } from "../render/embeddedArea.js";
 import { useMeshOps } from "../live/meshOps.js";
@@ -636,6 +636,111 @@ function Spacer(): ReactNode {
   return <div style={{ flex: 1 }} />;
 }
 
+/**
+ * VideoControl — the port of Blazor's VideoView.razor: a media source rendered either as a native
+ * `<video controls>` (VideoKind.Video, the default) or an embeddable player `<iframe>`
+ * (VideoKind.Embed), sized by the skin-free `aspectRatio` (default "16/9"). Enums arrive as their
+ * name on the wire, so `kind` is matched case-insensitively — the same shape SplitterSkin reads
+ * `orientation` with.
+ */
+function VideoView({ control }: { control: UiControl }): ReactNode {
+  const src = useText(control.src);
+  const poster = useText(control.poster);
+  const title = useText(control.title);
+  const ratio = useText(control.aspectRatio);
+  // Blazor renders nothing for an empty Src — hooks first, so the early return stays legal.
+  if (!src) return null;
+  const style = {
+    width: "100%",
+    aspectRatio: ratio || "16/9",
+    border: 0,
+    background: "#000",
+    ...controlStyle(control),
+  };
+  const className = controlClass(control);
+  return String(control.kind ?? "").toLowerCase() === "embed" ? (
+    <iframe
+      src={src}
+      title={title}
+      className={className}
+      style={style}
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+    />
+  ) : (
+    <video controls src={src} poster={poster || undefined} title={title || undefined} className={className} style={style} />
+  );
+}
+
+/** Presentation keys → action, mirroring SlideShowView.razor.js's `actionForKey`. */
+const PRESENT_KEY_ACTIONS: Record<string, "next" | "prev" | "first" | "last" | "exit"> = {
+  ArrowRight: "next",
+  ArrowDown: "next",
+  PageDown: "next",
+  " ": "next",
+  Spacebar: "next", // legacy Edge/IE spelling of the space key
+  Enter: "next",
+  ArrowLeft: "prev",
+  ArrowUp: "prev",
+  PageUp: "prev",
+  Home: "first",
+  End: "last",
+  Escape: "exit",
+  Esc: "exit", // legacy spelling
+};
+
+/**
+ * SlideShowControl — the port of Blazor's SlideShowView (+ its .razor.js keyboard driver): an
+ * INVISIBLE presenter-mode driver placed in a deck's `Present` area. It renders no chrome; it only
+ * binds the standard PowerPoint keys to the hrefs the control carries, and a null href makes that
+ * key a no-op (Next is null on the last slide).
+ *
+ * Blazor needs a module-level "most recently registered wins" registry because its JS module is
+ * cached across circuits and re-renders; React does not — the effect owns exactly one listener and
+ * its cleanup removes it, so re-rendering the Present area swaps rather than stacks listeners.
+ */
+function SlideShowView({ control }: { control: UiControl }): ReactNode {
+  const navigation = useNavigation();
+  const first = useText(control.firstHref);
+  const previous = useText(control.previousHref);
+  const next = useText(control.nextHref);
+  const last = useText(control.lastHref);
+  const exit = useText(control.exitHref);
+
+  // Read the current hrefs from a ref so the listener is bound ONCE per navigation context — a
+  // slide change updates the ref rather than tearing down and re-adding the document listener.
+  const hrefs = useRef({ first, previous, next, last, exit });
+  hrefs.current = { first, previous, next, last, exit };
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      // Never hijack keys while the user is typing in a field.
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.isContentEditable ||
+          target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.tagName === "SELECT")
+      )
+        return;
+      const action = PRESENT_KEY_ACTIONS[e.key];
+      if (!action) return;
+      const h = hrefs.current;
+      const href = action === "next" ? h.next : action === "prev" ? h.previous : h[action];
+      if (!href) return; // a null href disables that key (e.g. Next on the last slide)
+      e.preventDefault();
+      const normalized = normalizeTarget(href);
+      if (isExternalTarget(normalized)) window.location.assign(normalized);
+      else navigation.navigate(normalized);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [navigation]);
+
+  return null;
+}
+
 export const displayControls = {
   Label,
   Badge: BadgeView,
@@ -646,6 +751,8 @@ export const displayControls = {
   Highlight: CodeSample,
   Exception: ExceptionView,
   Spacer,
+  Video: VideoView,
+  SlideShow: SlideShowView,
 };
 
 export { Tooltip };

--- a/clients/react/src/controls/video.test.tsx
+++ b/clients/react/src/controls/video.test.tsx
@@ -1,0 +1,134 @@
+// Parity with Blazor's VideoView.razor and SlideShowView.razor (+ its .razor.js keyboard driver) —
+// two controls the Blazor pack has shipped since #407 that the React pack was missing entirely.
+//
+// VideoView: `<video controls>` for VideoKind.Video (the default), `<iframe>` for VideoKind.Embed,
+// both sized `width:100%` with the control's AspectRatio (default "16/9") on a black backdrop.
+// SlideShowView: renders NO chrome — it binds the presenter keys to the hrefs it carries, and a
+// null href makes that key a no-op.
+
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource, type AreaTree } from "../core.js";
+import type { UiControl } from "../area/types.js";
+import { NavigationProvider } from "../area/navigation.js";
+
+function tree(control: UiControl): AreaTree {
+  return { data: {}, areas: { main: control } };
+}
+
+describe("Video (Blazor VideoView parity)", () => {
+  it("renders a native <video controls> with poster and aspect ratio by default", () => {
+    const { container } = render(
+      <MeshAreaView
+        source={new StaticAreaSource(tree({ $type: "Video", src: "/media/lecture.mp4", poster: "/media/cover.jpg", title: "Lecture 1" }))}
+        rootArea="main"
+      />,
+    );
+    const video = container.querySelector("video");
+    expect(video).toBeTruthy();
+    expect(video!.getAttribute("src")).toBe("/media/lecture.mp4");
+    expect(video!.getAttribute("poster")).toBe("/media/cover.jpg");
+    expect(video!.getAttribute("title")).toBe("Lecture 1");
+    expect(video!.hasAttribute("controls")).toBe(true);
+    expect(video!.style.aspectRatio).toBe("16/9"); // the control's default
+    expect(container.querySelector("iframe")).toBeNull();
+  });
+
+  it("renders an embed <iframe> for VideoKind.Embed, honouring an explicit aspect ratio", () => {
+    const { container } = render(
+      <MeshAreaView
+        source={new StaticAreaSource(tree({ $type: "Video", src: "https://www.youtube.com/embed/x", kind: "Embed", aspectRatio: "4/3" }))}
+        rootArea="main"
+      />,
+    );
+    const frame = container.querySelector("iframe");
+    expect(frame).toBeTruthy();
+    expect(frame!.getAttribute("src")).toBe("https://www.youtube.com/embed/x");
+    expect(frame!.getAttribute("allowfullscreen")).not.toBeNull();
+    expect(frame!.style.aspectRatio).toBe("4/3");
+    expect(container.querySelector("video")).toBeNull();
+  });
+
+  it("renders nothing when Src is empty (Blazor's guard)", () => {
+    const { container } = render(<MeshAreaView source={new StaticAreaSource(tree({ $type: "Video", src: "" }))} rootArea="main" />);
+    expect(container.querySelector("video")).toBeNull();
+    expect(container.querySelector("iframe")).toBeNull();
+  });
+});
+
+describe("SlideShow (Blazor SlideShowView parity)", () => {
+  const deck = {
+    $type: "SlideShow",
+    firstHref: "/Deck/1",
+    previousHref: "/Deck/2",
+    nextHref: "/Deck/4",
+    lastHref: "/Deck/9",
+    exitHref: "/Deck",
+  };
+
+  function renderDeck(control: UiControl = deck) {
+    const navigate = vi.fn();
+    const result = render(
+      <NavigationProvider navigation={{ hrefFor: (t) => t, navigate }}>
+        <MeshAreaView source={new StaticAreaSource(tree(control))} rootArea="main" />
+      </NavigationProvider>,
+    );
+    return { navigate, ...result };
+  }
+
+  it("renders no visible chrome", () => {
+    const { container } = renderDeck();
+    expect(container.textContent).toBe("");
+  });
+
+  it.each([
+    ["ArrowRight", "/Deck/4"],
+    ["ArrowDown", "/Deck/4"],
+    ["PageDown", "/Deck/4"],
+    [" ", "/Deck/4"],
+    ["Enter", "/Deck/4"],
+    ["ArrowLeft", "/Deck/2"],
+    ["ArrowUp", "/Deck/2"],
+    ["PageUp", "/Deck/2"],
+    ["Home", "/Deck/1"],
+    ["End", "/Deck/9"],
+    ["Escape", "/Deck"],
+  ])("maps %s to %s", (key, href) => {
+    const { navigate } = renderDeck();
+    fireEvent.keyDown(document, { key });
+    expect(navigate).toHaveBeenCalledWith(href);
+  });
+
+  it("ignores unbound keys", () => {
+    const { navigate } = renderDeck();
+    fireEvent.keyDown(document, { key: "a" });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("treats a null href as a no-op (Next on the last slide)", () => {
+    const { navigate } = renderDeck({ ...deck, nextHref: null });
+    fireEvent.keyDown(document, { key: "ArrowRight" });
+    expect(navigate).not.toHaveBeenCalled();
+    // The other keys still work — only the disabled one is inert.
+    fireEvent.keyDown(document, { key: "ArrowLeft" });
+    expect(navigate).toHaveBeenCalledWith("/Deck/2");
+  });
+
+  it("never hijacks keys while the user is typing in a field", () => {
+    const { navigate } = renderDeck();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    fireEvent.keyDown(input, { key: "ArrowRight" });
+    expect(navigate).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it("unmounting removes the listener (no stacking across Present re-renders)", () => {
+    const { navigate, unmount } = renderDeck();
+    unmount();
+    fireEvent.keyDown(document, { key: "ArrowRight" });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/clients/react/src/render/menuItemSkin.test.tsx
+++ b/clients/react/src/render/menuItemSkin.test.tsx
@@ -1,0 +1,66 @@
+// MenuItemSkin parity with Blazor's MenuItemView.
+//
+// The regression this pins: MenuItemControl is a CONTAINER control that ALWAYS carries a
+// MenuItemSkin (MenuItemControl.cs passes `new(Title, Icon)` to the base ctor), and ControlRenderer
+// pops skins BEFORE it dispatches on $type. So on a live tree the leaf `MenuItem` control entry was
+// never reached — the skin missed the registry, fell through to `__default` passthrough, and every
+// nav item rendered as bare children with no title, no icon and no click. Title/icon live on the
+// SKIN, not the control, which is why reading them off the control was not enough either.
+
+/** @vitest-environment jsdom */
+import { beforeAll, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MeshAreaView } from "../index.js";
+import { StaticAreaSource, type AreaTree } from "../core.js";
+
+beforeAll(() => {
+  if (!(globalThis as any).ResizeObserver)
+    (globalThis as any).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+});
+
+/** A live-shaped menu item: the $type carries the C# class name and the skin holds title/icon. */
+function menuTree(skin: Record<string, unknown>, extra: Record<string, unknown> = {}, children = false): AreaTree {
+  return {
+    data: {},
+    areas: {
+      main: {
+        $type: "MenuItemControl",
+        skins: [{ $type: "MenuItemSkin", title: "Documentation", icon: "Book", ...skin }],
+        ...(children ? { areas: [{ area: "main/sub" }] } : {}),
+        ...extra,
+      },
+      "main/sub": { $type: "Label", data: "Getting started" },
+    },
+  };
+}
+
+describe("MenuItem skin (Blazor MenuItemView parity)", () => {
+  it("renders the skin's title — not passthrough children", () => {
+    render(<MeshAreaView source={new StaticAreaSource(menuTree({}))} rootArea="main" />);
+    expect(screen.getByRole("button", { name: /Documentation/ })).toBeTruthy();
+  });
+
+  it("fires the control's click when clickable", () => {
+    const source = new StaticAreaSource(menuTree({}, { isClickable: true }));
+    render(<MeshAreaView source={source} rootArea="main" />);
+    fireEvent.click(screen.getByRole("button", { name: /Documentation/ }));
+    expect(source.events.map((e) => e.kind)).toContain("click");
+  });
+
+  it("iconOnly drops the label (Blazor's icon-only mode)", () => {
+    render(<MeshAreaView source={new StaticAreaSource(menuTree({ iconOnly: true }))} rootArea="main" />);
+    expect(screen.queryByText("Documentation")).toBeNull();
+  });
+
+  it("expands its child areas on click when it has sub-menus", () => {
+    render(<MeshAreaView source={new StaticAreaSource(menuTree({}, {}, true))} rootArea="main" />);
+    // Collapsed initially — Blazor's dropdown only renders while isMenuOpen.
+    expect(screen.queryByText("Getting started")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Documentation/ }));
+    expect(screen.getByText("Getting started")).toBeTruthy();
+  });
+});

--- a/clients/react/src/render/parity.test.ts
+++ b/clients/react/src/render/parity.test.ts
@@ -1,50 +1,83 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { controlRegistry } from "./registry.js";
 import { skinRegistry } from "./skins.js";
 import { placeholderControlTypes } from "../controls/mesh.js";
 
 // Feature-parity guard: the Fluent React pack must render every control the Blazor portal renders.
-// These lists are the authoritative Blazor vocabulary — the `*Control` / `*Skin` types in
-// src/MeshWeaver.Layout (the `$type` is the class name minus the "Control"/"Skin" suffix). When a new
-// control is added to Layout, add its $type here; this test then fails until the React pack covers it,
-// keeping the port at 1:1 with Blazor. Containers (Stack/Layout/Tabs/…) render via SKINS, so they live in
-// the skin list, not the control list; DataGrid columns (Property/Template/Data) render inside DataGrid.
+//
+// The Blazor vocabulary is DERIVED, not hand-listed. It is parsed out of the switch arms in
+// src/MeshWeaver.Blazor/BlazorViewRegistry.cs — the single place that decides "this control/skin
+// gets this Blazor view". A hand-maintained list is what let Video, SlideShow and the MenuItem skin
+// ship on the Blazor side and stay silently missing here: the list never grew, so the test kept
+// passing. Reading the C# means adding a control to Blazor fails THIS test until React covers it.
 
-const BLAZOR_LEAF_CONTROLS = [
-  "Appearance", "Badge", "Button", "Catalog", "Chart", "CheckBox", "CodeEditor", "CodeSample",
-  "CollaborativeMarkdown", "Combobox", "DataGrid", "Date", "DateTime", "Dialog", "DiffEditor",
-  "DocumentSource", "Exception", "ExportDocument", "FileBrowser", "Highlight", "Html", "Icon",
-  "ItemTemplate", "Label", "LayoutArea", "LayoutAreaDefinition", "Listbox", "Markdown", "MarkdownEditor",
-  "MenuItem", "MeshNodeCard", "MeshNodeCollection", "MeshNodeContentEditor", "MeshNodePicker", "MeshSearch", "NamedArea", "NavLink", "NodeExport",
-  "NodeImport", "NumberField", "PivotGrid", "Progress", "RadioGroup", "Redirect", "SearchBox", "Select",
-  "Slider", "Spacer", "Switch", "TextArea", "ThreadChat", "ThreadMessageBubble", "UserProfile",
+// Vitest runs with cwd = this package root (clients/react), so the repo root is two levels up.
+const registryPath = resolve(process.cwd(), "../../src/MeshWeaver.Blazor/BlazorViewRegistry.cs");
+const registrySource = readFileSync(registryPath, "utf8");
+
+/**
+ * The `$type` names Blazor maps to a view, scraped from the two switch expressions:
+ *   `FooControl foo => StandardView<FooControl, FooView>(...)`   → "Foo"
+ *   `FooSkin foo => StandardSkinnedView<FooView>(...)`           → "Foo"
+ * Interface arms (`IContainerControl`) are dispatch fallbacks, not `$type`s, so they are excluded.
+ */
+function blazorTypes(suffix: "Control" | "Skin"): string[] {
+  const arm = new RegExp(String.raw`^\s*([A-Z]\w*)${suffix}\s+\w+\s*$|^\s*([A-Z]\w*)${suffix}\s+\w+\s*=>`, "gm");
+  const names = new Set<string>();
+  for (const m of registrySource.matchAll(arm)) {
+    const name = m[1] ?? m[2];
+    if (name && !name.startsWith("I")) names.add(name);
+  }
+  return [...names].sort();
+}
+
+const BLAZOR_LEAF_CONTROLS = blazorTypes("Control");
+const BLAZOR_SKINS = blazorTypes("Skin");
+
+// Controls Blazor dispatches through a path other than BlazorViewRegistry's switch (separate view
+// packs: Radzen charts/grids, the Graph pack, the Kernel notebook pack) — parity for these is
+// asserted the same way, they just have no arm to scrape.
+const EXTERNALLY_PACKED_CONTROLS = [
+  "Chart", "CodeSample", "Date", "Dialog", "Exception", "LayoutAreaDefinition", "MeshNodeContentEditor",
+  "PivotGrid", "Slider", "ThreadChat", "UserProfile",
 ];
 
-// Container + item skins the portal renders (the `*Skin` types + the container dispatch).
-const BLAZOR_SKINS = [
-  "LayoutStack", "Layout", "LayoutGrid", "LayoutGridItem", "Card", "Splitter", "Tabs", "Tab", "Toolbar",
-  "NavMenu", "NavGroup", "Header", "Footer", "Main", "BodyContent", "Property", "EditForm", "Editor",
-];
+// Skins the React renderer covers WITHOUT a registry entry, by design. SplitterPane is read by the
+// parent SplitterSkin (paneSkinOf → paneSpec) to size each pane, exactly as Blazor's
+// FluentMultiSplitterPane does — a registry entry would double-wrap it.
+const SKINS_HANDLED_BY_PARENT = ["SplitterPane"];
 
 describe("React ↔ Blazor control parity", () => {
+  it("scrapes a plausible vocabulary out of BlazorViewRegistry.cs", () => {
+    // Guard the guard: if the C# is refactored into a shape the regex no longer matches, the
+    // parity assertions below would vacuously pass on an empty list.
+    expect(BLAZOR_LEAF_CONTROLS.length).toBeGreaterThan(40);
+    expect(BLAZOR_SKINS.length).toBeGreaterThan(15);
+    expect(BLAZOR_LEAF_CONTROLS).toContain("Markdown");
+    expect(BLAZOR_SKINS).toContain("LayoutStack");
+  });
+
   it("the Fluent pack registers every Blazor leaf control $type", () => {
     const missing = BLAZOR_LEAF_CONTROLS.filter((t) => !(t in controlRegistry));
     expect(missing, `Missing Blazor controls in the React pack: ${missing.join(", ")}`).toEqual([]);
   });
 
   it("the Fluent pack registers every Blazor skin $type", () => {
-    const missing = BLAZOR_SKINS.filter((t) => !(t in skinRegistry));
+    const missing = BLAZOR_SKINS.filter((t) => !(t in skinRegistry) && !SKINS_HANDLED_BY_PARENT.includes(t));
     expect(missing, `Missing Blazor skins in the React pack: ${missing.join(", ")}`).toEqual([]);
   });
 
-  it("registered controls are React components (functions), not accidental values", () => {
-    const bad = BLAZOR_LEAF_CONTROLS.filter((t) => t in controlRegistry && typeof controlRegistry[t] !== "function");
-    expect(bad, `Non-component control entries: ${bad.join(", ")}`).toEqual([]);
+  it("also covers the controls dispatched by the external view packs", () => {
+    const missing = EXTERNALLY_PACKED_CONTROLS.filter((t) => !(t in controlRegistry));
+    expect(missing, `Missing externally-packed controls: ${missing.join(", ")}`).toEqual([]);
   });
 
-  it("covers Blazor's full leaf set (no silent shortfall)", () => {
-    const covered = BLAZOR_LEAF_CONTROLS.filter((t) => t in controlRegistry).length;
-    expect(covered).toBe(BLAZOR_LEAF_CONTROLS.length); // 52/52 — full $type parity
+  it("registered controls are React components (functions), not accidental values", () => {
+    const all = [...BLAZOR_LEAF_CONTROLS, ...EXTERNALLY_PACKED_CONTROLS];
+    const bad = all.filter((t) => t in controlRegistry && typeof controlRegistry[t] !== "function");
+    expect(bad, `Non-component control entries: ${bad.join(", ")}`).toEqual([]);
   });
 
   // RATCHET: the registered-but-placeholder long-tail (controls whose real rendering needs a live

--- a/clients/react/src/render/skins.tsx
+++ b/clients/react/src/render/skins.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import {
+  Button,
   Card,
   Divider,
   Tab,
@@ -15,6 +16,7 @@ import { ChevronDown20Regular, ChevronRight20Regular } from "@fluentui/react-ico
 import type { Skin, UiControl } from "../area/types.js";
 import { useResolve } from "../area/context.js";
 import { MeshIcon } from "../controls/MeshIcon.js";
+import { useClick } from "../controls/common.js";
 import { ControlRenderer, RenderArea, useChildAreas } from "./ControlRenderer.js";
 import { controlClass, controlStyle, cssAlign, cssSize, mergeClass } from "./style.js";
 import { GRID_BREAKPOINTS } from "./meshStyles.js";
@@ -342,6 +344,71 @@ function NavGroupSkin({ skin, control }: SkinProps): ReactNode {
   );
 }
 
+/**
+ * MenuItemSkin — the port of Blazor's MenuItemView. A MenuItemControl is a CONTAINER control that
+ * always carries a MenuItemSkin (see MenuItemControl.cs), so the renderer pops the skin before it
+ * ever reaches a leaf: without this entry a live nav item fell through to `__default` passthrough
+ * and rendered its children with NO title, icon or click. Title/icon/width therefore come off the
+ * SKIN here, not the control.
+ *
+ * Blazor's three sub-menu shapes collapse to one here: a button that fires the control's click when
+ * it is clickable, plus a chevron that expands the child areas when it has any (`iconOnly` drops
+ * the label and the chevron, matching MenuItemSkin.IconOnly).
+ */
+function MenuItemSkin({ skin, control }: SkinProps): ReactNode {
+  const title = useResolve(skin.title);
+  const children = useChildAreas(control);
+  const [open, setOpen] = useState(false);
+  const hasSubMenus = children.length > 0;
+  const iconOnly = skin.iconOnly === true;
+  const label = iconOnly ? null : String(title ?? "");
+  const onClick = useClick(control);
+  const width = cssSize(skin.width);
+
+  return (
+    <div
+      className={mergeClass("mw-menu-item", controlClass(control))}
+      style={{ position: "relative", width: width ?? "auto", ...controlStyle(control) }}
+    >
+      <div style={{ display: "flex", gap: 0 }}>
+        <Button
+          appearance={skin.appearance ? (String(skin.appearance).toLowerCase() as "primary" | "subtle" | "outline" | "transparent") : undefined}
+          icon={<MeshIcon value={skin.icon as never} size={20} />}
+          onClick={onClick ?? (hasSubMenus ? () => setOpen((o) => !o) : undefined)}
+          style={{ flex: 1, justifyContent: "flex-start", textAlign: "left" }}
+        >
+          {label}
+        </Button>
+        {hasSubMenus && !iconOnly && onClick ? (
+          // Clickable AND expandable → Blazor renders a split button: main action + chevron.
+          <Button appearance="subtle" icon={<ChevronDown20Regular />} onClick={() => setOpen((o) => !o)} />
+        ) : null}
+      </div>
+      {hasSubMenus && open ? (
+        <>
+          <div style={{ position: "fixed", inset: 0, zIndex: 999 }} onClick={() => setOpen(false)} />
+          <div
+            className="mw-menu-item-dropdown"
+            style={{
+              position: "absolute",
+              top: "100%",
+              left: 0,
+              zIndex: 1000,
+              minWidth: "100%",
+              padding: "4px 0",
+              borderRadius: 4,
+              background: "var(--colorNeutralBackground1)",
+              boxShadow: "0 4px 8px rgba(0,0,0,0.2)",
+            }}
+          >
+            <Children control={control} />
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
 function CardSkin({ control }: SkinProps): ReactNode {
   return (
     <Card className={controlClass(control)} style={{ padding: 16, rowGap: 8, ...controlStyle(control) }}>
@@ -415,6 +482,7 @@ export const skinRegistry: Record<string, SkinComponent> = {
   NavMenu: NavMenuSkin,
   NavGroup: NavGroupSkin,
   Card: CardSkin,
+  MenuItem: MenuItemSkin,
   Property: PropertySkin,
   EditForm: EditFormSkin,
   Editor: PlainLayoutSkin,

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-26-react-portal-video-slides-menus.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-26-react-portal-video-slides-menus.md
@@ -1,0 +1,12 @@
+---
+Name: Videos, presenter mode and menu labels in the React portal
+Category: What's New
+Description: The React portal now plays videos, drives slide decks from the keyboard, and shows navigation menu titles and icons.
+Icon: Sparkle
+---
+
+# Videos, presenter mode and menu labels in the React portal
+
+Three things the Blazor portal already did are now available in the React portal too. Videos on a page — lecture recordings, walkthroughs and embedded players — render and play instead of being skipped. Slide decks can be driven from the keyboard in presenter mode, using the usual arrow, space, page, Home/End and Escape keys to move between slides and leave the presentation.
+
+Navigation menu items also show their titles and icons again, and clicking them works. Items that group other entries expand to reveal them. Previously a menu built by the mesh could come through with its labels missing, which made the navigation hard to use.

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -22,7 +22,11 @@ namespace MeshWeaver.Graph;
 ///     subscription node itself (Pending → Fired), so nothing is lost.</item>
 /// </list>
 /// Continuations are idempotent (create-or-update grant, pin is a set-add, the terminal <c>Fired</c>
-/// write gates re-entry), so the two paths can't double-apply.
+/// write gates re-entry), so the paths can't double-APPLY — but idempotent is not the same as free, and
+/// the <c>Fired</c> gate only closes once that write has round-tripped. Until then every path is looking
+/// at the same still-Pending snapshot, so they would each launch the continuation. A per-subscription
+/// in-flight reservation (the <c>executing</c> registry) makes firing at-most-once instead: exactly one
+/// continuation per subscription, no unobserved duplicate writes trailing behind it.
 ///
 /// <para>🚨 The runner has NO ambient <c>AccessContext</c> (it's a background hosted service, not a
 /// request). Every read AND write goes through <see cref="AsSystem{T}"/> — <c>Using(ImpersonateAsSystem,
@@ -59,6 +63,21 @@ public sealed class EventSubscriptionRunner(
     // deferred invite fires even when the in-process/Orleans change feed's best-effort cross-silo relay
     // never delivers the User/Created event to this runner. Same lifecycle contract as timerSubs/statusSubs.
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, IDisposable> nodeChangeSubs = new();
+    // 🚨 Subscriptions whose continuation is currently IN FLIGHT — the at-most-once guard for Execute.
+    // EVERY firing path (change feed, cold-start reconcile, pending-set reconcile, trigger-node watch)
+    // fires off the same `pending` snapshot, and a subscription only LEAVES that snapshot once its
+    // terminal Fired write has round-tripped through the Admin partition. At startup all of those paths
+    // evaluate within a few ms of each other — i.e. while the subscription is still Pending in every
+    // snapshot — so ONE subscription launched N concurrent continuations, each issuing a duplicate
+    // upsert of the same membership/grant node plus its own SetStatus write. Idempotence made those
+    // writes harmless, never free: they are fire-and-forget requests nobody observes, they serialise
+    // behind each other on the target node's hub, and they outlive whatever triggered them (they were
+    // the CreateOrUpdateNodeRequest callbacks still pending at test teardown). The remedy is the same
+    // instance-scoped TryAdd reservation the timer / status / trigger-node registries already use:
+    // reserved before the chain starts, released on failure so a later emission retries, and pruned
+    // when the subscription leaves the pending set — so it stays bounded by the pending set rather than
+    // growing for the runner's whole uptime.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> executing = new();
     private IDisposable? pendingSub;
     private IDisposable? feedSub;
     private IDisposable? legacySub;
@@ -117,6 +136,12 @@ public sealed class EventSubscriptionRunner(
                     foreach (var id in subs.Keys.Where(id => !pendingIds.Contains(id)).ToList())
                         if (subs.TryRemove(id, out var d))
                             d.Dispose();
+                // The in-flight reservation is keyed the same way: a subscription that has left the
+                // pending set reached a terminal state (Fired / Failed / Cancelled) and can never fire
+                // again — every firing path draws its candidates from `pending` — so drop its entry.
+                // That keeps `executing` bounded by the pending set instead of the runner's uptime.
+                foreach (var id in executing.Keys.Where(id => !pendingIds.Contains(id)).ToList())
+                    executing.TryRemove(id, out _);
             }, ex => logger?.LogWarning(ex, "Event-subscriptions query failed"));
 
         // 🚨 Cold-start authoritative reconcile — the fix for the memex 2026-07-20 stranded-invite incident.
@@ -292,6 +317,11 @@ public sealed class EventSubscriptionRunner(
 
     private void Execute(EventSubscription subscription, string userId)
     {
+        // At-most-once per subscription: reserve the id BEFORE building the chain (see `executing`).
+        // Whichever firing path gets here first owns this subscription's continuation; the others —
+        // which are looking at the same still-Pending snapshot — must not launch a duplicate.
+        if (!executing.TryAdd(subscription.Id, 0))
+            return;
         BuildContinuation(subscription, userId)
             .SelectMany(_ => AsSystem(() => EventSubscriptionOps.SetStatus(
                 hub, EventSubscriptionNodeType.Path(subscription.Id), EventSubscriptionStatus.Fired)))
@@ -301,6 +331,10 @@ public sealed class EventSubscriptionRunner(
                     subscription.Id, subscription.ContinuationType, subscription.Role, userId, subscription.TargetPath),
                 ex =>
                 {
+                    // Release the reservation so a later pending-set emission can retry a TRANSIENT
+                    // failure — the same rule MigrateLegacyScheduledActions applies to its own id guard.
+                    // (A permanent failure writes Failed below and leaves the pending set anyway.)
+                    executing.TryRemove(subscription.Id, out _);
                     logger?.LogWarning(ex, "Event subscription {Id} failed", subscription.Id);
                     AsSystem(() => EventSubscriptionOps.SetStatus(
                             hub, EventSubscriptionNodeType.Path(subscription.Id), EventSubscriptionStatus.Failed, ex.Message))
@@ -497,5 +531,6 @@ public sealed class EventSubscriptionRunner(
             foreach (var id in subs.Keys.ToList())
                 if (subs.TryRemove(id, out var d))
                     d.Dispose();
+        executing.Clear();
     }
 }

--- a/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
+++ b/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
@@ -325,6 +325,101 @@ public class EventSubscriptionRunnerTest(ITestOutputHelper output) : MonolithMes
         Assert.NotNull(membership);
     }
 
+    /// <summary>
+    /// Regression for the duplicate-continuation defect behind the
+    /// <see cref="PreExistingUserAndSubscription_FireOnRunnerStartup_WithoutTheChangeFeed"/> flake: ONE
+    /// pending subscription must produce EXACTLY ONE continuation, however many of the runner's firing
+    /// paths happen to see it. At startup the cold-start reconcile, the pending-set reconcile and the
+    /// trigger-node watch all evaluate the SAME still-Pending snapshot (it only clears once the terminal
+    /// Fired write round-trips), so before the fix all three launched the continuation and the runner
+    /// issued three concurrent upserts of the same membership node plus three SetStatus writes. Nothing
+    /// observes the losers, so the last of them was still in flight when the test class disposed — the
+    /// "left Observe subscriptions pending past the Quiescing budget /
+    /// CreateOrUpdateNodeRequest@mesh/…" teardown failure, which turned into a CI flake as soon as
+    /// full-suite load stretched that tail past the drain budget.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task StartupFiresEachSubscriptionExactlyOnce_NotOncePerFiringPath()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var fires = new System.Collections.Concurrent.ConcurrentQueue<string>();
+
+        var groupPath = $"{Space}/Team4";
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode("Team4", Space)
+            {
+                NodeType = "Group",
+                Name = "Team4",
+                Content = new AccessObject { Description = "Test group" },
+            }).Should().Emit();
+
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.NodeChange,
+            TriggerNodeType = "User",
+            TriggerKind = MeshChangeKind.Created,
+            MatchField = "email",
+            MatchValue = InviteeEmail,
+            ContinuationType = EventContinuationType.AddToGroup,
+            TargetPath = groupPath,
+        };
+        await EventSubscriptionOps.CreateSubscription(meshService, subscription).Should().Emit();
+        using (accessService.ImpersonateAsSystem())
+        {
+            await meshService.CreateNode(new MeshNode(InviteeId)
+            {
+                NodeType = "User",
+                Name = "Newcomer",
+                Content = new User { Email = InviteeEmail, FullName = "Newcomer" },
+            }).Should().Emit();
+        }
+
+        // Every firing path is armed: the change feed IS live here (unlike the silent-feed tests), and
+        // both reconciles plus the trigger-node watch see the pre-existing, already-matching user.
+        using var runner = new EventSubscriptionRunner(Mesh,
+            Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>(), meshService, accessService,
+            new CountingRunnerLogger(fires));
+        await runner.StartAsync(default);
+
+        var final = await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Select(n => n?.Content as EventSubscription)
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.True(final!.Status == EventSubscriptionStatus.Fired,
+            $"subscription ended {final.Status}: {final.LastError}");
+
+        var membershipPath = $"{groupPath}/{InviteeId}_Membership";
+        await Mesh.GetWorkspace().GetMeshNodeStream(membershipPath)
+            .Where(n => n?.Content is GroupMembership gm && gm.Member == InviteeId)
+            .FirstAsync().Timeout(10.Seconds());
+
+        // Observation window for a MUST-NOT-HAPPEN assertion: the duplicate fires this pins arrive within
+        // ~50ms of the first, so the window can only ever hide the defect, never invent it. (Before the
+        // fix this reports 3 fires; after it, 1.)
+        await Task.Delay(3.Seconds());
+        Assert.True(fires.Count == 1,
+            $"the subscription's continuation ran {fires.Count} times — one per firing path instead of once. "
+            + $"Each extra run is an unobserved duplicate write that outlives the test:{Environment.NewLine}"
+            + string.Join(Environment.NewLine, fires));
+    }
+
+    /// <summary>Captures the runner's "fired" lines so a test can count continuations.</summary>
+    private sealed class CountingRunnerLogger(System.Collections.Concurrent.ConcurrentQueue<string> fires)
+        : Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+        public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var line = formatter(state, exception);
+            if (line.Contains(" fired: ", StringComparison.Ordinal))
+                fires.Enqueue(line);
+        }
+    }
+
     [Fact(Timeout = 60000)]
     public async Task LegacyScheduledAction_IsMigratedAndFires()
     {


### PR DESCRIPTION
Closes every open Dependabot alert on the repo, and — while re-visiting the react / react-native packages — fixes a React↔Blazor parity gap that the existing parity guard structurally could not catch.

## 1. All 64 open npm Dependabot alerts (2 critical, 13 high, 43 medium, 6 low)

| Package | Change | Alerts |
|---|---|---|
| portal-next | `next` ^14.2.5 → **^15.5.22** | 21 |
| react, portal-next | `mermaid` → **11.16.0** (also clears transitive dompurify / uuid / lodash-es — its parser dropped the `chevrotain → lodash-es@4.17.21` path) | 10 |
| react, portal | `vite` ^5.4.0 → **^7.3.6** | 6 |
| grpc-web, react-native | `vitest` ^2.1.0 → **^4.1.9** | 2 |
| portal-next, react, react-native | `overrides` (below) | 25 |

**Three alerts have no upgrade path** — a direct dependency pins the vulnerable version itself, so an override is the fix, not a shortcut:

- **postcss** — `next` pins `8.4.31` exactly (still true on 16.x) → `^8.5.23`
- **dompurify** — `monaco-editor` pins `3.2.7` exactly; even its latest `0.56.0` pins `3.4.8`, below the `3.4.12` patch → `^3.4.12`
- **sharp** — Next 15 pulls it optionally for image optimization (unused here) and it carries the libvips CVEs → `^0.35.3`. It was **not** present before this PR: leaving it would have traded 21 closed alerts for a fresh high-severity one.

Each override carries an inline note explaining why, so it isn't later removed as cruft.

**Next 14 → 15** required the App Router async-API migration: `params` / `searchParams` / `headers()` / `cookies()` are now Promises, and `experimental.outputFileTracingRoot` moved to the top level (the Dockerfile depends on the resulting `.next/standalone/portal-next/server.js` layout — verified it still lands there).

The pinned `vitest@2.1.9` in the react-native CI job is bumped too; without that, CI would have kept installing the vulnerable version regardless of package.json.

### Deliberately not overridden

`clients/react-native` carries 40 further advisories in the Expo 52 / RN 0.76 build toolchain. **None are Dependabot alerts** (no committed lockfile there, so Dependabot only sees direct deps). I traced them to 5 real leaves; each patched version is a breaking major for its CJS consumer inside `@expo/cli` / native prebuild — `brace-expansion@5` is ESM-only and `minimatch` `require()`s it, `uuid@11` likewise breaks `xcode`, `tar` 6→7 and `xmldom` 0.7→0.9 change APIs. All are unreachable from the web export and the test run. Forcing them would break the build to quiet a scanner; the real fix is the Expo SDK upgrade (`expo@57` + `react-native@0.86`), which is its own migration. Only **postcss** — reachable via `@expo/metro-config` and safe within its major — is overridden there, verified through a real `expo export --platform web`.

## 2. React ↔ Blazor parity: Video, SlideShow, MenuItem skin

`parity.test.ts` exists to assert React renders every Blazor control — but it asserted against a **hand-typed list** of `$type`s. Nothing added the newer controls to that list, so the ratchet kept passing while the port fell behind.

The **MenuItem** gap was the damaging one. `MenuItemControl` is a *container* that always carries a `MenuItemSkin`, and `ControlRenderer` pops skins **before** dispatching on `$type` — so React's leaf `MenuItem` entry was never reached on a live tree. The skin missed the registry, fell through to `__default` passthrough, and every live nav item rendered as bare children with **no title, no icon, no click**. Reading them off the control wouldn't have helped either: on the wire they live on the skin.

Ported, following each Blazor view's behaviour — including SlideShow's "never hijack keys while typing" guard and null-href-is-a-no-op. Blazor needs a module-level "last registered wins" registry for its keydown listener because its JS module is cached across circuits; React's effect cleanup gives that for free, so that dance is dropped (noted in the code).

**Root cause fix:** `parity.test.ts` now *derives* the Blazor vocabulary by parsing the switch arms out of `src/MeshWeaver.Blazor/BlazorViewRegistry.cs` — the single place that decides "this control gets this Blazor view". Adding a control to Blazor now fails this test until React covers it. I verified the guard actually bites by removing `Video` from the registry and confirming it fails with `Missing Blazor controls in the React pack: Video`; the old hand-list version passed that same state. It also self-checks that the scrape found a plausible vocabulary, so a C# refactor can't make it vacuously pass.

Two things checked and deliberately **not** "fixed" because they aren't broken: `SplitterPane` is already consumed by the parent `SplitterSkin` via `paneSpec` (a registry entry would double-wrap it), and `Chart` / `Dialog` / `PivotGrid` dispatch through separate view packs. Both are now recorded as explicit exclusions rather than silent holes.

## 3. CI job for portal-next

portal-next had **no** job in the Clients workflow, so nothing checked it — the Next 15 migration above would have landed unverified. Node 22 to match its Dockerfile; `npm ci` rather than `npm install` (it's the only client with a committed lockfile, and `npm ci` is what the Dockerfile runs, so drift fails in CI instead of the image build).

## Verification

Every package run with its full CI command set:

| Package | Result |
|---|---|
| react | typecheck + **215** tests + lib build |
| portal-next | typecheck + 63 tests + production build + `npm ci` |
| grpc-web | codegen + typecheck + 27 tests |
| react-native | typecheck + 58 tests + real `expo export --platform web` |
| portal | typecheck + build |

`npm audit`: 0 vulnerabilities in react, portal, grpc-web, portal-next. All 64 alerts re-checked programmatically against the actually-installed trees (not just declared ranges) after the parity work. Merged with current main and re-verified green.

What's New entry included for the user-facing part (videos, presenter mode, menu labels); the dependency and CI work is internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)