### PR TITLE
Node menu: read-gated Data item — the underlying record stays visible to viewers

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
@@ -162,6 +162,11 @@ public static class NodeMenuItemsExtensions
             var files = MeshNodeLayoutAreas.GetFilesMenuItem(menuPath, perms);
             if (files != null) items.Add(files with { Order = 30, Icon = "📁" });
 
+            // Read-gated: the underlying record stays reachable for viewers even when the type's
+            // Overview is a designed page and Edit is hidden behind Update permission.
+            var data = MeshNodeLayoutAreas.GetDataMenuItem(menuPath, perms);
+            if (data != null) items.Add(data with { Order = 31, Icon = "🧾" });
+
             var versions = VersionLayoutArea.GetMenuItem(menuPath, perms);
             if (versions != null) items.Add(versions with { Order = 32, Icon = "🕘" });
 

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -102,6 +102,9 @@ public static class MeshNodeLayoutAreas
     public const string ContentArea = "$Content";
     /// <summary>Area name for the UCR Data layout area.</summary>
     public const string DataArea = "$Data";
+
+    /// <summary>Area name of the node's reflected content page (<see cref="ContentData"/>).</summary>
+    public const string ContentDataArea = "Data";
     /// <summary>Area name for the UCR Schema layout area.</summary>
     public const string SchemaArea = "$Schema";
     /// <summary>Area name for the UCR Model layout area.</summary>
@@ -177,6 +180,7 @@ public static class MeshNodeLayoutAreas
             .WithView(GroupsArea, Groups)
             .WithView(CreateNodeArea, CreateNode)
             .WithView(EditArea, EditNode)
+            .WithView(ContentDataArea, ContentData)
             .WithView(ImportMeshNodesArea, ImportLayoutArea.ImportMeshNodes)
             .WithView(ExportArea, ExportLayoutArea.Export)
             .WithView(CopyArea, CopyLayoutArea.Copy)
@@ -230,6 +234,36 @@ public static class MeshNodeLayoutAreas
                                 $"[Continue here →](/{redirect.TrimStart('/')})"))
                         : BuildAccessDenied(hubPath));
             });
+    }
+
+    /// <summary>
+    /// The node's DATA page — the framework's reflected content view (header + property overview,
+    /// exactly what the default <see cref="Overview"/> renders), always available at
+    /// <c>/{node}/Data</c> even when a type overrides Overview with a designed page. Read-only for
+    /// viewers; editors keep click-to-edit. This is what the read-gated "Data" node-menu item opens,
+    /// so a viewer without Update rights can always see the underlying record.
+    /// </summary>
+    [Browsable(false)]
+    public static IObservable<UiControl?> ContentData(LayoutAreaHost host, RenderingContext _)
+    {
+        var hubPath = host.Hub.Address.ToString();
+        return host.Workspace.GetMeshNodeStream().CombineLatest(
+                host.Hub.GetEffectivePermissions(hubPath),
+                (node, permissions) => (Node: node, Permissions: permissions))
+            .Select(t => t.Permissions.HasFlag(Permission.Read)
+                ? (UiControl?)host.BuildDetailsContent(t.Node, null, t.Permissions.HasFlag(Permission.Update))
+                : BuildAccessDenied(hubPath));
+    }
+
+    /// <summary>
+    /// Returns the Data menu item — read-gated: every viewer can open the node's underlying record
+    /// even when the type's Overview is a designed page and Edit is hidden behind Update.
+    /// </summary>
+    public static NodeMenuItemDefinition? GetDataMenuItem(string hubPath, Permission perms)
+    {
+        if (!perms.HasFlag(Permission.Read))
+            return null;
+        return new("Data", ContentDataArea, Order: 31, Href: BuildUrl(hubPath, ContentDataArea));
     }
 
     internal static UiControl BuildAccessDenied(string nodePath)

