### PR TITLE
Version counts real changes: node-local counter, no mint without a diff

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -743,7 +743,6 @@ public static class DataExtensions
                 request.Message.Patch.Content ?? "{}",
                 hub.JsonSerializerOptions,
                 (string?)stream.StreamId,
-                hub.Version,
                 hub,
                 request
             });
@@ -921,26 +920,25 @@ public static class DataExtensions
     }
 
     /// <summary>
-    /// The version the OWNER mints when it applies a cross-hub MeshNode patch. 🚨 #325: advance
-    /// FORWARD-ONLY from the node's OWN current version, not straight off the per-message hub clock
-    /// (<paramref name="hubVersion"/>). <see cref="IMessageHub.Version"/> resets to 0 on every
-    /// (re)activation, so stamping it verbatim rolls the node's Version BACKWARD after a recycle /
-    /// idle-release / replica restart — mirrors holding the higher pre-recycle version then DROP the
-    /// regressed frame under the sync monotonicity guard (the write-rollback + index-vs-resolution
-    /// split-brain of #325). Flooring at <c>currentVersion + 1</c> keeps it strictly increasing
-    /// across activations WITHOUT touching Hub.Version, so layout-area Fulls (which ride Hub.Version)
-    /// are unaffected — the 2026-06-18 "cannot find pinned doc" wedge cannot recur. Mirrors
-    /// <c>MeshNode.NextVersion</c>; inlined because this assembly cannot reference MeshNode
+    /// The version the OWNER mints when it applies a cross-hub MeshNode patch that REALLY changed
+    /// the node: the node's own <c>Version + 1</c>. 🚨 It is derived purely from the node, never
+    /// from the per-message hub clock — <see cref="IMessageHub.Version"/> counts unrelated messages
+    /// and resets to 0 on every (re)activation, so stamping it rolled the node's Version BACKWARD
+    /// after a recycle / idle-release / replica restart; mirrors holding the higher pre-recycle
+    /// version then DROPPED the regressed frame under the sync monotonicity guard (the write-rollback
+    /// + index-vs-resolution split-brain of #325). A node-local counter is monotonic across
+    /// activations by construction, and layout-area Fulls (which ride Hub.Version) stay untouched.
+    /// Mirrors <c>MeshNode.NextVersion</c>; inlined because this assembly cannot reference MeshNode
     /// (same string-keyed approach used throughout this handler).
     /// </summary>
     private static long NextMeshNodeVersion(
-        System.Text.Json.Nodes.JsonObject currentNode, string versionKey, long hubVersion)
+        System.Text.Json.Nodes.JsonObject currentNode, string versionKey)
     {
         long currentVersion = 0;
         if (currentNode[versionKey] is System.Text.Json.Nodes.JsonValue jv
             && jv.TryGetValue<long>(out var parsed))
             currentVersion = parsed;
-        return System.Math.Max(hubVersion, currentVersion + 1);
+        return currentVersion + 1;
     }
 
     /// <summary>
@@ -1085,7 +1083,6 @@ public static class DataExtensions
         string patchText,
         System.Text.Json.JsonSerializerOptions jsonOpts,
         string? streamId,
-        long version,
         IMessageHub hub,
         IMessageDelivery<PatchDataRequest> request)
     {
@@ -1103,7 +1100,7 @@ public static class DataExtensions
             && hub.GetWorkspace().DataContext.GetDataSourceForType(typeof(T))
                 ?.GetStreamForPartition(null) is { } meshPrimary)
         {
-            ApplyMeshNodePatchInTurn(stream, meshPrimary, patchText, jsonOpts, version, hub, request);
+            ApplyMeshNodePatchInTurn(stream, meshPrimary, patchText, jsonOpts, hub, request);
             return;
         }
 
@@ -1138,12 +1135,25 @@ public static class DataExtensions
                     // 🚨 Three-way merge for a cross-hub MeshNode patch (base values carried on the
                     // request) so a reordered/stale write can't flap a field; falls back to the
                     // monotonic-trigger guard + last-write-wins when no base is carried.
+                    var preMergeNode = currentNode.DeepClone();
                     ApplyMeshNodeMerge(currentNode, patchNode,
                         typeof(T).FullName == "MeshWeaver.Mesh.MeshNode",
                         request.Message, jsonOpts,
                         hub.ServiceProvider.GetService<ILoggerFactory>()
                             ?.CreateLogger("MeshWeaver.Data.MergeGuard"),
                         hubPath);
+
+                    // 🚨 No-change backstop (same rule as ApplyMeshNodePatchInTurn): a patch whose
+                    // every value already matches the live state must NOT bump the version or
+                    // commit — the version bump below would otherwise MANUFACTURE the difference
+                    // that makes it look like a change. On THIS deferred path a no-op commit also
+                    // never emits, so the post-commit subscription would time out and NACK a write
+                    // that in fact succeeded. Ack success up front against the untouched state.
+                    if (System.Text.Json.Nodes.JsonNode.DeepEquals(preMergeNode, currentNode))
+                    {
+                        AckOnce(true);
+                        return;
+                    }
 
                     // 🚨 The OWNER mints the fresh monotonic Version on apply.
                     // Per the owned-stream contract — SynchronizationStream
@@ -1178,9 +1188,9 @@ public static class DataExtensions
                     if (typeof(T).FullName == "MeshWeaver.Mesh.MeshNode")
                     {
                         var versionKey = jsonOpts.PropertyNamingPolicy?.ConvertName("Version") ?? "Version";
-                        // 🚨 #325: advance forward-only from the node's own version (max(hub, cur+1)),
-                        // never straight off the per-activation hub clock — see NextMeshNodeVersion.
-                        currentNode[versionKey] = NextMeshNodeVersion(currentNode, versionKey, version);
+                        // 🚨 The node's OWN counter (+1), never the per-activation hub clock —
+                        // see NextMeshNodeVersion. Reached only for a real change (gated above).
+                        currentNode[versionKey] = NextMeshNodeVersion(currentNode, versionKey);
                     }
 
                     var mergedJson = currentNode.ToJsonString(jsonOpts);
@@ -1271,7 +1281,6 @@ public static class DataExtensions
         ISynchronizationStream<EntityStore> primary,
         string patchText,
         System.Text.Json.JsonSerializerOptions jsonOpts,
-        long version,
         IMessageHub hub,
         IMessageDelivery<PatchDataRequest> request)
     {
@@ -1452,11 +1461,24 @@ public static class DataExtensions
                     // 🚨 Three-way merge (MeshNode-only path) — base values carried on the request let a
                     // reordered/stale cross-hub patch merge instead of flapping; falls back to the
                     // monotonic-trigger guard + last-write-wins when no base is carried.
+                    var preMergeNode = currentNode.DeepClone();
                     ApplyMeshNodeMerge(currentNode, patchNode, isMeshNode: true,
                         request.Message, jsonOpts, mergeGuardLogger, hubPath);
-                    // The OWNER mints the monotonic Version on apply (same rule as the deferred path).
-                    // 🚨 #325: forward-only from the node's own version — see NextMeshNodeVersion.
-                    var minted = NextMeshNodeVersion(currentNode, versionKey, version);
+                    // 🚨 Owner-side no-change backstop: a patch whose every value already matches
+                    // the live node (an MCP patch re-asserting current state, a refused three-way
+                    // merge, an importer re-writing unchanged content) must NOT bump the Version,
+                    // persist a history row or tick the change feed. Gate BEFORE the bump — the
+                    // bump itself would otherwise manufacture the difference. Ack success with the
+                    // untouched state; the no-emission path is already handled (AckOnce latches,
+                    // postSub timeout dedupes) exactly like the NotFound no-op above.
+                    if (System.Text.Json.Nodes.JsonNode.DeepEquals(preMergeNode, currentNode))
+                    {
+                        AckOnce(true);
+                        return null;
+                    }
+                    // The OWNER bumps the Version on apply (same rule as the deferred path).
+                    // 🚨 The node's OWN counter (+1) — see NextMeshNodeVersion.
+                    var minted = NextMeshNodeVersion(currentNode, versionKey);
                     currentNode[versionKey] = minted;
                     var merged = System.Text.Json.JsonSerializer
                         .Deserialize<T>(currentNode.ToJsonString(jsonOpts), jsonOpts);

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -930,6 +930,9 @@ public static class DataExtensions
     /// activations by construction, and layout-area Fulls (which ride Hub.Version) stay untouched.
     /// Mirrors <c>MeshNode.NextVersion</c>; inlined because this assembly cannot reference MeshNode
     /// (same string-keyed approach used throughout this handler).
+    /// <para>🚨 <paramref name="currentNode"/> must be the owner's PRE-MERGE state, never the
+    /// node the client's patch has already been merged into: a patch carrying a <c>version</c>
+    /// field would otherwise steer the counter it is forbidden from setting.</para>
     /// </summary>
     private static long NextMeshNodeVersion(
         System.Text.Json.Nodes.JsonObject currentNode, string versionKey)
@@ -1135,7 +1138,7 @@ public static class DataExtensions
                     // 🚨 Three-way merge for a cross-hub MeshNode patch (base values carried on the
                     // request) so a reordered/stale write can't flap a field; falls back to the
                     // monotonic-trigger guard + last-write-wins when no base is carried.
-                    var preMergeNode = currentNode.DeepClone();
+                    var preMergeNode = currentNode.DeepClone().AsObject();
                     ApplyMeshNodeMerge(currentNode, patchNode,
                         typeof(T).FullName == "MeshWeaver.Mesh.MeshNode",
                         request.Message, jsonOpts,
@@ -1155,42 +1158,43 @@ public static class DataExtensions
                         return;
                     }
 
-                    // 🚨 The OWNER mints the fresh monotonic Version on apply.
+                    // 🚨 The OWNER mints the new Version on apply.
                     // Per the owned-stream contract — SynchronizationStream
                     // ("ONLY the owning hub sets Version", line ~255) and
-                    // NodeUpdatePipeline ("the OWNER assigns the fresh monotonic
-                    // version on apply") — a client/subscriber carries only the
-                    // BASE Version it observed, so the cross-hub JSON-merge patch
-                    // it computed never touches Version. The sync-stream
-                    // value-update path stamps Hub.Version on the owner; this
-                    // PatchDataRequest merge path must do the same, else every
-                    // cross-hub stream.Update reuses the base Version. For
-                    // MeshNode that collapses the version-history store (keyed on
+                    // NodeUpdatePipeline ("the OWNER assigns the fresh version on
+                    // apply") — a client/subscriber carries only the BASE Version
+                    // it observed and never mints. Without a stamp here every
+                    // cross-hub stream.Update would reuse that base Version, which
+                    // for MeshNode collapses the version-history store (keyed on
                     // {Id}_{Version}) onto a single snapshot — the
                     // VersionHistoryTest regression after cross-hub Update moved
-                    // from UpdateViaSyncStream (which stamped the owner Version)
-                    // to UpdateRemote (this merge). `version` is hub.Version
-                    // captured for THIS patch message (monotonic, distinct per
-                    // patch).
+                    // from UpdateViaSyncStream (which stamped on the owner) to
+                    // UpdateRemote (this merge).
+                    //
+                    // 🚨 Count from the PRE-MERGE node, never the merged one. The
+                    // incoming patch is client-supplied: if it carries a `version`
+                    // field, ApplyMeshNodeMerge has already merged that value into
+                    // currentNode, and counting from there would let a caller STEER
+                    // the owner's counter (an MCP `patch` with "version": 9999 would
+                    // mint 10000) — exactly the "only the owner mints" rule this is
+                    // here to enforce. preMergeNode is the owner's own state.
                     //
                     // 🚨 Stamp UNCONDITIONALLY for MeshNode (the only versioned
-                    // reduced stream). The owner's IN-MEMORY MeshNode carries
-                    // Version=0 until a write stamps it (the create's Version=1
-                    // lands only in the persisted file, not the live collection),
-                    // and Version=0 is OMITTED from the serialized `currentNode`
-                    // by DefaultIgnoreCondition=WhenWritingDefault — so a
-                    // ContainsKey guard would never fire and every update would
-                    // keep Version=0, which FileSystemVersionStore.WriteVersion
-                    // skips (Version <= 0) → version-history collapse. Scope to
-                    // MeshNode by type name (this assembly can't reference the
-                    // type — same string-keyed approach used elsewhere here) so
-                    // version-less reduced streams stay untouched.
+                    // reduced stream). Version=0 is OMITTED from the serialized node
+                    // by DefaultIgnoreCondition=WhenWritingDefault — so a ContainsKey
+                    // guard would never fire and a never-yet-stamped node would keep
+                    // Version=0, which FileSystemVersionStore.WriteVersion skips
+                    // (Version <= 0) → version-history collapse. Scope to MeshNode by
+                    // type name (this assembly can't reference the type — same
+                    // string-keyed approach used elsewhere here) so version-less
+                    // reduced streams stay untouched.
                     if (typeof(T).FullName == "MeshWeaver.Mesh.MeshNode")
                     {
                         var versionKey = jsonOpts.PropertyNamingPolicy?.ConvertName("Version") ?? "Version";
-                        // 🚨 The node's OWN counter (+1), never the per-activation hub clock —
-                        // see NextMeshNodeVersion. Reached only for a real change (gated above).
-                        currentNode[versionKey] = NextMeshNodeVersion(currentNode, versionKey);
+                        // The node's OWN counter (+1) off the owner's pre-merge state, never the
+                        // per-activation hub clock and never a client-supplied value — see
+                        // NextMeshNodeVersion. Reached only for a real change (gated above).
+                        currentNode[versionKey] = NextMeshNodeVersion(preMergeNode, versionKey);
                     }
 
                     var mergedJson = currentNode.ToJsonString(jsonOpts);
@@ -1461,7 +1465,7 @@ public static class DataExtensions
                     // 🚨 Three-way merge (MeshNode-only path) — base values carried on the request let a
                     // reordered/stale cross-hub patch merge instead of flapping; falls back to the
                     // monotonic-trigger guard + last-write-wins when no base is carried.
-                    var preMergeNode = currentNode.DeepClone();
+                    var preMergeNode = currentNode.DeepClone().AsObject();
                     ApplyMeshNodeMerge(currentNode, patchNode, isMeshNode: true,
                         request.Message, jsonOpts, mergeGuardLogger, hubPath);
                     // 🚨 Owner-side no-change backstop: a patch whose every value already matches
@@ -1477,8 +1481,11 @@ public static class DataExtensions
                         return null;
                     }
                     // The OWNER bumps the Version on apply (same rule as the deferred path).
