### PR TITLE
Compile NodeTypes in dependency order, sequentially

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDependencyGraph.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDependencyGraph.cs
@@ -145,6 +145,32 @@ public static class NodeTypeDependencyGraph
         IReadOnlyDictionary<string, ImmutableHashSet<string>> dependencies) =>
         TopologicalOrder(dependencies, out _);
 
+    /// <summary>
+    /// The dependency that BLOCKS <paramref name="path"/> — the first (path-ordered, so the answer
+    /// is stable) direct dependency already known to have failed — or <c>null</c> when nothing
+    /// upstream is broken.
+    ///
+    /// <para>Only DIRECT dependencies are examined, and that is deliberate: walk the types in
+    /// <see cref="TopologicalOrder(IReadOnlyDictionary{string, ImmutableHashSet{string}}, out ImmutableList{string})"/>
+    /// and add each blocked type to <paramref name="failed"/> as you skip it, and the block
+    /// propagates TRANSITIVELY on its own — a dependent of a skipped type sees its direct
+    /// dependency already in the set. No second traversal, and no way for the two notions of
+    /// "reachable" to disagree.</para>
+    ///
+    /// <para>Building a dependent whose upstream is broken cannot succeed: its assembly is missing
+    /// the very sources the upstream owns. Detecting that up front turns a guaranteed per-type
+    /// timeout into an immediate, named outcome.</para>
+    /// </summary>
+    public static string? FirstBlockedBy(
+        string path,
+        IReadOnlyDictionary<string, ImmutableHashSet<string>> dependencies,
+        IReadOnlySet<string> failed) =>
+        dependencies.TryGetValue(path, out var deps)
+            ? deps.Where(failed.Contains)
+                  .OrderBy(d => d, StringComparer.OrdinalIgnoreCase)
+                  .FirstOrDefault()
+            : null;
+
     /// <summary><c>path</c> is <paramref name="root"/> itself or lives under it.</summary>
     private static bool IsSelfOrUnder(string path, string root) =>
         path.Equals(root, StringComparison.OrdinalIgnoreCase)

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDependencyGraph.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDependencyGraph.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Which NodeTypes a NodeType must be built AFTER — computed from its DECLARED SOURCES, not guessed.
+///
+/// <para><b>Why this exists.</b> A NodeType may pull Code nodes out of ANOTHER NodeType's subtree:
+/// <c>Store/Plugin</c> declares <c>shared=@Store/Coupon/Source</c>, <c>shared=@Store/Order/Source</c>
+/// and <c>shared=@Store/BillingProfile/Source</c>. Those files are compiled INTO
+/// <c>Store/Plugin</c>'s assembly, so <c>Store/Plugin</c> is not buildable until the types that own
+/// them are themselves settled. Nothing expressed that ordering, so a cold pod raced every dynamic
+/// type at once and the dependents blew their 60s activation budget:</para>
+///
+/// <code>
+/// [STALE-CALLBACK] cache/krhs…: 3 callback(s) pending &gt; 30000ms:
+///     SubscribeRequest@AgenticEngineering(33034ms),
+///     SubscribeRequest@DataModeling(45043ms),
+///     SubscribeRequest@Store/Plugin(45028ms)
+/// System.TimeoutException: No response received … within 00:01:00
+///     for request SubscribeRequest → target Store/Plugin.
+/// </code>
+///
+/// <para>Every <c>AgenticEngineering</c>-style plugin root IS a <c>Store/Plugin</c> node, so the
+/// instance cannot activate until its type is built, and the type cannot build until ITS
+/// dependencies are. The cascade is a dependency chain, so the fix is a dependency ORDER.</para>
+///
+/// <para><b>Pure data on purpose.</b> Everything here is a static function over paths and declared
+/// source queries — no hub, no mesh, no I/O — so the ordering rules are unit-testable without a
+/// fixture (the same reason <c>ProvisionPlan</c> keeps its plan pure).</para>
+/// </summary>
+public static class NodeTypeDependencyGraph
+{
+    /// <summary>
+    /// The node paths one NodeType's source/test queries reach into, after expansion by
+    /// <see cref="CodeQueryResolver"/> (so <c>$self</c>, <c>@</c>-shorthand and bare-namespace
+    /// rebasing are already applied and we read the SAME queries the compiler runs).
+    /// </summary>
+    public static ImmutableHashSet<string> ReferencedPaths(NodeTypeDefinition? definition, string selfPath)
+    {
+        var queries = CodeQueryResolver
+            .ExpandAll(definition?.Sources, CodeQueryResolver.DefaultSources, selfPath)
+            .Concat(CodeQueryResolver.ExpandAll(definition?.Tests, CodeQueryResolver.DefaultTests, selfPath));
+
+        var paths = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var query in queries)
+            foreach (var value in PathValues(query))
+                paths.Add(value);
+        return paths.ToImmutable();
+    }
+
+    /// <summary>
+    /// The NodeType that OWNS a node path: the longest known type path that is the path itself or a
+    /// parent of it. Longest-wins matters — with both <c>Store</c> and <c>Store/Coupon</c> known,
+    /// <c>Store/Coupon/Source</c> belongs to <c>Store/Coupon</c>, not <c>Store</c>.
+    /// </summary>
+    public static string? OwningType(string path, IEnumerable<string> knownTypePaths) =>
+        knownTypePaths
+            .Where(t => !string.IsNullOrEmpty(t) && IsSelfOrUnder(path, t))
+            .OrderByDescending(t => t.Length)
+            .ThenBy(t => t, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+
+    /// <summary>
+    /// The types <paramref name="selfPath"/> must be built after. A reference into a type's own
+    /// subtree is not a dependency, and a reference to an unknown path is ignored rather than
+    /// invented — an unresolvable edge must never stall the build order.
+    /// </summary>
+    public static ImmutableHashSet<string> DependenciesOf(
+        NodeTypeDefinition? definition, string selfPath, IEnumerable<string> knownTypePaths)
+    {
+        var known = knownTypePaths as IReadOnlyCollection<string> ?? knownTypePaths.ToArray();
+        var deps = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var reference in ReferencedPaths(definition, selfPath))
+        {
+            var owner = OwningType(reference, known);
+            if (owner is not null && !string.Equals(owner, selfPath, StringComparison.OrdinalIgnoreCase))
+                deps.Add(owner);
+        }
+        return deps.ToImmutable();
+    }
+
+    /// <summary>Builds the whole dependency map from the known NodeTypes and their definitions.</summary>
+    public static ImmutableDictionary<string, ImmutableHashSet<string>> Build(
+        IReadOnlyDictionary<string, NodeTypeDefinition?> types)
+    {
+        var known = types.Keys.ToArray();
+        var map = ImmutableDictionary.CreateBuilder<string, ImmutableHashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (path, definition) in types)
+            map[path] = DependenciesOf(definition, path, known);
+        return map.ToImmutable();
+    }
+
+    /// <summary>
+    /// DEPENDENCIES FIRST. A deterministic topological order (Kahn, ties broken by path) so the same
+    /// mesh always warms in the same sequence and a failure is reproducible.
+    ///
+    /// <para>A dependency CYCLE cannot be ordered, so it must not be able to drop or duplicate a
+    /// type: the cycle's members are appended in path order after everything orderable, and reported
+    /// through <paramref name="cyclic"/>. Every input path is emitted exactly once, always.</para>
+    /// </summary>
+    public static ImmutableList<string> TopologicalOrder(
+        IReadOnlyDictionary<string, ImmutableHashSet<string>> dependencies,
+        out ImmutableList<string> cyclic)
+    {
+        var remaining = dependencies.ToDictionary(
+            kv => kv.Key,
+            // Only edges to types we actually know about can be waited on.
+            kv => kv.Value.Where(dependencies.ContainsKey)
+                          .ToHashSet(StringComparer.OrdinalIgnoreCase),
+            StringComparer.OrdinalIgnoreCase);
+
+        var ordered = ImmutableList.CreateBuilder<string>();
+        while (remaining.Count > 0)
+        {
+            var ready = remaining
+                .Where(kv => kv.Value.Count == 0)
+                .Select(kv => kv.Key)
+                .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (ready.Length == 0)
+                break;                                   // only cycles left
+
+            foreach (var path in ready)
+            {
+                ordered.Add(path);
+                remaining.Remove(path);
+            }
+            foreach (var deps in remaining.Values)
+                foreach (var path in ready)
+                    deps.Remove(path);
+        }
+
+        cyclic = remaining.Keys.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToImmutableList();
+        ordered.AddRange(cyclic);
+        return ordered.ToImmutable();
+    }
+
+    /// <summary>Convenience overload for callers that do not care which types were cyclic.</summary>
+    public static ImmutableList<string> TopologicalOrder(
+        IReadOnlyDictionary<string, ImmutableHashSet<string>> dependencies) =>
+        TopologicalOrder(dependencies, out _);
+
+    /// <summary><c>path</c> is <paramref name="root"/> itself or lives under it.</summary>
+    private static bool IsSelfOrUnder(string path, string root) =>
+        path.Equals(root, StringComparison.OrdinalIgnoreCase)
+        || path.StartsWith(root + "/", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The <c>path:</c> / <c>namespace:</c> values of one expanded query. Those are the only tokens
+    /// that name a location; everything else (<c>scope:</c>, <c>nodeType:</c>) is a filter.
+    /// </summary>
+    private static IEnumerable<string> PathValues(string query)
+    {
+        foreach (var token in query.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var colon = token.IndexOf(':');
+            if (colon <= 0) continue;
+            var key = token[..colon];
+            var value = token[(colon + 1)..];
+            if (value.Length == 0) continue;
+            if (key.Equals("path", StringComparison.OrdinalIgnoreCase)
+                || key.Equals("namespace", StringComparison.OrdinalIgnoreCase))
+                yield return value;
+        }
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDependencyGraph.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDependencyGraph.cs
@@ -99,8 +99,12 @@ public static class NodeTypeDependencyGraph
     /// mesh always warms in the same sequence and a failure is reproducible.
     ///
     /// <para>A dependency CYCLE cannot be ordered, so it must not be able to drop or duplicate a
-    /// type: the cycle's members are appended in path order after everything orderable, and reported
-    /// through <paramref name="cyclic"/>. Every input path is emitted exactly once, always.</para>
+    /// type. When the peel stalls, ONLY the types genuinely in a cycle (self-reachable through the
+    /// remaining edges) are released — in path order — and the peel then RESUMES. Types merely
+    /// DOWNSTREAM of a cycle are not cyclic and must not be treated as such: flushing the whole
+    /// remainder in path order would put a dependent ahead of the dependency it waits on, so it gets
+    /// attempted instead of failing fast, burning a full per-type budget on a build that cannot
+    /// succeed. Every input path is emitted exactly once, always.</para>
     /// </summary>
     public static ImmutableList<string> TopologicalOrder(
         IReadOnlyDictionary<string, ImmutableHashSet<string>> dependencies,
@@ -114,6 +118,7 @@ public static class NodeTypeDependencyGraph
             StringComparer.OrdinalIgnoreCase);
 
         var ordered = ImmutableList.CreateBuilder<string>();
+        var cyclicBuilder = ImmutableList.CreateBuilder<string>();
         while (remaining.Count > 0)
         {
             var ready = remaining
@@ -123,7 +128,21 @@ public static class NodeTypeDependencyGraph
                 .ToArray();
 
             if (ready.Length == 0)
-                break;                                   // only cycles left
+            {
+                // Stalled: release the actual cycle members so their dependents can order behind
+                // them on the next pass.
+                ready = remaining.Keys
+                    .Where(p => IsInCycle(p, remaining))
+                    .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                // Defensive: a stall with nothing self-reachable is not reachable by construction,
+                // but breaking out beats looping forever — the leftovers are still emitted below.
+                if (ready.Length == 0)
+                    break;
+
+                cyclicBuilder.AddRange(ready);
+            }
 
             foreach (var path in ready)
             {
@@ -135,9 +154,35 @@ public static class NodeTypeDependencyGraph
                     deps.Remove(path);
         }
 
-        cyclic = remaining.Keys.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToImmutableList();
-        ordered.AddRange(cyclic);
+        var stranded = remaining.Keys.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToArray();
+        cyclicBuilder.AddRange(stranded);
+        ordered.AddRange(stranded);
+
+        cyclic = cyclicBuilder.ToImmutable();
         return ordered.ToImmutable();
+    }
+
+    /// <summary>
+    /// Is <paramref name="start"/> genuinely part of a cycle — can it reach ITSELF by following
+    /// remaining dependency edges? Distinguishes a cycle member from a type that merely depends on
+    /// one, which is the difference between "cannot be ordered" and "must be ordered later".
+    /// </summary>
+    private static bool IsInCycle(string start, IReadOnlyDictionary<string, HashSet<string>> remaining)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var stack = new Stack<string>(remaining[start]);
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            if (current.Equals(start, StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (!seen.Add(current))
+                continue;
+            if (remaining.TryGetValue(current, out var deps))
+                foreach (var next in deps)
+                    stack.Push(next);
+        }
+        return false;
     }
 
     /// <summary>Convenience overload for callers that do not care which types were cyclic.</summary>

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -187,11 +187,7 @@ public static class DynamicTypePreWarmer
                     return order.Count == 0
                         ? Observable.Empty<PreWarmOutcome>()
                         : order
-<<<<<<< HEAD
-                            .Select((p, i) => WarmOne(workspace, accessService, p, budget, logger)
-                                .DelaySubscription(i == 0 ? TimeSpan.Zero : BetweenTypes))
-=======
-                            .Select(p => Observable.Defer(() =>
+                            .Select((p, i) => Observable.Defer(() =>
                             {
                                 var blocker = NodeTypeDependencyGraph.FirstBlockedBy(p, dependencies, failed);
                                 if (blocker is not null)
@@ -202,18 +198,20 @@ public static class DynamicTypePreWarmer
                                         + "did not reach a usable build, so it cannot compile either "
                                         + "(lazy compile still applies if the upstream recovers)",
                                         p, blocker);
+                                    // No pacing for a skip: it activates nothing, so there is no
+                                    // burst to spread out and no reason to slow the sweep down.
                                     return Observable.Return(new PreWarmOutcome(
                                         p, PreWarmStatus.UpstreamFailed, $"blocked by {blocker}"));
                                 }
 
                                 return WarmOne(workspace, accessService, p, budget, logger)
+                                    .DelaySubscription(i == 0 ? TimeSpan.Zero : BetweenTypes)
                                     .Do(o =>
                                     {
                                         if (o.Status != PreWarmStatus.Compiled)
                                             failed.Add(p);
                                     });
                             }))
->>>>>>> 477482393 (Fail gracefully downstream when an upstream NodeType fails)
                             .Concat();
                 })
                 .Catch<PreWarmOutcome, Exception>(ex =>

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -20,6 +20,14 @@ public enum PreWarmStatus
     CompileError,
     /// <summary>The per-type warm budget elapsed before the compile settled — Part 2 handles the late arrival.</summary>
     TimedOut,
+    /// <summary>
+    /// NOT ATTEMPTED: a NodeType this one draws sources from did not reach a usable build, so this
+    /// type cannot build either — its assembly would be missing exactly the sources the upstream
+    /// owns. <see cref="PreWarmOutcome.Detail"/> names the blocking type. Skipping is the graceful
+    /// outcome: warming it anyway burns the whole per-type budget on a guaranteed failure, and
+    /// doing that for a fan-out of dependents is how one broken type used to stall a whole sweep.
+    /// </summary>
+    UpstreamFailed,
     /// <summary>The warm subscription faulted (best-effort — the lazy path still works).</summary>
     Faulted
 }
