### PR TITLE
GitSync: a server-side addition was silently deleted one sync cycle later

### DIFF
--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -17,8 +17,10 @@ namespace MeshWeaver.Graph;
 
 /// <summary>Outcome of a <see cref="StaticRepoImporter.Import"/> run. <paramref name="Preserved"/> is
 /// the number of live nodes a two-way import kept because they were newer on the server (see
-/// <see cref="ImportConflictPolicy"/>) — non-zero means the mesh is now AHEAD of the repo, so the
-/// caller must NOT advance its last-sync baseline until those edits are committed back.</summary>
+/// <see cref="ImportConflictPolicy"/>) — BOTH kinds: kept-not-overwritten (the repo's copy differs) and
+/// kept-not-pruned (the repo has no copy at all — a server-side addition). Non-zero means the mesh is
+/// now AHEAD of the repo, so the caller must NOT advance its last-sync baseline until those changes are
+/// committed back.</summary>
 public sealed record StaticRepoImportResult(string Partition, string Fingerprint, string Outcome, int Count = 0, int Preserved = 0);
 
 /// <summary>
@@ -858,8 +860,27 @@ public static class StaticRepoImporter
                     // Two-way: never prune a node CREATED/changed on the server since the last sync. It
                     // isn't in the repo yet, but it's a local addition to be committed back — not a stale
                     // extra to remove. A forced import prunes it (the repo state wins).
+                    // 🚨 A node KEPT here counts as PRESERVED exactly like a kept upsert conflict — it is
+                    // the same statement: "this local change is not in the repo yet, so the mesh is AHEAD".
+                    // Reporting 0 here let GitHubSyncService.ReimportAtCommit advance the sync baseline
+                    // (LastSyncedAt) past the node it had just protected, so on the NEXT import the node was
+                    // no longer "newer on the server" and got PRUNED — the server addition silently deleted
+                    // one cycle later, which is precisely what that baseline guard exists to prevent.
+                    // Deterministic repro: TwoWaySyncTest.TwoWay_ServerAddition_SurvivesEveryLaterRepoPush.
+                    var keptFromPrune = Array.Empty<MeshNode>();
                     if (policy is { PreserveServerNewer: true, Force: false, Since: { } pruneSince })
+                    {
+                        keptFromPrune = toPrune.Where(n => n.LastModified > pruneSince).ToArray();
                         toPrune = toPrune.Where(n => n.LastModified <= pruneSince).ToArray();
+                        foreach (var kept in keptFromPrune)
+                        {
+                            logger?.LogInformation(
+                                "[StaticRepoImport] {Partition}: two-way — keeping server-added {Path} (not pruned).",
+                                source.Partition, kept.Path);
+                            NodeTypeCompilationActivity.AppendLog(hub, activityPath,
+                                $"↩ Kept {kept.Path} (added on the server — commit to sync it back).", logger!);
+                        }
+                    }
 
                     var pruned = toPrune.Count == 0
                         ? Observable.Return(0)
@@ -900,8 +921,10 @@ public static class StaticRepoImporter
                             // full diagnostic log (no torn "Succeeded but the ⚠ lines didn't land yet").
                             var failed = count.Failed;
                             var status = failed > 0 ? ActivityStatus.Warning : ActivityStatus.Succeeded;
-                            // Two-way preserved local edits (kept, not overwritten) noted only when any.
-                            var preservedNote = count.Preserved > 0 ? $", kept {count.Preserved} local edit(s)" : "";
+                            // Two-way preserved local changes: kept-not-overwritten (upsert conflicts) PLUS
+                            // kept-not-pruned (server additions). Both leave the mesh ahead of the repo.
+                            var preserved = count.Preserved + keptFromPrune.Length;
+                            var preservedNote = preserved > 0 ? $", kept {preserved} local change(s)" : "";
                             var summary = failed > 0
                                 ? $"Imported {count.Imported} node(s), {failed} FAILED (see ⚠ above){preservedNote}, pruned {prunedCount}, synced {contentCount} content file(s)."
                                 : $"Imported {count.Imported} node(s){preservedNote}, pruned {prunedCount}, synced {contentCount} content file(s).";
@@ -918,7 +941,7 @@ public static class StaticRepoImporter
                                 "[StaticRepoImport] {Partition}: imported {Count}, failed {Failed}, pruned {Pruned}, content {Content} at {Fingerprint}.",
                                 source.Partition, count.Imported, failed, prunedCount, contentCount, fingerprint);
                             return new StaticRepoImportResult(source.Partition, fingerprint,
-                                failed > 0 ? "ImportedWithErrors" : "Imported", count.Imported, count.Preserved);
+                                failed > 0 ? "ImportedWithErrors" : "Imported", count.Imported, preserved);
                         });
                         })));
                 });

