### PR TITLE
Compile state gains its satellite: {type}/_Activity/compile-state (#748 phase 1)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompileState.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompileState.cs
@@ -1,0 +1,262 @@
+using System.Collections.Immutable;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Services.LanguageServer;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The MESH-OWNED compile state of a NodeType, as a value of its own — the exact operational
+/// members the framework persists onto <see cref="NodeTypeDefinition"/> today (status,
+/// timestamps, assembly pointers, source-version maps, release-request bookkeeping), projected
+/// into a record that lives OFF the authored node: on the fixed-id compile-state satellite at
+/// <c>{type}/_Activity/compile-state</c> (issue #748, phase 1).
+///
+/// <para>Why: the NodeType node is repo-authored content, and every compile currently rewrites it —
+/// which made GitSync treat bookkeeping churn as server edits, carried stale verdicts into git, and
+/// let imports stamp them back (the stale-green class; see <see cref="NodeTypeOperationalContent"/>
+/// for the transitional seams). The satellite lives under <c>_Activity</c>, so GitSync export,
+/// prune protection and the activity table mapping all apply for free — the same pattern as the
+/// import manifest (<c>{partition}/_Activity/import-manifest</c>).</para>
+///
+/// <para>Phase 1 (this record + <see cref="NodeTypeCompileStateMirror"/>) DUAL-WRITES: the node
+/// stays the writers' target and the single source of truth, and the mirror projects every real
+/// state change onto the satellite. Phase 2 flips readers to the satellite; phase 3 stops writing
+/// the node members entirely and retires the mirror.</para>
+///
+/// <para>The member set is pinned to <see cref="NodeTypeOperationalContent.MemberNames"/> by test —
+/// the satellite carries exactly what the sync seams mask, so the two mechanisms cannot drift.</para>
+/// </summary>
+public record NodeTypeCompileState
+{
+    /// <summary>See <see cref="NodeTypeDefinition.CompilationStatus"/>.</summary>
+    public CompilationStatus? CompilationStatus { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.CompilationError"/>.</summary>
+    public string? CompilationError { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.CompilationDiagnostics"/>.</summary>
+    public ImmutableList<DiagnosticInfo>? CompilationDiagnostics { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.LastCompileStartedAt"/>.</summary>
+    public DateTimeOffset? LastCompileStartedAt { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.LastCompileSucceededAt"/>.</summary>
+    public DateTimeOffset? LastCompileSucceededAt { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.LastCompiledVersion"/>.</summary>
+    public long? LastCompiledVersion { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.LastCompilationActivityPath"/>.</summary>
+    public string? LastCompilationActivityPath { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.LatestReleasePath"/>.</summary>
+    public string? LatestReleasePath { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.RequestedReleasePath"/>.</summary>
+    public string? RequestedReleasePath { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.RequestedReleaseAt"/>.</summary>
+    public DateTimeOffset? RequestedReleaseAt { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.RequestedReleaseForce"/>.</summary>
+    public bool RequestedReleaseForce { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.RequestedReleaseBy"/>.</summary>
+    public string? RequestedReleaseBy { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.LastReleaseRequestHandledAt"/>.</summary>
+    public DateTimeOffset? LastReleaseRequestHandledAt { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.ReleaseNotes"/>.</summary>
+    public string? ReleaseNotes { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.LatestAssemblyCollection"/>.</summary>
+    public string? LatestAssemblyCollection { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.LatestAssemblyPath"/>.</summary>
+    public string? LatestAssemblyPath { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.CompiledSources"/>.</summary>
+    public IReadOnlyDictionary<string, long>? CompiledSources { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.CurrentSourceVersions"/>.</summary>
+    public IReadOnlyDictionary<string, long>? CurrentSourceVersions { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/>.</summary>
+    public string? CompiledFrameworkVersion { get; init; }
+
+    /// <summary>The state projected from a NodeType definition — pure. Null in, null out.</summary>
+    public static NodeTypeCompileState? FromDefinition(NodeTypeDefinition? definition) =>
+        definition is null
+            ? null
+            : new NodeTypeCompileState
+            {
+                CompilationStatus = definition.CompilationStatus,
+                CompilationError = definition.CompilationError,
+                CompilationDiagnostics = definition.CompilationDiagnostics,
+                LastCompileStartedAt = definition.LastCompileStartedAt,
+                LastCompileSucceededAt = definition.LastCompileSucceededAt,
+                LastCompiledVersion = definition.LastCompiledVersion,
+                LastCompilationActivityPath = definition.LastCompilationActivityPath,
+                LatestReleasePath = definition.LatestReleasePath,
+                RequestedReleasePath = definition.RequestedReleasePath,
+                RequestedReleaseAt = definition.RequestedReleaseAt,
+                RequestedReleaseForce = definition.RequestedReleaseForce,
+                RequestedReleaseBy = definition.RequestedReleaseBy,
+                LastReleaseRequestHandledAt = definition.LastReleaseRequestHandledAt,
+                ReleaseNotes = definition.ReleaseNotes,
+                LatestAssemblyCollection = definition.LatestAssemblyCollection,
+                LatestAssemblyPath = definition.LatestAssemblyPath,
+                CompiledSources = definition.CompiledSources,
+                CurrentSourceVersions = definition.CurrentSourceVersions,
+                CompiledFrameworkVersion = definition.CompiledFrameworkVersion,
+            };
+
+    /// <summary>Whether NO compile machinery has recorded anything yet — a never-compiled,
+    /// never-requested type. An empty state is not worth a satellite node.</summary>
+    public bool IsEmpty =>
+        CompilationStatus is null && CompilationError is null && CompilationDiagnostics is null
+        && LastCompileStartedAt is null && LastCompileSucceededAt is null
+        && LastCompiledVersion is null && LastCompilationActivityPath is null
+        && LatestReleasePath is null && RequestedReleasePath is null
+        && RequestedReleaseAt is null && !RequestedReleaseForce && RequestedReleaseBy is null
+        && LastReleaseRequestHandledAt is null && ReleaseNotes is null
+        && LatestAssemblyCollection is null && LatestAssemblyPath is null
+        && CompiledSources is null && CurrentSourceVersions is null
+        && CompiledFrameworkVersion is null;
+}
+
+/// <summary>
+/// Phase-1 dual-write of issue #748: mirrors a NodeType's operational compile state from its own
+/// MeshNode onto the fixed-id satellite at <c>{type}/_Activity/compile-state</c> — an Activity
+/// node whose <see cref="ActivityLog.ReturnValue"/> carries the <see cref="NodeTypeCompileState"/>
+/// (the import-manifest pattern). Installed on the per-NodeType hub beside the compile watchers.
+///
+/// <para>Write discipline: the mirror seeds itself with the ALREADY-PERSISTED satellite state so a
+/// mere hub re-activation writes nothing; it writes only when the projected state actually changes
+/// (serialized-form comparison — record equality is reference-based for the dictionary members);
+/// writes run under System (the satellite is framework bookkeeping, not user content) and are
+/// best-effort — a failed mirror write logs and never disturbs the compile pipeline. No self-feed:
+/// the mirror writes a satellite, never the node it observes.</para>
+/// </summary>
+public static class NodeTypeCompileStateMirror
+{
+    /// <summary>The fixed satellite node id.</summary>
+    public const string StateId = "compile-state";
+
+    /// <summary>The satellite path for a NodeType at <paramref name="nodeTypePath"/>.</summary>
+    public static string StatePath(string nodeTypePath) => $"{nodeTypePath}/_Activity/{StateId}";
+
+    /// <summary>
+    /// Reads the persisted compile state from the satellite — null when absent or unreadable
+    /// (a missing satellite means "not mirrored yet", never an error). Cold; one emission.
+    /// </summary>
+    public static IObservable<NodeTypeCompileState?> Read(IMessageHub hub, string nodeTypePath) =>
+        hub.GetMeshNode(StatePath(nodeTypePath), TimeSpan.FromSeconds(10))
+            .Catch((Exception _) => Observable.Return<MeshNode?>(null))
+            .Take(1)
+            .Select(node => Parse(node, hub.JsonSerializerOptions));
+
+    /// <summary>The state carried in a satellite node's <see cref="ActivityLog.ReturnValue"/>,
+    /// or null when absent/unreadable. Pure.</summary>
+    public static NodeTypeCompileState? Parse(MeshNode? node, JsonSerializerOptions options)
+    {
+        if (node is null)
+            return null;
+        try
+        {
+            return node.ContentAs<ActivityLog>(options)?.ReturnValue is { } value
+                ? value.Deserialize<NodeTypeCompileState>(options)
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>The satellite node carrying <paramref name="state"/> — pure, unit-testable.</summary>
+    public static MeshNode StateNode(
+        string nodeTypePath, NodeTypeCompileState state, JsonSerializerOptions options) =>
+        new(StateId, $"{nodeTypePath}/_Activity")
+        {
+            Name = $"Compile state ({nodeTypePath})",
+            NodeType = ActivityNodeType.NodeType,
+            MainNode = nodeTypePath,
+            State = MeshNodeState.Active,
+            Content = new ActivityLog(ActivityCategory.Compilation)
+            {
+                Id = StateId,
+                HubPath = nodeTypePath,
+                Status = ActivityStatus.Succeeded,
+                ReturnValue = JsonSerializer.SerializeToElement(state, options),
+            },
+        };
+
+    /// <summary>
+    /// Installs the mirror on the per-NodeType hub: every REAL change of the node's operational
+    /// members lands on the satellite; activations, authored edits and duplicate emissions write
+    /// nothing. Returns the subscription for <c>RegisterForDisposal</c>.
+    /// </summary>
+    public static IDisposable Install(IMessageHub hub, IWorkspace workspace)
+    {
+        var mesh = hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null)
+            return Disposable.Empty;
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Graph.CompileStateMirror");
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var options = hub.JsonSerializerOptions;
+        var nodeTypePath = hub.Address.Path;
+
+        // Installed on EVERY per-node hub (like the compile watchers) — only actual
+        // type-definition nodes mirror. The tolerant ContentAs would otherwise coerce
+        // arbitrary content into an empty definition, and a node whose content merely
+        // NAMES an operational member must not sprout a compile-state satellite.
+        //
+        // ONE subscription, no stored-state pre-read: the own stream does not replay to a
+        // late second subscriber, so any two-stage seeding design silently never writes
+        // (the first cut did exactly that). The first observed state per activation is
+        // written unconditionally — the owner's no-op upsert guard makes a redundant
+        // re-activation write version-free — and every subsequent write is gated by
+        // DistinctUntilChanged on the serialized state (record equality is reference-based
+        // for the dictionary members, so the serialized form is the value identity).
+        return workspace.GetMeshNodeStream()
+            .Where(NodeTypeOperationalContent.IsNodeTypeNode)
+            .Select(node => NodeTypeCompileState.FromDefinition(
+                node?.ContentAs<NodeTypeDefinition>(options, logger)))
+            .Where(state => state is { IsEmpty: false })
+            .Select(state => (State: state!, Key: JsonSerializer.Serialize(state, options)))
+            .DistinctUntilChanged(entry => entry.Key)
+            // One write at a time, latest state last — Concat keeps the satellite's final
+            // content equal to the final observed state without interleaving.
+            .Select(entry => Observable.Using(
+                    () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
+                    _ => mesh.CreateOrUpdateNode(StateNode(nodeTypePath, entry.State, options)).Take(1))
+                .Select(_ => true)
+                .Catch<bool, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "[CompileStateMirror] {NodeTypePath}: satellite write failed (state stays on the node; next change retries).",
+                        nodeTypePath);
+                    return Observable.Return(false);
+                }))
+            .Concat()
+            .Subscribe(
+                _ => { },
+                ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "[CompileStateMirror] {NodeTypePath}: mirror stream faulted — satellite no longer updates until the hub recycles.",
+                        nodeTypePath);
+                });
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompileState.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompileState.cs
@@ -156,12 +156,13 @@ public static class NodeTypeCompileStateMirror
     public static string StatePath(string nodeTypePath) => $"{nodeTypePath}/_Activity/{StateId}";
 
     /// <summary>
-    /// Reads the persisted compile state from the satellite — null when absent or unreadable
-    /// (a missing satellite means "not mirrored yet", never an error). Cold; one emission.
+    /// Reads the persisted compile state from the satellite — null when the satellite is ABSENT
+    /// ("not mirrored yet"; <c>GetMeshNode</c> itself emits null for a missing node) or its
+    /// content unparsable. A timeout or denial PROPAGATES: collapsing those into "no state"
+    /// would hand phase-2 readers a silent wrong answer for a mesh stall. Cold; one emission.
     /// </summary>
     public static IObservable<NodeTypeCompileState?> Read(IMessageHub hub, string nodeTypePath) =>
         hub.GetMeshNode(StatePath(nodeTypePath), TimeSpan.FromSeconds(10))
-            .Catch((Exception _) => Observable.Return<MeshNode?>(null))
             .Take(1)
             .Select(node => Parse(node, hub.JsonSerializerOptions));
 

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1036,6 +1036,17 @@ public static class MeshDataSourceExtensions
                     .InstallSourcesWatcher(hub, workspace);
                 hub.RegisterForDisposal(sourcesSub);
             }
+
+            // Compile-state mirror (issue #748, phase 1): every real change of a NodeType
+            // node's operational compile members is dual-written onto the fixed-id
+            // satellite at {type}/_Activity/compile-state, so the state gains a home OFF
+            // the repo-authored node. Installed like the compile watchers — on every
+            // per-node hub, filtering per emission — and independent of the compilation
+            // service: the mirror reflects whatever state the node carries, wherever it
+            // was written. Readers still consume the node; phase 2 flips them to the
+            // satellite, phase 3 stops the node writes.
+            var mirrorSub = NodeTypeCompileStateMirror.Install(hub, workspace);
+            hub.RegisterForDisposal(mirrorSub);
         }
         catch (Exception ex)
         {

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeContentExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeContentExtensions.cs
@@ -43,6 +43,24 @@ public static class MeshNodeContentExtensions
                         typeof(T).Name, node.Path, je.GetRawText());
                     return null;
                 }
+            case System.Text.Json.Nodes.JsonNode jn:
+                // The DOM twin of the JsonElement case. Node builders assign JsonObject content,
+                // and a freshly created node's own stream carries it in that shape until the
+                // materialization pipeline re-types it — falling through to the same-short-name
+                // branch below returned a SILENT null for it ("JsonObject" never matches T), the
+                // exact shape-blindness this accessor exists to prevent (found 2026-08-02: the
+                // compile-state mirror projected nothing for every just-created NodeType node).
+                try
+                {
+                    return jn.Deserialize<T>(options);
+                }
+                catch (JsonException ex)
+                {
+                    logger?.LogError(ex,
+                        "ContentAs<{TargetType}> could not recover Content for {Path}: {RawJson}",
+                        typeof(T).Name, node.Path, jn.ToJsonString());
+                    return null;
+                }
             default:
                 // Content is a typed object, but not OUR T. Recover ONLY when the runtime type has the
                 // SAME short name as T: the same class compiled into a different dynamic node assembly

--- a/test/MeshWeaver.Graph.Test/NodeTypeCompileStateMirrorTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeCompileStateMirrorTest.cs
@@ -87,8 +87,9 @@ public class NodeTypeCompileStateMirrorTest(ITestOutputHelper output) : Monolith
     /// the mirror writes asynchronously, so a single read can race it.</summary>
     private async Task WaitForState(string statePath, Func<NodeTypeCompileState, bool> predicate) =>
         await Observable.Interval(TimeSpan.FromMilliseconds(200)).StartWith(0L)
-            .SelectMany(_ => ReadNode(statePath)
-                .Catch((Exception _) => Observable.Return<MeshNode?>(null)))
+            // ReadNode maps the expected not-found to null itself; a genuine read failure
+            // (timeout with diagnostics, denial) must FAIL the test loudly, not poll on.
+            .SelectMany(_ => ReadNode(statePath))
             .Select(n => NodeTypeCompileStateMirror.Parse(n, Mesh.JsonSerializerOptions))
             .Where(s => s is not null && predicate(s))
             .FirstAsync()

--- a/test/MeshWeaver.Graph.Test/NodeTypeCompileStateMirrorTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeCompileStateMirrorTest.cs
@@ -1,0 +1,96 @@
+using System.Reactive.Linq;
+using System.Text.Json.Nodes;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The phase-1 dual-write of issue #748 on a REAL mesh: a NodeType node's operational compile
+/// members are mirrored onto the fixed-id satellite at <c>{type}/_Activity/compile-state</c>,
+/// and a later change of the node's state updates the satellite. The mirror is installed by the
+/// per-node hub setup (<c>MeshDataSource</c>), so this exercises the full activation path —
+/// not the projection in isolation.
+/// </summary>
+public class NodeTypeCompileStateMirrorTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Space = "MirrorSpace";
+    private const string TypePath = $"{Space}/Widget";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(new MeshNode(Space) { Name = "Mirror Space", NodeType = "Space" });
+
+    private static JsonObject WidgetContent(long compiledVersion) =>
+        JsonNode.Parse(
+            $$"""
+            {"$type":"NodeTypeDefinition","description":"widget type",
+             "configuration":"config => config",
+             "lastCompiledVersion":{{compiledVersion}},
+             "latestAssemblyPath":"Widget/v{{compiledVersion}}.dll"}
+            """)!.AsObject();
+
+    [Fact(Timeout = 120000)]
+    public async Task OperationalState_LandsOnTheSatellite_AndFollowsChanges()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var options = Mesh.JsonSerializerOptions;
+
+        using (accessService.ImpersonateAsSystem())
+            await meshService.CreateNode(new MeshNode("Widget", Space)
+            {
+                NodeType = MeshNode.NodeTypePath,
+                Name = "Widget",
+                State = MeshNodeState.Active,
+                Content = WidgetContent(1082),
+            }).Should().Emit();
+
+        // The mirror (installed by the per-node hub's activation) lands the state on the
+        // fixed-id satellite. Compile machinery may add its own flips (status kickoffs);
+        // the assembly pointer we seeded is not written by any failure path, so it is the
+        // stable assertion target.
+        var statePath = NodeTypeCompileStateMirror.StatePath(TypePath);
+        // Activate the type's own hub: the mirror installs on per-node hub activation, and a
+        // bare create in this fixture does not spin the hub up. In production type hubs
+        // activate constantly (compiles, instance resolution, the PreWarm sweep); the
+        // authoritative owner round-trip is the same touch.
+        await ReadNode(TypePath).FirstAsync().Timeout(30.Seconds());
+        await WaitForState(statePath, s =>
+            s.LastCompiledVersion == 1082 && s.LatestAssemblyPath == "Widget/v1082.dll");
+
+        // A state CHANGE on the node follows onto the satellite.
+        using (accessService.ImpersonateAsSystem())
+        {
+            var current = await ReadNode(TypePath).FirstAsync().Timeout(30.Seconds());
+            var content = current!.ContentAs<NodeTypeDefinition>(options)!;
+            await meshService.UpdateNode(current with
+            {
+                Content = content with
+                {
+                    LastCompiledVersion = 2026,
+                    LatestAssemblyPath = "Widget/v2026.dll",
+                },
+            }).Should().Emit();
+        }
+
+        await WaitForState(statePath, s =>
+            s.LastCompiledVersion == 2026 && s.LatestAssemblyPath == "Widget/v2026.dll");
+    }
+
+    /// <summary>Polls the satellite until its parsed state satisfies <paramref name="predicate"/> —
+    /// the mirror writes asynchronously, so a single read can race it.</summary>
+    private async Task WaitForState(string statePath, Func<NodeTypeCompileState, bool> predicate) =>
+        await Observable.Interval(TimeSpan.FromMilliseconds(200)).StartWith(0L)
+            .SelectMany(_ => ReadNode(statePath)
+                .Catch((Exception _) => Observable.Return<MeshNode?>(null)))
+            .Select(n => NodeTypeCompileStateMirror.Parse(n, Mesh.JsonSerializerOptions))
+            .Where(s => s is not null && predicate(s))
+            .FirstAsync()
+            .Timeout(60.Seconds());
+}

--- a/test/MeshWeaver.Graph.Test/NodeTypeCompileStateTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeCompileStateTest.cs
@@ -1,0 +1,152 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Services.LanguageServer;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the compile-state SATELLITE value (issue #748, phase 1): <see cref="NodeTypeCompileState"/>
+/// carries exactly the operational members the sync seams mask
+/// (<see cref="NodeTypeOperationalContent.MemberNames"/>), projects faithfully from the
+/// definition, and round-trips through the satellite node shape
+/// (<see cref="NodeTypeCompileStateMirror.StateNode"/> / <see cref="NodeTypeCompileStateMirror.Parse"/>).
+/// If the two member sets ever drift, the satellite would silently stop carrying a field the
+/// node no longer syncs — the drift MUST fail a test, not surface in production.
+/// </summary>
+public class NodeTypeCompileStateTest
+{
+    private static readonly JsonSerializerOptions CamelCase =
+        new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    [Fact]
+    public void StateMembers_AreExactlyTheMaskedOperationalMembers()
+    {
+        var stateMembers = typeof(NodeTypeCompileState).GetProperties()
+            .Where(p => p.Name != nameof(NodeTypeCompileState.IsEmpty))
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var masked in NodeTypeOperationalContent.MemberNames)
+            Assert.True(stateMembers.Contains(masked),
+                $"'{masked}' is masked by the sync seams but missing from NodeTypeCompileState — "
+                + "the satellite would silently drop it.");
+        foreach (var member in stateMembers)
+            Assert.True(NodeTypeOperationalContent.MemberNames.Contains(member),
+                $"'{member}' is carried by NodeTypeCompileState but not masked by the sync seams — "
+                + "either mask it or it is not operational state.");
+    }
+
+    [Fact]
+    public void FromDefinition_ProjectsEveryField_AndNullPassesThrough()
+    {
+        Assert.Null(NodeTypeCompileState.FromDefinition(null));
+
+        var definition = new NodeTypeDefinition
+        {
+            Configuration = "config => config",
+            CompilationStatus = CompilationStatus.Ok,
+            CompilationError = "none",
+            LastCompileStartedAt = new DateTimeOffset(2026, 8, 2, 8, 53, 45, TimeSpan.Zero),
+            LastCompileSucceededAt = new DateTimeOffset(2026, 8, 2, 8, 53, 46, TimeSpan.Zero),
+            LastCompiledVersion = 1095,
+            LastCompilationActivityPath = "Store/Plugin/_Activity/compile-x",
+            LatestReleasePath = "Store/Plugin/Release/x",
+            RequestedReleaseAt = new DateTimeOffset(2026, 8, 2, 8, 53, 45, TimeSpan.Zero),
+            RequestedReleaseForce = true,
+            RequestedReleaseBy = "rbuergi",
+            LastReleaseRequestHandledAt = new DateTimeOffset(2026, 8, 2, 8, 53, 45, TimeSpan.Zero),
+            ReleaseNotes = "notes",
+            LatestAssemblyCollection = "local",
+            LatestAssemblyPath = "Store_Plugin/v1095.dll",
+            CompiledSources = new Dictionary<string, long> { ["a"] = 1 },
+            CurrentSourceVersions = new Dictionary<string, long> { ["a"] = 2 },
+            CompiledFrameworkVersion = "37cd668a",
+        };
+        var state = NodeTypeCompileState.FromDefinition(definition)!;
+        Assert.Equal(CompilationStatus.Ok, state.CompilationStatus);
+        Assert.Equal("none", state.CompilationError);
+        Assert.Equal(1095, state.LastCompiledVersion);
+        Assert.Equal("Store/Plugin/_Activity/compile-x", state.LastCompilationActivityPath);
+        Assert.Equal("Store/Plugin/Release/x", state.LatestReleasePath);
+        Assert.True(state.RequestedReleaseForce);
+        Assert.Equal("rbuergi", state.RequestedReleaseBy);
+        Assert.Equal("notes", state.ReleaseNotes);
+        Assert.Equal("local", state.LatestAssemblyCollection);
+        Assert.Equal("Store_Plugin/v1095.dll", state.LatestAssemblyPath);
+        Assert.Equal(1, state.CompiledSources!["a"]);
+        Assert.Equal(2, state.CurrentSourceVersions!["a"]);
+        Assert.Equal("37cd668a", state.CompiledFrameworkVersion);
+        Assert.False(state.IsEmpty);
+    }
+
+    [Fact]
+    public void IsEmpty_TrueOnlyWhenNothingIsRecorded()
+    {
+        Assert.True(NodeTypeCompileState.FromDefinition(
+            new NodeTypeDefinition { Configuration = "authored only" })!.IsEmpty);
+        Assert.False(NodeTypeCompileState.FromDefinition(
+            new NodeTypeDefinition { CompilationStatus = CompilationStatus.Pending })!.IsEmpty);
+        Assert.False(NodeTypeCompileState.FromDefinition(
+            new NodeTypeDefinition { RequestedReleaseForce = true })!.IsEmpty);
+        Assert.False(NodeTypeCompileState.FromDefinition(
+            new NodeTypeDefinition { CurrentSourceVersions = new Dictionary<string, long>() })!.IsEmpty);
+    }
+
+    [Fact]
+    public void FromDefinition_ReadsJsonObjectContent_TheShapeAFreshNodeCarries()
+    {
+        // A just-created node's own stream carries the builder's JsonObject content until the
+        // pipeline re-types it; ContentAs must recover it (the silent-null found 2026-08-02).
+        var node = new MeshNode("Widget", "MirrorSpace")
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Content = System.Text.Json.Nodes.JsonNode.Parse(
+                """
+                {"$type":"NodeTypeDefinition","configuration":"config => config",
+                 "lastCompiledVersion":1082,"latestAssemblyPath":"Widget/v1082.dll"}
+                """)!.AsObject(),
+        };
+        var definition = node.ContentAs<NodeTypeDefinition>(CamelCase);
+        Assert.NotNull(definition);
+        Assert.Equal(1082, definition!.LastCompiledVersion);
+        var state = NodeTypeCompileState.FromDefinition(definition)!;
+        Assert.False(state.IsEmpty);
+        Assert.Equal("Widget/v1082.dll", state.LatestAssemblyPath);
+    }
+
+    [Fact]
+    public void StateNode_RoundTrips_ThroughParse()
+    {
+        var state = new NodeTypeCompileState
+        {
+            CompilationStatus = CompilationStatus.Ok,
+            LastCompiledVersion = 1095,
+            LatestAssemblyPath = "Store_Plugin/v1095.dll",
+            CompiledSources = new Dictionary<string, long> { ["Store/Plugin/Source/PluginGate"] = 639209062054682760 },
+            CompilationDiagnostics =
+            [
+                new DiagnosticInfo("CS0103", DiagnosticSeverity.Error, "The name 'x' does not exist",
+                    Location: null),
+            ],
+        };
+        var node = NodeTypeCompileStateMirror.StateNode("Store/Plugin", state, CamelCase);
+        Assert.Equal("Store/Plugin/_Activity/compile-state", node.Path);
+        Assert.Equal("Store/Plugin", node.MainNode);
+        Assert.Equal(ActivityNodeType.NodeType, node.NodeType);
+
+        var parsed = NodeTypeCompileStateMirror.Parse(node, CamelCase)!;
+        Assert.Equal(CompilationStatus.Ok, parsed.CompilationStatus);
+        Assert.Equal(1095, parsed.LastCompiledVersion);
+        Assert.Equal("Store_Plugin/v1095.dll", parsed.LatestAssemblyPath);
+        Assert.Equal(639209062054682760, parsed.CompiledSources!["Store/Plugin/Source/PluginGate"]);
+        Assert.Single(parsed.CompilationDiagnostics!);
+        Assert.Equal("CS0103", parsed.CompilationDiagnostics![0].Id);
+
+        Assert.Null(NodeTypeCompileStateMirror.Parse(null, CamelCase));
+        Assert.Null(NodeTypeCompileStateMirror.Parse(
+            new MeshNode("x", "y") { NodeType = "Markdown", Content = "not an activity" }, CamelCase));
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansCompileActivityAccessTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansCompileActivityAccessTest.cs
@@ -164,12 +164,17 @@ public class OrleansCompileActivityAccessTest(ITestOutputHelper output)
         // (WritingTests.md — wait on the condition, not a fixed sleep) instead of
         // a fixed 15s. The query is a LIVE stream, so the count flips 0→1 the
         // moment the activity create lands.
+        // Count compile-RUN activities only: the fixed-id compile-state satellite
+        // (NodeTypeCompileStateMirror, #748 phase 1) is System-written bookkeeping that
+        // lands under _Activity whenever the node carries operational state — the same
+        // "infrastructure, orthogonal to this invariant" category as the kickoff itself,
+        // and it upserts on every status flip, so counting it races firstCount.
         var activityCount = SiloMeshService
             .Query<MeshNode>(MeshQueryRequest.FromQuery(
                 $"namespace:{activityNamespace} scope:subtree"))
-            .Select(r => r.Items.Count);
+            .Select(r => r.Items.Count(n => n.Id != NodeTypeCompileStateMirror.StateId));
         var firstCount = await activityCount.Should().Within(30.Seconds()).Match(c => c >= 1);
-        Output.WriteLine($"_Activity rows after first background-activation: {firstCount}");
+        Output.WriteLine($"_Activity compile rows after first background-activation: {firstCount}");
 
         // Re-activate by a SECOND background read. If the kickoff is unguarded
         // (the original prod bug), this would fire ANOTHER compile and the
@@ -472,10 +477,15 @@ public class OrleansCompileActivityAccessTest(ITestOutputHelper output)
         // post-denial ambient context that sync subscription does not settle; a
         // one-shot query is the right primitive.)
         var activityNamespace = $"{typePath}/_Activity";
+        // Count compile-RUN activities only: the compile-state satellite
+        // (NodeTypeCompileStateMirror, #748 phase 1) mirrors the SEEDED terminal status
+        // under System on activation — infrastructure orthogonal to user authorization,
+        // exactly like the kickoff this test already excludes by seeding a settled
+        // status. The denial invariant is "no compile activity row", not "no satellite".
         var activityCount = SiloMeshService
             .Query<MeshNode>(MeshQueryRequest.FromQuery(
                 $"namespace:{activityNamespace} scope:subtree"))
-            .Select(r => r.Items.Count);
+            .Select(r => r.Items.Count(n => n.Id != NodeTypeCompileStateMirror.StateId));
         await activityCount
             .Where(c => c > 0)
             .Should().NotEmit(within: TimeSpan.FromSeconds(5),


### PR DESCRIPTION
Phase 1 of #748 ("move compile state to activity" — maintainer directive, 2026-08-02).

## What lands

- **`NodeTypeCompileState`** — the operational compile members as a value of their own, projected from `NodeTypeDefinition`. The member set is **pinned 1:1 against `NodeTypeOperationalContent.MemberNames` by test (both directions)**, so the satellite and the #749 sync seams cannot drift apart.
- **`NodeTypeCompileStateMirror`** — dual-writes the state onto the fixed-id satellite **`{type}/_Activity/compile-state`**: an Activity node whose `ReturnValue` carries the state (the import-manifest pattern — same table mapping, GitSync exclusion and prune protection for free). Installed on every per-node hub beside the compile watchers; one subscription, `DistinctUntilChanged` on the serialized state, System-identity writes, concatenated so the final satellite equals the final observed state; a failed write logs and retries on the next change.
- **Coverage argument:** every compile-state *change* happens on an active type hub (all writers run through the hub or its own stream), so the mirror cannot miss one. A dormant pre-existing type gets its satellite on next activation — one PreWarm sweep covers the fleet.
- The node stays the writers' target and single source of truth. Phase 2 flips readers to the satellite; phase 3 stops the node writes and retires the mirror (plan in #748).

## Root-caused along the way

`ContentAs<T>` — the canonical shape-tolerant accessor — handled typed, `JsonElement`, and same-short-named foreign content, but returned **silent null for `JsonNode`/`JsonObject`**: exactly the shape node builders assign and a freshly created node's own stream carries before re-typing. The mirror projected nothing for every just-created NodeType until the DOM case was added. This hardens every `ContentAs` call site, not just the mirror.

## Verification

- Unit: member-set pin (both directions), projection fidelity, `IsEmpty`, satellite round-trip through `StateNode`/`Parse`, `ContentAs` on JsonObject content.
- Integration (full monolith mesh): create a NodeType → satellite appears on hub activation with the seeded state; change the node's compile members → the satellite follows.
- `MeshWeaver.Graph.Test` 779/779 · `MeshWeaver.GitSync.Test` 143/143 · full solution `-c Release -warnaserror` clean.

No What's New entry — internal infrastructure, no user-visible behavior change yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)