@@ -146,8 +154,8 @@ public static class DynamicTypePreWarmer
                     //     TimeoutException: No response received … within 00:01:00 → Store/Plugin
                     // The order is computed from the DECLARED sources, so it stays correct as
                     // plugins add cross-type sources without anyone maintaining a list.
-                    var order = NodeTypeDependencyGraph.TopologicalOrder(
-                        NodeTypeDependencyGraph.Build(definitions), out var cyclic);
+                    var dependencies = NodeTypeDependencyGraph.Build(definitions);
+                    var order = NodeTypeDependencyGraph.TopologicalOrder(dependencies, out var cyclic);
 
                     logger?.LogInformation(
                         "DynamicTypePreWarmer: warming {Count} dynamic NodeType hub(s) in dependency order "
@@ -159,6 +167,18 @@ public static class DynamicTypePreWarmer
                             + "cannot be ordered — warmed last, in path order: {Cyclic}",
                             cyclic.Count, string.Join(", ", cyclic));
 
+                    // FAIL GRACEFULLY DOWNSTREAM. A type whose upstream did not reach a usable build
+                    // cannot build either, so it is not attempted: it is reported as UpstreamFailed
+                    // naming the blocker, and joins the failed set so ITS dependents are skipped too
+                    // — the propagation is transitive purely because we walk in topological order.
+                    // Without this, one broken type costs every dependent a full per-type budget of
+                    // waiting for something that cannot succeed.
+                    //
+                    // The set is mutated inside a Concat, which subscribes strictly one at a time,
+                    // so there is no concurrent access — and each step is wrapped in Defer so it
+                    // reads the set as it stands WHEN ITS TURN COMES, not when the chain was built.
+                    var failed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
                     // Concat, never Merge: the next type is SUBSCRIBED only after the previous one
                     // has completed, so "dependencies first" is structural rather than a convention.
                     // The gap between types keeps the sweep a background trickle rather than a queue