-                    // 🚨 The node's OWN counter (+1) — see NextMeshNodeVersion.
-                    var minted = NextMeshNodeVersion(currentNode, versionKey);
+                    // 🚨 Count from the PRE-MERGE node: the patch is client-supplied, and a
+                    // `version` field in it has already been merged into currentNode — counting
+                    // from there would let the caller steer the owner's counter. See
+                    // NextMeshNodeVersion.
+                    var minted = NextMeshNodeVersion(preMergeNode, versionKey);
                     currentNode[versionKey] = minted;
                     var merged = System.Text.Json.JsonSerializer
                         .Deserialize<T>(currentNode.ToJsonString(jsonOpts), jsonOpts);

--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeVersioning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeVersioning.md
@@ -1,151 +1,134 @@
 ---
 Name: MeshNode Versioning
 Category: Documentation
-Description: How MeshNode.Version is assigned from the owning hub's logical clock — the "1 op = 1 change" model
+Description: How MeshNode.Version counts REAL changes to a node — the node-local revision counter and the no-op gates that protect it
 ---
 
 # MeshNode Versioning
 
-Every `MeshNode` carries a `long Version`. It is not a node-local counter, and it is not an optimistic-concurrency token in the classic "increment by one per write" sense. It is a stamp of the **owning hub's logical clock** at the moment the node was last mutated — a record of *which operation* changed the node, not how many times the node has changed.
+Every `MeshNode` carries a `long Version`. It is the node's own **revision counter**: it increases by exactly one each time the node is really changed, and by nothing at all when a write turns out to change nothing.
 
-## The Hub Clock
+Two rules define it, and everything else on this page follows from them:
 
-`MessageHub.Version` increments exactly once per message dispatch — see `MessageHub.HandleMessageAsync` (`++Version` at the top of the method). The clock counts **operations the hub has processed**, not wall time and not writes to any particular node.
+1. **`Version = current.Version + 1`** — derived from the node, never from the hub that owns it.
+2. **Only a real change mints.** Every write path gates on a content diff *before* it touches `Version`.
 
+```csharp
+public static long NextVersion(long currentVersion) => currentVersion + 1;
 ```
