### PR TITLE
CLI harnesses are opt-in per user: install-gated out of the global catalog

### DIFF
--- a/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeHarness.cs
+++ b/src/MeshWeaver.AI.ClaudeCode/ClaudeCodeHarness.cs
@@ -35,7 +35,12 @@ public sealed class ClaudeCodeHarness(IOptions<ClaudeCodeConfiguration> options)
         // icon-allowlist plumbing. The renderer treats an Icon starting with '<' as raw markup.
         Icon = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><rect width='20' height='20' rx='4' fill='#D97757'/><g stroke='#fff' stroke-width='1.4' stroke-linecap='round'><line x1='10' y1='3.6' x2='10' y2='16.4'/><line x1='3.6' y1='10' x2='16.4' y2='10'/><line x1='5.5' y1='5.5' x2='14.5' y2='14.5'/><line x1='14.5' y1='5.5' x2='5.5' y2='14.5'/><line x1='7' y1='4.2' x2='13' y2='15.8'/><line x1='13' y1='4.2' x2='7' y2='15.8'/></g></svg>",
         Order = 1,
-        SupportsAgentSelection = false
+        SupportsAgentSelection = false,
+        // Not in the global catalog: needs a per-user Claude subscription login, so it is
+        // installed per user from the Store (localized into {user}/Harness) — never offered
+        // to users who haven't opted in (a fresh user hitting "Not logged in" was the
+        // 2026-08-01 onboarding-confusion root).
+        RequiresInstall = true
     };
 
     // Claude Code owns its auth slash-commands: /login (re)authenticates the user's Claude

--- a/src/MeshWeaver.AI.Copilot/CopilotHarness.cs
+++ b/src/MeshWeaver.AI.Copilot/CopilotHarness.cs
@@ -31,7 +31,11 @@ public sealed class CopilotHarness(IOptions<CopilotConfiguration> options) : IHa
         // Inline SVG (single-quoted attrs) — travels WITH the node; no /static file or allowlist plumbing.
         Icon = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><rect width='20' height='20' rx='4' fill='#24292e'/><g fill='#fff'><path d='M4.6 11.2c0-2.1 1.3-3.3 2.8-3.3.9 0 1.5.6 2.6.6s1.7-.6 2.6-.6c1.5 0 2.8 1.2 2.8 3.3 0 2.4-2 3.9-5.4 3.9s-5.4-1.5-5.4-3.9z'/><path d='M9.3 6.6c0-1 .3-2 .7-2 .4 0 .7 1 .7 2' stroke='#fff' stroke-width='1' fill='none' stroke-linecap='round'/></g><ellipse cx='8' cy='11.3' rx='1.05' ry='1.5' fill='#24292e'/><ellipse cx='12' cy='11.3' rx='1.05' ry='1.5' fill='#24292e'/></svg>",
         Order = 2,
-        SupportsAgentSelection = false
+        SupportsAgentSelection = false,
+        // Not in the global catalog: needs a per-user GitHub Copilot login, so it is
+        // installed per user from the Store (localized into {user}/Harness) — same
+        // opt-in contract as Claude Code.
+        RequiresInstall = true
     };
 
     // Copilot owns its auth slash-commands: /login runs the GitHub device-flow login via the Connect

--- a/src/MeshWeaver.AI/BuiltInHarnessProvider.cs
+++ b/src/MeshWeaver.AI/BuiltInHarnessProvider.cs
@@ -36,7 +36,12 @@ public sealed class BuiltInHarnessProvider(IEnumerable<IHarness> harnesses) : IS
             }
         };
 
-        foreach (var harness in harnesses.OrderBy(h => h.Definition.Order))
+        // RequiresInstall harnesses (the CLI ones) are NOT shipped in the global catalog: a Store
+        // plugin localizes their node into {user}/Harness on install, and the picker's registry
+        // union (namespace:{user}/Harness|{space}/Harness|Harness) surfaces it for that user only.
+        // Dropping them here also PRUNES the previously-shipped global rows on the DB-synced path:
+        // HarnessStaticRepoSource syncs Additive, which removes nodes the build previously owned.
+        foreach (var harness in harnesses.Where(h => !h.Definition.RequiresInstall).OrderBy(h => h.Definition.Order))
         {
             var def = harness.Definition;
             yield return new MeshNode(def.Id, HarnessNodeType.RootNamespace)

--- a/src/MeshWeaver.AI/Harness.cs
+++ b/src/MeshWeaver.AI/Harness.cs
@@ -44,6 +44,17 @@ public record Harness
     /// harnesses run their own agent loop, so they hide the agent/model pickers.
     /// </summary>
     public bool SupportsAgentSelection { get; init; }
+
+    /// <summary>
+    /// True when this harness is NOT shipped in the global <c>Harness</c> catalog and must be
+    /// installed per user (a Store plugin localizes the harness node into <c>{user}/Harness</c>)
+    /// before it appears in that user's picker. The CLI harnesses (Claude Code / GitHub Copilot)
+    /// set this: they need a per-user subscription login, so offering them to every user by
+    /// default only produces "Not logged in" dead ends. Execution verifies the picked node
+    /// still exists (<see cref="HarnessNodeType.ResolveInstalledHarness"/>), so an uninstall
+    /// revokes the harness even for composers that already selected it.
+    /// </summary>
+    public bool RequiresInstall { get; init; }
 }
 
 /// <summary>

