### PR TITLE
Static content: stamp the HTTP caller's AccessContext on the cross-hub post (#694)

### DIFF
--- a/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
+++ b/src/MeshWeaver.Blazor/Infrastructure/UserContextMiddleware.cs
@@ -325,6 +325,52 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
     /// observable bridging). Returns <c>null</c> until the cache has received
     /// its first <c>Query</c> emission.
     /// </summary>
+    /// <summary>
+    /// Resolves the ACCESS CONTEXT of an HTTP caller for surfaces this middleware deliberately
+    /// SKIPS (<see cref="ExcludedPrefixes"/> — <c>/static/…</c> above all). Those endpoints post
+    /// hub messages of their own, and a post with no identity is refused by the never-null
+    /// PostPipeline guard — which is invisible same-silo (local delivery) and fatal cross-silo:
+    /// with 2 replicas, ~half of all /static requests died with "AccessContext must never be null"
+    /// (#694), because the identity was never resolved for the request in the first place.
+    ///
+    /// <para>Same rules as the middleware path, NEVER null: authenticated → claims context with the
+    /// mesh User node's Id as ObjectId (cache-resolved; an email-shaped ObjectId is REFUSED —
+    /// better anonymous than mis-partitioned); otherwise — or on any resolution fault — the
+    /// well-known ANONYMOUS context, whose permissions are exactly the Anonymous grants
+    /// (public covers and declared public segments). Fail-closed by construction: this can widen
+    /// nothing, it only names who is asking so RLS can answer.</para>
+    /// </summary>
+    public static AccessContext ResolveHttpCaller(
+        ClaimsPrincipal? user, IServiceProvider services, ILogger? logger = null)
+    {
+        try
+        {
+            var ctx = user is null ? null : ExtractUserContext(user);
+            if (ctx is null)
+                return AnonymousContext;
+            if (!string.IsNullOrEmpty(ctx.Email))
+            {
+                var meshUser = services.GetService<UserIdentityCache>()
+                    ?.TryGetByEmail(ctx.Email);
+                if (meshUser is not null)
+                    ctx = ctx with { ObjectId = meshUser.Id, Name = meshUser.Name ?? meshUser.Id };
+            }
+            if (LooksLikeEmail(ctx.ObjectId))
+            {
+                logger?.LogWarning(
+                    "ResolveHttpCaller: refusing email-shaped ObjectId {ObjectId}; treating as anonymous.",
+                    ctx.ObjectId);
+                return AnonymousContext;
+            }
+            return ctx;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "ResolveHttpCaller failed; treating the request as anonymous.");
+            return AnonymousContext;
+        }
+    }
+
     private MeshNode? TryLoadMeshUser(string email, IMessageHub hub)
     {
         try
@@ -339,7 +385,7 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
         }
     }
 