-hub.Version:   1     2     3     4     5    ...
-               │     │     │     │     │
-message:       M1    M2    M3    M4    M5
-```
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 320" style="width:100%;max-width:760px;height:auto;display:block;margin:20px auto;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 300" style="width:100%;max-width:760px;height:auto;display:block;margin:20px auto;">
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="8" refX="7" refY="3.5" orient="auto">
       <path d="M0,0 L8,3.5 L0,7 Z" fill="#90a4ae"/>
     </marker>
-    <marker id="arr-blue" markerWidth="8" markerHeight="8" refX="7" refY="3.5" orient="auto">
-      <path d="M0,0 L8,3.5 L0,7 Z" fill="#1e88e5"/>
-    </marker>
     <marker id="arr-green" markerWidth="8" markerHeight="8" refX="7" refY="3.5" orient="auto">
       <path d="M0,0 L8,3.5 L0,7 Z" fill="#43a047"/>
     </marker>
-    <marker id="arr-orange" markerWidth="8" markerHeight="8" refX="7" refY="3.5" orient="auto">
-      <path d="M0,0 L8,3.5 L0,7 Z" fill="#f57c00"/>
+    <marker id="arr-grey" markerWidth="8" markerHeight="8" refX="7" refY="3.5" orient="auto">
+      <path d="M0,0 L8,3.5 L0,7 Z" fill="#78909c"/>
     </marker>
   </defs>
-  <text x="380" y="26" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="currentColor" fill-opacity=".85">Hub Logical Clock — One Operation, One Version Stamp</text>
-  <rect x="20" y="44" width="720" height="44" rx="8" fill="#263238" fill-opacity=".5" stroke="currentColor" stroke-opacity=".2" stroke-width="1"/>
-  <text x="36" y="61" font-family="sans-serif" font-size="11" fill="currentColor" fill-opacity=".5">hub.Version</text>
-  <rect x="100" y="50" width="52" height="32" rx="8" fill="#37474f"/>
-  <text x="126" y="71" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#90a4ae">1</text>
-  <rect x="220" y="50" width="52" height="32" rx="8" fill="#37474f"/>
-  <text x="246" y="71" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#90a4ae">2</text>
-  <rect x="340" y="50" width="52" height="32" rx="8" fill="#37474f"/>
-  <text x="366" y="71" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#90a4ae">3</text>
-  <rect x="460" y="50" width="52" height="32" rx="8" fill="#37474f"/>
-  <text x="486" y="71" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#90a4ae">47</text>
-  <rect x="580" y="50" width="52" height="32" rx="8" fill="#37474f"/>
-  <text x="606" y="71" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#90a4ae">48</text>
-  <line x1="152" y1="66" x2="218" y2="66" stroke="#90a4ae" stroke-opacity=".4" stroke-width="1.5" marker-end="url(#arr)"/>
-  <line x1="272" y1="66" x2="338" y2="66" stroke="#90a4ae" stroke-opacity=".4" stroke-width="1.5" marker-end="url(#arr)"/>
-  <line x1="392" y1="66" x2="414" y2="66" stroke="#90a4ae" stroke-opacity=".4" stroke-width="1.5"/>
-  <text x="420" y="70" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#90a4ae" fill-opacity=".5">…</text>
-  <line x1="430" y1="66" x2="458" y2="66" stroke="#90a4ae" stroke-opacity=".4" stroke-width="1.5" marker-end="url(#arr)"/>
-  <line x1="512" y1="66" x2="578" y2="66" stroke="#90a4ae" stroke-opacity=".4" stroke-width="1.5" marker-end="url(#arr)"/>
-  <line x1="632" y1="66" x2="700" y2="66" stroke="#90a4ae" stroke-opacity=".4" stroke-width="1.5"/>
-  <text x="710" y="70" font-family="sans-serif" font-size="11" fill="#90a4ae" fill-opacity=".5">…</text>
-  <rect x="60" y="128" width="130" height="44" rx="10" fill="#1e3a5f" stroke="#1e88e5" stroke-width="1.5"/>
-  <text x="125" y="146" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#fff">NodeA</text>
-  <text x="125" y="162" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#90caf9">Version = 1</text>
-  <rect x="300" y="128" width="130" height="44" rx="10" fill="#1b5e20" stroke="#43a047" stroke-width="1.5"/>
-  <text x="365" y="146" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#fff">NodeB</text>
-  <text x="365" y="162" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#a5d6a7">Version = 3</text>
-  <rect x="420" y="128" width="130" height="44" rx="10" fill="#e65100" stroke="#f57c00" stroke-width="1.5"/>
-  <text x="485" y="146" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#fff">NodeC</text>
-  <text x="485" y="162" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#ffcc80">Version = 3</text>
-  <rect x="540" y="128" width="130" height="44" rx="10" fill="#4a148c" stroke="#8e24aa" stroke-width="1.5"/>
-  <text x="605" y="146" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#fff">NodeA</text>
-  <text x="605" y="162" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#ce93d8">Version = 47</text>
-  <line x1="126" y1="82" x2="126" y2="127" stroke="#1e88e5" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr-blue)"/>
-  <line x1="366" y1="82" x2="366" y2="127" stroke="#43a047" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr-green)"/>
-  <line x1="486" y1="82" x2="486" y2="127" stroke="#f57c00" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr-orange)"/>
-  <line x1="606" y1="82" x2="606" y2="127" stroke="#8e24aa" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr-orange)"/>
-  <text x="192" y="152" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#43a047" fill-opacity=".8">same message →</text>
-  <text x="192" y="164" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#43a047" fill-opacity=".8">same Version</text>
-  <line x1="190" y1="148" x2="300" y2="152" stroke="#43a047" stroke-opacity=".5" stroke-width="1" stroke-dasharray="3,3"/>
-  <line x1="190" y1="148" x2="180" y2="150" stroke="#43a047" stroke-opacity=".5" stroke-width="1"/>
-  <rect x="60" y="220" width="130" height="44" rx="10" fill="#263238" stroke="currentColor" stroke-opacity=".3" stroke-width="1.5"/>
-  <text x="125" y="238" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="currentColor" fill-opacity=".7">Static Node</text>
-  <text x="125" y="254" text-anchor="middle" font-family="sans-serif" font-size="11" fill="currentColor" fill-opacity=".45">Version = 0</text>
-  <text x="125" y="276" text-anchor="middle" font-family="sans-serif" font-size="10" fill="currentColor" fill-opacity=".4">(never mutated)</text>
-  <rect x="300" y="220" width="130" height="44" rx="10" fill="#263238" stroke="#546e7a" stroke-width="1.5"/>
-  <text x="365" y="238" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="currentColor" fill-opacity=".8">New Node</text>
-  <text x="365" y="254" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#80cbc4">Version = 1</text>
-  <text x="365" y="276" text-anchor="middle" font-family="sans-serif" font-size="10" fill="currentColor" fill-opacity=".4">(CreateNodeRequest)</text>
-  <line x1="125" y1="175" x2="125" y2="218" stroke="currentColor" stroke-opacity=".2" stroke-width="1" stroke-dasharray="3,3"/>
-  <line x1="365" y1="175" x2="365" y2="218" stroke="#546e7a" stroke-opacity=".4" stroke-width="1" stroke-dasharray="3,3"/>
-  <text x="72" y="304" font-family="sans-serif" font-size="10" fill="currentColor" fill-opacity=".35">Version = hub.Version at mutation time — monotonic, not contiguous. Non-mutated nodes keep seed = 0. New nodes start at 1.</text>
+  <text x="380" y="26" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="currentColor" fill-opacity=".85">One Real Change, One Version — No-Ops Cost Nothing</text>
+
+  <text x="36" y="72" font-family="sans-serif" font-size="11" fill="currentColor" fill-opacity=".5">write</text>
+  <rect x="96" y="52" width="108" height="34" rx="8" fill="#1b5e20" stroke="#43a047" stroke-width="1.5"/>
+  <text x="150" y="74" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#a5d6a7">edit title</text>
+  <rect x="236" y="52" width="108" height="34" rx="8" fill="#263238" stroke="#546e7a" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="290" y="74" text-anchor="middle" font-family="sans-serif" font-size="11" fill="currentColor" fill-opacity=".55">re-save (same)</text>
+  <rect x="376" y="52" width="108" height="34" rx="8" fill="#1b5e20" stroke="#43a047" stroke-width="1.5"/>
+  <text x="430" y="74" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#a5d6a7">edit body</text>
+  <rect x="516" y="52" width="108" height="34" rx="8" fill="#263238" stroke="#546e7a" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="570" y="74" text-anchor="middle" font-family="sans-serif" font-size="11" fill="currentColor" fill-opacity=".55">import re-assert</text>
+  <rect x="656" y="52" width="76" height="34" rx="8" fill="#1b5e20" stroke="#43a047" stroke-width="1.5"/>
+  <text x="694" y="74" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#a5d6a7">rename</text>
+
+  <line x1="150" y1="88" x2="150" y2="150" stroke="#43a047" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr-green)"/>
+  <line x1="290" y1="88" x2="290" y2="150" stroke="#78909c" stroke-width="1.5" stroke-dasharray="2,4" marker-end="url(#arr-grey)"/>
+  <line x1="430" y1="88" x2="430" y2="150" stroke="#43a047" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr-green)"/>
+  <line x1="570" y1="88" x2="570" y2="150" stroke="#78909c" stroke-width="1.5" stroke-dasharray="2,4" marker-end="url(#arr-grey)"/>
+  <line x1="694" y1="88" x2="694" y2="150" stroke="#43a047" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr-green)"/>
+  <text x="290" y="120" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#78909c">no-op gate</text>
+  <text x="570" y="120" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#78909c">no-op gate</text>
+
+  <rect x="20" y="156" width="720" height="44" rx="8" fill="#263238" fill-opacity=".5" stroke="currentColor" stroke-opacity=".2" stroke-width="1"/>
+  <text x="36" y="173" font-family="sans-serif" font-size="11" fill="currentColor" fill-opacity=".5">node.Version</text>
+  <rect x="96" y="162" width="108" height="32" rx="8" fill="#37474f"/>
+  <text x="150" y="183" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#90a4ae">2</text>
+  <rect x="236" y="162" width="108" height="32" rx="8" fill="#2c383e"/>
+  <text x="290" y="183" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#607d8b">2</text>
+  <rect x="376" y="162" width="108" height="32" rx="8" fill="#37474f"/>
+  <text x="430" y="183" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#90a4ae">3</text>
+  <rect x="516" y="162" width="108" height="32" rx="8" fill="#2c383e"/>
+  <text x="570" y="183" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#607d8b">3</text>
+  <rect x="656" y="162" width="76" height="32" rx="8" fill="#37474f"/>
+  <text x="694" y="183" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#90a4ae">4</text>
+  <line x1="204" y1="178" x2="234" y2="178" stroke="#90a4ae" stroke-opacity=".4" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="344" y1="178" x2="374" y2="178" stroke="#90a4ae" stroke-opacity=".4" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="484" y1="178" x2="514" y2="178" stroke="#90a4ae" stroke-opacity=".4" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="624" y1="178" x2="654" y2="178" stroke="#90a4ae" stroke-opacity=".4" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <text x="36" y="238" font-family="sans-serif" font-size="10" fill="currentColor" fill-opacity=".45">Version counts REVISIONS OF THIS NODE — contiguous, monotonic, and completely independent of hub traffic,</text>
+  <text x="36" y="254" font-family="sans-serif" font-size="10" fill="currentColor" fill-opacity=".45">of other nodes, and of how many times the node happened to be re-saved. A recycle cannot move it.</text>
+  <text x="36" y="278" font-family="sans-serif" font-size="10" fill="currentColor" fill-opacity=".35">New node = 1 · never-mutated seeded node = 0 · v(n) → v(n+1) exactly once per real edit.</text>
 </svg>
 
-*Hub logical clock: each message increments the clock once; mutated nodes are stamped with the clock value at that operation — two nodes changed by the same message share a version, and a node skips from 3 to 47 if untouched in between.*
+*A write that changes nothing is completed, acked, and dropped — it never reaches the counter.*
 
-## One Operation, One Version Stamp
+## No `Version` Without a Change
 
-When a `MeshNode` is mutated through the framework write path — `MeshNodeStreamHandle.Update`, for both the own-node and remote-node branches — the framework stamps the result via `MeshNode.NextVersion`:
+The gate comes first at **every** place a write can land; the bump is what happens *after* it passes. This ordering is load-bearing: the bump would itself manufacture the difference that makes a no-op write look like a change.
 
-```csharp
-updated = updated with { Version = MeshNode.NextVersion(_workspace.Hub.Version, current.Version) };
-// NextVersion(hubVersion, currentVersion) => max(hubVersion, currentVersion + 1)
-```
+| Write path | Where the gate lives |
+|---|---|
+| Own-node write (`MeshNodeStreamHandle.UpdateOwn`) | `ReferenceEquals` → record `Equals` → `MeshNode.SerializedEquals`; a no-op completes the observable with the unchanged node and applies nothing |
+| Cross-hub write (`MeshNodeStreamHandle.UpdateRemote`) | the RFC 7396 merge-patch diff is computed on the lambda's raw output; an empty diff returns without posting |
+| Owner applying a cross-hub patch (`DataExtensions.ApplyMeshNodePatchInTurn` and the deferred path) | `JsonNode.DeepEquals(preMerge, postMerge)` — acks success and commits nothing |
+| `IMeshService.UpdateNode` (`NodeUpdatePipeline`) | normalises `Version` + `LastModified` to the live values, then `SerializedEquals` |
+| The persistence re-stamp (`MeshNodeTypeSource.UpdateImpl`) | record `Equals` ignoring `Version`, confirmed by `SerializedEquals` |
 
-The lambda you pass to `Update` does **not** set `Version` itself. The framework owns the clock. One operation (one message handler running one `Update`) produces exactly one new `Version` value: the hub clock at that point **or** one above the node's own version, whichever is higher.
+**Why `SerializedEquals` and not plain record `Equals`.** `MeshNode.Content` is an `object?`. A rebuilt-but-identical typed content, a re-parsed `JsonElement` (a struct whose default equality compares the parse buffer), or a content record holding collections (compared by reference) all read as "changed" under record equality while the persisted JSON is byte-identical. Every such write used to mint a version and persist a history row — the "v1170 with no edits" report. `MeshNode.SerializedEquals(a, b, options)` compares the serialized JSON and runs only after the cheap checks already disagreed, so an unchanged node costs nothing.
 
-This has three practical consequences:
+**`LastModified` is stamped only on a real change.** The audit stamp is applied *after* the diff, never before — otherwise the stamp is the only thing in the patch and every save looks like an edit.
 
-- **A node mutated during message N normally has `Version == N`.** While the hub clock leads, `NextVersion` returns it, so two different nodes changed by the same message share that version — they were touched by the same operation.
-- **`Version` is monotonic per node but not contiguous.** A node updated under message 3 and again under message 47 jumps `3 → 47`. Never assert `newVersion == oldVersion + 1`; always assert `newVersion > oldVersion`.
-- **Subscribers rely on monotonicity, not contiguity.** The `UpdateOwn` baseline check and `DistinctUntilChanged(n => n.Version)` both work correctly under non-contiguous version sequences.
+## Only the Owner Mints
 
-## Monotonic Across Activations — the `NextVersion` Floor (#325)
+A client/subscriber writing a node it does not own (a cross-hub `GetMeshNodeStream(path).Update(...)`) **carries the base version it last observed** and lets the owner assign the fresh value on apply. It never increments client-side. A pre-incremented client version (the old `Math.Max(existing, …) + 1`) ships a frame whose base is already out of date by the time it lands, and the owner's version-guarded merge mishandles it. See [DataSyncAndCrdt](/Doc/Architecture/DataSyncAndCrdt) §2 ("a subscriber never mints a version").
 
-The hub clock (`MessageHub.Version`) resets to **0 on every activation** and is the *same* clock that stamps the owning hub's **layout-area render Fulls**. If a node's `Version` were stamped straight off that clock, a deactivate → reactivate cycle (idle-release, `Recycle`/`DisposeRequest`, or a replica restart) would stamp the node's next write with the fresh *low* clock — rolling its `Version` **backward** below the value it already carried. A caller that re-reads the node (`get`/`UpdateNode`) then sees an OLDER version than the writes it just confirmed — the write-rollback / "v113 read back as v3" of [issue #325](https://github.com/Systemorph/MeshWeaver/issues/325).
+**Write through the live lambda parameter.** `stream.Update(node => node with { … })` must transform the node it is handed — the live, owner-reconciled value — never discard it and slam a separately-read full node (`_ => fetchedNode`). The owner computes the diff it applies against that live value; a discarded parameter bases the diff on a stale snapshot and can clobber a concurrent edit.
 
-`MeshNode.NextVersion` fixes this **without touching the hub clock**: it floors the stamp at `current.Version + 1`. The node loads its persisted `Version` verbatim on activation (`MeshNodeTypeSource.BuildInstanceCollection` leaves it alone — a load is a read), so the floor keeps every post-reactivation write **strictly above** the last persisted version. The node's `Version` is therefore a persistence clock that is monotonic *across* activations, while `Hub.Version` stays the per-activation render clock. The floor is applied at every place the owner mints a node `Version`: the own-write path (`MeshNodeStreamExtensions.UpdateOwn`), the persistence re-stamp (`MeshNodeTypeSource.UpdateImpl`), and the cross-hub merge apply (`DataExtensions.NextMeshNodeVersion`).
+**Each write bumps once.** The write path that commits a change is the one that bumps. `MeshNodeTypeSource.UpdateImpl` re-stamps only a node whose incoming version did **not** already advance past what it previously carried (a sync-stream value update, a client-carried base version) — re-stamping a node the write path already bumped would count one edit twice.
 
-> **Why not re-seed `Hub.Version` from the node?** That was tried (`SetInitialVersion(node.Version)`) and reverted: `Hub.Version` also stamps layout Fulls, which advance per *render* and run far ahead of a doc/static node's low `Version`. Re-seeding the shared clock *backward* to the node version on a catalog push made the monotonicity guard drop every later layout Full — the atioz 2026-06-18 "cannot find pinned doc" wedge. The node-version floor keeps the two clocks separate: layout Fulls keep using `Hub.Version` untouched.
+## Not the Hub Clock (#325)
 
-> **Frame version stays `Hub.Version` — the fix is mirror-side, not a frame-version floor.** The sync-stream *frame* version (what the receive-side monotonicity guard compares) rides `Hub.Version`: reliably monotonic **within** an activation (the owner `++`s it per message), and left exactly as-is — it is *not* present on every emitted frame (a partial cross-hub patch carries no `Version` field, so its reduced value reads `0`), so tying the frame version to the content `Version` makes it flap `7 → 0 → 11` and drops legitimate mid-stream frames (it broke the activity/export relay), and **flooring every originated frame at a per-activation content baseline broke the normal single-hub data-load frame sequence** — the initial-load/data-load path *is* the MeshDataSource stream, so a baseline on it perturbed the very frames a page/data load waits for (the `PageLoadingTest` / `SourceDocumentDataLoadingTest` hangs). Both owner-side approaches were reverted.
+`MessageHub.Version` increments once per message dispatch — it counts **operations the hub processed**. `MeshNode.Version` used to be stamped from it (`max(hubVersion, current + 1)`), which had two consequences that are now gone:
+
+- **Unrelated traffic moved the number.** A node touched under message 3 and again under message 47 jumped `3 → 47`. The version described the hub's workload, not the node's history.
+- **A recycle rolled it backward.** The hub clock resets to **0** on every activation, so a deactivate → reactivate cycle (idle-release, `Recycle`/`DisposeRequest`, a replica restart) stamped the node's next write with the fresh *low* clock. A caller re-reading the node saw an OLDER version than the writes it had just confirmed — the write-rollback / "v113 read back as v3" of [issue #325](https://github.com/Systemorph/MeshWeaver/issues/325).
+
+A node-local counter is monotonic across activations **by construction**: the node loads its persisted `Version` verbatim on activation (`MeshNodeTypeSource.BuildInstanceCollection` leaves it alone — a load is a read), and the next write is that value `+ 1`.
+
+> **The hub clock is untouched, and that matters.** `Hub.Version` also stamps the owning hub's **layout-area render Fulls**, and the sync-stream *frame* version rides it. Re-seeding the shared clock from a node version was tried (`SetInitialVersion(node.Version)`) and reverted: layout Fulls advance per *render* and run far ahead of a doc/static node's low `Version`, so seeding it backward made the monotonicity guard drop every later Full — the atioz 2026-06-18 "cannot find pinned doc" wedge. Likewise, flooring the *frame* version at a content baseline broke the normal single-hub data-load frame sequence (the `PageLoadingTest` / `SourceDocumentDataLoadingTest` hangs) and the activity/export relay. The two clocks stay separate: node revisions on the node, render/frame ordering on the hub.
 >
-> The residual cross-**silo** mirror-drop (#325 symptom 2, "index vs node-resolution split-brain", multi-replica only — the monolith heals it via the heartbeat resubscribe) is instead fixed **on the mirror side, scoped precisely to the resubscribe path** so no normal frame is touched. `Hub.Version` **resets to 0 on every (re)activation**, so after an owner grain idle-recycles, a mirror on another silo that cached the higher pre-recycle frame version drops the recycled owner's low post-recycle resubscribe Full under the guard (`version < Current.Version`) and stays orphaned. But that mirror **already detected it is behind** — `JsonSynchronizationStream.CreateExternalClient`'s version-gated resubscribe fires only when the change feed announced a *higher node version than the mirror holds* — and it is asking the owner for a fresh authoritative snapshot. So the resubscribe **arms a one-shot latch** (`SynchronizationStream.ExpectResubscribeFull`); the next `Full` that reaches `UpdateStream` consumes the latch and is **accepted even though its frame version regressed** (the recycled owner re-based its clock), then the mirror adopts that re-based clock. Only a `Full` consumes the latch (a stray reordered patch is still dropped), and it is set **only when the mirror is genuinely behind** (`receivedVersion < announcedVersion`) — so it can never clobber a newer optimistic write with a stale snapshot (that case keeps the gate closed and the guard intact).
->
-> Because nothing on the owner's originate path changes, every normal load/render frame is untouched (the layout-Full render path, the 2026-06-18 "cannot find pinned doc" wedge, and the activity/export relay all stay as-is). Proven by the deterministic 2-silo repro `TwoSiloRecycleConvergenceTest` (orphaned-on-main → converges-with-fix) and guarded by `PageLoadingTest` / `SourceDocumentDataLoadingTest` / `ExportDocumentScriptRelayTest` / `DataChangeStreamUpdateTest` / `InlineEditingTest`.
+> The residual cross-**silo** mirror-drop (#325 symptom 2, "index vs node-resolution split-brain", multi-replica only — the monolith heals it via the heartbeat resubscribe) is fixed **on the mirror side, scoped precisely to the resubscribe path** so no normal frame is touched. After an owner grain idle-recycles, a mirror on another silo that cached the higher pre-recycle frame version would drop the recycled owner's low post-recycle resubscribe Full under the guard (`version < Current.Version`) and stay orphaned. But that mirror **already detected it is behind** — `JsonSynchronizationStream.CreateExternalClient`'s version-gated resubscribe fires only when the change feed announced a *higher node version than the mirror holds* — and it is asking for a fresh authoritative snapshot. So the resubscribe **arms a one-shot latch** (`SynchronizationStream.ExpectResubscribeFull`); the next `Full` that reaches `UpdateStream` consumes the latch and is accepted even though its frame version regressed, then the mirror adopts that re-based clock. Only a `Full` consumes the latch (a stray reordered patch is still dropped), and it is set **only when the mirror is genuinely behind** (`receivedVersion < announcedVersion`) — so it can never clobber a newer optimistic write with a stale snapshot. Proven by `TwoSiloRecycleConvergenceTest` and guarded by `PageLoadingTest` / `SourceDocumentDataLoadingTest` / `ExportDocumentScriptRelayTest` / `DataChangeStreamUpdateTest` / `InlineEditingTest`.
 
 ## The Activation Seed Is Durable Storage — and the Store Refuses a Backward Write
 
-The `NextVersion` floor above only holds if the value it floors against is the node's **real** persisted version. Two invariants make that true, and both exist because they were once violated — with durable data loss.
+`current.Version + 1` only holds if the value it counts from is the node's **real** persisted version. Two invariants make that true, and both exist because they were once violated — with durable data loss.
 
 **1. A (re)activating hub seeds its own node from `IStorageAdapter`, not from a cache.** The routing layer attaches an own-node observable at hub instantiation (`WithOwnNodeStream`, set by `MessageHubGrain` / `MonolithRoutingService`). That stream is the right source for **live updates** — and on Orleans it is the only source of the *enriched* node, whose `HubConfiguration` delegate storage cannot hold — but it is **not durable state**: `PathResolutionService` memoizes the resolved `AddressResolution` *including its `MeshNode` snapshot*, invalidated only by the per-silo change feed, and `MeshNodeStreamCache` replays its last seen value. A hub that adopted such a snapshot as its live own-node state came up on an arbitrarily old node — which the persistence sampler then wrote back **over newer durable data**. So `MeshNodeTypeSource.Initialize` **merges** a one-shot durable read with the routing stream. Merge, not replace: a slow or faulted storage read never delays activation (the routing stream still seeds, and a node that has never been persisted reads back `null` and is simply dropped), while a stale routing emission loses to the durable one on version.
 
-**2. A hub never adopts an own-node emission whose `Version` regresses.** `MeshNodeTypeSource` keeps a per-hub floor raised by every state it adopts — the durable seed, a routing emission, **and every local write committed through `UpdateImpl`** (the last is load-bearing: the durable read is asynchronous on a real backend and can land *after* a local write already advanced the in-RAM node). Only a **strictly** lower version is dropped; equal passes, because a never-mutated node sits at its seed version forever. The one legitimate rewind — a same-path recreate restarting at `Version = 1` — is recognised through the existing delete tombstone (`RecentlyDeletedRegistry`) and resets the floor. This mirrors the forward-only refresh the change-notification handler in `MeshDataSourceExtensions.SubscribeToOwnDeletion` already applies: *a persisted snapshot may only replace the in-RAM commit when it is strictly newer*.
+**2. A hub never adopts an own-node emission whose `Version` regresses.** `MeshNodeTypeSource` keeps a per-hub floor raised by every state it adopts — the durable seed, a routing emission, **and every local write committed through `UpdateImpl`** (the last is load-bearing: the durable read is asynchronous on a real backend and can land *after* a local write already advanced the in-RAM node). Only a **strictly** lower version is dropped; equal passes, because a never-mutated node sits at its seed version forever. The one legitimate rewind — a same-path recreate restarting at `Version = 1` — is recognised through the existing delete tombstone (`RecentlyDeletedRegistry`) and resets the floor.
 
-**3. The store itself refuses a backward write.** `MonotonicWriteGuardStorageAdapter` is the outermost `IStorageAdapter` decorator (composed alongside the version writer, so every consumer that resolves `IStorageAdapter` from DI gets it). Since every mint goes through `NextVersion`, a write whose `Version` is below the stored one is **never** a newer state — it is a stale snapshot about to destroy acknowledged data, and it is refused with an `Error` log naming both versions; the write emits the stored (winning) node rather than throwing, so a data-integrity save cannot fault a create or dispose-flush chain. A per-path in-process high-water mark (fed by writes *and* reads, so it costs no extra I/O) is only a cheap **filter**: a suspected regression is verified against a real read of the current row before anything is refused, so a stale mark — another replica deleted and recreated the node, the store was restored out of band — can never refuse a legitimate write. There is deliberately **no bypass hatch**: every framework rewind already writes *forward* (version restore re-stamps `Version = 0` so the owner mints a new top version; imports and GitSync go through the owner's `stream.Update`; a delete drops the row, so a recreate faces no stored row at all).
+**3. The store itself refuses a backward write.** `MonotonicWriteGuardStorageAdapter` is the outermost `IStorageAdapter` decorator (composed alongside the version writer, so every consumer that resolves `IStorageAdapter` from DI gets it). Since the counter only ever moves forward, a write whose `Version` is below the stored one is **never** a newer state — it is a stale snapshot about to destroy acknowledged data, and it is refused with an `Error` log naming both versions; the write emits the stored (winning) node rather than throwing, so a data-integrity save cannot fault a create or dispose-flush chain. A per-path in-process high-water mark (fed by writes *and* reads, so it costs no extra I/O) is only a cheap **filter**: a suspected regression is verified against a real read of the current row before anything is refused, so a stale mark — another replica deleted and recreated the node, the store was restored out of band — can never refuse a legitimate write. Re-persisting an *unchanged* node at its existing version is accepted: the guard refuses only a **strictly** lower version. There is deliberately **no bypass hatch**: every framework rewind already writes *forward* (version restore re-stamps `Version = 0` so the owner mints a new top version; imports and GitSync go through the owner's `stream.Update`; a delete drops the row, so a recreate faces no stored row at all).
 
 Pinned by `StaleActivationSeedRollbackTest` (deterministic: recycle the owner, advance the durable row out of band, assert the reactivated hub serves durable state and never rolls the store back) and `MonotonicWriteGuardTests`.
-
-## Every Change Is Stamped — Including Updates — and Only by the Owner
-
-The stamp is not optional and not add-only. The owning hub's data source (`MeshNodeTypeSource`) re-stamps `Version = _workspace.Hub.Version` on **every** change it emits — a freshly *added* node **and** an *update* to an existing one. Both branches must stamp, because the stamp is what advances the version on the emitted frame, and that advance is what makes the change propagate:
-
-- the change feed and every subscriber's **monotonicity guard** key off `Version`; a frame whose version did **not** advance is indistinguishable from a duplicate and is dropped, so it never reaches subscribers' mirrors;
-- a node that an UPDATE left at its incoming version therefore emits a "nothing-new" frame and the reconciled value is silently lost — **the read-your-writes-after-update bug**. Create worked (adds were stamped); update/patch did not. The fix stamps the update branch too. Pinned by `MeshNodeStreamEmissionTest` (a node-stream re-emit + replay regression).
-
-**Only the owner mints a version.** A client/subscriber writing a node it does not own (a cross-hub `GetMeshNodeStream(path).Update(...)`) **carries the base version it last observed** and lets the owner assign the fresh value on apply — it never increments client-side. A pre-incremented client version (the old `Math.Max(existing, …) + 1`) ships a frame whose base is already out of date by the time it lands, and the owner's version-guarded merge mishandles it. See [DataSyncAndCrdt](/Doc/Architecture/DataSyncAndCrdt) §2 ("a subscriber never mints a version").
-
-**Write through the live lambda parameter.** `stream.Update(node => node with { … })` must transform the node it is handed — the live, owner-reconciled value — never discard it and slam a separately-read full node (`_ => fetchedNode`). The owner computes the diff it applies against that live value; a discarded parameter bases the diff on a stale snapshot and can clobber a concurrent edit.
 
 ## Never-Mutated Nodes Keep Their Seed Version
 
 A node loaded from persistence — or seeded via `AddMeshNodes` / `IStaticNodeProvider` — and **never** written through `Update` keeps whatever `Version` it was created with, typically `0`. The `HandleSaveMeshNode` path persists the node's `Version` verbatim; it does **not** synthesise a bump on save. So a static config node legitimately reads back as `Version == 0`.
+
+The same holds for a hub *reactivating*: its already-durable node is re-added to a fresh in-memory collection, but re-persisting it is not a change, so it keeps its version.
 
 ## Created Nodes Start at Version 1
 
@@ -163,7 +146,9 @@ A freshly created node gets `Version = 1` unless the caller explicitly supplied 
 |---|---|
 | Seeded static / config node, never mutated | `0` (its seed value) |
 | Node created via `CreateNodeRequest` | `1` (or caller-supplied, if > 0) |
-| Node mutated via `MeshNodeStreamHandle.Update` | `hub.Version` at that operation |
+| Node really changed through a write path | `previous + 1` |
+| Write that changes nothing (identical upsert, re-import, re-save) | unchanged — no bump, no history row |
+| Owning hub recycled and reactivated | unchanged — the durable value is loaded verbatim |
 | Persisted via `HandleSaveMeshNode` | verbatim — no synthetic bump |
 
 ## What This Is Not

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-31-version-counts-real-changes.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-07-31-version-counts-real-changes.md
@@ -1,0 +1,24 @@
+---
+Name: Version numbers now count your edits — and saving nothing no longer makes a version
+Category: What's New
+Description: A node's version used to jump by unrelated amounts (3 → 47) and could climb even when nothing was edited. It is now a plain revision counter: +1 per real change, and untouched by a save that changes nothing.
+Icon: Sparkle
+---
+
+# Version numbers now count your edits
+
+A node's version used to be stamped from the owning hub's internal message clock, so it jumped by
+whatever that hub happened to be busy with — a document edited twice could go from version 3 to
+version 47 — and it moved backwards after the hub restarted. It also climbed on saves that changed
+nothing at all: re-importing unchanged content, re-installing a plugin, or an editor re-asserting
+the state it already had each minted a version and a version-history entry for an edit that never
+happened.
+
+Version is now simply the node's own revision counter. Every real change adds exactly one, so
+"version 7" means the node has been changed seven times, and the version history contains one
+entry per actual edit. A save that turns out to change nothing is completed normally but leaves
+the version, the last-modified stamp, and the history untouched.
+
+Alongside this, markdown-backed nodes now keep their version across a reload — previously the
+number was dropped when the file was written, so a later edit could quietly overwrite the previous
+entry in the node's version history.

--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -257,20 +257,23 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
         // content change. The owner re-stamps Version on every update (below), so without
         // this guard each re-fire of the workspace pipeline would look like a fresh change
         // (a new version per dispatch) and spin an infinite re-stamp loop.
-        // 🚨 SerializedEquals is the second, load-bearing half of that guard: record Equals
-        // compares Content (an `object?`) by reference, so a re-parsed JsonElement or a
-        // rebuilt-but-identical typed content reads as "changed" and earned a version bump +
-        // a persisted history row for an edit that never happened. It runs only for the
-        // candidates record-Equals already flagged, so an unchanged collection costs nothing.
+        // 🚨 The comparison here stays REFLECTION-FREE — record Equals only, never
+        // MeshNode.SerializedEquals. This runs on the owning hub's data-source pipeline,
+        // including while hubs are tearing down, and a NodeType node's Content is an instance
+        // of a DYNAMICALLY COMPILED type in a collectible ALC: serializing it forces
+        // System.Text.Json to build a JsonTypeInfo by reflecting over a type whose ALC may be
+        // unloading — the documented FutuRe SIGSEGV ("post-dispose hub construction walks
+        // TypeRegistry over unloading collectible-ALC types", CI run 30660214122, exit=139).
+        // The no-op gates that matter run on the WRITE paths (UpdateOwn / UpdateRemote / the
+        // owner's patch apply) and refuse a no-op long before it reaches this pipeline, so the
+        // serialized comparison buys nothing here and costs a crash.
         // Pair each updated node with the version it PREVIOUSLY carried (_lastSaved) so the
         // re-stamp below can advance from the node's own version (#325) — the per-activation
         // Hub.Version regresses it after a recycle.
-        var jsonOptions = _workspace.Hub.JsonSerializerOptions;
         var updates = instances.Instances
             .Where(x => _lastSaved.Instances.TryGetValue(x.Key, out var existing)
                         && existing is MeshNode ex && x.Value is MeshNode nv
-                        && !ex.Equals(nv with { Version = ex.Version })
-                        && !MeshNode.SerializedEquals(ex, nv with { Version = ex.Version }, jsonOptions))
+                        && !ex.Equals(nv with { Version = ex.Version }))
             .Select(x => (Node: (MeshNode)x.Value,
                           PreviousVersion: ((MeshNode)_lastSaved.Instances[x.Key]).Version))
             .ToArray();

--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -257,13 +257,20 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
         // content change. The owner re-stamps Version on every update (below), so without
         // this guard each re-fire of the workspace pipeline would look like a fresh change
         // (a new version per dispatch) and spin an infinite re-stamp loop.
+        // 🚨 SerializedEquals is the second, load-bearing half of that guard: record Equals
+        // compares Content (an `object?`) by reference, so a re-parsed JsonElement or a
+        // rebuilt-but-identical typed content reads as "changed" and earned a version bump +
+        // a persisted history row for an edit that never happened. It runs only for the
+        // candidates record-Equals already flagged, so an unchanged collection costs nothing.
         // Pair each updated node with the version it PREVIOUSLY carried (_lastSaved) so the
-        // re-stamp below can advance forward-only from the node's own version (#325) — a fresh
-        // Hub.Version alone regresses it after a recycle.
+        // re-stamp below can advance from the node's own version (#325) — the per-activation
+        // Hub.Version regresses it after a recycle.
+        var jsonOptions = _workspace.Hub.JsonSerializerOptions;
         var updates = instances.Instances
             .Where(x => _lastSaved.Instances.TryGetValue(x.Key, out var existing)
                         && existing is MeshNode ex && x.Value is MeshNode nv
-                        && !ex.Equals(nv with { Version = ex.Version }))
+                        && !ex.Equals(nv with { Version = ex.Version })
+                        && !MeshNode.SerializedEquals(ex, nv with { Version = ex.Version }, jsonOptions))
             .Select(x => (Node: (MeshNode)x.Value,
                           PreviousVersion: ((MeshNode)_lastSaved.Instances[x.Key]).Version))
             .ToArray();
@@ -275,8 +282,6 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
 
         _logger?.LogDebug("MeshNodeTypeSource.UpdateImpl: adds={Adds}, updates={Updates}, deletes={Deletes}",
             adds.Length, updates.Length, deletes.Length);
-
-        var hubVersion = _workspace.Hub.Version;
 
         // Creates: enqueue for the debounce flush. Dict semantics collapse a
         // burst of UpdateImpl emissions for the same path into a single
@@ -291,7 +296,7 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
         // recently-deleted list — drop the add.
         var nowUtc = DateTimeOffset.UtcNow;
         PruneRecentlyDeleted(nowUtc);
-        foreach (var node in adds)
+        bool IsTombstoned(MeshNode node)
         {
             var perHubRecentlyDeleted = !string.IsNullOrEmpty(node.Path)
                 && _recentlyDeleted.TryGetValue(node.Path, out var deletedAt)
@@ -300,72 +305,96 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
             // AFTER the delete (fresh instance, empty per-hub set) and be about to resurrect
             // the row from a stale Replay(1) own-node snapshot. The owning hub recorded the
             // delete in the shared registry, so drop the add here. See RecentlyDeletedRegistry.
-            if (perHubRecentlyDeleted
-                || (_recentlyDeletedRegistry?.IsRecentlyDeleted(node.Path) ?? false))
-            {
-                _logger?.LogDebug(
-                    "MeshNodeTypeSource[{HubPath}]: skip save for recently-deleted {Path}",
-                    _hubPath, node.Path);
-                continue;
-            }
-            // 🚨 #325: the SAME forward-only floor the updates branch below applies. An "add" is
-            // add-relative-to-THIS-source-instance, NOT globally new: after an idle-recycle the
-            // reactivated hub's _lastSaved starts empty, so its own already-durable node is
-            // classified here as a create. A plain `Version = hubVersion` then stamps it with the
-            // fresh per-activation hub clock (which resets toward 0) and the debounce flush writes
-            // that REGRESSED version over the durable row — the write-rollback of #325, this time
-            // through the create path. MeshNode.NextVersion floors at the node's own carried
-            // version, so a genuinely new node (Version 0) is unaffected (max(hubVersion, 1) ==
-            // hubVersion for any live clock) while a re-added durable node can never go backward.
-            // Doc/Architecture/MeshNodeVersioning.md: the floor applies at EVERY place the owner
-            // mints a node Version — this is the persistence re-stamp it names.
-            // For the OWN node, additionally floor on _ownNodeVersionFloor: the highest
-            // own-node version this hub has adopted (activation seed, durable-truth rebase).
-            // A cache-seeded re-add can carry a version BELOW the floor; minting from the
-            // carried version alone would manufacture the backward write the
-            // MonotonicWriteGuard then refuses.
+            if (!perHubRecentlyDeleted
+                && !(_recentlyDeletedRegistry?.IsRecentlyDeleted(node.Path) ?? false))
+                return false;
+            _logger?.LogDebug(
+                "MeshNodeTypeSource[{HubPath}]: skip save for recently-deleted {Path}",
+                _hubPath, node.Path);
+            return true;
+        }
+
+        var stampedAdds = adds.Where(node => !IsTombstoned(node)).Select(node =>
+        {
+            // 🚨 An "add" is add-relative-to-THIS-source-instance, NOT globally new: after an
+            // idle-recycle the reactivated hub's _lastSaved starts empty, so its own
+            // already-durable node is classified here as a create. Re-persisting that node is
+            // NOT a change, so it must NOT get a new version — only a node that has never been
+            // versioned (Version 0) is genuinely new and starts at 1 (also the serialization
+            // requirement: DefaultIgnoreCondition=WhenWritingDefault OMITS Version 0 from the
+            // persisted JSON). Re-stamping a durable node here bumped its version on every
+            // reactivation, and off the per-activation hub clock it stamped a REGRESSED value
+            // that the debounce flush then wrote over the durable row — the write-rollback of
+            // #325 through the create path.
+            // For the OWN node, lift to _ownNodeVersionFloor: the highest own-node version this
+            // hub has adopted (activation seed, durable-truth rebase). A cache-seeded re-add can
+            // carry a version BELOW the floor; saving that carried version is the backward write
+            // the MonotonicWriteGuard refuses. Writing AT the floor is accepted (the guard only
+            // refuses a strictly-lower version).
             var addFloor = string.Equals(node.Path, _hubPath, StringComparison.OrdinalIgnoreCase)
                 ? Math.Max(node.Version, Volatile.Read(ref _ownNodeVersionFloor))
                 : node.Version;
-            var nodeWithVersion = node with { Version = MeshNode.NextVersion(hubVersion, addFloor) };
-            _pendingSaves[node.Path] = nodeWithVersion;
-        }
+            return node with { Version = addFloor > 0 ? addFloor : MeshNode.NextVersion(0) };
+        }).ToArray();
 
-        // 🚨 Stamp the owning hub's monotonic version onto every UPDATED node too.
-        // The owner is the single version clock (Host.Version == _workspace.Hub.Version,
-        // which initialises from the persisted node and increments once per dispatch).
-        // Adds are stamped above; updates were NOT, so an updated node kept its incoming
-        // (client-carried, deliberately-constant) version. The emitted frame then did not
-        // advance the version, so the change feed / subscriber monotonicity guard treated
-        // it as nothing-new and the reconciled update never reached subscribers' mirrors —
-        // the read-your-writes-after-update bug (create worked because adds were stamped).
-        // Re-emit the stamped nodes so propagation advances; the persistence subscriber
-        // then saves the bumped version.
+        foreach (var node in stampedAdds)
+            _pendingSaves[node.Path] = node;
+
+        // 🚨 The stamped version goes into the LIVE collection too, not just the save queue.
+        // Otherwise the in-RAM node and the durable row disagree: a created node persists at
+        // Version 1 while the owner's collection keeps the incoming 0, and the next write —
+        // which counts from the LIVE node — mints 1 again, landing a second, different payload
+        // on the version-history row {Id}_1 and silently overwriting the create snapshot
+        // (VersionHistoryTest). Same for a re-added durable node lifted to _ownNodeVersionFloor:
+        // the live node must carry the version the store is about to hold.
+        if (stampedAdds.Length > 0)
+            instances = instances with
+            {
+                Instances = instances.Instances.SetItems(
+                    stampedAdds.Select(n => new KeyValuePair<object, object>(n.Id, n)))
+            };
+
+        // 🚨 Advance the version of an UPDATED node whose incoming version did NOT already
+        // advance. The write paths (UpdateOwn, the owner's cross-hub patch apply) bump the
+        // version themselves before they commit, so those nodes arrive already carrying their
+        // new revision and MUST be left alone — re-stamping them here would bump a single edit
+        // TWICE. A node that arrives at its old version came in through a path that did not
+        // mint (a sync-stream value update, a client-carried base version): its frame would
+        // then look like a duplicate to the change feed and every subscriber's monotonicity
+        // guard, and the reconciled update would never reach their mirrors — the
+        // read-your-writes-after-update bug. Re-emit those with the next version so
+        // propagation advances; the persistence subscriber then saves it.
         if (updates.Length > 0)
         {
-            // 🚨 #325: advance forward-only from each node's OWN previous version, never straight
-            // off hubVersion. hubVersion resets to 0 on reactivation, so a plain `Version =
-            // hubVersion` re-stamp regresses the node's version after a recycle — the authoritative
-            // `get`/read then returns a version BELOW the writes it just confirmed (the write-
-            // rollback / "v113 read back as v3" of #325). MeshNode.NextVersion keeps it strictly
-            // increasing across activations WITHOUT touching Hub.Version (so layout Fulls, which
-            // ride Hub.Version, are unaffected — the 2026-06-18 wedge cannot recur).
-            // 🚨 Floor on BOTH the node's previously-saved version AND the version the write
-            // path just minted onto the incoming node (UpdateOwn stamps before the commit) —
-            // plus, for the own node, _ownNodeVersionFloor. _lastSaved is reset wholesale by
-            // BuildInstanceCollection from the merge of the durable seed and the CACHE-BACKED
-            // routing stream, so PreviousVersion alone can REGRESS after a reactivation whose
-            // durable seed lost to a stale replay (the "incoming Version=834 is BELOW the
-            // stored Version=2423" refusals of 2026-07-30): re-deriving the stamp from it
-            // manufactured a descending mint that MonotonicWriteGuard then refused forever.
+            // 🚨 The counter is the node's OWN (previous + 1), never the per-activation hub
+            // clock: that clock resets to 0 on reactivation, so a `Version = hubVersion`
+            // re-stamp regressed the node's version after a recycle and the authoritative
+            // `get`/read then returned a version BELOW the writes it just confirmed (the
+            // write-rollback / "v113 read back as v3" of #325).
+            // 🚨 Take the max of BOTH the node's previously-saved version AND the version the
+            // incoming node carries — plus, for the own node, _ownNodeVersionFloor. _lastSaved
+            // is reset wholesale by BuildInstanceCollection from the merge of the durable seed
+            // and the CACHE-BACKED routing stream, so PreviousVersion alone can REGRESS after a
+            // reactivation whose durable seed lost to a stale replay (the "incoming Version=834
+            // is BELOW the stored Version=2423" refusals of 2026-07-30): deriving the stamp
+            // from it manufactured a descending mint that MonotonicWriteGuard refused forever.
             var ownFloor = Volatile.Read(ref _ownNodeVersionFloor);
             var stampedUpdates = updates
                 .Select(u =>
                 {
+                    var isOwn = string.Equals(u.Node.Path, _hubPath, StringComparison.OrdinalIgnoreCase);
                     var floor = Math.Max(u.PreviousVersion, u.Node.Version);
-                    if (string.Equals(u.Node.Path, _hubPath, StringComparison.OrdinalIgnoreCase))
+                    if (isOwn)
                         floor = Math.Max(floor, ownFloor);
-                    return u.Node with { Version = MeshNode.NextVersion(hubVersion, floor) };
+                    // Already advanced by the write path that produced this change ⇒ that IS the
+                    // new revision. Only a node still sitting at (or below) its previous version
+                    // needs the bump here.
+                    var alreadyAdvanced = u.Node.Version > u.PreviousVersion
+                        && (!isOwn || u.Node.Version >= ownFloor);
+                    return u.Node with
+                    {
+                        Version = alreadyAdvanced ? u.Node.Version : MeshNode.NextVersion(floor)
+                    };
                 })
                 .ToArray();
             instances = instances with

