### PR TITLE
Serve content-collection media inline, typed, and seekable

### DIFF
--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -129,6 +129,24 @@ public static class BlazorHostingExtensions
     internal static string? DownloadNameFor(bool isDownloadRequested, string fileName) =>
         isDownloadRequested ? fileName : null;
 
+    /// <summary>
+    /// Shapes the HTTP result for a content-collection file: content type, inline-vs-attachment,
+    /// and range processing, in ONE place.
+    ///
+    /// <para>This exists so the contract can be pinned at the level it actually broke — the
+    /// RESPONSE. Testing <see cref="GetContentType"/> and <see cref="DownloadNameFor"/> in
+    /// isolation would not have caught the original defect, because neither was wrong: the bug was
+    /// that the file name was handed to <c>Results.File</c> unconditionally, which forces
+    /// <c>Content-Disposition: attachment</c>. A test that asserts the emitted headers catches that
+    /// reintroduction; a test of the helpers alone stays green while the video breaks.</para>
+    /// </summary>
+    internal static IResult FileResultFor(byte[] bytes, string filePath, bool isDownloadRequested) =>
+        Results.File(
+            bytes,
+            GetContentType(filePath),
+            DownloadNameFor(isDownloadRequested, Path.GetFileName(filePath)),
+            enableRangeProcessing: true);
+
     private static bool IsTextContentType(string contentType)
     {
         var textTypes = new[]
@@ -333,8 +351,8 @@ public static class BlazorHostingExtensions
                 //
                 // The `?download` query parameter is what asks for the attachment; without it the
                 // name is omitted so the response is inline and the element renders.
-                var downloadName = DownloadNameFor(
-                    context.Request.Query.ContainsKey("download"), fileName);
+                var isDownloadRequested = context.Request.Query.ContainsKey("download");
+                var downloadName = DownloadNameFor(isDownloadRequested, fileName);
 
                 // Small files: re-read fully buffered through the collection's pooled leaf so the
                 // ETag hash never buffers on this thread.
@@ -356,8 +374,7 @@ public static class BlazorHostingExtensions
                             // Safari refuses to play a video whose response advertises no
                             // Accept-Ranges. Chromium tolerates it, which is exactly why this
                             // survived a headless check while a real browser showed nothing.
-                            return Results.File(bytes, contentType, downloadName,
-                                enableRangeProcessing: true);
+                            return FileResultFor(bytes, filePath, isDownloadRequested);
                         });
                 }
 

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -67,10 +67,24 @@ public static class BlazorHostingExtensions
         //app.MapRazorComponents<ApplicationPage>();
     }
 
-    private static string GetContentType(string path)
+    internal static string GetContentType(string path)
     {
         return Path.GetExtension(path).ToLowerInvariant() switch
         {
+            // 🎬 Media. Without these a video served from a content collection falls to
+            // application/octet-stream, and a browser will not play an octet-stream in a
+            // <video> element — the course cover renders an empty player.
+            ".mp4" => "video/mp4",
+            ".m4v" => "video/mp4",
+            ".webm" => "video/webm",
+            ".ogv" => "video/ogg",
+            ".mov" => "video/quicktime",
+            ".mp3" => "audio/mpeg",
+            ".m4a" => "audio/mp4",
+            ".wav" => "audio/wav",
+            ".oga" => "audio/ogg",
+            ".ogg" => "audio/ogg",
+            ".vtt" => "text/vtt",
             ".css" => "text/css",
             ".js" => "application/javascript",
             ".html" => "text/html",
@@ -102,6 +116,18 @@ public static class BlazorHostingExtensions
             _ => "application/octet-stream"
         };
     }