@@ -167,8 +187,33 @@ public static class DynamicTypePreWarmer
                     return order.Count == 0
                         ? Observable.Empty<PreWarmOutcome>()
                         : order
+<<<<<<< HEAD
                             .Select((p, i) => WarmOne(workspace, accessService, p, budget, logger)
                                 .DelaySubscription(i == 0 ? TimeSpan.Zero : BetweenTypes))
+=======
+                            .Select(p => Observable.Defer(() =>
+                            {
+                                var blocker = NodeTypeDependencyGraph.FirstBlockedBy(p, dependencies, failed);
+                                if (blocker is not null)
+                                {
+                                    failed.Add(p);
+                                    logger?.LogWarning(
+                                        "DynamicTypePreWarmer: skipping {TypePath} — its dependency {Blocker} "
+                                        + "did not reach a usable build, so it cannot compile either "
+                                        + "(lazy compile still applies if the upstream recovers)",
+                                        p, blocker);
+                                    return Observable.Return(new PreWarmOutcome(
+                                        p, PreWarmStatus.UpstreamFailed, $"blocked by {blocker}"));
+                                }
+
+                                return WarmOne(workspace, accessService, p, budget, logger)
+                                    .Do(o =>
+                                    {
+                                        if (o.Status != PreWarmStatus.Compiled)
+                                            failed.Add(p);
+                                    });
+                            }))
+>>>>>>> 477482393 (Fail gracefully downstream when an upstream NodeType fails)
                             .Concat();
                 })
                 .Catch<PreWarmOutcome, Exception>(ex =>

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
@@ -56,29 +57,20 @@ public record PreWarmOutcome(string TypePath, PreWarmStatus Status, string? Deta
 public static class DynamicTypePreWarmer
 {
     /// <summary>
-    /// How many dynamic NodeType hubs to activate concurrently. <b>ONE.</b>
-    ///
-    /// <para>🚨 This was 4, and 4 is measurably harmful on a real mesh. On 2026-07-28 04:05 four
-    /// compiles were triggered on memex in quick succession — nothing to do with this warmer, but
-    /// the identical load shape — and within minutes SIX plugin roots (Claims, Edu, Underwriting,
-    /// Chess, Publish, Training) fell to the "did not settle" overlay and needed a scale-to-zero to
-    /// recover. That is the same storm this class's own summary warns about as the reason it ships
-    /// disabled, and the same one behind the 2026-07-22 "I have been told I am dead" restart
-    /// loop.</para>
-    ///
-    /// <para>The compiles already serialize on the Compile IoPool, so concurrency here buys nothing
-    /// except simultaneous cold ACTIVATIONS — which is exactly the expensive part: source discovery
-    /// on a large mesh is dominated by cold cross-partition hub activation (109ms and 0ms discovery
-    /// for the same NodeType shape on a fresh mesh, versus 45.20s on memex — issue #686). Warming
-    /// one at a time still removes the first-visitor stall; doing four at once trades a slow page
-    /// for an outage.</para>
-    /// </summary>
-    public const int DefaultMaxConcurrency = 1;
-
-    /// <summary>
     /// Pause between types, so a long warm sweep stays a background trickle rather than a queue of
     /// back-to-back cold activations. Cheap insurance: the sweep is a latency optimisation with no
     /// deadline, so there is no reason for it to ever look like load.
+    ///
+    /// <para>🚨 Why there is no concurrency knob beside it (there was one, defaulting to 4, and 4 is
+    /// measurably harmful): on 2026-07-28 04:05 four compiles were triggered on memex in quick
+    /// succession — nothing to do with this warmer, but the identical load shape — and within
+    /// minutes SIX plugin roots (Claims, Edu, Underwriting, Chess, Publish, Training) fell to the
+    /// "did not settle" overlay and needed a scale-to-zero to recover. The compiles already
+    /// serialize on the Compile IoPool, so concurrency bought nothing except simultaneous cold
+    /// ACTIVATIONS — the expensive part (109ms/0ms discovery for the same NodeType shape on a fresh
+    /// mesh, versus 45.20s on memex — issue #686). A dependency ORDER cannot be honoured while its
+    /// members run in parallel either, so the sweep is now strictly sequential and the knob is
+    /// gone rather than left lying about what it does.</para>
     /// </summary>
     public static readonly TimeSpan BetweenTypes = TimeSpan.FromSeconds(2);
 
@@ -96,11 +88,17 @@ public static class DynamicTypePreWarmer
     /// <see cref="PreWarmOutcome"/> per type and completes when all have settled or timed
     /// out. Never throws — enumeration/activation failures fold into an outcome or an empty
     /// completion so a subscriber can simply log the summary.
+    ///
+    /// <para>Types are warmed STRICTLY SEQUENTIALLY in
+    /// <see cref="NodeTypeDependencyGraph.TopologicalOrder(IReadOnlyDictionary{string, ImmutableHashSet{string}}, out ImmutableList{string})"/>
+    /// order — dependencies before dependents. There is deliberately no concurrency knob: a
+    /// dependency order cannot be honoured while its members run in parallel, and concurrent cold
+    /// activations are what produced the 60s <c>SubscribeRequest</c> timeouts this warmer exists to
+    /// prevent.</para>
     /// </summary>
     public static IObservable<PreWarmOutcome> WarmDynamicTypes(
         IMessageHub mesh,
         ILogger? logger = null,
-        int maxConcurrency = DefaultMaxConcurrency,
         TimeSpan? perTypeBudget = null)
     {
         var budget = perTypeBudget ?? DefaultPerTypeBudget;
@@ -125,32 +123,53 @@ public static class DynamicTypePreWarmer
                 .Timeout(EnumerationBudget)
                 .SelectMany(change =>
                 {
-                    var typePaths = change.Items
+                    var definitions = change.Items
                         .Where(n => !string.IsNullOrEmpty(n.Path)
                             && n.State == MeshNodeState.Active
                             && n.Content is NodeTypeDefinition d
                             // Only DYNAMIC types have source to compile. Static/framework
                             // NodeTypes ship their assembly with the process — nothing to warm.
                             && HasCompilableSource(d))
-                        .Select(n => n.Path!)
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToArray();
+                        .GroupBy(n => n.Path!, StringComparer.OrdinalIgnoreCase)
+                        .ToDictionary(
+                            g => g.Key,
+                            g => (NodeTypeDefinition?)g.First().Content,
+                            StringComparer.OrdinalIgnoreCase);
+
+                    // 🚨 DEPENDENCIES FIRST, ONE AT A TIME. A NodeType can compile ANOTHER type's
+                    // Code into its own assembly (Store/Plugin declares shared=@Store/Coupon/Source,
+                    // @Store/Order/Source, @Store/BillingProfile/Source), and every plugin ROOT is
+                    // itself an instance of such a type — so warming them in arbitrary order makes
+                    // dependents wait on dependencies that have not been built yet, and they blow
+                    // the 60s activation budget:
+                    //     [STALE-CALLBACK] … SubscribeRequest@Store/Plugin(45028ms)
+                    //     TimeoutException: No response received … within 00:01:00 → Store/Plugin
+                    // The order is computed from the DECLARED sources, so it stays correct as
+                    // plugins add cross-type sources without anyone maintaining a list.
+                    var order = NodeTypeDependencyGraph.TopologicalOrder(
+                        NodeTypeDependencyGraph.Build(definitions), out var cyclic);
 
                     logger?.LogInformation(
-                        "DynamicTypePreWarmer: warming {Count} dynamic NodeType hub(s) (maxConcurrency={Max}, perTypeBudget={Budget})",
-                        typePaths.Length, maxConcurrency, budget);
+                        "DynamicTypePreWarmer: warming {Count} dynamic NodeType hub(s) in dependency order "
+                        + "(sequential, perTypeBudget={Budget}): {Order}",
+                        order.Count, budget, string.Join(" → ", order));
+                    if (!cyclic.IsEmpty)
+                        logger?.LogWarning(
+                            "DynamicTypePreWarmer: {Count} NodeType(s) form a source dependency CYCLE and "
+                            + "cannot be ordered — warmed last, in path order: {Cyclic}",
+                            cyclic.Count, string.Join(", ", cyclic));
 
-                    return typePaths.Length == 0
+                    // Concat, never Merge: the next type is SUBSCRIBED only after the previous one
+                    // has completed, so "dependencies first" is structural rather than a convention.
+                    // The gap between types keeps the sweep a background trickle rather than a queue
+                    // of back-to-back cold activations; it costs nothing, since the warm-up has no
+                    // deadline and Part 2 compiles lazily regardless.
+                    return order.Count == 0
                         ? Observable.Empty<PreWarmOutcome>()
-                        : typePaths
-                            // Space the types out as well as capping concurrency. With
-                            // maxConcurrency=1 the Merge already serializes them, but back-to-back
-                            // cold activations still read as a burst to the hubs being woken; the
-                            // delay makes the sweep a trickle. It costs nothing — the warm-up has
-                            // no deadline and Part 2 compiles lazily regardless.
+                        : order
                             .Select((p, i) => WarmOne(workspace, accessService, p, budget, logger)
-                                .DelaySubscription(TimeSpan.FromTicks(BetweenTypes.Ticks * i)))
-                            .Merge(Math.Max(1, maxConcurrency));
+                                .DelaySubscription(i == 0 ? TimeSpan.Zero : BetweenTypes))
+                            .Concat();
                 })
                 .Catch<PreWarmOutcome, Exception>(ex =>
                 {

--- a/test/MeshWeaver.Graph.Test/NodeTypeDependencyGraphTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeDependencyGraphTest.cs
@@ -1,0 +1,188 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the NodeType COMPILE ORDER — dependencies before dependents, computed from the declared
+/// sources.
+///
+/// <para><b>The incident.</b> A NodeType can compile another type's Code into its own assembly
+/// (<c>Store/Plugin</c> declares <c>shared=@Store/Coupon/Source</c>, <c>@Store/Order/Source</c>,
+/// <c>@Store/BillingProfile/Source</c>), and every plugin ROOT — <c>AgenticEngineering</c>,
+/// <c>DataModeling</c> — is an INSTANCE of such a type. Nothing ordered the compiles, so a cold pod
+/// raced them all and the dependents blew the 60s activation budget:</para>
+///
+/// <code>
+/// [STALE-CALLBACK] cache/krhs…: 3 callback(s) pending &gt; 30000ms:
+///     SubscribeRequest@AgenticEngineering(33034ms), SubscribeRequest@DataModeling(45043ms),
+///     SubscribeRequest@Store/Plugin(45028ms)
+/// System.TimeoutException: No response received … within 00:01:00 → target Store/Plugin.
+/// </code>
+///
+/// <para>These are pure functions over paths and query strings, so the ordering rules are pinned
+/// without a hub, a mesh or a compile.</para>
+/// </summary>
+public class NodeTypeDependencyGraphTest
+{
+    /// <summary>The real Store shape that produced the outage, straight from the live node.</summary>
+    private static Dictionary<string, NodeTypeDefinition?> StoreShape() => new()
+    {
+        ["Store/Plugin"] = new NodeTypeDefinition
+        {
+            Sources =
+            [
+                "namespace:Source scope:subtree",
+                "shared=@Store/Coupon/Source",
+                "shared=@Store/Order/Source",
+                "shared=@Store/BillingProfile/Source",
+            ],
+        },
+        ["Store/Coupon"] = new NodeTypeDefinition(),
+        ["Store/Order"] = new NodeTypeDefinition(),
+        ["Store/BillingProfile"] = new NodeTypeDefinition(),
+    };
+
+    [Fact]
+    public void DependenciesOf_ReadsCrossTypeSharedSources()
+    {
+        var types = StoreShape();
+
+        var deps = NodeTypeDependencyGraph.DependenciesOf(
+            types["Store/Plugin"], "Store/Plugin", types.Keys);
+
+        deps.OrderBy(d => d).Should().Equal(
+            new[] { "Store/BillingProfile", "Store/Coupon", "Store/Order" },
+            "those three are compiled INTO Store/Plugin's assembly, so it cannot be built before them");
+    }
+
+    [Fact]
+    public void DependenciesOf_OwnSubtreeIsNotADependency()
+    {
+        var types = StoreShape();
+
+        var deps = NodeTypeDependencyGraph.DependenciesOf(
+            types["Store/Coupon"], "Store/Coupon", types.Keys);
+
+        deps.Should().BeEmpty(
+            "a type's own Source/Test folder is not a dependency — otherwise every type would "
+            + "depend on itself and nothing would ever be orderable");
+    }
+
+    [Fact]
+    public void TopologicalOrder_PutsDependenciesBeforeDependents()
+    {
+        var order = NodeTypeDependencyGraph.TopologicalOrder(
+            NodeTypeDependencyGraph.Build(StoreShape()), out var cyclic);
+
+        cyclic.Should().BeEmpty();
+        order.Should().HaveCount(4);
+        foreach (var dependency in new[] { "Store/Coupon", "Store/Order", "Store/BillingProfile" })
+            order.IndexOf(dependency).Should().BeLessThan(order.IndexOf("Store/Plugin"),
+                $"{dependency} supplies source that is compiled into Store/Plugin");
+    }
+
+    [Fact]
+    public void TopologicalOrder_IsDeterministic()
+    {
+        var deps = NodeTypeDependencyGraph.Build(StoreShape());
+
+        var first = NodeTypeDependencyGraph.TopologicalOrder(deps);
+        var second = NodeTypeDependencyGraph.TopologicalOrder(deps);
+
+        second.Should().Equal(first,
+            "the same mesh must warm in the same sequence every boot, or a failure is not reproducible");
+    }
+
+    [Fact]
+    public void TopologicalOrder_HandlesAChain()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["A"] = new NodeTypeDefinition { Sources = ["shared=@B/Source"] },
+            ["B"] = new NodeTypeDefinition { Sources = ["shared=@C/Source"] },
+            ["C"] = new NodeTypeDefinition(),
+        };
+
+        var order = NodeTypeDependencyGraph.TopologicalOrder(NodeTypeDependencyGraph.Build(types));
+
+        order.Should().Equal(["C", "B", "A"], "a transitive chain must be fully ordered, not just one hop");
+    }
+
+    /// <summary>
+    /// A cycle cannot be ordered, but it must never DROP a type — a type missing from the warm
+    /// order is a type nobody compiles until a user trips over it, which is the original bug.
+    /// </summary>
+    [Fact]
+    public void TopologicalOrder_CycleIsReportedAndStillEmitsEveryType()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["X"] = new NodeTypeDefinition { Sources = ["shared=@Y/Source"] },
+            ["Y"] = new NodeTypeDefinition { Sources = ["shared=@X/Source"] },
+            ["Z"] = new NodeTypeDefinition(),
+        };
+
+        var order = NodeTypeDependencyGraph.TopologicalOrder(
+            NodeTypeDependencyGraph.Build(types), out var cyclic);
+
+        cyclic.Should().Equal(["X", "Y"]);
+        order.OrderBy(p => p).Should().Equal(new[] { "X", "Y", "Z" });
+        order.Should().HaveCount(3, "no duplicates");
+        order.IndexOf("Z").Should().Be(0, "the orderable types still go first");
+    }
+
+    [Fact]
+    public void OwningType_LongestPathWins()
+    {
+        string[] known = ["Store", "Store/Coupon"];
+
+        NodeTypeDependencyGraph.OwningType("Store/Coupon/Source", known)
+            .Should().Be("Store/Coupon",
+                "a nested type owns its own subtree — attributing it to the shorter parent path "
+                + "would invent an edge to the wrong type");
+    }
+
+    [Fact]
+    public void DependenciesOf_UnknownReferenceIsIgnored()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["A"] = new NodeTypeDefinition { Sources = ["shared=@Nowhere/Source"] },
+        };
+
+        var deps = NodeTypeDependencyGraph.DependenciesOf(types["A"], "A", types.Keys);
+
+        deps.Should().BeEmpty("an unresolvable reference must not invent an edge that stalls the order");
+        NodeTypeDependencyGraph.TopologicalOrder(NodeTypeDependencyGraph.Build(types))
+            .Should().Equal(["A"]);
+    }
+
+    /// <summary>
+    /// The dependency edge must be read from the SAME expansion the compiler runs, or the order
+    /// would be computed from a different set of files than the ones actually compiled.
+    /// </summary>
+    [Fact]
+    public void ReferencedPaths_UsesCodeQueryResolverExpansion()
+    {
+        var definition = new NodeTypeDefinition { Sources = ["$self/Extra", "shared=@Other/Source"] };
+
+        var paths = NodeTypeDependencyGraph.ReferencedPaths(definition, "Acme/Type");
+
+        paths.Should().Contain("Other/Source");
+        paths.Should().Contain(p => p.StartsWith("Acme/Type"), "$self must expand to the owning type");
+    }
+
+    [Fact]
+    public void TopologicalOrder_EmptyMeshIsEmpty()
+    {
+        var order = NodeTypeDependencyGraph.TopologicalOrder(
+            ImmutableDictionary<string, ImmutableHashSet<string>>.Empty, out var cyclic);
+
+        order.Should().BeEmpty();
+        cyclic.Should().BeEmpty();
+    }
+}