--- a/src/MeshWeaver.Hosting/NodeUpdatePipeline.cs
+++ b/src/MeshWeaver.Hosting/NodeUpdatePipeline.cs
@@ -77,13 +77,26 @@ internal static class NodeUpdatePipeline
             // whose base is out of date by the time it lands, so the owner's
             // version-guarded merge mishandles it — the read-your-writes-after-update bug.
             _ => hub.GetMeshNodeStream(node.Path)
-                .Update(live => node with
+                .Update(live =>
                 {
-                    Version = live.Version,
-                    // 🚨 Re-stamp LastModified at APPLY time. NodeFactory.UpdateNode
-                    // carries the caller's node verbatim, whose LastModified is the
-                    // value the caller READ (e.g. `current with { … }`), NOT the edit
-                    // time — so without this the node persists with a stale
+                    // 🚨 No-op gate BEFORE the LastModified re-stamp: an UpdateNode carrying a
+                    // node identical to the live one (an importer re-asserting state, an MCP
+                    // update that changed nothing, a plugin re-install of unchanged content)
+                    // must NOT bump the version or persist a history row. Normalise the two
+                    // framework-owned fields to the live values so only REAL field differences
+                    // count, then return the LIVE instance — the stream's reference-equality
+                    // no-op gate completes the write without touching anything.
+                    var candidate = node with
+                    {
+                        Version = live.Version,
+                        LastModified = live.LastModified,
+                    };
+                    if (MeshNode.SerializedEquals(live, candidate, hub.JsonSerializerOptions))
+                        return live;
+                    // 🚨 Re-stamp LastModified at APPLY time (real change only).
+                    // NodeFactory.UpdateNode carries the caller's node verbatim, whose
+                    // LastModified is the value the caller READ (e.g. `current with { … }`),
+                    // NOT the edit time — so without this the node persists with a stale
                     // LastModified. NodeType IsDirty / CurrentSourceVersions key on
                     // LastModified.UtcTicks, so a stale stamp leaves an edited source
                     // looking clean and the V2 recompile never fires
@@ -91,7 +104,7 @@ internal static class NodeUpdatePipeline
                     // CachingStorageAdapter stamps it too; the in-memory adapter does
                     // not, so the owner-apply lambda here is the one place every
                     // storage config shares.
-                    LastModified = DateTimeOffset.UtcNow,
+                    return candidate with { LastModified = DateTimeOffset.UtcNow };
                 }));
 
     // 2. Run client-side Update validators sequentially (Concat preserves short-circuit:

