### PR TITLE
Defer the probe's query legs: a subscribe-time throw was killing the test host

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -615,7 +615,21 @@ internal class MeshNodeCompilationService(
                     // CHUNKS, so the first emission can be a partial set — and a partial source set
                     // compiles WRONG (missing files → phantom errors), which is worse than slow.
                     // Fold every change, then settle on a quiet window.
-                    mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(q))
+                    //
+                    // 🚨 Defer per LEG — this lambda runs inside CombineLatest's SUBSCRIPTION, and
+                    // the probe's subscription is SCHEDULED (DelaySubscription → a ThreadPool tick).
+                    // When the mesh is disposed between scheduling and firing, mesh.Query →
+                    // CaptureContext → GetService throws SYNCHRONOUSLY on the disposed Autofac
+                    // scope — and Rx routes a synchronous throw during a Producer's subscribe to
+                    // the SUBSCRIBE CALLER, not to OnError, so neither this leg's .Catch nor the
+                    // probe's outer .Catch ever sees it. The caller is the scheduler → unhandled on
+                    // the ThreadPool → xUnit v3's AppDomain handler reports "[FATAL ERROR]
+                    // ObjectDisposedException", waits for the run to finish, and Environment.Exit(2)s
+                    // — the CI "exit=2 with an all-green trx" shard failures (first seen when #690
+                    // made this probe run on every compile). Defer's FACTORY exceptions, by
+                    // contrast, ARE forwarded to OnError — so the throw lands in this leg's .Catch
+                    // below and the leg degrades to empty, exactly like any other faulted leg.
+                    Observable.Defer(() => mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(q)))
                         .Scan(ImmutableDictionary<string, MeshNode>.Empty, ApplyQueryChange)
                         .Throttle(SourceProbeQuietWindow)
                         .Take(1)


### PR DESCRIPTION
Root cause of the CI **`exit=2` with an all-green trx** shard failures — pinned from the failing run's own logs (#716's run), not inferred:

```
[FATAL ERROR] System.ObjectDisposedException
  at AutofacServiceProvider.GetService                ← disposed scope
  at MeshService.CaptureContext      (MeshService.cs:62)
  at MeshService.Query[T]            (MeshService.cs:257)
  at MeshNodeCompilationService.DirectSourceProbe b__2 (:618)
  at CombineLatest.Run ← SubscribeRaw ← DelaySubscription ← ThreadPool
```

## Mechanism

The probe's per-leg `mesh.Query(...)` lambda is evaluated **inside `CombineLatest`'s subscription**, and the probe's subscription is **scheduled** (`DelaySubscription` → a ThreadPool tick). When the mesh is disposed between scheduling and firing, `CaptureContext` throws synchronously on the dead Autofac scope — and Rx routes a synchronous throw during a `Producer`'s subscribe to the **subscribe caller**, not to `OnError`, so neither the leg's `.Catch` nor the probe's outer `.Catch` ever sees it. The caller is the scheduler → unhandled on the ThreadPool → xUnit v3's `AppDomain` handler reports `[FATAL ERROR]`, **waits for the run to finish** (`finishEvent.Wait()` — which is why the summary prints all green, `Errors: 0`), then `Environment.Exit(2)`. `TeardownStragglerCapturer` never sees it: xUnit's handler subscribed first and exits the process before later handlers run.

This is why the `exit=2` transients began exactly when #690 made this probe run on every compile (previously a delay-subscribed fallback that almost never fired): #708 attempt 1 (`AI.Test` + `Acme.Test`, both compile-heavy), attempt 2 green **on the identical commit** (won the timer race), #716 (base includes #690, its own diff is fixture-only).

## Fix

Wrap each leg in `Observable.Defer`. `Defer`'s *factory* exceptions **are** forwarded to `OnError`, so the throw lands in the leg's existing `.Catch` and the leg degrades to empty — the exact behaviour the probe already intends for a faulted leg (*"NEVER win the race with an EMPTY set… stay silent"*).

No deterministic in-repo repro: it needs the container to die between the probe's schedule and its tick — a window #715's construction drain also narrows. The CI FATAL stack above is the repro; the fix is the Rx-contract correction that makes the window harmless.

## Verification

- `CompileLeafStabilityTest` 2/2 + `CompileSourceSnapshotWedgeTest` 1/1 (the stalled-snapshot path #690 exists for)
- `MeshWeaver.Graph` builds clean under `-c Release -warnaserror`

No What's New entry: internal reliability fix, no user-visible change.

Related: #690 (made the window hot), #708/#716 (the runs it redded), #613 (the caught-straggler class is adjacent but distinct — this one was the *unhandled* escape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)