--- a/test/MeshWeaver.Security.Test/MenuAccessControlTest.cs
+++ b/test/MeshWeaver.Security.Test/MenuAccessControlTest.cs
@@ -181,16 +181,19 @@ public class MenuAccessControlTest(ITestOutputHelper output) : MonolithMeshTestB
 
         // Wait until the reactive menu settles on exactly the Viewer set.
         var items = await FetchAllMenuItems(client, nodeAddress,
-            LabelsAre("Files", "Versions", "Pin"));
+            LabelsAre("Files", "Data", "Versions", "Pin"));
 
         Output.WriteLine($"Menu items for Viewer: {items.Count}");
         foreach (var item in items)
             Output.WriteLine($"  {item.Label} (Area={item.Area})");
 
         items.Select(i => i.Label).Should().BeEquivalentTo(
-            new[] { "Files", "Versions", "Pin" },
+            new[] { "Files", "Data", "Versions", "Pin" },
             JsonSerializerOptions.Default,
-            because: "Viewer has only Read — no Create, Update, Delete, or Export items (Pin requires no permission; Settings is a dedicated header button; Threads moved to the AI menu slot)");
+            because: "Viewer has only Read — no Create, Update, Delete, or Export items, but DATA is "
+                     + "read-gated by design: the underlying record stays visible even when a type's "
+                     + "Overview is a designed page (Pin requires no permission; Settings is a dedicated "
+                     + "header button; Threads moved to the AI menu slot)");
     }
 
     [Fact(Timeout = 30000)]
@@ -210,7 +213,7 @@ public class MenuAccessControlTest(ITestOutputHelper output) : MonolithMeshTestB
         // fix for the old flake, where the menu was read before the Editor role propagated.
         var expected = new[]
         {
-            "Edit", "Create", "Copy", "Import", "Files", "Export", "Versions", "Pin", "Recycle",
+            "Edit", "Create", "Copy", "Import", "Files", "Data", "Export", "Versions", "Pin", "Recycle",
             "Stop synchronization"
         };
         var items = await FetchAllMenuItems(client, nodeAddress, LabelsAre(expected));
@@ -238,7 +241,7 @@ public class MenuAccessControlTest(ITestOutputHelper output) : MonolithMeshTestB
 
         var expected = new[]
         {
-            "Edit", "Create", "Copy", "Move", "Import", "Files", "Export", "Versions", "Delete", "Pin", "Recycle",
+            "Edit", "Create", "Copy", "Move", "Import", "Files", "Data", "Export", "Versions", "Delete", "Pin", "Recycle",
             "Stop synchronization"
         };
         var items = await FetchAllMenuItems(client, nodeAddress, LabelsAre(expected));
@@ -247,7 +250,7 @@ public class MenuAccessControlTest(ITestOutputHelper output) : MonolithMeshTestB
         foreach (var item in items)
             Output.WriteLine($"  {item.Label} (Area={item.Area})");
 
-        items.Should().HaveCount(12, "Admin should see all default menu items across Node and Mesh contexts plus Stop synchronization (Settings is a dedicated header button; Threads moved to the AI menu slot)");
+        items.Should().HaveCount(13, "Admin should see all default menu items across Node and Mesh contexts plus Stop synchronization (Settings is a dedicated header button; Threads moved to the AI menu slot)");
         items.Select(i => i.Label).Should().BeEquivalentTo(expected, JsonSerializerOptions.Default);
     }
 


### PR DESCRIPTION
Requested by the maintainer while reviewing the reinsurance demo: a type that overrides `Overview` with a designed page (the plugin dashboards) leaves **read-only users with no way to see the node's underlying data** — Edit is `Update`-gated and the default reflected view was only reachable *as* Overview.

- New default area **`Data`** (`/{node}/Data`): renders the framework's reflected content page (`BuildDetailsContent` — header + property overview) for every node; click-to-edit only with Update, plain read otherwise; access-denied handling as in Overview.
- The node menu gains a **read-gated `Data` item** (🧾, order 31) in the content group next to Files/Versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188hH6CwFoyszTtmKfd1Rka