### PR TITLE
Docs: the environment traps that cost us a morning

### DIFF
--- a/deploy/aks/DEPLOY-RUNBOOK.md
+++ b/deploy/aks/DEPLOY-RUNBOOK.md
@@ -169,7 +169,59 @@ kubectl -n monitoring port-forward svc/loki-grafana 3000:80    # http://localhos
 In Grafana → Explore → Loki, the portal logs are `{namespace="memex"}` (e.g. add
 `|= "error"` or `|~ "signin-microsoft"`).
 
+## 7. Rolling a new image — and the traps
+
+```bash
+# a) The manifest MUST carry every arch leg. A partial manifest list = ImagePullBackOff on the
+#    missing arch, which presents as "the deploy hung" (memex-cloud V46 outage, 2026-07-19).
+az acr manifest show -r meshweaver -n memex-portal-ai:<tag> \
+  | jq -r '.manifests[]?.platform | "\(.os)/\(.architecture)"'   # expect linux/amd64 AND linux/arm64
+
+# b) Roll.
+az aks command invoke -g memex-aks-rg -n memexaks-cluster --command \
+  "kubectl set image deploy/memex-portal-deployment memex-portal=meshweaver.azurecr.io/memex-portal-ai:<tag> -n <env> \
+   && kubectl rollout status deploy/memex-portal-deployment -n <env> --timeout=600s"
+
+# c) Verify with REAL signals, looped. HTTP 200 is the Blazor shell and proves nothing.
+for i in $(seq 1 10); do curl -s -o /dev/null -w "%{http_code} " https://<host>/static/<space>/content/<file>; done
+```
+
+**Expect a cold-compile window.** Fresh pods invalidate every dynamic NodeType's cached assembly
+(the framework MVID changed), so they all recompile. During it, pages and `/static/…` can fail with
+*"No response received … `GetDataRequest`/`SubscribeRequest` → target X"*. This is normal; it is not
+a bad image.
+
+- **Do not cycle pods while it warms** — that restarts the compile work from cold.
+- **Converging vs. stuck:** warm-up trends toward 100%. A *stable* ~50% over many minutes means one
+  replica is consistently failing — investigate that replica instead of waiting.
+- **Probes:** `startupProbe` gives 300s and gates liveness/readiness, so a slow boot is safe; a hang
+  or crash after startup is killed by liveness in 90s.
+
+### Scaling: KEDA wins
+`kubectl scale --replicas=0` (the documented heal for a wedged mesh) is **silently reverted** by a
+`ScaledObject` with `minReplicaCount: 2` — you conclude the heal failed when it never ran.
+`kubectl get scaledobject -n <env>` first, and check `PAUSED`.
+
+### Crash dumps: verify the MOUNT
+`DOTNET_DbgEnableMiniDump` + `DOTNET_DbgMiniDumpName=/data/dumps/…` do nothing without a volume at
+that path — `createdump` does not create directories, so the crash destroys its own evidence. The
+chart mounts a dedicated `memex-dumps` emptyDir; verify the LIVE pod actually has it:
+
+```bash
+kubectl get deploy memex-portal-deployment -n <env> \
+  -o jsonpath='{range .spec.template.spec.containers[0].volumeMounts[*]}{.name} -> {.mountPath}{"\n"}{end}' \
+  | grep dumps || echo "NO DUMP MOUNT — every crash will produce nothing"
+```
+
+⚠️ `envs/<env>/portal-patch.json` replaces volumes **by index**, so adding or reordering a chart
+volume silently misaligns an environment and a cluster can run an older volume set while the chart
+in git looks right. Diff live mounts against the chart after every deploy.
+
 ## Known gaps / follow-ups
