### PR TITLE
Install completes only after the root retype is persisted — kills the idempotence flap

### DIFF
--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -475,6 +475,28 @@ public static class PackageInstaller
                     .Timeout(TimeSpan.FromSeconds(30))
                     .Select(_ => System.Reactive.Unit.Default);
 
+        // 🚨 AND the retype must be PERSISTED, not just reconciled on the stream: the owning
+        // hub's persist is DEBOUNCED, and the decisions a LATER install makes — PlaceholderNeeded
+        // and UpsertIfChanged — read the STORAGE ADAPTER, not the stream. Completing the install
+        // on the stream echo alone leaves a window where a re-install still reads the Space
+        // placeholder from persistence, re-runs the placeholder dance, and rewrites the root:
+        // "re-install of the unchanged snapshot wrote 1 node(s)" — the FLAPPING idempotence
+        // failure in the plugin gate (identical packages pass/fail per run purely on whether the
+        // debounced persist flushed in time). Same bounded-poll shape as Visible(); the Timeout
+        // is the graceful sink for a wedged persist, never a fixed sleep.
+        IObservable<System.Reactive.Unit> RootRetypePersisted() =>
+            placeholderRoot is null || root is null || persistence is null
+                || string.IsNullOrEmpty(root.NodeType)
+                ? Observable.Return(System.Reactive.Unit.Default)
+                : Observable
+                    .Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+                    .SelectMany(_ => persistence.Read(root.Path, options))
+                    .Where(n => n is not null
+                        && string.Equals(n.NodeType, root.NodeType, StringComparison.Ordinal))
+                    .FirstAsync()
+                    .Timeout(TimeSpan.FromSeconds(30))
+                    .Select(_ => System.Reactive.Unit.Default);
+
         // Eager provisioning must also cover the package's OWN partition: with a dynamic root
         // type the placeholder covers it, but belt-and-braces keeps the fresh-mesh pin honest.
         // 🚨 The Space placeholder is for a FRESH mesh only — it lets the root exist before the
@@ -505,8 +527,11 @@ public static class PackageInstaller
                 .SelectMany(typeWrites => Visible(nodeTypePaths)
                     .SelectMany(_ => WriteAll(stage2))
                     // The retype's optimistic emit is not the reconciled state — wait for the
-                    // shared root handle to actually carry the in-package type before reporting.
-                    .SelectMany(rest => RootRetypeReconciled().Select(_ => rest))
+                    // shared root handle to carry the in-package type AND for the debounced
+                    // persist to land it in storage (a later install reads persistence).
+                    .SelectMany(rest => RootRetypeReconciled()
+                        .SelectMany(_ => RootRetypePersisted())
+                        .Select(_ => rest))
                     // 🚨 RECYCLE the retyped root's hub. It was ACTIVATED as the Space placeholder
                     // (RootRetypeReconciled reads the stream, and readers race the install anyway),
                     // so the live hub instance still carries the placeholder's configuration — the

--- a/test/MeshWeaver.PluginCatalog.Test/SelfTypedRootInstallTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/SelfTypedRootInstallTest.cs
@@ -11,7 +11,9 @@ using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.PluginCatalog.Test;
@@ -78,4 +80,62 @@ public class SelfTypedRootInstallTest(ITestOutputHelper output) : MonolithMeshTe
             .Where(n => n is not null).FirstAsync().Timeout(TimeSpan.FromSeconds(30)).ToTask();
         grant!.MainNode.Should().Be("Shop");
     }
