### PR TITLE
fix(auth): make Sign in with Apple actually work (form_post + generated client secret)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="AngleSharp" Version="1.5.2" />
     <PackageVersion Include="Appium.WebDriver" Version="8.3.0" />
     <PackageVersion Include="AspectCore.Extensions.Reflection" Version="2.4.0" />
+    <PackageVersion Include="AspNet.Security.OAuth.Apple" Version="10.0.0" />
     <!-- Open-source (MIT) MAUI UI libraries for the native view pack's rich controls (Phase 4+):
          charts, full data grid, and popups/expanders. All MIT-licensed — no Syncfusion/DevExpress/
          Telerik (commercial). Referenced by MeshWeaver.Maui / Memex.Client as the controls land. -->

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -192,6 +192,11 @@ data:
   Authentication__Microsoft__TenantId: "{{ .Values.config.memex_portal.Authentication__Microsoft__TenantId | default "" }}"
   Authentication__Google__ClientId: "{{ .Values.config.memex_portal.Authentication__Google__ClientId | default "" }}"
   Authentication__LinkedIn__ClientId: "{{ .Values.config.memex_portal.Authentication__LinkedIn__ClientId | default "" }}"
+  # Apple: ClientId is the Services ID; TeamId/KeyId identify the Sign in with Apple key
+  # whose private key (the secret) is Authentication__Apple__PrivateKey in secrets.yaml.
+  Authentication__Apple__ClientId: "{{ .Values.config.memex_portal.Authentication__Apple__ClientId | default "" }}"
+  Authentication__Apple__TeamId: "{{ .Values.config.memex_portal.Authentication__Apple__TeamId | default "" }}"
+  Authentication__Apple__KeyId: "{{ .Values.config.memex_portal.Authentication__Apple__KeyId | default "" }}"
   Social__LinkedIn__ClientId: "{{ .Values.config.memex_portal.Social__LinkedIn__ClientId | default "" }}"
   # ---- Onboarding: invitation-only gate (first user always bootstraps) ------
   Features__Onboarding__InvitationOnly: "{{ .Values.config.memex_portal.Features__Onboarding__InvitationOnly | default "false" }}"

--- a/deploy/helm/templates/memex-portal/secrets.yaml
+++ b/deploy/helm/templates/memex-portal/secrets.yaml
@@ -45,4 +45,10 @@ stringData:
   {{- if .Values.secrets.memex_portal.Authentication__Microsoft__ClientSecret }}
   Authentication__Microsoft__ClientSecret: "{{ .Values.secrets.memex_portal.Authentication__Microsoft__ClientSecret }}"
   {{- end }}
+  # Sign in with Apple: the .p8 key content (PEM; literal \n or base64 both accepted —
+  # the portal normalizes). With it the portal mints the ES256 client-secret JWT itself;
+  # Apple issues no static client secret.
+  {{- if .Values.secrets.memex_portal.Authentication__Apple__PrivateKey }}
+  Authentication__Apple__PrivateKey: "{{ .Values.secrets.memex_portal.Authentication__Apple__PrivateKey }}"
+  {{- end }}
 type: "Opaque"

--- a/src/MeshWeaver.Blazor.Portal/Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/MeshWeaver.Blazor.Portal/Authentication/AuthenticationBuilderExtensions.cs
@@ -184,15 +184,27 @@ public static class AuthenticationBuilderExtensions
         if (string.IsNullOrEmpty(clientId))
             return builder;
 
