### PR TITLE
NodeType sync owns authored content; compile bookkeeping stays on the mesh

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-02-nodetype-sync-owns-authored-content.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-02-nodetype-sync-owns-authored-content.md
@@ -1,0 +1,20 @@
+---
+Name: GitHub sync now compares what you authored, not compile bookkeeping
+Category: What's New
+Description: Type definitions sync on their authored content and code; compile state stays live on the mesh and out of your repo.
+Icon: Sparkle
+---
+
+# GitHub sync now compares what you authored, not compile bookkeeping
+
+A type definition carries two kinds of data: what you authored (its configuration, sources and
+code) and what the mesh recorded about compiling it (status, timestamps, assembly pointers). The
+sync used to treat both the same, with two bad effects: exported repo files carried a compile
+verdict that was stale the moment the next compile ran, and importing such a file stamped that
+stale verdict back over the live type — which could park the type after a restart and made
+plugin-source deploys need a force-sync followed by manual recompiles.
+
+Now the sync knows the difference. Exports commit only the authored definition, imports always
+keep the live compile state (even from older repos whose files still embed it), and change
+detection compares the authored content — including every code file — so a plain "Update to
+latest" deploys a source-only change correctly, with no force and no recompile ritual.

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -253,6 +253,13 @@ public sealed class GitHubSyncService
     private IObservable<RepoFile?> SerializeOne(
         MeshNode node, string partition, string[] allPaths, Action<string, LogLevel>? progress = null)
     {
+        // A repo file must not carry a compile verdict: the operational members on a NodeType node
+        // (status, assembly pointers, source-version maps) are MESH-owned bookkeeping that would
+        // otherwise ride into git and — being stale the moment the next compile runs — stamp a
+        // stale green back onto any mesh that later imports the file. Export the authored
+        // definition only. (Export-only seam on purpose: the file parsers are shared with the
+        // filesystem persistence backend, which must keep round-tripping the full node.)
+        node = NodeTypeOperationalContent.StripOperational(node, hub.JsonSerializerOptions);
         var serializer = parsers.GetSerializerFor(node);
         if (serializer is null)
         {

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -820,6 +820,14 @@ public static class StaticRepoImporter
                                 CreatedDate = target.CreatedDate,
                                 CreatedBy = target.CreatedBy
                             };
+                        // Mesh-owned compile state stays LIVE: a NodeType file in the repo embeds
+                        // whatever bookkeeping it had when exported, and letting it land regressed
+                        // the live node to a STALE GREEN (an assembly pointer weeks old, "Ok" for a
+                        // compile that never ran against these sources) — correct-looking until a
+                        // cold cache parks the type. The repo owns the authored definition; the
+                        // operational members end up exactly as the mesh last wrote them.
+                        materialized = NodeTypeOperationalContent.PreserveLiveOperational(
+                            materialized, target, hub.JsonSerializerOptions);
                         // 🚨 Per-FILE isolation. A single node's upsert faulting (bad content, a
                         // validator reject, a transient owner timeout) must NOT abort the whole
                         // partition import — the first failure used to propagate through Merge and

--- a/src/MeshWeaver.Mesh.Contract/NodeTypeOperationalContent.cs
+++ b/src/MeshWeaver.Mesh.Contract/NodeTypeOperationalContent.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// The MESH-OWNED (operational) members of a NodeType node's content — the compile bookkeeping the
+/// framework itself persists onto the <c>NodeTypeDefinition</c> as types compile (status,
+/// timestamps, assembly pointers, source-version maps, release-request triggers). These members are
+/// NOT authored content: the repo owns the definition (configuration, sources, description, …); the
+/// mesh owns the compile state. Every seam that moves a NodeType node between a git repo and a live
+/// mesh must honour that split:
+///
+/// <list type="bullet">
+/// <item><b>Export STRIPS them</b> (<see cref="StripOperational"/>) — a repo file must not carry a
+/// stale compile verdict into git.</item>
+/// <item><b>Import PRESERVES the live node's values</b> (<see cref="PreserveLiveOperational"/>) — a
+/// repo import must never regress live compile state to whatever stale copy the file happened to
+/// embed (the "stale green" that claims a weeks-old assembly is current, which parks the type when
+/// the cache is cold).</item>
+/// <item><b>Change detection IGNORES them</b> (<see cref="PartitionSourceFingerprint"/>) — a node
+/// differing only in bookkeeping has not changed.</item>
+/// </list>
+///
+/// <para>This is the transitional ownership rule until the compile state moves off the
+/// NodeTypeDefinition entirely (into the compile activity / a <c>_Compile</c> satellite the sync
+/// never touches); once that lands this class keeps legacy repo files and stored nodes honest.</para>
+/// </summary>
+public static class NodeTypeOperationalContent
+{
+    /// <summary>Whether <paramref name="node"/> is a type-definition node — the one node type whose
+    /// content carries the operational members.</summary>
+    public static bool IsNodeTypeNode(MeshNode? node) =>
+        string.Equals(node?.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal);
+
+    /// <summary>
+    /// The operational members by their serialized (camelCase) names, matched CASE-INSENSITIVELY:
+    /// stored content is camelCased under the hub's naming policy, but writers fall back to the
+    /// PascalCase property name when a hub carries no policy (see <c>StampReleaseRequest</c>), so
+    /// both casings denote the same member. Pinned against the <c>NodeTypeDefinition</c> record by
+    /// <c>NodeTypeOperationalContentTest</c> in the Graph test suite, so the list cannot silently
+    /// drift from the record.
+    /// </summary>
+    public static readonly IReadOnlySet<string> MemberNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "compilationStatus",
+        "compilationError",
+        "compilationDiagnostics",
+        "lastCompileStartedAt",
+        "lastCompileSucceededAt",
+        "lastCompiledVersion",
+        "lastCompilationActivityPath",
+        "latestReleasePath",
+        "requestedReleasePath",
+        "requestedReleaseAt",
+        "requestedReleaseForce",
+        "requestedReleaseBy",
+        "lastReleaseRequestHandledAt",
+        "releaseNotes",
+        "latestAssemblyCollection",
+        "latestAssemblyPath",
+        "compiledSources",
+        "currentSourceVersions",
+        "compiledFrameworkVersion",
+    };
+
+    /// <summary>
+    /// The node with the operational members REMOVED from its content — the shape a repo file (and
+    /// the change-detection token) uses. Non-NodeType nodes, non-object content, and content that
+    /// carries none of the members pass through as the SAME instance (no reshaping).
+    /// </summary>
+    public static MeshNode StripOperational(MeshNode node, JsonSerializerOptions options)
+    {
+        if (!IsNodeTypeNode(node) || ContentObject(node, options) is not { } content)
+            return node;
+        var removed = false;
+        foreach (var key in content.Select(member => member.Key).Where(MemberNames.Contains).ToArray())
+            removed |= content.Remove(key);
+        return removed ? node with { Content = content } : node;
+    }
+
+    /// <summary>
+    /// The INCOMING (repo) node with the LIVE node's operational members carried over — the import
+    /// ownership rule. Authored members come from the repo; each operational member ends up exactly
+    /// as the mesh last wrote it: the live value when the live node has one, ABSENT when it does not
+    /// (a stale value embedded in the file never survives, in either direction). Returns the same
+    /// instance when nothing would change, so an authored-identical import stays a no-op upsert.
+    /// </summary>
+    public static MeshNode PreserveLiveOperational(
+        MeshNode incoming, MeshNode? live, JsonSerializerOptions options)
+    {
+        if (!IsNodeTypeNode(incoming) || live is null
+            || ContentObject(incoming, options) is not { } original)
+            return incoming;
+        var liveContent = ContentObject(live, options);
+        var merged = (JsonObject)original.DeepClone();
+        foreach (var key in merged.Select(member => member.Key).Where(MemberNames.Contains).ToArray())
+            merged.Remove(key);
+        if (liveContent is not null)
+            foreach (var (key, value) in liveContent.Where(member => MemberNames.Contains(member.Key)))
+                merged[key] = value?.DeepClone();
+        return JsonNode.DeepEquals(merged, original) ? incoming : incoming with { Content = merged };
+    }
+
+    /// <summary>
+    /// The node's content as a fresh, mutable <see cref="JsonObject"/>, or null when the content is
+    /// not object-shaped. Typed content serializes with its CONCRETE runtime type — never the
+    /// <c>object</c> overload, whose polymorphic path adopts foreign types into the registry as a
+    /// side effect of a read.
+    /// </summary>
+    private static JsonObject? ContentObject(MeshNode node, JsonSerializerOptions options) =>
+        node.Content switch
+        {
+            null => null,
+            JsonObject jo => (JsonObject)jo.DeepClone(),
+            JsonNode => null,
+            JsonElement je => je.ValueKind == JsonValueKind.Object ? JsonObject.Create(je) : null,
+            var typed => JsonSerializer.SerializeToNode(typed, typed.GetType(), options) as JsonObject,
+        };
+}

