### PR TITLE
Answer deferred deliveries when a hub disposes (portal hang on recycle-during-activation)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -594,7 +594,8 @@ internal static class NodeTypeEnrichmentHelpers
                                 return TriggerRecompileAndRetry(
                                     node, nodeType, meshConfiguration, compilationService, meshHub,
                                     logger, recompileAttempts,
-                                    reason: $"pinned release '{requestedReleasePath}' bytes missing from store (collection={release.AssemblyCollection}, version={releaseVersion})");
+                                    reason: $"pinned release '{requestedReleasePath}' bytes missing from store (collection={release.AssemblyCollection}, version={releaseVersion})",
+                                    staleVersion: typeNode.Version);
                             }
                             return compilationService.GetConfigurationsFromExistingAssembly(localPath!, nodeType)
                                 .Take(1)
@@ -697,7 +698,8 @@ internal static class NodeTypeEnrichmentHelpers
                         return TriggerRecompileAndRetry(
                             node, nodeType, meshConfiguration, compilationService, meshHub,
                             logger, recompileAttempts,
-                            reason: $"latest assembly for '{nodeType}' missing from store (collection={def.LatestAssemblyCollection}, version={compileVersion})");
+                            reason: $"latest assembly for '{nodeType}' missing from store (collection={def.LatestAssemblyCollection}, version={compileVersion})",
+                            staleVersion: typeNode.Version);
                     }
                     if (compilationService is null)
                         return Observable.Return(ApplyEntry(
@@ -821,6 +823,7 @@ internal static class NodeTypeEnrichmentHelpers
         ILogger? logger,
         int recompileAttempts,
         string reason,
+        long? staleVersion = null,
         bool requireUsableBuild = false)
     {
         logger?.LogInformation(
@@ -858,62 +861,29 @@ internal static class NodeTypeEnrichmentHelpers
             // recompile is in flight, so wait for it to FINISH — never fault-and-cache
             // if the (possibly queue-delayed) compile outlasts the wall-clock. The
             // wall-clock only bounds the case where no compile ever goes in flight.
-            .SelectMany(_ => WaitForCompileSettled(typeStream, typeStream
-                .Where(typeNode =>
-                {
-                    if (typeNode.Content is not NodeTypeDefinition d)
-                        return true; // not a NodeTypeDefinition — nothing left to wait on
-
-                    // 🚨 Never settle on an IN-FLIGHT compile, and never re-snap the
-                    // STALE pre-flip node. The Ok→Pending flip above is a cross-hub
-                    // JSON-merge patch — it does NOT round-trip synchronously, so for
-                    // a few ms after we flip, THIS stream still replays the pre-flip
-                    // node (status Ok, OLD assembly/framework). A naive "terminal Ok
-                    // with an assembly" match re-snaps that stale Ok and recurses on
-                    // it before the recompile even starts → recompileAttempts hits the
-                    // cap → the instance lands on the bare overlay (the
-                    // rbuergi/CatBond/AtlanticBond symptom; observed as the recursion
-                    // capping 5ms after the flip). So: skip in-flight states, surface
-                    // a real Error, and for the framework-stale heal require the
-                    // rebuild to be GENUINELY USABLE (HasUsableBuild — the framework
-                    // version now matches), which the stale Ok can never satisfy.
-                    if (d.CompilationStatus is CompilationStatus.Pending
-                                             or CompilationStatus.Compiling)
-                        return false;
-
-                    // 🚨 Framework-stale heal: the ONLY acceptable terminal is a
-                    // GENUINELY USABLE build (the framework version now matches).
-                    // This MUST be checked BEFORE the Error short-circuit below.
-                    // While a stale-Ok type is rebuilt, a CONCURRENT self-heal
-                    // recompile (the instance is enriched twice — routing AND
-                    // activation — so two Ok→Pending flips race) can collide and
-                    // transiently flip the NodeType to Error ("Failed to load
-                    // assembly … corrupt cached .dll") for a few ms before the next
-                    // compile lands the healed Ok. Settling on that transient Error
-                    // (the old `if Error return true` ordering) froze the INSTANCE on
-                    // the compilation-error overlay for its whole lifetime — even
-                    // though the NodeType reaches Ok ~80ms later — because enrichment
-                    // binds HubConfiguration ONCE and never re-observes. That is the
-                    // exact rbuergi/CatBond/AtlanticBond symptom this test pins
-                    // (FrameworkStaleInstanceRenderTest line 182). The source is
-                    // known-good (it produced the stale-but-valid assembly), so an
-                    // Error here is transient — ride through it to HasUsableBuild
-                    // rather than giving up (the /debug "re-establish, never give up
-                    // on a non-terminal-for-your-purpose state" rule). If the rebuild
-                    // genuinely never lands, the Timeout below surfaces the overlay
-                    // (the graceful sink) — never a longer hang.
-                    if (requireUsableBuild)
-                        return NodeTypeCompilationHelpers.HasUsableBuild(typeNode, d);
-
-                    if (d.CompilationStatus == CompilationStatus.Error)
-                        return true;
-
-                    return (typeNode.HubConfiguration != null
-                            && !string.IsNullOrEmpty(d.LatestAssemblyPath))
-                        || (d.CompilationStatus == CompilationStatus.Ok
-                            && !string.IsNullOrEmpty(d.LatestAssemblyCollection)
-                            && !string.IsNullOrEmpty(d.LatestAssemblyPath));
-                })
+            .SelectMany(flipped =>
+            {
+                // 🚨 Arm the stale-re-snap version gate ONLY when a recompile is genuinely
+                // coming. The gate says "the state I already rejected is not an answer — keep
+                // waiting", which is right only if something is going to produce a NEW state.
+                //
+                // The flip lambda above is conditional (it only moves a terminal Ok), and the
+                // Update hands back the resulting node, so that node tells us which world we
+                // are in:
+                //  • Pending — either we just flipped it, or another caller already kicked it.
+                //    Either way a compile is in flight and will write a version-advancing
+                //    terminal state. Gate ON.
+                //  • anything else (e.g. a Status=Error that still carries assembly
+                //    coordinates, which HasUsableBuild deliberately accepts) — the flip was a
+                //    no-op, no compile is coming, and gating would only burn the whole
+                //    no-progress budget before reaching the same conclusion. Gate OFF, so the
+                //    terminal state we already have settles immediately, exactly as before.
+                var gate = flipped?.Content is NodeTypeDefinition flippedDef
+                           && flippedDef.CompilationStatus == CompilationStatus.Pending
+                    ? staleVersion
+                    : null;
+                return WaitForCompileSettled(typeStream, typeStream
+                .Where(typeNode => IsRecompileSettled(typeNode, gate, requireUsableBuild))
                 .Take(1),
                 SlowPathTimeout,
                 () => new TimeoutException(
@@ -921,7 +891,83 @@ internal static class NodeTypeEnrichmentHelpers
                     $"in flight (within {SlowPathTimeout.TotalSeconds:0}s)."))
                 .SelectMany(newTypeNode => ApplyStreamResult(
                     newTypeNode, node, nodeType, meshConfiguration,
-                    compilationService, meshHub, logger, recompileAttempts + 1)));
+                    compilationService, meshHub, logger, recompileAttempts + 1));
+            });
+    }
+
+    /// <summary>
+    /// Terminal-state predicate for the self-heal recompile started by
+    /// <see cref="TriggerRecompileAndRetry"/>: decides whether an emission on the NodeType's
+    /// stream is a genuine ANSWER to the recompile we just kicked off, or must be waited past.
+    /// Split out so the contract is unit-testable without a mesh (<c>RecompileSettlePredicateTest</c>),
+    /// exactly as <see cref="ArmOverlaySelfHeal"/> is.
+    ///
+    /// <para>🚨 The hazard this exists for: the Ok→Pending flip that starts the recompile is a
+    /// cross-hub JSON-merge patch and does NOT round-trip synchronously, so for a few ms the
+    /// stream still replays the PRE-FLIP node — the very state we already rejected. Accepting it
+    /// "settles" the wait in ~0 ms, burns the single <see cref="MaxRecompileAttempts"/> retry
+    /// before the recompile has even started, and drops the instance onto the error overlay or
+    /// the silent default-config fallback. Worse, that fallback arms a
+    /// <see cref="WithOverlaySelfHeal"/> watcher gated at the SAME version, so when the
+    /// recompile we started lands a newer usable build the watcher immediately recycles the
+    /// freshly-created instance hub — destroying the request that triggered the activation
+    /// (the ThreadAgentIntegrationTest 60 s stall).</para>
+    ///
+    /// <para>The rules, in order:</para>
+    /// <list type="bullet">
+    ///   <item>Content that is not a <see cref="NodeTypeDefinition"/> — nothing left to wait on.</item>
+    ///   <item>An IN-FLIGHT compile (Pending / Compiling) is never a terminal.</item>
+    ///   <item><paramref name="requireUsableBuild"/> (the framework-stale heal): the ONLY
+    ///     acceptable terminal is a genuinely usable build — checked BEFORE the Error
+    ///     short-circuit, so a transient collision Error from a concurrent self-heal is ridden
+    ///     through rather than frozen onto the instance.</item>
+    ///   <item>Otherwise, when <paramref name="staleVersion"/> is set (the bytes-missing heals),
+    ///     an emission whose Version has not ADVANCED past it is the stale re-snap — not news.</item>
+    ///   <item>Then: a real Error is terminal, and so is an Ok carrying assembly coordinates.</item>
+    /// </list>
+    /// Bounded either way: <see cref="WaitForCompileSettled"/> disarms its wall clock only once a
+    /// compile is genuinely in flight, and a compile always writes a version-advancing terminal
+    /// state; if no compile starts, the no-progress deadline surfaces the overlay.
+    /// </summary>
+    internal static bool IsRecompileSettled(
+        MeshNode typeNode, long? staleVersion, bool requireUsableBuild)
+    {
+        if (typeNode.Content is not NodeTypeDefinition d)
+            return true; // not a NodeTypeDefinition — nothing left to wait on
+
+        // An in-flight compile is transitional. Settling here would freeze the instance's
+        // HubConfiguration onto a mid-recompile state for the hub's whole lifetime (enrichment
+        // binds ONCE and never re-observes) — the rbuergi/CatBond/AtlanticBond symptom.
+        if (d.CompilationStatus is CompilationStatus.Pending or CompilationStatus.Compiling)
+            return false;
+
+        // 🚨 Framework-stale heal: the ONLY acceptable terminal is a GENUINELY USABLE build (the
+        // framework version now matches), and this MUST be checked BEFORE the Error short-circuit
+        // below. While a stale-Ok type is rebuilt, a CONCURRENT self-heal recompile (the instance
+        // is enriched twice — routing AND activation — so two Ok→Pending flips race) can collide
+        // and transiently flip the NodeType to Error ("Failed to load assembly … corrupt cached
+        // .dll") for a few ms before the next compile lands the healed Ok. Settling on that
+        // transient Error (the old `if Error return true` ordering) froze the INSTANCE on the
+        // compilation-error overlay for its whole lifetime even though the NodeType reaches Ok
+        // ~80 ms later. The source is known-good (it produced the stale-but-valid assembly), so
+        // ride through to HasUsableBuild rather than giving up. Pinned by
+        // FrameworkStaleInstanceRenderTest. If the rebuild genuinely never lands,
+        // WaitForCompileSettled's no-progress deadline surfaces the overlay — never a longer hang.
+        if (requireUsableBuild)
+            return NodeTypeCompilationHelpers.HasUsableBuild(typeNode, d);
+
+        // The stale pre-flip re-snap (see the remarks above): not news, keep waiting.
+        if (staleVersion is { } stale && typeNode.Version <= stale)
+            return false;
+
+        if (d.CompilationStatus == CompilationStatus.Error)
+            return true;
+
+        return (typeNode.HubConfiguration != null
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath))
+            || (d.CompilationStatus == CompilationStatus.Ok
+                && !string.IsNullOrEmpty(d.LatestAssemblyCollection)
+                && !string.IsNullOrEmpty(d.LatestAssemblyPath));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -291,6 +291,67 @@ public class MessageService : IMessageService
     }
 
 
