### PR TITLE
Course index: the whole course in the rail, exercises included — and never a link to the template

### DIFF
--- a/src/MeshWeaver.Graph/Education/EducationLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/Education/EducationLayoutAreas.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Reactive.Linq;
 using MeshWeaver.Application.Styles;
@@ -16,8 +17,9 @@ namespace MeshWeaver.Graph;
 /// <summary>
 /// The <b>edu module</b> — course/exercise layout areas shipped as standard functionality.
 ///
-/// <para>Two features, sharing one "course structure" model (the exercise's parent <em>module</em>
-/// subtree):</para>
+/// <para>Two features, sharing one "course structure" model — the learner's personal copy is the exercise's
+/// parent <em>module</em> subtree under <c>{viewer}/…</c>, and the reader shell's rail is the whole
+/// <em>course</em> (<see cref="BuildCourseNavModel"/>):</para>
 /// <list type="bullet">
 ///   <item><b><see cref="StartExercise"/></b> — the "Your Turn" landing. Resolve-or-copy: if the learner
 ///   already has a personal copy of the module under their own partition, go there; otherwise copy the
@@ -27,9 +29,9 @@ namespace MeshWeaver.Graph;
 ///   navigation-time resolve rather than a button.</item>
 ///   <item><b><see cref="Learn"/></b> — a reader shell (<c>Splitter</c>) that puts the course side-nav
 ///   (<see cref="CourseNav"/>) on the left and the page's own Overview on the right, so a learner always
-///   sees WHERE THEY ARE in the module. StartExercise lands the learner in this shell, and every nav link
-///   points back into it, so the side-nav persists as they move between pages. Same shape as
-///   <c>CodeLayoutAreas.Overview</c>.</item>
+///   sees WHERE THEY ARE in the COURSE. StartExercise lands the learner in this shell, and every nav link
+///   points back into it, so the side-nav persists as they move between pages — including while they work
+///   inside their own copy of an exercise. Same shape as <c>CodeLayoutAreas.Overview</c>.</item>
 ///   <item><b><see cref="GoToMyCopy"/></b> — the same resolve-or-copy as <see cref="StartExercise"/>, but
 ///   as an EMBEDDABLE button (<c>@@("area/GoToMyCopy")</c>) instead of an auto-redirect. A markdown course
 ///   page drops it inline: the learner sees a "Go to Exercise" button; the first press copies the module
@@ -251,8 +253,9 @@ public static class EducationLayoutAreas
     }
 
     /// <summary>
-    /// The course side-nav (table of contents) for the current page's module, with the current page
-    /// highlighted so the learner sees WHERE THEY ARE. Standalone area so it can also be embedded.
+    /// The course side-nav (table of contents) — the WHOLE course: every module as a collapsible group,
+    /// the current module expanded and the current page marked active, so the learner sees where they are
+    /// AND what else the course holds. Standalone area so it can also be embedded.
     /// </summary>
     [Browsable(false)]
     public static IObservable<UiControl?> CourseNav(LayoutAreaHost host, RenderingContext ctx)
@@ -262,51 +265,190 @@ public static class EducationLayoutAreas
     private static IObservable<UiControl> CourseNavStream(LayoutAreaHost host)
     {
         var currentPath = host.Hub.Address.ToString();
+        var viewer = ResolveViewerHome(host.Hub.ServiceProvider.GetService<AccessService>());
         var meshService = host.Hub.ServiceProvider.GetService<IMeshService>();
 
-        // Root the TOC at the current page's MODULE (its parent) — the same unit StartExercise copies, so
-        // the nav shows exactly the pages the learner has in their copy.
-        var segs = currentPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        var moduleRoot = segs.Length >= 2 ? string.Join("/", segs[..^1]) : currentPath;
+        // Root the TOC at the COURSE (the top-level partition), NOT at the current page's module — the rail
+        // is the course index, so all modules are listed however deep the learner has navigated. When the
+        // learner is working inside their own copy ({viewer}/{course}/…) the viewer prefix is stripped, so
+        // the rail still resolves to — and indexes — the CENTRAL course.
+        var courseRoot = ResolveCourseRoot(currentPath, viewer);
 
         if (meshService is null)
             return Observable.Return<UiControl>(Controls.NavMenu);
 
-        // Module + its main descendants in one live query; BuildCourseNav renders the module as the group
-        // header and its direct children as links (reactive — the nav follows adds/renames).
-        // GitHubSyncConfig (`{space}/_GitSync`) is a non-satellite internal config node — it's a real main
-        // node (MainNode == Path), so `is:main` correctly keeps it; exclude it by type here so it never
-        // appears as a learner-facing page in the rail. (See SatelliteEntityPatterns.md — the reader
-        // filters internal main-nodes; we do NOT forge a satellite MainNode on the node itself.)
-        return meshService
-            .Query<MeshNode>(MeshQueryRequest.FromQuery(
-                $"path:{moduleRoot} scope:subtree is:main -nodeType:GitHubSyncConfig"))
-            .Select(change => BuildCourseNav(moduleRoot, currentPath, change.Items));
+        // Course + its main descendants in one live query; BuildCourseNavModel turns it into the module
+        // groups (reactive — the nav follows adds/renames). Internal nodes are filtered in CODE
+        // (SelectCoursePages), not with a `-nodeType:` term: a negation-only exclusion is not honoured by
+        // every query provider — on the in-memory/static provider it empties the whole result, which would
+        // silently blank the rail.
+        var course = meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{courseRoot} scope:subtree is:main"))
+            .Scan(ImmutableDictionary<string, MeshNode>.Empty, ApplyQueryChange)
+            .Select(nodes => (IReadOnlyCollection<MeshNode>)nodes.Values.ToList());
+
+        // The viewer's OWN copies of this course, live: an exercise the learner already copied gets a direct
+        // link into that copy; one they have not gets the resolve-or-copy click (see BuildCourseNavModel).
+        // Starts empty so a slow/denied personal query can never hold the rail back — the click path is
+        // idempotent, so an under-reported copy costs nothing.
+        var personal = string.IsNullOrEmpty(viewer)
+            ? Observable.Return(NoPaths)
+            : meshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{viewer}/{courseRoot} scope:subtree is:main"))
+                .Scan(ImmutableDictionary<string, MeshNode>.Empty, ApplyQueryChange)
+                .Select(nodes => (IReadOnlySet<string>)nodes.Keys.ToHashSet(StringComparer.Ordinal))
+                .Catch((Exception _) => Observable.Return(NoPaths))
+                .StartWith(NoPaths);
+
+        return course.CombineLatest(personal, (nodes, copies) =>
+            (UiControl)RenderCourseNav(
+                BuildCourseNavModel(courseRoot, currentPath, viewer, nodes, copies)));
+    }
+
+    // A query stream reports Initial/Reset as the FULL result but Added/Updated/Removed as ONLY the changed
+    // items — so the rail folds the changes instead of re-rendering from a delta, which would blank every
+    // page the delta does not mention the moment someone adds or renames one.
+    private static ImmutableDictionary<string, MeshNode> ApplyQueryChange(
+        ImmutableDictionary<string, MeshNode> nodes, QueryResultChange<MeshNode> change)
+        => change.ChangeType switch
+        {
+            QueryChangeType.Initial or QueryChangeType.Reset => ImmutableDictionary<string, MeshNode>.Empty
+                .SetItems(change.Items.Select(n => new KeyValuePair<string, MeshNode>(n.Path, n))),
+            QueryChangeType.Removed => nodes.RemoveRange(change.Items.Select(n => n.Path)),
+            _ => nodes.SetItems(change.Items.Select(n => new KeyValuePair<string, MeshNode>(n.Path, n))),
+        };
+
+    // The empty personal-copy set — shared, never mutated (no static mutable state).
+    private static readonly IReadOnlySet<string> NoPaths = new HashSet<string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The sub-namespace under a module where exercises live — <c>{course}/{module}/Exercise/{n}</c>, the
+    /// convention <c>MeshWeaver.Courses.Configuration.ExerciseNodeType.ExerciseSubNamespace</c> declares and
+    /// the GitSync'd courses follow. Declared here rather than referenced because MeshWeaver.Graph must not
+    /// depend on MeshWeaver.Courses. The plural spelling is accepted too.
+    /// </summary>
+    public const string ExerciseSubNamespace = "Exercise";
+
+    /// <summary>
+    /// The CENTRAL course a page belongs to: the first path segment — except inside a learner's personal
+    /// copy (<c>{viewer}/{course}/…</c>), where the viewer prefix is stripped first so the rail indexes the
+    /// shared course rather than the learner's partition. Pure.
+    /// </summary>
+    /// <param name="currentPath">The full path of the page being viewed (template or personal copy).</param>
+    /// <param name="viewer">The viewer's home partition, or null/empty when there is none.</param>
+    public static string ResolveCourseRoot(string currentPath, string? viewer)
+    {
+        var source = ToSourcePath(currentPath, viewer);
+        var slash = source.IndexOf('/');
+        return slash < 0 ? source : source[..slash];
     }
 
     /// <summary>
