### PR TITLE
Compile: stop source discovery idling 90s on a missed Initial, and pin recursive compilation

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -562,14 +562,20 @@ internal class MeshNodeCompilationService(
                         .Take(1)
                         .Select(map => (IReadOnlyCollection<MeshNode>)map.Values.ToList())
                         .Catch((Exception _) => Observable.Return<IReadOnlyCollection<MeshNode>>([]))))
-                .Select(results =>
+                .Select(results => results
+                    .SelectMany(r => r ?? [])
+                    .Where(n => !string.IsNullOrEmpty(n.Path))
+                    .GroupBy(n => n.Path)
+                    .Select(g => g.First())
+                    .ToList())
+                // 🚨 NEVER win the race with an EMPTY set. Every per-query leg degrades to empty on
+                // error, so a probe that hit a cold partition or a permission wall would otherwise
+                // emit "no sources", beat the cached query, and compile the type against NOTHING —
+                // strictly worse than the stall it exists to dodge. No sources found ⇒ stay silent
+                // and let the cached query (and the outer Timeout) decide.
+                .Where(merged => merged.Count > 0)
+                .Select(merged =>
                 {
-                    var merged = results
-                        .SelectMany(r => r ?? [])
-                        .Where(n => !string.IsNullOrEmpty(n.Path))
-                        .GroupBy(n => n.Path)
-                        .Select(g => g.First())
-                        .ToList();
                     logger.LogWarning(
                         "Source discovery for '{SelfPath}' fell back to the UNCACHED probe after {Delay}s — "
                         + "the cached synced query stalled (a missed Initial idles until the {Heartbeat}s "

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -465,8 +465,27 @@ internal class MeshNodeCompilationService(
         NodeTypeDefinition? ntDef, string selfPath, IReadOnlyList<MeshNode>? sourcesOverride)
     {
         var bound = _cacheOptions.SourceSnapshotTimeout;
-        return ResolveSources(ntDef, selfPath, sourcesOverride)
-            .Take(1)
+        var cached = ResolveSources(ntDef, selfPath, sourcesOverride).Take(1);
+
+        // 🚨 THE 90-SECOND COMPILE. An override is already a direct snapshot, but the CACHED synced
+        // query has a lost-wakeup mode: when its subscription misses the Initial, nothing re-requests
+        // — the read simply idles until the sync stream's periodic HEARTBEAT (45s,
+        // SyncStreamOptions.HeartbeatInterval) re-delivers the content. memex, 2026-07-27: a
+        // Store/Plugin compile spent 90.19s — TWO missed heartbeats — between "Invoking compiler…"
+        // and its source queries resolving, while Roslyn itself took 2.6s. Every plugin root then
+        // blew the 60s settle window and served the "did not settle" fallback; the site was down.
+        //
+        // So RACE the cached query against a direct, uncached mesh read of the SAME expanded
+        // queries. Healthy path: the cache answers instantly and the probe never runs (it is
+        // subscription-delayed, so it costs nothing). Stalled path: the probe answers in about a
+        // read instead of 45 or 90 seconds. Amb takes whichever speaks first and drops the other.
+        if (sourcesOverride is not null)
+            return cached.Timeout(bound).Catch<IEnumerable<MeshNode>, TimeoutException>(ex =>
+                Observable.Throw<IEnumerable<MeshNode>>(new TimeoutException(
+                    $"Source snapshot for '{selfPath}' did not emit within {bound.TotalSeconds:0}s.", ex)));
+
+        return cached
+            .Amb(DirectSourceProbe(ntDef, selfPath))
             .Timeout(bound)
             .Catch<IEnumerable<MeshNode>, TimeoutException>(ex =>
                 Observable.Throw<IEnumerable<MeshNode>>(new TimeoutException(
@@ -475,6 +494,91 @@ internal class MeshNodeCompilationService(
                     + "its Initial (a lost/raced synced-query subscription, not a source-code error). "
                     + "The compile fails terminally instead of parking at Compiling forever; retry via "
                     + "the Compile button / a fresh RequestedReleaseAt.", ex)));
+    }
+
+    /// <summary>
+    /// How long the cached synced source query gets before the uncached probe is even subscribed.
+    /// Comfortably past a warm cache hit or one cold storage read, so the probe stays dormant in
+    /// every healthy compile and only wakes for a genuinely stalled subscription.
+    /// </summary>
+    private static readonly TimeSpan SourceStallProbeDelay = TimeSpan.FromSeconds(3);
+
+    /// <summary>How long the uncached probe waits for its chunked Initial to go quiet before
+    /// treating the accumulated set as complete.</summary>
+    private static readonly TimeSpan SourceProbeQuietWindow = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Fold one <see cref="QueryResultChange{T}"/> into the accumulating path→node map — pure, so
+    /// the chunk-accumulation contract is unit-testable. Initial/Reset/Added/Updated set; Removed
+    /// deletes. Keyed by path, so a re-delivered chunk is idempotent rather than a duplicate.
+    /// </summary>
+    internal static ImmutableDictionary<string, MeshNode> ApplyQueryChange(
+        ImmutableDictionary<string, MeshNode> acc, QueryResultChange<MeshNode> change)
+    {
+        if (change?.Items is not { Count: > 0 } items)
+            return acc;
+        foreach (var node in items)
+        {
+            if (string.IsNullOrEmpty(node?.Path))
+                continue;
+            acc = change.ChangeType == QueryChangeType.Removed
+                ? acc.Remove(node.Path)
+                : acc.SetItem(node.Path, node);
+        }
+        return acc;
+    }
+
+    /// <summary>
+    /// The uncached escape hatch behind <see cref="SnapshotSources"/>: the SAME expanded source
+    /// queries issued straight at <see cref="IMeshService"/>, bypassing the synced-query cache whose
+    /// missed Initial is what idles until the 45s heartbeat. Subscription-delayed, so a healthy
+    /// compile never issues it. Failures complete EMPTY rather than erroring — this is a fallback
+    /// racing a primary, and it must never be the thing that fails a compile.
+    /// </summary>
+    private IObservable<IEnumerable<MeshNode>> DirectSourceProbe(
+        NodeTypeDefinition? ntDef, string selfPath)
+    {
+        var queries = CodeQueryResolver
+            .ExpandAll(ntDef?.Sources, CodeQueryResolver.DefaultSources, selfPath)
+            .Concat(CodeQueryResolver.ExpandAll(ntDef?.Tests, CodeQueryResolver.DefaultTests, selfPath))
+            .ToArray();
+        if (queries.Length == 0)
+            return Observable.Empty<IEnumerable<MeshNode>>();
+
+        var mesh = hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null)
+            return Observable.Empty<IEnumerable<MeshNode>>();
+
+        return Observable
+            .Defer(() => Observable
+                .CombineLatest(queries.Select(q =>
+                    // ACCUMULATE, never Take(1) on the raw stream: a query's Initial arrives in
+                    // CHUNKS, so the first emission can be a partial set — and a partial source set
+                    // compiles WRONG (missing files → phantom errors), which is worse than slow.
+                    // Fold every change, then settle on a quiet window.
+                    mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(q))
+                        .Scan(ImmutableDictionary<string, MeshNode>.Empty, ApplyQueryChange)
+                        .Throttle(SourceProbeQuietWindow)
+                        .Take(1)
+                        .Select(map => (IReadOnlyCollection<MeshNode>)map.Values.ToList())
+                        .Catch((Exception _) => Observable.Return<IReadOnlyCollection<MeshNode>>([]))))
+                .Select(results =>
+                {
+                    var merged = results
+                        .SelectMany(r => r ?? [])
+                        .Where(n => !string.IsNullOrEmpty(n.Path))
+                        .GroupBy(n => n.Path)
+                        .Select(g => g.First())
+                        .ToList();
+                    logger.LogWarning(
+                        "Source discovery for '{SelfPath}' fell back to the UNCACHED probe after {Delay}s — "
+                        + "the cached synced query stalled (a missed Initial idles until the {Heartbeat}s "
+                        + "sync heartbeat). Recovered {Count} source node(s).",
+                        selfPath, SourceStallProbeDelay.TotalSeconds, 45, merged.Count);
+                    return (IEnumerable<MeshNode>)merged;
+                }))
+            .Catch((Exception _) => Observable.Empty<IEnumerable<MeshNode>>())
+            .DelaySubscription(SourceStallProbeDelay);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Graph.Test/RecursiveCompilationTest.cs
+++ b/test/MeshWeaver.Graph.Test/RecursiveCompilationTest.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// RECURSIVE COMPILATION — a NodeType whose sources reach into OTHER types' source folders
+/// (<c>shared=@Other/Source</c>). This is not an exotic case: it is what every Store type does, and
+/// it is the path that took memex down on 2026-07-27.
+///
+/// <para><b>The incident.</b> <c>Store/Plugin</c> declares four source specs — its own
+/// <c>Source</c> subtree plus <c>shared=@Store/Coupon/Source</c>, <c>shared=@Store/Order/Source</c>
+/// and <c>shared=@Store/BillingProfile/Source</c> — and a <c>Test</c> subtree. That expands to NINE
+/// separate mesh queries reaching across three other types. Its compile activity log shows
+/// <b>90.19s</b> between "Invoking compiler…" and those queries resolving, against <b>2.6s</b> of
+/// actual Roslyn work: 97% of the compile was waiting on cross-type source discovery. Every plugin
+/// root then blew the 60s settle window and served the "build did not settle" fallback.</para>
+///
+/// <para>So these tests pin the two halves that make recursive discovery correct and bounded:</para>
+/// <list type="bullet">
+///   <item><b>Expansion</b> — a shared reference must yield BOTH the folder node itself and its
+///     subtree, for every referenced type, with no entry silently dropped. A missing query means a
+///     missing source file, which surfaces as a phantom Roslyn error rather than as "discovery
+///     lost a query".</item>
+///   <item><b>Chunk accumulation</b> — each of those queries streams its Initial in CHUNKS. Taking
+///     the first emission yields a PARTIAL source set, and a partial set compiles WRONG. The fold
+///     must accumulate across chunks, apply removals, and be idempotent under re-delivery.</item>
+/// </list>
+/// </summary>
+public class RecursiveCompilationTest
+{
+    /// <summary>The real Store/Plugin declaration — the one that hung. Kept verbatim so this test
+    /// tracks the shape that actually ships, not a simplified stand-in.</summary>
+    private static readonly IReadOnlyList<string> StorePluginSources =
+    [
+        "namespace:Source scope:subtree",
+        "shared=@Store/Coupon/Source",
+        "shared=@Store/Order/Source",
+        "shared=@Store/BillingProfile/Source",
+    ];
+
+    private const string StorePluginPath = "Store/Plugin";
+
+    // ───────────────────────────────────────────────────────────── expansion (the recursion)
+
+    /// <summary>
+    /// A <c>shared=</c> reference to another type's source folder must expand to BOTH forms — the
+    /// folder node itself AND its subtree. Only one of the two would silently drop half the shared
+    /// code: the folder node alone misses every file inside it, the subtree alone misses code held
+    /// on the folder node.
+    /// </summary>
+    [Fact]
+    public void SharedReference_ExpandsToBothTheFolderAndItsSubtree()
+    {
+        var expanded = CodeQueryResolver
+            .Expand("shared=@Store/Coupon/Source", StorePluginPath)
+            .ToList();
+
+        expanded.Should().HaveCount(2, "a shared folder contributes both itself and its children");
+        expanded.Should().Contain("path:Store/Coupon/Source nodeType:Code");
+        expanded.Should().Contain("namespace:Store/Coupon/Source scope:subtree nodeType:Code");
+    }
+
+    /// <summary>
+    /// The full Store/Plugin declaration must expand to a query for EVERY referenced type — its own
+    /// sources plus all three shared folders. This is the count that became nine live mesh queries
+    /// in the incident; if a future refactor drops one, the type compiles missing files and the
+    /// failure looks like broken source code rather than broken discovery.
+    /// </summary>
+    [Fact]
+    public void RealStorePluginDeclaration_ReachesEveryReferencedType()
+    {
+        var expanded = CodeQueryResolver
+            .ExpandAll(StorePluginSources, CodeQueryResolver.DefaultSources, StorePluginPath)
+            .ToList();
+
+        // Own sources, rebased onto the type's own path.
+        expanded.Should().Contain(q => q.Contains("Store/Plugin/Source"),
+            "the type's own Source subtree must be discovered");
+
+        // Every shared type, in both forms — this is the recursion.
+        foreach (var shared in new[] { "Store/Coupon/Source", "Store/Order/Source", "Store/BillingProfile/Source" })
+        {
+            expanded.Should().Contain($"path:{shared} nodeType:Code",
+                $"the shared folder node '{shared}' must be discovered");
+            expanded.Should().Contain($"namespace:{shared} scope:subtree nodeType:Code",
+                $"the files inside '{shared}' must be discovered");
+        }
+
+        // Every entry is a Code query — a malformed expansion would compile the wrong node type.
+        expanded.Should().OnlyContain(q => q.Contains("nodeType:Code"));
+    }
+
+    /// <summary>
+    /// Expansion is PURE and bounded: the same declaration expands identically every time, and a
+    /// type that shares a folder inside ITSELF does not recurse into itself. A resolver that
+    /// re-entered on self-reference would hang discovery — indistinguishable, from the outside,
+    /// from the stall this suite exists for.
+    /// </summary>
+    [Fact]
+    public void Expansion_IsDeterministicAndDoesNotSelfRecurse()
+    {
+        var first = CodeQueryResolver.ExpandAll(StorePluginSources, CodeQueryResolver.DefaultSources, StorePluginPath).ToList();
+        var second = CodeQueryResolver.ExpandAll(StorePluginSources, CodeQueryResolver.DefaultSources, StorePluginPath).ToList();
+        first.Should().Equal(second, "expansion must be deterministic — discovery is cached on it");
+
+        // A self-referencing share resolves to a finite query set, it does not expand forever.
+        var selfShare = CodeQueryResolver
+            .Expand($"shared=@{StorePluginPath}/Source", StorePluginPath)
+            .ToList();
+        selfShare.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// The files a shared reference is supposed to pull in must actually MATCH the expanded
+    /// queries — expansion and matching are used by two different callers (the compiler and the
+    /// Sources menu), so a drift between them shows up as "the menu lists it but it didn't
+    /// compile".
+    /// </summary>
+    [Fact]
+    public void SharedSourceFiles_MatchTheExpandedQueries()
+    {
+        var expanded = CodeQueryResolver
+            .ExpandAll(StorePluginSources, CodeQueryResolver.DefaultSources, StorePluginPath)
+            .ToList();
+
+        CodeQueryResolver.Matches("Store/Coupon/Source/CouponContent", expanded)
+            .Should().BeTrue("a file inside a shared folder is part of the compile");
+        CodeQueryResolver.Matches("Store/Order/Source/StripeGateway", expanded)
+            .Should().BeTrue("every shared type contributes, not just the first");
+        CodeQueryResolver.Matches("Store/Plugin/Source/Localizer", expanded)
+            .Should().BeTrue("the type's own sources still compile");
+
+        CodeQueryResolver.Matches("Store/Catalog/Source/StoreCatalogLayoutAreas", expanded)
+            .Should().BeFalse("a type that was NOT shared must not leak into the compile");
+    }
+
+    // ──────────────────────────────────────────────── chunk accumulation (the partial-set hazard)
+
+    private static MeshNode Code(string path)
+    {
+        var slash = path.LastIndexOf('/');
+        return new MeshNode(path[(slash + 1)..], path[..slash]) { NodeType = "Code" };
+    }
+
+    private static QueryResultChange<MeshNode> Change(QueryChangeType type, params string[] paths) =>
+        new() { ChangeType = type, Items = paths.Select(Code).ToList() };
+
+    private static ImmutableDictionary<string, MeshNode> Fold(
+        params QueryResultChange<MeshNode>[] changes) =>
+        changes.Aggregate(
+            ImmutableDictionary<string, MeshNode>.Empty,
+            MeshNodeCompilationService.ApplyQueryChange);
+
+    /// <summary>
+    /// 🚨 A query's Initial arrives in CHUNKS. Taking the first emission yields a partial source
+    /// set, and a partial set compiles WRONG — the missing file surfaces as a phantom Roslyn error
+    /// pointing at code that is perfectly fine. The fold must accumulate across every chunk.
+    /// </summary>
+    [Fact]
+    public void ChunkedInitial_AccumulatesInsteadOfTruncating()
+    {
+        var folded = Fold(
+            Change(QueryChangeType.Initial, "Store/Plugin/Source/Localizer"),
+            Change(QueryChangeType.Initial, "Store/Coupon/Source/CouponContent"),
+            Change(QueryChangeType.Initial, "Store/Order/Source/StripeGateway"));
+
+        folded.Keys.OrderBy(k => k).Should().Equal(
+            "Store/Coupon/Source/CouponContent",
+            "Store/Order/Source/StripeGateway",
+            "Store/Plugin/Source/Localizer");
+    }
+
+    /// <summary>Re-delivery is idempotent (keyed by path), so a replayed chunk cannot duplicate a
+    /// source file into the compile.</summary>
+    [Fact]
+    public void RedeliveredChunk_IsIdempotent()
+    {
+        var folded = Fold(
+            Change(QueryChangeType.Initial, "Store/Coupon/Source/CouponContent"),
+            Change(QueryChangeType.Initial, "Store/Coupon/Source/CouponContent"),
+            Change(QueryChangeType.Updated, "Store/Coupon/Source/CouponContent"));
+
+        folded.Count.Should().Be(1, "the same path must never enter the compile twice");
+    }
+
+    /// <summary>A deleted source leaves the set, so a compile started after a deletion does not
+    /// resurrect the file.</summary>
+    [Fact]
+    public void RemovedChange_DropsTheSource()
+    {
+        var folded = Fold(
+            Change(QueryChangeType.Initial, "Store/Order/Source/StripeGateway", "Store/Order/Source/OrderContent"),
+            Change(QueryChangeType.Removed, "Store/Order/Source/StripeGateway"));
+
+        folded.Keys.Should().Equal("Store/Order/Source/OrderContent");
+    }
+
+    /// <summary>Empty and malformed changes are inert — discovery must not throw on a heartbeat or
+    /// an empty chunk, because an exception there fails the whole compile.</summary>
+    [Fact]
+    public void EmptyOrPathlessChanges_AreInert()
+    {
+        var seeded = Fold(Change(QueryChangeType.Initial, "Store/Plugin/Source/Localizer"));
+
+        MeshNodeCompilationService.ApplyQueryChange(
+                seeded, new QueryResultChange<MeshNode> { ChangeType = QueryChangeType.Initial })
+            .Should().BeSameAs(seeded, "an empty chunk changes nothing");
+
+        MeshNodeCompilationService.ApplyQueryChange(seeded, null!)
+            .Should().BeSameAs(seeded, "a null change must not throw mid-discovery");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/RecursiveCompilationTest.cs
+++ b/test/MeshWeaver.Graph.Test/RecursiveCompilationTest.cs
@@ -201,6 +201,29 @@ public class RecursiveCompilationTest
         folded.Keys.Should().Equal("Store/Order/Source/OrderContent");
     }
 
+    /// <summary>
+    /// 🚨 An EMPTY discovery result must never be treated as a valid source set. Every leg of the
+    /// uncached probe degrades to empty on error, so a probe that hit a cold partition or a
+    /// permission wall could otherwise report "no sources", beat the cached query, and compile the
+    /// type against NOTHING — strictly worse than the stall the probe exists to dodge. The fold
+    /// returning empty is exactly the state the probe must stay silent on.
+    /// </summary>
+    [Fact]
+    public void EmptyDiscovery_IsNotAValidSourceSet()
+    {
+        var nothing = Fold(
+            new QueryResultChange<MeshNode> { ChangeType = QueryChangeType.Initial },
+            new QueryResultChange<MeshNode> { ChangeType = QueryChangeType.Reset });
+
+        nothing.Should().BeEmpty(
+            "a probe whose queries all came back empty has found NO sources — and 'no sources' must "
+            + "never win the race against the cached query, or the type compiles against nothing");
+
+        // The moment one real source arrives, the set is usable and may be raced.
+        Fold(Change(QueryChangeType.Initial, "Store/Coupon/Source/CouponContent"))
+            .Should().NotBeEmpty();
+    }
+
     /// <summary>Empty and malformed changes are inert — discovery must not throw on a heartbeat or
     /// an empty chunk, because an exception there fails the whole compile.</summary>
     [Fact]


### PR DESCRIPTION
## The profile

Straight from the `Store/Plugin` compile activity node that preceded today's outage:

```
20:46:02.486  Invoking compiler…
20:47:32.673  Source query: … (all nine, one timestamp)
20:47:35.288  Compiled assembly written
```

| phase | time |
|---|---|
| source discovery | **90.19 s** |
| Roslyn compiling 30 files | **2.6 s** |
| write + release | 0.2 s |

**97% of the compile was waiting, not compiling.** And 90.19 s is `2 × SyncStreamOptions.HeartbeatInterval` (45 s).

## Root cause — a lost wakeup, not a lock

When the cached synced source query's subscription misses its `Initial`, **nothing re-requests it**. The read makes no progress until the sync stream's periodic heartbeat re-delivers content. Miss it twice and a 3-second compile takes a minute and a half — which is exactly how `Store/Plugin` blew the 60 s settle window and left every plugin root serving the *"did not settle"* fallback.

This failure mode has bitten before: one screen above the fix, an existing comment documents the identity-loss variant — *"the source reads run unauthenticated and stall until the next 45s sync-stream heartbeat — the ~42s freeze."* Same signature, different trigger.

## The fix

Race the cached query against a **direct, uncached** mesh read of the *same* expanded queries:

- the probe is **subscription-delayed (3 s)**, so a healthy compile — cache hit or one cold storage read — never issues it and pays nothing;
- a stalled compile answers in about a read instead of 45 or 90 seconds;
- `Amb` takes whichever speaks first and drops the other;
- when the probe wins it logs at **Warning** — "compiles are slow" was invisible until someone read microsecond timestamps out of an activity node.

The probe **accumulates chunks** rather than taking the first emission: a query's `Initial` arrives chunked, and a partial source set compiles **wrong** — the missing file surfaces as a phantom Roslyn error pointing at code that is perfectly fine.

**Fully reactive**: `Defer` / `CombineLatest` / `Scan` / `Throttle` / `Take` / `Select` / `Catch`. No `await`, no `ToTask`, no blocking bridge.

## Recursive compilation tests

The incident ran through the **cross-type** path: `Store/Plugin` declares `shared=@Store/Coupon/Source`, `shared=@Store/Order/Source`, `shared=@Store/BillingProfile/Source` — which is what turns discovery into nine live queries. `RecursiveCompilationTest` pins both halves:

- **Expansion** — a shared reference yields both the folder node *and* its subtree, for every referenced type; deterministic; no self-recursion; a non-shared type does not leak in; matching agrees with expansion (the compiler and the Sources menu use the same resolver).
- **Chunk accumulation** — chunked `Initial` accumulates instead of truncating, re-delivery is idempotent, removal drops, empty/null changes are inert.

Worth stating plainly: **these pass on `main`.** The recursion is correctly *specified* — what failed is the *execution* of those queries stalling. The tests are there so a regression in either half is caught, and so the next person profiling a slow compile starts from a pinned contract.

## Testing

**644/644** Graph tests pass.

## Follow-ups not in this PR

- Why the `Initial` is missed in the first place (cold subscription racing the source-update burst) — this makes it survivable, it does not remove the race.
- Per-stage compile timing in the activity log, so this is measurable without microsecond arithmetic.
- A readiness gate / deploy-time precompile — worth revisiting *after* this, on real numbers: a 3 s compile changes that calculus completely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)