--- a/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/MonotonicWriteGuardStorageAdapter.cs
@@ -12,10 +12,11 @@ namespace MeshWeaver.Hosting.Persistence;
 /// Outermost <see cref="IStorageAdapter"/> decorator that refuses a write whose
 /// <see cref="MeshNode.Version"/> would move a node's durable state BACKWARD.
 ///
-/// <para><b>Why.</b> <c>MeshNode.Version</c> is the owning hub's monotonic persistence
-/// clock (<c>Doc/Architecture/MeshNodeVersioning.md</c>): every mint goes through
-/// <see cref="MeshNode.NextVersion"/>, which floors the stamp at <c>current.Version + 1</c>,
-/// so a correctly-produced write is ALWAYS &gt;= the version already stored. A write that
+/// <para><b>Why.</b> <c>MeshNode.Version</c> is the node's own forward-only revision counter
+/// (<c>Doc/Architecture/MeshNodeVersioning.md</c>): every mint goes through
+/// <see cref="MeshNode.NextVersion"/>, which is <c>current.Version + 1</c>, and an unchanged
+/// node is re-persisted at the version it already carries — so a correctly-produced write is
+/// ALWAYS &gt;= the version already stored. A write that
 /// regresses is therefore never a legitimate newer state — it is a stale snapshot that some
 /// component adopted as live (a cache-seeded reactivation, a lagging change-feed echo, a
 /// debounce buffer that outlived its state) about to overwrite acked, durable data. Before

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/MarkdownFileParser.cs
@@ -214,6 +214,11 @@ public partial class MarkdownFileParser : IFileFormatParser
             ExcludeFromContext = frontMatter?.ExcludeFromContext is { Count: > 0 } excluded
                 ? excluded
                 : null,
