### PR TITLE
Make detached activity writes visible to shutdown, so disposal drains them

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/ActivityTrackingHub.cs
+++ b/src/MeshWeaver.Graph/Configuration/ActivityTrackingHub.cs
@@ -3,6 +3,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Graph.Configuration;
 
@@ -80,6 +81,9 @@ public static class ActivityTrackingHub
             // cache. This is the whole point: the tracking write must not spin up a
             // per-connection cache whose responses route through a transient mesh root.
             .AddData()
+            // The in-flight register for activity writes. Singleton on THIS hub because the
+            // writes run on this hub and it is this hub's disposal that must wait for them.
+            .WithServices(services => services.AddSingleton<ActivityWriteTracker>())
             // Graph type registry so ActivityLog / UserActivityRecord Content round-trips
             // typed across the cross-hub write. (WithGraphTypes also re-registers the
             // TrackActivityRequest handler here, which is harmless — a request routed to
@@ -94,5 +98,26 @@ public static class ActivityTrackingHub
                 var routing = h.ServiceProvider.GetService<IRoutingService>();
                 if (routing is not null)
                     h.RegisterForDisposal(routing.RegisterStream(h));
+
+                // 🚨 Make the detached activity writes VISIBLE to this hub's shutdown.
+                //
+                // HandleTrackActivity returns delivery.Processed() the moment it subscribes, so its
+                // write belongs to no request. Orleans only tracks work on an activation's scheduler
+                // INSIDE a request — a detached subscription on the thread pool is exactly what
+                // escapes that, so nothing keeps the activation alive while the write runs. When
+                // deactivation lands in that window, MessageHubGrain.OnDeactivateAsync calls
+                // CancelCurrentExecution() + Dispose() on the hub the write is still using and it
+                // dies mid-flight, silently — the request it belonged to succeeded long ago.
+                //
+                // Registering the drain here composes it into the dispose chain the hub subscribes
+                // at shutdown, so DisposalCompleted — which the grain already awaits, bounded to
+                // 5 s — now accounts for outstanding writes instead of racing them.
+                var tracker = h.ServiceProvider.GetService<ActivityWriteTracker>();
+                if (tracker is not null)
+                {
+                    var logger = h.ServiceProvider.GetService<ILoggerFactory>()
+                        ?.CreateLogger("MeshWeaver.Graph.ActivityTracking");
+                    h.RegisterForDisposal(_ => tracker.Drain(logger));
+                }
             });
 }

