### PR TITLE
Clickable stacks: link semantics and keyboard activation

### DIFF
--- a/src/MeshWeaver.Blazor/Components/LayoutStackView.razor
+++ b/src/MeshWeaver.Blazor/Components/LayoutStackView.razor
@@ -3,6 +3,9 @@
 
 @if (ViewModel.IsClickable)
 {
+    @* A clickable stack must be reachable and operable without a mouse: it is a tab stop with
+       link semantics, and Enter activates it (the ARIA link pattern — Enter-only, so no key's
+       browser default has to be suppressed). *@
     <FluentStack
         Class="@Class"
         Orientation="@Orientation"
@@ -13,7 +16,10 @@
         HorizontalGap="@HorizontalGap"
         Style="@ComputedStyle"
         Wrap="@Wrap"
-        @onclick="OnClick">
+        role="link"
+        tabindex="0"
+        @onclick="OnClick"
+        @onkeydown="OnKeyDown">
             <DispatchView ViewModel="@ViewModel" Stream="@Stream" Area="@Area"  />
     </FluentStack>
 }
@@ -66,5 +72,11 @@ else
         DataBind(Skin.VerticalAlignment, x => x.Vertical);
         DataBind(Skin.HorizontalAlignment, x => x.Horizontal);
         DataBind(Skin?.Orientation, x => x.Orientation);
+    }
+
+    private void OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+            OnClick();
     }
 }


### PR DESCRIPTION
A `StackControl` with a `ClickAction` rendered a bare `@onclick` div — not focusable, no role, no keyboard path. Raised by the review on MeshWeaver.Plugins#249 (Store cards becoming clickable): keyboard and screen-reader users couldn't use any clickable stack.

The clickable branch of `LayoutStackView` now renders `role="link"`, `tabindex="0"`, and `@onkeydown` activating on Enter — the ARIA link pattern. Enter-only on purpose: Space's default scroll would need `preventDefault`, which in Blazor applies to every keydown on the element and would break Tab-away.

Attributes flow through `FluentStack`'s unmatched-attribute capture, same as the existing `@onclick`. `MeshWeaver.Blazor` builds clean; no component-render test harness exists for view markup (the Blazor test project covers routing/services), so the compile is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H31ey1UdhPk4xXdhVQBw7