+            // Symmetric with Serialize — a node written by the mesh carries its revision
+            // counter in frontmatter and must load it back, else every reload restarts the
+            // counter and the next write collides with an existing version-history row.
+            // Absent (authored / imported content) ⇒ 0, i.e. "never versioned".
+            Version = frontMatter?.Version ?? 0,
             LastModified = lastModified,
             Content = nodeContent,
             PreRenderedHtml = markdownDocument.PrerenderedHtml
@@ -272,7 +277,11 @@ public partial class MarkdownFileParser : IFileFormatParser
             Background = slideBackground,
             ExcludeFromContext = node.ExcludeFromContext is { Count: > 0 } excluded
                 ? excluded.ToList()
-                : null
+                : null,
+            // Persist the revision counter so a reload does not restart it at 0 — see the
+            // field's declaration. 0 (never versioned) stays absent, so authored content
+            // files are unaffected.
+            Version = node.Version > 0 ? node.Version : null
         };
 
         // Only write YAML block if there's meaningful content
@@ -288,7 +297,8 @@ public partial class MarkdownFileParser : IFileFormatParser
                             frontMatter.Order != null ||
                             frontMatter.Notes != null ||
                             frontMatter.Background != null ||
-                            frontMatter.ExcludeFromContext?.Count > 0;
+                            frontMatter.ExcludeFromContext?.Count > 0 ||
+                            frontMatter.Version != null;
 
         if (hasYamlContent)
         {
@@ -537,6 +547,17 @@ public partial class MarkdownFileParser : IFileFormatParser
         // icon/title/meta header). Declared after the earlier keys for byte-stable
         // serialization of files that don't carry it.
         public List<string>? ExcludeFromContext { get; set; }
+
+        // 🚨 The node's revision counter — MUST round-trip. MeshNode.Version counts REAL
+        // changes to the node and every mint is `current + 1`
+        // (Doc/Architecture/MeshNodeVersioning.md), so a file format that DROPS it makes the
+        // counter restart from 0 on every reload: the next edit re-mints a version the node
+        // already had, and the version-history store (keyed {Id}_{Version}) silently
+        // OVERWRITES the earlier snapshot with the newer payload (VersionHistoryTest). Only
+        // emitted for a node that has actually been versioned (> 0), so authored/imported
+        // content files stay byte-identical. Declared last for the same byte-stability
+        // reason as the keys above.
+        public long? Version { get; set; }
 
         // Legacy aliases. YamlDotNet doesn't follow C# property hierarchy, so we
         // expose them as plain settable properties and fold them in below

--- a/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
+++ b/src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs
@@ -78,6 +78,10 @@ public sealed class InstanceSyncWorker : IDisposable
     private (string Url, string Token)? clientKey;
 
     private readonly SerialDisposable retryProbe = new();
+    // 1 while a connectivity retry probe is armed and has not yet fired. Read/written from both
+    // the drain pipeline and the pull loop, so the transitions go through Interlocked. See
+    // ResetRetry — whoever clears this owes the drain a RequestDrain().
+    private int retryArmed;
     private TimeSpan retryDelay;
     private volatile InstanceSyncConfig? lastKnownConfig;
     private volatile bool disposed;
@@ -359,7 +363,11 @@ public sealed class InstanceSyncWorker : IDisposable
                     .ToList())
                 .SelectMany(applied =>
                 {
-                    ResetRetry();
+                    // A successful pull proves the remote is reachable again. Clearing the backoff
+                    // also DISARMS the drain's retry probe, so take over its job: request the drain
+                    // it would have run, or the pending manifest stays stranded. See ResetRetry.
+                    if (ResetRetry())
+                        RequestDrain();
                     var pulled = applied.Count(x => x);
                     return pulled == 0
                         ? Observable.Return(Unit.Default)
@@ -487,7 +495,12 @@ public sealed class InstanceSyncWorker : IDisposable
             DropClient();
             var delay = retryDelay;
             retryDelay = TimeSpan.FromTicks(Math.Min(retryDelay.Ticks * 2, options.RetryMax.Ticks));
-            retryProbe.Disposable = Observable.Timer(delay).Subscribe(_ => RequestDrain());
+            Interlocked.Exchange(ref retryArmed, 1);
+            retryProbe.Disposable = Observable.Timer(delay).Subscribe(_ =>
+            {
+                Interlocked.Exchange(ref retryArmed, 0);
+                RequestDrain();
+            });
             return UpdateConfigAsSystem(c => c with
             {
                 Status = InstanceSyncStatus.Offline,
@@ -503,10 +516,23 @@ public sealed class InstanceSyncWorker : IDisposable
         }).Select(_ => Unit.Default);
     }
 
-    private void ResetRetry()
+    /// <summary>
+    /// Clears the connectivity backoff and disarms the pending probe.
+    /// <para>🚨 Returns whether a probe was actually armed — the caller MUST honour it. The probe
+    /// is the ONLY thing that re-runs the drain after the remote went away, and it lives in a
+    /// <see cref="SerialDisposable"/>, so disarming it silently strands the whole pending
+    /// manifest: the PULL sweep calls this on every successful sweep, which (once the remote is
+    /// back) cancelled the DRAIN's retry before it could fire. The offline edits then sat
+    /// undrained until some unrelated change happened to request a drain — the "landed after a
+    /// long flight, nothing syncs" defect (Offline_long_flight_accumulates_then_drains_and_converges).
+    /// A successful pull PROVES the remote is reachable, so the caller answers a <c>true</c> by
+    /// requesting the drain the probe would have run.</para>
+    /// </summary>
+    private bool ResetRetry()
     {
         retryDelay = options.RetryInitial;
         retryProbe.Disposable = Disposable.Empty;
+        return Interlocked.Exchange(ref retryArmed, 0) == 1;
     }
 
     /// <summary>Transport-level failures (remote down / DNS / timeout) anywhere in the chain.</summary>

--- a/src/MeshWeaver.Mesh.Contract/MeshNode.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNode.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using MeshWeaver.Layout;
 using MeshWeaver.Messaging;
@@ -208,34 +209,51 @@ public record MeshNode([property: Key] string Id, [property: Editable(false)] st
     public string? LastModifiedBy { get; init; }
 
     /// <summary>
-    /// The node's persistence clock — a version that increases <b>monotonically across
-    /// activations</b> and identifies the last operation that mutated this node.
-    /// <para>🚨 This is deliberately NOT the same clock as <see cref="IMessageHub.Version"/>.
-    /// The hub clock resets to 0 on every (re)activation and also stamps the owning hub's
-    /// LAYOUT-render Fulls; stamping <see cref="Version"/> straight from the fresh hub clock
-    /// made it REGRESS after a deactivate → reactivate cycle (idle-release / recycle / replica
-    /// restart) — the write-rollback / "v113 read back as v3" version regression of issue #325.
-    /// The node's Version is advanced forward-only from its OWN persisted value via
-    /// <see cref="NextVersion(long, long)"/>, so it survives a recycle without regressing while
-    /// the hub clock (and thus layout Fulls) is never touched. See
+    /// The node's own revision counter — the number of times this node has actually been
+    /// changed. It increases by exactly one per REAL modification and by nothing at all when a
+    /// write turns out to be a no-op.
+    /// <para>🚨 This is deliberately NOT <see cref="IMessageHub.Version"/>. The hub clock counts
+    /// MESSAGES the owning hub processed, so tying the node version to it made the number jump
+    /// by arbitrary amounts (3 → 47) for unrelated traffic, and made it REGRESS after a
+    /// deactivate → reactivate cycle (the hub clock resets to 0 — the write-rollback /
+    /// "v113 read back as v3" of issue #325). The node version is now derived purely from the
+    /// node's own previous value via <see cref="NextVersion(long)"/>, so it is monotonic across
+    /// activations by construction and means exactly "revision N of this node". See
     /// <c>Doc/Architecture/MeshNodeVersioning.md</c>.</para>
     /// </summary>
     [Editable(false)]
     public long Version { get; init; }
 
     /// <summary>
-    /// Computes the next persistence <see cref="Version"/> for a write to a node that currently
-    /// carries <paramref name="currentVersion"/>, given the owning hub's per-message clock
-    /// <paramref name="hubVersion"/>. The result is <c>max(hubVersion, currentVersion + 1)</c>:
-    /// it tracks the hub clock while that clock leads (preserving the "1 op = 1 version stamp"
-    /// model within an activation), but never falls to or below the version the node already
-    /// carries. After a recycle the hub clock has reset toward 0 while the node loaded its
-    /// persisted <paramref name="currentVersion"/> verbatim, so the <c>+ 1</c> floor keeps the
-    /// node's Version strictly increasing across activations — the fix for issue #325 that does
-    /// NOT re-seed the shared hub clock (which would drop layout Fulls, the 2026-06-18 wedge).
+    /// The next <see cref="Version"/> for a node that currently carries
+    /// <paramref name="currentVersion"/>: simply <c>currentVersion + 1</c>. The owning hub calls
+    /// this only once it has established that the write really changes the node — see
+    /// <see cref="SerializedEquals"/> and the no-op gates on every write path — so the counter
+    /// tracks revisions of the NODE, never the traffic of the hub that happens to own it.
     /// </summary>
-    public static long NextVersion(long hubVersion, long currentVersion)
-        => Math.Max(hubVersion, currentVersion + 1);
+    public static long NextVersion(long currentVersion)
+        => currentVersion + 1;
+
+    /// <summary>
+    /// Value equality at the SERIALIZED-JSON level — the no-op gate every write path uses
+    /// before it mints a <see cref="Version"/>.
+    /// <para>🚨 Record <c>Equals</c> alone is NOT a reliable change detector here:
+    /// <see cref="Content"/> is <c>object?</c>, so a rebuilt-but-identical typed content, a
+    /// re-parsed <c>JsonElement</c> (a struct whose default equality compares the parse
+    /// buffer), or a content record holding collections (compared by reference) all read as
+    /// "changed" while the persisted JSON is byte-identical. Every such write minted a fresh
+    /// Version and persisted a history row for an edit that never happened.</para>
+    /// <para>Serialization is only paid when the cheap reference/record checks already
+    /// disagreed, so the hot no-change path stays allocation-free.</para>
+    /// </summary>
+    public static bool SerializedEquals(MeshNode? a, MeshNode? b, JsonSerializerOptions options)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return false;
+        return JsonNode.DeepEquals(
+            JsonSerializer.SerializeToNode(a, options),
+            JsonSerializer.SerializeToNode(b, options));
+    }
 
     /// <summary>
     /// The lifecycle state of this node.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -646,16 +646,22 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
 
                     var updated = update(current);
                     // 🚨 No-op completion. When the update makes no net change to the node
-                    // (a guard `return node`, or an empty drain), the reduced stream emits
-                    // nothing: DistinctUntilChanged drops an identical value, and the Version
-                    // restamp below is ALSO a no-op whenever Hub.Version has not advanced since
-                    // the last write to this node (no intervening hub activity). The refStream
-                    // subscription above then never sees a second emission and this observable
-                    // HANGS forever — the host-hang behind check_inbox's no-timeout TCS
-                    // (InboxToolIntegrationTest.CheckInbox_TwoCallsBackToBack exceeded the 90s
-                    // blame-hang deadline → test-host crash → shard abort). Complete the
-                    // observable directly with the unchanged node and skip the meaningless write.
-                    if (ReferenceEquals(updated, current) || Equals(updated, current))
+                    // (a guard `return node`, an empty drain, or a lambda that rebuilds
+                    // IDENTICAL content), there is nothing to version and nothing to write:
+                    // the reduced stream emits nothing (DistinctUntilChanged drops an
+                    // identical value), the refStream subscription above never sees a second
+                    // emission and this observable would HANG forever — the host-hang behind
+                    // check_inbox's no-timeout TCS (InboxToolIntegrationTest
+                    // .CheckInbox_TwoCallsBackToBack exceeded the 90s blame-hang deadline →
+                    // test-host crash → shard abort). Complete the observable directly with
+                    // the unchanged node and skip the meaningless write.
+                    // 🚨 SerializedEquals is the load-bearing third check: record Equals is
+                    // reference-based for Content / collection fields, so a lambda that
+                    // rebuilds identical content slips past it — and every such "write"
+                    // minted a Version and persisted a history row for an edit that never
+                    // happened (the v1170-without-edits report).
+                    if (ReferenceEquals(updated, current) || Equals(updated, current)
+                        || MeshNode.SerializedEquals(current, updated, _jsonOptions))
                     {
                         EmitOnce(current);
                         return null; // nothing to apply — true no-op
@@ -664,11 +670,11 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     // by the OWNING hub here (this is an own write on the owner).
                     // DateTime/LastModified is NOT a cross-machine clock, so it must
                     // never drive reconciliation; the owner's monotonic Version does.
-                    // 🚨 #325: advance forward-only from the node's OWN version, not straight
-                    // off Hub.Version (which resets to 0 on every reactivation and would stamp a
-                    // LOWER version after a recycle → rollback + split-brain). See
-                    // MeshNode.NextVersion / Doc/Architecture/MeshNodeVersioning.md.
-                    // Also floor on the version the update lambda RETURNED: a durable-truth
+                    // 🚨 The counter is the NODE's own — `current.Version + 1`, never the hub
+                    // clock (which counts unrelated messages and resets to 0 on reactivation,
+                    // stamping a LOWER version after a recycle → rollback + split-brain, #325).
+                    // See MeshNode.NextVersion / Doc/Architecture/MeshNodeVersioning.md.
+                    // Take the max with the version the update lambda RETURNED: a durable-truth
                     // rebase (AdoptDurableTruth — the owner re-adopting a stored row that is
                     // AHEAD of its in-memory state after a MonotonicWriteGuard refusal) hands
                     // back a node carrying the stored Version; re-stamping it off the stale
@@ -678,8 +684,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     // restore writes Version = 0 and is likewise unaffected.
                     updated = updated with
                     {
-                        Version = MeshNode.NextVersion(_workspace.Hub.Version,
-                            Math.Max(current.Version, updated.Version))
+                        Version = MeshNode.NextVersion(Math.Max(current.Version, updated.Version))
                     };
                     // Stamp BEFORE the commit — the echo subscription above only emits
                     // once it can see this write's Version on the target node.
@@ -887,19 +892,54 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             var updated = update(current);
                             if (ReferenceEquals(updated, current) || Equals(updated, current))
                             {
-                                // 🚨 Lambda returned same instance — usually means
-                                // a typed pattern match (`curr.Content is MeshThread t`)
-                                // failed because Content is still JsonElement
-                                // (framework didn't deserialize to the registered
-                                // type). Log at Warning so the silent no-op is
-                                // visible without enabling Debug — otherwise a
-                                // stream.Update() that "succeeds" with no
-                                // observable effect (see CancelStream test failure
-                                // mode where RequestedCancellationAt stayed null).
-                                diagLogger?.LogWarning(
-                                    "[UpdateRemote] NO-OP hub={Hub} target={Path} contentType={ContentType} — lambda returned unchanged; check the lambda's content-type pattern match",
-                                    _workspace.Hub.Address, _path,
-                                    current.Content?.GetType().Name ?? "<null>");
+                                // A lambda that returns the node unchanged is a legitimate
+                                // no-op (an identical upsert, a guard `return node`, a
+                                // re-import of unchanged content) — it completes without a
+                                // write and without a version bump.
+                                // 🚨 …UNLESS Content is still a raw JsonElement: then the
+                                // no-op is almost certainly a typed pattern match
+                                // (`curr.Content is MeshThread t`) that failed because the
+                                // framework did not deserialize to the registered type, and
+                                // the caller's stream.Update() "succeeds" with no observable
+                                // effect (the CancelStream failure mode where
+                                // RequestedCancellationAt stayed null). Warn for THAT shape
+                                // only, so a real defect stays loud while intentional no-ops
+                                // stay quiet.
+                                if (current.Content is System.Text.Json.JsonElement)
+                                    diagLogger?.LogWarning(
+                                        "[UpdateRemote] NO-OP hub={Hub} target={Path} contentType=JsonElement — lambda returned unchanged; check the lambda's content-type pattern match",
+                                        _workspace.Hub.Address, _path);
+                                else
+                                    diagLogger?.LogDebug(
+                                        "[UpdateRemote] NO-OP hub={Hub} target={Path} contentType={ContentType} — lambda returned the node unchanged; nothing to write",
+                                        _workspace.Hub.Address, _path,
+                                        current.Content?.GetType().Name ?? "<null>");
+                                observer.OnNext(current);
+                                observer.OnCompleted();
+                                return;
+                            }
+
+                            var jsonOpts = _workspace.Hub.JsonSerializerOptions;
+                            var currentNode = System.Text.Json.JsonSerializer
+                                .SerializeToNode(current, jsonOpts) as System.Text.Json.Nodes.JsonObject
+                                ?? new System.Text.Json.Nodes.JsonObject();
+                            var updatedNode = System.Text.Json.JsonSerializer
+                                .SerializeToNode(updated, jsonOpts) as System.Text.Json.Nodes.JsonObject
+                                ?? new System.Text.Json.Nodes.JsonObject();
+                            // 🚨 Diff the lambda's ACTUAL output FIRST — before the audit stamp
+                            // below. The stamp used to run first, so a lambda that changed
+                            // NOTHING (a rebuilt-but-identical content slips past the
+                            // record-Equals check above) still produced a lastModified-only
+                            // patch, and the owner minted a Version + persisted a history row
+                            // for it on every save (the v1170-without-edits report). Only a REAL
+                            // change earns the audit stamp and the send.
+                            var patch = ComputeMergePatchDiff(currentNode, updatedNode);
+
+                            if (patch.Count == 0)
+                            {
+                                diagLogger?.LogDebug(
+                                    "[UpdateRemote] NO-OP hub={Hub} target={Path} — diff empty after serialisation",
+                                    _workspace.Hub.Address, _path);
                                 observer.OnNext(current);
                                 observer.OnCompleted();
                                 return;
@@ -914,33 +954,24 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             // the outgoing patch, so a client can't forge a different author.
                             // This preserves the audit trail UpdateNodeRequest used to stamp
                             // from UpdatedBy now that writes go through stream.Update.
+                            var stamped = false;
                             if (updated.LastModified == current.LastModified)
                             {
                                 updated = updated with { LastModified = DateTimeOffset.UtcNow };
+                                stamped = true;
                             }
                             if (updated.LastModifiedBy == current.LastModifiedBy
                                 && !string.IsNullOrEmpty(capturedContextAtEntry?.ObjectId))
                             {
                                 updated = updated with { LastModifiedBy = capturedContextAtEntry.ObjectId };
+                                stamped = true;
                             }
-
-                            var jsonOpts = _workspace.Hub.JsonSerializerOptions;
-                            var currentNode = System.Text.Json.JsonSerializer
-                                .SerializeToNode(current, jsonOpts) as System.Text.Json.Nodes.JsonObject
-                                ?? new System.Text.Json.Nodes.JsonObject();
-                            var updatedNode = System.Text.Json.JsonSerializer
-                                .SerializeToNode(updated, jsonOpts) as System.Text.Json.Nodes.JsonObject
-                                ?? new System.Text.Json.Nodes.JsonObject();
-                            var patch = ComputeMergePatchDiff(currentNode, updatedNode);
-
-                            if (patch.Count == 0)
+                            if (stamped)
                             {
-                                diagLogger?.LogDebug(
-                                    "[UpdateRemote] NO-OP hub={Hub} target={Path} — diff empty after serialisation",
-                                    _workspace.Hub.Address, _path);
-                                observer.OnNext(current);
-                                observer.OnCompleted();
-                                return;
+                                updatedNode = System.Text.Json.JsonSerializer
+                                    .SerializeToNode(updated, jsonOpts) as System.Text.Json.Nodes.JsonObject
+                                    ?? new System.Text.Json.Nodes.JsonObject();
+                                patch = ComputeMergePatchDiff(currentNode, updatedNode);
                             }
 
                             var patchJson = patch.ToJsonString(jsonOpts);

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeVersionCountsRealChangesTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeVersionCountsRealChangesTest.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// <see cref="MeshNode.Version"/> is the node's own revision counter: <b>+1 per REAL change, and
+/// nothing at all for a write that changes nothing</b> (Doc/Architecture/MeshNodeVersioning.md).
+///
+/// <para>Two defects this pins, both of which produced version numbers that had nothing to do with
+/// how often the node was edited:</para>
+/// <list type="number">
+/// <item><b>The hub clock leaked into the node.</b> The old mint was
+/// <c>max(Hub.Version, current + 1)</c>, so unrelated traffic on the owning hub moved the number
+/// (3 → 47) and a recycle — which resets that clock to 0 — rolled it BACKWARD (#325).</item>
+/// <item><b>Writes that changed nothing still minted.</b> Record equality compares
+/// <see cref="MeshNode.Content"/> (an <c>object?</c>) by reference, so a lambda that rebuilt
+/// identical content slipped past the no-op check; and the <see cref="MeshNode.LastModified"/>
+/// audit stamp was applied BEFORE the diff, manufacturing the very difference that made the write
+/// look like an edit. A node re-saved / re-imported / re-asserted N times gained N revisions and N
+/// history rows — the "v1170 with no edits" report.</item>
+/// </list>
+/// </summary>
+public class NodeVersionCountsRealChangesTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string Body = "# body";
+
+    /// <summary>
+    /// Each real edit advances the counter by EXACTLY one — not by the hub clock's jump, and not
+    /// by two (the write path mints, and <c>MeshNodeTypeSource.UpdateImpl</c> must NOT re-stamp a
+    /// node whose version the write path already advanced).
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task RealChange_AdvancesVersionByExactlyOne()
+    {
+        var path = $"{TestPartition}/version-counts-{Guid.NewGuid():N}";
+        await NodeFactory.CreateNode(NewNode(path, "v1")).Should().Within(30.Seconds()).Emit();
+
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var created = await ReadStable(storage, path);
+        created.Version.Should().Be(1, "a freshly created node starts at revision 1");
+
+        var stream = GetClient(c => c.AddData()).GetWorkspace().GetMeshNodeStream(path);
+
+        stream.Update(n => n with { Name = "v2" })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"[version] write 1 error: {ex.Message}"));
+        var afterFirst = await ReadStable(storage, path, n => n.Name == "v2");
+        afterFirst.Version.Should().Be(created.Version + 1,
+            $"one edit is one revision — got {created.Version} → {afterFirst.Version}. A jump means "
+            + "the hub clock leaked back into the mint; +2 means the write path AND the persistence "
+            + "re-stamp both counted the same edit.");
+
+        stream.Update(n => n with { Name = "v3" })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"[version] write 2 error: {ex.Message}"));
+        var afterSecond = await ReadStable(storage, path, n => n.Name == "v3");
+        afterSecond.Version.Should().Be(afterFirst.Version + 1,
+            "the counter keeps advancing by exactly one per edit");
+    }
+
+    /// <summary>
+    /// A cross-hub <c>stream.Update</c> whose lambda produces an identical node — including a
+    /// REBUILT-but-equal <see cref="MeshNode.Content"/>, which record equality alone reports as
+    /// changed — must leave both the version and the audit stamp untouched.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task NoOpUpdate_LeavesVersionAndLastModifiedUntouched()
+    {
+        var path = $"{TestPartition}/version-noop-{Guid.NewGuid():N}";
+        await NodeFactory.CreateNode(NewNode(path, "stable")).Should().Within(30.Seconds()).Emit();
+
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var before = await ReadStable(storage, path);
+
+        var stream = GetClient(c => c.AddData()).GetWorkspace().GetMeshNodeStream(path);
+        // Same values throughout, but a FRESH content instance: reference equality fails, so only
+        // a serialized diff can recognise this as the no-op it is.
+        stream.Update(n => n with
+            {
+                Name = n.Name,
+                Content = new MarkdownContent { Content = Body },
+            })
+            .Subscribe(_ => { }, ex => Output.WriteLine($"[version] no-op error: {ex.Message}"));
+
+        var after = await ReadStable(storage, path);
+        after.Version.Should().Be(before.Version,
+            "a write that changes nothing must not mint a revision (or a version-history row)");
+        after.LastModified.Should().Be(before.LastModified,
+            "the LastModified audit stamp is applied AFTER the diff — a no-op never earns it");
+    }
+
+    /// <summary>
+    /// The same rule on the <see cref="IMeshService.UpdateNode"/> surface (the MCP <c>update</c>
+    /// tool, importers, GitSync): re-asserting the node exactly as it stands is not an edit.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task IdenticalUpdateNode_LeavesVersionUntouched()
+    {
+        var path = $"{TestPartition}/version-reassert-{Guid.NewGuid():N}";
+        await NodeFactory.CreateNode(NewNode(path, "reassert")).Should().Within(30.Seconds()).Emit();
+
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var before = await ReadStable(storage, path);
+
+        // Re-assert the live node verbatim — the shape an importer / re-install produces.
+        await NodeFactory.UpdateNode(before).Should().Within(30.Seconds()).Emit();
+
+        var after = await ReadStable(storage, path);
+        after.Version.Should().Be(before.Version,
+            "re-asserting unchanged state through UpdateNode must not mint a revision");
+
+        // …and the guard must not over-skip: one changed field still advances the counter.
+        await NodeFactory.UpdateNode(before with { Name = "edited" })
+            .Should().Within(30.Seconds()).Emit();
+        var edited = await ReadStable(storage, path, n => n.Name == "edited");
+        edited.Version.Should().Be(before.Version + 1,
+            "a genuine field change is still exactly one revision");
+    }
+
+    private MeshNode NewNode(string path, string name) =>
+        new(path.Split('/')[^1], TestPartition)
+        {
+            Name = name,
+            NodeType = "Markdown",
+            Content = new MarkdownContent { Content = Body },
+            State = MeshNodeState.Active,
+        };
+
+    // Reads until the persisted node satisfies the predicate AND its Version is unchanged across
+    // 4 consecutive samples (~1.2s quiet — past the 200ms persist debounce), so an enrichment /
+    // debounce trail cannot masquerade as churn, and a stray no-op write cannot hide behind the
+    // read. The quiet window is the only way to assert that NOTHING happened.
+    private async Task<MeshNode> ReadStable(
+        IStorageAdapter storage, string path, Func<MeshNode, bool>? predicate = null)
+    {
+        MeshNode? last = null;
+        var stable = 0;
+        for (var i = 0; i < 100 && stable < 4; i++)
+        {
+            var current = await storage.Read(path, Mesh.JsonSerializerOptions).FirstAsync().ToTask();
+            stable = current is not null && last is not null
+                     && current.Version == last.Version
+                     && current.LastModified == last.LastModified
+                     && (predicate is null || predicate(current))
+                ? stable + 1
+                : 0;
+            last = current ?? last;
+            await Task.Delay(300);
+        }
+        last.Should().NotBeNull($"node {path} must be persisted");
+        return last!;
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeVersionCountsRealChangesTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeVersionCountsRealChangesTest.cs
@@ -158,6 +158,12 @@ public class NodeVersionCountsRealChangesTest(ITestOutputHelper output)
             await Task.Delay(300);
         }
         last.Should().NotBeNull($"node {path} must be persisted");