--- a/src/MeshWeaver.Graph/Configuration/ActivityWriteTracker.cs
+++ b/src/MeshWeaver.Graph/Configuration/ActivityWriteTracker.cs
@@ -1,0 +1,157 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Keeps the activity-tracking hub's IN-FLIGHT writes visible to its own shutdown.
+///
+/// <para>🚨 The gap this closes. <c>HandleTrackActivity</c> starts its write and returns
+/// <c>delivery.Processed()</c> immediately — deliberately, because <c>TrackLogin</c> sits on the
+/// cold-login hot path and must not stall behind a node write. The consequence is that the write is
+/// not part of any request: Orleans tracks work on an activation's scheduler <i>inside a request</i>,
+/// so once the handler returns there is nothing keeping the activation alive. A detached
+/// subscription running on the thread pool is invisible to the runtime — the thread pool is
+/// precisely what escapes Orleans' turn-based concurrency, so it can never hold a grain open.</para>
+///
+/// <para>When deactivation lands in that window, <c>MessageHubGrain.OnDeactivateAsync</c> calls
+/// <c>CancelCurrentExecution()</c> and <c>Dispose()</c> on the hub the write is still using. The
+/// write dies mid-flight. Nothing reports it as a failure, because from the message layer's point
+/// of view the request completed successfully some time ago.</para>
+///
+/// <para>The fix is not a different scheduler — it is making the work KNOWN. Each write registers
+/// here for its lifetime; the tracking hub registers <see cref="Drain"/> as a reactive dispose
+/// action, so hub disposal waits for the outstanding writes before completing, and
+/// <c>DisposalCompleted</c> — which the grain already awaits, bounded — now accounts for them.</para>
+///
+/// <para><b>Bounded, and honest about it.</b> Draining is best-effort within
+/// <see cref="DrainTimeout"/>. The grain gives hub disposal 5 s total before "moving on", and a
+/// deactivation must never hold a silo shutdown open indefinitely, so a drain that overruns logs
+/// what it abandoned rather than blocking. This buys the overwhelmingly common case — a write with
+/// milliseconds left to run — not a guarantee. A true "no shutdown until activities complete" would
+/// have to keep the work inside the request, which is the latency trade the detachment exists to
+/// avoid.</para>
+/// </summary>
+public sealed class ActivityWriteTracker
+{
+    /// <summary>
+    /// How long <see cref="Drain"/> waits for outstanding writes before giving up.
+    ///
+    /// <para>Deliberately under the grain's own 5 s hub-disposal budget
+    /// (<c>MessageHubGrain.OnDeactivateAsync</c>): a drain that outlived it would be cut off by the
+    /// grain anyway, and would only cost the OTHER registered dispose actions their share of the
+    /// window. Overrunning here should read as "activity writes lost", not as a disposal hang.</para>
+    /// </summary>
+    public static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(3);
+
+    private readonly object gate = new();
+
+    // Path -> how many writes are outstanding for it. A SET would be wrong: concurrent tracks for
+    // the same path are the documented create-vs-update race, `Add` on a set is idempotent, and the
+    // first release would then drop the only entry and report drained while the second write was
+    // still running. (Caught by ConcurrentWritesToTheSamePath_BothMustFinishBeforeDraining, which
+    // failed against exactly that first implementation.)
+    private ImmutableDictionary<string, int> inFlight =
+        ImmutableDictionary<string, int>.Empty;
+    private readonly BehaviorSubject<int> count = new(0);
+
+    /// <summary>Paths currently being written — what a drain overrun names.</summary>
+    public ImmutableHashSet<string> InFlight
+    {
+        get { lock (gate) return inFlight.Keys.ToImmutableHashSet(); }
+    }
+
+    /// <summary>Number of writes currently outstanding — counting each concurrent write to the
+    /// same path separately, since each has to finish.</summary>
+    public int Count
+    {
+        get { lock (gate) return inFlight.Values.Sum(); }
+    }
+
+    /// <summary>
+    /// Marks <paramref name="activityPath"/> as being written, and returns the token that clears it.
+    ///
+    /// <para>Keyed by path rather than a bare counter so a drain overrun can NAME what was lost —
+    /// an abandoned activity write is otherwise invisible. Counted PER PATH rather than held in a
+    /// set, because concurrent tracks for the same path are the documented create-vs-update race:
+    /// with a set the first release would drop the only entry and report drained while the second
+    /// write was still running.</para>
+    /// </summary>
+    public IDisposable Begin(string activityPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(activityPath);
+        int n;
+        lock (gate)
+        {
+            inFlight = inFlight.SetItem(
+                activityPath, inFlight.TryGetValue(activityPath, out var c) ? c + 1 : 1);
+            n = inFlight.Values.Sum();
+        }
+        count.OnNext(n);
+        return new Registration(this, activityPath);
+    }
+
+    private void Release(string activityPath)
+    {
+        int n;
+        lock (gate)
+        {
+            if (inFlight.TryGetValue(activityPath, out var c))
+                inFlight = c <= 1 ? inFlight.Remove(activityPath) : inFlight.SetItem(activityPath, c - 1);
+            n = inFlight.Values.Sum();
+        }
+        count.OnNext(n);
+    }
+
+    /// <summary>
+    /// Completes once every outstanding write has finished, or after <see cref="DrainTimeout"/>.
+    ///
+    /// <para>Registered by the tracking hub as a reactive dispose action, so hub disposal composes
+    /// it into the chain it subscribes at shutdown. Completes IMMEDIATELY when nothing is in flight,
+    /// which is the normal case — this must not add latency to an idle shutdown.</para>
+    /// </summary>
+    public IObservable<Unit> Drain(ILogger? logger = null) =>
+        Observable.Defer(() =>
+        {
+            if (Count == 0)
+                return Observable.Return(Unit.Default);
+
+            logger?.LogInformation(
+                "Activity drain: waiting for {Count} in-flight write(s) before disposal: {Paths}",
+                Count, string.Join(", ", InFlight));
+
+            return count
+                .Where(n => n == 0)
+                .Take(1)
+                .Select(_ => Unit.Default)
+                .Timeout(DrainTimeout)
+                .Catch<Unit, Exception>(_ =>
+                {
+                    // Loud, and it NAMES them: a lost activity write is otherwise invisible —
+                    // the request it belonged to completed successfully long before.
+                    logger?.LogWarning(
+                        "Activity drain: {Count} write(s) did not finish within {Timeout}s and are "
+                        + "being abandoned by shutdown: {Paths}",
+                        Count, DrainTimeout.TotalSeconds, string.Join(", ", InFlight));
+                    return Observable.Return(Unit.Default);
+                });
+        });
+
+    private sealed class Registration(ActivityWriteTracker owner, string path) : IDisposable
+    {
+        private int disposed;
+
+        public void Dispose()
+        {
+            // Idempotent: Rx can dispose a subscription more than once, and a double release
+            // would under-count the set and let a drain report clear while a write is running.
+            if (Interlocked.Exchange(ref disposed, 1) != 0)
+                return;
+            owner.Release(path);
+        }
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/ActivityWriteTracker.cs
+++ b/src/MeshWeaver.Graph/Configuration/ActivityWriteTracker.cs
@@ -57,7 +57,21 @@ public sealed class ActivityWriteTracker
     // failed against exactly that first implementation.)
     private ImmutableDictionary<string, int> inFlight =
         ImmutableDictionary<string, int>.Empty;
-    private readonly BehaviorSubject<int> count = new(0);
+
+    // 🚨 Subject.Synchronize — Rx subjects are NOT thread-safe across concurrent OnNext, and both
+    // sides of this one are concurrent by construction: Begin runs on whichever hub handled the
+    // request, Release runs on the detached pipeline's thread whenever that write ends. Same
+    // reasoning as MeshNodeStreamCache's eviction subject.
+    private readonly BehaviorSubject<int> countSubject = new(0);
+    private readonly IObserver<int> count;
+    private readonly IObservable<int> counts;
+
+    /// <summary>Creates an empty tracker.</summary>
+    public ActivityWriteTracker()
+    {
+        count = Observer.Synchronize(countSubject, preventReentrancy: true);
+        counts = countSubject.AsObservable();
+    }
 
     /// <summary>Paths currently being written — what a drain overrun names.</summary>
     public ImmutableHashSet<string> InFlight
@@ -84,27 +98,29 @@ public sealed class ActivityWriteTracker
     public IDisposable Begin(string activityPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(activityPath);
-        int n;
+        // Emit INSIDE the lock so the notification order matches the state transitions. Emitting
+        // outside it would let a Release's "0" overtake a concurrent Begin's "1", and a drain
+        // watching for zero would then complete while a write that had just started was still
+        // running — the exact loss this class exists to prevent. Safe to hold `gate` across the
+        // notification: the observer is synchronized with preventReentrancy, and the only
+        // subscriber is Drain's Where/Take filter, which never calls back in here.
         lock (gate)
         {
             inFlight = inFlight.SetItem(
                 activityPath, inFlight.TryGetValue(activityPath, out var c) ? c + 1 : 1);
-            n = inFlight.Values.Sum();
+            count.OnNext(inFlight.Values.Sum());
         }
-        count.OnNext(n);
         return new Registration(this, activityPath);
     }
 
     private void Release(string activityPath)
     {
-        int n;
         lock (gate)
         {
             if (inFlight.TryGetValue(activityPath, out var c))
                 inFlight = c <= 1 ? inFlight.Remove(activityPath) : inFlight.SetItem(activityPath, c - 1);
-            n = inFlight.Values.Sum();
+            count.OnNext(inFlight.Values.Sum());
         }
-        count.OnNext(n);
     }
 
     /// <summary>
@@ -124,7 +140,7 @@ public sealed class ActivityWriteTracker
                 "Activity drain: waiting for {Count} in-flight write(s) before disposal: {Paths}",
                 Count, string.Join(", ", InFlight));
 
-            return count
+            return counts
                 .Where(n => n == 0)
                 .Take(1)
                 .Select(_ => Unit.Default)

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -360,12 +360,31 @@ public static class MeshNodeExtensions
                 });
             }));
 
