### PR TITLE
Bake NodeTypes against the image before the pod serves

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -201,6 +201,20 @@ jobs:
           -p:ContainerRegistry=${{ env.ACR }}
           -p:ContainerRepository=memex-migration
           -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"'
+      # nodetype-bake — compiles every dynamic NodeType against THIS build into the shared assembly
+      # cache before the portal rolls onto it, and fails the release on a regression. It must be
+      # built from the SAME commit as the portal: the framework identity it bakes against is the
+      # Graph MVID of these binaries, so an image built from a different commit would warm a cache
+      # the portal cannot use. Same multi-arch publish; <RuntimeIdentifiers> is project-local.
+      - name: Build + push nodetype-bake
+        run: >
+          dotnet publish memex/aspire/Memex.NodeType.Bake/Memex.NodeType.Bake.csproj
+          -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
+          -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
+          -p:CIRun=true
+          -p:ContainerRegistry=${{ env.ACR }}
+          -p:ContainerRepository=memex-bake
+          -p:ContainerImageTags='"${{ steps.vars.outputs.version }};${{ steps.vars.outputs.sha }};main"'
 
   # The MeshWeaver.Plugins PR gate image: `mw-plugin-test` (tools/MeshWeaver.PluginTester)
   # imports a node-repo checkout into a fresh in-process mesh, asserts every NodeType compiles,

--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -32,6 +32,7 @@
     <Project Path="memex/aspire/Memex.AppHost/Memex.AppHost.csproj" />
     <Project Path="memex/aspire/Memex.Aspire.Hosting/Memex.Aspire.Hosting.csproj" />
     <Project Path="memex/aspire/Memex.Database.Migration/Memex.Database.Migration.csproj" />
+    <Project Path="memex/aspire/Memex.NodeType.Bake/Memex.NodeType.Bake.csproj" />
     <Project Path="memex/aspire/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj" />
     <Project Path="memex/aspire/Memex.Portal.ServiceDefaults/Memex.Portal.ServiceDefaults.csproj" />
   </Folder>

