### PR TITLE
Make error-path logging unable to escalate; surface the swallowed own-node setup failures

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -107,7 +107,7 @@ tempting to fix that and declare victory. Discipline:
 
 If a bare `catch {}` wraps the failing region, nothing is logged before the crash. That is not an
 accident of the dump — it is a defect in the code. Error paths must log (see
-[ErrorPropagationAndWedges](../Architecture/ErrorPropagationAndWedges)), and the logging itself must
+[ErrorPropagationAndWedges](../ErrorPropagationAndWedges)), and the logging itself must
 be unable to escalate: resolving a logger can throw `ObjectDisposedException` on a disposing
 container, so a diagnostic emitted from inside a `catch` or an Rx `onError` can convert a handled
 fault into an unhandled one. Route such emissions through a guarded helper whose single empty catch
@@ -115,8 +115,8 @@ swallows only the *logging* failure.
 
 ## Related
 
-- [DebuggingMessageFlow](../Architecture/DebuggingMessageFlow) — for hangs and lost messages (a
+- [DebuggingMessageFlow](../DebuggingMessageFlow) — for hangs and lost messages (a
   timeout, not a signal).
-- [DebuggingDisposalAndLeaks](../Architecture/DebuggingDisposalAndLeaks) — teardown stragglers and
+- [DebuggingDisposalAndLeaks](../DebuggingDisposalAndLeaks) — teardown stragglers and
   retention.
-- [WritingTests](../Architecture/WritingTests) — why a flake is a real race and re-running hides it.
+- [WritingTests](../WritingTests) — why a flake is a real race and re-running hides it.

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -1,0 +1,122 @@
+---
+Name: Debugging Native Crashes (core dumps)
+Category: Architecture
+Description: How to get and read a CI core dump when a test host dies on a signal (exit=139 SIGSEGV, exit=134 abort) instead of failing a test.
+Icon: Bug
+---
+
+# Debugging native crashes (core dumps)
+
+A test host that dies on a **signal** does not fail a test — it fails the *shard*. There is no
+assertion, no stack in the trx, often no trx at all. CI reds it via the exit-marker gate:
+
+```
+[CI] MeshWeaver.FutuRe.Test exit=139
+##[error]Shard 3: a test host exited non-zero (failure, crash, or timeout kill):
+```
+
+| marker | meaning |
+|---|---|
+| `exit=139` | SIGSEGV (128+11) — segmentation fault |
+| `exit=134` | SIGABRT (128+6) — runtime abort / failfast |
+| `exit=124` | **not** a crash — the wall-clock cap (`timeout`) killed a hang or a too-slow run |
+
+**The crashing project name is meaningful; the crashing TEST name usually is not.** The signal lands
+wherever the process happened to be, which is frequently not where the defect is.
+
+## The dump is already being collected
+
+`dotnet-test.yml` sets, for every shard:
+
+```yaml
+DOTNET_DbgEnableMiniDump: 1
+DOTNET_DbgMiniDumpType: 2          # heap dump — required for `verifyheap` / object inspection
+DOTNET_DbgMiniDumpName: /tmp/coredumps/%e-%p.dmp
+```
+
+and the collect + upload steps are `if: always()`, so a dump survives even when the shard is killed.
+It arrives inside the **`testResults-shard<N>`** artifact under `collected-logs/dotnet-<pid>.dmp`,
+alongside `_meshweaver-test-trace.log` and `_meshweaver-memory-delta.log`. **Retention is 15 days** —
+pull it before it expires.
+
+```bash
+# find the shard artifact (the crashing shard's is the big one — the others are ~0MB)
+gh api repos/Systemorph/MeshWeaver/actions/runs/<RUN_ID>/artifacts \
+  --jq '.artifacts[] | select(.name|test("shard")) | "\(.id)  \(.name)  \(.size_in_bytes/1048576|floor)MB  expired=\(.expired)"'
+
+mkdir -p "$HOME/segv-dump" && cd "$HOME/segv-dump"
+gh api repos/Systemorph/MeshWeaver/actions/artifacts/<ARTIFACT_ID>/zip > shard.zip
+unzip -q shard.zip -d shard && find shard -name '*.dmp'
+```
+
+## 🚨 You cannot open a Linux dump on macOS
+
+`dotnet-dump` on macOS **cannot** read a Linux core dump. Analyse it in a **linux/amd64** container
+(CI runners are x64; Apple-silicon Docker is arm64, so `--platform linux/amd64` and emulation are
+required — it is slow but it works).
+
+**Stage the dump under `$HOME`, not `/private/tmp`** — Colima does not mount `/private/tmp`, so a
+dump left in the scratch directory is invisible inside the container.
+
+```bash
+docker run --rm --platform linux/amd64 -v "$HOME/segv-dump/shard/collected-logs:/dumps" \
+  mcr.microsoft.com/dotnet/sdk:10.0 bash -c '
+    curl -sL https://aka.ms/dotnet-dump/linux-x64 -o /tmp/dotnet-dump && chmod +x /tmp/dotnet-dump
+    /tmp/dotnet-dump analyze /dumps/<name>.dmp -c "<command>" -c "exit"
+  '
+```
+
+## The command sequence that actually answers the question
+
+Run these in order; each one kills off a class of hypothesis.
+
+1. **`clrmodules`** — *confirm you have the right process first.* Grep for the test assembly
+   (`MeshWeaver.<X>.Test.dll`). Some dumps are produced deliberately (a DAC/unload probe test), so
+   check you are not analysing an intentional crash. Also count copies of a given assembly: **more
+   than one copy means duplicate statics across AssemblyLoadContexts**, which silently defeats any
+   process-wide lock.
+2. **`clrthreads`** — find the faulting thread. It is usually the one in **`Cooperative`** GC mode
+   and/or flagged **`(GC)`**; the `Exception` column is typically empty for a signal death.
+3. **`clrstack -all`** — every managed stack in one pass. Grep it for the suspect frames, and to test
+   *concurrency* hypotheses: if only one thread is inside the library you suspect of being torn by
+   concurrent access, a locking fix is not the answer.
+4. **`setthread <DBG-id>` + `clrstack -f`** — the faulting thread interleaved with native frames and
+   module names. This is the definitive stack.
+5. **`verifyheap`** — clean output means **no GC heap corruption**, which distinguishes "this code is
+   the culprit" from "this code is an innocent victim of corruption elsewhere". Requires
+   `DbgMiniDumpType: 2` (already set).
+6. **`eeheap -gc`** — heap size, to rule in/out memory pressure. Cross-check against
+   `_meshweaver-memory-delta.log` in the same artifact for the deltas around the crash.
+
+## Reading the result honestly
+
+The trap in this class of bug is confirmation: the stack shows *a* plausible culprit and it is
+tempting to fix that and declare victory. Discipline:
+
+- A stack tells you **where** the process died, not **why**. Use steps 5–6 to establish culprit vs
+  victim before proposing a fix.
+- **Check which phase you are in.** Read the bottom of the stack, not the top. `MeshBuilder.BuildHub`
+  means construction/fixture-init; a dispose cascade means teardown. Getting this wrong sends fixes
+  at the wrong guard — the FutuRe SIGSEGV was framed as a teardown race for weeks while the dump
+  showed it crashing during hub *construction*.
+- A method's **name** is not evidence of the phase. `SubscribeToOwnDeletion` is a
+  `.WithInitialization(...)` hook: it names what the subscription later watches for, not when it runs.
+- If a hypothesis survives, write down what would disprove it, then go and check that.
+
+## Why the dump may have no precursor in the logs
+
+If a bare `catch {}` wraps the failing region, nothing is logged before the crash. That is not an
+accident of the dump — it is a defect in the code. Error paths must log (see
+[ErrorPropagationAndWedges](../Architecture/ErrorPropagationAndWedges)), and the logging itself must
+be unable to escalate: resolving a logger can throw `ObjectDisposedException` on a disposing
+container, so a diagnostic emitted from inside a `catch` or an Rx `onError` can convert a handled
+fault into an unhandled one. Route such emissions through a guarded helper whose single empty catch
+swallows only the *logging* failure.
+
+## Related
+
+- [DebuggingMessageFlow](../Architecture/DebuggingMessageFlow) — for hangs and lost messages (a
+  timeout, not a signal).
+- [DebuggingDisposalAndLeaks](../Architecture/DebuggingDisposalAndLeaks) — teardown stragglers and
+  retention.
+- [WritingTests](../Architecture/WritingTests) — why a flake is a real race and re-running hides it.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -371,11 +371,9 @@ public static class MeshDataSourceExtensions
                         // Fail closed: a throwing validator is a denial, not a pass-through.
                         // Without this handler the fault was unobserved and the caller sat
                         // on the request timeout instead of getting a clean error response.
-                        hub.ServiceProvider.GetService<ILoggerFactory>()
-                            ?.CreateLogger(typeof(MeshDataSource))
-                            .LogWarning(ex,
-                                "Read validator faulted for {MessageType} on {Hub} — failing closed",
-                                delivery.Message.GetType().Name, hub.Address);
+                        TryLogWarning(hub, ex,
+                            "Read validator faulted for {MessageType} on {Hub} — failing closed",
+                            delivery.Message.GetType().Name, hub.Address);
                         hub.Post(
                             new GetDataResponse(null, 0)
                             {
@@ -390,11 +388,9 @@ public static class MeshDataSourceExtensions
                             // otherwise vanish unobserved inside the validator pipeline.
                             next.Invoke(delivery, ct).Subscribe(
                                 _ => { },
-                                ex => hub.ServiceProvider.GetService<ILoggerFactory>()
-                                    ?.CreateLogger(typeof(MeshDataSource))
-                                    .LogError(ex,
-                                        "Downstream pipeline faulted after validator pass for {MessageType} on {Hub}",
-                                        delivery.Message.GetType().Name, hub.Address));
+                                ex => TryLogError(hub, ex,
+                                    "Downstream pipeline faulted after validator pass for {MessageType} on {Hub}",
+                                    delivery.Message.GetType().Name, hub.Address));
                         else
                             hub.Post(
                                 new GetDataResponse(null, 0)
@@ -696,6 +692,52 @@ public static class MeshDataSourceExtensions
             .FirstOrDefault(n => !n.IsDefinitionOnly
                 && string.Equals(n.Path, hubPath, StringComparison.OrdinalIgnoreCase));
 
+    /// <summary>
+    /// Emits a diagnostic that can NEVER take down its caller — the ONLY sanctioned way to log from
+    /// an error path in this file (a <c>catch</c> body or an Rx <c>onError</c> handler).
+    ///
+    /// <para>🚨 Why the empty catch here is legitimate, and why it is the only one allowed:
+    /// resolving and using a logger is itself fallible. <c>GetService&lt;ILoggerFactory&gt;()</c> and
+    /// <c>CreateLogger(...)</c> both throw <c>ObjectDisposedException</c> once the container is
+    /// disposing, and a provider can throw on write if the sink is gone. On an error path the
+    /// caller is ALREADY handling a failure, so a throwing logger converts a handled fault into an
+    /// unhandled one — thrown out of a catch block or out of an Rx onError, where nothing is left
+    /// to observe it. During hub teardown or a re-entrant hub build (see SubscribeToOwnDeletion)
+    /// that is precisely when logging is least available and a secondary throw is most damaging.</para>
+    ///
+    /// <para>This swallow hides ONLY a logging failure — never the original error, which the caller
+    /// has already dealt with. It is deliberately the single place that risk is absorbed, instead of
+    /// an empty catch at every call site.</para>
+    /// </summary>
+    private static void TryLogWarning(IMessageHub hub, Exception error, string message, params object?[] args)
+    {
+        try
+        {
+            hub.ServiceProvider.GetService<ILoggerFactory>()
+                ?.CreateLogger(typeof(MeshDataSource))
+                .LogWarning(error, message, args);
+        }
+        catch
+        {
+            // Intentionally empty — see the note above. Logging must not be able to escalate.
+        }
+    }
+
+    /// <summary>Error-severity twin of <see cref="TryLogWarning"/>; same never-escalate contract.</summary>
+    private static void TryLogError(IMessageHub hub, Exception error, string message, params object?[] args)
+    {
+        try
+        {
+            hub.ServiceProvider.GetService<ILoggerFactory>()
+                ?.CreateLogger(typeof(MeshDataSource))
+                .LogError(error, message, args);
+        }
+        catch
+        {
+            // Intentionally empty — see TryLogWarning.
+        }
+    }
+
     private static void SubscribeToOwnDeletion(IMessageHub hub)
     {
         var cache = hub.ServiceProvider.GetService<OwnNodeCache>();
@@ -921,10 +963,24 @@ public static class MeshDataSourceExtensions
                 hub.RegisterForDisposal(sourcesSub);
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Workspace has no MeshNodeReference reducer (e.g., hub without
-            // MeshDataSource) — leave Current = null; pipeline falls through.
+            // The EXPECTED case is a workspace with no MeshNodeReference reducer (a hub without
+            // MeshDataSource) — leave Current = null and let the pipeline fall through.
+            //
+            // 🚨 It must still be VISIBLE. This block guards the whole own-node subscription setup
+            // above, and that setup is not cheap: `ownStream.Subscribe(...)` synchronously
+            // materialises the reduced stream, which can lazily construct ANOTHER hub
+            // (HostedHubsCollection.CreateHub → MessageHub..ctor → full type registration). A bare
+            // `catch {}` therefore swallowed every failure of a re-entrant hub build during THIS
+            // hub's initialization and left the hub running in a partial state with no breadcrumb —
+            // which is why the FutuRe.Test SIGSEGV (exit=139, issue #613) has no precursor in any
+            // log. Logging here does not change control flow; it just stops the failure being
+            // invisible. If the next dump is preceded by this line, the crash has a cause we can
+            // name instead of a stack we have to guess from.
+            TryLogWarning(hub, ex,
+                "Own-node subscription setup failed on {Hub} — OwnNodeCache stays empty and the "
+                + "persistence sampler is not installed for this hub", hub.Address);
         }
 
         // Per-node hub reconciles its own cached state when the mesh hub
@@ -1004,15 +1060,17 @@ public static class MeshDataSourceExtensions
                                     : newNode)
                             .Subscribe(
                                 _ => { },
-                                ex => hub.ServiceProvider.GetService<ILoggerFactory>()
-                                    ?.CreateLogger(typeof(MeshDataSource))
-                                    .LogWarning(ex,
-                                        "Own-node refresh from change notification failed on {Hub}",
-                                        hub.Address));
+                                ex => TryLogWarning(hub, ex,
+                                    "Own-node refresh from change notification failed on {Hub}",
+                                    hub.Address));
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        /* workspace has no MeshNodeReference reducer */
+                        // Expected: workspace has no MeshNodeReference reducer. Logged for the same
+                        // reason as the setup guard above — this path also reaches stream
+                        // materialisation, so a silent swallow here hides a real fault.
+                        TryLogWarning(hub, ex,
+                            "Own-node change-notification reconcile failed on {Hub}", hub.Address);
                     }
                     return;
             }