-    /// The pages a course side-nav lists for <paramref name="moduleRoot"/>: the module's DIRECT children
+    /// The CENTRAL (template) path a page corresponds to: <paramref name="path"/> itself, or — when it sits
+    /// in the viewer's personal copy (<c>{viewer}/…</c>) — the same page in the shared course. The inverse of
+    /// <see cref="PersonalExercisePath"/>; used to mark the rail's active link and expand the current module
+    /// no matter which of the two copies the learner is reading. Pure.
+    /// </summary>
+    /// <param name="path">A page path, in the course or in the viewer's copy of it.</param>
+    /// <param name="viewer">The viewer's home partition, or null/empty when there is none.</param>
+    public static string ToSourcePath(string path, string? viewer)
+        => !string.IsNullOrEmpty(viewer) && path.StartsWith(viewer + "/", StringComparison.Ordinal)
+            ? path[(viewer.Length + 1)..]
+            : path;
+
+    /// <summary>
+    /// The path of the viewer's OWN copy of an exercise — the same target
+    /// <see cref="EnsurePersonalCopy"/> resolves to (<c>{viewer}/{exercisePath}</c>). Returns
+    /// <c>null</c> when there is no such path (no signed-in home, or the exercise is not inside
+    /// <paramref name="coursePath"/>) so a caller can never fall back to the template: <b>the rail must
+    /// never link the source exercise</b>. An already-personal path is returned unchanged (idempotent).
+    /// Pure — this is the invariant, so it is unit-testable without a mesh.
+    /// </summary>
+    /// <param name="coursePath">The central course root the exercise must live under.</param>
+    /// <param name="exercisePath">The exercise's path in the central course (or already in the copy).</param>
+    /// <param name="viewer">The viewer's home partition, or null/empty when there is none.</param>
+    public static string? PersonalExercisePath(string coursePath, string exercisePath, string? viewer)
+    {
+        if (string.IsNullOrEmpty(viewer) || string.IsNullOrEmpty(exercisePath))
+            return null;
+        if (exercisePath.StartsWith(viewer + "/", StringComparison.Ordinal))
+            return exercisePath;                     // already the learner's own copy
+        if (string.IsNullOrEmpty(coursePath)
+            || !exercisePath.StartsWith(coursePath + "/", StringComparison.Ordinal))
+            return null;                             // not part of this course — no copy to point at
+        return $"{viewer}/{exercisePath}";
+    }
+
+    /// <summary>
+    /// Whether a node is an EXERCISE — a page the learner works on in their own copy rather than reads from
+    /// the template. Two signals, both grounded in how courses are authored: an exercise node type
+    /// (<c>Exercise</c>, <c>Edu/Exercise</c>, …), or a node sitting directly in a module's
+    /// <see cref="ExerciseSubNamespace"/> folder (<c>{course}/{module}/Exercise/{n}</c>). Pure.
+    /// </summary>
+    /// <param name="node">The node to classify.</param>
+    public static bool IsExercise(MeshNode node)
+        => IsExerciseNodeType(node.NodeType) || IsExerciseSegment(ParentSegment(node.Path));
+
+    private static bool IsExerciseNodeType(string? nodeType)
+        => nodeType is not null
+           && (nodeType.Equals(ExerciseSubNamespace, StringComparison.OrdinalIgnoreCase)
+               || nodeType.EndsWith("/" + ExerciseSubNamespace, StringComparison.OrdinalIgnoreCase));
+
+    // The 'Exercise' (or 'Exercises') folder segment courses group their your-turn pages under.
+    private static bool IsExerciseSegment(ReadOnlySpan<char> segment)
+        => segment.Equals(ExerciseSubNamespace, StringComparison.OrdinalIgnoreCase)
+           || segment.Equals(ExerciseSubNamespace + "s", StringComparison.OrdinalIgnoreCase);
+
+    private static ReadOnlySpan<char> ParentSegment(string path)
+    {
+        var last = path.LastIndexOf('/');
+        if (last <= 0)
+            return [];
+        var parent = path.AsSpan(0, last);
+        var beforeParent = parent.LastIndexOf('/');
+        return beforeParent < 0 ? parent : parent[(beforeParent + 1)..];
+    }
+
+    private static ReadOnlySpan<char> LastSegment(string path)
+    {
+        var last = path.LastIndexOf('/');
+        return last < 0 ? path.AsSpan() : path.AsSpan(last + 1);
+    }
+
+    /// <summary>
+    /// The pages a course side-nav lists under <paramref name="parentPath"/>: its DIRECT children
     /// (deeper support nodes such as <c>Source/…</c> are excluded to keep the TOC a clean page list), ordered
     /// by <see cref="MeshNode.Order"/> then <see cref="MeshNode.Name"/> (case-insensitive). Internal /
     /// satellite nodes — any whose final path segment starts with <c>_</c> (<c>_GitSync</c>, <c>_Access</c>,
