### PR TITLE
EventSubscriptionRunner: fire each subscription at most once, not once per firing path (main-red flake)

### DIFF
--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -22,7 +22,11 @@ namespace MeshWeaver.Graph;
 ///     subscription node itself (Pending → Fired), so nothing is lost.</item>
 /// </list>
 /// Continuations are idempotent (create-or-update grant, pin is a set-add, the terminal <c>Fired</c>
-/// write gates re-entry), so the two paths can't double-apply.
+/// write gates re-entry), so the paths can't double-APPLY — but idempotent is not the same as free, and
+/// the <c>Fired</c> gate only closes once that write has round-tripped. Until then every path is looking
+/// at the same still-Pending snapshot, so they would each launch the continuation. A per-subscription
+/// in-flight reservation (the <c>executing</c> registry) makes firing at-most-once instead: exactly one
+/// continuation per subscription, no unobserved duplicate writes trailing behind it.
 ///
 /// <para>🚨 The runner has NO ambient <c>AccessContext</c> (it's a background hosted service, not a
 /// request). Every read AND write goes through <see cref="AsSystem{T}"/> — <c>Using(ImpersonateAsSystem,
@@ -59,6 +63,21 @@ public sealed class EventSubscriptionRunner(
     // deferred invite fires even when the in-process/Orleans change feed's best-effort cross-silo relay
     // never delivers the User/Created event to this runner. Same lifecycle contract as timerSubs/statusSubs.
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, IDisposable> nodeChangeSubs = new();
+    // 🚨 Subscriptions whose continuation is currently IN FLIGHT — the at-most-once guard for Execute.
+    // EVERY firing path (change feed, cold-start reconcile, pending-set reconcile, trigger-node watch)
+    // fires off the same `pending` snapshot, and a subscription only LEAVES that snapshot once its
+    // terminal Fired write has round-tripped through the Admin partition. At startup all of those paths
+    // evaluate within a few ms of each other — i.e. while the subscription is still Pending in every
+    // snapshot — so ONE subscription launched N concurrent continuations, each issuing a duplicate
+    // upsert of the same membership/grant node plus its own SetStatus write. Idempotence made those
+    // writes harmless, never free: they are fire-and-forget requests nobody observes, they serialise
+    // behind each other on the target node's hub, and they outlive whatever triggered them (they were
+    // the CreateOrUpdateNodeRequest callbacks still pending at test teardown). The remedy is the same
+    // instance-scoped TryAdd reservation the timer / status / trigger-node registries already use:
+    // reserved before the chain starts, released on failure so a later emission retries, and pruned
+    // when the subscription leaves the pending set — so it stays bounded by the pending set rather than
+    // growing for the runner's whole uptime.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> executing = new();
     private IDisposable? pendingSub;
     private IDisposable? feedSub;
     private IDisposable? legacySub;
@@ -117,6 +136,12 @@ public sealed class EventSubscriptionRunner(
                     foreach (var id in subs.Keys.Where(id => !pendingIds.Contains(id)).ToList())
                         if (subs.TryRemove(id, out var d))
                             d.Dispose();
+                // The in-flight reservation is keyed the same way: a subscription that has left the
+                // pending set reached a terminal state (Fired / Failed / Cancelled) and can never fire
+                // again — every firing path draws its candidates from `pending` — so drop its entry.
+                // That keeps `executing` bounded by the pending set instead of the runner's uptime.
+                foreach (var id in executing.Keys.Where(id => !pendingIds.Contains(id)).ToList())
+                    executing.TryRemove(id, out _);
             }, ex => logger?.LogWarning(ex, "Event-subscriptions query failed"));
 
         // 🚨 Cold-start authoritative reconcile — the fix for the memex 2026-07-20 stranded-invite incident.
