### PR TITLE
DataTest: wait on the persisted state instead of sampling a field mid-write-back

### DIFF
--- a/test/MeshWeaver.Data.Test/DataTest.cs
+++ b/test/MeshWeaver.Data.Test/DataTest.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
-using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,7 +39,24 @@ public record MyData(
 public class DataTest(ITestOutputHelper output) : HubTestBase(output)
 {
 
-    private ImmutableDictionary<object, object> storage = ImmutableDictionary<object, object>.Empty;
+    // 🚨 The type source's WithUpdate hook is an ASYNCHRONOUS write-back, NOT part of the
+    // change's publication. SynchronizationStream.SetCurrent assigns Current and then calls
+    // Store.OnNext(...) on a ReplaySubject; the data source's own subscription
+    // (TypeSourceBasedUnpartitionedDataSource.SetupDataSourceStream) is just one more
+    // subscriber, and every reduced read stream the workspace hands out is another —
+    // created lazily, per GetObservable(...) call. A ReplaySubject does not hold its gate
+    // across the fan-out, so a reader can replay/receive the new value on its own thread
+    // WHILE the write-back subscriber is still running. (DataSourceWithStorage makes the
+    // asynchrony explicit: it dispatches the write onto a separate persistence hub.)
+    // So "the host workspace surfaced the new state" says NOTHING about whether the
+    // write-back has run yet — the tests must await the write-back itself. Exposed as an
+    // observable so they can wait on that actual condition instead of sampling a field at
+    // an arbitrary moment — which raced, and failed 3 of 8 full-project runs.
+    private readonly BehaviorSubject<ImmutableDictionary<object, object>> storage =
+        new(ImmutableDictionary<object, object>.Empty);
+
+    /// <summary>The type source's persisted state; emits on every write-back.</summary>
+    private IObservable<ImmutableDictionary<object, object>> Persisted => storage;
 
     /// <summary>
     /// Configures the host message hub for data plugin testing
@@ -134,9 +151,12 @@ public class DataTest(ITestOutputHelper output) : HubTestBase(output)
             .ToArray();
 
         data.ToArray().Should().BeEquivalentTo(expectedItems, GetHost().JsonSerializerOptions);
-        // The host workspace surfacing count == 3 means the committed update
-        // (which runs SaveMyData → storage) has already landed — no Task.Delay needed.
-        storage.Values.Cast<MyData>().OrderBy(x => x.Id).Should().BeEquivalentTo(expectedItems, GetHost().JsonSerializerOptions);
+        // The write-back runs asynchronously alongside the read path (see the `storage`
+        // field note), so await it rather than sampling it.
+        var persisted = await Persisted
+            .Should().Within(10.Seconds())
+            .Match(s => s.Count == expectedItems.Length);
+        persisted.Values.Cast<MyData>().OrderBy(x => x.Id).Should().BeEquivalentTo(expectedItems, GetHost().JsonSerializerOptions);
     }
 
     /// <summary>
@@ -169,8 +189,12 @@ public class DataTest(ITestOutputHelper output) : HubTestBase(output)
             .Should().Within(10.Seconds())
             .Match(i => i.Count == 1);
         data.Should().BeEquivalentTo(expectedItems, GetHost().JsonSerializerOptions);
-        // count == 1 surfacing means the commit (SaveMyData → storage) already ran.
-        storage.Values.Should().BeEquivalentTo(expectedItems, GetHost().JsonSerializerOptions);
+        // The write-back runs asynchronously alongside the read path (see the `storage`
+        // field note), so await it rather than sampling it.
+        var persisted = await Persisted
+            .Should().Within(10.Seconds())
+            .Match(s => s.Count == expectedItems.Length);
+        persisted.Values.Should().BeEquivalentTo(expectedItems, GetHost().JsonSerializerOptions);
     }
 
     /// <summary>
@@ -212,8 +236,12 @@ public class DataTest(ITestOutputHelper output) : HubTestBase(output)
             .Should().Within(10.Seconds())
             .Match(i => i?.Text == TextChange);
         instance.Should().NotBeNull();
-        // host observing the changed text means the commit (SaveMyData → storage) already ran.
-        storage.Values.Should().Contain(i => ((MyData)i).Text == TextChange);
+        // The write-back runs asynchronously alongside the read path (see the `storage`
+        // field note), so await it rather than sampling it.
+        var persisted = await Persisted
+            .Should().Within(10.Seconds())
+            .Match(s => s.Values.Any(i => ((MyData)i).Text == TextChange));
+        persisted.Values.Should().Contain(i => ((MyData)i).Text == TextChange);
     }
 
     /// <summary>
@@ -222,7 +250,7 @@ public class DataTest(ITestOutputHelper output) : HubTestBase(output)
     /// <returns>An observable yielding the initialized MyData instances</returns>
     private IObservable<IEnumerable<MyData>> InitializeMyData()
     {
-        storage = MyData.InitialData.ToImmutableDictionary(x => (object)x.Id, x => (object)x);
+        storage.OnNext(MyData.InitialData.ToImmutableDictionary(x => (object)x.Id, x => (object)x));
         return Observable.Return<IEnumerable<MyData>>(MyData.InitialData);
     }
 
