### PR TITLE
Write down what this week's hang investigation cost to learn

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -87,6 +87,58 @@ keep digging in the bulk run.**
    | `SubscribeAck` then silence until a heartbeat | Initial `Full` dropped | owner-side echo filter / `ChangedBy` (see doc §"never sent the initial Full") |
    | `type … is not registered in this hub's TypeRegistry` | Type-registry mismatch | `WithType(typeof(T), nameof(T))` on **every** hub the message transits |
 
+## Read the DURATION first — it separates a hang from a real failure
+
+Before any tracing, look at how long the failing case took. This is the cheapest signal there is and
+it is decisive:
+
+| Duration | What it is |
+|---|---|
+| **seconds** | a REAL assertion failure — the code ran and produced a wrong answer |
+| **minutes, no assertion output** | a HANG — something never arrived and the harness timed out |
+
+Observed 2026-07-28 on the education suite: 251 tests, 6 failures, **every one of them 1-3.5 minutes
+with no assertion text**, while the one genuine content bug in the same suite failed in **2.4s**. Six
+multi-minute failures across four different courses were ONE broken edge wearing six hats — not six
+bugs, and not "flaky tests to retry".
+
+🚨 **Do not read a slow failure as "the CI runner is slow".** That reading is seductive (it even
+explains the durations) and it is how this class hides: a bigger timeout or a beefier runner makes it
+rarer without fixing anything, so it comes back later and less reproducibly. Same-machine proof that
+load was NOT the cause: the portal answered `/health` in **6 ms** while the hang still reproduced —
+the identical suite had shown 5.1 s under genuine load earlier that day.
+
+## Retry belongs in the CALLER, never in the shared cache
+
+Once you find a transient `NotFound` / `DeliveryFailureException`, the obvious fix — "resubscribe
+automatically at the stream layer" — is the one that has already taken production down twice. Do not
+write it.
+
+- `MeshNodeStreamCache` is deliberately **evict-only**: its negative entry EXPIRES and the next
+  *natural* read re-probes. Its own comment is explicit — *"Self-healing, NEVER a watchdog … an
+  auto-resubscribe watchdog is exactly what caused the 2026-06-08 prod outage; this only ever evicts,
+  never re-subscribes."*
+- Unbounded caller-side retry is the OTHER outage: *"resubscribing forever to an inexistent address
+  produced an endless `[ROUTE] NotFound` message storm that burned a core and wedged the partition's
+  hub"* (atioz, 2026-06-14).
+
+So the shape that is actually safe is the one `MeshWeaver.Layout/AreaStreamRetry` already implements:
+**bounded** retries, exponential backoff on `Observable.Timer` (never `Task.Delay`), a caller-supplied
+`shouldRetry` predicate, and the last error surfaced after giving up so the UI reports a real failure
+instead of spinning. It is wired for layout-area streams; a caller on another stream type needs the
+same wrapper, not a new mechanism and not a change to the cache.
+
+## A green CI badge is not a green suite
+
+Check the JOBS, not the run conclusion. A job marked `continue-on-error: true` fails while its
+workflow still reports **success** — observed 2026-07-28: `Education Content CI` green with **3/3**
+e2e shards red, which is how the hang above sat unnoticed. Before trusting a gate, confirm it can
+actually fail:
+
+```bash
+gh run view <run-id> --json jobs --jq '.jobs[] | "\(.conclusion)\t\(.name)"'
+```
+
 ## Is it a lock, or a missed observation? (they look identical from the outside)
 
 Most "deadlocks" in this codebase are **not** locks — they are a reactive emission that nobody

--- a/deploy/CHANGE-PROPAGATION.md
+++ b/deploy/CHANGE-PROPAGATION.md
@@ -125,3 +125,43 @@ Properties that bound the damage:
 
 See `deploy/helm/values.yaml` (`bake`, `probes.startup`) — all bake flags default **off**, and
 enabling the readiness gate requires raising the startup-probe budget in the same change.
