### PR TITLE
Onboarding: real first-user check, guard-compliant platform grants, V50 rescope

### DIFF
--- a/memex/Memex.Client/Services/DeviceOnboarding.cs
+++ b/memex/Memex.Client/Services/DeviceOnboarding.cs
@@ -55,12 +55,14 @@ public sealed class DeviceOnboarding(IMessageHub hub)
                         Role = string.IsNullOrWhiteSpace(role) ? null : role.Trim(),
                     },
                 })
-                // Global admin of this instance — Admin/_Access, MainNode="" (the sanctioned shape).
+                // Global admin of this instance — Admin/_Access, MainNode="Admin": the scope
+                // the path encodes, enforced by AccessAssignmentGuard (an empty MainNode is
+                // a ROOT/data-superuser grant and is refused at the write boundary).
                 .SelectMany(_ => meshService.CreateNode(new MeshNode($"{DeviceUserId}_Access", "Admin/_Access")
                 {
                     NodeType = "AccessAssignment",
                     Name = $"{name} — Admin",
-                    MainNode = "",
+                    MainNode = "Admin",
                     Content = new AccessAssignment
                     {
                         AccessObject = DeviceUserId,

--- a/memex/Memex.Portal.Shared/Authentication/GlobalAdminSeed.cs
+++ b/memex/Memex.Portal.Shared/Authentication/GlobalAdminSeed.cs
@@ -67,7 +67,11 @@ public static class GlobalAdminSeed
                     DisplayName = userId,
                     Roles = [new RoleAssignment { Role = "Admin" }],
                 },
-                MainNode = "",
+                // Scoped to the Admin partition — MainNode MUST equal the scope the path
+                // encodes (AccessAssignmentGuard refuses the write otherwise). An empty
+                // MainNode here is NOT "the Admin folder": it is a ROOT grant — a data
+                // superuser over every partition (see AccessControl.md → the scope invariant).
+                MainNode = "Admin",
             };
 
             nodes[i * 2 + 1] = new MeshNode(userId + "_Access", "Provider/_Access")

--- a/memex/Memex.Portal.Shared/Authentication/UserOnboardingService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/UserOnboardingService.cs
@@ -181,31 +181,31 @@ public sealed class UserOnboardingService(
     /// <summary>
     /// First-user-only: grants the user global admin by making them an admin on the
     /// <b>Admin partition</b> — an <see cref="AccessAssignment"/> at namespace
-    /// <c>Admin/_Access</c> (scope <c>Admin</c>) with <c>MainNode=""</c>. The exact shape
-    /// <see cref="GlobalAdminSeed"/> writes for config-driven admins, and the one
-    /// canonical platform-admin grant: <c>PermissionEvaluator</c>'s global-admin
-    /// short-circuit turns <see cref="MeshWeaver.Mesh.Security.Permission.All"/> at scope
-    /// <c>Admin</c> into a platform superuser (All on every path), and
-    /// <c>hub.IsGlobalAdmin()</c> reads the same scope. See
-    /// Doc/Architecture/AccessControl.md → "The Admin partition".
+    /// <c>Admin/_Access</c> with <c>MainNode="Admin"</c>: the scope the path encodes,
+    /// which <c>AccessAssignmentGuard</c> enforces at the write boundary. The same shape
+    /// <see cref="GlobalAdminSeed"/> writes for config-driven admins. This confers the
+    /// platform gates (<c>hub.IsGlobalAdmin()</c> = <see cref="MeshWeaver.Mesh.Security.Permission.All"/>
+    /// at scope <c>Admin</c>) — it is deliberately NOT a data superuser; an empty
+    /// <c>MainNode</c> would scope the grant to ROOT (every partition) and is refused.
+    /// See Doc/Architecture/AccessControl.md → "The scope invariant".
     ///
-    /// <para>Caller gates this on the "no existing User nodes" check. Subscribe to drive —
-    /// a silent failure would leave the platform with no admins, so callers must surface
-    /// OnError.</para>
+    /// <para>Caller gates this on the platform-bootstrap check (no admin grant exists yet).
+    /// Subscribe to drive — a silent failure would leave the platform with no admins, so
+    /// callers must surface OnError.</para>
     /// </summary>
     public IObservable<MeshNode> GrantPlatformAdmin(string username)
     {
-        // Global admin = admin on the ADMIN PARTITION: namespace "Admin/_Access" (scope
-        // "Admin") + MainNode "". PermissionEvaluator's global-admin short-circuit turns
-        // Permission.All at scope "Admin" into platform superuser (All on every path),
-        // so this single grant gives the first user the platform gates
-        // (hub.IsGlobalAdmin) AND cross-partition power. Mirrors GlobalAdminSeed's
-        // config-admin shape. See Doc/Architecture/AccessControl.md.
+        // Global admin = admin on the ADMIN PARTITION: namespace "Admin/_Access", MainNode
+        // "Admin". MainNode MUST equal the scope the path encodes — AccessAssignmentGuard
+        // refuses the write otherwise (an empty MainNode is a ROOT grant, the 43-superuser
+        // incident shape). hub.IsGlobalAdmin() reads Permission.All at scope "Admin"; the
+        // platform gates come from this grant, cross-partition data access deliberately
+        // does NOT. Mirrors GlobalAdminSeed's config-admin shape. See AccessControl.md.
         var assignment = new MeshNode($"{username}_Access", "Admin/_Access")
         {
             NodeType = "AccessAssignment",
             Name = $"{username} — Admin",
-            MainNode = "",
+            MainNode = "Admin",
             Content = new AccessAssignment
             {
                 AccessObject = username,
@@ -221,7 +221,7 @@ public sealed class UserOnboardingService(
             () => accessService.ImpersonateAsSystem(),
             _ => meshService.CreateOrUpdateNode(assignment)
                 .Do(__ => logger?.LogInformation(
-                    "Onboarding: granted platform Admin (first user) to '{Username}' on the Admin partition (Admin/_Access, MainNode=\"\")", username)));
+                    "Onboarding: granted platform Admin (first user) to '{Username}' on the Admin partition (Admin/_Access, MainNode=\"Admin\")", username)));
     }
 }
 

--- a/memex/Memex.Portal.Shared/Pages/Onboarding.razor
+++ b/memex/Memex.Portal.Shared/Pages/Onboarding.razor
@@ -194,8 +194,17 @@ else
         var invitationOnly = Features.Value.Onboarding.InvitationOnly;
         var needFirstUser = !allowSelfOnboarding || invitationOnly;
 
+        // Bootstrap signal = "does ANY platform-admin grant exist yet". PATH-scoped on
+        // Admin/_Access (like the invitation query below): `namespace:User` matched
+        // NOTHING on partitioned PG — users are partition ROOTS (namespace ''), so every
+        // onboarder read as "first user", which bypassed the invitation gate AND fired
+        // GrantPlatformAdmin for everyone (the 43-root-superuser incident; the guard now
+        // refuses that write, which failed the whole submit). Admin-grant emptiness is
+        // also the truer bootstrap condition: the first-user override exists so the
+        // platform never locks out with NO admin — config-seeded admins count.
         var firstUserQuery = needFirstUser
-            ? workspace.GetQuery("onboarding:firstUserCheck", "namespace:User limit:1")
+            ? workspace.GetQuery("onboarding:firstUserCheck",
+                "path:Admin/_Access scope:children nodeType:AccessAssignment limit:1")
             : Observable.Return(Enumerable.Empty<MeshNode>());
         // PATH-scoped (path:Admin/Invitation scope:children): the PG router routes by the
         // path's first segment, and a path-less nodeType:Invitation query fans out
@@ -329,12 +338,24 @@ else
         // MeshNodes (see Doc/Architecture/SyncedMeshNodeQueries.md). Distinct
         // cache ids per check; the username/email ones live for the page's
         // lifetime, which is fine for one-shot pre-checks.
+        //
+        // Bootstrap signal — MUST match the page-load check above (same cache id ⇒ same
+        // query string). PATH-scoped on Admin/_Access: the old `namespace:User limit:1`
+        // matched NOTHING on partitioned PG (users are partition roots, namespace ''),
+        // so EVERY onboarder counted as "first user" — bypassing the invitation gate and
+        // firing GrantPlatformAdmin for everyone (the 43-root-superuser incident shape,
+        // now refused by AccessAssignmentGuard, which failed the whole submit).
         var firstUserQuery = workspace.GetQuery(
             "onboarding:firstUserCheck",
-            "namespace:User limit:1");
+            "path:Admin/_Access scope:children nodeType:AccessAssignment limit:1");
+        // Username-taken probe: the partition ROOT at the bare `{username}` path. The old
+        // `path:User/{username}` shape matched nothing (no node ever lives there post-V31),
+        // so the check was inert — and CreateUser's atomic CreateOrUpdateNode would have
+        // silently OVERWRITTEN an existing user's partition root on a name collision. Any
+        // Active node at the root path (user, space, reserved segment) blocks the name.
         var usernameQuery = workspace.GetQuery(
             $"onboarding:username:{username}",
-            $"path:User/{username} scope:self");
+            $"path:{username}");
         var emailQuery = workspace.GetQuery(
             $"onboarding:email:{email}",
             $"nodeType:User content.email:{email}");