+        // 🚨 The loop can also exit on the iteration cap. Returning an UNSTABLE snapshot would
+        // silently weaken every assertion built on it (a "version unchanged" check would be
+        // reading a value that is still moving), so the cap is a failure, not a result.
+        stable.Should().BeGreaterThanOrEqualTo(4,
+            $"node {path} must settle (4 consecutive samples with the same Version + LastModified) "
+            + "before it can be asserted on — the read hit the iteration cap while still churning");
         return last!;
     }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeVersionRegressionOnRecycleTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeVersionRegressionOnRecycleTest.cs
@@ -27,11 +27,10 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// post-recycle state — with no reload race to confound the measurement.</para>
 ///
 /// <para><b>The fix (what this proves).</b> The node's persistence version is decoupled from the
-/// per-activation hub clock: every place the owner mints a node Version advances it forward-only
-/// from the node's OWN version via <see cref="MeshNode.NextVersion(long, long)"/>
-/// (<c>max(Hub.Version, current.Version + 1)</c>) — the own-write path (UpdateOwn), the persistence
-/// re-stamp (MeshNodeTypeSource.UpdateImpl), and the cross-hub merge apply
-/// (DataExtensions.NextMeshNodeVersion). So a write made while the hub clock sits far below the node
+/// per-activation hub clock: every place the owner mints a node Version derives it from the node's
+/// OWN version via <see cref="MeshNode.NextVersion(long)"/> (<c>current.Version + 1</c>) — the
+/// own-write path (UpdateOwn), the persistence re-stamp (MeshNodeTypeSource.UpdateImpl), and the
+/// cross-hub merge apply (DataExtensions.NextMeshNodeVersion). So a write made while the hub clock sits far below the node
 /// version still lands a Version strictly ABOVE it — the authoritative <c>get</c> never regresses.
 /// Crucially the fix does NOT touch <c>Hub.Version</c> (re-seeding that shared clock backward is
 /// what dropped live layout Fulls, the atioz 2026-06-18 "cannot find pinned doc" wedge), and it