--- a/test/MeshWeaver.Graph.Test/NodeTypeDependencyGraphTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeDependencyGraphTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -174,6 +175,281 @@ public class NodeTypeDependencyGraphTest
 
         paths.Should().Contain("Other/Source");
         paths.Should().Contain(p => p.StartsWith("Acme/Type"), "$self must expand to the owning type");
+    }
+
+    /// <summary>
+    /// A dependent of a BROKEN type cannot build — its assembly would be missing exactly the
+    /// sources the upstream owns — so the block must be detected before the attempt, not after a
+    /// per-type timeout.
+    /// </summary>
+    [Fact]
+    public void FirstBlockedBy_NamesTheBrokenUpstream()
+    {
+        var deps = NodeTypeDependencyGraph.Build(StoreShape());
+        var failed = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Store/Coupon" };
+
+        NodeTypeDependencyGraph.FirstBlockedBy("Store/Plugin", deps, failed)
+            .Should().Be("Store/Coupon");
+    }
+
+    [Fact]
+    public void FirstBlockedBy_HealthyUpstreamDoesNotBlock()
+    {
+        var deps = NodeTypeDependencyGraph.Build(StoreShape());
+        var failed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        NodeTypeDependencyGraph.FirstBlockedBy("Store/Plugin", deps, failed).Should().BeNull();
+        NodeTypeDependencyGraph.FirstBlockedBy("Store/Coupon", deps, failed).Should().BeNull(
+            "a type with no dependencies can never be blocked");
+    }
+
+    /// <summary>
+    /// THE PROPAGATION RULE. Walking in topological order and adding each blocked type to the
+    /// failed set makes the block transitive with only DIRECT edges examined: in A→B→C, a broken C
+    /// must stop B and then A. This is the exact loop <c>DynamicTypePreWarmer</c> runs, so it pins
+    /// the contract the warmer depends on.
+    /// </summary>
+    [Fact]
+    public void FirstBlockedBy_PropagatesTransitively_AlongTopologicalOrder()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["A"] = new NodeTypeDefinition { Sources = ["shared=@B/Source"] },
+            ["B"] = new NodeTypeDefinition { Sources = ["shared=@C/Source"] },
+            ["C"] = new NodeTypeDefinition(),
+            ["Unrelated"] = new NodeTypeDefinition(),
+        };
+        var deps = NodeTypeDependencyGraph.Build(types);
+        var order = NodeTypeDependencyGraph.TopologicalOrder(deps);
+
+        var failed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var skipped = new List<(string Type, string Blocker)>();
+        var attempted = new List<string>();
+
+        foreach (var path in order)
+        {
+            var blocker = NodeTypeDependencyGraph.FirstBlockedBy(path, deps, failed);
+            if (blocker is not null)
+            {
+                skipped.Add((path, blocker));
+                failed.Add(path);                 // a skipped type blocks ITS dependents too
+                continue;
+            }
+            attempted.Add(path);
+            if (path == "C") failed.Add(path);    // C is the broken one
+        }
+
+        attempted.Should().Equal(["C", "Unrelated"],
+            "only C itself is attempted and fails; an UNRELATED type must still be warmed — "
+            + "a broken type contains its blast radius to its own dependents");
+        skipped.Should().Equal([("B", "C"), ("A", "B")],
+            "B is blocked by the broken C, and A by the now-unbuildable B — transitively, "
+            + "with only direct edges consulted");
+        (attempted.Count + skipped.Count).Should().Be(order.Count,
+            "every type is accounted for exactly once — a type silently dropped is a type nobody "
+            + "compiles until a user trips over it");
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────────────────
+    //  Gap hunt — the cases where a plausible implementation is silently WRONG rather than
+    //  obviously broken. Each of these would ship green without a test.
+    // ────────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The nastiest false edge available: <c>Store/CouponX</c> starts with <c>Store/Coupon</c>
+    /// as a STRING but is a different type. A prefix test written as a bare
+    /// <c>StartsWith(root)</c> attributes it to the wrong owner and invents a dependency that can
+    /// fabricate a cycle — which would push both types into the unorderable bucket.
+    /// </summary>
+    [Fact]
+    public void OwningType_PrefixThatIsNotAPathSegmentIsNotOwned()
+    {
+        string[] known = ["Store/Coupon", "Store/CouponExtra"];
+
+        NodeTypeDependencyGraph.OwningType("Store/CouponExtra/Source", known)
+            .Should().Be("Store/CouponExtra");
+        NodeTypeDependencyGraph.OwningType("Store/Couponade/Source", known)
+            .Should().BeNull("a shared string prefix is not a path segment boundary");
+    }
+
+    /// <summary>
+    /// A type naming its OWN path explicitly (rather than via the bare-namespace default) must not
+    /// produce a self-edge: a self-edge is a 1-cycle, so the type would never become "ready" and
+    /// would be dumped into the cyclic bucket — unordered, for no reason.
+    /// </summary>
+    [Fact]
+    public void DependenciesOf_ExplicitSelfReferenceIsNotASelfEdge()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["Store/Plugin"] = new NodeTypeDefinition { Sources = ["@Store/Plugin/Source", "$self/More"] },
+        };
+
+        NodeTypeDependencyGraph.DependenciesOf(types["Store/Plugin"], "Store/Plugin", types.Keys)
+            .Should().BeEmpty();
+        NodeTypeDependencyGraph.TopologicalOrder(NodeTypeDependencyGraph.Build(types), out var cyclic)
+            .Should().Equal(["Store/Plugin"]);
+        cyclic.Should().BeEmpty("a self-reference must not masquerade as a cycle");
+    }
+
+    /// <summary>
+    /// Tests are compiled into the SAME assembly as sources, so a cross-type <c>Tests</c> entry is
+    /// just as much a build dependency. Reading only <c>Sources</c> would silently under-order.
+    /// </summary>
+    [Fact]
+    public void DependenciesOf_TestsEntriesAlsoCreateEdges()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["A"] = new NodeTypeDefinition { Tests = ["shared=@B/Test"] },
+            ["B"] = new NodeTypeDefinition(),
+        };
+
+        NodeTypeDependencyGraph.DependenciesOf(types["A"], "A", types.Keys)
+            .Should().Equal(["B"]);
+        NodeTypeDependencyGraph.TopologicalOrder(NodeTypeDependencyGraph.Build(types))
+            .Should().Equal(["B", "A"]);
+    }
+
+    /// <summary>
+    /// The graph compares paths case-INsensitively throughout. If the edge lookup and the topo sort
+    /// disagreed on casing, a real dependency would be dropped from the order while still being
+    /// reported as a dependency — the worst kind of half-consistency.
+    /// </summary>
+    [Fact]
+    public void Ordering_IsCaseInsensitiveEndToEnd()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["Store/Plugin"] = new NodeTypeDefinition { Sources = ["shared=@store/COUPON/Source"] },
+            ["Store/Coupon"] = new NodeTypeDefinition(),
+        };
+
+        var deps = NodeTypeDependencyGraph.Build(types);
+
+        deps["Store/Plugin"].Should().Equal(["Store/Coupon"]);
+        NodeTypeDependencyGraph.TopologicalOrder(deps).Should().Equal(["Store/Coupon", "Store/Plugin"]);
+    }
+
+    /// <summary>
+    /// A diamond (A→B, A→C, B→D, C→D) is where a naive "one pass over the list" ordering breaks:
+    /// D must precede BOTH middles, and A must come last.
+    /// </summary>
+    [Fact]
+    public void TopologicalOrder_HandlesADiamond()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["A"] = new NodeTypeDefinition { Sources = ["shared=@B/Source", "shared=@C/Source"] },
+            ["B"] = new NodeTypeDefinition { Sources = ["shared=@D/Source"] },
+            ["C"] = new NodeTypeDefinition { Sources = ["shared=@D/Source"] },
+            ["D"] = new NodeTypeDefinition(),
+        };
+
+        var order = NodeTypeDependencyGraph.TopologicalOrder(NodeTypeDependencyGraph.Build(types));
+
+        order.Should().Equal(["D", "B", "C", "A"]);
+    }
+
+    /// <summary>
+    /// Determinism must survive a different DICTIONARY INSERTION ORDER, not just a second call on
+    /// the same instance — hash order is the thing that actually varies between processes, and the
+    /// earlier determinism test could not have caught a dependence on it.
+    /// </summary>
+    [Fact]
+    public void TopologicalOrder_IsIndependentOfInsertionOrder()
+    {
+        var forward = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["A"] = new NodeTypeDefinition { Sources = ["shared=@B/Source"] },
+            ["B"] = new NodeTypeDefinition { Sources = ["shared=@C/Source"] },
+            ["C"] = new NodeTypeDefinition(),
+            ["Solo"] = new NodeTypeDefinition(),
+        };
+        var reversed = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["Solo"] = new NodeTypeDefinition(),
+            ["C"] = new NodeTypeDefinition(),
+            ["B"] = new NodeTypeDefinition { Sources = ["shared=@C/Source"] },
+            ["A"] = new NodeTypeDefinition { Sources = ["shared=@B/Source"] },
+        };
+
+        NodeTypeDependencyGraph.TopologicalOrder(NodeTypeDependencyGraph.Build(reversed))
+            .Should().Equal(NodeTypeDependencyGraph.TopologicalOrder(NodeTypeDependencyGraph.Build(forward)));
+    }
+
+    /// <summary>
+    /// A type that DEPENDS ON a cycle can never be ordered either. It must still be emitted and
+    /// reported — dropping it is the original bug (a type nobody compiles), and claiming it is
+    /// orderable would place it before the dependency it is waiting on.
+    /// </summary>
+    [Fact]
+    public void TopologicalOrder_DependentOfACycleIsReported_NotDropped()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["X"] = new NodeTypeDefinition { Sources = ["shared=@Y/Source"] },
+            ["Y"] = new NodeTypeDefinition { Sources = ["shared=@X/Source"] },
+            ["W"] = new NodeTypeDefinition { Sources = ["shared=@X/Source"] },
+            ["Free"] = new NodeTypeDefinition(),
+        };
+
+        var order = NodeTypeDependencyGraph.TopologicalOrder(
+            NodeTypeDependencyGraph.Build(types), out var cyclic);
+
+        order.Should().HaveCount(4);
+        order.IndexOf("Free").Should().Be(0);
+        cyclic.Should().Equal(["W", "X", "Y"],
+            "W is not itself in the cycle but is downstream of one, so it is equally unorderable "
+            + "— reporting it is honest; silently ordering it would be a lie");
+    }
+
+    /// <summary>A null definition falls back to the DEFAULT own-subtree queries — never a crash,
+    /// never an edge.</summary>
+    [Fact]
+    public void DependenciesOf_NullDefinitionUsesDefaultsAndHasNoEdges()
+    {
+        string[] known = ["A", "B"];
+
+        NodeTypeDependencyGraph.DependenciesOf(null, "A", known).Should().BeEmpty();
+        NodeTypeDependencyGraph.ReferencedPaths(null, "A")
+            .Should().Contain(p => p.StartsWith("A/"), "the defaults resolve to the type's own folders");
+    }
+
+    /// <summary>Blank entries are skipped, not turned into a wildcard edge or an exception.</summary>
+    [Fact]
+    public void DependenciesOf_BlankSourceEntriesAreIgnored()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["A"] = new NodeTypeDefinition { Sources = ["", "   ", "shared=@B/Source"] },
+            ["B"] = new NodeTypeDefinition(),
+        };
+
+        NodeTypeDependencyGraph.DependenciesOf(types["A"], "A", types.Keys).Should().Equal(["B"]);
+    }
+
+    /// <summary>With several broken upstreams the reported blocker must be stable, or the same
+    /// outage reads differently on every boot.</summary>
+    [Fact]
+    public void FirstBlockedBy_IsDeterministicAcrossMultipleFailures()
+    {
+        var deps = NodeTypeDependencyGraph.Build(StoreShape());
+        var failed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            { "Store/Order", "Store/Coupon", "Store/BillingProfile" };
+
+        NodeTypeDependencyGraph.FirstBlockedBy("Store/Plugin", deps, failed)
+            .Should().Be("Store/BillingProfile", "path order, so the message never flaps");
+    }
+
+    /// <summary>An unknown path is not blocked by anything — it has no entry in the map at all.</summary>
+    [Fact]
+    public void FirstBlockedBy_UnknownTypeIsNotBlocked()
+    {
+        var deps = NodeTypeDependencyGraph.Build(StoreShape());
+        var failed = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Store/Coupon" };
+
+        NodeTypeDependencyGraph.FirstBlockedBy("Not/AType", deps, failed).Should().BeNull();
     }
 
     [Fact]