@@ -378,6 +399,10 @@ else
                             $"This email is already assigned to user '{existingByEmail.Id}'. " +
                             "Please sign in with that account."));
 
+                    // "First user" = platform bootstrap: no admin grant exists yet
+                    // (checks.all is the Admin/_Access grant probe above). Config-seeded
+                    // admins (GlobalAdminSeed) count — with any admin present the
+                    // override is off and the normal gates apply.
                     var isFirstUser = !checks.all.Any();
                     var onboarding = Features.Value.Onboarding;
 
@@ -388,8 +413,8 @@ else
 
                     // Closed-registration gate. The security boundary is HERE (gating
                     // the CreateUser call), not the UI: the page is the only caller that
-                    // orchestrates CreateUser. The first-user bootstrap (zero existing
-                    // User nodes) always succeeds or the platform locks out with no admin.
+                    // orchestrates CreateUser. The first-user bootstrap (no platform
+                    // admin exists) always succeeds or the platform locks out with no admin.
                     //
                     // Invitation-only takes precedence: when on, onboarding requires a
                     // Pending invitation (regardless of AllowSelfOnboarding). Otherwise

--- a/memex/Memex.Portal.Shared/Pages/Onboarding.razor
+++ b/memex/Memex.Portal.Shared/Pages/Onboarding.razor
@@ -17,8 +17,10 @@
 @using Memex.Portal.Shared.Authentication
 @using Microsoft.Extensions.DependencyInjection
 @using Microsoft.Extensions.Logging
