### PR TITLE
Pre-warm one NodeType at a time — 4-at-once is the storm that keeps boot warming disabled

### DIFF
--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -55,9 +55,32 @@ public record PreWarmOutcome(string TypePath, PreWarmStatus Status, string? Deta
 /// </summary>
 public static class DynamicTypePreWarmer
 {
-    /// <summary>How many dynamic NodeType hubs to activate concurrently. The compiles
-    /// themselves serialize on the Compile IoPool; this just caps in-flight activations.</summary>
-    public const int DefaultMaxConcurrency = 4;
+    /// <summary>
+    /// How many dynamic NodeType hubs to activate concurrently. <b>ONE.</b>
+    ///
+    /// <para>🚨 This was 4, and 4 is measurably harmful on a real mesh. On 2026-07-28 04:05 four
+    /// compiles were triggered on memex in quick succession — nothing to do with this warmer, but
+    /// the identical load shape — and within minutes SIX plugin roots (Claims, Edu, Underwriting,
+    /// Chess, Publish, Training) fell to the "did not settle" overlay and needed a scale-to-zero to
+    /// recover. That is the same storm this class's own summary warns about as the reason it ships
+    /// disabled, and the same one behind the 2026-07-22 "I have been told I am dead" restart
+    /// loop.</para>
+    ///
+    /// <para>The compiles already serialize on the Compile IoPool, so concurrency here buys nothing
+    /// except simultaneous cold ACTIVATIONS — which is exactly the expensive part: source discovery
+    /// on a large mesh is dominated by cold cross-partition hub activation (109ms and 0ms discovery
+    /// for the same NodeType shape on a fresh mesh, versus 45.20s on memex — issue #686). Warming
+    /// one at a time still removes the first-visitor stall; doing four at once trades a slow page
+    /// for an outage.</para>
+    /// </summary>
+    public const int DefaultMaxConcurrency = 1;
+
+    /// <summary>
+    /// Pause between types, so a long warm sweep stays a background trickle rather than a queue of
+    /// back-to-back cold activations. Cheap insurance: the sweep is a latency optimisation with no
+    /// deadline, so there is no reason for it to ever look like load.
+    /// </summary>
+    public static readonly TimeSpan BetweenTypes = TimeSpan.FromSeconds(2);
 
     /// <summary>Per-type warm budget — generous, because a cold Roslyn compile queued behind
     /// others on the Compile IoPool can legitimately take a while. On elapse we log
@@ -120,7 +143,13 @@ public static class DynamicTypePreWarmer
                     return typePaths.Length == 0
                         ? Observable.Empty<PreWarmOutcome>()
                         : typePaths
-                            .Select(p => WarmOne(workspace, accessService, p, budget, logger))
+                            // Space the types out as well as capping concurrency. With
+                            // maxConcurrency=1 the Merge already serializes them, but back-to-back
+                            // cold activations still read as a burst to the hubs being woken; the
+                            // delay makes the sweep a trickle. It costs nothing — the warm-up has
+                            // no deadline and Part 2 compiles lazily regardless.
+                            .Select((p, i) => WarmOne(workspace, accessService, p, budget, logger)
+                                .DelaySubscription(TimeSpan.FromTicks(BetweenTypes.Ticks * i)))
                             .Merge(Math.Max(1, maxConcurrency));
                 })
                 .Catch<PreWarmOutcome, Exception>(ex =>

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
@@ -81,4 +81,31 @@ public class DynamicTypePreWarmerTest(ITestOutputHelper output) : MonolithMeshTe
         broken.Status.Should().Be(PreWarmStatus.CompileError,
             "a non-compiling type surfaces a bounded CompileError — never a hang, never blocking the good type");
     }