-    private AccessContext? ExtractUserContext(ClaimsPrincipal user)
+    private static AccessContext? ExtractUserContext(ClaimsPrincipal user)
     {
         if (user?.Identity?.IsAuthenticated != true)
             return null;

--- a/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
+++ b/src/MeshWeaver.Hosting.Blazor/BlazorHostingExtensions.cs
@@ -247,12 +247,25 @@ public static class BlazorHostingExtensions
             var targetAddress = (Address)resolution.Prefix;
             var qualifiedCollectionName = $"{resolution.Prefix}/{addressCollectionName}";
 
+            // 🚨 STAMP THE CALLER on the post. The user-context middleware deliberately skips
+            // /static/ (perf), so nothing has resolved an identity for this request — and a hub
+            // post with no AccessContext is refused by the never-null PostPipeline guard. That
+            // refusal is INVISIBLE at one replica (local delivery) and killed ~half of all /static
+            // requests at two: whenever the target partition's hub lived on the OTHER silo, the
+            // cross-silo post died with "AccessContext must never be null" and the file 500'd
+            // (#694 — the reason memex runs single-replica). Resolve the caller here (claims →
+            // mesh user; anonymous otherwise) and stamp the DELIVERY — per-request, never the
+            // ambient AccessService (concurrent static requests carry different users). Identity
+            // only names WHO is asking; the owning hub's RLS still decides what they may read, so
+            // anonymous gets exactly the Anonymous grants and gated files stay gated.
+            var caller = UserContextMiddleware.ResolveHttpCaller(context.User, mainHub.ServiceProvider);
+
             // Cached collection config — short-circuit; otherwise compose hub.Observe.
             IObservable<ContentCollectionConfig?> configObs = collectionCache.TryGetValue(qualifiedCollectionName, out var cached)
                 ? Observable.Return<ContentCollectionConfig?>(cached)
                 : mainHub.Observe(
                         new GetDataRequest(new ContentCollectionReference([addressCollectionName])),
-                        o => o.WithTarget(targetAddress))
+                        o => o.WithTarget(targetAddress).WithAccessContext(caller))
                     .Select<IMessageDelivery, ContentCollectionConfig?>(collectionResponse =>
                     {
                         IReadOnlyCollection<ContentCollectionConfig>? configs = collectionResponse?.Message switch

--- a/test/MeshWeaver.Hosting.Blazor.Test/ResolveHttpCallerTest.cs
+++ b/test/MeshWeaver.Hosting.Blazor.Test/ResolveHttpCallerTest.cs
@@ -1,0 +1,66 @@
+using System.Security.Claims;
+using MeshWeaver.Blazor.Infrastructure;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Blazor.Test;
+
+/// <summary>
+/// Pins <see cref="UserContextMiddleware.ResolveHttpCaller"/> — the identity source for HTTP
+/// surfaces the user-context middleware deliberately skips (<c>/static/…</c>). Those endpoints
+/// post hub messages, and a post with no <c>AccessContext</c> is refused by the never-null
+/// PostPipeline guard — invisible at one replica (local delivery), fatal cross-silo: at two
+/// replicas ~half of all /static requests died with "AccessContext must never be null" (#694).
+/// The resolver must therefore NEVER return null, never widen anonymous rights, and never emit
+/// an email-shaped ObjectId (the mis-partitioning trap).
+/// </summary>
+public class ResolveHttpCallerTest
+{
+    // The resolver needs only a service provider (an absent UserIdentityCache means
+    // "no mesh-user resolution", which is a legal production state on a fresh host).
+    private static IServiceProvider Services() => new ServiceCollection().BuildServiceProvider();
+
+    [Fact]
+    public void Anonymous_YieldsTheWellKnownAnonymousContext_NeverNull()
+    {
+        var services = Services();
+        var ctx = UserContextMiddleware.ResolveHttpCaller(null, services);
+        Assert.NotNull(ctx);
+        Assert.Equal(WellKnownUsers.Anonymous, ctx.ObjectId);
+
+        var unauthenticated = new ClaimsPrincipal(new ClaimsIdentity());
+        var ctx2 = UserContextMiddleware.ResolveHttpCaller(unauthenticated, services);
+        Assert.Equal(WellKnownUsers.Anonymous, ctx2.ObjectId);
+    }
+
+    [Fact]
+    public void Authenticated_CarriesTheUsername_NeverTheEmailShape()
+    {
+        var services = Services();
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("preferred_username", "rbuergi@systemorph.com"),
+            new Claim(ClaimTypes.Email, "rbuergi@systemorph.com"),
+            new Claim(ClaimTypes.Name, "Roland"),
+        ], authenticationType: "test"));
+
+        var ctx = UserContextMiddleware.ResolveHttpCaller(principal, services);
+        // The email local-part is the mesh partition key; an email-shaped ObjectId routes
+        // to a parallel partition owning none of the user's data.
+        Assert.Equal("rbuergi", ctx.ObjectId);
+        Assert.DoesNotContain("@", ctx.ObjectId);
+    }
+
+    [Fact]
+    public void ResolutionFaults_FailClosedToAnonymous()
+    {
+        // A principal whose identity claims are pathological must never produce null or throw —
+        // the static pipeline turns any throw into a 500 for the asset. Fail closed: anonymous.
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.Email, "not-an-email")], authenticationType: "test"));
+        var ctx = UserContextMiddleware.ResolveHttpCaller(principal, Services());
+        Assert.NotNull(ctx);
+    }
+}


### PR DESCRIPTION
Fixes #694.

## The defect

With 2 replicas, ~half of all `/static/{address}/{collection}/{file}` requests died with **"AccessContext must never be null for an application post"**. The 60 s "no response" in the HTTP error was a red herring — the post was never delivered: whenever the target partition's hub lived on the **other silo**, the cross-silo post hit the never-null PostPipeline guard and was refused. At one replica the same null context rides local delivery unpunished — which is why memex has been pinned single-replica since 07-28, and why every scale-up re-broke static content at ~50%.

The identity was never resolved for these requests at all: `UserContextMiddleware` deliberately **skips `/static/`** (perf), and the endpoint posted from the main mesh hub with whatever ambient context existed — none.

## The fix — at the seam the guard's own message prescribes

*"Wire its source: user-context from the circuit/HTTP user."*

- **`UserContextMiddleware.ResolveHttpCaller(ClaimsPrincipal?, IServiceProvider)`** — the middleware's own rules, reusable by the surfaces it skips, **never null**: authenticated → claims context with the mesh User node's Id as ObjectId (cache-resolved; an email-shaped ObjectId is refused — better anonymous than mis-partitioned); otherwise, or on any fault, the well-known **Anonymous** context. Fail-closed by construction: the context only names *who is asking* — the owning hub's RLS still decides what they may read, so gated files stay gated.
- The static endpoint stamps it **on the delivery** (`PostOptions.WithAccessContext`) — per-request, never the ambient `AccessService` (concurrent static requests carry different users).

## Tests

`ResolveHttpCallerTest`: never-null (null *and* unauthenticated principal), username-not-email ObjectId, fail-closed-to-anonymous. The first cut took `IMessageHub` and needed a full mesh to test; the resolver only used the service provider, so the signature now says so. Suite: `MeshWeaver.Hosting.Blazor.Test` **202/202**.

## Rollout

After this ships in an image: unpause KEDA (`min=2`) on memex-cloud + systemorph and verify with the issue's own curl loop — **10/10 across collections** at 2 replicas is the acceptance bar.