### PR TITLE
Cross-silo replies to the root mesh hub: stream-route 'mesh' and register the reply stream (#694 layer 2)

### DIFF
--- a/src/MeshWeaver.Hosting.Monolith/MonolithRegistryExtensions.cs
+++ b/src/MeshWeaver.Hosting.Monolith/MonolithRegistryExtensions.cs
@@ -1,4 +1,5 @@
-﻿using MeshWeaver.Hosting.Persistence;
+﻿using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Persistence;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,6 +26,9 @@ public static class MonolithRegistryExtensions
         {
             services.AddMeshCatalog();
             services.TryAddSingleton<IRoutingService, MonolithRoutingService>();
+            // Root-hub reply stream — a no-op for in-process routing but keeps both
+            // transports symmetric (core#694 layer 2; see RootMeshHubReplyStreamService).
+            services.AddRootMeshHubReplyStream();
             return services;
         });
         builder.ConfigureHub(conf =>

--- a/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
+++ b/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
@@ -1,4 +1,5 @@
-﻿using MeshWeaver.Connection.Orleans;
+﻿using MeshWeaver.Hosting;
+using MeshWeaver.Connection.Orleans;
 using MeshWeaver.Hosting.Persistence;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -114,6 +115,9 @@ public static class OrleansServerRegistryExtensions
         // Partition routing is the default (see OrleansConnectionExtensions for rationale).
         services.AddPartitionedInMemoryPersistence();
         services.TryAddSingleton<IRoutingService, OrleansRoutingService>();
+        // The root mesh hub's cross-silo REPLY stream (core#694 layer 2) — see
+        // RootMeshHubReplyStreamService for the full story.
+        services.AddRootMeshHubReplyStream();
 
         // Mesh-scoped registry of the last per-grain activation failure. MessageHubGrain
         // records the real activation error here (the same one it feeds to _hubReadyRaw.OnError);

--- a/src/MeshWeaver.Hosting/RootMeshHubReplyStreamService.cs
+++ b/src/MeshWeaver.Hosting/RootMeshHubReplyStreamService.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>
+/// Registers the ROOT MESH HUB's reply stream with the routing service at host start.
+///
+/// <para><b>Why it exists.</b> Requests are still issued on the root <c>mesh/{id}</c> hub by
+/// surfaces that predate the portal-hub migration (#707) — the static-content endpoint above
+/// all — and their RESPONSES are separate posts targeted back at <c>mesh/{id}</c>. Same-silo
+/// those replies hit the routing service's local stream table; CROSS-silo they can only arrive
+/// over the cluster-wide memory stream this registration subscribes (<c>mesh</c> is a
+/// stream-routed address type — see <c>MeshConfiguration.DefaultStreamRoutedAddressTypes</c>).
+/// Without it a reply produced on another silo had NOWHERE to go and the requester hung
+/// silently: core#694 layer 2 — at 2 replicas ~half of all <c>/static</c> requests (memex
+/// 2026-07-29, 35/60), the ratio tracking which silo owned each partition's per-node grain.</para>
+///
+/// <para><b>Why a HOSTED SERVICE and not <c>WithInitialization</c> on the hub.</b> The
+/// registration needs <see cref="IRoutingService"/>, whose monolith implementation takes
+/// <see cref="IMessageHub"/> in its constructor — resolving it from inside the hub singleton's
+/// own factory re-enters that factory and the process dies with a STACK OVERFLOW (found by the
+/// first cut of this fix; the two-silo repro crashed with exit 134 before running a single
+/// test). A hosted service starts after the DI graph is complete, so both resolutions are
+/// cycle-free — and it starts before/alongside the Orleans silo, whose stream provider the
+/// registration tolerates via its own bounded retry (<c>SubscribeWithRetryAsync</c>).</para>
+///
+/// <para><b>Rollover.</b> Each pod's root address is a fresh guid, so replicas never collide on
+/// a stream name, and the subscription dies with the pod — a departed pod's in-flight replies
+/// have no requester left to serve, which is the correct semantic.</para>
+/// </summary>
+internal sealed class RootMeshHubReplyStreamService(IServiceProvider services) : IHostedService
+{
+    private IDisposable? registration;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var hub = services.GetRequiredService<IMessageHub>();
+        var routing = services.GetService<IRoutingService>();
+        if (routing is not null)
+            registration = routing.RegisterStream(hub);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        registration?.Dispose();
+        registration = null;
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>Wires <see cref="RootMeshHubReplyStreamService"/> — called by each transport's
+/// server registry beside its <c>IRoutingService</c> registration.</summary>
+public static class RootMeshHubReplyStreamExtensions
+{
+    /// <summary>Adds the root-hub reply-stream registration to the host.</summary>
+    public static IServiceCollection AddRootMeshHubReplyStream(this IServiceCollection services)
+    {
+        services.AddHostedService<RootMeshHubReplyStreamService>();
+        return services;
+    }
+}

--- a/src/MeshWeaver.Hosting/RootMeshHubReplyStreamService.cs
+++ b/src/MeshWeaver.Hosting/RootMeshHubReplyStreamService.cs
@@ -43,7 +43,17 @@ internal sealed class RootMeshHubReplyStreamService(IServiceProvider services) :
         var hub = services.GetRequiredService<IMessageHub>();
         var routing = services.GetService<IRoutingService>();
         if (routing is not null)
+        {
             registration = routing.RegisterStream(hub);
+            // 🚨 ALSO tie the registration to the HUB's own disposal. The stream callback closes
+            // over the hub and lives in the routing service's table; releasing it only at host
+            // StopAsync leaves a window where a disposed hub is still pinned by the table — under
+            // CI load that window is long enough for MeshHub_IsCollected_AfterMeshAndService-
+            // ProviderDisposal's GC probe to catch it (shard-red on the first CI run of this fix,
+            // green locally: a timing sensitivity, made deterministic here). Disposable.Create's
+            // dispose-once semantics make the double registration (hub disposal + StopAsync) safe.
+            hub.RegisterForDisposal(registration);
+        }
         return Task.CompletedTask;
     }
 

--- a/src/MeshWeaver.Mesh.Contract/MeshConfiguration.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshConfiguration.cs
@@ -49,6 +49,16 @@ public class MeshConfiguration(
     ///   <item><c>portal</c> — Blazor user circuits (PortalApplication).</item>
     ///   <item><c>client</c> — test client hubs / SDK clients.</item>
     ///   <item><c>cache</c> — MeshNodeStreamCache's mesh-node-cache hub.</item>
+    ///   <item><c>mesh</c> — each process's ROOT mesh hub (<c>mesh/{id}</c>). It is a
+    ///   POD-PROCESS hub like the three above, and any surface that still posts requests
+    ///   from it (the static-content endpoint, tooling) needs its REPLIES routed back.
+    ///   Without this entry a cross-silo reply for <c>mesh/{id}</c> fell into the grain
+    ///   path — a black hole, since no grain can reach a hub hosted in another pod's
+    ///   process. Prod signature: at 2 replicas ~half of all /static requests hung
+    ///   silently (core#694 layer 2, memex 2026-07-29, 35/60); the reader's own
+    ///   diagnostic even names it: "owned by another silo, so no reply was ever going
+    ///   to be produced". The root hub registers its reply stream in
+    ///   <c>MeshBuilder.Register</c>.</item>
     /// </list>
     /// Module-owned host-hub types register themselves via
     /// <c>MeshBuilder.AddStreamRoutedAddressType</c> (e.g. Graph registers <c>import</c>
@@ -56,7 +66,7 @@ public class MeshConfiguration(
     /// so this core list stays free of higher-layer knowledge.
     /// </summary>
     public static readonly IReadOnlySet<string> DefaultStreamRoutedAddressTypes =
-        new HashSet<string>(StringComparer.Ordinal) { "portal", "client", "cache" };
+        new HashSet<string>(StringComparer.Ordinal) { "portal", "client", "cache", "mesh" };
 
     // No public Nodes / MeshNodes property. Static nodes registered via
     // MeshBuilder.AddMeshNodes(...) flow through StaticMeshNodeListProvider

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansCrossSiloReplyTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansCrossSiloReplyTest.cs
@@ -1,0 +1,157 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.TestingHost;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// The REPLY path for requests issued on a pod's ROOT MESH HUB (<c>mesh/{id}</c>) — the exact
+/// shape of core#694 layer 2. The static-content endpoint (and anything else still posting from
+/// the root hub) issues <c>GetDataRequest</c>-style reads whose RESPONSE is a separate post
+/// targeted back at <c>mesh/{id}</c>. Same-silo that reply hits the routing service's local
+/// stream table; CROSS-silo it reached the RoutingGrain, and because <c>mesh</c> was not a
+/// stream-routed address type it fell into the grain path — a black hole. The observable
+/// symptom in prod: at 2 replicas ~half of all /static requests hang silently (35/60 measured
+/// on memex, 2026-07-29), ratio tracking which silo owns each partition's per-node hub grain.
+///
+/// <para>The repro is DETERMINISTIC without knowing the grain placement: the same read is
+/// issued from BOTH silos' root mesh hubs — whichever silo does not own the per-node grain is
+/// guaranteed to exercise the cross-silo reply.</para>
+/// </summary>
+public class OrleansCrossSiloReplyTest : IClassFixture<TwoSiloCacheUpdateFixture>
+{
+    private readonly TwoSiloCacheUpdateFixture _fixture;
+
+    public OrleansCrossSiloReplyTest(TwoSiloCacheUpdateFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static IMessageHub SiloMeshHub(TestCluster cluster, int index)
+        => ((InProcessSiloHandle)cluster.Silos[index]).SiloHost.Services
+            .GetRequiredService<IMessageHub>();
+
+    /// <summary>
+    /// A node read issued on EACH silo's root mesh hub must receive its reply — including the
+    /// silo that does NOT own the target's per-node hub grain, whose reply crosses silos.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task RootMeshHubRead_ReceivesItsReply_FromBothSilos()
+    {
+        var ct = new CancellationTokenSource(TimeSpan.FromSeconds(100)).Token;
+        var cluster = _fixture.Cluster;
+        cluster.Silos.Count.Should().BeGreaterThanOrEqualTo(2, "the repro needs two silos");
+
+        var hubA = SiloMeshHub(cluster, 0);
+        var hubB = SiloMeshHub(cluster, 1);
+
+        // One node; its per-node hub grain hashes onto exactly one silo, so of the two reads
+        // below one is same-silo and one is cross-silo — no placement knowledge needed.
+        var ns = $"xsilo-{Guid.NewGuid():N}";
+        var path = $"{ns}/Doc";
+        var create = await hubA
+            .Observe(new CreateNodeRequest(new MeshNode("Doc", ns)
+            {
+                NodeType = "Markdown",
+                Name = "Doc",
+                State = MeshNodeState.Active,
+            }), o => o.WithTarget(hubA.Address))
+            .FirstAsync().ToTask(ct);
+        create.Message.Success.Should().BeTrue(create.Message.Error ?? "");
+
+        // Same-silo leg first: proves the node reads fine at all, so a cross-silo failure
+        // below can only be the REPLY path, not the node.
+        foreach (var (hub, label) in new[] { (hubA, "silo A"), (hubB, "silo B") })
+        {
+            var node = await hub.GetMeshNode(path, TimeSpan.FromSeconds(20))
+                .FirstAsync()
+                .ToTask(ct);
+            node.Should().NotBeNull(
+                $"the read issued on {label}'s root mesh hub must receive its reply — "
+                + "when this is the non-owning silo, the reply crosses silos, and a hang here "
+                + "IS core#694 layer 2 (the memex 35/60 static-content failure at 2 replicas)");
+            node!.Path.Should().Be(path);
+        }
+    }
+
+}
+
+/// <summary>
+/// ROLLOVER variant — its OWN class and therefore its OWN two-silo cluster: the test STOPS the
+/// secondary silo, so sharing a fixture with the steady-state test would starve it of its
+/// second silo (exactly what the first cut did — xUnit ran this class-mate first and the
+/// steady-state test found a one-silo cluster).
+/// </summary>
+public class OrleansCrossSiloReplyRolloverTest : IClassFixture<TwoSiloCacheUpdateFixture>
+{
+    private readonly TwoSiloCacheUpdateFixture _fixture;
+
+    public OrleansCrossSiloReplyRolloverTest(TwoSiloCacheUpdateFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static IMessageHub SiloMeshHub(TestCluster cluster, int index)
+        => ((InProcessSiloHandle)cluster.Silos[index]).SiloHost.Services
+            .GetRequiredService<IMessageHub>();
+
+    /// <summary>
+    /// ROLLOVER: after the secondary silo leaves (a rolling deploy's constant reality — every
+    /// deploy has a two-silo window and then one leaves), a read from the surviving silo must
+    /// still complete: if the departed silo owned the per-node grain, Orleans reactivates it on
+    /// the survivor; the reply is then same-silo. Bounded — a hang here is a failed rollover.
+    /// </summary>
+    [Fact(Timeout = 180000)]
+    public async Task RootMeshHubRead_SurvivesSecondarySiloDeparture()
+    {
+        var ct = new CancellationTokenSource(TimeSpan.FromSeconds(160)).Token;
+        var cluster = _fixture.Cluster;
+        cluster.Silos.Count.Should().BeGreaterThanOrEqualTo(2, "the rollover repro needs two silos");
+
+        var hubA = SiloMeshHub(cluster, 0);
+
+        var ns = $"rollover-{Guid.NewGuid():N}";
+        var path = $"{ns}/Doc";
+        var create = await hubA
+            .Observe(new CreateNodeRequest(new MeshNode("Doc", ns)
+            {
+                NodeType = "Markdown",
+                Name = "Doc",
+                State = MeshNodeState.Active,
+            }), o => o.WithTarget(hubA.Address))
+            .FirstAsync().ToTask(ct);
+        create.Message.Success.Should().BeTrue(create.Message.Error ?? "");
+
+        // Touch the node once so its grain is activated (on whichever silo).
+        var before = await hubA.GetMeshNode(path, TimeSpan.FromSeconds(20)).FirstAsync().ToTask(ct);
+        before.Should().NotBeNull("the node must read before the rollover");
+
+        // The rollover: the secondary silo leaves gracefully (the rolling-deploy shape).
+        await cluster.StopSecondarySilosAsync();
+
+        // The surviving silo must still serve the read — grain reactivation on the survivor,
+        // bounded. Retry across the reactivation window; a persistent hang is the defect.
+        var after = await Observable
+            .Interval(TimeSpan.FromSeconds(2)).StartWith(0L)
+            .SelectMany(_ => hubA.GetMeshNode(path, TimeSpan.FromSeconds(15),
+                    ReadTimeoutBehavior.EmitNull)
+                .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null)))
+            .Where(n => n is not null)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(90))
+            .ToTask(ct);
+        after!.Path.Should().Be(path,
+            "after the secondary silo departs, the surviving silo must re-own the grain and "
+            + "serve the read — a hang here is a failed rollover");
+    }
+}


### PR DESCRIPTION
Second (and final) layer of #694. Layer 1 — the null `AccessContext` — was fixed in #718; the scale-up test then exposed this one: **35/60** static requests at 2 replicas, hanging **silently** (no server-side error at all).

## The defect

A request issued on a pod's root `mesh/{id}` hub gets its reply as a separate post targeted back at `mesh/{id}`. Same-silo, that hits the routing service's local stream table. Cross-silo it reached the `RoutingGrain` — and because `mesh` was **not a stream-routed address type**, it went down the **grain path**: a black hole, since no grain can reach a hub hosted in another pod's process. The reader's own diagnostic names it: *"owned by another silo, so no reply was ever going to be produced."*

## The fix — mirror how portal/client/cache pod-hubs already work

1. **`mesh` joins `DefaultStreamRoutedAddressTypes`** — replies ride the cluster-wide memory stream.
2. **`RootMeshHubReplyStreamService`** (hosted service, wired beside each transport's `IRoutingService` registration) subscribes the root hub's reply stream at host start. A hosted service *deliberately*: the monolith `IRoutingService` takes `IMessageHub` in its constructor, so resolving it inside the hub singleton's own factory re-enters that factory — the first cut **died with a stack overflow** before running one test. Host start is post-DI-graph; the Orleans stream provider's not-ready window is covered by `RegisterStream`'s own bounded retry.

**Rollover:** each pod's address is a fresh guid (no stream-name collisions between replicas) and the subscription dies with the pod — a departed pod's in-flight replies have no requester left to serve.

## Repro — deterministic, no placement knowledge

`OrleansCrossSiloReplyTest` issues the **same read from both silos' root hubs** — one leg is cross-silo by construction:

| | pre-fix | post-fix |
|---|---|---|
| steady-state | 20 s timeout, *"NO LOCAL HUB … owned by another silo"* | **156 ms** |
| rollover (own cluster — it stops the secondary silo) | n/a | **363 ms**, survivor re-owns the grain |

## Suites

```
Hosting.Orleans.Test 136/136 · Hosting.Test 95/95 · Query.Test 357/357
```

## Rollout acceptance (issue #694's own bar)

Ship image → scale to 2 → warm both silos → curl loop 20× per file across ≥3 collections → **60/60 sustained** + browser sweep. Pod status is not the test; the request loop is.