+
+    /// <summary>
+    /// 🚨 THE STORM GUARD. The warm-up must default to ONE activation at a time.
+    ///
+    /// <para>It shipped defaulting to 4, and 4 is measurably harmful: on 2026-07-28 04:05 four
+    /// compiles fired at memex in quick succession — the identical load shape — and within minutes
+    /// SIX plugin roots fell to the "did not settle" overlay and needed a scale-to-zero. That is the
+    /// storm this class's own summary cites as the reason it ships disabled, and the same one behind
+    /// the 2026-07-22 "told I am dead" restart loop.</para>
+    ///
+    /// <para>Concurrency buys nothing here — the compiles already serialize on the Compile IoPool —
+    /// so the only thing it adds is simultaneous cold ACTIVATIONS, which is the expensive part
+    /// (issue #686: the same NodeType shape is 0ms discovery on a fresh mesh and 45.20s on memex).
+    /// Pinned as a value because the damage only shows up at production scale, where no test runs.</para>
+    /// </summary>
+    [Fact]
+    public void DefaultConcurrency_IsOne_AndTypesArePaced()
+    {
+        DynamicTypePreWarmer.DefaultMaxConcurrency.Should().Be(1,
+            "warming several cold NodeType hubs at once is what knocks roots offline; the sweep has "
+            + "no deadline, so it must trickle");
+
+        DynamicTypePreWarmer.BetweenTypes.Should().BeGreaterThan(TimeSpan.Zero,
+            "back-to-back cold activations still read as a burst even at concurrency 1");
+        DynamicTypePreWarmer.BetweenTypes.Should().BeLessThan(TimeSpan.FromSeconds(30),
+            "…but the sweep must still finish in a sensible time on a mesh with many types");
+    }
 }


### PR DESCRIPTION
## The fix already existed; it was just unsafe to turn on

`DynamicTypePreWarmer` front-loads the cold per-type compile so the first visitor after a deploy doesn't wait for it — exactly the stall behind the 2026-07-27 outage. It ships **disabled**, and its own summary says why:

> *"enumerates EVERY NodeType across EVERY partition and activates + compiles each dynamic one — on a mesh with many partitions that is a boot-time subscribe/compile storm that starves the hubs (and, multi-silo, the Orleans membership probes — the 'I have been told I am dead' restart loop on memex, 2026-07-22)."*

**That storm is a concurrency choice, not an inherent property.** `DefaultMaxConcurrency` was **4**.

## I reproduced the storm by accident, which is the evidence

On 2026-07-28 04:05 I triggered four compiles at memex in quick succession while gathering diagnostics — nothing to do with this warmer, but the identical load shape. Within minutes **six plugin roots** (Claims, Edu, Underwriting, Chess, Publish, Training) fell to the *"did not settle"* overlay and needed a **scale-to-zero** to recover.

## Why concurrency buys nothing

The compiles already serialize on the Compile IoPool. So `4` adds only simultaneous cold **activations** — and activation is the expensive part. [Issue #686](https://github.com/Systemorph/MeshWeaver/issues/686) measured it directly: the same NodeType shape, same image, compiles in **109 ms with 0 ms discovery** on a fresh mesh, versus **45.20 s of discovery** on memex. The delta is cold cross-partition hubs — precisely what warming exists to pay off, and precisely what doing four at once turns into an outage.

## Change

- `DefaultMaxConcurrency` **4 → 1**
- 2 s stagger between types, so back-to-back cold activations don't read as a burst even at concurrency 1

The sweep has no deadline and lazy compilation still covers correctness, so a trickle costs nothing. This is what makes `PreWarm:DynamicTypes` **safe to actually enable** — which is the real fix for a stall that only ever bites the first request after a deploy.

## Testing

`DefaultConcurrency_IsOne_AndTypesArePaced` pins the value, because the damage only appears at production scale where no test runs. 2/2 `DynamicTypePreWarmerTest` pass.

## Deploy note

Merging this changes nothing by itself — the warmer is still opt-in. Enabling it (`PreWarm__DynamicTypes=true`) is a separate, deliberate step, and should be done on one instance first with the roots watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)