### PR TITLE
Issue every API surface on a portal hub, never the root mesh hub

### DIFF
--- a/clients/python/meshweaver/connection.py
+++ b/clients/python/meshweaver/connection.py
@@ -181,7 +181,15 @@ class MeshConnection:
 #: an address win, so two concurrent client processes sharing one machine-wide id would silently
 #: steal each other's pushes. Set ``MESHWEAVER_CLIENT_ID`` to pin a stable id across process
 #: invocations (a long-lived agent or CLI session reconnecting to its own hub).
-_CLIENT_ID = os.environ.get("MESHWEAVER_CLIENT_ID") or uuid.uuid4().hex
+#:
+#: The value is sanitised to ``[A-Za-z0-9_-]`` (mirroring ``SessionHubResolver.Sanitize`` on the
+#: server): an operator-supplied id containing ``/`` would otherwise claim a multi-segment address
+#: like ``portal/a/b`` — a different address shape than intended, which would not round-trip
+#: through the server's ``Address`` parsing.
+_CLIENT_ID = "".join(
+    c if (c.isascii() and c.isalnum()) or c in "-_" else "-"
+    for c in (os.environ.get("MESHWEAVER_CLIENT_ID") or uuid.uuid4().hex)
+)
 
 
 def client_address() -> str:

--- a/clients/python/meshweaver/connection.py
+++ b/clients/python/meshweaver/connection.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import uuid
 from typing import Any, AsyncIterator, Awaitable, Callable, Optional
 
@@ -168,6 +169,26 @@ class MeshConnection:
             self._subscriptions.pop(stream_id, None)
 
 
+#: This process's participant id, minted once and reused by every :func:`connect` call.
+#:
+#: The address a client connects with IS its portal-hub address on the server: the portal
+#: materialises a hub there and keeps this participant's subscriptions and per-stream sync
+#: sub-hubs alive against it. A fresh id per connect therefore mints a FRESH server-side hub on
+#: every connect/reconnect and abandons the previous one's state — so the id is cached, not
+#: regenerated. Mirrors ``stableClientId()`` in the portal-next web client.
+#:
+#: Process-scoped rather than persisted to disk on purpose: the server lets the LATEST claimant of
+#: an address win, so two concurrent client processes sharing one machine-wide id would silently
+#: steal each other's pushes. Set ``MESHWEAVER_CLIENT_ID`` to pin a stable id across process
+#: invocations (a long-lived agent or CLI session reconnecting to its own hub).
+_CLIENT_ID = os.environ.get("MESHWEAVER_CLIENT_ID") or uuid.uuid4().hex
+
+
+def client_address() -> str:
+    """Return this process's stable ``portal/<id>`` participant address."""
+    return f"portal/{_CLIENT_ID}"
+
+
 async def connect(url: str, token: Optional[str] = None, address: Optional[str] = None,
                   root_certificates: Optional[bytes] = None) -> MeshConnection:
     """Connect a Python process to the mesh as a participant.
@@ -183,13 +204,16 @@ async def connect(url: str, token: Optional[str] = None, address: Optional[str] 
       authentication, and the server honours an ``accessContext`` carried on deliveries.
 
     ``token`` is a MeshWeaver API token; the server validates it and stamps every write with your
-    identity. ``address`` defaults to a fresh ``py/<uuid>`` participant.
+    identity. ``address`` defaults to this process's cached ``portal/<id>`` participant
+    (see :data:`_CLIENT_ID`) — stable across reconnects, so the server keeps ONE hub for this
+    client instead of minting a new one per connect. Workers pass an explicit stable address
+    (e.g. ``py/python-kernel``) that the .NET kernel targets.
     """
     target = url.split("://", 1)[-1]
     if url.startswith("https://"):
         channel = grpc.aio.secure_channel(target, grpc.ssl_channel_credentials(root_certificates))
     else:
         channel = grpc.aio.insecure_channel(target)
