### PR TITLE
GetMeshNode: a timed-out read is not "node not found"

### DIFF
--- a/src/MeshWeaver.ContentCollections.Indexing.Graph/MeshDocumentSink.cs
+++ b/src/MeshWeaver.ContentCollections.Indexing.Graph/MeshDocumentSink.cs
@@ -90,7 +90,7 @@ public sealed class MeshDocumentSink(IMessageHub hub) : IDocumentSink
         // One-shot request/response read of the node at the deterministic path; null (not found,
         // timeout, routing failure) counts as absent — per the interface contract, indeterminate
         // leans towards a heal because the write is an idempotent upsert.
-        return hub.GetMeshNode(path, ExistsProbeTimeout)
+        return hub.GetMeshNode(path, ExistsProbeTimeout, ReadTimeoutBehavior.EmitNull)
             .Select(node =>
             {
                 if (node is not null)

--- a/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
@@ -110,6 +110,11 @@ public static class CodeNodeType
         // true request/response, no SubscribeRequest+immediate-unsubscribe. Handler
         // itself returns Processed() immediately; the callback below fires when the
         // response arrives.
+        // Strict timeout (the default): a stalled read must NOT be answered as
+        // "Not executable" — that tells the caller the script is misconfigured when in
+        // fact the mesh never replied, and it is unfixable by the user. The error sink
+        // below turns the timeout into a truthful failure response (and, being a
+        // handler, gives the OnError somewhere to land instead of the timer thread).
         hub.GetMeshNode(hub.Address.ToString())
             .Subscribe(node =>
             {
@@ -322,6 +327,18 @@ public static class CodeNodeType
                                 },
                                 o => o.ResponseFor(request));
                         });
