### PR TITLE
CD: publish mw-plugin-test to GHCR so the plugins test gate can actually run

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -29,6 +29,9 @@ on:
 permissions:
   contents: read
   id-token: write
+  # packages: write — the mw-plugin-test image is ALSO published to GHCR so the
+  # MeshWeaver.Plugins CI can pull it with a GitHub token instead of ACR credentials.
+  packages: write
 
 # Never let two main merges deploy concurrently — a later merge waits for the in-flight
 # rollout rather than racing it. cancel-in-progress:false so we don't abort a half-done deploy.
@@ -254,7 +257,7 @@ jobs:
       # Lean console image on the standard multi-arch base; <RuntimeIdentifiers> lives in the
       # csproj (project-local — a global -p:RuntimeIdentifiers breaks referenced libs, see above).
       # `latest` rides along so the plugins repo can pin MW_TEST_IMAGE=…/mw-plugin-test:latest.
-      - name: Build + push mw-plugin-test
+      - name: Build + push mw-plugin-test (ACR)
         run: >
           dotnet publish tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
@@ -262,6 +265,29 @@ jobs:
           -p:CIRun=true
           -p:ContainerRegistry=${{ env.ACR }}
           -p:ContainerRepository=mw-plugin-test
+          -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main;latest"'
+
+      # ALSO publish to GHCR. The MeshWeaver.Plugins CI runs its `test-repos` gate INSIDE this
+      # image, and that repo has no ACR credentials — it used to gate the whole job on a repo
+      # variable nobody had set, so the gate reported "skipping" on every PR and every plugin's
+      # `Tests` area was compiled but never executed. Publishing here gives that repo a registry
+      # it can reach with a GitHub token, so the gate runs by default.
+      - name: Lowercase image namespace (GHCR requires lowercase)
+        run: echo "IMAGE_NS=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build + push mw-plugin-test (GHCR)
+        run: >
+          dotnet publish tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+          -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
+          -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
+          -p:CIRun=true
+          -p:ContainerRegistry=ghcr.io
+          -p:ContainerRepository=$IMAGE_NS/mw-plugin-test
           -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main;latest"'
 
   # ───────────────────────────── FAILURE ALERTING ────────────────────────────


### PR DESCRIPTION
## Why

The `MeshWeaver.Plugins` CI runs its `test-repos` gate **inside** the `mw-plugin-test` image — the job that imports every node repo into a real mesh and asserts each NodeType compiles, renders, and its `Tests` layout area runs **green**.

That image is published to ACR only, and the plugins repo has no ACR credentials. So the job was gated on a repo variable (`MW_TEST_IMAGE`) that nobody had set, and reported **"skipping" on every PR**. Every plugin's `Tests` area was compiled and never executed.

That is the hole the Store access defects merged through — see Systemorph/MeshWeaver.Plugins#200 and #201, and the companion PR Systemorph/MeshWeaver.Plugins#212 which points the gate at GHCR.

## What

The same multi-arch image is now also pushed to `ghcr.io/<owner>/mw-plugin-test` with the same tag set (`<version>`, `<sha>`, `main`, `latest`). The plugins repo can pull that with a GitHub token, so its gate runs by default and fails loudly when the image is missing instead of silently disappearing.

- ACR stays the primary; nothing that consumes it changes.
- Adds `packages: write` at the workflow level (needed for the GHCR push).
- No change to the portal or migration image legs.

## Order of operations

Merge this first and let one `main` CD run publish the image; the plugins-side PR turns red until `ghcr.io/systemorph/mw-plugin-test:latest` exists (that failure is by design — the gate is no longer allowed to skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)