-    /// <c>_Thread</c>, <c>_Activity</c>, …) — are filtered out: they are plumbing, never learner-facing pages.
-    /// Pure — the nav-rendering and the ordering contract are the same function, so a test can pin the order
-    /// without reaching through the render/serialization layer.
+    /// <c>_Thread</c>, <c>_Activity</c>, …) and any <c>GitHubSyncConfig</c> (a real main node that <c>is:main</c>
+    /// keeps) — are filtered out: they are plumbing, never learner-facing pages.
+    /// Applied at every level of the rail (course → modules, module → pages, module → exercises), so one
+    /// ordering contract governs the whole index. Pure — the nav-rendering and the ordering contract are the
+    /// same function, so a test can pin the order without reaching through the render/serialization layer.
     /// </summary>
-    /// <param name="moduleRoot">The containing space (the current page's parent module) whose children are listed.</param>
-    /// <param name="mainNodes">The module + its main descendants (the <c>scope:subtree is:main</c> query result).</param>
+    /// <param name="parentPath">The containing node (course, module, or exercise folder) whose children are listed.</param>
+    /// <param name="mainNodes">The course + its main descendants (the <c>scope:subtree is:main</c> query result).</param>
     public static IReadOnlyList<MeshNode> SelectCoursePages(
-        string moduleRoot, IReadOnlyCollection<MeshNode> mainNodes)
+        string parentPath, IReadOnlyCollection<MeshNode> mainNodes)
     {
-        var prefix = moduleRoot + "/";
+        var prefix = parentPath + "/";
         return mainNodes
-            .Where(n => !string.IsNullOrEmpty(n.Path) && IsDirectChildPage(n.Path.AsSpan(), prefix))
+            .Where(n => !string.IsNullOrEmpty(n.Path)
+                        && IsDirectChildPage(n.Path.AsSpan(), prefix)
+                        && !GitHubSyncConfigNodeType.Equals(n.NodeType, StringComparison.OrdinalIgnoreCase))
             .OrderBy(n => n.Order)
             .ThenBy(n => n.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
 
-    // A direct-child PAGE of the module: sits immediately under moduleRoot (no deeper), and its own segment
+    // `{space}/_GitSync` is a non-satellite internal config node — it's a real main node (MainNode == Path),
+    // so `is:main` keeps it; drop it by type so it never shows up as a learner-facing page in the rail. (See
+    // SatelliteEntityPatterns.md — the READER filters internal main-nodes; we do NOT forge a satellite
+    // MainNode on the node itself.) Mirrors GitHubSyncService.ConfigNodeType, which MeshWeaver.Graph cannot
+    // reference.
+    private const string GitHubSyncConfigNodeType = "GitHubSyncConfig";
+
+    // A direct-child PAGE of the parent: sits immediately under it (no deeper), and its own segment
     // is not an internal/satellite node (leading '_' — _GitSync, _Access, _Thread, …).
     private static bool IsDirectChildPage(ReadOnlySpan<char> path, string prefix)
     {
@@ -316,33 +458,251 @@ public static class EducationLayoutAreas
         return segment.Length > 0 && !segment.Contains('/') && segment[0] != '_';
     }
 
-    private static UiControl BuildCourseNav(
-        string moduleRoot, string currentPath, IReadOnlyCollection<MeshNode> mainNodes)
+    /// <summary>
+    /// One entry in the course rail. Either a plain <b>page</b> link into the shared course, or an
+    /// <b>exercise</b> that resolves into the learner's OWN copy — never the template
+    /// (<see cref="PersonalExercisePath"/>).
+    /// </summary>
+    /// <param name="Title">The label shown in the rail.</param>
+    /// <param name="SourcePath">The node in the CENTRAL course this entry stands for (its identity).</param>
+    /// <param name="Href">Where the link navigates, or <c>null</c> when the target must be resolved on click.</param>
+    /// <param name="ResolveFromPath">The source path to run <see cref="EnsurePersonalCopy"/> on when clicked
+    /// (set only when <paramref name="Href"/> is null); <c>null</c> together with a null Href means the entry
+    /// is listed but not navigable — the rail shows the exercise exists without ever linking the template.</param>
+    /// <param name="IsActive">Whether this entry is the page currently being read.</param>
+    /// <param name="IsExercise">Whether this entry is an exercise (personal-copy target) rather than a page.</param>
+    /// <param name="Icon">The node's icon, or null.</param>
+    public sealed record CourseNavLink(
+        string Title,
+        string SourcePath,
+        string? Href,
+        string? ResolveFromPath,
+        bool IsActive,
+        bool IsExercise,
+        string? Icon);
+
+    /// <summary>One module of the course rail: a collapsible group of page + exercise links.</summary>
+    /// <param name="Title">The module's name (the group heading).</param>
+    /// <param name="Path">The module's path in the central course.</param>
+    /// <param name="Expanded">Whether the group renders expanded — true only for the module being read, so a
+    /// long course stays scannable.</param>
+    /// <param name="Links">The module home, its pages, then its exercises (each ordered by Order then Name).</param>
+    public sealed record CourseNavModule(
+        string Title,
+        string Path,
+        bool Expanded,
+        IReadOnlyList<CourseNavLink> Links);
+
+    /// <summary>
+    /// The whole course index the rail renders: the course home, any course-level pages, and every module.
+    /// A pure value — <see cref="BuildCourseNavModel"/> computes it and <see cref="RenderCourseNav"/> renders
+    /// it, so the structure, ordering, expansion and link-target invariants are testable without a renderer.
+    /// </summary>
+    /// <param name="CoursePath">The central course root the rail is indexed on.</param>
+    /// <param name="Home">The course home link.</param>
+    /// <param name="Pages">Course-level pages that are not modules (childless direct children, e.g. a cover).</param>
+    /// <param name="Modules">Every module of the course, ordered by Order then Name.</param>
+    public sealed record CourseNavModel(
+        string CoursePath,
+        CourseNavLink Home,
+        IReadOnlyList<CourseNavLink> Pages,
+        IReadOnlyList<CourseNavModule> Modules);
+
+    /// <summary>
+    /// Builds the whole course index from one <c>scope:subtree</c> query result. Pure and total:
+    /// <list type="bullet">
+    ///   <item>EVERY module of the course is listed (a direct child that has children), ordered by
+    ///   <see cref="MeshNode.Order"/> then name; a childless direct child is a course-level page.</item>
+    ///   <item>Only the module containing the current page is <see cref="CourseNavModule.Expanded"/>, and the
+    ///   current page's link is <see cref="CourseNavLink.IsActive"/> — computed on the CENTRAL path, so it
+    ///   holds while the learner reads their own copy.</item>
+    ///   <item>Exercises (<see cref="IsExercise"/>, including everything in a module's
+    ///   <see cref="ExerciseSubNamespace"/> folder) link into the learner's own copy: a direct href when the
+    ///   copy exists (<paramref name="personalPaths"/>), otherwise a resolve-or-copy click. NEVER the
+    ///   template.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="coursePath">The central course root (see <see cref="ResolveCourseRoot"/>).</param>
+    /// <param name="currentPath">The page being read — the template page or the learner's copy of it.</param>
+    /// <param name="viewer">The viewer's home partition, or null/empty when there is none.</param>
+    /// <param name="mainNodes">The course + its main descendants (<c>path:{course} scope:subtree is:main</c>).</param>
+    /// <param name="personalPaths">The paths that exist in the viewer's own copy of the course (may be empty).</param>
+    public static CourseNavModel BuildCourseNavModel(
+        string coursePath,
+        string currentPath,
+        string? viewer,
+        IReadOnlyCollection<MeshNode> mainNodes,
+        IReadOnlySet<string> personalPaths)
     {
-        var root = mainNodes.FirstOrDefault(n => string.Equals(n.Path, moduleRoot, StringComparison.Ordinal));
-        var groupTitle = root?.Name ?? moduleRoot.Split('/').Last();
+        // Everything is compared on the CENTRAL path: a learner reading {viewer}/{course}/… is on the same
+        // page of the same course, so their rail highlights and expands exactly like the template's.
+        var current = ToSourcePath(currentPath, viewer);
 
-        // Direct children of the module = the pages (ordered by Order then Name).
-        var pages = SelectCoursePages(moduleRoot, mainNodes);
+        var root = mainNodes.FirstOrDefault(n => string.Equals(n.Path, coursePath, StringComparison.Ordinal));
+        var home = new CourseNavLink(
+            root?.Name ?? new string(LastSegment(coursePath)),
+            coursePath,
+            LearnHref(coursePath),
+            null,
+            string.Equals(current, coursePath, StringComparison.Ordinal),
+            false,
+            root?.Icon);
 
-        var group = new NavGroupControl(groupTitle).WithSkin(s => s.WithExpanded(true));
+        var pages = new List<CourseNavLink>();
+        var modules = new List<CourseNavModule>();
 
-        // Module home first (active when we're on the module root itself).
-        group = group.WithView(
-            new NavLinkControl(groupTitle, root?.Icon, new LayoutAreaReference(LearnArea).ToHref(moduleRoot))
-                .WithIsActive(string.Equals(currentPath, moduleRoot, StringComparison.Ordinal)));
-
-        foreach (var page in pages)
+        foreach (var child in SelectCoursePages(coursePath, mainNodes))
         {
-            var href = new LayoutAreaReference(LearnArea).ToHref(page.Path);
-            group = group.WithView(
-                new NavLinkControl(page.Name ?? page.Id, page.Icon, href)
-                    .WithIsActive(string.Equals(currentPath, page.Path, StringComparison.Ordinal)));
+            var childPages = SelectCoursePages(child.Path, mainNodes);
+            if (childPages.Count == 0)
+            {
+                // A leaf directly under the course — a cover/outline page, not a module.
+                pages.Add(PageLink(child, current));
+                continue;
+            }
+
+            modules.Add(BuildModule(child, childPages, coursePath, current, viewer, mainNodes, personalPaths));
         }
 
-        return Controls.NavMenu
+        return new CourseNavModel(coursePath, home, pages, modules);
+    }
+
+    private static CourseNavModule BuildModule(
+        MeshNode module,
+        IReadOnlyList<MeshNode> modulePages,
+        string coursePath,
+        string current,
+        string? viewer,
+        IReadOnlyCollection<MeshNode> mainNodes,
+        IReadOnlySet<string> personalPaths)
+    {
+        var title = module.Name ?? module.Id;
+        var links = new List<CourseNavLink>
+        {
+            // Module home first (active when we're on the module root itself).
+            new(title, module.Path, LearnHref(module.Path), null,
+                string.Equals(current, module.Path, StringComparison.Ordinal), false, module.Icon)
+        };
+
+        // Exercises are collected separately so they always land at the END of the module — the reading
+        // pages first, then the "your turn" list.
+        var exercises = new List<CourseNavLink>();
+
+        foreach (var page in modulePages)
+        {
+            if (IsExerciseSegment(LastSegment(page.Path)))
+            {
+                // The module's Exercise/ folder: its children ARE the exercises, so the folder's own index
+                // page is replaced by them rather than listed alongside. With no children the node is not a
+                // folder at all — it IS the module's single exercise.
+                var contained = SelectCoursePages(page.Path, mainNodes);
+                exercises.AddRange(contained.Count > 0
+                    ? contained.Select(x => ExerciseLink(x, coursePath, current, viewer, personalPaths))
+                    : [ExerciseLink(page, coursePath, current, viewer, personalPaths)]);
+                continue;
+            }
+
+            if (IsExercise(page))
+            {
+                exercises.Add(ExerciseLink(page, coursePath, current, viewer, personalPaths));
+                continue;
+            }
+
+            links.Add(PageLink(page, current));
+        }
+
+        links.AddRange(exercises);
+
+        // Expanded only for the module the learner is inside (its own page, one of its pages, or one of its
+        // exercises) — an 18-module course stays a scannable list rather than a wall of links.
+        var expanded = string.Equals(current, module.Path, StringComparison.Ordinal)
+                       || current.StartsWith(module.Path + "/", StringComparison.Ordinal);
+
+        return new CourseNavModule(title, module.Path, expanded, links);
+    }
+
+    private static CourseNavLink PageLink(MeshNode page, string current)
+        => new(page.Name ?? page.Id, page.Path, LearnHref(page.Path), null,
+            string.Equals(current, page.Path, StringComparison.Ordinal), false, page.Icon);
+
+    // An exercise entry. NEVER links the template: it points at the learner's own copy when that copy
+    // exists, and otherwise carries the resolve-or-copy source for the click (the same EnsurePersonalCopy
+    // GoToMyCopy runs), so the first click creates the copy and lands there.
+    private static CourseNavLink ExerciseLink(
+        MeshNode exercise,
+        string coursePath,
+        string current,
+        string? viewer,
+        IReadOnlySet<string> personalPaths)
+    {
+        var personal = PersonalExercisePath(coursePath, exercise.Path, viewer);
+        var hasCopy = personal is not null && personalPaths.Contains(personal);
+        return new CourseNavLink(
+            exercise.Name ?? exercise.Id,
+            exercise.Path,
+            hasCopy ? LearnHref(personal!) : null,
+            hasCopy || personal is null ? null : exercise.Path,
+            string.Equals(current, exercise.Path, StringComparison.Ordinal),
+            true,
+            exercise.Icon);
+    }
+
+    private static string LearnHref(string path) => new LayoutAreaReference(LearnArea).ToHref(path);
+
+    /// <summary>
+    /// Renders a <see cref="CourseNavModel"/> as the rail: the course home, its course-level pages, then one
+    /// collapsible <see cref="NavGroupControl"/> per module. A link with no href but a
+    /// <see cref="CourseNavLink.ResolveFromPath"/> becomes a click that runs
+    /// <see cref="EnsurePersonalCopy"/> and navigates into the resulting copy — so an exercise the learner
+    /// has not started yet is still one click away, without the rail ever emitting a template href.
+    /// </summary>
+    /// <param name="model">The course index to render.</param>
+    public static NavMenuControl RenderCourseNav(CourseNavModel model)
+    {
+        var menu = Controls.NavMenu
             .WithSkin(s => s.WithWidth(300).WithCollapsible(false))
-            .WithNavGroup(group);
+            .WithNavLink(RenderNavLink(model.Home));
+
+        foreach (var page in model.Pages)
+            menu = menu.WithNavLink(RenderNavLink(page));
+
+        foreach (var module in model.Modules)
+        {
+            var group = new NavGroupControl(module.Title).WithSkin(s => s.WithExpanded(module.Expanded));
+            foreach (var link in module.Links)
+                group = group.WithView(RenderNavLink(link));
+            menu = menu.WithNavGroup(group);
+        }
+
+        return menu;
+    }
+
+    private static NavLinkControl RenderNavLink(CourseNavLink link)
+    {
+        var control = new NavLinkControl(link.Title, link.Icon, link.Href).WithIsActive(link.IsActive);
+        if (link.Href is not null || link.ResolveFromPath is null)
+            return control;
+
+        // No copy yet: resolve-or-copy on click (idempotent), exactly like the GoToMyCopy button — and with
+        // no href, so the rail cannot navigate to the template even by accident.
+        var source = link.ResolveFromPath;
+        return control.WithClickAction(ctx =>
+        {
+            var hub = ctx.Host.Hub;
+            var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+                ?.CreateLogger("MeshWeaver.Graph.Education");
+            EnsurePersonalCopy(hub, source).Subscribe(
+                landing => ctx.NavigateTo(LearnHref(landing)),
+                ex =>
+                {
+                    logger?.LogWarning(ex, "CourseNav: could not open the personal copy of {Source}", source);
+                    ctx.Host.UpdateArea(DialogControl.DialogArea, Controls.Dialog(
+                            Controls.Markdown($"**Couldn't open your copy:**\n\n{ex.Message}"),
+                            "Go to Exercise")
+                        .WithSize("M").WithClosable(true));
+                });
+            return Task.CompletedTask;
+        });
     }
 
     private static UiControl RedirectToLearn(string path) =>

--- a/test/MeshWeaver.AI.Test/EducationStartExerciseTest.cs
+++ b/test/MeshWeaver.AI.Test/EducationStartExerciseTest.cs
@@ -38,8 +38,10 @@ namespace MeshWeaver.AI.Test;
 ///   <item>The embeddable <see cref="EducationLayoutAreas.GoToMyCopy"/> button renders a "Go to Exercise"
 ///   button for a read-only learner (the click's resolve-or-copy logic, <see cref="EducationLayoutAreas.EnsurePersonalCopy"/>,
 ///   creates the copy once and is idempotent thereafter).</item>
-///   <item><see cref="EducationLayoutAreas.CourseNav"/> lists the containing space's child pages ordered by
-///   <c>Order</c>, and the <see cref="EducationLayoutAreas.Learn"/> reader shell's nav pane is
+///   <item><see cref="EducationLayoutAreas.CourseNav"/> indexes the WHOLE course — every module as a group
+///   ordered by <c>Order</c>, only the current one expanded, the current page active (also while the learner
+///   reads their own copy), and each exercise resolving into <c>{viewer}/…</c> and NEVER into the central
+///   template — and the <see cref="EducationLayoutAreas.Learn"/> reader shell's nav pane is
 ///   collapsible.</item>
 /// </list>
 /// </summary>
@@ -63,17 +65,33 @@ public class EducationStartExerciseTest(ITestOutputHelper output) : MonolithMesh
                         Roles = [new RoleAssignment { Role = "Viewer" }]
                     }
                 },