--- a/src/MeshWeaver.Messaging.Hub/Serialization/TypeDefinition.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/TypeDefinition.cs
@@ -35,24 +35,8 @@ public record TypeDefinition : ITypeDefinition
             Icon = new Icon(iconAttribute.Provider, iconAttribute.Id);
 
         Key = new(() => keyFunctionBuilder.GetKeyFunction(Type)!);
-
-        // 🚨 LAZY, and it must stay lazy — this is the FutuRe.Test teardown SIGSEGV (exit=139).
-        // XmlDocs.Summary reflects into the type's assembly XML documentation. Constructing a
-        // TypeDefinition happens for EVERY type registered on EVERY hub, i.e. squarely on the hub
-        // CONSTRUCTION path (MessageHub.ctor → Register → WithTypeAndRelatedTypesFor →
-        // TypeRegistry.WithType → here). Compiled scope NodeTypes live in COLLECTIBLE ALCs, so when
-        // one is unloading while another hub is being built, that read walks metadata for an
-        // assembly whose image is going away and the process dies with SIGSEGV inside
-        // Namotion.Reflection (dump: ToXmlDocsContent → StringBuilder.ToString on the GC thread).
-        //
-        // HostedHubsCollection.CloseCreation() does NOT cover this: it is a TEARDOWN guard, flipped
-        // when the owning hub's disposal begins. The crash reproduces on a BUILD path
-        // (MeshBuilder.BuildHub → … → HostedHubsCollection.CreateHub), where creation is legitimate
-        // and refusing it would be wrong. Keeping the XML-docs read off the construction path is
-        // what actually closes the window.
-        //
-        // Description is pure display metadata with a single consumer, so deferring costs nothing.
-        description = new(() => XmlDocs.Summary(Type));
+        
+        Description = XmlDocs.Summary(Type);
     }
 
     /// <summary>