+    /// <summary>
+    /// Posts a transient <see cref="ErrorType.ShuttingDown"/> <see cref="DeliveryFailure"/> for
+    /// <paramref name="delivery"/> through the PARENT hub — our own <see cref="Post"/> would
+    /// re-enter this service's shutdown gate and be dropped.
+    ///
+    /// <para>Used by BOTH paths on which a hub going down abandons a delivery a sender is
+    /// awaiting: the intake gate (a message arriving after RunLevel flipped) and disposal
+    /// (a message already parked in the deferred queue behind a closed init gate). Both used
+    /// to vanish silently, leaving the sender's <c>hub.Observe(...)</c> to burn its full
+    /// request budget with nothing to show for it.</para>
+    ///
+    /// <para>Gated to deliveries a caller can actually be awaiting:
+    /// <list type="bullet">
+    ///   <item>typed <see cref="IRequest"/> messages (request/response);</item>
+    ///   <item><see cref="RawJson"/> — cross-hub deliveries reach us UNDESERIALIZED, so the
+    ///     payload type cannot be inspected: fail LOUD rather than reintroduce the silent
+    ///     hang. The one RawJson skipped is a payload that looks like a DeliveryFailure
+    ///     itself (cheap content sniff) — NACKing a NACK between two concurrently-disposing
+    ///     hubs would ping-pong.</item>
+    /// </list>
+    /// Typed fire-and-forget events (DataChangedEvent &amp; co) keep the historical silent
+    /// drop — nobody awaits them, and NACKing them was pure disposal noise. Cascade-safe by
+    /// the same exclusions <see cref="ReportFailure"/> applies.</para>
+    ///
+    /// <para>🚨 The NACK is a TRANSIENT rejection — <see cref="ErrorType.ShuttingDown"/>, never
+    /// NotFound, never a generic terminal failure. A disposing hub cannot know whether its
+    /// address is gone for good (node deleted) or about to REACTIVATE (recycle / restart);
+    /// the sender's next probe gets the authoritative answer. Consumers with their own
+    /// recovery machinery ride it out (SynchronizationStream keeps the stream ALIVE on this
+    /// ErrorType so its change-feed resubscribe latch rehydrates after the reactivation).</para>
+    /// </summary>
+    private void NackThroughParent(IMessageDelivery delivery, string reason)
+    {
+        if (delivery.Message is not IRequest
+            && !(delivery.Message is RawJson rawJson
+                 && !rawJson.Content.Contains(nameof(DeliveryFailure), StringComparison.Ordinal)))
+            return;
+        if (delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>())
+            return;
+        if (delivery.Sender is null || delivery.Sender.Equals(Address))
+            return;
+        // No live parent ⇒ nothing can carry the NACK. At a full mesh teardown the parent is
+        // itself past DisposeHostedHubs, so this correctly stays silent: every sender is going
+        // away too. Only a TARGETED hub disposal (recycle, node delete) under a live parent
+        // NACKs — exactly the case where a sender is still there to hear it.
+        if (ParentHub is not { } parent || parent.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
+            return;
+        try
+        {
+            parent.Post(
+                new DeliveryFailure(delivery) { ErrorType = ErrorType.ShuttingDown, Message = reason },
+                o => o.ResponseFor(delivery));
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex,
+                "Failed to NACK {MessageType} (ID: {MessageId}) abandoned by shutting-down hub {Address}",
+                delivery.Message.GetType().Name, delivery.Id, Address);
+        }
+    }
+
     private IMessageDelivery ReportFailure(IMessageDelivery delivery, ErrorType errorType = ErrorType.Unknown)
     {
         var error = delivery.Properties.TryGetValue("Error", out var e) ? e?.ToString() : null;
@@ -443,31 +504,9 @@ public class MessageService : IMessageService
             // a NotFound NACK faulted the stream cache's shared Replay(1) with no re-probe
             // path, and ANY terminal treatment killed the sync stream's resubscribe latch —
             // each wedged every read of the mid-recycle NodeType.
-            if ((delivery.Message is IRequest
-                    || (delivery.Message is RawJson rawJson
-                        && !rawJson.Content.Contains(nameof(DeliveryFailure), StringComparison.Ordinal)))
-                && !delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>()
-                && delivery.Sender is not null
-                && !delivery.Sender.Equals(Address)
-                && ParentHub is { } parent
-                && parent.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
-            {
-                try
-                {
-                    parent.Post(new DeliveryFailure(delivery)
-                    {
-                        ErrorType = ErrorType.ShuttingDown,
-                        Message = $"Hub {Address} is shutting down (RunLevel={hub.RunLevel}) — cannot process "
-                                  + $"{typeName}; the address may reactivate (recycle / restart). Rejecting now."
-                    }, o => o.ResponseFor(delivery));
-                }
-                catch (Exception ex)
-                {
-                    logger.LogDebug(ex,
-                        "Failed to NACK {MessageType} (ID: {MessageId}) dropped by shutting-down hub {Address}",
-                        typeName, delivery.Id, Address);
-                }
-            }
+            NackThroughParent(delivery,
+                $"Hub {Address} is shutting down (RunLevel={hub.RunLevel}) — cannot process "
+                + $"{typeName}; the address may reactivate (recycle / restart). Rejecting now.");
             return delivery.Failed("Hub is shutting down");
         }
 
@@ -1249,13 +1288,36 @@ public class MessageService : IMessageService
                 hangDetectionStopwatch.ElapsedMilliseconds, Address);
         }
 
