### PR TITLE
Code-include scanner: a path must look like a path — stop scraping prose

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -201,9 +201,22 @@ internal class MeshNodeCompilationService(
     }
 
     /// <summary>
-    /// Regex matching @@path references in code files, consistent with InlineReferenceResolver in MeshWeaver.AI.
+    /// Regex matching @@path references in code files. The capture must LOOK LIKE A NODE PATH —
+    /// it starts with a word character and continues with path characters only — because this
+    /// pattern runs over RAW C# SOURCE, where <c>@@</c> also appears in prose: XML doc comments
+    /// citing the markdown embed idiom (<c>@@("area/Search")</c>) and string literals in tests
+    /// asserting exactly that idiom.
+    ///
+    /// <para>🚨 The permissive predecessor (<c>@@([^\s#\]]+)</c>, shared with the AI
+    /// InlineReferenceResolver, which reads PROSE where that is correct) scraped those fragments
+    /// as include paths — <c>("area/CoverCta")&lt;/c&gt;</c>, <c>("Install/area/CoverCta")"),</c> —
+    /// and each garbage match cost a SERIAL 15s GetMeshNode timeout on the resolving hub. On memex
+    /// 2026-07-29 that stall starved the Store root's activation reads (its subtree holds ~44 Code
+    /// nodes): SubscribeRequest hit its 60s ceiling and the page died with "activation faulted".
+    /// A scanner over source code must reject anything a node path cannot begin with — quotes,
+    /// parentheses, XML markup.</para>
     /// </summary>
-    private static readonly Regex CodeIncludePattern = new(@"@@([^\s#\]]+)", RegexOptions.Compiled);
+    internal static readonly Regex CodeIncludePattern = new(@"@@([\w][\w\-./]*)", RegexOptions.Compiled);
 
     private IObservable<string> ResolveCodeIncludes(string code, HashSet<string> resolved)
     {

--- a/test/MeshWeaver.Graph.Test/CodeIncludePatternTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeIncludePatternTest.cs
@@ -1,0 +1,57 @@
+using System.Linq;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the compile-source include scanner's pattern
+/// (<see cref="MeshNodeCompilationService.CodeIncludePattern"/>) against the 2026-07-29 Store
+/// outage: the permissive predecessor (<c>@@([^\s#\]]+)</c>) ran over RAW C# source and scraped
+/// prose — XML doc comments citing the markdown embed idiom, and test string literals asserting
+/// it — as include paths. Each garbage match cost a SERIAL 15s GetMeshNode timeout on the
+/// resolving hub; with ~44 Code nodes in the Store subtree those stalls starved the Store root's
+/// activation reads until its SubscribeRequest died at the 60s ceiling ("activation faulted",
+/// /Store down). A code-include path must LOOK like a node path.
+/// </summary>
+public class CodeIncludePatternTest
+{
+    /// <summary>The literal fragments the old pattern scraped out of memex's live sources —
+    /// captured verbatim from the incident logs. None of them may ever match again.</summary>
+    [Theory]
+    [InlineData("embed with <c>@@(\"area/CoverCta\")</c> under the hero")]
+    [InlineData("\"the self-embed @@(\\\"area/CoverCta\\\") suppresses the type's panel\");")]
+    [InlineData("\"hero…\\n\\n@@(\\\"Install/area/CoverCta\\\")\\n\\nmore\"),")]
+    [InlineData("/// one <c>@@(\"Quiz/area/Quiz\")</c> uses: a small sibling INSTANCE node")]
+    [InlineData("return $\"@@(\\\"{target}/area/{area}\\\")\";")]
+    [InlineData("@@\"quoted\"")]
+    [InlineData("@@(paren")]
+    [InlineData("@@<markup>")]
+    public void ProseNeverMatches(string sourceLine)
+    {
+        Assert.Empty(MeshNodeCompilationService.CodeIncludePattern.Matches(sourceLine));
+    }
+
+    /// <summary>Genuine include directives — a node path after the marker — must keep resolving.</summary>
+    [Theory]
+    [InlineData("@@Store/Plugin/Source/PluginGate", "Store/Plugin/Source/PluginGate")]
+    [InlineData("// include the shared helper: @@Edu/Shared/NodeContent", "Edu/Shared/NodeContent")]
+    [InlineData("@@Doc/Architecture/Plugins.md", "Doc/Architecture/Plugins.md")]
+    [InlineData("@@my-space/sub_dir/File", "my-space/sub_dir/File")]
+    public void NodePathsStillMatch(string sourceLine, string expectedPath)
+    {
+        var match = Assert.Single(MeshNodeCompilationService.CodeIncludePattern.Matches(sourceLine).Cast<System.Text.RegularExpressions.Match>());
+        Assert.Equal(expectedPath, match.Groups[1].Value);
+    }
+
+    /// <summary>A path capture stops at the first character a node path cannot contain — trailing
+    /// prose punctuation is not part of the include.</summary>
+    [Theory]
+    [InlineData("@@Doc/Guide, then more prose", "Doc/Guide")]
+    [InlineData("(@@Doc/Guide)", "Doc/Guide")]
+    public void CaptureStopsAtPathBoundary(string sourceLine, string expectedPath)
+    {
+        var match = Assert.Single(MeshNodeCompilationService.CodeIncludePattern.Matches(sourceLine).Cast<System.Text.RegularExpressions.Match>());
+        Assert.Equal(expectedPath, match.Groups[1].Value);
+    }
+}


### PR DESCRIPTION
Scanner side of the memex 2026-07-29 `/Store` outage (data side: MeshWeaver.Plugins#227).

## The defect

`MeshNodeCompilationService` scanned raw C# source for `@@` includes with the AI `InlineReferenceResolver`'s pattern — `@@([^\s#\]]+)` — which is right for **prose** but wrong for **code**, where `@@` also appears in doc comments citing the markdown embed idiom and in test literals asserting it:

```
Could not resolve code include @@("Install/area/CoverCta")"),
GetDataRequest@("area/MyExercises")</c>.</summary>
```

Each garbage match cost a **serial 15 s** `GetMeshNode` timeout on the resolving hub. With ~44 Code nodes in the Store subtree, those stalls starved the Store root's activation reads → `SubscribeRequest` 60 s ceiling → *activation faulted*, `/Store` down.

## The fix

The capture must **look like a node path**: `@@([\w][\w\-./]*)` — word character first, path characters after. Quotes, parentheses and XML markup can't begin a node path, so prose can't match.

## Tests

`CodeIncludePatternTest` pins:
- the **incident strings verbatim** — none may ever match again;
- the genuine directive shapes — all keep matching, with the exact capture asserted;
- the capture boundary (`@@Doc/Guide, prose` captures `Doc/Guide`).

```
CodeIncludePatternTest 14/14 · full MeshWeaver.Graph.Test 743/743
```

## Deliberately NOT here

The serial 15 s timeout per unresolvable include is an outage **amplifier** independent of what feeds it — worth its own change (parallel resolution or a short negative-cache) rather than a rider on a regex fix.