--- a/deploy/helm/templates/memex-bake/job.yaml
+++ b/deploy/helm/templates/memex-bake/job.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.bake.enabled }}
+---
+# Run-once NODETYPE BAKE job — compile every dynamic NodeType against the image being deployed,
+# into the shared assembly cache, BEFORE the portal rolls onto it. Same shape as memex-migration:
+# a Job (not a Deployment) so it runs to completion and STOPS.
+#
+# 🚨 WHY THIS EXISTS. Every image roll changes the framework identity (Graph's MVID), and that
+# identity is part of the assembly store's filename AND its lookup glob — so a new image misses the
+# whole compile cache BY DESIGN (ABI safety). Left to the portal, that guaranteed miss is paid
+# lazily, unordered, on user requests, after the pod is already serving: ~90 s of cold Roslyn per
+# NodeType on somebody's page load. Paid here it is paid once, on a container nobody is waiting for.
+#
+# 🚦 AND IT IS THE GATE. The job exits non-zero when a NodeType that USED TO compile no longer does,
+# so a broken type is discovered before any traffic moves. A type that was already broken beforehand
+# does NOT fail the bake — it is broken in production right now, and blocking every future rollout
+# on it would freeze deploys entirely.
+#
+# Safe to run while the OLD image is still serving: the framework tag is in the store filename, so
+# old- and new-image assemblies coexist and this writes files the running pods never read.
+#
+# The name embeds .Release.Revision so a fresh bake runs on every `helm upgrade`, and
+# ttlSecondsAfterFinished auto-cleans the completed Job — same reasoning as memex-migration.
+apiVersion: "batch/v1"
+kind: "Job"
+metadata:
+  name: "memex-bake-{{ .Release.Revision }}"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "memex-bake"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+spec:
+  # 🚨 backoffLimit 0 — a bake failure is a VERDICT, not a flake. Retrying a NodeType that does not
+  # compile just burns another full sweep to reach the same answer, and a retried-then-passed bake
+  # would be indistinguishable from a clean one. Fix the type and re-run the upgrade.
+  backoffLimit: 0
+  ttlSecondsAfterFinished: {{ .Values.bake.ttlSecondsAfterFinished }}
+  # A full cold bake is ~90 s per NodeType, strictly sequential. Sized generously: hitting this
+  # deadline kills the bake mid-flight and reports failure for work that was merely slow.
+  activeDeadlineSeconds: {{ .Values.bake.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
+        app.kubernetes.io/component: "memex-bake"
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+    spec:
+      restartPolicy: "Never"
+      initContainers:
+        - name: "wait-for-postgres"
+          image: "busybox:1.36"
+          command:
+            - "sh"
+            - "-c"
+            - "until nc -z memex-postgres-service 5432; do echo 'waiting for postgres'; sleep 2; done"
+      containers:
+        - image: "{{ .Values.bake.image }}"
+          name: "memex-bake"
+          # 🚨 The PORTAL's config, deliberately — not a bake-specific one. The bake must compile
+          # against the same Graph:Storage / content wiring the portal will serve with; a divergent
+          # config would compile a different world than the one that runs, and certify it green.
+          envFrom:
+            - configMapRef:
+                name: "memex-portal-config"
+            - secretRef:
+                name: "memex-portal-secrets"
+          volumeMounts:
+            # The SAME shared volume the portal reads assemblies from. Baking anywhere else would
+            # produce a green exit code and an empty cache — the worst outcome for a gate. The
+            # service refuses to start if Deployment__DataRoot is unset, but the mount is what makes
+            # the setting true.
+            - name: "memex-data"
+              mountPath: "/data"
+          imagePullPolicy: "IfNotPresent"
+      volumes:
+        - name: "memex-data"
+{{- if ((.Values.persistence).data).claimName }}
+          persistentVolumeClaim:
+            claimName: "{{ .Values.persistence.data.claimName }}"
+{{- else if .Values.persistDataVolume }}
+          hostPath:
+            path: /var/lib/memex-portal-data
+            type: DirectoryOrCreate
+{{- else }}
+          # Dev/test only. With an emptyDir the bake writes into a directory that dies with the Job,
+          # so it warms nothing — harmless, but pointless: enable bake only where /data is shared.
+          emptyDir: {}
+{{- end }}
+{{- end }}

--- a/deploy/helm/templates/memex-migration/job.yaml
+++ b/deploy/helm/templates/memex-migration/job.yaml
@@ -40,7 +40,7 @@ spec:
             - "-c"
             - "until nc -z memex-postgres-service 5432; do echo 'waiting for postgres'; sleep 2; done"
       containers:
-        - image: "ghcr.io/systemorph/memex-migration:latest"
+        - image: "{{ .Values.migration.image }}"
           name: "memex-migration"
           envFrom:
             - configMapRef:

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -31,6 +31,22 @@ data:
 {{- end }}
   Deployment__Backend: "{{ .Values.config.memex_portal.Deployment__Backend }}"
   Deployment__DataRoot: "{{ .Values.config.memex_portal.Deployment__DataRoot }}"
+  # ---- NodeType bake ------------------------------------------------------
+  # PreWarm__DynamicTypes: compile every dynamic NodeType at startup, sequentially and in
+  #   dependency order, RESUMING from the shared assembly cache under Deployment__DataRoot
+  #   (already-baked types for this framework are skipped). Off → types compile lazily on
+  #   first access, which is what makes the first visitor after each image roll wait.
+  # PreWarm__GateReadiness: hold /health RED until that bake is green. With the
+  #   startupProbe on /health and maxUnavailable:0, a NodeType that REGRESSED on the new
+  #   image stalls the rollout with the previous image still serving, instead of erroring
+  #   in front of users. Only a type that WAS working can gate — a pre-existing broken type
+  #   is logged and skipped, so one abandoned NodeType can't freeze every future deploy.
+  #
+  # ⚠️ Enabling GateReadiness REQUIRES a startupProbe budget covering a full COLD bake
+  #    (~90 s per NodeType, sequential). See probes.startup in values — turning the gate on
+  #    without raising it means Kubernetes kills the pod mid-bake, every time, forever.
+  PreWarm__DynamicTypes: "{{ .Values.config.memex_portal.PreWarm__DynamicTypes }}"
+  PreWarm__GateReadiness: "{{ .Values.config.memex_portal.PreWarm__GateReadiness }}"
   Deployment__Orleans__Clustering: "{{ .Values.config.memex_portal.Deployment__Orleans__Clustering }}"
   Storage__Name: "{{ .Values.config.memex_portal.Storage__Name }}"
   Storage__SourceType: "{{ .Values.config.memex_portal.Storage__SourceType }}"

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - "-c"
             - "until nc -z memex-postgres-service 5432; do echo 'waiting for postgres'; sleep 2; done"
       containers:
-        - image: "ghcr.io/systemorph/memex-portal-ai:latest"
+        - image: "{{ .Values.portal.image }}"
           name: "memex-portal"
           # On rollout, endpoint removal propagates to the ingress-nginx upstreams asynchronously —
           # without this grace window the pod stops accepting the instant it is SIGTERMed and

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -126,10 +126,16 @@ spec:
           startupProbe:
             # Generous window for a cold boot (schema provisioning + static import). While this is
             # failing, readiness/liveness are suspended, so a slow boot is never flagged unhealthy.
+            #
+            # ⚠️ This budget is what bounds a NodeType BAKE (PreWarm__GateReadiness). A cold compile
+            # is ~90 s per NodeType and the sweep is strictly sequential, so a mesh with dozens of
+            # types needs HOURS here, not minutes. periodSeconds × failureThreshold is the ceiling:
+            # the default 5 × 60 = 5 minutes is right for a plain boot and far too small for a cold
+            # bake — turning the gate on without raising this kills the pod mid-bake, every time.
             httpGet: { path: /health, port: 8080 }
-            periodSeconds: 5
-            timeoutSeconds: 5
-            failureThreshold: 60
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
           readinessProbe:
             # ⚠️ /alive (light: process-up), NOT /health (heavy: DB + mesh checks). /health as the
             # readiness probe is the "probe death-spiral": under load a heavy /health times out (5s) →

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -81,6 +81,16 @@ ollama:
 #     the portal's own pod (the shipped node / bun / python gates). Reachability IS the
 #     authentication: no API token, nothing to rotate; deliveries may carry through the requesting
 #     user's AccessContext (see GrpcOptions.TrustedPort).
+# ---- Images --------------------------------------------------------------------------------------
+# Defaults are the published tags, so an unchanged install behaves exactly as before. They are
+# overridable so a local or CI cluster can run images built from a working tree WITHOUT `docker tag`
+# -ing over the shared ghcr names — retagging those is global to the Docker daemon, so it silently
+# swaps whatever else on the machine is already running them at its next restart.
+portal:
+  image: "ghcr.io/systemorph/memex-portal-ai:latest"
+migration:
+  image: "ghcr.io/systemorph/memex-migration:latest"
+
 # ---- NodeType bake job ---------------------------------------------------------------------------
 # Compiles every dynamic NodeType against the image being deployed, into the shared /data assembly
 # cache, BEFORE the portal rolls onto it — and fails the release when a type that USED TO compile no

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -81,6 +81,22 @@ ollama:
 #     the portal's own pod (the shipped node / bun / python gates). Reachability IS the
 #     authentication: no API token, nothing to rotate; deliveries may carry through the requesting
 #     user's AccessContext (see GrpcOptions.TrustedPort).
+# ---- Startup probe budget ------------------------------------------------------------------------
+# periodSeconds × failureThreshold is the HARD ceiling on how long a pod may take to serve /health
+# before Kubernetes kills it. Defaults (5 × 60) = 5 minutes: right for a plain cold boot (schema
+# provisioning + static import).
+#
+# ⚠️ If you enable config.memex_portal.PreWarm__GateReadiness, raise failureThreshold in the SAME
+# change. The bake compiles every dynamic NodeType sequentially at ~90 s each, so a mesh with 60-100
+# types needs 2-3 HOURS. Suggested paired setting: periodSeconds 10, failureThreshold 1080 (3h).
+# Under-budgeting here is not a slow rollout — it is a pod that is killed mid-bake and never
+# converges, on every single attempt.
+probes:
+  startup:
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 60
+
 grpc:
   enabled: true
   port: 8081
@@ -191,6 +207,12 @@ config:
     ASPNETCORE_HTTP_PORTS: "8080"
     Deployment__Backend: "Filesystem"
     Deployment__DataRoot: "/data"
+    # Both OFF by default. The bake is a deliberate operational choice, not something a
+    # self-host should inherit: it front-loads every NodeType compile into startup, and the
+    # gate can hold a pod out of rotation. Enable them together, and raise probes.startup
+    # in the same change. See config.yaml for what each one does.
+    PreWarm__DynamicTypes: "false"
+    PreWarm__GateReadiness: "false"
     Deployment__Orleans__Clustering: "Localhost"
     Storage__Name: "content"
     Storage__SourceType: "FileSystem"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -81,6 +81,22 @@ ollama:
 #     the portal's own pod (the shipped node / bun / python gates). Reachability IS the
 #     authentication: no API token, nothing to rotate; deliveries may carry through the requesting
 #     user's AccessContext (see GrpcOptions.TrustedPort).
+# ---- NodeType bake job ---------------------------------------------------------------------------
+# Compiles every dynamic NodeType against the image being deployed, into the shared /data assembly
+# cache, BEFORE the portal rolls onto it — and fails the release when a type that USED TO compile no
+# longer does. Same run-once Job shape as memex-migration.
+#
+# OFF by default: it only makes sense where /data is a SHARED, persistent volume
+# (persistence.data.claimName). With an emptyDir it warms a directory that dies with the Job.
+bake:
+  enabled: false
+  image: "ghcr.io/systemorph/memex-bake:latest"
+  # A cold bake is ~90 s per NodeType and strictly sequential — 60-100 types is 2-3 hours. This
+  # deadline kills the Job, so size it above the real worst case: tripping it reports a failure for
+  # work that was only slow, which is the one wrong answer a gate must not give.
+  activeDeadlineSeconds: 14400   # 4h
+  ttlSecondsAfterFinished: 3600
+
 # ---- Startup probe budget ------------------------------------------------------------------------
 # periodSeconds × failureThreshold is the HARD ceiling on how long a pod may take to serve /health
 # before Kubernetes kills it. Defaults (5 × 60) = 5 minutes: right for a plain cold boot (schema

--- a/memex/aspire/Memex.NodeType.Bake/Memex.NodeType.Bake.csproj
+++ b/memex/aspire/Memex.NodeType.Bake/Memex.NodeType.Bake.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <ProjectGuid>{6f2a8c14-91d7-4b3e-a5c2-7d18e40b9f63}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Multi-arch container publish — same reasoning as Memex.Database.Migration: the RID set is
+         declared project-locally so the SDK drives a per-RID inner build and assembles an OCI image
+         index, without propagating an invalid RuntimeIdentifier into every ProjectReference. -->
+    <RuntimeIdentifiers>linux-x64;linux-arm64</RuntimeIdentifiers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Azure.Npgsql" />
+    <PackageReference Include="Aspire.Npgsql" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- 🚨 REFERENCE FIDELITY IS THE POINT OF THIS LIST.
+         A NodeType is compiled against the assemblies LOADED IN THE PROCESS doing the compiling. If
+         this service referenced a hand-picked subset, a type could compile green here and still fail
+         in the portal (or the reverse) — and a bake whose result does not predict the portal's is
+         worse than no bake, because the gate would certify it. So we reference Memex.Portal.Shared,
+         which drags in the portal's whole closure, rather than naming individual libraries.
+         Monolith is the one addition: this process must NOT join the Orleans cluster. -->
+    <ProjectReference Include="..\..\Memex.Portal.Shared\Memex.Portal.Shared.csproj" />
+    <ProjectReference Include="..\..\..\src\MeshWeaver.Hosting.Monolith\MeshWeaver.Hosting.Monolith.csproj" />
+    <ProjectReference Include="..\..\..\src\MeshWeaver.Hosting.PostgreSql\MeshWeaver.Hosting.PostgreSql.csproj" />
+    <ProjectReference Include="..\Memex.Portal.ServiceDefaults\Memex.Portal.ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/memex/aspire/Memex.NodeType.Bake/Program.cs
+++ b/memex/aspire/Memex.NodeType.Bake/Program.cs
@@ -1,0 +1,148 @@
+﻿using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using Memex.Portal.ServiceDefaults;
+using Memex.Portal.Shared;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.PostgreSql;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// NODETYPE BAKE — compile every dynamic NodeType against THIS image, into the shared assembly
+// cache, BEFORE the portal rolls onto it. Runs as its own container, exactly like db-migration.
+//
+// WHY A SEPARATE SERVICE. Every image roll changes the framework identity (Graph's MVID), and that
+// identity is baked into the assembly store's filename AND its lookup glob — so a new image misses
+// the whole cache BY DESIGN (ABI safety). Left to the portal, that guaranteed miss is paid lazily,
+// unordered, on user requests, after the pod is already serving. Paid here, it is paid once, on a
+// container nobody is waiting for, and a NodeType that no longer compiles is discovered BEFORE any
+// traffic moves — the same contract db-migration gives the schema.
+//
+// WHY IT DOES NOT JOIN THE CLUSTER. UseMonolithMesh, never UseOrleansMeshServer: this process must
+// compile and upload assemblies without taking grain ownership from the pods currently serving
+// production, and without vanishing mid-activation when it exits.
+//
+// WHY THIS IS SAFE TO RUN WHILE THE OLD IMAGE SERVES. The store key carries the framework tag, so
+// old- and new-image assemblies COEXIST — this writes files the running pods never read. The one
+// hazard was the compile write-back stamping CompiledFrameworkVersion onto the shared NodeType
+// record: the live pods would see a mismatch, fire the framework-stale kickoff and recompile back,
+// storming production. That kickoff now probes the store first and skips when bytes for its own
+// framework exist, so the stamp is inert to them.
+//
+// EXIT CODE IS THE GATE. 0 = every type that was healthy going in has a usable build on the share.
+// 1 = a REGRESSION: something that used to compile no longer does. Deploy on 0, hold on 1.
+// A type that was ALREADY broken before this image cannot fail the bake — it is broken in
+// production right now, and blocking every future rollout on it would freeze deploys entirely.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+Console.WriteLine("[Bake] Starting NodeType bake...");
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.AddServiceDefaults();
+
+var connectionString = builder.Configuration.GetConnectionString("memex") ?? "";
+if (connectionString.Contains("database.azure.com"))
+    builder.AddAzureNpgsqlDataSource("memex", configureDataSourceBuilder: dsb => dsb.UseVector());
+else
+    builder.AddNpgsqlDataSource("memex", configureDataSourceBuilder: dsb => dsb.UseVector());
+
+// The shared volume the portal reads its assemblies from. Baking anywhere else would be a no-op
+// with a green exit code — the worst possible outcome for a gate — so this is required, not
+// defaulted: a bake with nowhere durable to write is a configuration error, and it fails loudly.
+var dataRoot = builder.Configuration["Deployment:DataRoot"];
+if (string.IsNullOrWhiteSpace(dataRoot))
+{
+    Console.Error.WriteLine(
+        "[Bake] Deployment__DataRoot is not set. The bake would compile into a container-local "
+        + "directory that dies with this pod, and report success. Refusing to run.");
+    return 2;
+}
+var assemblyCache = Path.Combine(dataRoot, "assembly-cache");
+
+builder.UseMeshWeaver(
+    AddressExtensions.CreateMeshAddress(),
+    mesh => mesh
+        .UseMonolithMesh()
+        .ConfigureServices(services => services
+            .AddPartitionedPostgreSqlPersistence()
+            .AddFileSystemAssemblyStore(assemblyCache)
+            // Same lease the portal takes: if a pod is already baking this framework, follow its
+            // work rather than compiling the same types into the same volume alongside it.
+            .AddSingleton(new BakeCoordination(assemblyCache))
+            .AddNodeTypeBakeGate())
+        // The portal's own mesh configuration — the NodeType registrations and content wiring have
+        // to match, or this would compile a different world than the one that will serve.
+        .ConfigureMemexMesh(builder.Configuration));
+
+var host = builder.Build();
+var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Bake");
+
+await host.StartAsync();
+
+var exitCode = 0;
+try
+{
+    var meshHub = host.Services.GetRequiredService<IMessageHub>();
+    var startedAt = DateTimeOffset.UtcNow;
+    logger.LogInformation("Bake starting — compiling dynamic NodeTypes into {Cache}", assemblyCache);
+
+    var outcomes = await DynamicTypePreWarmer
+        .WarmDynamicTypes(meshHub, logger)
+        .ToList()
+        .ToTask();
+
+    // A regression is a type that WAS healthy going in and did not reach a usable build. Anything
+    // already broken beforehand is reported and ignored — see the header.
+    var regressions = outcomes
+        .Where(o => !o.ReachedUsableBuild && o.WasHealthyBeforeBake)
+        .ToList();
+    var preexisting = outcomes
+        .Where(o => !o.ReachedUsableBuild && !o.WasHealthyBeforeBake)
+        .ToList();
+
+    logger.LogInformation(
+        "Bake finished in {Elapsed} — {Total} type(s): compiled={Compiled} alreadyBaked={Baked} "
+        + "regressions={Regressions} preExistingFailures={PreExisting}",
+        DateTimeOffset.UtcNow - startedAt, outcomes.Count,
+        outcomes.Count(o => o.Status == PreWarmStatus.Compiled),
+        outcomes.Count(o => o.Status == PreWarmStatus.AlreadyBaked),
+        regressions.Count, preexisting.Count);
+
+    foreach (var stale in preexisting)
+        logger.LogWarning(
+            "Bake: {TypePath} did not build ({Status}: {Detail}) — but it was ALREADY broken before "
+            + "this image, so it does not fail the bake",
+            stale.TypePath, stale.Status, stale.Detail);
+
+    if (regressions.Count > 0)
+    {
+        exitCode = 1;
+        foreach (var regression in regressions)
+            logger.LogCritical(
+                "Bake REGRESSION: {TypePath} used to have a usable build and no longer compiles "
+                + "against this image — {Status}: {Detail}",
+                regression.TypePath, regression.Status, regression.Detail);
+        logger.LogCritical(
+            "Bake FAILED with {Count} regression(s) — do NOT roll the portal onto this image",
+            regressions.Count);
+    }
+}
+catch (Exception ex)
+{
+    // An unprovable bake must not read as a green one.
+    logger.LogCritical(ex, "Bake failed unexpectedly — treating as a failed bake");
+    exitCode = 1;
+}
+finally
+{
+    await host.StopAsync();
+}
+
+Console.WriteLine($"[Bake] Exiting with code {exitCode}");
+return exitCode;

--- a/memex/aspire/Memex.NodeType.Bake/Program.cs
+++ b/memex/aspire/Memex.NodeType.Bake/Program.cs
@@ -65,6 +65,46 @@ if (string.IsNullOrWhiteSpace(dataRoot))
 }
 var assemblyCache = Path.Combine(dataRoot, "assembly-cache");
 
+// Block until the database migration has recorded a db_version.
+//
+// 🚨 The bake and the migration are separate Jobs with NO ordering between them, and both only gate
+// on Postgres accepting TCP. Racing them is not a slow start — it is a SILENT PASS: the mesh comes
+// up against an unmigrated database, the NodeType query returns nothing, and the bake reports
+// "0 of 0 types" and exits 0 in a tenth of a second, while the portal goes on to compile everything
+// lazily. Observed on the first real run (bake-test, 2026-07-28): four NodeTypes compiled in the
+// portal AFTER a green bake.
+//
+// Same condition the portal's own DbVersionGate enforces, so the two cannot disagree about what
+// "migrated" means.
+static async Task<bool> WaitForMigratedDatabase(NpgsqlDataSource source, TimeSpan budget, ILogger log)
+{
+    var deadline = DateTimeOffset.UtcNow + budget;
+    while (DateTimeOffset.UtcNow < deadline)
+    {
+        try
+        {
+            await using var cmd = source.CreateCommand("""
+                SELECT (content->>'Version')::int FROM admin.mesh_nodes
+                 WHERE id = 'db_version' AND namespace = '' LIMIT 1
+                """);
+            if ((await cmd.ExecuteScalarAsync()) switch { int v => v, long l => (int)l, _ => 0 } is > 0 and var version)
+            {
+                log.LogInformation("Database is migrated (db_version={Version})", version);
+                return true;
+            }
+            log.LogInformation("Waiting for the migration to record a db_version...");
+        }
+        catch (Exception ex)
+        {
+            // The admin schema may not exist yet — that IS the state we are waiting out.
+            log.LogInformation("Waiting for the database schema ({Error}: {Message})",
+                ex.GetType().Name, ex.Message);
+        }
+        await Task.Delay(TimeSpan.FromSeconds(5));
+    }
+    return false;
+}
+
 builder.UseMeshWeaver(
     AddressExtensions.CreateMeshAddress(),
     mesh => mesh
@@ -82,6 +122,17 @@ builder.UseMeshWeaver(
 
 var host = builder.Build();
 var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Bake");
+
+// Before StartAsync — resolving a singleton does not start hosted services, so the mesh never comes
+// up against an unmigrated schema in the first place.
+if (!await WaitForMigratedDatabase(
+        host.Services.GetRequiredService<NpgsqlDataSource>(), TimeSpan.FromMinutes(15), logger))
+{
+    logger.LogCritical(
+        "Database still not migrated after 15 minutes. Refusing to bake — an unmigrated database "
+        + "yields an EMPTY NodeType set, which would look exactly like a clean bake.");
+    return 2;
+}
 
 await host.StartAsync();
 
@@ -120,7 +171,24 @@ try
             + "this image, so it does not fail the bake",
             stale.TypePath, stale.Status, stale.Detail);
 
-    if (regressions.Count > 0)
+    // 🚨 FINDING NOTHING IS NOT PASSING. An empty outcome set means the enumeration returned no
+    // dynamic NodeTypes — and that is indistinguishable from the ways it FAILS: an unmigrated or
+    // wrong database, a query that timed out (WarmDynamicTypes catches enumeration errors and
+    // completes empty, by design, because in the portal a failed warm must not be fatal), a mesh
+    // that has not finished seeding. A gate that certifies "I verified nothing" is worse than no
+    // gate, because the rollout proceeds with a green light nobody earned.
+    //
+    // Real deployments always have dynamic NodeTypes. A genuinely empty mesh must say so explicitly.
+    var allowEmpty = bool.TryParse(builder.Configuration["Bake:AllowEmpty"], out var parsed) && parsed;
+    if (outcomes.Count == 0 && !allowEmpty)
+    {
+        logger.LogCritical(
+            "Bake found NO dynamic NodeTypes. Refusing to report success: an empty result is what a "
+            + "failed enumeration, an unseeded mesh and a wrong database all look like. If this mesh "
+            + "genuinely has none, set Bake__AllowEmpty=true.");
+        exitCode = 3;
+    }
+    else if (regressions.Count > 0)
     {
         exitCode = 1;
         foreach (var regression in regressions)

--- a/memex/aspire/Memex.Portal.Distributed/NodeTypeBakeHealthCheck.cs
+++ b/memex/aspire/Memex.Portal.Distributed/NodeTypeBakeHealthCheck.cs
@@ -1,0 +1,44 @@
+using MeshWeaver.Hosting;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Memex.Portal.Distributed;
+
+/// <summary>
+/// Readiness gate: reports Unhealthy until this pod's dynamic NodeTypes are built against the image
+/// it is actually running.
+///
+/// <para><b>What it buys — "fail before prod, not in prod".</b> The chart already keeps the OLD pod
+/// serving until the new one passes its <c>startupProbe</c> on <c>/health</c> (<c>maxSurge: 1</c>,
+/// <c>maxUnavailable: 0</c>). Wiring the bake into <c>/health</c> therefore turns a NodeType that no
+/// longer compiles from a production incident into a STALLED ROLLOUT: the new pod never goes ready,
+/// traffic never moves, and the previous image keeps serving. That is the difference between
+/// discovering a broken type from a user's error page and discovering it from a rollout that
+/// declined to finish.</para>
+///
+/// <para><b>Fail CLOSED on a regression, fail OPEN on "not running".</b> A detected regression holds
+/// the pod out of rotation — the entire point. But <see cref="BakePhase.NotStarted"/> reports
+/// HEALTHY: if this check is registered while the sweep is not enabled, that is a configuration
+/// mistake, and a configuration mistake must never black-hole a pod forever. The gate withholds
+/// readiness only for a condition it is actively measuring.</para>
+///
+/// <para><b>Deliberately NOT tagged <c>"live"</c>.</b> It must gate <c>/health</c> (startup +
+/// rollout) and never <c>/alive</c> (liveness): a long bake is not a wedged process, and failing
+/// liveness would have Kubernetes restart the pod in the middle of the very work it is waiting for.
+/// Same reasoning that keeps <c>/alive</c> light in <c>ServiceDefaults</c>.</para>
+/// </summary>
+public sealed class NodeTypeBakeHealthCheck(NodeTypeBakeGateState state) : IHealthCheck
+{
+    /// <inheritdoc />
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+        => Task.FromResult(state.Phase switch
+        {
+            // Nobody is baking — never gate on an unmeasured condition.
+            BakePhase.NotStarted => HealthCheckResult.Healthy($"bake not gating ({state.Detail})"),
+            BakePhase.Complete => HealthCheckResult.Healthy(state.Detail),
+            BakePhase.Regressed => HealthCheckResult.Unhealthy(
+                "NodeType bake regressed on this image — refusing readiness so the rollout stalls "
+                + $"with the previous image still serving. {state.Detail}"),
+            _ => HealthCheckResult.Unhealthy($"NodeType bake in progress — {state.Detail}"),
+        });
+}

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -274,9 +274,27 @@ builder.Services.AddHealthChecks()
 
 // Front-load dynamic NodeType compiles at startup so a fresh pod (every image roll /
 // self-update spins one up) doesn't make the first visitor of each type wait out a cold
-// Roslyn compile. Best-effort, non-blocking, does NOT gate readiness — Part 2
-// (enrichment awaits the in-flight compile) handles anything still compiling on arrival.
+// Roslyn compile. The sweep is sequential, in dependency order, and RESUMES from the shared
+// assembly cache — types already baked for this framework are skipped, so a second replica
+// (or a restart) inherits the first pod's work instead of repeating it.
 builder.Services.AddDynamicTypePreWarming();
+// Shared bake state the sweep writes and the readiness gate below reads.
+builder.Services.AddNodeTypeBakeGate();
+
+// 🚦 "Fail before prod, not in prod." Opt-in (PreWarm:GateReadiness) gate that holds /health
+// RED until this pod's NodeTypes are built against ITS image. Combined with the deployment's
+// startupProbe on /health and maxUnavailable:0, a NodeType that regressed on the new image
+// stalls the ROLLOUT — the new pod never takes traffic and the previous image keeps serving —
+// instead of surfacing as user-facing errors after the switch.
+//
+// Registered only when explicitly enabled: a gate that can withhold readiness should be an
+// intentional deployment choice, not something a self-host inherits by accident. It also
+// REQUIRES a startupProbe budget large enough for a full cold bake (see values.aks.yaml) —
+// without that, Kubernetes kills the pod mid-bake and it never converges.
+if (bool.TryParse(builder.Configuration[NodeTypeBakeGateExtensions.EnabledConfigKey], out var gateBake)
+    && gateBake)
+    builder.Services.AddHealthChecks()
+        .AddCheck<Memex.Portal.Distributed.NodeTypeBakeHealthCheck>("nodetype_bake");
 
 var app = builder.Build();
 

--- a/memex/aspire/Memex.Portal.Distributed/Program.cs
+++ b/memex/aspire/Memex.Portal.Distributed/Program.cs
@@ -88,7 +88,15 @@ else
     // AddBlobAssemblyStore() runs; both use TryAddSingleton<IAssemblyStore>, so this
     // first registration wins and the blob factory (which needs a keyed BlobServiceClient
     // we deliberately don't register here) is never constructed.
-    builder.Services.AddFileSystemAssemblyStore(Path.Combine(dataRoot, "assembly-cache"));
+    var assemblyCache = Path.Combine(dataRoot, "assembly-cache");
+    builder.Services.AddFileSystemAssemblyStore(assemblyCache);
+
+    // 🚨 ONE POD BAKES. The compile cache is shared but the decision to rebuild is per-process, so
+    // without a lease every replica on a new image starts the SAME sweep over the SAME NodeTypes
+    // into this SAME directory — concurrent cold compiles of one type, which is the storm the
+    // sequential sweep exists to prevent. Any rollout with maxSurge hits this by default.
+    // The lease lives beside the assemblies it guards, so it is shared exactly when they are.
+    builder.Services.AddSingleton(new BakeCoordination(assemblyCache));
 
     // NuGet package cache → filesystem (zip-per-version, shared-volume safe).
     builder.Services.Replace(ServiceDescriptor.Singleton<INuGetPackageCache>(sp =>

--- a/memex/aspire/Memex.Portal.Distributed/appsettings.json
+++ b/memex/aspire/Memex.Portal.Distributed/appsettings.json
@@ -26,6 +26,14 @@
       // is the "one object = one log line" channel — orders of magnitude below the
       // per-message MESSAGE_FLOW trace that only appears when MeshWeaver is forced to Trace.
       "MeshWeaver.Mesh.CreateNode": "Information",
+      // NodeType bake / pre-warm lifecycle — the channel an operator reads when a rollout stalls.
+      // Without this the whole mechanism is INVISIBLE under the "MeshWeaver": "Warning" default:
+      // "which types still need building", "another pod is baking — following", "the shared cache
+      // was cleared", and the per-type outcomes all log at Information, so a pod held out of
+      // rotation by the readiness gate would explain itself to nobody. Bounded volume: a handful of
+      // lines per pod lifetime plus one per dynamic NodeType, emitted once at startup — the same
+      // "one object = one line" shape as the node-creation trail above, not a per-message trace.
+      "MeshWeaver.Hosting.DynamicTypePreWarmerHostedService": "Information",
       // Deploy-timing lifecycle markers — ≤4 lines per pod lifetime ("PortalReady in X ms",
       // "PortalShutdown starting/complete in X ms"; StartMemexApplication). The Grafana
       // "Memex Deploy Timings" dashboard unwraps these; without this level they never

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeBakeStatus.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeBakeStatus.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// What the SHARED ASSEMBLY STORE actually holds for one dynamic NodeType, on the live framework.
+/// </summary>
+public enum BakeState
+{
+    /// <summary>
+    /// The store holds loadable bytes for this NodeType's last compiled version, built against the
+    /// LIVE framework. Nothing to do — this is the only state that does not need a bake.
+    /// </summary>
+    Baked,
+
+    /// <summary>No assembly was ever recorded for this NodeType. First build.</summary>
+    NeverBuilt,
+
+    /// <summary>
+    /// An assembly is recorded, but it was compiled against a DIFFERENT framework than the live one.
+    /// This is the ordinary every-deploy state: <see cref="NodeTypeCompilationHelpers.FrameworkVersion"/>
+    /// (Graph's MVID) is baked into the store's filename AND its lookup glob, so a new image misses
+    /// the whole cache by design — ABI safety, not a bug.
+    /// </summary>
+    FrameworkStale,
+
+    /// <summary>
+    /// 🚨 The NodeType's own record CLAIMS a usable build for the live framework — right collection,
+    /// right path, matching <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/> — but the store
+    /// has no bytes at that key. The record is writing a cheque the share cannot cash.
+    ///
+    /// <para>This is the state nothing else in the framework can see. <c>HasUsableBuild</c> is
+    /// deliberately a pure record check ("no store probe, no File.Exists") because the kickoff path
+    /// prefers a redundant compile over a blocking store round-trip on every stream emission. That is
+    /// the right trade THERE, but it means an operator who clears <c>/data/assembly-cache</c> — or a
+    /// remounted / re-provisioned / partially-restored volume — leaves every NodeType still claiming
+    /// Ok while its bytes are gone. Nothing re-drives a compile, and the miss only surfaces LATER, one
+    /// instance at a time, when activation tries to hydrate the assembly.</para>
+    ///
+    /// <para>Probing the store is what turns that into a state we can act on BEFORE serving.</para>
+    /// </summary>
+    BytesMissing,
+
+    /// <summary>
+    /// The last compile settled at <see cref="CompilationStatus.Error"/>. Needs a bake like any other
+    /// non-<see cref="Baked"/> state — but see <see cref="NodeTypeBakeEntry.WasHealthy"/>: a type that
+    /// was ALREADY broken before this image must not be allowed to block the rollout.
+    /// </summary>
+    PreviouslyBroken,
+}
+
+/// <summary>One dynamic NodeType's bake state, as read from the store rather than from its record.</summary>
+/// <param name="TypePath">The NodeType's mesh path.</param>
+/// <param name="State">What the store actually holds.</param>
+/// <param name="Detail">Human-readable context for logs and the health payload.</param>
+public sealed record NodeTypeBakeEntry(string TypePath, BakeState State, string? Detail = null)
+{
+    /// <summary>True when this type still has to be compiled against the live framework.</summary>
+    public bool NeedsBake => State is not BakeState.Baked;
+
+    /// <summary>
+    /// 🚨 Whether this type was WORKING before this image — the regression baseline, and the reason
+    /// a permanently-broken type cannot wedge every future deploy.
+    ///
+    /// <para>The rollout gate must fail on a REGRESSION (a type that used to compile and no longer
+    /// does), not on pre-existing breakage. A NodeType that was already sitting at
+    /// <see cref="CompilationStatus.Error"/> before the deploy is not made worse by the new image: it
+    /// is broken in production right now, and blocking the rollout on it would mean one abandoned
+    /// type freezes the platform's deploys forever — discovered, inevitably, at the worst possible
+    /// moment. Such a type is logged loudly and skipped by the gate.</para>
+    /// </summary>
+    public bool WasHealthy => State is not BakeState.PreviouslyBroken;
+}
+
+/// <summary>
+/// The bake state of every dynamic NodeType on this mesh — the "actual reality of the share",
+/// resolved by asking the <see cref="IAssemblyStore"/> for bytes rather than trusting each
+/// NodeType's own record.
+/// </summary>
+/// <param name="Entries">One entry per dynamic NodeType, in the order probed.</param>
+/// <param name="FrameworkVersion">The live framework identity the probe resolved against.</param>
+public sealed record NodeTypeBakeReport(
+    ImmutableList<NodeTypeBakeEntry> Entries,
+    string FrameworkVersion)
+{
+    /// <summary>An empty report — no dynamic NodeTypes, so the bake is trivially complete.</summary>
+    public static NodeTypeBakeReport Empty(string frameworkVersion) =>
+        new(ImmutableList<NodeTypeBakeEntry>.Empty, frameworkVersion);
+
+    /// <summary>Every type is <see cref="BakeState.Baked"/> — the share is fully warm for this image.</summary>
+    public bool IsComplete => Entries.All(e => !e.NeedsBake);
+
+    /// <summary>The types that still need compiling, in probe order (callers re-order by dependency).</summary>
+    public ImmutableList<NodeTypeBakeEntry> Pending =>
+        Entries.Where(e => e.NeedsBake).ToImmutableList();
+
+    /// <summary>
+    /// Types whose bytes vanished from under a record that claims they are fine — the cleared-cache
+    /// signal. Surfaced separately because it means the SHARE changed, not the code, and it is worth
+    /// saying so out loud rather than reporting a generic recompile.
+    /// </summary>
+    public ImmutableList<NodeTypeBakeEntry> BytesMissing =>
+        Entries.Where(e => e.State is BakeState.BytesMissing).ToImmutableList();
+
+    /// <summary>
+    /// The types the rollout gate is allowed to fail on: they must be baked AND they were healthy
+    /// before this image, so a compile failure is a genuine regression. See
+    /// <see cref="NodeTypeBakeEntry.WasHealthy"/>.
+    /// </summary>
+    public ImmutableList<NodeTypeBakeEntry> GateRelevant =>
+        Entries.Where(e => e.NeedsBake && e.WasHealthy).ToImmutableList();
+
+    /// <summary>One-line summary for logs and the health-check payload.</summary>
+    public string Summary =>
+        $"framework={FrameworkVersion[..Math.Min(8, FrameworkVersion.Length)]} "
+        + $"total={Entries.Count} baked={Entries.Count(e => !e.NeedsBake)} pending={Pending.Count}"
+        + string.Concat(Entries
+            .GroupBy(e => e.State)
+            .Where(g => g.Key is not BakeState.Baked)
+            .OrderBy(g => g.Key)
+            .Select(g => $" {g.Key.ToString().ToLowerInvariant()}={g.Count()}"));
+}
+
+/// <summary>
+/// Classifies dynamic NodeTypes by what the shared assembly store ACTUALLY holds, so a bake can be
+/// driven from the share's reality instead of from a marker that can lie.
+///
+/// <para><b>Level-triggered, never edge-triggered.</b> There is no "the bake ran" flag anywhere in
+/// this design, on purpose. A flag records history; the share records truth, and the two diverge
+/// exactly when it matters most — someone clears the cache, a volume is remounted or restored from a
+/// stale snapshot, a bake is interrupted half-way. Every consumer re-probes and acts on what it finds,
+/// so all of those heal by themselves on the next pass, and an interrupted bake RESUMES (the types
+/// already written come back <see cref="BakeState.Baked"/>) instead of starting over.</para>
+///
+/// <para><b>The classification is pure.</b> <see cref="Classify"/> is a static function over a record,
+/// a bool and a version string — no hub, no mesh, no I/O — so every state (including the ones that are
+/// awkward to stage against a real store, like bytes disappearing under a healthy record) is
+/// unit-testable without a fixture. Only <see cref="Probe"/> touches the store. Same split, and same
+/// reason, as <see cref="NodeTypeDependencyGraph"/>.</para>
+/// </summary>
+public static class NodeTypeBakeStatus
+{
+    /// <summary>
+    /// Decide one NodeType's bake state. Pure: <paramref name="storeHasBytes"/> is the caller's
+    /// already-resolved answer to "does the store hold this key?", so this function never does I/O.
+    ///
+    /// <para>Order matters. A record with no assembly at all is <see cref="BakeState.NeverBuilt"/>
+    /// regardless of status; a recorded assembly from another framework is
+    /// <see cref="BakeState.FrameworkStale"/> and we do NOT probe for it (its key contains a different
+    /// framework tag, so a miss is certain and tells us nothing). Only when the record claims a
+    /// live-framework build does the store's answer decide between <see cref="BakeState.Baked"/> and
+    /// <see cref="BakeState.BytesMissing"/>.</para>
+    ///
+    /// <para><see cref="BakeState.PreviouslyBroken"/> is checked FIRST among the needs-bake states so
+    /// the regression baseline is preserved: a type sitting at Error keeps that label even though it
+    /// is also, technically, framework-stale — otherwise it would look healthy-but-stale and the gate
+    /// would start blocking deploys on it.</para>
+    /// </summary>
+    /// <param name="definition">The NodeType's definition, as persisted.</param>
+    /// <param name="storeHasBytes">
+    /// Whether <see cref="IAssemblyStore.TryGetAssemblyPath"/> resolved bytes for this type's
+    /// <see cref="NodeTypeDefinition.LastCompiledVersion"/>. Ignored unless the record claims a
+    /// live-framework build.
+    /// </param>
+    /// <param name="liveFrameworkVersion">
+    /// The framework identity to compare against — injected rather than read from
+    /// <see cref="NodeTypeCompilationHelpers.FrameworkVersion"/> so tests can stage a
+    /// framework roll without rebuilding the framework.
+    /// </param>
+    public static BakeState Classify(
+        NodeTypeDefinition definition,
+        bool storeHasBytes,
+        string liveFrameworkVersion)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        if (definition.CompilationStatus == CompilationStatus.Error)
+            return BakeState.PreviouslyBroken;
+
+        var hasRecordedAssembly =
+            !string.IsNullOrEmpty(definition.LatestAssemblyCollection)
+            && !string.IsNullOrEmpty(definition.LatestAssemblyPath)
+            && definition.LastCompiledVersion is not null;
+
+        if (!hasRecordedAssembly)
+            return BakeState.NeverBuilt;
+
+        if (!string.Equals(definition.CompiledFrameworkVersion, liveFrameworkVersion, StringComparison.Ordinal))
+            return BakeState.FrameworkStale;
+
+        // The record claims a live-framework build. Only the store can say whether that is true.
+        return storeHasBytes ? BakeState.Baked : BakeState.BytesMissing;
+    }
+
+    /// <summary>
+    /// Probe the store for every supplied dynamic NodeType and build the report.
+    ///
+    /// <para>Probes run SEQUENTIALLY (<c>Concat</c>, never <c>Merge</c>): the store is typically a
+    /// shared network volume or blob container, and a fan-out of lookups across every NodeType at
+    /// startup is precisely the kind of cold burst this whole mechanism exists to remove. Each probe
+    /// is a directory glob or a blob-exists — cheap — so sequential costs nothing worth having.</para>
+    ///
+    /// <para>Never throws: a store that faults on one type yields <see cref="BakeState.BytesMissing"/>
+    /// for it (fail SAFE — an unreadable store means "assume it is not there and bake", never "assume
+    /// it is fine and serve").</para>
+    /// </summary>
+    /// <param name="definitions">Dynamic NodeTypes to probe, keyed by mesh path.</param>
+    /// <param name="store">The shared assembly store to interrogate.</param>
+    /// <param name="liveFrameworkVersion">
+    /// Framework identity to compare against; defaults to the live
+    /// <see cref="NodeTypeCompilationHelpers.FrameworkVersion"/>.
+    /// </param>
+    /// <param name="logger">Optional logger for per-type probe outcomes.</param>
+    public static IObservable<NodeTypeBakeReport> Probe(
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        IAssemblyStore store,
+        string? liveFrameworkVersion = null,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(definitions);
+        ArgumentNullException.ThrowIfNull(store);
+
+        var framework = liveFrameworkVersion ?? NodeTypeCompilationHelpers.FrameworkVersion;
+
+        var probes = definitions
+            .Where(kvp => kvp.Value is not null && !string.IsNullOrEmpty(kvp.Key))
+            .OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(kvp => ProbeOne(kvp.Key, kvp.Value!, store, framework, logger))
+            .ToList();
+
+        return probes.Count == 0
+            ? Observable.Return(NodeTypeBakeReport.Empty(framework))
+            : probes
+                .Concat()
+                .ToList()
+                .Select(entries => new NodeTypeBakeReport(entries.ToImmutableList(), framework));
+    }
+
+    private static IObservable<NodeTypeBakeEntry> ProbeOne(
+        string typePath,
+        NodeTypeDefinition definition,
+        IAssemblyStore store,
+        string framework,
+        ILogger? logger)
+        => Observable.Defer(() =>
+        {
+            // Only a record that claims a LIVE-framework build is worth a store round-trip: every
+            // other state is decided by the record alone, and the store key for a stale framework
+            // could not match anyway (the tag is part of the key).
+            var claimsLiveBuild =
+                !string.IsNullOrEmpty(definition.LatestAssemblyCollection)
+                && !string.IsNullOrEmpty(definition.LatestAssemblyPath)
+                && definition.LastCompiledVersion is { } version
+                && version >= 0
+                && string.Equals(definition.CompiledFrameworkVersion, framework, StringComparison.Ordinal)
+                && definition.CompilationStatus != CompilationStatus.Error;
+
+            if (!claimsLiveBuild)
+                return Observable.Return(Describe(typePath, definition, Classify(definition, false, framework)));
+
+            return store
+                .TryGetAssemblyPath(typePath, definition.LastCompiledVersion!.Value)
+                .Take(1)
+                .Select(path => Describe(
+                    typePath, definition, Classify(definition, !string.IsNullOrEmpty(path), framework)))
+                // Fail SAFE, never fail OPEN: an unreadable store must mean "bake it", not "trust
+                // the record and serve bytes that may not exist".
+                .Catch<NodeTypeBakeEntry, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "Bake probe: assembly store lookup failed for {TypePath} — treating as missing bytes",
+                        typePath);
+                    return Observable.Return(new NodeTypeBakeEntry(
+                        typePath, BakeState.BytesMissing, $"store probe failed: {ex.Message}"));
+                });
+        });
+
+    private static NodeTypeBakeEntry Describe(string typePath, NodeTypeDefinition definition, BakeState state)
+        => new(typePath, state, state switch
+        {
+            BakeState.Baked => null,
+            BakeState.NeverBuilt => "no assembly recorded",
+            BakeState.FrameworkStale =>
+                $"built against framework {Short(definition.CompiledFrameworkVersion)}",
+            BakeState.BytesMissing =>
+                $"record claims {definition.LatestAssemblyCollection}/{definition.LatestAssemblyPath} "
+                + "but the store has no bytes",
+            BakeState.PreviouslyBroken => "last compile settled at Error",
+            _ => null,
+        });
+
+    private static string Short(string? version) =>
+        string.IsNullOrEmpty(version) ? "(none)" : version[..Math.Min(8, version.Length)];
+}

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeBakeStatus.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeBakeStatus.cs
@@ -191,11 +191,22 @@ public static class NodeTypeBakeStatus
         if (!hasRecordedAssembly)
             return BakeState.NeverBuilt;
 
+        // 🚨 BYTES WIN OVER THE RECORD, in both directions — this is the whole premise.
+        //
+        // The store is looked up as (nodeTypePath, version) with the LIVE framework tag baked into
+        // the key, so a hit means "bytes compiled against THIS framework exist", whatever the record
+        // claims. A record can name another framework while the share already holds our build —
+        // another replica compiled it and its write-back lagged, failed, or was never made at all.
+        // Reporting that FrameworkStale would rebuild something already sitting on the volume, which
+        // is exactly the wasted work this probe exists to avoid.
+        if (storeHasBytes)
+            return BakeState.Baked;
+
         if (!string.Equals(definition.CompiledFrameworkVersion, liveFrameworkVersion, StringComparison.Ordinal))
             return BakeState.FrameworkStale;
 
-        // The record claims a live-framework build. Only the store can say whether that is true.
-        return storeHasBytes ? BakeState.Baked : BakeState.BytesMissing;
+        // The record claims a live-framework build and the store does not have it.
+        return BakeState.BytesMissing;
     }
 
     /// <summary>
