### PR TITLE
Flake reproducer has been dead since #395 — and its failure looked like a repro

### DIFF
--- a/.github/workflows/flake-repro.yml
+++ b/.github/workflows/flake-repro.yml
@@ -83,15 +83,15 @@ jobs:
       # (Release, same warnings-as-errors gate). Faithful repro > speed.
       - name: Build
         run: dotnet build --no-restore -c Release -p:CIRun=true -warnaserror
-      # The mesh-local #r feed some dynamic-compilation tests resolve at runtime
-      # (version-less `#r "nuget:MeshWeaver.X"`), packed exactly as dotnet-test.yml does.
-      - name: Pack mesh-local #r packages
-        run: |
-          set -euo pipefail
-          dotnet pack src/MeshWeaver.BusinessRules/MeshWeaver.BusinessRules.csproj \
-            -c Release --no-build --no-restore -o dist/packages --nologo
-          dotnet pack src/MeshWeaver.BusinessRules.Generator/MeshWeaver.BusinessRules.Generator.csproj \
-            -c Release --no-build --no-restore -o dist/packages --nologo
+      # NO mesh-local #r pack step — deliberately, and this workflow was DEAD without
+      # this removal. It used to pack src/MeshWeaver.BusinessRules{,.Generator} "exactly as
+      # dotnet-test.yml does"; #395 removed that step from dotnet-test.yml (the scope generator
+      # ships in-process, and legacy `#r "nuget:MeshWeaver.BusinessRules.Generator"` directives
+      # are filtered out of the resolve set at compile) and the projects left src/ with it.
+      # This copy kept packing them, so every dispatch died at
+      #   MSBUILD : error MSB1009: Project file does not exist.
+      # BEFORE the loop step, which then showed as `skipped` while the job reported `failure` —
+      # a run that looks exactly like "the flake reproduced" and never ran the test once.
       # 🚨 DO NOT crank the CompileWatcher log levels here. Repro #3/#4 proved it's a HEISENBUG:
       # Debug logging in the watcher hot path changes the scheduling enough to MASK the race
       # (runs #1/#2 caught it at iter 19/4 at the committed Warning level; runs #3/#4 with the
@@ -99,11 +99,23 @@ jobs:
       # rely on the timing-NEUTRAL stuck-state diagnostic in WaitForLatestRelease (it runs only
       # on the 50s timeout, never during the race) to pin the stalled stage.
       - name: Loop the suspect test until it fails
+        # `always()` so a failure in ANY earlier step still reaches this step's own guard below,
+        # which says loudly that the loop did not run. Without it an earlier failure leaves this
+        # `skipped` while the job reports `failure` — indistinguishable from "the flake reproduced"
+        # unless you open the step list, and that is exactly how a harness that had been dead since
+        # #395 kept reading as a successful repro.
+        if: always()
         run: |
           set -uo pipefail
           iters="$REPRO_ITERS"
           proj="$REPRO_PROJECT"
           filt="$REPRO_FILTER"
+          # A repro run that never executed the test is the one outcome that must NOT be silent:
+          # its exit code is identical to a real reproduction.
+          if [ ! -d "$proj" ]; then
+            echo "::error::REPRO DID NOT RUN — project '$proj' not found. Nothing was reproduced; the job's failure is the harness, not the flake."
+            exit 1
+          fi
           echo "Looping '$filt' in $proj up to $iters× on a 2-vCPU runner (nproc=$(nproc))."
           failed=0
           for i in $(seq 1 "$iters"); do


### PR DESCRIPTION
**Every dispatch of `flake-repro.yml` has died before running the test.**

It packs `src/MeshWeaver.BusinessRules{,.Generator}` *"exactly as dotnet-test.yml does"*. #395 removed that step from `dotnet-test.yml` — the scope generator ships in-process, and legacy `#r "nuget:MeshWeaver.BusinessRules.Generator"` directives are filtered out of the resolve set at compile — and the projects left `src/` with it. This copy kept packing them:

```
MSBUILD : error MSB1009: Project file does not exist.
Switch: src/MeshWeaver.BusinessRules/MeshWeaver.BusinessRules.csproj
```

## Why it survived this long

The pack step runs **before** the loop, so:

```
success  7  Build
failure  8  Pack mesh-local          ← dies here
skipped  9  Loop the suspect test until it fails
```

The loop shows as `skipped` while the job reports `failure` — **the exact shape of a successful reproduction**, whose entire purpose is to fail. I dispatched it against the `TrackActivity` flake, saw `failure`, and was one step from reporting a repro of a test that never executed. What caught it was an artifact list that came back empty.

A reproducer whose *did-not-run* is indistinguishable from its *did-reproduce* is worse than no reproducer: it answers the question you asked it, with the wrong answer.

## The fix

- Remove the dead pack step.
- Make that outcome impossible to mistake: the loop step now runs with `always()` and fails loudly — `REPRO DID NOT RUN … the job's failure is the harness, not the flake` — when its project is absent.

## Deliberately not changed

The log-level guidance. This file already warns that `Debug` in the CompileWatcher hot path **masks** the race — repros #1/#2 caught it at the committed level, #3/#4 with Debug missed it across 120+ iterations. Dispatch at the default first; treat `Trace` as a last resort. Worth flagging that my own dispatch used `Trace`, which on that evidence may itself have suppressed the race it was hunting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJiX3ou4QJnUppszJytrNj