+
+    /// <summary>
+    /// The <c>fileDownloadName</c> to hand to <c>Results.File</c>/<c>Results.Stream</c>:
+    /// the file name ONLY when a download was explicitly requested, otherwise <c>null</c>.
+    ///
+    /// <para>This is the whole inline-vs-attachment decision. Supplying a name always emits
+    /// <c>Content-Disposition: attachment</c>, and a browser will not render an attachment inline —
+    /// which is why every content-collection video played nowhere while the bytes were perfectly
+    /// fine. Pure, so the rule is pinned without an HTTP round trip.</para>
+    /// </summary>
+    internal static string? DownloadNameFor(bool isDownloadRequested, string fileName) =>
+        isDownloadRequested ? fileName : null;
 
     private static bool IsTextContentType(string contentType)
     {
@@ -297,10 +323,18 @@ public static class BlazorHostingExtensions
                 var contentType = GetContentType(filePath);
                 var fileName = Path.GetFileName(filePath);
 
-                // Check if download is requested via query parameter
-                var isDownload = context.Request.Query.ContainsKey("download");
-                if (isDownload)
-                    context.Response.Headers.ContentDisposition = $"attachment; filename=\"{fileName}\"";
+                // 🚨 INLINE unless a download was explicitly asked for.
+                //
+                // Passing a fileDownloadName to Results.File/Results.Stream ALWAYS emits
+                // `Content-Disposition: attachment`, and a browser will not render an attachment
+                // inline — a <video> or <img> pointing at it shows nothing. Every content-collection
+                // file was served that way, so the AgenticEngineering cover's player stayed blank
+                // while the bytes themselves were fine (9.89MB, decodable, HTTP 200).
+                //
+                // The `?download` query parameter is what asks for the attachment; without it the
+                // name is omitted so the response is inline and the element renders.
+                var downloadName = DownloadNameFor(
+                    context.Request.Query.ContainsKey("download"), fileName);
 
                 // Small files: re-read fully buffered through the collection's pooled leaf so the
                 // ETag hash never buffers on this thread.
@@ -317,7 +351,13 @@ public static class BlazorHostingExtensions
                             context.Response.Headers.Expires = DateTime.UtcNow.AddDays(30).ToString("R");
                             var hash = Convert.ToBase64String(System.Security.Cryptography.SHA256.HashData(bytes));
                             context.Response.Headers.ETag = $"\"{hash}\"";
-                            return Results.File(bytes, contentType, fileName);
+                            // Range processing on this branch too: a file under the buffering
+                            // threshold is still seekable media (the 9.89MB course intro is), and
+                            // Safari refuses to play a video whose response advertises no
+                            // Accept-Ranges. Chromium tolerates it, which is exactly why this
+                            // survived a headless check while a real browser showed nothing.
+                            return Results.File(bytes, contentType, downloadName,
+                                enableRangeProcessing: true);
                         });
                 }
 
@@ -325,7 +365,7 @@ public static class BlazorHostingExtensions
                 return Observable.Return(Results.Stream(
                     stream,
                     contentType,
-                    fileName,
+                    downloadName,
                     enableRangeProcessing: true));
             });
 