@@ -84,19 +68,8 @@ public record TypeDefinition : ITypeDefinition
     public int? Order { get; }
     /// <summary>The display group name, from <see cref="DisplayAttribute"/>, if specified.</summary>
     public string? GroupName { get; }
-    /// <summary>
-    /// The description, taken from the type's XML documentation summary. Resolved on FIRST READ,
-    /// never during construction — see the note in the constructor (FutuRe.Test teardown SIGSEGV).
-    /// </summary>
-    public string Description
-    {
-        get => description.Value;
-        init => description = new(value);
-    }
-
-    // Backing store. `init` accepts an already-materialised value (record `with` / deserialization),
-    // so an explicitly-supplied Description still wins and is never recomputed from XML docs.
-    private readonly Lazy<string> description = new(string.Empty);
+    /// <summary>The description, taken from the type's XML documentation summary.</summary>
+    public string Description { get; init; }
 
     /// <summary>
     /// Returns the key identifying the given instance using the type's configured key function.

--- a/src/MeshWeaver.Messaging.Hub/Serialization/TypeDefinition.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/TypeDefinition.cs
@@ -35,8 +35,24 @@ public record TypeDefinition : ITypeDefinition
             Icon = new Icon(iconAttribute.Provider, iconAttribute.Id);
 
         Key = new(() => keyFunctionBuilder.GetKeyFunction(Type)!);
