### PR TITLE
Finish in-flight hub constructions at disposal instead of racing them

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
+++ b/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
@@ -130,8 +130,14 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
     // In-flight construction tracking (see GetHub): count of callers currently inside a
     // creation Lazy, and a ping per completion so DisposeHubsReactive can wait reactively
     // for the drain — no async/await, no blocking wait on the disposal path.
+    //
+    // 🚨 Synchronized: concurrent creations of DIFFERENT addresses complete on different
+    // threads, and a bare Subject's OnNext is not safe under concurrent callers — a torn
+    // notification could drop the very ping that reports the count reaching zero, stalling
+    // the drain leg until the join's Timeout. Subject.Synchronize serialises the
+    // notifications (same pattern as MeshNodeStreamCache).
     private int inflightCreations;
-    private readonly Subject<Unit> inflightChanged = new();
+    private readonly ISubject<Unit> inflightChanged = Subject.Synchronize(new Subject<Unit>());
 
     /// <summary>
     /// Per-address construction single-flight (see <see cref="GetHub"/>). Entries

--- a/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
+++ b/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
@@ -98,13 +98,40 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
             return newHub;
         }, LazyThreadSafetyMode.ExecutionAndPublication));
 
-        var created = lazy.Value;
-        // The Lazy only guards single-flight DURING construction — messageHubs is
-        // the steady-state map (same as before). Dropping the entry afterwards
-        // also restores the old retry semantics when creation failed/was refused.
-        creations.TryRemove(address, out _);
-        return created;
+        // 🚨 In-flight construction is TRACKED so disposal can FINISH it instead of racing it.
+        // CloseCreation refuses NEW creations the instant disposal begins, but a creation that
+        // passed the IsDisposing check moments earlier keeps building while the owner tears
+        // down — and DisposeHubsReactive's snapshot cannot see it (the hub lands in messageHubs
+        // only after construction). The container then dies UNDER the running Build:
+        // SyncBuildupActions resolves services from the disposed scope (ObjectDisposedException
+        // stragglers; on CI, the TypeRegistry walk over an unloading ALC = the #613 SIGSEGV).
+        // The contract is: finish the requests we started, refuse new ones — so disposal WAITS
+        // for this counter to drain (see the inflight leg in DisposeHubsReactive) and then
+        // disposes whatever the late construction produced, instead of leaking it as a zombie.
+        Interlocked.Increment(ref inflightCreations);
+        try
+        {
+            var created = lazy.Value;
+            return created;
+        }
+        finally
+        {
+            // The Lazy only guards single-flight DURING construction — messageHubs is
+            // the steady-state map (same as before). Dropping the entry afterwards
+            // also restores the old retry semantics when creation failed/was refused.
+            creations.TryRemove(address, out _);
+            // Decrement BEFORE pinging so an observer probing on the ping reads the
+            // post-decrement count.
+            Interlocked.Decrement(ref inflightCreations);
+            try { inflightChanged.OnNext(Unit.Default); } catch { /* disposal-time ping must never throw */ }
+        }
     }
+
+    // In-flight construction tracking (see GetHub): count of callers currently inside a
+    // creation Lazy, and a ping per completion so DisposeHubsReactive can wait reactively
+    // for the drain — no async/await, no blocking wait on the disposal path.
+    private int inflightCreations;
+    private readonly Subject<Unit> inflightChanged = new();
 
     /// <summary>
     /// Per-address construction single-flight (see <see cref="GetHub"/>). Entries
@@ -247,9 +274,55 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
                 });
         }).ToArray();
 
