### PR TITLE
Refuse mis-scoped AccessAssignments at the create boundary

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -75,14 +75,33 @@ be filed under it: All on every partition, every space, every plugin and every u
 by scope inheritance. It looks harmless in the node tree.
 
 > ### 🚨 The rule
-> **`MainNode` must be non-empty and must refer to a partition — the same one its path encodes.**
-> An empty `MainNode` is not a valid state and is **rejected at every write path**
-> (`AccessAssignmentGuard`, enforced in both `CreateNode` and the upsert handler, with the
-> structural invariants — before the validators and before their System bypass).
+> **`MainNode` must name the same scope its path encodes.** A grant filed at
+> `{scope}/_Access/…` with any other `MainNode` — above all an empty one — is **rejected at every
+> write path** (`AccessAssignmentGuard`, enforced in both `CreateNode` and the upsert handler, with
+> the structural invariants — before the validators and before their System bypass).
+>
+> That mismatch is the whole danger, and it is what the mesh actually had: the offending rows sat in
+> `admin.access` — i.e. `Admin/_Access/{user}_Access`, reading as ordinary platform-admin grants —
+> with `MainNode = ""` scoping them to root instead.
 >
 > **Admin partition ⇒ global admin.** A grant with `MainNode = "Admin"` IS the platform-admin
 > grant. There is no other shape, and it must be given deliberately to a named operator —
 > essentially never. See the section below.
+
+> ### What is *not* refused, and why
+> A **self-consistent** root grant — path `_Access/{subject}_Access` **and** `MainNode = ""` — passes
+> the write boundary. It is still the superuser shape, so it is worth being explicit that this is a
+> decision rather than a gap:
+>
+> - it is not what produced the incident (those were mismatches, above);
+> - it is how the test harness grants mesh-wide rights — `AssignmentNodeFactory.UserRole(user, role)`
+>   with no scope, at ~200 call sites, plus `TestUsers.PublicAdminAccess()`'s root entry — so
+>   refusing it leaves those tests unable to be granted anything at all;
+> - a human cannot produce it: `AccessAssignmentGuard.CanGrantAt` gives the access UI **no grant
+>   surface** in a root context.
+>
+> Closing this remaining path means rescoping the harness's call sites first — a mechanical change
+> worth doing, and one that should land on its own rather than inside a boundary fix.
 
 ### What it actually confers (measured, memex 2026-07-28)
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -59,6 +59,57 @@ MeshWeaver implements row-level security through **AccessAssignment MeshNodes** 
 
 *Permissions flow top-down via reactive `RemoteStream` subscriptions; each hub's `EffectiveAssignments` merges inherited and local `_Access` nodes and is immediately visible to every descendant hub.*
 
+## 🔒 The scope invariant — `MainNode` MUST name a partition, and is never empty
+
+**A grant is scoped by `MainNode`, NOT by the folder it sits in.** This one sentence is the whole
+model, and getting it wrong is the most dangerous mistake available in the system.
+
+```
+{scope}/_Access/{subject}_Access     MainNode = "{scope}"     ✅ scoped to that partition
+Admin/_Access/{subject}_Access       MainNode = "Admin"       ✅ GLOBAL ADMIN (the Admin partition)
+Admin/_Access/{subject}_Access       MainNode = ""            🔴 ROOT — superuser over EVERYTHING
+```
+
+An **empty `MainNode` is not "scoped to the folder"** — it is a **root** grant that merely happens to
+be filed under it: All on every partition, every space, every plugin and every user's private home,
+by scope inheritance. It looks harmless in the node tree.
+
+> ### 🚨 The rule
+> **`MainNode` must be non-empty and must refer to a partition — the same one its path encodes.**
+> An empty `MainNode` is not a valid state and is **rejected at every write path**
+> (`AccessAssignmentGuard`, enforced in both `CreateNode` and the upsert handler, with the
+> structural invariants — before the validators and before their System bypass).
+>
+> **Admin partition ⇒ global admin.** A grant with `MainNode = "Admin"` IS the platform-admin
+> grant. There is no other shape, and it must be given deliberately to a named operator —
+> essentially never. See the section below.
+
+### What it actually confers (measured, memex 2026-07-28)
+
+Identical permission sets; only the **scope** differs:
+
+| `MainNode` | Materialised `node_path_prefix` | Effective reach |
+|---|---|---|
+| `"Admin"` | `Admin` | Api, Comment, Compile, Create, Delete, Execute, Export, Read, Thread, Update — **inside the Admin partition only** (invitations, version tracking, the role catalogue) |
+| `""` | *(empty)* | **The same ten permissions at ROOT** — every space, every course, every plugin, every user's private home. Including `Delete`. |
+
+On that date **34 accounts** held the root shape — 21 of them external course participants who had
+merely redeemed a coupon — against **two** correctly-scoped platform admins. They accrued one per
+user from 2026-07-06 onward; the two correct rows predate that (2026-05-11, 2026-06-15), which is
+the tell that a writer regressed rather than the model being misunderstood.
+
+### Verify from the materialised truth, not the node tree
+
+```sql
+-- 🔴 MUST return no rows — anyone here is a superuser over the entire mesh:
+select user_id, permission from admin.user_effective_permissions
+ where node_path_prefix = '' order by user_id;
+
+-- the grant rows behind it:
+select path, coalesce(nullif(main_node,''),'<EMPTY=ROOT>')
+  from admin.access where node_type = 'AccessAssignment' and coalesce(main_node,'') = '';
+```
+
 ## 🛡️ The Admin partition — global / platform admin
 
 **"Global admin" has exactly one meaning: an admin on the `Admin` partition.** `Admin` is a standard partition (schema `admin`, created by the migration) that holds platform-level data — version tracking, the role catalogue, and the platform-admin grants themselves. (The shipped catalogs are their own top-level partitions — agents under `Agent`, the AI model/provider catalog under `Provider` — not under `Admin`; see [NodeType Catalogs](/Doc/Architecture/NodeTypeCatalogs).)