-                // A minimal course: landing → module → two pages. Ex1 ("Your Turn") is given a LOWER Order
+                // A minimal course: landing → TWO modules → pages. Ex1 ("Your Turn") is given a LOWER Order
                 // than Solutions even though its name sorts AFTER — so the CourseNav ordering test can prove
-                // the nav follows Order, not the alphabet.
+                // the nav follows Order, not the alphabet. Module2 ("Advanced") sorts BEFORE "Module 1"
+                // alphabetically but carries a higher Order, so the module ordering is pinned the same way.
                 new MeshNode("TestCourse")
                 { Name = "Test Course", NodeType = "Markdown", Content = new MarkdownContent { Content = "# Test Course" } },
+                // A childless direct child of the course: a course-level PAGE, not a module.
+                new MeshNode("Intro", "TestCourse")
+                { Name = "Introduction", NodeType = "Markdown", Order = 0, Content = new MarkdownContent { Content = "# Intro" } },
                 new MeshNode("Module1", "TestCourse")
-                { Name = "Module 1", NodeType = "Markdown", Content = new MarkdownContent { Content = "# Module 1" } },
+                { Name = "Module 1", NodeType = "Markdown", Order = 1, Content = new MarkdownContent { Content = "# Module 1" } },
                 new MeshNode("Ex1", "TestCourse/Module1")
                 { Name = "Your Turn", NodeType = "Markdown", Order = 1, Content = new MarkdownContent { Content = "# Exercises" } },
                 new MeshNode("Solutions", "TestCourse/Module1")