@@ -250,18 +261,22 @@ public static class NodeTypeBakeStatus
         ILogger? logger)
         => Observable.Defer(() =>
         {
-            // Only a record that claims a LIVE-framework build is worth a store round-trip: every
-            // other state is decided by the record alone, and the store key for a stale framework
-            // could not match anyway (the tag is part of the key).
-            var claimsLiveBuild =
+            // Probe whenever there is a version to probe WITH — not only when the record already
+            // agrees we are current. The store key carries the LIVE framework tag, so the lookup
+            // answers "are there bytes for THIS framework?" independently of what the record claims,
+            // and a record naming another framework can still be sitting on top of a usable build
+            // (another replica compiled it; its write-back lagged or never landed).
+            //
+            // A type with no recorded assembly has no key to ask about, and one that terminally
+            // failed keeps its PreviouslyBroken label — both are decided by the record alone.
+            var probeable =
                 !string.IsNullOrEmpty(definition.LatestAssemblyCollection)
                 && !string.IsNullOrEmpty(definition.LatestAssemblyPath)
                 && definition.LastCompiledVersion is { } version
                 && version >= 0
-                && string.Equals(definition.CompiledFrameworkVersion, framework, StringComparison.Ordinal)
                 && definition.CompilationStatus != CompilationStatus.Error;
 
-            if (!claimsLiveBuild)
+            if (!probeable)
                 return Observable.Return(Describe(typePath, definition, Classify(definition, false, framework)));
 
             return store

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -433,6 +433,38 @@ internal static class NodeTypeCompilationHelpers
                 && !IsStaticOnlyNodeType(node, def)
                 && parkRegistry?.IsParked(hubPath) != true)
             .Take(1)
+            // 🚨 ASK THE STORE BEFORE REBUILDING. The record's CompiledFrameworkVersion says which
+            // framework the LAST WRITE-BACK came from; it does not say whether bytes for OUR
+            // framework exist. Those are different questions, and the assembly store answers the one
+            // that matters — its key carries the live framework tag, so a hit IS a usable build.
+            //
+            // They diverge whenever something else compiled for this framework without this hub
+            // seeing the write-back: another replica, or a dedicated bake service that pre-fills the
+            // share ahead of a rollout. Flipping to Pending on the version mismatch alone then
+            // recompiles what is already on the volume — and, while two images are live at once,
+            // does it on BOTH sides: each pod rebuilds to stamp its own version, the other sees the
+            // stamp and rebuilds back. A pre-bake would not merely be wasted, it would storm the pods
+            // currently serving production.
+            //
+            // So: mismatch is the CHEAP pre-filter (a pure record read on every emission, unchanged),
+            // and the store probe runs at most once per hub lifetime, here, after Take(1).
+            .SelectMany(node => ResolveAssemblyStore(hub)
+                .TryGetAssemblyPath(hubPath, DefinitionOf(hub, node)?.LastCompiledVersion ?? node.Version)
+                .Take(1)
+                .Catch<string?, Exception>(_ => Observable.Return<string?>(null))
+                .Select(path => (Node: node, HasBytes: !string.IsNullOrEmpty(path))))
+            .Where(probe =>
+            {
+                if (!probe.HasBytes)
+                    return true;
+                logger?.LogInformation(
+                    "Framework-stale kickoff SKIPPED for {HubPath}: its record names framework {Compiled} "
+                    + "but the assembly store already holds a build for the live framework {Live} — "
+                    + "nothing to rebuild",
+                    hubPath, DefinitionOf(hub, probe.Node)?.CompiledFrameworkVersion ?? "(null)", FrameworkVersion);
+                return false;
+            })
+            .Select(probe => probe.Node)
             .Subscribe(node =>
             {
                 logger?.LogInformation(
@@ -986,6 +1018,18 @@ internal static class NodeTypeCompilationHelpers
     /// <para>Distinct from <see cref="HasUsableBuild"/>: a NodeType that was never compiled
     /// (no assembly fields) is NOT "stale" — it is handled by the first-build kickoff.</para>
     /// </summary>
+    /// <summary>
+    /// The shared assembly store, or <see cref="NullAssemblyStore"/> when the host registered none.
+    /// A null store reports every lookup as a miss, so callers fall back to their pre-store behaviour
+    /// (rebuild) rather than wrongly concluding a build exists.
+    /// </summary>
+    private static IAssemblyStore ResolveAssemblyStore(IMessageHub hub) =>
+        hub.ServiceProvider.GetService<IAssemblyStore>() ?? NullAssemblyStore.Instance;
+
+    /// <summary>The node's content as a <see cref="NodeTypeDefinition"/>, or null.</summary>
+    private static NodeTypeDefinition? DefinitionOf(IMessageHub hub, MeshNode? node) =>
+        node?.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions);
+
     internal static bool HasStaleFrameworkBuild(NodeTypeDefinition def) =>
         !string.IsNullOrEmpty(def.LatestAssemblyCollection)
         && !string.IsNullOrEmpty(def.LatestAssemblyPath)

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -188,10 +188,11 @@ public static class DynamicTypePreWarmer
                     // which buys three properties at once: a cleared cache re-bakes by itself, an
                     // interrupted bake RESUMES (what already landed comes back Baked), and a second
                     // pod inherits the first pod's work instead of repeating it.
+                    var store = ResolveAssemblyStore(mesh);
                     return NodeTypeBakeStatus
-                        .Probe(definitions, ResolveAssemblyStore(mesh), logger: logger)
-                        .SelectMany(report => WarmPending(
-                            workspace, accessService, definitions, report, budget, logger));
+                        .Probe(definitions, store, logger: logger)
+                        .SelectMany(report => BakeOrFollow(
+                            mesh, workspace, accessService, definitions, store, report, budget, logger));
                 })
                 .Catch<PreWarmOutcome, Exception>(ex =>
                 {
@@ -209,6 +210,72 @@ public static class DynamicTypePreWarmer
     /// </summary>
     private static IAssemblyStore ResolveAssemblyStore(IMessageHub mesh) =>
         mesh.ServiceProvider.GetService<IAssemblyStore>() ?? NullAssemblyStore.Instance;
+
+    /// <summary>How often a FOLLOWING pod re-checks the share (and re-attempts the lease).</summary>
+    public static readonly TimeSpan FollowPollInterval = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// 🚨 ONE POD BAKES; the rest WATCH THE SHARE FILL.
+    ///
+    /// <para>The cache is shared but the decision to rebuild is per-process, so without this every
+    /// replica on a new image independently finds the same framework-stale cache and starts the same
+    /// sweep into the same volume. That is not just duplicated work — it is concurrent cold compiles
+    /// of the SAME NodeType, which is precisely the storm the sequential ordered sweep exists to
+    /// prevent (four concurrent compiles on memex, 2026-07-28 04:05, dropped six plugin roots to the
+    /// "did not settle" overlay). A rollout with <c>maxSurge</c>, or any <c>replicas &gt; 1</c>, hits
+    /// this by default.</para>
+    ///
+    /// <para><b>The follower is not passive.</b> Each poll it re-probes the share AND re-attempts the
+    /// lease. So when the share completes it finishes immediately, and when the baker DIES its lease
+    /// goes stale and the next poll takes the bake over. There is no state that requires a human to
+    /// notice — the same level-triggered rule as the rest of this design.</para>
+    ///
+    /// <para>With no <see cref="BakeCoordination"/> registered there is no fleet to coordinate with
+    /// (monolith, tests, dev), and the caller simply bakes.</para>
+    /// </summary>
+    private static IObservable<PreWarmOutcome> BakeOrFollow(
+        IMessageHub mesh,
+        IWorkspace workspace,
+        AccessService? accessService,
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        IAssemblyStore store,
+        NodeTypeBakeReport report,
+        TimeSpan budget,
+        ILogger? logger)
+    {
+        // Nothing outstanding — no lease needed, and nothing for a follower to wait for.
+        if (report.IsComplete)
+            return WarmPending(workspace, accessService, definitions, report, budget, logger);
+
+        var coordination = mesh.ServiceProvider.GetService<BakeCoordination>();
+        if (coordination is null)
+            return WarmPending(workspace, accessService, definitions, report, budget, logger);
+
+        var lease = NodeTypeBakeLease.TryAcquire(
+            coordination.LeaseDirectory, report.FrameworkVersion, Environment.MachineName, logger);
+
+        if (lease is not null)
+            // Observable.Using holds the lease for the LIFETIME of the bake and releases it on
+            // completion, error or unsubscribe — a lease that outlived its sweep would lock the
+            // fleet out until it went stale.
+            return Observable.Using(
+                () => lease,
+                _ => WarmPending(workspace, accessService, definitions, report, budget, logger));
+
+        logger?.LogInformation(
+            "DynamicTypePreWarmer: another pod is baking framework {Framework} — following the shared "
+            + "assembly store instead of compiling ({Pending} type(s) outstanding)",
+            report.Summary, report.Pending.Count);
+
+        // Re-enter after a pause: re-probe (has the baker finished?) and re-attempt the lease (has
+        // the baker died?). Recursion, not a loop, because each round's decision depends on the fresh
+        // probe — bounded in practice by the poll interval against a bake measured in hours.
+        return Observable
+            .Timer(FollowPollInterval)
+            .SelectMany(_ => NodeTypeBakeStatus.Probe(definitions, store, logger: logger))
+            .SelectMany(fresh => BakeOrFollow(
+                mesh, workspace, accessService, definitions, store, fresh, budget, logger));
+    }
 
     /// <summary>
     /// Warm every NodeType the <paramref name="report"/> says still needs building, dependencies

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -16,6 +16,13 @@ public enum PreWarmStatus
 {
     /// <summary>The NodeType reached a usable compiled build.</summary>
     Compiled,
+    /// <summary>
+    /// NOT ATTEMPTED because it did not need to be: the shared assembly store already holds this
+    /// NodeType's bytes for the LIVE framework (<see cref="BakeState.Baked"/>), so there is nothing
+    /// to compile. This is what makes the sweep restartable — an interrupted or partial bake resumes
+    /// from the share instead of starting over, and a second pod finds the first pod's work.
+    /// </summary>
+    AlreadyBaked,
     /// <summary>The NodeType's compile settled at Error (its diagnostics are already logged by the compile watcher).</summary>
     CompileError,
     /// <summary>The per-type warm budget elapsed before the compile settled — Part 2 handles the late arrival.</summary>
@@ -33,7 +40,31 @@ public enum PreWarmStatus
 }
 
 /// <summary>One dynamic NodeType's pre-warm result.</summary>
-public record PreWarmOutcome(string TypePath, PreWarmStatus Status, string? Detail = null);
+public record PreWarmOutcome(string TypePath, PreWarmStatus Status, string? Detail = null)
+{
+    /// <summary>
+    /// The type is usable on this framework now — whether this sweep compiled it
+    /// (<see cref="PreWarmStatus.Compiled"/>) or found it already on the shared store
+    /// (<see cref="PreWarmStatus.AlreadyBaked"/>).
+    ///
+    /// <para>Callers deciding "is this mesh ready to serve?" want THIS, not an equality check
+    /// against <see cref="PreWarmStatus.Compiled"/> — a warm share is a success, not a miss, and a
+    /// gate that insisted on a fresh compile would fail every pod that inherited a good cache.</para>
+    /// </summary>
+    public bool ReachedUsableBuild =>
+        Status is PreWarmStatus.Compiled or PreWarmStatus.AlreadyBaked;
+
+    /// <summary>
+    /// Whether this NodeType was WORKING before the sweep started — the regression baseline, taken
+    /// from <see cref="NodeTypeBakeEntry.WasHealthy"/>.
+    ///
+    /// <para>Only a failure on a type that was previously healthy is a REGRESSION, and only a
+    /// regression may hold a pod out of rotation. A type that was already sitting at
+    /// <c>CompilationStatus.Error</c> before this image failing again is not new damage — gating on it
+    /// would let one abandoned NodeType block every future deploy.</para>
+    /// </summary>
+    public bool WasHealthyBeforeBake { get; init; } = true;
+}
 
 /// <summary>
 /// Best-effort, background PRE-WARM of dynamic NodeType hubs at startup (Part 1 of the
@@ -144,75 +175,23 @@ public static class DynamicTypePreWarmer
                             g => (NodeTypeDefinition?)g.First().Content,
                             StringComparer.OrdinalIgnoreCase);
 
-                    // 🚨 DEPENDENCIES FIRST, ONE AT A TIME. A NodeType can compile ANOTHER type's
-                    // Code into its own assembly (Store/Plugin declares shared=@Store/Coupon/Source,
-                    // @Store/Order/Source, @Store/BillingProfile/Source), and every plugin ROOT is
-                    // itself an instance of such a type — so warming them in arbitrary order makes
-                    // dependents wait on dependencies that have not been built yet, and they blow
-                    // the 60s activation budget:
-                    //     [STALE-CALLBACK] … SubscribeRequest@Store/Plugin(45028ms)
-                    //     TimeoutException: No response received … within 00:01:00 → Store/Plugin
-                    // The order is computed from the DECLARED sources, so it stays correct as
-                    // plugins add cross-type sources without anyone maintaining a list.
-                    var dependencies = NodeTypeDependencyGraph.Build(definitions);
-                    var order = NodeTypeDependencyGraph.TopologicalOrder(dependencies, out var cyclic);
-
-                    logger?.LogInformation(
-                        "DynamicTypePreWarmer: warming {Count} dynamic NodeType hub(s) in dependency order "
-                        + "(sequential, perTypeBudget={Budget}): {Order}",
-                        order.Count, budget, string.Join(" → ", order));
-                    if (!cyclic.IsEmpty)
-                        logger?.LogWarning(
-                            "DynamicTypePreWarmer: {Count} NodeType(s) form a source dependency CYCLE and "
-                            + "cannot be ordered — warmed last, in path order: {Cyclic}",
-                            cyclic.Count, string.Join(", ", cyclic));
-
-                    // FAIL GRACEFULLY DOWNSTREAM. A type whose upstream did not reach a usable build
-                    // cannot build either, so it is not attempted: it is reported as UpstreamFailed
-                    // naming the blocker, and joins the failed set so ITS dependents are skipped too
-                    // — the propagation is transitive purely because we walk in topological order.
-                    // Without this, one broken type costs every dependent a full per-type budget of
-                    // waiting for something that cannot succeed.
+                    // 🚨 ASK THE SHARE WHAT IS ACTUALLY THERE, before deciding what to build.
                     //
-                    // The set is mutated inside a Concat, which subscribes strictly one at a time,
-                    // so there is no concurrent access — and each step is wrapped in Defer so it
-                    // reads the set as it stands WHEN ITS TURN COMES, not when the chain was built.
-                    var failed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-                    // Concat, never Merge: the next type is SUBSCRIBED only after the previous one
-                    // has completed, so "dependencies first" is structural rather than a convention.
-                    // The gap between types keeps the sweep a background trickle rather than a queue
-                    // of back-to-back cold activations; it costs nothing, since the warm-up has no
-                    // deadline and Part 2 compiles lazily regardless.
-                    return order.Count == 0
-                        ? Observable.Empty<PreWarmOutcome>()
-                        : order
-                            .Select((p, i) => Observable.Defer(() =>
-                            {
-                                var blocker = NodeTypeDependencyGraph.FirstBlockedBy(p, dependencies, failed);
-                                if (blocker is not null)
-                                {
-                                    failed.Add(p);
-                                    logger?.LogWarning(
-                                        "DynamicTypePreWarmer: skipping {TypePath} — its dependency {Blocker} "
-                                        + "did not reach a usable build, so it cannot compile either "
-                                        + "(lazy compile still applies if the upstream recovers)",
-                                        p, blocker);
-                                    // No pacing for a skip: it activates nothing, so there is no
-                                    // burst to spread out and no reason to slow the sweep down.
-                                    return Observable.Return(new PreWarmOutcome(
-                                        p, PreWarmStatus.UpstreamFailed, $"blocked by {blocker}"));
-                                }
-
-                                return WarmOne(workspace, accessService, p, budget, logger)
-                                    .DelaySubscription(i == 0 ? TimeSpan.Zero : BetweenTypes)
-                                    .Do(o =>
-                                    {
-                                        if (o.Status != PreWarmStatus.Compiled)
-                                            failed.Add(p);
-                                    });
-                            }))
-                            .Concat();
+                    // The obvious shortcut — trust each NodeType's own record (HasUsableBuild) — is
+                    // wrong in the one case that matters operationally: that check is deliberately a
+                    // pure record read ("no store probe, no File.Exists"), so when the assembly-cache
+                    // volume is cleared, remounted, or restored from a stale snapshot, every type
+                    // still claims a usable build while its bytes are gone. Nothing re-drives a
+                    // compile and the miss surfaces later, one instance at a time, at activation.
+                    //
+                    // Probing the STORE makes this level-triggered on reality rather than on history,
+                    // which buys three properties at once: a cleared cache re-bakes by itself, an
+                    // interrupted bake RESUMES (what already landed comes back Baked), and a second
+                    // pod inherits the first pod's work instead of repeating it.
+                    return NodeTypeBakeStatus
+                        .Probe(definitions, ResolveAssemblyStore(mesh), logger: logger)
+                        .SelectMany(report => WarmPending(
+                            workspace, accessService, definitions, report, budget, logger));
                 })
                 .Catch<PreWarmOutcome, Exception>(ex =>
                 {
@@ -222,11 +201,267 @@ public static class DynamicTypePreWarmer
                 }));
     }
 