+- **Dump mount not applied to the live clusters** (2026-07-28): all three namespaces carry the dump
+  env vars while no pod mounts `/data/dumps`, so every production `exit=139` so far produced no
+  dump. Applying the current chart fixes it; until then a `mkdir /data/dumps` on the `/data` PVC is
+  a stopgap that puts heap-sized dumps on a shared 16Gi share instead of the size-bounded emptyDir.
 - **Multi-replica HA**: needs Orleans `AzureTables` clustering wired on the Filesystem backend
   (the portal currently registers the clustering table client only in the Azure-backend branch).
 - **Chart connection string**: `../helm/templates/memex-portal/secrets.yaml` hardcodes the

--- a/src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md
@@ -170,6 +170,63 @@ See [Memex Cloud Deployment](/Doc/Architecture/MemexCloudDeployment) for the pro
   and scrape **every** namespace — query `{namespace="<env>"}` in Grafana Explore (reach it via
   the P2S VPN + `kubectl -n monitoring port-forward svc/loki-grafana 3000:80`). Loki retains logs
   across pod restarts, unlike `kubectl logs`.
+- **🩺 Crash dumps need the MOUNT, not just the env vars.** `DOTNET_DbgEnableMiniDump` +
+  `DOTNET_DbgMiniDumpName=/data/dumps/…` are worthless on their own: `createdump` does **not create
+  directories**, so without a volume mounted at that path every crash fails with *"Could not create
+  output file … No such file or directory"* — **destroying its own evidence** — and burns ~6s plus a
+  ~350k-line log storm on the way down. The chart mounts a dedicated `memex-dumps` emptyDir there;
+  an env whose live pod lacks it produces **zero dumps while looking fully instrumented**. Verified
+  2026-07-28: all three environments had the env vars pointing at a non-existent directory, so every
+  production `exit=139` since had left nothing to analyse. Check the MOUNT, never the env:
+  ```bash
+  kubectl get deploy memex-portal-deployment -n <env> \
+    -o jsonpath='{range .spec.template.spec.containers[0].volumeMounts[*]}{.name} -> {.mountPath}{"\n"}{end}' \
+    | grep dumps || echo "NO DUMP MOUNT — crashes will produce nothing"
+  ```
+- **The per-env patch replaces volumes BY INDEX.** `deploy/aks/envs/<env>/portal-patch.json` targets
+  `/spec/template/spec/volumes/0`, `/1`, … so **adding or reordering a volume in the chart silently
+  misaligns every environment**, and a cluster can keep running an older volume set while the chart
+  in git looks correct. After any deploy, diff the live mounts against the chart — do not assume the
+  chart is what is running.
+- **KEDA overrides `kubectl scale`.** A `ScaledObject` with `minReplicaCount: 2` silently restores
+  replicas, so "scale to zero" (the documented heal for a wedged mesh) **does not take** and you
+  conclude the heal failed when it never ran. Check first — and note `PAUSED`:
+  ```bash
+  kubectl get scaledobject -n <env>
+  ```
+- **HTTP 200 proves nothing.** The Blazor shell returns 200 for a page that renders an error, a
+  paywall redirect, or nothing at all. Verify a deploy with response **headers** for static assets
+  and with actual rendered content (`get @<Node>/area/<Area>` through the MCP, or a real browser) —
+  never with a status code.
+
+## Verifying a rollout (and what "normal turbulence" looks like)
+
+A new image means **fresh pods**, and every dynamic NodeType's cached assembly is ABI-stale against
+the new framework build — so they all recompile. Expect a window where pages and `/static/…` return
+errors like *"No response received … for request `GetDataRequest`/`SubscribeRequest` → target X"*.
+That is cold-compile, not a bad image.
+
+```bash
+# 1. BEFORE rolling: the manifest must have every arch leg. A partial manifest list is an
+#    ImagePullBackOff on the missing arch, which reads as "the deploy hung".
+az acr manifest show -r <registry> -n memex-portal-ai:<tag> \
+  | jq -r '.manifests[]?.platform | "\(.os)/\(.architecture)"'
+
+# 2. Roll and wait.
+kubectl set image deploy/memex-portal-deployment memex-portal=<registry>/memex-portal-ai:<tag> -n <env>
+kubectl rollout status deploy/memex-portal-deployment -n <env> --timeout=600s
+
+# 3. Verify with real signals, in a LOOP (one probe can hit a warm pod and lie).
+for i in $(seq 1 10); do curl -s -o /dev/null -w "%{http_code} " https://<host>/static/<space>/content/<file>; done
+```
+
+- **Do not cycle pods while it warms.** Deleting or scaling pods restarts the compile work from
+  cold and makes the window longer, not shorter.
+- **A steady ratio is a signal, not warm-up.** Warm-up converges toward 100%; a stable ~50% across
+  many minutes means *one replica is failing consistently* — investigate that, do not wait it out.
+- **Probe budgets** (`startupProbe` 300s, `liveness` 90s, `readiness` 30s): liveness and readiness
+  do not run until the startup probe succeeds, so a **slow boot is safe**. What is not safe is a
+  hang or crash *after* startup — 90s of failed `/alive` and kubelet restarts the container.
 
 ## Related
 


