### PR TITLE
Docs: NEVER make anyone a global admin — and mainNode "" means ROOT, not Admin

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -66,8 +66,64 @@ MeshWeaver implements row-level security through **AccessAssignment MeshNodes** 
 A user is a **global (platform) admin** iff they hold `Permission.All` at scope `Admin` — i.e. there is an `AccessAssignment` granting them the `Admin` role in the **`Admin/_Access`** namespace:
 
 ```
-Admin/_Access/{user}_Access   →   AccessObject = {user}, Roles = [ Admin ],  MainNode = ""
+Admin/_Access/{user}_Access   →   AccessObject = {user}, Roles = [ Admin ],  MainNode = "Admin"
 ```
+
+> ## 🚨🚨 NEVER MAKE ANYONE A GLOBAL ADMIN
+>
+> **Global admin is not a convenience, a default, or something onboarding hands out. It is the
+> single most dangerous grant in the system and it must be granted to a named human, deliberately,
+> and essentially never.** If you are about to add a row to `Admin/_Access`, stop: the answer is
+> almost always a **partition admin** on the one partition they actually need.
+>
+> ### `MainNode` is the whole ballgame — `""` means ROOT, not "Admin"
+>
+> | `mainNode` | Scope it resolves to | What the user actually gets |
+> |---|---|---|
+> | `"Admin"` | `Admin` partition | ✅ platform management only — the intended shape |
+> | `""` (empty) | **ROOT** | 🔴 **DATA SUPERUSER — All on every partition, every space, every user's private home, by scope inheritance** |
+>
+> An empty `mainNode` does **not** mean "scoped to the folder it sits in". The grant is scoped by
+> `mainNode`, **not** by its path — so `Admin/_Access/{user}_Access` with `mainNode: ""` is a
+> **root grant that happens to be filed under `Admin/`**. It reads as harmless and is catastrophic.
+>
+> **Verify in Postgres, never by eyeballing the folder** — the materialised truth is
+> `admin.user_effective_permissions`, and an **empty `node_path_prefix` means root**:
+>
+> ```sql
+> -- 🔴 Anyone listed here is a DATA SUPERUSER over the entire mesh:
+> select user_id, permission from admin.user_effective_permissions
+> where node_path_prefix = '' order by user_id;
+>
+> -- ✅ Correctly-scoped platform admins:
+> select user_id, permission from admin.user_effective_permissions
+> where node_path_prefix = 'Admin' order by user_id;
+> ```
+>
+> This is not hypothetical. On 2026-07-28 memex had **43 accounts with an empty `node_path_prefix`**
+> — holding `Delete`, `Update`, `Create`, `Compile`, `Execute` and `Export` on everything —
+> against exactly **one** correctly-scoped platform admin. Most were created minutes after the
+> holder first signed in, so **user onboarding was minting mesh-wide superusers**, including
+> external course participants who had merely redeemed a coupon.
+
+### Where to look — global vs. partition admins
+
+| Question | Where to look | Correct shape |
+|---|---|---|
+| Who is a **global/platform admin**? | `Admin/_Access/*` | `mainNode: "Admin"`, role `Admin`. Predicate: `hub.IsGlobalAdmin()` |
+| Who administers **one partition** (a space, a plugin, a course)? | `{partition}/_Access/*` | `mainNode: "{partition}"`, role `Admin` |
+| Who administers **their own home**? | `{user}/_Access/{user}_Access` | `mainNode: "{user}"`, role `Admin` |
+| Who is a **root superuser** (should be nobody)? | `admin.user_effective_permissions` where `node_path_prefix = ''` | 🔴 must be **empty** |
+
+### Every user is admin of their own partition — and of nothing else
+
+Each user's home partition (`{user}/…`) carries exactly one grant — **`{user}/_Access/{user}_Access`,
+role `Admin`, `mainNode: "{user}"`**. That is what lets someone manage their own space: their
+installed courses, their exercises, their notes. It is the *only* admin grant an ordinary user
+should ever hold. Onboarding must create this and **must not** touch `Admin/_Access`.
+
+A grant elsewhere is a deliberate act: partition admin on a space they own, or — very rarely, for a
+named platform operator — `Admin/_Access` with `mainNode: "Admin"`.
 
 Such a user is a **platform admin — NOT a data superuser.** The `Admin/_Access` grant is scoped to the Admin partition (it covers `Admin/Invitation`, version tracking, the role catalogue, …) and **does not** confer access to **spaces** or **user partitions** — nor to the top-level catalog partitions (`Agent`, `Provider`), which carry their own grants (e.g. the `Provider/_Access` Admin grant seeded by `GlobalAdminSeed`). Standing access is platform management (send invites, delete things, platform config); emergency changes to space/user *data* require an explicit **elevation (break-glass)** — a separate, auditable step, never standing permission. `IsGlobalAdmin()` reports "is a platform admin" and gates the platform features; it is **not** a permission override (a root `_Access` grant — *that* is the data-superuser shape — is deliberately NOT how platform admins are provisioned).
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/GrantingAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GrantingAccess.md
@@ -163,7 +163,7 @@ mcp update --nodes '[{
 
 ## Recipe 2 — Grant a user Global (Platform) Admin
 