+
+---
+
+# Bootstrapping a fresh mesh: nobody is a global admin
+
+A brand-new mesh has **no global admin at all**, and the way that fails is circular enough to burn an
+afternoon, so it is written down here rather than rediscovered.
+
+- **`Admin` is a framework BUILT-IN partition** (`DefaultPartitionProvider`, listed among the reserved
+  names), so it exists on every mesh from first boot.
+- **A fresh mesh has no grants on it.** Verified against a disposable mesh's Postgres:
+  `Admin/Partition/Admin`, `Admin/PlatformVersion`, `Admin/UpdatePolicy` — and **no `_Access` rows at
+  all**. (`samples/Graph/Data/Admin/_Access/*` grants `Roland`/`Samuel`/`TestUser`, but that is dev
+  sample data and does **not** ship in the portal image.)
+- **`IsGlobalAdmin` is defined as `Permission.All` at scope `Admin`** — so with no grant on `Admin`,
+  nobody holds it.
+
+**The circularity:** anything that writes under `Admin/…` (seeding a Store coupon at the fixed
+`Admin/Coupons/{CODE}`, say) is denied. The obvious escape — create the `Admin` Space, since a Space
+grants Admin to its creator — **cannot work**: `Admin` already exists, so the create is a tolerated
+no-op and no grant is ever issued. Writing under `Admin` requires a grant obtainable only by writing
+under `Admin`.
+
+**The supported way in is `Auth:GlobalAdmins`.** `GlobalAdminSeed` materialises a root-scope Admin
+`AccessAssignment` for each configured id through `AddMeshNodes`, which bypasses exactly that
+circularity because seeded nodes are not permission-checked:
+
+```yaml
+Auth__GlobalAdmins__0: "the-user-id"
+```
+
+Dev-login does **not** confer this. Self-provisioning gives a user their own space and nothing more —
+"the first user becomes the platform admin" is folklore, and a harness that assumes it will fail on
+the first write into a framework partition.
+
+> ⚠️ **Env-var gotcha.** Logging categories are DOTTED keys, so
+> `Logging__LogLevel__MeshWeaver__Messaging` silently creates a *nested* `MeshWeaver:Messaging`
+> section and changes nothing. The category is `"MeshWeaver.Messaging"` — write
+> `Logging__LogLevel__MeshWeaver.Messaging=Trace`. Symptom: you raise the level, re-run, and the
+> trace file has zero `MESSAGE_FLOW` lines.


### PR DESCRIPTION
Four things that were each rediscovered the expensive way this week and existed in no doc.

## 1. Duration separates a hang from a failure

**Seconds = a real assertion failure. Minutes with no assertion output = a hang.**

2026-07-28, education suite: 251 tests, 6 failures, **every one 1–3.5 minutes** — while the single genuine content bug in the same suite failed in **2.4s**. Six multi-minute failures across four different courses were **one** broken edge wearing six hats, not six bugs.

Includes the same-machine proof that load wasn't the cause: `/health` answered in **6 ms** while the hang still reproduced, versus **5.1 s** under genuine load earlier the same day. "The runner is slow" is the seductive misreading — it even explains the durations — and it makes this class rarer instead of fixed, so it returns later and less reproducibly. I made that mistake mid-investigation; hence the warning.

## 2. Retry belongs in the caller, never in the shared cache

The obvious fix once you find a transient `NotFound` — resubscribe automatically at the stream layer — **has already taken production down twice**, and both are documented in the code itself:

- `MeshNodeStreamCache` is deliberately evict-only: *"an auto-resubscribe watchdog is exactly what caused the 2026-06-08 prod outage; this only ever evicts, never re-subscribes."*
- Unbounded caller retry is the other one: *"resubscribing forever to an inexistent address produced an endless `[ROUTE] NotFound` storm that burned a core and wedged the partition's hub"* (atioz, 2026-06-14).

The safe shape already exists in `AreaStreamRetry` — bounded, backoff on `Observable.Timer`, caller-supplied `shouldRetry`, last error surfaced. A caller on another stream type needs *that wrapper*, not a new mechanism and not a change to the cache.

## 3. A green badge is not a green suite

A `continue-on-error` job fails while its workflow reports **success**. `Education Content CI` was green with **3/3** e2e shards red — which is exactly how the hang above sat unnoticed. With the one-liner that inspects jobs rather than the run conclusion.

## 4. Nobody is a global admin on a fresh mesh

And the failure is circular: `Admin` is a framework built-in with no `_Access` rows, `IsGlobalAdmin` means `Permission.All` at scope `Admin`, and creating the `Admin` Space to earn the grant **cannot work** because it already exists (the create is a tolerated no-op). `Auth:GlobalAdmins` is the supported way in. Dev-login does not confer it — "the first user becomes the platform admin" is folklore that a harness will believe until its first write into a framework partition.

Plus the env-var gotcha that hid the trace for a whole run: logging categories are **dotted** keys, so `Logging__LogLevel__MeshWeaver__Messaging` creates a nested section and changes nothing.

Docs only — `.claude/skills/debug/SKILL.md` and `deploy/CHANGE-PROPAGATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)