--- a/src/MeshWeaver.AI/HarnessNodeType.cs
+++ b/src/MeshWeaver.AI/HarnessNodeType.cs
@@ -1,8 +1,12 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.AI;
 
@@ -85,6 +89,45 @@ public static class HarnessNodeType
             ? null
             : services.GetServices<IHarness>()
                 .FirstOrDefault(h => string.Equals(h.Id, id, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>How long the install probe waits for the picked harness node before treating the
+    /// harness as not installed (graceful fallback to the default agent path — never a wedge).</summary>
+    public static readonly TimeSpan InstallProbeTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Resolves the harness for a round AND enforces the per-user install contract: a
+    /// <see cref="Harness.RequiresInstall"/> harness (the CLI ones) runs only when the picked node
+    /// path — <c>{user}/Harness/{id}</c> or <c>{space}/Harness/{id}</c>, localized there by its
+    /// Store plugin — still resolves to an Active node. A missing/deleted node (never installed,
+    /// uninstalled, or a stale global <c>Harness/{id}</c> path from before the catalog gate) emits
+    /// <c>null</c>, which execution treats exactly like an unresolvable harness: log + fall back to
+    /// the default MeshWeaver agent path. The probe is one read off the shared
+    /// <c>IMeshNodeStreamCache</c> handle, bounded by <see cref="InstallProbeTimeout"/> with a
+    /// graceful <c>null</c> sink — a stalled probe degrades, it never wedges the round.
+    /// </summary>
+    public static IObservable<IHarness?> ResolveInstalledHarness(
+        IMessageHub hub, string? harnessPath, ILogger? logger = null)
+    {
+        var harness = ResolveHarness(hub.ServiceProvider, harnessPath);
+        if (harness is null || !harness.Definition.RequiresInstall)
+            return Observable.Return(harness);
+
+        return Observable.Defer(() => hub.GetWorkspace()
+                .GetMeshNodeStream(harnessPath!)
+                .Where(node => node is not null)
+                .Take(1)
+                .Timeout(InstallProbeTimeout)
+                .Select(node => node is { State: MeshNodeState.Active } ? harness : null))
+            .Catch<IHarness?, Exception>(_ => Observable.Return<IHarness?>(null))
+            .Do(resolved =>
+            {
+                if (resolved is null)
+                    logger?.LogWarning(
+                        "[Harness] '{Harness}' requires install but no Active node exists at the picked "
+                        + "path — not installed (or uninstalled); falling back to the default agent path",
+                        harnessPath);
+            });
     }
 
     /// <summary>The type-definition node for nodeType="Harness".</summary>

--- a/src/MeshWeaver.AI/HarnessNodeType.cs
+++ b/src/MeshWeaver.AI/HarnessNodeType.cs
@@ -118,15 +118,27 @@ public static class HarnessNodeType
                 .Where(node => node is not null)
                 .Take(1)
                 .Timeout(InstallProbeTimeout)
-                .Select(node => node is { State: MeshNodeState.Active } ? harness : null))
-            .Catch<IHarness?, Exception>(_ => Observable.Return<IHarness?>(null))
-            .Do(resolved =>
-            {
-                if (resolved is null)
+                .Select(node =>
+                {
+                    if (node is { State: MeshNodeState.Active })
+                        return harness;
                     logger?.LogWarning(
-                        "[Harness] '{Harness}' requires install but no Active node exists at the picked "
-                        + "path — not installed (or uninstalled); falling back to the default agent path",
+                        "[Harness] '{Harness}' requires install but the picked node is not Active — "
+                        + "not installed (or uninstalled); falling back to the default agent path",
                         harnessPath);
+                    return (IHarness?)null;
+                }))
+            // The graceful degrade sink — a Timeout here just means "no such node" (never
+            // installed, or a stale pre-gate global path); anything else (denied read, a
+            // stalled stream) is logged WITH the exception so production diagnosis isn't
+            // reduced to a misleading "not installed".
+            .Catch<IHarness?, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "[Harness] install probe for '{Harness}' failed or timed out — treating as "
+                    + "not installed; falling back to the default agent path",
+                    harnessPath);
+                return Observable.Return<IHarness?>(null);
             });
     }
 

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -953,6 +953,10 @@ internal static class ThreadExecution
         // stripping the path here defeated it. Keep the model path; the resolver collapses it to the
         // wire id at the exact node. (The cell-stamp display name is normalized to the short name at
         // write time in PushToResponseMessage, so the persisted friendly name is unaffected.)