+@using System.Collections.Immutable
 @using System.Reactive.Disposables
 @using System.Reactive.Linq
+@using System.Text.RegularExpressions
 @using Microsoft.Extensions.Options
 @inject AccessService AccessService
 @inject UserOnboardingService OnboardingService
@@ -317,10 +319,30 @@ else
             return;
         }
 
+        var username = model.Username.Trim().ToLowerInvariant();
+        // STRICT shape gate BEFORE the username reaches any query string or becomes the
+        // partition-root path/schema: exactly one safe path segment. The username is
+        // user-controlled and interpolated into GetQuery(...) strings below — whitespace,
+        // ':', '/' or wildcards would change the query's meaning, and a non-segment value
+        // would land as an invalid partition root. Reserved segments are refused outright:
+        // they name framework partitions/schemas (admin, auth, public, …) or top-level URL
+        // routes the mesh path shape would shadow — the path probe below only catches the
+        // ones that already have a node.
+        if (!UsernamePattern.IsMatch(username))
+        {
+            errorMessage = "Username must be 2–64 characters — lowercase letters, digits, " +
+                           "'.', '-' or '_' — and start and end with a letter or digit.";
+            return;
+        }
+        if (ReservedUsernames.Contains(username))
+        {
+            errorMessage = $"'{username}' is a reserved name. Please choose a different username.";
+            return;
+        }
+
         isSaving = true;
         errorMessage = null;
 
-        var username = model.Username.Trim().ToLowerInvariant();
         var email = model.Email.Trim();
         var fullName = model.FullName?.Trim();
         var workspace = PortalApplication!.Hub.GetWorkspace();
@@ -520,6 +542,24 @@ else
     }
 
     public void Dispose() => subscriptions.Dispose();
