### PR TITLE
Self-heal version forks: floor owner mints, rebase on refused writes

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-30-version-fork-selfheal.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-30-version-fork-selfheal.md
@@ -1,0 +1,19 @@
+---
+Name: Stuck threads self-heal — version forks now reconcile instead of wedging
+Category: What's New
+Description: A thread (or any node) whose storage row got ahead of its live hub used to wedge permanently — every save silently refused. The owner now detects the refusal and rebases onto the durable truth, so the next write lands.
+Icon: Sparkle
+---
+
+# Stuck threads self-heal — version forks now reconcile instead of wedging
+
+Previously, if a node's durable storage row ended up on a newer version lineage than the live hub
+serving it (for example after a reactivation seeded from a stale cache), every write the hub made
+was refused by the storage write guard — silently. Chat threads hit by this froze forever: the
+status never left "executing", new messages queued but never ran, and even the built-in recovery
+watchdog's writes were refused.
+
+Now the owner detects a refused write, adopts the durable truth, and continues from there — the
+very next write lands and the thread (or node) recovers on its own. The version stamping that
+manufactured these forks after a reactivation has also been fixed at the root, so the situation
+arises far less often in the first place.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -254,13 +254,63 @@ public static class MeshDataSourceExtensions
         // Storage adapter's own Changes feed publishes the Updated event
         // (see IStorageAdapter.Changes / InMemoryStorageAdapter.Write) — no
         // separate fan-out from the handler.
+        var written = node;
         persistence.Write(node, hub.JsonSerializerOptions)
             .Subscribe(
-                saved => logger?.LogDebug("[SaveMeshNode] persisted path={Path} version={Version}",
-                    saved?.Path, saved?.Version),
+                saved =>
+                {
+                    // MonotonicWriteGuard refusal contract: a refused backward write emits the
+                    // STORED (winning) node, whose Version is strictly ABOVE what we wrote. The
+                    // durable row is on another lineage (a second activation's clock, or this
+                    // hub was seeded from a stale cache snapshot) — every further write from
+                    // this hub's current clock would be refused too, which is the permanent
+                    // wedge of 2026-07-30 (the Init watchdog's forced-Idle refused every 90s).
+                    // Rebase THIS owner onto the durable truth so the next write lands.
+                    if (saved is not null && saved.Version > written.Version)
+                    {
+                        AdoptDurableTruth(hub, saved, written.Version, logger);
+                        return;
+                    }
+                    logger?.LogDebug("[SaveMeshNode] persisted path={Path} version={Version}",
+                        saved?.Path, saved?.Version);
+                },
                 ex => logger?.LogWarning(ex, "SaveMeshNode failed for {Path} (version={Version})",
                     node.Path, node.Version));
         return request.Processed();