@@ -233,12 +261,7 @@ public class DataTest(ITestOutputHelper output) : HubTestBase(output)
     /// <returns>The saved instance collection</returns>
     private InstanceCollection SaveMyData(InstanceCollection instanceCollection)
     {
-        // Simple file logging to verify if this method is called
-        var logPath = "/tmp/savedata.log";
-        var itemsInfo = string.Join(", ", instanceCollection.Instances.Select(kvp => $"{kvp.Key}:{((MyData)kvp.Value).Text}"));
-        File.AppendAllText(logPath, $"{DateTime.Now:HH:mm:ss.fff} SaveMyData called with {instanceCollection.Instances.Count} instances: {itemsInfo}\n");
-
-        storage = instanceCollection.Instances;
+        storage.OnNext(instanceCollection.Instances);
         return instanceCollection;
     }
     /// <summary>


### PR DESCRIPTION
`DataTest.Delete` and `DataTest.CheckUsagesFromWorkspaceVariable` failed **3 of 8** full-project runs on pristine `main` ("expected 1 item, found 2"). Unlike the other four flakes chased in this campaign, **this one is a test defect** — the tests asserted an invariant the data layer never offered.

## Mechanism

`SynchronizationStream<T>.SetCurrent` publishes through a `ReplaySubject(1)`. The data source's write-back — `Synchronize` → `ITypeSource.Update` → the test's `WithUpdate(SaveMyData)` → `storage` — is **just one Rx subscriber** on that subject. Every reader stream the workspace hands out is another, created lazily per `GetObservable<T>()` call.

The tests' own comments assumed the write-back (subscribed first, at stream creation) always completes before any reader can observe the value. **That premise is false**, and the proof is standalone rather than statistical: a `ReplaySubject` does *not* hold its gate across fan-out. With observer #0 sleeping 300 ms inside `OnNext`, a subscriber arriving 50 ms later received the buffered value **immediately, on its own thread**.

So a reader surfaces the post-change state while the write-back subscriber is still running. The window was widened by a leftover `File.AppendAllText("/tmp/savedata.log", …)` sitting *inside* `SaveMyData` **before** the `storage` assignment — dead debug from `556a24e4c` (2026-03-22, *"Debug DataTest.Delete"*) — adding a file open+append on the hub thread. Removed.

## Why the data layer is exonerated

- The deleted item **is not visible** — `Match(i => i.Count == 1)` succeeds.
- **Nothing is dropped**: `/tmp/savedata.log` independently recorded `SaveMyData` for both failing runs, ~1 ms *after* the assertion.
- The asynchrony is **by design**: `DataSourceWithStorage.Synchronize` explicitly dispatches the write onto a separate persistence hub (`persistenceHub.InvokeAsync`).

## The fix

`storage` becomes a `BehaviorSubject`, and the three storage assertions wait on the **actual condition** through the project's own reactive assertion instead of sampling a field:

```csharp
var persisted = await Persisted.Should().Within(10.Seconds()).Match(s => s.Count == expectedItems.Length);
persisted.Values.Should().BeEquivalentTo(expectedItems, GetHost().JsonSerializerOptions);
```

No sleep, no retry, no widened timeout (10 s is this file's existing standard), no `Clear()`-for-isolation. Regression power is unchanged — if the write-back never runs, the tests still fail.

## Numbers

| configuration | full-project runs |
|---|---|
| before — pristine `main` | **3 failed / 8** |
| after, debug write **deliberately retained** | **0 / 8** |
| after, shipped state | **0 / 8** (+ a confirming 287/287) |

The middle row is the load-bearing one: keeping the debug write held the race window wide, isolating the fix from mere window-narrowing. That mattered — a build with the debug write removed but the assertions **unfixed** was 0/9 green, i.e. **deleting the debug write alone hides the flake without fixing it.**

16 green post-fix runs against a 37.5% baseline is ~1e-4 by luck — strong, but still probabilistic. The **deterministic** evidence is the Rx fan-out probe, which disproves the ordering premise independent of any test run.

Full solution `-c Release -p:CIRun=true -warnaserror`: 0 warnings, 0 errors.

## Found but not fixed — worth their own tickets

1. **Silent write-back drop.** `SetupDataSourceStream`'s filter `Where(x => isFirst || (x.ChangedBy is not null && …))` discards any change with `ChangedBy == null` after the first emission — never persisted, never logged. `UpdateStream`'s Full path builds exactly such a `ChangeItem` (3-arg ctor ⇒ `ChangedBy == null`). Reachability on a data-source stream could not be proven, so it was left alone — but it is a **silent-data-loss shape**.
2. **`WithUpdate`'s transform is a no-op**: `Synchronize` discards `ITypeSource.Update`'s return value, so the documented "transforms the collection before it is stored" only ever works as a side effect.
3. **`HubTestBase.CreateClientAddress()` is unique per call**, so `client.Observe(req, o => o.WithTarget(CreateClientAddress()))` spins up a brand-new *cold* client hub per request rather than targeting the `client` just created. Every `DataChangeRequest` in this class races a cold hub's subscribe.
4. **`TestBase.DisposeAsync` never disposes the service provider** (deliberate, with a comment), so every test method leaks a live mesh for the process lifetime — this is the "full-project context" that makes these races far likelier than running the class alone.
5. `File.AppendAllText` under concurrency **silently loses data** on this platform rather than throwing (1310 of 4000 lines survived in a probe).
6. `DataChangeStatus.Committed` is returned before the write-back runs — consistent with the design, but the name over-promises.

No What's New entry — test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