-        // No fire-and-forget: the pipeline is fully observed and faults surface at Error.
-        pipeline.Subscribe(
-            _ => logger?.LogDebug("TrackActivity DONE: {Path}", activityPath),
-            ex => logger?.LogError(ex,
-                "Failed to track activity for user={UserId} path={Path}",
-                req.UserId, req.NodePath));
+        // The write is DETACHED from this request on purpose — TrackLogin sits on the cold-login
+        // hot path and must not stall behind a node write — so the delivery is Processed below
+        // while the pipeline is still running. Faults are observed (they surface at Error, never
+        // as an unobserved exception), but "observed" is not "awaited": nothing about this
+        // subscription belongs to the request any more.
+        //
+        // 🚨 That is why it REGISTERS. Orleans tracks work on an activation's scheduler inside a
+        // request; a detached subscription on the thread pool is precisely what escapes that, so it
+        // cannot keep the activation alive. Without the registration, a deactivation landing in
+        // this window runs CancelCurrentExecution() + Dispose() on the hub the write is using and
+        // kills it mid-flight — invisibly, because the request succeeded long ago. Registering
+        // makes the hub's own disposal wait for it (bounded — see ActivityWriteTracker.Drain).
+        var tracker = activityHub.ServiceProvider.GetService<ActivityWriteTracker>();
+        var inFlight = tracker?.Begin(activityPath);
+        pipeline
+            // Finally, not the observer's onCompleted: the registration must clear on EVERY
+            // termination — success, error, or an unsubscribe forced by disposal — or a single
+            // failed write would keep the tracker non-empty and make every later shutdown burn the
+            // full drain budget waiting for something that already ended.
+            .Finally(() => inFlight?.Dispose())
+            .Subscribe(
+                _ => logger?.LogDebug("TrackActivity DONE: {Path}", activityPath),
+                ex => logger?.LogError(ex,
+                    "Failed to track activity for user={UserId} path={Path}",
+                    req.UserId, req.NodePath));
         return delivery.Processed();
     }
 