+    /// <summary>
+    /// The shared assembly store this mesh compiles into, or <see cref="NullAssemblyStore"/> when the
+    /// host registered none. A null store reports every lookup as a miss, so every type is treated as
+    /// needing a bake — which matches what a storeless host does anyway (it recompiles on every
+    /// activation), so the sweep degrades to its previous behaviour rather than misreporting.
+    /// </summary>
+    private static IAssemblyStore ResolveAssemblyStore(IMessageHub mesh) =>
+        mesh.ServiceProvider.GetService<IAssemblyStore>() ?? NullAssemblyStore.Instance;
+
+    /// <summary>
+    /// Warm every NodeType the <paramref name="report"/> says still needs building, dependencies
+    /// first, one at a time. Types the share already holds are reported
+    /// <see cref="PreWarmStatus.AlreadyBaked"/> and never activated.
+    /// </summary>
+    private static IObservable<PreWarmOutcome> WarmPending(
+        IWorkspace workspace,
+        AccessService? accessService,
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        NodeTypeBakeReport report,
+        TimeSpan budget,
+        ILogger? logger)
+    {
+        var baked = report.Entries
+            .Where(e => !e.NeedsBake)
+            .Select(e => e.TypePath)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var bytesMissing = report.BytesMissing
+            .Select(e => e.TypePath)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // The regression baseline, captured BEFORE anything is rebuilt: which types were working on
+        // the way in. A type missing from this set was already broken, so its failure is pre-existing
+        // damage rather than something this image caused — see PreWarmOutcome.WasHealthyBeforeBake.
+        var healthyBefore = report.Entries
+            .Where(e => e.WasHealthy)
+            .Select(e => e.TypePath)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Say it out loud when the SHARE changed rather than the code: a record that claims a
+        // live-framework build with no bytes behind it means the cache was cleared, remounted or
+        // restored — a very different diagnosis from "these types are stale", and one an operator
+        // reading the log at 3am should not have to infer from a recompile count.
+        if (!report.BytesMissing.IsEmpty)
+            logger?.LogWarning(
+                "DynamicTypePreWarmer: {Count} NodeType(s) claim a usable build for the live "
+                + "framework but the assembly store has NO bytes for them — the shared cache was "
+                + "cleared or replaced. Rebuilding: {Types}",
+                report.BytesMissing.Count,
+                string.Join(", ", report.BytesMissing.Select(e => e.TypePath)));
+
+        // 🚨 DEPENDENCIES FIRST, ONE AT A TIME. A NodeType can compile ANOTHER type's
+        // Code into its own assembly (Store/Plugin declares shared=@Store/Coupon/Source,
+        // @Store/Order/Source, @Store/BillingProfile/Source), and every plugin ROOT is
+        // itself an instance of such a type — so warming them in arbitrary order makes
+        // dependents wait on dependencies that have not been built yet, and they blow
+        // the 60s activation budget:
+        //     [STALE-CALLBACK] … SubscribeRequest@Store/Plugin(45028ms)
+        //     TimeoutException: No response received … within 00:01:00 → Store/Plugin
+        // The order is computed from the DECLARED sources, so it stays correct as
+        // plugins add cross-type sources without anyone maintaining a list.
+        //
+        // The order is computed over EVERY type, not just the pending ones: an
+        // already-baked dependency still has to be positioned before its dependents so
+        // the blocked-by walk below sees it as satisfied rather than as absent.
+        var dependencies = NodeTypeDependencyGraph.Build(definitions);
+        var order = NodeTypeDependencyGraph.TopologicalOrder(dependencies, out var cyclic);
+        var pending = order.Where(p => !baked.Contains(p)).ToList();
+
+        logger?.LogInformation(
+            "DynamicTypePreWarmer: {Pending} of {Total} dynamic NodeType(s) need building "
+            + "(sequential, dependency order, perTypeBudget={Budget}) — {Baked} already on the share. "
+            + "{Report}. Building: {Order}",
+            pending.Count, order.Count, budget, baked.Count, report.Summary,
+            pending.Count == 0 ? "(nothing)" : string.Join(" → ", pending));
+        if (!cyclic.IsEmpty)
+            logger?.LogWarning(
+                "DynamicTypePreWarmer: {Count} NodeType(s) form a source dependency CYCLE and "
+                + "cannot be ordered — warmed last, in path order: {Cyclic}",
+                cyclic.Count, string.Join(", ", cyclic));
+
+        // FAIL GRACEFULLY DOWNSTREAM. A type whose upstream did not reach a usable build
+        // cannot build either, so it is not attempted: it is reported as UpstreamFailed
+        // naming the blocker, and joins the failed set so ITS dependents are skipped too
+        // — the propagation is transitive purely because we walk in topological order.
+        // Without this, one broken type costs every dependent a full per-type budget of
+        // waiting for something that cannot succeed.
+        //
+        // The set is mutated inside a Concat, which subscribes strictly one at a time,
+        // so there is no concurrent access — and each step is wrapped in Defer so it
+        // reads the set as it stands WHEN ITS TURN COMES, not when the chain was built.
+        var failed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Concat, never Merge: the next type is SUBSCRIBED only after the previous one
+        // has completed, so "dependencies first" is structural rather than a convention.
+        // The gap between types keeps the sweep a background trickle rather than a queue
+        // of back-to-back cold activations; it costs nothing, since the warm-up has no
+        // deadline and Part 2 compiles lazily regardless.
+        return order.Count == 0
+            ? Observable.Empty<PreWarmOutcome>()
+            : order
+                .Select((p, i) => Observable.Defer(() =>
+                {
+                    // Already on the share: report it and move on WITHOUT activating the hub.
+                    // Skipping the activation is the entire saving — it is what turns a
+                    // re-run, a second replica, or a resumed bake from hours of Roslyn into
+                    // a directory listing.
+                    if (baked.Contains(p))
+                        return Observable.Return(new PreWarmOutcome(
+                            p, PreWarmStatus.AlreadyBaked, "assembly store already holds this build"));
+
+                    var blocker = NodeTypeDependencyGraph.FirstBlockedBy(p, dependencies, failed);
+                    var missingBytes = bytesMissing.Contains(p);
+                    if (blocker is not null)
+                    {
+                        failed.Add(p);
+                        logger?.LogWarning(
+                            "DynamicTypePreWarmer: skipping {TypePath} — its dependency {Blocker} "
+                            + "did not reach a usable build, so it cannot compile either "
+                            + "(lazy compile still applies if the upstream recovers)",
+                            p, blocker);
+                        // No pacing for a skip: it activates nothing, so there is no
+                        // burst to spread out and no reason to slow the sweep down.
+                        return Observable.Return(new PreWarmOutcome(
+                            p, PreWarmStatus.UpstreamFailed, $"blocked by {blocker}"));
+                    }
+
+                    // 🚨 A type whose BYTES are gone cannot be warmed by activation alone.
+                    // WarmOne waits for HasUsableBuild, which is a RECORD check that deliberately
+                    // ignores status — and in this state the record is pristine. Activating the hub
+                    // would therefore return "Compiled" instantly without rebuilding anything, and
+                    // the sweep would report a green bake over a share that is still empty. The
+                    // rebuild has to be DRIVEN.
+                    var warm = missingBytes
+                        ? RebuildMissingBytes(workspace, accessService, p, budget, logger)
+                        : WarmOne(workspace, accessService, p, budget, logger);
+
+                    return warm
+                        .DelaySubscription(i == 0 ? TimeSpan.Zero : BetweenTypes)
+                        .Do(o =>
+                        {
+                            if (!o.ReachedUsableBuild)
+                                failed.Add(p);
+                        });
+                }))
+                .Concat()
+                // Stamp the regression baseline on every outcome so a downstream readiness gate can
+                // tell a NEW failure from one that was already broken on the way in, without having
+                // to re-read the report.
+                .Select(o => o with { WasHealthyBeforeBake = healthyBefore.Contains(o.TypePath) });
+    }
+
     /// <summary>A NodeType has something for Roslyn to compile (so it is a dynamic type worth warming).</summary>
     private static bool HasCompilableSource(NodeTypeDefinition d) =>
         !string.IsNullOrWhiteSpace(d.Configuration)
         || !string.IsNullOrWhiteSpace(d.HubConfiguration)
         || (d.Sources is { Count: > 0 });