--- a/test/MeshWeaver.GitSync.Test/TwoWaySyncTest.cs
+++ b/test/MeshWeaver.GitSync.Test/TwoWaySyncTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.GitSync;
@@ -55,4 +56,67 @@ public class TwoWaySyncTest(ITestOutputHelper output) : GitHubSyncTestBase(outpu
         Assert.True(await IsAbsent($"{a}/ServerOnly"));
         Assert.NotNull(await WaitForNode($"{a}/Welcome"));
     }
+
+    /// <summary>
+    /// The same baseline invariant under REAL repo traffic — the deterministic form of the guard
+    /// above (which relies on the second update short-circuiting on an unchanged fingerprint).
+    /// Every update here imports a genuinely new commit, so prune runs for real each time: a node
+    /// added on the server must survive update after update until it is committed back, because
+    /// PRESERVING it (here: by not pruning it) leaves the mesh AHEAD of the repo and must NOT
+    /// advance the sync baseline. Advancing it loses the node on the NEXT push — silent data loss.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task TwoWay_ServerAddition_SurvivesEveryLaterRepoPush()
+    {
+        await Connect();
+        var a = "GhY" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(a, "Space Y");
+        await CreateMarkdown($"{a}/Welcome", "Welcome", "# Welcome\n\nv1.");
+
+        var repo = "https://github.com/test/space-y";
+        await Sync.SaveConfig(a, repo, "main", subdirectory: null,
+                createBranchIfMissing: true, createRepoIfMissing: true,
+                direction: SyncDirection.Bidirectional, sourceId: null, twoWay: true)
+            .Timeout(30.Seconds()).ToTask();
+
+        var c1 = await Sync.SyncToGitHub(a, UserId).Timeout(60.Seconds()).ToTask();
+        var baseline = await WaitForConfig(a, c => c.LastSyncedAt != null && c.LastSyncCommitSha == c1.CommitSha);
+
+        // A user adds a node on the SERVER after that baseline — not in the repo at any commit.
+        await CreateMarkdown($"{a}/ServerOnly", "ServerOnly", "# ServerOnly\n\nadded on the server.");
+
+        // Someone commits to the repo; the update imports it and KEEPS the server addition.
+        await PushRepoFile(repo, "Docs.md", "# Docs\n\nfrom the repo.");
+        var update1 = await Sync.ReimportAtCommit(a, "main", UserId).Timeout(90.Seconds()).ToTask();
+        Assert.NotNull(await WaitForNode($"{a}/Docs"));
+        Assert.NotNull(await WaitForNode($"{a}/ServerOnly"));
+
+        // The invariant the survival above RESTS on, asserted directly: keeping the server addition
+        // (by not pruning it) is a PRESERVE, and a preserving import leaves the mesh ahead of the
+        // repo — so the sync baseline must NOT advance past the node it just protected. Reporting
+        // Preserved=0 here is what silently disarmed the protection and deleted the node one update
+        // later; the assertions below would then fail.
+        Assert.True(update1.Preserved > 0, $"kept-not-pruned must count as preserved (was {update1.Preserved})");
+        var afterUpdate1 = await Sync.ReadConfig(a).Timeout(30.Seconds()).ToTask();
+        Assert.Equal(baseline.LastSyncedAt, afterUpdate1!.LastSyncedAt);
+
+        // A SECOND repo commit must not delete it either — the baseline may not have moved past it.
+        await PushRepoFile(repo, "Docs2.md", "# Docs2\n\nfrom the repo.");
+        await Sync.ReimportAtCommit(a, "main", UserId).Timeout(90.Seconds()).ToTask();
+        Assert.NotNull(await WaitForNode($"{a}/Docs2"));
+        Assert.NotNull(await WaitForNode($"{a}/ServerOnly"));
+    }
+
+    /// <summary>Simulates a repo-side commit: the current tree plus one added file.</summary>
+    private Task<GitHubPushResult> PushRepoFile(string repo, string path, string content) =>
+        Fake.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = repo,
+            Branch = "main",
+            Files = Fake.Tree(repo).Append(new RepoFile(path, content)).ToImmutableList(),
+            CommitMessage = $"add {path}",
+            AuthorName = "octocat",
+            AuthorEmail = "octocat@users.noreply.github.com",
+            AccessToken = "ghp_test_token",
+        }).Timeout(30.Seconds()).ToTask();
 }