+        // The ORIGINAL picked harness node path ({user}/Harness/{id} after a Store install,
+        // Harness/{id} for the global catalog) — the install gate probes THIS node; the
+        // id-normalization below erases it from request.Harness.
+        var pickedHarnessPath = request.Harness;
         request = request with
         {
             ModelName = request.ModelName,
@@ -1367,8 +1371,15 @@ internal static class ThreadExecution
                 // revokes it. Resolved reactively BEFORE the round body; a refused/missing node
                 // yields null, which the body treats exactly like an unresolvable harness:
                 // graceful fallback to the default agent path (ResolveInstalledHarness logs why).
+                // 🚨 Probe the PICKED PATH, never request.Harness: the top-of-method
+                // normalization collapsed request.Harness to the bare id, which as a path is a
+                // partition ROOT — probing it would license the harness off the wrong node. A
+                // recovered request may carry its own full path; prefer it over the capture.
                 .SelectMany(initClient => HarnessNodeType
-                    .ResolveInstalledHarness(parentHub, request.Harness, logger)
+                    .ResolveInstalledHarness(
+                        parentHub,
+                        request.Harness is { } rh && rh.Contains('/') ? rh : pickedHarnessPath,
+                        logger)
                     .Select(installedHarness => (Client: initClient, InstalledHarness: installedHarness)))
                 .SelectMany(init =>
                 {

--- a/src/MeshWeaver.AI/ThreadExecution.cs
+++ b/src/MeshWeaver.AI/ThreadExecution.cs
@@ -1361,8 +1361,18 @@ internal static class ThreadExecution
             return chatClient.WhenInitialized
                 .Take(1)
                 .Timeout(TimeSpan.FromSeconds(60))
-                .SelectMany(client =>
+                // 🚦 Per-user install gate: a RequiresInstall harness (the CLI ones) runs only
+                // while its PICKED node ({user}/Harness/{id}, localized by its Store plugin) is
+                // still Active — so an uninstall (or a stale pre-gate global Harness/{id} path)
+                // revokes it. Resolved reactively BEFORE the round body; a refused/missing node
+                // yields null, which the body treats exactly like an unresolvable harness:
+                // graceful fallback to the default agent path (ResolveInstalledHarness logs why).
+                .SelectMany(initClient => HarnessNodeType
+                    .ResolveInstalledHarness(parentHub, request.Harness, logger)
+                    .Select(installedHarness => (Client: initClient, InstalledHarness: installedHarness)))
+                .SelectMany(init =>
                 {
+                var client = init.Client;
                 logger.LogDebug("[ThreadExec] Agents ready for {ThreadPath}, starting execution", threadPath);
 
                 // 🚦 Harness dispatch. A harness is NOT a model provider: Claude Code /
@@ -1371,7 +1381,7 @@ internal static class ThreadExecution
                 // The MeshWeaver harness returns null → keep the agent/model client.
                 // This is the fix for "harness selected → Azure DeploymentNotFound":
                 // the round no longer routes a harness through a provider.
-                var selectedHarness = HarnessNodeType.ResolveHarness(parentHub.ServiceProvider, request.Harness);
+                var selectedHarness = init.InstalledHarness;
                 // CLI harnesses (Claude Code / Copilot) return their own IChatClient;
                 // the MeshWeaver harness returns null → use the AgentChatClient (which
                 // has its own non-IChatClient streaming signature). harnessClient stays
@@ -1380,8 +1390,10 @@ internal static class ThreadExecution
                 // say it was NOT FOUND (a stale/renamed id, e.g. an old "Claude Code" path before
                 // the slug fix, or a CLI harness whose feature flag is off). Fall back to the
                 // default agent path rather than crashing or silently ignoring it. (Empty harness
-                // ⇒ no selection ⇒ default; not a "not found".)
-                if (selectedHarness is null && !string.IsNullOrEmpty(request.Harness))
+                // ⇒ no selection ⇒ default; not a "not found". The not-INSTALLED case is logged by
+                // ResolveInstalledHarness, so the unregistered check re-resolves to not double-log.)
+                if (selectedHarness is null && !string.IsNullOrEmpty(request.Harness)
+                    && HarnessNodeType.ResolveHarness(parentHub.ServiceProvider, request.Harness) is null)
                     logger.LogWarning(
                         "[ThreadExec] Harness '{Harness}' not found (no registered IHarness with that id) for " +
                         "{ThreadPath} — falling back to the default agent path", request.Harness, threadPath);

--- a/src/MeshWeaver.Documentation/Data/Architecture/FeatureFlags.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/FeatureFlags.md
@@ -52,8 +52,8 @@ Configuration is layered (last wins):
 | `Features:Ai:Providers:AzureFoundry` | bool | `true` | Ships the Azure AI Foundry provider. |
 | `Features:Ai:Providers:AzureOpenAI` | bool | `true` | Ships the Azure OpenAI provider. |
 | `Features:Ai:Providers:OpenAI` | bool | `true` | Ships the OpenAI provider. |
-| `Features:Ai:Clis:ClaudeCode` | bool | `true` | Ships the co-hosted Claude Code CLI provider (per-user Connect login). |
-| `Features:Ai:Clis:Copilot` | bool | `true` | Ships the co-hosted GitHub Copilot CLI provider. |
+| `Features:Ai:Clis:ClaudeCode` | bool | `true` | Deploys the co-hosted Claude Code CLI **runtime** (per-user Connect login). The harness is NOT offered to users by default: its catalog node is install-gated (`Harness.RequiresInstall`) — a user opts in by installing the Claude Code plugin from the Store, which localizes the harness node into `{user}/Harness`. |
+| `Features:Ai:Clis:Copilot` | bool | `true` | Deploys the co-hosted GitHub Copilot CLI **runtime**. Same per-user install gate as Claude Code. |
 | `Features:Onboarding:AllowSelfOnboarding` | bool | `true` | When `false`, registration is **closed** — only the first-ever user may onboard. |
 | `Features:Onboarding:InvitationOnly` | bool | `false` | When `true`, only an email with a Pending invitation may onboard. See [Invitation-Only Onboarding](/Doc/Architecture/InvitationOnlyOnboarding). |
 | `Features:Orleans:Clustering` | string | `AzureTables` | Cluster-membership provider: `AzureTables`, `AdoNet` (PostgreSQL), or `Localhost` (single in-process silo; dev only). |

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-02-cli-harnesses-opt-in.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-02-cli-harnesses-opt-in.md
@@ -1,0 +1,18 @@
+---
+Name: Claude Code and GitHub Copilot are now opt-in per user
+Category: What's New
+Description: The CLI harnesses no longer appear in everyone's chat picker by default — install them from the Store when you want them; uninstalling removes them again.
+Icon: Sparkle
+---
+
+# Claude Code and GitHub Copilot are now opt-in per user
+
+The Claude Code and GitHub Copilot execution harnesses require a personal subscription login — offering them to every user by default only produced confusing "Not logged in" dead ends for people who had never chosen them.
+
+They are now install-gated per user:
+
+- **By default**, the chat's harness picker offers the native MeshWeaver harness only. Nobody lands on a CLI harness without asking for it.
+- **Opting in** is a Store install: installing the Claude Code (or GitHub Copilot) plugin places the harness in *your* picker only, ready for `/login`.
+- **Uninstalling** removes it again — including for threads that had already selected it, which fall back gracefully to the standard agent path instead of erroring.
+
+Existing threads or composers still pointing at a CLI harness they no longer have simply run on the default harness; nothing breaks.

--- a/test/MeshWeaver.AI.Test/HarnessInstallGateTest.cs
+++ b/test/MeshWeaver.AI.Test/HarnessInstallGateTest.cs
@@ -1,0 +1,111 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using MeshWeaver.AI;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// The per-user install gate for <see cref="Harness.RequiresInstall"/> harnesses (the CLI ones):
+/// <see cref="HarnessNodeType.ResolveInstalledHarness"/> runs such a harness only while the picked
+/// node path resolves to an Active node — the node a Store plugin localizes into
+/// <c>{user}/Harness</c> on install and deletes on uninstall. No node (never installed,
+/// uninstalled, or a stale pre-gate global <c>Harness/{id}</c> path) resolves to <c>null</c>, which
+/// execution treats as "fall back to the default agent path" — a graceful degrade, never a wedge.
+/// </summary>
+public class HarnessInstallGateTest : AITestBase
+{
+    public HarnessInstallGateTest(ITestOutputHelper output) : base(output) { }
+
+    protected override bool ShareMeshAcrossTests => true;
+
+    private const string GatedId = "GatedCli";
+
+    private sealed class GatedCliHarness : IHarness
+    {
+        public string Id => GatedId;
+        public Harness Definition => new()
+        {
+            Id = GatedId, DisplayName = "Gated CLI", Order = 9,
+            SupportsAgentSelection = false, RequiresInstall = true
+        };
+        public IChatClient? CreateChatClient(HarnessExecutionContext context) => null;
+    }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IHarness, GatedCliHarness>();
+                return services;
+            });
+
+    // The client needs the data/layout wiring for GetWorkspace().GetMeshNodeStream(path) —
+    // the same surface ThreadExecution's parentHub has in prod (see ThreadComposerFlowTest).
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+    {
+        configuration.TypeRegistry.AddAITypes();
+        return base.ConfigureClient(configuration).AddLayoutClient();
+    }
+
+    /// <summary>Not installed: the picked path has no node → null → default agent path.</summary>
+    [Fact(Timeout = 30000)]
+    public async Task RequiresInstall_WithoutInstalledNode_ResolvesNull()
+    {
+        var hub = GetClient();
+        // The absent-node case emits only after the InstallProbeTimeout elapses — give the
+        // assertion strictly more than that so it never races the probe.
+        var resolved = await HarnessNodeType
+            .ResolveInstalledHarness(hub, $"{MonolithMeshTestBase.TestPartition}/Harness/{GatedId}")
+            .Should().Within(HarnessNodeType.InstallProbeTimeout + TimeSpan.FromSeconds(10)).Emit();
+        resolved.Should().BeNull(
+            "a RequiresInstall harness without its installed node must fall back — this is what " +
+            "makes uninstall (and the pre-gate stale global path) actually revoke the harness");
+    }
+
+    /// <summary>Installed: the localized node exists in the user/space partition → the harness runs.</summary>
+    [Fact(Timeout = 30000)]
+    public async Task RequiresInstall_WithInstalledNode_ResolvesHarness()
+    {
+        var hub = GetClient();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        // The node the Store plugin's install localizes into the viewer's partition.
+        var installed = new MeshNode(GatedId, $"{MonolithMeshTestBase.TestPartition}/Harness")
+        {
+            NodeType = HarnessNodeType.NodeType,
+            Name = "Gated CLI",
+            State = MeshNodeState.Active,
+            Content = new Harness
+            {
+                Id = GatedId, DisplayName = "Gated CLI", Order = 9, RequiresInstall = true
+            }
+        };
+        await meshService.CreateNode(installed).Should().Emit();
+
+        var resolved = await HarnessNodeType
+            .ResolveInstalledHarness(hub, installed.Path)
+            .Should().Emit();
+        resolved.Should().NotBeNull("the installed node is what licenses the harness for this user");
+        resolved!.Id.Should().Be(GatedId);
+    }
+
+    /// <summary>A non-gated harness (MeshWeaver) resolves with no node probe at all.</summary>
+    [Fact(Timeout = 30000)]
+    public async Task NonGatedHarness_ResolvesWithoutProbe()
+    {
+        var hub = GetClient();
+        var resolved = await HarnessNodeType
+            .ResolveInstalledHarness(hub, $"{HarnessNodeType.RootNamespace}/{Harnesses.MeshWeaver}")
+            .Should().Emit();
+        resolved.Should().BeOfType<MeshWeaverHarness>(
+            "the default harness needs no install and must resolve immediately");
+    }
+}

--- a/test/MeshWeaver.AI.Test/HarnessInstallGateTest.cs
+++ b/test/MeshWeaver.AI.Test/HarnessInstallGateTest.cs
@@ -1,6 +1,9 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
+using System.Runtime.CompilerServices;
+using System.Reactive.Linq;
 using MeshWeaver.AI;
+using MeshWeaver.Data;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh;
@@ -9,6 +12,7 @@ using MeshWeaver.Messaging;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using MeshThread = MeshWeaver.AI.Thread;
 
 namespace MeshWeaver.AI.Test;
 
@@ -27,6 +31,7 @@ public class HarnessInstallGateTest : AITestBase
     protected override bool ShareMeshAcrossTests => true;
 
     private const string GatedId = "GatedCli";
+    private const string HarnessAck = "GATED HARNESS RAN";
 
     private sealed class GatedCliHarness : IHarness
     {
@@ -36,7 +41,61 @@ public class HarnessInstallGateTest : AITestBase
             Id = GatedId, DisplayName = "Gated CLI", Order = 9,
             SupportsAgentSelection = false, RequiresInstall = true
         };
-        public IChatClient? CreateChatClient(HarnessExecutionContext context) => null;
+        // A distinctive client so a round-level test can tell WHICH path answered:
+        // the harness ack vs the FakeChatClientFactory's agent-path ack.
+        public IChatClient? CreateChatClient(HarnessExecutionContext context) => new AckChatClient(HarnessAck);
+    }
+
+    private sealed class AckChatClient(string ack) : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, ack)));
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            yield return new ChatResponseUpdate(ChatRole.Assistant, ack);
+            await Task.Yield();
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(IChatClient) ? this : null;
+
+        public void Dispose() { }
+    }
+
+    private sealed class FakeChatClientFactory : IChatClientFactory
+    {
+        public const string AgentAck = "agent path ack";
+        public string Name => "FakeFactory";
+        public IReadOnlyList<string> Models => ["fake-model"];
+        public int Order => 0;
+
+        public Microsoft.Agents.AI.ChatClientAgent CreateAgent(
+            AgentConfiguration config,
+            IAgentChat chat,
+            IReadOnlyDictionary<string, Microsoft.Agents.AI.ChatClientAgent> existingAgents,
+            IReadOnlyList<AgentConfiguration> hierarchyAgents,
+            string? modelName = null)
+            => new(
+                chatClient: new AckChatClient(AgentAck),
+                instructions: config.Instructions ?? "You are a fake test assistant.",
+                name: config.Id,
+                description: config.Description ?? config.Id,
+                tools: [],
+                loggerFactory: null,
+                services: null);
+
+        public Task<Microsoft.Agents.AI.ChatClientAgent> CreateAgentAsync(
+            AgentConfiguration config,
+            IAgentChat chat,
+            IReadOnlyDictionary<string, Microsoft.Agents.AI.ChatClientAgent> existingAgents,
+            IReadOnlyList<AgentConfiguration> hierarchyAgents,
+            string? modelName = null)
+            => Task.FromResult(CreateAgent(config, chat, existingAgents, hierarchyAgents, modelName));
     }
 
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
@@ -44,6 +103,7 @@ public class HarnessInstallGateTest : AITestBase
             .ConfigureServices(services =>
             {
                 services.AddSingleton<IHarness, GatedCliHarness>();
+                services.AddSingleton<IChatClientFactory>(new FakeChatClientFactory());
                 return services;
             });
 
