### PR TITLE
Issue test reads on a stable hosted hub, never the root mesh/{id} hub

### DIFF
--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -904,12 +904,29 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     /// from the NotFound path.</para>
     /// </summary>
     protected IObservable<MeshNode?> ReadNode(string path)
-        => Mesh.GetMeshNode(path, ReadNodeTimeout)
+        => ReadHub.GetMeshNode(path, ReadNodeTimeout)
             .Select(n => (MeshNode?)n)
             .Catch((Exception ex) =>
                 IsNotFoundFailure(ex)
                     ? Observable.Return<MeshNode?>(null)
                     : Observable.Throw<MeshNode?>(ex));
+
+    /// <summary>
+    /// 🚨 Reads are issued HERE, never on <see cref="Mesh"/>. `Mesh` resolves the ROOT
+    /// <c>mesh/{id}</c> hub, and a call routed through the root mesh hub always faults — it is
+    /// transient routing infrastructure, not a call target. Every API surface (REST, MCP, gRPC,
+    /// CLI) uses the portal hub for exactly this reason; this stable hosted hub is the test-side
+    /// equivalent, and <see cref="ReadHubAddress"/> is deliberately CONSTANT so every read reuses
+    /// one hub rather than minting a fresh one per call.
+    ///
+    /// <para>The symptom this cures is a <c>GetDataRequest</c> that never gets an answer, surfacing
+    /// 60 s later as <c>GetMeshNode('…') timed out … the owning per-node hub never answered</c>.
+    /// The diagnostic's <c>Hub mesh/…</c> field names the root hub as the caller — that field IS
+    /// the diagnosis, and misreading it as "caller healthy, target silent" sends you hunting a
+    /// load-dependent race that does not exist (ThreadAgentIntegrationTest, which never reproduced
+    /// locally at any load).</para>
+    /// </summary>
+    private IMessageHub ReadHub => Mesh.GetHostedHub(ReadHubAddress, c => c.AddData());
 
     private static readonly Address ReadHubAddress = new("test-reader", "shared");
 


### PR DESCRIPTION
`MonolithMeshTestBase.ReadNode` did `Mesh.GetMeshNode(path, 60s)` — and `Mesh` resolves `IMessageHub` from the root service provider, i.e. the **root `mesh/{id}` hub**. A call routed through the root mesh hub always faults: it is transient routing infrastructure, not a call target. Every API surface (REST, MCP, gRPC, CLI) is supposed to use the **portal hub** for exactly this reason.

## This is the ThreadAgentIntegrationTest 60s hang

```
GetMeshNode('ACME/ProductLaunch') timed out after 60.0s — the owning per-node hub never
answered the GetDataRequest. This is NOT 'node not found'.
Hub mesh/ZKdRpz… RunLevel=Started Queue(buffer=0,deferred=0,exec=0)
PendingCallbacks=1[…=GetDataRequest@ACME/ProductLaunch(60000ms)]
```

The **`Hub mesh/…`** field names the ROOT hub as the caller — that field is the whole diagnosis.

Read instead as *"caller healthy (empty queue, `RunLevel=Started`), target silent"*, it looks like a load-dependent race. That reading is why this was hunted as a flake and **never reproduced locally at any load** — including a full-project bulk run at 889/889. It is not a race; it is an invalid call site. The #661/#663 diagnostics already printed everything needed to see it.

## The change

Reads now go through a hosted hub at the **already-declared but unused** `ReadHubAddress` (`"test-reader"`/`"shared"`) — the test-side equivalent of the portal hub. The address is deliberately **constant** so every read reuses one hub rather than minting a fresh one per call (the same id stability the CLI's portal hub needs).

## Verification — and its limits

Build clean under `-c Release -p:CIRun=true -warnaserror`; `ThreadAgentIntegrationTest` 3/3.

**Local verification is weak here and I want that on the record**: these tests always passed locally, which is consistent with the root hub faulting only under CI routing. CI is the real gate — and since this touches the base class every suite inherits, the full run is the verification, not the three tests I ran.

## Follow-ups (not in this PR)

- **Finish the API audit** against the portal-hub rule — gRPC, MCP/`MeshOperations`, REST, and the CLI's portal-id stability. My search patterns were too narrow to clear gRPC; absence of matches there is not evidence it is clean.
- **Re-entrant hub build during init** — `MessageHubConfiguration.Build` runs `SyncBuildupActions` synchronously before `StartMessageProcessing()`, and `SubscribeToOwnDeletion`'s `ownStream.Subscribe(...)` materialises a reduced stream → `CreateHub` → a nested `Build`. That ~25-frame chain is where the FutuRe SIGSEGV dies. Fix direction: defer that subscribe past `StartMessageProcessing`.

**No What's New entry** — test-infrastructure fix, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)