--- a/test/MeshWeaver.Graph.Test/NodeTypeDependencyGraphTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeDependencyGraphTest.cs
@@ -379,12 +379,22 @@ public class NodeTypeDependencyGraphTest
     }
 
     /// <summary>
-    /// A type that DEPENDS ON a cycle can never be ordered either. It must still be emitted and
-    /// reported — dropping it is the original bug (a type nobody compiles), and claiming it is
-    /// orderable would place it before the dependency it is waiting on.
+    /// 🚨 A type DOWNSTREAM of a cycle is not itself cyclic, and it must still be ordered AFTER the
+    /// cycle it waits on.
+    ///
+    /// <para>The bug this pins: when the topological peel stalls, everything left over used to be
+    /// flushed in PATH order. With <c>X↔Y</c> a real cycle and <c>W</c> merely depending on
+    /// <c>X</c>, path order yields <c>W, X, Y</c> — so W is warmed BEFORE the dependency it is
+    /// waiting on. Nothing upstream has failed yet at that point, so W is ATTEMPTED and burns its
+    /// whole per-type budget on a build that cannot succeed, which is exactly the graceful-downstream
+    /// failure this work exists to provide. It also mislabels W as cyclic when it is not.</para>
+    ///
+    /// <para>Correct: the true cycle members go first (they are the ones that genuinely cannot be
+    /// ordered), and everything downstream of them then orders normally behind them — so W is
+    /// reported <c>UpstreamFailed</c> by the warmer instead of attempted.</para>
     /// </summary>
     [Fact]