-        IObservable<Unit> all = childCompletions.Length == 0
-            ? Observable.Return(Unit.Default)
-            : Observable.CombineLatest(childCompletions).Select(_ => Unit.Default).Take(1);
+        // 🚨 FINISH in-flight constructions, don't race them. The snapshot above cannot see a
+        // hub that is mid-Build (it lands in messageHubs only after construction), so without
+        // this leg the collection signalled DisposalCompleted — and the owner tore down the
+        // container — while a creation that had passed the IsDisposing check was still resolving
+        // services (the ObjectDisposedException straggler class / #613 SIGSEGV; the "check-then-
+        // act residue" #488 named). The contract: refuse NEW requests (CloseCreation, above),
+        // properly finish the ones already started. Merge order matters: inflightChanged is
+        // subscribed FIRST, then the immediate probe — so a decrement between the snapshot and
+        // this subscription is caught by the probe, and one after it by the ping. Whatever a
+        // late construction produced is then disposed here, inside the join, so it is never a
+        // zombie outside the disposal snapshot.
+        var inflightDrain = Observable
+            .Merge(inflightChanged, Observable.Return(Unit.Default))
+            .Where(_ => Volatile.Read(ref inflightCreations) == 0)
+            .Take(1)
+            .SelectMany(_ =>
+            {
+                var late = messageHubs.Values.Except(hubs).ToArray();
+                if (late.Length == 0)
+                    return Observable.Return(Unit.Default);
+                logger.LogInformation(
+                    "Disposing {count} hub(s) whose construction completed after disposal began: [{addresses}]",
+                    late.Length, string.Join(", ", late.Select(h => h.Address.ToString())));
+                var lateCompletions = late.Select(h =>
+                {
+                    try
+                    {
+                        h.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Error during disposal of late-constructed hub {address}", h.Address);
+                    }
+                    return h.DisposalCompleted
+                        .Take(1)
+                        .Catch<Unit, Exception>(ex =>
+                        {
+                            logger.LogError(ex, "Late-constructed hub {address} disposal faulted", h.Address);
+                            return Observable.Return(Unit.Default);
+                        });
+                }).ToArray();
+                return Observable.CombineLatest(lateCompletions).Select(_ => Unit.Default).Take(1);
+            });
+
+        var completionLegs = childCompletions.Append(inflightDrain).ToArray();
+        IObservable<Unit> all = Observable
+            .CombineLatest(completionLegs)
+            .Select(_ => Unit.Default)
+            .Take(1);
 
         disposalSubscription = all
             .Timeout(TimeSpan.FromSeconds(5))