### PR DESCRIPTION
Everything here was verified against the live clusters on 2026-07-28, during the memex roll. It lands in **two** places: the **shipped platform docs** (`Doc/Architecture/OnboardingNewEnvironment` — the "how to set up an environment" page) and the operator-facing AKS runbook.

## 🩺 Crash dumps need the MOUNT, not the env vars

`DOTNET_DbgEnableMiniDump` + `DOTNET_DbgMiniDumpName=/data/dumps/…` are worthless alone: `createdump` **does not create directories**. Without a volume at that path every crash fails with *"Could not create output file … No such file or directory"* — **destroying its own evidence** — and burns ~6s plus a ~350k-line log storm on the way down.

Checked all three environments: **every one carried the env vars while no pod mounted `/data/dumps`.** So every production `exit=139` to date produced nothing, while the setup looked fully instrumented. The doc now says to verify the *mount*, with the command.

## The per-env patch replaces volumes BY INDEX

`envs/<env>/portal-patch.json` targets `/spec/template/spec/volumes/0`, `/1`, … so **adding or reordering a chart volume silently misaligns every environment** — and a cluster can keep running an older volume set while the chart in git looks correct. Diff live mounts against the chart after every deploy.

## KEDA overrides `kubectl scale`

A `ScaledObject` with `minReplicaCount: 2` silently restores replicas, so **"scale to zero" — the documented heal for a wedged mesh — never actually runs**, and you conclude the heal failed. Check `kubectl get scaledobject` (and `PAUSED`) first.

## HTTP 200 proves nothing

The Blazor shell returns 200 for an error page, a paywall redirect, or a blank render. Verify with response **headers** and real rendered content.

## New: "Verifying a rollout (and what normal turbulence looks like)"

Fresh pods invalidate every dynamic NodeType's cached assembly, so they all recompile; during that window pages and `/static/…` can fail with *"No response received … `GetDataRequest`/`SubscribeRequest` → target X"*. That's cold-compile, not a bad image. Plus the two things easiest to get wrong under pressure:

- **Do not cycle pods while it warms** — it restarts the compile work from cold and lengthens the outage.
- **A stable ~50% is not warm-up.** Warm-up converges; a steady ratio means one replica is consistently failing.

It also records the probe budgets — `startupProbe` 300s and it *gates* liveness/readiness, so a slow boot is safe; a hang after startup is killed in 90s — and the multi-arch manifest check the V46 `ImagePullBackOff` outage taught us.

## Known gaps

Documents the live dump-mount drift (chart has `memex-dumps`, clusters don't) and the `mkdir` stopgap, including its trade-off: heap-sized dumps land on the shared 16Gi `/data` share instead of the size-bounded emptyDir.

---

Docs only — no code, no behaviour change.