### PR TITLE
Model calls run without transport timeout; side panel scrolls node content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI agents working with this repository.
 
 ## Git Workflow
 
-**NEVER commit or push automatically.** Always wait for the user to explicitly ask.
+**When the task's goal is reached, automatically follow the [`pullrequest` skill](.claude/skills/pullrequest/SKILL.md)** — What's New entry, commit, push, open the PR, wait for green CI, merge. "Goal reached" means the work is implemented, verified, and the touched projects build clean with CI's flags (`-c Release -warnaserror`); don't stop to ask permission for the PR flow at that point. Everything short of that stays manual: never commit or push half-done or unverified work, and the merge gate is absolute — never merge with CI red or pending.
 
 ### 🚨🚨🚨 ABSOLUTE: NEVER work on the primary checkout — it stays on `main`, untouched. EVERYONE creates a worktree.
 

--- a/src/MeshWeaver.AI.AzureFoundry/AzureClaudeChatClient.cs
+++ b/src/MeshWeaver.AI.AzureFoundry/AzureClaudeChatClient.cs
@@ -86,7 +86,9 @@ public class AzureClaudeChatClient : IChatClient
         this.modelId = modelId;
         this.logger = logger;
         this.ownsHttpClient = httpClient == null;
-        this.httpClient = httpClient ?? new HttpClient();
+        // Model calls are bounded by round cancellation, not the transport —
+        // HttpClient's default 100s timeout kills long generations mid-round.
+        this.httpClient = httpClient ?? new HttpClient { Timeout = Timeout.InfiniteTimeSpan };
     }
 
     /// <inheritdoc />

--- a/src/MeshWeaver.AI.AzureFoundry/AzureFoundryChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI.AzureFoundry/AzureFoundryChatClientAgentFactory.cs
@@ -119,9 +119,14 @@ public class AzureFoundryChatClientAgentFactory(
 
         try
         {
+            // Model calls are bounded by round cancellation, not the transport —
+            // the SDK's default 100s network timeout kills long generations mid-round.
+            var clientOptions = new AzureAIInferenceClientOptions();
+            clientOptions.Retry.NetworkTimeout = Timeout.InfiniteTimeSpan;
             var client = new ChatCompletionsClient(
                 new Uri(endpoint),
-                new AzureKeyCredential(apiKey));
+                new AzureKeyCredential(apiKey),
+                clientOptions);
 
             IChatClient chatClient = client.AsIChatClient(modelName);
 

--- a/src/MeshWeaver.AI.OpenAI/AzureOpenAIChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI.OpenAI/AzureOpenAIChatClientAgentFactory.cs
@@ -84,10 +84,13 @@ public class AzureOpenAIChatClientAgentFactory(
             "[AzureOpenAI] Creating chat client model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint}",
             modelName, endpoint, source, Fingerprint(apiKey));
 
-        // Create Azure OpenAI client and get chat client
+        // Create Azure OpenAI client and get chat client. Model calls are bounded
+        // by round cancellation, not the transport — the SDK's default 100s network
+        // timeout kills long generations mid-round.
         var azureClient = new AzureOpenAIClient(
             new Uri(endpoint),
-            new AzureKeyCredential(apiKey));
+            new AzureKeyCredential(apiKey),
+            new AzureOpenAIClientOptions { NetworkTimeout = Timeout.InfiniteTimeSpan });
 
         // Get the chat completion client for the model and convert it to IChatClient
         var openAIChatClient = azureClient.GetChatClient(modelName);

--- a/src/MeshWeaver.AI.OpenAI/OpenAIChatClientAgentFactory.cs
+++ b/src/MeshWeaver.AI.OpenAI/OpenAIChatClientAgentFactory.cs
@@ -159,7 +159,12 @@ public class OpenAIChatClientAgentFactory(
             "[OpenAI] Creating chat client model={ModelName} endpoint={Endpoint} source={Source} apiKeyFp={ApiKeyFingerprint}",
             modelName, endpoint ?? "(default api.openai.com)", source, Fingerprint(apiKey));
 