-        
-        Description = XmlDocs.Summary(Type);
+
+        // 🚨 LAZY, and it must stay lazy — this is the FutuRe.Test teardown SIGSEGV (exit=139).
+        // XmlDocs.Summary reflects into the type's assembly XML documentation. Constructing a
+        // TypeDefinition happens for EVERY type registered on EVERY hub, i.e. squarely on the hub
+        // CONSTRUCTION path (MessageHub.ctor → Register → WithTypeAndRelatedTypesFor →
+        // TypeRegistry.WithType → here). Compiled scope NodeTypes live in COLLECTIBLE ALCs, so when
+        // one is unloading while another hub is being built, that read walks metadata for an
+        // assembly whose image is going away and the process dies with SIGSEGV inside
+        // Namotion.Reflection (dump: ToXmlDocsContent → StringBuilder.ToString on the GC thread).
+        //
+        // HostedHubsCollection.CloseCreation() does NOT cover this: it is a TEARDOWN guard, flipped
+        // when the owning hub's disposal begins. The crash reproduces on a BUILD path
+        // (MeshBuilder.BuildHub → … → HostedHubsCollection.CreateHub), where creation is legitimate
+        // and refusing it would be wrong. Keeping the XML-docs read off the construction path is
+        // what actually closes the window.
+        //
+        // Description is pure display metadata with a single consumer, so deferring costs nothing.
+        description = new(() => XmlDocs.Summary(Type));
     }
 
     /// <summary>
