### PR TITLE
Self-heal a stuck compile overlay even when the type's version never moves — and tell admins when it can't

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1,3 +1,5 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
 using MeshWeaver.Layout;
@@ -1124,30 +1126,62 @@ internal static class NodeTypeEnrichmentHelpers
     /// <summary>
     /// Watcher core of <see cref="WithOverlaySelfHeal"/>, split out so the
     /// firing contract is unit-testable without building a hub
-    /// (<c>OverlaySelfHealWatcherTest</c>): the FIRST emission whose content is
-    /// a <see cref="NodeTypeDefinition"/> with a genuinely usable build
-    /// (<see cref="NodeTypeCompilationHelpers.HasUsableBuild"/>) AND — when
-    /// <paramref name="typeVersionAtOverlay"/> is set — a Version strictly past
-    /// it posts exactly ONE self-<see cref="DisposeRequest"/> (Take(1));
-    /// everything else (unsettled states, the replayed at-overlay state,
-    /// non-advancing versions, non-NodeTypeDefinition content) is ignored.
-    /// Errors are logged, never rethrown — the watcher is best-effort by
-    /// design.
+    /// (<c>OverlaySelfHealWatcherTest</c>). It posts exactly ONE self-
+    /// <see cref="DisposeRequest"/> (Take(1)) when the NodeType reaches a
+    /// genuinely usable build (<see cref="NodeTypeCompilationHelpers.HasUsableBuild"/>),
+    /// by EITHER route:
+    /// <list type="bullet">
+    ///   <item><b>Version advance</b> — a new build landed past
+    ///     <paramref name="typeVersionAtOverlay"/>: heal immediately.</item>
+    ///   <item><b>Grace</b> (<see cref="SelfHealGrace"/>) — the type is usable but its version
+    ///     never moved. A recompile of an already-<c>Ok</c> type does NOT rewrite its node, so
+    ///     after a pod restart the version equals the one captured at overlay time and the
+    ///     version-only gate could never fire: the overlay stayed until someone restarted the
+    ///     pods (memex, 2026-07-27). Re-reading after a delay heals it while keeping the
+    ///     anti-hot-loop property — never instant, so an instance that still cannot build
+    ///     recycles at most once per grace window.</item>
+    /// </list>
+    /// Unsettled states and non-<see cref="NodeTypeDefinition"/> content are ignored. Errors are
+    /// logged, never rethrown — the watcher is best-effort by design.
     /// </summary>
     internal static IDisposable ArmOverlaySelfHeal(
         IObservable<MeshNode> typeStream,
         IMessageHub instanceHub,
         string nodeType,
         long? typeVersionAtOverlay,
-        ILogger? logger)
-        => typeStream
-            .Where(t => t?.Content is NodeTypeDefinition d
-                && NodeTypeCompilationHelpers.HasUsableBuild(t, d)
-                && (typeVersionAtOverlay is null || t.Version > typeVersionAtOverlay.Value))
+        ILogger? logger,
+        IScheduler? scheduler = null)
+    {
+        var usable = typeStream.Where(t => t?.Content is NodeTypeDefinition d
+            && NodeTypeCompilationHelpers.HasUsableBuild(t, d));
+
+        // FAST path — the version advanced past the overlay: a genuinely NEW build landed, heal now.
+        var advanced = usable.Where(t =>
+            typeVersionAtOverlay is null || t.Version > typeVersionAtOverlay.Value);
+
+        // GRACE path — the version NEVER advances. A recompile of an already-`Ok` type does not
+        // rewrite its node, so after a pod restart the type reports a usable build at the SAME
+        // version the overlay captured. The old version-only gate could then never fire, and the
+        // overlay was permanent until someone restarted the pods — the memex 2026-07-27 outage
+        // (Store/Plugin stuck at v796 all day; compile SUCCEEDED at 20:47:35 and every plugin root
+        // still rendered "did not settle" until a scale-to-zero; five recycles did nothing, because
+        // each re-activation re-armed the same unsatisfiable predicate).
+        //
+        // So: re-read the type AFTER a grace window and heal if it is usable by then. The delay is
+        // what keeps the original anti-hot-loop guarantee — an instance that overlays again because
+        // it STILL cannot build recycles at most once per grace period instead of spinning.
+        var graced = Observable
+            .Timer(SelfHealGrace, scheduler ?? Scheduler.Default)
+            .SelectMany(_ => usable.Take(1));
+
+        var healed = 0;
+        var heal = advanced
+            .Merge(graced)
             .Take(1)
             .Subscribe(
                 t =>
                 {
+                    Interlocked.Exchange(ref healed, 1);
                     logger?.LogInformation(
                         "Overlay self-heal: NodeType '{NodeType}' reached a usable build (version {Version}, at-overlay {VersionAtOverlay}) — recycling stuck instance '{InstancePath}'",
                         nodeType, t.Version, typeVersionAtOverlay, instanceHub.Address);
@@ -1159,6 +1193,78 @@ internal static class NodeTypeEnrichmentHelpers
                 ex => logger?.LogWarning(ex,
                     "Overlay self-heal watcher for NodeType '{NodeType}' (instance '{InstancePath}') faulted — falling back to manual Recycle",
                     nodeType, instanceHub.Address));
+
+        // AND IF IT DOES NOT HEAL, SAY SO. The 2026-07-27 outage was invisible from the inside:
+        // no log line carried the overlay text, no notification was raised, and the first signal
+        // was a user reporting a dead page. A page that is still serving the fallback well past
+        // the heal window is a platform fault, so it now raises ONE admin-scoped notification
+        // naming the type and the instance. Best-effort and self-contained: reporting can never
+        // throw back onto the enrichment path.
+        var report = Observable
+            .Timer(StuckReportDelay, scheduler ?? Scheduler.Default)
+            .Subscribe(
+                _ =>
+                {
+                    if (Volatile.Read(ref healed) != 0)
+                        return;
+                    ReportStuckOverlayToAdmins(instanceHub, nodeType, logger);
+                },
+                ex => logger?.LogWarning(ex,
+                    "Overlay stuck-reporter for NodeType '{NodeType}' faulted", nodeType));
+
+        return new CompositeDisposable(heal, report);
+    }
+
+    /// <summary>
+    /// Raise ONE platform-admin notification for an instance still serving the compile fallback
+    /// after the self-heal window — anchored under the <c>Admin</c> partition, whose RLS scopes it
+    /// to platform admins (the same anchoring <c>StartupErrorNotifier</c> and
+    /// <c>NodeTypeCompileParkRegistry</c> use). Wrapped whole: an unavailable notification service,
+    /// a failed write, anything — degrades to a log line and never disturbs rendering.
+    /// </summary>
+    private static void ReportStuckOverlayToAdmins(
+        IMessageHub instanceHub, string nodeType, ILogger? logger)
+    {
+        try
+        {
+            var instance = instanceHub.Address.ToString();
+            NotificationService.Dispatch(
+                instanceHub,
+                recipient: null,
+                mainNodePath: StartupErrorNotifier.AdminPartition,
+                title: $"Type '{nodeType}' is serving a fallback page",
+                message:
+                    $"The instance '{instance}' has been rendering the \"build did not settle\" "
+                    + $"fallback for over {StuckReportDelay.TotalSeconds:0}s and did not self-heal. "
+                    + "Its NodeType has no usable build on this pod. Users see a broken page until "
+                    + "the type builds or the instance is recycled.",
+                type: NotificationType.System,
+                targetNodePath: nodeType);
+            logger?.LogWarning(
+                "Overlay self-heal: instance '{InstancePath}' still stuck on NodeType '{NodeType}' after {Delay}s — platform admins notified",
+                instanceHub.Address, nodeType, StuckReportDelay.TotalSeconds);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex,
+                "Overlay self-heal: could not notify admins that '{InstancePath}' is stuck on '{NodeType}'",
+                instanceHub.Address, nodeType);
+        }
+    }
+
+    /// <summary>
+    /// How long an instance may keep serving the fallback before platform admins are told. Sits
+    /// past <see cref="SelfHealGrace"/> so the notification means "self-heal already failed",
+    /// not "healing is in progress".
+    /// </summary>
+    private static readonly TimeSpan StuckReportDelay = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// How long the self-heal waits before healing a stuck overlay on a type whose VERSION never
+    /// advances (the post-restart recompile case). Long enough that a genuinely-still-broken
+    /// instance cannot spin, short enough that a deploy heals itself well inside a support call.
+    /// </summary>
+    private static readonly TimeSpan SelfHealGrace = TimeSpan.FromSeconds(45);
 
     public static MeshNode WithCompilationErrorOverlay(
         MeshNode node,

--- a/test/MeshWeaver.Graph.Test/OverlaySelfHealWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/OverlaySelfHealWatcherTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reactive.Subjects;
+using Microsoft.Reactive.Testing;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -179,6 +180,72 @@ public class OverlaySelfHealWatcherTest
         // floor (the timeout/probe-missing sites hold no type node, and a
         // currently-usable state would have settled instead of timing out).
         typeStream.OnNext(TypeNode(version: 102, usable: true));
+        AssertDisposedExactlyOnce(hub);
+    }
+
+    /// <summary>
+    /// 🚨 THE 2026-07-27 memex OUTAGE. A CD deploy replaced both portal pods; every NodeType had to
+    /// recompile on first activation; <c>Store/Plugin</c> missed the 60s settle window, so every
+    /// plugin root (AgenticEngineering, Claims, DataModelling, Reinsurance, Underwriting, …) bound
+    /// the "did not settle" overlay. The recompile then SUCCEEDED — but recompiling an
+    /// already-<c>Ok</c> type does not rewrite its node, so the type stayed at the SAME version the
+    /// overlay had captured (v796, untouched since 08:34). The version-only gate could therefore
+    /// never fire: the overlay outlived the condition it described, five manual recycles changed
+    /// nothing (each re-activation re-armed the same unsatisfiable predicate), and only a
+    /// scale-to-zero brought the site back.
+    ///
+    /// <para>The grace path is the fix: a usable build at an UNCHANGED version heals the instance
+    /// once the window elapses. Time is driven by a TestScheduler, so this pins the behaviour
+    /// deterministically rather than by sleeping.</para>
+    /// </summary>
+    [Fact]
+    public void UsableBuildAtUnchangedVersion_HealsAfterTheGrace()
+    {
+        var hub = BuildInstanceHub(out _);
+        var typeStream = new ReplaySubject<MeshNode>(1);
+        var scheduler = new TestScheduler();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, hub, NodeTypePath, typeVersionAtOverlay: 796, logger: null, scheduler);
+
+        // The post-restart reality: the type reports a usable build at EXACTLY the version the
+        // overlay captured. Nothing advances, ever — this is what stayed broken all day.
+        typeStream.OnNext(TypeNode(version: 796, usable: true));
+
+        // Still nothing immediately: the anti-hot-loop guarantee is preserved, so an instance that
+        // re-overlays because it genuinely cannot build does not spin on recycle.
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(30).Ticks);
+        AssertNoDispose(hub);
+
+        // Once the grace elapses the stuck instance heals ITSELF — no operator, no pod restart.
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(20).Ticks);
+        AssertDisposedExactlyOnce(hub);
+
+        // Take(1) still holds across both routes — one recycle, never a storm.
+        typeStream.OnNext(TypeNode(version: 796, usable: true));
+        scheduler.AdvanceBy(TimeSpan.FromMinutes(5).Ticks);
+        AssertDisposedExactlyOnce(hub);
+    }
+
+    /// <summary>
+    /// The grace must not paper over a type that is still broken: if no usable build exists when
+    /// the window elapses, nothing is recycled — the overlay stays and keeps telling the truth.
+    /// </summary>
+    [Fact]
+    public void StillUnusableWhenTheGraceElapses_DoesNotRecycle()
+    {
+        var hub = BuildInstanceHub(out _);
+        var typeStream = new ReplaySubject<MeshNode>(1);
+        var scheduler = new TestScheduler();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal(
+            typeStream, hub, NodeTypePath, typeVersionAtOverlay: 796, logger: null, scheduler);
+
+        typeStream.OnNext(TypeNode(version: 796, usable: false));
+        scheduler.AdvanceBy(TimeSpan.FromMinutes(2).Ticks);
+        AssertNoDispose(hub);
+
+        // …and when the build finally lands, the still-armed watcher heals on the next read.
+        typeStream.OnNext(TypeNode(version: 796, usable: true));
+        scheduler.AdvanceBy(TimeSpan.FromMinutes(2).Ticks);
         AssertDisposedExactlyOnce(hub);
     }
 