-        var clientOptions = new OpenAIClientOptions();
+        var clientOptions = new OpenAIClientOptions
+        {
+            // Model calls are bounded by round cancellation, not the transport —
+            // the SDK's default 100s network timeout kills long generations mid-round.
+            NetworkTimeout = Timeout.InfiniteTimeSpan
+        };
         if (!string.IsNullOrEmpty(endpoint))
             clientOptions.Endpoint = new Uri(endpoint);
 

--- a/src/MeshWeaver.Blazor.Portal/SidePanel/SidePanel.razor.css
+++ b/src/MeshWeaver.Blazor.Portal/SidePanel/SidePanel.razor.css
@@ -67,7 +67,13 @@
     max-width: 100%;
     position: relative;
     min-height: 0;
-    overflow: hidden;
+    /* The panel body is the scroll container — the side-panel twin of the main
+       panel's .body-content (overflow: auto). A hosted node area (LayoutAreaView
+       Fill=true) has no scroll container of its own, so overflow: hidden clipped
+       long content with no way to scroll. Chat is unaffected: it fills exactly
+       and scrolls its message list internally. */
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 /* Hide the thread full-page header when rendered inside the side panel */

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-01-unlimited-model-calls-scrollable-side-panel.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-01-unlimited-model-calls-scrollable-side-panel.md
@@ -1,0 +1,12 @@
+---
+Name: Long agent responses no longer time out, and the side panel scrolls content
+Category: What's New
+Description: Model calls are no longer cut off after 100 seconds, and node content shown in the side panel is now scrollable.
+Icon: Sparkle
+---
+
+# Long agent responses no longer time out, and the side panel scrolls content
+
+Agent rounds using models that think or generate for a long time (for example DeepSeek reasoning models) used to fail mid-answer with a timeout error after 100 seconds. That limit came from the underlying SDK defaults, not from anything you configured. Model calls now run without a transport time limit across all providers — a round ends when it finishes, when you cancel it, or at the platform's safety backstop.
+
+Separately, when a thread shows a node's content in the side panel, long content was cut off at the bottom with no way to scroll. The side panel now scrolls its content just like the main view.


### PR DESCRIPTION
## What

Three changes:

1. **Unlimited transport timeout on model calls.** A DeepSeek round on memex.meshweaver.cloud died mid-task with *"The operation was cancelled because it exceeded the configured timeout of 0:01:40"* — the Azure SDK's default 100s network timeout. Every provider transport had the same default via a different mechanism, and none of the factories configured it:
   - Azure Foundry (`ChatCompletionsClient`, Azure.Core `Retry.NetworkTimeout`)
   - OpenAI + OpenAICompatible (`OpenAIClientOptions.NetworkTimeout`, System.ClientModel)
   - Azure OpenAI (`AzureOpenAIClientOptions.NetworkTimeout`, System.ClientModel)
   - Azure Claude (raw `new HttpClient()` — `HttpClient.Timeout`)

   All four now set `Timeout.InfiniteTimeSpan`: model calls are bounded by round cancellation and the deliberate 30-min `MaxStreamingDuration` anti-wedge backstop (#147), never by the transport.

2. **Side panel scrolls hosted node content.** `.side-panel-content` was `overflow: hidden` — fine for chat (fills exactly, scrolls its message list internally), but a node area hosted via `LayoutAreaView Fill=true` has no inner scroll container, so long content was clipped with no way to scroll. The panel body is now the vertical scroll container — the twin of the main panel's `.body-content` (`overflow: auto`), with horizontal clipping preserved.

3. **AGENTS.md**: once a task's goal is reached and verified (CI-flag build green), agents follow the `pullrequest` skill automatically instead of waiting for an explicit ask. The merge gate (CI green) is unchanged and absolute.

## Verification

- `MeshWeaver.AI.AzureFoundry`, `MeshWeaver.AI.OpenAI`, `MeshWeaver.Blazor.Portal` build clean with `-c Release -warnaserror`.
- Option types confirmed present in the referenced package versions (Azure.AI.Inference 1.0.0-beta.5, Azure.AI.OpenAI 2.9.0-beta.1).
- Side panel height chain verified definite (`.side-panel-wrapper` → `.side-panel` → `.side-panel-content`), so the scroll container bounds correctly.

Includes a What's New entry for the two user-facing fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)