### PR TITLE
Query.Test: Debug-level landing-path channels for the shard-1 CI flake

### DIFF
--- a/test/MeshWeaver.Query.Test/appsettings.json
+++ b/test/MeshWeaver.Query.Test/appsettings.json
@@ -3,7 +3,19 @@
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Warning",
-      "System": "Warning"
+      "System": "Warning",
+      // 🔍 Diagnosability for the shard-1 CI flake (2026-07-30, red twice on main):
+      // ActivityTrackingHubTest.TrackActivity_InitiatedFromConnectionHub_LandsNode — PollForFirst
+      // "no value within 15s" ONLY on GH runners; not reproducible locally (full-project bulk,
+      // DOTNET_PROCESSOR_COUNT=2, and a 2-CPU Linux container all green). These channels put the
+      // landing path's stages — the TrackActivity handler (MeshWeaver.Graph.ActivityTracking),
+      // the save/persistence chain, the stream-cache write handle, and the query provider — into
+      // the xUnit-captured log (the FAIL block's "Output:" section in the shard log), so the next
+      // CI occurrence shows WHICH stage stalled instead of a bare timeout. ServiceSetup loads this
+      // file from the test output dir (reloadOnChange). Scoped to this one test project.
+      "MeshWeaver.Graph": "Debug",
+      "MeshWeaver.Hosting.Persistence": "Debug",
+      "MeshWeaver.Hosting.MeshNodeStreamCache": "Debug"
     }
   }
 }


### PR DESCRIPTION
## Why

`ActivityTrackingHubTest.TrackActivity_InitiatedFromConnectionHub_LandsNode` turned main red twice today (runs 30547261887 / 30549874333, shard 1): `PollForFirst` "Expected the observable to emit a value within 15s" — the `UserActivity` node never became queryable after `TrackActivityRequest`. GH-runner-only: full-project bulk, `DOTNET_PROCESSOR_COUNT=2`, and a 2-CPU Linux container all pass locally (357/357 each). A sibling shard-1 failure this morning (`NodeHubContentCollectionTest.CollectionNamedArea_UrlDecodesEncodedPathSegments`, run 30536498490) predates all of today's merges — this is a pre-existing, load-dependent race cluster.

At Warning-default the failing test's captured output holds only the class init/dispose lines — a bare timeout with zero stage information, which is why the race is still unpinned.

## What

Raise three channels to **Debug** in `test/MeshWeaver.Query.Test/appsettings.json` (committed test config — `src/` log levels untouched, per the log-levels-are-production-contract rule):

- `MeshWeaver.Graph` — the TrackActivity handler (`ENTER`, skip-guards) + MeshNodeTypeSource/SaveMeshNode stages
- `MeshWeaver.Hosting.Persistence` — the storage/guard/query-provider chain
- `MeshWeaver.Hosting.MeshNodeStreamCache` — the write-handle path

`ServiceSetup` loads this file from the test output dir (`AddJsonFile`, reload-on-change), and the fixture's xUnit logger honors config levels — so the next CI occurrence's `[FAIL]` block shows **which stage of the landing path stalled**: handler entry, existence probe, create/save, guard, or query feed.

No What's New entry — pure test-config change with no user-visible effect (deliberate skip).

## Verification

- `dotnet build test/MeshWeaver.Query.Test -c Release -warnaserror` clean; `ActivityTrackingHubTest` 2/2 green with the new config (comments parse — .NET config JSON allows them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119fAVTT6hAxDY9Y3X4CNWH