+
+    /// <summary>
+    /// Rebuild a NodeType whose record claims a usable build for the LIVE framework but whose bytes
+    /// are no longer in the shared assembly store — a cleared, remounted or partially-restored
+    /// assembly-cache volume.
+    ///
+    /// <para><b>Why activation is not enough.</b> Every existing kickoff is keyed on the RECORD:
+    /// first-build needs null assembly fields, recovery needs <c>Compiling</c>, framework-stale needs
+    /// a version mismatch, and the release watcher needs a fresh release request. In this state the
+    /// record satisfies none of them — it is a clean <c>Ok</c> pointing at bytes that are gone — so
+    /// activating the hub fires nothing, and <see cref="WarmOne"/>'s <c>HasUsableBuild</c> wait
+    /// (which deliberately ignores status) would return <see cref="PreWarmStatus.Compiled"/> at once.
+    /// The sweep would then report a green bake over an empty share, which is the one outcome a bake
+    /// gate must never produce.</para>
+    ///
+    /// <para><b>How.</b> Flip <see cref="CompilationStatus.Pending"/> — the same lever the
+    /// framework-stale kickoff and the enrichment self-heal pull — so the per-NodeType compile
+    /// watcher rebuilds, then wait for a compile that is demonstrably FRESH: a settled
+    /// <see cref="CompilationStatus.Ok"/> whose <see cref="NodeTypeDefinition.LastCompileSucceededAt"/>
+    /// is newer than the one we observed before flipping. Matching on status alone would accept the
+    /// replayed pre-existing Ok and green-light a share that never got its bytes back.</para>
+    ///
+    /// <para>The settle subscription is established BEFORE the flip is issued (left-to-right
+    /// <c>Merge</c>), so a compile that completes quickly cannot land in the gap between triggering
+    /// and listening.</para>
+    /// </summary>
+    private static IObservable<PreWarmOutcome> RebuildMissingBytes(
+        IWorkspace workspace,
+        AccessService? accessService,
+        string typePath,
+        TimeSpan budget,
+        ILogger? logger)
+        => Observable.Using(
+                () => AccessContextScope.AsSystem(accessService),
+                _ =>
+                {
+                    var stream = workspace.GetMeshNodeStream(typePath);
+                    return stream
+                        .Take(1)
+                        .Timeout(budget)
+                        .SelectMany(current =>
+                        {
+                            var baseline = (current?.Content as NodeTypeDefinition)?.LastCompileSucceededAt;
+                            logger?.LogInformation(
+                                "DynamicTypePreWarmer: {TypePath} has no bytes in the assembly store despite a "
+                                + "clean record — flipping CompilationStatus=Pending to force a rebuild "
+                                + "(previous success {Baseline})",
+                                typePath, baseline);
+
+                            var settled = stream
+                                .Where(n => n?.Content is NodeTypeDefinition d
+                                    && (d.CompilationStatus == CompilationStatus.Error
+                                        || (d.CompilationStatus == CompilationStatus.Ok
+                                            && IsFreshSuccess(d.LastCompileSucceededAt, baseline))))
+                                .Take(1)
+                                .Timeout(budget)
+                                .Select(n =>
+                                {
+                                    var d = (NodeTypeDefinition)n!.Content!;
+                                    return d.CompilationStatus == CompilationStatus.Error
+                                        ? new PreWarmOutcome(typePath, PreWarmStatus.CompileError, d.CompilationError)
+                                        : new PreWarmOutcome(typePath, PreWarmStatus.Compiled, "rebuilt after store miss");
+                                });
+
+                            // Never emits — it exists only for its write side effect, and it is
+                            // merged SECOND so `settled` is already subscribed when it fires.
+                            var trigger = stream
+                                .Update(node =>
+                                {
+                                    if (node?.Content is not NodeTypeDefinition def)
+                                        return node!;
+                                    // Don't clobber an in-flight compile someone else already started.
+                                    if (def.CompilationStatus is CompilationStatus.Pending
+                                                              or CompilationStatus.Compiling)
+                                        return node;
+                                    return node with
+                                    {
+                                        Content = def with { CompilationStatus = CompilationStatus.Pending }
+                                    };
+                                })
+                                .IgnoreElements()
+                                .Select(_ => default(PreWarmOutcome)!)
+                                .Catch<PreWarmOutcome, Exception>(ex =>
+                                {
+                                    logger?.LogWarning(ex,
+                                        "DynamicTypePreWarmer: could not flip {TypePath} to Pending — the settle "
+                                        + "wait below will time out and report it", typePath);
+                                    return Observable.Empty<PreWarmOutcome>();
+                                });
+
+                            return Observable.Merge(settled, trigger).Take(1);
+                        });
+                })
+            .Catch<PreWarmOutcome, Exception>(ex => Observable.Return(
+                ex is TimeoutException
+                    ? new PreWarmOutcome(typePath, PreWarmStatus.TimedOut, "rebuild after store miss did not settle")
+                    : new PreWarmOutcome(typePath, PreWarmStatus.Faulted, ex.Message)));
+
+    /// <summary>
+    /// A compile success that is demonstrably NEWER than the one observed before the rebuild was
+    /// triggered. With no baseline, any recorded success counts.
+    /// </summary>
+    private static bool IsFreshSuccess(DateTimeOffset? succeeded, DateTimeOffset? baseline) =>
+        succeeded is { } s && (baseline is not { } b || s > b);
 
     /// <summary>
     /// Activate one dynamic NodeType's hub by subscribing to its own MeshNode stream —

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -263,9 +263,9 @@ public static class DynamicTypePreWarmer
                 _ => WarmPending(workspace, accessService, definitions, report, budget, logger));
 
         logger?.LogInformation(
-            "DynamicTypePreWarmer: another pod is baking framework {Framework} — following the shared "
-            + "assembly store instead of compiling ({Pending} type(s) outstanding)",
-            report.Summary, report.Pending.Count);
+            "DynamicTypePreWarmer: another pod holds the bake lease — following the shared assembly "
+            + "store instead of compiling ({Pending} type(s) outstanding). {Report}",
+            report.Pending.Count, report.Summary);
 
         // Re-enter after a pause: re-probe (has the baker finished?) and re-attempt the lease (has
         // the baker died?). Recursion, not a loop, because each round's decision depends on the fresh

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -70,9 +70,17 @@ public sealed class DynamicTypePreWarmerHostedService(
 
         var startedAt = DateTimeOffset.UtcNow;
         var compiled = 0;
+        var alreadyBaked = 0;
         var errored = 0;
         var timedOut = 0;
+        var skipped = 0;
         var faulted = 0;
+
+        // The readiness gate reads this. Resolved (not required) so a host that never called
+        // AddNodeTypeBakeGate simply warms without gating — the warmer stays a latency optimisation
+        // unless a deployment explicitly opts into making it a rollout gate.
+        var gate = services.GetService<NodeTypeBakeGateState>();
+        gate?.MarkRunning("enumerating dynamic NodeTypes");
 
         logger.LogInformation("DynamicTypePreWarmer: starting background warm-up of dynamic NodeType hubs");
         _warmSubscription = DynamicTypePreWarmer
@@ -80,20 +88,50 @@ public sealed class DynamicTypePreWarmerHostedService(
             .Subscribe(
                 outcome =>
                 {
+                    gate?.MarkOutcome(outcome);
                     switch (outcome.Status)
                     {
                         case PreWarmStatus.Compiled: Interlocked.Increment(ref compiled); break;
+                        case PreWarmStatus.AlreadyBaked: Interlocked.Increment(ref alreadyBaked); break;
                         case PreWarmStatus.CompileError: Interlocked.Increment(ref errored); break;
                         case PreWarmStatus.TimedOut: Interlocked.Increment(ref timedOut); break;
+                        // A type skipped because its upstream failed is not a FAULT — it is a
+                        // deliberate, reported outcome. Counting it as one made the summary read
+                        // like the warmer had crashed N times when one dependency was broken.
+                        case PreWarmStatus.UpstreamFailed: Interlocked.Increment(ref skipped); break;
                         default: Interlocked.Increment(ref faulted); break;
                     }
                 },
-                ex => logger.LogWarning(ex, "DynamicTypePreWarmer: warm-up stream faulted (best-effort — lazy compile still works)"),
-                () => logger.LogInformation(
-                    "DynamicTypePreWarmer: warm-up complete in {Elapsed} — compiled={Compiled} compileErrors={Errored} timedOut={TimedOut} faulted={Faulted}",
-                    DateTimeOffset.UtcNow - startedAt,
-                    Volatile.Read(ref compiled), Volatile.Read(ref errored),
-                    Volatile.Read(ref timedOut), Volatile.Read(ref faulted)));
+                ex =>
+                {
+                    logger.LogWarning(ex, "DynamicTypePreWarmer: warm-up stream faulted (best-effort — lazy compile still works)");
+                    // A faulted sweep proved nothing. Release the gate rather than hold the pod out
+                    // of rotation forever on a stream error: the lazy compile path still works, so
+                    // an un-provable bake must not become an outage. A genuine broken type is caught
+                    // by MarkOutcome above, which is what the gate is actually for.
+                    gate?.MarkComplete("warm-up stream faulted — gate released, lazy compile applies");
+                },
+                () =>
+                {
+                    var elapsed = DateTimeOffset.UtcNow - startedAt;
+                    logger.LogInformation(
+                        "DynamicTypePreWarmer: warm-up complete in {Elapsed} — compiled={Compiled} alreadyBaked={AlreadyBaked} "
+                        + "compileErrors={Errored} timedOut={TimedOut} skipped={Skipped} faulted={Faulted}",
+                        elapsed,
+                        Volatile.Read(ref compiled), Volatile.Read(ref alreadyBaked), Volatile.Read(ref errored),
+                        Volatile.Read(ref timedOut), Volatile.Read(ref skipped), Volatile.Read(ref faulted));
+
+                    // MarkComplete keeps a recorded regression red — completion is not absolution.
+                    gate?.MarkComplete(
+                        $"baked in {elapsed:hh\\:mm\\:ss} — compiled={Volatile.Read(ref compiled)} "
+                        + $"alreadyBaked={Volatile.Read(ref alreadyBaked)}");
+                    if (gate is { Phase: BakePhase.Regressed })
+                        logger.LogCritical(
+                            "DynamicTypePreWarmer: REFUSING READINESS — {Detail}. The rollout will stall "
+                            + "with the previous image still serving. Regressions: {Regressions}",
+                            gate.Detail,
+                            string.Join(" | ", gate.Regressions.Select(r => $"{r.Key} → {r.Value}")));
+                });
     }
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>How far this pod's dynamic-NodeType bake has got.</summary>
+public enum BakePhase
+{
+    /// <summary>The sweep has not been started — typically because pre-warming is disabled.</summary>
+    NotStarted,
+    /// <summary>The sweep is running; some types are not yet built against this framework.</summary>
+    Running,
+    /// <summary>Every type the sweep touched reached a usable build.</summary>
+    Complete,
+    /// <summary>
+    /// At least one type that WAS working before this image failed to build against it — a
+    /// regression. The pod must not take traffic.
+    /// </summary>
+    Regressed,
+}
+
+/// <summary>
+/// This pod's live bake state, written by <see cref="DynamicTypePreWarmerHostedService"/> and read by
+/// the host's readiness probe (<c>Memex.Portal.Distributed.NodeTypeBakeHealthCheck</c>).
+///
+/// <para>Kept as a tiny mutable singleton rather than threaded through the reactive pipeline on
+/// purpose: a health check is a synchronous pull from ASP.NET's probe endpoint, and it must never
+/// block on, subscribe to, or take a dependency on the mesh — a readiness probe that can hang is a
+/// readiness probe that takes the pod out of rotation under load (the /health-as-readiness
+/// death-spiral this deployment already fixed once).</para>
+/// </summary>
+public sealed class NodeTypeBakeGateState
+{
+    private readonly ConcurrentDictionary<string, string> regressions = new(StringComparer.OrdinalIgnoreCase);
+    private int phase = (int)BakePhase.NotStarted;
+    private volatile string detail = "pre-warm not started";
+
+    /// <summary>The current phase.</summary>
+    public BakePhase Phase => (BakePhase)Volatile.Read(ref phase);
+
+    /// <summary>Human-readable status for the health payload and the logs.</summary>
+    public string Detail => detail;
+
+    /// <summary>Types that regressed on this image, with their compile error.</summary>
+    public IReadOnlyDictionary<string, string> Regressions => regressions;
+
+    /// <summary>The sweep has begun.</summary>
+    public void MarkRunning(string message)
+    {
+        Interlocked.Exchange(ref phase, (int)BakePhase.Running);
+        detail = message;
+    }
+
+    /// <summary>
+    /// Record one type's outcome. Only a type that was HEALTHY before this image can put the gate
+    /// into <see cref="BakePhase.Regressed"/> — a type already sitting at Error before the deploy is
+    /// broken in production right now, and blocking every future rollout on it would let one
+    /// abandoned NodeType freeze the platform.
+    /// </summary>
+    public void MarkOutcome(PreWarmOutcome outcome)
+    {
+        if (outcome.ReachedUsableBuild || !outcome.WasHealthyBeforeBake)
+            return;
+
+        regressions[outcome.TypePath] = $"{outcome.Status}: {outcome.Detail ?? "(no detail)"}";
+        Interlocked.Exchange(ref phase, (int)BakePhase.Regressed);
+        detail = $"{regressions.Count} NodeType(s) regressed on this image";
+    }
+
+    /// <summary>
+    /// The sweep finished. A run that recorded a regression STAYS regressed — completion is not
+    /// absolution.
+    /// </summary>
+    public void MarkComplete(string message)
+    {
+        if (!regressions.IsEmpty)
+        {
+            detail = $"{regressions.Count} NodeType(s) regressed on this image: "
+                + string.Join(", ", regressions.Keys.OrderBy(k => k, StringComparer.Ordinal));
+            return;
+        }
+
+        Interlocked.Exchange(ref phase, (int)BakePhase.Complete);
+        detail = message;
+    }
+}
+
+/// <summary>DI helper for the bake readiness gate.</summary>
+///
+/// <remarks>
+/// Only the STATE lives in the framework. The <c>IHealthCheck</c> that surfaces it on <c>/health</c>
+/// belongs to the host (see <c>Memex.Portal.Distributed.NodeTypeBakeHealthCheck</c>), which already
+/// owns its probe wiring — that keeps the health-check package out of the framework's dependency
+/// closure and lets a self-host surface the same state however it likes.
+/// </remarks>
+public static class NodeTypeBakeGateExtensions
+{
+    /// <summary>Config key a host reads to decide whether to gate readiness. Default: off.</summary>
+    public const string EnabledConfigKey = "PreWarm:GateReadiness";
+
+    /// <summary>
+    /// Registers the shared bake state. Safe and cheap to call unconditionally: the pre-warm hosted
+    /// service writes to it whether or not anything gates on it, so the diagnostics are always there.
+    ///
+    /// <para>⚠️ A host that gates readiness on this MUST raise its <c>startupProbe.failureThreshold</c>
+    /// to cover a full cold bake. A cold compile is ~90 s per NodeType and the sweep is strictly
+    /// sequential, so a mesh with dozens of types needs HOURS of startup budget. Left at the usual
+    /// default (60 × 5 s = 5 minutes) Kubernetes kills and restarts the pod mid-bake, forever.</para>
+    /// </summary>
+    public static IServiceCollection AddNodeTypeBakeGate(this IServiceCollection services)
+    {
+        services.AddSingleton<NodeTypeBakeGateState>();
+        return services;
+    }
+}