+
+    /// <summary>
+    /// The PERSISTENCE-visibility guarantee behind re-install idempotence: install completion is a
+    /// happens-before for the STORAGE ADAPTER too, not just the shared node stream — the decisions
+    /// a later install makes (PlaceholderNeeded, UpsertIfChanged) read persistence, and the owning
+    /// hub's persist is debounced. Without the RootRetypePersisted barrier, an IMMEDIATE re-install
+    /// intermittently read the Space placeholder from storage, re-ran the placeholder dance and
+    /// rewrote the root — the flapping "re-install wrote 1 node(s)" idempotence failure in the
+    /// plugins repo's gate. Pin both halves: the retype is storage-visible the moment the first
+    /// install reports done, and the back-to-back re-install writes ZERO nodes.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task SelfTypedRoot_ReinstallImmediately_WritesNothing()
+    {
+        Func<string, string, string?, string, IObservable<RepoSnapshot>> fetch =
+            (_, _, _, _) => Observable.Return(new RepoSnapshot("commit-shop2", Repo2));
+        var source = new NodeRepoPackageSource(fetch, "https://github.com/acme/shop2");
+        var manifest = new PackageManifest
+        {
+            Id = "Shop2",
+            Name = "Shop2",
+            Kind = PackageKind.NodeRepo,
+            TargetPartition = "Shop2",
+            SourceFolder = "Shop2",
+            Version = "commit-shop2",
+        };
+        var files = await source.FetchPackageFiles(manifest, "HEAD").FirstAsync().ToTask();
+
+        var first = await PackageInstaller.Install(Mesh, manifest, files, "HEAD")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(60)).ToTask();
+        first.Written.Should().Be(3);
+
+        // (a) The retype is visible via the STORAGE ADAPTER at completion — the exact read the
+        //     next install's PlaceholderNeeded performs.
+        var persistence = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var persisted = await persistence.Read("Shop2", Mesh.JsonSerializerOptions)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(10)).ToTask();
+        persisted.Should().NotBeNull("install completion must be a happens-before for persistence");
+        persisted!.NodeType.Should().Be("Shop2/Front2",
+            "the root's final type — not the Space placeholder — must be the persisted state the "
+            + "moment the install reports done");
+
+        // (b) The back-to-back re-install of the unchanged snapshot writes NOTHING.
+        var second = await PackageInstaller.Install(Mesh, manifest, files, "HEAD")
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(60)).ToTask();
+        second.Written.Should().Be(0,
+            $"an unchanged re-install must be a no-op; wrote: [{string.Join(", ", second.WrittenPaths)}]");
+    }
+
+    private static readonly IReadOnlyList<RepoFile> Repo2 = new List<RepoFile>
+    {
+        new("Shop2/index.json",
+            """{"$type":"MeshNode","id":"Shop2","namespace":"","path":"Shop2","mainNode":"Shop2","name":"Shop2","nodeType":"Shop2/Front2","state":"Active","content":{"$type":"Front2Content","intro":"hello"}}"""),
+        new("Shop2/Front2.json",
+            """{"$type":"MeshNode","id":"Front2","namespace":"Shop2","path":"Shop2/Front2","mainNode":"Shop2/Front2","name":"Front2","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"The shop front.","configuration":"config => config.WithContentType<Front2Content>()","includeGlobalTypes":true}}"""),
+        new("Shop2/Front2/Source/Front2Content.cs",
+            "public record Front2Content { public string? Intro { get; init; } }"),
+    };
 }


### PR DESCRIPTION
## The flap

The MeshWeaver.Plugins `mw-plugin-test` gate's idempotence check ("re-install of an unchanged snapshot writes 0 nodes") flaps: on Systemorph/MeshWeaver.Plugins#295, three consecutive runs produced three different pass/fail sets across identical two-node packages (ClaudeCode / Copilot / Collaboration), and 14 packages carry the failure as permanent allow-listed debt. A ratchet cannot converge on a coin flip.

## Root cause

`InstallNodeRepo`'s self-typed-root dance completes when the retype echoes on the shared node **stream** (`RootRetypeReconciled`), but the decisions a later install makes — `PlaceholderNeeded`, `UpsertIfChanged` — read the **storage adapter**, and the owning hub's persist is debounced. When the flush lags the install's completion, a re-install reads the stale `Space` placeholder from persistence, re-runs the placeholder dance, and rewrites the root — "wrote 1 node(s)", purely timing-dependent.

## Fix

A bounded persistence-visibility poll (`RootRetypePersisted`, same shape as the existing `Visible()` barrier for types) on the root's final NodeType before the install reports done. Graceful 30s timeout sink, no fixed sleeps.

Full `MeshWeaver.PluginCatalog.Test` suite green locally (54/54), builds `-c Release -warnaserror`.

No What's New entry — internal installer determinism, no user-visible behavior change.

After merge + CD image rebuild, the plugins repo's gate becomes deterministic and its idempotence debt list can start draining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)