-                { Name = "Solutions", NodeType = "Markdown", Order = 2, Content = new MarkdownContent { Content = "# Solutions" } }
+                { Name = "Solutions", NodeType = "Markdown", Order = 2, Content = new MarkdownContent { Content = "# Solutions" } },
+                new MeshNode("Module2", "TestCourse")
+                { Name = "Advanced", NodeType = "Markdown", Order = 2, Content = new MarkdownContent { Content = "# Advanced" } },
+                new MeshNode("Theory", "TestCourse/Module2")
+                { Name = "Theory", NodeType = "Markdown", Order = 1, Content = new MarkdownContent { Content = "# Theory" } },
+                // The module's Exercise/ sub-namespace — the convention real courses use
+                // ({course}/{module}/Exercise/{n}); its CHILDREN are the exercises.
+                new MeshNode("Exercise", "TestCourse/Module2")
+                { Name = "Exercises", NodeType = "Markdown", Order = 5, Content = new MarkdownContent { Content = "# Exercises" } },
+                new MeshNode("Drill1", "TestCourse/Module2/Exercise")
+                { Name = "Drill One", NodeType = "Markdown", Order = 1, Content = new MarkdownContent { Content = "# Drill 1" } },
+                new MeshNode("Drill2", "TestCourse/Module2/Exercise")
+                { Name = "Drill Two", NodeType = "Markdown", Order = 2, Content = new MarkdownContent { Content = "# Drill 2" } }
             );
 
     // The layout-client config so GetClient().GetWorkspace() + GetControlStream can render an area to a