@@ -107,5 +167,102 @@ public class HarnessInstallGateTest : AITestBase
             .Should().Emit();
         resolved.Should().BeOfType<MeshWeaverHarness>(
             "the default harness needs no install and must resolve immediately");
+    }
+
+    /// <summary>
+    /// THE round-level pin — through the REAL execution pipeline (StartThread →
+    /// ExecuteMessageAsync), not the resolver in isolation: ExecuteMessageAsync normalizes
+    /// request.Harness to the bare id early, so the install gate MUST probe the ORIGINAL picked
+    /// node path. Probing the normalized value would license off the wrong node (the bare id is
+    /// a partition ROOT path) — the exact regression a resolver-only test cannot catch. With the
+    /// installed node present, the round answers from the HARNESS client.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task Round_WithInstalledNode_RunsTheGatedHarness()
+    {
+        var client = GetClient();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var harnessPath = $"{MonolithMeshTestBase.TestPartition}/Harness/{GatedId}";
+
+        await meshService.CreateNode(new MeshNode(GatedId, $"{MonolithMeshTestBase.TestPartition}/Harness")
+        {
+            NodeType = HarnessNodeType.NodeType,
+            Name = "Gated CLI",
+            State = MeshNodeState.Active,
+            Content = new Harness { Id = GatedId, DisplayName = "Gated CLI", Order = 9, RequiresInstall = true }
+        }).Should().Emit();
+
+        var threadCreated = new System.Reactive.Subjects.AsyncSubject<MeshNode>();
+        client.StartThread(
+            namespacePath: MonolithMeshTestBase.TestPartition,
+            userText: "run on the gated harness",
+            agentName: "Agent/Assistant",
+            modelName: "_Provider/Fake/fake-model",
+            harness: harnessPath,
+            contextPath: MonolithMeshTestBase.TestPartition,
+            createdBy: "rbuergi@systemorph.com",
+            onCreated: node => { threadCreated.OnNext(node); threadCreated.OnCompleted(); });
+
+        var created = await threadCreated.Should().Emit();
+        var thread = await WaitForThread(created!.Path!, t => t.Messages.Count >= 2);
+
+        var responseText = await LastAssistantText(created.Path!, thread);
+        responseText.Should().Contain(HarnessAck,
+            "the installed picked-path node licenses the gated harness — the round must run its " +
+            "client, not fall back (falling back here means the gate probed the WRONG path, e.g. " +
+            "the id-normalized value instead of the picked node path)");
+    }
+
+    /// <summary>
+    /// The same round WITHOUT the installed node: the gate refuses and the round answers from the
+    /// default agent path — graceful fallback, no error, no wedge.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task Round_WithoutInstalledNode_FallsBackToAgentPath()
+    {
+        var client = GetClient();
+        // A picked path whose node deliberately does not exist (uninstalled / never installed).
+        var harnessPath = $"{MonolithMeshTestBase.TestPartition}/Harness/never-installed-{GatedId}";
+
+        var threadCreated = new System.Reactive.Subjects.AsyncSubject<MeshNode>();
+        client.StartThread(
+            namespacePath: MonolithMeshTestBase.TestPartition,
+            userText: "run without an install",
+            agentName: "Agent/Assistant",
+            modelName: "_Provider/Fake/fake-model",
+            harness: harnessPath,
+            contextPath: MonolithMeshTestBase.TestPartition,
+            createdBy: "rbuergi@systemorph.com",
+            onCreated: node => { threadCreated.OnNext(node); threadCreated.OnCompleted(); });
+
+        var created = await threadCreated.Should().Emit();
+        var thread = await WaitForThread(created!.Path!, t => t.Messages.Count >= 2);
+
+        var responseText = await LastAssistantText(created.Path!, thread);
+        responseText.Should().NotContain(HarnessAck,
+            "an uninstalled harness must never run — the gate falls back to the agent path");
+        responseText.Should().Contain(FakeChatClientFactory.AgentAck,
+            "the fallback is the default agent path, a graceful degrade rather than an error");
+    }
+
+    private async Task<MeshThread> WaitForThread(string threadPath, Func<MeshThread, bool> predicate)
+        => (await Mesh.GetWorkspace().GetMeshNodeStream(threadPath)
+            .Select(n => n?.Content as MeshThread)
+            .Where(t => t is not null)
+            .Should().Within(TimeSpan.FromSeconds(45))
+            .Match(t => predicate(t!)))!;
+
+    // The text of the thread's last assistant message cell (messages are satellite nodes).
+    // The cell is created with placeholder text ("Allocating agent...") and streamed into —
+    // wait for the TERMINAL status, not for a first/non-empty emission.
+    private async Task<string> LastAssistantText(string threadPath, MeshThread thread)
+    {
+        var lastId = thread.Messages[^1];
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream($"{threadPath}/{lastId}")
+            .Where(n => n?.ContentAs<ThreadMessage>(Mesh.JsonSerializerOptions) is
+                { Status: ThreadMessageStatus.Completed })
+            .Take(1)
+            .Should().Within(TimeSpan.FromSeconds(30)).Emit();
+        return node!.ContentAs<ThreadMessage>(Mesh.JsonSerializerOptions)!.Text ?? "";
     }
 }