--- a/test/MeshWeaver.Messaging.Hub.Test/InflightHubCreationDrainTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/InflightHubCreationDrainTest.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Deterministic repro for the in-flight-construction teardown race (#613's trigger; the
+/// "check-then-act residue" #488 named): a hosted-hub creation that passed the IsDisposing
+/// check keeps building while the owner disposes. Before the drain leg in
+/// <c>HostedHubsCollection.DisposeHubsReactive</c>, the owner signalled DisposalCompleted —
+/// and the host then tore down the DI container — while the Build was still resolving
+/// services, which is the ObjectDisposedException straggler class locally and the
+/// TypeRegistry-over-unloading-ALC SIGSEGV on CI.
+///
+/// <para>The contract under test: disposal FINISHES the requests already started (waits for
+/// the in-flight construction, then disposes whatever it produced — no zombie) and refuses
+/// new ones. The gate/latch pair below is the sanctioned deterministic-concurrency-repro
+/// shape: the latch proves construction is mid-flight before disposal starts, the gate
+/// holds it there until the test has asserted disposal is waiting.</para>
+/// </summary>
+public class InflightHubCreationDrainTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    [Fact]
+    public async Task Disposal_WaitsForInflightConstruction_ThenDisposesTheLateHub()
+    {
+        var client = GetClient();
+
+        using var constructionEntered = new ManualResetEventSlim(false);
+        using var releaseConstruction = new ManualResetEventSlim(false);
+
+        // Kick the creation off a background thread: the WithInitialization hook runs
+        // synchronously inside MessageHubConfiguration.Build, so this thread parks inside
+        // construction — exactly where the routed-emission creations of the straggler class
+        // sit when teardown begins.
+        var creation = Task.Run(() => client.GetHostedHub(
+            new Address("inflight", "1"),
+            c => c.WithInitialization(_ =>
+            {
+                constructionEntered.Set();
+                releaseConstruction.Wait(TimeSpan.FromSeconds(30));
+            }),
+            HostedHubCreation.Always));
+
+        constructionEntered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue(
+            "the hosted-hub construction must have started before disposal begins");
+
+        var disposalCompleted = client.DisposalCompleted.Take(1).ToTask();
+        client.Dispose();
+
+        // Negative wait (sanctioned "confirm nothing happened" shape): disposal must NOT
+        // complete while the construction it started is still in flight — completing here is
+        // the bug, because the owner would proceed to tear down the container under the
+        // running Build.
+        var winner = await Task.WhenAny(disposalCompleted, Task.Delay(TimeSpan.FromSeconds(1)));
+        winner.Should().NotBe(disposalCompleted,
+            "disposal must wait for the in-flight hosted-hub construction to finish");
+
+        releaseConstruction.Set();
+
+        // Now disposal finishes the started request and completes.
+        await disposalCompleted.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // And the late-constructed hub was disposed with the collection — not leaked as a
+        // zombie outside the disposal snapshot.
+        var lateHub = await creation.WaitAsync(TimeSpan.FromSeconds(10));
+        lateHub.Should().NotBeNull("the in-flight creation was started before disposal and must be finished, not refused");
+        await lateHub!.DisposalCompleted.Take(1).ToTask().WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public void Creation_AfterDisposalBegan_IsRefused()
+    {
+        var client = GetClient();
+        client.Dispose();
+
+        // The other half of the contract: NEW requests after disposal began are refused,
+        // transparently (null — the caller's dead-stream handling takes over), never a
+        // half-built hub on a dying container.
+        var refused = client.GetHostedHub(
+            new Address("late", "1"),
+            c => c,
+            HostedHubCreation.Always);
+
+        refused.Should().BeNull("creation after disposal began must be refused");
+    }
+}


### PR DESCRIPTION
Closes the **finish** half of the teardown contract — *properly finish the requests already started, transparently refuse new ones* — for hosted-hub construction. The refusal half already exists (`CloseCreation` cascade, #635); this PR closes the "check-then-act residue" #488 named and #613's dump analysis pinned.

## The race

A routed emission's hub creation passes the `IsDisposing` check moments before disposal begins. `DisposeHubsReactive` then snapshots `messageHubs` — but the hub under construction isn't there yet (it lands only after `Build`), so the collection signalled `DisposalCompleted` and the owner tore down the container **while `Build` was still resolving services**:

```
MeshQuery emission (still live at teardown)
 → MonolithRoutingService.CreateHub → HostedHubsCollection.CreateHub
   → MessageHubConfiguration.Build → SubscribeToOwnDeletion → InstallReleaseRequestWatcher
     → GetService → disposed Autofac LifetimeScope
```

Locally that's the `ObjectDisposedException` teardown-straggler class; on CI the same construction walking the TypeRegistry over an unloading collectible ALC is the **#613 SIGSEGV**.

Why such emissions exist at all: `hub.Post` is fire-and-forget by design, so a test's (or teardown's own) last write's route resolution can always straddle `DisposeAsync`. The traffic can't be eliminated — only drained.

## The fix

Fully reactive, no async/await, no blocking wait: `GetHub` counts callers inside a creation `Lazy` and pings a `Subject` on completion; `DisposeHubsReactive`'s completion join gains an **inflight leg** that waits for the count to drain and then disposes whatever the late construction produced — inside the join, before `DisposalCompleted` — so the container outlives every in-flight `Build` and the late hub is never a zombie outside the disposal snapshot. Merge order (ping subscribed before the immediate probe) closes the probe/ping race; the existing join `Timeout` still caps a wedged construction.

## Proven, not asserted

- **Deterministic repro** (`InflightHubCreationDrainTest`): a creation parked inside `WithInitialization` — the same hook the straggler stacks die in — while the parent disposes. **Without this change the test FAILS** (disposal completed in ~20 ms with the construction still in flight); with it, disposal waits, then the late hub's own `DisposalCompleted` terminates. A second test pins the refusal half (creation after dispose-start returns null).
- **End-to-end measurement** — `MeshWeaver.AI.Test` via the native xUnit host, the way CI runs it: the hub-construction straggler chain goes **14 → 0** (total 19 → 12; 919/919 green before and after). The remaining 12 are a *different* class — in-flight `ThreadExecution` round work (`AgentChatClient.GetStreamingResponseAsync`, `MeshQuery` reads) touching disposed state — consumer-side, deliberately untouched here.
- `Messaging.Hub.Test` 109/109; both projects build clean under `-c Release -warnaserror`.

No What's New entry: hub-lifecycle/teardown internals, no user-visible change.

Related: #613 (this removes its trigger), #488 (same diagnosis, closed — this is that idea rebased onto the CloseCreation architecture), #708 (independent; unbreaks main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)