-Global/platform admin has **one** canonical shape: an `AccessAssignment` granting the `Admin` role **on the Admin partition** — namespace `Admin/_Access`, `mainNode` left empty. This is exactly what `GlobalAdminSeed` (config-driven admins via `Auth:GlobalAdmins`) and `UserOnboardingService.GrantPlatformAdmin` (first user) write, and what `hub.IsGlobalAdmin()` reads.
+🚨 **NEVER make anyone a global admin** unless it is a named platform operator and you mean it — see [Access Control](/Doc/Architecture/AccessControl). Global/platform admin has **one** canonical shape: an `AccessAssignment` granting the `Admin` role **on the Admin partition** — namespace `Admin/_Access`, **`mainNode: "Admin"`**. ⚠️ An EMPTY `mainNode` is NOT "scoped to Admin" — it is a **ROOT** grant, i.e. a data superuser over every partition. Verify with `select user_id from admin.user_effective_permissions where node_path_prefix = ''` — that result must be empty. This is exactly what `GlobalAdminSeed` (config-driven admins via `Auth:GlobalAdmins`) and `UserOnboardingService.GrantPlatformAdmin` (first user) write, and what `hub.IsGlobalAdmin()` reads.
 
 ```bash
 mcp create --node '{


### PR DESCRIPTION
## What memex actually looks like today

```sql
select user_id, node_path_prefix, permission from admin.user_effective_permissions;
```

```
roswitha.escher       | (EMPTY)  | Delete   | t
christoph.hofstetter  | (EMPTY)  | Update   | t
denise.munari         | (EMPTY)  | Create   | t
markus.staeger        | (EMPTY)  | Compile  | t
bari                  | (EMPTY)  | Execute  | t
…
rsalzmann             | Admin    | Read     | t     ← the ONLY correctly-scoped one
```

**43 accounts have an empty `node_path_prefix` — root scope** — holding `Delete`/`Update`/`Create`/`Compile`/`Execute`/`Export` over **every partition, every space, and every user's private home**. Exactly **one** is scoped correctly.

Most were created minutes after the holder first signed in — including external course participants who had merely redeemed a coupon — so **onboarding was minting mesh-wide superusers**. One was created today (`julipahl`, 12:06).

## Why nobody spotted it: the doc contradicted itself

It documented the canonical shape as:

```
Admin/_Access/{user}_Access  →  Roles = [Admin],  MainNode = ""
```

…and then, two paragraphs later, warned that a root grant makes a **data superuser** *"which platform admins must NOT be."* Both cannot be true.

**The grant is scoped by `mainNode`, not by the folder it sits in.** So `Admin/_Access/{user}_Access` with `mainNode: ""` is a **ROOT grant that merely happens to be filed under `Admin/`**. It reads as harmless and is catastrophic. The one correct row (`rsalzmann`) has `mainNode: "Admin"` — that is the real canonical shape, and the doc now says so.

## What this PR adds

- 🚨 **NEVER MAKE ANYONE A GLOBAL ADMIN** — stated up front. If you're about to add a row to `Admin/_Access`, stop; the answer is almost always a **partition admin**.
- A table making the distinction impossible to miss: `mainNode: ""` → **ROOT / data superuser**; `mainNode: "Admin"` → platform management only.
- **Verify from the materialised truth, not the folder**, with the invariant stated as SQL:
  ```sql
  select user_id from admin.user_effective_permissions where node_path_prefix = '';  -- MUST be empty
  ```
- **Where to look**, one row each: global admins (`Admin/_Access`), partition admins (`{partition}/_Access`), home admins (`{user}/_Access`), root superusers (must be nobody).
- **Every user is admin of their own partition** — `{user}/_Access/{user}_Access`, `mainNode: "{user}"` — and of nothing else. Onboarding must create that and **must never** touch `Admin/_Access`.
- The same warning echoed at the top of `GrantingAccess`'s global-admin section, since that's the page someone follows when granting.

## Not in this PR — deliberately

- **The 43 grants are untouched.** Removing them is a live security change on a customer-facing mesh and needs your decision on who legitimately stays.
- **The source is not fixed.** Something in the onboarding path writes these; that code isn't in this repo (`GrantPlatformAdmin`/`UserOnboardingService` resolve only in docs here), so it needs locating in the portal repo. Pruning without fixing the writer just refills the list.

Docs only.