--- a/test/MeshWeaver.Graph.Test/ActivityWriteTrackerTest.cs
+++ b/test/MeshWeaver.Graph.Test/ActivityWriteTrackerTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using MeshWeaver.Graph.Configuration;
@@ -151,5 +150,31 @@ public class ActivityWriteTrackerTest
     {
         var tracker = new ActivityWriteTracker();
         Assert.Throws<ArgumentException>(() => tracker.Begin("  "));
+    }
+
+    /// <summary>
+    /// Begin and Release are concurrent by construction — Begin runs on whichever hub handled the
+    /// request, Release on the detached pipeline's thread — and an Rx subject is not thread-safe
+    /// across concurrent OnNext. Hammer both sides and require the count to land exactly at zero:
+    /// a torn or reordered notification stream shows up here as a non-zero residue or a throw.
+    /// </summary>
+    [Fact]
+    public async Task BeginAndRelease_AreSafeUnderConcurrency()
+    {
+        var tracker = new ActivityWriteTracker();
+        const int writers = 16, perWriter = 60;
+
+        await Task.WhenAll(Enumerable.Range(0, writers).Select(w => Task.Run(() =>
+        {
+            for (var i = 0; i < perWriter; i++)
+            {
+                // Deliberately overlapping paths: same-path concurrency is the real-world race.
+                var token = tracker.Begin($"user{w % 4}/_UserActivity/Doc_{i % 3}");
+                token.Dispose();
+            }
+        })));
+
+        tracker.Count.Should().Be(0, "every write released — a torn subject would leave a residue");
+        await tracker.Drain().Timeout(TimeSpan.FromSeconds(3)).FirstAsync();
     }
 }