-        // Cancel every outstanding deferral-timeout timer so they don't post
-        // a DeliveryFailure into a hub that's already disposing (would race
-        // with the buffer.Complete below and produce noise).
+        // 🚨 ANSWER the deferred backlog — never just silence it.
+        //
+        // Everything still in deferredDeliveries is a delivery this hub ACCEPTED and parked
+        // behind a closed init gate. Disposal throws that queue away. Cancelling the
+        // deferral-timeout timers (which we must — they would fire ReportFailure into a hub
+        // that can no longer post) without answering the deliveries made the abandonment
+        // TOTALLY SILENT: the sender's hub.Observe(...) had nothing to resolve on and burned
+        // its entire request budget.
+        //
+        // That is a production hang, not a test artefact: DisposeRequest is deliberately
+        // exempt from the init gate (see the gate bypass in ScheduleNotify's deferral path)
+        // while an ordinary request is NOT — so any recycle that lands during activation
+        // (WithOverlaySelfHeal's self-recycle, RecycleLayoutArea, the MCP recycle tool, a
+        // node delete) jumps the queue and annihilates the very request that triggered the
+        // activation. The caller — a page load, a GetMeshNode read — then spins for its full
+        // budget with no error to show. Proven by ThreadAgentIntegrationTest: the instance
+        // hub was created, handed the routed GetDataRequest, and self-disposed 13 ms later;
+        // the reader sat idle for its whole 60 s and the target probe reported NO LOCAL HUB.
+        //
+        // The NACK is transient (ErrorType.ShuttingDown) — a recycled address reactivates on
+        // the next access, so the sender must read this as "ask again", never as "gone".
         foreach (var (_, tracker) in deferredDeliveries)
         {
             tracker.TimeoutCts.Cancel();
             tracker.TimeoutCts.Dispose();
+            NackThroughParent(tracker.Delivery,
+                $"Hub {Address} was disposed while {tracker.Delivery.Message.GetType().Name} "
+                + $"(id={tracker.Delivery.Id}) was still deferred behind its initialization gates "
+                + $"[{string.Join(",", gates.Keys)}] — the message was never processed. The address "
+                + "may reactivate (recycle / restart); retry to get the authoritative answer.");
         }
         deferredDeliveries.Clear();
 