### PR DESCRIPTION
`TwoWaySyncTest.TwoWay_Update_KeepsServerAddition_UnlessForced` was on the flake list. It is not a flake — **GitSync silently deletes a server-side addition one sync cycle later.**

## Mechanism

Two-way sync protects a server-side change two ways: it refuses to **overwrite** it (upsert conflict) and it refuses to **prune** it (the repo has no copy — a server-side *addition*). Only the first path incremented `StaticRepoImportResult.Preserved`; the prune path filtered the node out of `toPrune` and reported nothing.

`GitHubSyncService.ReimportAtCommit` uses exactly that number to decide whether to advance the sync baseline `LastSyncedAt`, and its comment states the invariant: a preserving import leaves the mesh ahead of the repo, so advancing the baseline would move it past the very node two-way just protected. A kept-not-pruned node reported `Preserved = 0`, so the baseline advanced past it and the protection (`node.LastModified > LastSyncedAt`) **silently disarmed**. The next import that actually runs prunes the node.

**Why it looked like a flake**: the test usually passes only because the second update short-circuits on the unchanged content fingerprint (`Skipped`, so prune never runs). That short-circuit reads an eventually-consistent query — the importer itself documents a stale miss as *"wasteful, not wrong"*. Under CI load the read misses, the second update really imports, prune runs against the advanced baseline, and the node is gone (run `30250682456`, shard 5, `WaitForNode` timeout at `TwoWaySyncTest.cs:51`). A cache-ish short-circuit was concealing a data-loss bug.

## Evidence

Pre-fix, instrumented, the failing test's own sequence:

```
baseline=…30.4931640  serverOnly.LastModified=…30.5879100   ← protected (T1 > T0)
update1 outcome=Imported preserved=0 baseline=…30.8564380   ← baseline jumped PAST T1
update2 outcome=Skipped  → ServerOnly survives (passes by luck)
```

With the short-circuit disabled (activity marker dropped — i.e. the CI query miss), pre-fix: `update2 outcome=Imported → ServerOnly absent = True`, reproducing the CI failure exactly. Post-fix, 3/3: `update1 preserved=1`, baseline unchanged; `update2 preserved=2`; `ServerOnly absent = False`.

New test `TwoWay_ServerAddition_SurvivesEveryLaterRepoPush` makes every update import a genuinely new commit so prune runs for real each time, and asserts the **invariant** (`Preserved > 0`, `LastSyncedAt` unchanged) rather than only the symptom. Unfixed it fails **3/3** in ~0.7 s; fixed it passes.

`GitSync.Test` 142/142 ×3, `Graph.Test` 633/633, `Content.Test` 249 + 1 skipped, full solution `-c Release -p:CIRun=true -warnaserror` clean.

**What this does not establish**: the original test passes locally both before *and* after — locally the short-circuit always engages, so it never reproduced untouched. Green runs of it prove nothing; the load-bearing evidence is the deterministic new test plus the marker-drop emulation.

## ⚠️ Behaviour change to weigh before merging

Freezing the baseline does refuse some later repo edits. Measured: with a server addition pending, a repo edit to `Welcome` applies (v2), but a **second** edit (v3) is *preserved* instead of applied — because the import itself re-stamped `Welcome.LastModified` past the frozen horizon, so it looks "server-newer" though no user touched it.

This false-conflict is **inherent to the existing horizon design** (it already occurred for upsert-preserved nodes); this change makes it reachable more often. It is not data loss — v3 stays in git and the import activity says `↩ Kept …` — but a subsequent commit-back mirrors mesh state and would revert v3 in the repo, visible in the diff.

Clean follow-up: record per-node import write-times in the manifest so "server-newer" means "changed since the import wrote it" rather than "changed since a global timestamp".

## Found, not fixed — same defect, second live route

The fingerprint short-circuit returns `Preserved = 0`, so a no-op "Update to latest" **records** last sync and advances the horizon past pending uncommitted changes although it verified nothing (pre-fix probe: `update2 outcome=Skipped`, `LastSyncedAt` moved …30.8564380 → …30.8765430). The git-diff scope skip has the same shape for a server-edited node whose repo file didn't change. Both can still lose a server addition on a later push.

The honest fix is to split the two fields — `LastSyncCommitSha` is safe to advance, `LastSyncedAt` (the conflict horizon) is not — but that changes the meaning of a persisted field and affects "are we up to date?" (a repo commit touching no node files would otherwise leave the space permanently "behind"). Left as a maintainer decision rather than bundled into this fix.

No What's New entry — silent data-loss fix; no user-visible behaviour change when sync is working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