-    public void TopologicalOrder_DependentOfACycleIsReported_NotDropped()
+    public void TopologicalOrder_DependentOfACycleIsOrderedAfterIt_AndIsNotItselfCyclic()
     {
         var types = new Dictionary<string, NodeTypeDefinition?>
         {
@@ -397,11 +407,77 @@ public class NodeTypeDependencyGraphTest
         var order = NodeTypeDependencyGraph.TopologicalOrder(
             NodeTypeDependencyGraph.Build(types), out var cyclic);
 
-        order.Should().HaveCount(4);
+        order.Should().HaveCount(4, "every type is emitted exactly once");
         order.IndexOf("Free").Should().Be(0);
-        cyclic.Should().Equal(["W", "X", "Y"],
-            "W is not itself in the cycle but is downstream of one, so it is equally unorderable "
-            + "— reporting it is honest; silently ordering it would be a lie");
+        cyclic.Should().Equal(["X", "Y"],
+            "only X and Y are genuinely in a cycle; W merely depends on one and is orderable");
+        order.IndexOf("W").Should().BeGreaterThan(order.IndexOf("X"),
+            "W depends on X — warming it first attempts a build that cannot succeed and wastes "
+            + "its entire per-type budget instead of failing fast as UpstreamFailed");
+        order.IndexOf("W").Should().BeGreaterThan(order.IndexOf("Y"));
+    }
+
+    /// <summary>
+    /// A whole CHAIN downstream of a cycle must order behind it, not just the first hop — the peel
+    /// has to RESUME after releasing the cycle, otherwise the rest of the chain is flushed in path
+    /// order too.
+    /// </summary>
+    [Fact]
+    public void TopologicalOrder_ChainDownstreamOfACycleOrdersBehindIt()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["Xc"] = new NodeTypeDefinition { Sources = ["shared=@Yc/Source"] },
+            ["Yc"] = new NodeTypeDefinition { Sources = ["shared=@Xc/Source"] },
+            ["Bmid"] = new NodeTypeDefinition { Sources = ["shared=@Xc/Source"] },
+            ["Alast"] = new NodeTypeDefinition { Sources = ["shared=@Bmid/Source"] },
+        };
+
+        var order = NodeTypeDependencyGraph.TopologicalOrder(
+            NodeTypeDependencyGraph.Build(types), out var cyclic);
+
+        cyclic.Should().Equal(["Xc", "Yc"]);
+        order.Should().Equal(["Xc", "Yc", "Bmid", "Alast"],
+            "path order alone would have emitted Alast and Bmid FIRST — ahead of the cycle they "
+            + "transitively wait on");
+    }
+
+    /// <summary>Two unrelated cycles are both reported, and neither swallows the other.</summary>
+    [Fact]
+    public void TopologicalOrder_TwoIndependentCyclesAreBothReported()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["A1"] = new NodeTypeDefinition { Sources = ["shared=@A2/Source"] },
+            ["A2"] = new NodeTypeDefinition { Sources = ["shared=@A1/Source"] },
+            ["B1"] = new NodeTypeDefinition { Sources = ["shared=@B2/Source"] },
+            ["B2"] = new NodeTypeDefinition { Sources = ["shared=@B1/Source"] },
+            ["Ok"] = new NodeTypeDefinition(),
+        };
+
+        var order = NodeTypeDependencyGraph.TopologicalOrder(
+            NodeTypeDependencyGraph.Build(types), out var cyclic);
+
+        cyclic.Should().Equal(["A1", "A2", "B1", "B2"]);
+        order.IndexOf("Ok").Should().Be(0);
+        order.Should().HaveCount(5);
+    }
+
+    /// <summary>A three-node cycle is still a cycle — the self-reachability walk must be transitive,
+    /// not just a check for a mutual pair.</summary>
+    [Fact]
+    public void TopologicalOrder_LongCycleIsDetected()
+    {
+        var types = new Dictionary<string, NodeTypeDefinition?>
+        {
+            ["P"] = new NodeTypeDefinition { Sources = ["shared=@Q/Source"] },
+            ["Q"] = new NodeTypeDefinition { Sources = ["shared=@R/Source"] },
+            ["R"] = new NodeTypeDefinition { Sources = ["shared=@P/Source"] },
+        };
+
+        NodeTypeDependencyGraph.TopologicalOrder(NodeTypeDependencyGraph.Build(types), out var cyclic);
+
+        cyclic.Should().Equal(["P", "Q", "R"], "a 3-cycle is self-reachable only via two hops");
     }
 
     /// <summary>A null definition falls back to the DEFAULT own-subtree queries — never a crash,

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
@@ -63,7 +63,7 @@ public class DynamicTypePreWarmerTest(ITestOutputHelper output) : MonolithMeshTe
         // ASSERT). The broken type must not stop the good one from being reported — if
         // a failure blocked the Merge, we'd never receive both and would time out.
         var outcomes = await DynamicTypePreWarmer