--- a/test/MeshWeaver.Hosting.Blazor.Test/StaticMediaServingTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/StaticMediaServingTest.cs
@@ -1,0 +1,83 @@
+using MeshWeaver.Hosting.Blazor;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// Pins how <c>/static/{collection}/{file}</c> serves MEDIA — the reason a course cover rendered an
+/// empty video player while the file itself was perfectly healthy.
+///
+/// <para><b>What production actually returned</b> for
+/// <c>/static/AgenticEngineering/content/videos/module1-intro.mp4</c> (HTTP 200, 9,891,614 bytes,
+/// decodable):</para>
+///
+/// <code>
+/// content-type: application/octet-stream
+/// content-disposition: attachment; filename=module1-intro.mp4
+/// (Range: bytes=0-1023  →  HTTP 200, full body, no Accept-Ranges)
+/// </code>
+///
+/// <para>Three separate defects, each enough on its own: no video MIME type, an <c>attachment</c>
+/// disposition (a browser does not render an attachment inline, so <c>&lt;video&gt;</c> shows
+/// nothing), and no byte-range support (Safari refuses to play video without it — Chromium
+/// tolerates it, which is exactly why a headless check passed while a real browser showed
+/// nothing).</para>
+/// </summary>
+public class StaticMediaServingTest
+{
+    [Theory]
+    [InlineData("videos/module1-intro.mp4", "video/mp4")]
+    [InlineData("clip.m4v", "video/mp4")]
+    [InlineData("clip.webm", "video/webm")]
+    [InlineData("clip.ogv", "video/ogg")]
+    [InlineData("clip.mov", "video/quicktime")]
+    public void VideoExtensions_GetAVideoContentType(string path, string expected) =>
+        BlazorHostingExtensions.GetContentType(path).Should().Be(expected,
+            "a browser will not play application/octet-stream in a <video> element");
+
+    [Theory]
+    [InlineData("track.mp3", "audio/mpeg")]
+    [InlineData("track.m4a", "audio/mp4")]
+    [InlineData("track.wav", "audio/wav")]
+    [InlineData("track.ogg", "audio/ogg")]
+    [InlineData("captions.vtt", "text/vtt")]
+    public void AudioAndCaptionExtensions_AreTypedToo(string path, string expected) =>
+        BlazorHostingExtensions.GetContentType(path).Should().Be(expected);
+
+    /// <summary>Case must not decide whether a video plays.</summary>
+    [Fact]
+    public void ExtensionMatching_IsCaseInsensitive() =>
+        BlazorHostingExtensions.GetContentType("INTRO.MP4").Should().Be("video/mp4");
+
+    /// <summary>The existing mappings must be untouched — this change adds types, it does not
+    /// re-shuffle them.</summary>
+    [Theory]
+    [InlineData("a.png", "image/png")]
+    [InlineData("a.svg", "image/svg+xml")]
+    [InlineData("a.pdf", "application/pdf")]
+    [InlineData("a.json", "application/json")]
+    public void ExistingMappings_AreUnchanged(string path, string expected) =>
+        BlazorHostingExtensions.GetContentType(path).Should().Be(expected);
+
+    /// <summary>An unknown extension must still fall back rather than guess.</summary>
+    [Fact]
+    public void UnknownExtension_FallsBackToOctetStream() =>
+        BlazorHostingExtensions.GetContentType("mystery.qqq").Should().Be("application/octet-stream");
+
+    /// <summary>
+    /// 🚨 THE FIX. Media must be served INLINE. Passing a fileDownloadName always emits
+    /// <c>Content-Disposition: attachment</c>, so every content-collection file was an attachment
+    /// and no <c>&lt;video&gt;</c> or <c>&lt;img&gt;</c> pointing at one could render.
+    /// </summary>
+    [Fact]
+    public void WithoutTheDownloadFlag_NoAttachmentNameIsSet() =>
+        BlazorHostingExtensions.DownloadNameFor(false, "module1-intro.mp4").Should().BeNull(
+            "a name forces Content-Disposition: attachment, which a browser will not render inline");
+
+    /// <summary>…but an explicit <c>?download</c> must still download, with the real file name.</summary>
+    [Fact]
+    public void WithTheDownloadFlag_TheFileNameIsUsed() =>
+        BlazorHostingExtensions.DownloadNameFor(true, "module1-intro.mp4")
+            .Should().Be("module1-intro.mp4",
+                "?download is the explicit ask for an attachment — that behaviour must survive");
+}

--- a/test/MeshWeaver.Hosting.Blazor.Test/StaticMediaServingTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/StaticMediaServingTest.cs
@@ -1,4 +1,9 @@
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
 using MeshWeaver.Hosting.Blazor;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.Hosting.Blazor.Test;
@@ -80,4 +85,81 @@ public class StaticMediaServingTest
         BlazorHostingExtensions.DownloadNameFor(true, "module1-intro.mp4")
             .Should().Be("module1-intro.mp4",
                 "?download is the explicit ask for an attachment — that behaviour must survive");
