### PR TITLE
Point the AI-content references at content/ai, not the path that no longer exists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ All docs embedded in `src/MeshWeaver.Documentation/` and served under `Doc/` at 
 | DataMesh | `src/MeshWeaver.Documentation/Data/DataMesh/` |
 | GUI | `src/MeshWeaver.Documentation/Data/GUI/` |
 | AI Integration | `src/MeshWeaver.Documentation/Data/AI/` |
-| Agent definitions | `src/MeshWeaver.AI/Data/Agent/` |
+| Agent definitions | `content/ai/Agent/` |
 
 **Writing/editing a doc page:** follow [AuthoringDocumentation.md](src/MeshWeaver.Documentation/Data/Architecture/AuthoringDocumentation.md). Links resolve against the page's FULL node path at render time — sibling links need `../Sibling`, absolute links start `/Doc/…`; `xref:` and `.md` suffixes never resolve. `DocumentationLinkIntegrityTest` (test/MeshWeaver.Documentation.Test) fails on any broken internal link — run it after doc edits.
 
@@ -508,7 +508,7 @@ For detailed patterns with code examples, read:
 
 ## Testing Guidelines
 
-Before building NodeTypes, data models, layout areas, or CSV loaders — read the [/code skill](src/MeshWeaver.AI/Data/Skill/code.md) first (canonical guide + non-negotiable testing standards).
+Before building NodeTypes, data models, layout areas, or CSV loaders — read the [/code skill](content/ai/Skill/code.md) first (canonical guide + non-negotiable testing standards).
 
 **No mocking.** Use `MonolithMeshTestBase` or `OrleansTestBase` — never mock `IMessageHub`, `IMeshService`, or core interfaces.  
 **Always `run_in_background: true`** for test runs (they take minutes).  

--- a/src/MeshWeaver.Documentation/Data/AI/ChatCommands.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ChatCommands.md
@@ -84,7 +84,7 @@ result as-is — to change which nodes appear or their order, change the **query
 ### The standard skills are authored as `.md` files
 
 `/agent`, `/model`, `/harness` ship as `Pick` skill nodes, authored the **same way as agents**: a markdown
-file with a YAML frontmatter header (`src/MeshWeaver.AI/Data/Skill/*.md` — e.g. `agent.md` → `/agent`),
+file with a YAML frontmatter header (`content/ai/Skill/*.md` — e.g. `agent.md` → `/agent`),
 loaded by `BuiltInSkillProvider`. A behaviour skill puts its `action:` block in the frontmatter; an
 instruction skill puts its how-to in the markdown body:
 
@@ -128,7 +128,7 @@ This guidance lives in the shared agent base prompt (`AgentChatClient`); the age
 - **`OpenContent`** — load a node/manual into the content window (side panel) via the navigation bridge
   (`SidePanelState.SetContentPath`). Set `action.contentPath`, or pair a `Pick` with the content window.
 - **`Navigate`** — **take me there.** Navigate the UI to a node, doc, or page. Ships as the built-in
-  **`/navigate`** skill (`src/MeshWeaver.AI/Data/Skill/navigate.md`). Two properties make it robust:
+  **`/navigate`** skill (`content/ai/Skill/navigate.md`). Two properties make it robust:
   - **Pane-aware** — the target opens in the pane *opposite* the thread, so the conversation and where it
     sent you sit side by side (the same rule as the context chip, `OnContextChipClicked`):
     a thread in the **main pane** opens the target in the **side panel**; a thread in the **side panel**
@@ -145,7 +145,7 @@ This guidance lives in the shared agent base prompt (`AgentChatClient`); the age
   honestly no matter who asks. Tested by `NavigationTargetResolverTest` (the pure algorithm) and
   `MeshPluginTest` (resilient + honest resolution against the live mesh).
 - **`NewThread`** — **start a fresh chat.** Ships as the built-in **`/clear`** skill
-  (`src/MeshWeaver.AI/Data/Skill/clear.md`). It REPLACES whatever is showing in the **side panel** with an
+  (`content/ai/Skill/clear.md`). It REPLACES whatever is showing in the **side panel** with an
   empty new-chat composer and **leaves the main pane alone** — the same target as the "+" button
   (`SidePanelState.SetContentPath(null)` drops the open thread so `ThreadSidePanelContent` swaps in the
   composer; the panel is opened if it was closed). No navigation. Handled by `ThreadChatView.RunSkill`.

--- a/src/MeshWeaver.Documentation/Data/Architecture/AuthoringDocumentation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AuthoringDocumentation.md
@@ -18,7 +18,7 @@ Documentation lives as markdown files under `src/MeshWeaver.Documentation/Data/`
 | `Data/GUI/ContainerControl/Stack.md` | `Doc/GUI/ContainerControl/Stack` |
 | `Data/ReleaseNotes/3_0_0/index.md` | `Doc/ReleaseNotes/3_0_0` (an `index.md` *is* its folder's node) |
 
-Note the pairing: `Architecture.md` is the **index node** and the folder `Architecture/` holds its children. Agent definitions follow the same scheme under the **`Agent`** partition (`src/MeshWeaver.AI/Data/Agent/Researcher.md` → `Agent/Researcher`), and skills under the **`Skill`** partition (`src/MeshWeaver.AI/Data/Skill/code.md` → `Skill/code`).
+Note the pairing: `Architecture.md` is the **index node** and the folder `Architecture/` holds its children. Agent definitions follow the same scheme under the **`Agent`** partition (`content/ai/Agent/Researcher.md` → `Agent/Researcher`), and skills under the **`Skill`** partition (`content/ai/Skill/code.md` → `Skill/code`).
 
 ## 🚨 Link rules — pinned by `DocumentationLinkIntegrityTest`
 


### PR DESCRIPTION
`AGENTS.md` told agents that agent definitions live in `src/MeshWeaver.AI/Data/Agent/`, and linked the `/code` skill at `src/MeshWeaver.AI/Data/Skill/code.md`. **That directory does not exist.** The content moved to `content/ai/`, embedded into MeshWeaver.AI via:

```xml
<EmbeddedResource Include="..\..\content\ai\**\*.md" LinkBase="Data" />
```

which is why the *manifest* names still read `MeshWeaver.AI.Data.Skill.agent.md` while the *source* path is `content/ai/` — an easy thing to be misled by.

## Why this isn't cosmetic

The stale pointer reads as "the built-in agent catalog is gone". That is the wrong conclusion: `BuiltInAgentProvider` ships 13 agents from `content/ai/Agent`, and `BuiltInSkillProvider` ships the skills.

I acted on it during #670 and it cost a wrong turn — I chased a "agents come from plugins now, so tests can't rely on a catalog" premise, started rewriting tests that were never fragile (and reverted them), and left the false claim in a code comment that the Copilot review had to catch. A doc that sends readers to a path that isn't there will keep doing that.

## The change

Six references across three files, all the same mechanical substitution `src/MeshWeaver.AI/Data/` → `content/ai/`:

| File | Refs |
|---|---|
| `AGENTS.md` | the docs table row + the `/code` skill link |
| `Architecture/AuthoringDocumentation.md` | the partition-pairing example (`Researcher.md`, `code.md`) |
| `AI/ChatCommands.md` | three skill-file references (`agent.md`, `navigate.md`, `clear.md`) |

## Verification

Every referenced file confirmed to exist at its new path (`Researcher.md`, `code.md`, `navigate.md`, `clear.md`, `agent.md`), no `MeshWeaver.AI/Data` references remain in any markdown, and `DocumentationLinkIntegrityTest` passes.

**No What's New entry** — documentation-only correction with no user-visible product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)