--- a/test/MeshWeaver.AI.Test/HarnessTest.cs
+++ b/test/MeshWeaver.AI.Test/HarnessTest.cs
@@ -20,10 +20,14 @@ namespace MeshWeaver.AI.Test;
 public class HarnessTest
 {
     /// <summary>A CLI-style fake harness for tests — returns a non-null client.</summary>
-    private sealed class FakeCliHarness(string id) : IHarness
+    private sealed class FakeCliHarness(string id, bool requiresInstall = false) : IHarness
     {
         public string Id => id;
-        public Harness Definition => new() { Id = id, DisplayName = id, Order = 9, SupportsAgentSelection = false };
+        public Harness Definition => new()
+        {
+            Id = id, DisplayName = id, Order = 9, SupportsAgentSelection = false,
+            RequiresInstall = requiresInstall
+        };
         public IChatClient? CreateChatClient(HarnessExecutionContext context) => new FakeChatClient();
     }
 
@@ -71,6 +75,53 @@ public class HarnessTest
         ids.Should().Contain(Harnesses.MeshWeaver);
         ids.Should().Contain("Claude Code");
         ids.Should().Contain("GitHub Copilot");
+    }
+
+    /// <summary>
+    /// The per-user install contract at the catalog boundary: a RequiresInstall harness (the CLI
+    /// ones) is NOT projected into the global Harness catalog — its node reaches a user only via
+    /// the Store plugin's localize into {user}/Harness. Dropping it here also prunes the
+    /// previously-shipped global rows on the DB-synced path (Additive sync removes nodes the
+    /// build previously owned).
+    /// </summary>
+    [Fact]
+    public void BuiltInHarnessProvider_SkipsRequiresInstallHarnesses()
+    {
+        var provider = new BuiltInHarnessProvider(new IHarness[]
+        {
+            new MeshWeaverHarness(),
+            new FakeCliHarness("GatedCli", requiresInstall: true),
+        });
+
+        var harnessNodes = provider.GetStaticNodes()
+            .Where(n => n.NodeType == HarnessNodeType.NodeType)
+            .ToList();
+
+        harnessNodes.Should().ContainSingle(n => n.Id == Harnesses.MeshWeaver,
+            "the built-in MeshWeaver harness ships globally");
+        harnessNodes.Should().NotContain(n => n.Id == "GatedCli",
+            "a RequiresInstall harness must never ship in the global catalog — it is installed " +
+            "per user from the Store");
+    }
+
+    /// <summary>
+    /// Shape-lock for the real definitions: the CLI harnesses need a per-user subscription login,
+    /// so they are install-gated; MeshWeaver is not (it is the always-available default).
+    /// </summary>
+    [Fact]
+    public void CliHarnesses_RequireInstall_MeshWeaverDoesNot()
+    {
+        IHarness claude = new MeshWeaver.AI.ClaudeCode.ClaudeCodeHarness(
+            Microsoft.Extensions.Options.Options.Create(new MeshWeaver.AI.ClaudeCode.ClaudeCodeConfiguration()));
+        IHarness copilot = new MeshWeaver.AI.Copilot.CopilotHarness(
+            Microsoft.Extensions.Options.Options.Create(new MeshWeaver.AI.Copilot.CopilotConfiguration()));
+
+        claude.Definition.RequiresInstall.Should().BeTrue(
+            "Claude Code needs a per-user Claude login — offered only after Store install");
+        copilot.Definition.RequiresInstall.Should().BeTrue(
+            "GitHub Copilot needs a per-user GitHub login — offered only after Store install");
+        new MeshWeaverHarness().Definition.RequiresInstall.Should().BeFalse(
+            "the native harness is the default and must always be available");
     }
 
     [Fact]