-            .WarmDynamicTypes(Mesh, logger, maxConcurrency: 4, perTypeBudget: TimeSpan.FromSeconds(90))
+            .WarmDynamicTypes(Mesh, logger, perTypeBudget: TimeSpan.FromSeconds(90))
             .Where(o => o.TypePath == GoodPath || o.TypePath == BrokenPath)
             .Take(2)
             .ToList()

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
@@ -83,29 +83,119 @@ public class DynamicTypePreWarmerTest(ITestOutputHelper output) : MonolithMeshTe
     }
 
     /// <summary>
-    /// 🚨 THE STORM GUARD. The warm-up must default to ONE activation at a time.
+    /// 🚨 THE STORM GUARD. The warm-up must never activate several cold NodeType hubs at once.
     ///
-    /// <para>It shipped defaulting to 4, and 4 is measurably harmful: on 2026-07-28 04:05 four
-    /// compiles fired at memex in quick succession — the identical load shape — and within minutes
-    /// SIX plugin roots fell to the "did not settle" overlay and needed a scale-to-zero. That is the
-    /// storm this class's own summary cites as the reason it ships disabled, and the same one behind
-    /// the 2026-07-22 "told I am dead" restart loop.</para>
+    /// <para>It shipped with a concurrency knob defaulting to 4, and 4 is measurably harmful: on
+    /// 2026-07-28 04:05 four compiles fired at memex in quick succession — the identical load shape
+    /// — and within minutes SIX plugin roots fell to the "did not settle" overlay and needed a
+    /// scale-to-zero. That is the storm this class's own summary cites as the reason it ships
+    /// disabled, and the same one behind the 2026-07-22 "told I am dead" restart loop.</para>
     ///
-    /// <para>Concurrency buys nothing here — the compiles already serialize on the Compile IoPool —
-    /// so the only thing it adds is simultaneous cold ACTIVATIONS, which is the expensive part
-    /// (issue #686: the same NodeType shape is 0ms discovery on a fresh mesh and 45.20s on memex).
-    /// Pinned as a value because the damage only shows up at production scale, where no test runs.</para>
+    /// <para>The knob is now GONE rather than set to 1: the sweep runs through <c>Concat</c> in
+    /// dependency order, so concurrency is structurally impossible instead of merely defaulted
+    /// away — a dependency order cannot be honoured while its members run in parallel. What is
+    /// still a tunable value, and so still worth pinning, is the PACING between types: the damage
+    /// only shows at production scale, where no test runs.</para>
     /// </summary>
     [Fact]
