### PR TITLE
Reminders: durable record + scheduling decisions (Orleans wiring next)

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/Reminder.cs
+++ b/src/MeshWeaver.Mesh.Contract/Reminder.cs
@@ -1,0 +1,98 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>Where a reminder is in its lifecycle.</summary>
+public enum ReminderState
+{
+    /// <summary>Waiting for <see cref="Reminder.DueAt"/>.</summary>
+    Pending,
+
+    /// <summary>Claimed by one instance and running right now.</summary>
+    Firing,
+
+    /// <summary>One-shot reminder that has fired; recurring reminders return to
+    /// <see cref="Pending"/> instead and are never Completed.</summary>
+    Completed,
+
+    /// <summary>The work failed and will not be retried automatically.</summary>
+    Failed,
+
+    /// <summary>Switched off by a human; never fires, never reschedules.</summary>
+    Paused,
+}
+
+/// <summary>
+/// A durable, mesh-native TIME TRIGGER: at <see cref="DueAt"/> the reminder service launches an
+/// Activity against <see cref="TargetPath"/>. One-shot when <see cref="IntervalSeconds"/> is null
+/// (publish this post at its slot), recurring otherwise (refresh stats four times a day).
+///
+/// <para><b>Why a node and not an in-process timer.</b> A timer dies with the pod, and an in-memory
+/// queue is pod-local: with two replicas only one knows the work exists, and a restart loses it
+/// silently. A reminder is a node, so it survives restarts, is visible, and can be inspected and
+/// cancelled like any other content. (This is exactly how the never-shipped
+/// <c>InMemoryPublishQueue</c> would have lost every scheduled post.)</para>
+///
+/// <para><b>Exactly-once across replicas.</b> Every instance sees the same due reminder, so firing
+/// is guarded by a CLAIM: an instance writes <see cref="ClaimedBy"/>/<see cref="ClaimedAt"/> and
+/// only proceeds if that write wins. The node write — not timing — is the idempotency token. A
+/// claim whose owner died is reclaimed once it goes stale (see <c>ReminderSchedule.ClaimExpired</c>),
+/// so a crash cannot strand a reminder in <see cref="ReminderState.Firing"/> forever.</para>
+/// </summary>
+public record Reminder
+{
+    /// <summary>Unique identifier for the reminder.</summary>
+    [Browsable(false)]
+    [Key]
+    public string Id { get; init; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Path of the node this reminder acts on — the node whose hub runs the work (e.g. the social
+    /// profile that owns the credential). Also where permissions come from: whoever may update the
+    /// target may cancel its reminders.
+    /// </summary>
+    public string TargetPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// What to do when it fires — the discriminator the target's hub switches on
+    /// (e.g. <c>PublishPost</c>, <c>RefreshStats</c>). Free-form so a plugin can define its own
+    /// without a core change.
+    /// </summary>
+    public string Kind { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional payload for <see cref="Kind"/> — e.g. the path of the single post to publish.
+    /// Kept as a string so the contract does not have to know any plugin's shape.
+    /// </summary>
+    public string? Argument { get; init; }
+
+    /// <summary>When this reminder should next fire (UTC).</summary>
+    public DateTime DueAt { get; init; }
+
+    /// <summary>
+    /// Seconds between firings for a RECURRING reminder; null for a one-shot. Four times a day is
+    /// 21600. A recurring reminder reschedules itself after each run and is never Completed.
+    /// </summary>
+    public int? IntervalSeconds { get; init; }
+
+    /// <summary>Lifecycle state.</summary>
+    public ReminderState State { get; init; } = ReminderState.Pending;
+
+    /// <summary>Instance that currently holds the firing claim; null when unclaimed.</summary>
+    [Browsable(false)]
+    public string? ClaimedBy { get; init; }
+
+    /// <summary>When the current claim was taken (UTC); null when unclaimed.</summary>
+    [Browsable(false)]
+    public DateTime? ClaimedAt { get; init; }
+
+    /// <summary>When it last fired (UTC), successfully or not.</summary>
+    public DateTime? LastFiredAt { get; init; }
+
+    /// <summary>How many times it has fired — recurring reminders keep counting.</summary>
+    public int FireCount { get; init; }
+
+    /// <summary>The last failure's message; cleared on the next success.</summary>
+    public string? LastError { get; init; }
+}

--- a/src/MeshWeaver.Mesh.Contract/ReminderSchedule.cs
+++ b/src/MeshWeaver.Mesh.Contract/ReminderSchedule.cs
@@ -1,0 +1,159 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// The PURE decisions behind reminders — is it due, may this instance claim it, what does it look
+/// like after firing, and when does a recurring one run next. No hub, no clock of its own: every
+/// answer is a function of the reminder plus the <c>now</c> the caller passes in, so the awkward
+/// cases (a crashed claim, a reminder that slept through several intervals, a paused recurrence)
+/// are unit-tested rather than reasoned about in production.
+/// </summary>
+public static class ReminderSchedule
+{
+    /// <summary>
+    /// How long a firing claim is honoured before another instance may take it. Longer than any
+    /// sane activity, short enough that a pod crash does not strand the reminder for an hour.
+    /// </summary>
+    public static readonly TimeSpan ClaimLease = TimeSpan.FromMinutes(10);
+
+    /// <summary>Four times a day — the stats-refresh cadence, as an interval.</summary>
+    public const int FourTimesDailySeconds = 6 * 60 * 60;
+
+    /// <summary>Whether this reminder is RECURRING (reschedules itself) rather than one-shot.</summary>
+    public static bool IsRecurring(Reminder reminder) =>
+        reminder.IntervalSeconds is > 0;
+
+    /// <summary>
+    /// Whether the reminder wants to run at <paramref name="now"/>: Pending (or a Firing whose
+    /// claim has expired) and past its due time. Paused, Completed and Failed never run — a
+    /// failure is deliberately terminal so a broken reminder cannot hammer an external API every
+    /// tick forever.
+    /// </summary>
+    public static bool IsDue(Reminder reminder, DateTime now) =>
+        reminder.State switch
+        {
+            ReminderState.Pending => reminder.DueAt <= now,
+            ReminderState.Firing => ClaimExpired(reminder, now),
+            _ => false,
+        };
+
+    /// <summary>
+    /// Whether a Firing reminder's claim is stale — the owning instance died mid-run. Only then may
+    /// another instance take it over; without this a crash strands the reminder in Firing forever.
+    /// An absent <see cref="Reminder.ClaimedAt"/> counts as expired: a Firing state with no claim
+    /// is already corrupt, and refusing to reclaim it would strand it just the same.
+    /// </summary>
+    public static bool ClaimExpired(Reminder reminder, DateTime now) =>
+        reminder.ClaimedAt is not { } claimedAt || claimedAt + ClaimLease <= now;
+
+    /// <summary>
+    /// The reminder as CLAIMED by <paramref name="instanceId"/>. The caller must write this and
+    /// verify the write won (an optimistic-concurrency conflict means another instance claimed it
+    /// first — stand down, do NOT run the work). Returns the reminder unchanged when it is not due,
+    /// so a caller that skipped the <see cref="IsDue"/> check cannot accidentally fire it.
+    /// </summary>
+    public static Reminder Claim(Reminder reminder, string instanceId, DateTime now) =>
+        IsDue(reminder, now)
+            ? reminder with
+            {
+                State = ReminderState.Firing,
+                ClaimedBy = instanceId,
+                ClaimedAt = now,
+            }
+            : reminder;
+
+    /// <summary>
+    /// The reminder after a SUCCESSFUL run: a one-shot is Completed, a recurring one goes back to
+    /// Pending at its next occurrence. The claim is released either way and
+    /// <see cref="Reminder.LastError"/> is cleared — a success must not leave a stale failure
+    /// showing on the node.
+    /// </summary>
+    public static Reminder Succeeded(Reminder reminder, DateTime now) =>
+        reminder with
+        {
+            State = IsRecurring(reminder) ? ReminderState.Pending : ReminderState.Completed,
+            DueAt = IsRecurring(reminder) ? NextOccurrence(reminder, now) : reminder.DueAt,
+            LastFiredAt = now,
+            FireCount = reminder.FireCount + 1,
+            LastError = null,
+            ClaimedBy = null,
+            ClaimedAt = null,
+        };
+
+    /// <summary>
+    /// The reminder after a FAILED run. A recurring reminder keeps its schedule and tries again at
+    /// its next occurrence — a transient outage must not kill the stats refresh forever. A one-shot
+    /// goes to <see cref="ReminderState.Failed"/> and stops: retrying an unattended publish on a
+    /// loop is how you end up posting six times.
+    /// </summary>
+    public static Reminder Failed(Reminder reminder, string error, DateTime now) =>
+        reminder with
+        {
+            State = IsRecurring(reminder) ? ReminderState.Pending : ReminderState.Failed,
+            DueAt = IsRecurring(reminder) ? NextOccurrence(reminder, now) : reminder.DueAt,
+            LastFiredAt = now,
+            FireCount = reminder.FireCount + 1,
+            LastError = string.IsNullOrWhiteSpace(error) ? "unknown error" : error.Trim(),
+            ClaimedBy = null,
+            ClaimedAt = null,
+        };
+
+    /// <summary>
+    /// When a recurring reminder runs next: strictly AFTER <paramref name="now"/>, on the original
+    /// cadence. Stepping the interval forward (rather than adding it to <c>now</c>) keeps a 4×/day
+    /// refresh on its slots instead of drifting later on every run.
+    ///
+    /// <para>A reminder that slept through several intervals — the pod was down for a day — fires
+    /// ONCE and resumes on cadence; it does not replay every missed slot. For a stats refresh the
+    /// missed runs are worthless (the next one reads the same current numbers) and replaying them
+    /// would burst an external API immediately after an outage, which is exactly when it is least
+    /// welcome.</para>
+    ///
+    /// <para>Returns <see cref="Reminder.DueAt"/> unchanged for a one-shot: it has no next.</para>
+    /// </summary>
+    public static DateTime NextOccurrence(Reminder reminder, DateTime now)
+    {
+        if (!IsRecurring(reminder))
+            return reminder.DueAt;
+
+        var interval = TimeSpan.FromSeconds(reminder.IntervalSeconds!.Value);
+        var next = reminder.DueAt;
+        if (next > now)
+            return next;
+
+        // Step whole intervals past `now` in one arithmetic jump — a loop here would spin for
+        // millions of iterations on a long-dormant reminder with a short interval.
+        var skipped = (now - next).Ticks / interval.Ticks + 1;
+        return next + TimeSpan.FromTicks(interval.Ticks * skipped);
+    }
+
+    /// <summary>
+    /// A one-shot reminder for <paramref name="targetPath"/> at <paramref name="dueAt"/> — what
+    /// "schedule this post" registers at the moment of the click.
+    /// </summary>
+    public static Reminder OneShot(string targetPath, string kind, DateTime dueAt, string? argument = null) =>
+        new()
+        {
+            TargetPath = targetPath,
+            Kind = kind,
+            Argument = argument,
+            DueAt = dueAt,
+            IntervalSeconds = null,
+            State = ReminderState.Pending,
+        };
+
+    /// <summary>
+    /// A recurring reminder every <paramref name="intervalSeconds"/>, first firing at
+    /// <paramref name="firstDueAt"/> — what the 4×/day stats refresh registers.
+    /// </summary>
+    public static Reminder Recurring(
+        string targetPath, string kind, DateTime firstDueAt, int intervalSeconds, string? argument = null) =>
+        new()
+        {
+            TargetPath = targetPath,
+            Kind = kind,
+            Argument = argument,
+            DueAt = firstDueAt,
+            IntervalSeconds = intervalSeconds,
+            State = ReminderState.Pending,
+        };
+}

--- a/test/MeshWeaver.Data.Test/ReminderScheduleTest.cs
+++ b/test/MeshWeaver.Data.Test/ReminderScheduleTest.cs
@@ -1,0 +1,141 @@
+using System;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// The reminder decisions, pinned. These are the cases that decide whether a scheduled publish
+/// happens once, twice, or never — so they are tested as pure functions rather than discovered in
+/// production with two replicas and a pod restart.
+/// </summary>
+public class ReminderScheduleTest
+{
+    private static readonly DateTime Now = new(2026, 8, 3, 9, 0, 0, DateTimeKind.Utc);
+
+    private static Reminder OneShotAt(DateTime due) =>
+        ReminderSchedule.OneShot("Profiles/RolandLinkedIn", "PublishPost", due, "Posts/Hello");
+
+    private static Reminder FourTimesDaily(DateTime first) =>
+        ReminderSchedule.Recurring(
+            "Profiles/RolandLinkedIn", "RefreshStats", first, ReminderSchedule.FourTimesDailySeconds);
+
+    [Fact]
+    public void A_reminder_is_due_only_once_its_time_has_come()
+    {
+        ReminderSchedule.IsDue(OneShotAt(Now.AddMinutes(1)), Now).Should().BeFalse("it is not due yet");
+        ReminderSchedule.IsDue(OneShotAt(Now), Now).Should().BeTrue("due exactly now counts");
+        ReminderSchedule.IsDue(OneShotAt(Now.AddMinutes(-1)), Now).Should().BeTrue("overdue still fires");
+    }
+
+    [Fact]
+    public void Terminal_and_paused_reminders_never_fire()
+    {
+        var due = OneShotAt(Now.AddMinutes(-1));
+        foreach (var state in new[] { ReminderState.Completed, ReminderState.Failed, ReminderState.Paused })
+            ReminderSchedule.IsDue(due with { State = state }, Now).Should()
+                .BeFalse($"a {state} reminder must never run again");
+    }
+
+    [Fact]
+    public void A_live_claim_blocks_a_second_instance_but_a_dead_one_is_reclaimed()
+    {
+        var claimed = ReminderSchedule.Claim(OneShotAt(Now.AddMinutes(-1)), "pod-a", Now);
+        claimed.State.Should().Be(ReminderState.Firing);
+        claimed.ClaimedBy.Should().Be("pod-a");
+
+        // Pod B sees the same reminder a second later: the claim is live, so it must stand down —
+        // this is what stops both replicas publishing the same post.
+        ReminderSchedule.IsDue(claimed, Now.AddSeconds(1)).Should().BeFalse("pod-a holds a live claim");
+
+        // Pod A dies mid-run. Once the lease expires the work must not be stranded forever.
+        var afterLease = Now + ReminderSchedule.ClaimLease;
+        ReminderSchedule.IsDue(claimed, afterLease).Should().BeTrue("an expired claim is reclaimable");
+
+        // A Firing state with no claim at all is corrupt — reclaim it rather than strand it.
+        ReminderSchedule.ClaimExpired(claimed with { ClaimedAt = null }, Now).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Claiming_something_that_is_not_due_changes_nothing()
+    {
+        var notYet = OneShotAt(Now.AddHours(1));
+        ReminderSchedule.Claim(notYet, "pod-a", Now).Should().Be(notYet,
+            "the claim helper must not let a caller who skipped the due check fire early");
+    }
+
+    [Fact]
+    public void A_one_shot_completes_and_a_recurring_one_reschedules()
+    {
+        var once = ReminderSchedule.Succeeded(OneShotAt(Now), Now);
+        once.State.Should().Be(ReminderState.Completed);
+        once.FireCount.Should().Be(1);
+        once.ClaimedBy.Should().BeNull("the claim is released");
+
+        var repeated = ReminderSchedule.Succeeded(FourTimesDaily(Now), Now);
+        repeated.State.Should().Be(ReminderState.Pending, "a recurring reminder is never Completed");
+        repeated.DueAt.Should().Be(Now.AddHours(6), "next of four daily slots");
+    }
+
+    [Fact]
+    public void Success_clears_a_previous_error()
+    {
+        var recovered = ReminderSchedule.Succeeded(
+            FourTimesDaily(Now) with { LastError = "429 from LinkedIn" }, Now);
+        recovered.LastError.Should().BeNull("a stale failure must not keep showing after a success");
+    }
+
+    [Fact]
+    public void A_failed_one_shot_stops_but_a_failed_recurring_one_keeps_its_cadence()
+    {
+        var once = ReminderSchedule.Failed(OneShotAt(Now), "boom", Now);
+        once.State.Should().Be(ReminderState.Failed,
+            "retrying an unattended publish on a loop is how you post six times");
+        once.LastError.Should().Be("boom");
+
+        var repeated = ReminderSchedule.Failed(FourTimesDaily(Now), "429", Now);
+        repeated.State.Should().Be(ReminderState.Pending,
+            "a transient outage must not kill the stats refresh forever");
+        repeated.DueAt.Should().Be(Now.AddHours(6));
+    }
+
+    [Fact]
+    public void A_reminder_that_slept_through_many_intervals_fires_once_and_resumes_on_cadence()
+    {
+        // The pod was down for two days. A 4×/day reminder must NOT replay eight missed runs the
+        // moment it comes back — that bursts the API exactly when it is least welcome.
+        var dormant = FourTimesDaily(Now);
+        var wokeUp = Now.AddDays(2).AddMinutes(5);
+
+        var next = ReminderSchedule.NextOccurrence(dormant, wokeUp);
+        next.Should().BeAfter(wokeUp, "the next slot is strictly in the future");
+        next.Should().BeBefore(wokeUp.AddHours(6), "and it is the very next slot, not one per missed run");
+
+        // Still on the ORIGINAL 6-hour grid — no drift from the outage.
+        (next - dormant.DueAt).TotalHours.Should().Be(Math.Round((next - dormant.DueAt).TotalHours / 6) * 6);
+    }
+
+    [Fact]
+    public void Recurring_slots_do_not_drift_when_a_run_finishes_late()
+    {
+        // Firing takes 4 minutes; the next slot must still be on the grid, not 6h after completion.
+        var reminder = FourTimesDaily(Now);
+        var finishedLate = Now.AddMinutes(4);
+        ReminderSchedule.Succeeded(reminder, finishedLate).DueAt.Should().Be(Now.AddHours(6),
+            "stepping the interval keeps the cadence; adding to 'now' would drift later every run");
+    }
+
+    [Fact]
+    public void A_one_shot_has_no_next_occurrence()
+    {
+        var once = OneShotAt(Now);
+        ReminderSchedule.NextOccurrence(once, Now.AddYears(1)).Should().Be(once.DueAt);
+        ReminderSchedule.IsRecurring(once).Should().BeFalse();
+        ReminderSchedule.IsRecurring(once with { IntervalSeconds = 0 }).Should()
+            .BeFalse("a zero interval is not a recurrence — it would be an infinite loop");
+    }
+
+    [Fact]
+    public void Four_times_daily_is_six_hours()
+        => ReminderSchedule.FourTimesDailySeconds.Should().Be(21600);
+}


### PR DESCRIPTION
First half of the reminder primitive: the **durable record** and the **pure decisions**. Orleans wiring is the next commit — see below.

## Why a node, not a timer

A timer dies with the pod; an in-memory queue is pod-local, so with two replicas only one knows the work exists and a restart loses it silently. That is precisely how core's never-registered `InMemoryPublishQueue` would have lost every scheduled post. A reminder is a node: it survives restarts, is inspectable, and is cancellable like any other content.

One-shot (*publish this post at its slot*) and recurring (*refresh stats 4×/day*) are the same record — `IntervalSeconds` distinguishes them.

## The decisions worth pinning

| Case | Behaviour | Why |
|---|---|---|
| Two replicas, same due reminder | live claim blocks the second; **expired** claim is reclaimable | a pod dying mid-run must not strand it in `Firing` forever |
| One-shot fails | **stops** (`Failed`) | retrying an unattended publish on a loop is how you post six times |
| Recurring fails | keeps its cadence | a transient 429 must not kill the stats refresh forever |
| Dormant through many intervals | fires **once**, resumes on cadence | replaying 8 missed runs bursts the API right after an outage |
| Run finishes late | next slot still on the grid | adding to `now` would drift the cadence later every firing |

11/11 green.

## Next: Orleans wiring

`grep` finds **no** `UseInMemoryReminderService` / `UseAdoNetReminderService` / `AddReminders` anywhere in `src/` or `memex/` — the silo configures no reminder service at all. So the next commit must:

1. Register a reminder table provider on the silo — ADO.NET against the existing Postgres for the real clusters, in-memory for monolith/tests.
2. Add an `IRemindable` grain that registers a reminder per node record and calls back on fire.
3. Launch the `Activity` on the target node's hub from that callback.

Orleans guarantees a single activation per grain, so its reminders give exactly-once firing on their own. The claim/lease in `ReminderSchedule` stays as defence for the non-Orleans hosting paths (monolith) and for reclaiming a crashed run — it is not redundant with Orleans, it covers the case where the activity itself dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)