--- a/src/MeshWeaver.Hosting/NodeTypeBakeLease.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBakeLease.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>
+/// Where the fleet coordinates its bake — a directory every replica can see, normally the shared
+/// assembly-cache volume. Registered by the host only when such a directory exists; absent it, there
+/// is nothing to coordinate (a monolith, a test, a dev box) and every process simply bakes.
+/// </summary>
+/// <param name="LeaseDirectory">Shared directory the lease file lives in.</param>
+public sealed record BakeCoordination(string LeaseDirectory);
+
+/// <summary>
+/// ONE POD BAKES. The others wait.
+///
+/// <para><b>Why this has to exist.</b> The compile cache is shared and durable, but the DECISION to
+/// rebuild is per-process. With <c>maxSurge</c> during a rollout, or any <c>replicas &gt; 1</c>, every
+/// pod on the new image independently discovers the same framework-stale cache and starts the same
+/// sweep over the same NodeTypes into the same volume. That is not merely duplicated work: it is
+/// several cold Roslyn compiles of the SAME type running concurrently, contending on one network
+/// volume — the exact storm the sequential, dependency-ordered sweep exists to prevent. Four
+/// concurrent compiles on memex (2026-07-28 04:05) dropped six plugin roots to the "did not settle"
+/// overlay and needed a scale-to-zero.</para>
+///
+/// <para><b>How.</b> An atomic <c>CreateNew</c> on a lease file in a directory every replica can see.
+/// The winner bakes and heartbeats; every other pod FOLLOWS — it polls the store probe and watches the
+/// share fill, compiling nothing. The lease carries a heartbeat so a pod that dies mid-bake does not
+/// wedge the fleet: once the timestamp goes stale any follower may steal it and finish the job.</para>
+///
+/// <para><b>Keyed per framework version.</b> A bake-ahead pod on a NEW image and the live pods on the
+/// OLD one are baking different tags into different files and must not block each other; two replicas
+/// of the SAME image must. The framework version is exactly that distinction, so it is the key.</para>
+///
+/// <para>Best-effort by construction: every failure path returns "you may bake". A coordination
+/// mechanism that can deny work on an I/O error would turn a transient volume blip into a fleet that
+/// never compiles anything — strictly worse than the duplicate work it prevents.</para>
+/// </summary>
+public sealed class NodeTypeBakeLease : IDisposable
+{
+    /// <summary>
+    /// How long a lease survives without a heartbeat before a follower may steal it. Generously
+    /// larger than <see cref="HeartbeatInterval"/>: a missed beat under load must never hand the bake
+    /// to a second pod while the first is still working — that would produce the concurrent compile
+    /// this class exists to prevent.
+    /// </summary>
+    public static readonly TimeSpan StaleAfter = TimeSpan.FromMinutes(10);
+
+    /// <summary>How often the holder refreshes the lease while it bakes.</summary>
+    public static readonly TimeSpan HeartbeatInterval = TimeSpan.FromMinutes(2);
+
+    private readonly string path;
+    private readonly ILogger? logger;
+    private readonly Timer? heartbeat;
+    private int disposed;
+
+    private NodeTypeBakeLease(string path, ILogger? logger)
+    {
+        this.path = path;
+        this.logger = logger;
+        heartbeat = new Timer(_ => Beat(), null, HeartbeatInterval, HeartbeatInterval);
+    }
+
+    /// <summary>The lease file for a framework version.</summary>
+    public static string PathFor(string directory, string frameworkVersion) =>
+        Path.Combine(directory, $".bake-lease-{Short(frameworkVersion)}");
+
+    /// <summary>
+    /// Try to become THE baker for <paramref name="frameworkVersion"/>. Returns the held lease, or
+    /// <c>null</c> when another live pod holds it — in which case the caller must FOLLOW, not bake.
+    ///
+    /// <para>A lease whose heartbeat has gone stale is stolen (its holder died mid-bake), and any
+    /// I/O failure resolves to "you may bake" so a coordination problem can never stop the fleet
+    /// compiling.</para>
+    /// </summary>
+    public static NodeTypeBakeLease? TryAcquire(
+        string directory, string frameworkVersion, string holder, ILogger? logger = null)
+    {
+        var path = PathFor(directory, frameworkVersion);
+        try
+        {
+            Directory.CreateDirectory(directory);
+
+            // Atomic: exactly one process across the fleet can create the file.
+            try
+            {
+                using (var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                using (var writer = new StreamWriter(stream))
+                    writer.Write(Stamp(holder));
+                logger?.LogInformation(
+                    "Bake lease ACQUIRED for framework {Framework} by {Holder} — this pod bakes; others follow",
+                    Short(frameworkVersion), holder);
+                return new NodeTypeBakeLease(path, logger);
+            }
+            catch (IOException)
+            {
+                // Someone holds it. Steal only if their heartbeat is stale.
+            }
+
+            var age = DateTimeOffset.UtcNow - File.GetLastWriteTimeUtc(path);
+            if (age <= StaleAfter)
+            {
+                logger?.LogInformation(
+                    "Bake lease for framework {Framework} is held elsewhere (last beat {Age} ago) — following, not baking",
+                    Short(frameworkVersion), age);
+                return null;
+            }
+
+            logger?.LogWarning(
+                "Bake lease for framework {Framework} is STALE ({Age} since last heartbeat, limit {Limit}) — "
+                + "its holder probably died mid-bake. Stealing it as {Holder}",
+                Short(frameworkVersion), age, StaleAfter, holder);
+            File.WriteAllText(path, Stamp(holder));
+            return new NodeTypeBakeLease(path, logger);
+        }
+        catch (Exception ex)
+        {
+            // Fail OPEN: duplicate work is a cost, a fleet that never compiles is an outage.
+            logger?.LogWarning(ex,
+                "Bake lease could not be evaluated at {Path} — proceeding to bake without coordination",
+                path);
+            return new NodeTypeBakeLease(path, logger);
+        }
+    }
+
+    private void Beat()
+    {
+        if (Volatile.Read(ref disposed) != 0)
+            return;
+        try
+        {
+            File.SetLastWriteTimeUtc(path, DateTime.UtcNow);
+        }
+        catch (Exception ex)
+        {
+            // A missed beat only risks an early steal after StaleAfter — not worth failing the bake.
+            logger?.LogDebug(ex, "Bake lease heartbeat failed at {Path}", path);
+        }
+    }
+
+    private static string Stamp(string holder) =>
+        $"{holder} {DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture)}";
+
+    private static string Short(string version) =>
+        string.IsNullOrEmpty(version) ? "none" : version[..Math.Min(8, version.Length)];
+
+    /// <summary>Releases the lease so the next image roll can acquire it immediately.</summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref disposed, 1) != 0)
+            return;
+
+        heartbeat?.Dispose();
+        try
+        {
+            File.Delete(path);
+            logger?.LogInformation("Bake lease released at {Path}", path);
+        }
+        catch (Exception ex)
+        {
+            // Left behind, it simply expires after StaleAfter — never a permanent block.
+            logger?.LogDebug(ex, "Bake lease could not be deleted at {Path} — it will expire", path);
+        }
+    }
+}