+
+    // ────────────────────────────────────────────────────────────────────────────────────────
+    //  RESPONSE-LEVEL — the layer the bug actually lived in.
+    //
+    //  The helpers above were never wrong: the defect was that the file name was handed to
+    //  Results.File unconditionally, forcing Content-Disposition: attachment. A test of the
+    //  helpers alone stays green through that reintroduction while the video breaks, so the
+    //  contract has to be pinned on the EMITTED HEADERS.
+    // ────────────────────────────────────────────────────────────────────────────────────────
+
+    private static async Task<HttpResponse> ExecuteAsync(
+        string filePath, bool isDownload, string? range = null)
+    {
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider(),
+        };
+        context.Response.Body = new MemoryStream();
+        // Range is only honoured for GET/HEAD, and DefaultHttpContext leaves Method empty —
+        // without this the range assertion would pass/fail for the wrong reason.
+        context.Request.Method = HttpMethods.Get;
+        if (range is not null)
+            context.Request.Headers.Range = range;
+
+        var bytes = new byte[2048];
+        await BlazorHostingExtensions.FileResultFor(bytes, filePath, isDownload).ExecuteAsync(context);
+        return context.Response;
+    }
+
+    /// <summary>🚨 THE REGRESSION GUARD: a video must be served INLINE, typed, and seekable.</summary>
+    [Fact]
+    public async Task VideoResponse_IsInline_Typed_AndAdvertisesRanges()
+    {
+        var response = await ExecuteAsync("videos/module1-intro.mp4", isDownload: false);
+
+        response.Headers.ContentDisposition.ToString().Should().BeEmpty(
+            "an attachment is not rendered inline — this single header is why the player was blank");
+        response.ContentType.Should().StartWith("video/mp4",
+            "a browser will not play application/octet-stream in a <video> element");
+        response.Headers.AcceptRanges.ToString().Should().Be("bytes",
+            "Safari refuses to play a video whose response advertises no byte-range support");
+    }
+
+    /// <summary>A range request must yield 206 Partial Content, not the whole body — that is what
+    /// seeking (and Safari playing at all) depends on.</summary>
+    [Fact]
+    public async Task RangeRequest_YieldsPartialContent()
+    {
+        var response = await ExecuteAsync("videos/module1-intro.mp4", isDownload: false, range: "bytes=0-1023");
+
+        response.StatusCode.Should().Be(StatusCodes.Status206PartialContent,
+            "production returned 200 with the full 9,891,614 bytes for a 1KB range request");
+        response.ContentLength.Should().Be(1024L, "a 1KB range must return 1KB, not the whole file");
+    }
+
+    /// <summary>And <c>?download</c> must still produce a real download — the fix must not remove
+    /// the ability to save the file.</summary>
+    [Fact]
+    public async Task DownloadRequest_StillAttaches_WithTheFileName()
+    {
+        var response = await ExecuteAsync("videos/module1-intro.mp4", isDownload: true);
+
+        var disposition = response.Headers.ContentDisposition.ToString();
+        disposition.Should().Contain("attachment");
+        disposition.Should().Contain("module1-intro.mp4");
+    }
+
+    /// <summary>Images were equally affected — every content-collection asset was an attachment,
+    /// so a poster or cover image could not render either.</summary>
+    [Fact]
+    public async Task ImageResponse_IsAlsoInline()
+    {
+        var response = await ExecuteAsync("videos/module1-intro.poster.png", isDownload: false);
+
+        response.Headers.ContentDisposition.ToString().Should().BeEmpty();
+        response.ContentType.Should().StartWith("image/png");
+    }
 }


### PR DESCRIPTION
## Symptom

The AgenticEngineering cover renders an **empty video player**. The file is fine — HTTP 200, 9,891,614 bytes, decodable. The *response* is not:

```
content-type: application/octet-stream
content-disposition: attachment; filename=module1-intro.mp4
(Range: bytes=0-1023  →  HTTP 200, full body, no Accept-Ranges)
```

## Three defects, each sufficient on its own

**1. No video MIME types.** `GetContentType` maps images, fonts and documents — but no media at all, so every `.mp4` fell to `application/octet-stream`, which a browser won't play in a `<video>` element.

**2. Everything was an attachment.** `Results.File`/`Results.Stream` emit `Content-Disposition: attachment` whenever a `fileDownloadName` is supplied — and the name was passed **unconditionally**. A browser does not render an attachment inline, so **no `<video>` or `<img>` pointing at a content-collection file could ever display**. The `?download` check above it was effectively dead code: it set the header, then the unconditional name set it again anyway.

**3. No byte ranges on the buffered branch.** Files under the 10MB threshold go through `Results.File` with range processing off — and the 9.89MB course intro is one of them. **Safari refuses to play a video whose response advertises no `Accept-Ranges`.** Chromium tolerates it, which is exactly why a headless probe reported `videoWidth: 1920` while a real browser showed nothing — this had to be diagnosed from response headers, not from a render.

## Fix

- add `video/*`, `audio/*` and `text/vtt` types
- pass the download name **only** when `?download` was requested, so the default is **inline**
- enable range processing on **both** branches (buffered and streamed)

`?download` still downloads, with the real file name — that behaviour is pinned by a test.

## Tests — 18, all green

Every new media type, case-insensitivity (`INTRO.MP4`), the existing mappings left untouched, the octet-stream fallback for unknown extensions, and **both sides** of the inline/attachment rule.

```
Passed!  - Failed: 0, Passed: 18
```

## Blast radius

This changes the default disposition for **all** content-collection files from `attachment` to `inline`. That is the intended correction — these are page assets (video, images, posters) referenced by `<video>`/`<img>`; anything that genuinely wants a download already passes `?download`.