--- a/test/MeshWeaver.Graph.Test/RecompileSettlePredicateTest.cs
+++ b/test/MeshWeaver.Graph.Test/RecompileSettlePredicateTest.cs
@@ -1,0 +1,127 @@
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Unit contract for <see cref="NodeTypeEnrichmentHelpers.IsRecompileSettled"/> — the predicate
+/// that decides when the self-heal recompile started by <c>TriggerRecompileAndRetry</c> has
+/// actually ANSWERED, as opposed to the stream merely replaying the state we already rejected.
+///
+/// <para><b>The bug this pins.</b> The Ok→Pending flip that starts the recompile is a cross-hub
+/// JSON-merge patch and does not round-trip synchronously, so for a few ms the NodeType stream
+/// still replays the PRE-FLIP node. The bytes-missing path had no version gate, so its "terminal
+/// Ok with assembly coordinates" clause matched that stale replay 0 ms after the flip. The retry
+/// therefore burned its single attempt before the recompile it had just kicked off even started,
+/// concluded "still missing", and bound the silent default-config fallback wrapped in a
+/// <c>WithOverlaySelfHeal</c> watcher gated at that same version. The recompile then landed a
+/// NEWER usable build — exactly the watcher's trigger — so the watcher recycled the instance hub
+/// milliseconds after it was created, taking the request that triggered the activation with it.
+/// Observed end-to-end as <c>ThreadAgentIntegrationTest</c>'s 60 s
+/// <c>GetMeshNode('ACME/ProductLaunch')</c> stall (create at T+0, self-dispose at T+13 ms, reader
+/// idle until its budget expired).</para>
+/// </summary>
+public class RecompileSettlePredicateTest
+{
+    private const string NodeTypePath = "TestData/RecompileType";
+
+    private static MeshNode TypeNode(
+        CompilationStatus? status,
+        long version,
+        string? collection = "local",
+        string? assemblyPath = "TestData_RecompileType/v1-abc.dll")
+        => new(NodeTypePath)
+        {
+            Version = version,
+            Content = new NodeTypeDefinition
+            {
+                CompilationStatus = status,
+                LatestAssemblyCollection = collection,
+                LatestAssemblyPath = assemblyPath,
+                CompiledFrameworkVersion = "some-old-framework",
+            }
+        };
+
+    [Fact]
+    public void StaleReSnapOfTheVersionWeAlreadyRejected_IsNotSettled()
+    {
+        // The bytes-missing heal failed on version 20 and flipped Ok→Pending. Before that flip
+        // round-trips, the stream replays version 20 unchanged. Accepting it here is the defect.
+        NodeTypeEnrichmentHelpers
+            .IsRecompileSettled(TypeNode(CompilationStatus.Ok, version: 20), staleVersion: 20, requireUsableBuild: false)
+            .Should().BeFalse(
+                "re-snapping the exact state whose assembly we already failed to resolve is not "
+                + "news — it burns the single retry attempt before the recompile even starts");
+
+        // A version BEHIND the one we rejected is an even older replay; same verdict.
+        NodeTypeEnrichmentHelpers
+            .IsRecompileSettled(TypeNode(CompilationStatus.Ok, version: 19), staleVersion: 20, requireUsableBuild: false)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void VersionAdvancePastTheRejectedState_IsSettled()
+    {
+        // The recompile landed: a NEW version carrying assembly coordinates. This is the genuine
+        // answer the wait exists for, and it must be accepted or activation would hang.
+        NodeTypeEnrichmentHelpers
+            .IsRecompileSettled(TypeNode(CompilationStatus.Ok, version: 21), staleVersion: 20, requireUsableBuild: false)
+            .Should().BeTrue();
+
+        // A real compile failure at an advanced version is also terminal — the caller overlays it.
+        NodeTypeEnrichmentHelpers
+            .IsRecompileSettled(TypeNode(CompilationStatus.Error, version: 21), staleVersion: 20, requireUsableBuild: false)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void InFlightCompile_IsNeverSettled_EvenPastTheVersionGate()
+    {
+        // Pending/Compiling are transitional. Settling on them would freeze the instance's
+        // HubConfiguration onto a mid-recompile state for the hub's whole lifetime.
+        foreach (var status in new[] { CompilationStatus.Pending, CompilationStatus.Compiling })
+            NodeTypeEnrichmentHelpers
+                .IsRecompileSettled(TypeNode(status, version: 99), staleVersion: 20, requireUsableBuild: false)
+                .Should().BeFalse($"{status} is an in-flight compile, not a terminal state");
+    }
+
+    [Fact]
+    public void WithoutAVersionGate_ATerminalOkIsStillSettled()
+    {
+        // The framework-stale path and any caller with no rejected version in hand pass null;
+        // the gate must then be inert, preserving the pre-existing behaviour.
+        NodeTypeEnrichmentHelpers
+            .IsRecompileSettled(TypeNode(CompilationStatus.Ok, version: 1), staleVersion: null, requireUsableBuild: false)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void RequireUsableBuild_IgnoresTheVersionGate_AndRidesThroughTransientErrors()
+    {
+        // The framework-stale heal keeps its own, stricter rule: only a genuinely usable build
+        // counts. A stale Ok can never satisfy it (its CompiledFrameworkVersion does not match),
+        // and a transient collision Error must be ridden through rather than frozen onto the
+        // instance — so neither is settled, regardless of version.
+        NodeTypeEnrichmentHelpers
+            .IsRecompileSettled(TypeNode(CompilationStatus.Ok, version: 99), staleVersion: null, requireUsableBuild: true)
+            .Should().BeFalse("the assembly is still compiled against a different framework");
+
+        NodeTypeEnrichmentHelpers
+            .IsRecompileSettled(TypeNode(CompilationStatus.Error, version: 99), staleVersion: null, requireUsableBuild: true)
+            .Should().BeFalse(
+                "an Error during the framework-stale rebuild is transient (a concurrent self-heal "
+                + "collision); settling on it froze instances on the overlay for their whole lifetime");
+    }
+
+    [Fact]
+    public void NonNodeTypeDefinitionContent_IsSettled_SoTheWaitCannotHang()
+    {
+        // Nothing left to wait on: the path is not a NodeTypeDefinition at all.
+        var plain = new MeshNode(NodeTypePath) { Version = 5, Content = "not a node type definition" };
+        NodeTypeEnrichmentHelpers
+            .IsRecompileSettled(plain, staleVersion: 20, requireUsableBuild: false)
+            .Should().BeTrue();
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/DeferredDeliveryNackedOnDisposeTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DeferredDeliveryNackedOnDisposeTest.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Deterministic repro for the SILENT-ABANDONMENT hang: a hub that is disposed while a
+/// request is still parked behind its initialization gates used to throw that request away
+/// without telling anyone, so the sender's <c>hub.Observe(...)</c> had nothing to resolve on
+/// and burned its entire request budget in total silence.
+///
+/// <para><b>Why this is a production bug, not a test artefact.</b> <see cref="DisposeRequest"/>
+/// is deliberately exempt from the init gate (deferring it would break disposal) while an
+/// ordinary request is NOT. So any recycle that lands during a hub's activation window jumps
+/// the queue and annihilates the very request that triggered the activation — and every recycle
+/// path is affected: <c>NodeTypeEnrichmentHelpers.WithOverlaySelfHeal</c>'s self-recycle,
+/// <c>RecycleLayoutArea</c>, the MCP <c>recycle</c> tool, a node delete. The caller — a page
+/// load, a <c>GetMeshNode</c> read — then spins for its whole budget with no error to show.</para>
+///
+/// <para><b>Field evidence.</b> <c>ThreadAgentIntegrationTest</c> on CI: the
+/// <c>ACME/ProductLaunch</c> instance hub was created, handed the routed <c>GetDataRequest</c>,
+/// and self-disposed 13 ms later via the overlay self-heal watcher. The reader sat idle for its
+/// full 60 s (process memory flat throughout — nothing was running) and the timeout diagnostic
+/// reported <c>Target: NO LOCAL HUB</c>.</para>
+///
+/// <para><b>The contract pinned here.</b> The abandoned delivery is NACKed through the PARENT
+/// hub (our own Post would re-enter the disposing service's shutdown gate and be dropped) with
+/// the TRANSIENT <see cref="ErrorType.ShuttingDown"/> — never NotFound, never a generic terminal
+/// failure. A recycled address reactivates on the next access, so the sender must read this as
+/// "ask again", not "gone"; consumers with their own recovery machinery (SynchronizationStream's
+/// resubscribe latch) rely on exactly that classification.</para>
+/// </summary>
+public class DeferredDeliveryNackedOnDisposeTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record GatedRequest : IRequest<GatedResponse>;
+
+    private record GatedResponse;
+
+    private static readonly Address GatedAddress = new("gated", "1");
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration).WithTypes(typeof(GatedRequest), typeof(GatedResponse));
+
+    [Fact(Timeout = 30_000)]
+    public async Task DeferredRequest_IsNacked_WhenHubIsDisposedBeforeItsGateOpens()
+    {
+        var host = GetHost();
+
+        // A hosted hub whose gate never opens — the activation window, held open forever so the
+        // race is deterministic rather than millisecond-timed. It registers a handler that WOULD
+        // answer, so a pass can only come from the NACK, never from the request being served.
+        var gated = host.GetHostedHub(
+            GatedAddress,
+            c => c.WithTypes(typeof(GatedRequest), typeof(GatedResponse))
+                .WithInitializationGate("test-never-opens", _ => false)
+                .WithHandler<GatedRequest>((h, d) =>
+                {
+                    h.Post(new GatedResponse(), o => o.ResponseFor(d));
+                    return d.Processed();
+                }));
+        gated.Should().NotBeNull();
+
+        // Pre-registers the callback, then posts. The request lands on the gated hub and defers.
+        var response = host
+            .Observe<GatedResponse>(new GatedRequest(), o => o.WithTarget(GatedAddress))
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        // Wait until the request is DEMONSTRABLY parked in the deferred queue before recycling.
+        // Without this the test could dispose before the delivery was ever accepted, which is the
+        // already-handled intake-gate case (ScheduleNotify NACKs that one) — a different code path
+        // that would pass even with the defect present.
+        await WaitForDeferredBacklog(host);
+
+        // The recycle. DisposeRequest bypasses the gate, so it overtakes the deferred request and
+        // tears the hub down with the request still inside it.
+        host.Post(new DisposeRequest(), o => o.WithTarget(GatedAddress));
+
+        // WITHOUT the fix this task never completes and the [Fact] timeout fires with no
+        // explanation — precisely the production symptom (a page that spins).
+        var failure = await Assert.ThrowsAsync<DeliveryFailureException>(() => response);
+
+        // TRANSIENT, so a recycled address reads as "retry", never as "gone".
+        failure.Failure.Should().NotBeNull();
+        failure.Failure!.ErrorType.Should().Be(ErrorType.ShuttingDown);
+        failure.Failure.Message.Should().Contain("deferred",
+            "the NACK must name WHY the message was abandoned — a bare failure sends the next "
+            + "investigator hunting the wrong layer");
+    }
+
+    /// <summary>
+    /// Polls the public disposal diagnostics (which report <c>deferred=&lt;N&gt;</c> per hub,
+    /// walking hosted hubs) until something is parked. The gated hub is the only hub in this test
+    /// that defers, so a non-zero count is unambiguously our request.
+    /// </summary>
+    private static async Task WaitForDeferredBacklog(IMessageHub host)
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            foreach (Match m in Regex.Matches(host.GetDisposalDiagnostics(), @"deferred=(\d+)"))
+                if (int.Parse(m.Groups[1].Value) > 0)
+                    return;
+            await Task.Delay(50);
+        }
+
+        Assert.Fail(
+            "The request never reached the gated hub's deferred queue, so this test never "
+            + "exercised the disposal path it exists to pin. Check that GatedRequest still "
+            + "defers behind a closed initialization gate.");
+    }
+}


### PR DESCRIPTION
The `ThreadAgentIntegrationTest` 60 s stalls were not slow tests. They were **a hung request against a hub that had disposed underneath it** — a production hang, not a fixture-cost problem.

## How it was identified

#663's target probe answered it on the first occurrence, CI run `30250682456`:

```
Target: NO LOCAL HUB at 'ACME/ProductLaunch' — it never activated here
        (or is owned by another silo), so no reply was ever going to be produced.
```

On a monolith mesh there is no other silo. And the memory trace from run `30242205261` shows the process was **idle** for the entire 60 s — `managed=94MiB rss=615MiB` unchanged across all 12 watchdog samples, `alc=1`, `asm` static. Nothing was compiling, nothing was slow. It was stopped.

## Defect A — the production hang (`MessageService`)

A request arriving while a hub is still activating sits in `deferredQueue` behind the init gate. **`DisposeRequest` is deliberately exempt from that gate**, so a recycle landing mid-activation jumps the queue — and `Dispose` then cancelled the deferral-timeout timers and cleared the tracker **without answering a single delivery**. The sender's `hub.Observe(...)` had nothing left to resolve on and burned its whole budget in silence.

**In a portal that is a page that spins forever.** Every recycle path reaches it: `WithOverlaySelfHeal`, `RecycleLayoutArea`, the MCP `recycle` tool, a node delete.

The same NACK **already existed on the intake path** (a message arriving after `RunLevel` flipped); the already-accepted deferred backlog was simply left out. This factors that block into `NackThroughParent(...)` and applies it to every deferred delivery at disposal — transient `ErrorType.ShuttingDown`, because a recycled address reactivates, so the honest answer is "ask again", never "gone" — posted through the parent hub with the same cascade-safety exclusions. Net one duplicated block removed.

## Defect B — why it fired here (`NodeTypeEnrichmentHelpers`)

The bytes-missing heal burned its single retry *before the recompile started*. `TriggerRecompileAndRetry` flips `Ok → Pending`, but that flip is a cross-hub merge patch which does not round-trip synchronously — so the stream still replays the **pre-flip node**, and the non-`requireUsableBuild` settle predicate matched it **0 ms later** (traced: flip at `29.501`, "settled" at `29.501`). The instance then bound the silent default-config fallback plus a `WithOverlaySelfHeal` watcher gated at that version — and the recompile it had itself kicked off landed a newer usable build, which is exactly the watcher's trigger:

```
29.501 CREATEHUB resolved addr=ACME/ProductLaunch
29.549 SELFHEAL armed    instance=ACME/ProductLaunch gate=20
29.551 SELFHEAL FIRED    v=21 gate=20 -> DisposeRequest
29.563 SELFHEAL instance hub DISPOSED
```

The hub was recycled **2 ms after arming the watcher**, with the activating request still parked. The code already documents this stale-re-snap hazard and guards the *framework-stale* path; the bytes-missing path had no guard. Adds a `staleVersion` gate, extracts the settle predicate as testable `IsRecompileSettled(...)`, and arms the gate **only when the flip actually produced `Pending`** — so a `Status=Error` node carrying assembly coordinates still settles immediately instead of waiting out the no-progress budget.

## Evidence

Harness: `DOTNET_PROCESSOR_COUNT=2`, cold `.mesh-cache`, pristine `TestData` per round, one test process at a time, no spinners.

| build | rounds failed | executions failed |
|---|---|---|
| `main`, no fix | **5 / 5** | 8 / 15 |
| `main`, with fix | **0 / 8** | 0 / 24 |
| `fix/owner-recycle-rollback`, no fix | 2 / 5 | 4 / 15 |
| `fix/owner-recycle-rollback`, with fix | **0 / 6** | 0 / 18 |

Both new tests were verified to fail without their fix: `DeferredDeliveryNackedOnDisposeTest` **hangs to its 30 s `[Fact]` timeout** — reproducing the production symptom exactly — then passes in 193 ms; `RecompileSettlePredicateTest`'s stale-re-snap case fails when the version gate is disabled.

Suites: `AI.Test` **902/0** (5 env-gated skips), `Graph.Test` 633/633, `Messaging.Hub.Test` 104/104. Full solution `-c Release -p:CIRun=true -warnaserror`: 0 warnings, 0 errors.

**What this does not prove**: the harness is a *sensitised* repro with a far higher failure rate than CI, not a calibrated one, so it does not establish that CI's rate goes to zero.

## On #665

#665 adds a raw `IStorageAdapter.Read` on every per-node activation, which widens the window this bug lives in. **The aggravation hypothesis is not confirmed** — on this harness that branch failed *less* than `main` (2/5 vs 5/5), and the sample is far too small to conclude either way. What is established is what unblocks it: the defect is present on both branches, and with this fix the activation path tolerates the extra read (6/6 green on `fix/owner-recycle-rollback`).

## Found, not fixed

- **`MaxDeferredMessages` overflow returns `Ignored()`** — deliberately silent to avoid feeding a storm, but a sender awaiting one of those still gets nothing. Documented trade-off, left alone.
- **`mainQueue` at disposal is not waited on** (`Dispose` explicitly skips the completion wait), so a non-deferred queued delivery could still be dropped silently. Different shape; tracking every queued delivery would cost the hot path.
- **`WithOverlaySelfHeal` can still recycle a hub milliseconds after creation.** With Defect A fixed that is now a clean transient NACK rather than a hang, but the caller still fails rather than being served — deferring the recycle until the hub is idle would be the fuller design.
- **The fixture cost is real but is the coverage, not the bug**: a fresh Guid assembly-store root per `[Fact]` against an on-disk NodeType pointing at the previous mesh's store is what drives this class through the bytes-missing self-heal every single test. Deliberately untouched — it is the only regression coverage for that path, and post-fix each test runs in ~0.7–2 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
