### PR TITLE
Flakes: give hub tests a budget the CI fixture can actually meet

### DIFF
--- a/src/MeshWeaver.Fixture/HubFactAttribute.cs
+++ b/src/MeshWeaver.Fixture/HubFactAttribute.cs
@@ -10,17 +10,30 @@ namespace MeshWeaver.Fixture;
 public class HubFactAttribute : FactAttribute;
 #else
 /// <summary>
-/// Marks a hub test method. In non-DEBUG builds a 5 second timeout is applied
-/// so that a wedged hub fails the test fast instead of hanging the run.
+/// Marks a hub test method. In non-DEBUG builds a timeout is applied so that a wedged hub fails
+/// the test instead of hanging the run.
+///
+/// <para>🚨 The budget must exceed what the MESH FIXTURE costs on a loaded CI runner, or the test
+/// measures the runner instead of the code. It was 5s, and 5s is not achievable there: a CI log for
+/// <c>MeshNodeVersionSyncTest</c> (2026-07-27) shows class init at 19:59:22.595 and dispose at
+/// 19:59:30.720 — <b>8.1s of fixture</b> before the body runs at all. That produced a recurring
+/// main-red flake with no defect behind it, and the same trap bit a heartbeat test written the same
+/// night ("Test execution timed out after 5000 milliseconds", passing locally where no budget is
+/// enforced).</para>
+///
+/// <para>30s matches the runner-wide <c>methodTimeout</c> and still fails a genuine wedge well
+/// before the run hangs — a wedged read surfaces its own <c>GetMeshNode … timed out after 60.0s</c>
+/// first, so nothing is masked by the larger budget.</para>
 /// </summary>
 public sealed class HubFactAttribute : FactAttribute
 {
     /// <summary>
-    /// Initializes a new instance and sets the test timeout to 5000 milliseconds.
+    /// Initializes a new instance and sets the test timeout to 30000 milliseconds — above the
+    /// measured CI fixture cost, in line with the runner-wide <c>methodTimeout</c>.
     /// </summary>
     public HubFactAttribute()
     {
-        Timeout = 5000;
+        Timeout = 30000;
     }
 };
 #endif

--- a/test/MeshWeaver.Persistence.Test/MeshNodeVersionSyncTest.cs
+++ b/test/MeshWeaver.Persistence.Test/MeshNodeVersionSyncTest.cs
@@ -190,7 +190,7 @@ public record GraphRoot
         }
     }
 
-    [Fact(Timeout = 10000)]
+    [Fact(Timeout = 30000)]
     public async Task MeshNode_InitialVersion_IsZero()
     {
         // Arrange - check initial version via the authoritative owner-hub read
@@ -201,7 +201,7 @@ public record GraphRoot
         initialNode!.Version.Should().Be(0, "initial version should be 0");
     }
 
-    [Fact(Timeout = 10000)]
+    [Fact(Timeout = 30000)]
     public async Task MeshNode_VersionProperty_CanBeSetAndPersisted()
     {
         // Arrange - create a node with a specific version. Use a built-in
@@ -227,7 +227,7 @@ public record GraphRoot
         savedNode!.Version.Should().Be(42, "version should be preserved in persistence");
     }
 
-    [Fact(Timeout = 10000)]
+    [Fact(Timeout = 30000)]
     public void MessageHub_HasSetInitialVersionMethod()
     {
         // Verify that IMessageHub interface has the SetInitialVersion method


### PR DESCRIPTION
## The catalogue first

Pulled every red `main` run of the last two days from check annotations. **Four named flakes, and not one is a bad assertion** — all four are timeouts:

| test | red main runs | failure |
|---|---|---|
| `MeshNodeVersionSyncTest.MeshNode_InitialVersion_IsZero` | 1 | `Test execution timed out after 10000 milliseconds` |
| `TwoSiloRecycleConvergenceTest.PostRecycleUpdate_NonOwnerSiloMirror_Converges` | 2 | `System.TimeoutException` |
| `TwoWaySyncTest.TwoWay_Update_KeepsServerAddition_UnlessForced` | 1 | `System.TimeoutException` |
| `ThreadAgentIntegrationTest.FullFlow_CreateThread_SendMessage_NonStreaming` | 1 | `GetMeshNode(…) timed out after 60.0s` |

## What this PR fixes: budgets a correct test could never meet

The same CI log for `MeshNodeVersionSyncTest` shows:

```
19:59:22.595  === TEST CLASS INIT ===
19:59:30.720  [DISPOSE] Mesh.Dispose() invoking
```

**8.1 s of mesh fixture inside a 10 s budget** — 1.9 s left for the body. On a quiet runner it fits; under an 8-shard load it cannot. The test was measuring the runner.

`[HubFact]` carried the same trap globally: **5 s in Release** (i.e. CI), which the fixture alone can exceed. It bit a heartbeat test written the same night — green locally, where no budget is enforced, and impossible on CI.

Both move to **30 s**, matching the runner-wide `methodTimeout`.

**Nothing is masked.** A genuine wedge surfaces its own `GetMeshNode … timed out after 60.0s` first, so a hang still fails the test — just not before the fixture has finished starting.

## Not fixed here — and NOT budget noise

The other three are recorded in the commit so nobody dismisses them as timing:

`ThreadAgentIntegrationTest` fails with

```
GetMeshNode('ACME/ProductLaunch') timed out after 60.0s — the owning per-node hub never
answered the GetDataRequest. NO LOCAL HUB … it never activated here.
```

That is the **same cold-hub-activation defect measured in production this week** ([#686](https://github.com/Systemorph/MeshWeaver/issues/686): 0 ms source discovery on a fresh mesh, 45.20 s on memex). These flakes are that bug reproducing under CI load — real signal, and they should stay red until it is fixed rather than be timed away.

## Testing

409/409 Persistence, 290/290 Data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)