### PR DESCRIPTION
## The outage

memex went down at **20:07 UTC, 2026-07-27**. A CD deploy (`ci.1451`) replaced both portal pods. Every NodeType had to recompile on first activation; `Store/Plugin` missed the 60s settle window, so **sixteen plugin roots** — AgenticEngineering, Claims, DataModelling, Reinsurance, Underwriting, Chess, … — bound the *"build did not settle"* overlay.

The recompile then **succeeded at 20:47:35**. The pages stayed broken anyway. Five manual recycles changed nothing. Only a scale-to-zero restored the site.

## Root cause — one clause

```csharp
&& (typeVersionAtOverlay is null || t.Version > typeVersionAtOverlay.Value)
```

The self-heal fires only when the NodeType node's **version advances**. But **recompiling an already-`Ok` type does not rewrite its node** — `Store/Plugin` sat at **v796, last modified 08:34**, untouched all day, while its assembly rebuilt fine.

So the watcher waited for a bump that could never come, and every re-activation re-armed the same unsatisfiable predicate. Sticky forever, by construction — and that is precisely why `recycle` was useless and only a pod restart worked.

## The fix

The version gate was **deliberate** (it prevents a recycle → re-overlay → recycle hot loop), so it stays. A second route is added: a usable build at an **unchanged version** heals after a grace window.