--- a/test/MeshWeaver.Graph.Test/ActivityWriteTrackerTest.cs
+++ b/test/MeshWeaver.Graph.Test/ActivityWriteTrackerTest.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The in-flight register that makes detached activity writes visible to shutdown.
+///
+/// <para>What is actually being pinned: a write that is still running when the hub disposes must
+/// DELAY that disposal rather than be killed by it — and a write that will never finish must not
+/// hold shutdown open. Both halves matter; a drain with no timeout trades a lost write for a hung
+/// silo, which is worse.</para>
+/// </summary>
+public class ActivityWriteTrackerTest
+{
+    /// <summary>An idle hub must not pay for this — the overwhelmingly common shutdown.</summary>
+    [Fact]
+    public async Task Drain_WithNothingInFlight_CompletesImmediately()
+    {
+        var tracker = new ActivityWriteTracker();
+
+        var completed = await tracker.Drain().Timeout(TimeSpan.FromSeconds(2)).FirstAsync();
+
+        completed.Should().Be(System.Reactive.Unit.Default);
+        tracker.Count.Should().Be(0);
+    }
+
+    /// <summary>
+    /// 🚨 THE POINT. While a write is outstanding the drain must NOT complete — that is the whole
+    /// mechanism by which hub disposal, and therefore the grain's bounded wait, accounts for it.
+    /// </summary>
+    [Fact]
+    public async Task Drain_WaitsWhileAWriteIsInFlight_AndCompletesWhenItEnds()
+    {
+        var tracker = new ActivityWriteTracker();
+        var write = tracker.Begin("alice/_UserActivity/Doc_Page");
+        tracker.Count.Should().Be(1);
+
+        var drain = tracker.Drain().FirstAsync().ToTask();
+
+        // Still running: the drain must be pending, not completed.
+        var early = await Task.WhenAny(drain, Task.Delay(300));
+        early.Should().NotBe(drain, "the drain must wait while a write is still in flight");
+
+        write.Dispose();                        // the write finishes
+
+        await drain.WaitAsync(TimeSpan.FromSeconds(3));
+        tracker.Count.Should().Be(0);
+    }
+
+    /// <summary>
+    /// A write that never ends must NOT hold shutdown open forever. The grain gives hub disposal
+    /// 5 s before "moving on", so overrunning here would only rob the other dispose actions of
+    /// their share of that window and surface as a disposal hang instead of a lost write.
+    /// </summary>
+    [Fact]
+    public async Task Drain_TimesOutRatherThanBlockingShutdownForever()
+    {
+        var tracker = new ActivityWriteTracker();
+        _ = tracker.Begin("alice/_UserActivity/Stuck");   // never released
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await tracker.Drain()
+            .Timeout(ActivityWriteTracker.DrainTimeout + TimeSpan.FromSeconds(5))
+            .FirstAsync();
+        sw.Stop();
+
+        sw.Elapsed.Should().BeGreaterThan(TimeSpan.FromSeconds(1),
+            "it must actually have waited for the write, not returned instantly");
+        sw.Elapsed.Should().BeLessThan(ActivityWriteTracker.DrainTimeout + TimeSpan.FromSeconds(3),
+            "…and it must give up on its own rather than blocking the silo");
+    }
+
+    /// <summary>
+    /// The budget must sit UNDER the grain's 5 s hub-disposal window
+    /// (<c>MessageHubGrain.OnDeactivateAsync</c>), or the grain cuts the drain off anyway and the
+    /// other registered dispose actions lose their share of it.
+    /// </summary>
+    [Fact]
+    public void DrainTimeout_IsUnderTheGrainsDisposalBudget() =>
+        ActivityWriteTracker.DrainTimeout.Should().BeLessThan(TimeSpan.FromSeconds(5),
+            "the grain gives hub disposal 5 s total before moving on");
+
+    /// <summary>
+    /// Concurrent tracks for the SAME path are the documented create-vs-update race. Releasing one
+    /// must not report the path drained while the other is still writing.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentWritesToTheSamePath_BothMustFinishBeforeDraining()
+    {
+        var tracker = new ActivityWriteTracker();
+        var first = tracker.Begin("alice/_UserActivity/Same");
+        var second = tracker.Begin("alice/_UserActivity/Same");
+
+        var drain = tracker.Drain().FirstAsync().ToTask();
+        first.Dispose();
+
+        var early = await Task.WhenAny(drain, Task.Delay(300));
+        early.Should().NotBe(drain,
+            "one of two concurrent writes to the same path finished — the other is still running");
+
+        second.Dispose();
+        await drain.WaitAsync(TimeSpan.FromSeconds(3));
+    }
+
+    /// <summary>
+    /// Rx may dispose a subscription more than once. A double release would under-count and let a
+    /// drain report clear while a write is still running.
+    /// </summary>
+    [Fact]
+    public async Task ReleasingTwice_IsIdempotent()
+    {
+        var tracker = new ActivityWriteTracker();
+        var a = tracker.Begin("alice/_UserActivity/A");
+        var b = tracker.Begin("alice/_UserActivity/B");
+
+        a.Dispose();
+        a.Dispose();                               // the double release
+
+        tracker.Count.Should().Be(1, "B is still in flight — the repeat release must not remove it");
+
+        b.Dispose();
+        await tracker.Drain().Timeout(TimeSpan.FromSeconds(3)).FirstAsync();
+    }
+
+    /// <summary>
+    /// A drain overrun must NAME what it abandoned. A lost activity write is otherwise invisible:
+    /// the request it belonged to completed successfully long before.
+    /// </summary>
+    [Fact]
+    public void InFlight_NamesThePathsSoAnOverrunIsDiagnosable()
+    {
+        var tracker = new ActivityWriteTracker();
+        _ = tracker.Begin("alice/_UserActivity/Doc_One");
+        _ = tracker.Begin("bob/_UserActivity/Doc_Two");
+
+        tracker.InFlight.Should().HaveCount(2);
+        tracker.InFlight.Should().Contain("alice/_UserActivity/Doc_One");
+        tracker.InFlight.Should().Contain("bob/_UserActivity/Doc_Two");
+    }
+
+    /// <summary>An empty or whitespace path is a caller bug, not something to silently register.</summary>
+    [Fact]
+    public void Begin_RejectsAnEmptyPath()
+    {
+        var tracker = new ActivityWriteTracker();
+        Assert.Throws<ArgumentException>(() => tracker.Begin("  "));
+    }
+}