+
+    // One safe path segment: 2–64 chars, lowercase alphanumerics with inner '.', '-', '_',
+    // alphanumeric at both ends. Anything outside this can alter an interpolated query
+    // string or escape the partition-root segment. Immutable constants — allowed statics.
+    private static readonly Regex UsernamePattern =
+        new(@"^[a-z0-9][a-z0-9._-]{0,62}[a-z0-9]$", RegexOptions.Compiled);
+
+    // Structurally special segments a username must never claim: framework partitions /
+    // Postgres schemas (a username IS its schema name, lowercased) and top-level URL
+    // routes the `{baseUrl}/{meshpath}` shape would shadow. The path:{username} probe in
+    // HandleSubmit only blocks segments that already hold a node — these are reserved
+    // even when empty.
+    private static readonly ImmutableHashSet<string> ReservedUsernames =
+    [
+        "admin", "auth", "user", "provider", "agent", "doc", "store", "system",
+        "public", "pg_catalog", "information_schema", "pg_toast",
+        "api", "webhooks", "onboarding", "login", "logout", "static", "events", "healthz",
+    ];
 
     private class OnboardingModel
     {

--- a/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
+++ b/memex/aspire/Memex.Database.Migration/MigrationRegistry.cs
@@ -58,6 +58,7 @@ public static class MigrationRegistry
         new V47_SerializeUepRebuildAdvisoryLock(),
         new V48_RetypeBuiltinFeedbackToPlugin(),
         new V49_FixAccessAssignmentMainNode(),
+        new V50_RescopePlatformAdminGrants(),
     ];
 
     /// <summary>