+        var privateKey = NormalizePrivateKey(section["PrivateKey"]);
+        var teamId = section["TeamId"];
+        var keyId = section["KeyId"];
+        if (privateKey is not null && (string.IsNullOrEmpty(teamId) || string.IsNullOrEmpty(keyId)))
+            throw new InvalidOperationException(
+                "Authentication:Apple:PrivateKey is set but "
+                + (string.IsNullOrEmpty(teamId) ? "Authentication:Apple:TeamId" : "Authentication:Apple:KeyId")
+                + " is missing — the Apple client-secret JWT is signed with the key identified by TeamId + KeyId.");
+
         builder.AddApple(options =>
         {
             options.ClientId = clientId;
-            var privateKey = NormalizePrivateKey(section["PrivateKey"]);
+            // The Blazor catch-all excludes this literal path (NonfileRouteConstraint), so the
+            // callback endpoint is part of the app's routing contract — pin it rather than
+            // relying on the package default staying identical.
+            options.CallbackPath = "/signin-apple";
             if (privateKey is not null)
             {
                 options.GenerateClientSecret = true;
-                options.TeamId = section["TeamId"] ?? "";
-                options.KeyId = section["KeyId"] ?? "";
+                options.TeamId = teamId!;
+                options.KeyId = keyId;
                 options.PrivateKey = (_, _) => Task.FromResult(privateKey.AsMemory());
             }
             else

--- a/src/MeshWeaver.Blazor.Portal/Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/MeshWeaver.Blazor.Portal/Authentication/AuthenticationBuilderExtensions.cs
@@ -165,9 +165,17 @@ public static class AuthenticationBuilderExtensions
     }
 
     /// <summary>
-    /// Adds Apple authentication via OAuth2.
-    /// Reads from Authentication:Apple section: ClientId, ClientSecret.
+    /// Adds Sign in with Apple via the AspNet.Security.OAuth.Apple handler.
+    /// Reads from Authentication:Apple section: ClientId (the Services ID), TeamId, KeyId,
+    /// PrivateKey (the Sign in with Apple .p8 key content).
     /// </summary>
+    /// <remarks>
+    /// Apple's protocol deviates from generic OAuth in two ways the plain OAuth handler cannot
+    /// serve: requesting the name/email scopes REQUIRES response_mode=form_post (the callback
+    /// arrives as a cross-site POST, not a GET), and there is no static client secret — the
+    /// secret is an ES256-signed JWT minted from the Sign in with Apple key, valid at most six
+    /// months. The Apple handler does both; this method only wires configuration into it.
+    /// </remarks>
     public static AuthenticationBuilder AddAppleAuthentication(
         this AuthenticationBuilder builder, IConfiguration configuration)
     {
@@ -176,35 +184,75 @@ public static class AuthenticationBuilderExtensions
         if (string.IsNullOrEmpty(clientId))
             return builder;
 
-        builder.AddOAuth("Apple", options =>
+        builder.AddApple(options =>
         {
             options.ClientId = clientId;
-            options.ClientSecret = section["ClientSecret"] ?? "";
-            options.CallbackPath = "/signin-apple";
-            options.AuthorizationEndpoint = "https://appleid.apple.com/auth/authorize";
-            options.TokenEndpoint = "https://appleid.apple.com/auth/token";
-            options.Scope.Add("name");
-            options.Scope.Add("email");
-            options.ClaimActions.MapJsonKey(System.Security.Claims.ClaimTypes.NameIdentifier, "sub");
-            options.ClaimActions.MapJsonKey(System.Security.Claims.ClaimTypes.Name, "name");
-            options.ClaimActions.MapJsonKey(System.Security.Claims.ClaimTypes.Email, "email");
-            options.Events = new OAuthEvents
+            var privateKey = NormalizePrivateKey(section["PrivateKey"]);
+            if (privateKey is not null)
             {
-                OnCreatingTicket = async context =>
-                {
-                    // Apple returns user info in the initial authorization response, not via userinfo endpoint.
-                    // The ID token (if present) contains the claims.
-                    if (context.TokenResponse?.Response?.RootElement is { } root
-                        && root.TryGetProperty("id_token", out _))
-                    {
-                        // Claims already extracted from token by the middleware
-                        return;
-                    }
-                }
+                options.GenerateClientSecret = true;
+                options.TeamId = section["TeamId"] ?? "";
+                options.KeyId = section["KeyId"] ?? "";
+                options.PrivateKey = (_, _) => Task.FromResult(privateKey.AsMemory());
+            }
+            else
+            {
+                // Externally minted client-secret JWT; expires within six months, so
+                // PrivateKey-based generation is the intended configuration.
+                options.ClientSecret = section["ClientSecret"] ?? "";
+            }
+            // The form_post callback is a cross-site POST; same correlation-cookie
+            // rationale as the Microsoft handler above.
+            options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
+            options.Events.OnRemoteFailure = context =>
+            {
+                var logger = context.HttpContext.RequestServices
+                    .GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("AppleAuth");
+                logger.LogError(context.Failure, "Apple OIDC remote failure");
+                context.Response.Redirect("/login?error=auth_failed");
+                context.HandleResponse();
+                return Task.CompletedTask;
             };
         });
 
         return builder;
+    }
+
+    private const string PemHeader = "-----BEGIN PRIVATE KEY-----";
+    private const string PemFooter = "-----END PRIVATE KEY-----";
+
+    /// <summary>
+    /// Accepts the Sign in with Apple key in every shape an environment realistically delivers
+    /// it: the .p8 PEM as-is, PEM with literal \n escapes (single-line env vars), base64 of the
+    /// whole PEM file (kubectl-style), or the bare base64 PKCS#8 body. Returns a well-formed PEM
+    /// for ECDsa.ImportFromPem, or null when no key is configured.
+    /// </summary>
+    internal static string? NormalizePrivateKey(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var key = value.Replace("\\n", "\n").Trim();
+        if (key.Contains(PemHeader))
+            return key;
+
+        var compact = string.Concat(key.Where(c => !char.IsWhiteSpace(c)));
+        try
+        {
+            var decoded = Convert.FromBase64String(compact);
+            var text = System.Text.Encoding.UTF8.GetString(decoded);
+            if (text.Contains(PemHeader))
+                return text.Trim();
+        }
+        catch (FormatException)
+        {
+            // Not base64: pass the trimmed value through so ImportFromPem reports what's wrong.
+            return key;
+        }
+
+        var body = string.Join('\n', compact.Chunk(64).Select(chunk => new string(chunk)));
+        return $"{PemHeader}\n{body}\n{PemFooter}";
     }
 
     /// <summary>

--- a/src/MeshWeaver.Blazor.Portal/MeshWeaver.Blazor.Portal.csproj
+++ b/src/MeshWeaver.Blazor.Portal/MeshWeaver.Blazor.Portal.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="MeshWeaver.Acme.Test" />
+    <InternalsVisibleTo Include="Memex.Portal.Shared.Test" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MeshWeaver.AI\MeshWeaver.AI.csproj" />
@@ -22,6 +23,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AspNet.Security.OAuth.Apple" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" />
   </ItemGroup>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-02-sign-in-with-apple.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-02-sign-in-with-apple.md
@@ -1,0 +1,15 @@
+---
+Name: Sign in with Apple
+Category: What's New
+Description: The login page's Apple sign-in now works end to end — Apple's form_post callback and self-renewing client secret are handled properly.
+Icon: Sparkle
+---
+
+# Sign in with Apple
+
+The Apple button on the login page now signs you in reliably. Apple's sign-in flow differs from
+other providers — it posts the response back instead of redirecting, and it requires a
+cryptographically signed, short-lived client secret instead of a static one. The portal now speaks
+that dialect natively and renews the secret automatically, so an operator only configures the
+Services ID, Team ID, Key ID and the Sign in with Apple key. Providers stay opt-in: the button
+appears only when a deployment configures Apple credentials.

--- a/test/Memex.Portal.Shared.Test/AppleAuthenticationTest.cs
+++ b/test/Memex.Portal.Shared.Test/AppleAuthenticationTest.cs
@@ -1,0 +1,152 @@
+using System.Security.Cryptography;
+using System.Text;
+using AspNet.Security.OAuth.Apple;
+using MeshWeaver.Blazor.Portal.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The Sign in with Apple wiring. Apple deviates from generic OAuth in two ways that broke the
+/// previous hand-rolled AddOAuth("Apple") registration: requesting name/email scopes requires
+/// response_mode=form_post (a cross-site POST callback the generic handler cannot parse), and
+/// there is no static client secret — it is an ES256 JWT minted from the .p8 key. These tests pin
+/// the configuration wiring into the AspNet.Security.OAuth.Apple handler (which owns the protocol)
+/// and the private-key normalization for every shape an environment can deliver the key in.
+/// The full authorize → form_post callback → cookie flow is Apple-server-dependent and is
+/// exercised manually against the live instance.
+/// </summary>
+public class AppleAuthenticationTest
+{
+    private static (string Pem, byte[] Pkcs8) CreateKey()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var pkcs8 = ecdsa.ExportPkcs8PrivateKey();
+        return (PemEncoding.WriteString("PRIVATE KEY", pkcs8), pkcs8);
+    }
+
+    private static void AssertImportable(string pem)
+    {
+        using var ecdsa = ECDsa.Create();
+        ecdsa.ImportFromPem(pem); // throws if the normalized form is not valid PEM/PKCS#8
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NormalizePrivateKey_NoKeyConfigured_ReturnsNull(string? value) =>
+        Assert.Null(AuthenticationBuilderExtensions.NormalizePrivateKey(value));
+
+    [Fact]
+    public void NormalizePrivateKey_RawPem_PassesThroughImportable()
+    {
+        var (pem, _) = CreateKey();
+        var normalized = AuthenticationBuilderExtensions.NormalizePrivateKey(pem);
+        Assert.NotNull(normalized);
+        AssertImportable(normalized);
+    }
+
+    [Fact]
+    public void NormalizePrivateKey_PemWithLiteralNewlineEscapes_Importable()
+    {
+        // A single-line env var: the PEM's newlines arrive as the two characters '\' 'n'.
+        var (pem, _) = CreateKey();
+        var normalized = AuthenticationBuilderExtensions.NormalizePrivateKey(pem.Replace("\n", "\\n"));
+        Assert.NotNull(normalized);
+        AssertImportable(normalized);
+    }
+
+    [Fact]
+    public void NormalizePrivateKey_Base64OfWholePemFile_Importable()
+    {
+        // kubectl-style: the whole .p8 file base64-encoded.
+        var (pem, _) = CreateKey();
+        var normalized = AuthenticationBuilderExtensions.NormalizePrivateKey(
+            Convert.ToBase64String(Encoding.UTF8.GetBytes(pem)));
+        Assert.NotNull(normalized);
+        AssertImportable(normalized);
+    }
+
+    [Fact]
+    public void NormalizePrivateKey_BarePkcs8Base64Body_WrappedAndImportable()
+    {
+        // The .p8 with its armor lines stripped — just the base64 body.
+        var (_, pkcs8) = CreateKey();
+        var normalized = AuthenticationBuilderExtensions.NormalizePrivateKey(
+            Convert.ToBase64String(pkcs8));
+        Assert.NotNull(normalized);
+        Assert.StartsWith("-----BEGIN PRIVATE KEY-----", normalized);
+        AssertImportable(normalized);
+    }
+
+    [Fact]
+    public void NormalizePrivateKey_Garbage_PassedThroughForImportToReport()
+    {
+        // Not silently swallowed: ImportFromPem gets the value and names the problem.
+        Assert.Equal("not-a-key", AuthenticationBuilderExtensions.NormalizePrivateKey("not-a-key"));
+    }
+
+    private static ServiceProvider BuildProvider(Dictionary<string, string?> settings)
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAuthentication().AddAppleAuthentication(configuration);
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task AddAppleAuthentication_WithoutClientId_RegistersNoScheme()
+    {
+        await using var provider = BuildProvider([]);
+        var schemes = provider.GetRequiredService<IAuthenticationSchemeProvider>();
+        Assert.Null(await schemes.GetSchemeAsync("Apple"));
+    }
+
+    [Fact]
+    public async Task AddAppleAuthentication_WithPrivateKey_GeneratesClientSecretFromKey()
+    {
+        var (pem, _) = CreateKey();
+        await using var provider = BuildProvider(new Dictionary<string, string?>
+        {
+            ["Authentication:Apple:ClientId"] = "cloud.meshweaver.memex.signin",
+            ["Authentication:Apple:TeamId"] = "TEAM123456",
+            ["Authentication:Apple:KeyId"] = "KEY1234567",
+            ["Authentication:Apple:PrivateKey"] = pem.Replace("\n", "\\n"),
+        });
+
+        var schemes = provider.GetRequiredService<IAuthenticationSchemeProvider>();
+        var scheme = await schemes.GetSchemeAsync("Apple");
+        Assert.NotNull(scheme);
+        Assert.Equal(typeof(AppleAuthenticationHandler), scheme.HandlerType);
+
+        var options = provider.GetRequiredService<IOptionsMonitor<AppleAuthenticationOptions>>().Get("Apple");
+        Assert.True(options.GenerateClientSecret);
+        Assert.Equal("TEAM123456", options.TeamId);
+        Assert.Equal("KEY1234567", options.KeyId);
+        Assert.NotNull(options.PrivateKey);
+
+        // The delegate must hand the secret generator an importable PEM.
+        var delivered = await options.PrivateKey("KEY1234567", CancellationToken.None);
+        AssertImportable(delivered.ToString());
+    }
+
+    [Fact]
+    public async Task AddAppleAuthentication_WithStaticSecretOnly_FallsBackToClientSecret()
+    {
+        await using var provider = BuildProvider(new Dictionary<string, string?>
+        {
+            ["Authentication:Apple:ClientId"] = "cloud.meshweaver.memex.signin",
+            ["Authentication:Apple:ClientSecret"] = "externally.minted.jwt",
+        });
+
+        var options = provider.GetRequiredService<IOptionsMonitor<AppleAuthenticationOptions>>().Get("Apple");
+        Assert.False(options.GenerateClientSecret);
+        Assert.Equal("externally.minted.jwt", options.ClientSecret);
+    }
+}

--- a/test/Memex.Portal.Shared.Test/AppleAuthenticationTest.cs
+++ b/test/Memex.Portal.Shared.Test/AppleAuthenticationTest.cs
@@ -136,6 +136,23 @@ public class AppleAuthenticationTest
         AssertImportable(delivered.ToString());
     }
 
+    [Theory]
+    [InlineData(null, "KEY1234567", "Authentication:Apple:TeamId")]
+    [InlineData("TEAM123456", null, "Authentication:Apple:KeyId")]
+    public void AddAppleAuthentication_PrivateKeyWithoutTeamOrKeyId_FailsFastNamingTheKey(
+        string? teamId, string? keyId, string expectedInMessage)
+    {
+        var (pem, _) = CreateKey();
+        var ex = Assert.Throws<InvalidOperationException>(() => BuildProvider(new Dictionary<string, string?>
+        {
+            ["Authentication:Apple:ClientId"] = "cloud.meshweaver.memex.signin",
+            ["Authentication:Apple:TeamId"] = teamId,
+            ["Authentication:Apple:KeyId"] = keyId,
+            ["Authentication:Apple:PrivateKey"] = pem,
+        }));
+        Assert.Contains(expectedInMessage, ex.Message);
+    }
+
     [Fact]
     public async Task AddAppleAuthentication_WithStaticSecretOnly_FallsBackToClientSecret()
     {


### PR DESCRIPTION
## What

`AddAppleAuthentication` could never complete a sign-in:

1. **Missing `response_mode=form_post`.** Apple requires it whenever scopes are requested (the code requested `name`+`email`), so the authorization request was rejected outright — and the callback would have arrived as a cross-site POST the generic `OAuthHandler` cannot parse anyway.
2. **Static client secret.** Apple issues none: the secret is an ES256-signed JWT minted from the Sign in with Apple `.p8` key, valid ≤6 months.

## How

- Swap the hand-rolled `AddOAuth("Apple")` body for **`AspNet.Security.OAuth.Apple` 10.0.0**, which owns the protocol (form_post challenge + POST callback parsing, cached client-secret generation, id-token validation against Apple's published keys). The extension now only wires configuration.
- Config surface: `Authentication:Apple:{ClientId,TeamId,KeyId,PrivateKey}` — `ClientId` is the Services ID; `PrivateKey` is the `.p8` content, accepted as raw PEM, PEM with literal `\n`, base64 of the PEM file, or bare PKCS#8 base64 (`NormalizePrivateKey`). Static `ClientSecret` remains as fallback for an externally minted JWT. Still a no-op without `ClientId`.
- Correlation cookie forced `Secure` (form_post = cross-site POST; same rationale as the Microsoft handler).
- Helm chart: `Authentication__Apple__{ClientId,TeamId,KeyId}` in the portal ConfigMap, `Authentication__Apple__PrivateKey` conditional in the Secret.
- What's New entry included.

## Tests

`AppleAuthenticationTest` (Memex.Portal.Shared.Test, 11 cases): scheme registers with the Apple handler, generated-vs-static secret selection, no-op without ClientId, and every key-normalization shape proven importable via `ECDsa.ImportFromPem` with a real ES256 key. `dotnet build -c Release -warnaserror` clean; `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)