### PR TITLE
helm: keep the portal off the autoscaler's eviction list (stop zombie-silo churn)

### DIFF
--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -21,6 +21,16 @@ spec:
         azure.workload.identity/use: "true"
         {{- end }}
         {{- end }}
+      annotations:
+        # Keep the STATEFUL portal (live Blazor circuits + an Orleans silo) off the cluster
+        # autoscaler's scale-down list. Draining a portal pod for node consolidation tore its silo
+        # down mid-flight, and each abrupt departure left a ZOMBIE entry in the Orleans membership
+        # table: the cluster kept placing new grain activations on the dead silo, so writes timed out
+        # ("no initial state arrived within 30s") mesh-wide — which surfaced as GitSync imports
+        # reporting "Imported Failed (0 nodes)" and flaky reads. Pods still move on a rollout or a
+        # node image-upgrade, but gracefully and one at a time (the PDB beside this file + the 120s
+        # terminationGracePeriod above), never on every autoscaler bin-packing pass.
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       # The in-pod self-updater patches this deployment via the Kubernetes API using this SA's
       # projected token (RBAC in rbac.yaml). See Doc/Architecture/ReleaseStrategy.

--- a/deploy/helm/templates/memex-portal/pdb.yaml
+++ b/deploy/helm/templates/memex-portal/pdb.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.keda.enabled }}
+# A PodDisruptionBudget for the portal. Rendered only under KEDA autoscaling (min 2) — i.e. the HA
+# deployments (AKS). A single-replica self-host leaves KEDA off, where a PDB would only block node
+# maintenance, so it is templated out there.
+#
+# maxUnavailable: 1 lets a VOLUNTARY disruption (node image-upgrade, a manual drain) take at most
+# one portal pod at a time — the other keeps serving, and the departing silo leaves the Orleans
+# cluster gracefully within the 120s terminationGracePeriod. Together with the
+# cluster-autoscaler.kubernetes.io/safe-to-evict: "false" pod annotation (deployment.yaml), this is
+# what stops the zombie-silo churn: the autoscaler never evicts a portal pod for bin-packing, and
+# what disruption remains is throttled to one-at-a-time and graceful.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "memex-portal-pdb"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "memex-portal"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
+      app.kubernetes.io/component: "memex-portal"
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+{{- end }}


### PR DESCRIPTION
## Problem

Zombie Orleans silos accumulate from portal **pod churn** — the cluster-autoscaler evicts portal pods for bin-packing and KEDA scale events add/drain replicas, so silos are torn down un-gracefully and the mesh wedges (SiloUnavailable storms; the 2026-07-25/26 memex sync failures traced to this). The live fix was applied by hand (`kubectl annotate` + a manually-applied PDB + a temporary KEDA `paused-replicas` pin) and needs to live in the chart.

## Fix (generic chart hardening — renders only for HA/KEDA self-hosts)

- **`deployment.yaml`**: add the pod annotation `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` so the cluster-autoscaler never evicts a portal pod for scale-down/bin-packing.
- **`pdb.yaml`** (new): a `PodDisruptionBudget` with `maxUnavailable: 1`, **guarded by `{{- if .Values.keda.enabled }}`** — it renders only for the HA (KEDA, min-2) deployments and is templated out for single-replica self-hosts (where a PDB would only block node maintenance).

Together: the autoscaler stops evicting the portal, and any remaining voluntary disruption (node image-upgrade, manual drain) is throttled to one pod at a time and drains gracefully within the 120s `terminationGracePeriod`.

## Why the chart (not an env file)

These are **generic deployment-hardening template changes**, not env-specific values (no cluster names, PVC claims, hosts, or replica counts). Env-specific values stay in the gitignored `values.memexcloud.yaml` / `deploy/aks/envs/*`. The KEDA guard means a self-host without KEDA is unaffected. `helm lint` passes; the PDB renders under `keda.enabled=true` and is absent under `false`.

## After merge

Reconcile the live stopgap on memex-cloud: once the chart-rendered annotation + PDB are applied, drop the manual `kubectl` annotation and remove the temporary KEDA `paused-replicas` pin.

> ⚠️ Merging triggers a full-fleet portal self-update deploy — merge deliberately, on green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)