@@ -68,8 +84,19 @@ public record TypeDefinition : ITypeDefinition
     public int? Order { get; }
     /// <summary>The display group name, from <see cref="DisplayAttribute"/>, if specified.</summary>
     public string? GroupName { get; }
-    /// <summary>The description, taken from the type's XML documentation summary.</summary>
-    public string Description { get; init; }
+    /// <summary>
+    /// The description, taken from the type's XML documentation summary. Resolved on FIRST READ,
+    /// never during construction — see the note in the constructor (FutuRe.Test teardown SIGSEGV).
+    /// </summary>
+    public string Description
+    {
+        get => description.Value;
+        init => description = new(value);
+    }
+
+    // Backing store. `init` accepts an already-materialised value (record `with` / deserialization),
+    // so an explicitly-supplied Description still wins and is never recomputed from XML docs.
+    private readonly Lazy<string> description = new(string.Empty);
 
     /// <summary>
     /// Returns the key identifying the given instance using the type's configured key function.


### PR DESCRIPTION
> **This does not fix the FutuRe.Test SIGSEGV.** It is hardening plus the instrumentation needed to diagnose it. The four hypotheses the core dump has already ruled out are recorded below so nobody re-runs them.

## What the dump actually says

Analysed `dotnet-2910.dmp` (run 30330569833, shard 3) in a linux/amd64 container. Confirmed it is the right process — `MeshWeaver.FutuRe.Test.dll` is loaded and ClrMD is absent, so it is not the deliberate `ClrMdDacUnloadCrashTest` dump.