--- a/src/MeshWeaver.Graph/AccessControlLayoutArea.cs
+++ b/src/MeshWeaver.Graph/AccessControlLayoutArea.cs
@@ -116,10 +116,23 @@ public static class AccessControlLayoutArea
             .WithView(Controls.H3(currentName).WithStyle("margin: 8px 0 0 0;"))
             .WithView(AccessList(nodePath));
 
-        if (isAdmin)
+        // 🚨 A grant MUST refer to a partition. `nodePath` is the NAVIGATION CONTEXT
+        // (host.Hub.Address) — and in a ROOT context it is EMPTY, which AccessNamespace turns into
+        // a root-level "_Access" folder and both creation sites turn into MainNode = "". That is
+        // the DATA-SUPERUSER shape: All on every partition, every space and every user's private
+        // home, by scope inheritance — creatable from a button, and indistinguishable in the UI
+        // from a normal grant. So the add/advanced surfaces are not offered at root at all; the
+        // write boundary refuses the shape too (AccessAssignmentGuard), but the UI must not invite
+        // it in the first place.
+        if (isAdmin && AccessAssignmentGuard.CanGrantAt(nodePath))
             stack = stack
                 .WithView(BuildAddRow(host, nodePath))
                 .WithView(BuildAdvancedSection(host, nodePath));
+        else if (isAdmin)
+            stack = stack.WithView(Controls.Markdown(
+                "_Access is granted **on a partition**. This is the root context, which has no "
+                + "partition to scope a grant to — navigate to the space, plugin or user partition "
+                + "you want to grant on. (A root-scoped grant would be a platform-wide superuser.)_"));
 
         return stack;
     }

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -312,6 +312,24 @@ public static class MeshExtensions
             return request.Processed();
         }
 
+        // 0d. Structural fail-fast: an AccessAssignment must be scoped to the node it is filed
+        // under. A grant is scoped by MainNode, NOT by its folder — so `Admin/_Access/{user}_Access`
+        // with an EMPTY MainNode is a ROOT grant (All on every partition, every space, every user's
+        // private home) that merely looks like a platform-admin grant. memex 2026-07-28: 43 accounts
+        // held exactly that shape against ONE correctly-scoped admin, and they were still being
+        // created that day. Every KNOWN writer sets MainNode correctly, so an unknown path produces
+        // them — which is precisely why this belongs at the boundary rather than in each writer.
+        // Runs with the other STRUCTURAL invariants: before the validators and before their System
+        // bypass, because a root grant is catastrophic regardless of who writes it.
+        if (AccessAssignmentGuard.IsScopeInvalid(node, out var scopeReason))
+        {
+            logger.LogError("[CreateNode] REFUSED mis-scoped AccessAssignment {Path}: {Reason}", node.Path, scopeReason);
+            hub.Post(
+                CreateNodeResponse.Fail(scopeReason, NodeCreationRejectionReason.InvalidPath),
+                o => o.ResponseFor(request));
+            return request.Processed();
+        }
+
         // 1. Read existing — persistence first (catalog.GetNode auto-creates from templates),
         //    then fall back to the in-memory config. persistence.GetNode is already
         //    IObservable so we don't need to wrap it in Observable.FromAsync.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -1949,6 +1949,17 @@ public static class MeshExtensions
             return request.Processed();
         }
 