--- a/test/MeshWeaver.Graph.Test/NodeTypeBakeStatusTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeBakeStatusTest.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Unit tests for <see cref="NodeTypeBakeStatus"/> — the probe that decides what still has to be
+/// compiled by asking the SHARED ASSEMBLY STORE, rather than trusting each NodeType's own record.
+///
+/// <para>The case worth reading first is
+/// <see cref="Classify_RecordClaimsLiveBuild_ButStoreHasNoBytes_IsBytesMissing"/>: it is the state the
+/// rest of the framework structurally cannot see, because <c>HasUsableBuild</c> is a pure record check
+/// by design. Clearing the assembly-cache volume leaves every NodeType claiming Ok with its bytes
+/// gone, and nothing re-drives a compile.</para>
+/// </summary>
+public class NodeTypeBakeStatusTest
+{
+    private const string Live = "03d6f01eb6654e199d31fc59668d7b62";
+    private const string Previous = "b7e11c9a44d24f0d8e2a5c31f9048ab6";
+
+    /// <summary>A NodeType record that compiled cleanly against <paramref name="framework"/>.</summary>
+    private static NodeTypeDefinition Healthy(string framework = Live, long version = 845) => new()
+    {
+        Configuration = "config => config",
+        Sources = ["namespace:Source scope:subtree"],
+        CompilationStatus = CompilationStatus.Ok,
+        CompiledFrameworkVersion = framework,
+        LastCompiledVersion = version,
+        LatestAssemblyCollection = "local",
+        LatestAssemblyPath = $"Store_Plugin/v{version}-{framework[..8]}-fef027803a74.dll",
+    };
+
+    // ---- Classify: the pure rules -------------------------------------------------------------
+
+    [Fact]
+    public void Classify_RecordClaimsLiveBuild_AndStoreHasBytes_IsBaked() =>
+        NodeTypeBakeStatus.Classify(Healthy(), storeHasBytes: true, Live)
+            .Should().Be(BakeState.Baked);
+
+    /// <summary>
+    /// 🚨 The cleared-cache case. The record is pristine — status Ok, framework matches, assembly
+    /// coordinates populated — and the bytes are simply not there. Every record-only check in the
+    /// framework calls this healthy; only a store probe catches it.
+    /// </summary>
+    [Fact]
+    public void Classify_RecordClaimsLiveBuild_ButStoreHasNoBytes_IsBytesMissing() =>
+        NodeTypeBakeStatus.Classify(Healthy(), storeHasBytes: false, Live)
+            .Should().Be(BakeState.BytesMissing);
+
+    [Fact]
+    public void Classify_AssemblyBuiltAgainstAnotherFramework_IsFrameworkStale() =>
+        NodeTypeBakeStatus.Classify(Healthy(Previous), storeHasBytes: true, Live)
+            .Should().Be(BakeState.FrameworkStale);
+
+    [Fact]
+    public void Classify_NoAssemblyRecorded_IsNeverBuilt() =>
+        NodeTypeBakeStatus.Classify(
+                new NodeTypeDefinition { Configuration = "config => config" }, storeHasBytes: false, Live)
+            .Should().Be(BakeState.NeverBuilt);
+
+    /// <summary>
+    /// Assembly coordinates without a compiled VERSION cannot be probed — the store is keyed on
+    /// (path, version), so there is no key to ask about. Treated as never built rather than assumed
+    /// good.
+    /// </summary>
+    [Fact]
+    public void Classify_AssemblyCoordinatesButNoCompiledVersion_IsNeverBuilt() =>
+        NodeTypeBakeStatus.Classify(
+                Healthy() with { LastCompiledVersion = null }, storeHasBytes: true, Live)
+            .Should().Be(BakeState.NeverBuilt);
+
+    [Fact]
+    public void Classify_LastCompileErrored_IsPreviouslyBroken() =>
+        NodeTypeBakeStatus.Classify(
+                Healthy() with { CompilationStatus = CompilationStatus.Error }, storeHasBytes: true, Live)
+            .Should().Be(BakeState.PreviouslyBroken);
+
+    /// <summary>
+    /// A broken type is ALSO framework-stale on a new image. It must keep the broken label, or the
+    /// gate would treat it as a healthy-but-stale type and start blocking deploys on a type that was
+    /// already failing before the image changed.
+    /// </summary>
+    [Fact]
+    public void Classify_BrokenAndFrameworkStale_StaysPreviouslyBroken() =>
+        NodeTypeBakeStatus.Classify(
+                Healthy(Previous) with { CompilationStatus = CompilationStatus.Error },
+                storeHasBytes: false, Live)
+            .Should().Be(BakeState.PreviouslyBroken);
+
+    // ---- The regression baseline --------------------------------------------------------------
+
+    [Fact]
+    public void PreviouslyBrokenEntry_IsNotGateRelevant() =>
+        new NodeTypeBakeEntry("A", BakeState.PreviouslyBroken).WasHealthy.Should().BeFalse();
+
+    [Theory]
+    [InlineData(BakeState.Baked)]
+    [InlineData(BakeState.NeverBuilt)]
+    [InlineData(BakeState.FrameworkStale)]
+    [InlineData(BakeState.BytesMissing)]
+    public void NonBrokenEntries_AreGateRelevant(BakeState state) =>
+        new NodeTypeBakeEntry("A", state).WasHealthy.Should().BeTrue();
+
+    [Fact]
+    public void OnlyBaked_NeedsNoBake()
+    {
+        new NodeTypeBakeEntry("A", BakeState.Baked).NeedsBake.Should().BeFalse();
+        foreach (var state in Enum.GetValues<BakeState>().Where(s => s != BakeState.Baked))
+            new NodeTypeBakeEntry("A", state).NeedsBake.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A type that was already broken must not appear in the gate set even though it needs a bake —
+    /// otherwise one abandoned NodeType freezes every future deploy.
+    /// </summary>
+    [Fact]
+    public void GateRelevant_ExcludesPreviouslyBroken_ButKeepsStaleAndMissing()
+    {
+        var report = Report(
+            new NodeTypeBakeEntry("Ok", BakeState.Baked),
+            new NodeTypeBakeEntry("Stale", BakeState.FrameworkStale),
+            new NodeTypeBakeEntry("Cleared", BakeState.BytesMissing),
+            new NodeTypeBakeEntry("Broken", BakeState.PreviouslyBroken));
+
+        report.GateRelevant.Select(e => e.TypePath).Should().Equal("Stale", "Cleared");
+        report.Pending.Select(e => e.TypePath).Should().Equal("Stale", "Cleared", "Broken");
+        report.IsComplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AllBaked_IsComplete()
+    {
+        var report = Report(
+            new NodeTypeBakeEntry("A", BakeState.Baked),
+            new NodeTypeBakeEntry("B", BakeState.Baked));
+
+        report.IsComplete.Should().BeTrue();
+        report.Pending.Should().BeEmpty();
+        report.GateRelevant.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EmptyReport_IsComplete() =>
+        NodeTypeBakeReport.Empty(Live).IsComplete.Should().BeTrue();
+
+    [Fact]
+    public void Summary_NamesTheFrameworkAndTheOutstandingStates()
+    {
+        var summary = Report(
+            new NodeTypeBakeEntry("A", BakeState.Baked),
+            new NodeTypeBakeEntry("B", BakeState.BytesMissing),
+            new NodeTypeBakeEntry("C", BakeState.FrameworkStale)).Summary;
+
+        summary.Should().Contain("framework=03d6f01e");
+        summary.Should().Contain("total=3").And.Contain("baked=1").And.Contain("pending=2");
+        summary.Should().Contain("bytesmissing=1").And.Contain("frameworkstale=1");
+    }
+
+    // ---- Probe: against a store ---------------------------------------------------------------
+
+    /// <summary>The whole point: a wiped share re-bakes, even though every record still says Ok.</summary>
+    [Fact]
+    public void Probe_ClearedCache_ReportsEveryTypeAsBytesMissing()
+    {
+        var report = Probe(new FakeStore(), ("Store/Plugin", Healthy()), ("Edu/Course", Healthy(version: 12)));
+
+        report.IsComplete.Should().BeFalse();
+        report.Entries.Should().OnlyContain(e => e.State == BakeState.BytesMissing);
+        report.BytesMissing.Should().HaveCount(2);
+        report.GateRelevant.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Probe_WarmShare_ReportsComplete()
+    {
+        var store = new FakeStore();
+        store.Add("Store/Plugin", 845);
+        store.Add("Edu/Course", 12);
+
+        var report = Probe(store, ("Store/Plugin", Healthy()), ("Edu/Course", Healthy(version: 12)));
+
+        report.IsComplete.Should().BeTrue();
+        report.Entries.Should().OnlyContain(e => e.State == BakeState.Baked);
+    }
+
+    /// <summary>
+    /// An interrupted bake resumes: what is already on the share comes back Baked, and only the rest
+    /// is pending. This is what makes the sweep restartable without a checkpoint file.
+    /// </summary>
+    [Fact]
+    public void Probe_PartiallyBakedShare_ReportsOnlyTheRemainderAsPending()
+    {
+        var store = new FakeStore();
+        store.Add("Store/Plugin", 845);
+
+        var report = Probe(store, ("Store/Plugin", Healthy()), ("Edu/Course", Healthy(version: 12)));
+
+        report.IsComplete.Should().BeFalse();
+        report.Pending.Select(e => e.TypePath).Should().Equal("Edu/Course");
+    }
+
+    /// <summary>
+    /// A framework roll must not consult the store at all: the framework tag is part of the store key,
+    /// so a lookup is a guaranteed miss that tells us nothing and costs a round-trip per type.
+    /// </summary>
+    [Fact]
+    public void Probe_FrameworkRoll_ReportsStaleWithoutTouchingTheStore()
+    {
+        var store = new FakeStore();
+        var report = Probe(store, ("Store/Plugin", Healthy(Previous)), ("Edu/Course", Healthy(Previous, 12)));
+
+        report.Entries.Should().OnlyContain(e => e.State == BakeState.FrameworkStale);
+        store.Lookups.Should().BeEmpty();
+    }
+
+    /// <summary>Fail SAFE: an unreadable store means "bake it", never "trust the record and serve".</summary>
+    [Fact]
+    public void Probe_StoreThrows_TreatsTypeAsBytesMissing()
+    {
+        var report = Probe(new ThrowingStore(), ("Store/Plugin", Healthy()));
+
+        report.Entries.Should().ContainSingle()
+            .Which.State.Should().Be(BakeState.BytesMissing);
+        report.IsComplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Probe_NoDynamicTypes_IsCompleteAndProbesNothing()
+    {
+        var store = new FakeStore();
+        var report = NodeTypeBakeStatus
+            .Probe(new Dictionary<string, NodeTypeDefinition?>(), store, Live)
+            .Wait();
+
+        report.IsComplete.Should().BeTrue();
+        report.Entries.Should().BeEmpty();
+        store.Lookups.Should().BeEmpty();
+    }
+
+    /// <summary>Probes are sequential — a shared network volume must not see a fan-out at startup.</summary>
+    [Fact]
+    public void Probe_IsSequential()
+    {
+        var store = new FakeStore();
+        var report = Probe(store,
+            ("A/One", Healthy(version: 1)),
+            ("B/Two", Healthy(version: 2)),
+            ("C/Three", Healthy(version: 3)));
+
+        report.Entries.Should().HaveCount(3);
+        store.MaxConcurrent.Should().Be(1);
+    }
+
+    // ---- helpers ------------------------------------------------------------------------------
+
+    private static NodeTypeBakeReport Report(params NodeTypeBakeEntry[] entries) =>
+        new([.. entries], Live);
+
+    private static NodeTypeBakeReport Probe(
+        IAssemblyStore store, params (string Path, NodeTypeDefinition Definition)[] types) =>
+        NodeTypeBakeStatus
+            .Probe(types.ToDictionary(t => t.Path, t => (NodeTypeDefinition?)t.Definition), store, Live)
+            .Wait();
+
+    /// <summary>In-memory <see cref="IAssemblyStore"/> that records what was asked of it.</summary>
+    private sealed class FakeStore : IAssemblyStore
+    {
+        private readonly HashSet<string> present = [];
+        private int concurrent;
+
+        public List<string> Lookups { get; } = [];
+        public int MaxConcurrent { get; private set; }
+
+        public void Add(string nodeTypePath, long version) => present.Add(Key(nodeTypePath, version));
+
+        public IObservable<string?> TryGetAssemblyPath(string nodeTypePath, long version) =>
+            Observable.Defer(() =>
+            {
+                var key = Key(nodeTypePath, version);
+                Lookups.Add(key);
+                MaxConcurrent = Math.Max(MaxConcurrent, ++concurrent);
+                try
+                {
+                    return Observable.Return<string?>(present.Contains(key) ? $"/data/assembly-cache/{key}.dll" : null);
+                }
+                finally
+                {
+                    concurrent--;
+                }
+            });
+
+        public IObservable<string> Put(string nodeTypePath, long version, byte[] assemblyBytes, byte[]? pdbBytes)
+        {
+            present.Add(Key(nodeTypePath, version));
+            return Observable.Return($"/data/assembly-cache/{Key(nodeTypePath, version)}.dll");
+        }
+
+        private static string Key(string nodeTypePath, long version) =>
+            $"{nodeTypePath.Replace('/', '_')}_v{version}";
+    }
+
+    private sealed class ThrowingStore : IAssemblyStore
+    {
+        public IObservable<string?> TryGetAssemblyPath(string nodeTypePath, long version) =>
+            Observable.Throw<string?>(new InvalidOperationException("share unreachable"));
+
+        public IObservable<string> Put(string nodeTypePath, long version, byte[] assemblyBytes, byte[]? pdbBytes) =>
+            Observable.Return(string.Empty);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/NodeTypeBakeStatusTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeBakeStatusTest.cs
@@ -53,9 +53,21 @@ public class NodeTypeBakeStatusTest
             .Should().Be(BakeState.BytesMissing);
 
     [Fact]
-    public void Classify_AssemblyBuiltAgainstAnotherFramework_IsFrameworkStale() =>
-        NodeTypeBakeStatus.Classify(Healthy(Previous), storeHasBytes: true, Live)
+    public void Classify_AssemblyBuiltAgainstAnotherFramework_AndNoBytes_IsFrameworkStale() =>
+        NodeTypeBakeStatus.Classify(Healthy(Previous), storeHasBytes: false, Live)
             .Should().Be(BakeState.FrameworkStale);
+
+    /// <summary>
+    /// 🚨 Bytes win over the record. The store is keyed with the LIVE framework tag, so a hit means
+    /// "a build for THIS framework exists" no matter what the record says — another replica compiled
+    /// it and its write-back lagged, failed, or never happened. Rebuilding it would recompile
+    /// something already sitting on the shared volume, which is the exact waste this probe exists to
+    /// prevent.
+    /// </summary>
+    [Fact]
+    public void Classify_RecordNamesAnotherFramework_ButStoreHasOurBytes_IsBaked() =>
+        NodeTypeBakeStatus.Classify(Healthy(Previous), storeHasBytes: true, Live)
+            .Should().Be(BakeState.Baked);
 
     [Fact]
     public void Classify_NoAssemblyRecorded_IsNeverBuilt() =>
@@ -204,18 +216,32 @@ public class NodeTypeBakeStatusTest
         report.Pending.Select(e => e.TypePath).Should().Equal("Edu/Course");
     }
 
-    /// <summary>
-    /// A framework roll must not consult the store at all: the framework tag is part of the store key,
-    /// so a lookup is a guaranteed miss that tells us nothing and costs a round-trip per type.
-    /// </summary>
+    /// <summary>A framework roll with an empty share: everything is stale and must be rebuilt.</summary>
     [Fact]
-    public void Probe_FrameworkRoll_ReportsStaleWithoutTouchingTheStore()
+    public void Probe_FrameworkRoll_WithEmptyShare_ReportsStale()
     {
         var store = new FakeStore();
         var report = Probe(store, ("Store/Plugin", Healthy(Previous)), ("Edu/Course", Healthy(Previous, 12)));
 
         report.Entries.Should().OnlyContain(e => e.State == BakeState.FrameworkStale);
-        store.Lookups.Should().BeEmpty();
+        report.IsComplete.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The share is still consulted on a framework roll — that is what lets a pod inherit a build
+    /// another replica already produced for this framework, instead of repeating it because the
+    /// record has not caught up.
+    /// </summary>
+    [Fact]
+    public void Probe_FrameworkRoll_ButShareAlreadyWarm_ReportsComplete()
+    {
+        var store = new FakeStore();
+        store.Add("Store/Plugin", 845);
+
+        var report = Probe(store, ("Store/Plugin", Healthy(Previous)));
+
+        report.IsComplete.Should().BeTrue("bytes for the live framework outrank a lagging record");
+        store.Lookups.Should().NotBeEmpty("the share must actually be consulted");
     }
 
     /// <summary>Fail SAFE: an unreadable store means "bake it", never "trust the record and serve".</summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DynamicTypePreWarmerTest.cs
@@ -76,8 +76,12 @@ public class DynamicTypePreWarmerTest(ITestOutputHelper output) : MonolithMeshTe
         Output.WriteLine($"Good  → {good.Status} {good.Detail}");
         Output.WriteLine($"Broken → {broken.Status} {broken.Detail}");
 
-        good.Status.Should().Be(PreWarmStatus.Compiled,
-            "the pre-warmer must drive a healthy dynamic type to a usable compiled build");
+        // ReachedUsableBuild, not == Compiled: the type is equally fine whether THIS sweep compiled
+        // it or found it already on the shared assembly store (AlreadyBaked) — which is exactly what
+        // happens when the create-time compile landed before the sweep reached it. Asserting the
+        // status verbatim would make this test a race against the store probe.
+        good.ReachedUsableBuild.Should().BeTrue(
+            "the pre-warmer must leave a healthy dynamic type with a usable build");
         broken.Status.Should().Be(PreWarmStatus.CompileError,
             "a non-compiling type surfaces a bounded CompileError — never a hang, never blocking the good type");
     }
@@ -193,9 +197,9 @@ public class DynamicTypePreWarmerTest(ITestOutputHelper output) : MonolithMeshTe
         blocked.Detail.Should().Contain(upstream,
             "the outcome must NAME the blocker — 'something upstream failed' is not actionable");
 
-        outcomes.Single(o => o.TypePath == unrelated).Status
-            .Should().Be(PreWarmStatus.Compiled,
+        outcomes.Single(o => o.TypePath == unrelated).ReachedUsableBuild
+            .Should().BeTrue(
                 "a broken type contains its blast radius to its own dependents; unrelated types "
-                + "must still be warmed");
+                + "must still end up with a usable build");
     }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeGateStateTest.cs
@@ -1,0 +1,130 @@
+using MeshWeaver.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The readiness gate's state machine — "fail before prod, not in prod".
+///
+/// <para>Two rules carry the whole design, and both are here because getting either wrong turns a
+/// safety feature into an outage:</para>
+/// <list type="number">
+///   <item><b>Only a REGRESSION gates.</b> A type that was already broken before this image failing
+///     again is pre-existing damage; gating on it would let one abandoned NodeType freeze every
+///     future deploy.</item>
+///   <item><b>NotStarted is HEALTHY.</b> Gating on a condition nobody is measuring would black-hole
+///     a pod on a config mistake. The gate withholds readiness only for what it actively measures.</item>
+/// </list>
+/// </summary>
+public class NodeTypeBakeGateStateTest
+{
+    private static PreWarmOutcome Failed(string path, bool wasHealthy) =>
+        new(path, PreWarmStatus.CompileError, "boom") { WasHealthyBeforeBake = wasHealthy };
+
+    [Fact]
+    public void FreshState_IsNotStarted() =>
+        new NodeTypeBakeGateState().Phase.Should().Be(BakePhase.NotStarted);
+
+    [Fact]
+    public void MarkRunning_MovesToRunning()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("enumerating");
+
+        state.Phase.Should().Be(BakePhase.Running);
+        state.Detail.Should().Be("enumerating");
+    }
+
+    [Fact]
+    public void CleanRun_CompletesHealthy()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(new PreWarmOutcome("A", PreWarmStatus.Compiled));
+        state.MarkOutcome(new PreWarmOutcome("B", PreWarmStatus.AlreadyBaked));
+        state.MarkComplete("done");
+
+        state.Phase.Should().Be(BakePhase.Complete);
+        state.Regressions.Should().BeEmpty();
+    }
+
+    /// <summary>A type that was working and now is not — the one thing that may stall a rollout.</summary>
+    [Fact]
+    public void PreviouslyHealthyTypeThatFails_Regresses()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(Failed("Store/Plugin", wasHealthy: true));
+
+        state.Phase.Should().Be(BakePhase.Regressed);
+        state.Regressions.Keys.Should().Contain("Store/Plugin");
+    }
+
+    /// <summary>
+    /// 🚨 The deploy-freeze guard. A NodeType already sitting at Error before this image is broken in
+    /// production right now; the new image did not break it. If this gated, every subsequent rollout
+    /// would be blocked by it — and nobody would find out until they urgently needed to deploy.
+    /// </summary>
+    [Fact]
+    public void AlreadyBrokenTypeThatFailsAgain_DoesNotGate()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(Failed("Abandoned/Type", wasHealthy: false));
+        state.MarkComplete("done");
+
+        state.Phase.Should().Be(BakePhase.Complete);
+        state.Regressions.Should().BeEmpty();
+    }
+
+    /// <summary>Completion is not absolution: finishing the sweep must not clear a recorded regression.</summary>
+    [Fact]
+    public void MarkComplete_DoesNotClearARegression()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(Failed("Store/Plugin", wasHealthy: true));
+        state.MarkComplete("baked in 00:12:00");
+
+        state.Phase.Should().Be(BakePhase.Regressed);
+        state.Detail.Should().Contain("Store/Plugin");
+    }
+
+    /// <summary>A regression among successes still gates — one bad type is enough.</summary>
+    [Fact]
+    public void OneRegressionAmongSuccesses_StillGates()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(new PreWarmOutcome("Good", PreWarmStatus.Compiled));
+        state.MarkOutcome(Failed("Bad", wasHealthy: true));
+        state.MarkOutcome(new PreWarmOutcome("AlsoGood", PreWarmStatus.AlreadyBaked));
+        state.MarkComplete("done");
+
+        state.Phase.Should().Be(BakePhase.Regressed);
+        state.Regressions.Keys.Should().Equal("Bad");
+    }
+
+    /// <summary>
+    /// A type SKIPPED because its upstream failed is itself a failure to reach a usable build, so it
+    /// counts — otherwise a broken dependency would gate while its dependents slipped through.
+    /// </summary>
+    [Fact]
+    public void UpstreamFailedOnAPreviouslyHealthyType_AlsoGates()
+    {
+        var state = new NodeTypeBakeGateState();
+        state.MarkRunning("go");
+        state.MarkOutcome(new PreWarmOutcome("Dependent", PreWarmStatus.UpstreamFailed, "blocked by Up")
+        {
+            WasHealthyBeforeBake = true
+        });
+
+        state.Phase.Should().Be(BakePhase.Regressed);
+        state.Regressions.Keys.Should().Contain("Dependent");
+    }
+
+    /// <summary>Outcomes default to "was healthy" so a caller that never sets the flag fails safe.</summary>
+    [Fact]
+    public void OutcomeWasHealthyBeforeBake_DefaultsToTrue() =>
+        new PreWarmOutcome("A", PreWarmStatus.Compiled).WasHealthyBeforeBake.Should().BeTrue();
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeLeaseTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeBakeLeaseTest.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using MeshWeaver.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The single-baker lease. Without it, every replica on a new image finds the same framework-stale
+/// cache and starts the same sweep into the same volume — concurrent cold compiles of one NodeType,
+/// which is exactly the storm the sequential sweep exists to prevent.
+///
+/// <para>Three properties matter, and each has a failure mode worse than the problem it solves:
+/// mutual exclusion (or the storm returns), stealability (or one dead pod wedges the fleet forever),
+/// and fail-open (or a volume blip stops the fleet compiling at all).</para>
+/// </summary>
+public class NodeTypeBakeLeaseTest : IDisposable
+{
+    private readonly string dir = Path.Combine(
+        Path.GetTempPath(), $"mw-bake-lease-{Guid.NewGuid():N}");
+
+    private const string Framework = "03d6f01eb6654e199d31fc59668d7b62";
+
+    public NodeTypeBakeLeaseTest() => Directory.CreateDirectory(dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Exactly one holder — the property the whole class exists for.</summary>
+    [Fact]
+    public void SecondPod_DoesNotGetTheLease()
+    {
+        using var first = NodeTypeBakeLease.TryAcquire(dir, Framework, "pod-a");
+        var second = NodeTypeBakeLease.TryAcquire(dir, Framework, "pod-b");
+
+        first.Should().NotBeNull("the first pod to arrive bakes");
+        second.Should().BeNull("a second pod must FOLLOW, never bake concurrently");
+    }
+
+    /// <summary>Releasing hands the bake straight to the next pod — no waiting out the stale window.</summary>
+    [Fact]
+    public void ReleasingTheLease_LetsTheNextPodTakeIt()
+    {
+        var first = NodeTypeBakeLease.TryAcquire(dir, Framework, "pod-a");
+        first.Should().NotBeNull();
+        first!.Dispose();
+
+        using var second = NodeTypeBakeLease.TryAcquire(dir, Framework, "pod-b");
+        second.Should().NotBeNull("a released lease is immediately available");
+    }
+
+    /// <summary>
+    /// 🚨 The fleet-wedge guard. A pod that dies mid-bake cannot hold the bake hostage: once its
+    /// heartbeat goes stale another pod takes over. Without this, one crash means nothing ever
+    /// compiles again and every subsequent rollout stalls on a gate that can never go green.
+    /// </summary>
+    [Fact]
+    public void StaleLease_IsStolen()
+    {
+        using var dead = NodeTypeBakeLease.TryAcquire(dir, Framework, "pod-that-dies");
+        dead.Should().NotBeNull();
+
+        // Age the heartbeat past the staleness limit, as a crashed holder's would.
+        var path = NodeTypeBakeLease.PathFor(dir, Framework);
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow - NodeTypeBakeLease.StaleAfter - TimeSpan.FromMinutes(1));
+
+        using var successor = NodeTypeBakeLease.TryAcquire(dir, Framework, "pod-b");
+        successor.Should().NotBeNull("a lease whose holder stopped heartbeating must be stealable");
+    }
+
+    /// <summary>
+    /// A live holder's lease is NOT stolen just because the bake is long. Stealing early would put
+    /// two pods on the same compile — the failure this prevents, reintroduced.
+    /// </summary>
+    [Fact]
+    public void FreshLease_IsNotStolen()
+    {
+        using var holder = NodeTypeBakeLease.TryAcquire(dir, Framework, "pod-a");
+        holder.Should().NotBeNull();
+
+        var path = NodeTypeBakeLease.PathFor(dir, Framework);
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow - NodeTypeBakeLease.StaleAfter + TimeSpan.FromMinutes(2));
+
+        NodeTypeBakeLease.TryAcquire(dir, Framework, "pod-b")
+            .Should().BeNull("a holder that is still heartbeating keeps the bake");
+    }
+
+    /// <summary>
+    /// Keyed per framework: a bake-ahead pod on a NEW image and the live pods on the OLD one write
+    /// different files and must not block each other. Only same-image replicas contend.
+    /// </summary>
+    [Fact]
+    public void DifferentFrameworkVersions_DoNotContend()
+    {
+        using var oldImage = NodeTypeBakeLease.TryAcquire(dir, Framework, "pod-old");
+        using var newImage = NodeTypeBakeLease.TryAcquire(dir, "b7e11c9a44d24f0d8e2a5c31f9048ab6", "pod-new");
+
+        oldImage.Should().NotBeNull();
+        newImage.Should().NotBeNull("a different image bakes different files — it must not be blocked");
+    }
+
+    /// <summary>
+    /// Fail OPEN. An unusable coordination directory must still let the pod bake: duplicate work is a
+    /// cost, a fleet that never compiles is an outage.
+    /// </summary>
+    [Fact]
+    public void UnusableDirectory_StillAllowsBaking()
+    {
+        // A FILE where the lease directory should be — CreateDirectory and the lease write both fail.
+        var blocked = Path.Combine(dir, "not-a-directory");
+        File.WriteAllText(blocked, "x");
+
+        using var lease = NodeTypeBakeLease.TryAcquire(blocked, Framework, "pod-a");
+        lease.Should().NotBeNull("coordination failure must never deny the bake");
+    }
+
+    [Fact]
+    public void HeartbeatInterval_IsWellInsideTheStaleWindow() =>
+        NodeTypeBakeLease.HeartbeatInterval.Should()
+            .BeLessThan(NodeTypeBakeLease.StaleAfter / 2,
+                "a single missed beat under load must not hand the bake to a second pod while the "
+                + "first is still compiling");
+
+    [Fact]
+    public void DisposingTwice_IsHarmless()
+    {
+        var lease = NodeTypeBakeLease.TryAcquire(dir, Framework, "pod-a");
+        lease.Should().NotBeNull();
+        lease!.Dispose();
+        lease.Dispose();
+    }
+}