Faulting thread `0xb76` — the **only** thread in `Cooperative` mode, flagged `(GC)`:

```
MeshBuilder.BuildHub                            ← outer hub being CONSTRUCTED
└ MessageHubConfiguration.Build
  └ MeshDataSourceExtensions.SubscribeToOwnDeletion   ← .WithInitialization hook
    └ InstallPersistenceSampler → ownStream.Subscribe(…)
      └ WorkspaceStreams.CreateReducedStream
        └ Lazy → HostedHubsCollection.CreateHub  ← hub #2 built RE-ENTRANTLY
          └ MessageHub..ctor → WithTypeAndRelatedTypesFor
            └ XmlDocs.Summary(Type) → Namotion ToXmlDocsContent
              └ StringBuilder.ToString() → SIGSEGV
```

**This is fixture INIT, not teardown.** `SubscribeToOwnDeletion` is registered via `.WithInitialization(...)`; the name describes what the subscription later watches for, not the phase. That invalidates the teardown framing in the July-25 notes *and* in the `HostedHubsCollection.CloseCreation` doc comment, and explains why #645's teardown guard was never going to catch it.

### Ruled out by the dump — please don't re-run these

| Hypothesis | Killed by |
|---|---|
| Post-dispose / ALC-unload teardown race | Crash is on `MeshBuilder.BuildHub`; **no** thread is unloading an ALC or emitting |
| Per-ALC duplicate statics splitting the `XmlDocs` lock | Exactly **one** copy of `MeshWeaver.Messaging.Hub` and **one** of `Namotion.Reflection` across 130 modules |
| Concurrent XLinq enumeration tearing the cached `XDocument` (what `XmlDocs`'s lock exists to prevent) | **Only one thread** is in Namotion at all — no concurrency to serialise |
| GC heap corruption, XmlDocs merely the victim | `verifyheap` **clean**; heap 183 MB; no memory spike at crash (last delta +8 MiB) |

So: a single-threaded, non-concurrent, non-corrupt SIGSEGV inside an allocation. Root cause still unknown — most likely inside Namotion/XLinq itself, or a stack condition on that ~25-frame re-entrant chain.

## The changes

**1. Error-path logging can no longer escalate.** Every diagnostic in `MeshDataSource` resolved its logger inline — `GetService<ILoggerFactory>()` then `CreateLogger()`. Both throw `ObjectDisposedException` once the container is disposing, and a provider can throw on write when its sink is gone. Inside a `catch` body or an Rx `onError`, that turns a **handled** fault into an **unhandled** one, thrown where nothing is left to observe it — and during teardown or a re-entrant hub build that is exactly when logging is least available.

Added `TryLogWarning`/`TryLogError`: one guarded helper pair, **one** documented empty catch, all five error-path emissions routed through it. The swallow covers only a *logging* failure, never the original error. Two of the five were pre-existing (read-validator fail-closed, downstream-pipeline `onError`) — same defect, not introduced here.

**2. The own-node setup no longer fails silently.** `SubscribeToOwnDeletion` was wrapped in a bare `catch {}` claiming the only cause was "a workspace with no MeshNodeReference reducer". That block spans the **whole** setup — including the `ownStream.Subscribe(...)` that can construct a second hub — so every failure of a re-entrant hub build during initialization vanished without trace. That is why this crash has no precursor in any log. Both bare catches now log; control flow unchanged.

**3. XML-doc reflection off the construction path.** `TypeDefinition`'s ctor eagerly ran `XmlDocs.Summary(Type)` for every type on every hub. `Description` is display metadata with a single consumer, so it is now lazy. This removes the observed crash site from hub construction — but if the fault originates inside Namotion it may relocate rather than cure, which is precisely why this PR does not claim to fix it. No equality impact: the record already carries `internal Lazy<KeyFunction> Key`, so its value-equality was already reference-bound.

## Follow-up worth doing

The re-entrant hub creation itself — hub B built from inside hub A's initialization hook — is a structural problem independent of this crash, and it is what drags full type registration (and hence XML-doc reflection) onto an init path. Worth removing on its own merits.

## Verification

`-c Release -p:CIRun=true -warnaserror` clean; FutuRe.Test 59/59; Graph.Test 674/674. (FutuRe.Test has always passed locally — the crash is CI-only.)

**No What's New entry** — internal diagnostics/hardening, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)