Never instant — **the delay *is* the anti-hot-loop property**, so an instance that still cannot build recycles at most once per window instead of spinning. All four original contracts pass unchanged.

## And it was invisible

The overlay text appears **zero times in Loki** across the entire window. No notification was raised. The first signal was a person reporting a dead page.

An instance still serving the fallback past the heal window is a platform fault, so it now raises **one admin-scoped notification** naming the type and the instance — anchored under the `Admin` partition, whose RLS scopes it to platform admins (the same anchoring `StartupErrorNotifier` and `NodeTypeCompileParkRegistry` already use). Wrapped whole: reporting can never throw back onto the render path.

## Tests

Two new cases drive time with a `TestScheduler` (no sleeping) and pin both halves:

- a usable build at an **unchanged version** heals after the grace — and **not before**;
- a type still **unusable** when the window elapses is **not** recycled, so the overlay keeps telling the truth until a build actually lands.

**638/638** Graph tests pass.

## What this does NOT fix

Honest scope — this stops the *stuck* state, it does not stop the *cold* state:

1. **No readiness gate.** Pods still serve traffic while types are cold, so the first users after a deploy can still meet a fallback — now self-healing within the window instead of until a restart. A boot pre-warm that holds readiness until hot types have a usable build is the change that removes the window entirely.
2. **`SlowPathTimeout` is a hard-coded 60s**, which turns a legitimately slow compile into a broken page.
3. **`DeactivateOnIdle` fires mid-activation** — the activate → 60s subscribe timeout → deactivate → re-activate thrash (38 events in the window) is its own bug.
4. **Compile events aren't logged at all**, which is why the RCA needed the database rather than Loki.
5. Modelling this as a first-class **Activity** (rather than a background subscription plus a notification) is not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)