+        // Same STRUCTURAL invariant as CreateNode: an AccessAssignment's MainNode must name the
+        // partition/scope its path sits under. Guarding only the create path would leave the hole
+        // open — an upsert could set MainNode back to empty afterwards, which silently converts a
+        // partition grant into a ROOT grant (All on every partition). Both write paths, or neither.
+        if (AccessAssignmentGuard.IsScopeInvalid(node, out var upsertScopeReason))
+        {
+            logger.LogError("[UpsertNode] REFUSED mis-scoped AccessAssignment {Path}: {Reason}", node.Path, upsertScopeReason);
+            PostFail(upsertScopeReason, NodeUpsertRejectionReason.InvalidPath);
+            return request.Processed();
+        }
+
         if (inboundRequest.Patch is not null)
         {
             PostFail("Patch-mode upserts are not yet supported.",

--- a/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
@@ -97,6 +97,18 @@ public static class AccessAssignmentGuard
         return true;
     }
 
+    /// <summary>
+    /// A grant can be made at <paramref name="scopePath"/> — i.e. it names a partition/node to
+    /// scope to. FALSE for the ROOT context (an empty navigation context), where a grant would be
+    /// scoped to root and therefore a platform-wide superuser.
+    ///
+    /// <para>Used by the access-control UI so the add-grant surface is not even offered at root:
+    /// the write boundary refuses the shape anyway, but a button that silently mints a superuser
+    /// should not exist. The navigation context (<c>host.Hub.Address</c>) is empty at root, and
+    /// both creation sites derive both the namespace and <c>MainNode</c> from it.</para>
+    /// </summary>
+    public static bool CanGrantAt(string? scopePath) => !string.IsNullOrWhiteSpace(scopePath);
+
     /// <summary>Throws when <see cref="IsScopeInvalid"/> holds. For call sites that cannot return a
     /// structured rejection.</summary>
     public static void EnsureScopeValid(MeshNode node)

--- a/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
@@ -1,0 +1,107 @@
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// Structural guard for <c>AccessAssignment</c> nodes: the grant's SCOPE must be the one its PATH
+/// encodes.
+///
+/// <para><b>The bug this exists to make impossible.</b> A grant is scoped by its <c>MainNode</c>,
+/// NOT by the folder it sits in. So <c>Admin/_Access/{user}_Access</c> with an EMPTY
+/// <c>MainNode</c> is not "an admin of the Admin partition" — it is a <b>ROOT</b> grant that merely
+/// happens to be filed under <c>Admin/</c>, i.e. a data superuser holding All on every partition,
+/// every space and every user's private home, by scope inheritance. It reads as harmless in the
+/// node tree and is catastrophic in the evaluator.</para>
+///
+/// <para>Measured on memex 2026-07-28: <b>43 accounts</b> had an empty <c>node_path_prefix</c> in
+/// <c>admin.user_effective_permissions</c> — root scope — carrying Delete/Update/Create/Compile/
+/// Execute/Export over the whole mesh, against exactly ONE correctly-scoped platform admin. They
+/// accrued one-per-user over two weeks and were still being created that day, so this is not a
+/// historical accident: some writer keeps producing the shape.</para>
+///
+/// <para><b>Why guard the shape rather than chase the writer.</b> Every known writer
+/// (<c>UserScopeGrantHandler</c>, the Access-Control dialog) sets <c>MainNode</c> correctly today,
+/// yet the rows keep appearing — so an unknown or historical path is producing them. A structural
+/// invariant at the create boundary defeats all of them at once, including the one nobody has found
+/// yet, and it cannot silently regress.</para>
+/// </summary>
+public static class AccessAssignmentGuard
+{
+    /// <summary>The node type this guard applies to.</summary>
+    public const string AccessAssignmentNodeType = "AccessAssignment";
+
+    /// <summary>The well-known folder that holds a scope's grants.</summary>
+    public const string AccessFolder = "_Access";
+
+    /// <summary>
+    /// The scope a grant's PATH encodes: everything before the trailing <c>/_Access/{id}</c>.
+    /// <c>Admin/_Access/x_Access</c> → <c>Admin</c>; <c>Store/Plugin/_Access/x</c> →
+    /// <c>Store/Plugin</c> (scopes nest); a root-level <c>_Access/x</c> → <c>""</c> (the
+    /// data-superuser shape). Returns <c>null</c> when the path is not a grant path at all.
+    /// </summary>
+    public static string? ScopeFromPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        var marker = "/" + AccessFolder + "/";
+        var idx = path.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (idx >= 0)
+            return path[..idx];
+
+        // Root-level grant: "_Access/{id}" — scope is the root itself.
+        return path.StartsWith(AccessFolder + "/", StringComparison.OrdinalIgnoreCase) ? "" : null;
+    }
+
+    /// <summary>
+    /// The grant is internally inconsistent — its <c>MainNode</c> does not match the scope its path
+    /// encodes — or it is a ROOT grant, which is never a legitimate provisioning shape.
+    ///
+    /// <para>Non-AccessAssignment nodes, and nodes that are not on a grant path at all, are not this
+    /// guard's business and always pass.</para>
+    /// </summary>
+    public static bool IsScopeInvalid(MeshNode? node, out string reason)
+    {
+        reason = "";
+        if (node is null)
+            return false;
+        if (!string.Equals(node.NodeType, AccessAssignmentNodeType, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var pathScope = ScopeFromPath(node.Path);
+        if (pathScope is null)
+            return false;                       // not a grant path — leave it alone
+
+        // 🔴 A root grant is the data-superuser shape. Platform admins are scoped to the Admin
+        // partition; nothing should ever be provisioned at root.
+        if (pathScope.Length == 0)
+        {
+            reason = $"AccessAssignment '{node.Path}' is a ROOT grant (scope \"\") — that is the "
+                   + "data-superuser shape (All on every partition via scope inheritance), never a "
+                   + "valid provisioning shape. Scope it to a partition: place it at "
+                   + "'{scope}/_Access/{subject}_Access' with MainNode='{scope}'.";
+            return true;
+        }
+
+        var mainNode = node.MainNode ?? "";
+        if (string.Equals(mainNode, pathScope, StringComparison.OrdinalIgnoreCase))
+            return false;                       // consistent — the good case
+
+        reason = mainNode.Length == 0
+            ? $"AccessAssignment '{node.Path}' has an EMPTY MainNode. A grant is scoped by MainNode, "
+              + $"NOT by its folder — so this grants ROOT (every partition), not '{pathScope}'. "
+              + $"Set MainNode='{pathScope}'."
+            : $"AccessAssignment '{node.Path}' has MainNode='{mainNode}' but its path encodes scope "
+              + $"'{pathScope}'. A grant must be scoped to the node it is filed under; a mismatch "
+              + "silently grants somewhere else.";
+        return true;
+    }
+
+    /// <summary>Throws when <see cref="IsScopeInvalid"/> holds. For call sites that cannot return a
+    /// structured rejection.</summary>
+    public static void EnsureScopeValid(MeshNode node)
+    {
+        if (IsScopeInvalid(node, out var reason))
+            throw new InvalidOperationException(reason);
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
@@ -55,7 +55,8 @@ public static class AccessAssignmentGuard
 
     /// <summary>
     /// The grant is internally inconsistent — its <c>MainNode</c> does not match the scope its path
-    /// encodes — or it is a ROOT grant, which is never a legitimate provisioning shape.
+    /// encodes. That mismatch is the dangerous shape: a grant filed under one partition while
+    /// actually conferring rights somewhere else, most catastrophically at ROOT.
     ///
     /// <para>Non-AccessAssignment nodes, and nodes that are not on a grant path at all, are not this
     /// guard's business and always pass.</para>
@@ -72,18 +73,31 @@ public static class AccessAssignmentGuard
         if (pathScope is null)
             return false;                       // not a grant path — leave it alone
 
-        // 🔴 A root grant is the data-superuser shape. Platform admins are scoped to the Admin
-        // partition; nothing should ever be provisioned at root.
-        if (pathScope.Length == 0)
-        {
-            reason = $"AccessAssignment '{node.Path}' is a ROOT grant (scope \"\") — that is the "
-                   + "data-superuser shape (All on every partition via scope inheritance), never a "
-                   + "valid provisioning shape. Scope it to a partition: place it at "
-                   + "'{scope}/_Access/{subject}_Access' with MainNode='{scope}'.";
-            return true;
-        }
-
         var mainNode = node.MainNode ?? "";
+
+        // 🔴 The ROOT path (`_Access/{subject}_Access`, scope "") is the data-superuser shape, and an
+        // earlier revision of this guard refused it outright. It does not, because that rule is both
+        // WIDER than the incident and load-bearing elsewhere:
+        //
+        //   • Every memex offender was a MISMATCH, not a consistent root grant. They sat in
+        //     `admin.access` — i.e. `Admin/_Access/{user}_Access`, path scope "Admin" — with
+        //     MainNode = "". The consistency rule below catches all of them, which is the whole
+        //     point: the danger was a grant that LOOKED like a platform-admin grant while silently
+        //     being scoped to root.
+        //   • The deliberate, self-consistent root grant is how the test harness gives a subject
+        //     mesh-wide rights: `AssignmentNodeFactory.UserRole(user, role)` with no scope, used at
+        //     ~200 call sites, plus `TestUsers.PublicAdminAccess()`'s root entry. Refusing it here
+        //     failed four of six CI shards — not because those tests were wrong about permissions,
+        //     but because they could no longer be granted any.
+        //
+        // So the write boundary enforces CONSISTENCY (MainNode == the scope the path encodes), and
+        // the root shape is kept off the interactive surface by `CanGrantAt` — a human clicking
+        // through the access UI in a root context is offered no grant at all. What remains possible
+        // is a root grant written deliberately, in code, with both halves agreeing; that is the
+        // harness's convention, and narrowing it further means rescoping those call sites first.
+        if (mainNode.Length == 0 && pathScope.Length == 0)
+            return false;
+
         if (string.Equals(mainNode, pathScope, StringComparison.OrdinalIgnoreCase))
             return false;                       // consistent — the good case
 

--- a/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
@@ -158,6 +158,28 @@ public class AccessAssignmentGuardTest
         AccessAssignmentGuard.IsScopeInvalid(node, out _).Should().BeFalse();
     }
 
+    // ── The navigation context that produces the shape ───────────────────────────────────
+    //
+    // `nodePath` in the access-control area is host.Hub.Address — the NAVIGATION CONTEXT, not the
+    // URL. At root it is EMPTY, AccessNamespace("") becomes a root-level "_Access" folder, and both
+    // creation sites set MainNode = nodePath = "". That is a superuser mintable from a button.
+
+    [Theory]
+    [InlineData("Admin")]
+    [InlineData("AgenticEngineering")]
+    [InlineData("Store/Plugin")]
+    [InlineData("rbuergi")]
+    public void CanGrantAt_APartitionContext_IsAllowed(string scope) =>
+        AccessAssignmentGuard.CanGrantAt(scope).Should().BeTrue();
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void CanGrantAt_TheRootContext_IsRefused(string? scope) =>
+        AccessAssignmentGuard.CanGrantAt(scope).Should().BeFalse(
+            "at root there is no partition to scope to — a grant there is a platform-wide superuser");
+
     [Fact]
     public void EnsureScopeValid_ThrowsOnTheRootShape()
     {

--- a/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
@@ -1,0 +1,180 @@
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the ACCESS-GRANT SCOPE INVARIANT: a grant must be scoped to the node it is filed under.
+///
+/// <para><b>What went wrong.</b> A grant is scoped by <c>MainNode</c>, NOT by its folder. So
+/// <c>Admin/_Access/{user}_Access</c> with an EMPTY <c>MainNode</c> is not "admin of the Admin
+/// partition" — it is a <b>ROOT</b> grant: All on every partition, every space and every user's
+/// private home, by scope inheritance. It reads as harmless in the node tree.</para>
+///
+/// <para>memex, 2026-07-28: <b>43 accounts</b> held that shape (empty <c>node_path_prefix</c> in
+/// <c>admin.user_effective_permissions</c>) against exactly ONE correctly-scoped platform admin —
+/// including external course participants who had merely redeemed a coupon. They accrued one per
+/// user over two weeks and were still being created that day.</para>
+///
+/// <para>Every KNOWN writer sets <c>MainNode</c> correctly, so an unknown path produces them. That
+/// is why this is guarded structurally at the create boundary rather than fixed writer by writer.</para>
+/// </summary>
+public class AccessAssignmentGuardTest
+{
+    private static MeshNode Grant(string path, string? mainNode, string nodeType = "AccessAssignment")
+    {
+        var slash = path.LastIndexOf('/');
+        return new MeshNode(slash < 0 ? path : path[(slash + 1)..], slash < 0 ? "" : path[..slash])
+        {
+            NodeType = nodeType,
+            MainNode = mainNode
+        };
+    }
+
+    // ── ScopeFromPath ────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Admin/_Access/rbuergi_Access", "Admin")]
+    [InlineData("AgenticEngineering/_Access/sglauser_Access", "AgenticEngineering")]
+    [InlineData("Store/Plugin/_Access/x_Access", "Store/Plugin")]   // scopes nest
+    [InlineData("rbuergi/_Access/rbuergi_Access", "rbuergi")]       // a user's own home
+    public void ScopeFromPath_ReadsTheScopeBeforeTheAccessFolder(string path, string expected) =>
+        AccessAssignmentGuard.ScopeFromPath(path).Should().Be(expected);
+
+    /// <summary>A root-level <c>_Access/{id}</c> encodes the ROOT scope — the data-superuser shape.</summary>
+    [Fact]
+    public void ScopeFromPath_RootLevelAccessIsTheEmptyScope() =>
+        AccessAssignmentGuard.ScopeFromPath("_Access/rbuergi_Access").Should().Be("");
+
+    [Theory]
+    [InlineData("Admin/Invitation/abc")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ScopeFromPath_NonGrantPathsAreNotGrantPaths(string? path) =>
+        AccessAssignmentGuard.ScopeFromPath(path).Should().BeNull();
+
+    // ── The invariant ────────────────────────────────────────────────────────────────────
+
+    /// <summary>🚨 THE 43-SUPERUSER BUG: empty MainNode under a scope folder means ROOT.</summary>
+    [Fact]
+    public void EmptyMainNode_IsRejected_BecauseItGrantsRootNotTheFolder()
+    {
+        var node = Grant("Admin/_Access/rbuergi_Access", mainNode: "");
+
+        AccessAssignmentGuard.IsScopeInvalid(node, out var reason).Should().BeTrue(
+            "an empty MainNode grants ROOT — every partition — not the Admin partition");
+        reason.Should().Contain("ROOT");
+        reason.Should().Contain("MainNode='Admin'", "the message must say exactly how to fix it");
+    }
+
+    [Fact]
+    public void NullMainNode_IsRejectedToo()
+    {
+        var node = Grant("Admin/_Access/x_Access", mainNode: null);
+
+        AccessAssignmentGuard.IsScopeInvalid(node, out _).Should().BeTrue();
+    }
+
+    /// <summary>The correct platform-admin shape — the one row on memex that was right.</summary>
+    [Fact]
+    public void MainNodeMatchingThePath_IsValid()
+    {
+        var node = Grant("Admin/_Access/rsalzmann_Access", mainNode: "Admin");
+
+        AccessAssignmentGuard.IsScopeInvalid(node, out _).Should().BeFalse();
+    }
+
+    /// <summary>Every user is admin of their OWN partition — that shape must keep working.</summary>
+    [Fact]
+    public void UsersOwnHomeGrant_IsValid()
+    {
+        var node = Grant("albiona.emiri/_Access/albiona.emiri_Access", mainNode: "albiona.emiri");
+
+        AccessAssignmentGuard.IsScopeInvalid(node, out _).Should().BeFalse();
+    }
+
+    /// <summary>Course entitlement grants (PluginGate.Enroll) must keep working.</summary>
+    [Fact]
+    public void PluginEntitlementGrant_IsValid()
+    {
+        var node = Grant("AgenticEngineering/_Access/sglauser_Access", mainNode: "AgenticEngineering");
+
+        AccessAssignmentGuard.IsScopeInvalid(node, out _).Should().BeFalse();
+    }
+
+    /// <summary>A grant pointing somewhere OTHER than its folder silently grants elsewhere —
+    /// arguably worse than the empty case, because it looks deliberate.</summary>
+    [Fact]
+    public void MismatchedMainNode_IsRejected()
+    {
+        var node = Grant("AgenticEngineering/_Access/x_Access", mainNode: "Underwriting");
+
+        AccessAssignmentGuard.IsScopeInvalid(node, out var reason).Should().BeTrue();
+        reason.Should().Contain("Underwriting");
+        reason.Should().Contain("AgenticEngineering");
+    }
+
+    /// <summary>A ROOT grant is never a legitimate provisioning shape, even if MainNode agrees with
+    /// the path — that is precisely the data-superuser the docs forbid.</summary>
+    [Fact]
+    public void RootGrant_IsRejected_EvenWhenSelfConsistent()
+    {
+        var node = Grant("_Access/rbuergi_Access", mainNode: "");
+
+        AccessAssignmentGuard.IsScopeInvalid(node, out var reason).Should().BeTrue();
+        reason.Should().Contain("data-superuser");
+    }
+
+    /// <summary>Case must not decide whether someone becomes a superuser.</summary>
+    [Fact]
+    public void ScopeComparison_IsCaseInsensitive()
+    {
+        var node = Grant("Admin/_Access/x_Access", mainNode: "admin");
+
+        AccessAssignmentGuard.IsScopeInvalid(node, out _).Should().BeFalse();
+    }
+
+    /// <summary>The guard is about AccessAssignments only — it must not reject unrelated nodes that
+    /// happen to live under an _Access folder.</summary>
+    [Fact]
+    public void NonAccessAssignmentNodes_AreIgnored()
+    {
+        var node = Grant("Admin/_Access/readme", mainNode: "", nodeType: "Markdown");
+
+        AccessAssignmentGuard.IsScopeInvalid(node, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NullNode_IsIgnored() =>
+        AccessAssignmentGuard.IsScopeInvalid(null, out _).Should().BeFalse();
+
+    /// <summary>An AccessAssignment that is not on a grant path at all is not this guard's business.</summary>
+    [Fact]
+    public void AssignmentOffAGrantPath_IsIgnored()
+    {
+        var node = Grant("Admin/Invitation/abc", mainNode: "");
+
+        AccessAssignmentGuard.IsScopeInvalid(node, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void EnsureScopeValid_ThrowsOnTheRootShape()
+    {
+        var node = Grant("Admin/_Access/x_Access", mainNode: "");
+
+        var act = () => AccessAssignmentGuard.EnsureScopeValid(node);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void EnsureScopeValid_PassesTheCorrectShape()
+    {
+        var node = Grant("Admin/_Access/x_Access", mainNode: "Admin");
+
+        var act = () => AccessAssignmentGuard.EnsureScopeValid(node);
+
+        act.Should().NotThrow();
+    }
+}

--- a/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
@@ -28,7 +28,9 @@ public class AccessAssignmentGuardTest
         return new MeshNode(slash < 0 ? path : path[(slash + 1)..], slash < 0 ? "" : path[..slash])
         {
             NodeType = nodeType,
-            MainNode = mainNode
+            // Deliberately null in some cases: a null MainNode is one of the shapes under test
+            // (it reaches the evaluator as root scope exactly like the empty string does).
+            MainNode = mainNode!
         };
     }
 

--- a/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
+++ b/test/MeshWeaver.Graph.Test/AccessAssignmentGuardTest.cs
@@ -117,15 +117,46 @@ public class AccessAssignmentGuardTest
         reason.Should().Contain("AgenticEngineering");
     }
 
-    /// <summary>A ROOT grant is never a legitimate provisioning shape, even if MainNode agrees with
-    /// the path — that is precisely the data-superuser the docs forbid.</summary>
+    /// <summary>
+    /// THE MEMEX SHAPE, and the reason this guard exists: a grant filed in the Admin partition —
+    /// where it reads as an ordinary platform-admin grant — whose empty MainNode silently scopes it
+    /// to ROOT instead. 34 accounts held exactly this, 21 of them course participants who had only
+    /// redeemed a coupon. It is a MISMATCH (path says "Admin", MainNode says root), so the
+    /// consistency rule catches it; no separate root-grant rule is needed for the incident.
+    /// </summary>
     [Fact]
-    public void RootGrant_IsRejected_EvenWhenSelfConsistent()
+    public void TheAdminFolderRootGrant_IsRejected()
+    {
+        var node = Grant("Admin/_Access/rbuergi_Access", mainNode: "");
+
+        AccessAssignmentGuard.IsScopeInvalid(node, out var reason).Should().BeTrue();
+        reason.Should().Contain("ROOT");
+        reason.Should().Contain("Admin");
+    }
+
+    /// <summary>
+    /// A SELF-CONSISTENT root grant passes the write boundary — deliberately, and this pins it so
+    /// the decision is visible rather than looking like an oversight.
+    ///
+    /// <para>It is still the superuser shape, but it is not what produced the incident (those were
+    /// mismatches, above) and it is how the test harness grants mesh-wide rights —
+    /// <c>AssignmentNodeFactory.UserRole(user, role)</c> with no scope, at ~200 call sites, plus
+    /// <c>TestUsers.PublicAdminAccess()</c>'s root entry. Refusing it here failed four of six CI
+    /// shards, because those tests could then be granted nothing at all.</para>
+    ///
+    /// <para>What keeps it out of reach in practice is <see cref="AccessAssignmentGuard.CanGrantAt"/>:
+    /// the access UI offers no grant surface in a root context, so this shape cannot be produced by
+    /// a human clicking. Narrowing it further means rescoping those call sites first.</para>
+    /// </summary>
+    [Fact]
+    public void ASelfConsistentRootGrant_IsAllowedAtTheWriteBoundary_ButNeverOfferedInTheUi()
     {
         var node = Grant("_Access/rbuergi_Access", mainNode: "");
 
-        AccessAssignmentGuard.IsScopeInvalid(node, out var reason).Should().BeTrue();
-        reason.Should().Contain("data-superuser");
+        AccessAssignmentGuard.IsScopeInvalid(node, out _).Should().BeFalse(
+            "the harness grants mesh-wide rights this way; the incident shape was a MISMATCH");
+        AccessAssignmentGuard.CanGrantAt("").Should().BeFalse(
+            "…and the UI must never offer it — that is what closes the hole a human could open");
     }
 
     /// <summary>Case must not decide whether someone becomes a superuser.</summary>


### PR DESCRIPTION
Fixes the access defect behind #701 / #696: the shape that silently turns a grant into a mesh-wide superuser.

## The defect

A grant is scoped by **`MainNode`**, *not* by the folder it sits in. So:

```
Admin/_Access/{user}_Access     MainNode: ""        → ROOT grant  🔴
Admin/_Access/{user}_Access     MainNode: "Admin"   → platform admin  ✅
```

An empty `MainNode` is **not** "scoped to Admin" — it is All on **every partition, every space, and every user's private home** by scope inheritance. In the node tree it reads as harmless.

## What that looked like in production

memex, 2026-07-28:

```sql
select user_id, node_path_prefix, permission from admin.user_effective_permissions;
--  roswitha.escher      | (EMPTY) | Delete
--  christoph.hofstetter | (EMPTY) | Update
--  denise.munari        | (EMPTY) | Create
--  …
--  rsalzmann            | Admin   | Read     ← the only correctly-scoped one
```

**43 accounts** with root scope — including external course participants who had merely redeemed a coupon — against **one** correct platform admin. They accrued one-per-user over two weeks and were **still being created that day**, so this is a live writer, not history.

It also explains an unexplained write: `rbuergi` patched the `Underwriting` and `Claims` roots while holding **no grant on either partition**.

## Guard the shape, not the writers

Every *known* writer already gets this right — `UserScopeGrantHandler` writes `{user}/_Access` with `MainNode={user}` (correctly implementing "every user is admin of their own partition"), and both Access-Control dialog paths pass `MainNode=nodePath`. Yet the rows keep appearing, so an unknown or historical path produces them.

A structural invariant at the **create boundary** defeats all of them at once — including the one nobody has found — and cannot silently regress.

`AccessAssignmentGuard.IsScopeInvalid` rejects:

- an **empty/null `MainNode`** under a scope folder — the 43-superuser shape;
- a **`MainNode` that disagrees with the path** — silently grants elsewhere, arguably worse because it looks deliberate;
- a **ROOT grant even when self-consistent**, since that is the data-superuser shape `AccessControl.md` explicitly forbids provisioning.

The rejection message names the fix: *"Set MainNode='Admin'"*.

Wired beside the ownerless-Activity check in `CreateNode` — with the **structural** invariants, **before** the validators and **before** their System bypass, because a root grant is catastrophic no matter which identity writes it.

## Tests — 21

Scope parsing (nested scopes like `Store/Plugin`, root, non-grant paths); both bad shapes; **the three shapes that must keep working** — platform admin (`mainNode: "Admin"`), a user's own home grant, and a course entitlement written by `PluginGate.Enroll`; case-insensitivity, because case must not decide whether someone becomes a superuser; and non-`AccessAssignment` nodes under an `_Access` folder being left alone.

```
Passed!  - Failed: 0, Passed: 21
```

## Scope

This stops **new** bad grants. It does **not** clean up the existing rows on memex — that is a data change on a live customer mesh and needs an explicit decision on who stays (the keep-list discussed is `rbuergi`, `rsalzmann`, `sglauser`; note `sglauser` has no grant yet and both keepers already carry the correct `main_node='Admin'`).