@@ -95,7 +94,7 @@ public class NodeVersionRegressionOnRecycleTest(ITestOutputHelper output)
 
         // Assert — THE FIX. Read the authoritative post-write node from the owner. Its Version must
         // have advanced FORWARD, above the pre-write version — never rolled back to the low hub
-        // clock (MeshNode.NextVersion floors it at current.Version + 1). Before the fix it stamped
+        // clock (MeshNode.NextVersion derives it as current.Version + 1). Before the fix it stamped
         // ~hubClock, so the authoritative get read a version BELOW the confirmed writes ("v113 read
         // back as v3").
         var after = await Observable.Interval(TimeSpan.FromMilliseconds(200)).StartWith(0L)

--- a/test/MeshWeaver.Hosting.Monolith.Test/StaleActivationSeedRollbackTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/StaleActivationSeedRollbackTest.cs
@@ -166,8 +166,8 @@ public class StaleActivationSeedRollbackTest(ITestOutputHelper output) : Monolit
 
         Output.WriteLine($"[persisted] name={persisted!.Name} version={persisted.Version}");
         persisted.Version.Should().BeGreaterThan(durableVersion,
-            "the owner's persistence clock is monotonic across activations (MeshNode.NextVersion floors "
-            + "at current+1) — a post-recycle write below the durable version means the hub reactivated "
+            "the node's revision counter is monotonic across activations (MeshNode.NextVersion is "
+            + "current + 1) — a post-recycle write below the durable version means the hub reactivated "
             + "on a stale snapshot");
     }
 }


### PR DESCRIPTION
## What

`MeshNode.Version` is now the node's **own revision counter** — `NextVersion(current) => current + 1` — and **no write path mints a version without a real content diff**.

Before, the version was stamped from the owning hub's message clock (`max(hubVersion, current + 1)`), so it:
- jumped by unrelated traffic (a node touched under message 3 and again under 47 went `3 → 47`), and
- **regressed** after a reactivation, because that clock resets to 0 (#325).

It also climbed on writes that changed nothing: the `LastModified` audit stamp was applied **before** the diff — manufacturing the very change it recorded — and record equality compares `Content` (an `object?`) by reference, so a rebuilt-but-identical content slipped through as an edit. A node re-imported / re-installed / re-asserted N times gained N revisions and N version-history rows.

## The gates (mint only on a real change)

| Write path | Gate |
|---|---|
| `MeshNodeStreamHandle.UpdateOwn` | `ReferenceEquals` → record `Equals` → new `MeshNode.SerializedEquals` |
| `MeshNodeStreamHandle.UpdateRemote` | the RFC 7396 diff is computed on the lambda's raw output; only a non-empty diff earns the `LastModified`/`LastModifiedBy` stamp and the post |
| owner's patch apply (in-turn + deferred) | `JsonNode.DeepEquals(preMerge, postMerge)` → ack success, commit nothing — gated **before** the mint, which would otherwise manufacture the difference |
| `IMeshService.UpdateNode` (`NodeUpdatePipeline`) | normalise `Version` + `LastModified` to the live values, then `SerializedEquals` |
| `MeshNodeTypeSource.UpdateImpl` | record `Equals` ignoring Version, confirmed by `SerializedEquals` |

`MeshNodeTypeSource` additionally stops re-versioning a reactivated hub's already-durable node (a reactivation is not a change), stops re-stamping an update the write path already advanced (that counted one edit **twice** under a `+1` counter), and writes the stamped version into the **live collection**, not just the save queue.

## Two latent defects the hub clock had been masking — fixed at the root

**1. `.md` frontmatter never round-tripped `Version`.** A storage `Write(v5)` → `Read` returned **v0** — verified identically on `origin/main`. With a node-local counter, a markdown-backed node restarts its counter on every reload, re-mints a version it already had, and the version-history store (keyed `{Id}_{Version}`) silently **overwrites** the earlier snapshot with the newer payload (`VersionHistoryTest` read "version 1 contains V2"). `Version` is now symmetric in `MarkdownFileParser.Parse`/`Serialize`, emitted only when `> 0` so authored/imported content files stay byte-identical.

**2. InstanceSync's push retry was cancelled by the pull sweep.** `RunPullSweep` called `ResetRetry()` on every successful sweep, disposing the `SerialDisposable` holding the **drain's** connectivity retry probe — so once the remote came back, the pull cancelled the push retry and the offline manifest sat undrained (`Offline_long_flight_accumulates_then_drains_and_converges` timed out). It only passed before by accident: each failed drain re-wrote an *identical* config node, and the unconditional version/`LastModified` stamp made that a "change" → config event → `OnConfigChanged` → `RequestDrain`. Killing the no-op write removed that accidental retry driver. `ResetRetry()` now reports whether a probe was armed, and the pull sweep answers `true` with `RequestDrain()` — a successful pull **proves** the remote is reachable.

## Docs + tests

- `Doc/Architecture/MeshNodeVersioning.md` rewritten around the counter model (new diagram, gate table, "not the hub clock" section keeps the #325 / layout-Full history).
- New `NodeVersionCountsRealChangesTest`: exactly `+1` per edit (catches both a hub-clock jump and a double-bump), no bump on a rebuilt-identical content write, no bump on an identical `UpdateNode` — plus the "must not over-skip" case.
- What's New entry included (user-visible: version numbers and version history).

## Verification

Full Release build with `dotnet build -c Release -p:CIRun=true -warnaserror` clean, after merging current `main`.

Green, 0 failures: Monolith 423 (re-run with `--blame-hang`), AI 914, Graph 752, Persistence 413, Query 357, Data 290, Layout 343, Content 245, GitSync 142, Auth 114, Messaging 109, Hosting 95, NodeOperations 85, PluginCatalog 54, Sqlite 30, InstanceSync 24, Documentation 19, PluginTester 17, Serialization 14, AccessControl 10, Search 5.

### Known pre-existing failure, not from this PR

`StaleActivationSeedRollbackTest.PostRecycleWrite_LandsAboveTheDurableVersion` fails in one narrow multi-class filter run. The identical command on an `origin/main` worktree fails too (main: 2 failed, branch: 1). Separate cause: the reactivating hub loses the durable-seed race **and** `MonotonicWriteGuardStorageAdapter._highWater` is a per-instance field, so a fresh guard instance has no mark and never verifies the first write to a path. Left for its own fix rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)