### PR TITLE
Add /thread skill: thread management without schema archaeology

### DIFF
--- a/content/ai/Skill/thread.md
+++ b/content/ai/Skill/thread.md
@@ -30,7 +30,7 @@ Satellites under a thread: `{threadPath}/{messageId}` message cells, `_Usage/*` 
 
 # 2. Mark a thread Done — one patch
 
-```json
+```text
 patch @{owner}/_Thread/{id}   { "content": { "status": "Done" } }
 ```
 

--- a/content/ai/Skill/thread.md
+++ b/content/ai/Skill/thread.md
@@ -1,0 +1,78 @@
+---
+nodeType: Skill
+name: /thread
+description: Manage conversation threads — read a thread's real status, mark threads Done (one or in bulk), and use the one submission surface. A thread's lifecycle lives on content.status (Idle | StartingExecution | Executing | Cancelled | Done) — managing threads is one search plus one patch per thread, never schema archaeology.
+icon: 🧵
+category: Skills
+order: 14
+---
+
+You are managing **conversation threads**. Everything you need is on the thread node's `content` —
+do not probe schemas, do not inspect sibling threads one by one, do not delegate one-line patches
+to a worker. This page IS the schema summary.
+
+# 1. What a Thread node is
+
+A thread lives at `{owner}/_Thread/{id}` with `nodeType: "Thread"`. The content fields that matter
+for management:
+
+| Field | Meaning |
+|---|---|
+| `status` | The lifecycle: `Idle`, `StartingExecution`, `Executing`, `Cancelled`, `Done`. **This is the only "done" flag.** The MeshNode-level `state` (`Active`, …) is node lifecycle, not thread lifecycle — never touch it. |
+| `messages` | Ids of the conversation cells (ingested user messages + assistant response cells). Each id is a child node `{threadPath}/{messageId}` of `nodeType: ThreadMessage`. Owned by the execution watcher — never edit by hand. |
+| `pendingUserMessages` | The inbox: submitted-but-not-yet-ingested user messages. The watcher drains it at round boundaries — never clear it by hand. |
+| `userMessageIds` / `ingestedMessageIds` | Submission bookkeeping, also watcher-owned. |
+| `summary`, `lastActivityAt` | Last round's summary; last execution heartbeat. |
+| `composer` | The thread's defaults (harness, agent, model, context path). |
+
+Satellites under a thread: `{threadPath}/{messageId}` message cells, `_Usage/*` (TokenUsage),
+`_Notification/*` (the completion bell), and delegation sub-threads nested under a response cell.
+
+# 2. Mark a thread Done — one patch
+
+```json
+patch @{owner}/_Thread/{id}   { "content": { "status": "Done" } }
+```
+
+That is the whole operation. It is **idempotent** — patching an already-Done thread is harmless, so
+you do not need to read each thread's status first.
+
+From code, the same operation is `hub.MarkThreadDone(threadPath, done)` — part of the one thread
+surface in `HubThreadExtensions` (`StartThread`, `SubmitMessage`, `ResubmitMessage`,
+`DeleteFromMessage`, `MarkThreadDone`, `RecordSubmissionFailure`). Never invent a request type
+(`SetThreadStatusRequest` and friends do not exist and must not be created).
+
+# 3. Bulk housekeeping ("mark all done except …")
+
+1. **List once:** `search nodeType:Thread namespace:{owner}/_Thread scope:children sort:lastModified-desc`
+2. **Pick the keep-set from that listing** (e.g. the top N rows).
+3. **Patch every other row** with `{ "content": { "status": "Done" } }` — idempotent, so no
+   per-thread `get`, no status pre-check, no worker delegation. N threads = 1 search + ≤N patches.
+
+Two exclusions to respect:
+
+- **Never mark the thread you are currently executing in.** Its status belongs to the running
+  round's watcher; it flips to a terminal state when the round ends.
+- Delegation sub-threads live *under* their parent's response cell and end with their parent —
+  `scope:children` on `{owner}/_Thread` already excludes them, so don't go hunting with
+  `scope:descendants`.
+
+# 4. Reading a thread's real state
+
+`get @{threadPath}` is live and authoritative. Interpreting what you see:
+
+- `status: Done` / `Cancelled` / `Idle` — terminal or at rest; safe to patch.
+- `status: StartingExecution` / `Executing` with a **recent** `lastActivityAt` — a round is running;
+  leave it alone.
+- `status: StartingExecution` / `Executing` with `lastActivityAt` far in the past and pending
+  messages that never drain — the thread is **wedged**. That is a framework bug, not a state you
+  fix by patching: report it (thread path + timestamps) instead of fighting the watcher, which owns
+  that status.
+
+# 5. Anti-patterns (each of these has burned a real session)
+
+- Fetching `<nodeType>/schema`, probing sibling threads one at a time, or "checking how Done looks
+  elsewhere" — the schema is §1.
+- Delegating a batch of one-line patches to a Worker agent — just issue the patches.
+- Setting the MeshNode-level `state`, hand-editing `messages`/`pendingUserMessages`, or inventing a
+  request/response type for a status flip — the status patch (§2) is the entire surface.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-30-thread-skill.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-30-thread-skill.md
@@ -1,0 +1,19 @@
+---
+Name: New /thread skill — manage conversation threads without the guesswork
+Category: What's New
+Description: The chat assistant now has a built-in /thread skill that knows the thread lifecycle — mark threads Done (one or in bulk) with a single patch each, no schema exploration.
+Icon: Sparkle
+---
+
+# New /thread skill — manage conversation threads without the guesswork
+
+The skill catalog now includes **/thread**, a built-in guide to managing your conversation threads.
+Ask the assistant to close a thread, or to clean up your thread list ("mark everything done except
+the last few"), and it now knows exactly what to do: a thread's lifecycle lives on its
+`content.status`, marking one Done is a single idempotent patch, and bulk housekeeping is one
+listing plus one patch per thread.
+
+The skill also teaches the assistant what *not* to touch — the message bookkeeping that the
+execution engine owns — and how to recognize a genuinely stuck thread and report it instead of
+fighting it. The practical effect: thread housekeeping requests complete in seconds instead of
+wandering through schema exploration.

--- a/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillHarnessImportSourceTest.cs
@@ -42,7 +42,7 @@ public class SkillHarnessImportSourceTest(ITestOutputHelper output) : MonolithMe
         ((MeshWeaver.Mesh.Security.PartitionAccessPolicy)policy!.Content!).PublicRead.Should().BeTrue();
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "activity", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "activity", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space", "thread");
         skills.Should().AllSatisfy(n =>
         {
             n.Namespace.Should().Be(SkillNodeType.RootNamespace);

--- a/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
+++ b/test/MeshWeaver.AI.Test/SkillNodeTypeTest.cs
@@ -29,7 +29,7 @@ public class SkillNodeTypeTest
 
         var skills = nodes.Where(n => n.NodeType == SkillNodeType.NodeType).ToList();
         skills.Should().OnlyContain(n => n.Namespace == SkillNodeType.RootNamespace);
-        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "activity", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space");
+        skills.Select(n => n.Id).OrderBy(x => x).Should().Equal("access", "activity", "agent", "clear", "code", "feedback", "group", "harness", "layout-area", "markdown", "maui", "model", "navigate", "presentation", "provider-keys", "pull-request", "slide", "space", "thread");
 
         var def = (SkillDefinition)skills.Single(n => n.Id == "model").Content!;
         def.Action!.Kind.Should().Be(SkillActionKind.Pick);


### PR DESCRIPTION
## What

Adds a built-in **/thread** skill (`content/ai/Skill/thread.md`) so chat agents manage conversation threads deterministically:

- `content.status` is the one lifecycle flag (`Idle | StartingExecution | Executing | Cancelled | Done`) — never MeshNode-level `state`, never an invented request type.
- Mark Done = one idempotent patch (`{"content":{"status":"Done"}}`) / `hub.MarkThreadDone` in code.
- Bulk housekeeping = one `scope:children` listing + one patch per thread — no per-thread status pre-reads, no Worker delegation for one-line patches.
- Documents watcher-owned fields (`messages`, `pendingUserMessages`, ingestion bookkeeping) that must never be hand-edited, and how to distinguish a wedged thread (stale `lastActivityAt`, undrained inbox) from a running one — report it, don't fight the watcher.

## Why

A 2026-07-30 "mark all threads done except top 8" request on memex-cloud burned **1.25M input tokens** rediscovering all of the above via schema archaeology, sibling probing, and a cancelled Worker delegation. With this skill the same request is 1 search + N patches.

## Changes

- `content/ai/Skill/thread.md` — the skill (catalog auto-discovers the folder; no registration code).
- `SkillNodeTypeTest` / `SkillHarnessImportSourceTest` — add `thread` to the two pinned catalog lists.
- `src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-30-thread-skill.md` — What's New entry.

## Verification

- `dotnet build test/MeshWeaver.AI.Test -c Release -warnaserror` — clean (0 warnings/errors).
- `dotnet test test/MeshWeaver.AI.Test --filter "FullyQualifiedName~Skill"` — 35/35 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119fAVTT6hAxDY9Y3X4CNWH