@@ -231,6 +249,9 @@ public class EducationStartExerciseTest(ITestOutputHelper output) : MonolithMesh
     {
         // The nav rail is learner-facing: internal / satellite nodes (any whose final path segment starts
         // with '_' — _GitSync, _Access, _Thread, _Activity, …) are plumbing and must NOT appear as pages.
+        // A GitHubSyncConfig is dropped BY TYPE too — it is a real main node that `is:main` keeps, and the
+        // exclusion lives here rather than as a `-nodeType:` query term (a negation-only term is not honoured
+        // by every provider — on the in-memory one it empties the whole result and blanks the rail).
         const string moduleRoot = "TestCourse/Module1";
         var nodes = new[]
         {
@@ -239,6 +260,8 @@ public class EducationStartExerciseTest(ITestOutputHelper output) : MonolithMesh
             new MeshNode("_GitSync", moduleRoot) { Name = "GitHub Sync", Order = 2 }, // internal — filtered
             new MeshNode("TDD", moduleRoot) { Name = "TDD", Order = 3 },
             new MeshNode("_Access", moduleRoot) { Name = "Access", Order = 4 },        // satellite — filtered
+            new MeshNode("Sync", moduleRoot)                                           // by TYPE — filtered
+            { Name = "Sync", Order = 5, NodeType = "GitHubSyncConfig" },
         };
 
         var pages = EducationLayoutAreas.SelectCoursePages(moduleRoot, nodes);
@@ -247,6 +270,287 @@ public class EducationStartExerciseTest(ITestOutputHelper output) : MonolithMesh
         pages.Select(p => p.Path).Should().Equal(
             "TestCourse/Module1/Intro",
             "TestCourse/Module1/TDD");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task CourseNav_IndexesTheWholeCourse_EveryModuleInOrder()
+    {
+        // The rail is the COURSE index, not the current module: reading a page of Module 1 must still list
+        // EVERY module. Modules come back in Order sequence — "Advanced" (Order 2) after "Module 1"
+        // (Order 1), the REVERSE of alphabetical, proving the module list follows Order, not the name.
+        var nodes = await QueryCourseSubtree();
+
+        var model = EducationLayoutAreas.BuildCourseNavModel(
+            "TestCourse", "TestCourse/Module1/Ex1", LearnerId, nodes, NoCopies);
+
+        model.CoursePath.Should().Be("TestCourse");
+        model.Home.SourcePath.Should().Be("TestCourse");
+        model.Home.Href.Should().Be($"TestCourse/{EducationLayoutAreas.LearnArea}");
+        model.Modules.Select(m => m.Path).Should().Equal("TestCourse/Module1", "TestCourse/Module2");
+        model.Modules.Select(m => m.Title).Should().Equal("Module 1", "Advanced");
+        // A childless direct child of the course is a course-level PAGE, not an (empty) module group.
+        model.Pages.Select(p => p.SourcePath).Should().Equal("TestCourse/Intro");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task CourseNav_CurrentModuleExpanded_OtherModulesCollapsed_AndCurrentPageActive()
+    {
+        // "Where am I": only the module being read is expanded (an 18-module course stays scannable) and the
+        // page being read is the one active link.
+        var nodes = await QueryCourseSubtree();
+
+        var model = EducationLayoutAreas.BuildCourseNavModel(
+            "TestCourse", "TestCourse/Module1/Ex1", LearnerId, nodes, NoCopies);
+
+        var module1 = model.Modules.Single(m => m.Path == "TestCourse/Module1");
+        var module2 = model.Modules.Single(m => m.Path == "TestCourse/Module2");
+        module1.Expanded.Should().BeTrue("the learner is reading a page of Module 1");
+        module2.Expanded.Should().BeFalse("every other module stays collapsed");
+
+        // Module home first, then its pages in Order sequence.
+        module1.Links.Select(l => l.SourcePath).Should().Equal(
+            "TestCourse/Module1", "TestCourse/Module1/Ex1", "TestCourse/Module1/Solutions");
+        AllLinks(model).Where(l => l.IsActive).Select(l => l.SourcePath)
+            .Should().Equal("TestCourse/Module1/Ex1");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task CourseNav_FromThePersonalCopy_StillIndexesTheCourse_AndKnowsWhereYouAre()
+    {
+        // Working inside your OWN copy ({viewer}/{course}/…) must not shrink the rail to your partition:
+        // the index is still the shared course, and the page you are editing is still the active link.
+        var nodes = await QueryCourseSubtree();
+        const string inMyCopy = $"{LearnerId}/TestCourse/Module1/Ex1";
+
+        EducationLayoutAreas.ResolveCourseRoot(inMyCopy, LearnerId).Should().Be("TestCourse");
+
+        var model = EducationLayoutAreas.BuildCourseNavModel(
+            "TestCourse", inMyCopy, LearnerId, nodes, NoCopies);
+
+        model.Modules.Select(m => m.Path).Should().Equal("TestCourse/Module1", "TestCourse/Module2");
+        model.Modules.Single(m => m.Path == "TestCourse/Module1").Expanded.Should().BeTrue();
+        AllLinks(model).Where(l => l.IsActive).Select(l => l.SourcePath)
+            .Should().Equal("TestCourse/Module1/Ex1");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task CourseNav_ListsExercises_AndNeverLinksTheCourseTemplate()
+    {
+        // Exercises ({course}/{module}/Exercise/{n}) are listed under their module — but a learner must NEVER
+        // be sent to the read-only template. With no copy yet the entry carries the resolve-or-copy source
+        // (the click runs EnsurePersonalCopy, exactly like GoToMyCopy) and NO href at all.
+        var nodes = await QueryCourseSubtree();
+
+        var model = EducationLayoutAreas.BuildCourseNavModel(
+            "TestCourse", "TestCourse/Module2/Theory", LearnerId, nodes, NoCopies);
+
+        var module2 = model.Modules.Single(m => m.Path == "TestCourse/Module2");
+        // Pages first, then the exercises — and the Exercise/ FOLDER is replaced by its children, never
+        // listed alongside them.
+        module2.Links.Select(l => l.SourcePath).Should().Equal(
+            "TestCourse/Module2",
+            "TestCourse/Module2/Theory",
+            "TestCourse/Module2/Exercise/Drill1",
+            "TestCourse/Module2/Exercise/Drill2");
+        module2.Links.Where(l => l.IsExercise).Select(l => l.Title).Should().Equal("Drill One", "Drill Two");
+
+        var exercises = AllLinks(model).Where(l => l.IsExercise).ToList();
+        exercises.Should().HaveCount(2);
+        exercises.Should().OnlyContain(l => l.Href == null,
+            "with no personal copy yet the entry resolves on click — it never gets a template href");
+        exercises.Select(l => l.ResolveFromPath).Should().Equal(
+            "TestCourse/Module2/Exercise/Drill1", "TestCourse/Module2/Exercise/Drill2");
+
+        // THE invariant: no exercise link the rail emits points into the central course.
+        AssertNoExerciseLinksTheTemplate(model, "TestCourse");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task CourseNav_ExerciseWithAPersonalCopy_LinksIntoThatCopy()
+    {
+        // Once the copy exists the entry becomes a real href — into {viewer}/…, still never the template.
+        var nodes = await QueryCourseSubtree();
+        var copies = new HashSet<string>(StringComparer.Ordinal)
+        {
+            $"{LearnerId}/TestCourse/Module2/Exercise",
+            $"{LearnerId}/TestCourse/Module2/Exercise/Drill1",
+        };
+
+        var model = EducationLayoutAreas.BuildCourseNavModel(
+            "TestCourse", "TestCourse/Module2/Theory", LearnerId, nodes, copies);
+
+        var exercises = AllLinks(model).Where(l => l.IsExercise).ToList();
+        var drill1 = exercises.Single(l => l.SourcePath == "TestCourse/Module2/Exercise/Drill1");
+        drill1.Href.Should().Be($"{LearnerId}/TestCourse/Module2/Exercise/Drill1/{EducationLayoutAreas.LearnArea}");
+        drill1.ResolveFromPath.Should().BeNull("the copy exists — nothing left to resolve");
+
+        // The one WITHOUT a copy still resolves on click.
+        var drill2 = exercises.Single(l => l.SourcePath == "TestCourse/Module2/Exercise/Drill2");
+        drill2.Href.Should().BeNull();
+        drill2.ResolveFromPath.Should().Be("TestCourse/Module2/Exercise/Drill2");
+
+        AssertNoExerciseLinksTheTemplate(model, "TestCourse");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task CourseNav_AnonymousViewer_ListsExercises_WithoutLinkingTheTemplate()
+    {
+        // No writable home → no personal copy is possible. The exercise is still listed (the index stays
+        // complete) but it is NOT navigable: linking the template is the one thing we never do.
+        var nodes = await QueryCourseSubtree();
+
+        var model = EducationLayoutAreas.BuildCourseNavModel(
+            "TestCourse", "TestCourse/Module2/Theory", viewer: null, nodes, NoCopies);
+
+        var exercises = AllLinks(model).Where(l => l.IsExercise).ToList();
+        exercises.Should().HaveCount(2);
+        exercises.Should().OnlyContain(l => l.Href == null && l.ResolveFromPath == null);
+        AssertNoExerciseLinksTheTemplate(model, "TestCourse");
+
+        // The reading pages are unaffected — an anonymous visitor still browses the course itself.
+        model.Home.Href.Should().Be($"TestCourse/{EducationLayoutAreas.LearnArea}");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task CourseNav_Area_RendersTheWholeCourseRail_OnAModulePage()
+    {
+        // End-to-end through the real area (the course query + the viewer's-copies query + the render),
+        // deserialized exactly as the browser receives it: a NavMenu with the course home, the course-level
+        // page, and ONE GROUP PER MODULE — proof the rail is no longer scoped to the current module.
+        // The rail is LIVE, so we wait for the emission that has the full index rather than pinning the
+        // first one (the query index is eventually consistent right after mesh start).
+        var control = await RenderControl(
+            EducationLayoutAreas.CourseNavArea, c => c is NavMenuControl { Areas.Count: 4 });
+
+        var menu = control.Should().BeOfType<NavMenuControl>("the course rail is a NavMenu").Subject;
+        menu.Areas.Count.Should().Be(4,
+            "course home + the Introduction page + one group for each of the two modules");
+    }
+
+    [Fact]
+    public void PersonalExercisePath_ResolvesToTheViewersCopy_OrNothing()
+    {
+        // The "never link the source" invariant, pinned on the pure helper.
+        EducationLayoutAreas.PersonalExercisePath("Course", "Course/M1/Exercise/Drill", "u1")
+            .Should().Be("u1/Course/M1/Exercise/Drill");
+        // Already the viewer's copy → unchanged (idempotent).
+        EducationLayoutAreas.PersonalExercisePath("Course", "u1/Course/M1/Exercise/Drill", "u1")
+            .Should().Be("u1/Course/M1/Exercise/Drill");
+        // No writable home → no personal path exists; the caller must NOT fall back to the source.
+        EducationLayoutAreas.PersonalExercisePath("Course", "Course/M1/Exercise/Drill", null)
+            .Should().BeNull();
+        EducationLayoutAreas.PersonalExercisePath("Course", "Course/M1/Exercise/Drill", "")
+            .Should().BeNull();
+        // Outside the course (or the course root itself) → null, never the source path.
+        EducationLayoutAreas.PersonalExercisePath("Course", "Other/M1/Drill", "u1").Should().BeNull();
+        EducationLayoutAreas.PersonalExercisePath("Course", "Course", "u1").Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveCourseRoot_StripsTheViewerPartition()
+    {
+        // The rail is rooted at the COURSE — the first segment of the CENTRAL path, so a learner working in
+        // their own copy still gets the shared course index.
+        EducationLayoutAreas.ResolveCourseRoot("Course/M1/Page", null).Should().Be("Course");
+        EducationLayoutAreas.ResolveCourseRoot("u1/Course/M1/Page", "u1").Should().Be("Course");
+        // A different partition that merely LOOKS like the viewer's is not stripped.
+        EducationLayoutAreas.ResolveCourseRoot("u12/Course/M1", "u1").Should().Be("u12");
+        EducationLayoutAreas.ResolveCourseRoot("Course", "u1").Should().Be("Course");
+        EducationLayoutAreas.ToSourcePath("u1/Course/M1", "u1").Should().Be("Course/M1");
+        EducationLayoutAreas.ToSourcePath("Course/M1", "u1").Should().Be("Course/M1");
+    }
+
+    [Fact]
+    public void IsExercise_MatchesNodeType_AndTheExerciseSubNamespace()
+    {
+        // Two signals: an exercise NODE TYPE (the Edu/Exercise plugin type, or core's "Exercise"), and the
+        // {course}/{module}/Exercise/{n} folder convention.
+        EducationLayoutAreas.IsExercise(
+            new MeshNode("Kata", "Course/M1") { NodeType = "Edu/Exercise" }).Should().BeTrue();
+        EducationLayoutAreas.IsExercise(
+            new MeshNode("Kata", "Course/M1") { NodeType = "Exercise" }).Should().BeTrue();
+        EducationLayoutAreas.IsExercise(
+            new MeshNode("Drill", "Course/M1/Exercise") { NodeType = "Markdown" }).Should().BeTrue();
+        EducationLayoutAreas.IsExercise(
+            new MeshNode("Drill", "Course/M1/Exercises") { NodeType = "Markdown" }).Should().BeTrue();
+        // A reading page — and the exercise FOLDER itself — are not exercises.
+        EducationLayoutAreas.IsExercise(
+            new MeshNode("Theory", "Course/M1") { NodeType = "Markdown" }).Should().BeFalse();
+        EducationLayoutAreas.IsExercise(
+            new MeshNode("Exercise", "Course/M1") { NodeType = "Markdown" }).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CourseNav_ExercisesByNodeType_AreListedLast_AndTargetThePersonalCopy()
+    {
+        // An exercise identified by NODE TYPE (no Exercise/ folder) is treated the same: listed after the
+        // reading pages, resolving into the learner's own copy.
+        var nodes = new[]
+        {
+            new MeshNode("Course") { Name = "Course" },
+            new MeshNode("M1", "Course") { Name = "Module 1", Order = 1 },
+            new MeshNode("Kata", "Course/M1") { Name = "Kata", NodeType = "Edu/Exercise", Order = 1 },
+            new MeshNode("Theory", "Course/M1") { Name = "Theory", NodeType = "Markdown", Order = 2 },
+        };
+
+        var model = EducationLayoutAreas.BuildCourseNavModel(
+            "Course", "Course/M1", "u1", nodes,
+            new HashSet<string>(StringComparer.Ordinal) { "u1/Course/M1/Kata" });
+
+        var module = model.Modules.Single();
+        module.Links.Select(l => l.SourcePath).Should().Equal(
+            "Course/M1", "Course/M1/Theory", "Course/M1/Kata");
+        module.Links.Last().Href.Should().Be($"u1/Course/M1/Kata/{EducationLayoutAreas.LearnArea}");
+        AssertNoExerciseLinksTheTemplate(model, "Course");
+    }
+
+    [Fact]
+    public void CourseNav_ALoneExerciseLeaf_IsTheExercise_NotAFolder()
+    {
+        // A module whose "Exercise" child has no children of its own is not a FOLDER of exercises — it IS the
+        // module's exercise, and must still resolve into the learner's copy rather than vanish from the rail.
+        var nodes = new[]
+        {
+            new MeshNode("Course") { Name = "Course" },
+            new MeshNode("M1", "Course") { Name = "Module 1", Order = 1 },
+            new MeshNode("Theory", "Course/M1") { Name = "Theory", Order = 1 },
+            new MeshNode("Exercise", "Course/M1") { Name = "Your Turn", Order = 2 },
+        };
+
+        var model = EducationLayoutAreas.BuildCourseNavModel("Course", "Course/M1", "u1", nodes, NoCopies);
+
+        var module = model.Modules.Single();
+        module.Links.Select(l => l.SourcePath).Should().Equal(
+            "Course/M1", "Course/M1/Theory", "Course/M1/Exercise");
+        var exercise = module.Links.Single(l => l.IsExercise);
+        exercise.Href.Should().BeNull();
+        exercise.ResolveFromPath.Should().Be("Course/M1/Exercise");
+        AssertNoExerciseLinksTheTemplate(model, "Course");
+    }
+
+    [Fact]
+    public void RenderCourseNav_EmitsHomeLink_CoursePages_AndOneGroupPerModule()
+    {
+        // The renderer is a straight projection of the model: home + course-level pages + one collapsible
+        // group per module.
+        var nodes = new[]
+        {
+            new MeshNode("Course") { Name = "Course" },
+            new MeshNode("Cover", "Course") { Name = "Cover", Order = 0 },
+            new MeshNode("M1", "Course") { Name = "Module 1", Order = 1 },
+            new MeshNode("Page", "Course/M1") { Name = "Page", Order = 1 },
+            new MeshNode("M2", "Course") { Name = "Module 2", Order = 2 },
+            new MeshNode("Page", "Course/M2") { Name = "Page", Order = 1 },
+        };
+        var model = EducationLayoutAreas.BuildCourseNavModel(
+            "Course", "Course/M1/Page", "u1", nodes, NoCopies);
+
+        var menu = EducationLayoutAreas.RenderCourseNav(model);
+
+        menu.Should().BeOfType<NavMenuControl>();
+        menu.Areas.Count.Should().Be(1 + model.Pages.Count + model.Modules.Count,
+            "one area for the course home, one per course-level page, one per module group");
+        model.Modules.Should().HaveCount(2);
     }
 
     [Fact(Timeout = 120_000)]
@@ -264,9 +568,38 @@ public class EducationStartExerciseTest(ITestOutputHelper output) : MonolithMesh
         paneSkin!.Collapsible.Should().Be(true, "the course side-nav pane is collapsible");
     }
 
+    // No personal copies of the course exist yet — the state a learner starts in.
+    private static readonly IReadOnlySet<string> NoCopies = new HashSet<string>(StringComparer.Ordinal);
+
+    // The live COURSE-scoped query the rail is built from (the same one CourseNavStream issues), so the
+    // model tests are fed the REAL query result rather than a hand-made node list.
+    private Task<IReadOnlyCollection<MeshNode>> QueryCourseSubtree()
+        => Mesh.ServiceProvider.GetRequiredService<IMeshService>()
+            .Query<MeshNode>(MeshQueryRequest.FromQuery("path:TestCourse scope:subtree is:main"))
+            .Where(c => c.ChangeType == QueryChangeType.Initial).Take(1)
+            .Select(c => (IReadOnlyCollection<MeshNode>)c.Items)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
+
+    private static IEnumerable<EducationLayoutAreas.CourseNavLink> AllLinks(
+        EducationLayoutAreas.CourseNavModel model)
+        => new[] { model.Home }.Concat(model.Pages).Concat(model.Modules.SelectMany(m => m.Links));
+
+    // THE invariant the maintainer cares about: an exercise entry may point into the learner's own
+    // partition or nowhere at all — never at the central course template.
+    private static void AssertNoExerciseLinksTheTemplate(
+        EducationLayoutAreas.CourseNavModel model, string coursePath)
+    {
+        foreach (var link in AllLinks(model).Where(l => l.IsExercise))
+        {
+            link.Href.Should().NotBe(coursePath);
+            link.Href.Should().NotStartWith(coursePath + "/",
+                $"the exercise link '{link.Title}' must resolve into the learner's own copy, never the template");
+        }
+    }
+
     // Renders one area on the TestCourse/Module1/Ex1 node through the layout client (GetControlStream), so
     // the assertion inspects the real deserialized UiControl the browser would receive.
-    private async Task<UiControl?> RenderControl(string area)
+    private async Task<UiControl?> RenderControl(string area, Func<UiControl, bool>? until = null)
     {
         var client = GetClient();
         var nodeAddress = new Address("TestCourse/Module1/Ex1");
@@ -277,7 +610,7 @@ public class EducationStartExerciseTest(ITestOutputHelper output) : MonolithMesh
         var stream = client.GetWorkspace()
             .GetRemoteStream<JsonElement, LayoutAreaReference>(nodeAddress, reference);
         return await stream.GetControlStream(reference.Area!)
-            .Where(c => c is not null)
+            .Where(c => c is not null && (until is null || until(c)))
             .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
     }
 


### PR DESCRIPTION
## Why

The reader rail rooted itself at the **current page's parent**, so it only ever showed the module you were already in — and inside a learner's own copy (`{viewer}/{course}/{module}/Exercise/…`) it showed just the copied folder.

## What

- **Rooted at the COURSE** (`ResolveCourseRoot` strips a `{viewer}/` prefix, so a learner working in their copy still gets the shared index). Renders: course home → course-level pages → **one group per module**, ordered by `Order` then name.
- **Only the current module is expanded**; the rest collapse, so an 18-module course stays usable. The active link is matched on **central** paths, so "where am I" holds whether you're reading the template or your own copy.
- **Exercises are listed**, with the invariant that the rail **never links the source**: `PersonalExercisePath` returns the learner's copy or *nothing*. Copy exists → direct href. No copy → **no href at all**, plus a click action running the same idempotent `EnsurePersonalCopy` as `GoToMyCopy`, so the first click creates it. Anonymous → listed, not navigable. Five tests assert no exercise link is, or descends from, the template path.
- Exercise pages **already** rendered in the `Learn` shell — what was broken was the rail's *content*, not its persistence.

## Two bugs found on the way

1. The query term `-nodeType:GitHubSyncConfig` returns **zero rows** on the in-memory/static provider — the rail rendered **empty** there (proved with a probe; the first end-to-end test failed with one area). The exclusion moved into code.
2. The nav was rebuilt from `change.Items`, but a query stream reports Added/Updated/Removed as **deltas** — a live add or rename would have blanked the rail. Both feeds are now `Scan`-folded.

## Tests

**19/19 executed green** (was 6; +13), including an end-to-end render through the real area and layout client. `MeshWeaver.Graph` builds 0 warnings / 0 errors.

Scoped to `src/MeshWeaver.Graph/Education/*` + its tests — no overlap with the in-flight timeout work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)