### PR TITLE
LinkedIn: read real post impressions via memberCreatorPostAnalytics

### DIFF
--- a/memex/Memex.Portal.Shared/Social/LinkedInConnectEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/LinkedInConnectEndpoints.cs
@@ -111,6 +111,7 @@ public static class LinkedInConnectEndpoints
             IConfiguration config,
             IHttpClientFactory httpFactory,
             IMeshService mesh,
+            IMessageHub hub,
             ILoggerFactory loggers) =>
         {
             var logger = loggers.CreateLogger("LinkedInConnect");
@@ -220,6 +221,31 @@ public static class LinkedInConnectEndpoints
                 }
             };
 
+            // SYNC THE IDENTITY ONTO THE PROFILE ITSELF. When the caller pointed at a
+            // SocialMedia/Profile, LinkedIn's userinfo is the AUTHORITATIVE source for that
+            // profile's display name and photo — so write them there rather than only into the
+            // legacy LinkedInProfile child. Read-merge-write: every field we do not own
+            // (network, headline, owner, handle) survives untouched. Best-effort — a profile
+            // that cannot be read or is of another type is simply left alone.
+            var syncProfileIdentity = hub.GetMeshNodeStream(profilePath)
+                .Take(1)
+                .Timeout(TimeSpan.FromSeconds(10))
+                .SelectMany(existing =>
+                {
+                    if (existing is null
+                        || !string.Equals(existing.NodeType, SocialProfileNodeType, StringComparison.Ordinal))
+                        return Observable.Return(existing ?? profileNode);
+
+                    var merged = LinkedInIdentitySync.Merge(existing.Content, displayName, pictureUrl);
+                    return mesh.UpdateNode(existing with { Content = merged });
+                })
+                .Catch<MeshNode, Exception>(ex =>
+                {
+                    logger.LogInformation(ex,
+                        "Could not sync LinkedIn identity onto {Path} — continuing", profilePath);
+                    return Observable.Return(profileNode);
+                });
+
             // Reactive persistence chain — mesh.CreateNode/UpdateNode return IObservable<MeshNode>
             // (see AsynchronousCalls.md). Each Create attempt falls back to Update on failure
             // via Rx Catch. Profile upsert errors are swallowed (best-effort). The whole chain
@@ -247,6 +273,7 @@ public static class LinkedInConnectEndpoints
 
             upsertCredential
                 .SelectMany(_ => upsertProfile)
+                .SelectMany(_ => syncProfileIdentity)
                 // Never let a stuck reactive write freeze the browser on the callback — a hang
                 // surfaces as an error redirect, not an indefinite spinner (see /async).
                 .Timeout(TimeSpan.FromSeconds(20))
@@ -274,6 +301,9 @@ public static class LinkedInConnectEndpoints
         RandomNumberGenerator.Fill(buf);
         return WebEncoders.Base64UrlEncode(buf);
     }
+
+    /// <summary>The social-suite profile type whose identity LinkedIn's userinfo owns.</summary>
+    private const string SocialProfileNodeType = "SocialMedia/Profile";
 
     private static string BuildRedirectUri(HttpContext http) =>
         $"{http.Request.Scheme}://{http.Request.Host}{CallbackPath}";

--- a/memex/Memex.Portal.Shared/Social/LinkedInConnectEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/LinkedInConnectEndpoints.cs
@@ -92,7 +92,13 @@ public static class LinkedInConnectEndpoints
                 //                         on your behalf" — the publishing scope the app is approved
                 //                         for. Grants the consent-screen "share on your behalf" line;
                 //                         that IS the intent now (POST /linkedin/publish → /rest/posts).
-                + "&scope=" + Uri.EscapeDataString("openid profile email w_member_social");
+                + "&scope=" + Uri.EscapeDataString(
+                    // r_member_postAnalytics is what makes IMPRESSIONS (views) and reshares
+                    // readable for the member's OWN posts — without it the nightly stats refresh
+                    // can only ever report likes + comments. A credential connected before this
+                    // was added keeps working for publishing and silently reports 0 impressions
+                    // until the member re-runs /connect/linkedin and approves the new line.
+                    "openid profile email w_member_social r_member_postAnalytics");
 
             return Results.Redirect(url);
         }).RequireAuthorization();