@@ -292,6 +317,11 @@ public sealed class EventSubscriptionRunner(
 
     private void Execute(EventSubscription subscription, string userId)
     {
+        // At-most-once per subscription: reserve the id BEFORE building the chain (see `executing`).
+        // Whichever firing path gets here first owns this subscription's continuation; the others —
+        // which are looking at the same still-Pending snapshot — must not launch a duplicate.
+        if (!executing.TryAdd(subscription.Id, 0))
+            return;
         BuildContinuation(subscription, userId)
             .SelectMany(_ => AsSystem(() => EventSubscriptionOps.SetStatus(
                 hub, EventSubscriptionNodeType.Path(subscription.Id), EventSubscriptionStatus.Fired)))
@@ -301,6 +331,10 @@ public sealed class EventSubscriptionRunner(
                     subscription.Id, subscription.ContinuationType, subscription.Role, userId, subscription.TargetPath),
                 ex =>
                 {
+                    // Release the reservation so a later pending-set emission can retry a TRANSIENT
+                    // failure — the same rule MigrateLegacyScheduledActions applies to its own id guard.
+                    // (A permanent failure writes Failed below and leaves the pending set anyway.)
+                    executing.TryRemove(subscription.Id, out _);
                     logger?.LogWarning(ex, "Event subscription {Id} failed", subscription.Id);
                     AsSystem(() => EventSubscriptionOps.SetStatus(
                             hub, EventSubscriptionNodeType.Path(subscription.Id), EventSubscriptionStatus.Failed, ex.Message))
@@ -497,5 +531,6 @@ public sealed class EventSubscriptionRunner(
             foreach (var id in subs.Keys.ToList())
                 if (subs.TryRemove(id, out var d))
                     d.Dispose();
+        executing.Clear();
     }
 }

--- a/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
+++ b/test/MeshWeaver.Graph.Test/EventSubscriptionRunnerTest.cs
@@ -325,6 +325,101 @@ public class EventSubscriptionRunnerTest(ITestOutputHelper output) : MonolithMes
         Assert.NotNull(membership);
     }
 
+    /// <summary>
+    /// Regression for the duplicate-continuation defect behind the
+    /// <see cref="PreExistingUserAndSubscription_FireOnRunnerStartup_WithoutTheChangeFeed"/> flake: ONE
+    /// pending subscription must produce EXACTLY ONE continuation, however many of the runner's firing
+    /// paths happen to see it. At startup the cold-start reconcile, the pending-set reconcile and the
+    /// trigger-node watch all evaluate the SAME still-Pending snapshot (it only clears once the terminal
+    /// Fired write round-trips), so before the fix all three launched the continuation and the runner
+    /// issued three concurrent upserts of the same membership node plus three SetStatus writes. Nothing
+    /// observes the losers, so the last of them was still in flight when the test class disposed — the
+    /// "left Observe subscriptions pending past the Quiescing budget /
+    /// CreateOrUpdateNodeRequest@mesh/…" teardown failure, which turned into a CI flake as soon as
+    /// full-suite load stretched that tail past the drain budget.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task StartupFiresEachSubscriptionExactlyOnce_NotOncePerFiringPath()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var fires = new System.Collections.Concurrent.ConcurrentQueue<string>();
+
+        var groupPath = $"{Space}/Team4";
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode("Team4", Space)
+            {
+                NodeType = "Group",
+                Name = "Team4",
+                Content = new AccessObject { Description = "Test group" },
+            }).Should().Emit();
+
+        var subscription = new EventSubscription
+        {
+            TriggerType = EventTriggerType.NodeChange,
+            TriggerNodeType = "User",
+            TriggerKind = MeshChangeKind.Created,
+            MatchField = "email",
+            MatchValue = InviteeEmail,
+            ContinuationType = EventContinuationType.AddToGroup,
+            TargetPath = groupPath,
+        };
+        await EventSubscriptionOps.CreateSubscription(meshService, subscription).Should().Emit();
+        using (accessService.ImpersonateAsSystem())
+        {
+            await meshService.CreateNode(new MeshNode(InviteeId)
+            {
+                NodeType = "User",
+                Name = "Newcomer",
+                Content = new User { Email = InviteeEmail, FullName = "Newcomer" },
+            }).Should().Emit();
+        }
+
+        // Every firing path is armed: the change feed IS live here (unlike the silent-feed tests), and
+        // both reconciles plus the trigger-node watch see the pre-existing, already-matching user.
+        using var runner = new EventSubscriptionRunner(Mesh,
+            Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>(), meshService, accessService,
+            new CountingRunnerLogger(fires));
+        await runner.StartAsync(default);
+
+        var final = await Mesh.GetWorkspace().GetMeshNodeStream(EventSubscriptionNodeType.Path(subscription.Id))
+            .Select(n => n?.Content as EventSubscription)
+            .Where(s => s is not null and not { Status: EventSubscriptionStatus.Pending })
+            .FirstAsync().Timeout(40.Seconds());
+        Assert.True(final!.Status == EventSubscriptionStatus.Fired,
+            $"subscription ended {final.Status}: {final.LastError}");
+
+        var membershipPath = $"{groupPath}/{InviteeId}_Membership";
+        await Mesh.GetWorkspace().GetMeshNodeStream(membershipPath)
+            .Where(n => n?.Content is GroupMembership gm && gm.Member == InviteeId)
+            .FirstAsync().Timeout(10.Seconds());
+
+        // Observation window for a MUST-NOT-HAPPEN assertion: the duplicate fires this pins arrive within
+        // ~50ms of the first, so the window can only ever hide the defect, never invent it. (Before the
+        // fix this reports 3 fires; after it, 1.)
+        await Task.Delay(3.Seconds());
+        Assert.True(fires.Count == 1,
+            $"the subscription's continuation ran {fires.Count} times — one per firing path instead of once. "
+            + $"Each extra run is an unobserved duplicate write that outlives the test:{Environment.NewLine}"
+            + string.Join(Environment.NewLine, fires));
+    }
+
+    /// <summary>Captures the runner's "fired" lines so a test can count continuations.</summary>
+    private sealed class CountingRunnerLogger(System.Collections.Concurrent.ConcurrentQueue<string> fires)
+        : Microsoft.Extensions.Logging.ILogger<EventSubscriptionRunner>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+        public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var line = formatter(state, exception);
+            if (line.Contains(" fired: ", StringComparison.Ordinal))
+                fires.Enqueue(line);
+        }
+    }
+
     [Fact(Timeout = 60000)]
     public async Task LegacyScheduledAction_IsMigratedAndFires()
     {


### PR DESCRIPTION
## Why

`main` is red on `EventSubscriptionRunnerTest.PreExistingUserAndSubscription_FireOnRunnerStartup_WithoutTheChangeFeed` — CI shard 4 on both `89332e347` and `4fb03f017`, and **3 of 10** full `MeshWeaver.Graph.Test` runs on a clean `main` worktree locally. Not a new regression: it predates today's merges.

The test body **passes**. What fails is the class dispose gate:

```
EventSubscriptionRunnerTest left Observe subscriptions pending past the Quiescing budget.
This is a leaked callback — the test posted a request and never received (or never awaited) its reply.
  1 pending callback(s) after 0.50s: …=CreateOrUpdateNodeRequest@mesh/…(640ms)
```

That callback is real, and the budget is not the problem.

## Root cause

The runner fires **one subscription three times** at startup.

All four firing paths — change feed, cold-start authoritative reconcile, pending-set reconcile, trigger-node watch — draw their candidates from the same `pending` snapshot, and a subscription only leaves that snapshot once its terminal `Fired` write has round-tripped through the Admin partition. At startup every path evaluates within a few milliseconds of the others, i.e. while the subscription is still `Pending` in all of them, so each launches its own continuation: three concurrent upserts of the same membership/grant node plus three `SetStatus` writes, every one fire-and-forget (`.Subscribe(...)` handle discarded).

The assertions are satisfied by whichever execution lands first; #2 and #3 are still in flight, serialising behind each other on the target node's hub. Measured in an isolated run: assertions satisfied at 148 ms, the three fires logged at 160/178/194 ms, one `CreateOrUpdateNodeRequest` still pending at test-body end. Under full-suite load that tail stretches past the 0.5 s quiescing budget — which is exactly why it only flakes there and passes in isolation.

The class doc asserted that idempotence made the overlapping paths safe. **Idempotent means they cannot double-*apply*, not that they do not double-*run*** — and a duplicate run still costs an unobserved request that outlives whatever triggered it. Doc corrected in this PR.

## The fix

A per-subscription in-flight reservation in `EventSubscriptionRunner` — the same instance-scoped `ConcurrentDictionary.TryAdd` pattern the class already uses for `timerSubs` / `statusSubs` / `nodeChangeSubs` / `migratedLegacyIds`:

- reserved **before** the continuation chain is built, so whichever path arrives first owns it;
- released in the error handler, so a later pending-set emission still retries a *transient* failure (a permanent one writes `Failed` and leaves the pending set anyway);
- pruned alongside the existing registries when a subscription leaves the pending set — terminal subscriptions can never fire again, so the registry stays bounded by the pending set rather than by runner uptime;
- cleared on `Dispose`.

No timeout widened, no retry loop, no sleep, no `Clear()`-for-test-isolation, nothing `async` introduced.

## Evidence

New regression test `StartupFiresEachSubscriptionExactlyOnce_NotOncePerFiringPath` counts continuations via a capturing `ILogger` with all firing paths armed (live change feed, not the silent one):

| | result |
|---|---|
| Regression test **before** the fix | fails 3/3 — "the subscription's continuation ran **3** times" |
| Regression test **after** | passes 3/3 — 1 continuation |
| Pending callbacks at test-body end, after | **zero** (was 1 `CreateOrUpdateNodeRequest` + 2 `PatchDataRequest`) |
| Full `MeshWeaver.Graph.Test`, baseline clean `main` | **3 of 10 runs failed**, always this test, 625/626 |
| Full suite after the fix | **11/11 green**, 627/627 — plus 3 independent confirmation runs, 627/627 each |

Builds clean at `-c Release -p:CIRun=true -warnaserror`, 0 warnings.

No What's New entry: internal reliability fix with no user-visible behaviour change (the duplicate writes were idempotent — they cost work and a leaked callback, not wrong data).

## Found but not fixed (follow-ups, deliberately out of scope)

- **`WatchTriggerNodeType` is a live query over every node of the trigger type** and re-reconciles all pending `Created` subscriptions on each emission, so any unrelated `User` write re-enters `Execute` for every pending subscription. This PR removes the concurrent duplicates, but the repeated *evaluation* (one `meshService.Query` per pending subscription per emission) is still O(pending × emissions) at boot — a plausible contributor to the known boot-storm write amplification.
- **The no-op upsert path in `MeshExtensions.HandleCreateOrUpdateNodeRequest` can hold a request open for up to `NodeOpForwardTimeout` (15 s)** waiting on `GetEffectivePermissions` before falling through to the write path. Correct as written, but it means *any* duplicate upsert parks a callback far longer than the 0.5 s dispose budget — it amplified this flake and would amplify the next one into the same misleading teardown failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