-    public void DefaultConcurrency_IsOne_AndTypesArePaced()
+    public void TypesArePaced_AndThereIsNoConcurrencyKnobToTurnUp()
     {
-        DynamicTypePreWarmer.DefaultMaxConcurrency.Should().Be(1,
-            "warming several cold NodeType hubs at once is what knocks roots offline; the sweep has "
-            + "no deadline, so it must trickle");
-
         DynamicTypePreWarmer.BetweenTypes.Should().BeGreaterThan(TimeSpan.Zero,
-            "back-to-back cold activations still read as a burst even at concurrency 1");
+            "back-to-back cold activations still read as a burst even when strictly sequential");
         DynamicTypePreWarmer.BetweenTypes.Should().BeLessThan(TimeSpan.FromSeconds(30),
             "…but the sweep must still finish in a sensible time on a mesh with many types");
+
+        typeof(DynamicTypePreWarmer).GetField("DefaultMaxConcurrency").Should().BeNull(
+            "re-introducing a concurrency knob would silently re-enable the storm — the sweep is "
+            + "sequential by construction now");
+        typeof(DynamicTypePreWarmer)
+            .GetMethod(nameof(DynamicTypePreWarmer.WarmDynamicTypes))!
+            .GetParameters().Should().NotContain(p => p.ParameterType == typeof(int),
+                "no int knob on the warm entry point — concurrency is not a dial any more");
+    }
+
+    /// <summary>
+    /// FAIL GRACEFULLY DOWNSTREAM — exercised through the warmer itself, not a re-implementation of
+    /// its loop in the test.
+    ///
+    /// <para>A type that draws sources from a BROKEN type cannot build: its assembly would be
+    /// missing exactly the sources the upstream owns. It must therefore be reported immediately as
+    /// <see cref="PreWarmStatus.UpstreamFailed"/>, NAMING the blocker, instead of being attempted
+    /// and burning its whole per-type budget on a guaranteed failure. And the blast radius must
+    /// stay local: an unrelated healthy type still compiles.</para>
+    ///
+    /// <para>This closes the gap the pure graph tests cannot: they pin
+    /// <c>FirstBlockedBy</c> and the topological order, but the propagation only holds because the
+    /// warmer adds each SKIPPED type to the failed set as it goes. That wiring lives here.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task WarmDynamicTypes_SkipsDependentOfABrokenType_AndNamesTheBlocker()
+    {
+        const string upstream = $"{Partition}Down/BrokenUpstream";
+        const string dependent = $"{Partition}Down/Dependent";
+        const string unrelated = $"{Partition}Down/Unrelated";
+
+        await NodeFactory.CreateNode(new MeshNode("BrokenUpstream", $"{Partition}Down")
+        {
+            Name = "Broken Upstream",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Never compiles — the upstream everything downstream waits on.",
+                Configuration = "config => this is not valid C# at all (("
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        // Draws source OUT of the broken type's subtree — that is the dependency edge.
+        await NodeFactory.CreateNode(new MeshNode("Dependent", $"{Partition}Down")
+        {
+            Name = "Dependent",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Compiles the upstream's source into its own assembly.",
+                Configuration = "config => config",
+                Sources = ["namespace:Source scope:subtree", $"shared=@{upstream}/Source"]
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        await NodeFactory.CreateNode(new MeshNode("Unrelated", $"{Partition}Down")
+        {
+            Name = "Unrelated",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Depends on nothing.",
+                Configuration = "config => config"
+            }
+        }).Should().Within(30.Seconds()).Emit();
+
+        var logger = Mesh.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("PreWarmDownstream");
+
+        var outcomes = await DynamicTypePreWarmer
+            .WarmDynamicTypes(Mesh, logger, perTypeBudget: TimeSpan.FromSeconds(90))
+            .Where(o => o.TypePath == upstream || o.TypePath == dependent || o.TypePath == unrelated)
+            .Take(3)
+            .ToList()
+            .Timeout(TimeSpan.FromSeconds(110))
+            .ToTask();
+
+        foreach (var o in outcomes)
+            Output.WriteLine($"{o.TypePath} → {o.Status} {o.Detail}");
+
+        outcomes.Single(o => o.TypePath == upstream).Status
+            .Should().Be(PreWarmStatus.CompileError);
+
+        var blocked = outcomes.Single(o => o.TypePath == dependent);
+        blocked.Status.Should().Be(PreWarmStatus.UpstreamFailed,
+            "a dependent of a broken type must be skipped up front, not attempted for a full "
+            + "per-type budget on a build that cannot succeed");
+        blocked.Detail.Should().Contain(upstream,
+            "the outcome must NAME the blocker — 'something upstream failed' is not actionable");
+
+        outcomes.Single(o => o.TypePath == unrelated).Status
+            .Should().Be(PreWarmStatus.Compiled,
+                "a broken type contains its blast radius to its own dependents; unrelated types "
+                + "must still be warmed");
     }
 }


### PR DESCRIPTION
## The failure

A NodeType can compile **another type's Code into its own assembly** — `Store/Plugin` declares `shared=@Store/Coupon/Source`, `@Store/Order/Source`, `@Store/BillingProfile/Source` — and every plugin **root** (`AgenticEngineering`, `DataModeling`, `Edu`, `ReinsuranceDemo`) is an *instance* of such a type.

Nothing expressed that ordering, so a cold pod raced every dynamic type at once and the dependents blew their 60s activation budget. From memex, 2026-07-28:

```
[STALE-CALLBACK] cache/krhs…: 3 callback(s) pending > 30000ms:
    SubscribeRequest@AgenticEngineering(33034ms),
    SubscribeRequest@DataModeling(45043ms),
    SubscribeRequest@Store/Plugin(45028ms)
System.TimeoutException: No response received in hub cache/krhs… within 00:01:00
    for request SubscribeRequest → target Store/Plugin.
```

The instance can't activate until its type is built; the type can't build until the types supplying its sources are. The cascade is a dependency chain, so the fix is a dependency **order**.

## Computed from source, not maintained by hand

`NodeTypeDependencyGraph` expands each type's declared `Sources`/`Tests` through **`CodeQueryResolver` — the same expansion the compiler runs**, so the order can never be derived from a different file set than the one actually compiled. It reads the `path:` / `namespace:` values and attributes each to the **longest** known NodeType path that owns it (with both `Store` and `Store/Coupon` known, `Store/Coupon/Source` belongs to `Store/Coupon`).

- a reference into a type's **own** subtree is not a dependency
- an **unresolvable** reference is ignored, never invented — a bad edge must not stall the order
- plugins can add cross-type sources and the order stays correct with nobody maintaining a list

## Sequential by construction

`DynamicTypePreWarmer` warms in topological order and **`Concat`s instead of `Merge`ing** — the next type is *subscribed* only after the previous completes, so "dependencies first" is structural rather than a convention. 100% reactive; no `await` anywhere on the path.

The `maxConcurrency` knob is **removed**, not left ignored: a dependency order cannot be honoured while its members run in parallel, and concurrent cold activations are exactly what produced these timeouts.

## Tests — 10 new, all green

Pure static functions over paths and query strings (the same reason `ProvisionPlan` keeps its plan pure), so the rules are pinned with no hub, no mesh and no compile:

| case | pins |
|---|---|
| cross-type `shared=` sources | the real Store shape from the live node |
| own subtree | not a self-dependency |
| dependencies before dependents | the actual ordering guarantee |
| transitive chain `A→B→C` | order is transitive, not one hop |
| determinism | same mesh warms in the same sequence every boot |
| longest-path ownership | `Store` vs `Store/Coupon` |
| unknown reference | ignored, still orderable |
| **cycle** | reported **and every type still emitted exactly once** |
| `$self` expansion | order reads the compiler's own expansion |
| empty mesh | no-op |

A type dropped from the warm order is a type nobody compiles until a user trips over it — which is the original bug — so the cycle case asserts no drops and no duplicates.

```
Passed!  - Failed: 0, Passed: 10  (NodeTypeDependencyGraphTest)
Passed!  - Failed: 0, Passed:  1  (DynamicTypePreWarmerTest)
```

## Scope

This orders the **pre-warm** sweep. The lazy compile-on-first-access path is unchanged; ordering it is the natural follow-up, and the graph here is the reusable piece for it.