+    }
+
+    /// <summary>
+    /// Owner-side reconciliation after a <c>MonotonicWriteGuard</c> refusal: the durable row is
+    /// AHEAD of this hub's in-memory own-node state (a forked lineage — stale activation seed or
+    /// a second writer), so re-adopt the stored node through the sanctioned own-write path.
+    /// <c>UpdateOwn</c> floors its mint on the version the lambda returns, so the adopted state
+    /// commits at <c>stored.Version + 1</c>, the workspace pipeline raises
+    /// <c>_ownNodeVersionFloor</c> and re-emits to every mirror, and the persistence sampler's
+    /// next save LANDS — converged in one bounded cycle. This is reconciliation at the point of a
+    /// detected conflict, never a watchdog: it runs only when an actual write was refused, and
+    /// each further cycle requires a NEW foreign write to the row. If the in-memory state already
+    /// advanced past the stored version, the lambda no-ops (UpdateOwn completes with the
+    /// unchanged node and skips the write).
+    /// </summary>
+    private static void AdoptDurableTruth(IMessageHub hub, MeshNode stored, long refusedVersion, ILogger? logger)
+    {
+        logger?.LogWarning(
+            "[SaveMeshNode] write at Version={RefusedVersion} for {Path} was refused — the durable row is at "
+            + "Version={StoredVersion} (forked lineage: stale activation seed or a second writer). Rebasing this "
+            + "owner onto the durable truth so subsequent writes land.",
+            refusedVersion, stored.Path, stored.Version);
+        // Own-node adoption is infrastructure (same class as cache hydration / sync heartbeats):
+        // run it under the system identity, matching MeshNodeStreamCache / PathResolutionService.
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        using (accessService?.ImpersonateAsSystem())
+        {
+            hub.GetWorkspace().GetMeshNodeStream(stored.Path)
+                .Update(current => stored.Version > current.Version ? stored : current)
+                .Subscribe(
+                    _ => { },
+                    ex => logger?.LogWarning(ex,
+                        "[SaveMeshNode] durable-truth rebase failed for {Path}", stored.Path));
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -265,10 +265,21 @@ public static class MeshDataSourceExtensions
                     // hub was seeded from a stale cache snapshot) — every further write from
                     // this hub's current clock would be refused too, which is the permanent
                     // wedge of 2026-07-30 (the Init watchdog's forced-Idle refused every 90s).
-                    // Rebase THIS owner onto the durable truth so the next write lands.
+                    // Rebase THIS owner onto the durable truth so the next write lands — LIVE
+                    // hubs only, same rule as FlushPendingWrites: a save draining during
+                    // Quiescing/teardown is the stale-snapshot shape the guard exists to drop,
+                    // and rebasing mid-teardown would spin new writes on a dying hub. Either
+                    // way, never fall through to the "persisted" log for a refused write.
                     if (saved is not null && saved.Version > written.Version)
                     {
-                        AdoptDurableTruth(hub, saved, written.Version, logger);
+                        if (hub.RunLevel <= MessageHubRunLevel.Started)
+                            AdoptDurableTruth(hub, saved, written.Version, logger);
+                        else
+                            logger?.LogWarning(
+                                "[SaveMeshNode] write at Version={RefusedVersion} for {Path} was refused "
+                                + "(durable row at Version={StoredVersion}) during teardown — dropped, "
+                                + "the guard's refusal is final for a disposing hub.",
+                                written.Version, saved.Path, saved.Version);
                         return;
                     }
                     logger?.LogDebug("[SaveMeshNode] persisted path={Path} version={Version}",

--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -319,7 +319,15 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
             // hubVersion for any live clock) while a re-added durable node can never go backward.
             // Doc/Architecture/MeshNodeVersioning.md: the floor applies at EVERY place the owner
             // mints a node Version — this is the persistence re-stamp it names.
-            var nodeWithVersion = node with { Version = MeshNode.NextVersion(hubVersion, node.Version) };
+            // For the OWN node, additionally floor on _ownNodeVersionFloor: the highest
+            // own-node version this hub has adopted (activation seed, durable-truth rebase).
+            // A cache-seeded re-add can carry a version BELOW the floor; minting from the
+            // carried version alone would manufacture the backward write the
+            // MonotonicWriteGuard then refuses.
+            var addFloor = string.Equals(node.Path, _hubPath, StringComparison.OrdinalIgnoreCase)
+                ? Math.Max(node.Version, Volatile.Read(ref _ownNodeVersionFloor))
+                : node.Version;
+            var nodeWithVersion = node with { Version = MeshNode.NextVersion(hubVersion, addFloor) };
             _pendingSaves[node.Path] = nodeWithVersion;
         }
 
@@ -342,10 +350,22 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
             // rollback / "v113 read back as v3" of #325). MeshNode.NextVersion keeps it strictly
             // increasing across activations WITHOUT touching Hub.Version (so layout Fulls, which
             // ride Hub.Version, are unaffected — the 2026-06-18 wedge cannot recur).
+            // 🚨 Floor on BOTH the node's previously-saved version AND the version the write
+            // path just minted onto the incoming node (UpdateOwn stamps before the commit) —
+            // plus, for the own node, _ownNodeVersionFloor. _lastSaved is reset wholesale by
+            // BuildInstanceCollection from the merge of the durable seed and the CACHE-BACKED
+            // routing stream, so PreviousVersion alone can REGRESS after a reactivation whose
+            // durable seed lost to a stale replay (the "incoming Version=834 is BELOW the
+            // stored Version=2423" refusals of 2026-07-30): re-deriving the stamp from it
+            // manufactured a descending mint that MonotonicWriteGuard then refused forever.
+            var ownFloor = Volatile.Read(ref _ownNodeVersionFloor);
             var stampedUpdates = updates
-                .Select(u => u.Node with
+                .Select(u =>
                 {
-                    Version = MeshNode.NextVersion(hubVersion, u.PreviousVersion)
+                    var floor = Math.Max(u.PreviousVersion, u.Node.Version);
+                    if (string.Equals(u.Node.Path, _hubPath, StringComparison.OrdinalIgnoreCase))
+                        floor = Math.Max(floor, ownFloor);
+                    return u.Node with { Version = MeshNode.NextVersion(hubVersion, floor) };
                 })
                 .ToArray();
             instances = instances with
@@ -526,6 +546,31 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
             _persistenceCore.Write(node, options)
                 .Select(saved =>
                 {
+                    // MonotonicWriteGuard refusal: the stored row is AHEAD of what this hub
+                    // just tried to write (forked lineage — see AdoptDurableTruth's doc in
+                    // MeshDataSource). Rebase the own node so subsequent writes land. Live
+                    // hubs only: a dispose-time flush of a stale snapshot is exactly what
+                    // the guard exists to drop, and the refusal is the correct final word.
+                    if (saved is not null && saved.Version > node.Version
+                        && string.Equals(saved.Path, _hubPath, StringComparison.OrdinalIgnoreCase)
+                        && _workspace.Hub.RunLevel <= MessageHubRunLevel.Started)
+                    {
+                        _logger?.LogWarning(
+                            "MeshNodeTypeSource: create-flush at Version={RefusedVersion} for {Path} was refused — "
+                            + "durable row is at Version={StoredVersion}. Rebasing onto the durable truth.",
+                            node.Version, saved.Path, saved.Version);
+                        var accessService = _workspace.Hub.ServiceProvider.GetService<AccessService>();
+                        using (accessService?.ImpersonateAsSystem())
+                        {
+                            _workspace.GetMeshNodeStream(saved.Path)
+                                .Update(current => saved.Version > current.Version ? saved : current)
+                                .Subscribe(
+                                    _ => { },
+                                    ex => _logger?.LogWarning(ex,
+                                        "MeshNodeTypeSource: durable-truth rebase failed for {Path}", saved.Path));
+                        }
+                        return System.Reactive.Unit.Default;
+                    }
                     _logger?.LogDebug("MeshNodeTypeSource: Saved {Path} (version={Version})",
                         saved?.Path, saved?.Version);
                     return System.Reactive.Unit.Default;

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -668,9 +668,18 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     // off Hub.Version (which resets to 0 on every reactivation and would stamp a
                     // LOWER version after a recycle → rollback + split-brain). See
                     // MeshNode.NextVersion / Doc/Architecture/MeshNodeVersioning.md.
+                    // Also floor on the version the update lambda RETURNED: a durable-truth
+                    // rebase (AdoptDurableTruth — the owner re-adopting a stored row that is
+                    // AHEAD of its in-memory state after a MonotonicWriteGuard refusal) hands
+                    // back a node carrying the stored Version; re-stamping it off the stale
+                    // in-memory `current` alone would discard that signal and keep minting
+                    // below the durable row forever. Ordinary lambdas (`current with {…}`)
+                    // carry current.Version, so the extra term is a no-op for them; version
+                    // restore writes Version = 0 and is likewise unaffected.
                     updated = updated with
                     {
-                        Version = MeshNode.NextVersion(_workspace.Hub.Version, current.Version)
+                        Version = MeshNode.NextVersion(_workspace.Hub.Version,
+                            Math.Max(current.Version, updated.Version))
                     };
                     // Stamp BEFORE the commit — the echo subscription above only emits
                     // once it can see this write's Version on the target node.

--- a/test/MeshWeaver.Hosting.Monolith.Test/RefusedWriteOwnerRebaseTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/RefusedWriteOwnerRebaseTest.cs
@@ -1,0 +1,122 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// DETERMINISTIC repro of the 2026-07-30 memex-cloud thread wedge: a LIVE owner hub whose durable
+/// row has been advanced by another lineage (a second activation's clock, a stale-seeded sibling —
+/// here: an out-of-band <see cref="IStorageAdapter"/> write) keeps minting versions BELOW the
+/// stored row, so <c>MonotonicWriteGuardStorageAdapter</c> refuses every persistence write it
+/// makes — including the recovery paths ("Init watchdog … forcing Idle" refused every 90 s,
+/// `incoming Version=834 is BELOW the stored Version=2423`). The refusal emits the STORED node,
+/// which every caller used to treat as success, so the owner never learned and the fork was
+/// permanent.
+///
+/// <para><b>The fix under test</b> (owner-side, no watchdog, no frame-version floor):
+/// <c>HandleSaveMeshNode</c> / <c>MeshNodeTypeSource.FlushPendingWrites</c> detect the refusal
+/// (<c>saved.Version &gt; written.Version</c>) and REBASE the owner onto the durable truth through
+/// the sanctioned own-write path (<c>AdoptDurableTruth</c>); <c>UpdateOwn</c> and the
+/// <c>UpdateImpl</c> re-stamp floor their mints on the adopted version, so the next write lands
+/// above the stored row. One bounded reconciliation cycle per detected conflict — never a timer.</para>
+///
+/// <para><b>Loss semantics pinned here:</b> the write that collided with the foreign advance is
+/// condemned by the guard (durable truth wins — that is its contract); what the fix guarantees is
+/// that the fork HEALS: the owner converges to the durable version and every write after
+/// convergence lands. Before the fix this test times out: no write ever becomes durable again.</para>
+/// </summary>
+public class RefusedWriteOwnerRebaseTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Share Mesh/SP across [Fact]s — see MonolithMeshTestBase.ShareMeshAcrossTests.</summary>
+    protected override bool ShareMeshAcrossTests => true;
+
+    private IStorageAdapter Storage => Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+    private JsonSerializerOptions JsonOptions => Mesh.JsonSerializerOptions;
+
+    /// <summary>Reads the node straight out of durable storage — bypassing every hub, stream and
+    /// cache — so an assertion about DURABILITY cannot be satisfied by an in-RAM snapshot.</summary>
+    private IObservable<MeshNode?> ReadDurable(string path) => Storage.Read(path, JsonOptions);
+
+    [Fact(Timeout = 55_000)]
+    public async Task LiveOwnerBehindTheDurableRow_RebasesOnRefusal_AndSubsequentWritesLand()
+    {
+        var id = $"refused-rebase-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        // 1. Create and keep the owner hub LIVE (no recycle — this is the wedged-live-hub shape,
+        //    not the stale-reactivation one StaleActivationSeedRollbackTest covers).
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "created", NodeType = "Markdown", State = MeshNodeState.Active
+        }).Should().Within(30.Seconds()).Emit();
+
+        var created = await ReadNode(path).Should().Within(30.Seconds()).Match(n => n is { Name: "created" });
+        Output.WriteLine($"[created] version={created!.Version}");
+
+        // 2. The durable row advances OUT OF BAND to a far-ahead lineage — the fork. Straight
+        //    through IStorageAdapter (forward write: the guard passes it and raises its
+        //    high-water mark); no IMeshChangeFeed publish, so the live hub keeps serving and
+        //    minting from its own, now-behind clock.
+        var durableVersion = created.Version + 5000L;
+        await Storage.Write(created with
+        {
+            Name = "foreign-advance", Version = durableVersion
+        }, JsonOptions).Should().Within(30.Seconds()).Emit();
+
+        (await ReadDurable(path).Should().Within(30.Seconds()).Emit())!
+            .Version.Should().Be(durableVersion, "the fork must be durable before the owner writes again");
+
+        // 3. An own write through the LIVE hub. It mints from the behind clock, the persistence
+        //    sampler's save is REFUSED by the MonotonicWriteGuard — and the refusal detection
+        //    must now rebase the owner onto the durable truth. (This write's content is condemned
+        //    by the guard — durable truth wins; see the class doc for the loss semantics.)
+        var client = GetClient(c => c.AddData());
+        client.GetWorkspace().GetMeshNodeStream(path)
+            .Update(n => n with { Name = "collided-write" })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"[collided-write error] {ex.Message}"));
+
+        // 4. CONVERGENCE: the owner's live stream must come up to (past) the durable version —
+        //    the rebase echo. Before the fix the stream stays on the behind lineage forever.
+        var converged = await client.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null)
+            .Should().Within(30.Seconds())
+            .Match(n => n.Version >= durableVersion,
+                "a refused backward write must rebase the owner onto the durable truth "
+                + "(AdoptDurableTruth) — before the fix the owner never learns and keeps minting "
+                + "below the stored row forever");
+        Output.WriteLine($"[converged] name={converged.Name} version={converged.Version}");
+
+        // 5. HEALED: a write issued after convergence mints above the stored row and becomes
+        //    DURABLE. Before the fix this is the permanent wedge — no write ever lands again
+        //    (the prod shape: the watchdog's forced-Idle refused every 90 s for hours).
+        client.GetWorkspace().GetMeshNodeStream(path)
+            .Update(n => n with { Name = "post-rebase" })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"[post-rebase error] {ex.Message}"));
+
+        var persisted = await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+            .SelectMany(_ => ReadDurable(path))
+            .Should().Within(30.Seconds()).Match(n => n is { Name: "post-rebase" });
+
+        Output.WriteLine($"[persisted] name={persisted!.Name} version={persisted.Version}");
+        persisted.Version.Should().BeGreaterThan(durableVersion,
+            "after the rebase the owner's clock is at-or-above the stored row, so its mints are "
+            + "strictly above it — the write lands instead of being refused");
+
+        // 6. And the durable row never went backward at any point.
+        var final = await ReadDurable(path).Should().Within(20.Seconds()).Emit();
+        final!.Version.Should().BeGreaterThanOrEqualTo(durableVersion,
+            "the MonotonicWriteGuard's invariant holds throughout: durable state never regresses");
+    }
+}