### PR DESCRIPTION
Answers the question directly: **no, it is not guaranteed** — and the mechanism is the inverse of the one proposed.

## Why `TaskScheduler.Default` can't keep a grain busy

Orleans tracks work on an **activation's scheduler, inside a request**. The thread pool is *outside* turn-based concurrency, so work there is invisible to the runtime and can never hold an activation open. The only thing that keeps a grain busy is an **open request**.

`HandleTrackActivity` subscribes its pipeline and returns `delivery.Processed()` immediately. That's deliberate — `TrackLogin` is on the cold-login hot path and mustn't stall behind a node write — but it means the write belongs to no request. The comment above it read:

```csharp
// No fire-and-forget: the pipeline is fully observed and faults surface at Error.
```

which conflates two different guarantees. *Errors being observed* is not *the caller awaiting*.

So when deactivation lands in that window, `MessageHubGrain.OnDeactivateAsync` calls `CancelCurrentExecution()` + `Dispose()` on the hub the write is still using, and it dies mid-flight — silently, because from the message layer's view the request succeeded long ago.

That's a precise fit for the education e2e signature:

```
Message delivery failed for DataChangeRequest in {user}/_Activity/markdown-…:
System.NullReferenceException
```

— a write continuing against a torn-down hub.

## The fix: make the work known, not reschedule it

Each write registers with an `ActivityWriteTracker` for its lifetime; the tracking hub registers `Drain()` as a reactive dispose action. Hub disposal then waits for outstanding writes, and `DisposalCompleted` — which the grain **already** awaits — accounts for them.

The registration clears in `Finally`, not the observer's `onCompleted`, so it releases on *every* termination including an unsubscribe forced by disposal. Releasing only on success would pin a failed write and make every later shutdown burn the full drain budget on something that already ended.

## Bounded, and honest about it

`Drain` gives up after **3 s** — under the grain's own 5 s hub-disposal budget — so an overrun reads as *"activity writes lost"* (logged, **naming the paths**) rather than a disposal hang, and can't rob the other dispose actions of their share.

This buys the common case: a write with milliseconds left to run. **It is not a guarantee.** A true "no shutdown until activities complete" needs the work inside the request — the latency trade the detachment exists to avoid. Worth deciding deliberately rather than inheriting.

## What this does NOT fix

**`TrackActivity_InitiatedFromConnectionHub_LandsNode`** — the flaky test currently blocking main. That test never disposes anything; it posts and polls 15 s. Shutdown isn't its failure mode, so this change cannot explain it. It needs its own diagnosis, and I'd rather say so than let a green CI imply otherwise.

## Tests

8, and they earned their keep. `ConcurrentWritesToTheSamePath_BothMustFinishBeforeDraining` **caught a real bug in my first implementation**, which used a `HashSet` keyed by path: concurrent tracks for the same path are the documented create-vs-update race, `Add` on a set is idempotent, so the first release dropped the only entry and reported drained while the second write was still running. Now a per-path refcount.

Re-verified by mutation — restoring the set-style release turns that test red.

```
✓ 8/8 ActivityWriteTracker
✓ 751/751 Graph.Test
✓ 9/9 activity-tracking integration tests
✓ mutation-checked
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJiX3ou4QJnUppszJytrNj