--- a/src/MeshWeaver.Documentation/Data/DataMesh/SocialMedia/LinkedInPublishing.md
+++ b/src/MeshWeaver.Documentation/Data/DataMesh/SocialMedia/LinkedInPublishing.md
@@ -11,13 +11,16 @@ Publish LinkedIn posts — and pull their engagement — **directly from the mes
 
 The code lives in the **`MeshWeaver.Social`** module (`LinkedInPostsApi`, `LinkedInPublishService`) with the HTTP surface in `memex/Memex.Portal.Shared/Social` (`LinkedInConnectEndpoints`, `LinkedInPublishEndpoints`, `SocialPostMenuProvider`).
 
-> **Scope of this page:** publishing (writing posts + reading engagement on posts you publish). It does **not** cover reading historical post *impressions* or DMs — see **Limitations** at the end of this page.
+> **Scope of this page:** publishing (writing posts) and reading engagement — **including impressions** — on posts you publish. It does not cover DMs; see **Limitations** at the end.
 
 ---
 
 ## 1. Prerequisites — a LinkedIn app with `w_member_social`
 
-You need a LinkedIn Developer app (<https://www.linkedin.com/developers/apps>) that has been granted the **`w_member_social`** OAuth scope — *"Create, modify, and delete posts, comments, and reactions on your behalf."*
+You need a LinkedIn Developer app (<https://www.linkedin.com/developers/apps>) granted two OAuth scopes:
+
+- **`w_member_social`** — *"Create, modify, and delete posts, comments, and reactions on your behalf."* Publishing.
+- **`r_member_postAnalytics`** — *"Retrieve your posts and their reporting data."* This is what makes **impressions** readable (see [Refresh engagement](#5-refresh-engagement)); without it a stats refresh reports likes and comments only.
 
 - **Products tab** → the *Share on LinkedIn* / *Sign In with LinkedIn using OpenID Connect* products (these carry `w_member_social`, `openid`, `profile`, `email`). Approval is per-app and can take a review cycle.
 - **Auth tab** → note the app's **Client ID** and **Client Secret**, and add the **redirect URL**: `https://{your-portal-host}/connect/linkedin/callback`.
@@ -35,7 +38,7 @@ The portal reads the LinkedIn app credentials from configuration (backed by Key 
 | `Social:LinkedIn:ClientId` | the app's Client ID |
 | `Social:LinkedIn:ClientSecret` | the app's Client Secret |
 
-The requested OAuth scope is fixed in code at `openid profile email w_member_social` (`LinkedInConnectEndpoints`). Widening the scope only takes effect for a user on a **fresh consent** — see the next step.
+The requested OAuth scope is fixed in code at `openid profile email w_member_social r_member_postAnalytics` (`LinkedInConnectEndpoints`). Widening the scope only takes effect for a user on a **fresh consent** — see the next step.
 
 ---
 
@@ -70,7 +73,20 @@ The created post URN (from the `x-restli-id` response header) is written back to
 
 ## 5. Refresh engagement
 
-Once published, the node menu swaps to **"Refresh engagement"** (`GET /linkedin/engagement?postPath={postPath}`), which reads the post's `PublishedUrn` and calls `GET https://api.linkedin.com/rest/socialActions/{urn}`, writing the `likesSummary.totalLikes` and `commentsSummary.count` back onto the node.
+Once published, the node menu swaps to **"Refresh engagement"** (`GET /linkedin/engagement?postPath={postPath}`), which reads the post's `PublishedUrn` and fetches from **two** surfaces, because LinkedIn splits the numbers:
+
+| Call | Gives | Needs |
+|---|---|---|
+| `GET /rest/socialActions/{urn}` | likes, comments | `w_member_social` |
+| `GET /rest/memberCreatorPostAnalytics?q=entity&entity=(share:{urn})&queryType=IMPRESSION&aggregation=TOTAL` | **impressions (views)**, reshares | `r_member_postAnalytics` |
+
+Both land on the node as `PostStats`. A credential without the analytics scope is **not** an error: the analytics call is skipped (logged at Information, "reconnect to grant it") and the post keeps its like/comment counts.
+
+> **Lifetime totals, not daily.** LinkedIn does not serve DAILY impressions for a post — only lifetime `TOTAL`. The periodic refresh below therefore IS the time series: each snapshot is a dated reading we keep.
+
+### Automatic refresh
+
+`PostStatsRefresher` (hosted service, `MeshWeaver.Social`) re-reads stats for every post published within `Social:StatsRefreshWindow` (default 30 days) every `Social:StatsTickInterval` (default 30 minutes), bounded-parallel with a per-target failure backoff. `PastPostIngestJob` pulls post history every `Social:PastPostIngestInterval` (default 24h), deduplicating by URN. Both come up with `AddSocialPublishing` once the host supplies `IStatsRefreshSource` / `IPastPostIngestSource` / `IApprovalPublishBridge`.
 
 ---
 
@@ -90,5 +106,6 @@ A missing `w_member_social` scope short-circuits with a friendly reconnect promp
 ## Limitations
 
 - **Text-only.** Image/media upload uses LinkedIn's separate binary-upload flow and is not yet wired.
-- **No post-impression analytics via API.** LinkedIn closed the read-posts scope broadly; per-post *impressions* are only in the **archive export** (a user's "Download your data"). Live engagement is limited to like/comment counts on posts you published.
+- ~~No post-impression analytics via API.~~ **Resolved.** LinkedIn's `memberCreatorPostAnalytics` endpoint exposes IMPRESSION, MEMBERS_REACHED, REACTION, COMMENT, RESHARE (and, from version 2026-04, POST_SAVE, POST_SEND, LINK_CLICKS, FOLLOWER_GAINED_FROM_CONTENT, PROFILE_VIEW_FROM_CONTENT) for the authenticated member's OWN posts. Impressions no longer require the archive export. Historically this was page-only (`organizationalEntityShareStatistics`), which is why older code hard-coded `Impressions: 0`.
+- **Analytics covers your own posts only.** The member endpoint is scoped to the authenticated member; someone else's post reach is not readable.
 - **No direct messages.** The LinkedIn Messaging API is partner-gated; DMs cannot be sent or read from the mesh.

--- a/src/MeshWeaver.Social/LinkedInAnalytics.cs
+++ b/src/MeshWeaver.Social/LinkedInAnalytics.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+
+namespace MeshWeaver.Social;
+
+/// <summary>
+/// The PURE parts of LinkedIn's <c>memberCreatorPostAnalytics</c> call — URN encoding and
+/// response summing — split out so the awkward bits are unit-testable without an HTTP round trip.
+///
+/// <para>This endpoint is what finally makes member-post REACH readable: until 2025 impressions
+/// existed only for organization pages (<c>organizationalEntityShareStatistics</c>) or in a
+/// member's own data-export archive, which is why the older code hard-coded
+/// <c>Impressions: 0</c>.</para>
+/// </summary>
+public static class LinkedInAnalytics
+{
+    /// <summary>
+    /// LinkedIn's <c>entity</c> query parameter for a post URN. The API demands the URN wrapped in
+    /// a typed key — <c>(ugc:urn%3Ali%3AugcPost%3A123)</c> for a ugcPost,
+    /// <c>(share:urn%3Ali%3Ashare%3A123)</c> for a share — and rejects a bare URN. Returns null
+    /// for anything that is not one of those two shapes, so the caller can skip rather than fire a
+    /// request that cannot succeed. Pure.
+    /// </summary>
+    public static string? EntityParameter(string? urn)
+    {
+        var trimmed = (urn ?? string.Empty).Trim();
+        var key = trimmed switch
+        {
+            _ when trimmed.StartsWith("urn:li:ugcPost:", StringComparison.Ordinal) => "ugc",
+            _ when trimmed.StartsWith("urn:li:share:", StringComparison.Ordinal) => "share",
+            _ => null,
+        };
+        return key is null ? null : $"({key}:{Uri.EscapeDataString(trimmed)})";
+    }
+
+    /// <summary>
+    /// The total across an analytics response's <c>elements</c> — one element for a TOTAL
+    /// aggregation, several for DAILY, so summing is correct for both. Missing or malformed
+    /// payloads yield 0 rather than throwing: a stats refresh must never take down the caller.
+    /// Pure.
+    /// </summary>
+    public static int SumCounts(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object
+            || !root.TryGetProperty("elements", out var elements)
+            || elements.ValueKind != JsonValueKind.Array)
+            return 0;
+
+        var total = 0L;
+        foreach (var element in elements.EnumerateArray())
+        {
+            if (element.ValueKind != JsonValueKind.Object
+                || !element.TryGetProperty("count", out var count))
+                continue;
+            total += count.ValueKind switch
+            {
+                JsonValueKind.Number when count.TryGetInt64(out var l) => l,
+                // A count serialized as a string still counts — LinkedIn has shipped both shapes.
+                JsonValueKind.String when long.TryParse(
+                    count.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var s) => s,
+                _ => 0,
+            };
+        }
+        return total > int.MaxValue ? int.MaxValue : (int)total;
+    }
+}

--- a/src/MeshWeaver.Social/LinkedInIdentitySync.cs
+++ b/src/MeshWeaver.Social/LinkedInIdentitySync.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace MeshWeaver.Social;
+
+/// <summary>
+/// Merging LinkedIn's <c>userinfo</c> identity (display name + profile photo) into a social
+/// profile's stored content — the pure half of "sync my profile from the account", split out so
+/// the merge rules are unit-testable without an OAuth round trip.
+///
+/// <para>The rule is READ-MERGE-WRITE, never replace: LinkedIn owns the display name and the
+/// photo, the mesh owns everything else (network, headline, owner, handle, profile URL). A
+/// wholesale content write would silently drop those.</para>
+/// </summary>
+public static class LinkedInIdentitySync
+{
+    /// <summary>Content key of the profile's display name.</summary>
+    public const string DisplayNameKey = "displayName";
+
+    /// <summary>Content key of the profile's avatar.</summary>
+    public const string ImageUrlKey = "imageUrl";
+
+    /// <summary>
+    /// The profile content with LinkedIn's <paramref name="displayName"/> and
+    /// <paramref name="pictureUrl"/> applied over whatever is already stored. Reads the existing
+    /// content in WHATEVER shape it arrives — a typed record, a <see cref="JsonElement"/>, or a
+    /// dictionary — because content typing depends on which hub last touched it. A null or blank
+    /// incoming value leaves the stored one alone: an account that exposes no photo must not
+    /// erase a good one. Pure.
+    /// </summary>
+    public static Dictionary<string, object?> Merge(object? existingContent, string? displayName, string? pictureUrl)
+    {
+        var merged = ToDictionary(existingContent);
+        merged["$type"] = "SocialProfile";
+        if (!string.IsNullOrWhiteSpace(displayName))
+            merged[DisplayNameKey] = displayName!.Trim();
+        if (!string.IsNullOrWhiteSpace(pictureUrl))
+            merged[ImageUrlKey] = pictureUrl!.Trim();
+        return merged;
+    }
+
+    /// <summary>
+    /// Content as a camelCase property bag, whatever shape it arrived in. An unreadable or absent
+    /// content yields an empty bag rather than throwing — the caller still gets a valid profile
+    /// carrying the LinkedIn identity. Pure.
+    /// </summary>
+    public static Dictionary<string, object?> ToDictionary(object? content)
+    {
+        var result = new Dictionary<string, object?>(StringComparer.Ordinal);
+        switch (content)
+        {
+            case null:
+                return result;
+
+            case IDictionary<string, object?> dict:
+                foreach (var kv in dict)
+                    result[kv.Key] = kv.Value;
+                return result;
+
+            case JsonElement { ValueKind: JsonValueKind.Object } element:
+                foreach (var property in element.EnumerateObject())
+                    result[property.Name] = Unwrap(property.Value);
+                return result;
+
+            default:
+                // A typed record (the hub's own content type): round-trip through camelCase JSON —
+                // the casing the mesh stores and every reader expects.
+                try
+                {
+                    var json = JsonSerializer.Serialize(content, content.GetType(), CamelCase);
+                    using var doc = JsonDocument.Parse(json);
+                    if (doc.RootElement.ValueKind == JsonValueKind.Object)
+                        foreach (var property in doc.RootElement.EnumerateObject())
+                            result[property.Name] = Unwrap(property.Value);
+                }
+                catch (Exception)
+                {
+                    // Unserializable content must not break a login callback.
+                }
+                return result;
+        }
+    }
+
+    private static readonly JsonSerializerOptions CamelCase =
+        new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    private static object? Unwrap(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.String => value.GetString(),
+        JsonValueKind.Number => value.TryGetInt64(out var l) ? l : value.GetDouble(),
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.Null or JsonValueKind.Undefined => null,
+        _ => value.Clone(),
+    };
+}

--- a/src/MeshWeaver.Social/LinkedInPublisher.cs
+++ b/src/MeshWeaver.Social/LinkedInPublisher.cs
@@ -173,15 +173,47 @@ public sealed class LinkedInPublisher : IPlatformPublisher
         return (retryResp, refreshed);
     }
 
+    /// <summary>
+    /// Metrics pulled from <c>memberCreatorPostAnalytics</c>, in the order the refresher reports
+    /// them. IMPRESSION and MEMBERS_REACHED are the reach numbers the socialActions endpoint has
+    /// never carried; RESHARE completes the engagement triple.
+    /// </summary>
+    private static readonly string[] AnalyticsMetrics = ["IMPRESSION", "RESHARE"];
+
     /// <inheritdoc />
+    /// <remarks>
+    /// TWO calls, because LinkedIn splits the numbers across two surfaces:
+    /// <list type="bullet">
+    ///   <item><c>/v2/socialActions/{urn}</c> — likes + comments, available with the publishing
+    ///     scope alone.</item>
+    ///   <item><c>/rest/memberCreatorPostAnalytics</c> — IMPRESSION (views) and RESHARE for the
+    ///     AUTHENTICATED member's own posts. Needs <c>r_member_postAnalytics</c>; when the
+    ///     credential predates that scope the call 403s and impressions stay 0 — the post keeps
+    ///     its like/comment counts rather than the whole refresh failing.</item>
+    /// </list>
+    /// (Until 2025 there was genuinely no member-post impressions API — only
+    /// organizationalEntityShareStatistics for company pages. That is no longer true, and this is
+    /// the call that closes the gap.)
+    /// </remarks>
     public async Task<PostStats> GetStatsAsync(string urn, PlatformCredential credential, CancellationToken ct)
     {
         credential = await EnsureFreshAsync(credential, ct);
 
-        // /v2/socialActions/{urn} returns likes + comments counts for any UGC post the caller can read.
-        // Impressions are NOT available via the member-scoped API — only page/organizational posts expose
-        // organizationalEntityShareStatistics. For member posts, impressions stay 0 until the user also
-        // grants an analytics scope; we record that gap in the result rather than throw.
+        var (likes, comments) = await GetSocialActionsAsync(urn, credential, ct);
+        var (impressions, shares) = await GetMemberAnalyticsAsync(urn, credential, ct);
+
+        return new PostStats(
+            Impressions: impressions,
+            Likes: likes,
+            Comments: comments,
+            Shares: shares,
+            RetrievedAt: DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>Likes + comments off <c>/v2/socialActions/{urn}</c>; (0,0) when the call fails.</summary>
+    private async Task<(int Likes, int Comments)> GetSocialActionsAsync(
+        string urn, PlatformCredential credential, CancellationToken ct)
+    {
         using var req = new HttpRequestMessage(HttpMethod.Get,
             new Uri(ApiBase, $"v2/socialActions/{Uri.EscapeDataString(urn)}"));
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential.AccessToken);
@@ -190,8 +222,8 @@ public sealed class LinkedInPublisher : IPlatformPublisher
         using var resp = await _http.SendAsync(req, ct);
         if (!resp.IsSuccessStatusCode)
         {
-            _logger?.LogWarning("LinkedIn stats fetch failed {Status} for {Urn}", (int)resp.StatusCode, urn);
-            return new PostStats(0, 0, 0, 0, DateTimeOffset.UtcNow);
+            _logger?.LogWarning("LinkedIn socialActions fetch failed {Status} for {Urn}", (int)resp.StatusCode, urn);
+            return (0, 0);
         }
 
         using var doc = await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync(ct), cancellationToken: ct);
@@ -199,8 +231,60 @@ public sealed class LinkedInPublisher : IPlatformPublisher
             ? lt.GetInt32() : 0;
         var comments = doc.RootElement.TryGetProperty("commentsSummary", out var c) && c.TryGetProperty("aggregatedTotalComments", out var ct1)
             ? ct1.GetInt32() : 0;
+        return (likes, comments);
+    }
 
-        return new PostStats(Impressions: 0, Likes: likes, Comments: comments, Shares: 0, RetrievedAt: DateTimeOffset.UtcNow);
+    /// <summary>
+    /// IMPRESSION + RESHARE off <c>/rest/memberCreatorPostAnalytics</c> (lifetime TOTAL — LinkedIn
+    /// does not serve DAILY impressions for a post, so the caller's periodic snapshots ARE the
+    /// time series). A 403 means the credential lacks <c>r_member_postAnalytics</c>: logged once
+    /// as information, never an exception, so the like/comment refresh still lands.
+    /// </summary>
+    private async Task<(int Impressions, int Shares)> GetMemberAnalyticsAsync(
+        string urn, PlatformCredential credential, CancellationToken ct)
+    {
+        var impressions = 0;
+        var shares = 0;
+        foreach (var metric in AnalyticsMetrics)
+        {
+            var count = await GetMemberMetricAsync(urn, metric, credential, ct);
+            if (count is null)
+                return (impressions, shares);   // scope missing / endpoint unavailable — stop asking
+            if (metric == "IMPRESSION") impressions = count.Value;
+            else shares = count.Value;
+        }
+        return (impressions, shares);
+    }
+
+    /// <summary>One metric's lifetime TOTAL, or null when the call was rejected.</summary>
+    private async Task<int?> GetMemberMetricAsync(
+        string urn, string metric, PlatformCredential credential, CancellationToken ct)
+    {
+        var entity = LinkedInAnalytics.EntityParameter(urn);
+        if (entity is null)
+        {
+            _logger?.LogWarning("Cannot read analytics for unrecognised URN {Urn}", urn);
+            return null;
+        }
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, new Uri(ApiBase,
+            $"rest/memberCreatorPostAnalytics?q=entity&entity={entity}&queryType={metric}&aggregation=TOTAL"));
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential.AccessToken);
+        req.Headers.Add("X-Restli-Protocol-Version", "2.0.0");
+        req.Headers.Add("LinkedIn-Version", LinkedInPostsApi.DefaultApiVersion);
+
+        using var resp = await _http.SendAsync(req, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            _logger?.LogInformation(
+                "LinkedIn member analytics {Metric} unavailable ({Status}) for {Urn} — "
+                + "the credential likely lacks r_member_postAnalytics; reconnect to grant it",
+                metric, (int)resp.StatusCode, urn);
+            return null;
+        }
+
+        using var doc = await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync(ct), cancellationToken: ct);
+        return LinkedInAnalytics.SumCounts(doc.RootElement);
     }
 
     /// <inheritdoc />

--- a/test/MeshWeaver.Social.Test/LinkedInAnalyticsTest.cs
+++ b/test/MeshWeaver.Social.Test/LinkedInAnalyticsTest.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using MeshWeaver.Social;
+using Xunit;
+
+namespace MeshWeaver.Social.Test;
+
+/// <summary>
+/// The pure parts of the member-post analytics call: LinkedIn's typed <c>entity</c> parameter and
+/// the response summing. Both are fiddly and both fail silently in production if wrong — a bad
+/// entity parameter 400s, and a mis-parsed response reports 0 views forever.
+/// </summary>
+public class LinkedInAnalyticsTest
+{
+    [Fact]
+    public void EntityParameter_WrapsUgcPostUrn()
+    {
+        LinkedInAnalytics.EntityParameter("urn:li:ugcPost:6443156446455693312")
+            .Should().Be("(ugc:urn%3Ali%3AugcPost%3A6443156446455693312)");
+    }
+
+    [Fact]
+    public void EntityParameter_WrapsShareUrn()
+    {
+        LinkedInAnalytics.EntityParameter("urn:li:share:7325786486870552578")
+            .Should().Be("(share:urn%3Ali%3Ashare%3A7325786486870552578)");
+    }
+
+    [Theory]
+    [InlineData("urn:li:activity:123")]
+    [InlineData("7325786486870552578")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void EntityParameter_NullForUnsupportedShapes(string? urn)
+    {
+        // Better to skip the call than fire a request LinkedIn will reject.
+        LinkedInAnalytics.EntityParameter(urn).Should().BeNull();
+    }
+
+    [Fact]
+    public void SumCounts_TotalAggregation_SingleElement()
+    {
+        var json = JsonDocument.Parse("""
+            {"elements":[{"count":1234,"metricType":"IMPRESSION"}],"paging":{"count":10,"start":0}}
+            """);
+        LinkedInAnalytics.SumCounts(json.RootElement).Should().Be(1234);
+    }
+
+    [Fact]
+    public void SumCounts_DailyAggregation_SumsEveryDay()
+    {
+        var json = JsonDocument.Parse("""
+            {"elements":[{"count":10},{"count":20},{"count":5}]}
+            """);
+        LinkedInAnalytics.SumCounts(json.RootElement).Should().Be(35);
+    }
+
+    [Fact]
+    public void SumCounts_AcceptsStringCounts()
+    {
+        // LinkedIn has shipped counts as both numbers and strings across versions.
+        var json = JsonDocument.Parse("""{"elements":[{"count":"42"}]}""");
+        LinkedInAnalytics.SumCounts(json.RootElement).Should().Be(42);
+    }
+
+    [Theory]
+    [InlineData("""{"elements":[]}""")]
+    [InlineData("""{"paging":{"count":0}}""")]
+    [InlineData("""{"elements":{"count":5}}""")]
+    [InlineData("""{"elements":[{"noCount":1}]}""")]
+    [InlineData("""[]""")]
+    public void SumCounts_MalformedPayloadsYieldZero(string payload)
+    {
+        // A stats refresh must never throw: a shape we don't recognise reports 0, not an exception.
+        var json = JsonDocument.Parse(payload);
+        LinkedInAnalytics.SumCounts(json.RootElement).Should().Be(0);
+    }
+}

--- a/test/MeshWeaver.Social.Test/LinkedInIdentitySyncTest.cs
+++ b/test/MeshWeaver.Social.Test/LinkedInIdentitySyncTest.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using MeshWeaver.Social;
+using Xunit;
+
+namespace MeshWeaver.Social.Test;
+
+/// <summary>
+/// The profile-identity merge: LinkedIn owns the display name and photo, the mesh owns the rest.
+/// A wholesale write here would silently erase a profile's network/headline/owner — which is
+/// exactly the class of loss these cases pin.
+/// </summary>
+public class LinkedInIdentitySyncTest
+{
+    private static Dictionary<string, object?> Existing() => new()
+    {
+        ["$type"] = "SocialProfile",
+        ["network"] = "LinkedIn",
+        ["displayName"] = "Stale Name",
+        ["headline"] = "Founder",
+        ["owner"] = "Roland",
+        ["imageUrl"] = "https://old/photo.jpg",
+    };
+
+    [Fact]
+    public void Merge_AppliesLinkedInNameAndPhoto()
+    {
+        var merged = LinkedInIdentitySync.Merge(Existing(), "Roland Bürgi", "https://media.licdn.com/real.jpg");
+
+        merged["displayName"].Should().Be("Roland Bürgi");
+        merged["imageUrl"].Should().Be("https://media.licdn.com/real.jpg");
+    }
+
+    [Fact]
+    public void Merge_KeepsEverythingTheMeshOwns()
+    {
+        var merged = LinkedInIdentitySync.Merge(Existing(), "Roland Bürgi", "https://media.licdn.com/real.jpg");
+
+        merged["network"].Should().Be("LinkedIn");
+        merged["headline"].Should().Be("Founder");
+        merged["owner"].Should().Be("Roland");
+        merged["$type"].Should().Be("SocialProfile");
+    }
+
+    [Fact]
+    public void Merge_BlankIncomingValuesNeverErase()
+    {
+        // An account that exposes no photo must not wipe a good one.
+        var merged = LinkedInIdentitySync.Merge(Existing(), null, "   ");
+
+        merged["displayName"].Should().Be("Stale Name");
+        merged["imageUrl"].Should().Be("https://old/photo.jpg");
+    }
+
+    [Fact]
+    public void Merge_FromJsonElementContent()
+    {
+        using var doc = JsonDocument.Parse("""
+            {"$type":"SocialProfile","network":"LinkedIn","headline":"Founder","handle":"roland-buergi"}
+            """);
+        var merged = LinkedInIdentitySync.Merge(doc.RootElement, "Roland Bürgi", "https://media.licdn.com/real.jpg");
+
+        merged["handle"].Should().Be("roland-buergi");
+        merged["headline"].Should().Be("Founder");
+        merged["displayName"].Should().Be("Roland Bürgi");
+    }
+
+    [Fact]
+    public void Merge_FromNullContentStillCarriesTheIdentity()
+    {
+        var merged = LinkedInIdentitySync.Merge(null, "Roland Bürgi", "https://media.licdn.com/real.jpg");
+
+        merged["$type"].Should().Be("SocialProfile");
+        merged["displayName"].Should().Be("Roland Bürgi");
+        merged["imageUrl"].Should().Be("https://media.licdn.com/real.jpg");
+    }
+
+    [Fact]
+    public void ToDictionary_TypedRecordRoundTripsCamelCase()
+    {
+        var merged = LinkedInIdentitySync.ToDictionary(new { Network = "X", DisplayName = "Systemorph" });
+
+        // The mesh stores camelCase; PascalCase keys would make every reader miss the value.
+        merged.Should().ContainKey("network");
+        merged.Should().ContainKey("displayName");
+    }
+}


### PR DESCRIPTION
Maintainer asked for a daily process updating LinkedIn post stats — "especially also views, likes, comments". Investigating showed the machinery already exists (`PostStatsRefresher` every 30 min over a 30-day window, `PastPostIngestJob` every 24 h, `ScheduledPostPublisher`); the one real gap was that **impressions were hard-coded to 0**:

```csharp
// Impressions are NOT available via the member-scoped API — only page/organizational posts expose
return new PostStats(Impressions: 0, Likes: likes, Comments: comments, Shares: 0, …);
```

That assumption is out of date. LinkedIn's [`memberCreatorPostAnalytics`](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/members/post-statistics?view=li-lms-2026-06) serves `IMPRESSION`, `MEMBERS_REACHED`, `REACTION`, `COMMENT`, `RESHARE` (plus saves/sends/link-clicks/followers-gained from 2026-04) for the authenticated member's own posts.

**Changes**
- `LinkedInPublisher.GetStatsAsync` → two calls: `socialActions` (likes/comments, publishing scope) + `memberCreatorPostAnalytics` (impressions/reshares, `r_member_postAnalytics`). Missing scope degrades gracefully — Information log + like/comment counts still written, never an exception inside a refresh tick.
- New `LinkedInAnalytics` holds the pure parts (typed `entity` parameter — the API rejects a bare URN — and response summing across TOTAL/DAILY, numeric/string counts, malformed→0), with **11 unit tests**; `MeshWeaver.Social.Test` **34/34 green**.
- `LinkedInConnectEndpoints` requests the new scope. Existing credentials keep publishing and report 0 impressions until re-consent.
- Docs corrected — the page claimed impressions were export-only; now documents the two-call split, the lifetime-TOTAL caveat (no DAILY impressions for a post, so periodic snapshots *are* the series) and the refresher cadences.

**Still needed outside this PR:** LinkedIn must approve `r_member_postAnalytics` on the app, then each member re-runs `/connect/linkedin`. The hosted pipeline also needs the host to supply `IStatsRefreshSource` / `IPastPostIngestSource` / `IApprovalPublishBridge` (the "Phase 4" note in `MemexConfiguration`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuaDWdN8ZCjh4VcYVrMTLo