--- a/memex/aspire/Memex.Database.Migration/Migrations/V50_RescopePlatformAdminGrants.cs
+++ b/memex/aspire/Memex.Database.Migration/Migrations/V50_RescopePlatformAdminGrants.cs
@@ -1,0 +1,99 @@
+namespace Memex.Database.Migration.Migrations;
+
+/// <summary>
+/// Rescopes platform-admin grants from ROOT to the Admin partition, then rebuilds the
+/// permissions derived from them.
+///
+/// <para><b>The bug.</b> The two platform-admin writers — <c>GlobalAdminSeed</c> (config-driven)
+/// and <c>UserOnboardingService.GrantPlatformAdmin</c> (first-user bootstrap) — wrote their
+/// <c>Admin/_Access/{user}_Access</c> grants with <c>main_node = ''</c>. The permission projection
+/// (<c>rebuild_user_effective_permissions()</c>) scopes a grant by <c>main_node</c>, and <c>''</c>
+/// is the MESH-WIDE prefix: every such "platform admin" was silently a data superuser holding All
+/// on every partition, space and private home. <c>AccessAssignmentGuard</c> now refuses the shape
+/// at the write boundary (both halves must agree: path scope <c>Admin</c> ⇒ <c>MainNode='Admin'</c>),
+/// and the writers are fixed — this migration repairs the rows already stored.</para>
+///
+/// <para><b>Effect on existing admins.</b> They KEEP the platform gates — <c>hub.IsGlobalAdmin()</c>
+/// reads <c>Permission.All</c> at scope <c>Admin</c>, which a <c>main_node='Admin'</c> grant
+/// provides — and LOSE standing root data access, which is the documented model (a global admin is
+/// NOT a data superuser; cross-partition change is break-glass elevation, never standing). See
+/// Doc/Architecture/AccessControl.md → "The scope invariant".</para>
+///
+/// <para>Idempotent: only touches <c>namespace = 'Admin/_Access'</c> rows whose <c>main_node</c>
+/// is still NULL/empty; re-running matches nothing. V49 deliberately left these rows alone (the
+/// empty value was then believed intentional); this migration completes that repair under the
+/// guard's now-enforced invariant.</para>
+/// </summary>
+public sealed class V50_RescopePlatformAdminGrants : IMigration
+{
+    public int Version => 50;
+    public string Description =>
+        "Rescope Admin/_Access platform-admin grants from root (main_node='') to the Admin partition (main_node='Admin') and rebuild permissions";
+
+    public async Task RunAsync(MigrationContext ctx)
+    {
+        var schemas = new List<string>();
+        await using (var discover = ctx.DataSource.CreateCommand("""
+            SELECT t.table_schema
+            FROM information_schema.tables t
+            WHERE t.table_name = 'access'
+              AND t.table_schema NOT IN ('information_schema','pg_catalog','pg_toast')
+              AND t.table_schema NOT LIKE '%\_versions'
+            ORDER BY t.table_schema
+            """))
+        await using (var rdr = await discover.ExecuteReaderAsync())
+        {
+            while (await rdr.ReadAsync())
+                schemas.Add(rdr.GetString(0));
+        }
+
+        var totalFixed = 0;
+        foreach (var schema in schemas)
+        {
+            var quotedSchema = "\"" + schema.Replace("\"", "\"\"") + "\"";
+
+            // Only grants FILED under Admin/_Access: their path encodes scope 'Admin', so an
+            // empty main_node is the guard-refused mismatch (root grant in admin clothing).
+            // Deliberate root grants (namespace '_Access') are NOT touched — same reasoning
+            // as V49: activating/deactivating those is an operator decision, not an upgrade
+            // side effect.
+            int affected;
+            await using (var fix = ctx.DataSource.CreateCommand($"""
+                UPDATE {quotedSchema}.access
+                SET main_node = 'Admin'
+                WHERE namespace = 'Admin/_Access'
+                  AND (main_node IS NULL OR main_node = '')
+                """))
+            {
+                affected = await fix.ExecuteNonQueryAsync();
+            }
+
+            if (affected == 0)
+                continue;
+
+            totalFixed += affected;
+            ctx.Logger.LogInformation(
+                "Repair v50: '{Schema}' — {Count} platform-admin grant(s) rescoped from root to 'Admin'",
+                schema, affected);
+
+            // The permission rows were materialized from the root prefix — re-project them.
+            // Guarded like V49: a schema without the rebuild function still gets its data repaired.
+            try
+            {
+                await using var rebuild = ctx.DataSource.CreateCommand(
+                    $"SELECT {quotedSchema}.rebuild_user_effective_permissions()");
+                await rebuild.ExecuteNonQueryAsync();
+            }
+            catch (Exception ex)
+            {
+                ctx.Logger.LogWarning(ex,
+                    "Repair v50: '{Schema}' — permission rebuild failed; rows are repaired and the next "
+                    + "access write (or the boot-time self-heal) re-projects them", schema);
+            }
+        }
+
+        ctx.Logger.LogInformation(
+            "Repair v50: done — {Count} platform-admin grant(s) rescoped across {Schemas} schema(s)",
+            totalFixed, schemas.Count);
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -212,7 +212,7 @@ Readers that gate on it: `AdminMenuGate` (Invitations / Inbox tabs), `UserNodeTy
 ### Where the grant comes from (db-init)
 
 - **Config-driven** — `Auth:GlobalAdmins: [ "rbuergi", … ]` → `GlobalAdminSeed` seeds a static `Admin/_Access/{user}_Access` grant at boot. A fresh DB with the config set comes up with each listed user already a platform admin.
-- **First user** — `UserOnboardingService.GrantPlatformAdmin` writes the same shape for the bootstrap user when the deployment has zero existing users.
+- **First user** — `UserOnboardingService.GrantPlatformAdmin` writes the same shape for the bootstrap user when the deployment has **no platform-admin grant yet** (the onboarding page probes `path:Admin/_Access scope:children nodeType:AccessAssignment` — the same path-scoped shape the evaluator itself loads admin grants with; config-seeded admins count, so a seeded deployment never mints a second bootstrap admin). Both writers stamp `MainNode = "Admin"` — the scope the path encodes — which `AccessAssignmentGuard` enforces at the write boundary.
 
 > 🚨 **Platform-admin grants live in `Admin/_Access`, never root `_Access`.** A root `_Access` grant makes a user a **data superuser** (All on every partition via scope inheritance) — which platform admins must NOT be. An `Admin/_Access` grant scopes them to platform management only. Writers (`GlobalAdminSeed`, `GrantPlatformAdmin`) and readers (`hub.IsGlobalAdmin`) both use the Admin partition — they disagreed before 2026-06-08 (writers wrote root, readers checked Admin scope), which silently locked configured admins out of every admin tab.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-01-onboarding-second-user-fix.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-01-onboarding-second-user-fix.md
@@ -1,0 +1,16 @@
+---
+Name: Onboarding works again for every new user, and platform-admin grants are correctly scoped
+Category: What's New
+Description: New users no longer hit a failed submit at the end of onboarding, the invitation gate holds again, and platform admins are scoped to the Admin partition instead of silently becoming data superusers.
+Icon: Sparkle
+---
+
+# Onboarding works again for every new user, and platform-admin grants are correctly scoped
+
+Signing up on a portal that already had users could fail at the final step: the platform mistook **every** new user for the very first one, tried to grant them platform admin, and the security guard (correctly) refused the mis-scoped grant — failing the whole submit. The same confusion also let users self-onboard past the invitation gate.
+
+Both checks are fixed at the root:
+
+- **"Is this the first user?"** now asks the question that actually matters — *does any platform-admin grant exist yet?* — with a path-scoped query that works on partitioned storage (the old check matched nothing, ever). Config-seeded admins count, so a seeded deployment never mints a second bootstrap admin, and the invitation / closed-registration gates hold as configured.
+- **The username-taken check** now probes the real partition root, so picking an existing username is rejected instead of silently overwriting that user's profile.
+- **Platform-admin grants** (first-user bootstrap and config-seeded) are now written scoped to the Admin partition (`MainNode = "Admin"`), the shape the access guard enforces. A repair migration rescopes existing platform-admin grants the same way: admins keep all platform-management capabilities, and no longer carry standing superuser access to every partition's data — emergency cross-partition access remains an explicit break-glass elevation.

--- a/test/MeshWeaver.Auth.Test/UserOnboardingServiceTests.cs
+++ b/test/MeshWeaver.Auth.Test/UserOnboardingServiceTests.cs
@@ -186,6 +186,63 @@ public class UserOnboardingServiceTests(ITestOutputHelper output) : MonolithMesh
     }
 
     /// <summary>
+    /// The platform-admin grant must pass the write boundary and land Admin-scoped.
+    /// Regression for the 2026-08-01 memex-cloud onboarding outage: GrantPlatformAdmin
+    /// wrote <c>MainNode=""</c> — a ROOT grant (data superuser over every partition) —
+    /// which <c>AccessAssignmentGuard</c> refuses, so the whole onboarding submit failed
+    /// for every user the (also broken) bootstrap check counted as "first". The canonical
+    /// shape is <c>MainNode="Admin"</c>: the scope the path encodes, which confers the
+    /// platform gates (hub.IsGlobalAdmin) WITHOUT standing cross-partition data access.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task GrantPlatformAdmin_WritesGuardCompliantAdminScopedGrant()
+    {
+        var username = $"obtest-{Guid.NewGuid():N}".ToLowerInvariant()[..16];
+        var service = Mesh.ServiceProvider.GetRequiredService<UserOnboardingService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        // Pre-fix this OnErrors: the guard refuses the empty-MainNode shape at the
+        // write boundary ("[UpsertNode] REFUSED mis-scoped AccessAssignment").
+        using (accessService.ImpersonateAsSystem())
+        {
+            await service.GrantPlatformAdmin(username).Should().Emit();
+        }
+
+        var grant = await ReadNode($"Admin/_Access/{username}_Access").Should().Emit();
+        grant.Should().NotBeNull("the platform-admin grant must land in Admin/_Access");
+        grant!.MainNode.Should().Be("Admin",
+            "a grant is scoped by MainNode, not its folder — empty means ROOT (every partition), " +
+            "'Admin' is the platform-admin scope hub.IsGlobalAdmin() reads");
+        AccessAssignmentGuard.IsScopeInvalid(grant, out var reason).Should().BeFalse(reason);
+    }
+
+    /// <summary>
+    /// The self-grant scopes the new user to exactly their OWN partition — MainNode is
+    /// the bare username the path encodes, valid under the same guard.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task GrantSelfAdmin_ScopesToOwnPartition()
+    {
+        var username = $"obtest-{Guid.NewGuid():N}".ToLowerInvariant()[..16];
+        var service = Mesh.ServiceProvider.GetRequiredService<UserOnboardingService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+        using (accessService.ImpersonateAsSystem())
+        {
+            await service.CreateUser(new UserOnboardingRequest(
+                    username, $"{username}@example.com", FullName: "Self Grant Test"))
+                .Should().Emit();
+            await service.GrantSelfAdmin(username).Should().Emit();
+        }
+
+        var grant = await ReadNode($"{username}/_Access/{username}_Access").Should().Emit();
+        grant.Should().NotBeNull("the self-grant must land in the user's own _Access satellite");
+        grant!.MainNode.Should().Be(username,
+            "the self-grant scopes the user to their own partition root");
+        AccessAssignmentGuard.IsScopeInvalid(grant, out var reason).Should().BeFalse(reason);
+    }
+
+    /// <summary>
     /// ONBOARD-FIRST (the rule): tracking activity for an identity that has NOT
     /// been onboarded (no partition root / User node) must NOT create the
     /// partition. Reproduces the "partition created before onboarding" bug —

--- a/test/MeshWeaver.Hosting.PostgreSql.Test/FirstUserOnboardingTests.cs
+++ b/test/MeshWeaver.Hosting.PostgreSql.Test/FirstUserOnboardingTests.cs
@@ -1,11 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Graph;
 using MeshWeaver.Blazor.Portal;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Persistence.Query;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
@@ -82,8 +86,10 @@ public class FirstUserOnboardingTests
         }, _options).Should().Within(30.Seconds()).Emit();
 
         // Step 2: Assign global Admin role (simulates the fixed onboarding code)
-        // AddUserRoleAsync(username, Role.Admin.Id, "Admin", username)
-        // → namespace = "Admin/_Access", stored in admin.access table
+        // → namespace = "Admin/_Access", stored in admin.access table. MainNode is the
+        // SCOPE the path encodes — 'Admin' — the only shape AccessAssignmentGuard accepts
+        // (an empty MainNode is a ROOT grant; the old 'Admin/_Access' container value
+        // projected the grant one level too deep, see migration V49).
         var ns = "Admin/_Access";
         var nodeId = $"{username}_Access";
         await adminAdapter.Write(new MeshNode(nodeId, ns)
@@ -91,7 +97,7 @@ public class FirstUserOnboardingTests
             Name = username,
             NodeType = "AccessAssignment",
             State = MeshNodeState.Active,
-            MainNode = ns,
+            MainNode = "Admin",
             Content = new AccessAssignment
             {
                 DisplayName = username,
@@ -150,7 +156,7 @@ public class FirstUserOnboardingTests
             Name = username,
             NodeType = "AccessAssignment",
             State = MeshNodeState.Active,
-            MainNode = "Admin/_Access",
+            MainNode = "Admin",
             Content = new AccessAssignment
             {
                 DisplayName = username,
@@ -206,6 +212,82 @@ public class FirstUserOnboardingTests
         results.Should().HaveCount(2, "Global admin should see all organizations (has partition_access to both)");
         results.Select(n => n.Name).Should().Contain("OrgAlpha Corp");
         results.Select(n => n.Name).Should().Contain("OrgBeta Corp");
+    }
+
+    /// <summary>
+    /// The onboarding bootstrap check ("is there a platform admin yet?") must actually SEE the
+    /// grant on partitioned PG. The old check — <c>namespace:User limit:1</c> — matched NOTHING
+    /// (users are partition roots with namespace <c>''</c>), so every onboarder counted as the
+    /// first user: the invitation gate was bypassed and GrantPlatformAdmin fired for everyone
+    /// (the 43-root-superuser incident; once AccessAssignmentGuard refused that shape, every
+    /// onboarding submit failed instead — memex-cloud, user 'bing', 2026-08-01). The fixed
+    /// check is PATH-scoped on Admin/_Access, the same routing the invitation query relies on.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task BootstrapCheck_PathScopedAdminGrantQuery_SeesTheGrant()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await _fixture.CleanData().Should().Within(60.Seconds()).Emit();
+
+        var partitionDef = new PartitionDefinition
+        {
+            Namespace = "Admin",
+            Schema = "admin",
+            TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+            NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings()
+        };
+        var (_, adminAdapter) = await _fixture.CreateSchemaAdapter("admin", partitionDef, ct)
+            .Should().Within(60.Seconds()).Emit();
+
+        using var provider = new PostgreSqlPartitionStorageProvider(
+            _fixture.DataSource,
+            _fixture.ConnectionString,
+            new PostgreSqlStorageOptions { ConnectionString = _fixture.ConnectionString },
+            partitions: null);
+        var query = new PostgreSqlPartitionedMeshQuery(
+            new PostgreSqlCrossSchemaQueryProvider(_fixture.DataSource),
+            partitionProvider: provider);
+
+        // The EXACT query string Onboarding.razor uses for onboarding:firstUserCheck.
+        const string bootstrapQuery =
+            "path:Admin/_Access scope:children nodeType:AccessAssignment limit:1";
+
+        // (a) No grant yet → bootstrap: the first onboarder becomes platform admin.
+        var before = await query
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(bootstrapQuery, WellKnownUsers.System), _options)
+            .Where(c => c.ChangeType == QueryChangeType.Initial)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(ct);
+        before.Items.Should().BeEmpty(
+            "an empty Admin/_Access means platform bootstrap — the first user must be granted admin");
+
+        // (b) Write the guard-compliant platform-admin grant (the shape GrantPlatformAdmin
+        //     and GlobalAdminSeed produce) — the check must now see it, so the SECOND
+        //     onboarder is NOT treated as first user.
+        await adminAdapter.Write(new MeshNode("firstadmin_Access", "Admin/_Access")
+        {
+            Name = "firstadmin — Admin",
+            NodeType = "AccessAssignment",
+            State = MeshNodeState.Active,
+            MainNode = "Admin",
+            Content = new AccessAssignment
+            {
+                DisplayName = "firstadmin",
+                AccessObject = "firstadmin",
+                Roles = [new RoleAssignment { Role = Role.Admin.Id }]
+            }
+        }, _options).Should().Within(30.Seconds()).Emit();
+
+        var after = await query
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(bootstrapQuery, WellKnownUsers.System), _options)
+            .Where(c => c.ChangeType == QueryChangeType.Initial)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(ct);
+        after.Items.Should().ContainSingle(
+            "the bootstrap check MUST see an existing platform-admin grant — matching nothing " +
+            "here is what made every onboarder a 'first user' (gate bypass + root-grant misfire)");
     }
 
     // â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€


### PR DESCRIPTION
## What broke (memex-cloud, 2026-08-01 — user `bing`)

A new user's onboarding submit failed with `AccessAssignment 'Admin/_Access/bing_Access' has an EMPTY MainNode … grants ROOT`. Root cause chain:

1. **The first-user bootstrap check was blind.** `namespace:User limit:1` matches nothing on partitioned PG (users are partition roots, namespace `''`), so **every** onboarder counted as the first user. That (a) bypassed the invitation-only / closed-registration gates, and (b) fired `GrantPlatformAdmin` for every onboarder — this is the "unknown writer" behind the one-per-user root-superuser rows documented in `AccessAssignmentGuard` (measured 2026-07-28: 43 accounts).
2. **The platform-admin writers wrote the root shape.** `GrantPlatformAdmin` and `GlobalAdminSeed` stamped `MainNode=""` — root scope in the PG `user_effective_permissions` projection. Once the guard landed, that write is refused, so the submit chain errored for every onboarder while `CreateUser` + `GrantSelfAdmin` had already succeeded (half-onboarded UX).
3. **The username-taken check was inert.** `path:User/{username}` matches nothing post-V31; with atomic `CreateOrUpdateNode`, a name collision would have silently overwritten the existing user's partition root.

## The fix

- Bootstrap check → `path:Admin/_Access scope:children nodeType:AccessAssignment limit:1` — the same path-scoped shape `PermissionEvaluator.ObserveScopeAssignments` uses (namespace queries never reach `admin.access` because `searchable_schemas` excludes admin). Config-seeded admins count, so a seeded deployment never mints a second bootstrap admin.
- Username check → `path:{username}` (exact partition-root probe; any Active node at the root path blocks the name).
- `GrantPlatformAdmin` + `GlobalAdminSeed` stamp `MainNode="Admin"` — the scope the path encodes, the only shape the guard accepts. In-memory evaluation is unchanged (it scopes by namespace path); `IsGlobalAdmin` (All at scope `Admin`) works with the `Admin` prefix in the PG projection.
- **V50_RescopePlatformAdminGrants**: rescopes stored `Admin/_Access` rows with empty `main_node` to `'Admin'` + rebuilds `user_effective_permissions`. Existing platform admins keep all platform gates and **lose standing root data access** — the documented model (break-glass elevation, never standing). Deliberate root grants (`_Access/...`) are untouched, same policy as V49.

## Tests

- `UserOnboardingServiceTests.GrantPlatformAdmin_WritesGuardCompliantAdminScopedGrant` — through the real write boundary; fails pre-fix with the guard refusal.
- `UserOnboardingServiceTests.GrantSelfAdmin_ScopesToOwnPartition`.
- `FirstUserOnboardingTests.BootstrapCheck_PathScopedAdminGrantQuery_SeesTheGrant` (PG) — pins the exact onboarding query string: empty before a grant, sees the guard-compliant grant after.
- Existing FirstUserOnboardingTests fixtures updated to the canonical `MainNode="Admin"` shape.
- `DocumentationLinkIntegrityTest` green after the AccessControl.md update.

All touched projects + `Memex.Portal.Distributed` build clean `-c Release -warnaserror`; new/changed test classes green locally (7/7 Auth, 3/3 PG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)