### PR DESCRIPTION
## The outage this fixes

2026-07-30, memex-cloud: `rbuergi/_Thread/mark-all-threads-done-except-top-8-dac9` wedged permanently. The thread node's durable row was on a higher version lineage (v2423) than the live owner hub's clock (~600–900); from then on the `MonotonicWriteGuard` refused **every** owner write — round bookkeeping, the inbox drain, and the Init watchdog's forced-Idle, which re-fired (and was refused) every 90 s for hours:

```
[MonotonicWriteGuard] REFUSED a backward write to rbuergi/_Thread/…: incoming Version=834 is BELOW the stored Version=2423
[ThreadExec] Init watchdog: … wedged non-terminal with no progress for 90s — forcing Idle (guarantee terminal).
```

The refusal emits the stored node, which every caller treated as success — the owner never learned, the fork was permanent. Same fingerprint observed on `sglauser/_Activity/markdown-*` rows.

## The fix (owner-side; the guard is untouched — no bypass, no frame-version floor per the #544 rule, no watchdogs)

1. **`UpdateOwn` floors its mint on the version the update lambda returns**, not only the in-memory `current` — so a durable-truth adoption can carry the stored version forward.
2. **`MeshNodeTypeSource.UpdateImpl` floors the add- and update-path re-stamps on the node's carried `Version` and `_ownNodeVersionFloor`.** The update branch previously re-derived the stamp from `_lastSaved`'s `PreviousVersion` alone — which `BuildInstanceCollection` resets wholesale from the cache-backed routing stream — manufacturing the descending mints after a reactivation whose durable seed lost to a stale replay.
3. **`HandleSaveMeshNode` / `FlushPendingWrites` detect a refusal (`saved.Version > written.Version`) and rebase the owner onto the durable truth** through the sanctioned own-write path (`AdoptDurableTruth`): the adopted state commits above the stored row, the floor rises, the next write lands. One bounded reconciliation cycle per detected conflict — never a timer. Live hubs only: a dispose-time flush refusal remains the guard's correct final word.

**Loss semantics:** the write that collided with a foreign advance stays condemned (durable truth wins — the guard's contract); the fix guarantees convergence, not replay.

## Verification

- **`RefusedWriteOwnerRebaseTest`** (new, deterministic — live owner + out-of-band durable advance): **red on baseline** (30 s convergence timeout: no write ever lands again — the prod wedge), **green with the fix**.
- `MonotonicWriteGuardTests` 9/9 · `StaleActivationSeedRollbackTest` 2/2 · Data.Test version/merge suites 17/17 · `MeshNodeVersionSync` 3/3.
- `dotnet build -c Release -warnaserror` clean on all touched projects.

The prod thread itself was recovered manually (recycle → reconstruction patch, v2423→v2424); this PR removes the bug class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119fAVTT6hAxDY9Y3X4CNWH