### PR TITLE
GetMeshNode timeout: probe the target hub too, not just the reader

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1422,10 +1422,30 @@ public static class MeshNodeStreamExtensions
                 string diagnostics;
                 try { diagnostics = hub.GetPendingRequestDiagnostics(); }
                 catch (Exception diagEx) { diagnostics = $"<diagnostics unavailable: {diagEx.GetType().Name}>"; }
+                // …and the OWNER's state, which is what actually decides the verdict. The reader's
+                // snapshot alone proves only that the reader is innocent (idle queues + our request
+                // still pending = "the reply never came"), leaving "owner never activated" and
+                // "owner answered, reply lost" indistinguishable. HostedHubCreation.Never is a pure
+                // probe — a dictionary lookup that must NEVER activate the hub as a side effect of
+                // diagnosing it.
+                string targetState;
+                try
+                {
+                    targetState = string.Equals(hub.Address.ToString(), path, StringComparison.Ordinal)
+                        ? "Target: this hub itself."
+                        : hub.GetHostedHub(new Address(path), HostedHubCreation.Never) is { } owner
+                            ? $"Target: {owner.GetPendingRequestDiagnostics()}"
+                            : $"Target: NO LOCAL HUB at '{path}' — it never activated here (or is owned "
+                              + "by another silo), so no reply was ever going to be produced.";
+                }
+                catch (Exception targetEx)
+                {
+                    targetState = $"<target diagnostics unavailable: {targetEx.GetType().Name}>";
+                }
                 var message =
                     $"GetMeshNode('{path}') timed out after {elapsed.TotalSeconds:F1}s "
                     + $"(budget {budget.TotalSeconds:F0}s) — the owning per-node hub never answered the "
-                    + $"GetDataRequest. This is NOT 'node not found'. {diagnostics}";
+                    + $"GetDataRequest. This is NOT 'node not found'. Reader: {diagnostics} {targetState}";
                 // Best-effort log. This runs on the CTS timer thread and the hub (with its
                 // ServiceProvider) may already be torn down — an exception escaping here would
                 // be an unobserved fault on a pool thread, i.e. exactly the class of failure

--- a/test/MeshWeaver.Hosting.Monolith.Test/GetMeshNodeTimeoutSurfacingTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/GetMeshNodeTimeoutSurfacingTest.cs
@@ -88,6 +88,11 @@ public class GetMeshNodeTimeoutSurfacingTest(ITestOutputHelper output) : Monolit
             + "that never arrived, as opposed to a hub busy with something else");
         ex.Message.Should().Contain("RunLevel",
             "the snapshot must carry the hub's run level and queue state");
+        ex.Message.Should().Contain("Reader:",
+            "the reader's state must be labelled — it is only half the verdict");
+        ex.Message.Should().Contain("Target:",
+            "the OWNER's state is what separates 'never activated' from 'answered but the reply "
+            + "was lost'; without it the reader snapshot alone cannot close the diagnosis");
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #661, driven by what its first CI occurrence actually said.

## What #661's diagnostic proved

Verbatim from the trx of run 30242205261 (`ThreadAgentIntegrationTest.cs:280` — the `ReadNode` call itself, 60.49 s):

```
System.TimeoutException : GetMeshNode('ACME/ProductLaunch') timed out after 60.0s (budget 60s)
— the owning per-node hub never answered the GetDataRequest. This is NOT 'node not found'.
Hub mesh/ErNNufoXIke8fYHLFHYQpg RunLevel=Started Queue(buffer=0,deferred=0,exec=0)
PendingCallbacks=1[…=GetDataRequest@ACME/ProductLaunch(60000ms)]
```

The **reader is exonerated, precisely**: `RunLevel=Started`, all queues empty, and no `Executing(...)` clause at all — so it wasn't congested, blocked or starved, and its only outstanding work was our own read. The request left the reader, was routed, and the owner produced no reply in 60 s.

What the message can't yet distinguish is **why**: *owner never activated* versus *owner answered and the reply was lost*. Those need completely different fixes.

## The change

The timeout branch now probes the target as well, via `GetHostedHub(address, HostedHubCreation.Never)` — a pure dictionary lookup that must never activate the hub as a side effect of diagnosing it (`RoutingServiceBase` already uses exactly this probe). The message becomes `Reader: … Target: …` with three outcomes:

- `Target: NO LOCAL HUB at 'X' — it never activated here (or is owned by another silo), so no reply was ever going to be produced.`
- `Target: Hub X RunLevel=… Queue(…) Executing(…) PendingCallbacks=…` → activated but stuck, and on what.
- `Target: this hub itself.` → self-read, so no false "no local hub" claim.

Either of the first two closes the diagnosis on the next occurrence.

Two assertions added to `GetMeshNodeTimeoutSurfacingTest` (`Reader:` / `Target:`). Verified locally: Release `-p:CIRun=true -warnaserror` clean; `MeshWeaver.AI.Test` 889/894 (5 skipped, 0 failed); `Hosting.Monolith.Test` 398/400 (2 skipped, 0 failed).

## Where this points

The timing profile in that run puts the money on **cold activation**, not a dropped reply: the two sibling tests in the same class were already 5–10× slower than a healthy run *before* the failing one executed (11.69 s and 3.72 s vs 2.09 s and 0.83 s). Every `[Fact]` builds a fresh mesh with a fresh assembly-store root, so the class activates `ACME/ProductLaunch` — an `ACME/Project` node requiring a Roslyn compile — three times over, on a 4-core runner. That also explains `SwitchThread_IsolatesConversationState` failing the same way on a different PR: same class, same path, whichever method draws the short straw pays the cost.

No What's New entry — diagnostics only, no user-visible behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)