### PR TITLE
MeshNodeTypeSource: version floor on adds + flush current state (cleanup — does NOT fix the TwoSilo flake)

### DIFF
--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -268,7 +268,18 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
                     _hubPath, node.Path);
                 continue;
             }
-            var nodeWithVersion = node with { Version = hubVersion };
+            // 🚨 #325: the SAME forward-only floor the updates branch below applies. An "add" is
+            // add-relative-to-THIS-source-instance, NOT globally new: after an idle-recycle the
+            // reactivated hub's _lastSaved starts empty, so its own already-durable node is
+            // classified here as a create. A plain `Version = hubVersion` then stamps it with the
+            // fresh per-activation hub clock (which resets toward 0) and the debounce flush writes
+            // that REGRESSED version over the durable row — the write-rollback of #325, this time
+            // through the create path. MeshNode.NextVersion floors at the node's own carried
+            // version, so a genuinely new node (Version 0) is unaffected (max(hubVersion, 1) ==
+            // hubVersion for any live clock) while a re-added durable node can never go backward.
+            // Doc/Architecture/MeshNodeVersioning.md: the floor applies at EVERY place the owner
+            // mints a node Version — this is the persistence re-stamp it names.
+            var nodeWithVersion = node with { Version = MeshNode.NextVersion(hubVersion, node.Version) };
             _pendingSaves[node.Path] = nodeWithVersion;
         }
 
@@ -364,6 +375,22 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
     }
 
     /// <summary>
+    /// Resolves the freshest known state for a queued save: the entry from <see cref="_lastSaved"/>
+    /// (this source's authoritative post-diff collection) when it is still present and carries a
+    /// Version at-or-above the queued snapshot, else the queued snapshot itself. Never lets a stale
+    /// queued node overwrite newer state — see <see cref="FlushPendingWrites"/>.
+    /// </summary>
+    private MeshNode CurrentStateFor(MeshNode queued)
+    {
+        if (_lastSaved.Instances.TryGetValue(queued.Id, out var live)
+            && live is MeshNode current
+            && current.Version >= queued.Version
+            && string.Equals(current.Path, queued.Path, StringComparison.OrdinalIgnoreCase))
+            return current;
+        return queued;
+    }
+
+    /// <summary>
     /// Drains <see cref="_pendingSaves"/> and <see cref="_pendingDeletes"/> into
     /// a composed IObservable&lt;Unit&gt; — each save/delete becomes one step
     /// in a Concat chain that completes only after every op has acked. The
@@ -376,10 +403,23 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
         if (_persistenceCore is null)
             return Observable.Return(System.Reactive.Unit.Default);
 
+        // 🚨 Flush the node's CURRENT state, never the enqueue-time snapshot. _pendingSaves is
+        // populated by the ADD branch of UpdateImpl only; later UPDATES to the same node
+        // deliberately bypass this queue (the own-node persistence sampler saves those), so a
+        // queued entry is NEVER refreshed. ResetDebounceTimer re-arms the one-shot 200 ms timer on
+        // EVERY UpdateImpl, so under sustained churn a create-time entry can sit here across many
+        // subsequent acked writes and then be drained by FlushOnDispose at hub teardown — writing
+        // the CREATE-time node over a durable row that has since advanced. That is a durable
+        // rollback of acked writes (observed: a node at Version 12 / ApiKey "sk-v6" rolled back to
+        // Version 2 / ApiKey "sk-v0" by an idle-recycle) and IStorageAdapter.Write has no
+        // monotonic guard to catch it. _lastSaved is this source's authoritative post-diff
+        // collection, so re-resolving the path against it makes the flush write what the node
+        // actually IS at flush time; the queued snapshot is only the fallback for a node that has
+        // since left the collection.
         var saves = new List<MeshNode>();
         foreach (var key in _pendingSaves.Keys.ToArray())
             if (_pendingSaves.TryRemove(key, out var node))
-                saves.Add(node);
+                saves.Add(CurrentStateFor(node));
 
         var deletes = new List<string>();
         while (_pendingDeletes.TryTake(out var path))


### PR DESCRIPTION
Two invariant repairs found while investigating `TwoSiloRecycleConvergenceTest`. **Neither fixes that test** — read the last section before merging, and please don't take this PR as closing the flake.

## The repairs

1. **`UpdateImpl` adds-branch version floor.** It stamped the raw per-activation `Hub.Version`, which resets toward 0 on reactivation — and after a recycle `_lastSaved` starts empty, so an already-durable node is classified as an *add*. The `updates` branch 15 lines below already applies `MeshNode.NextVersion(hubVersion, previousVersion)` with a comment referencing #325 explaining exactly this hazard, and `Doc/Architecture/MeshNodeVersioning.md` states the floor applies "at every place the owner mints a node Version: … the persistence re-stamp (`MeshNodeTypeSource.UpdateImpl`)". The adds branch violated it.

2. **`FlushPendingWrites` flushes current state, not the enqueue-time snapshot.** `_pendingSaves` is populated only by the adds branch; later updates bypass it deliberately, so an entry is never refreshed — while `ResetDebounceTimer` re-arms the 200 ms one-shot on *every* `UpdateImpl`. A create-time entry can survive many newer acked writes and then be drained by `FlushOnDispose` at teardown. `CurrentStateFor` re-resolves each pending save against `_lastSaved`, taking it only when its `Version >=` the queued one.

Verified: **Orleans 134/134**, **Graph 626/626**, `-c Release -p:CIRun=true -warnaserror` clean.

## 🚨 This does NOT fix the flake, and the flake is not a flake

Under CPU contention (48 spinners; CI runners have 4 cores) the failure still reproduces **1/40 with both changes applied**, against **1/11 on `origin/main`** — not a significant difference (Fisher exact p ≈ 0.36).

The underlying defect is **production write loss**, reported with full evidence on #648: an owner-grain idle-recycle durably rolls the node back to its creation state — captured live as `Version=12 / ApiKey=sk-v6` → `Version=2 / ApiKey=sk-v0`, six acked writes destroyed while the write reports success in 93 ms. `WaitForPersistedBeyond` is correctly detecting that loss; it is not asserting anything the design doesn't promise.

The surviving route (not addressed here): `MessageHubGrain` hands its cache-backed activation-resolution stream to the hub as the authoritative own-node source via `WithOwnNodeStream`, `MeshNodeTypeSource.Initialize` prefers it over `_persistenceCore.Read`, and no write path rejects a backward write.

No What's New entry — internal invariant repair, no user-visible behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)