-    conn = MeshConnection(channel, address or f"py/{uuid.uuid4().hex}", token)
+    conn = MeshConnection(channel, address or client_address(), token)
     await conn._open()
     return conn

--- a/clients/typescript/src/connection.ts
+++ b/clients/typescript/src/connection.ts
@@ -36,7 +36,15 @@ export interface ConnectOptions {
 // an address win, so two concurrent client processes sharing one machine-wide id would silently
 // steal each other's pushes. Set MESHWEAVER_CLIENT_ID to pin a stable id across process
 // invocations (a long-lived agent or CLI session reconnecting to its own hub).
-const CLIENT_ID = process.env.MESHWEAVER_CLIENT_ID || randomUUID().replace(/-/g, "");
+//
+// Sanitised to [A-Za-z0-9_-] (mirroring SessionHubResolver.Sanitize on the server): an
+// operator-supplied id containing "/" would otherwise claim a multi-segment address like
+// "portal/a/b" — a different address shape than intended, which would not round-trip through the
+// server's Address parsing.
+const CLIENT_ID = (process.env.MESHWEAVER_CLIENT_ID || randomUUID().replace(/-/g, "")).replace(
+  /[^A-Za-z0-9_-]/g,
+  "-",
+);
 
 /** This process's stable `portal/<id>` participant address. */
 export function clientAddress(): string {

--- a/clients/typescript/src/connection.ts
+++ b/clients/typescript/src/connection.ts
@@ -24,6 +24,25 @@ export interface ConnectOptions {
   address?: string;
 }
 
+// This process's participant id, minted once and reused by every connect() call.
+//
+// The address a client connects with IS its portal-hub address on the server: the portal
+// materialises a hub there and keeps this participant's subscriptions and per-stream sync sub-hubs
+// alive against it. A fresh id per connect therefore mints a FRESH server-side hub on every
+// connect/reconnect and abandons the previous one's state — so the id is cached, not regenerated.
+// Mirrors stableClientId() in the portal-next web client and _CLIENT_ID in the Python SDK.
+//
+// Process-scoped rather than persisted to disk on purpose: the server lets the LATEST claimant of
+// an address win, so two concurrent client processes sharing one machine-wide id would silently
+// steal each other's pushes. Set MESHWEAVER_CLIENT_ID to pin a stable id across process
+// invocations (a long-lived agent or CLI session reconnecting to its own hub).
+const CLIENT_ID = process.env.MESHWEAVER_CLIENT_ID || randomUUID().replace(/-/g, "");
+
+/** This process's stable `portal/<id>` participant address. */
+export function clientAddress(): string {
+  return `portal/${CLIENT_ID}`;
+}
+
 export class MeshConnection {
   readonly address: string;
   private readonly call: DuplexCall;
@@ -37,7 +56,9 @@ export class MeshConnection {
   }
 
   static async connect(url: string, opts: ConnectOptions = {}): Promise<MeshConnection> {
-    const address = opts.address ?? `node/${randomUUID().replace(/-/g, "")}`;
+    // Defaults to this process's cached portal address — stable across reconnects, so the server
+    // keeps ONE hub for this client. Workers pass an explicit stable address (node/node-kernel).
+    const address = opts.address ?? clientAddress();
     const target = url.replace(/^https?:\/\//, "");
     const creds = url.startsWith("https://")
       ? grpc.credentials.createSsl()

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-29-api-surface-portal-hub.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-29-api-surface-portal-hub.md
@@ -1,0 +1,14 @@
+---
+Name: More reliable REST, MCP and gRPC access
+Category: What's New
+Description: API, MCP and gRPC calls now run on a proper portal session, so unauthenticated calls no longer stall and SDK clients keep their subscriptions across reconnects.
+Icon: Sparkle
+---
+
+# More reliable REST, MCP and gRPC access
+
+Calls arriving over the REST API or MCP without a resolvable session — an anonymous request, or a client that sends no session header — were handled on the mesh's internal routing layer instead of a real portal session. Those calls could hang until they timed out rather than returning an answer. Every API and MCP call now runs on a proper portal session, and the same applies to the GitHub sync operations started from MCP.
+
+For gRPC, validating an API token now happens on a portal session too. Previously a failure in that step was quietly treated as "not signed in", so a valid token could silently lose its identity and the caller would see permission errors instead of a clear failure.
+
+The Python and TypeScript SDKs now reuse one connection identity for the lifetime of the process instead of generating a new one on every connect. Reconnecting keeps the subscriptions and live streams you already set up, rather than leaving them behind on an abandoned session. Set `MESHWEAVER_CLIENT_ID` if you want that identity to stay the same across restarts as well.

--- a/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
@@ -35,7 +35,12 @@ public sealed class GrpcConnectionRegistry : IDisposable, IParticipantPresence
     private readonly IIoPool ioPool;
 
     /// <summary>Initializes a new instance of the <c>GrpcConnectionRegistry</c> class.</summary>
-    /// <param name="hub">The portal message hub used for serialization options and token validation.</param>
+    /// <param name="hub">
+    /// The hub this transport is hosted from — from DI this is the root <c>mesh/{id}</c> hub. It is
+    /// used ONLY as a hosting parent (<see cref="MessageHub.GetHostedHub"/>), a service-provider
+    /// handle, and a source of serializer options. Transport-level requests are issued on
+    /// <see cref="TransportHub"/> instead; see the 🚨 note there.
+    /// </param>
     /// <param name="routingService">The routing service used to register per-connection push routes.</param>
     /// <param name="ioPools">Optional I/O pool registry; the HTTP pool bridges the async outbound write, falling back to the unbounded pool when not supplied.</param>
     public GrpcConnectionRegistry(
@@ -48,6 +53,35 @@ public sealed class GrpcConnectionRegistry : IDisposable, IParticipantPresence
         accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
         ioPool = ioPools?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
     }
+
+    /// <summary>
+    /// Per-registry disambiguator for this transport's portal-hub address. Instance state, never
+    /// static (Doc/Architecture/NoStaticState) — and it keeps each replica's routing anchor unique,
+    /// so two replicas never materialise a hub at the same <c>portal/…</c> address.
+    /// </summary>
+    private readonly string instanceId = Guid.NewGuid().ToString("N")[..8];
+
+    /// <summary>
+    /// The stable <c>portal/grpc-{instance}</c> hub every transport-level request is issued on.
+    ///
+    /// <para>🚨 NEVER issue a request on <see cref="hub"/>. From DI that is the root
+    /// <c>mesh/{id}</c> hub — transient routing infrastructure, not a call target. A request
+    /// originating there never answers: the caller's queue stays empty at <c>RunLevel=Started</c>
+    /// while the pending callback runs out its timeout. For token validation that is especially
+    /// silent, because the <c>.Catch</c> below degrades a faulted validation to Anonymous — a
+    /// valid API token would quietly lose its identity instead of failing loudly.</para>
+    ///
+    /// <para>Resolution is a hosted-hubs dictionary lookup that creates on first use and returns
+    /// the same instance afterwards, so this needs no gate of its own — and creating it lazily
+    /// (rather than in the constructor) keeps hub construction out of DI construction.</para>
+    /// </summary>
+    private IMessageHub TransportHub =>
+        hub.GetHostedHub(
+            AddressExtensions.CreatePortalAddress($"grpc-{instanceId}"),
+            c => c,
+            HostedHubCreation.Always)
+        ?? throw new InvalidOperationException(
+            "Failed to materialise the gRPC transport portal hub.");
 
     // Immutable write-once constant (NoStaticState permits static readonly constants).
     private static readonly AccessContext Anonymous = new()
@@ -148,7 +182,8 @@ public sealed class GrpcConnectionRegistry : IDisposable, IParticipantPresence
                 // Token validation is the auth bootstrap — it runs BEFORE any identity exists, so it
                 // must run as System (Permission.All) or the never-null guard fail-closes the post.
                 () => accessService.ImpersonateAsSystem(),
-                _ => hub.Observe(new ValidateTokenRequest(rawToken), o => o.WithTarget(tokenAddress))
+                // 🚨 Issued on the transport's PORTAL hub, never on the root mesh hub — see TransportHub.
+                _ => TransportHub.Observe(new ValidateTokenRequest(rawToken), o => o.WithTarget(tokenAddress))
                         .Select(d => d.Message as ValidateTokenResponse))
             .Take(1)
             .Select(resp =>

--- a/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
+++ b/src/MeshWeaver.Hosting.Grpc/GrpcConnectionRegistry.cs
@@ -74,11 +74,20 @@ public sealed class GrpcConnectionRegistry : IDisposable, IParticipantPresence
     /// <para>Resolution is a hosted-hubs dictionary lookup that creates on first use and returns
     /// the same instance afterwards, so this needs no gate of its own — and creating it lazily
     /// (rather than in the constructor) keeps hub construction out of DI construction.</para>
+    ///
+    /// <para>🚨 <c>RegisterStream</c> is REQUIRED, not decoration: <c>portal</c> is a stream-routed
+    /// address type (<c>MeshConfiguration.DefaultStreamRoutedAddressTypes</c>), so on Orleans
+    /// the RoutingGrain dispatches to this address over the cluster-wide memory stream. Without the
+    /// registration the RESPONSE (e.g. <c>ValidateTokenResponse</c>) has nowhere to land cross-silo
+    /// and the request times out — reintroducing the very failure this hub exists to avoid. The
+    /// monolith masks it (routing short-circuits on <c>GetHostedHub</c>), so tests would not catch
+    /// it. Same wiring as <c>SessionHubResolver</c>'s session hubs.</para>
     /// </summary>
     private IMessageHub TransportHub =>
         hub.GetHostedHub(
             AddressExtensions.CreatePortalAddress($"grpc-{instanceId}"),
-            c => c,
+            c => c.WithInitialization(h =>
+                h.RegisterForDisposal(routingService.RegisterStream(h))),
             HostedHubCreation.Always)
         ?? throw new InvalidOperationException(
             "Failed to materialise the gRPC transport portal hub.");

--- a/src/MeshWeaver.Mcp/McpMeshPlugin.cs
+++ b/src/MeshWeaver.Mcp/McpMeshPlugin.cs
@@ -507,11 +507,16 @@ When the sync source has two-way enabled, `update` never overwrites a node chang
         var opRun = new System.Reactive.Disposables.SingleAssignmentDisposable();
         using (accessService.SwitchAccessContext(user))
         {
+            // 🚨 Issued on the SESSION hub, never on rootHub. These extensions call
+            // hub.RunActivity(...), which creates and drives an Activity node from the hub
+            // it is invoked on — and the root mesh/{id} hub is transient routing
+            // infrastructure on which request-shaped work never answers. The GUI's
+            // GitHubActionArea calls the same extensions on its portal host hub.
             IObservable<string> action = operation switch
             {
-                "commit" => rootHub.CommitToGitHub(spacePath, userId, OnCreated, normalizedSource),
-                "update" => rootHub.UpdateToLatestFromGitHub(spacePath, userId, OnCreated, normalizedSource, force),
-                _ => rootHub.CheckBranchStateOnGitHub(spacePath, userId, OnCreated, normalizedSource),
+                "commit" => sessionHub.CommitToGitHub(spacePath, userId, OnCreated, normalizedSource),
+                "update" => sessionHub.UpdateToLatestFromGitHub(spacePath, userId, OnCreated, normalizedSource, force),
+                _ => sessionHub.CheckBranchStateOnGitHub(spacePath, userId, OnCreated, normalizedSource),
             };
             opRun.Disposable = action
                 .Finally(() => opRun.Dispose())

--- a/src/MeshWeaver.Mcp/SessionHubResolver.cs
+++ b/src/MeshWeaver.Mcp/SessionHubResolver.cs
@@ -16,8 +16,16 @@ namespace MeshWeaver.Mcp;
 /// <para>
 /// Both transports must share this helper so their routing semantics stay
 /// identical — same address shape, same <see cref="DataExtensions.AddData(MessageHubConfiguration)"/>
-/// + <see cref="IRoutingService.RegisterStream(IMessageHub)"/> wiring, same fallback to the
-/// root hub when no session is resolvable.
+/// + <see cref="IRoutingService.RegisterStream(IMessageHub)"/> wiring, and the same
+/// guarantee that the returned hub is ALWAYS a <c>portal/…</c> hub.
+/// </para>
+///
+/// <para>
+/// 🚨 This helper NEVER returns the root <c>mesh/{id}</c> hub. That hub is transient
+/// routing infrastructure, not a call target: request-shaped work issued on it never
+/// answers — the caller's queue stays empty at <c>RunLevel=Started</c> while the pending
+/// callback runs out its timeout, which reads misleadingly like "the target never
+/// replied". Every API surface (MCP, REST, gRPC, CLI) issues on a portal hub.
 /// </para>
 /// </summary>
 public static class SessionHubResolver
@@ -34,12 +42,24 @@ public static class SessionHubResolver
     private static readonly string InstanceId = Guid.NewGuid().ToString("N")[..8];
 
     /// <summary>
-    /// Materialises (or reuses) a hosted hub for the calling user × protocol session
-    /// at address <c>portal/{prefix}-{sessionId}-{instance}</c>. Falls back to
-    /// <paramref name="rootHub"/> if no caller / session can be derived from
-    /// <paramref name="ctx"/>.
+    /// Session-segment used when no caller / session can be derived from the request.
+    /// Combined with <see cref="InstanceId"/> this yields ONE process-stable shared
+    /// anonymous hub at <c>portal/{prefix}-anon-{instance}</c> — never the root mesh hub,
+    /// and never a fresh hub per request (which would leak a hub + routing registration
+    /// on every anonymous call).
     /// </summary>
-    /// <param name="rootHub">Portal-level hub from which to host the child.</param>
+    private const string AnonymousSession = "anon";
+
+    /// <summary>
+    /// Materialises (or reuses) a hosted hub for the calling user × protocol session
+    /// at address <c>portal/{prefix}-{sessionId}-{instance}</c>. When no caller / session
+    /// can be derived from <paramref name="ctx"/>, falls back to the process-stable shared
+    /// anonymous portal hub — NEVER to <paramref name="rootHub"/>.
+    /// </summary>
+    /// <param name="rootHub">
+    /// The hub that HOSTS the returned child (typically the root mesh hub). Used only as the
+    /// hosting parent and as a service-provider handle — never as the hub a call is issued on.
+    /// </param>
     /// <param name="ctx">Current HTTP context (claims + Mcp-Session-Id header).</param>
     /// <param name="prefix">Transport label used in the address segment: <c>"mcp"</c>, <c>"api"</c>, …</param>
     /// <param name="logger">Diagnostic sink.</param>
@@ -52,11 +72,15 @@ public static class SessionHubResolver
         var sessionId = ResolveSessionId(ctx);
         if (sessionId is null)
         {
+            // 🚨 NEVER return rootHub here. It is the root mesh/{id} hub, on which
+            // request-shaped work never answers. Anonymous callers share one stable
+            // portal hub instead: it has the routing + lifetime mesh operations need.
+            sessionId = AnonymousSession;
             logger.LogWarning(
-                "No {Prefix} session id resolvable from request — falling back to root hub. "
-                + "Some routing rules (kernel dispatch, etc.) will not fire.",
+                "No {Prefix} session id resolvable from request — using the shared anonymous "
+                + "portal hub. Callers that authenticate (or send an Mcp-Session-Id header) "
+                + "get their own isolated session hub.",
                 prefix);
-            return rootHub;
         }
 
         var routingService = rootHub.ServiceProvider.GetRequiredService<IRoutingService>();


### PR DESCRIPTION
## Why

The root `mesh/{id}` hub is transient routing infrastructure, not a call target — request-shaped work issued on it never answers. The caller's queue stays empty at `RunLevel=Started` while the pending callback runs out its timeout, which reads like *"the target never replied"* and sends you hunting a race that doesn't exist. That misreading is exactly what cost a session on the `ThreadAgentIntegrationTest` hang (fixed separately in #705).

**Why grep can't find this class of bug:** `MeshHostApplicationBuilder` installs `MessageHubServiceProviderFactory(BuildHub)`, so the mesh hub's own provider **is** the ASP.NET root provider. Every constructor-injected or `RequestServices`-resolved `IMessageHub` is therefore the root mesh hub. Resolving it is fine — using it as a **call origin** is the defect. `hub.ServiceProvider.GetService<T>()`, `hub.JsonSerializerOptions`, and `hub.GetHostedHub(...)` as a hosting *parent* are all left alone.

## Server surfaces

| Surface | Defect | Fix |
|---|---|---|
| MCP **and** REST | `SessionHubResolver` returned `rootHub` outright when no session id resolved → every anonymous/claimless call ran on the root mesh hub | always materialise a portal hub; those callers share one process-stable `portal/{prefix}-anon-{instance}` (shared, so an anonymous call can't leak a hub + routing registration per request) |
| MCP | `rootHub.CommitToGitHub` / `UpdateToLatestFromGitHub` / `CheckBranchStateOnGitHub` — these call `hub.RunActivity(...)` | issued on `sessionHub`, matching `GitHubActionArea`, which already calls them on its portal host hub |
| gRPC | `ValidateTokenRequest` issued on the root hub — and the surrounding `.Catch` degrades a faulted validation to **Anonymous**, so a valid API token silently lost its identity instead of failing loudly | lazily-materialised `portal/grpc-{instance}` transport hub |

REST was audited endpoint-by-endpoint: all mesh-operation endpoints route through `ResolveSession`, so the resolver fix covers them. `SeoEndpoints` and `PluginRegistryEndpoints` use the hub only as a service-provider/serializer handle. The CLI is clean — it's pure HTTP over `/api/mesh/*` and its session id comes from claims.

## Clients — cache the portal id

The address a client connects with **is** its portal-hub address on the server, so a fresh id per connect mints a fresh server-side hub on every connect/reconnect and abandons the previous one's subscriptions and sync sub-hubs. The Python and TypeScript SDKs minted `py/<uuid>` / `node/<uuid>` per `connect()`; they now reuse one cached `portal/<id>` per process (`MESHWEAVER_CLIENT_ID` pins it across invocations).

The cache is **per-process, not a machine-wide file** — the server lets the *latest* claimant of an address win, so a shared id would make two concurrent client processes steal each other's pushes. Same reason portal-next's `stableClientId()` is per-tab rather than a cookie. Workers are unaffected: they pass explicit stable addresses (`py/python-kernel`, `node/node-kernel`).

`portal` is already a default stream-routed address type (`MeshConfiguration.DefaultStreamRoutedAddressTypes`), so these route on Orleans without any new `AddStreamRoutedAddressType`.

## Verification

- `MeshWeaver.Hosting.Grpc.Test` — 8/8 green
- `DocumentationLinkIntegrityTest` — green
- `Hosting.Grpc`, `Mcp`, `Memex.Portal.Shared`, `Documentation` all build clean under `-c Release -warnaserror`

Includes a What's New entry (user-facing: API/MCP/gRPC reliability + SDK reconnect behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)