--- a/src/MeshWeaver.Mesh.Contract/PartitionSourceFingerprint.cs
+++ b/src/MeshWeaver.Mesh.Contract/PartitionSourceFingerprint.cs
@@ -90,6 +90,15 @@ public static class PartitionSourceFingerprint
     /// </summary>
     private static string NodeContentToken(MeshNode node, JsonSerializerOptions? options)
     {
+        // Mesh-owned compile bookkeeping is NOT source content: a NodeType file whose only diff is
+        // a stale compilationStatus / assembly pointer has not changed — hashing those members made
+        // bookkeeping churn look like authored changes (needless re-imports and recompiles) while
+        // the AUTHORED change signal (configuration, sources, and every Code node's text) is what
+        // this token exists to capture. Changing the token semantics re-hashes every stored
+        // NodeType entry ONCE (the next import re-upserts them); the import-side operational
+        // preserve makes that pass a structural no-op.
+        if (NodeTypeOperationalContent.IsNodeTypeNode(node))
+            node = NodeTypeOperationalContent.StripOperational(node, options ?? DefaultContentOptions);
         var contentJson = node.Content is null
             ? string.Empty
             : JsonSerializer.Serialize(node.Content, options ?? DefaultContentOptions);

--- a/test/MeshWeaver.GitSync.Test/NodeTypeOwnershipSyncTest.cs
+++ b/test/MeshWeaver.GitSync.Test/NodeTypeOwnershipSyncTest.cs
@@ -1,0 +1,102 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.GitSync.Test;
+
+/// <summary>
+/// NodeType content ownership through the FULL sync loop: the repo owns a type's AUTHORED
+/// definition; the mesh owns its compile bookkeeping. Export must strip the bookkeeping from the
+/// committed file, and an import of a legacy file that still embeds a stale copy must take the
+/// authored change while keeping the LIVE compile state — never stamping the file's stale verdict
+/// back onto the mesh (the "stale green" that made every plugin-source deploy on memex a
+/// force-sync + manual-recompile ritual, 2026-08-02).
+/// </summary>
+public class NodeTypeOwnershipSyncTest(ITestOutputHelper output) : GitHubSyncTestBase(output)
+{
+    [Fact(Timeout = 120000)]
+    public async Task Export_StripsBookkeeping_And_Import_KeepsLiveCompileState()
+    {
+        await Connect();
+        var space = "GhN" + Guid.NewGuid().ToString("N")[..8];
+        await CreateSpace(space, "Types");
+
+        // A live NodeType whose content carries authored members AND current compile state.
+        var content = JsonNode.Parse(
+            """
+            {"$type":"NodeTypeDefinition","description":"widget type",
+             "configuration":"config => config","includeGlobalTypes":true,
+             "lastCompiledVersion":1082,"latestAssemblyPath":"Widget/v1082.dll"}
+            """)!.AsObject();
+        await NodeFactory.CreateNode(new MeshNode("Widget", space)
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Name = "Widget",
+            State = MeshNodeState.Active,
+            Content = content,
+        }).Timeout(60.Seconds()).ToTask();
+
+        var repo = "https://github.com/test/space-types";
+        await Sync.SaveConfig(space, repo, "main", subdirectory: null,
+                createBranchIfMissing: true, createRepoIfMissing: true,
+                direction: SyncDirection.Bidirectional, sourceId: null, twoWay: false)
+            .Timeout(30.Seconds()).ToTask();
+        var commit = await Sync.SyncToGitHub(space, UserId).Timeout(60.Seconds()).ToTask();
+        await WaitForConfig(space, c => c.LastSyncCommitSha == commit.CommitSha);
+
+        // EXPORT: the committed file carries the authored definition only — no compile verdict.
+        var tree = Fake.Tree(repo);
+        var file = tree.Single(f => f.Path.EndsWith("Widget.json", StringComparison.Ordinal));
+        var fileContent = JsonNode.Parse(file.Content)!.AsObject()["content"]!.AsObject();
+        Assert.Equal("config => config", (string?)fileContent["configuration"]);
+        Assert.False(fileContent.ContainsKey("lastCompiledVersion"),
+            "the exported file must not carry the compile verdict");
+        Assert.False(fileContent.ContainsKey("latestAssemblyPath"),
+            "the exported file must not carry the assembly pointer");
+
+        // A LEGACY repo file (committed before the strip existed) embeds a STALE verdict next to
+        // a genuine authored change. Seed it as the new HEAD (the fake replaces the whole tree,
+        // so every other exported file rides along unchanged).
+        var edited = JsonNode.Parse(file.Content)!.AsObject();
+        var editedContent = edited["content"]!.AsObject();
+        editedContent["configuration"] = "config => CHANGED";
+        editedContent["lastCompiledVersion"] = 202;
+        editedContent["latestAssemblyPath"] = "Widget/v202.dll";
+        var seeded = tree
+            .Select(f => f.Path == file.Path
+                ? f with { Content = edited.ToJsonString(new JsonSerializerOptions { WriteIndented = true }) }
+                : f)
+            .ToImmutableList();
+        await Fake.Push(new GitHubPushRequest
+        {
+            RepositoryUrl = repo,
+            Branch = "main",
+            Files = seeded,
+            CommitMessage = "legacy file with stale bookkeeping",
+            AuthorName = "test",
+            AuthorEmail = "test@test",
+            AccessToken = "x",
+        }).Timeout(30.Seconds()).ToTask();
+
+        await Sync.ReimportAtCommit(space, "main", UserId).Timeout(90.Seconds()).ToTask();
+
+        // IMPORT: the authored change landed; the live compile state survived; the file's stale
+        // verdict did not.
+        var options = Mesh.JsonSerializerOptions;
+        var updated = await Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => ReadNode($"{space}/Widget"))
+            .Select(n => n?.ContentAs<NodeTypeDefinition>(options))
+            .Where(d => d?.Configuration == "config => CHANGED")
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask();
+        Assert.NotNull(updated);
+        Assert.Equal(1082, updated!.LastCompiledVersion);
+        Assert.Equal("Widget/v1082.dll", updated.LatestAssemblyPath);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/NodeTypeOperationalContentTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeOperationalContentTest.cs
@@ -1,0 +1,226 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the NODE-TYPE CONTENT OWNERSHIP split: the repo owns a NodeType node's AUTHORED definition
+/// (configuration, sources, description, …); the mesh owns its OPERATIONAL compile state (status,
+/// timestamps, assembly pointers, source-version maps, release triggers). The split is enforced at
+/// three seams — export strips the operational members, import preserves the LIVE node's values,
+/// and the change-detection token ignores them entirely.
+///
+/// <para><b>What went wrong without it</b> (memex, 2026-08-02): every GitSync export embedded the
+/// compile bookkeeping into the repo's <c>index.json</c>, and every later import stamped that
+/// stale copy back over the live node — a STALE GREEN claiming a weeks-old assembly was current
+/// (the class that parks a type on the next cold cache), which made every plugin-source deploy a
+/// force-sync + manual-recompile ritual. And because the token hashed the bookkeeping, a repo
+/// diff consisting of nothing but stale bookkeeping re-imported (and recompiled) types whose
+/// authored content never changed.</para>
+/// </summary>
+public class NodeTypeOperationalContentTest
+{
+    private static readonly JsonSerializerOptions CamelCase =
+        new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    private static MeshNode TypeNode(object? content) =>
+        new("Plugin", "Store") { NodeType = MeshNode.NodeTypePath, Name = "Plugin", Content = content };
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    // ── The member list is pinned to the record ─────────────────────────────────────────────
+
+    [Fact]
+    public void EveryOperationalMember_IsARealNodeTypeDefinitionProperty()
+    {
+        var properties = typeof(NodeTypeDefinition).GetProperties()
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var member in NodeTypeOperationalContent.MemberNames)
+            Assert.True(properties.Contains(member),
+                $"'{member}' is listed as operational but is not a NodeTypeDefinition property — "
+                + "the list drifted from the record.");
+    }
+
+    [Fact]
+    public void AuthoredMembers_AreNeverListedAsOperational()
+    {
+        // The authored surface — what the repo owns. If one of these ever lands in MemberNames,
+        // imports would stop honouring the repo for it (silently).
+        string[] authored =
+        [
+            nameof(NodeTypeDefinition.Description), nameof(NodeTypeDefinition.Configuration),
+            nameof(NodeTypeDefinition.HubConfiguration), nameof(NodeTypeDefinition.Sources),
+            nameof(NodeTypeDefinition.Tests), nameof(NodeTypeDefinition.IncludeGlobalTypes),
+            nameof(NodeTypeDefinition.Dependencies), nameof(NodeTypeDefinition.DefaultNamespace),
+            nameof(NodeTypeDefinition.RestrictedToNamespaces), nameof(NodeTypeDefinition.CreatableTypes),
+        ];
+        foreach (var member in authored)
+            Assert.False(NodeTypeOperationalContent.MemberNames.Contains(member),
+                $"'{member}' is authored content and must never be masked as operational.");
+    }
+
+    // ── Strip (the export / token shape) ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Strip_RemovesOperationalMembers_KeepsAuthoredOnes()
+    {
+        var node = TypeNode(Parse(
+            """
+            {"$type":"NodeTypeDefinition","description":"d","configuration":"config => config",
+             "sources":["namespace:Source scope:subtree"],"includeGlobalTypes":true,
+             "compilationStatus":"Ok","lastCompiledVersion":202,
+             "latestAssemblyPath":"Store_Plugin/v202.dll","compiledSources":{"a":1}}
+            """));
+        var stripped = NodeTypeOperationalContent.StripOperational(node, CamelCase);
+        var content = Assert.IsType<JsonObject>(stripped.Content);
+        Assert.False(content.ContainsKey("compilationStatus"));
+        Assert.False(content.ContainsKey("lastCompiledVersion"));
+        Assert.False(content.ContainsKey("latestAssemblyPath"));
+        Assert.False(content.ContainsKey("compiledSources"));
+        Assert.Equal("config => config", (string?)content["configuration"]);
+        Assert.Equal("d", (string?)content["description"]);
+        Assert.True((bool?)content["includeGlobalTypes"]);
+    }
+
+    [Fact]
+    public void Strip_HandlesTypedContent_WhateverTheNamingPolicy()
+    {
+        // Typed content serialized WITHOUT a camelCase policy emits PascalCase members — the
+        // match is case-insensitive so both casings denote the same member.
+        var node = TypeNode(new NodeTypeDefinition
+        {
+            Configuration = "config => config",
+            CompilationStatus = CompilationStatus.Ok,
+            LatestAssemblyPath = "Store_Plugin/v202.dll",
+        });
+        var stripped = NodeTypeOperationalContent.StripOperational(node, new JsonSerializerOptions());
+        var content = Assert.IsType<JsonObject>(stripped.Content);
+        Assert.DoesNotContain(content, member =>
+            NodeTypeOperationalContent.MemberNames.Contains(member.Key));
+        Assert.Contains(content, member =>
+            string.Equals(member.Key, "Configuration", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Strip_LeavesOtherNodesAndCleanContentAlone()
+    {
+        var markdown = new MeshNode("Guide", "Chess") { NodeType = "Markdown", Content = Parse(
+            """{"$type":"MarkdownContent","content":"# hi","compilationStatus":"not-a-real-member"}""") };
+        Assert.Same(markdown, NodeTypeOperationalContent.StripOperational(markdown, CamelCase));
+
+        var clean = TypeNode(Parse("""{"$type":"NodeTypeDefinition","configuration":"c"}"""));
+        Assert.Same(clean, NodeTypeOperationalContent.StripOperational(clean, CamelCase));
+    }
+
+    // ── Preserve (the import ownership rule) ────────────────────────────────────────────────
+
+    [Fact]
+    public void Preserve_LiveOperationalStateWins_AuthoredComesFromTheRepo()
+    {
+        // The repo file embeds a STALE verdict (v202, weeks old); the live node has the current
+        // one (v1082). The import must take the repo's authored change and keep the live state.
+        var incoming = TypeNode(Parse(
+            """
+            {"$type":"NodeTypeDefinition","configuration":"config => NEW",
+             "compilationStatus":"Ok","lastCompiledVersion":202,"latestAssemblyPath":"v202.dll"}
+            """));
+        var live = TypeNode(Parse(
+            """
+            {"$type":"NodeTypeDefinition","configuration":"config => OLD",
+             "compilationStatus":"Ok","lastCompiledVersion":1082,"latestAssemblyPath":"v1082.dll",
+             "currentSourceVersions":{"Store/Plugin/Source/PluginGate":639209062054682760}}
+            """));
+        var merged = NodeTypeOperationalContent.PreserveLiveOperational(incoming, live, CamelCase);
+        var content = Assert.IsType<JsonObject>(merged.Content);
+        Assert.Equal("config => NEW", (string?)content["configuration"]);
+        Assert.Equal(1082, (long?)content["lastCompiledVersion"]);
+        Assert.Equal("v1082.dll", (string?)content["latestAssemblyPath"]);
+        Assert.True(content.ContainsKey("currentSourceVersions"));
+    }
+
+    [Fact]
+    public void Preserve_DropsStaleMembers_TheLiveNodeDoesNotCarry()
+    {
+        // A live node that never compiled must not inherit the file's stale verdict.
+        var incoming = TypeNode(Parse(
+            """{"$type":"NodeTypeDefinition","configuration":"c","compilationStatus":"Ok","latestAssemblyPath":"v202.dll"}"""));
+        var live = TypeNode(Parse("""{"$type":"NodeTypeDefinition","configuration":"c-old"}"""));
+        var merged = NodeTypeOperationalContent.PreserveLiveOperational(incoming, live, CamelCase);
+        var content = Assert.IsType<JsonObject>(merged.Content);
+        Assert.False(content.ContainsKey("compilationStatus"));
+        Assert.False(content.ContainsKey("latestAssemblyPath"));
+        Assert.Equal("c", (string?)content["configuration"]);
+    }
+
+    [Fact]
+    public void Preserve_IsAnIdentityWhenNothingWouldChange()
+    {
+        // Same operational members, same values → the SAME instance comes back, so an
+        // authored-identical import stays a structural no-op upsert (no churn, no version bump).
+        var json = """{"$type":"NodeTypeDefinition","configuration":"c","compilationStatus":"Ok"}""";
+        var incoming = TypeNode(Parse(json));
+        var live = TypeNode(Parse(json));
+        Assert.Same(incoming, NodeTypeOperationalContent.PreserveLiveOperational(incoming, live, CamelCase));
+
+        // No live node (a create) and non-NodeType nodes pass through untouched.
+        Assert.Same(incoming, NodeTypeOperationalContent.PreserveLiveOperational(incoming, null, CamelCase));
+    }
+
+    // ── The change-detection token ignores the operational members ──────────────────────────
+
+    [Fact]
+    public void NodeToken_IgnoresOperationalChurn_SeesAuthoredChanges()
+    {
+        var clean = TypeNode(Parse("""{"$type":"NodeTypeDefinition","configuration":"c","sources":["s"]}"""));
+        var churned = TypeNode(Parse(
+            """
+            {"$type":"NodeTypeDefinition","configuration":"c","sources":["s"],
+             "compilationStatus":"Ok","lastCompileSucceededAt":"2026-07-19T13:07:45Z",
+             "lastCompiledVersion":202,"compiledSources":{"a":1}}
+            """));
+        var authored = TypeNode(Parse("""{"$type":"NodeTypeDefinition","configuration":"CHANGED","sources":["s"]}"""));
+
+        Assert.Equal(
+            PartitionSourceFingerprint.ComputeNodeToken(clean, CamelCase),
+            PartitionSourceFingerprint.ComputeNodeToken(churned, CamelCase));
+        Assert.NotEqual(
+            PartitionSourceFingerprint.ComputeNodeToken(clean, CamelCase),
+            PartitionSourceFingerprint.ComputeNodeToken(authored, CamelCase));
+    }
+
+    [Fact]
+    public void CodeNodes_StillCompareByTheirFullText()
+    {
+        // "Compare all code": a Code node's token is its content — a one-character source edit
+        // must change it (this is what re-imports a type whose ONLY change is in Source/*.cs).
+        MeshNode Code(string text) => new("CouponRedemption", "Store/Plugin/Source")
+        {
+            NodeType = "Code",
+            Content = Parse($$"""{"$type":"CodeConfiguration","code":{{JsonSerializer.Serialize(text)}},"language":"csharp"}"""),
+        };
+        Assert.NotEqual(
+            PartitionSourceFingerprint.ComputeNodeToken(Code("class A { }"), CamelCase),
+            PartitionSourceFingerprint.ComputeNodeToken(Code("class A { int x; }"), CamelCase));
+        Assert.Equal(
+            PartitionSourceFingerprint.ComputeNodeToken(Code("class A { }"), CamelCase),
+            PartitionSourceFingerprint.ComputeNodeToken(Code("class A { }"), CamelCase));
+    }
+
+    [Fact]
+    public void PartitionFingerprint_IsStableAcrossOperationalChurn()
+    {
+        var content = Parse("""{"$type":"NodeTypeDefinition","configuration":"c"}""");
+        var churned = Parse(
+            """{"$type":"NodeTypeDefinition","configuration":"c","compilationStatus":"Ok","lastCompiledVersion":7}""");
+        var fresh = PartitionSourceFingerprint.Compute(
+            [TypeNode(content)], versioned: false, CamelCase);
+        var afterChurn = PartitionSourceFingerprint.Compute(
+            [TypeNode(churned)], versioned: false, CamelCase);
+        Assert.Equal(fresh, afterChurn);
+    }
+}


### PR DESCRIPTION
## The defect (memex, 2026-08-02)

A NodeType node's content mixes the repo-authored definition (configuration, sources, description) with mesh-owned compile bookkeeping (`compilationStatus`, `latestAssemblyPath`, `compiledSources`, …). The sync treated both alike:

- **Export** committed a compile verdict into git — stale the moment the next compile ran.
- **Import** stamped that stale copy back over the live node — a **stale green** claiming a weeks-old assembly is current (the class that parks a type on a cold cache). Operationally this made every plugin-source deploy a **force-sync + manual recompile of every touched type** (today's Store/Chess deploys, live evidence: `Store/Plugin` regressed to a 2026-07-19 v202 verdict by a force import).
- **Change detection** hashed the bookkeeping, so bookkeeping-only diffs read as authored changes.

## The fix — inside the existing import logic, no parallel comparison mechanism

`NodeTypeOperationalContent` (Mesh.Contract) is the ownership split; the three seams consume it:

| Seam | Rule |
|---|---|
| `GitHubSyncService.SerializeOne` (export) | **Strip** operational members — repo files carry the authored definition only. Export-only seam: the file parsers stay shared with filesystem persistence, which must round-trip full nodes. |
| `StaticRepoImporter` (import, incl. force) | **Preserve** the live node's operational members — authored changes land, live compile state stays exactly as the mesh last wrote it, stale embedded copies never land. Authored-identical imports return the same instance → structural no-op upserts. |
| `PartitionSourceFingerprint` (per-node manifest token + partition fingerprint) | **Ignore** operational members — authored content only, and every `Code` node still hashes its full text ("compare all code"). Existing NodeType manifest entries re-hash once; the preserve rule makes that pass write-free. |

Member matching is case-insensitive (stored content is camelCased; writers fall back to PascalCase on hubs without a naming policy — see `StampReleaseRequest`); the member list is pinned against the `NodeTypeDefinition` record by test.

Transitional by design: #748 tracks moving the compile state off the NodeTypeDefinition entirely (compile activity + `_Compile` satellite); this PR keeps legacy repo files and stored nodes honest meanwhile and remains correct after the move.

## Verification

- 11 unit cases (`NodeTypeOperationalContentTest`): strip/preserve/token semantics, typed + degraded-JSON shapes, both naming policies, record pinning both directions.
- Full-loop `NodeTypeOwnershipSyncTest` (fake GitHub): export strips; a legacy stale file imports with the authored change landing and the live compile state kept.
- `MeshWeaver.GitSync.Test` 143/143 · `MeshWeaver.Graph.Test` 773/773 · full solution `-c Release -warnaserror` clean.

What's New entry included (deploys of source-only changes work with a plain Update — no force, no recompile ritual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)