### PR DESCRIPTION
## The problem

Every image roll changes Graph's MVID. `FileSystemAssemblyStore` bakes `FrameworkVersion[..8]` into every filename **and** the lookup glob, so a new image misses the whole assembly cache **by design** (ABI safety — it's what prevents the `BadImageFormatException` wedge). The shared `/data/assembly-cache` PVC buys cross-pod and cross-restart reuse *on the same image*; it does nothing for a deploy.

Today that guaranteed miss is paid **lazily, unordered, on user requests, after the pod is already taking traffic**. That's the compile churn behind the "did not settle" overlays.

## What this does

**1. Decide what to build by probing the store, not the record.**

`HasUsableBuild` is deliberately a pure record check — its own doc says *"no store probe, no `File.Exists`"*. Right on the hot path; wrong as a source of truth. Clear or remount `/data/assembly-cache` and every NodeType still claims `Ok` with its bytes gone. Nothing re-drives a compile; the miss surfaces later, one instance at a time, at activation (with a sticky default-config fallback if it exhausts retries).

`NodeTypeBakeStatus` asks the store instead. Level-triggered on reality rather than on history, which buys three things at once: a wiped share re-bakes itself, an interrupted bake **resumes**, and a second replica inherits the first one's work. No checkpoint file, no marker that can lie.

**2. The sweep consumes the report.**

Types already on the share are `AlreadyBaked` and never activated — that's what turns a re-run from hours of Roslyn into a directory listing.

A type whose **bytes** are missing cannot be warmed by activation alone: every existing kickoff is keyed on the record (first-build needs null fields, recovery needs `Compiling`, framework-stale needs a mismatch), and in this state the record is pristine. `WarmOne` would have reported `Compiled` instantly **over an empty share** — the one outcome a bake gate must never produce. `RebuildMissingBytes` drives it properly: flip to `Pending`, then wait for a compile demonstrably newer than the one observed before the flip. Matching on status alone would accept the replayed pre-existing `Ok`.

**3. An opt-in readiness gate — "fail before prod, not in prod".**

The chart already keeps the old pod serving until the new one passes its `startupProbe` on `/health` (`maxSurge: 1`, `maxUnavailable: 0`). Gating `/health` on the bake turns a NodeType that no longer compiles from a production incident into a **stalled rollout**: the new pod never takes traffic, the previous image keeps serving.

Two safety rules, both tested:
- **Fails closed on a regression, open on "not running".** A type already broken before this image cannot gate — otherwise one abandoned NodeType freezes every future deploy, discovered when you urgently need to ship. A gate registered while the sweep is disabled reports healthy rather than black-holing the pod on a config mistake.
- **Never tagged `live`.** A long bake is not a wedged process; failing liveness would have Kubernetes restart the pod mid-bake.

## Deployment

Chart plumbing only — `PreWarm__DynamicTypes` and `PreWarm__GateReadiness` both default `false`, so **no behaviour change until someone flips them**. `probes.startup` is now configurable because the gate is unusable without it: a cold compile is ~90 s per NodeType and the sweep is sequential, so 60-100 types needs 2-3 **hours** of startup budget. The current default (5 × 60 = 5 min) would kill the pod mid-bake on every attempt. Suggested paired setting is in the values comment.

I'd enable this on one env with someone watching rather than land it on by default.

## Tests

- `NodeTypeBakeStatusTest` — 24 cases. Classification is pure, so every state is testable without a fixture, including bytes disappearing under a healthy record and a store that throws (fails safe → rebuild).
- `NodeTypeBakeGateStateTest` — 8 cases pinning the regression-vs-pre-existing rule and "completion is not absolution".
- `DynamicTypePreWarmerTest` — existing 3 still green; two assertions relaxed from `== Compiled` to `ReachedUsableBuild`, since a type found already on the share is equally fine and asserting the status verbatim made the test a race against the probe.

## Not in this PR

The bake-ahead pod (warm the new tag's cache while the old image still serves, then gate the rollout on the result) — safe to build separately because the FrameworkTag is in the filename, so old- and new-image assemblies coexist in the share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)