### PR TITLE
Refuse to build a dead SynchronizationStream; classify the refusal as transient (page dies on recycle)

### DIFF
--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -158,8 +158,13 @@ public static class JsonSynchronizationStream
     where TReference : WorkspaceReference
     {
         var hub = workspace.Hub;
+        // Typed since 2026-07-27: same condition, same ObjectDisposedException base (so the
+        // Blazor circuit's `catch (ObjectDisposedException)` around BindStream still applies),
+        // but now CLASSIFIABLE as the transient ErrorType.ShuttingDown when it escapes a
+        // handler — the sibling refusal in SynchronizationStream's constructor throws the same
+        // type, so "the host is going down, ask again" has ONE shape across stream creation.
         if (hub.RunLevel > MessageHubRunLevel.Started)
-            throw new ObjectDisposedException($"ParentHub {hub.Address} is disposing, cannot create stream for {reference}.");
+            throw new HubDisposingException(hub.Address, reference);
 
         var logger = GetLogger(hub.ServiceProvider);
         // link to deserialized world. Will also potentially link to workspace.

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -649,10 +649,12 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
            && !string.Equals(ctx.ObjectId, SystemUserId, StringComparison.Ordinal);
 
     /// <summary>
-    /// Resolves the synchronization hub if the stream is alive and the hub is
-    /// non-null. Dead streams (constructed against a disposing parent) have
-    /// no hub; calling Hub.Post would NRE. Returns false in that case so
-    /// callers can no-op gracefully.
+    /// Resolves the synchronization hub if the stream is still alive. A stream that has been
+    /// DISPOSED must not post — its hub is gone — so callers no-op gracefully instead.
+    /// <para>The <c>Hub is null</c> arm is belt-and-braces only: since the constructor REFUSES
+    /// (<see cref="HubDisposingException"/>) rather than fabricating a hub-less "dead stream",
+    /// a constructed instance always has a hub. Cheap to keep, and it documents that nothing
+    /// downstream may assume otherwise.</para>
     /// </summary>
     private bool TryGetActiveHub(out IMessageHub hub)
     {
@@ -718,8 +720,8 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
                 logger.LogDebug(ex, "[SYNC_STREAM] Exception from Store.OnError propagation for {StreamId}", StreamId);
             }
             // Always fault startup and open gate, even if Store.OnError throws.
-            // Dead-stream guard: Hub may be null on a stream constructed against
-            // a disposing parent — there's nothing to fault or unblock there.
+            // (Hub is non-null on every constructed stream — the ctor refuses rather
+            // than fabricating a hub-less one; the guard is belt-and-braces.)
             if (Hub is not null)
             {
                 Hub.FailStartup(error);
@@ -771,7 +773,7 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
     {
         if (isDisposed || Hub is null)
         {
-            // Dead stream — no hub to register on. Dispose the registrant
+            // Disposed stream — no hub to register on. Dispose the registrant
             // immediately so the caller doesn't leak it. The caller's intent
             // (couple this disposable to the stream's lifetime) is satisfied
             // because the stream is already terminal.
@@ -804,9 +806,8 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
     /// <param name="value">The change item to publish.</param>
     public void OnNext(ChangeItem<TStream> value)
     {
-        // Dead stream (created against a disposing parent — see ctor) has no
-        // Hub. Propagate the dead state to subscribers via Store.OnCompleted
-        // instead of NRE'ing on Hub.Post.
+        // A DISPOSED stream has no hub to post to; drop the value rather than
+        // NRE'ing on Hub.Post. (Subscribers already saw Store.OnCompleted.)
         if (isDisposed || Hub is null)
         {
             logger.LogDebug("[SYNC_STREAM] OnNext skipped for {StreamId} — stream is dead/disposed", StreamId);
@@ -864,14 +865,17 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
 
     /// <summary>
     /// Creates a synchronization stream hosted under <paramref name="Host"/>. Spins up a dedicated
-    /// hosted hub for the stream and captures the creating user's identity; if the host is already
-    /// shutting down the stream is created dead-on-arrival (subscriptions complete immediately, writes no-op).
+    /// hosted hub for the stream and captures the creating user's identity.
     /// </summary>
     /// <param name="StreamIdentity">Identity (owner + partition) of the stream.</param>
     /// <param name="Host">The hub hosting this stream.</param>
     /// <param name="Reference">The projected reference selecting what this stream represents.</param>
     /// <param name="ReduceManager">The reduce manager for deriving reduced streams and applying patches.</param>
     /// <param name="configuration">Optional configuration of the stream (client id, subscriber, initialization, …).</param>
+    /// <exception cref="HubDisposingException">
+    /// <paramref name="Host"/> (or an ancestor of it) has begun disposing, so the stream's own
+    /// sub-hub can no longer be created. TRANSIENT — see the constructor body.
+    /// </exception>
     public SynchronizationStream(
         StreamIdentity StreamIdentity,
         IMessageHub Host,
@@ -892,49 +896,55 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>
 
         logger = Host.ServiceProvider.GetRequiredService<ILogger<SynchronizationStream<TStream>>>();
 
-        // Disposing parent hub: don't throw — that surfaced as an unhandled
-        // ObjectDisposedException at every call site (including Blazor circuit
-        // teardowns where the IDE breaks on user-unhandled). The stream is
-        // dead-on-arrival; mark it disposed so any Subscribe completes
-        // immediately and any Update is a no-op. Callers walking the parent's
-        // disposal chain will dispose this child too via the registration
-        // chain — this is just defensive belt-and-braces for the late-arrival
-        // race where someone calls Reduce on a parent that just started
-        // disposing.
-        if (Host.RunLevel > MessageHubRunLevel.Started)
-        {
-            logger.LogDebug(
-                "[SYNC_STREAM] Parent hub {Host} disposing (RunLevel={RunLevel}); creating dead stream for {Reference}",
-                Host.Address, Host.RunLevel, Reference);
-            isDisposed = true;
-            // Hub stays null on a dead stream — every code path that touches
-            // Hub goes through TryGetActiveHub (guards isDisposed first) or
-            // the explicit null check in OnNext. The null! tells the
-            // compiler we accept the non-null contract gap; the runtime
-            // guards enforce it.
-            Hub = null!;
-            Store.OnCompleted();
-            return;
-        }
-
         logger.LogDebug("Creating Synchronization Stream {StreamId} for Host {Host} and {StreamIdentity} and {Reference}", StreamId, Host.Address, StreamIdentity, Reference);
 
-        var syncHub = Host.GetHostedHub(
-            SynchronizationAddress.Create(ClientId), ConfigureSynchronizationHub, HostedHubCreation.Always);
+        // 🚨 A stream that cannot own its sub-hub is NOT a stream — REFUSE, never fabricate.
+        //
+        // The condition below is one fact: hosted-hub creation is frozen, so
+        // GetHostedHub cannot give us the Hub this type declares as non-null. The freeze is
+        // flipped by HostedHubsCollection.CloseCreation at the FIRST instant of
+        // MessageHub.Dispose — strictly BEFORE RunLevel leaves Started — and it CASCADES
+        // through the entire hosted-hub subtree, so an ancestor's disposal freezes us while
+        // our own RunLevel still reads Started. That is why the RunLevel probe alone is not
+        // sufficient and why GetHostedHub returning null is the authoritative signal.
+        //
+        // The predecessor of this code answered that by building a DEAD stream — isDisposed,
+        // Store completed, `Hub = null!` — and documenting that "every code path that touches
+        // Hub goes through TryGetActiveHub". NO CONSUMER HONOURED THAT: `grep -rn
+        // TryGetActiveHub src` found only this file, while ~96 sites dereference
+        // ISynchronizationStream.Hub, which the interface declares NON-NULLABLE. And a
+        // consumer cannot even detect the corpse: ISynchronizationStream exposes no
+        // liveness/disposal member. Handing one out is a contract violation by construction —
+        // it cost a production NRE inside LayoutAreaHost's constructor
+        // (`Stream.Hub.ServiceProvider…`) on the overlay self-heal recycle window, which
+        // escaped to the subscriber as a TERMINAL DeliveryFailure. A page that subscribed
+        // during a recycle got "this failed forever" instead of "ask again".
+        //
+        // Throwing is also what the sibling creation path already does — CreateExternalClient
+        // has always thrown here, and the Blazor circuit already catches ObjectDisposedException
+        // around BindStream() for exactly this ("old circuit's hub may already be disposing").
+        // HubDisposingException IS an ObjectDisposedException, so that existing handling keeps
+        // working; what is new is the CLASSIFICATION: escaping a message handler it becomes an
+        // ErrorType.ShuttingDown DeliveryFailure (MessageService), i.e. the transient "the
+        // address may reactivate — retry" answer #672 established one layer down, instead of a
+        // terminal fault. See Doc/Architecture/HubDisposalModel.
+        //
+        // The RunLevel probe stays as the cheap FIRST gate — it also covers the (vanishingly
+        // rare) case where GetHostedHub would hand back a PRE-EXISTING sub-hub at our address
+        // while the Host is already winding down: an existing-hub lookup is a pure read and is
+        // deliberately not refused by the freeze.
+        var syncHub = Host.RunLevel > MessageHubRunLevel.Started
+            ? null
+            : Host.GetHostedHub(
+                SynchronizationAddress.Create(ClientId), ConfigureSynchronizationHub, HostedHubCreation.Always);
         if (syncHub is null)
         {
-            // Creation was refused: an ANCESTOR hub began disposing and the
-            // creation-freeze cascade closed this collection before the Host's
-            // own RunLevel moved (the gap the RunLevel check above cannot see).
-            // Same dead-stream semantics as that check — without this, Hub
-            // would be a null on a LIVE stream and every downstream touch NREs.
             logger.LogDebug(
-                "[SYNC_STREAM] Hosted-hub creation refused for {Reference} on {Host} (teardown creation freeze); creating dead stream",
-                Reference, Host.Address);
+                "[SYNC_STREAM] Cannot host stream for {Reference} on {Host} (RunLevel={RunLevel}, hosted-hub creation frozen); refusing to create the stream",
+                Reference, Host.Address, Host.RunLevel);
             isDisposed = true;
-            Hub = null!;
             Store.OnCompleted();
-            return;
+            throw new HubDisposingException(Host.Address, Reference);
         }
         Hub = syncHub;
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
@@ -290,8 +290,47 @@ order of how early they stop the work:
 > **The principle:** a teardown is a terminal signal that must propagate *outward* to
 > producers — silently dropping their writes leaves them spinning, and letting their write
 > throw kills the process. Error the write, let the producer stop, and make the drop layers
-> below it inert. Repros: `DeadStreamSafetyTest.Update_OnDeadStream_SignalsDisposedToProducer`
+> below it inert. Repros: `DeadStreamSafetyTest.Update_OnDisposedStream_SignalsDisposedToProducer`
 > and `Post_OnDisposingHost_DropsWithoutInvokingPipeline`.
+
+## The creation window: a disposing hub accepts work it can no longer perform
+
+There is a gap the phases above open by design, and every stream-creating request falls
+into it:
+
+- **Hosted-hub creation is frozen on the FIRST statement of `Dispose()`**
+  (`HostedHubsCollection.CloseCreation`), *before* the `ShutdownRequest` that moves
+  `RunLevel` off `Started` is even posted — and the freeze **cascades through the whole
+  subtree**, so a child hub is frozen while its own `RunLevel` still reads `Started`.
+- **Message intake stays open until `DisposeHostedHubs`** — `ScheduleNotify`'s shutdown
+  gate. The entire `Quiescing` drain (up to `QuiesceTimeout`) sits inside the gap.
+
+So from the first instant of disposal until several phases later the hub **accepts requests
+it structurally cannot serve**. A `SubscribeRequest` for a layout area is the canonical one:
+serving it means constructing a `SynchronizationStream`, and a synchronization stream owns a
+hosted sub-hub.
+
+**The rule: refuse, typed and transient — never fabricate a half-built object.**
+`SynchronizationStream`'s constructor throws `HubDisposingException` (an
+`ObjectDisposedException`, so teardown-aware callers such as Blazor's
+`catch (ObjectDisposedException)` around `BindStream()` keep working), and
+`JsonSynchronizationStream.CreateExternalClient` throws the same type for the same reason.
+`MessageService` then classifies any handler exception that *is or wraps* one as
+`ErrorType.ShuttingDown` — the same transient "the address may reactivate, ask again" answer
+the intake and deferred-queue NACKs give — so `SynchronizationStream`'s keep-alive and
+change-feed resubscribe latch **stay armed** and the subscriber rehydrates after the recycle.
+
+> The predecessor built a "dead stream" here instead: `isDisposed`, completed store, and
+> `Hub = null!`, with a comment requiring every consumer to go through `TryGetActiveHub`. No
+> consumer did — `grep -rn TryGetActiveHub src` matched only the stream itself, against ~96
+> sites dereferencing the interface's **non-nullable** `Hub` — and `ISynchronizationStream`
+> exposes no liveness member for a consumer to check even if it wanted to. The result was a
+> `NullReferenceException` in `LayoutAreaHost`'s constructor whenever a page subscribed during
+> a recycle (the overlay self-heal posts a self-`DisposeRequest`), surfacing to the subscriber
+> as a **terminal** `DeliveryFailure`. Deterministic repros:
+> `SubscribeDuringRecycleTest` (Layout.Test, end-to-end) and
+> `HubDisposalFailureClassificationTest` (Messaging.Hub.Test, the classification, including
+> the reflection-wrapped case).
 
 ---
 

--- a/src/MeshWeaver.Messaging.Contract/HubDisposingException.cs
+++ b/src/MeshWeaver.Messaging.Contract/HubDisposingException.cs
@@ -1,0 +1,77 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// TRANSIENT: an operation needed machinery that a hub can no longer create because that hub
+/// (or an ancestor of it) has begun disposing — a recycle, a restart, a node delete. The
+/// canonical case is a synchronization stream: it must host its own sub-hub, and hosted-hub
+/// creation is FROZEN from the first instant of <see cref="IDisposable.Dispose"/>
+/// (<c>HostedHubsCollection.CloseCreation</c>, which cascades through the whole subtree).
+///
+/// <para>🚨 This is NOT a terminal error. A disposing hub cannot know whether its address is
+/// gone for good or about to REACTIVATE, so the honest answer to the caller is "ask again" —
+/// the same contract <see cref="ErrorType.ShuttingDown"/> carries on the messaging layer
+/// (<c>MessageService.NackThroughParent</c>). When this escapes a message handler,
+/// <c>MessageService</c> classifies the resulting <see cref="DeliveryFailure"/> as
+/// <see cref="ErrorType.ShuttingDown"/> so long-lived consumers (chiefly
+/// <c>SynchronizationStream</c>'s keep-alive + change-feed resubscribe latch) ride it out and
+/// rehydrate against the fresh activation instead of faulting.</para>
+///
+/// <para>Derives from <see cref="ObjectDisposedException"/> because that is the shape the
+/// framework already uses for "this stream/hub is torn down": <c>CreateExternalClient</c>
+/// threw it, <c>LayoutAreaView.SetParametersAsync</c> catches it around <c>BindStream()</c>
+/// ("old circuit's hub may already be disposing"), and <c>SynchronizationStream.OnError</c>
+/// classifies it as benign teardown (Debug, no stack-trace pageant). Existing handling keeps
+/// working; only the classification is new.</para>
+/// </summary>
+public sealed class HubDisposingException : ObjectDisposedException
+{
+    /// <summary>The address of the hub that is disposing (or whose ancestor is).</summary>
+    public Address HubAddress { get; }
+
+    /// <summary>
+    /// Creates the exception for <paramref name="hubAddress"/>. The message deliberately
+    /// contains the words "is shutting down" — the same banner
+    /// <c>MessageService</c>'s intake NACK uses — because the GUI's
+    /// <c>AreaErrorClassifier.IsTransientHubFailure</c> and
+    /// <c>MeshNodeStreamCache.IsTransientOwnerFailure</c> match on it when the typed failure
+    /// has already been flattened into a <c>DeliveryFailureException</c> message.
+    /// </summary>
+    /// <param name="hubAddress">Address of the disposing hub.</param>
+    /// <param name="what">What could not be created, e.g. the stream reference.</param>
+    public HubDisposingException(Address hubAddress, object what)
+        : base(hubAddress.ToString(),
+            $"Hub {hubAddress} is shutting down — cannot create '{what}'. "
+            + "The address may reactivate (recycle / restart); retry to get the authoritative answer.")
+    {
+        HubAddress = hubAddress;
+    }
+
+    /// <summary>
+    /// True when <paramref name="exception"/> is — or wraps, at any depth — a
+    /// <see cref="HubDisposingException"/>. Handler exceptions reach
+    /// <c>MessageService</c> wrapped (e.g. <see cref="System.Reflection.TargetInvocationException"/>
+    /// from <c>Workspace.SubscribeToClient</c>'s reflective dispatch), so the check must walk
+    /// the chain rather than test the outermost type.
+    /// </summary>
+    /// <param name="exception">The exception to classify; may be null.</param>
+    /// <returns><c>true</c> when the failure is a hub-disposal race.</returns>
+    public static bool IsHubDisposal(Exception? exception) => IsHubDisposal(exception, depth: 0);
+
+    // depth caps the walk: an exception graph is caller-supplied data, and AggregateException
+    // fan-out makes the traversal a tree, not a chain. 16 is far beyond any real wrapping depth
+    // (the deepest observed is TargetInvocationException → HubDisposingException).
+    private static bool IsHubDisposal(Exception? exception, int depth)
+    {
+        if (depth > 16)
+            return false;
+        for (var e = exception; e is not null; e = e.InnerException)
+        {
+            if (e is HubDisposingException)
+                return true;
+            if (e is AggregateException agg
+                && agg.InnerExceptions.Any(inner => IsHubDisposal(inner, depth + 1)))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -1053,6 +1053,37 @@ public class MessageService : IMessageService
                         cbEx => logger.LogWarning(cbEx,
                             "ExceptionCallback for ExecutionRequest itself threw in {Address}; original execution error: {Original}",
                             Address, e.Message));
+                else if (HubDisposingException.IsHubDisposal(e))
+                {
+                    // 🚨 TRANSIENT, not a fault: the handler needed machinery a disposing hub
+                    // can no longer create (hosted-hub creation is frozen from the first
+                    // instant of Dispose, and the freeze CASCADES to the whole subtree — so
+                    // this fires while RunLevel can still read Started and the intake gate at
+                    // ScheduleNotify, which only rejects from DisposeHostedHubs on, has let the
+                    // message through). Canonical case: a SubscribeRequest for a layout area
+                    // landing in the overlay self-heal's recycle window — LayoutAreaHost's ctor
+                    // could not build its SynchronizationStream.
+                    //
+                    // It MUST reach the sender as ErrorType.ShuttingDown, exactly like the
+                    // intake/deferred NACKs (#672): the address is about to REACTIVATE, so the
+                    // honest answer is "ask again". Reported as Unknown it was terminal — the
+                    // subscriber's sync stream OnError'd, killing the keep-alive + change-feed
+                    // resubscribe latch that would have rehydrated it after the recycle, and
+                    // the page stayed dead (it surfaced as a DeliveryFailureException wrapping
+                    // an NRE before SynchronizationStream's ctor started refusing).
+                    //
+                    // Debug, not Error: a recycle race is routine and self-healing; logging it
+                    // at Error paged operators for normal teardown traffic and bled Loki ingest
+                    // on every recycle. A genuine failure still logs Error below.
+                    //
+                    // Message TYPE + id, never LogText(delivery): serializing the payload for a
+                    // Debug line is evaluated even when Debug is off and was itself a hot-path
+                    // regression (the LogText storm, core #608).
+                    logger.LogDebug(e,
+                        "{MessageType} (ID: {MessageId}) raced hub disposal in {Address} after {Duration}ms — NACKing as transient (ShuttingDown).",
+                        messageTypeName, delivery.Id, Address, executionStopwatch.ElapsedMilliseconds);
+                    ReportFailure(delivery.Failed(e.ToString()), ErrorType.ShuttingDown);
+                }
                 else
                 {
                     logger.LogError("An exception occurred during the processing of {Delivery} after {Duration}ms. Exception: {Exception}. Address: {Address}.",

--- a/test/MeshWeaver.Data.Test/DeadStreamSafetyTest.cs
+++ b/test/MeshWeaver.Data.Test/DeadStreamSafetyTest.cs
@@ -11,100 +11,98 @@ using Xunit;
 namespace MeshWeaver.Data.Test;
 
 /// <summary>
-/// Regression tests for the dead-stream safety net in
-/// <see cref="SynchronizationStream{TStream}"/>: when a Reduce / construct
-/// races a parent hub that has just started disposing, the resulting
-/// stream's Hub field stays null — every public method that touched Hub
-/// used to NRE. The IDE then surfaced "user-unhandled" first-chance breaks
-/// at the call site (typically inside a Blazor circuit teardown's Rx
-/// pipeline) even when the call site had a Catch downstream.
+/// Pins the disposal contract of <see cref="SynchronizationStream{TStream}"/>.
 ///
-/// <para>The fixes:</para>
-/// <list type="bullet">
-/// <item><description>Constructor on a disposing parent: don't throw — log
-/// Debug, mark <c>isDisposed = true</c>, complete the Store, leave Hub null.</description></item>
-/// <item><description><see cref="SynchronizationStream{TStream}.OnNext"/>,
-/// both <c>ISynchronizationStream&lt;TStream&gt;.Update</c> overloads,
-/// <see cref="ISynchronizationStream.RegisterForDisposal"/>,
-/// <c>DeliverMessage</c>: guard against <c>isDisposed</c> / Hub-null,
-/// log Debug + bail (or in OnNext's case forward the failure to subscribers
-/// via Store.OnError).</description></item>
-/// <item><description>OnError path: don't touch Hub.FailStartup / OpenGate
-/// when Hub is null.</description></item>
-/// <item><description>Dispose: only call Hub.Dispose() when Hub is non-null.</description></item>
-/// </list>
+/// <para><b>Construction against a disposing host REFUSES</b> — it does not hand back a
+/// half-built stream. A synchronization stream owns a hosted sub-hub, and hosted-hub creation
+/// is frozen from the first instant of <c>MessageHub.Dispose</c> (cascading through the whole
+/// subtree), so on a disposing host there is no hub to give. The predecessor of this contract
+/// built a "dead stream" instead — <c>isDisposed</c>, completed store, and <c>Hub = null!</c>
+/// with a comment saying every consumer must go through <c>TryGetActiveHub</c>. NO CONSUMER
+/// DID (<c>grep -rn TryGetActiveHub src</c> found only the stream itself, against ~96 sites
+/// dereferencing the interface's NON-NULLABLE <c>Hub</c>), and <see cref="ISynchronizationStream"/>
+/// exposes no liveness member for them to check even if they wanted to. It cost a production
+/// NullReferenceException in <c>LayoutAreaHost</c>'s constructor whenever a page subscribed
+/// during a hub recycle. Refusing with a TRANSIENT, typed
+/// <see cref="HubDisposingException"/> is what lets the messaging layer answer the caller
+/// "the address may reactivate — ask again" (<see cref="ErrorType.ShuttingDown"/>) instead of
+/// crashing it, and it makes the non-null <c>Hub</c> declaration true again.</para>
 ///
-/// <para>Test strategy: build a host hub, stop it (RunLevel becomes ShutDown),
-/// then construct a SynchronizationStream against it and exercise every
-/// public method. None should throw NRE; all should produce a benign no-op.</para>
+/// <para><b>A stream that is DISPOSED after a healthy life stays inert, never throwing</b> —
+/// <c>OnNext</c>, both <c>Update</c> overloads, <c>RegisterForDisposal</c>, <c>DeliverMessage</c>
+/// and <c>Dispose</c> itself are all no-ops (or signal back to the producer). That half of the
+/// original safety net is unchanged and still covered below.</para>
 /// </summary>
 public class DeadStreamSafetyTest(ITestOutputHelper output) : HubTestBase(output)
 {
     private record Empty;
 
-    private async Task<SynchronizationStream<Empty>> CreateAgainstDisposingHost()
+    /// <summary>Builds a healthy stream on a live host, then disposes the stream.</summary>
+    private SynchronizationStream<Empty> CreateAndDispose(out bool completed)
     {
         var host = GetHost();
-
-        // Force the host past Started so the dead-stream branch in the ctor
-        // fires. Calling Dispose() bumps RunLevel to DisposeHostedHubs and
-        // ultimately ShutDown — both > Started, both trigger the dead path.
-        host.Dispose();
-        // RunLevel check in ctor compares against MessageHubRunLevel.Started.
-        // Wait briefly for the dispose to begin so RunLevel is past Started.
-        await host.DisposalCompleted
-            .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
-            .FirstOrDefaultAsync()
-            .Timeout(2.Seconds())
-            .ToTask(TestContext.Current.CancellationToken);
-
-        var reduceManager = new ReduceManager<Empty>(host);
-        return new SynchronizationStream<Empty>(
+        var stream = new SynchronizationStream<Empty>(
             new StreamIdentity(host.Address, null),
             host,
             new EntityReference("X", "Y"),
-            reduceManager,
+            new ReduceManager<Empty>(host),
             null);
+
+        var sawCompletion = false;
+        // Subscribe BEFORE disposal so the terminal notification is observable.
+        stream.Subscribe(_ => { }, _ => { }, () => sawCompletion = true);
+        stream.Dispose();
+        completed = sawCompletion;
+        return stream;
     }
 
     [HubFact]
-    public async Task Ctor_OnDisposingHost_DoesNotThrow_AndProducesDeadStream()
+    public async Task Ctor_OnDisposingHost_Refuses_WithATransientHubDisposalError()
     {
-        // Pre-fix: ObjectDisposedException at the user's call site (Reduce
-        // chain). Post-fix: ctor returns a "dead" stream, no exception.
-        Func<Task> act = () => CreateAgainstDisposingHost();
-        await act.Should().NotThrowAsync(
-            "the dead-stream branch must replace the throw with a benign no-op stream");
+        var host = GetHost();
+        host.Dispose();
+        await host.DisposalCompleted
+            .Catch<Unit, Exception>(_ => Observable.Return(Unit.Default))
+            .FirstOrDefaultAsync()
+            .Timeout(10.Seconds())
+            .ToTask(TestContext.Current.CancellationToken);
+
+        Action act = () => _ = new SynchronizationStream<Empty>(
+            new StreamIdentity(host.Address, null),
+            host,
+            new EntityReference("X", "Y"),
+            new ReduceManager<Empty>(host),
+            null);
+
+        var ex = act.Should().Throw<HubDisposingException>(
+            "a stream that cannot own its sub-hub is not a stream — refusing is what keeps "
+            + "ISynchronizationStream.Hub's non-null declaration honest. Fabricating a hub-less "
+            + "'dead stream' pushed the failure onto consumers as a NullReferenceException.");
+        ex.Which.HubAddress.Should().Be(host.Address,
+            "the failure must name the hub that is going down, so the caller can retry the right address");
+        // The Blazor circuit already catches ObjectDisposedException around BindStream()
+        // ("old circuit's hub may already be disposing"), and SynchronizationStream.OnError
+        // classifies it as benign teardown. Keeping the refusal in that family is what makes it
+        // fit the existing handling instead of blowing past it.
+        (ex.Which is ObjectDisposedException).Should().BeTrue(
+            "the refusal must stay in the ObjectDisposedException family that teardown-aware "
+            + "callers (Blazor's BindStream catch, the stream's own OnError classifier) already handle");
     }
 
     [HubFact]
-    public async Task OnNext_OnDeadStream_DoesNotThrow_AndCompletesSubscribers()
+    public void DisposedStream_CompletesSubscribersAndDropsWrites()
     {
-        var stream = await CreateAgainstDisposingHost();
-        var emitted = false;
-        var errored = false;
-        var completed = false;
-        using var sub = ((IObservable<ChangeItem<Empty>>)stream).Subscribe(
-            _ => emitted = true,
-            _ => errored = true,
-            () => completed = true);
+        var stream = CreateAndDispose(out var completed);
+        completed.Should().BeTrue("disposing a stream must complete its subscribers");
 
         var act = () => stream.OnNext(new ChangeItem<Empty>(new Empty(), stream.StreamId, 0));
-        act.Should().NotThrow(
-            "OnNext on a dead stream must not NRE on the null Hub — " +
-            "this was the original Blazor-circuit-teardown crash");
-
-        // Store.OnCompleted was called from the ctor — subscribers see completion,
-        // never see emissions or errors from the dead stream's OnNext.
-        completed.Should().BeTrue("dead-stream subscribers receive Store.OnCompleted from the ctor");
-        emitted.Should().BeFalse("dead stream cannot emit values");
-        errored.Should().BeFalse("dead stream OnNext must not OnError subscribers — that path is reserved for live-stream Hub.Post failures");
+        act.Should().NotThrow("OnNext on a disposed stream must drop the value, never throw");
     }
 
     [HubFact]
-    public async Task Update_OnDeadStream_SignalsDisposedToProducer()
+    public void Update_OnDisposedStream_SignalsDisposedToProducer()
     {
-        var stream = await CreateAgainstDisposingHost();
+        var stream = CreateAndDispose(out _);
         var updateInvoked = false;
         Exception? signaled = null;
 
@@ -113,41 +111,40 @@ public class DeadStreamSafetyTest(ITestOutputHelper output) : HubTestBase(output
             ex => signaled = ex);
 
         act.Should().NotThrow(
-            "Update on a dead stream must not throw — it errors back to the producer instead");
-        // The update delegate itself should NOT have been invoked — the dead
-        // stream's TryGetActiveHub guard returns false BEFORE Hub.Post runs.
+            "Update on a disposed stream must not throw — it errors back to the producer instead");
+        // The update delegate itself should NOT have been invoked — TryGetActiveHub
+        // returns false BEFORE Hub.Post runs.
         updateInvoked.Should().BeFalse(
-            "the update delegate executes on the hub action block; a dead stream has no hub to post to");
-        // New contract: a dead/disposed stream ERRORS incoming writes (ObjectDisposedException) so the
-        // producer — a FileSystemWatcher, a remote subscription — tears down its own source instead of
-        // pushing into a disposed hub. See Doc/Architecture/HubDisposalModel.
+            "the update delegate executes on the hub action block; a disposed stream has no hub to post to");
+        // A disposed stream ERRORS incoming writes (ObjectDisposedException) so the producer — a
+        // FileSystemWatcher, a remote subscription — tears down its own source instead of pushing
+        // into a disposed hub. See Doc/Architecture/HubDisposalModel.
         signaled.Should().BeOfType<ObjectDisposedException>(
-            "incoming writes to a dead stream must error so the producer stops feeding it");
+            "incoming writes to a disposed stream must error so the producer stops feeding it");
     }
 
     [HubFact]
-    public async Task RegisterForDisposal_OnDeadStream_DisposesImmediately()
+    public void RegisterForDisposal_OnDisposedStream_DisposesImmediately()
     {
-        var stream = await CreateAgainstDisposingHost();
+        var stream = CreateAndDispose(out _);
         var disposed = false;
         var disposable = new ActionDisposable(() => disposed = true);
 
         var act = () => stream.RegisterForDisposal(disposable);
 
-        act.Should().NotThrow(
-            "RegisterForDisposal on a dead stream must not NRE on the null Hub");
+        act.Should().NotThrow("RegisterForDisposal on a disposed stream must not throw");
         disposed.Should().BeTrue(
-            "the registrant should be disposed immediately so the caller doesn't leak it — " +
-            "the caller's intent was 'couple this disposable to the stream's lifetime', " +
-            "and a dead stream is already terminal");
+            "the registrant should be disposed immediately so the caller doesn't leak it — "
+            + "the caller's intent was 'couple this disposable to the stream's lifetime', "
+            + "and a disposed stream is already terminal");
     }
 
     [HubFact]
-    public async Task Dispose_OnDeadStream_DoesNotThrow()
+    public void Dispose_IsIdempotent()
     {
-        var stream = await CreateAgainstDisposingHost();
+        var stream = CreateAndDispose(out _);
         var act = () => stream.Dispose();
-        act.Should().NotThrow("Dispose on a dead stream must skip the null Hub branch cleanly");
+        act.Should().NotThrow("a second Dispose must be a clean no-op");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/OverlaySelfHealInstanceRecycleTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/OverlaySelfHealInstanceRecycleTest.cs
@@ -140,8 +140,26 @@ public class OverlaySelfHealInstanceRecycleTest(ITestOutputHelper output) : Mono
         //    with fresh clients — each probe is a new subscription, i.e. a new
         //    activation once the stuck hub disposed; a probe that lands before
         //    the recycle sees the overlay and times out its bounded window, so
-        //    retry. Before the fix EVERY probe hit the still-alive overlay hub
-        //    and this wait exhausted all attempts (the prod 14h symptom).
+        //    retry. Before the self-heal fix EVERY probe hit the still-alive
+        //    overlay hub and this wait exhausted all attempts (the prod 14h
+        //    symptom).
+        //
+        //    🚨 Only TimeoutException is caught, deliberately. A probe that
+        //    lands INSIDE the self-recycle window must still end up retryable:
+        //    the owner answers the SubscribeRequest with a transient
+        //    ErrorType.ShuttingDown NACK, which the client's sync stream rides
+        //    out (keep-alive + resubscribe latch stay armed), so the probe
+        //    simply produces nothing and times out here. A DeliveryFailure-
+        //    Exception reaching this loop is therefore a REGRESSION and must
+        //    fail the test loudly — never be swallowed as "retry".
+        //
+        //    That is exactly how this test failed 1-4 runs in 8 before
+        //    2026-07-27: LayoutAreaHost's ctor NRE'd on a hub-less "dead
+        //    stream" and the terminal DeliveryFailureException escaped this
+        //    catch on the FIRST probe. The earlier reading — "the wait
+        //    exhausted all attempts" — was wrong: the loop never got to
+        //    attempt 1, and a 2.1-2.6 s failure is far too fast for six 15 s
+        //    windows. See SubscribeDuringRecycleTest for the deterministic pin.
         string? healedHtml = null;
         for (var attempt = 0; attempt < 6 && healedHtml is null; attempt++)
         {

--- a/test/MeshWeaver.Layout.Test/SubscribeDuringRecycleTest.cs
+++ b/test/MeshWeaver.Layout.Test/SubscribeDuringRecycleTest.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Deterministic repro for the RECYCLE-WINDOW SUBSCRIBE crash: a
+/// <see cref="SubscribeRequest"/> for a layout area that lands on a hub which has just begun
+/// disposing used to fail with a <b>NullReferenceException</b> inside
+/// <c>LayoutAreaHost</c>'s constructor, and that reached the subscriber as a TERMINAL
+/// <see cref="DeliveryFailureException"/>.
+///
+/// <para><b>The window is not a millisecond fluke — it is structural.</b>
+/// <c>MessageHub.Dispose</c> freezes hosted-hub creation SYNCHRONOUSLY, on its very first
+/// statement (<c>HostedHubsCollection.CloseCreation</c>, which cascades through the whole
+/// subtree), and only THEN posts the <c>ShutdownRequest</c> that moves <c>RunLevel</c> off
+/// <c>Started</c>. Message intake, meanwhile, stays open until <c>DisposeHostedHubs</c> — the
+/// whole <c>Quiescing</c> drain sits inside the gap. So a disposing hub happily ACCEPTS work it
+/// can no longer perform, and serving a layout area means creating a hosted sub-hub for its
+/// <c>SynchronizationStream</c>. The stream constructor used to paper over the refusal by
+/// fabricating a "dead stream" with <c>Hub = null!</c>; <c>LayoutAreaHost</c> dereferenced
+/// <c>Stream.Hub.ServiceProvider</c> on the next line.</para>
+///
+/// <para><b>How the window is held open</b> (no sleeps, no racing): one un-answered response
+/// callback is parked on the area hub, so its <c>Quiescing</c> phase cannot drain and the hub
+/// sits in the disposal window for its whole quiesce budget. The test then WAITS until
+/// <c>RunLevel</c> has demonstrably reached <c>Quiescing</c> before subscribing — the state is
+/// verified, not timed.</para>
+///
+/// <para><b>The contract pinned here</b> is the same one #672 established one layer down: a
+/// caller caught in a recycle window gets a TRANSIENT <see cref="ErrorType.ShuttingDown"/>
+/// rejection — "the address may reactivate, ask again" — never a terminal fault. That
+/// classification is what keeps <c>SynchronizationStream</c>'s keep-alive and change-feed
+/// resubscribe latch ALIVE so the page rehydrates after the recycle instead of staying dead.
+/// A page is exactly what hits this: the overlay self-heal posts a self-<c>DisposeRequest</c>
+/// (<c>NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal</c>) and any subscriber in that window
+/// landed here — <c>OverlaySelfHealInstanceRecycleTest</c> failed 1-4 runs in 8 on exactly this.</para>
+/// </summary>
+public class SubscribeDuringRecycleTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string StaticView = nameof(StaticView);
+    private static readonly Address AreaAddress = new("area", "1");
+
+    /// <summary>Accepted by the area hub and never answered — parks one pending response callback.</summary>
+    private record HoldRequest : IRequest<HoldResponse>;
+
+    private record HoldResponse;
+
+    // The subscribing side needs the data message contract (SubscribeRequest / SubscribeAck /
+    // LayoutAreaReference) registered, exactly as a real client hub has it.
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData()
+            .AddLayoutTypes()
+            .WithTypes(typeof(HoldRequest), typeof(HoldResponse));
+
+    [HubFact]
+    public async Task SubscribeRacingDisposal_IsRejectedAsTransient_NotWithANullReference()
+    {
+        var host = GetHost();
+
+        // A hub that serves a layout area, fully started before the race so the subscribe can
+        // NOT be answered by the already-fixed deferred-behind-an-init-gate path (#672) — this
+        // test must exercise the stream-creation refusal, not that one.
+        var area = host.GetHostedHub(
+            AreaAddress,
+            c => c.WithTypes(typeof(HoldRequest), typeof(HoldResponse))
+                .WithHandler<HoldRequest>((_, d) => d.Processed())
+                .AddLayout(layout => layout.WithView(StaticView, Controls.Html("Hello")))
+                // Plumbing fixture, no logged-in user: post as infrastructure, exactly like
+                // HubTestBase does for its own host/client hubs (never-null AccessContext).
+                .WithPostingIdentity(PostingIdentity.System));
+        area.Should().NotBeNull();
+        await area!.Started.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        // Park an un-answered callback so the Quiescing drain cannot complete: the hub then
+        // stays in the disposal window (creation frozen, intake still open) for its whole
+        // quiesce budget instead of racing through teardown in under a millisecond.
+        using var held = area
+            .Observe<HoldResponse>(new HoldRequest(), o => o.WithTarget(AreaAddress))
+            // Never throw from these callbacks — they run on the hub's scheduler, where an
+            // exception would be unobserved. If the hold ever resolved, WaitForDisposalWindow
+            // below would find the hub already Dead and fail the test with a clear message.
+            .Subscribe(
+                d => Output.WriteLine($"Hold callback answered unexpectedly: {d.Message}"),
+                ex => Output.WriteLine($"Hold callback released: {ex.GetType().Name}: {ex.Message}"));
+
+        // THE RECYCLE — the same self-DisposeRequest the overlay self-heal watcher posts.
+        host.Post(new DisposeRequest(), o => o.WithTarget(AreaAddress));
+        await WaitForDisposalWindow(area);
+
+        var ack = host
+            .Observe<SubscribeAck>(
+                new SubscribeRequest(Guid.NewGuid().ToString("N"), new LayoutAreaReference(StaticView)),
+                o => o.WithTarget(AreaAddress))
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        var failure = await Assert.ThrowsAsync<DeliveryFailureException>(() => ack);
+        Output.WriteLine($"NACK: errorType={failure.Failure?.ErrorType} message={failure.Failure?.Message}");
+
+        failure.Failure.Should().NotBeNull();
+        failure.Failure!.ErrorType.Should().Be(ErrorType.ShuttingDown,
+            "a subscriber caught in a recycle window must get a RETRYABLE answer — the address "
+            + "reactivates on the next access. Terminal classification kills the sync stream's "
+            + "resubscribe latch and the page never comes back.");
+        failure.Failure.Message.Should().Contain(nameof(HubDisposingException),
+            "the failure must name the real cause — the host could not host the stream's sub-hub. "
+            + "This also proves the test exercised the STREAM-CREATION refusal and was not "
+            + "answered by MessageService's intake / deferred-queue NACKs, which carry a "
+            + "different banner and are a different, already-fixed defect");
+        failure.Failure.Message.Should().NotContain(nameof(NullReferenceException),
+            "the pre-fix symptom: SynchronizationStream handed LayoutAreaHost a stream whose "
+            + "non-nullable Hub was null, and the ctor NRE'd on the very next line");
+    }
+
+    /// <summary>
+    /// Waits until <paramref name="hub"/> has demonstrably entered the disposal window
+    /// (<see cref="MessageHubRunLevel.Quiescing"/> or later) — creation frozen, message intake
+    /// still open. Polling a PUBLIC state property, not a sleep: the test acts on a verified
+    /// state rather than hoping to hit a race.
+    /// </summary>
+    private static async Task WaitForDisposalWindow(IMessageHub hub)
+    {
+        for (var i = 0; i < 200 && hub.RunLevel < MessageHubRunLevel.Quiescing; i++)
+            await Task.Delay(10);
+        (hub.RunLevel >= MessageHubRunLevel.Quiescing).Should().BeTrue(
+            "the DisposeRequest must have moved the hub into its teardown phases — without that "
+            + $"this test never exercises the window it exists to pin (RunLevel={hub.RunLevel})");
+        (hub.RunLevel < MessageHubRunLevel.DisposeHostedHubs).Should().BeTrue(
+            "past DisposeHostedHubs the message service's own intake gate rejects everything, so "
+            + $"the subscribe would never reach the layout stack (RunLevel={hub.RunLevel})");
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/HubDisposalFailureClassificationTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/HubDisposalFailureClassificationTest.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Pins the CLASSIFICATION half of the recycle-window contract: when a handler cannot complete
+/// because the hub it needs is tearing down — signalled by <see cref="HubDisposingException"/> —
+/// the sender must receive the TRANSIENT <see cref="ErrorType.ShuttingDown"/>, never a generic
+/// terminal failure.
+///
+/// <para><b>Why this matters.</b> A disposing hub cannot know whether its address is gone for
+/// good or about to REACTIVATE (recycle / restart), so "ask again" is the only honest answer.
+/// #672 established exactly this for the two paths the MESSAGING layer owns (a message arriving
+/// after the intake gate closed, and a delivery abandoned in the deferred queue at disposal).
+/// The DATA/LAYOUT layer has a third: hosted-hub creation is frozen from the first instant of
+/// <c>Dispose</c> — strictly BEFORE the intake gate closes — so a <c>SubscribeRequest</c> in
+/// that window is accepted, reaches <c>LayoutAreaHost</c>, and cannot build its
+/// <c>SynchronizationStream</c>. Reported as <see cref="ErrorType.Unknown"/> that killed the
+/// subscriber's resubscribe latch and the page never came back.</para>
+///
+/// <para>Also pinned: the exception reaches <c>MessageService</c> WRAPPED (the layout subscribe
+/// path dispatches through reflection, so the real cause arrives inside a
+/// <see cref="System.Reflection.TargetInvocationException"/>). The classifier must walk the
+/// inner-exception chain, not test the outermost type — a top-level-only check would have
+/// missed the production case entirely.</para>
+/// </summary>
+public class HubDisposalFailureClassificationTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record DirectRequest : IRequest<Ack>;
+
+    private record WrappedRequest : IRequest<Ack>;
+
+    private record OrdinaryFailureRequest : IRequest<Ack>;
+
+    private record Ack;
+
+    private static readonly Address ServerAddress = new("host", "1");
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithTypes(typeof(DirectRequest), typeof(WrappedRequest), typeof(OrdinaryFailureRequest), typeof(Ack))
+            .WithHandler<DirectRequest>((h, _) => throw new HubDisposingException(h.Address, "area/Overview"))
+            .WithHandler<WrappedRequest>((h, _) => throw new System.Reflection.TargetInvocationException(
+                new HubDisposingException(h.Address, "area/Overview")))
+            .WithHandler<OrdinaryFailureRequest>((_, _) => throw new InvalidOperationException("a genuine bug"));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .WithTypes(typeof(DirectRequest), typeof(WrappedRequest), typeof(OrdinaryFailureRequest), typeof(Ack));
+
+    [HubFact]
+    public async Task HubDisposalDuringHandling_IsReportedAsTransient()
+    {
+        var failure = await Nack(new DirectRequest());
+        failure.Failure!.ErrorType.Should().Be(ErrorType.ShuttingDown,
+            "the address may reactivate, so the caller must read this as 'ask again'; consumers "
+            + "with their own recovery machinery (SynchronizationStream's resubscribe latch) ride "
+            + "it out instead of tearing down");
+    }
+
+    [HubFact]
+    public async Task WrappedHubDisposal_IsStillReportedAsTransient()
+    {
+        var failure = await Nack(new WrappedRequest());
+        failure.Failure!.ErrorType.Should().Be(ErrorType.ShuttingDown,
+            "the production path (Workspace.SubscribeToClient's reflective dispatch) delivers the "
+            + "cause wrapped in a TargetInvocationException — classifying only the outermost type "
+            + "would miss every real occurrence");
+    }
+
+    [HubFact]
+    public async Task AnOrdinaryHandlerBug_StaysTerminal()
+    {
+        var failure = await Nack(new OrdinaryFailureRequest());
+        failure.Failure!.ErrorType.Should().NotBe(ErrorType.ShuttingDown,
+            "only a hub-disposal race is retryable — dressing a genuine bug as transient would "
+            + "turn a hard failure into an invisible retry loop");
+    }
+
+    private async Task<DeliveryFailureException> Nack(IRequest<Ack> request)
+    {
+        var client = GetClient();
+        var response = client
+            .Observe<Ack>(request, o => o.WithTarget(ServerAddress))
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+        var failure = await Assert.ThrowsAsync<DeliveryFailureException>(() => response);
+        Output.WriteLine($"{request.GetType().Name}: errorType={failure.Failure?.ErrorType} message={failure.Failure?.Message}");
+        failure.Failure.Should().NotBeNull();
+        return failure;
+    }
+}


### PR DESCRIPTION
A page subscribing while its hub recycles died with a **terminal** `DeliveryFailure` — `NullReferenceException at LayoutAreaHost..ctor`. Reproduced 6 times in 26 rounds locally (a sweep saw 4/8). This is the same bug class as #672, one layer up: #672 taught the *messaging* layer to answer a recycle race with a retryable nack; the *data/layout* layer still hard-faulted.

## The window is structural, not a fluke

Two gates disagree:

- **`MessageHub.Dispose()` freezes hosted-hub creation on its first statement** (`HostedHubsCollection.CloseCreation`) — *before* the `ShutdownRequest` that moves `RunLevel` off `Started` is even posted — and the freeze **cascades to the whole subtree**, so a child is frozen while its own `RunLevel` still reads `Started`.
- **`MessageService.ScheduleNotify`'s intake gate only rejects from `DisposeHostedHubs` on.**

The entire `Quiescing` drain sits in that gap, so **a disposing hub accepts requests it structurally cannot serve.**

Serving a layout area means constructing a `SynchronizationStream`, which must own a hosted sub-hub. The constructor answered the refusal by **fabricating a corpse** — `isDisposed`, completed store, `Hub = null!` — documenting that consumers must use `TryGetActiveHub`.

**No consumer can honour that contract**: `grep -rn TryGetActiveHub src` matches only that file, ~96 sites dereference the interface's **non-nullable** `Hub`, and `ISynchronizationStream` exposes no liveness member to check. `LayoutAreaHost..ctor:136` NRE'd, and it reached the subscriber as a terminal `DeliveryFailure` (`ErrorType.Unknown`) — which the client's sync stream `OnError`s, killing the keep-alive and resubscribe latch. Page dead.

## Chosen fix: make the corpse unconstructible, then classify the refusal

The constructor **refuses** rather than fabricating an invariant-violating object, throwing a typed transient `HubDisposingException`; `MessageService` classifies any handler exception that **is or wraps** one as `ErrorType.ShuttingDown` — the same "ask again" answer #672 gave one layer down. One decision point, covering every stream-creating path.

Alternatives rejected, for the record:

- **Guard every dereference** — untenable at ~96 sites, and node-native plugins register their own reducers compiled live on the mesh, so the site set is *unbounded*.
- **Early-reject `SubscribeRequest`** — racy and incomplete: can't cover the ancestor-cascade freeze (RunLevel still `Started`), misses in-process stream creation (Blazor circuit, `WorkspaceStreams`, `MeshNodeStreamCache`), and duplicates the decision in two places.

Two existing facts made refusal the *safe* shape rather than a risky change: the sibling path `JsonSynchronizationStream.CreateExternalClient` **already threw** here, and Blazor already wraps `BindStream` in `catch (ObjectDisposedException)` with the comment *"old circuit's hub may already be disposing"*. So `HubDisposingException : ObjectDisposedException` — existing teardown handling keeps working, and only the classification is new. The original "don't throw" rationale was an IDE first-chance-break annoyance at a call site that already had a `Catch` downstream.

Logged at **Debug**, not Error — a recycle race is routine and paging operators for normal teardown is noise — and logging message **type + id**, never `LogText(delivery)`, which was the core #608 hot-path serialization storm.

## Evidence

The new `SubscribeDuringRecycleTest` holds the window open by parking one un-answered response callback so `Quiescing` cannot drain, then **waits until `RunLevel` has demonstrably reached `Quiescing`** before subscribing — verified state, no sleeps, no racing. **Reverting only the constructor makes it fail with exactly the production signature** (`errorType=Unknown`, `TargetInvocationException` → NRE).

| | rounds | NRE at `LayoutAreaHost..ctor` |
|---|---|---|
| baseline | 26 | **6** |
| with fix | 26 | **0** |

Also corrected: the test's own comment claimed *"the wait exhausted all attempts"*. That is wrong — the loop catches only `TimeoutException`, so the `DeliveryFailureException` escaped on the **first** probe; six 15 s windows cannot fit in a 2.1–2.6 s failure.

`Messaging.Hub` 107/107 · `Data` 287/287 · `Layout` 338/338 · `Graph` 636/636 · `Hosting.Monolith` 402/402 (2 env-gated skips) · full solution `-c Release -p:CIRun=true -warnaserror` clean.

**What this does not establish**: that CI's rate for `OverlaySelfHealInstanceRecycleTest` goes to zero — see below.

## Found but not fixed

1. **A second, independent failure mode in the same test**, pre-existing and untouched: **2/18 baseline vs 2/26 with the fix** (~10% either way). After this fix, step 3 times out because the NodeType never reaches `Ok` with a usable build within 90 s (the parked-`Error` → auto-un-park → recompile path). Different signature, no NRE, never reaches the probe loop. It will keep this test red at roughly that rate until investigated separately.
2. **`Workspace.GetExternalClientSynchronizationStream`'s `Lazy<…>(ExecutionAndPublication)` caches the exception** when `CreateExternalClient` throws — `lazy.Value` throws before the loop's removal code runs, so the poisoned entry never clears. Harmless today (that hub's workspace is dying anyway), pre-existing.
3. **`HandleSubscribeRequest` dispatches `SubscribeToClient` inside `RunReadValidators(...).Subscribe(onNext)`.** Every validator completes synchronously today, so a throw propagates into the handler and is caught — but if one ever completes off the hub turn, the exception escapes unobserved on a foreign thread. Pre-existing; the NRE had the same exposure.

Documentation: new "The creation window" section in `HubDisposalModel.md` (plus a stale test-name reference fixed).

No What's New entry — the user-visible effect is a page that no longer dies during a recycle; there is no new behaviour to describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