### PR DESCRIPTION
## Why

Claude Code and GitHub Copilot need a personal subscription login. Shipping them in every user's harness picker by default produced "Not logged in" dead ends — exactly the trail that confused the new user in the 2026-08-01 onboarding incident (switched composer to ClaudeCode → `/model` → `AuthRequiredException`). Directive: **do not ship the CLI harnesses by default; the user must opt in (install) first.**

## What

- **`Harness.RequiresInstall`** — a harness so marked is NOT projected into the global `Harness` catalog (`BuiltInHarnessProvider` skips it). The ClaudeCode and Copilot definitions set it; the CLI *runtimes* still ship with the image behind the existing `Features:Ai:Clis:*` flags.
- **Per-user availability = node presence.** The picker's registry union (`namespace:{user}/Harness|{space}/Harness|Harness`) already surfaces user-partition harness nodes, so a Store install that localizes the node into `{user}/Harness` puts the harness in that user's picker only. Companion PR in MeshWeaver.Plugins adds the `Harness` fixed-target install segment + the two Store items (install/uninstall).
- **Execution gate** — `HarnessNodeType.ResolveInstalledHarness`: a `RequiresInstall` harness runs only while its picked node is Active (one bounded read off the shared node-stream cache). Uninstalled / never-installed / stale pre-gate global paths fall back gracefully to the default agent path — same fallback as an unresolvable harness, never a wedge.
- **Deployed-state cleanup is automatic**: `HarnessStaticRepoSource` syncs `Additive`, which prunes nodes the build previously shipped — the existing global `Harness/ClaudeCode`/`Copilot` rows disappear on next boot import.
- Default composer selection needs no change: with the CLI nodes gone from the catalog, lowest-Order = MeshWeaver; stored stale selections validate against the catalog and reset.

## Tests

- `HarnessTest`: provider skips `RequiresInstall` harnesses; real-definition shape locks (CC/Copilot gated, MeshWeaver not).
- `HarnessInstallGateTest` (live Monolith mesh): absent node → resolves null (graceful fallback), installed node in the user partition → harness runs, non-gated harness → no probe.
- Full `MeshWeaver.AI.Test` suite green locally (919 passed / 0 failed); `DocumentationLinkIntegrityTest` green; `Memex.Portal.Distributed` builds `-c Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)