### PR TITLE
LinkedIn publish: accept authorPath, so node-native posts can publish at all

### DIFF
--- a/src/MeshWeaver.Social/LinkedInPublishService.cs
+++ b/src/MeshWeaver.Social/LinkedInPublishService.cs
@@ -73,7 +73,7 @@ public sealed class LinkedInPublishService
             return PublishNodeOutcome.Fail("access-denied");
 
         var text = textOverride ?? Prop(postNode, "body") ?? Prop(postNode, "text");
-        var profilePath = Prop(postNode, "profilePath");
+        var profilePath = ProfilePathOf(postNode);
         if (string.IsNullOrWhiteSpace(profilePath))
             return PublishNodeOutcome.Fail("profile-path-missing");
         if (string.IsNullOrWhiteSpace(text))
@@ -135,7 +135,7 @@ public sealed class LinkedInPublishService
         var urn = Prop(postNode, "publishedUrn");
         if (string.IsNullOrWhiteSpace(urn))
             return EngagementNodeOutcome.Fail("not-published");
-        var profilePath = Prop(postNode, "profilePath");
+        var profilePath = ProfilePathOf(postNode);
         if (string.IsNullOrWhiteSpace(profilePath))
             return EngagementNodeOutcome.Fail("profile-path-missing");
 
@@ -249,6 +249,18 @@ public sealed class LinkedInPublishService
                 dict[p.Name] = p.Value.Clone();
         return dict;
     }
+
+    /// <summary>
+    /// The profile a post publishes as. Reads <c>profilePath</c> (the legacy compiled-in
+    /// <c>SocialMediaPost</c>) and falls back to <c>authorPath</c> — what the node-native
+    /// <c>SocialMedia/Post</c> type stores. Both name a <c>SocialMedia/Profile</c> node whose
+    /// <c>_ApiCredentials/linkedin</c> child holds the member token, so the publish path is
+    /// identical from here on; only the field name differs between the two post shapes. Without
+    /// this a node-native post fails as <c>profile-path-missing</c> even though it names its
+    /// author perfectly well.
+    /// </summary>
+    private static string? ProfilePathOf(MeshNode node) =>
+        Prop(node, "profilePath") ?? Prop(node, "authorPath");
 
     private static string? Prop(MeshNode node, string name)
     {

--- a/test/MeshWeaver.Hosting.Monolith.Test/LinkedInPublishServiceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/LinkedInPublishServiceTest.cs
@@ -60,6 +60,38 @@ public class LinkedInPublishServiceTest(ITestOutputHelper output) : MonolithMesh
         StrProp(published, "publishedUrn").Should().Be("urn:li:share:9001");
     }
 
+    /// <summary>
+    /// A node-native <c>SocialMedia/Post</c> publishes too. It names its profile in
+    /// <c>authorPath</c> rather than <c>profilePath</c>, and before this was accepted every such
+    /// post failed as <c>profile-path-missing</c> without ever reaching LinkedIn — the whole
+    /// node-native posting surface was unreachable from the publish endpoint.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task PublishPost_accepts_a_node_native_post_that_names_its_profile_as_authorPath()
+    {
+        var profile = $"TestData/pub_{Guid.NewGuid():N}";
+        var postPath = $"{profile}/posts/post1";
+
+        await SeedCredentialAsync(profile, scope: "openid profile email w_member_social");
+        await SeedNodeNativePostAsync(postPath, profile, text: "Node-native hello 👋");
+
+        var handler = new StubHandler(HttpStatusCode.Created, ("x-restli-id", "urn:li:share:9002"));
+        var svc = new LinkedInPublishService(Mesh, NodeFactory);
+
+        var outcome = await svc.PublishPostAsync(
+            new HttpClient(handler), postPath, textOverride: null, visibility: null,
+            LinkedInPostsApi.DefaultApiVersion, TestContext.Current.CancellationToken);
+
+        outcome.Success.Should().BeTrue(because: outcome.Reason ?? "publish should succeed");
+        outcome.Urn.Should().Be("urn:li:share:9002");
+        handler.CallCount.Should().Be(1);
+
+        var published = await Mesh.GetWorkspace().GetMeshNodeStream(postPath)
+            .Should().Within(30.Seconds())
+            .Match(n => StrProp(n, "status") == "Published");
+        StrProp(published, "publishedUrn").Should().Be("urn:li:share:9002");
+    }
+
     [Fact(Timeout = 60000)]
     public async Task PublishPost_without_w_member_social_scope_makes_no_http_call()
     {
@@ -104,6 +136,29 @@ public class LinkedInPublishServiceTest(ITestOutputHelper output) : MonolithMesh
                 AcquiredAt = DateTimeOffset.UtcNow,
             }
         }).Should().Within(30.Seconds()).Emit();
+
+    /// <summary>
+    /// Seeds a NODE-NATIVE <c>SocialMedia/Post</c>: the text lives in <c>text</c> (not
+    /// <c>body</c>) and the profile reference in <c>authorPath</c> (not <c>profilePath</c>).
+    /// </summary>
+    private Task SeedNodeNativePostAsync(string postPath, string profile, string text)
+    {
+        var (id, ns) = SplitPath(postPath);
+        return NodeFactory.CreateNode(new MeshNode(id, ns)
+        {
+            Name = "Test post",
+            // The node TYPE is irrelevant here (and a type this mesh does not host would never
+            // activate); what is under test is the node-native CONTENT SHAPE.
+            NodeType = "Systemorph/Post",
+            State = MeshNodeState.Active,
+            Content = new Dictionary<string, object?>
+            {
+                ["text"] = text,
+                ["authorPath"] = profile,
+                ["status"] = "Scheduled",
+            }
+        }).Should().Within(30.Seconds()).Emit();
+    }
 
     private Task SeedPostAsync(string postPath, string profile, string body)
     {


### PR DESCRIPTION
`PublishPostAsync` resolved the member credential from the post's `profilePath` — the field the legacy compiled-in `SocialMediaPost` uses. The **node-native `SocialMedia/Post`** type names its profile in `authorPath`, so every node-native post failed as `profile-path-missing` **before any outbound call**: the whole `Posts` surface was unreachable from `GET /linkedin/publish`, even with a valid connected credential.

Everything else already lined up:

- text is read from `body` ?? `text` — node-native posts store `text` ✓
- the credential lives at `{profile}/_ApiCredentials/linkedin` either way ✓
- the write-back stamps `status=Published`, `publishedUrn`, `publishedAt` ✓

One field name was the entire gap.

## Test

Pins a node-native post (`text` + `authorPath`) publishing end to end and writing `Published` + the URN back. Verified **non-vacuous**: dropping the fallback fails it, restoring it passes.

The test seeds the node-native *content shape* under a node type this mesh hosts — seeding `nodeType: "SocialMedia/Post"` in a mesh without that module never activates and the test hangs rather than fails, which is the missing-dependency trap in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)