+            },
+            readError =>
+            {
+                // The self-read failed (timeout / access denial). Answer the caller with what
+                // actually happened instead of the misleading "Not executable" verdict above.
+                hub.Post(
+                    new ExecuteScriptResponse
+                    {
+                        Success = false,
+                        Error = $"Could not read the code node to execute: {readError.Message}"
+                    },
+                    o => o.ResponseFor(request));
             });
         return request.Processed();
     }

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -228,7 +228,11 @@ internal class MeshNodeCompilationService(
                 if (!resolved.Add(path))
                     return Observable.Return(current.Replace(matchValue, string.Empty));
 
-                return hub.GetMeshNode(path, TimeSpan.FromSeconds(15))
+                // EmitNull — see the note on the NodeType-definition reads below: this is the
+                // hub-ACTIVATION path, where turning a transient stall into a hard fault would
+                // park the type. Behaviour is unchanged (the include stays unresolved and the
+                // LogWarning below fires); the read itself now also logs the stall + diagnostics.
+                return hub.GetMeshNode(path, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.EmitNull)
                     .SelectMany(referencedNode =>
                     {
                         if (referencedNode?.Content is CodeConfiguration cf
@@ -294,7 +298,15 @@ internal class MeshNodeCompilationService(
         }
         else
         {
-            resolveDef = hub.GetMeshNode(node.NodeType, TimeSpan.FromSeconds(15))
+            // ⚠️ EmitNull here is a DELIBERATE HOLD, not an endorsement. A stalled read of the
+            // NodeType definition currently yields ntDef == null and the compile proceeds
+            // against a null definition — a silently wrong compile. Making it throw is the
+            // right end state, but this runs on the hub-ACTIVATION path where compile status
+            // is cached: a transient stall would flip from "wrong compile" to "PARKED type"
+            // (the UWDeepfield outage class), which needs its own retry/park semantics and its
+            // own tests. Held at today's behaviour on purpose; the stall is no longer silent
+            // (the read logs it at Warning with hub diagnostics). See the report.
+            resolveDef = hub.GetMeshNode(node.NodeType, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.EmitNull)
                 .Select(typeNode => typeNode.ContentAs<NodeTypeDefinition>(JsonOptions));
             selfPath = node.NodeType;
         }
@@ -948,7 +960,8 @@ internal class MeshNodeCompilationService(
         NodeTypeDefinition? selfDef = node.ContentAs<NodeTypeDefinition>(JsonOptions);
         IObservable<NodeTypeDefinition?> resolveDef = selfDef != null
             ? Observable.Return<NodeTypeDefinition?>(selfDef)
-            : hub.GetMeshNode(node.NodeType, TimeSpan.FromSeconds(15))
+            // EmitNull — same deliberate hold as GetCompilationInputs above (activation path).
+            : hub.GetMeshNode(node.NodeType, TimeSpan.FromSeconds(15), ReadTimeoutBehavior.EmitNull)
                 .Select(typeNode => typeNode.ContentAs<NodeTypeDefinition>(JsonOptions));
         string selfPath = selfDef != null ? node.Path : node.NodeType;
 

--- a/src/MeshWeaver.Graph/GroupsLayoutArea.cs
+++ b/src/MeshWeaver.Graph/GroupsLayoutArea.cs
@@ -264,7 +264,12 @@ public static class GroupsLayoutArea
 
                             // Existence check via one-shot GetDataRequest — true
                             // request/response, no SubscribeRequest+immediate-unsubscribe.
-                            saveCtx.Hub.GetMeshNode(path, TimeSpan.FromSeconds(5))
+                            // EmitNull: fire-and-forget save action with no error sink — an
+                            // OnError would rethrow on the timeout's timer thread. On a stall
+                            // the existence probe reads as "absent" (unchanged behaviour: the
+                            // create below is guarded by the mesh's own uniqueness handling);
+                            // the read logs the timeout + hub diagnostics at Warning.
+                            saveCtx.Hub.GetMeshNode(path, TimeSpan.FromSeconds(5), ReadTimeoutBehavior.EmitNull)
                                 .Subscribe(existing =>
                                 {
                                     saveCtx.Host.UpdateArea(DialogControl.DialogArea, null!);
@@ -276,7 +281,10 @@ public static class GroupsLayoutArea
                                     }
 
                                     // Look up member icon via one-shot GetDataRequest (best-effort).
-                                    saveCtx.Hub.GetMeshNode(selectedMember, TimeSpan.FromSeconds(2))
+                                    // EmitNull — best-effort icon lookup (the comment above says
+                                    // so) on a subscription with no error sink; a stall must
+                                    // degrade to "no icon", not throw on the timer thread.
+                                    saveCtx.Hub.GetMeshNode(selectedMember, TimeSpan.FromSeconds(2), ReadTimeoutBehavior.EmitNull)
                                         .Subscribe(memberNode =>
                                         {
                                             var newNode = new MeshNode(nodeId, nodePath)

--- a/src/MeshWeaver.Graph/PinLayoutArea.cs
+++ b/src/MeshWeaver.Graph/PinLayoutArea.cs
@@ -141,7 +141,11 @@ public static class PinLayoutArea
                     // userAddress, not this host's hub). One-shot read, apply transform,
                     // post DataChangeRequest. The owning hub broadcasts to subscribers, so
                     // the viewer's dashboard re-renders and the card disappears.
-                    ctx.Host.Hub.GetMeshNode(userPath, TimeSpan.FromSeconds(10))
+                    // EmitNull: a fire-and-forget click action with no error sink — an OnError
+                    // here would rethrow on the timeout's timer thread and take the process
+                    // down. Behaviour on a stall is unchanged (the unpin does not happen);
+                    // the read logs the timeout + hub diagnostics at Warning.
+                    ctx.Host.Hub.GetMeshNode(userPath, TimeSpan.FromSeconds(10), ReadTimeoutBehavior.EmitNull)
                         .Subscribe(n =>
                         {
                             if (n?.Content is not User user) return;
@@ -179,7 +183,9 @@ public static class PinLayoutArea
         // Single-op remote write: one-shot read via GetDataRequest, apply the
         // pin/unpin transform, post DataChangeRequest to the owning user hub. The
         // viewer's dashboard subscribes to that user node and re-renders on the echo.
-        host.Hub.GetMeshNode(userPath, TimeSpan.FromSeconds(10))
+        // EmitNull — same reason as the unpin action above: no error sink on this
+        // fire-and-forget subscription, so a stall must not throw on the timer thread.
+        host.Hub.GetMeshNode(userPath, TimeSpan.FromSeconds(10), ReadTimeoutBehavior.EmitNull)
             .Subscribe(node =>
             {
                 if (node?.Content is not User user) return;

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -374,7 +374,10 @@ public static class UserActivityLayoutAreas
         var backHref = MeshNodeLayoutAreas.BuildUrl(hubPath, ActivityArea);
         var userAddress = host.Hub.Address;
 
-        host.Hub.GetMeshNode(hubPath, TimeSpan.FromSeconds(10))
+        // EmitNull: fire-and-forget click action with no error sink — an OnError would
+        // rethrow on the timeout's timer thread. Stall behaviour unchanged (the reset does
+        // not happen); the read logs the timeout + hub diagnostics at Warning.
+        host.Hub.GetMeshNode(hubPath, TimeSpan.FromSeconds(10), ReadTimeoutBehavior.EmitNull)
             .Subscribe(node =>
             {
                 if (node?.Content is not User user || string.IsNullOrWhiteSpace(user.Body))
@@ -395,7 +398,9 @@ public static class UserActivityLayoutAreas
     private static Func<UiActionContext, Task> ClearBodyAction(string userPath) => ctx =>
     {
         var userAddress = new Address(userPath);
-        ctx.Host.Hub.GetMeshNode(userPath, TimeSpan.FromSeconds(10))
+        // EmitNull — same reason as ResetHomeAction above: no error sink on this
+        // fire-and-forget subscription.
+        ctx.Host.Hub.GetMeshNode(userPath, TimeSpan.FromSeconds(10), ReadTimeoutBehavior.EmitNull)
             .Subscribe(node =>
             {
                 if (node?.Content is not User user) return;

--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -638,8 +638,21 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     private DateTimeOffset _testMethodStartedAt;
     /// <summary>Soft cap — anything above this gets a warning in the test log.</summary>
     protected virtual TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(30);
-    /// <summary>Hard cap — anything above this throws at DisposeAsync, failing the test class.</summary>
-    protected virtual TimeSpan TestHardDeadline => TimeSpan.FromSeconds(60);
+    /// <summary>
+    /// Hard cap — anything above this throws at DisposeAsync, failing the test class.
+    ///
+    /// <para>🚨 MUST stay strictly ABOVE every in-test operation budget, above all
+    /// <see cref="ReadNodeTimeout"/> (60 s). It used to be EQUAL to it, and that collision
+    /// hid the real cause of a whole class of failures: a read that burned its full budget
+    /// tripped this watchdog at the same instant, so the only error the author ever saw was
+    /// the generic "you probably ignored your CancellationToken" — while the actual fault was
+    /// a mesh read that never got its reply (ThreadAgentIntegrationTest, CI 2026-07-26). The
+    /// operation's own loud, specific timeout must win the race; this watchdog is the
+    /// backstop for hangs that have NO budget of their own, not a competitor to the ones
+    /// that do. Widening it does not weaken any assertion — the test still fails, it just
+    /// fails naming the operation instead of the harness.</para>
+    /// </summary>
+    protected virtual TimeSpan TestHardDeadline => TimeSpan.FromSeconds(90);
 
     /// <summary>
     /// xUnit async lifecycle hook run before each test: records the start time and performs any
@@ -878,16 +891,23 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     /// <summary>
     /// Authoritative single-node read as an <see cref="IObservable{T}"/>: the owner-hub round-trip via
     /// <c>Mesh.GetMeshNode</c> — NOT the cache stream (which can serve a stale Replay(1) buffer). Emits the
-    /// node, or <c>null</c> when the routing service reports NotFound or the read exceeds
-    /// <see cref="ReadNodeTimeout"/>. Assert reactively: <c>ReadNode(path).Should().Emit()</c> /
-    /// <c>.Match(...)</c>. Never bridge back to a Task. (Replaced the old cache-stream ReadNode +
-    /// the deleted ReadNodeAsync.)
+    /// node, or <c>null</c> when the routing service reports NotFound. Assert reactively:
+    /// <c>ReadNode(path).Should().Emit()</c> / <c>.Match(...)</c>. Never bridge back to a Task.
+    /// (Replaced the old cache-stream ReadNode + the deleted ReadNodeAsync.)
+    ///
+    /// <para>🚨 A read that exceeds <see cref="ReadNodeTimeout"/> FAULTS with a
+    /// <see cref="TimeoutException"/> naming the path and the reading hub's in-flight state — it
+    /// does NOT emit null. Mapping the timeout to null (as this helper used to) meant a stalled
+    /// mesh read was indistinguishable from a deleted node, so a test could burn its whole budget,
+    /// silently assert against a null it never expected, PASS, and then die in DisposeAsync
+    /// blaming the CancellationToken. A test that legitimately expects "absent" still gets null
+    /// from the NotFound path.</para>
     /// </summary>
     protected IObservable<MeshNode?> ReadNode(string path)
         => Mesh.GetMeshNode(path, ReadNodeTimeout)
             .Select(n => (MeshNode?)n)
             .Catch((Exception ex) =>
-                ex is TimeoutException || IsNotFoundFailure(ex)
+                IsNotFoundFailure(ex)
                     ? Observable.Return<MeshNode?>(null)
                     : Observable.Throw<MeshNode?>(ex));
 

--- a/src/MeshWeaver.Markdown.Export/Branding/BrandingResolver.cs
+++ b/src/MeshWeaver.Markdown.Export/Branding/BrandingResolver.cs
@@ -53,7 +53,10 @@ public class BrandingResolver
         }
 
         // One-shot read — GetDataRequest, no SubscribeRequest round-trip.
-        return hub.GetMeshNode(brandNodePath, TimeSpan.FromSeconds(10))
+        // EmitNull: branding is cosmetic and this method's contract is "Default on any miss" —
+        // a slow brand read must degrade to portal defaults, never fail the export. The
+        // timeout is still logged at Warning by the read itself.
+        return hub.GetMeshNode(brandNodePath, TimeSpan.FromSeconds(10), ReadTimeoutBehavior.EmitNull)
             .SelectMany(node =>
             {
                 if (node is null)

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Disposables;
+﻿using System.Diagnostics;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.Json;
 using MeshWeaver.Data;
@@ -1341,12 +1342,19 @@ public static class MeshNodeStreamExtensions
     /// click actions that just need the current value once.
     ///
     /// <para>
-    /// Emits <c>null</c> on timeout, on routing failure (the node does not exist â€”
-    /// routing returns DeliveryFailure with NotFound; routing NEVER falls back to
-    /// an ancestor, so a returned non-null node is always the requested path), or
-    /// when the response carries no data. Failures during deserialisation also fall
-    /// through as <c>null</c>; turn on debug-level logging on this type to see the
+    /// Emits <c>null</c> when the node is genuinely absent: routing failure (routing
+    /// returns DeliveryFailure with NotFound; routing NEVER falls back to an ancestor, so a
+    /// returned non-null node is always the requested path), a read-validator verdict that
+    /// hides the node, or a response carrying no data. Failures during deserialisation also
+    /// fall through as <c>null</c>; turn on debug-level logging on this type to see the
     /// underlying exception.
+    /// </para>
+    ///
+    /// <para>
+    /// 🚨 A <b>timeout is NOT</b> one of those: by default it surfaces as a
+    /// <see cref="TimeoutException"/> naming the path, the elapsed time and the hub's
+    /// in-flight snapshot (see <paramref name="onTimeout"/>). "The read gave up" and
+    /// "the node does not exist" are different facts and callers get to tell them apart.
     /// </para>
     ///
     /// <para>
@@ -1355,11 +1363,24 @@ public static class MeshNodeStreamExtensions
     /// subscribed (no <c>.Take(1)</c>). See <c>Doc/Architecture/AsynchronousCalls.md</c>.
     /// </para>
     /// </summary>
+    /// <param name="hub">The hub that posts the read.</param>
+    /// <param name="path">The mesh path to read.</param>
+    /// <param name="timeout">Wall-clock budget for the read; defaults to 10 seconds.</param>
+    /// <param name="onTimeout">
+    /// What happens when the budget elapses. Defaults to
+    /// <see cref="ReadTimeoutBehavior.Throw"/>. Pass <see cref="ReadTimeoutBehavior.EmitNull"/>
+    /// ONLY where "indeterminate ⇒ treat as absent" is the documented, deliberate contract of
+    /// the caller (a cosmetic fallback, an idempotent-upsert existence probe) — never to
+    /// silence a stall you have not reasoned about.
+    /// </param>
     public static IObservable<MeshNode?> GetMeshNode(this IMessageHub hub, string path,
-        TimeSpan? timeout = null)
+        TimeSpan? timeout = null,
+        ReadTimeoutBehavior onTimeout = ReadTimeoutBehavior.Throw)
         => Observable.Create<MeshNode?>(observer =>
         {
-            var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(10));
+            var budget = timeout ?? TimeSpan.FromSeconds(10);
+            var started = Stopwatch.StartNew();
+            var cts = new CancellationTokenSource(budget);
             var emitted = 0;
             // Inner hub.Observe subscription tracker. Captured so the returned
             // disposable can tear it down â€” without this, the outer CTS-timeout
@@ -1384,7 +1405,46 @@ public static class MeshNodeStreamExtensions
                 observer.OnError(error);
             }
 
-            cts.Token.Register(() => EmitOnce(null));
+            // ⏱️ TIMEOUT IS NOT "NOT FOUND". A read that gave up knows nothing about the node;
+            // collapsing that into the same `null` the not-found path emits made every caller
+            // silently substitute "missing" for "the mesh stalled" — and made the stall itself
+            // invisible (a Debug log nobody reads). Surface it, loudly, with the hub's own
+            // in-flight snapshot so the next occurrence says WHY: our GetDataRequest still
+            // outstanding = the reply never came (dead per-node hub / dropped response);
+            // the hub Executing(...) something else for seconds = action-block congestion or
+            // ThreadPool starvation. Callers that genuinely want "indeterminate ⇒ absent"
+            // opt in explicitly via ReadTimeoutBehavior.EmitNull — and even they get the
+            // warning below, so no stall is ever fully silent.
+            cts.Token.Register(() =>
+            {
+                if (Volatile.Read(ref emitted) != 0) return;
+                var elapsed = started.Elapsed;
+                string diagnostics;
+                try { diagnostics = hub.GetPendingRequestDiagnostics(); }
+                catch (Exception diagEx) { diagnostics = $"<diagnostics unavailable: {diagEx.GetType().Name}>"; }
+                var message =
+                    $"GetMeshNode('{path}') timed out after {elapsed.TotalSeconds:F1}s "
+                    + $"(budget {budget.TotalSeconds:F0}s) — the owning per-node hub never answered the "
+                    + $"GetDataRequest. This is NOT 'node not found'. {diagnostics}";
+                // Best-effort log. This runs on the CTS timer thread and the hub (with its
+                // ServiceProvider) may already be torn down — an exception escaping here would
+                // be an unobserved fault on a pool thread, i.e. exactly the class of failure
+                // this change exists to remove. The emission below must happen regardless.
+                try
+                {
+                    hub.ServiceProvider.GetService<ILoggerFactory>()
+                        ?.CreateLogger("MeshWeaver.Mesh.GetMeshNode")
+                        ?.LogWarning("{Message}", message);
+                }
+                catch
+                {
+                    // Logging must never mask the timeout it is reporting.
+                }
+                if (onTimeout == ReadTimeoutBehavior.EmitNull)
+                    EmitOnce(null);
+                else
+                    EmitError(new TimeoutException(message));
+            });
 
             try
             {

--- a/src/MeshWeaver.Mesh.Contract/ReadTimeoutBehavior.cs
+++ b/src/MeshWeaver.Mesh.Contract/ReadTimeoutBehavior.cs
@@ -1,0 +1,33 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// What a one-shot mesh read (<see cref="MeshNodeStreamExtensions.GetMeshNode"/>) does when
+/// its wall-clock budget elapses before the owning per-node hub answers.
+///
+/// <para>The distinction exists because a stalled read and a missing node are different
+/// facts. Collapsing both into <c>null</c> — the shape this API shipped with — let a 60 s
+/// mesh stall masquerade as "node not found": callers substituted defaults, rendered empty
+/// areas and compiled against missing NodeType definitions, while the stall itself left
+/// nothing louder than a Debug log. See the ThreadAgentIntegrationTest CI failure of
+/// 2026-07-26, where the read burned its full 60 s budget, returned <c>null</c>, and the
+/// test still passed — only a dispose-time watchdog caught it, blaming the wrong thing.</para>
+/// </summary>
+public enum ReadTimeoutBehavior
+{
+    /// <summary>
+    /// Default. Surface a <see cref="System.TimeoutException"/> naming the path, the elapsed
+    /// time and the reading hub's in-flight snapshot (queue depths, the message it is
+    /// executing, outstanding response callbacks). The caller decides how to degrade —
+    /// but it can never mistake the stall for an absent node.
+    /// </summary>
+    Throw,
+
+    /// <summary>
+    /// Emit <c>null</c>, exactly as a genuine not-found does. Legitimate ONLY where
+    /// "indeterminate ⇒ treat as absent" is the caller's documented, deliberate contract —
+    /// a cosmetic fallback, or an existence probe whose follow-up write is an idempotent
+    /// upsert. The timeout is still logged at Warning with the same diagnostics, so opting
+    /// in suppresses the exception, never the evidence.
+    /// </summary>
+    EmitNull
+}

--- a/src/MeshWeaver.Messaging.Hub/IMessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/IMessageHub.cs
@@ -232,6 +232,17 @@ public interface IMessageHub : IMessageHandlerRegistry, IDisposable
     string GetDisposalDiagnostics();
 
     /// <summary>
+    /// Single-line snapshot of THIS hub's in-flight state — queue depths, the message
+    /// currently executing, and the outstanding response callbacks (request type, target
+    /// and age). Unlike <see cref="GetDisposalDiagnostics"/> it does NOT walk the hosted-hub
+    /// tree, so it is cheap enough to attach to a live request timeout: a read that gave up
+    /// can say whether its own request is still outstanding (reply never arrived), whether
+    /// the hub is stuck executing something else, or whether the queue is backed up.
+    /// </summary>
+    /// <returns>A one-line diagnostic string; never null.</returns>
+    string GetPendingRequestDiagnostics();
+
+    /// <summary>
     /// True if this hub or any hosted hub hit Quiescing-phase timeout — i.e. there
     /// were Observe-registered response callbacks still pending when the dispose
     /// drain budget elapsed. Tests should treat this as a dispose failure: a

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1565,6 +1565,36 @@ public sealed class MessageHub : IMessageHub
     }
 
     /// <summary>
+    /// Single-line snapshot of THIS hub's in-flight state — queue depths, the message
+    /// currently executing on the action block, and the outstanding response callbacks.
+    /// Deliberately NOT recursive (unlike <see cref="GetDisposalDiagnostics"/>, which walks
+    /// the whole hosted-hub tree): this one is cheap enough to attach to a live request
+    /// timeout on a portal mesh hub that hosts hundreds of per-node hubs.
+    /// </summary>
+    /// <returns>A one-line diagnostic string; never null.</returns>
+    public string GetPendingRequestDiagnostics()
+    {
+        var snapshot = (messageService is MessageService ms)
+            ? ms.GetQueueSnapshot()
+            : (Buffer: -1, Deferred: -1, Execution: -1, OpenGates: -1, DeliveryCompleted: false,
+               CurrentMessage: (string?)null, CurrentMessageElapsedMs: 0L);
+        var pending = SnapshotPendingCallbacks();
+        var sb = new System.Text.StringBuilder();
+        sb.Append("Hub ").Append(Address)
+          .Append(" RunLevel=").Append(RunLevel)
+          .Append(" Queue(buffer=").Append(snapshot.Buffer)
+          .Append(",deferred=").Append(snapshot.Deferred)
+          .Append(",exec=").Append(snapshot.Execution)
+          .Append(')');
+        if (snapshot.CurrentMessage != null)
+            sb.Append(" Executing(").Append(snapshot.CurrentMessage)
+              .Append(", ").Append(snapshot.CurrentMessageElapsedMs).Append("ms)");
+        sb.Append(" PendingCallbacks=").Append(pending.Length)
+          .Append('[').Append(FormatPendingCallbacks(pending)).Append(']');
+        return sb.ToString();
+    }
+
+    /// <summary>
     /// Hard cap on hosted-hub tree recursion. Real hierarchies are at most a few
     /// levels deep; anything beyond this is almost certainly a cycle (e.g. hub A
     /// hosts hub B whose configuration re-creates A). Without this guard the

--- a/test/MeshWeaver.AI.Test/ThreadAgentIntegrationTest.cs
+++ b/test/MeshWeaver.AI.Test/ThreadAgentIntegrationTest.cs
@@ -278,6 +278,11 @@ public class ThreadAgentIntegrationTest : MonolithMeshTestBase
         await agentChat.Initialize("ACME/ProductLaunch").WhenInitialized.FirstAsync().ToTask(ct);
 
         var contextNode = await ReadNode("ACME/ProductLaunch").FirstAsync().ToTask(ct);
+        // Parity with the streaming sibling above. Without this assertion a stalled read
+        // (which used to surface as a silent null) let the whole flow run against a NULL
+        // context and still pass every assertion below — the failure only appeared 60 s
+        // later as a dispose-time watchdog blaming the CancellationToken.
+        contextNode.Should().NotBeNull("ACME/ProductLaunch node should exist in test data");
 
         agentChat.SetContext(new AgentContext
         {

--- a/test/MeshWeaver.Hosting.Monolith.Test/GetMeshNodeTimeoutSurfacingTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/GetMeshNodeTimeoutSurfacingTest.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Pins the timeout contract of the one-shot read <c>hub.GetMeshNode(path)</c>: a read that
+/// gives up must SURFACE, never masquerade as "node not found".
+///
+/// <para>Why: the read used to map its own timeout to <c>null</c> — the identical value the
+/// not-found path emits. Every caller therefore substituted "missing" for "the mesh stalled":
+/// layout areas rendered empty, the compilation service resolved a null NodeType definition,
+/// and in CI (ThreadAgentIntegrationTest, 2026-07-26) a test burned the full 60 s read budget,
+/// asserted against a null context it never expected, PASSED, and then failed in DisposeAsync
+/// with a watchdog message blaming the CancellationToken. The stall itself left nothing behind
+/// but a Debug log.</para>
+///
+/// <para>The black hole below is deterministic, not timing-based: the target hub ACCEPTS the
+/// <see cref="GetDataRequest"/> and never answers it, so the reply does not exist — no amount of
+/// machine speed can make this test flaky in either direction.</para>
+/// </summary>
+public class GetMeshNodeTimeoutSurfacingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    protected override bool ShareMeshAcrossTests => true;
+
+    private static readonly TimeSpan ReadBudget = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// A hub that swallows every <see cref="GetDataRequest"/> — marks it processed and never
+    /// posts a response. Reading its own address through <c>GetMeshNode</c> therefore always
+    /// exhausts the budget.
+    /// </summary>
+    private IMessageHub CreateSilentHub()
+        => GetClient(c => ConfigureClient(c)
+            .WithHandler<GetDataRequest>((_, request) => request.Processed()));
+
+    [Fact(Timeout = 30000)]
+    public async Task ReadTimesOut_SurfacesTimeoutException_NotSilentNull()
+    {
+        var silent = CreateSilentHub();
+        var path = silent.Address.ToString();
+
+        Func<Task> act = () => silent.GetMeshNode(path, ReadBudget).FirstAsync().ToTask();
+
+        var ex = (await act.Should().ThrowAsync<TimeoutException>(
+            "a read that never got its reply must surface, not resolve to the same null "
+            + "that means 'node not found'")).Which;
+
+        Output.WriteLine($"Surfaced: {ex.Message}");
+
+        ex.Message.Should().Contain(path,
+            "the failure must name the path that stalled, or it is unactionable");
+        ex.Message.Should().Contain("timed out",
+            "the failure must say what happened");
+        ex.Message.Should().Contain("NOT 'node not found'",
+            "the message must stop the reader concluding the node is missing");
+    }
+
+    /// <summary>
+    /// The timeout carries the reading hub's in-flight snapshot, so the next occurrence says
+    /// WHY: our own GetDataRequest still listed as pending = the reply never came (dead owner
+    /// hub / dropped response), versus a hub that is executing something else / has a backed-up
+    /// queue = congestion or ThreadPool starvation.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task ReadTimesOut_MessageCarriesPendingRequestDiagnostics()
+    {
+        var silent = CreateSilentHub();
+        var path = silent.Address.ToString();
+
+        Func<Task> act = () => silent.GetMeshNode(path, ReadBudget).FirstAsync().ToTask();
+        var ex = (await act.Should().ThrowAsync<TimeoutException>()).Which;
+
+        Output.WriteLine($"Surfaced: {ex.Message}");
+
+        ex.Message.Should().Contain("PendingCallbacks",
+            "the timeout must carry the hub's pending-callback snapshot");
+        ex.Message.Should().Contain(nameof(GetDataRequest),
+            "the snapshot must name the outstanding request — that is what identifies a reply "
+            + "that never arrived, as opposed to a hub busy with something else");
+        ex.Message.Should().Contain("RunLevel",
+            "the snapshot must carry the hub's run level and queue state");
+    }
+
+    /// <summary>
+    /// The documented opt-out still works for callers whose contract really is
+    /// "indeterminate ⇒ treat as absent" (a cosmetic fallback, an idempotent-upsert existence
+    /// probe). Those callers pass <see cref="ReadTimeoutBehavior.EmitNull"/> explicitly — the
+    /// stall is still logged at Warning with the same diagnostics, so opting in suppresses the
+    /// exception, never the evidence.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task ReadTimesOut_WithEmitNullOptIn_StillEmitsNull()
+    {
+        var silent = CreateSilentHub();
+        var path = silent.Address.ToString();
+
+        var node = await silent
+            .GetMeshNode(path, ReadBudget, ReadTimeoutBehavior.EmitNull)
+            .FirstAsync()
+            .ToTask();
+
+        node.Should().BeNull(
+            "the explicit opt-in keeps the legacy lenient behaviour for callers that documented it");
+    }
+
+    /// <summary>
+    /// The other half of the contract: a genuine miss is NOT a timeout. Reading a path that
+    /// does not exist still resolves to <c>null</c> — promptly, via the routing NotFound
+    /// delivery failure — so the strict default costs "absent" callers nothing.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task NodeThatDoesNotExist_StillEmitsNull_Promptly()
+    {
+        var node = await ReadNode($"{TestPartition}/no-such-node-{Guid.NewGuid():N}")
+            .Should().Within(TimeSpan.FromSeconds(20)).Emit();
+
+        node.Should().BeNull("a genuine not-found must stay a null emission, not become an error");
+    }
+}


### PR DESCRIPTION
## The defect

A read that gives up knows nothing about the node — but `GetMeshNode` emitted the **same `null` the not-found path emits**, with nothing louder than a Debug log. At all 45 call sites a 60 s mesh stall was indistinguishable from an absent node: callers substituted defaults, rendered empty areas, and compiled against missing NodeType definitions.

That is exactly how `ThreadAgentIntegrationTest.FullFlow_CreateThread_SendMessage_NonStreamingResponse` failed on CI (main `89332e347`, and again on #659). From the trx:

| | target test | its 2 siblings, same class, same node | project total |
|---|---|---|---|
| Failing run | **60.27 s** ❌ | 1.15 s / 0.69 s ✅ | 332.7 s |
| Passing run | 0.51 s ✅ | 2.09 s / 0.83 s ✅ | 280.8 s |

`ReadNode` burned its full 60 s budget, returned `null`, the test never asserted the node, every assertion passed — and only the class watchdog failed it, with *"this test almost certainly ignored its CancellationToken"*, which the test had threaded correctly. The runner wasn't slow; one read stalled in an otherwise healthy process.

## The change

- **`GetMeshNode(path, timeout, onTimeout)`** — `ReadTimeoutBehavior.Throw` by default. The timeout surfaces a `TimeoutException` naming the path, elapsed time, budget and the hub's in-flight snapshot:
  ```
  GetMeshNode('ACME/ProductLaunch') timed out after 60.0s (budget 60s) — the owning
  per-node hub never answered the GetDataRequest. This is NOT 'node not found'.
  Hub mesh/xyz RunLevel=Started Queue(buffer=0,deferred=0,exec=1) …
  PendingCallbacks=1[…=GetDataRequest@ACME/ProductLaunch(59998ms)]
  ```
  Strict is the right default: the API **already** surfaced `OnError` for `Unauthorized`, so callers already needed error discipline — 8 src sites had added `.Catch`/error lambdas for that reason.
- **`EmitNull`** is the explicit opt-in for callers whose documented contract is "indeterminate ⇒ absent". It still logs at Warning — opting in suppresses the exception, never the evidence.
- **`IMessageHub.GetPendingRequestDiagnostics()`** — focused and deliberately **non-recursive**, unlike `GetDisposalDiagnostics()`, which walks the whole hosted-hub tree and is far too heavy to attach to a live timeout on a portal mesh hub.
- **`TestHardDeadline` 60 s → 90 s.** It was *equal* to `ReadNodeTimeout`, so a read that burned its budget tripped the watchdog at the same instant and the specific error could never win the race. `ReadNode` also stops mapping `TimeoutException` → `null`; NotFound → `null` is unchanged, so "absent" assertions are unaffected.

## Caller audit — all 45 src sites

- **13 already had an error sink** → unchanged.
- **8 fire-and-forget click actions → explicit `EmitNull`** (`PinLayoutArea` ×2, `UserActivityLayoutAreas` ×2, `GroupsLayoutArea` ×2, `MeshDocumentSink.DocumentExists`, `BrandingResolver`). With no error sink they would have rethrown on the CTS timer thread — an unobserved fault, precisely the failure class this removes.
- **Layout areas stay strict, deliberately**: `LayoutAreaHost.FailRendering` renders a faulted area as a visible error control, so a stall now shows the timeout instead of a false empty state.
- **One real bug fixed**: `CodeNodeType.HandleExecuteScript` answered a stalled self-read with *"Not executable"* — a lie the user cannot act on.

## Deliberately not changed

`MeshNodeCompilationService`'s three NodeType-definition reads are pinned to `EmitNull` with a comment. There is a **real defect** there — on a stalled read `ContentAs<NodeTypeDefinition>()` yields null and the compile proceeds **against a null definition** — but it runs on the hub *activation* path where compile status is cached, so making it throw would turn a transient stall into a **parked type** (the UWDeepfield outage class). That needs its own retry/park semantics and tests, not a rider on this change. It is no longer silent either way. Follow-up issue recommended.

## Tests

`GetMeshNodeTimeoutSurfacingTest` (4 cases) is **deterministic, not timing-based**: a hub whose `GetDataRequest` handler returns `Processed()` and never replies, read at its own address — the reply does not exist, so no machine speed can flake it in either direction. Cases: surfaces `TimeoutException` naming the path; the message carries the pending-callback snapshot; `EmitNull` still returns null; a genuine miss still returns null promptly.

Verified — full solution `-c Release -p:CIRun=true -warnaserror`, 0 warnings:

| Suite | Result |
|---|---|
| `Hosting.Monolith.Test` (incl. 4 new) | 398 passed, 2 skipped / 400 |
| `AI.Test` | 889 passed, 5 skipped / 894 |
| `Graph.Test` | 626 / 626 |
| `Query.Test` | 357 / 357 |
| `Security.Test` | 344 / 344 |
| `Threading.Test` | 128 / 128 |

No What's New entry: no user-visible behaviour change in normal operation — it changes what happens when the mesh is already failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
